### PR TITLE
feat(models): pydantic v2 models for Fabric entities

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,5 +20,6 @@ repos:
         additional_dependencies:
           - "azure-identity>=1.19"
           - "azure-core>=1.30"
+          - "pydantic>=2.9"
           - "pytest"
         args: ["--config-file", "pyproject.toml"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
 ]
-dependencies = ["azure-identity>=1.19"]
+dependencies = ["azure-identity>=1.19", "pydantic>=2.9"]
 
 [project.scripts]
 fabric-dw = "fabric_dw.cli:main"

--- a/src/fabric_dw/models.py
+++ b/src/fabric_dw/models.py
@@ -1,0 +1,116 @@
+"""Pydantic v2 models for Microsoft Fabric Data Warehouse domain objects."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import StrEnum
+from typing import Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class _FabricBase(BaseModel):
+    """Shared config for all Fabric domain models."""
+
+    model_config = ConfigDict(extra="ignore", frozen=True, populate_by_name=True)
+
+
+class Workspace(_FabricBase):
+    """A Microsoft Fabric workspace."""
+
+    id: UUID
+    name: str = Field(alias="displayName")
+    description: str | None = None
+    capacity_id: UUID | None = Field(default=None, alias="capacityId")
+    default_dataset_storage_format: str | None = None
+
+
+class WarehouseKind(StrEnum):
+    """Discriminates between a full warehouse, a SQL analytics endpoint, and a snapshot."""
+
+    WAREHOUSE = "Warehouse"
+    SQL_ENDPOINT = "SQLEndpoint"
+    SNAPSHOT = "WarehouseSnapshot"
+
+
+class Warehouse(_FabricBase):
+    """A Microsoft Fabric Data Warehouse or SQL analytics endpoint."""
+
+    id: UUID
+    name: str = Field(alias="displayName")
+    description: str | None = None
+    workspace_id: UUID = Field(alias="workspaceId")
+    kind: WarehouseKind
+    connection_string: str | None = Field(default=None, alias="connectionString")
+    collation: str | None = Field(default=None, alias="defaultCollation")
+    created_date: datetime | None = Field(default=None, alias="createdDate")
+
+    @classmethod
+    def from_api(cls, payload: dict[str, object], kind: WarehouseKind) -> Warehouse:
+        """Build a Warehouse from a raw API response dict.
+
+        Picks up the connection string from the correct nested properties path
+        depending on whether the item is a WAREHOUSE or SQL_ENDPOINT.
+        """
+        props: dict[str, object] = payload.get("properties") or {}  # type: ignore[assignment]
+
+        if kind == WarehouseKind.WAREHOUSE:
+            conn_string = props.get("connectionString")
+        elif kind == WarehouseKind.SQL_ENDPOINT:
+            sql_ep: dict[str, object] = props.get("sqlEndpointProperties") or {}  # type: ignore[assignment]
+            conn_string = sql_ep.get("connectionString")
+        else:
+            conn_string = None
+
+        flat: dict[str, object] = {
+            "id": payload.get("id"),
+            "displayName": payload.get("displayName"),
+            "description": payload.get("description"),
+            "workspaceId": payload.get("workspaceId"),
+            "kind": kind,
+            "connectionString": conn_string,
+            "defaultCollation": props.get("defaultCollation"),
+            "createdDate": props.get("createdDate"),
+        }
+        return cls.model_validate(flat)
+
+
+class WarehouseSnapshot(_FabricBase):
+    """A point-in-time snapshot of a Warehouse."""
+
+    id: UUID
+    name: str
+    parent_warehouse_id: UUID = Field(alias="parentWarehouseId")
+    snapshot_dt: datetime | None = Field(default=None, alias="snapshotDateTime")
+
+
+class RestorePoint(_FabricBase):
+    """A restore point for a Warehouse."""
+
+    id: UUID
+    name: str
+    description: str | None = None
+    created_at: datetime = Field(alias="createdAt")
+    is_system_created: bool = Field(alias="isSystemCreated")
+
+
+class AuditSettings(_FabricBase):
+    """Auditing configuration for a Warehouse."""
+
+    state: Literal["Enabled", "Disabled"]
+    retention_days: int = Field(alias="retentionDays")
+    action_groups: list[str] = Field(default_factory=list, alias="auditActionsAndGroups")
+
+
+class RunningQuery(_FabricBase):
+    """A currently-executing or recently-completed SQL query."""
+
+    session_id: int
+    request_id: str
+    status: str
+    start_time: datetime
+    total_elapsed_time_ms: int
+    login_name: str | None = None
+    command: str | None = None
+    query_text: str | None = None

--- a/src/fabric_dw/models.py
+++ b/src/fabric_dw/models.py
@@ -23,7 +23,9 @@ class Workspace(_FabricBase):
     name: str = Field(alias="displayName")
     description: str | None = None
     capacity_id: UUID | None = Field(default=None, alias="capacityId")
-    default_dataset_storage_format: str | None = None
+    default_dataset_storage_format: str | None = Field(
+        default=None, alias="defaultDatasetStorageFormat"
+    )
 
 
 class WarehouseKind(StrEnum):
@@ -61,7 +63,8 @@ class Warehouse(_FabricBase):
             sql_ep: dict[str, object] = props.get("sqlEndpointProperties") or {}  # type: ignore[assignment]
             conn_string = sql_ep.get("connectionString")
         else:
-            conn_string = None
+            msg = f"from_api does not support kind={kind}"
+            raise ValueError(msg)
 
         flat: dict[str, object] = {
             "id": payload.get("id"),
@@ -80,7 +83,7 @@ class WarehouseSnapshot(_FabricBase):
     """A point-in-time snapshot of a Warehouse."""
 
     id: UUID
-    name: str
+    name: str = Field(alias="displayName")
     parent_warehouse_id: UUID = Field(alias="parentWarehouseId")
     snapshot_dt: datetime | None = Field(default=None, alias="snapshotDateTime")
 
@@ -110,7 +113,7 @@ class RunningQuery(_FabricBase):
     request_id: str
     status: str
     start_time: datetime
-    total_elapsed_time_ms: int
+    total_elapsed_time_ms: int = Field(alias="total_elapsed_time")
     login_name: str | None = None
     command: str | None = None
     query_text: str | None = None

--- a/tests/fixtures/api_payloads.py
+++ b/tests/fixtures/api_payloads.py
@@ -65,7 +65,7 @@ AUDIT_SETTINGS_PAYLOAD = """{
 
 WAREHOUSE_SNAPSHOT_PAYLOAD = """{
   "id": "f6a7b8c9-d0e1-2345-f012-34567890abcd",
-  "name": "SalesWarehouse_Snapshot_20240315",
+  "displayName": "SalesWarehouse_Snapshot_20240315",
   "parentWarehouseId": "d4e5f6a7-b8c9-0123-def0-123456789abc",
   "snapshotDateTime": "2024-03-15T08:00:00Z"
 }"""

--- a/tests/fixtures/api_payloads.py
+++ b/tests/fixtures/api_payloads.py
@@ -1,0 +1,79 @@
+"""Realistic JSON payload constants adapted from Microsoft Learn documentation shapes."""
+
+WORKSPACE_LIST_PAYLOAD = """{
+  "value": [
+    {
+      "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      "displayName": "AnalyticsWorkspace",
+      "description": "Primary analytics workspace for data engineering",
+      "type": "Workspace",
+      "capacityId": "cafebabe-dead-beef-cafe-babe12345678"
+    },
+    {
+      "id": "b2c3d4e5-f6a7-8901-bcde-f01234567891",
+      "displayName": "DataScienceWorkspace",
+      "description": null,
+      "type": "Workspace",
+      "capacityId": null
+    }
+  ],
+  "continuationUri": "https://api.fabric.microsoft.com/v1/workspaces?continuationToken=eyJ0b2tlbiI6InRlc3QifQ%3D%3D"
+}"""
+
+WAREHOUSE_GET_PAYLOAD = """{
+  "id": "d4e5f6a7-b8c9-0123-def0-123456789abc",
+  "displayName": "SalesWarehouse",
+  "description": "Data warehouse for sales analytics",
+  "type": "Warehouse",
+  "workspaceId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "properties": {
+    "connectionString": "saleswarehouse.datawarehouse.fabric.microsoft.com",
+    "defaultCollation": "Latin1_General_100_BIN2_UTF8",
+    "createdDate": "2024-03-15T10:30:00Z",
+    "oneLakeFilesPath": "https://onelake.dfs.fabric.microsoft.com/a1b2c3d4-e5f6-7890-abcd-ef1234567890/d4e5f6a7-b8c9-0123-def0-123456789abc/Files",
+    "oneLakeTablesPath": "https://onelake.dfs.fabric.microsoft.com/a1b2c3d4-e5f6-7890-abcd-ef1234567890/d4e5f6a7-b8c9-0123-def0-123456789abc/Tables",
+    "sqlEndpointProperties": {
+      "connectionString": "warehouse-sql-ep.datawarehouse.fabric.microsoft.com",
+      "id": "e5f6a7b8-c9d0-1234-ef01-234567890abc",
+      "provisioningStatus": "Success"
+    }
+  }
+}"""
+
+LAKEHOUSE_GET_PAYLOAD = """{
+  "id": "e5f6a7b8-c9d0-1234-ef01-234567890abc",
+  "displayName": "SalesLakehouse",
+  "description": "Lakehouse for raw sales data",
+  "type": "Lakehouse",
+  "workspaceId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "properties": {
+    "oneLakeFilesPath": "https://onelake.dfs.fabric.microsoft.com/a1b2c3d4-e5f6-7890-abcd-ef1234567890/e5f6a7b8-c9d0-1234-ef01-234567890abc/Files",
+    "oneLakeTablesPath": "https://onelake.dfs.fabric.microsoft.com/a1b2c3d4-e5f6-7890-abcd-ef1234567890/e5f6a7b8-c9d0-1234-ef01-234567890abc/Tables",
+    "sqlEndpointProperties": {
+      "connectionString": "lakehouse-sql-ep.datawarehouse.fabric.microsoft.com",
+      "id": "f6a7b8c9-d0e1-2345-f012-34567890abcd",
+      "provisioningStatus": "Success"
+    }
+  }
+}"""
+
+AUDIT_SETTINGS_PAYLOAD = """{
+  "state": "Enabled",
+  "retentionDays": 30,
+  "auditActionsAndGroups": ["BATCH_COMPLETED_GROUP", "SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP"]
+}"""
+
+WAREHOUSE_SNAPSHOT_PAYLOAD = """{
+  "id": "f6a7b8c9-d0e1-2345-f012-34567890abcd",
+  "name": "SalesWarehouse_Snapshot_20240315",
+  "parentWarehouseId": "d4e5f6a7-b8c9-0123-def0-123456789abc",
+  "snapshotDateTime": "2024-03-15T08:00:00Z"
+}"""
+
+RESTORE_POINT_PAYLOAD = """{
+  "id": "07a8b9c0-d1e2-3456-0123-456789abcdef",
+  "name": "RestorePoint_20240315",
+  "description": "Automated restore point before schema migration",
+  "createdAt": "2024-03-15T06:00:00Z",
+  "isSystemCreated": false
+}"""

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,0 +1,290 @@
+"""TDD tests for fabric_dw.models — written before the models exist."""
+
+import json
+from copy import deepcopy
+from uuid import UUID
+
+import pytest
+
+from tests.fixtures.api_payloads import (
+    AUDIT_SETTINGS_PAYLOAD,
+    LAKEHOUSE_GET_PAYLOAD,
+    RESTORE_POINT_PAYLOAD,
+    WAREHOUSE_GET_PAYLOAD,
+    WAREHOUSE_SNAPSHOT_PAYLOAD,
+    WORKSPACE_LIST_PAYLOAD,
+)
+
+
+class TestWorkspace:
+    def test_round_trip(self) -> None:
+        from fabric_dw.models import Workspace
+
+        raw = json.loads(WORKSPACE_LIST_PAYLOAD)
+        workspace_data = raw["value"][0]
+        obj = Workspace.model_validate(workspace_data)
+        dumped = obj.model_dump(by_alias=True, exclude_none=True)
+        assert dumped["id"] == UUID(workspace_data["id"])
+        assert dumped["displayName"] == workspace_data["displayName"]
+        assert dumped["capacityId"] == UUID(workspace_data["capacityId"])
+
+    def test_round_trip_no_capacity(self) -> None:
+        from fabric_dw.models import Workspace
+
+        raw = json.loads(WORKSPACE_LIST_PAYLOAD)
+        workspace_data = raw["value"][1]
+        obj = Workspace.model_validate(workspace_data)
+        assert obj.capacity_id is None
+        assert obj.description is None
+
+    def test_extra_fields_ignored(self) -> None:
+        from fabric_dw.models import Workspace
+
+        raw = json.loads(WORKSPACE_LIST_PAYLOAD)
+        workspace_data = dict(raw["value"][0])
+        workspace_data["unexpectedField"] = "some_value"
+        obj = Workspace.model_validate(workspace_data)
+        assert obj.name == workspace_data["displayName"]
+
+    def test_frozen(self) -> None:
+        from fabric_dw.models import Workspace
+
+        raw = json.loads(WORKSPACE_LIST_PAYLOAD)
+        obj = Workspace.model_validate(raw["value"][0])
+        with pytest.raises((TypeError, Exception)):
+            obj.name = "changed"  # type: ignore[misc]
+
+
+class TestWarehouse:
+    def test_from_api_warehouse_kind(self) -> None:
+        from fabric_dw.models import Warehouse, WarehouseKind
+
+        payload = json.loads(WAREHOUSE_GET_PAYLOAD)
+        obj = Warehouse.from_api(payload, kind=WarehouseKind.WAREHOUSE)
+        expected_conn = payload["properties"]["connectionString"]
+        assert obj.connection_string == expected_conn
+        assert obj.kind == WarehouseKind.WAREHOUSE
+
+    def test_from_api_sql_endpoint_kind(self) -> None:
+        from fabric_dw.models import Warehouse, WarehouseKind
+
+        payload = json.loads(LAKEHOUSE_GET_PAYLOAD)
+        obj = Warehouse.from_api(payload, kind=WarehouseKind.SQL_ENDPOINT)
+        expected_conn = payload["properties"]["sqlEndpointProperties"]["connectionString"]
+        assert obj.connection_string == expected_conn
+        assert obj.kind == WarehouseKind.SQL_ENDPOINT
+
+    def test_from_api_warehouse_collation_and_created_date(self) -> None:
+        from fabric_dw.models import Warehouse, WarehouseKind
+
+        payload = json.loads(WAREHOUSE_GET_PAYLOAD)
+        obj = Warehouse.from_api(payload, kind=WarehouseKind.WAREHOUSE)
+        assert obj.collation == payload["properties"]["defaultCollation"]
+        assert obj.created_date is not None
+
+    def test_extra_fields_ignored(self) -> None:
+        from fabric_dw.models import Warehouse, WarehouseKind
+
+        payload = json.loads(WAREHOUSE_GET_PAYLOAD)
+        payload_copy = deepcopy(payload)
+        payload_copy["totallyRandomExtraField"] = "noise"
+        obj = Warehouse.from_api(payload_copy, kind=WarehouseKind.WAREHOUSE)
+        assert obj.name == payload["displayName"]
+
+    def test_frozen(self) -> None:
+        from fabric_dw.models import Warehouse, WarehouseKind
+
+        payload = json.loads(WAREHOUSE_GET_PAYLOAD)
+        obj = Warehouse.from_api(payload, kind=WarehouseKind.WAREHOUSE)
+        with pytest.raises((TypeError, Exception)):
+            obj.name = "changed"  # type: ignore[misc]
+
+    def test_workspace_id_field(self) -> None:
+        from fabric_dw.models import Warehouse, WarehouseKind
+
+        payload = json.loads(WAREHOUSE_GET_PAYLOAD)
+        obj = Warehouse.from_api(payload, kind=WarehouseKind.WAREHOUSE)
+        assert str(obj.workspace_id) == payload["workspaceId"]
+
+
+class TestWarehouseKind:
+    def test_warehouse_value(self) -> None:
+        from fabric_dw.models import WarehouseKind
+
+        assert WarehouseKind.WAREHOUSE == "Warehouse"
+
+    def test_sql_endpoint_value(self) -> None:
+        from fabric_dw.models import WarehouseKind
+
+        assert WarehouseKind.SQL_ENDPOINT == "SQLEndpoint"
+
+    def test_snapshot_value(self) -> None:
+        from fabric_dw.models import WarehouseKind
+
+        assert WarehouseKind.SNAPSHOT == "WarehouseSnapshot"
+
+
+class TestWarehouseSnapshot:
+    def test_round_trip(self) -> None:
+        from fabric_dw.models import WarehouseSnapshot
+
+        payload = json.loads(WAREHOUSE_SNAPSHOT_PAYLOAD)
+        obj = WarehouseSnapshot.model_validate(payload)
+        assert str(obj.id) == payload["id"]
+        assert obj.name == payload["name"]
+        assert str(obj.parent_warehouse_id) == payload["parentWarehouseId"]
+        assert obj.snapshot_dt is not None
+
+    def test_extra_fields_ignored(self) -> None:
+        from fabric_dw.models import WarehouseSnapshot
+
+        payload = json.loads(WAREHOUSE_SNAPSHOT_PAYLOAD)
+        payload_copy = dict(payload)
+        payload_copy["extraKey"] = "extraValue"
+        obj = WarehouseSnapshot.model_validate(payload_copy)
+        assert obj.name == payload["name"]
+
+    def test_frozen(self) -> None:
+        from fabric_dw.models import WarehouseSnapshot
+
+        payload = json.loads(WAREHOUSE_SNAPSHOT_PAYLOAD)
+        obj = WarehouseSnapshot.model_validate(payload)
+        with pytest.raises((TypeError, Exception)):
+            obj.name = "changed"  # type: ignore[misc]
+
+
+class TestRestorePoint:
+    def test_round_trip(self) -> None:
+        from fabric_dw.models import RestorePoint
+
+        payload = json.loads(RESTORE_POINT_PAYLOAD)
+        obj = RestorePoint.model_validate(payload)
+        assert str(obj.id) == payload["id"]
+        assert obj.name == payload["name"]
+        assert obj.description == payload["description"]
+        assert obj.is_system_created == payload["isSystemCreated"]
+        assert obj.created_at is not None
+
+    def test_extra_fields_ignored(self) -> None:
+        from fabric_dw.models import RestorePoint
+
+        payload = json.loads(RESTORE_POINT_PAYLOAD)
+        payload_copy = dict(payload)
+        payload_copy["unknownProp"] = 42
+        obj = RestorePoint.model_validate(payload_copy)
+        assert obj.name == payload["name"]
+
+    def test_frozen(self) -> None:
+        from fabric_dw.models import RestorePoint
+
+        payload = json.loads(RESTORE_POINT_PAYLOAD)
+        obj = RestorePoint.model_validate(payload)
+        with pytest.raises((TypeError, Exception)):
+            obj.name = "changed"  # type: ignore[misc]
+
+
+class TestAuditSettings:
+    def test_round_trip(self) -> None:
+        from fabric_dw.models import AuditSettings
+
+        payload = json.loads(AUDIT_SETTINGS_PAYLOAD)
+        obj = AuditSettings.model_validate(payload)
+        assert obj.state == payload["state"]
+        assert obj.retention_days == payload["retentionDays"]
+        assert obj.action_groups == payload["auditActionsAndGroups"]
+
+    def test_default_action_groups(self) -> None:
+        from fabric_dw.models import AuditSettings
+
+        obj = AuditSettings.model_validate({"state": "Disabled", "retentionDays": 7})
+        assert obj.action_groups == []
+
+    def test_extra_fields_ignored(self) -> None:
+        from fabric_dw.models import AuditSettings
+
+        payload = json.loads(AUDIT_SETTINGS_PAYLOAD)
+        payload_copy = dict(payload)
+        payload_copy["bogusField"] = "bogus"
+        obj = AuditSettings.model_validate(payload_copy)
+        assert obj.state == payload["state"]
+
+    def test_frozen(self) -> None:
+        from fabric_dw.models import AuditSettings
+
+        payload = json.loads(AUDIT_SETTINGS_PAYLOAD)
+        obj = AuditSettings.model_validate(payload)
+        with pytest.raises((TypeError, Exception)):
+            obj.state = "Disabled"  # type: ignore[misc]
+
+
+class TestRunningQuery:
+    def test_round_trip(self) -> None:
+        from fabric_dw.models import RunningQuery
+
+        payload = {
+            "session_id": 12,
+            "request_id": "request-abc-123",
+            "status": "running",
+            "start_time": "2024-03-15T10:30:00Z",
+            "total_elapsed_time_ms": 5432,
+            "login_name": "user@example.com",
+            "command": "SELECT",
+            "query_text": "SELECT * FROM sales.orders",
+        }
+        obj = RunningQuery.model_validate(payload)
+        assert obj.session_id == payload["session_id"]
+        assert obj.request_id == payload["request_id"]
+        assert obj.login_name == payload["login_name"]
+        assert obj.query_text == payload["query_text"]
+
+    def test_nullable_fields(self) -> None:
+        from fabric_dw.models import RunningQuery
+
+        payload = {
+            "session_id": 5,
+            "request_id": "req-xyz",
+            "status": "completed",
+            "start_time": "2024-03-15T10:00:00Z",
+            "total_elapsed_time_ms": 100,
+            "login_name": None,
+            "command": None,
+            "query_text": None,
+        }
+        obj = RunningQuery.model_validate(payload)
+        assert obj.login_name is None
+        assert obj.command is None
+        assert obj.query_text is None
+
+    def test_extra_fields_ignored(self) -> None:
+        from fabric_dw.models import RunningQuery
+
+        payload = {
+            "session_id": 1,
+            "request_id": "req-1",
+            "status": "running",
+            "start_time": "2024-03-15T10:00:00Z",
+            "total_elapsed_time_ms": 200,
+            "login_name": "admin",
+            "command": "SELECT",
+            "query_text": "SELECT 1",
+            "unknownColumn": "noise",
+        }
+        obj = RunningQuery.model_validate(payload)
+        assert obj.session_id == 1
+
+    def test_frozen(self) -> None:
+        from fabric_dw.models import RunningQuery
+
+        payload = {
+            "session_id": 1,
+            "request_id": "req-1",
+            "status": "running",
+            "start_time": "2024-03-15T10:00:00Z",
+            "total_elapsed_time_ms": 200,
+            "login_name": None,
+            "command": None,
+            "query_text": None,
+        }
+        obj = RunningQuery.model_validate(payload)
+        with pytest.raises((TypeError, Exception)):
+            obj.status = "completed"  # type: ignore[misc]

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,10 +1,10 @@
-"""TDD tests for fabric_dw.models — written before the models exist."""
+"""Tests for fabric_dw.models — Pydantic v2 round-trip, alias handling, and frozen behaviour."""
 
 import json
 from copy import deepcopy
-from uuid import UUID
 
 import pytest
+from pydantic import ValidationError
 
 from fabric_dw.models import (
     AuditSettings,
@@ -30,10 +30,17 @@ class TestWorkspace:
         raw = json.loads(WORKSPACE_LIST_PAYLOAD)
         workspace_data = raw["value"][0]
         obj = Workspace.model_validate(workspace_data)
-        dumped = obj.model_dump(by_alias=True, exclude_none=True)
-        assert dumped["id"] == UUID(workspace_data["id"])
-        assert dumped["displayName"] == workspace_data["displayName"]
-        assert dumped["capacityId"] == UUID(workspace_data["capacityId"])
+        dumped = obj.model_dump(by_alias=True, mode="json", exclude_none=True)
+        # Strip extra fields not modelled (e.g. "type") before comparing.
+        modelled_keys = {
+            "id",
+            "displayName",
+            "description",
+            "capacityId",
+            "defaultDatasetStorageFormat",
+        }
+        expected = {k: v for k, v in workspace_data.items() if k in modelled_keys and v is not None}
+        assert dumped == expected
 
     def test_round_trip_no_capacity(self) -> None:
         raw = json.loads(WORKSPACE_LIST_PAYLOAD)
@@ -52,8 +59,8 @@ class TestWorkspace:
     def test_frozen(self) -> None:
         raw = json.loads(WORKSPACE_LIST_PAYLOAD)
         obj = Workspace.model_validate(raw["value"][0])
-        with pytest.raises((TypeError, Exception)):
-            obj.name = "changed"  # pydantic frozen raises ValidationError at runtime
+        with pytest.raises(ValidationError):
+            obj.name = "changed"
 
 
 class TestWarehouse:
@@ -71,6 +78,11 @@ class TestWarehouse:
         assert obj.connection_string == expected_conn
         assert obj.kind == WarehouseKind.SQL_ENDPOINT
 
+    def test_from_api_snapshot_kind_raises(self) -> None:
+        payload = json.loads(WAREHOUSE_GET_PAYLOAD)
+        with pytest.raises(ValueError, match="from_api does not support kind="):
+            Warehouse.from_api(payload, kind=WarehouseKind.SNAPSHOT)
+
     def test_from_api_warehouse_collation_and_created_date(self) -> None:
         payload = json.loads(WAREHOUSE_GET_PAYLOAD)
         obj = Warehouse.from_api(payload, kind=WarehouseKind.WAREHOUSE)
@@ -87,8 +99,8 @@ class TestWarehouse:
     def test_frozen(self) -> None:
         payload = json.loads(WAREHOUSE_GET_PAYLOAD)
         obj = Warehouse.from_api(payload, kind=WarehouseKind.WAREHOUSE)
-        with pytest.raises((TypeError, Exception)):
-            obj.name = "changed"  # pydantic frozen raises ValidationError at runtime
+        with pytest.raises(ValidationError):
+            obj.name = "changed"
 
     def test_workspace_id_field(self) -> None:
         payload = json.loads(WAREHOUSE_GET_PAYLOAD)
@@ -111,34 +123,29 @@ class TestWarehouseSnapshot:
     def test_round_trip(self) -> None:
         payload = json.loads(WAREHOUSE_SNAPSHOT_PAYLOAD)
         obj = WarehouseSnapshot.model_validate(payload)
-        assert str(obj.id) == payload["id"]
-        assert obj.name == payload["name"]
-        assert str(obj.parent_warehouse_id) == payload["parentWarehouseId"]
-        assert obj.snapshot_dt is not None
+        dumped = obj.model_dump(by_alias=True, mode="json", exclude_none=True)
+        assert dumped == payload
 
     def test_extra_fields_ignored(self) -> None:
         payload = json.loads(WAREHOUSE_SNAPSHOT_PAYLOAD)
         payload_copy = dict(payload)
         payload_copy["extraKey"] = "extraValue"
         obj = WarehouseSnapshot.model_validate(payload_copy)
-        assert obj.name == payload["name"]
+        assert obj.name == payload["displayName"]
 
     def test_frozen(self) -> None:
         payload = json.loads(WAREHOUSE_SNAPSHOT_PAYLOAD)
         obj = WarehouseSnapshot.model_validate(payload)
-        with pytest.raises((TypeError, Exception)):
-            obj.name = "changed"  # pydantic frozen raises ValidationError at runtime
+        with pytest.raises(ValidationError):
+            obj.name = "changed"
 
 
 class TestRestorePoint:
     def test_round_trip(self) -> None:
         payload = json.loads(RESTORE_POINT_PAYLOAD)
         obj = RestorePoint.model_validate(payload)
-        assert str(obj.id) == payload["id"]
-        assert obj.name == payload["name"]
-        assert obj.description == payload["description"]
-        assert obj.is_system_created == payload["isSystemCreated"]
-        assert obj.created_at is not None
+        dumped = obj.model_dump(by_alias=True, mode="json", exclude_none=True)
+        assert dumped == payload
 
     def test_extra_fields_ignored(self) -> None:
         payload = json.loads(RESTORE_POINT_PAYLOAD)
@@ -150,17 +157,16 @@ class TestRestorePoint:
     def test_frozen(self) -> None:
         payload = json.loads(RESTORE_POINT_PAYLOAD)
         obj = RestorePoint.model_validate(payload)
-        with pytest.raises((TypeError, Exception)):
-            obj.name = "changed"  # pydantic frozen raises ValidationError at runtime
+        with pytest.raises(ValidationError):
+            obj.name = "changed"
 
 
 class TestAuditSettings:
     def test_round_trip(self) -> None:
         payload = json.loads(AUDIT_SETTINGS_PAYLOAD)
         obj = AuditSettings.model_validate(payload)
-        assert obj.state == payload["state"]
-        assert obj.retention_days == payload["retentionDays"]
-        assert obj.action_groups == payload["auditActionsAndGroups"]
+        dumped = obj.model_dump(by_alias=True, mode="json", exclude_none=True)
+        assert dumped == payload
 
     def test_default_action_groups(self) -> None:
         obj = AuditSettings.model_validate({"state": "Disabled", "retentionDays": 7})
@@ -176,27 +182,26 @@ class TestAuditSettings:
     def test_frozen(self) -> None:
         payload = json.loads(AUDIT_SETTINGS_PAYLOAD)
         obj = AuditSettings.model_validate(payload)
-        with pytest.raises((TypeError, Exception)):
-            obj.state = "Disabled"  # pydantic frozen raises ValidationError at runtime
+        with pytest.raises(ValidationError):
+            obj.state = "Disabled"
 
 
 class TestRunningQuery:
     def test_round_trip(self) -> None:
+        # Keys use DMV column names (aliases); total_elapsed_time is already in milliseconds.
         payload = {
             "session_id": 12,
             "request_id": "request-abc-123",
             "status": "running",
             "start_time": "2024-03-15T10:30:00Z",
-            "total_elapsed_time_ms": 5432,
+            "total_elapsed_time": 5432,
             "login_name": "user@example.com",
             "command": "SELECT",
             "query_text": "SELECT * FROM sales.orders",
         }
         obj = RunningQuery.model_validate(payload)
-        assert obj.session_id == payload["session_id"]
-        assert obj.request_id == payload["request_id"]
-        assert obj.login_name == payload["login_name"]
-        assert obj.query_text == payload["query_text"]
+        dumped = obj.model_dump(by_alias=True, mode="json", exclude_none=True)
+        assert dumped == payload
 
     def test_nullable_fields(self) -> None:
         payload = {
@@ -204,7 +209,7 @@ class TestRunningQuery:
             "request_id": "req-xyz",
             "status": "completed",
             "start_time": "2024-03-15T10:00:00Z",
-            "total_elapsed_time_ms": 100,
+            "total_elapsed_time": 100,
             "login_name": None,
             "command": None,
             "query_text": None,
@@ -220,7 +225,7 @@ class TestRunningQuery:
             "request_id": "req-1",
             "status": "running",
             "start_time": "2024-03-15T10:00:00Z",
-            "total_elapsed_time_ms": 200,
+            "total_elapsed_time": 200,
             "login_name": "admin",
             "command": "SELECT",
             "query_text": "SELECT 1",
@@ -235,11 +240,11 @@ class TestRunningQuery:
             "request_id": "req-1",
             "status": "running",
             "start_time": "2024-03-15T10:00:00Z",
-            "total_elapsed_time_ms": 200,
+            "total_elapsed_time": 200,
             "login_name": None,
             "command": None,
             "query_text": None,
         }
         obj = RunningQuery.model_validate(payload)
-        with pytest.raises((TypeError, Exception)):
-            obj.status = "completed"  # pydantic frozen raises ValidationError at runtime
+        with pytest.raises(ValidationError):
+            obj.status = "completed"

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -6,6 +6,15 @@ from uuid import UUID
 
 import pytest
 
+from fabric_dw.models import (
+    AuditSettings,
+    RestorePoint,
+    RunningQuery,
+    Warehouse,
+    WarehouseKind,
+    WarehouseSnapshot,
+    Workspace,
+)
 from tests.fixtures.api_payloads import (
     AUDIT_SETTINGS_PAYLOAD,
     LAKEHOUSE_GET_PAYLOAD,
@@ -18,8 +27,6 @@ from tests.fixtures.api_payloads import (
 
 class TestWorkspace:
     def test_round_trip(self) -> None:
-        from fabric_dw.models import Workspace
-
         raw = json.loads(WORKSPACE_LIST_PAYLOAD)
         workspace_data = raw["value"][0]
         obj = Workspace.model_validate(workspace_data)
@@ -29,8 +36,6 @@ class TestWorkspace:
         assert dumped["capacityId"] == UUID(workspace_data["capacityId"])
 
     def test_round_trip_no_capacity(self) -> None:
-        from fabric_dw.models import Workspace
-
         raw = json.loads(WORKSPACE_LIST_PAYLOAD)
         workspace_data = raw["value"][1]
         obj = Workspace.model_validate(workspace_data)
@@ -38,8 +43,6 @@ class TestWorkspace:
         assert obj.description is None
 
     def test_extra_fields_ignored(self) -> None:
-        from fabric_dw.models import Workspace
-
         raw = json.loads(WORKSPACE_LIST_PAYLOAD)
         workspace_data = dict(raw["value"][0])
         workspace_data["unexpectedField"] = "some_value"
@@ -47,18 +50,14 @@ class TestWorkspace:
         assert obj.name == workspace_data["displayName"]
 
     def test_frozen(self) -> None:
-        from fabric_dw.models import Workspace
-
         raw = json.loads(WORKSPACE_LIST_PAYLOAD)
         obj = Workspace.model_validate(raw["value"][0])
         with pytest.raises((TypeError, Exception)):
-            obj.name = "changed"  # type: ignore[misc]
+            obj.name = "changed"  # pydantic frozen raises ValidationError at runtime
 
 
 class TestWarehouse:
     def test_from_api_warehouse_kind(self) -> None:
-        from fabric_dw.models import Warehouse, WarehouseKind
-
         payload = json.loads(WAREHOUSE_GET_PAYLOAD)
         obj = Warehouse.from_api(payload, kind=WarehouseKind.WAREHOUSE)
         expected_conn = payload["properties"]["connectionString"]
@@ -66,8 +65,6 @@ class TestWarehouse:
         assert obj.kind == WarehouseKind.WAREHOUSE
 
     def test_from_api_sql_endpoint_kind(self) -> None:
-        from fabric_dw.models import Warehouse, WarehouseKind
-
         payload = json.loads(LAKEHOUSE_GET_PAYLOAD)
         obj = Warehouse.from_api(payload, kind=WarehouseKind.SQL_ENDPOINT)
         expected_conn = payload["properties"]["sqlEndpointProperties"]["connectionString"]
@@ -75,16 +72,12 @@ class TestWarehouse:
         assert obj.kind == WarehouseKind.SQL_ENDPOINT
 
     def test_from_api_warehouse_collation_and_created_date(self) -> None:
-        from fabric_dw.models import Warehouse, WarehouseKind
-
         payload = json.loads(WAREHOUSE_GET_PAYLOAD)
         obj = Warehouse.from_api(payload, kind=WarehouseKind.WAREHOUSE)
         assert obj.collation == payload["properties"]["defaultCollation"]
         assert obj.created_date is not None
 
     def test_extra_fields_ignored(self) -> None:
-        from fabric_dw.models import Warehouse, WarehouseKind
-
         payload = json.loads(WAREHOUSE_GET_PAYLOAD)
         payload_copy = deepcopy(payload)
         payload_copy["totallyRandomExtraField"] = "noise"
@@ -92,16 +85,12 @@ class TestWarehouse:
         assert obj.name == payload["displayName"]
 
     def test_frozen(self) -> None:
-        from fabric_dw.models import Warehouse, WarehouseKind
-
         payload = json.loads(WAREHOUSE_GET_PAYLOAD)
         obj = Warehouse.from_api(payload, kind=WarehouseKind.WAREHOUSE)
         with pytest.raises((TypeError, Exception)):
-            obj.name = "changed"  # type: ignore[misc]
+            obj.name = "changed"  # pydantic frozen raises ValidationError at runtime
 
     def test_workspace_id_field(self) -> None:
-        from fabric_dw.models import Warehouse, WarehouseKind
-
         payload = json.loads(WAREHOUSE_GET_PAYLOAD)
         obj = Warehouse.from_api(payload, kind=WarehouseKind.WAREHOUSE)
         assert str(obj.workspace_id) == payload["workspaceId"]
@@ -109,25 +98,17 @@ class TestWarehouse:
 
 class TestWarehouseKind:
     def test_warehouse_value(self) -> None:
-        from fabric_dw.models import WarehouseKind
-
-        assert WarehouseKind.WAREHOUSE == "Warehouse"
+        assert WarehouseKind.WAREHOUSE.value == "Warehouse"
 
     def test_sql_endpoint_value(self) -> None:
-        from fabric_dw.models import WarehouseKind
-
-        assert WarehouseKind.SQL_ENDPOINT == "SQLEndpoint"
+        assert WarehouseKind.SQL_ENDPOINT.value == "SQLEndpoint"
 
     def test_snapshot_value(self) -> None:
-        from fabric_dw.models import WarehouseKind
-
-        assert WarehouseKind.SNAPSHOT == "WarehouseSnapshot"
+        assert WarehouseKind.SNAPSHOT.value == "WarehouseSnapshot"
 
 
 class TestWarehouseSnapshot:
     def test_round_trip(self) -> None:
-        from fabric_dw.models import WarehouseSnapshot
-
         payload = json.loads(WAREHOUSE_SNAPSHOT_PAYLOAD)
         obj = WarehouseSnapshot.model_validate(payload)
         assert str(obj.id) == payload["id"]
@@ -136,8 +117,6 @@ class TestWarehouseSnapshot:
         assert obj.snapshot_dt is not None
 
     def test_extra_fields_ignored(self) -> None:
-        from fabric_dw.models import WarehouseSnapshot
-
         payload = json.loads(WAREHOUSE_SNAPSHOT_PAYLOAD)
         payload_copy = dict(payload)
         payload_copy["extraKey"] = "extraValue"
@@ -145,18 +124,14 @@ class TestWarehouseSnapshot:
         assert obj.name == payload["name"]
 
     def test_frozen(self) -> None:
-        from fabric_dw.models import WarehouseSnapshot
-
         payload = json.loads(WAREHOUSE_SNAPSHOT_PAYLOAD)
         obj = WarehouseSnapshot.model_validate(payload)
         with pytest.raises((TypeError, Exception)):
-            obj.name = "changed"  # type: ignore[misc]
+            obj.name = "changed"  # pydantic frozen raises ValidationError at runtime
 
 
 class TestRestorePoint:
     def test_round_trip(self) -> None:
-        from fabric_dw.models import RestorePoint
-
         payload = json.loads(RESTORE_POINT_PAYLOAD)
         obj = RestorePoint.model_validate(payload)
         assert str(obj.id) == payload["id"]
@@ -166,8 +141,6 @@ class TestRestorePoint:
         assert obj.created_at is not None
 
     def test_extra_fields_ignored(self) -> None:
-        from fabric_dw.models import RestorePoint
-
         payload = json.loads(RESTORE_POINT_PAYLOAD)
         payload_copy = dict(payload)
         payload_copy["unknownProp"] = 42
@@ -175,18 +148,14 @@ class TestRestorePoint:
         assert obj.name == payload["name"]
 
     def test_frozen(self) -> None:
-        from fabric_dw.models import RestorePoint
-
         payload = json.loads(RESTORE_POINT_PAYLOAD)
         obj = RestorePoint.model_validate(payload)
         with pytest.raises((TypeError, Exception)):
-            obj.name = "changed"  # type: ignore[misc]
+            obj.name = "changed"  # pydantic frozen raises ValidationError at runtime
 
 
 class TestAuditSettings:
     def test_round_trip(self) -> None:
-        from fabric_dw.models import AuditSettings
-
         payload = json.loads(AUDIT_SETTINGS_PAYLOAD)
         obj = AuditSettings.model_validate(payload)
         assert obj.state == payload["state"]
@@ -194,14 +163,10 @@ class TestAuditSettings:
         assert obj.action_groups == payload["auditActionsAndGroups"]
 
     def test_default_action_groups(self) -> None:
-        from fabric_dw.models import AuditSettings
-
         obj = AuditSettings.model_validate({"state": "Disabled", "retentionDays": 7})
         assert obj.action_groups == []
 
     def test_extra_fields_ignored(self) -> None:
-        from fabric_dw.models import AuditSettings
-
         payload = json.loads(AUDIT_SETTINGS_PAYLOAD)
         payload_copy = dict(payload)
         payload_copy["bogusField"] = "bogus"
@@ -209,18 +174,14 @@ class TestAuditSettings:
         assert obj.state == payload["state"]
 
     def test_frozen(self) -> None:
-        from fabric_dw.models import AuditSettings
-
         payload = json.loads(AUDIT_SETTINGS_PAYLOAD)
         obj = AuditSettings.model_validate(payload)
         with pytest.raises((TypeError, Exception)):
-            obj.state = "Disabled"  # type: ignore[misc]
+            obj.state = "Disabled"  # pydantic frozen raises ValidationError at runtime
 
 
 class TestRunningQuery:
     def test_round_trip(self) -> None:
-        from fabric_dw.models import RunningQuery
-
         payload = {
             "session_id": 12,
             "request_id": "request-abc-123",
@@ -238,8 +199,6 @@ class TestRunningQuery:
         assert obj.query_text == payload["query_text"]
 
     def test_nullable_fields(self) -> None:
-        from fabric_dw.models import RunningQuery
-
         payload = {
             "session_id": 5,
             "request_id": "req-xyz",
@@ -256,8 +215,6 @@ class TestRunningQuery:
         assert obj.query_text is None
 
     def test_extra_fields_ignored(self) -> None:
-        from fabric_dw.models import RunningQuery
-
         payload = {
             "session_id": 1,
             "request_id": "req-1",
@@ -273,8 +230,6 @@ class TestRunningQuery:
         assert obj.session_id == 1
 
     def test_frozen(self) -> None:
-        from fabric_dw.models import RunningQuery
-
         payload = {
             "session_id": 1,
             "request_id": "req-1",
@@ -287,4 +242,4 @@ class TestRunningQuery:
         }
         obj = RunningQuery.model_validate(payload)
         with pytest.raises((TypeError, Exception)):
-            obj.status = "completed"  # type: ignore[misc]
+            obj.status = "completed"  # pydantic frozen raises ValidationError at runtime

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,15 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -465,6 +474,7 @@ name = "fabric-dw-mcp-cli"
 source = { editable = "." }
 dependencies = [
     { name = "azure-identity" },
+    { name = "pydantic" },
 ]
 
 [package.optional-dependencies]
@@ -486,6 +496,7 @@ requires-dist = [
     { name = "azure-identity", specifier = ">=1.19" },
     { name = "mypy", marker = "extra == 'dev'" },
     { name = "pre-commit", marker = "extra == 'dev'" },
+    { name = "pydantic", specifier = ">=2.9" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest-asyncio", marker = "extra == 'dev'" },
     { name = "pytest-cov", marker = "extra == 'dev'" },
@@ -810,6 +821,123 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/fa/6d7708d2cfc1a832acb6aeb0cd16e801902df8a0f583bb3b4b527fde022e/pydantic_core-2.46.4-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:0e96592440881c74a213e5ad528e2b24d3d4f940de2766bed9010ab1d9e51594", size = 2111872, upload-time = "2026-05-06T13:40:27.596Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6f/aa064a3e74b5745afbdf250594f38e7ead05e2d651bcb35994b9417a0d4d/pydantic_core-2.46.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e0d65b8c354be7fb5f720c3caa8bc940bc2d20ce749c8e06135f07f8ed95dd7c", size = 1948255, upload-time = "2026-05-06T13:39:12.574Z" },
+    { url = "https://files.pythonhosted.org/packages/43/3a/41114a9f7569b84b4d84e7a018c57c56347dac30c0d4a872946ec4e36c46/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7bfb192b3f4b9e8a89b6277b6ce787564f62cfd272055f6e685726b111dc7826", size = 1972827, upload-time = "2026-05-06T13:38:19.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/25/1ab42e8048fe551934d9884e8d64daa7e990ad386f310a15981aeb6a5b08/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9037063db01f09b09e237c282b6792bd4da634b5402c4e7f0c61effed7701a04", size = 2041051, upload-time = "2026-05-06T13:38:10.447Z" },
+    { url = "https://files.pythonhosted.org/packages/94/c2/1a934597ddf08da410385b3b7aae91956a5a76c635effef456074fad7e88/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fc010ab034c8c7452522748bf937df58020d256ccae0874463d1f4d01758af8e", size = 2221314, upload-time = "2026-05-06T13:40:13.089Z" },
+    { url = "https://files.pythonhosted.org/packages/02/6d/9e8ad178c9c4df27ad3c8f25d1fe2a7ab0d2ba0559fad4aee5d3d1f16771/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c5dac79fa1614d1e06ca695109c6105923bd9c7d1d6c918d4e637b7e6b32fd3", size = 2285146, upload-time = "2026-05-06T13:38:59.224Z" },
+    { url = "https://files.pythonhosted.org/packages/80/50/540cd3aeefc041beb111125c4bff779831a2111fc6b15a9138cda277d32c/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f9fa868638bf362d3d138ea55829cefb3d5f4b0d7f142234382a15e2485dbec4", size = 2089685, upload-time = "2026-05-06T13:38:17.762Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/a4/b440ad35f05f6a38f89fa0f149accb3f0e02be94ca5e15f3c449a61b4bc9/pydantic_core-2.46.4-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:17299feefe090f2caa5b8e37222bb5f663e4935a8bfa6931d4102e5df1a9f398", size = 2115420, upload-time = "2026-05-06T13:37:58.195Z" },
+    { url = "https://files.pythonhosted.org/packages/99/61/de4f55db8dfd57bfdfa9a12ec90fe1b57c4f41062f7ca86f08586b3e0ac0/pydantic_core-2.46.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4c63ebc82684aa89d9a3bcbd13d515b3be44250dc68dd3bd81526c1cb31286c3", size = 2165122, upload-time = "2026-05-06T13:37:01.167Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/52/7c529d7bdb2d1068bd52f51fe32572c8301f9a4febf1948f10639f1436f5/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:aaa2a54443eff1950ba5ddc6b6ccda0d9c84a364276a62f969bdf2a390650848", size = 2182573, upload-time = "2026-05-06T13:38:45.04Z" },
+    { url = "https://files.pythonhosted.org/packages/37/b3/7c40325848ba78247f2812dcf9c7274e38cd801820ca6dd9fe63bcfb0eb4/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:18e5ceec2ab67e6d5f1a9085e5a24c9c4e2ac4545730bfe668680bca05e555f3", size = 2317139, upload-time = "2026-05-06T13:37:15.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/37/f913f81a657c865b75da6c0dbed79876073c2a43b5bd9edbe8da785e4d49/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:a0f62d0a58f4e7da165457e995725421e0064f2255d8eccebc49f41bbc23b109", size = 2360433, upload-time = "2026-05-06T13:37:30.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/67/6acaa1be2567f9256b056d8477158cac7240813956ce86e49deae8e173b4/pydantic_core-2.46.4-cp311-cp311-win32.whl", hash = "sha256:041bde0a48fd37cf71cab1c9d56d3e8625a3793fef1f7dd232b3ff37e978ecda", size = 1985513, upload-time = "2026-05-06T13:38:15.669Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/e6/c505f83dfeda9a2e5c995cfd872949e4d05e12f7feb3dca72f633daefa94/pydantic_core-2.46.4-cp311-cp311-win_amd64.whl", hash = "sha256:6f2eeda33a839975441c86a4119e1383c50b47faf0cbb5176985565c6bb02c33", size = 2071114, upload-time = "2026-05-06T13:40:35.416Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/da/7a263a96d965d9d0df5e8de8a475f33495451117035b09acb110288c381f/pydantic_core-2.46.4-cp311-cp311-win_arm64.whl", hash = "sha256:14f4c5d6db102bd796a627bbb3a17b4cf4574b9ae861d8b7c9a9661c6dd3362d", size = 2044298, upload-time = "2026-05-06T13:38:29.754Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/8c/af022f0af448d7747c5154288d46b5f2bc5f17366eaa0e23e9aa04d59f3b/pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2", size = 2106158, upload-time = "2026-05-06T13:38:57.215Z" },
+    { url = "https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f", size = 1951724, upload-time = "2026-05-06T13:37:02.697Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/bc/f47d1ff9cbb1620e1b5b697eef06010035735f07820180e74178226b27b3/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7", size = 1975742, upload-time = "2026-05-06T13:37:09.448Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/11/9b9a5b0306345664a2da6410877af6e8082481b5884b3ddd78d47c6013ce/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a233125ac121aa3ffba9a2b59edfc4a985a76092dc8279586ab4b71390875e7", size = 2052418, upload-time = "2026-05-06T13:37:38.234Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b7/a65fec226f5d78fc39f4a13c4cc0c768c22b113438f60c14adc9d2865038/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b712b53160b79a5850310b912a5ef8e57e56947c8ad690c227f5c9d7e561712", size = 2232274, upload-time = "2026-05-06T13:38:27.753Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f0/92039db98b907ef49269a8271f67db9cb78ae2fc68062ef7e4e77adb5f61/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9401557acd873c3a7f3eb9383edef8ac4968f9510e340f4808d427e75667e7b4", size = 2309940, upload-time = "2026-05-06T13:38:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce", size = 2094516, upload-time = "2026-05-06T13:39:10.577Z" },
+    { url = "https://files.pythonhosted.org/packages/22/37/a8aca44d40d737dde2bc05b3c6c07dff0de07ce6f82e9f3167aeaf4d5dea/pydantic_core-2.46.4-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:56cb4851bcaf3d117eddcef4fe66afd750a50274b0da8e22be256d10e5611987", size = 2136854, upload-time = "2026-05-06T13:40:22.59Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/fcef1b79238c06a8cbec70819ac722ba76e02bc8ada9b0fd66eba40da01b/pydantic_core-2.46.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c68fcd102d71ea85c5b2dfac3f4f8476eff42a9e078fd5faefff6d145063536b", size = 2180306, upload-time = "2026-05-06T13:40:10.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6c/fc44000918855b42779d007ae63b0532794739027b2f417321cddbc44f6a/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458", size = 2190044, upload-time = "2026-05-06T13:40:43.231Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/65/d9cadc9f1920d7a127ad2edba16c1db7916e59719285cd6c94600b0080ba/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b", size = 2329133, upload-time = "2026-05-06T13:39:57.365Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/cf/c873d91679f3a30bcf5e7ac280ce5573483e72295307685120d0d5ad3416/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c", size = 2374464, upload-time = "2026-05-06T13:38:06.976Z" },
+    { url = "https://files.pythonhosted.org/packages/47/bd/6f2fc8188f31bf10590f1e98e7b306336161fac930a8c514cd7bd828c7dc/pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894", size = 1974823, upload-time = "2026-05-06T13:40:47.985Z" },
+    { url = "https://files.pythonhosted.org/packages/40/8c/985c1d41ea1107c2534abd9870e4ed5c8e7669b5c308297835c001e7a1c4/pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89", size = 2072919, upload-time = "2026-05-06T13:39:21.153Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ba/f463d006e0c47373ca7ec5e1a261c59dc01ef4d62b2657af925fb0deee3a/pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a", size = 2027604, upload-time = "2026-05-06T13:39:03.753Z" },
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/a4/73995fd4ebbb46ba0ee51e6fa049b8f02c40daebb762208feda8a6b7894d/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:14d4edf427bdcf950a8a02d7cb44a08614388dd6e1bdcbf4f67504fa7887da9c", size = 2111589, upload-time = "2026-05-06T13:37:10.817Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/7f/f37d3a5e8bfcc2e403f5c57a730f2d815693fb42119e8ea48b3789335af1/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:0ce40cd7b21210e99342afafbd4d0f76d784eb5b1d60f3bdc566be4983c6c73b", size = 1944552, upload-time = "2026-05-06T13:36:56.717Z" },
+    { url = "https://files.pythonhosted.org/packages/15/3c/d7eb777b3ff43e8433a4efb39a17aa8fd98a4ee8561a24a67ef5db07b2d6/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:90884113d8b48f760e9587002789ddd741e76ab9f89518cd1e43b1f1a52ec44b", size = 1982984, upload-time = "2026-05-06T13:39:06.207Z" },
+    { url = "https://files.pythonhosted.org/packages/63/87/70b9f40170a81afd55ca26c9b2acb25c20d64bcfbf888fafecb3ba077d4c/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:66ce7632c22d837c95301830e111ad0128a32b8207533b60896a96c4915192ea", size = 2138417, upload-time = "2026-05-06T13:39:45.476Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/1d/8987ad40f65ae1432753072f214fb5c74fe47ffbd0698bb9cbbb585664f8/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:1d8ba486450b14f3b1d63bc521d410ec7565e52f887b9fb671791886436a42f7", size = 2095527, upload-time = "2026-05-06T13:39:52.283Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
+    { url = "https://files.pythonhosted.org/packages/11/cb/428de0385b6c8d44b716feba566abfacfbd23ee3c4439faa789a1456242f/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:0c563b08bca408dc7f65f700633d8442fffb2421fc47b8101377e9fd65051ff0", size = 2112782, upload-time = "2026-05-06T13:37:04.016Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b5/6a17bdadd0fc1f170adfd05a20d37c832f52b117b4d9131da1f41bb097ce/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:db06ffe51636ffe9ca531fe9023dd64bdd794be8754cb5df57c5498ae5b518a7", size = 1952146, upload-time = "2026-05-06T13:39:43.092Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/dc/03734d80e362cd43ef65428e9de77c730ce7f2f11c60d2b1e1b39f0fbf99/pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:133878133d271ade3d41d1bfb2a45ec38dbdbda40bc065921c6b04e4630127e2", size = 2134492, upload-time = "2026-05-06T13:36:58.124Z" },
+    { url = "https://files.pythonhosted.org/packages/de/df/5e5ffc085ed07cc22d298134d3d911c63e91f6a0eb91fe646750a3209910/pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9bc519fbf2b7578398853d815009ae5e4d4603d12f4e3f91da8c06852d3da3e9", size = 2156604, upload-time = "2026-05-06T13:37:49.88Z" },
+    { url = "https://files.pythonhosted.org/packages/81/44/6e112a4253e56f5705467cbab7ab5e91ee7398ba3d56d358635958893d3e/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:c7a7bd4e39e8e4c12c39cd480356842b6a8a06e41b23a55a5e3e191718838ddf", size = 2183828, upload-time = "2026-05-06T13:37:43.053Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ad/5565071e937d8e752842ac241463944c9eb14c87e2d269f2658a5bd05e98/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:d396ec2b979760aaf3218e76c24e65bd0aca24983298653b3a9d7a45f9e47b30", size = 2310000, upload-time = "2026-05-06T13:37:56.694Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c3/66883a5cec183e7fba4d024b4cbbe61851a63750ef606b0afecc46d1f2bf/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:86e1a4418c6cd97d60c95c71164158eaf7324fae7b0923264016baa993eba6fc", size = 2361286, upload-time = "2026-05-06T13:40:05.667Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/2d/69abac8f838090bbecd5df894befb2c2619e7996a98ddb949db9f3b93225/pydantic_core-2.46.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:d51026d73fcfd93610abc7b27789c26b313920fcfb20e27462d74a7f8b06e983", size = 2193071, upload-time = "2026-05-06T13:38:08.682Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1103,6 +1231,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #10

Adds strict Pydantic v2 models for Workspace, Warehouse, WarehouseSnapshot, RestorePoint, AuditSettings, RunningQuery, plus the API-payload fixtures used by every later test file.

Foundation slice. No service-layer wiring yet.

## Test plan
- [x] tests/unit/test_models.py covers round-trip serialization, alias handling, Warehouse.from_api dispatch on kind, extra-field tolerance, frozen behavior
- [x] ruff / mypy / pytest all green
- [x] uv.lock updated for pydantic