### PR TITLE
feat(cache+resolver): 24h filesystem cache and name-or-GUID resolver

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,4 +28,5 @@ repos:
           - "respx>=0.21"
           - "freezegun>=1.5"
           - "mssql-python>=0.13"
+          - "filelock>=3.16"
         args: ["--config-file", "pyproject.toml"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "aiolimiter>=1.2",
     "tenacity>=9",
     "mssql-python>=0.13",
+    "filelock>=3.16",
 ]
 
 [project.scripts]

--- a/src/fabric_dw/cache.py
+++ b/src/fabric_dw/cache.py
@@ -13,7 +13,7 @@ JSON shape::
         },
         "items": {
             "<ws_uuid>": {
-                "<name_lower>": {
+                "<name_lower_or_guid_lower>": {
                     "id": "<guid>",
                     "kind": "<WarehouseKind>",
                     "connection_string": "<str | null>",
@@ -22,13 +22,19 @@ JSON shape::
             }
         }
     }
+
+Names are stripped of leading/trailing whitespace and lower-cased at the
+cache boundary.  GUID keys are stored lower-cased (the canonical UUID
+string form is lower-case hex with hyphens).
 """
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import os
+import tempfile
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -114,9 +120,26 @@ class LookupCache:
             return data
 
     def _write(self, data: dict[str, Any]) -> None:
-        """Atomically write *data* to the cache file, creating parent dirs as needed."""
+        """Atomically write *data* to the cache file, creating parent dirs as needed.
+
+        Uses a temp file + os.replace() so readers always see either the old or
+        the new complete file — a crash during write can never leave a truncated
+        or partially-written JSON file on disk.
+        """
         self._path.parent.mkdir(parents=True, exist_ok=True)
-        self._path.write_text(json.dumps(data, indent=None), encoding="utf-8")
+        fd, tmp_name = tempfile.mkstemp(
+            dir=self._path.parent,
+            prefix=".lookup_tmp_",
+            suffix=".json",
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                fh.write(json.dumps(data, indent=None))
+            os.replace(tmp_name, self._path)
+        except Exception:
+            with contextlib.suppress(OSError):
+                os.unlink(tmp_name)
+            raise
 
     def _is_fresh(self, fetched_at_str: str) -> bool:
         """Return True when *fetched_at_str* is within the TTL window."""
@@ -139,19 +162,22 @@ class LookupCache:
         with self._lock:
             data = self._read()
         workspaces: dict[str, Any] = data.get("workspaces", {})
-        record = workspaces.get(name.lower())
-        if record is None:
+        record = workspaces.get(name.strip().lower())
+        if not isinstance(record, dict):
             return None
         if not self._is_fresh(record.get("fetched_at", "")):
             return None
-        return WorkspaceEntry(
-            id=UUID(record["id"]),
-            fetched_at=datetime.fromisoformat(record["fetched_at"]),
-        )
+        try:
+            return WorkspaceEntry(
+                id=UUID(record["id"]),
+                fetched_at=datetime.fromisoformat(record["fetched_at"]),
+            )
+        except (KeyError, ValueError, TypeError):
+            return None
 
     def put_workspace(self, name: str, id: UUID) -> None:
         """Store a workspace name→UUID mapping with the current timestamp."""
-        key = name.lower()
+        key = name.strip().lower()
         with self._lock:
             data = self._read()
             workspaces: dict[str, Any] = data.setdefault("workspaces", {})
@@ -162,27 +188,39 @@ class LookupCache:
             self._write(data)
 
     def get_item(self, workspace_id: UUID, name: str) -> ItemEntry | None:
-        """Return a fresh cached item entry or *None* on miss/expiry."""
+        """Return a fresh cached item entry or *None* on miss/expiry.
+
+        *name* may be a display name or a GUID string; both are normalised to
+        lower-case (and stripped) before lookup so the same key is found
+        regardless of how the entry was stored.
+        """
         with self._lock:
             data = self._read()
         items: dict[str, Any] = data.get("items", {})
         ws_items: dict[str, Any] = items.get(str(workspace_id), {})
-        record = ws_items.get(name.lower())
-        if record is None:
+        record = ws_items.get(name.strip().lower())
+        if not isinstance(record, dict):
             return None
         if not self._is_fresh(record.get("fetched_at", "")):
             return None
-        conn = record.get("connection_string")
-        return ItemEntry(
-            id=UUID(record["id"]),
-            kind=WarehouseKind(record["kind"]),
-            connection_string=conn if isinstance(conn, str) else None,
-            fetched_at=datetime.fromisoformat(record["fetched_at"]),
-        )
+        try:
+            conn = record.get("connection_string")
+            return ItemEntry(
+                id=UUID(record["id"]),
+                kind=WarehouseKind(record["kind"]),
+                connection_string=conn if isinstance(conn, str) else None,
+                fetched_at=datetime.fromisoformat(record["fetched_at"]),
+            )
+        except (KeyError, ValueError, TypeError):
+            return None
 
     def put_item(self, workspace_id: UUID, name: str, entry: ItemEntry) -> None:
-        """Store an item entry under *workspace_id* / *name*."""
-        key = name.lower()
+        """Store an item entry under *workspace_id* / *name*.
+
+        *name* is stripped and lower-cased.  Pass either the display name or
+        the GUID string to store an alias entry under the GUID key.
+        """
+        key = name.strip().lower()
         with self._lock:
             data = self._read()
             items: dict[str, Any] = data.setdefault("items", {})

--- a/src/fabric_dw/cache.py
+++ b/src/fabric_dw/cache.py
@@ -1,0 +1,217 @@
+"""Persistent 24-hour filesystem name<->ID lookup cache.
+
+Stores workspace and item (Warehouse / SQLEndpoint / WarehouseSnapshot)
+name-to-UUID mappings in a single JSON file, protected by a FileLock so
+multiple concurrent CLI or MCP processes can share the cache safely.
+
+JSON shape::
+
+    {
+        "version": 1,
+        "workspaces": {
+            "<name_lower>": {"id": "<guid>", "fetched_at": "<iso8601>"}
+        },
+        "items": {
+            "<ws_uuid>": {
+                "<name_lower>": {
+                    "id": "<guid>",
+                    "kind": "<WarehouseKind>",
+                    "connection_string": "<str | null>",
+                    "fetched_at": "<iso8601>"
+                }
+            }
+        }
+    }
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+from uuid import UUID
+
+import filelock
+
+from fabric_dw.models import WarehouseKind
+
+__all__ = [
+    "ItemEntry",
+    "LookupCache",
+    "WorkspaceEntry",
+]
+
+_log = logging.getLogger(__name__)
+
+_SCHEMA_VERSION = 1
+
+
+@dataclass(frozen=True)
+class WorkspaceEntry:
+    """A cached workspace name→UUID mapping."""
+
+    id: UUID
+    fetched_at: datetime
+
+
+@dataclass(frozen=True)
+class ItemEntry:
+    """A cached item (Warehouse / SQLEndpoint / Snapshot) name→detail mapping."""
+
+    id: UUID
+    kind: WarehouseKind
+    connection_string: str | None
+    fetched_at: datetime
+
+
+class LookupCache:
+    """Persistent filesystem name<->UUID cache with TTL and file locking.
+
+    All name keys are normalised to lower-case at read and write time so
+    that lookups are case-insensitive.
+    """
+
+    def __init__(
+        self,
+        path: Path | None = None,
+        ttl: timedelta = timedelta(hours=24),
+    ) -> None:
+        if path is None:
+            xdg = os.environ.get("XDG_CACHE_HOME")
+            base = Path(xdg) if xdg else Path.home() / ".cache"
+            path = base / "fabric-dw" / "lookup.json"
+        self._path = path
+        self._ttl = ttl
+        self._lock = filelock.FileLock(str(path) + ".lock", timeout=5)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _empty() -> dict[str, Any]:
+        """Return a fresh empty cache skeleton (never share the same inner dicts)."""
+        return {"version": _SCHEMA_VERSION, "workspaces": {}, "items": {}}
+
+    def _read(self) -> dict[str, Any]:
+        """Read and parse the cache file; return empty skeleton on missing/corrupt."""
+        if not self._path.exists():
+            return self._empty()
+        try:
+            raw = self._path.read_text(encoding="utf-8")
+            data: dict[str, Any] = json.loads(raw)
+        except Exception:
+            _log.warning("Cache file %s is missing or corrupt; treating as empty", self._path)
+            return self._empty()
+        else:
+            if not isinstance(data, dict):
+                _log.warning("Cache file %s has unexpected shape; treating as empty", self._path)
+                return self._empty()
+            return data
+
+    def _write(self, data: dict[str, Any]) -> None:
+        """Atomically write *data* to the cache file, creating parent dirs as needed."""
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._path.write_text(json.dumps(data, indent=None), encoding="utf-8")
+
+    def _is_fresh(self, fetched_at_str: str) -> bool:
+        """Return True when *fetched_at_str* is within the TTL window."""
+        try:
+            fetched_at = datetime.fromisoformat(fetched_at_str)
+        except (ValueError, TypeError):
+            return False
+        now = datetime.now(tz=UTC)
+        # Handle naive datetimes by assuming UTC
+        if fetched_at.tzinfo is None:
+            fetched_at = fetched_at.replace(tzinfo=UTC)
+        return (now - fetched_at) < self._ttl
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def get_workspace(self, name: str) -> WorkspaceEntry | None:
+        """Return a fresh cached workspace entry or *None* on miss/expiry."""
+        with self._lock:
+            data = self._read()
+        workspaces: dict[str, Any] = data.get("workspaces", {})
+        record = workspaces.get(name.lower())
+        if record is None:
+            return None
+        if not self._is_fresh(record.get("fetched_at", "")):
+            return None
+        return WorkspaceEntry(
+            id=UUID(record["id"]),
+            fetched_at=datetime.fromisoformat(record["fetched_at"]),
+        )
+
+    def put_workspace(self, name: str, id: UUID) -> None:
+        """Store a workspace name→UUID mapping with the current timestamp."""
+        key = name.lower()
+        with self._lock:
+            data = self._read()
+            workspaces: dict[str, Any] = data.setdefault("workspaces", {})
+            workspaces[key] = {
+                "id": str(id),
+                "fetched_at": datetime.now(tz=UTC).isoformat(),
+            }
+            self._write(data)
+
+    def get_item(self, workspace_id: UUID, name: str) -> ItemEntry | None:
+        """Return a fresh cached item entry or *None* on miss/expiry."""
+        with self._lock:
+            data = self._read()
+        items: dict[str, Any] = data.get("items", {})
+        ws_items: dict[str, Any] = items.get(str(workspace_id), {})
+        record = ws_items.get(name.lower())
+        if record is None:
+            return None
+        if not self._is_fresh(record.get("fetched_at", "")):
+            return None
+        conn = record.get("connection_string")
+        return ItemEntry(
+            id=UUID(record["id"]),
+            kind=WarehouseKind(record["kind"]),
+            connection_string=conn if isinstance(conn, str) else None,
+            fetched_at=datetime.fromisoformat(record["fetched_at"]),
+        )
+
+    def put_item(self, workspace_id: UUID, name: str, entry: ItemEntry) -> None:
+        """Store an item entry under *workspace_id* / *name*."""
+        key = name.lower()
+        with self._lock:
+            data = self._read()
+            items: dict[str, Any] = data.setdefault("items", {})
+            ws_items: dict[str, Any] = items.setdefault(str(workspace_id), {})
+            ws_items[key] = {
+                "id": str(entry.id),
+                "kind": str(entry.kind),
+                "connection_string": entry.connection_string,
+                "fetched_at": entry.fetched_at.isoformat(),
+            }
+            self._write(data)
+
+    def clear(self) -> None:
+        """Erase all cached entries by writing an empty skeleton file."""
+        with self._lock:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            self._write(self._empty())
+
+    def invalidate_workspace(self, workspace_id: UUID) -> None:
+        """Remove *workspace_id* and all items cached under it."""
+        ws_id_str = str(workspace_id)
+        with self._lock:
+            data = self._read()
+            # Remove workspace entry whose id field matches
+            workspaces: dict[str, Any] = data.get("workspaces", {})
+            to_remove = [k for k, v in workspaces.items() if v.get("id") == ws_id_str]
+            for key in to_remove:
+                del workspaces[key]
+            # Drop all items under this workspace
+            items: dict[str, Any] = data.get("items", {})
+            items.pop(ws_id_str, None)
+            self._write(data)

--- a/src/fabric_dw/resolver.py
+++ b/src/fabric_dw/resolver.py
@@ -39,6 +39,25 @@ _KIND_MAP: dict[str, WarehouseKind] = {
     "WarehouseSnapshot": WarehouseKind.SNAPSHOT,
 }
 
+# Type-specific Fabric REST endpoints for detail fetching.
+# The generic /items/{id} endpoint does not reliably return the `properties`
+# block for all item types; using the type-specific endpoints is required to
+# get `connectionString` for Warehouse and SQLEndpoint.
+_TYPE_ENDPOINT: dict[str, str] = {
+    "Warehouse": "warehouses",
+    "SQLEndpoint": "sqlEndpoints",
+    # WarehouseSnapshot has no type-specific detail endpoint; fall back to generic.
+}
+
+
+def _odata_escape(value: str) -> str:
+    """Escape a string value for use inside an OData single-quoted literal.
+
+    Per the OData specification, a single quote inside a single-quoted string
+    must be escaped by doubling it (e.g. ``O'Brien`` → ``O''Brien``).
+    """
+    return value.replace("'", "''")
+
 
 def _connection_string_from_detail(payload: dict[str, Any], kind: WarehouseKind) -> str | None:
     """Extract the connection string from a raw item detail payload."""
@@ -68,6 +87,8 @@ class Resolver:
     async def workspace_id(self, value: str) -> UUID:
         """Resolve *value* (name or GUID) to a workspace UUID.
 
+        Leading/trailing whitespace in *value* is stripped before lookup.
+
         Args:
             value: A workspace display name or a GUID string.
 
@@ -78,6 +99,8 @@ class Resolver:
             NotFound: If no workspace matches *value*.
             FabricError: If *value* matches more than one workspace.
         """
+        value = value.strip()
+
         # 1. GUID fast-path
         if GUID_RE.match(value):
             return UUID(value)
@@ -87,12 +110,12 @@ class Resolver:
         if cached is not None:
             return cached.id
 
-        # 3. Power BI OData filter
+        # 3. Power BI OData filter — escape single quotes per OData spec
         resp = await self._http.request(
             "GET",
             HttpBase.POWERBI,
             "/groups",
-            params={"$filter": f"name eq '{value}'"},
+            params={"$filter": f"name eq '{_odata_escape(value)}'"},
         )
         body: dict[str, Any] = resp.json()
         results: list[dict[str, Any]] = body.get("value", [])
@@ -117,6 +140,8 @@ class Resolver:
     async def item(self, workspace: str, value: str) -> ItemEntry:
         """Resolve *value* (name or GUID) to an ItemEntry within *workspace*.
 
+        Leading/trailing whitespace in *value* is stripped before lookup.
+
         Args:
             workspace: Workspace name or GUID.
             value: Item display name or GUID.
@@ -127,11 +152,16 @@ class Resolver:
         Raises:
             NotFound: If the item is not found in the workspace.
         """
+        value = value.strip()
         ws_id = await self.workspace_id(workspace)
 
-        # 1. GUID fast-path: fetch detail directly
+        # 1. GUID fast-path: check cache first, then fetch detail
         if GUID_RE.match(value):
-            return await self._fetch_item_detail(ws_id, UUID(value))
+            item_uuid = UUID(value)
+            cached_item = self._cache.get_item(ws_id, value)
+            if cached_item is not None:
+                return cached_item
+            return await self._fetch_item_detail(ws_id, item_uuid)
 
         # 2. Cache hit
         cached_item = self._cache.get_item(ws_id, value)
@@ -155,22 +185,56 @@ class Resolver:
         raise NotFound(f"item {value!r} not found in workspace {ws_id}")  # noqa: TRY003
 
     async def _fetch_item_detail(self, workspace_id: UUID, item_id: UUID) -> ItemEntry:
-        """Fetch a single item's full detail, build ItemEntry, cache and return it."""
+        """Fetch a single item's full detail, build ItemEntry, cache and return it.
+
+        Resolution strategy:
+        1. GET the generic ``/items/{id}`` endpoint to discover the item's type.
+        2. If the type has a dedicated endpoint (Warehouse → /warehouses/{id},
+           SQLEndpoint → /sqlEndpoints/{id}), fetch that endpoint for the full
+           ``properties`` payload including ``connectionString``.
+        3. Store the entry under both the display name and the GUID string so
+           subsequent GUID lookups also hit the cache.
+        4. Raise ``FabricError`` for any unsupported item type.
+        """
+        # Step 1 — generic discovery
         resp = await self._http.request(
             "GET",
             HttpBase.FABRIC,
             f"/workspaces/{workspace_id}/items/{item_id}",
         )
-        payload: dict[str, Any] = resp.json()
-        item_type = str(payload.get("type", ""))
-        kind = _KIND_MAP.get(item_type, WarehouseKind.WAREHOUSE)
+        generic_payload: dict[str, Any] = resp.json()
+        item_type = str(generic_payload.get("type", ""))
+
+        if item_type not in _KIND_MAP:
+            raise FabricError(  # noqa: TRY003
+                f"item {item_id} has unsupported type {item_type!r}; "
+                "expected Warehouse, SQLEndpoint or WarehouseSnapshot"
+            )
+
+        kind = _KIND_MAP[item_type]
+
+        # Step 2 — type-specific detail fetch (if available)
+        type_segment = _TYPE_ENDPOINT.get(item_type)
+        if type_segment is not None:
+            detail_resp = await self._http.request(
+                "GET",
+                HttpBase.FABRIC,
+                f"/workspaces/{workspace_id}/{type_segment}/{item_id}",
+            )
+            payload: dict[str, Any] = detail_resp.json()
+        else:
+            payload = generic_payload
+
         conn = _connection_string_from_detail(payload, kind)
-        display_name = str(payload.get("displayName", str(item_id)))
+        display_name = str(generic_payload.get("displayName", str(item_id)))
         entry = ItemEntry(
             id=item_id,
             kind=kind,
             connection_string=conn,
             fetched_at=datetime.now(tz=UTC),
         )
+        # Store under display name for name-based lookups
         self._cache.put_item(workspace_id, display_name, entry)
+        # Store under the GUID string (lower-cased) so future GUID lookups hit cache
+        self._cache.put_item(workspace_id, str(item_id), entry)
         return entry

--- a/src/fabric_dw/resolver.py
+++ b/src/fabric_dw/resolver.py
@@ -1,0 +1,176 @@
+"""Name-or-GUID resolver for Fabric workspaces and warehouse items.
+
+Every CLI / MCP command accepts either a human-readable name or a raw GUID
+for workspace and item (warehouse / SQL endpoint / snapshot) arguments.
+
+Resolution order:
+
+1. If the value already looks like a GUID, skip the API and return immediately.
+2. If the name is in the local 24-hour cache (not expired), return from cache.
+3. Otherwise hit the API, populate the cache, and return.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import UTC, datetime
+from typing import Any
+from uuid import UUID
+
+from fabric_dw.cache import ItemEntry, LookupCache
+from fabric_dw.exceptions import FabricError, NotFound
+from fabric_dw.http_client import FabricHttpClient, HttpBase
+from fabric_dw.models import WarehouseKind
+
+__all__ = [
+    "GUID_RE",
+    "Resolver",
+]
+
+GUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
+
+_ITEM_TYPES = frozenset({"Warehouse", "SQLEndpoint", "WarehouseSnapshot"})
+_KIND_MAP: dict[str, WarehouseKind] = {
+    "Warehouse": WarehouseKind.WAREHOUSE,
+    "SQLEndpoint": WarehouseKind.SQL_ENDPOINT,
+    "WarehouseSnapshot": WarehouseKind.SNAPSHOT,
+}
+
+
+def _connection_string_from_detail(payload: dict[str, Any], kind: WarehouseKind) -> str | None:
+    """Extract the connection string from a raw item detail payload."""
+    props: dict[str, Any] = payload.get("properties") or {}
+    if kind == WarehouseKind.WAREHOUSE:
+        conn = props.get("connectionString")
+        return conn if isinstance(conn, str) else None
+    if kind == WarehouseKind.SQL_ENDPOINT:
+        sql_ep: dict[str, Any] = props.get("sqlEndpointProperties") or {}
+        conn = sql_ep.get("connectionString")
+        return conn if isinstance(conn, str) else None
+    # WarehouseSnapshot has no connection string
+    return None
+
+
+class Resolver:
+    """Resolves workspace / item names or GUIDs to UUIDs and ItemEntry objects."""
+
+    def __init__(self, http: FabricHttpClient, cache: LookupCache) -> None:
+        self._http = http
+        self._cache = cache
+
+    # ------------------------------------------------------------------
+    # workspace_id
+    # ------------------------------------------------------------------
+
+    async def workspace_id(self, value: str) -> UUID:
+        """Resolve *value* (name or GUID) to a workspace UUID.
+
+        Args:
+            value: A workspace display name or a GUID string.
+
+        Returns:
+            The workspace UUID.
+
+        Raises:
+            NotFound: If no workspace matches *value*.
+            FabricError: If *value* matches more than one workspace.
+        """
+        # 1. GUID fast-path
+        if GUID_RE.match(value):
+            return UUID(value)
+
+        # 2. Cache hit
+        cached = self._cache.get_workspace(value)
+        if cached is not None:
+            return cached.id
+
+        # 3. Power BI OData filter
+        resp = await self._http.request(
+            "GET",
+            HttpBase.POWERBI,
+            "/groups",
+            params={"$filter": f"name eq '{value}'"},
+        )
+        body: dict[str, Any] = resp.json()
+        results: list[dict[str, Any]] = body.get("value", [])
+
+        if not results:
+            raise NotFound(f"workspace {value!r} not found")  # noqa: TRY003
+
+        if len(results) > 1:
+            ids = ", ".join(str(r.get("id", "?")) for r in results)
+            raise FabricError(  # noqa: TRY003
+                f"workspace name {value!r} is ambiguous: ids = {ids}"
+            )
+
+        ws_id = UUID(str(results[0]["id"]))
+        self._cache.put_workspace(value, ws_id)
+        return ws_id
+
+    # ------------------------------------------------------------------
+    # item
+    # ------------------------------------------------------------------
+
+    async def item(self, workspace: str, value: str) -> ItemEntry:
+        """Resolve *value* (name or GUID) to an ItemEntry within *workspace*.
+
+        Args:
+            workspace: Workspace name or GUID.
+            value: Item display name or GUID.
+
+        Returns:
+            The resolved ItemEntry with ``connection_string`` populated.
+
+        Raises:
+            NotFound: If the item is not found in the workspace.
+        """
+        ws_id = await self.workspace_id(workspace)
+
+        # 1. GUID fast-path: fetch detail directly
+        if GUID_RE.match(value):
+            return await self._fetch_item_detail(ws_id, UUID(value))
+
+        # 2. Cache hit
+        cached_item = self._cache.get_item(ws_id, value)
+        if cached_item is not None:
+            return cached_item
+
+        # 3. Page through /v1/workspaces/{ws}/items, filter by kind + name
+        async for raw_item in self._http.iter_paginated(
+            HttpBase.FABRIC, f"/workspaces/{ws_id}/items"
+        ):
+            item_type = str(raw_item.get("type", ""))
+            if item_type not in _ITEM_TYPES:
+                continue
+            display_name = str(raw_item.get("displayName", ""))
+            if display_name.lower() != value.lower():
+                continue
+            # Found a name match — fetch full detail to get connection_string
+            item_id = UUID(str(raw_item["id"]))
+            return await self._fetch_item_detail(ws_id, item_id)
+
+        raise NotFound(f"item {value!r} not found in workspace {ws_id}")  # noqa: TRY003
+
+    async def _fetch_item_detail(self, workspace_id: UUID, item_id: UUID) -> ItemEntry:
+        """Fetch a single item's full detail, build ItemEntry, cache and return it."""
+        resp = await self._http.request(
+            "GET",
+            HttpBase.FABRIC,
+            f"/workspaces/{workspace_id}/items/{item_id}",
+        )
+        payload: dict[str, Any] = resp.json()
+        item_type = str(payload.get("type", ""))
+        kind = _KIND_MAP.get(item_type, WarehouseKind.WAREHOUSE)
+        conn = _connection_string_from_detail(payload, kind)
+        display_name = str(payload.get("displayName", str(item_id)))
+        entry = ItemEntry(
+            id=item_id,
+            kind=kind,
+            connection_string=conn,
+            fetched_at=datetime.now(tz=UTC),
+        )
+        self._cache.put_item(workspace_id, display_name, entry)
+        return entry

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -1,0 +1,307 @@
+"""Tests for LookupCache - written BEFORE the implementation (TDD)."""
+
+from __future__ import annotations
+
+import json
+import threading
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from uuid import UUID
+
+import pytest
+
+from fabric_dw.cache import ItemEntry, LookupCache, WorkspaceEntry
+from fabric_dw.models import WarehouseKind
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+WS_ID = UUID("a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+WS_ID_2 = UUID("b2c3d4e5-f6a7-8901-bcde-f01234567891")
+ITEM_ID = UUID("d4e5f6a7-b8c9-0123-def0-123456789abc")
+
+
+def _make_cache(tmp_path: Path, ttl: timedelta = timedelta(hours=24)) -> LookupCache:
+    return LookupCache(path=tmp_path / "lookup.json", ttl=ttl)
+
+
+def _make_item_entry(
+    item_id: UUID = ITEM_ID,
+    kind: WarehouseKind = WarehouseKind.WAREHOUSE,
+    conn: str | None = "srv.fabric.microsoft.com",
+    fetched_at: datetime | None = None,
+) -> ItemEntry:
+    return ItemEntry(
+        id=item_id,
+        kind=kind,
+        connection_string=conn,
+        fetched_at=fetched_at or datetime.now(tz=UTC),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Round-trip: workspace
+# ---------------------------------------------------------------------------
+
+
+def test_put_get_workspace_round_trip(tmp_path: Path) -> None:
+    cache = _make_cache(tmp_path)
+    cache.put_workspace("MyWorkspace", WS_ID)
+    result = cache.get_workspace("MyWorkspace")
+    assert result is not None
+    assert result.id == WS_ID
+
+
+def test_get_workspace_missing_returns_none(tmp_path: Path) -> None:
+    cache = _make_cache(tmp_path)
+    assert cache.get_workspace("NonExistent") is None
+
+
+# ---------------------------------------------------------------------------
+# Round-trip: item
+# ---------------------------------------------------------------------------
+
+
+def test_put_get_item_round_trip(tmp_path: Path) -> None:
+    cache = _make_cache(tmp_path)
+    entry = _make_item_entry()
+    cache.put_item(WS_ID, "SalesWarehouse", entry)
+    result = cache.get_item(WS_ID, "SalesWarehouse")
+    assert result is not None
+    assert result.id == ITEM_ID
+    assert result.kind == WarehouseKind.WAREHOUSE
+    assert result.connection_string == "srv.fabric.microsoft.com"
+
+
+def test_get_item_missing_returns_none(tmp_path: Path) -> None:
+    cache = _make_cache(tmp_path)
+    assert cache.get_item(WS_ID, "NonExistent") is None
+
+
+def test_put_item_no_connection_string(tmp_path: Path) -> None:
+    cache = _make_cache(tmp_path)
+    entry = _make_item_entry(conn=None, kind=WarehouseKind.SNAPSHOT)
+    cache.put_item(WS_ID, "snap", entry)
+    result = cache.get_item(WS_ID, "snap")
+    assert result is not None
+    assert result.connection_string is None
+    assert result.kind == WarehouseKind.SNAPSHOT
+
+
+# ---------------------------------------------------------------------------
+# Case-insensitive lookups
+# ---------------------------------------------------------------------------
+
+
+def test_workspace_lookup_case_insensitive(tmp_path: Path) -> None:
+    cache = _make_cache(tmp_path)
+    cache.put_workspace("MyWorkspace", WS_ID)
+    assert cache.get_workspace("myworkspace") is not None
+    assert cache.get_workspace("MYWORKSPACE") is not None
+    assert cache.get_workspace("MyWorkspace") is not None
+
+
+def test_item_lookup_case_insensitive(tmp_path: Path) -> None:
+    cache = _make_cache(tmp_path)
+    entry = _make_item_entry()
+    cache.put_item(WS_ID, "SalesWarehouse", entry)
+    assert cache.get_item(WS_ID, "saleswarehouse") is not None
+    assert cache.get_item(WS_ID, "SALESWAREHOUSE") is not None
+    assert cache.get_item(WS_ID, "SalesWarehouse") is not None
+
+
+def test_put_uppercase_get_lowercase(tmp_path: Path) -> None:
+    cache = _make_cache(tmp_path)
+    cache.put_workspace("Foo", WS_ID)
+    result = cache.get_workspace("foo")
+    assert result is not None
+    assert result.id == WS_ID
+
+
+# ---------------------------------------------------------------------------
+# TTL expiry
+# ---------------------------------------------------------------------------
+
+
+def test_workspace_expired_returns_none(tmp_path: Path) -> None:
+    cache = _make_cache(tmp_path, ttl=timedelta(hours=1))
+    past = datetime.now(tz=UTC) - timedelta(hours=2)
+    expired_entry = WorkspaceEntry(id=WS_ID, fetched_at=past)
+    # Write the entry directly with a past fetched_at via put then overwrite JSON
+    cache_file = tmp_path / "lookup.json"
+    cache.put_workspace("ws", WS_ID)
+    # Overwrite fetched_at to be in the past
+    data = json.loads(cache_file.read_text())
+    data["workspaces"]["ws"]["fetched_at"] = past.isoformat()
+    cache_file.write_text(json.dumps(data))
+    assert cache.get_workspace("ws") is None
+
+
+def test_item_expired_returns_none(tmp_path: Path) -> None:
+    cache = _make_cache(tmp_path, ttl=timedelta(hours=1))
+    past = datetime.now(tz=UTC) - timedelta(hours=2)
+    entry = _make_item_entry(fetched_at=past)
+    cache_file = tmp_path / "lookup.json"
+    cache.put_item(WS_ID, "wh", entry)
+    # Overwrite fetched_at in the JSON
+    data = json.loads(cache_file.read_text())
+    ws_key = str(WS_ID)
+    data["items"][ws_key]["wh"]["fetched_at"] = past.isoformat()
+    cache_file.write_text(json.dumps(data))
+    assert cache.get_item(WS_ID, "wh") is None
+
+
+def test_item_within_ttl_returned(tmp_path: Path) -> None:
+    cache = _make_cache(tmp_path, ttl=timedelta(hours=24))
+    entry = _make_item_entry()
+    cache.put_item(WS_ID, "wh", entry)
+    result = cache.get_item(WS_ID, "wh")
+    assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# clear()
+# ---------------------------------------------------------------------------
+
+
+def test_clear_empties_file(tmp_path: Path) -> None:
+    cache = _make_cache(tmp_path)
+    cache.put_workspace("ws", WS_ID)
+    cache.put_item(WS_ID, "item", _make_item_entry())
+    cache.clear()
+    raw = json.loads((tmp_path / "lookup.json").read_text())
+    assert raw == {"version": 1, "workspaces": {}, "items": {}}
+
+
+def test_clear_then_get_returns_none(tmp_path: Path) -> None:
+    cache = _make_cache(tmp_path)
+    cache.put_workspace("ws", WS_ID)
+    cache.clear()
+    assert cache.get_workspace("ws") is None
+
+
+# ---------------------------------------------------------------------------
+# invalidate_workspace
+# ---------------------------------------------------------------------------
+
+
+def test_invalidate_workspace_removes_entry(tmp_path: Path) -> None:
+    cache = _make_cache(tmp_path)
+    cache.put_workspace("ws", WS_ID)
+    cache.invalidate_workspace(WS_ID)
+    assert cache.get_workspace("ws") is None
+
+
+def test_invalidate_workspace_removes_items_under_it(tmp_path: Path) -> None:
+    cache = _make_cache(tmp_path)
+    cache.put_workspace("ws", WS_ID)
+    cache.put_item(WS_ID, "item1", _make_item_entry())
+    cache.invalidate_workspace(WS_ID)
+    assert cache.get_item(WS_ID, "item1") is None
+
+
+def test_invalidate_workspace_leaves_other_workspaces(tmp_path: Path) -> None:
+    cache = _make_cache(tmp_path)
+    cache.put_workspace("ws1", WS_ID)
+    cache.put_workspace("ws2", WS_ID_2)
+    cache.put_item(WS_ID_2, "item2", _make_item_entry())
+    cache.invalidate_workspace(WS_ID)
+    # ws2 and its items should still be reachable
+    assert cache.get_workspace("ws2") is not None
+    assert cache.get_item(WS_ID_2, "item2") is not None
+
+
+def test_invalidate_workspace_only_targets_matching_uuid(tmp_path: Path) -> None:
+    cache = _make_cache(tmp_path)
+    cache.put_workspace("ws1", WS_ID)
+    cache.put_workspace("ws2", WS_ID_2)
+    cache.invalidate_workspace(WS_ID)
+    # ws2 survives
+    assert cache.get_workspace("ws2") is not None
+
+
+# ---------------------------------------------------------------------------
+# Concurrent writes (file locking)
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_writes_produce_valid_json(tmp_path: Path) -> None:
+    """Two threads writing simultaneously must not corrupt the file."""
+    cache_file = tmp_path / "lookup.json"
+    errors: list[Exception] = []
+
+    def writer_a() -> None:
+        try:
+            c = LookupCache(path=cache_file)
+            for i in range(5):
+                c.put_workspace(f"ws_a_{i}", WS_ID)
+        except Exception as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    def writer_b() -> None:
+        try:
+            c = LookupCache(path=cache_file)
+            for i in range(5):
+                c.put_workspace(f"ws_b_{i}", WS_ID_2)
+        except Exception as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    t1 = threading.Thread(target=writer_a)
+    t2 = threading.Thread(target=writer_b)
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    assert not errors, f"Thread errors: {errors}"
+    # File must be valid JSON after concurrent writes
+    raw = json.loads(cache_file.read_text())
+    assert "workspaces" in raw
+    assert "items" in raw
+    # Both sets of keys must be present
+    for i in range(5):
+        assert f"ws_a_{i}" in raw["workspaces"]
+        assert f"ws_b_{i}" in raw["workspaces"]
+
+
+# ---------------------------------------------------------------------------
+# Corrupt-file resilience
+# ---------------------------------------------------------------------------
+
+
+def test_corrupt_file_get_returns_none(tmp_path: Path) -> None:
+    cache_file = tmp_path / "lookup.json"
+    cache_file.write_text("not json")
+    cache = LookupCache(path=cache_file)
+    assert cache.get_workspace("anything") is None
+    assert cache.get_item(WS_ID, "anything") is None
+
+
+def test_corrupt_file_then_put_overwrites_cleanly(tmp_path: Path) -> None:
+    cache_file = tmp_path / "lookup.json"
+    cache_file.write_text("not json")
+    cache = LookupCache(path=cache_file)
+    cache.put_workspace("ws", WS_ID)
+    # File should now be valid JSON
+    raw = json.loads(cache_file.read_text())
+    assert raw["workspaces"]["ws"]["id"] == str(WS_ID)
+
+
+# ---------------------------------------------------------------------------
+# Default path resolution (does NOT touch ~/.cache in tests)
+# ---------------------------------------------------------------------------
+
+
+def test_custom_path_used(tmp_path: Path) -> None:
+    custom = tmp_path / "subdir" / "cache.json"
+    cache = LookupCache(path=custom)
+    cache.put_workspace("ws", WS_ID)
+    assert custom.exists()
+
+
+def test_parent_directory_created_lazily(tmp_path: Path) -> None:
+    deep_path = tmp_path / "a" / "b" / "c" / "lookup.json"
+    cache = LookupCache(path=deep_path)
+    cache.put_workspace("ws", WS_ID)
+    assert deep_path.exists()

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -8,6 +8,8 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from uuid import UUID
 
+import pytest
+
 from fabric_dw.cache import ItemEntry, LookupCache
 from fabric_dw.models import WarehouseKind
 
@@ -302,3 +304,64 @@ def test_parent_directory_created_lazily(tmp_path: Path) -> None:
     cache = LookupCache(path=deep_path)
     cache.put_workspace("ws", WS_ID)
     assert deep_path.exists()
+
+
+# ---------------------------------------------------------------------------
+# XDG_CACHE_HOME path resolution (finding 5)
+# ---------------------------------------------------------------------------
+
+
+def test_xdg_cache_home_used_for_default_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """LookupCache without explicit path should place the file under XDG_CACHE_HOME."""
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    cache = LookupCache()
+    cache.put_workspace("ws", WS_ID)
+    expected = tmp_path / "fabric-dw" / "lookup.json"
+    assert expected.exists(), f"Expected cache file at {expected}"
+    assert cache.get_workspace("ws") is not None
+
+
+# ---------------------------------------------------------------------------
+# Name whitespace stripping (finding 6)
+# ---------------------------------------------------------------------------
+
+
+def test_put_workspace_strips_whitespace(tmp_path: Path) -> None:
+    """put_workspace should strip leading/trailing whitespace before storing."""
+    cache = _make_cache(tmp_path)
+    cache.put_workspace("  Foo  ", WS_ID)
+    # Lookup without whitespace should work
+    result = cache.get_workspace("foo")
+    assert result is not None
+    assert result.id == WS_ID
+
+
+def test_get_workspace_strips_whitespace(tmp_path: Path) -> None:
+    """get_workspace should strip whitespace in the query key."""
+    cache = _make_cache(tmp_path)
+    cache.put_workspace("Foo", WS_ID)
+    result = cache.get_workspace("  foo  ")
+    assert result is not None
+    assert result.id == WS_ID
+
+
+def test_put_item_strips_whitespace(tmp_path: Path) -> None:
+    """put_item should strip whitespace from name before storing."""
+    cache = _make_cache(tmp_path)
+    entry = _make_item_entry()
+    cache.put_item(WS_ID, "  SalesWarehouse  ", entry)
+    result = cache.get_item(WS_ID, "saleswarehouse")
+    assert result is not None
+    assert result.id == ITEM_ID
+
+
+def test_get_item_strips_whitespace(tmp_path: Path) -> None:
+    """get_item should strip whitespace in the query key."""
+    cache = _make_cache(tmp_path)
+    entry = _make_item_entry()
+    cache.put_item(WS_ID, "SalesWarehouse", entry)
+    result = cache.get_item(WS_ID, "  SalesWarehouse  ")
+    assert result is not None
+    assert result.id == ITEM_ID

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -8,9 +8,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from uuid import UUID
 
-import pytest
-
-from fabric_dw.cache import ItemEntry, LookupCache, WorkspaceEntry
+from fabric_dw.cache import ItemEntry, LookupCache
 from fabric_dw.models import WarehouseKind
 
 # ---------------------------------------------------------------------------
@@ -127,7 +125,6 @@ def test_put_uppercase_get_lowercase(tmp_path: Path) -> None:
 def test_workspace_expired_returns_none(tmp_path: Path) -> None:
     cache = _make_cache(tmp_path, ttl=timedelta(hours=1))
     past = datetime.now(tz=UTC) - timedelta(hours=2)
-    expired_entry = WorkspaceEntry(id=WS_ID, fetched_at=past)
     # Write the entry directly with a past fetched_at via put then overwrite JSON
     cache_file = tmp_path / "lookup.json"
     cache.put_workspace("ws", WS_ID)
@@ -161,7 +158,7 @@ def test_item_within_ttl_returned(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# clear()
+# LookupCache.clear
 # ---------------------------------------------------------------------------
 
 
@@ -236,7 +233,7 @@ def test_concurrent_writes_produce_valid_json(tmp_path: Path) -> None:
             c = LookupCache(path=cache_file)
             for i in range(5):
                 c.put_workspace(f"ws_a_{i}", WS_ID)
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             errors.append(exc)
 
     def writer_b() -> None:
@@ -244,7 +241,7 @@ def test_concurrent_writes_produce_valid_json(tmp_path: Path) -> None:
             c = LookupCache(path=cache_file)
             for i in range(5):
                 c.put_workspace(f"ws_b_{i}", WS_ID_2)
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             errors.append(exc)
 
     t1 = threading.Thread(target=writer_a)

--- a/tests/unit/test_resolver.py
+++ b/tests/unit/test_resolver.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import time
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -157,7 +156,7 @@ async def test_workspace_id_name_hits_api(tmp_path: Path) -> None:
 
 @pytest.mark.asyncio
 async def test_workspace_id_name_cached_after_first_call(tmp_path: Path) -> None:
-    resolver, client, cache = _make_resolver(tmp_path)
+    resolver, client, _cache = _make_resolver(tmp_path)
     with respx.mock:
         route = respx.get(_PBI_GROUPS_URL).mock(
             return_value=httpx.Response(

--- a/tests/unit/test_resolver.py
+++ b/tests/unit/test_resolver.py
@@ -219,10 +219,15 @@ async def test_workspace_id_multiple_matches_error_mentions_all_ids(tmp_path: Pa
 @pytest.mark.asyncio
 async def test_item_guid_fetches_detail_endpoint(tmp_path: Path) -> None:
     resolver, client, _ = _make_resolver(tmp_path)
-    payload = _warehouse_detail_payload(ITEM_GUID, WS_GUID, "SalesWarehouse")
+    generic_payload = _warehouse_detail_payload(ITEM_GUID, WS_GUID, "SalesWarehouse")
+    specific_payload = _warehouse_detail_payload(ITEM_GUID, WS_GUID, "SalesWarehouse")
     with respx.mock:
         # workspace_id will be a GUID too, so no PBI call needed
-        respx.get(_FABRIC_ITEM_URL).mock(return_value=httpx.Response(200, json=payload))
+        # Step 1: generic discovery; Step 2: warehouse-specific endpoint
+        respx.get(_FABRIC_ITEM_URL).mock(return_value=httpx.Response(200, json=generic_payload))
+        respx.get(
+            f"https://api.fabric.microsoft.com/v1/workspaces/{WS_GUID}/warehouses/{ITEM_GUID}"
+        ).mock(return_value=httpx.Response(200, json=specific_payload))
         async with client:
             result = await resolver.item(WS_GUID, ITEM_GUID)
     assert result.id == ITEM_UUID
@@ -233,9 +238,13 @@ async def test_item_guid_fetches_detail_endpoint(tmp_path: Path) -> None:
 @pytest.mark.asyncio
 async def test_item_guid_sql_endpoint_connection_string(tmp_path: Path) -> None:
     resolver, client, _ = _make_resolver(tmp_path)
-    payload = _sql_endpoint_detail_payload(ITEM_GUID, WS_GUID, "MySQLEndpoint")
+    generic_payload = _sql_endpoint_detail_payload(ITEM_GUID, WS_GUID, "MySQLEndpoint")
+    specific_payload = _sql_endpoint_detail_payload(ITEM_GUID, WS_GUID, "MySQLEndpoint")
     with respx.mock:
-        respx.get(_FABRIC_ITEM_URL).mock(return_value=httpx.Response(200, json=payload))
+        respx.get(_FABRIC_ITEM_URL).mock(return_value=httpx.Response(200, json=generic_payload))
+        respx.get(
+            f"https://api.fabric.microsoft.com/v1/workspaces/{WS_GUID}/sqlEndpoints/{ITEM_GUID}"
+        ).mock(return_value=httpx.Response(200, json=specific_payload))
         async with client:
             result = await resolver.item(WS_GUID, ITEM_GUID)
     assert result.kind == WarehouseKind.SQL_ENDPOINT
@@ -253,10 +262,14 @@ async def test_item_name_pages_items_and_fetches_detail(tmp_path: Path) -> None:
     list_payload = _items_list_payload(
         _warehouse_list_item(ITEM_GUID, "SalesWarehouse"),
     )
-    detail_payload = _warehouse_detail_payload(ITEM_GUID, WS_GUID, "SalesWarehouse")
+    generic_payload = _warehouse_detail_payload(ITEM_GUID, WS_GUID, "SalesWarehouse")
+    specific_payload = _warehouse_detail_payload(ITEM_GUID, WS_GUID, "SalesWarehouse")
     with respx.mock:
         respx.get(_FABRIC_ITEMS_URL).mock(return_value=httpx.Response(200, json=list_payload))
-        respx.get(_FABRIC_ITEM_URL).mock(return_value=httpx.Response(200, json=detail_payload))
+        respx.get(_FABRIC_ITEM_URL).mock(return_value=httpx.Response(200, json=generic_payload))
+        respx.get(
+            f"https://api.fabric.microsoft.com/v1/workspaces/{WS_GUID}/warehouses/{ITEM_GUID}"
+        ).mock(return_value=httpx.Response(200, json=specific_payload))
         async with client:
             result = await resolver.item(WS_GUID, "SalesWarehouse")
     assert result.id == ITEM_UUID
@@ -270,10 +283,14 @@ async def test_item_name_case_insensitive_match(tmp_path: Path) -> None:
     list_payload = _items_list_payload(
         _warehouse_list_item(ITEM_GUID, "SalesWarehouse"),
     )
-    detail_payload = _warehouse_detail_payload(ITEM_GUID, WS_GUID, "SalesWarehouse")
+    generic_payload = _warehouse_detail_payload(ITEM_GUID, WS_GUID, "SalesWarehouse")
+    specific_payload = _warehouse_detail_payload(ITEM_GUID, WS_GUID, "SalesWarehouse")
     with respx.mock:
         respx.get(_FABRIC_ITEMS_URL).mock(return_value=httpx.Response(200, json=list_payload))
-        respx.get(_FABRIC_ITEM_URL).mock(return_value=httpx.Response(200, json=detail_payload))
+        respx.get(_FABRIC_ITEM_URL).mock(return_value=httpx.Response(200, json=generic_payload))
+        respx.get(
+            f"https://api.fabric.microsoft.com/v1/workspaces/{WS_GUID}/warehouses/{ITEM_GUID}"
+        ).mock(return_value=httpx.Response(200, json=specific_payload))
         async with client:
             result = await resolver.item(WS_GUID, "saleswarehouse")
     assert result.id == ITEM_UUID
@@ -299,14 +316,18 @@ async def test_item_name_cached_after_first_call(tmp_path: Path) -> None:
     list_payload = _items_list_payload(
         _warehouse_list_item(ITEM_GUID, "SalesWarehouse"),
     )
-    detail_payload = _warehouse_detail_payload(ITEM_GUID, WS_GUID, "SalesWarehouse")
+    generic_payload = _warehouse_detail_payload(ITEM_GUID, WS_GUID, "SalesWarehouse")
+    specific_payload = _warehouse_detail_payload(ITEM_GUID, WS_GUID, "SalesWarehouse")
     with respx.mock:
         list_route = respx.get(_FABRIC_ITEMS_URL).mock(
             return_value=httpx.Response(200, json=list_payload)
         )
         detail_route = respx.get(_FABRIC_ITEM_URL).mock(
-            return_value=httpx.Response(200, json=detail_payload)
+            return_value=httpx.Response(200, json=generic_payload)
         )
+        respx.get(
+            f"https://api.fabric.microsoft.com/v1/workspaces/{WS_GUID}/warehouses/{ITEM_GUID}"
+        ).mock(return_value=httpx.Response(200, json=specific_payload))
         async with client:
             first = await resolver.item(WS_GUID, "SalesWarehouse")
             # Second call should hit cache
@@ -322,10 +343,14 @@ async def test_item_name_sql_endpoint(tmp_path: Path) -> None:
     list_payload = _items_list_payload(
         _sql_endpoint_list_item(ITEM_GUID, "MySQLEndpoint"),
     )
-    detail_payload = _sql_endpoint_detail_payload(ITEM_GUID, WS_GUID, "MySQLEndpoint")
+    generic_payload = _sql_endpoint_detail_payload(ITEM_GUID, WS_GUID, "MySQLEndpoint")
+    specific_payload = _sql_endpoint_detail_payload(ITEM_GUID, WS_GUID, "MySQLEndpoint")
     with respx.mock:
         respx.get(_FABRIC_ITEMS_URL).mock(return_value=httpx.Response(200, json=list_payload))
-        respx.get(_FABRIC_ITEM_URL).mock(return_value=httpx.Response(200, json=detail_payload))
+        respx.get(_FABRIC_ITEM_URL).mock(return_value=httpx.Response(200, json=generic_payload))
+        respx.get(
+            f"https://api.fabric.microsoft.com/v1/workspaces/{WS_GUID}/sqlEndpoints/{ITEM_GUID}"
+        ).mock(return_value=httpx.Response(200, json=specific_payload))
         async with client:
             result = await resolver.item(WS_GUID, "MySQLEndpoint")
     assert result.kind == WarehouseKind.SQL_ENDPOINT
@@ -339,7 +364,8 @@ async def test_item_name_workspace_resolved_first(tmp_path: Path) -> None:
     list_payload = _items_list_payload(
         _warehouse_list_item(ITEM_GUID, "SalesWarehouse"),
     )
-    detail_payload = _warehouse_detail_payload(ITEM_GUID, WS_GUID, "SalesWarehouse")
+    generic_payload = _warehouse_detail_payload(ITEM_GUID, WS_GUID, "SalesWarehouse")
+    specific_payload = _warehouse_detail_payload(ITEM_GUID, WS_GUID, "SalesWarehouse")
     with respx.mock:
         respx.get(_PBI_GROUPS_URL).mock(
             return_value=httpx.Response(
@@ -347,7 +373,177 @@ async def test_item_name_workspace_resolved_first(tmp_path: Path) -> None:
             )
         )
         respx.get(_FABRIC_ITEMS_URL).mock(return_value=httpx.Response(200, json=list_payload))
-        respx.get(_FABRIC_ITEM_URL).mock(return_value=httpx.Response(200, json=detail_payload))
+        respx.get(_FABRIC_ITEM_URL).mock(return_value=httpx.Response(200, json=generic_payload))
+        respx.get(
+            f"https://api.fabric.microsoft.com/v1/workspaces/{WS_GUID}/warehouses/{ITEM_GUID}"
+        ).mock(return_value=httpx.Response(200, json=specific_payload))
         async with client:
             result = await resolver.item("AnalyticsWorkspace", "SalesWarehouse")
     assert result.id == ITEM_UUID
+
+
+# ---------------------------------------------------------------------------
+# Finding 1: OData single-quote escaping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_workspace_id_name_with_single_quote_escaped(tmp_path: Path) -> None:
+    """Workspace names containing a single quote are properly OData-escaped."""
+    resolver, client, _ = _make_resolver(tmp_path)
+    name_with_apostrophe = "O'Brien Analytics"
+    with respx.mock:
+        route = respx.get(_PBI_GROUPS_URL).mock(
+            return_value=httpx.Response(
+                200, json=_pbi_group_response(WS_GUID, name_with_apostrophe)
+            )
+        )
+        async with client:
+            result = await resolver.workspace_id(name_with_apostrophe)
+    assert result == WS_UUID
+    # Verify the escaped value was sent in the OData filter.
+    # The query is percent-encoded, so single quotes appear as %27.
+    called_request = route.calls[0].request
+    # Decoded form: "O''Brien" → percent-encoded: "O%27%27Brien"
+    assert "O%27%27Brien" in called_request.url.query.decode()
+
+
+@pytest.mark.asyncio
+async def test_workspace_id_name_with_double_apostrophe_escaped(tmp_path: Path) -> None:
+    """Names with consecutive apostrophes are double-escaped correctly."""
+    resolver, client, _ = _make_resolver(tmp_path)
+    # "It's here" has one apostrophe → should escape to "It''s here"
+    name = "It's here"
+    with respx.mock:
+        respx.get(_PBI_GROUPS_URL).mock(
+            return_value=httpx.Response(200, json=_pbi_group_response(WS_GUID, name))
+        )
+        async with client:
+            result = await resolver.workspace_id(name)
+    assert result == WS_UUID
+
+
+# ---------------------------------------------------------------------------
+# Finding 2: GUID item cache — second call within TTL hits cache, not API
+# ---------------------------------------------------------------------------
+
+# Type-specific endpoint URLs for finding 3 tests
+_FABRIC_WAREHOUSE_URL = (
+    f"https://api.fabric.microsoft.com/v1/workspaces/{WS_GUID}/warehouses/{ITEM_GUID}"
+)
+_FABRIC_SQL_ENDPOINT_URL = (
+    f"https://api.fabric.microsoft.com/v1/workspaces/{WS_GUID}/sqlEndpoints/{ITEM_GUID}"
+)
+
+
+@pytest.mark.asyncio
+async def test_item_guid_second_call_hits_cache_not_api(tmp_path: Path) -> None:
+    """GUID input: first call hits API, second call within TTL hits cache (no extra HTTP)."""
+    resolver, client, _ = _make_resolver(tmp_path)
+    generic_payload = _warehouse_detail_payload(ITEM_GUID, WS_GUID, "SalesWarehouse")
+    specific_payload = _warehouse_detail_payload(ITEM_GUID, WS_GUID, "SalesWarehouse")
+    with respx.mock:
+        generic_route = respx.get(_FABRIC_ITEM_URL).mock(
+            return_value=httpx.Response(200, json=generic_payload)
+        )
+        respx.get(_FABRIC_WAREHOUSE_URL).mock(
+            return_value=httpx.Response(200, json=specific_payload)
+        )
+        async with client:
+            first = await resolver.item(WS_GUID, ITEM_GUID)
+            # Second call with same GUID — should use cache, not call API again
+            second = await resolver.item(WS_GUID, ITEM_GUID)
+        # Generic discovery endpoint called exactly once
+        assert generic_route.call_count == 1
+    assert first.id == second.id == ITEM_UUID
+
+
+# ---------------------------------------------------------------------------
+# Finding 3: type-specific endpoint dispatch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_item_guid_warehouse_uses_type_specific_endpoint(tmp_path: Path) -> None:
+    """Warehouse items: detail fetch uses /warehouses/{id}, not generic /items/{id}."""
+    resolver, client, _ = _make_resolver(tmp_path)
+    generic_payload = _warehouse_detail_payload(ITEM_GUID, WS_GUID, "SalesWarehouse")
+    specific_payload = _warehouse_detail_payload(ITEM_GUID, WS_GUID, "SalesWarehouse")
+    with respx.mock:
+        generic_route = respx.get(_FABRIC_ITEM_URL).mock(
+            return_value=httpx.Response(200, json=generic_payload)
+        )
+        warehouse_route = respx.get(_FABRIC_WAREHOUSE_URL).mock(
+            return_value=httpx.Response(200, json=specific_payload)
+        )
+        async with client:
+            result = await resolver.item(WS_GUID, ITEM_GUID)
+    assert result.kind == WarehouseKind.WAREHOUSE
+    assert result.connection_string == "mywarehouse.datawarehouse.fabric.microsoft.com"
+    assert generic_route.call_count == 1
+    assert warehouse_route.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_item_guid_sql_endpoint_uses_type_specific_endpoint(tmp_path: Path) -> None:
+    """SQLEndpoint items: detail fetch uses /sqlEndpoints/{id}, not generic /items/{id}."""
+    resolver, client, _ = _make_resolver(tmp_path)
+    generic_payload = _sql_endpoint_detail_payload(ITEM_GUID, WS_GUID, "MySQLEndpoint")
+    specific_payload = _sql_endpoint_detail_payload(ITEM_GUID, WS_GUID, "MySQLEndpoint")
+    with respx.mock:
+        generic_route = respx.get(_FABRIC_ITEM_URL).mock(
+            return_value=httpx.Response(200, json=generic_payload)
+        )
+        sql_route = respx.get(_FABRIC_SQL_ENDPOINT_URL).mock(
+            return_value=httpx.Response(200, json=specific_payload)
+        )
+        async with client:
+            result = await resolver.item(WS_GUID, ITEM_GUID)
+    assert result.kind == WarehouseKind.SQL_ENDPOINT
+    assert result.connection_string == "mysqlep.datawarehouse.fabric.microsoft.com"
+    assert generic_route.call_count == 1
+    assert sql_route.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_item_guid_snapshot_uses_generic_endpoint_only(tmp_path: Path) -> None:
+    """WarehouseSnapshot: no type-specific endpoint; uses generic /items/{id} only."""
+    resolver, client, _ = _make_resolver(tmp_path)
+    snapshot_payload: dict[str, object] = {
+        "id": ITEM_GUID,
+        "displayName": "MySnapshot",
+        "type": "WarehouseSnapshot",
+        "workspaceId": WS_GUID,
+    }
+    with respx.mock:
+        generic_route = respx.get(_FABRIC_ITEM_URL).mock(
+            return_value=httpx.Response(200, json=snapshot_payload)
+        )
+        async with client:
+            result = await resolver.item(WS_GUID, ITEM_GUID)
+    assert result.kind == WarehouseKind.SNAPSHOT
+    assert result.connection_string is None
+    # Generic endpoint called exactly once; no additional type-specific call
+    assert generic_route.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Finding 4: unknown item type raises FabricError
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_item_guid_unknown_type_raises_fabric_error(tmp_path: Path) -> None:
+    """An unsupported item type (e.g. Lakehouse) must raise FabricError, not silently default."""
+    resolver, client, _ = _make_resolver(tmp_path)
+    lakehouse_payload: dict[str, object] = {
+        "id": ITEM_GUID,
+        "displayName": "MyLakehouse",
+        "type": "Lakehouse",
+        "workspaceId": WS_GUID,
+    }
+    with respx.mock:
+        respx.get(_FABRIC_ITEM_URL).mock(return_value=httpx.Response(200, json=lakehouse_payload))
+        async with client:
+            with pytest.raises(FabricError, match="unsupported type"):
+                await resolver.item(WS_GUID, ITEM_GUID)

--- a/tests/unit/test_resolver.py
+++ b/tests/unit/test_resolver.py
@@ -1,0 +1,354 @@
+"""Tests for Resolver - written BEFORE the implementation (TDD)."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from unittest.mock import MagicMock
+from uuid import UUID
+
+import httpx
+import pytest
+import respx
+from azure.core.credentials import AccessToken, TokenCredential
+
+from fabric_dw.cache import LookupCache
+from fabric_dw.exceptions import FabricError, NotFound
+from fabric_dw.http_client import FabricHttpClient
+from fabric_dw.models import WarehouseKind
+from fabric_dw.resolver import Resolver
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+_FAKE_TOKEN = AccessToken(token="fake-token", expires_on=int(time.time()) + 3600)  # noqa: S106
+
+WS_GUID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+WS_UUID = UUID(WS_GUID)
+WS_GUID_2 = "b2c3d4e5-f6a7-8901-bcde-f01234567891"
+
+ITEM_GUID = "d4e5f6a7-b8c9-0123-def0-123456789abc"
+ITEM_UUID = UUID(ITEM_GUID)
+
+# Power BI OData group endpoint
+_PBI_GROUPS_URL = "https://api.powerbi.com/v1.0/myorg/groups"
+
+# Fabric items listing endpoint
+_FABRIC_ITEMS_URL = f"https://api.fabric.microsoft.com/v1/workspaces/{WS_GUID}/items"
+_FABRIC_ITEM_URL = f"https://api.fabric.microsoft.com/v1/workspaces/{WS_GUID}/items/{ITEM_GUID}"
+
+
+def _make_credential() -> TokenCredential:
+    cred = MagicMock(spec=TokenCredential)
+    cred.get_token = MagicMock(return_value=_FAKE_TOKEN)
+    return cred
+
+
+def _make_resolver(tmp_path: Path) -> tuple[Resolver, FabricHttpClient, LookupCache]:
+    cache = LookupCache(path=tmp_path / "lookup.json")
+    client = FabricHttpClient(credential=_make_credential(), rps=100)
+    resolver = Resolver(http=client, cache=cache)
+    return resolver, client, cache
+
+
+def _pbi_group_response(ws_id: str, name: str) -> dict[str, object]:
+    return {"value": [{"id": ws_id, "name": name, "type": "Workspace"}]}
+
+
+def _pbi_empty_response() -> dict[str, object]:
+    return {"value": []}
+
+
+def _pbi_multi_response() -> dict[str, object]:
+    return {
+        "value": [
+            {"id": WS_GUID, "name": "Ambiguous", "type": "Workspace"},
+            {"id": WS_GUID_2, "name": "Ambiguous", "type": "Workspace"},
+        ]
+    }
+
+
+def _warehouse_detail_payload(item_id: str, ws_id: str, name: str) -> dict[str, object]:
+    return {
+        "id": item_id,
+        "displayName": name,
+        "type": "Warehouse",
+        "workspaceId": ws_id,
+        "properties": {
+            "connectionString": "mywarehouse.datawarehouse.fabric.microsoft.com",
+        },
+    }
+
+
+def _sql_endpoint_detail_payload(item_id: str, ws_id: str, name: str) -> dict[str, object]:
+    return {
+        "id": item_id,
+        "displayName": name,
+        "type": "SQLEndpoint",
+        "workspaceId": ws_id,
+        "properties": {
+            "sqlEndpointProperties": {
+                "connectionString": "mysqlep.datawarehouse.fabric.microsoft.com",
+                "id": "deadbeef-dead-beef-dead-beef00000001",
+                "provisioningStatus": "Success",
+            }
+        },
+    }
+
+
+def _items_list_payload(*items: dict[str, object]) -> dict[str, object]:
+    return {"value": list(items), "continuationUri": None}
+
+
+def _warehouse_list_item(item_id: str, name: str) -> dict[str, object]:
+    return {
+        "id": item_id,
+        "displayName": name,
+        "type": "Warehouse",
+        "workspaceId": WS_GUID,
+    }
+
+
+def _sql_endpoint_list_item(item_id: str, name: str) -> dict[str, object]:
+    return {
+        "id": item_id,
+        "displayName": name,
+        "type": "SQLEndpoint",
+        "workspaceId": WS_GUID,
+    }
+
+
+# ---------------------------------------------------------------------------
+# workspace_id: GUID input bypasses API
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_workspace_id_guid_no_api_call(tmp_path: Path) -> None:
+    resolver, client, _ = _make_resolver(tmp_path)
+    with respx.mock:
+        async with client:
+            result = await resolver.workspace_id(WS_GUID)
+        # No routes should have been called
+        assert result == WS_UUID
+        assert len(respx.calls) == 0
+
+
+# ---------------------------------------------------------------------------
+# workspace_id: name input hits Power BI OData
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_workspace_id_name_hits_api(tmp_path: Path) -> None:
+    resolver, client, _ = _make_resolver(tmp_path)
+    with respx.mock:
+        respx.get(_PBI_GROUPS_URL).mock(
+            return_value=httpx.Response(
+                200, json=_pbi_group_response(WS_GUID, "AnalyticsWorkspace")
+            )
+        )
+        async with client:
+            result = await resolver.workspace_id("AnalyticsWorkspace")
+    assert result == WS_UUID
+
+
+@pytest.mark.asyncio
+async def test_workspace_id_name_cached_after_first_call(tmp_path: Path) -> None:
+    resolver, client, cache = _make_resolver(tmp_path)
+    with respx.mock:
+        route = respx.get(_PBI_GROUPS_URL).mock(
+            return_value=httpx.Response(
+                200, json=_pbi_group_response(WS_GUID, "AnalyticsWorkspace")
+            )
+        )
+        async with client:
+            first = await resolver.workspace_id("AnalyticsWorkspace")
+            # Second call should hit cache (not API)
+            second = await resolver.workspace_id("AnalyticsWorkspace")
+        # Only one HTTP call should have been made
+        assert route.call_count == 1
+    assert first == second == WS_UUID
+
+
+@pytest.mark.asyncio
+async def test_workspace_id_name_not_found(tmp_path: Path) -> None:
+    resolver, client, _ = _make_resolver(tmp_path)
+    with respx.mock:
+        respx.get(_PBI_GROUPS_URL).mock(
+            return_value=httpx.Response(200, json=_pbi_empty_response())
+        )
+        async with client:
+            with pytest.raises(NotFound, match="workspace"):
+                await resolver.workspace_id("NonExistentWorkspace")
+
+
+@pytest.mark.asyncio
+async def test_workspace_id_name_multiple_matches_raises_fabric_error(tmp_path: Path) -> None:
+    resolver, client, _ = _make_resolver(tmp_path)
+    with respx.mock:
+        respx.get(_PBI_GROUPS_URL).mock(
+            return_value=httpx.Response(200, json=_pbi_multi_response())
+        )
+        async with client:
+            with pytest.raises(FabricError, match=WS_GUID):
+                await resolver.workspace_id("Ambiguous")
+
+
+@pytest.mark.asyncio
+async def test_workspace_id_multiple_matches_error_mentions_all_ids(tmp_path: Path) -> None:
+    resolver, client, _ = _make_resolver(tmp_path)
+    with respx.mock:
+        respx.get(_PBI_GROUPS_URL).mock(
+            return_value=httpx.Response(200, json=_pbi_multi_response())
+        )
+        async with client:
+            with pytest.raises(FabricError) as exc_info:
+                await resolver.workspace_id("Ambiguous")
+    err_msg = str(exc_info.value)
+    assert WS_GUID in err_msg
+    assert WS_GUID_2 in err_msg
+
+
+# ---------------------------------------------------------------------------
+# item: GUID input fetches detail directly
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_item_guid_fetches_detail_endpoint(tmp_path: Path) -> None:
+    resolver, client, _ = _make_resolver(tmp_path)
+    payload = _warehouse_detail_payload(ITEM_GUID, WS_GUID, "SalesWarehouse")
+    with respx.mock:
+        # workspace_id will be a GUID too, so no PBI call needed
+        respx.get(_FABRIC_ITEM_URL).mock(return_value=httpx.Response(200, json=payload))
+        async with client:
+            result = await resolver.item(WS_GUID, ITEM_GUID)
+    assert result.id == ITEM_UUID
+    assert result.kind == WarehouseKind.WAREHOUSE
+    assert result.connection_string == "mywarehouse.datawarehouse.fabric.microsoft.com"
+
+
+@pytest.mark.asyncio
+async def test_item_guid_sql_endpoint_connection_string(tmp_path: Path) -> None:
+    resolver, client, _ = _make_resolver(tmp_path)
+    payload = _sql_endpoint_detail_payload(ITEM_GUID, WS_GUID, "MySQLEndpoint")
+    with respx.mock:
+        respx.get(_FABRIC_ITEM_URL).mock(return_value=httpx.Response(200, json=payload))
+        async with client:
+            result = await resolver.item(WS_GUID, ITEM_GUID)
+    assert result.kind == WarehouseKind.SQL_ENDPOINT
+    assert result.connection_string == "mysqlep.datawarehouse.fabric.microsoft.com"
+
+
+# ---------------------------------------------------------------------------
+# item: name input pages through /items
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_item_name_pages_items_and_fetches_detail(tmp_path: Path) -> None:
+    resolver, client, _ = _make_resolver(tmp_path)
+    list_payload = _items_list_payload(
+        _warehouse_list_item(ITEM_GUID, "SalesWarehouse"),
+    )
+    detail_payload = _warehouse_detail_payload(ITEM_GUID, WS_GUID, "SalesWarehouse")
+    with respx.mock:
+        respx.get(_FABRIC_ITEMS_URL).mock(return_value=httpx.Response(200, json=list_payload))
+        respx.get(_FABRIC_ITEM_URL).mock(return_value=httpx.Response(200, json=detail_payload))
+        async with client:
+            result = await resolver.item(WS_GUID, "SalesWarehouse")
+    assert result.id == ITEM_UUID
+    assert result.kind == WarehouseKind.WAREHOUSE
+    assert result.connection_string == "mywarehouse.datawarehouse.fabric.microsoft.com"
+
+
+@pytest.mark.asyncio
+async def test_item_name_case_insensitive_match(tmp_path: Path) -> None:
+    resolver, client, _ = _make_resolver(tmp_path)
+    list_payload = _items_list_payload(
+        _warehouse_list_item(ITEM_GUID, "SalesWarehouse"),
+    )
+    detail_payload = _warehouse_detail_payload(ITEM_GUID, WS_GUID, "SalesWarehouse")
+    with respx.mock:
+        respx.get(_FABRIC_ITEMS_URL).mock(return_value=httpx.Response(200, json=list_payload))
+        respx.get(_FABRIC_ITEM_URL).mock(return_value=httpx.Response(200, json=detail_payload))
+        async with client:
+            result = await resolver.item(WS_GUID, "saleswarehouse")
+    assert result.id == ITEM_UUID
+
+
+@pytest.mark.asyncio
+async def test_item_name_not_found(tmp_path: Path) -> None:
+    resolver, client, _ = _make_resolver(tmp_path)
+    # Return a list with no matching items
+    list_payload = _items_list_payload(
+        _warehouse_list_item(ITEM_GUID, "OtherWarehouse"),
+    )
+    with respx.mock:
+        respx.get(_FABRIC_ITEMS_URL).mock(return_value=httpx.Response(200, json=list_payload))
+        async with client:
+            with pytest.raises(NotFound):
+                await resolver.item(WS_GUID, "NonExistentWarehouse")
+
+
+@pytest.mark.asyncio
+async def test_item_name_cached_after_first_call(tmp_path: Path) -> None:
+    resolver, client, _ = _make_resolver(tmp_path)
+    list_payload = _items_list_payload(
+        _warehouse_list_item(ITEM_GUID, "SalesWarehouse"),
+    )
+    detail_payload = _warehouse_detail_payload(ITEM_GUID, WS_GUID, "SalesWarehouse")
+    with respx.mock:
+        list_route = respx.get(_FABRIC_ITEMS_URL).mock(
+            return_value=httpx.Response(200, json=list_payload)
+        )
+        detail_route = respx.get(_FABRIC_ITEM_URL).mock(
+            return_value=httpx.Response(200, json=detail_payload)
+        )
+        async with client:
+            first = await resolver.item(WS_GUID, "SalesWarehouse")
+            # Second call should hit cache
+            second = await resolver.item(WS_GUID, "SalesWarehouse")
+        assert list_route.call_count == 1
+        assert detail_route.call_count == 1
+    assert first.id == second.id
+
+
+@pytest.mark.asyncio
+async def test_item_name_sql_endpoint(tmp_path: Path) -> None:
+    resolver, client, _ = _make_resolver(tmp_path)
+    list_payload = _items_list_payload(
+        _sql_endpoint_list_item(ITEM_GUID, "MySQLEndpoint"),
+    )
+    detail_payload = _sql_endpoint_detail_payload(ITEM_GUID, WS_GUID, "MySQLEndpoint")
+    with respx.mock:
+        respx.get(_FABRIC_ITEMS_URL).mock(return_value=httpx.Response(200, json=list_payload))
+        respx.get(_FABRIC_ITEM_URL).mock(return_value=httpx.Response(200, json=detail_payload))
+        async with client:
+            result = await resolver.item(WS_GUID, "MySQLEndpoint")
+    assert result.kind == WarehouseKind.SQL_ENDPOINT
+    assert result.connection_string == "mysqlep.datawarehouse.fabric.microsoft.com"
+
+
+@pytest.mark.asyncio
+async def test_item_name_workspace_resolved_first(tmp_path: Path) -> None:
+    """When workspace is given as a name, it gets resolved via PBI first."""
+    resolver, client, _ = _make_resolver(tmp_path)
+    list_payload = _items_list_payload(
+        _warehouse_list_item(ITEM_GUID, "SalesWarehouse"),
+    )
+    detail_payload = _warehouse_detail_payload(ITEM_GUID, WS_GUID, "SalesWarehouse")
+    with respx.mock:
+        respx.get(_PBI_GROUPS_URL).mock(
+            return_value=httpx.Response(
+                200, json=_pbi_group_response(WS_GUID, "AnalyticsWorkspace")
+            )
+        )
+        respx.get(_FABRIC_ITEMS_URL).mock(return_value=httpx.Response(200, json=list_payload))
+        respx.get(_FABRIC_ITEM_URL).mock(return_value=httpx.Response(200, json=detail_payload))
+        async with client:
+            result = await resolver.item("AnalyticsWorkspace", "SalesWarehouse")
+    assert result.id == ITEM_UUID

--- a/uv.lock
+++ b/uv.lock
@@ -505,6 +505,7 @@ source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },
     { name = "azure-identity" },
+    { name = "filelock" },
     { name = "httpx", extra = ["http2"] },
     { name = "mssql-python" },
     { name = "pydantic" },
@@ -535,6 +536,7 @@ requires-dist = [
     { name = "aiolimiter", specifier = ">=1.2" },
     { name = "anyio", extras = ["trio"], marker = "extra == 'dev'" },
     { name = "azure-identity", specifier = ">=1.19" },
+    { name = "filelock", specifier = ">=3.16" },
     { name = "freezegun", marker = "extra == 'dev'", specifier = ">=1.5" },
     { name = "httpx", extras = ["http2"], specifier = ">=0.27" },
     { name = "mssql-python", specifier = ">=0.13" },


### PR DESCRIPTION
Closes #12

Adds the persistent 24h name→ID cache (shared between CLI and MCP) and the resolver that lets every command accept either a workspace/warehouse name OR a GUID.

## Test plan
- [x] Cache round-trip, TTL, clear, invalidate_workspace, case-insensitive, concurrent writes, corrupt-file resilience
- [x] Resolver: GUID short-circuits; name hits Power BI OData; subsequent calls hit cache; zero/multiple matches mapped to NotFound/FabricError
- [x] Resolver.item picks correct connection string for Warehouse vs SQLEndpoint
- [x] ruff / mypy / pytest / pre-commit all green
- [x] CI all 4 checks green after push

🤖 Generated with [Claude Code](https://claude.com/claude-code)