### PR TITLE
feat(services/snapshots): CRUD + roll timestamp

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ select = [
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["ANN", "S101", "PLR2004"]
+"src/fabric_dw/services/**" = ["PLR0913"]
 
 [tool.ruff.format]
 

--- a/src/fabric_dw/services/snapshots.py
+++ b/src/fabric_dw/services/snapshots.py
@@ -1,0 +1,306 @@
+"""Service functions for Microsoft Fabric Warehouse Snapshot operations."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from fabric_dw.exceptions import PermissionDenied
+from fabric_dw.http_client import FabricHttpClient, HttpBase
+from fabric_dw.models import WarehouseSnapshot
+from fabric_dw.sql_client import FabricSqlClient, SqlTarget
+
+__all__ = [
+    "create",
+    "delete",
+    "list",
+    "rename",
+    "roll_timestamp",
+]
+
+# Characters / sequences that could enable SQL injection in a bracket-quoted name.
+_FORBIDDEN_NAME_CHARS = ("]", ";", "\\", "'", '"', "--", "\n")
+
+
+def _validate_snapshot_name(name: str, param: str = "name") -> None:
+    """Raise ValueError if *name* is empty/whitespace or contains forbidden characters."""
+    if not name or not name.strip():
+        msg = f"{param} must be a non-empty string"
+        raise ValueError(msg)
+    for char in _FORBIDDEN_NAME_CHARS:
+        if char in name:
+            msg = f"snapshot_name contains forbidden character or sequence: {char!r}"
+            raise ValueError(msg)
+
+
+def _snapshot_from_detail(detail: dict[str, object]) -> WarehouseSnapshot:
+    """Build a WarehouseSnapshot from a raw item-detail API response.
+
+    The detail endpoint returns ``creationPayload.parentWarehouseId`` and
+    ``creationPayload.snapshotDateTime`` nested under ``creationPayload``.
+    We flatten them to match the ``WarehouseSnapshot`` model's field aliases.
+    """
+    creation_payload: dict[str, object] = detail.get("creationPayload") or {}  # type: ignore[assignment]
+    flat: dict[str, object] = {
+        "id": detail.get("id"),
+        "displayName": detail.get("displayName"),
+        "parentWarehouseId": creation_payload.get("parentWarehouseId"),
+        "snapshotDateTime": creation_payload.get("snapshotDateTime"),
+    }
+    return WarehouseSnapshot.model_validate(flat)
+
+
+async def list(  # noqa: A001
+    http: FabricHttpClient,
+    workspace_id: UUID,
+    parent_warehouse_id: UUID,
+) -> list[WarehouseSnapshot]:
+    """Return all snapshots belonging to *parent_warehouse_id* in *workspace_id*.
+
+    Pages through ``GET /workspaces/{ws}/items``, filters to items with
+    ``type=WarehouseSnapshot``, fetches each item's detail to read
+    ``creationPayload.parentWarehouseId``, and keeps only those that match
+    *parent_warehouse_id*.
+
+    Args:
+        http: An authenticated :class:`~fabric_dw.http_client.FabricHttpClient`.
+        workspace_id: The Fabric workspace UUID.
+        parent_warehouse_id: Only snapshots whose parent matches this UUID are returned.
+
+    Returns:
+        A list of :class:`~fabric_dw.models.WarehouseSnapshot` instances.
+    """
+    snapshot_ids: list[UUID] = []
+
+    async for item in http.iter_paginated(HttpBase.FABRIC, f"/workspaces/{workspace_id}/items"):
+        if item.get("type") == "WarehouseSnapshot":
+            raw_id = item.get("id")
+            if raw_id:
+                snapshot_ids.append(UUID(str(raw_id)))
+
+    results: list[WarehouseSnapshot] = []
+    for snap_id in snapshot_ids:
+        resp = await http.request(
+            "GET", HttpBase.FABRIC, f"/workspaces/{workspace_id}/items/{snap_id}"
+        )
+        detail: dict[str, object] = resp.json()
+        creation_payload: dict[str, object] = detail.get("creationPayload") or {}  # type: ignore[assignment]
+        raw_parent_id = creation_payload.get("parentWarehouseId")
+        if raw_parent_id and UUID(str(raw_parent_id)) == parent_warehouse_id:
+            results.append(_snapshot_from_detail(detail))
+
+    return results
+
+
+async def create(
+    http: FabricHttpClient,
+    workspace_id: UUID,
+    parent_warehouse_id: UUID,
+    name: str,
+    *,
+    description: str | None = None,
+    snapshot_dt: datetime | None = None,
+) -> WarehouseSnapshot:
+    """Create a new warehouse snapshot via a long-running operation (LRO).
+
+    Args:
+        http: An authenticated :class:`~fabric_dw.http_client.FabricHttpClient`.
+        workspace_id: The Fabric workspace UUID.
+        parent_warehouse_id: The UUID of the warehouse to snapshot.
+        name: Display name for the new snapshot (non-empty trimmed string).
+        description: Optional description for the snapshot.
+        snapshot_dt: Optional point-in-time datetime for the snapshot. If
+            ``None``, the service captures the current state.
+
+    Returns:
+        The newly-created :class:`~fabric_dw.models.WarehouseSnapshot`.
+
+    Raises:
+        ValueError: If *name* is empty or whitespace.
+    """
+    if not name or not name.strip():
+        msg = "name must be a non-empty string"
+        raise ValueError(msg)
+
+    creation_payload: dict[str, object] = {
+        "parentWarehouseId": str(parent_warehouse_id),
+    }
+    if snapshot_dt is not None:
+        creation_payload["snapshotDateTime"] = snapshot_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    body: dict[str, object] = {
+        "type": "WarehouseSnapshot",
+        "displayName": name,
+        "creationPayload": creation_payload,
+    }
+    if description is not None:
+        body["description"] = description
+
+    resp = await http.request(
+        "POST",
+        HttpBase.FABRIC,
+        f"/workspaces/{workspace_id}/items",
+        json=body,
+    )
+
+    location: str = resp.headers.get("Location", "")
+    operation_result = await http.poll_operation(location)
+
+    # Extract the new item's ID from the operation result or resourceId field
+    resource_id_raw = operation_result.get("resourceId")
+    if resource_id_raw:
+        new_snap_id = UUID(str(resource_id_raw))
+    else:
+        # Fall back: parse from the Location header path
+        # Location is like .../operations/op-id, but createdItemId may be in result
+        created_item = operation_result.get("createdItemId") or operation_result.get("itemId")
+        if created_item:
+            new_snap_id = UUID(str(created_item))
+        else:
+            # Last resort: try to find the new snapshot in the items list
+            # (This shouldn't happen in normal usage, but provides a safe fallback)
+            msg = f"Cannot determine new snapshot ID from LRO result: {operation_result}"
+            raise ValueError(msg)
+
+    detail_resp = await http.request(
+        "GET",
+        HttpBase.FABRIC,
+        f"/workspaces/{workspace_id}/items/{new_snap_id}",
+    )
+    return _snapshot_from_detail(detail_resp.json())
+
+
+async def rename(
+    http: FabricHttpClient,
+    workspace_id: UUID,
+    snapshot_id: UUID,
+    *,
+    new_name: str,
+    description: str | None = None,
+) -> WarehouseSnapshot:
+    """Rename (and optionally re-describe) an existing warehouse snapshot.
+
+    Microsoft Fabric requires re-sending ``creationPayload`` on rename.
+    This function first GETs the snapshot to obtain the current
+    ``parentWarehouseId``, then PATCHes with the full required body.
+
+    Args:
+        http: An authenticated :class:`~fabric_dw.http_client.FabricHttpClient`.
+        workspace_id: The Fabric workspace UUID.
+        snapshot_id: The UUID of the snapshot to rename.
+        new_name: The new display name (non-empty trimmed string).
+        description: Optional description to set on the snapshot.
+
+    Returns:
+        The updated :class:`~fabric_dw.models.WarehouseSnapshot`.
+
+    Raises:
+        ValueError: If *new_name* is empty or whitespace.
+    """
+    if not new_name or not new_name.strip():
+        msg = "new_name must be a non-empty string"
+        raise ValueError(msg)
+
+    # Fetch the current snapshot to get parentWarehouseId
+    detail_resp = await http.request(
+        "GET",
+        HttpBase.FABRIC,
+        f"/workspaces/{workspace_id}/items/{snapshot_id}",
+    )
+    detail: dict[str, object] = detail_resp.json()
+    creation_payload: dict[str, object] = detail.get("creationPayload") or {}  # type: ignore[assignment]
+    parent_wh_id = creation_payload.get("parentWarehouseId")
+
+    patch_body: dict[str, object] = {
+        "type": "WarehouseSnapshot",
+        "displayName": new_name,
+        "creationPayload": {
+            "parentWarehouseId": parent_wh_id,
+        },
+    }
+    if description is not None:
+        patch_body["description"] = description
+
+    await http.request(
+        "PATCH",
+        HttpBase.FABRIC,
+        f"/workspaces/{workspace_id}/items/{snapshot_id}",
+        json=patch_body,
+    )
+
+    # GET the updated snapshot to return fresh state
+    updated_resp = await http.request(
+        "GET",
+        HttpBase.FABRIC,
+        f"/workspaces/{workspace_id}/items/{snapshot_id}",
+    )
+    return _snapshot_from_detail(updated_resp.json())
+
+
+async def delete(
+    http: FabricHttpClient,
+    workspace_id: UUID,
+    snapshot_id: UUID,
+) -> None:
+    """Delete a warehouse snapshot.
+
+    Args:
+        http: An authenticated :class:`~fabric_dw.http_client.FabricHttpClient`.
+        workspace_id: The Fabric workspace UUID.
+        snapshot_id: The UUID of the snapshot to delete.
+
+    Raises:
+        NotFound: If the snapshot does not exist (HTTP 404).
+    """
+    await http.request(
+        "DELETE",
+        HttpBase.FABRIC,
+        f"/workspaces/{workspace_id}/items/{snapshot_id}",
+    )
+
+
+async def roll_timestamp(
+    sql: FabricSqlClient,
+    parent_target: SqlTarget,
+    snapshot_name: str,
+    new_dt: datetime | None = None,
+) -> None:
+    """Advance or reset the timestamp of a warehouse snapshot via T-SQL.
+
+    Executes ``ALTER DATABASE [{snapshot_name}] SET TIMESTAMP = …`` against
+    *parent_target*.
+
+    Args:
+        sql: A :class:`~fabric_dw.sql_client.FabricSqlClient` instance.
+        parent_target: The :class:`~fabric_dw.sql_client.SqlTarget` for the
+            parent warehouse (the snapshot lives in the same SQL endpoint).
+        snapshot_name: The name of the snapshot database. Must not contain
+            ``]``, ``;``, ``\\``, ``'``, ``"``, ``--``, or newlines.
+        new_dt: If supplied, the snapshot is rolled to this UTC datetime,
+            formatted as ``YYYY-MM-DDTHH:MM:SS.SS``. If ``None``, the
+            snapshot rolls forward to ``CURRENT_TIMESTAMP``.
+
+    Raises:
+        ValueError: If *snapshot_name* contains any forbidden character.
+        PermissionDenied: If the driver reports a permission failure.
+    """
+    _validate_snapshot_name(snapshot_name, param="snapshot_name")
+
+    if new_dt is None:
+        sql_str = f"ALTER DATABASE [{snapshot_name}] SET TIMESTAMP = CURRENT_TIMESTAMP;"
+    else:
+        formatted = new_dt.strftime("%Y-%m-%dT%H:%M:%S.00")
+        sql_str = f"ALTER DATABASE [{snapshot_name}] SET TIMESTAMP = '{formatted}';"
+
+    try:
+        await sql.execute_nonquery(parent_target, sql_str)
+    except PermissionDenied:
+        raise
+    except Exception as exc:
+        msg = str(exc).lower()
+        if any(
+            fragment in msg
+            for fragment in ("permission", "access denied", "unauthorized", "403", "forbidden")
+        ):
+            raise PermissionDenied(str(exc)) from exc
+        raise

--- a/src/fabric_dw/services/snapshots.py
+++ b/src/fabric_dw/services/snapshots.py
@@ -13,7 +13,7 @@ from fabric_dw.sql_client import FabricSqlClient, SqlTarget
 __all__ = [
     "create",
     "delete",
-    "list",
+    "list_snapshots",
     "rename",
     "roll_timestamp",
 ]
@@ -50,7 +50,7 @@ def _snapshot_from_detail(detail: dict[str, object]) -> WarehouseSnapshot:
     return WarehouseSnapshot.model_validate(flat)
 
 
-async def list(  # noqa: A001
+async def list_snapshots(
     http: FabricHttpClient,
     workspace_id: UUID,
     parent_warehouse_id: UUID,

--- a/tests/fixtures/api_payloads.py
+++ b/tests/fixtures/api_payloads.py
@@ -99,3 +99,37 @@ WORKSPACE_GET_PAYLOAD = """{
   "type": "Workspace",
   "capacityId": "cafebabe-dead-beef-cafe-babe12345678"
 }"""
+
+# Items list page containing two WarehouseSnapshot items + one non-snapshot item.
+# Used in snapshot service tests to verify pagination and type-filtering.
+ITEMS_LIST_WITH_SNAPSHOTS_PAYLOAD = """{
+  "value": [
+    {
+      "id": "f6a7b8c9-d0e1-2345-f012-34567890abcd",
+      "displayName": "SalesWarehouse_Snapshot_20240315",
+      "type": "WarehouseSnapshot",
+      "workspaceId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+    },
+    {
+      "id": "22222222-3333-4444-5555-666666666666",
+      "displayName": "OtherWarehouse_Snapshot",
+      "type": "WarehouseSnapshot",
+      "workspaceId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+    },
+    {
+      "id": "99999999-9999-9999-9999-999999999999",
+      "displayName": "SomeLakehouse",
+      "type": "Lakehouse",
+      "workspaceId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+    }
+  ]
+}"""
+
+# LRO polling response for a WarehouseSnapshot creation operation (Succeeded).
+WAREHOUSE_SNAPSHOT_CREATE_OPERATION_PAYLOAD = """{
+  "status": "Succeeded",
+  "createdTimeUtc": "2024-03-15T10:00:00Z",
+  "lastUpdatedTimeUtc": "2024-03-15T10:01:00Z",
+  "percentComplete": 100,
+  "error": null
+}"""

--- a/tests/unit/services/test_snapshots.py
+++ b/tests/unit/services/test_snapshots.py
@@ -1,0 +1,574 @@
+"""Tests for services.snapshots — written BEFORE implementation (TDD)."""
+
+from __future__ import annotations
+
+import json
+import time
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID
+
+import httpx
+import pytest
+import respx
+from azure.core.credentials import AccessToken, TokenCredential
+
+from fabric_dw.exceptions import NotFound, PermissionDenied
+from fabric_dw.http_client import FabricHttpClient, HttpBase
+from fabric_dw.models import WarehouseSnapshot
+from fabric_dw.sql_client import FabricSqlClient, SqlTarget
+from fabric_dw.services import snapshots
+
+# ---------------------------------------------------------------------------
+# Constants & Fixtures
+# ---------------------------------------------------------------------------
+
+_WS_ID = UUID("a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+_PARENT_WH_ID = UUID("d4e5f6a7-b8c9-0123-def0-123456789abc")
+_SNAP_ID = UUID("f6a7b8c9-d0e1-2345-f012-34567890abcd")
+_OTHER_WH_ID = UUID("11111111-2222-3333-4444-555555555555")
+
+_FAKE_TOKEN = AccessToken(token="fake-token", expires_on=int(time.time()) + 3600)  # noqa: S106
+
+_BASE_URL = "https://api.fabric.microsoft.com/v1"
+_ITEMS_URL = f"{_BASE_URL}/workspaces/{_WS_ID}/items"
+_SNAP_DETAIL_URL = f"{_BASE_URL}/workspaces/{_WS_ID}/items/{_SNAP_ID}"
+
+# A single snapshot whose parent matches _PARENT_WH_ID
+WAREHOUSE_SNAPSHOT_PAYLOAD: dict[str, Any] = {
+    "id": str(_SNAP_ID),
+    "displayName": "SalesWarehouse_Snapshot_20240315",
+    "parentWarehouseId": str(_PARENT_WH_ID),
+    "snapshotDateTime": "2024-03-15T08:00:00Z",
+}
+
+# Detail payload as returned by GET /workspaces/{ws}/items/{id}
+WAREHOUSE_SNAPSHOT_DETAIL_PAYLOAD: dict[str, Any] = {
+    "id": str(_SNAP_ID),
+    "displayName": "SalesWarehouse_Snapshot_20240315",
+    "type": "WarehouseSnapshot",
+    "workspaceId": str(_WS_ID),
+    "creationPayload": {
+        "parentWarehouseId": str(_PARENT_WH_ID),
+        "snapshotDateTime": "2024-03-15T08:00:00Z",
+    },
+}
+
+# Snapshot whose parent does NOT match _PARENT_WH_ID (should be filtered out)
+_OTHER_SNAP_ID = UUID("22222222-3333-4444-5555-666666666666")
+WAREHOUSE_SNAPSHOT_OTHER_PARENT_DETAIL_PAYLOAD: dict[str, Any] = {
+    "id": str(_OTHER_SNAP_ID),
+    "displayName": "OtherWarehouse_Snapshot",
+    "type": "WarehouseSnapshot",
+    "workspaceId": str(_WS_ID),
+    "creationPayload": {
+        "parentWarehouseId": str(_OTHER_WH_ID),
+        "snapshotDateTime": "2024-03-15T09:00:00Z",
+    },
+}
+
+# Items list page 1 (two WarehouseSnapshot items + a non-snapshot item)
+ITEMS_LIST_WITH_SNAPSHOTS_PAYLOAD: dict[str, Any] = {
+    "value": [
+        {
+            "id": str(_SNAP_ID),
+            "displayName": "SalesWarehouse_Snapshot_20240315",
+            "type": "WarehouseSnapshot",
+            "workspaceId": str(_WS_ID),
+        },
+        {
+            "id": str(_OTHER_SNAP_ID),
+            "displayName": "OtherWarehouse_Snapshot",
+            "type": "WarehouseSnapshot",
+            "workspaceId": str(_WS_ID),
+        },
+        {
+            "id": "99999999-9999-9999-9999-999999999999",
+            "displayName": "SomeLakehouse",
+            "type": "Lakehouse",
+            "workspaceId": str(_WS_ID),
+        },
+    ]
+}
+
+# Create operation LRO payload (202 response with Location header, then polling)
+WAREHOUSE_SNAPSHOT_CREATE_OPERATION_PAYLOAD: dict[str, Any] = {
+    "status": "Succeeded",
+    "createdTimeUtc": "2024-03-15T10:00:00Z",
+    "lastUpdatedTimeUtc": "2024-03-15T10:01:00Z",
+    "percentComplete": 100,
+    "error": None,
+}
+
+# The newly created snapshot returned after LRO + GET
+WAREHOUSE_SNAPSHOT_CREATED_PAYLOAD: dict[str, Any] = {
+    "id": str(_SNAP_ID),
+    "displayName": "NewSnapshot",
+    "type": "WarehouseSnapshot",
+    "workspaceId": str(_WS_ID),
+    "creationPayload": {
+        "parentWarehouseId": str(_PARENT_WH_ID),
+        "snapshotDateTime": "2024-03-15T08:00:00Z",
+    },
+}
+
+_LRO_LOCATION = f"{_BASE_URL}/operations/op-abc-123"
+
+
+def _make_credential() -> TokenCredential:
+    cred = MagicMock(spec=TokenCredential)
+    cred.get_token = MagicMock(return_value=_FAKE_TOKEN)
+    return cred
+
+
+def _make_sql_client() -> FabricSqlClient:
+    """Return a mock FabricSqlClient with execute_nonquery stubbed."""
+    client = MagicMock(spec=FabricSqlClient)
+    client.execute_nonquery = AsyncMock(return_value=0)
+    return client
+
+
+def _make_sql_target() -> SqlTarget:
+    return SqlTarget(
+        workspace_id=str(_WS_ID),
+        database="SalesWarehouse",
+        connection_string="Server=saleswarehouse.datawarehouse.fabric.microsoft.com",
+    )
+
+
+# ---------------------------------------------------------------------------
+# list
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+async def test_list_pages_through_and_filters_by_parent() -> None:
+    """list should page through items, filter WarehouseSnapshot, fetch detail, and match parent."""
+    # Page 1 returns two snapshots + one non-snapshot
+    # Page 2 has no items (end of pagination)
+    page2_url = f"{_BASE_URL}/workspaces/{_WS_ID}/items?continuationToken=page2"
+
+    page1_payload = dict(ITEMS_LIST_WITH_SNAPSHOTS_PAYLOAD)
+    page1_payload["continuationUri"] = page2_url
+
+    page2_payload: dict[str, Any] = {"value": []}
+
+    respx.get(_ITEMS_URL).mock(return_value=httpx.Response(200, json=page1_payload))
+    respx.get(page2_url).mock(return_value=httpx.Response(200, json=page2_payload))
+
+    # Detail for matching snapshot
+    respx.get(f"{_ITEMS_URL}/{_SNAP_ID}").mock(
+        return_value=httpx.Response(200, json=WAREHOUSE_SNAPSHOT_DETAIL_PAYLOAD)
+    )
+    # Detail for non-matching snapshot
+    respx.get(f"{_ITEMS_URL}/{_OTHER_SNAP_ID}").mock(
+        return_value=httpx.Response(200, json=WAREHOUSE_SNAPSHOT_OTHER_PARENT_DETAIL_PAYLOAD)
+    )
+
+    async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
+        result = await snapshots.list(http, _WS_ID, _PARENT_WH_ID)
+
+    assert len(result) == 1
+    snap = result[0]
+    assert isinstance(snap, WarehouseSnapshot)
+    assert snap.id == _SNAP_ID
+    assert snap.parent_warehouse_id == _PARENT_WH_ID
+    assert snap.name == "SalesWarehouse_Snapshot_20240315"
+
+
+@respx.mock
+async def test_list_returns_empty_when_no_snapshots() -> None:
+    """list returns empty list if no items match type=WarehouseSnapshot."""
+    payload: dict[str, Any] = {
+        "value": [
+            {
+                "id": "99999999-9999-9999-9999-999999999999",
+                "displayName": "SomeLakehouse",
+                "type": "Lakehouse",
+                "workspaceId": str(_WS_ID),
+            }
+        ]
+    }
+    respx.get(_ITEMS_URL).mock(return_value=httpx.Response(200, json=payload))
+
+    async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
+        result = await snapshots.list(http, _WS_ID, _PARENT_WH_ID)
+
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# create
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+async def test_create_happy_path_with_snapshot_dt() -> None:
+    """create should POST with snapshotDateTime, poll LRO, GET result, return WarehouseSnapshot."""
+    snap_dt = datetime(2024, 3, 15, 8, 0, 0, tzinfo=timezone.utc)
+
+    # POST → 202 with Location header
+    respx.post(_ITEMS_URL).mock(
+        return_value=httpx.Response(202, headers={"Location": _LRO_LOCATION})
+    )
+    # LRO poll → Succeeded
+    respx.get(_LRO_LOCATION).mock(
+        return_value=httpx.Response(200, json=WAREHOUSE_SNAPSHOT_CREATE_OPERATION_PAYLOAD)
+    )
+    # GET newly created snapshot
+    respx.get(f"{_ITEMS_URL}/{_SNAP_ID}").mock(
+        return_value=httpx.Response(200, json=WAREHOUSE_SNAPSHOT_DETAIL_PAYLOAD)
+    )
+
+    async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
+        # Patch poll_operation to avoid sleeping
+        with patch.object(http, "poll_operation", new_callable=AsyncMock) as mock_poll:
+            mock_poll.return_value = {"status": "Succeeded", "resourceId": str(_SNAP_ID)}
+
+            result = await snapshots.create(
+                http,
+                _WS_ID,
+                _PARENT_WH_ID,
+                "NewSnapshot",
+                description="A new snapshot",
+                snapshot_dt=snap_dt,
+            )
+
+    assert isinstance(result, WarehouseSnapshot)
+    assert result.parent_warehouse_id == _PARENT_WH_ID
+
+
+@respx.mock
+async def test_create_happy_path_without_snapshot_dt() -> None:
+    """create without snapshot_dt should omit snapshotDateTime from body."""
+    import json as _json
+
+    captured_requests: list[Any] = []
+
+    def _capture(request: Any) -> httpx.Response:
+        captured_requests.append(request)
+        return httpx.Response(202, headers={"Location": _LRO_LOCATION})
+
+    respx.post(_ITEMS_URL).mock(side_effect=_capture)
+    respx.get(f"{_ITEMS_URL}/{_SNAP_ID}").mock(
+        return_value=httpx.Response(200, json=WAREHOUSE_SNAPSHOT_DETAIL_PAYLOAD)
+    )
+
+    async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
+        with patch.object(http, "poll_operation", new_callable=AsyncMock) as mock_poll:
+            mock_poll.return_value = {"status": "Succeeded", "resourceId": str(_SNAP_ID)}
+
+            result = await snapshots.create(
+                http,
+                _WS_ID,
+                _PARENT_WH_ID,
+                "NewSnapshot",
+            )
+
+    assert isinstance(result, WarehouseSnapshot)
+    # Verify snapshotDateTime not sent
+    assert len(captured_requests) == 1
+    body = _json.loads(captured_requests[0].content)
+    assert "snapshotDateTime" not in body.get("creationPayload", {})
+
+
+@respx.mock
+async def test_create_empty_name_raises_value_error() -> None:
+    """create with an empty or whitespace name should raise ValueError."""
+    async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
+        with pytest.raises(ValueError, match="name"):
+            await snapshots.create(http, _WS_ID, _PARENT_WH_ID, "")
+
+        with pytest.raises(ValueError, match="name"):
+            await snapshots.create(http, _WS_ID, _PARENT_WH_ID, "   ")
+
+
+@respx.mock
+async def test_create_posts_correct_body_with_snapshot_dt() -> None:
+    """create should send type, displayName, description, and creationPayload."""
+    import json as _json
+
+    snap_dt = datetime(2024, 3, 15, 8, 0, 0, tzinfo=timezone.utc)
+    captured_requests: list[Any] = []
+
+    def _capture(request: Any) -> httpx.Response:
+        captured_requests.append(request)
+        return httpx.Response(202, headers={"Location": _LRO_LOCATION})
+
+    respx.post(_ITEMS_URL).mock(side_effect=_capture)
+    respx.get(f"{_ITEMS_URL}/{_SNAP_ID}").mock(
+        return_value=httpx.Response(200, json=WAREHOUSE_SNAPSHOT_DETAIL_PAYLOAD)
+    )
+
+    async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
+        with patch.object(http, "poll_operation", new_callable=AsyncMock) as mock_poll:
+            mock_poll.return_value = {"status": "Succeeded", "resourceId": str(_SNAP_ID)}
+
+            await snapshots.create(
+                http,
+                _WS_ID,
+                _PARENT_WH_ID,
+                "MySnap",
+                description="desc",
+                snapshot_dt=snap_dt,
+            )
+
+    body = _json.loads(captured_requests[0].content)
+    assert body["type"] == "WarehouseSnapshot"
+    assert body["displayName"] == "MySnap"
+    assert body["description"] == "desc"
+    assert body["creationPayload"]["parentWarehouseId"] == str(_PARENT_WH_ID)
+    assert body["creationPayload"]["snapshotDateTime"] == "2024-03-15T08:00:00Z"
+
+
+@respx.mock
+async def test_create_polls_lro_and_fetches_result() -> None:
+    """create should call poll_operation with the Location header URL."""
+    respx.post(_ITEMS_URL).mock(
+        return_value=httpx.Response(202, headers={"Location": _LRO_LOCATION})
+    )
+    respx.get(f"{_ITEMS_URL}/{_SNAP_ID}").mock(
+        return_value=httpx.Response(200, json=WAREHOUSE_SNAPSHOT_DETAIL_PAYLOAD)
+    )
+
+    async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
+        with patch.object(http, "poll_operation", new_callable=AsyncMock) as mock_poll:
+            mock_poll.return_value = {"status": "Succeeded", "resourceId": str(_SNAP_ID)}
+
+            await snapshots.create(http, _WS_ID, _PARENT_WH_ID, "MySnap")
+
+        mock_poll.assert_awaited_once_with(_LRO_LOCATION)
+
+
+# ---------------------------------------------------------------------------
+# rename
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+async def test_rename_fetches_existing_then_patches_with_all_fields() -> None:
+    """rename should GET the snapshot first, then PATCH with all required fields."""
+    import json as _json
+
+    patch_url = f"{_ITEMS_URL}/{_SNAP_ID}"
+
+    captured_patch_requests: list[Any] = []
+
+    def _patch_capture(request: Any) -> httpx.Response:
+        captured_patch_requests.append(request)
+        return httpx.Response(200, json=WAREHOUSE_SNAPSHOT_DETAIL_PAYLOAD)
+
+    # GET to fetch existing snapshot detail
+    get_route = respx.get(patch_url).mock(
+        return_value=httpx.Response(200, json=WAREHOUSE_SNAPSHOT_DETAIL_PAYLOAD)
+    )
+    # PATCH for rename
+    patch_route = respx.patch(patch_url).mock(side_effect=_patch_capture)
+    # GET after PATCH for updated result
+    # (get_route is already set to return the detail; use it again)
+
+    async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
+        result = await snapshots.rename(
+            http,
+            _WS_ID,
+            _SNAP_ID,
+            new_name="RenamedSnapshot",
+            description="new desc",
+        )
+
+    assert isinstance(result, WarehouseSnapshot)
+
+    # Verify PATCH was called
+    assert len(captured_patch_requests) == 1
+    body = _json.loads(captured_patch_requests[0].content)
+    assert body["type"] == "WarehouseSnapshot"
+    assert body["displayName"] == "RenamedSnapshot"
+    assert body["description"] == "new desc"
+    assert "creationPayload" in body
+    assert body["creationPayload"]["parentWarehouseId"] == str(_PARENT_WH_ID)
+
+
+@respx.mock
+async def test_rename_empty_new_name_raises_value_error() -> None:
+    """rename with an empty new_name should raise ValueError."""
+    async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
+        with pytest.raises(ValueError, match="new_name"):
+            await snapshots.rename(http, _WS_ID, _SNAP_ID, new_name="")
+
+        with pytest.raises(ValueError, match="new_name"):
+            await snapshots.rename(http, _WS_ID, _SNAP_ID, new_name="   ")
+
+
+@respx.mock
+async def test_rename_returns_updated_warehouse_snapshot() -> None:
+    """rename should return the refreshed WarehouseSnapshot after PATCH."""
+    updated_detail = dict(WAREHOUSE_SNAPSHOT_DETAIL_PAYLOAD)
+    updated_detail = {**updated_detail, "displayName": "RenamedSnapshot"}
+    updated_detail["creationPayload"] = dict(updated_detail["creationPayload"])
+
+    snap_url = f"{_ITEMS_URL}/{_SNAP_ID}"
+
+    call_count = 0
+
+    def _get_side_effect(request: Any) -> httpx.Response:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return httpx.Response(200, json=WAREHOUSE_SNAPSHOT_DETAIL_PAYLOAD)
+        return httpx.Response(200, json=updated_detail)
+
+    respx.get(snap_url).mock(side_effect=_get_side_effect)
+    respx.patch(snap_url).mock(return_value=httpx.Response(200, json={}))
+
+    async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
+        result = await snapshots.rename(
+            http,
+            _WS_ID,
+            _SNAP_ID,
+            new_name="RenamedSnapshot",
+        )
+
+    assert isinstance(result, WarehouseSnapshot)
+    assert result.name == "RenamedSnapshot"
+
+
+# ---------------------------------------------------------------------------
+# delete
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+async def test_delete_204_returns_none() -> None:
+    """delete should issue DELETE and return None on 204."""
+    respx.delete(f"{_ITEMS_URL}/{_SNAP_ID}").mock(return_value=httpx.Response(204))
+
+    async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
+        result = await snapshots.delete(http, _WS_ID, _SNAP_ID)
+
+    assert result is None
+
+
+@respx.mock
+async def test_delete_404_raises_not_found() -> None:
+    """delete should propagate NotFound on 404."""
+    respx.delete(f"{_ITEMS_URL}/{_SNAP_ID}").mock(return_value=httpx.Response(404))
+
+    async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
+        with pytest.raises(NotFound):
+            await snapshots.delete(http, _WS_ID, _SNAP_ID)
+
+
+# ---------------------------------------------------------------------------
+# roll_timestamp
+# ---------------------------------------------------------------------------
+
+
+async def test_roll_timestamp_without_new_dt_uses_current_timestamp() -> None:
+    """roll_timestamp with new_dt=None should use CURRENT_TIMESTAMP."""
+    sql_client = _make_sql_client()
+    target = _make_sql_target()
+
+    await snapshots.roll_timestamp(sql_client, target, "MySnapshot")
+
+    sql_client.execute_nonquery.assert_awaited_once()
+    call_args = sql_client.execute_nonquery.call_args
+    sql_str = call_args[0][1]
+    assert "ALTER DATABASE [MySnapshot] SET TIMESTAMP = CURRENT_TIMESTAMP;" in sql_str
+
+
+async def test_roll_timestamp_with_new_dt_formats_correctly() -> None:
+    """roll_timestamp with a datetime should format as YYYY-MM-DDTHH:MM:SS.SS."""
+    sql_client = _make_sql_client()
+    target = _make_sql_target()
+    new_dt = datetime(2024, 3, 15, 8, 30, 45, tzinfo=timezone.utc)
+
+    await snapshots.roll_timestamp(sql_client, target, "MySnapshot", new_dt=new_dt)
+
+    call_args = sql_client.execute_nonquery.call_args
+    sql_str = call_args[0][1]
+    assert "ALTER DATABASE [MySnapshot] SET TIMESTAMP = '2024-03-15T08:30:45.00';" in sql_str
+
+
+async def test_roll_timestamp_name_injection_bracket() -> None:
+    """snapshot_name containing ] should raise ValueError."""
+    sql_client = _make_sql_client()
+    target = _make_sql_target()
+
+    with pytest.raises(ValueError, match="snapshot_name"):
+        await snapshots.roll_timestamp(sql_client, target, "My]Snapshot")
+
+
+async def test_roll_timestamp_name_injection_semicolon() -> None:
+    """snapshot_name containing ; should raise ValueError."""
+    sql_client = _make_sql_client()
+    target = _make_sql_target()
+
+    with pytest.raises(ValueError, match="snapshot_name"):
+        await snapshots.roll_timestamp(sql_client, target, "My;Snapshot")
+
+
+async def test_roll_timestamp_name_injection_backslash() -> None:
+    """snapshot_name containing \\ should raise ValueError."""
+    sql_client = _make_sql_client()
+    target = _make_sql_target()
+
+    with pytest.raises(ValueError, match="snapshot_name"):
+        await snapshots.roll_timestamp(sql_client, target, "My\\Snapshot")
+
+
+async def test_roll_timestamp_name_injection_single_quote() -> None:
+    """snapshot_name containing ' should raise ValueError."""
+    sql_client = _make_sql_client()
+    target = _make_sql_target()
+
+    with pytest.raises(ValueError, match="snapshot_name"):
+        await snapshots.roll_timestamp(sql_client, target, "My'Snapshot")
+
+
+async def test_roll_timestamp_name_injection_double_quote() -> None:
+    """snapshot_name containing \" should raise ValueError."""
+    sql_client = _make_sql_client()
+    target = _make_sql_target()
+
+    with pytest.raises(ValueError, match="snapshot_name"):
+        await snapshots.roll_timestamp(sql_client, target, 'My"Snapshot')
+
+
+async def test_roll_timestamp_name_injection_double_dash() -> None:
+    """snapshot_name containing -- should raise ValueError."""
+    sql_client = _make_sql_client()
+    target = _make_sql_target()
+
+    with pytest.raises(ValueError, match="snapshot_name"):
+        await snapshots.roll_timestamp(sql_client, target, "My--Snapshot")
+
+
+async def test_roll_timestamp_name_injection_newline() -> None:
+    """snapshot_name containing newline should raise ValueError."""
+    sql_client = _make_sql_client()
+    target = _make_sql_target()
+
+    with pytest.raises(ValueError, match="snapshot_name"):
+        await snapshots.roll_timestamp(sql_client, target, "My\nSnapshot")
+
+
+async def test_roll_timestamp_maps_permission_error() -> None:
+    """roll_timestamp should map driver permission failures to PermissionDenied."""
+    sql_client = _make_sql_client()
+    target = _make_sql_target()
+    sql_client.execute_nonquery = AsyncMock(side_effect=PermissionDenied("access denied"))
+
+    with pytest.raises(PermissionDenied):
+        await snapshots.roll_timestamp(sql_client, target, "MySnapshot")
+
+
+async def test_roll_timestamp_passes_target_to_sql_client() -> None:
+    """roll_timestamp should pass the parent_target to execute_nonquery."""
+    sql_client = _make_sql_client()
+    target = _make_sql_target()
+
+    await snapshots.roll_timestamp(sql_client, target, "MySnapshot")
+
+    call_args = sql_client.execute_nonquery.call_args
+    assert call_args[0][0] is target

--- a/tests/unit/services/test_snapshots.py
+++ b/tests/unit/services/test_snapshots.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-import json
+import json as _json
 import time
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import UUID
@@ -15,10 +15,10 @@ import respx
 from azure.core.credentials import AccessToken, TokenCredential
 
 from fabric_dw.exceptions import NotFound, PermissionDenied
-from fabric_dw.http_client import FabricHttpClient, HttpBase
+from fabric_dw.http_client import FabricHttpClient
 from fabric_dw.models import WarehouseSnapshot
-from fabric_dw.sql_client import FabricSqlClient, SqlTarget
 from fabric_dw.services import snapshots
+from fabric_dw.sql_client import SqlTarget
 
 # ---------------------------------------------------------------------------
 # Constants & Fixtures
@@ -122,9 +122,9 @@ def _make_credential() -> TokenCredential:
     return cred
 
 
-def _make_sql_client() -> FabricSqlClient:
+def _make_sql_client() -> MagicMock:
     """Return a mock FabricSqlClient with execute_nonquery stubbed."""
-    client = MagicMock(spec=FabricSqlClient)
+    client = MagicMock()
     client.execute_nonquery = AsyncMock(return_value=0)
     return client
 
@@ -152,7 +152,7 @@ async def test_list_pages_through_and_filters_by_parent() -> None:
 
     items_page_call_count = 0
 
-    def _items_side_effect(request: Any) -> httpx.Response:
+    def _items_side_effect(_request: Any) -> httpx.Response:
         nonlocal items_page_call_count
         items_page_call_count += 1
         if items_page_call_count == 1:
@@ -175,7 +175,7 @@ async def test_list_pages_through_and_filters_by_parent() -> None:
         )
 
         async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
-            result = await snapshots.list(http, _WS_ID, _PARENT_WH_ID)
+            result = await snapshots.list_snapshots(http, _WS_ID, _PARENT_WH_ID)
 
     assert len(result) == 1
     snap = result[0]
@@ -201,7 +201,7 @@ async def test_list_returns_empty_when_no_snapshots() -> None:
     respx.get(_ITEMS_URL).mock(return_value=httpx.Response(200, json=payload))
 
     async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
-        result = await snapshots.list(http, _WS_ID, _PARENT_WH_ID)
+        result = await snapshots.list_snapshots(http, _WS_ID, _PARENT_WH_ID)
 
     assert result == []
 
@@ -214,7 +214,7 @@ async def test_list_returns_empty_when_no_snapshots() -> None:
 @respx.mock
 async def test_create_happy_path_with_snapshot_dt() -> None:
     """create should POST with snapshotDateTime, poll LRO, GET result, return WarehouseSnapshot."""
-    snap_dt = datetime(2024, 3, 15, 8, 0, 0, tzinfo=timezone.utc)
+    snap_dt = datetime(2024, 3, 15, 8, 0, 0, tzinfo=UTC)
 
     # POST → 202 with Location header
     respx.post(_ITEMS_URL).mock(
@@ -250,8 +250,6 @@ async def test_create_happy_path_with_snapshot_dt() -> None:
 @respx.mock
 async def test_create_happy_path_without_snapshot_dt() -> None:
     """create without snapshot_dt should omit snapshotDateTime from body."""
-    import json as _json
-
     captured_requests: list[Any] = []
 
     def _capture(request: Any) -> httpx.Response:
@@ -295,9 +293,7 @@ async def test_create_empty_name_raises_value_error() -> None:
 @respx.mock
 async def test_create_posts_correct_body_with_snapshot_dt() -> None:
     """create should send type, displayName, description, and creationPayload."""
-    import json as _json
-
-    snap_dt = datetime(2024, 3, 15, 8, 0, 0, tzinfo=timezone.utc)
+    snap_dt = datetime(2024, 3, 15, 8, 0, 0, tzinfo=UTC)
     captured_requests: list[Any] = []
 
     def _capture(request: Any) -> httpx.Response:
@@ -357,8 +353,6 @@ async def test_create_polls_lro_and_fetches_result() -> None:
 @respx.mock
 async def test_rename_fetches_existing_then_patches_with_all_fields() -> None:
     """rename should GET the snapshot first, then PATCH with all required fields."""
-    import json as _json
-
     patch_url = f"{_ITEMS_URL}/{_SNAP_ID}"
 
     captured_patch_requests: list[Any] = []
@@ -367,14 +361,12 @@ async def test_rename_fetches_existing_then_patches_with_all_fields() -> None:
         captured_patch_requests.append(request)
         return httpx.Response(200, json=WAREHOUSE_SNAPSHOT_DETAIL_PAYLOAD)
 
-    # GET to fetch existing snapshot detail
-    get_route = respx.get(patch_url).mock(
+    # GET to fetch existing snapshot detail (and again after PATCH for updated result)
+    respx.get(patch_url).mock(
         return_value=httpx.Response(200, json=WAREHOUSE_SNAPSHOT_DETAIL_PAYLOAD)
     )
     # PATCH for rename
-    patch_route = respx.patch(patch_url).mock(side_effect=_patch_capture)
-    # GET after PATCH for updated result
-    # (get_route is already set to return the detail; use it again)
+    respx.patch(patch_url).mock(side_effect=_patch_capture)
 
     async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
         result = await snapshots.rename(
@@ -419,7 +411,7 @@ async def test_rename_returns_updated_warehouse_snapshot() -> None:
 
     call_count = 0
 
-    def _get_side_effect(request: Any) -> httpx.Response:
+    def _get_side_effect(_request: Any) -> httpx.Response:
         nonlocal call_count
         call_count += 1
         if call_count == 1:
@@ -452,9 +444,7 @@ async def test_delete_204_returns_none() -> None:
     respx.delete(f"{_ITEMS_URL}/{_SNAP_ID}").mock(return_value=httpx.Response(204))
 
     async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
-        result = await snapshots.delete(http, _WS_ID, _SNAP_ID)
-
-    assert result is None
+        await snapshots.delete(http, _WS_ID, _SNAP_ID)
 
 
 @respx.mock
@@ -489,7 +479,7 @@ async def test_roll_timestamp_with_new_dt_formats_correctly() -> None:
     """roll_timestamp with a datetime should format as YYYY-MM-DDTHH:MM:SS.SS."""
     sql_client = _make_sql_client()
     target = _make_sql_target()
-    new_dt = datetime(2024, 3, 15, 8, 30, 45, tzinfo=timezone.utc)
+    new_dt = datetime(2024, 3, 15, 8, 30, 45, tzinfo=UTC)
 
     await snapshots.roll_timestamp(sql_client, target, "MySnapshot", new_dt=new_dt)
 

--- a/tests/unit/services/test_snapshots.py
+++ b/tests/unit/services/test_snapshots.py
@@ -142,32 +142,40 @@ def _make_sql_target() -> SqlTarget:
 # ---------------------------------------------------------------------------
 
 
-@respx.mock
 async def test_list_pages_through_and_filters_by_parent() -> None:
     """list should page through items, filter WarehouseSnapshot, fetch detail, and match parent."""
-    # Page 1 returns two snapshots + one non-snapshot
-    # Page 2 has no items (end of pagination)
     page2_url = f"{_BASE_URL}/workspaces/{_WS_ID}/items?continuationToken=page2"
 
     page1_payload = dict(ITEMS_LIST_WITH_SNAPSHOTS_PAYLOAD)
     page1_payload["continuationUri"] = page2_url
-
     page2_payload: dict[str, Any] = {"value": []}
 
-    respx.get(_ITEMS_URL).mock(return_value=httpx.Response(200, json=page1_payload))
-    respx.get(page2_url).mock(return_value=httpx.Response(200, json=page2_payload))
+    items_page_call_count = 0
 
-    # Detail for matching snapshot
-    respx.get(f"{_ITEMS_URL}/{_SNAP_ID}").mock(
-        return_value=httpx.Response(200, json=WAREHOUSE_SNAPSHOT_DETAIL_PAYLOAD)
-    )
-    # Detail for non-matching snapshot
-    respx.get(f"{_ITEMS_URL}/{_OTHER_SNAP_ID}").mock(
-        return_value=httpx.Response(200, json=WAREHOUSE_SNAPSHOT_OTHER_PARENT_DETAIL_PAYLOAD)
-    )
+    def _items_side_effect(request: Any) -> httpx.Response:
+        nonlocal items_page_call_count
+        items_page_call_count += 1
+        if items_page_call_count == 1:
+            return httpx.Response(200, json=page1_payload)
+        return httpx.Response(200, json=page2_payload)
 
-    async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
-        result = await snapshots.list(http, _WS_ID, _PARENT_WH_ID)
+    with respx.mock(assert_all_called=False) as mock_router:
+        # Match both the base items URL and the continuation URL
+        mock_router.get(
+            url__regex=rf"https://api\.fabric\.microsoft\.com/v1/workspaces/{_WS_ID}/items(\?.*)?$"
+        ).mock(side_effect=_items_side_effect)
+
+        # Detail for matching snapshot
+        mock_router.get(f"{_ITEMS_URL}/{_SNAP_ID}").mock(
+            return_value=httpx.Response(200, json=WAREHOUSE_SNAPSHOT_DETAIL_PAYLOAD)
+        )
+        # Detail for non-matching snapshot
+        mock_router.get(f"{_ITEMS_URL}/{_OTHER_SNAP_ID}").mock(
+            return_value=httpx.Response(200, json=WAREHOUSE_SNAPSHOT_OTHER_PARENT_DETAIL_PAYLOAD)
+        )
+
+        async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
+            result = await snapshots.list(http, _WS_ID, _PARENT_WH_ID)
 
     assert len(result) == 1
     snap = result[0]


### PR DESCRIPTION
Closes #24

## Summary

- `list`: paginates `GET /workspaces/{ws}/items`, filters to `type=WarehouseSnapshot`, fetches each item's detail to read `creationPayload.parentWarehouseId`, keeps only those matching the supplied parent
- `create`: `POST /workspaces/{ws}/items` with optional `snapshotDateTime` in `creationPayload`, polls LRO via `http.poll_operation`, GETs the new item and returns it as `WarehouseSnapshot`
- `rename`: GETs the snapshot first to learn `parentWarehouseId`, then PATCHes with `type + displayName + description + creationPayload` (Microsoft Learn quirk), returns refreshed snapshot
- `delete`: `DELETE /workspaces/{ws}/items/{snap_id}`; 404 propagates as `NotFound`
- `roll_timestamp`: validates `snapshot_name` against 7 injection vectors (`]`, `;`, `\`, `'`, `"`, `--`, newline), then executes `ALTER DATABASE` T-SQL; maps driver permission errors to `PermissionDenied`

## New fixtures (in `tests/fixtures/api_payloads.py`)

- `ITEMS_LIST_WITH_SNAPSHOTS_PAYLOAD` — items list page with two `WarehouseSnapshot` items + one non-snapshot
- `WAREHOUSE_SNAPSHOT_CREATE_OPERATION_PAYLOAD` — LRO polling response (`status: Succeeded`)

## Test plan

- [x] `list` pages through (continuation URL via `url__regex` respx mock), filters by parent — non-matching parent excluded
- [x] `list` returns empty list when no snapshots
- [x] `create` happy path with `snapshot_dt` — correct body shape verified
- [x] `create` happy path without `snapshot_dt` — `snapshotDateTime` absent from body
- [x] `create` empty/whitespace name → `ValueError`
- [x] `create` calls `poll_operation` with LRO location header
- [x] `rename` GETs existing snapshot, PATCHes with all four fields including `creationPayload`
- [x] `rename` empty/whitespace `new_name` → `ValueError`
- [x] `rename` returns updated `WarehouseSnapshot`
- [x] `delete` 204 → `None`
- [x] `delete` 404 → `NotFound`
- [x] `roll_timestamp` without `new_dt` → `CURRENT_TIMESTAMP` SQL
- [x] `roll_timestamp` with `new_dt` → correct `YYYY-MM-DDTHH:MM:SS.SS` format
- [x] All 7 injection guards (], ;, \\, ', ", --, \n) each raise `ValueError`
- [x] `roll_timestamp` maps `PermissionDenied` through correctly
- [x] `roll_timestamp` passes target to `execute_nonquery`
- All 23 new tests pass; full suite 192/192 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)