### PR TITLE
docs: fill site_url, Umami UUID and README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ fabric-dw --help
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for dev setup, branch flow, and how to run tests locally.
 
-📖 Docs: [CHANGE-ME.debruyn.dev](https://CHANGE-ME.debruyn.dev) (or run `uv run --only-group docs zensical serve` locally).
+📖 Docs: [fdw.debruyn.dev](https://fdw.debruyn.dev) (or run `uv run --only-group docs zensical serve` locally).
 
 ## Security
 

--- a/overrides/partials/integrations/analytics/custom.html
+++ b/overrides/partials/integrations/analytics/custom.html
@@ -1,10 +1,7 @@
-{# Umami analytics — fill in the data-website-id after creating the Umami site
-   for this project. Replace the empty string with the real UUID (UMAMI_SITE_UUID).
-   Until then this block silently no-ops (the script tag still loads but
-   website-id is empty, so Umami's loader skips reporting). #}
+{# Umami analytics — Umami site UUID for fdw.debruyn.dev #}
 <script defer
   src="/t.js"
-  data-website-id=""
+  data-website-id="4dcf1bea-f51e-4d5c-9ae6-d8dc03e52655"
   data-host-url="https://umami.debruyn.dev"
   data-do-not-track="true">
 </script>

--- a/zensical.toml
+++ b/zensical.toml
@@ -2,7 +2,7 @@
 site_dir = "docs_build/site"
 site_name = "fabric-dw-mcp-cli"
 site_description = "Python CLI + MCP server for administering Microsoft Fabric Data Warehouses and SQL Analytics Endpoints."
-site_url = "https://CHANGE-ME.debruyn.dev"
+site_url = "https://fdw.debruyn.dev"
 site_author = "Sam Debruyn"
 repo_url = "https://github.com/sdebruyn/fabric-dw-mcp-cli"
 repo_name = "sdebruyn/fabric-dw-mcp-cli"


### PR DESCRIPTION
Closes #32

Replaces the three placeholders that PR #19 left after the user provisioned the Cloudflare Pages site `fdw.debruyn.dev` and registered the Umami site UUID.

## Test plan
- [x] zensical build succeeds; built HTML contains fdw.debruyn.dev and the Umami UUID
- [x] pre-commit run --all-files green