### PR TITLE
feat(services/workspaces): list, get, get/set collation

### DIFF
--- a/src/fabric_dw/services/__init__.py
+++ b/src/fabric_dw/services/__init__.py
@@ -1,0 +1,5 @@
+"""Service modules for Microsoft Fabric Data Warehouse."""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/src/fabric_dw/services/workspaces.py
+++ b/src/fabric_dw/services/workspaces.py
@@ -1,0 +1,131 @@
+"""Service functions for Microsoft Fabric workspace operations."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from fabric_dw.exceptions import FabricError, NotFound
+from fabric_dw.http_client import FabricHttpClient, HttpBase
+from fabric_dw.models import Workspace
+
+__all__ = [
+    "SUPPORTED_COLLATIONS",
+    "get",
+    "get_collation",
+    "list_all",
+    "set_collation",
+]
+
+# Collation values supported by Microsoft Fabric Data Warehouse.
+# TODO: https://learn.microsoft.com/en-us/fabric/data-warehouse/collation
+SUPPORTED_COLLATIONS: frozenset[str] = frozenset(
+    {
+        "Latin1_General_100_BIN2_UTF8",
+        "Latin1_General_100_CI_AS_KS_WS_SC_UTF8",
+    }
+)
+
+
+async def list_all(http: FabricHttpClient) -> list[Workspace]:
+    """Return all workspaces the caller has access to, following pagination.
+
+    Args:
+        http: An authenticated :class:`~fabric_dw.http_client.FabricHttpClient`.
+
+    Returns:
+        A list of :class:`~fabric_dw.models.Workspace` instances.
+    """
+    return [
+        Workspace.model_validate(item)
+        async for item in http.iter_paginated(HttpBase.FABRIC, "/workspaces")
+    ]
+
+
+async def get(http: FabricHttpClient, workspace_id: UUID) -> Workspace:
+    """Fetch a single workspace by ID.
+
+    Args:
+        http: An authenticated :class:`~fabric_dw.http_client.FabricHttpClient`.
+        workspace_id: The UUID of the workspace to retrieve.
+
+    Returns:
+        A populated :class:`~fabric_dw.models.Workspace` instance.
+    """
+    resp = await http.request("GET", HttpBase.FABRIC, f"/workspaces/{workspace_id}")
+    return Workspace.model_validate(resp.json())
+
+
+async def get_collation(http: FabricHttpClient, workspace_id: UUID) -> str | None:
+    """Return the default Data Warehouse collation for a workspace, or ``None`` if absent.
+
+    Microsoft's v1 REST API does not yet document a dedicated collation property
+    on the workspace resource. If the field is present in the payload it is
+    returned; otherwise ``None`` is returned without error. Do not fall back to
+    a SQL query — keep scope small.
+
+    Args:
+        http: An authenticated :class:`~fabric_dw.http_client.FabricHttpClient`.
+        workspace_id: The UUID of the workspace to inspect.
+
+    Returns:
+        The collation string, or ``None`` if the workspace payload does not
+        carry a ``defaultDataWarehouseCollation`` field.
+    """
+    resp = await http.request("GET", HttpBase.FABRIC, f"/workspaces/{workspace_id}")
+    data: dict[str, object] = resp.json()
+    value = data.get("defaultDataWarehouseCollation")
+    return str(value) if value is not None else None
+
+
+async def set_collation(
+    http: FabricHttpClient,
+    workspace_id: UUID,
+    collation: str,
+) -> None:
+    """Set the default Data Warehouse collation for a workspace.
+
+    Performs a best-effort PATCH on the workspace resource. If the Fabric API
+    returns a 4xx response (e.g. because the endpoint is not yet available in
+    the tenant region), a :class:`~fabric_dw.exceptions.FabricError` is raised
+    with guidance to use the Fabric portal instead.
+
+    Args:
+        http: An authenticated :class:`~fabric_dw.http_client.FabricHttpClient`.
+        workspace_id: The UUID of the workspace to update.
+        collation: The desired collation. Must be one of
+            :data:`SUPPORTED_COLLATIONS`.
+
+    Raises:
+        ValueError: If *collation* is not in :data:`SUPPORTED_COLLATIONS`.
+        FabricError: If the API rejects the PATCH with a 4xx status code.
+    """
+    if collation not in SUPPORTED_COLLATIONS:
+        msg = f"Unsupported collation {collation!r}. Allowed values: {sorted(SUPPORTED_COLLATIONS)}"
+        raise ValueError(msg)
+
+    # TODO: https://learn.microsoft.com/en-us/rest/api/fabric/core/workspaces/update-workspace
+    # The v1 API may not yet expose defaultDataWarehouseCollation on all tenants.
+    # If the PATCH fails with 4xx, instruct the user to set it via the portal.
+    portal_url = "https://app.fabric.microsoft.com"
+    portal_msg = (
+        "Failed to set collation via the Fabric REST API. "
+        "Please set the default Data Warehouse collation manually via the Fabric portal: "
+        f"{portal_url}"
+    )
+
+    try:
+        resp = await http.request(
+            "PATCH",
+            HttpBase.FABRIC,
+            f"/workspaces/{workspace_id}",
+            json={"defaultDataWarehouseCollation": collation},
+        )
+    except NotFound as exc:
+        raise FabricError(portal_msg) from exc
+    except FabricError:
+        raise
+
+    # http_client returns non-error responses (including 400) without raising;
+    # treat any remaining 4xx as a portal-redirect case.
+    if 400 <= resp.status_code < 500:  # noqa: PLR2004
+        raise FabricError(portal_msg)

--- a/tests/fixtures/api_payloads.py
+++ b/tests/fixtures/api_payloads.py
@@ -77,3 +77,25 @@ RESTORE_POINT_PAYLOAD = """{
   "createdAt": "2024-03-15T06:00:00Z",
   "isSystemCreated": false
 }"""
+
+# Second page of workspace listing (no continuationUri → last page)
+WORKSPACE_LIST_PAGE2_PAYLOAD = """{
+  "value": [
+    {
+      "id": "c3d4e5f6-a7b8-9012-cdef-012345678901",
+      "displayName": "MLWorkspace",
+      "description": "Machine learning workspace",
+      "type": "Workspace",
+      "capacityId": "cafebabe-dead-beef-cafe-babe12345678"
+    }
+  ]
+}"""
+
+# Single workspace GET response (no collation-related field)
+WORKSPACE_GET_PAYLOAD = """{
+  "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "displayName": "AnalyticsWorkspace",
+  "description": "Primary analytics workspace for data engineering",
+  "type": "Workspace",
+  "capacityId": "cafebabe-dead-beef-cafe-babe12345678"
+}"""

--- a/tests/unit/services/test_workspaces.py
+++ b/tests/unit/services/test_workspaces.py
@@ -15,6 +15,7 @@ from azure.core.credentials import AccessToken, TokenCredential
 from fabric_dw.exceptions import FabricError
 from fabric_dw.http_client import FabricHttpClient
 from fabric_dw.models import Workspace
+from fabric_dw.services import workspaces
 from tests.fixtures.api_payloads import (
     WORKSPACE_GET_PAYLOAD,
     WORKSPACE_LIST_PAGE2_PAYLOAD,
@@ -29,8 +30,7 @@ _FAKE_TOKEN = AccessToken(token="fake-token", expires_on=int(time.time()) + 3600
 
 _WORKSPACE_ID = UUID("a1b2c3d4-e5f6-7890-abcd-ef1234567890")
 _CONTINUATION_URL = (
-    "https://api.fabric.microsoft.com/v1/workspaces"
-    "?continuationToken=eyJ0b2tlbiI6InRlc3QifQ%3D%3D"
+    "https://api.fabric.microsoft.com/v1/workspaces?continuationToken=eyJ0b2tlbiI6InRlc3QifQ%3D%3D"
 )
 
 
@@ -52,11 +52,9 @@ async def _make_client(rps: int = 10) -> FabricHttpClient:
 @pytest.mark.asyncio
 async def test_list_all_follows_continuation_uri() -> None:
     """list_all must follow continuationUri for ≥2 pages and return all workspaces."""
-    from fabric_dw.services import workspaces
-
     call_count = 0
 
-    def side_effect(request: httpx.Request) -> httpx.Response:
+    def side_effect(_request: httpx.Request) -> httpx.Response:
         nonlocal call_count
         call_count += 1
         if call_count == 1:
@@ -84,8 +82,6 @@ async def test_list_all_follows_continuation_uri() -> None:
 @pytest.mark.asyncio
 async def test_list_all_returns_workspace_instances() -> None:
     """list_all items must be validated Workspace model instances."""
-    from fabric_dw.services import workspaces
-
     payload = json.loads(WORKSPACE_LIST_PAYLOAD)
     # Remove continuation so only one page is returned
     payload.pop("continuationUri", None)
@@ -114,13 +110,12 @@ async def test_list_all_returns_workspace_instances() -> None:
 @pytest.mark.asyncio
 async def test_get_returns_populated_workspace() -> None:
     """get must return a single populated Workspace for the given workspace_id."""
-    from fabric_dw.services import workspaces
-
     ws_id = _WORKSPACE_ID
     url = f"https://api.fabric.microsoft.com/v1/workspaces/{ws_id}"
+    ws_payload = json.loads(WORKSPACE_GET_PAYLOAD)
 
     with respx.mock:
-        respx.get(url).mock(return_value=httpx.Response(200, json=json.loads(WORKSPACE_GET_PAYLOAD)))
+        respx.get(url).mock(return_value=httpx.Response(200, json=ws_payload))
 
         client = await _make_client()
         async with client:
@@ -141,14 +136,13 @@ async def test_get_returns_populated_workspace() -> None:
 @pytest.mark.asyncio
 async def test_get_collation_returns_none_when_absent() -> None:
     """get_collation must return None when the workspace payload has no collation field."""
-    from fabric_dw.services import workspaces
-
     ws_id = _WORKSPACE_ID
     url = f"https://api.fabric.microsoft.com/v1/workspaces/{ws_id}"
+    ws_payload = json.loads(WORKSPACE_GET_PAYLOAD)
 
     # WORKSPACE_GET_PAYLOAD has no defaultDataWarehouseCollation
     with respx.mock:
-        respx.get(url).mock(return_value=httpx.Response(200, json=json.loads(WORKSPACE_GET_PAYLOAD)))
+        respx.get(url).mock(return_value=httpx.Response(200, json=ws_payload))
 
         client = await _make_client()
         async with client:
@@ -160,8 +154,6 @@ async def test_get_collation_returns_none_when_absent() -> None:
 @pytest.mark.asyncio
 async def test_get_collation_returns_value_when_present() -> None:
     """get_collation must return the collation string when present in the workspace payload."""
-    from fabric_dw.services import workspaces
-
     ws_id = _WORKSPACE_ID
     url = f"https://api.fabric.microsoft.com/v1/workspaces/{ws_id}"
 
@@ -186,8 +178,6 @@ async def test_get_collation_returns_value_when_present() -> None:
 @pytest.mark.asyncio
 async def test_set_collation_happy_path_returns_none() -> None:
     """set_collation must return None on a successful PATCH (200/202)."""
-    from fabric_dw.services import workspaces
-
     ws_id = _WORKSPACE_ID
     url = f"https://api.fabric.microsoft.com/v1/workspaces/{ws_id}"
 
@@ -196,18 +186,14 @@ async def test_set_collation_happy_path_returns_none() -> None:
 
         client = await _make_client()
         async with client:
-            result = await workspaces.set_collation(
-                client, ws_id, "Latin1_General_100_BIN2_UTF8"
-            )
+            await workspaces.set_collation(client, ws_id, "Latin1_General_100_BIN2_UTF8")
 
-    assert result is None
+    # set_collation returns None implicitly on success; no assertion needed beyond no exception
 
 
 @pytest.mark.asyncio
 async def test_set_collation_202_happy_path() -> None:
     """set_collation must also return None on 202 (accepted)."""
-    from fabric_dw.services import workspaces
-
     ws_id = _WORKSPACE_ID
     url = f"https://api.fabric.microsoft.com/v1/workspaces/{ws_id}"
 
@@ -216,18 +202,14 @@ async def test_set_collation_202_happy_path() -> None:
 
         client = await _make_client()
         async with client:
-            result = await workspaces.set_collation(
-                client, ws_id, "Latin1_General_100_CI_AS_KS_WS_SC_UTF8"
-            )
+            await workspaces.set_collation(client, ws_id, "Latin1_General_100_CI_AS_KS_WS_SC_UTF8")
 
-    assert result is None
+    # set_collation returns None implicitly on success; no assertion needed beyond no exception
 
 
 @pytest.mark.asyncio
 async def test_set_collation_400_raises_fabric_error_with_portal_link() -> None:
     """set_collation must raise FabricError mentioning the portal on a 400 response."""
-    from fabric_dw.services import workspaces
-
     ws_id = _WORKSPACE_ID
     url = f"https://api.fabric.microsoft.com/v1/workspaces/{ws_id}"
 
@@ -239,16 +221,12 @@ async def test_set_collation_400_raises_fabric_error_with_portal_link() -> None:
         client = await _make_client()
         async with client:
             with pytest.raises(FabricError, match="portal"):
-                await workspaces.set_collation(
-                    client, ws_id, "Latin1_General_100_BIN2_UTF8"
-                )
+                await workspaces.set_collation(client, ws_id, "Latin1_General_100_BIN2_UTF8")
 
 
 @pytest.mark.asyncio
 async def test_set_collation_invalid_value_raises_value_error() -> None:
     """set_collation must raise ValueError for unsupported collation strings."""
-    from fabric_dw.services import workspaces
-
     ws_id = _WORKSPACE_ID
 
     client = await _make_client()
@@ -264,8 +242,6 @@ async def test_set_collation_invalid_value_raises_value_error() -> None:
 
 def test_supported_collations_constant() -> None:
     """SUPPORTED_COLLATIONS must be a frozenset with the two documented values."""
-    from fabric_dw.services import workspaces
-
     assert isinstance(workspaces.SUPPORTED_COLLATIONS, frozenset)
     assert "Latin1_General_100_BIN2_UTF8" in workspaces.SUPPORTED_COLLATIONS
     assert "Latin1_General_100_CI_AS_KS_WS_SC_UTF8" in workspaces.SUPPORTED_COLLATIONS

--- a/tests/unit/services/test_workspaces.py
+++ b/tests/unit/services/test_workspaces.py
@@ -1,0 +1,272 @@
+"""Tests for fabric_dw.services.workspaces — written BEFORE the implementation (TDD)."""
+
+from __future__ import annotations
+
+import json
+import time
+from unittest.mock import MagicMock
+from uuid import UUID
+
+import httpx
+import pytest
+import respx
+from azure.core.credentials import AccessToken, TokenCredential
+
+from fabric_dw.exceptions import FabricError
+from fabric_dw.http_client import FabricHttpClient
+from fabric_dw.models import Workspace
+from tests.fixtures.api_payloads import (
+    WORKSPACE_GET_PAYLOAD,
+    WORKSPACE_LIST_PAGE2_PAYLOAD,
+    WORKSPACE_LIST_PAYLOAD,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_FAKE_TOKEN = AccessToken(token="fake-token", expires_on=int(time.time()) + 3600)  # noqa: S106
+
+_WORKSPACE_ID = UUID("a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+_CONTINUATION_URL = (
+    "https://api.fabric.microsoft.com/v1/workspaces"
+    "?continuationToken=eyJ0b2tlbiI6InRlc3QifQ%3D%3D"
+)
+
+
+def _make_credential(token: AccessToken = _FAKE_TOKEN) -> TokenCredential:
+    cred = MagicMock(spec=TokenCredential)
+    cred.get_token = MagicMock(return_value=token)
+    return cred
+
+
+async def _make_client(rps: int = 10) -> FabricHttpClient:
+    return FabricHttpClient(credential=_make_credential(), rps=rps)
+
+
+# ---------------------------------------------------------------------------
+# list_all
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_all_follows_continuation_uri() -> None:
+    """list_all must follow continuationUri for ≥2 pages and return all workspaces."""
+    from fabric_dw.services import workspaces
+
+    call_count = 0
+
+    def side_effect(request: httpx.Request) -> httpx.Response:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return httpx.Response(200, json=json.loads(WORKSPACE_LIST_PAYLOAD))
+        return httpx.Response(200, json=json.loads(WORKSPACE_LIST_PAGE2_PAYLOAD))
+
+    with respx.mock(assert_all_called=False) as mock_router:
+        mock_router.get(url__regex=r"https://api\.fabric\.microsoft\.com/v1/workspaces.*").mock(
+            side_effect=side_effect
+        )
+
+        client = await _make_client()
+        async with client:
+            result = await workspaces.list_all(client)
+
+    assert call_count == 2
+    assert len(result) == 3  # 2 from page 1 + 1 from page 2
+    assert all(isinstance(ws, Workspace) for ws in result)
+    names = {ws.name for ws in result}
+    assert "AnalyticsWorkspace" in names
+    assert "DataScienceWorkspace" in names
+    assert "MLWorkspace" in names
+
+
+@pytest.mark.asyncio
+async def test_list_all_returns_workspace_instances() -> None:
+    """list_all items must be validated Workspace model instances."""
+    from fabric_dw.services import workspaces
+
+    payload = json.loads(WORKSPACE_LIST_PAYLOAD)
+    # Remove continuation so only one page is returned
+    payload.pop("continuationUri", None)
+
+    with respx.mock:
+        respx.get("https://api.fabric.microsoft.com/v1/workspaces").mock(
+            return_value=httpx.Response(200, json=payload)
+        )
+
+        client = await _make_client()
+        async with client:
+            result = await workspaces.list_all(client)
+
+    assert len(result) == 2
+    first = result[0]
+    assert isinstance(first, Workspace)
+    assert first.id == UUID("a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+    assert first.name == "AnalyticsWorkspace"
+
+
+# ---------------------------------------------------------------------------
+# get
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_returns_populated_workspace() -> None:
+    """get must return a single populated Workspace for the given workspace_id."""
+    from fabric_dw.services import workspaces
+
+    ws_id = _WORKSPACE_ID
+    url = f"https://api.fabric.microsoft.com/v1/workspaces/{ws_id}"
+
+    with respx.mock:
+        respx.get(url).mock(return_value=httpx.Response(200, json=json.loads(WORKSPACE_GET_PAYLOAD)))
+
+        client = await _make_client()
+        async with client:
+            result = await workspaces.get(client, ws_id)
+
+    assert isinstance(result, Workspace)
+    assert result.id == ws_id
+    assert result.name == "AnalyticsWorkspace"
+    assert result.description == "Primary analytics workspace for data engineering"
+    assert result.capacity_id == UUID("cafebabe-dead-beef-cafe-babe12345678")
+
+
+# ---------------------------------------------------------------------------
+# get_collation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_collation_returns_none_when_absent() -> None:
+    """get_collation must return None when the workspace payload has no collation field."""
+    from fabric_dw.services import workspaces
+
+    ws_id = _WORKSPACE_ID
+    url = f"https://api.fabric.microsoft.com/v1/workspaces/{ws_id}"
+
+    # WORKSPACE_GET_PAYLOAD has no defaultDataWarehouseCollation
+    with respx.mock:
+        respx.get(url).mock(return_value=httpx.Response(200, json=json.loads(WORKSPACE_GET_PAYLOAD)))
+
+        client = await _make_client()
+        async with client:
+            result = await workspaces.get_collation(client, ws_id)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_collation_returns_value_when_present() -> None:
+    """get_collation must return the collation string when present in the workspace payload."""
+    from fabric_dw.services import workspaces
+
+    ws_id = _WORKSPACE_ID
+    url = f"https://api.fabric.microsoft.com/v1/workspaces/{ws_id}"
+
+    payload = json.loads(WORKSPACE_GET_PAYLOAD)
+    payload["defaultDataWarehouseCollation"] = "Latin1_General_100_BIN2_UTF8"
+
+    with respx.mock:
+        respx.get(url).mock(return_value=httpx.Response(200, json=payload))
+
+        client = await _make_client()
+        async with client:
+            result = await workspaces.get_collation(client, ws_id)
+
+    assert result == "Latin1_General_100_BIN2_UTF8"
+
+
+# ---------------------------------------------------------------------------
+# set_collation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_collation_happy_path_returns_none() -> None:
+    """set_collation must return None on a successful PATCH (200/202)."""
+    from fabric_dw.services import workspaces
+
+    ws_id = _WORKSPACE_ID
+    url = f"https://api.fabric.microsoft.com/v1/workspaces/{ws_id}"
+
+    with respx.mock:
+        respx.patch(url).mock(return_value=httpx.Response(200, json={}))
+
+        client = await _make_client()
+        async with client:
+            result = await workspaces.set_collation(
+                client, ws_id, "Latin1_General_100_BIN2_UTF8"
+            )
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_set_collation_202_happy_path() -> None:
+    """set_collation must also return None on 202 (accepted)."""
+    from fabric_dw.services import workspaces
+
+    ws_id = _WORKSPACE_ID
+    url = f"https://api.fabric.microsoft.com/v1/workspaces/{ws_id}"
+
+    with respx.mock:
+        respx.patch(url).mock(return_value=httpx.Response(202, json={}))
+
+        client = await _make_client()
+        async with client:
+            result = await workspaces.set_collation(
+                client, ws_id, "Latin1_General_100_CI_AS_KS_WS_SC_UTF8"
+            )
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_set_collation_400_raises_fabric_error_with_portal_link() -> None:
+    """set_collation must raise FabricError mentioning the portal on a 400 response."""
+    from fabric_dw.services import workspaces
+
+    ws_id = _WORKSPACE_ID
+    url = f"https://api.fabric.microsoft.com/v1/workspaces/{ws_id}"
+
+    with respx.mock:
+        respx.patch(url).mock(
+            return_value=httpx.Response(400, json={"error": {"code": "BadRequest"}})
+        )
+
+        client = await _make_client()
+        async with client:
+            with pytest.raises(FabricError, match="portal"):
+                await workspaces.set_collation(
+                    client, ws_id, "Latin1_General_100_BIN2_UTF8"
+                )
+
+
+@pytest.mark.asyncio
+async def test_set_collation_invalid_value_raises_value_error() -> None:
+    """set_collation must raise ValueError for unsupported collation strings."""
+    from fabric_dw.services import workspaces
+
+    ws_id = _WORKSPACE_ID
+
+    client = await _make_client()
+    async with client:
+        with pytest.raises(ValueError, match="collation"):
+            await workspaces.set_collation(client, ws_id, "SQL_Latin1_General_CP1_CI_AS")
+
+
+# ---------------------------------------------------------------------------
+# SUPPORTED_COLLATIONS constant
+# ---------------------------------------------------------------------------
+
+
+def test_supported_collations_constant() -> None:
+    """SUPPORTED_COLLATIONS must be a frozenset with the two documented values."""
+    from fabric_dw.services import workspaces
+
+    assert isinstance(workspaces.SUPPORTED_COLLATIONS, frozenset)
+    assert "Latin1_General_100_BIN2_UTF8" in workspaces.SUPPORTED_COLLATIONS
+    assert "Latin1_General_100_CI_AS_KS_WS_SC_UTF8" in workspaces.SUPPORTED_COLLATIONS
+    assert len(workspaces.SUPPORTED_COLLATIONS) == 2


### PR DESCRIPTION
Closes #20

First service module. Pure async, returns Pydantic models. Best-effort PATCH for workspace default collation with portal-link fallback on 4xx.

## Test plan
- [x] list_all follows continuationUri for ≥2 pages
- [x] get returns populated Workspace
- [x] get_collation returns None when absent
- [x] get_collation returns value when present
- [x] set_collation happy path (200)
- [x] set_collation happy path (202)
- [x] set_collation 400 → FabricError with portal link
- [x] set_collation invalid value → ValueError
- [x] SUPPORTED_COLLATIONS constant verified
- [x] ruff / mypy / pytest / pre-commit green

🤖 Generated with [Claude Code](https://claude.com/claude-code)