### PR TITLE
feat(http): async HTTP client with rate limit and 429 handling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,4 +22,9 @@ repos:
           - "azure-core>=1.30"
           - "pydantic>=2.9"
           - "pytest"
+          - "httpx[http2]>=0.27"
+          - "aiolimiter>=1.2"
+          - "tenacity>=9"
+          - "respx>=0.21"
+          - "freezegun>=1.5"
         args: ["--config-file", "pyproject.toml"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,13 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
 ]
-dependencies = ["azure-identity>=1.19", "pydantic>=2.9"]
+dependencies = [
+    "azure-identity>=1.19",
+    "pydantic>=2.9",
+    "httpx[http2]>=0.27",
+    "aiolimiter>=1.2",
+    "tenacity>=9",
+]
 
 [project.scripts]
 fabric-dw = "fabric_dw.cli:main"
@@ -24,7 +30,8 @@ dev = [
     "pytest",
     "pytest-asyncio",
     "anyio[trio]",
-    "respx",
+    "respx>=0.21",
+    "freezegun>=1.5",
     "pytest-randomly",
     "pytest-cov",
     "mypy",

--- a/src/fabric_dw/exceptions.py
+++ b/src/fabric_dw/exceptions.py
@@ -2,6 +2,26 @@ class FabricError(Exception):
     """Base error for all fabric-dw errors."""
 
 
+class AuthError(FabricError):
+    """Raised on HTTP 401 - authentication token missing or invalid."""
+
+
+class PermissionDenied(FabricError):  # noqa: N818
+    """Raised on HTTP 403 - caller lacks the required permission."""
+
+
+class NotFound(FabricError):  # noqa: N818
+    """Raised on HTTP 404 - requested resource does not exist."""
+
+
+class RateLimitedError(FabricError):
+    """Raised when the server returns 429 more times than the max consecutive limit."""
+
+
+class FabricServerError(FabricError):
+    """Raised on persistent 5xx errors or a failed LRO operation."""
+
+
 class ConfigError(FabricError):
     """Raised when required configuration is missing or invalid."""
 

--- a/src/fabric_dw/http_client.py
+++ b/src/fabric_dw/http_client.py
@@ -14,9 +14,10 @@ from __future__ import annotations
 import asyncio
 import datetime
 import time as _time
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Mapping
 from email.utils import parsedate_to_datetime
 from enum import StrEnum
+from typing import Any
 
 import httpx
 from aiolimiter import AsyncLimiter
@@ -89,6 +90,7 @@ class FabricHttpClient:
         self._limiter = AsyncLimiter(max_rate=rps, time_period=1)
         self._http: httpx.AsyncClient | None = None
         self._token: AccessToken | None = None
+        self._token_lock = asyncio.Lock()
         # Pause gate: set when idle, clear when sleeping for a 429
         self._pause_event = asyncio.Event()
         self._pause_event.set()
@@ -107,9 +109,15 @@ class FabricHttpClient:
     # ------------------------------------------------------------------
 
     async def _get_token(self) -> str:
-        """Return a valid bearer token, refreshing if close to expiry."""
-        if self._token is None or self._token.expires_on - _time.time() < _TOKEN_REFRESH_BUFFER:
-            self._token = await auth.get_token(self._credential, auth.FABRIC_SCOPE)
+        """Return a valid bearer token, refreshing if close to expiry.
+
+        A lock ensures that under concurrent calls only one refresh is
+        performed even if multiple coroutines see the token as expired at
+        the same time.
+        """
+        async with self._token_lock:
+            if self._token is None or self._token.expires_on - _time.time() < _TOKEN_REFRESH_BUFFER:
+                self._token = await auth.get_token(self._credential, auth.FABRIC_SCOPE)
         return self._token.token
 
     # ------------------------------------------------------------------
@@ -123,7 +131,7 @@ class FabricHttpClient:
         path: str,
         *,
         json: object = None,
-        params: dict[str, str] | None = None,
+        params: Mapping[str, Any] | None = None,
     ) -> httpx.Response:
         """Send a single HTTP request, applying rate-limiting and error handling.
 
@@ -159,7 +167,7 @@ class FabricHttpClient:
         url: str,
         *,
         json: object = None,
-        params: dict[str, str] | None = None,
+        params: Mapping[str, Any] | None = None,
     ) -> httpx.Response:
         """Inner request method wrapped with tenacity 5xx retry."""
         return await self._do_request(method, url, json=json, params=params)
@@ -170,7 +178,7 @@ class FabricHttpClient:
         url: str,
         *,
         json: object = None,
-        params: dict[str, str] | None = None,
+        params: Mapping[str, Any] | None = None,
     ) -> httpx.Response:
         """Execute a request with rate limiting and 429 handling."""
         if self._http is None:

--- a/src/fabric_dw/http_client.py
+++ b/src/fabric_dw/http_client.py
@@ -1,0 +1,312 @@
+"""Async HTTP client for Microsoft Fabric and Power BI REST APIs.
+
+Provides:
+- Global rate-limiting via aiolimiter (default 2 RPS).
+- 429 Retry-After handling with a shared asyncio pause gate.
+- 5xx retry with tenacity exponential back-off (max 3 attempts).
+- Standard error mapping (401 -> AuthError, 403 -> PermissionDenied, 404 -> NotFound).
+- continuationUri pagination.
+- LRO (202 + Location) polling.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import datetime
+import time as _time
+from collections.abc import AsyncIterator
+from email.utils import parsedate_to_datetime
+from enum import StrEnum
+
+import httpx
+from aiolimiter import AsyncLimiter
+from azure.core.credentials import AccessToken, TokenCredential
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
+
+from fabric_dw import auth
+from fabric_dw.exceptions import (
+    AuthError,
+    FabricServerError,
+    NotFound,
+    PermissionDenied,
+    RateLimitedError,
+)
+
+__all__ = [
+    "FabricHttpClient",
+    "HttpBase",
+    "_parse_retry_after",
+]
+
+_MAX_429_RETRIES = 5
+_DEFAULT_POLL_INTERVAL = 2.0
+_TOKEN_REFRESH_BUFFER = 300  # seconds before expiry to refresh
+
+
+class HttpBase(StrEnum):
+    """Base URLs for Fabric and Power BI REST APIs."""
+
+    FABRIC = "https://api.fabric.microsoft.com/v1"
+    POWERBI = "https://api.powerbi.com/v1.0/myorg"
+
+
+def _parse_retry_after(value: str) -> float:
+    """Parse a Retry-After header value into a wait duration in seconds.
+
+    Handles both the integer-seconds form and the HTTP-date form
+    (RFC 7231 section 7.1.3).
+
+    Args:
+        value: The raw Retry-After header value.
+
+    Returns:
+        Number of seconds to wait as a float (>= 0).
+    """
+    value = value.strip()
+    try:
+        return float(value)
+    except ValueError:
+        pass
+
+    # Try HTTP-date form, e.g. "Wed, 21 Oct 2026 07:28:00 GMT"
+    retry_dt = parsedate_to_datetime(value)
+    now = datetime.datetime.now(tz=datetime.UTC)
+    delta = (retry_dt - now).total_seconds()
+    return max(0.0, delta)
+
+
+class FabricHttpClient:
+    """Async HTTP client for Fabric and Power BI REST APIs.
+
+    Usage::
+
+        async with FabricHttpClient(credential) as client:
+            resp = await client.request("GET", HttpBase.FABRIC, "/workspaces")
+    """
+
+    def __init__(self, credential: TokenCredential, rps: int = 2) -> None:
+        self._credential = credential
+        self._limiter = AsyncLimiter(max_rate=rps, time_period=1)
+        self._http: httpx.AsyncClient | None = None
+        self._token: AccessToken | None = None
+        # Pause gate: set when idle, clear when sleeping for a 429
+        self._pause_event = asyncio.Event()
+        self._pause_event.set()
+
+    async def __aenter__(self) -> FabricHttpClient:
+        self._http = httpx.AsyncClient(http2=True, timeout=30)
+        return self
+
+    async def __aexit__(self, *_exc: object) -> None:
+        if self._http is not None:
+            await self._http.aclose()
+            self._http = None
+
+    # ------------------------------------------------------------------
+    # Token management
+    # ------------------------------------------------------------------
+
+    async def _get_token(self) -> str:
+        """Return a valid bearer token, refreshing if close to expiry."""
+        if self._token is None or self._token.expires_on - _time.time() < _TOKEN_REFRESH_BUFFER:
+            self._token = await auth.get_token(self._credential, auth.FABRIC_SCOPE)
+        return self._token.token
+
+    # ------------------------------------------------------------------
+    # Core request
+    # ------------------------------------------------------------------
+
+    async def request(
+        self,
+        method: str,
+        base: HttpBase,
+        path: str,
+        *,
+        json: object = None,
+        params: dict[str, str] | None = None,
+    ) -> httpx.Response:
+        """Send a single HTTP request, applying rate-limiting and error handling.
+
+        Args:
+            method: HTTP method (e.g. "GET", "POST").
+            base: Base URL enum value.
+            path: Path to append to the base URL.
+            json: Optional JSON body.
+            params: Optional query parameters.
+
+        Returns:
+            The successful httpx.Response.
+
+        Raises:
+            AuthError: On 401.
+            PermissionDenied: On 403.
+            NotFound: On 404.
+            RateLimitedError: When the server returns 429 more than _MAX_429_RETRIES times.
+            FabricServerError: On persistent 5xx errors.
+        """
+        url = f"{base}{path}"
+        return await self._request_with_retry(method, url, json=json, params=params)
+
+    @retry(
+        retry=retry_if_exception_type(FabricServerError),
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=0.1, min=0.1, max=2),
+        reraise=True,
+    )
+    async def _request_with_retry(
+        self,
+        method: str,
+        url: str,
+        *,
+        json: object = None,
+        params: dict[str, str] | None = None,
+    ) -> httpx.Response:
+        """Inner request method wrapped with tenacity 5xx retry."""
+        return await self._do_request(method, url, json=json, params=params)
+
+    async def _do_request(
+        self,
+        method: str,
+        url: str,
+        *,
+        json: object = None,
+        params: dict[str, str] | None = None,
+    ) -> httpx.Response:
+        """Execute a request with rate limiting and 429 handling."""
+        if self._http is None:
+            msg = "Client must be used as an async context manager"
+            raise RuntimeError(msg)
+
+        consecutive_429 = 0
+
+        while True:
+            # Wait if another coroutine is paused for 429
+            await self._pause_event.wait()
+
+            # Acquire rate-limit token
+            async with self._limiter:
+                token = await self._get_token()
+                headers = {"Authorization": f"Bearer {token}"}
+
+                resp = await self._http.request(
+                    method,
+                    url,
+                    headers=headers,
+                    json=json,
+                    params=params,
+                )
+
+            if resp.status_code == 429:  # noqa: PLR2004
+                consecutive_429 += 1
+                if consecutive_429 >= _MAX_429_RETRIES:
+                    raise RateLimitedError(  # noqa: TRY003
+                        f"Received 429 {consecutive_429} consecutive times for {url}"
+                    )
+
+                retry_after_raw = resp.headers.get("Retry-After", "1")
+                wait_s = _parse_retry_after(retry_after_raw)
+
+                # Pause all other concurrent callers while we sleep
+                self._pause_event.clear()
+                try:
+                    await asyncio.sleep(wait_s)
+                finally:
+                    self._pause_event.set()
+
+                continue
+
+            # Reset counter on non-429
+            consecutive_429 = 0
+
+            if resp.status_code == 401:  # noqa: PLR2004
+                raise AuthError(f"Authentication failed for {url}: {resp.text}")  # noqa: TRY003
+            if resp.status_code == 403:  # noqa: PLR2004
+                raise PermissionDenied(f"Permission denied for {url}: {resp.text}")  # noqa: TRY003
+            if resp.status_code == 404:  # noqa: PLR2004
+                raise NotFound(f"Resource not found: {url}: {resp.text}")  # noqa: TRY003
+            if resp.status_code >= 500:  # noqa: PLR2004
+                raise FabricServerError(  # noqa: TRY003
+                    f"Server error {resp.status_code} for {url}: {resp.text}"
+                )
+
+            return resp
+
+    # ------------------------------------------------------------------
+    # Pagination
+    # ------------------------------------------------------------------
+
+    async def iter_paginated(self, base: HttpBase, path: str) -> AsyncIterator[dict[str, object]]:
+        """Iterate over all items across paginated responses.
+
+        Follows the ``continuationUri`` field in each page until it is absent.
+
+        Args:
+            base: Base URL enum value (used only for the first request).
+            path: Initial path to request.
+
+        Yields:
+            Individual items from the ``value`` array in each page.
+        """
+        url: str | None = f"{base}{path}"
+
+        while url is not None:
+            # continuationUri is always a full URL; use _request_with_retry directly
+            resp = await self._request_with_retry("GET", url)
+            data: dict[str, object] = resp.json()
+            value = data.get("value", [])
+            if isinstance(value, list):
+                for item in value:
+                    if isinstance(item, dict):
+                        yield item
+
+            cont = data.get("continuationUri")
+            url = cont if isinstance(cont, str) else None
+
+    # ------------------------------------------------------------------
+    # LRO polling
+    # ------------------------------------------------------------------
+
+    async def poll_operation(
+        self,
+        location: str,
+        *,
+        timeout_s: float = 600,
+    ) -> dict[str, object]:
+        """Poll a long-running operation URL until it succeeds or fails.
+
+        Args:
+            location: Full URL of the LRO status endpoint.
+            timeout_s: Maximum wall-clock seconds to wait (default 600).
+
+        Returns:
+            The final response body when ``status == "Succeeded"``.
+
+        Raises:
+            FabricServerError: If the operation status is ``"Failed"`` or the
+                timeout is exceeded.
+        """
+        deadline = _time.monotonic() + timeout_s
+
+        while True:
+            if _time.monotonic() >= deadline:
+                raise FabricServerError(  # noqa: TRY003
+                    f"LRO timed out after {timeout_s}s for {location}"
+                )
+
+            resp = await self._request_with_retry("GET", location)
+            body: dict[str, object] = resp.json()
+            status = body.get("status", "")
+
+            if status == "Succeeded":
+                return body
+            if status == "Failed":
+                raise FabricServerError(  # noqa: TRY003
+                    f"LRO failed for {location}: {body.get('error', body)}"
+                )
+
+            # Not finished yet - honour Retry-After or fall back to default
+            retry_after_raw = resp.headers.get("Retry-After")
+            wait_s = (
+                _parse_retry_after(retry_after_raw) if retry_after_raw else _DEFAULT_POLL_INTERVAL
+            )
+            await asyncio.sleep(wait_s)

--- a/tests/unit/test_http_client.py
+++ b/tests/unit/test_http_client.py
@@ -66,7 +66,11 @@ def test_parse_retry_after_http_date() -> None:
 
 @pytest.mark.asyncio
 async def test_rps_limiter_timing() -> None:
-    """6 concurrent requests at 2 RPS should complete in ~3 s (±0.5 s tolerance)."""
+    """6 requests at 2 RPS complete in ~2.0s.
+
+    AsyncLimiter(2, 1) drains at 2 tokens/s: first 2 fire immediately,
+    then 1 more every 0.5 s, so the 6th fires at ~2.0 s.
+    """
     elapsed: float = 0.0
 
     with respx.mock:
@@ -83,11 +87,8 @@ async def test_rps_limiter_timing() -> None:
             elapsed = time.monotonic() - start
 
         assert route.call_count == 6
-    # With AsyncLimiter(2, 1): 6 requests at 2 RPS takes ~2 s
-    # (first 2 immediate, next 2 after 1 s, last 2 after 2 s)
-    # Allow ±0.5 s tolerance for scheduling jitter
-    assert elapsed >= 1.5, f"Too fast: {elapsed:.2f}s — rate limiter not enforced"
-    assert elapsed <= 4.0, f"Too slow: {elapsed:.2f}s — unexpected delay"
+    assert elapsed >= 1.9, f"Too fast: {elapsed:.2f}s — rate limiter not enforced"
+    assert elapsed <= 3.0, f"Too slow: {elapsed:.2f}s — unexpected delay"
 
 
 # ---------------------------------------------------------------------------
@@ -122,17 +123,28 @@ async def test_429_retry_after_honored() -> None:
 
 
 @pytest.mark.asyncio
-async def test_429_five_consecutive_raises() -> None:
-    """Five consecutive 429 responses should raise RateLimitedError."""
+async def test_429_raises_after_five_in_a_row() -> None:
+    """Exactly 5 consecutive 429 responses must trigger RateLimitedError (_MAX_429_RETRIES = 5).
+
+    The implementation raises when consecutive_429 >= 5, so the 5th 429 response
+    is the one that causes the exception — meaning exactly 5 mocked 429s are consumed.
+    """
+    call_count = 0
+
+    def side_effect(_request: httpx.Request) -> httpx.Response:
+        nonlocal call_count
+        call_count += 1
+        return httpx.Response(429, headers={"Retry-After": "0"}, json={})
+
     with respx.mock:
-        respx.get("https://api.fabric.microsoft.com/v1/items").mock(
-            return_value=httpx.Response(429, headers={"Retry-After": "1"}, json={})
-        )
+        respx.get("https://api.fabric.microsoft.com/v1/items").mock(side_effect=side_effect)
 
         client = await _get_client(rps=10)
         async with client:
             with pytest.raises(RateLimitedError):
                 await client.request("GET", HttpBase.FABRIC, "/items")
+
+    assert call_count == 5, f"Expected exactly 5 429 responses before raising; got {call_count}"
 
 
 # ---------------------------------------------------------------------------
@@ -284,3 +296,82 @@ async def test_poll_operation_failed_raises() -> None:
         async with client:
             with pytest.raises(FabricServerError):
                 await client.poll_operation("https://api.fabric.microsoft.com/v1/operations/op-456")
+
+
+@pytest.mark.asyncio
+async def test_poll_operation_timeout_raises() -> None:
+    """poll_operation should raise FabricServerError when timeout_s is exceeded.
+
+    Uses timeout_s=0.1 so the deadline is always past by the first iteration.
+    The mock always returns "Running" so the operation never completes.
+    """
+    with respx.mock:
+        respx.get("https://api.fabric.microsoft.com/v1/operations/op-timeout").mock(
+            return_value=httpx.Response(200, json={"status": "Running"})
+        )
+
+        client = await _get_client()
+        async with client:
+            with pytest.raises(FabricServerError, match="timed out"):
+                await client.poll_operation(
+                    "https://api.fabric.microsoft.com/v1/operations/op-timeout",
+                    timeout_s=0.1,
+                )
+
+
+# ---------------------------------------------------------------------------
+# params type: Mapping[str, Any]
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_request_params_int_value_serialized() -> None:
+    """request() must accept int param values and serialize them correctly (e.g. ?top=100)."""
+    captured_url: str | None = None
+
+    def side_effect(request: httpx.Request) -> httpx.Response:
+        nonlocal captured_url
+        captured_url = str(request.url)
+        return httpx.Response(200, json={})
+
+    with respx.mock(assert_all_called=False) as mock_router:
+        mock_router.get(url__regex=r"https://api\.fabric\.microsoft\.com/v1/x.*").mock(
+            side_effect=side_effect
+        )
+
+        client = await _get_client()
+        async with client:
+            await client.request("GET", HttpBase.FABRIC, "/x", params={"top": 100})
+
+    assert captured_url is not None
+    assert "top=100" in captured_url, f"Expected 'top=100' in URL; got {captured_url}"
+
+
+# ---------------------------------------------------------------------------
+# Token refresh concurrency safety
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_concurrent_requests_fetch_token_once() -> None:
+    """Five concurrent requests before any token is fetched must call get_token exactly once."""
+    cred = MagicMock(spec=TokenCredential)
+    # get_token is synchronous; auth.get_token wraps it via asyncio.to_thread
+    cred.get_token = MagicMock(
+        return_value=AccessToken(token="tok", expires_on=int(time.time()) + 3600)  # noqa: S106
+    )
+
+    with respx.mock:
+        respx.get("https://api.fabric.microsoft.com/v1/items").mock(
+            return_value=httpx.Response(200, json={})
+        )
+
+        client = FabricHttpClient(credential=cred, rps=10)
+        async with client:
+            await asyncio.gather(
+                *[client.request("GET", HttpBase.FABRIC, "/items") for _ in range(5)]
+            )
+
+    assert cred.get_token.call_count == 1, (
+        f"Expected get_token called once; called {cred.get_token.call_count} times"
+    )

--- a/tests/unit/test_http_client.py
+++ b/tests/unit/test_http_client.py
@@ -1,12 +1,11 @@
-"""Tests for FabricHttpClient – written BEFORE the implementation (TDD)."""
+"""Tests for FabricHttpClient - written BEFORE the implementation (TDD)."""
 
 from __future__ import annotations
 
 import asyncio
 import time
-from collections.abc import AsyncIterator
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock
 
 import httpx
 import pytest
@@ -27,7 +26,7 @@ from fabric_dw.http_client import FabricHttpClient, HttpBase, _parse_retry_after
 # Helpers
 # ---------------------------------------------------------------------------
 
-_FAKE_TOKEN = AccessToken(token="fake-token", expires_on=int(time.time()) + 3600)
+_FAKE_TOKEN = AccessToken(token="fake-token", expires_on=int(time.time()) + 3600)  # noqa: S106
 
 
 def _make_credential(token: AccessToken = _FAKE_TOKEN) -> TokenCredential:
@@ -68,6 +67,8 @@ def test_parse_retry_after_http_date() -> None:
 @pytest.mark.asyncio
 async def test_rps_limiter_timing() -> None:
     """6 concurrent requests at 2 RPS should complete in ~3 s (±0.5 s tolerance)."""
+    elapsed: float = 0.0
+
     with respx.mock:
         route = respx.get("https://api.fabric.microsoft.com/v1/items").mock(
             return_value=httpx.Response(200, json={"value": []})
@@ -81,11 +82,12 @@ async def test_rps_limiter_timing() -> None:
             )
             elapsed = time.monotonic() - start
 
-    assert route.call_count == 6
-    # With AsyncLimiter(2, 1): 6 requests / 2 rps = 3 s minimum (first 2 are free)
-    # Allow ±0.6 s tolerance for scheduling jitter
-    assert elapsed >= 2.4, f"Too fast: {elapsed:.2f}s — rate limiter not enforced"
-    assert elapsed <= 4.5, f"Too slow: {elapsed:.2f}s — unexpected delay"
+        assert route.call_count == 6
+    # With AsyncLimiter(2, 1): 6 requests at 2 RPS takes ~2 s
+    # (first 2 immediate, next 2 after 1 s, last 2 after 2 s)
+    # Allow ±0.5 s tolerance for scheduling jitter
+    assert elapsed >= 1.5, f"Too fast: {elapsed:.2f}s — rate limiter not enforced"
+    assert elapsed <= 4.0, f"Too slow: {elapsed:.2f}s — unexpected delay"
 
 
 # ---------------------------------------------------------------------------
@@ -98,7 +100,7 @@ async def test_429_retry_after_honored() -> None:
     """A 429 with Retry-After: 1 should retry once and succeed; elapsed >= ~0.9 s."""
     call_count = 0
 
-    def side_effect(request: httpx.Request) -> httpx.Response:
+    def side_effect(_request: httpx.Request) -> httpx.Response:
         nonlocal call_count
         call_count += 1
         if call_count == 1:
@@ -114,8 +116,8 @@ async def test_429_retry_after_honored() -> None:
             resp = await client.request("GET", HttpBase.FABRIC, "/items")
             elapsed = time.monotonic() - start
 
-    assert resp.status_code == 200
-    assert call_count == 2
+        assert resp.status_code == 200
+        assert call_count == 2
     assert elapsed >= 0.9, f"Retry-After not honored: {elapsed:.2f}s"
 
 
@@ -213,15 +215,15 @@ async def test_iter_paginated_follows_continuation_uri() -> None:
 
     call_count = 0
 
-    def side_effect(request: httpx.Request) -> httpx.Response:
+    def side_effect(_request: httpx.Request) -> httpx.Response:
         nonlocal call_count
         call_count += 1
         if call_count == 1:
             return httpx.Response(200, json=page1)
         return httpx.Response(200, json=page2)
 
-    with respx.mock(assert_all_called=False):
-        respx.get(url__regex=r"https://api\.fabric\.microsoft\.com/v1/items.*").mock(
+    with respx.mock(assert_all_called=False) as mock_router:
+        mock_router.get(url__regex=r"https://api\.fabric\.microsoft\.com/v1/items.*").mock(
             side_effect=side_effect
         )
 
@@ -229,8 +231,8 @@ async def test_iter_paginated_follows_continuation_uri() -> None:
         async with client:
             items = [item async for item in client.iter_paginated(HttpBase.FABRIC, "/items")]
 
-    assert items == [{"id": "a"}, {"id": "b"}, {"id": "c"}]
-    assert call_count == 2
+        assert items == [{"id": "a"}, {"id": "b"}, {"id": "c"}]
+        assert call_count == 2
 
 
 # ---------------------------------------------------------------------------
@@ -244,7 +246,7 @@ async def test_poll_operation_succeeded() -> None:
     poll_count = 0
     final_body = {"status": "Succeeded", "result": {"id": "op-123"}}
 
-    def side_effect(request: httpx.Request) -> httpx.Response:
+    def side_effect(_request: httpx.Request) -> httpx.Response:
         nonlocal poll_count
         poll_count += 1
         if poll_count == 1:
@@ -266,8 +268,8 @@ async def test_poll_operation_succeeded() -> None:
                 "https://api.fabric.microsoft.com/v1/operations/op-123"
             )
 
-    assert result == final_body
-    assert poll_count == 2
+        assert result == final_body
+        assert poll_count == 2
 
 
 @pytest.mark.asyncio
@@ -281,6 +283,4 @@ async def test_poll_operation_failed_raises() -> None:
         client = await _get_client()
         async with client:
             with pytest.raises(FabricServerError):
-                await client.poll_operation(
-                    "https://api.fabric.microsoft.com/v1/operations/op-456"
-                )
+                await client.poll_operation("https://api.fabric.microsoft.com/v1/operations/op-456")

--- a/tests/unit/test_http_client.py
+++ b/tests/unit/test_http_client.py
@@ -1,0 +1,286 @@
+"""Tests for FabricHttpClient – written BEFORE the implementation (TDD)."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+import respx
+from azure.core.credentials import AccessToken, TokenCredential
+from freezegun import freeze_time
+
+from fabric_dw.exceptions import (
+    AuthError,
+    FabricServerError,
+    NotFound,
+    PermissionDenied,
+    RateLimitedError,
+)
+from fabric_dw.http_client import FabricHttpClient, HttpBase, _parse_retry_after
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_FAKE_TOKEN = AccessToken(token="fake-token", expires_on=int(time.time()) + 3600)
+
+
+def _make_credential(token: AccessToken = _FAKE_TOKEN) -> TokenCredential:
+    """Build a mock credential that returns *token*."""
+    cred = MagicMock(spec=TokenCredential)
+    cred.get_token = MagicMock(return_value=token)
+    return cred
+
+
+async def _get_client(rps: int = 10) -> FabricHttpClient:
+    """Instantiate a FabricHttpClient with a mock credential."""
+    return FabricHttpClient(credential=_make_credential(), rps=rps)
+
+
+# ---------------------------------------------------------------------------
+# _parse_retry_after
+# ---------------------------------------------------------------------------
+
+
+def test_parse_retry_after_integer() -> None:
+    """Integer-second string should return that value as float."""
+    assert _parse_retry_after("3") == 3.0
+
+
+@freeze_time("2026-10-21 07:27:00 UTC")
+def test_parse_retry_after_http_date() -> None:
+    """HTTP-date string should return seconds-until-that-time as positive float."""
+    result = _parse_retry_after("Wed, 21 Oct 2026 07:28:00 GMT")
+    # frozen at 07:27:00 → 60 seconds until 07:28:00
+    assert result == pytest.approx(60.0, abs=1.0)
+
+
+# ---------------------------------------------------------------------------
+# Timed RPS test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rps_limiter_timing() -> None:
+    """6 concurrent requests at 2 RPS should complete in ~3 s (±0.5 s tolerance)."""
+    with respx.mock:
+        route = respx.get("https://api.fabric.microsoft.com/v1/items").mock(
+            return_value=httpx.Response(200, json={"value": []})
+        )
+
+        client = await _get_client(rps=2)
+        async with client:
+            start = time.monotonic()
+            await asyncio.gather(
+                *[client.request("GET", HttpBase.FABRIC, "/items") for _ in range(6)]
+            )
+            elapsed = time.monotonic() - start
+
+    assert route.call_count == 6
+    # With AsyncLimiter(2, 1): 6 requests / 2 rps = 3 s minimum (first 2 are free)
+    # Allow ±0.6 s tolerance for scheduling jitter
+    assert elapsed >= 2.4, f"Too fast: {elapsed:.2f}s — rate limiter not enforced"
+    assert elapsed <= 4.5, f"Too slow: {elapsed:.2f}s — unexpected delay"
+
+
+# ---------------------------------------------------------------------------
+# 429 handling
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_429_retry_after_honored() -> None:
+    """A 429 with Retry-After: 1 should retry once and succeed; elapsed >= ~0.9 s."""
+    call_count = 0
+
+    def side_effect(request: httpx.Request) -> httpx.Response:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return httpx.Response(429, headers={"Retry-After": "1"}, json={})
+        return httpx.Response(200, json={"value": []})
+
+    with respx.mock:
+        respx.get("https://api.fabric.microsoft.com/v1/items").mock(side_effect=side_effect)
+
+        client = await _get_client(rps=10)
+        async with client:
+            start = time.monotonic()
+            resp = await client.request("GET", HttpBase.FABRIC, "/items")
+            elapsed = time.monotonic() - start
+
+    assert resp.status_code == 200
+    assert call_count == 2
+    assert elapsed >= 0.9, f"Retry-After not honored: {elapsed:.2f}s"
+
+
+@pytest.mark.asyncio
+async def test_429_five_consecutive_raises() -> None:
+    """Five consecutive 429 responses should raise RateLimitedError."""
+    with respx.mock:
+        respx.get("https://api.fabric.microsoft.com/v1/items").mock(
+            return_value=httpx.Response(429, headers={"Retry-After": "1"}, json={})
+        )
+
+        client = await _get_client(rps=10)
+        async with client:
+            with pytest.raises(RateLimitedError):
+                await client.request("GET", HttpBase.FABRIC, "/items")
+
+
+# ---------------------------------------------------------------------------
+# Status-code error mapping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_401_raises_auth_error() -> None:
+    """HTTP 401 should raise AuthError."""
+    with respx.mock:
+        respx.get("https://api.fabric.microsoft.com/v1/items").mock(
+            return_value=httpx.Response(401, json={"error": "unauthorized"})
+        )
+        client = await _get_client()
+        async with client:
+            with pytest.raises(AuthError):
+                await client.request("GET", HttpBase.FABRIC, "/items")
+
+
+@pytest.mark.asyncio
+async def test_403_raises_permission_denied() -> None:
+    """HTTP 403 should raise PermissionDenied."""
+    with respx.mock:
+        respx.get("https://api.fabric.microsoft.com/v1/items").mock(
+            return_value=httpx.Response(403, json={"error": "forbidden"})
+        )
+        client = await _get_client()
+        async with client:
+            with pytest.raises(PermissionDenied):
+                await client.request("GET", HttpBase.FABRIC, "/items")
+
+
+@pytest.mark.asyncio
+async def test_404_raises_not_found() -> None:
+    """HTTP 404 should raise NotFound."""
+    with respx.mock:
+        respx.get("https://api.fabric.microsoft.com/v1/items").mock(
+            return_value=httpx.Response(404, json={"error": "not found"})
+        )
+        client = await _get_client()
+        async with client:
+            with pytest.raises(NotFound):
+                await client.request("GET", HttpBase.FABRIC, "/items")
+
+
+# ---------------------------------------------------------------------------
+# 5xx retried then FabricServerError
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_500_retried_then_raises() -> None:
+    """HTTP 500 should be retried (tenacity) and finally raise FabricServerError."""
+    with respx.mock:
+        respx.get("https://api.fabric.microsoft.com/v1/items").mock(
+            return_value=httpx.Response(500, json={"error": "server error"})
+        )
+        client = await _get_client()
+        async with client:
+            with pytest.raises(FabricServerError):
+                await client.request("GET", HttpBase.FABRIC, "/items")
+
+
+# ---------------------------------------------------------------------------
+# Pagination
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_iter_paginated_follows_continuation_uri() -> None:
+    """iter_paginated should follow continuationUri across pages and yield all items."""
+    page1 = {
+        "value": [{"id": "a"}, {"id": "b"}],
+        "continuationUri": "https://api.fabric.microsoft.com/v1/items?continuation=xyz",
+    }
+    page2: dict[str, Any] = {
+        "value": [{"id": "c"}],
+    }
+
+    call_count = 0
+
+    def side_effect(request: httpx.Request) -> httpx.Response:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return httpx.Response(200, json=page1)
+        return httpx.Response(200, json=page2)
+
+    with respx.mock(assert_all_called=False):
+        respx.get(url__regex=r"https://api\.fabric\.microsoft\.com/v1/items.*").mock(
+            side_effect=side_effect
+        )
+
+        client = await _get_client()
+        async with client:
+            items = [item async for item in client.iter_paginated(HttpBase.FABRIC, "/items")]
+
+    assert items == [{"id": "a"}, {"id": "b"}, {"id": "c"}]
+    assert call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# LRO polling
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_poll_operation_succeeded() -> None:
+    """poll_operation should return the body when status == 'Succeeded'."""
+    poll_count = 0
+    final_body = {"status": "Succeeded", "result": {"id": "op-123"}}
+
+    def side_effect(request: httpx.Request) -> httpx.Response:
+        nonlocal poll_count
+        poll_count += 1
+        if poll_count == 1:
+            return httpx.Response(
+                202,
+                headers={"Retry-After": "1"},
+                json={"status": "Running"},
+            )
+        return httpx.Response(200, json=final_body)
+
+    with respx.mock:
+        respx.get("https://api.fabric.microsoft.com/v1/operations/op-123").mock(
+            side_effect=side_effect
+        )
+
+        client = await _get_client()
+        async with client:
+            result = await client.poll_operation(
+                "https://api.fabric.microsoft.com/v1/operations/op-123"
+            )
+
+    assert result == final_body
+    assert poll_count == 2
+
+
+@pytest.mark.asyncio
+async def test_poll_operation_failed_raises() -> None:
+    """poll_operation should raise FabricServerError when status == 'Failed'."""
+    with respx.mock:
+        respx.get("https://api.fabric.microsoft.com/v1/operations/op-456").mock(
+            return_value=httpx.Response(200, json={"status": "Failed", "error": "boom"})
+        )
+
+        client = await _get_client()
+        async with client:
+            with pytest.raises(FabricServerError):
+                await client.poll_operation(
+                    "https://api.fabric.microsoft.com/v1/operations/op-456"
+                )

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,15 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "aiolimiter"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/23/b52debf471f7a1e42e362d959a3982bdcb4fe13a5d46e63d28868807a79c/aiolimiter-1.2.1.tar.gz", hash = "sha256:e02a37ea1a855d9e832252a105420ad4d15011505512a1a1d814647451b5cca9", size = 7185, upload-time = "2024-12-08T15:31:51.496Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/ba/df6e8e1045aebc4778d19b8a3a9bc1808adb1619ba94ca354d9ba17d86c3/aiolimiter-1.2.1-py3-none-any.whl", hash = "sha256:d3f249e9059a20badcb56b61601a83556133655c11d1eb3dd3e04ff069e5f3c7", size = 6711, upload-time = "2024-12-08T15:31:49.874Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -473,13 +482,17 @@ wheels = [
 name = "fabric-dw-mcp-cli"
 source = { editable = "." }
 dependencies = [
+    { name = "aiolimiter" },
     { name = "azure-identity" },
+    { name = "httpx", extra = ["http2"] },
     { name = "pydantic" },
+    { name = "tenacity" },
 ]
 
 [package.optional-dependencies]
 dev = [
     { name = "anyio", extra = ["trio"] },
+    { name = "freezegun" },
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pytest" },
@@ -492,8 +505,11 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiolimiter", specifier = ">=1.2" },
     { name = "anyio", extras = ["trio"], marker = "extra == 'dev'" },
     { name = "azure-identity", specifier = ">=1.19" },
+    { name = "freezegun", marker = "extra == 'dev'", specifier = ">=1.5" },
+    { name = "httpx", extras = ["http2"], specifier = ">=0.27" },
     { name = "mypy", marker = "extra == 'dev'" },
     { name = "pre-commit", marker = "extra == 'dev'" },
     { name = "pydantic", specifier = ">=2.9" },
@@ -501,8 +517,9 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'" },
     { name = "pytest-cov", marker = "extra == 'dev'" },
     { name = "pytest-randomly", marker = "extra == 'dev'" },
-    { name = "respx", marker = "extra == 'dev'" },
+    { name = "respx", marker = "extra == 'dev'", specifier = ">=0.21" },
     { name = "ruff", marker = "extra == 'dev'" },
+    { name = "tenacity", specifier = ">=9" },
 ]
 provides-extras = ["dev"]
 
@@ -516,12 +533,46 @@ wheels = [
 ]
 
 [[package]]
+name = "freezegun"
+version = "1.5.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/95/dd/23e2f4e357f8fd3bdff613c1fe4466d21bfb00a6177f238079b17f7b1c84/freezegun-1.5.5.tar.gz", hash = "sha256:ac7742a6cc6c25a2c35e9292dfd554b897b517d2dec26891a2e8debf205cb94a", size = 35914, upload-time = "2025-08-09T10:39:08.338Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/2e/b41d8a1a917d6581fc27a35d05561037b048e47df50f27f8ac9c7e27a710/freezegun-1.5.5-py3-none-any.whl", hash = "sha256:cd557f4a75cf074e84bc374249b9dd491eaeacd61376b9eb3c423282211619d2", size = 19266, upload-time = "2025-08-09T10:39:06.636Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "h2"
+version = "4.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "hpack" },
+    { name = "hyperframe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1", size = 2152026, upload-time = "2025-08-23T18:12:19.778Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd", size = 61779, upload-time = "2025-08-23T18:12:17.779Z" },
+]
+
+[[package]]
+name = "hpack"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/48/71de9ed269fdae9c8057e5a4c0aa7402e8bb16f2c6e90b3aa53327b113f8/hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca", size = 51276, upload-time = "2025-01-22T21:44:58.347Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/c6/80c95b1b2b94682a72cbdbfb85b81ae2daffa4291fbfa1b1464502ede10d/hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496", size = 34357, upload-time = "2025-01-22T21:44:56.92Z" },
 ]
 
 [[package]]
@@ -550,6 +601,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[package.optional-dependencies]
+http2 = [
+    { name = "h2" },
+]
+
+[[package]]
+name = "hyperframe"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
 ]
 
 [[package]]
@@ -1016,6 +1081,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "python-discovery"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1136,6 +1213,15 @@ wheels = [
 ]
 
 [[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1151,6 +1237,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
+]
+
+[[package]]
+name = "tenacity"
+version = "9.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #8

Implements the singleton async HTTP client used by all subsequent service layers. AsyncLimiter for 2 RPS, Retry-After-strict 429 handling, continuationUri pagination, LRO polling on 202+Location, exceptions for the standard status codes.

## Summary

- Extends `exceptions.py` with `AuthError`, `PermissionDenied`, `NotFound`, `RateLimitedError`, `FabricServerError`
- New `src/fabric_dw/http_client.py` with `HttpBase(StrEnum)` and `FabricHttpClient`
- Single `httpx.AsyncClient(http2=True, timeout=30)` owned by the client; closed in `__aexit__`
- Token via `auth.get_token(credential, FABRIC_SCOPE)`; cached until `expires_on - 300s`
- `aiolimiter.AsyncLimiter(max_rate=rps, time_period=1)` for global rate limiting
- 429: parses `Retry-After` (int seconds or HTTP-date), sleeps with asyncio pause gate blocking concurrent callers, max 5 retries → `RateLimitedError`
- 5xx: tenacity exponential back-off (max 3 attempts) → `FabricServerError`
- `iter_paginated` follows `continuationUri` until absent, yields each `value` item
- `poll_operation` polls until `status` in `{"Succeeded","Failed"}`, honours `Retry-After`

## Test plan
- [x] tests/unit/test_http_client.py covers `_parse_retry_after` both forms (int + HTTP-date with freezegun), timed RPS bucket, 429 Retry-After honoured, 5 consecutive 429s → `RateLimitedError`, 401/403/404 mapping, 500 retried via tenacity, pagination (2 pages), LRO poll Succeeded/Failed
- [x] ruff / mypy / pytest all green
- [x] pre-commit all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)