### PR TITLE
feat(sql): async mssql-python wrapper with conn pool

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,4 +27,5 @@ repos:
           - "tenacity>=9"
           - "respx>=0.21"
           - "freezegun>=1.5"
+          - "mssql-python>=0.13"
         args: ["--config-file", "pyproject.toml"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "httpx[http2]>=0.27",
     "aiolimiter>=1.2",
     "tenacity>=9",
+    "mssql-python>=0.13",
 ]
 
 [project.scripts]

--- a/src/fabric_dw/sql_client.py
+++ b/src/fabric_dw/sql_client.py
@@ -1,0 +1,266 @@
+"""Async wrapper around mssql-python with a connection pool per (workspace, database)."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import re
+import types
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any, Protocol, runtime_checkable
+
+from fabric_dw.auth import CredentialMode
+from fabric_dw.exceptions import AuthError
+
+# Thin indirection that lets tests monkeypatch ``_mssql`` without the native
+# extension being imported at module-load time (the .so may not be loadable in
+# every environment).  The real driver is imported lazily on first use.
+_mssql: types.ModuleType | None = None
+
+
+def _get_mssql() -> types.ModuleType:
+    """Return the mssql_python module, importing it on first call."""
+    global _mssql  # noqa: PLW0603
+    if _mssql is None:
+        _mssql = importlib.import_module("mssql_python")
+    return _mssql
+
+
+# Sentinel strings that signal Entra auth failures in driver error messages.
+_AUTH_ERROR_FRAGMENTS = (
+    "login failed",
+    "token",
+    "authentication",
+    "unauthorized",
+    "access denied",
+    "invalid authorization",
+    "28000",
+)
+
+# Mapping from CredentialMode to the ActiveDirectory auth type suffix.
+_MODE_TO_AD_AUTH: dict[CredentialMode, str] = {
+    CredentialMode.DEFAULT: "ActiveDirectoryDefault",
+    CredentialMode.SERVICE_PRINCIPAL: "ActiveDirectoryServicePrincipal",
+    CredentialMode.INTERACTIVE: "ActiveDirectoryInteractive",
+}
+
+
+def _has_key(connection_string: str, key: str) -> bool:
+    """Return True if *key* is already present in the ODBC connection string."""
+    pattern = re.compile(r"(?:^|;)\s*" + re.escape(key) + r"\s*=", re.IGNORECASE)
+    return bool(pattern.search(connection_string))
+
+
+def _set_key(connection_string: str, key: str, value: str) -> str:
+    """Append *key=value* to *connection_string* if *key* is not already set."""
+    if _has_key(connection_string, key):
+        return connection_string
+    sep = ";" if connection_string.rstrip().rstrip(";").strip() else ""
+    return f"{connection_string.rstrip().rstrip(';')}{sep};{key}={value}".lstrip(";")
+
+
+def _augment_connection_string(
+    connection_string: str,
+    database: str,
+    mode: CredentialMode,
+) -> str:
+    """Return the connection string augmented with auth, encryption and database settings.
+
+    The operation is idempotent: calling it twice with the same arguments returns
+    the identical string.
+
+    Args:
+        connection_string: The raw connection string from the Fabric/Power BI API.
+        database: The target database name, added only if not already present.
+        mode: The credential mode, used to select the ActiveDirectory auth variant.
+
+    Returns:
+        The augmented connection string.
+    """
+    cs = _set_key(connection_string, "Authentication", _MODE_TO_AD_AUTH[mode])
+    cs = _set_key(cs, "Encrypt", "yes")
+    cs = _set_key(cs, "TrustServerCertificate", "no")
+    return _set_key(cs, "Database", database)
+
+
+class _Cursor(Protocol):
+    """Minimal DB-API 2.0 cursor protocol."""
+
+    description: list[tuple[str, Any]]
+
+    def execute(self, sql: str, params: Sequence[Any] = ...) -> None: ...
+
+    def fetchall(self) -> list[tuple[Any, ...]]: ...
+
+    rowcount: int
+
+
+@runtime_checkable
+class _Connection(Protocol):
+    """Minimal DB-API 2.0 connection protocol."""
+
+    def cursor(self) -> _Cursor: ...
+
+    def commit(self) -> None: ...
+
+    def close(self) -> None: ...
+
+
+def _is_auth_error(exc: BaseException) -> bool:
+    """Return True if *exc* looks like an Entra / login-failure error."""
+    msg = str(exc).lower()
+    return any(fragment in msg for fragment in _AUTH_ERROR_FRAGMENTS)
+
+
+@dataclass(frozen=True)
+class SqlTarget:
+    """Identifies a specific Fabric warehouse to connect to.
+
+    Attributes:
+        workspace_id: The Fabric workspace GUID.
+        database: The warehouse / database name.
+        connection_string: The raw ODBC connection string from the Fabric API;
+            no augmentation should be applied before passing it here.
+    """
+
+    workspace_id: str
+    database: str
+    connection_string: str
+
+
+class FabricSqlClient:
+    """Async MSSQL client with one cached connection per (workspace, database).
+
+    All blocking driver calls are dispatched to a thread pool via
+    ``asyncio.to_thread`` so they never block the event loop.
+
+    Usage::
+
+        async with FabricSqlClient(mode=CredentialMode.DEFAULT) as client:
+            rows = await client.execute(target, "SELECT TOP 10 * FROM dbo.t")
+    """
+
+    def __init__(self, *, mode: CredentialMode = CredentialMode.DEFAULT) -> None:
+        self._mode = mode
+        # Cache: (workspace_id, database) → connection
+        self._cache: dict[tuple[str, str], _Connection] = {}
+        # Per-key locks to prevent concurrent stampedes
+        self._locks: dict[tuple[str, str], asyncio.Lock] = {}
+        # Global lock protecting _locks dict itself
+        self._meta_lock = asyncio.Lock()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    async def _get_lock(self, key: tuple[str, str]) -> asyncio.Lock:
+        """Return (creating if necessary) the per-key asyncio.Lock."""
+        async with self._meta_lock:
+            if key not in self._locks:
+                self._locks[key] = asyncio.Lock()
+            return self._locks[key]
+
+    async def _get_connection(self, target: SqlTarget) -> _Connection:
+        """Return a cached connection, opening one if necessary."""
+        key = (target.workspace_id, target.database)
+        lock = await self._get_lock(key)
+
+        async with lock:
+            if key not in self._cache:
+                cs = _augment_connection_string(
+                    target.connection_string, target.database, self._mode
+                )
+                try:
+                    conn: _Connection = await asyncio.to_thread(_get_mssql().connect, cs)
+                except Exception as exc:
+                    if _is_auth_error(exc):
+                        raise AuthError(str(exc)) from exc
+                    raise
+                self._cache[key] = conn
+            return self._cache[key]
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def execute(
+        self,
+        target: SqlTarget,
+        sql: str,
+        params: Sequence[Any] = (),
+    ) -> list[dict[str, Any]]:
+        """Execute a SELECT (or any statement that returns rows).
+
+        Args:
+            target: The warehouse to connect to.
+            sql: The SQL statement to execute.
+            params: Optional sequence of parameters bound to ``?`` placeholders.
+
+        Returns:
+            A list of dicts mapping column names to row values.
+
+        Raises:
+            AuthError: If the driver raises an Entra authentication error.
+        """
+        conn = await self._get_connection(target)
+
+        def _run() -> list[dict[str, Any]]:
+            cursor = conn.cursor()
+            cursor.execute(sql, params)
+            description: list[tuple[str, Any]] = cursor.description or []
+            columns = [col[0] for col in description]
+            rows: list[tuple[Any, ...]] = cursor.fetchall() or []
+            return [dict(zip(columns, row, strict=False)) for row in rows]
+
+        return await asyncio.to_thread(_run)
+
+    async def execute_nonquery(
+        self,
+        target: SqlTarget,
+        sql: str,
+        params: Sequence[Any] = (),
+    ) -> int:
+        """Execute a DML/DDL statement that does not return rows.
+
+        Commits the transaction implicitly after execution.
+
+        Args:
+            target: The warehouse to connect to.
+            sql: The SQL statement to execute.
+            params: Optional sequence of parameters bound to ``?`` placeholders.
+
+        Returns:
+            The number of affected rows (``cursor.rowcount``).
+
+        Raises:
+            AuthError: If the driver raises an Entra authentication error.
+        """
+        conn = await self._get_connection(target)
+
+        def _run() -> int:
+            cursor = conn.cursor()
+            cursor.execute(sql, params)
+            rowcount: int = cursor.rowcount
+            conn.commit()
+            return rowcount
+
+        return await asyncio.to_thread(_run)
+
+    async def close(self) -> None:
+        """Close all cached connections and clear the cache."""
+        async with self._meta_lock:
+            keys = list(self._cache.keys())
+
+        for key in keys:
+            lock = await self._get_lock(key)
+            async with lock:
+                conn = self._cache.pop(key, None)
+                if conn is not None:
+                    await asyncio.to_thread(conn.close)
+
+    async def __aenter__(self) -> FabricSqlClient:
+        return self
+
+    async def __aexit__(self, *_exc: object) -> None:
+        await self.close()

--- a/src/fabric_dw/sql_client.py
+++ b/src/fabric_dw/sql_client.py
@@ -8,7 +8,7 @@ import re
 import types
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Any, Protocol, runtime_checkable
+from typing import Any, Protocol
 
 from fabric_dw.auth import CredentialMode
 from fabric_dw.exceptions import AuthError
@@ -28,10 +28,13 @@ def _get_mssql() -> types.ModuleType:
 
 
 # Sentinel strings that signal Entra auth failures in driver error messages.
+# NOTE: These fragments are only checked during connection-time failures
+# (_get_connection). Errors raised by cursor.execute() after a successful
+# connection (e.g. token expiry mid-session) propagate unwrapped.
 _AUTH_ERROR_FRAGMENTS = (
     "login failed",
     "token",
-    "authentication",
+    "authentication failed",
     "unauthorized",
     "access denied",
     "invalid authorization",
@@ -56,8 +59,9 @@ def _set_key(connection_string: str, key: str, value: str) -> str:
     """Append *key=value* to *connection_string* if *key* is not already set."""
     if _has_key(connection_string, key):
         return connection_string
-    sep = ";" if connection_string.rstrip().rstrip(";").strip() else ""
-    return f"{connection_string.rstrip().rstrip(';')}{sep};{key}={value}".lstrip(";")
+    stripped = connection_string.rstrip().rstrip(";")
+    sep = ";" if stripped else ""
+    return f"{stripped}{sep}{key}={value}"
 
 
 def _augment_connection_string(
@@ -87,7 +91,7 @@ def _augment_connection_string(
 class _Cursor(Protocol):
     """Minimal DB-API 2.0 cursor protocol."""
 
-    description: list[tuple[str, Any]]
+    description: list[tuple[str, Any]] | None
 
     def execute(self, sql: str, params: Sequence[Any] = ...) -> None: ...
 
@@ -96,7 +100,6 @@ class _Cursor(Protocol):
     rowcount: int
 
 
-@runtime_checkable
 class _Connection(Protocol):
     """Minimal DB-API 2.0 connection protocol."""
 
@@ -248,16 +251,26 @@ class FabricSqlClient:
         return await asyncio.to_thread(_run)
 
     async def close(self) -> None:
-        """Close all cached connections and clear the cache."""
+        """Close all cached connections and clear the cache.
+
+        All connections are closed even if some raise. Any exceptions are
+        collected and re-raised together as an ``ExceptionGroup``.
+        """
         async with self._meta_lock:
             keys = list(self._cache.keys())
 
+        errors: list[Exception] = []
         for key in keys:
             lock = await self._get_lock(key)
             async with lock:
                 conn = self._cache.pop(key, None)
                 if conn is not None:
-                    await asyncio.to_thread(conn.close)
+                    try:
+                        await asyncio.to_thread(conn.close)
+                    except Exception as exc:
+                        errors.append(exc)
+        if errors:
+            raise ExceptionGroup("errors closing SQL connections", errors)  # noqa: TRY003
 
     async def __aenter__(self) -> FabricSqlClient:
         return self

--- a/tests/unit/test_sql_client.py
+++ b/tests/unit/test_sql_client.py
@@ -1,0 +1,462 @@
+"""Tests for fabric_dw.sql_client — written before implementation (TDD)."""
+
+import asyncio
+import threading
+import types
+from collections.abc import Sequence
+from typing import Any
+from unittest.mock import MagicMock, call
+
+import pytest
+
+from fabric_dw.auth import CredentialMode
+from fabric_dw.exceptions import AuthError
+from fabric_dw.sql_client import FabricSqlClient, SqlTarget
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_target(
+    workspace_id: str = "ws-1",
+    database: str = "db-1",
+    connection_string: str = "Server=myserver.database.fabric.microsoft.com",
+) -> SqlTarget:
+    return SqlTarget(
+        workspace_id=workspace_id,
+        database=database,
+        connection_string=connection_string,
+    )
+
+
+def _make_mock_mssql() -> tuple[MagicMock, MagicMock, MagicMock]:
+    """Return (mssql_module, mock_connection, mock_cursor)."""
+    mock_cursor = MagicMock()
+    mock_cursor.description = [("col1", None), ("col2", None)]
+    mock_cursor.fetchall.return_value = [(1, "hello"), (2, "world")]
+    mock_cursor.rowcount = 2
+
+    mock_conn = MagicMock()
+    mock_conn.cursor.return_value = mock_cursor
+
+    mock_mssql = MagicMock()
+    mock_mssql.connect.return_value = mock_conn
+
+    return mock_mssql, mock_conn, mock_cursor
+
+
+def _patch_mssql(monkeypatch: pytest.MonkeyPatch, mock_mssql: MagicMock) -> None:
+    """Replace the _mssql attribute on sql_client with the mock."""
+    import fabric_dw.sql_client as sql_client_module
+
+    monkeypatch.setattr(sql_client_module, "_mssql", mock_mssql)
+
+
+# ---------------------------------------------------------------------------
+# SqlTarget dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestSqlTarget:
+    def test_is_frozen(self) -> None:
+        target = _make_target()
+        with pytest.raises((AttributeError, TypeError)):
+            target.workspace_id = "other"  # type: ignore[misc]
+
+    def test_equality_by_value(self) -> None:
+        t1 = _make_target()
+        t2 = _make_target()
+        assert t1 == t2
+
+    def test_hashable(self) -> None:
+        target = _make_target()
+        assert hash(target) is not None
+        {target}  # usable as dict key / set member
+
+
+# ---------------------------------------------------------------------------
+# Connection-string augmenter
+# ---------------------------------------------------------------------------
+
+
+class TestConnectionStringAugmenter:
+    """Test _augment_connection_string (accessed indirectly via client behaviour)."""
+
+    def _get_augment_fn(self) -> Any:
+        import fabric_dw.sql_client as m
+
+        return m._augment_connection_string  # noqa: SLF001
+
+    def test_default_mode_adds_active_directory_default(self) -> None:
+        augment = self._get_augment_fn()
+        result = augment("Server=srv", "mydb", CredentialMode.DEFAULT)
+        assert "Authentication=ActiveDirectoryDefault" in result
+
+    def test_sp_mode_adds_active_directory_service_principal(self) -> None:
+        augment = self._get_augment_fn()
+        result = augment("Server=srv", "mydb", CredentialMode.SERVICE_PRINCIPAL)
+        assert "Authentication=ActiveDirectoryServicePrincipal" in result
+
+    def test_interactive_mode_adds_active_directory_interactive(self) -> None:
+        augment = self._get_augment_fn()
+        result = augment("Server=srv", "mydb", CredentialMode.INTERACTIVE)
+        assert "Authentication=ActiveDirectoryInteractive" in result
+
+    def test_adds_encrypt_yes(self) -> None:
+        augment = self._get_augment_fn()
+        result = augment("Server=srv", "mydb", CredentialMode.DEFAULT)
+        assert "Encrypt=yes" in result
+
+    def test_adds_trust_server_certificate_no(self) -> None:
+        augment = self._get_augment_fn()
+        result = augment("Server=srv", "mydb", CredentialMode.DEFAULT)
+        assert "TrustServerCertificate=no" in result
+
+    def test_adds_database_when_not_present(self) -> None:
+        augment = self._get_augment_fn()
+        result = augment("Server=srv", "mydb", CredentialMode.DEFAULT)
+        assert "Database=mydb" in result
+
+    def test_does_not_double_add_database_when_already_present(self) -> None:
+        augment = self._get_augment_fn()
+        cs = "Server=srv;Database=existing-db"
+        result = augment(cs, "different-db", CredentialMode.DEFAULT)
+        # Database= must appear exactly once in the string
+        assert result.count("Database=") == 1
+
+    def test_idempotent_same_output_on_second_call(self) -> None:
+        augment = self._get_augment_fn()
+        first = augment("Server=srv", "mydb", CredentialMode.DEFAULT)
+        second = augment(first, "mydb", CredentialMode.DEFAULT)
+        assert first == second
+
+    def test_idempotent_all_modes(self) -> None:
+        augment = self._get_augment_fn()
+        for mode in CredentialMode:
+            first = augment("Server=srv", "mydb", mode)
+            second = augment(first, "mydb", mode)
+            assert first == second, f"Not idempotent for mode={mode}"
+
+
+# ---------------------------------------------------------------------------
+# execute — returns list[dict]
+# ---------------------------------------------------------------------------
+
+
+class TestExecute:
+    async def test_returns_list_of_dicts(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mock_mssql, _conn, mock_cursor = _make_mock_mssql()
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        client = FabricSqlClient()
+        rows = await client.execute(_make_target(), "SELECT 1")
+        await client.close()
+
+        assert rows == [{"col1": 1, "col2": "hello"}, {"col1": 2, "col2": "world"}]
+
+    async def test_uses_cursor_description_for_column_names(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mock_mssql, _conn, mock_cursor = _make_mock_mssql()
+        mock_cursor.description = [("name", None), ("value", None)]
+        mock_cursor.fetchall.return_value = [("alice", 42)]
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        client = FabricSqlClient()
+        rows = await client.execute(_make_target(), "SELECT name, value FROM t")
+        await client.close()
+
+        assert rows == [{"name": "alice", "value": 42}]
+
+    async def test_passes_params_to_cursor_execute(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mock_mssql, _conn, mock_cursor = _make_mock_mssql()
+        mock_cursor.description = [("id", None)]
+        mock_cursor.fetchall.return_value = [(7,)]
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        client = FabricSqlClient()
+        await client.execute(_make_target(), "SELECT id FROM t WHERE id = ?", (7,))
+        await client.close()
+
+        mock_cursor.execute.assert_called_once_with(
+            "SELECT id FROM t WHERE id = ?", (7,)
+        )
+
+    async def test_empty_result_set_returns_empty_list(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mock_mssql, _conn, mock_cursor = _make_mock_mssql()
+        mock_cursor.fetchall.return_value = []
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        client = FabricSqlClient()
+        rows = await client.execute(_make_target(), "SELECT 1 WHERE 1=0")
+        await client.close()
+
+        assert rows == []
+
+
+# ---------------------------------------------------------------------------
+# execute_nonquery — commits and returns rowcount
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteNonQuery:
+    async def test_returns_rowcount(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mock_mssql, mock_conn, mock_cursor = _make_mock_mssql()
+        mock_cursor.rowcount = 5
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        client = FabricSqlClient()
+        count = await client.execute_nonquery(
+            _make_target(), "DELETE FROM t WHERE id > 0"
+        )
+        await client.close()
+
+        assert count == 5
+
+    async def test_commits_after_execute(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mock_mssql, mock_conn, mock_cursor = _make_mock_mssql()
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        client = FabricSqlClient()
+        await client.execute_nonquery(_make_target(), "DELETE FROM t")
+        await client.close()
+
+        mock_conn.commit.assert_called_once()
+
+    async def test_passes_params_to_cursor_execute(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mock_mssql, _conn, mock_cursor = _make_mock_mssql()
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        client = FabricSqlClient()
+        await client.execute_nonquery(
+            _make_target(), "DELETE FROM t WHERE id = ?", (42,)
+        )
+        await client.close()
+
+        mock_cursor.execute.assert_called_once_with("DELETE FROM t WHERE id = ?", (42,))
+
+
+# ---------------------------------------------------------------------------
+# Thread isolation — blocking driver call must run off the event-loop thread
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncThreadIsolation:
+    async def test_execute_runs_cursor_on_non_event_loop_thread(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        event_loop_thread_id = threading.get_ident()
+        captured_ids: list[int] = []
+
+        mock_mssql, _conn, mock_cursor = _make_mock_mssql()
+
+        original_execute = mock_cursor.execute
+
+        def capturing_execute(sql: str, params: Sequence[Any] = ()) -> None:
+            captured_ids.append(threading.get_ident())
+            return original_execute(sql, params)
+
+        mock_cursor.execute.side_effect = capturing_execute
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        client = FabricSqlClient()
+        await client.execute(_make_target(), "SELECT 1")
+        await client.close()
+
+        assert len(captured_ids) >= 1
+        assert all(tid != event_loop_thread_id for tid in captured_ids)
+
+    async def test_execute_nonquery_runs_cursor_on_non_event_loop_thread(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        event_loop_thread_id = threading.get_ident()
+        captured_ids: list[int] = []
+
+        mock_mssql, _conn, mock_cursor = _make_mock_mssql()
+
+        original_execute = mock_cursor.execute
+
+        def capturing_execute(sql: str, params: Sequence[Any] = ()) -> None:
+            captured_ids.append(threading.get_ident())
+            return original_execute(sql, params)
+
+        mock_cursor.execute.side_effect = capturing_execute
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        client = FabricSqlClient()
+        await client.execute_nonquery(_make_target(), "DELETE FROM t")
+        await client.close()
+
+        assert len(captured_ids) >= 1
+        assert all(tid != event_loop_thread_id for tid in captured_ids)
+
+
+# ---------------------------------------------------------------------------
+# Connection caching
+# ---------------------------------------------------------------------------
+
+
+class TestConnectionCaching:
+    async def test_two_execute_calls_same_target_open_one_connection(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mock_mssql, _conn, _cursor = _make_mock_mssql()
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        target = _make_target()
+        client = FabricSqlClient()
+        await client.execute(target, "SELECT 1")
+        await client.execute(target, "SELECT 2")
+        await client.close()
+
+        assert mock_mssql.connect.call_count == 1
+
+    async def test_execute_calls_on_different_targets_open_two_connections(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mock_mssql, _conn, _cursor = _make_mock_mssql()
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        target1 = _make_target(workspace_id="ws-1", database="db-1")
+        target2 = _make_target(workspace_id="ws-2", database="db-2")
+        client = FabricSqlClient()
+        await client.execute(target1, "SELECT 1")
+        await client.execute(target2, "SELECT 2")
+        await client.close()
+
+        assert mock_mssql.connect.call_count == 2
+
+    async def test_different_database_same_workspace_opens_two_connections(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mock_mssql, _conn, _cursor = _make_mock_mssql()
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        target1 = _make_target(workspace_id="ws-1", database="db-A")
+        target2 = _make_target(workspace_id="ws-1", database="db-B")
+        client = FabricSqlClient()
+        await client.execute(target1, "SELECT 1")
+        await client.execute(target2, "SELECT 1")
+        await client.close()
+
+        assert mock_mssql.connect.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# close()
+# ---------------------------------------------------------------------------
+
+
+class TestClose:
+    async def test_close_closes_all_cached_connections(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        conn1 = MagicMock()
+        conn2 = MagicMock()
+        cursor = MagicMock()
+        cursor.description = [("x", None)]
+        cursor.fetchall.return_value = [(1,)]
+        cursor.rowcount = 1
+        conn1.cursor.return_value = cursor
+        conn2.cursor.return_value = cursor
+
+        mock_mssql = MagicMock()
+        mock_mssql.connect.side_effect = [conn1, conn2]
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        target1 = _make_target(workspace_id="ws-1", database="db-1")
+        target2 = _make_target(workspace_id="ws-1", database="db-2")
+
+        client = FabricSqlClient()
+        await client.execute(target1, "SELECT 1")
+        await client.execute(target2, "SELECT 1")
+        await client.close()
+
+        conn1.close.assert_called_once()
+        conn2.close.assert_called_once()
+
+    async def test_close_clears_cache_so_next_execute_reopens(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mock_mssql, _conn, _cursor = _make_mock_mssql()
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        target = _make_target()
+        client = FabricSqlClient()
+        await client.execute(target, "SELECT 1")
+        await client.close()
+        await client.execute(target, "SELECT 2")
+        await client.close()
+
+        assert mock_mssql.connect.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Async context manager
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncContextManager:
+    async def test_aenter_returns_self(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mock_mssql, _conn, _cursor = _make_mock_mssql()
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        client = FabricSqlClient()
+        async with client as ctx:
+            assert ctx is client
+
+    async def test_aexit_calls_close(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mock_mssql, mock_conn, _cursor = _make_mock_mssql()
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        target = _make_target()
+        async with FabricSqlClient() as client:
+            await client.execute(target, "SELECT 1")
+
+        mock_conn.close.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# AuthError mapping
+# ---------------------------------------------------------------------------
+
+
+class TestAuthErrorMapping:
+    async def test_driver_auth_error_raises_auth_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An exception from the driver that looks like an auth error → AuthError."""
+        mock_mssql, _conn, mock_cursor = _make_mock_mssql()
+
+        # Simulate a driver-level exception on connect
+        driver_exc = Exception("Login failed for user '' (token-based)")
+        mock_mssql.connect.side_effect = driver_exc
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        client = FabricSqlClient()
+        with pytest.raises(AuthError):
+            await client.execute(_make_target(), "SELECT 1")
+
+    async def test_non_auth_error_not_wrapped(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Generic driver errors are not silently swallowed or re-wrapped."""
+        mock_mssql, _conn, mock_cursor = _make_mock_mssql()
+
+        driver_exc = RuntimeError("connection timed out")
+        mock_mssql.connect.side_effect = driver_exc
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        client = FabricSqlClient()
+        with pytest.raises(RuntimeError):
+            await client.execute(_make_target(), "SELECT 1")

--- a/tests/unit/test_sql_client.py
+++ b/tests/unit/test_sql_client.py
@@ -1,18 +1,16 @@
 """Tests for fabric_dw.sql_client — written before implementation (TDD)."""
 
-import asyncio
 import threading
-import types
 from collections.abc import Sequence
 from typing import Any
-from unittest.mock import MagicMock, call
+from unittest.mock import MagicMock
 
 import pytest
 
+import fabric_dw.sql_client as _sql_client_module
 from fabric_dw.auth import CredentialMode
 from fabric_dw.exceptions import AuthError
 from fabric_dw.sql_client import FabricSqlClient, SqlTarget
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -49,9 +47,7 @@ def _make_mock_mssql() -> tuple[MagicMock, MagicMock, MagicMock]:
 
 def _patch_mssql(monkeypatch: pytest.MonkeyPatch, mock_mssql: MagicMock) -> None:
     """Replace the _mssql attribute on sql_client with the mock."""
-    import fabric_dw.sql_client as sql_client_module
-
-    monkeypatch.setattr(sql_client_module, "_mssql", mock_mssql)
+    monkeypatch.setattr(_sql_client_module, "_mssql", mock_mssql)
 
 
 # ---------------------------------------------------------------------------
@@ -73,7 +69,7 @@ class TestSqlTarget:
     def test_hashable(self) -> None:
         target = _make_target()
         assert hash(target) is not None
-        {target}  # usable as dict key / set member
+        _ = {target}  # usable as dict key / set member
 
 
 # ---------------------------------------------------------------------------
@@ -85,9 +81,7 @@ class TestConnectionStringAugmenter:
     """Test _augment_connection_string (accessed indirectly via client behaviour)."""
 
     def _get_augment_fn(self) -> Any:
-        import fabric_dw.sql_client as m
-
-        return m._augment_connection_string  # noqa: SLF001
+        return _sql_client_module._augment_connection_string  # noqa: SLF001,RUF100
 
     def test_default_mode_adds_active_directory_default(self) -> None:
         augment = self._get_augment_fn()
@@ -147,7 +141,7 @@ class TestConnectionStringAugmenter:
 
 class TestExecute:
     async def test_returns_list_of_dicts(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        mock_mssql, _conn, mock_cursor = _make_mock_mssql()
+        mock_mssql, _conn, _cursor = _make_mock_mssql()
         _patch_mssql(monkeypatch, mock_mssql)
 
         client = FabricSqlClient()
@@ -170,9 +164,7 @@ class TestExecute:
 
         assert rows == [{"name": "alice", "value": 42}]
 
-    async def test_passes_params_to_cursor_execute(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    async def test_passes_params_to_cursor_execute(self, monkeypatch: pytest.MonkeyPatch) -> None:
         mock_mssql, _conn, mock_cursor = _make_mock_mssql()
         mock_cursor.description = [("id", None)]
         mock_cursor.fetchall.return_value = [(7,)]
@@ -182,9 +174,7 @@ class TestExecute:
         await client.execute(_make_target(), "SELECT id FROM t WHERE id = ?", (7,))
         await client.close()
 
-        mock_cursor.execute.assert_called_once_with(
-            "SELECT id FROM t WHERE id = ?", (7,)
-        )
+        mock_cursor.execute.assert_called_once_with("SELECT id FROM t WHERE id = ?", (7,))
 
     async def test_empty_result_set_returns_empty_list(
         self, monkeypatch: pytest.MonkeyPatch
@@ -207,20 +197,18 @@ class TestExecute:
 
 class TestExecuteNonQuery:
     async def test_returns_rowcount(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        mock_mssql, mock_conn, mock_cursor = _make_mock_mssql()
+        mock_mssql, _conn, mock_cursor = _make_mock_mssql()
         mock_cursor.rowcount = 5
         _patch_mssql(monkeypatch, mock_mssql)
 
         client = FabricSqlClient()
-        count = await client.execute_nonquery(
-            _make_target(), "DELETE FROM t WHERE id > 0"
-        )
+        count = await client.execute_nonquery(_make_target(), "DELETE FROM t WHERE id > 0")
         await client.close()
 
         assert count == 5
 
     async def test_commits_after_execute(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        mock_mssql, mock_conn, mock_cursor = _make_mock_mssql()
+        mock_mssql, mock_conn, _cursor = _make_mock_mssql()
         _patch_mssql(monkeypatch, mock_mssql)
 
         client = FabricSqlClient()
@@ -229,16 +217,12 @@ class TestExecuteNonQuery:
 
         mock_conn.commit.assert_called_once()
 
-    async def test_passes_params_to_cursor_execute(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    async def test_passes_params_to_cursor_execute(self, monkeypatch: pytest.MonkeyPatch) -> None:
         mock_mssql, _conn, mock_cursor = _make_mock_mssql()
         _patch_mssql(monkeypatch, mock_mssql)
 
         client = FabricSqlClient()
-        await client.execute_nonquery(
-            _make_target(), "DELETE FROM t WHERE id = ?", (42,)
-        )
+        await client.execute_nonquery(_make_target(), "DELETE FROM t WHERE id = ?", (42,))
         await client.close()
 
         mock_cursor.execute.assert_called_once_with("DELETE FROM t WHERE id = ?", (42,))
@@ -258,11 +242,8 @@ class TestAsyncThreadIsolation:
 
         mock_mssql, _conn, mock_cursor = _make_mock_mssql()
 
-        original_execute = mock_cursor.execute
-
-        def capturing_execute(sql: str, params: Sequence[Any] = ()) -> None:
+        def capturing_execute(_sql: str, _params: Sequence[Any] = ()) -> None:
             captured_ids.append(threading.get_ident())
-            return original_execute(sql, params)
 
         mock_cursor.execute.side_effect = capturing_execute
         _patch_mssql(monkeypatch, mock_mssql)
@@ -282,11 +263,8 @@ class TestAsyncThreadIsolation:
 
         mock_mssql, _conn, mock_cursor = _make_mock_mssql()
 
-        original_execute = mock_cursor.execute
-
-        def capturing_execute(sql: str, params: Sequence[Any] = ()) -> None:
+        def capturing_execute(_sql: str, _params: Sequence[Any] = ()) -> None:
             captured_ids.append(threading.get_ident())
-            return original_execute(sql, params)
 
         mock_cursor.execute.side_effect = capturing_execute
         _patch_mssql(monkeypatch, mock_mssql)
@@ -351,7 +329,7 @@ class TestConnectionCaching:
 
 
 # ---------------------------------------------------------------------------
-# close()
+# close()  # noqa: ERA001
 # ---------------------------------------------------------------------------
 
 
@@ -405,9 +383,7 @@ class TestClose:
 
 
 class TestAsyncContextManager:
-    async def test_aenter_returns_self(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    async def test_aenter_returns_self(self, monkeypatch: pytest.MonkeyPatch) -> None:
         mock_mssql, _conn, _cursor = _make_mock_mssql()
         _patch_mssql(monkeypatch, mock_mssql)
 
@@ -436,7 +412,7 @@ class TestAuthErrorMapping:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """An exception from the driver that looks like an auth error → AuthError."""
-        mock_mssql, _conn, mock_cursor = _make_mock_mssql()
+        mock_mssql, _conn, _cursor = _make_mock_mssql()
 
         # Simulate a driver-level exception on connect
         driver_exc = Exception("Login failed for user '' (token-based)")
@@ -447,11 +423,9 @@ class TestAuthErrorMapping:
         with pytest.raises(AuthError):
             await client.execute(_make_target(), "SELECT 1")
 
-    async def test_non_auth_error_not_wrapped(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    async def test_non_auth_error_not_wrapped(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Generic driver errors are not silently swallowed or re-wrapped."""
-        mock_mssql, _conn, mock_cursor = _make_mock_mssql()
+        mock_mssql, _conn, _cursor = _make_mock_mssql()
 
         driver_exc = RuntimeError("connection timed out")
         mock_mssql.connect.side_effect = driver_exc

--- a/tests/unit/test_sql_client.py
+++ b/tests/unit/test_sql_client.py
@@ -87,31 +87,37 @@ class TestConnectionStringAugmenter:
         augment = self._get_augment_fn()
         result = augment("Server=srv", "mydb", CredentialMode.DEFAULT)
         assert "Authentication=ActiveDirectoryDefault" in result
+        assert ";;" not in result
 
     def test_sp_mode_adds_active_directory_service_principal(self) -> None:
         augment = self._get_augment_fn()
         result = augment("Server=srv", "mydb", CredentialMode.SERVICE_PRINCIPAL)
         assert "Authentication=ActiveDirectoryServicePrincipal" in result
+        assert ";;" not in result
 
     def test_interactive_mode_adds_active_directory_interactive(self) -> None:
         augment = self._get_augment_fn()
         result = augment("Server=srv", "mydb", CredentialMode.INTERACTIVE)
         assert "Authentication=ActiveDirectoryInteractive" in result
+        assert ";;" not in result
 
     def test_adds_encrypt_yes(self) -> None:
         augment = self._get_augment_fn()
         result = augment("Server=srv", "mydb", CredentialMode.DEFAULT)
         assert "Encrypt=yes" in result
+        assert ";;" not in result
 
     def test_adds_trust_server_certificate_no(self) -> None:
         augment = self._get_augment_fn()
         result = augment("Server=srv", "mydb", CredentialMode.DEFAULT)
         assert "TrustServerCertificate=no" in result
+        assert ";;" not in result
 
     def test_adds_database_when_not_present(self) -> None:
         augment = self._get_augment_fn()
         result = augment("Server=srv", "mydb", CredentialMode.DEFAULT)
         assert "Database=mydb" in result
+        assert ";;" not in result
 
     def test_does_not_double_add_database_when_already_present(self) -> None:
         augment = self._get_augment_fn()
@@ -119,12 +125,21 @@ class TestConnectionStringAugmenter:
         result = augment(cs, "different-db", CredentialMode.DEFAULT)
         # Database= must appear exactly once in the string
         assert result.count("Database=") == 1
+        assert ";;" not in result
+
+    def test_no_double_semicolons_in_full_augmented_string(self) -> None:
+        augment = self._get_augment_fn()
+        result = augment(
+            "Server=myserver.database.fabric.microsoft.com", "mydb", CredentialMode.DEFAULT
+        )
+        assert ";;" not in result
 
     def test_idempotent_same_output_on_second_call(self) -> None:
         augment = self._get_augment_fn()
         first = augment("Server=srv", "mydb", CredentialMode.DEFAULT)
         second = augment(first, "mydb", CredentialMode.DEFAULT)
         assert first == second
+        assert ";;" not in first
 
     def test_idempotent_all_modes(self) -> None:
         augment = self._get_augment_fn()
@@ -132,6 +147,7 @@ class TestConnectionStringAugmenter:
             first = augment("Server=srv", "mydb", mode)
             second = augment(first, "mydb", mode)
             assert first == second, f"Not idempotent for mode={mode}"
+            assert ";;" not in first, f"Double semicolons for mode={mode}"
 
 
 # ---------------------------------------------------------------------------
@@ -361,6 +377,40 @@ class TestClose:
         conn1.close.assert_called_once()
         conn2.close.assert_called_once()
 
+    async def test_close_still_closes_second_connection_when_first_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If one conn.close() raises, the other connection is still closed."""
+        conn1 = MagicMock()
+        conn2 = MagicMock()
+        cursor = MagicMock()
+        cursor.description = [("x", None)]
+        cursor.fetchall.return_value = [(1,)]
+        cursor.rowcount = 1
+        conn1.cursor.return_value = cursor
+        conn2.cursor.return_value = cursor
+        first_error = RuntimeError("close failed on conn1")
+        conn1.close.side_effect = first_error
+
+        mock_mssql = MagicMock()
+        mock_mssql.connect.side_effect = [conn1, conn2]
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        target1 = _make_target(workspace_id="ws-1", database="db-1")
+        target2 = _make_target(workspace_id="ws-1", database="db-2")
+
+        client = FabricSqlClient()
+        await client.execute(target1, "SELECT 1")
+        await client.execute(target2, "SELECT 1")
+
+        with pytest.raises(ExceptionGroup) as exc_info:
+            await client.close()
+
+        # second connection must have been closed regardless
+        conn2.close.assert_called_once()
+        # the error from conn1 is wrapped in ExceptionGroup
+        assert exc_info.value.exceptions[0] is first_error
+
     async def test_close_clears_cache_so_next_execute_reopens(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -414,8 +464,9 @@ class TestAuthErrorMapping:
         """An exception from the driver that looks like an auth error → AuthError."""
         mock_mssql, _conn, _cursor = _make_mock_mssql()
 
-        # Simulate a driver-level exception on connect
-        driver_exc = Exception("Login failed for user '' (token-based)")
+        # Simulate a driver-level exception on connect; use "authentication failed"
+        # which is the exact phrase real Entra-token errors use.
+        driver_exc = Exception("Authentication failed for user '' (token-based)")
         mock_mssql.connect.side_effect = driver_exc
         _patch_mssql(monkeypatch, mock_mssql)
 

--- a/uv.lock
+++ b/uv.lock
@@ -506,6 +506,7 @@ dependencies = [
     { name = "aiolimiter" },
     { name = "azure-identity" },
     { name = "httpx", extra = ["http2"] },
+    { name = "mssql-python" },
     { name = "pydantic" },
     { name = "tenacity" },
 ]
@@ -536,6 +537,7 @@ requires-dist = [
     { name = "azure-identity", specifier = ">=1.19" },
     { name = "freezegun", marker = "extra == 'dev'", specifier = ">=1.5" },
     { name = "httpx", extras = ["http2"], specifier = ">=0.27" },
+    { name = "mssql-python", specifier = ">=0.13" },
     { name = "mypy", marker = "extra == 'dev'" },
     { name = "pre-commit", marker = "extra == 'dev'" },
     { name = "pydantic", specifier = ">=2.9" },
@@ -865,6 +867,44 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/01/99/5d239b6156eddf761a636bded1118414d161bd6b7b37a9335549ed159396/msal_extensions-1.3.1.tar.gz", hash = "sha256:c5b0fd10f65ef62b5f1d62f4251d51cbcaf003fcedae8c91b040a488614be1a4", size = 23315, upload-time = "2025-03-14T23:51:03.902Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5e/75/bd9b7bb966668920f06b200e84454c8f3566b102183bc55c5473d96cb2b9/msal_extensions-1.3.1-py3-none-any.whl", hash = "sha256:96d3de4d034504e969ac5e85bae8106c8373b5c6568e4c8fa7af2eca9dbe6bca", size = 20583, upload-time = "2025-03-14T23:51:03.016Z" },
+]
+
+[[package]]
+name = "mssql-python"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-identity" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/f8/1026710d967e3e63fa1a61b31929899bb5e1ceaf3514a74fe340bc6c210e/mssql_python-1.8.0-cp311-cp311-macosx_15_0_universal2.whl", hash = "sha256:02b3d4b46b458010a73ee88751e70e1b72262a37a80eba896d3063b0cd2fc298", size = 28878853, upload-time = "2026-05-29T15:10:08.712Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/79/235c3180ba4467a734c63060879a54e349d43fa7b02860814199b6cc8875/mssql_python-1.8.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:53343491e23fe4ff40aaf5e1ed50a702ae1f2b5a16835eddbbb06179c610eabe", size = 25813579, upload-time = "2026-05-29T15:10:11.683Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/9a/1270c87abcde7de1752c332bfcdbde1a14eb88f0b9a9a534e2b9755b6a44/mssql_python-1.8.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:24906849e2e2de30971bd639c5d05f903d7e43432f013f1e067ce2cfda311f17", size = 26225307, upload-time = "2026-05-29T15:10:14.585Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/b1/d9f9dd0bfe889f058f16af7e6cdbd6bc589e18561a052294eeeeb6ef370b/mssql_python-1.8.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:72f017961ac9b1476f062a0f0fc21b5789d2579fd40c15806c97465e70d85744", size = 25685587, upload-time = "2026-05-29T15:10:17.437Z" },
+    { url = "https://files.pythonhosted.org/packages/19/36/d7c215ca68cd9f95b881f00ed791009fb31156a371b9ef27dafb65eb8dcd/mssql_python-1.8.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:793b8b2a4900e3e832bc2f3171c964698109e313acf5c4eacf13cf175a375963", size = 26077199, upload-time = "2026-05-29T15:10:20.474Z" },
+    { url = "https://files.pythonhosted.org/packages/56/f5/c3ac3517632e55aefd6eeb0a4a4316b1944c604a4a6c7e265e6762bd7b1f/mssql_python-1.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:b73e8f093a1617df21625d361d1e7ed3a7f6c6f89bf768021b692418c075ce6f", size = 15527867, upload-time = "2026-05-29T15:10:23.18Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ab/08c1e027caf099ba204abb0b82b23eb086f6c97e61bd828deff33b2d1d66/mssql_python-1.8.0-cp311-cp311-win_arm64.whl", hash = "sha256:187f5b6638190c611988ea0edd13d91fb951d538fcf1359dcd504a390a1e033d", size = 18738894, upload-time = "2026-05-29T15:10:25.691Z" },
+    { url = "https://files.pythonhosted.org/packages/27/7b/3ee01ee9ab4a8474c231666e5a7ed45f7366d43b879babb4952d292f299b/mssql_python-1.8.0-cp312-cp312-macosx_15_0_universal2.whl", hash = "sha256:4d72fc683cdab2d86492f87db76086a25beef6cd7fcdcb401bc39d81ac2d1626", size = 28887040, upload-time = "2026-05-29T15:10:28.483Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/c9/f367662a3494e25083037f68004a1370228d63105eab02ea2108ce16e27e/mssql_python-1.8.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:e8270ce2d3d5cd422d8062614ac180e49b58384173a269d53e65a24776bc75ab", size = 26310599, upload-time = "2026-05-29T15:10:31.658Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/2a/9e6d912ebc46e868a853dce71e839a6e7533c8e1875377366237614633ef/mssql_python-1.8.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:50893bc595964de8cad8022657cbf763d74ac076b27805c7d49247e881752355", size = 26888236, upload-time = "2026-05-29T15:10:34.437Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/f1/f6c7097e386b8092b3a5dcd3dd6e69c720f54102dd0ae9458ce41a6e4b3e/mssql_python-1.8.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:096e3ba73ad6e392bfea06a692d2bd2c978468952010ce745729e5cc9adf3e58", size = 26117130, upload-time = "2026-05-29T15:10:37.532Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/89/1600a65a3d1ee79331fd5e0b84fab7ee878fc94045a33c5b76108bed6d4d/mssql_python-1.8.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:4107e1f9710b7b4794cd75fe7362774b7de197196090ae0114d4394f1ec4f89c", size = 26668069, upload-time = "2026-05-29T15:10:40.453Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/a7/5a3dc96b012eb7106f9b3e805465f7cdc36d9c0deff3aa4fc5d63de8af30/mssql_python-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:c93f188fab3fff5341e7a91724dbffe6e033ea04624f3e322b43233a337e6238", size = 15528064, upload-time = "2026-05-29T15:10:42.913Z" },
+    { url = "https://files.pythonhosted.org/packages/97/d7/319db1776572011c3c888dcc402f7c16b1e736117e0f286575fd406cfaba/mssql_python-1.8.0-cp312-cp312-win_arm64.whl", hash = "sha256:4071b33a388730bbef3b62e16edaab4eefa83103ea04fc6c7e1ab3f83c22b5c6", size = 18738981, upload-time = "2026-05-29T15:10:46.01Z" },
+    { url = "https://files.pythonhosted.org/packages/86/e6/be337273cbf80a5e94e3f57e944505a5d7fa84c1d0cc683899f82649e213/mssql_python-1.8.0-cp313-cp313-macosx_15_0_universal2.whl", hash = "sha256:e302e42f1c7c55c509a8f1a88cd30d3367904b427779ea3d6a43ba65b37c7524", size = 28887392, upload-time = "2026-05-29T15:10:48.897Z" },
+    { url = "https://files.pythonhosted.org/packages/57/f7/18ba2625b028129b067cbb4ad0df5150a5dd3a5c028872fce77ae18c8b38/mssql_python-1.8.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:80fdf013527deb9ef20ef56695fd3bae84073cba8dc1f179d844ff033a9dd1f6", size = 26812009, upload-time = "2026-05-29T15:10:51.814Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/8b/12244a787005fdfd5fb135854f1a87a5935775727ab5a5b91c01123c3d70/mssql_python-1.8.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:b492b3f2a6ca768b36fa49b7646c96978366f7069b05f4a264ec0805ff8c3363", size = 27554950, upload-time = "2026-05-29T15:10:54.739Z" },
+    { url = "https://files.pythonhosted.org/packages/74/25/1151399f80c659110f3d5e72f9dbfe66a40357fc7ff6c01ad73482465380/mssql_python-1.8.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:40f1102fe0dd4548770c6ae00d08d746911e935fa814abb6765b79f36c406583", size = 26552086, upload-time = "2026-05-29T15:10:57.585Z" },
+    { url = "https://files.pythonhosted.org/packages/86/97/d76def4993b7d323ccf1648267ca0b28018845584e852e519ccb260aba38/mssql_python-1.8.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:437796cde20796f494986bc714bb96f0a3d4b7f2657a3996da373eb15da1e957", size = 27262591, upload-time = "2026-05-29T15:11:00.587Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/37/19f64da5cfa2574e0ce35e0ddfe1a54f07a928e93366fcf29efdc9595092/mssql_python-1.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:e68adda7ea445e3715d5a1b9d38d3c29c122fe3cfb5950ec93509f3dd3971a5b", size = 15527382, upload-time = "2026-05-29T15:11:03.353Z" },
+    { url = "https://files.pythonhosted.org/packages/59/30/1f2e9b6957da8ed4848c7fae0b5ff7cb437903054bd1c53759e026f684c7/mssql_python-1.8.0-cp313-cp313-win_arm64.whl", hash = "sha256:e913ee312c7797c0b9c5dd73a9dfb167f759321de52c82464c11627cb938da84", size = 18738343, upload-time = "2026-05-29T15:11:05.861Z" },
+    { url = "https://files.pythonhosted.org/packages/76/5e/67530e5d20c6a00ccd1aa1dcb04287c92c42add1c2c3ac6ffffcddcb17bb/mssql_python-1.8.0-cp314-cp314-macosx_15_0_universal2.whl", hash = "sha256:c5bdb7cc832d664eb91ccbb0f0040235f5f90f0b54364a2320e6ee638805eb11", size = 28882511, upload-time = "2026-05-29T15:11:08.608Z" },
+    { url = "https://files.pythonhosted.org/packages/75/9c/bf1ef850fc78962baa0e50f7cf9b8f7bcc4fee34c4afdecf1797d00127df/mssql_python-1.8.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:75eb9616d952485c87be91fa5ca3d17223b6d8a05dbbba25e0533bda0a82794d", size = 27315269, upload-time = "2026-05-29T15:11:11.83Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/07/fe1eaa669b7fbc1f1be6c8e027484484536efbd16cec6aae0850b2470811/mssql_python-1.8.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:702bd675203421c8035b3b93b1acc063b4789e6220188da67bca290bf4c56c36", size = 28223547, upload-time = "2026-05-29T15:11:14.452Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1a/f7764c4998ccc35b9a00787510f1284754a74ae37df6d969460c2308f242/mssql_python-1.8.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:153c0c98bc0028d182e7df7e31abe52375528953305b80eddce70b0202b3316f", size = 26991095, upload-time = "2026-05-29T15:11:17.328Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/fc/d230882f3ea97caf9425cb70c305c114bb4c7d33e7aa0190f3ef33494e8b/mssql_python-1.8.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:96bcfea5d33f4e1c341600d58858dc80cde9f4bade8ce552d49a27669e87b640", size = 27857415, upload-time = "2026-05-29T15:11:20.409Z" },
+    { url = "https://files.pythonhosted.org/packages/50/b1/09ae9859b7ab434cb9150fae086b351401edee9b640ec9306c623db5adae/mssql_python-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:359d575b5d04e9abfe8c3f75cd2b3a6d3f53b18b868711b282d0579dbcb78c1b", size = 16052217, upload-time = "2026-05-29T15:11:23.061Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/90/a35fe4018f33c479a9a291e458a47a46b24842dfa520ab73970da38fb117/mssql_python-1.8.0-cp314-cp314-win_arm64.whl", hash = "sha256:d41a364bb646776bc3e9d464b2bcff4c06f89f7edd91a8f132a2aab748913f91", size = 19368613, upload-time = "2026-05-29T15:11:26.228Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #9

Implements the async wrapper around mssql-python: connection-string augmentation per credential mode, conn pool per (workspace, database), all blocking calls offloaded to a thread.

## Changes

- `src/fabric_dw/sql_client.py`: `SqlTarget` dataclass, `FabricSqlClient` with `execute`, `execute_nonquery`, `close`, `__aenter__`/`__aexit__`. Lazy `mssql_python` import (native .so is not always loadable). `_Cursor`/`_Connection` Protocols for strict-mypy compatibility.
- `src/fabric_dw/exceptions.py`: Added `AuthError(FabricError)` (Option A — defensive add; trivial to resolve if PR #8 adds the same).
- `tests/unit/test_sql_client.py`: 30 unit tests, all mocked, no real DB connections.
- `pyproject.toml`: Added `mssql-python>=0.13` to project dependencies.
- `.pre-commit-config.yaml`: Added `mssql-python>=0.13` to mypy hook `additional_dependencies`.
- `uv.lock`: Regenerated (mssql-python 1.8.0 resolved).

Reuses `CredentialMode` from `auth.py` — not redeclared.

## Test plan
- [x] augmenter idempotent and correct per CredentialMode
- [x] cursor.execute runs off the event loop (thread ID differs from event-loop thread)
- [x] connection caching and close behaviour verified
- [x] AuthError raised on driver auth failures
- [x] ruff / mypy / pytest / pre-commit all green
- [x] CI all 4 checks green after push