### PR TITLE
feat(services/warehouses): list, get, create, rename, delete

### DIFF
--- a/src/fabric_dw/services/warehouses.py
+++ b/src/fabric_dw/services/warehouses.py
@@ -1,0 +1,194 @@
+"""Service functions for Microsoft Fabric Warehouse and SQL Analytics Endpoint operations."""
+
+from __future__ import annotations
+
+import builtins
+from uuid import UUID
+
+from fabric_dw.http_client import FabricHttpClient, HttpBase
+from fabric_dw.models import Warehouse, WarehouseKind
+from fabric_dw.services.workspaces import SUPPORTED_COLLATIONS
+
+__all__ = [
+    "create",
+    "delete",
+    "get",
+    "list",
+    "rename",
+]
+
+# Alias to allow return-type annotations after the `list` name is shadowed by the function below.
+_List = builtins.list
+
+
+async def list(http: FabricHttpClient, workspace_id: UUID) -> _List[Warehouse]:
+    """Return all warehouses and SQL analytics endpoints in a workspace.
+
+    Combines results from ``GET /workspaces/{ws}/warehouses`` and
+    ``GET /workspaces/{ws}/sqlEndpoints``, both followed through pagination.
+
+    Args:
+        http: An authenticated :class:`~fabric_dw.http_client.FabricHttpClient`.
+        workspace_id: The UUID of the workspace to query.
+
+    Returns:
+        A list of :class:`~fabric_dw.models.Warehouse` instances with their
+        respective :class:`~fabric_dw.models.WarehouseKind`.
+    """
+    result: _List[Warehouse] = []
+
+    wh_path = f"/workspaces/{workspace_id}/warehouses"
+    async for item in http.iter_paginated(HttpBase.FABRIC, wh_path):
+        result.append(Warehouse.from_api(item, kind=WarehouseKind.WAREHOUSE))
+
+    async for item in http.iter_paginated(
+        HttpBase.FABRIC, f"/workspaces/{workspace_id}/sqlEndpoints"
+    ):
+        result.append(Warehouse.from_api(item, kind=WarehouseKind.SQL_ENDPOINT))
+
+    return result
+
+
+async def get(http: FabricHttpClient, workspace_id: UUID, warehouse_id: UUID) -> Warehouse:
+    """Fetch a single warehouse by ID.
+
+    Uses the type-specific ``GET /workspaces/{ws}/warehouses/{wh}`` endpoint.
+    SQL analytics endpoints should be discovered via :func:`list`.
+
+    Args:
+        http: An authenticated :class:`~fabric_dw.http_client.FabricHttpClient`.
+        workspace_id: The UUID of the workspace containing the warehouse.
+        warehouse_id: The UUID of the warehouse to retrieve.
+
+    Returns:
+        A populated :class:`~fabric_dw.models.Warehouse` instance.
+    """
+    resp = await http.request(
+        "GET", HttpBase.FABRIC, f"/workspaces/{workspace_id}/warehouses/{warehouse_id}"
+    )
+    return Warehouse.from_api(resp.json(), kind=WarehouseKind.WAREHOUSE)
+
+
+async def create(
+    http: FabricHttpClient,
+    workspace_id: UUID,
+    name: str,
+    *,
+    collation: str | None = None,
+    description: str | None = None,
+) -> Warehouse:
+    """Create a new Warehouse in a workspace.
+
+    Validates *name* and *collation* before issuing any HTTP requests. The
+    create call returns a 202 with a ``Location`` header; this function polls
+    the LRO to completion and then fetches and returns the populated Warehouse.
+
+    Args:
+        http: An authenticated :class:`~fabric_dw.http_client.FabricHttpClient`.
+        workspace_id: The UUID of the workspace in which to create the warehouse.
+        name: Display name for the new warehouse. Must be a non-empty string.
+        collation: Optional default collation. Must be one of
+            :data:`~fabric_dw.services.workspaces.SUPPORTED_COLLATIONS` if provided.
+        description: Optional description for the new warehouse.
+
+    Returns:
+        A populated :class:`~fabric_dw.models.Warehouse` instance.
+
+    Raises:
+        ValueError: If *name* is empty/whitespace, or *collation* is unsupported.
+    """
+    if not name or not name.strip():
+        msg = "Warehouse name must be a non-empty string"
+        raise ValueError(msg)
+
+    if collation is not None and collation not in SUPPORTED_COLLATIONS:
+        msg = f"Unsupported collation {collation!r}. Allowed values: {sorted(SUPPORTED_COLLATIONS)}"
+        raise ValueError(msg)
+
+    body: dict[str, object] = {"type": "Warehouse", "displayName": name}
+    if description is not None:
+        body["description"] = description
+    if collation is not None:
+        body["creationPayload"] = {"defaultCollation": collation}
+
+    resp = await http.request(
+        "POST", HttpBase.FABRIC, f"/workspaces/{workspace_id}/items", json=body
+    )
+
+    # 202 = LRO initiated; poll the operation then fetch the new warehouse
+    location = resp.headers["Location"]
+    lro_result = await http.poll_operation(location)
+
+    # Extract the new warehouse ID from resourceLocation or Location URL
+    resource_location: str = str(lro_result.get("resourceLocation", ""))
+    if resource_location:
+        new_id = UUID(resource_location.rstrip("/").split("/")[-1])
+    else:
+        new_id = UUID(location.rstrip("/").split("/")[-1])
+
+    return await get(http, workspace_id, new_id)
+
+
+async def rename(
+    http: FabricHttpClient,
+    workspace_id: UUID,
+    warehouse_id: UUID,
+    new_name: str,
+    *,
+    description: str | None = None,
+) -> Warehouse:
+    """Rename a Warehouse (and optionally update its description).
+
+    Args:
+        http: An authenticated :class:`~fabric_dw.http_client.FabricHttpClient`.
+        workspace_id: The UUID of the workspace containing the warehouse.
+        warehouse_id: The UUID of the warehouse to rename.
+        new_name: The new display name. Must be a non-empty string.
+        description: Optional new description. Omitted from the body if ``None``.
+
+    Returns:
+        The updated :class:`~fabric_dw.models.Warehouse` as returned by the API.
+
+    Raises:
+        ValueError: If *new_name* is empty/whitespace.
+    """
+    if not new_name or not new_name.strip():
+        msg = "Warehouse name must be a non-empty string"
+        raise ValueError(msg)
+
+    body: dict[str, object] = {"displayName": new_name}
+    if description is not None:
+        body["description"] = description
+
+    resp = await http.request(
+        "PATCH",
+        HttpBase.FABRIC,
+        f"/workspaces/{workspace_id}/warehouses/{warehouse_id}",
+        json=body,
+    )
+    return Warehouse.from_api(resp.json(), kind=WarehouseKind.WAREHOUSE)
+
+
+async def delete(
+    http: FabricHttpClient,
+    workspace_id: UUID,
+    warehouse_id: UUID,
+) -> None:
+    """Delete a Warehouse.
+
+    Args:
+        http: An authenticated :class:`~fabric_dw.http_client.FabricHttpClient`.
+        workspace_id: The UUID of the workspace containing the warehouse.
+        warehouse_id: The UUID of the warehouse to delete.
+
+    Returns:
+        ``None`` on success (204 No Content).
+
+    Raises:
+        NotFound: If the warehouse does not exist (404).
+    """
+    await http.request(
+        "DELETE",
+        HttpBase.FABRIC,
+        f"/workspaces/{workspace_id}/warehouses/{warehouse_id}",
+    )

--- a/src/fabric_dw/services/warehouses.py
+++ b/src/fabric_dw/services/warehouses.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-import builtins
 from uuid import UUID
 
+from fabric_dw.exceptions import FabricServerError
 from fabric_dw.http_client import FabricHttpClient, HttpBase
 from fabric_dw.models import Warehouse, WarehouseKind
 from fabric_dw.services.workspaces import SUPPORTED_COLLATIONS
@@ -12,20 +12,18 @@ from fabric_dw.services.workspaces import SUPPORTED_COLLATIONS
 __all__ = [
     "create",
     "delete",
-    "get",
-    "list",
+    "get_warehouse",
+    "list_warehouses",
     "rename",
 ]
 
-# Alias to allow return-type annotations after the `list` name is shadowed by the function below.
-_List = builtins.list
 
-
-async def list(http: FabricHttpClient, workspace_id: UUID) -> _List[Warehouse]:
+async def list_warehouses(http: FabricHttpClient, workspace_id: UUID) -> list[Warehouse]:
     """Return all warehouses and SQL analytics endpoints in a workspace.
 
     Combines results from ``GET /workspaces/{ws}/warehouses`` and
     ``GET /workspaces/{ws}/sqlEndpoints``, both followed through pagination.
+    Warehouses are listed first, followed by SQL analytics endpoints.
 
     Args:
         http: An authenticated :class:`~fabric_dw.http_client.FabricHttpClient`.
@@ -35,25 +33,28 @@ async def list(http: FabricHttpClient, workspace_id: UUID) -> _List[Warehouse]:
         A list of :class:`~fabric_dw.models.Warehouse` instances with their
         respective :class:`~fabric_dw.models.WarehouseKind`.
     """
-    result: _List[Warehouse] = []
-
-    wh_path = f"/workspaces/{workspace_id}/warehouses"
-    async for item in http.iter_paginated(HttpBase.FABRIC, wh_path):
-        result.append(Warehouse.from_api(item, kind=WarehouseKind.WAREHOUSE))
-
-    async for item in http.iter_paginated(
-        HttpBase.FABRIC, f"/workspaces/{workspace_id}/sqlEndpoints"
-    ):
-        result.append(Warehouse.from_api(item, kind=WarehouseKind.SQL_ENDPOINT))
-
+    result: list[Warehouse] = [
+        Warehouse.from_api(item, kind=WarehouseKind.WAREHOUSE)
+        async for item in http.iter_paginated(
+            HttpBase.FABRIC, f"/workspaces/{workspace_id}/warehouses"
+        )
+    ]
+    result += [
+        Warehouse.from_api(item, kind=WarehouseKind.SQL_ENDPOINT)
+        async for item in http.iter_paginated(
+            HttpBase.FABRIC, f"/workspaces/{workspace_id}/sqlEndpoints"
+        )
+    ]
     return result
 
 
-async def get(http: FabricHttpClient, workspace_id: UUID, warehouse_id: UUID) -> Warehouse:
+async def get_warehouse(
+    http: FabricHttpClient, workspace_id: UUID, warehouse_id: UUID
+) -> Warehouse:
     """Fetch a single warehouse by ID.
 
     Uses the type-specific ``GET /workspaces/{ws}/warehouses/{wh}`` endpoint.
-    SQL analytics endpoints should be discovered via :func:`list`.
+    SQL analytics endpoints should be discovered via :func:`list_warehouses`.
 
     Args:
         http: An authenticated :class:`~fabric_dw.http_client.FabricHttpClient`.
@@ -119,14 +120,16 @@ async def create(
     location = resp.headers["Location"]
     lro_result = await http.poll_operation(location)
 
-    # Extract the new warehouse ID from resourceLocation or Location URL
-    resource_location: str = str(lro_result.get("resourceLocation", ""))
-    if resource_location:
-        new_id = UUID(resource_location.rstrip("/").split("/")[-1])
+    # Extract the new warehouse ID from resourceLocation.
+    # str(None) == "None" (truthy) so we must use isinstance instead of truthiness.
+    resource_location = lro_result.get("resourceLocation")
+    if isinstance(resource_location, str) and resource_location:
+        new_id = UUID(resource_location.rsplit("/", 1)[-1])
     else:
-        new_id = UUID(location.rstrip("/").split("/")[-1])
+        msg = f"create warehouse LRO completed but no resourceLocation returned: {lro_result}"
+        raise FabricServerError(msg)
 
-    return await get(http, workspace_id, new_id)
+    return await get_warehouse(http, workspace_id, new_id)
 
 
 async def rename(

--- a/tests/fixtures/api_payloads.py
+++ b/tests/fixtures/api_payloads.py
@@ -133,3 +133,141 @@ WAREHOUSE_SNAPSHOT_CREATE_OPERATION_PAYLOAD = """{
   "percentComplete": 100,
   "error": null
 }"""
+
+# First page of warehouse listing (with continuationUri for pagination tests)
+WAREHOUSE_LIST_PAYLOAD = """{
+  "value": [
+    {
+      "id": "d4e5f6a7-b8c9-0123-def0-123456789abc",
+      "displayName": "SalesWarehouse",
+      "description": "Data warehouse for sales analytics",
+      "type": "Warehouse",
+      "workspaceId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      "properties": {
+        "connectionString": "saleswarehouse.datawarehouse.fabric.microsoft.com",
+        "defaultCollation": "Latin1_General_100_BIN2_UTF8",
+        "createdDate": "2024-03-15T10:30:00Z"
+      }
+    },
+    {
+      "id": "a7b8c9d0-e1f2-3456-a012-345678901234",
+      "displayName": "FinanceWarehouse",
+      "description": "Data warehouse for finance analytics",
+      "type": "Warehouse",
+      "workspaceId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      "properties": {
+        "connectionString": "financewarehouse.datawarehouse.fabric.microsoft.com",
+        "defaultCollation": "Latin1_General_100_CI_AS_KS_WS_SC_UTF8",
+        "createdDate": "2024-04-01T09:00:00Z"
+      }
+    }
+  ],
+  "continuationUri": "https://api.fabric.microsoft.com/v1/workspaces/a1b2c3d4-e5f6-7890-abcd-ef1234567890/warehouses?continuationToken=eyJ3aCI6InBhZ2UyIn0%3D"
+}"""
+
+# Second page of warehouse listing (no continuationUri → last page)
+WAREHOUSE_LIST_PAGE2_PAYLOAD = """{
+  "value": [
+    {
+      "id": "b8c9d0e1-f2a3-4567-b012-456789012345",
+      "displayName": "HRWarehouse",
+      "description": "Data warehouse for HR analytics",
+      "type": "Warehouse",
+      "workspaceId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      "properties": {
+        "connectionString": "hrwarehouse.datawarehouse.fabric.microsoft.com",
+        "defaultCollation": "Latin1_General_100_BIN2_UTF8",
+        "createdDate": "2024-05-10T12:00:00Z"
+      }
+    }
+  ]
+}"""
+
+# SQL analytics endpoints listing for a workspace
+WAREHOUSE_SQL_ENDPOINTS_PAYLOAD = """{
+  "value": [
+    {
+      "id": "e5f6a7b8-c9d0-1234-ef01-234567890abc",
+      "displayName": "SalesLakehouse",
+      "description": "SQL endpoint for sales lakehouse",
+      "type": "SQLEndpoint",
+      "workspaceId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      "properties": {
+        "sqlEndpointProperties": {
+          "connectionString": "lakehouse-sql-ep.datawarehouse.fabric.microsoft.com",
+          "id": "f6a7b8c9-d0e1-2345-f012-34567890abcd",
+          "provisioningStatus": "Success"
+        }
+      }
+    }
+  ]
+}"""
+
+# 202 response body for warehouse create (LRO initiated)
+WAREHOUSE_CREATE_202_PAYLOAD = """{
+  "id": "d4e5f6a7-b8c9-0123-def0-123456789abc",
+  "displayName": "SalesWarehouse",
+  "type": "Warehouse",
+  "workspaceId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+}"""
+
+# SQL analytics endpoints first page with continuationUri (for pagination tests)
+WAREHOUSE_SQL_ENDPOINTS_PAGE1_PAYLOAD = """{
+  "value": [
+    {
+      "id": "e5f6a7b8-c9d0-1234-ef01-234567890abc",
+      "displayName": "SalesLakehouse",
+      "description": "SQL endpoint for sales lakehouse",
+      "type": "SQLEndpoint",
+      "workspaceId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      "properties": {
+        "sqlEndpointProperties": {
+          "connectionString": "lakehouse-sql-ep.datawarehouse.fabric.microsoft.com",
+          "id": "f6a7b8c9-d0e1-2345-f012-34567890abcd",
+          "provisioningStatus": "Success"
+        }
+      }
+    }
+  ],
+  "continuationUri": "https://api.fabric.microsoft.com/v1/workspaces/a1b2c3d4-e5f6-7890-abcd-ef1234567890/sqlEndpoints?continuationToken=eyJzcWwiOiJwYWdlMiJ9"
+}"""
+
+# Second page of SQL endpoints listing (no continuationUri → last page)
+WAREHOUSE_SQL_ENDPOINTS_PAGE2_PAYLOAD = """{
+  "value": [
+    {
+      "id": "a1b2c3d4-0000-1111-2222-ef1234567890",
+      "displayName": "HRLakehouse",
+      "description": "SQL endpoint for HR lakehouse",
+      "type": "SQLEndpoint",
+      "workspaceId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      "properties": {
+        "sqlEndpointProperties": {
+          "connectionString": "hr-sql-ep.datawarehouse.fabric.microsoft.com",
+          "id": "b2c3d4e5-f6a7-8901-bcde-f01234567891",
+          "provisioningStatus": "Success"
+        }
+      }
+    }
+  ]
+}"""
+
+# LRO poll result when the operation has succeeded
+WAREHOUSE_OPERATION_SUCCEEDED_PAYLOAD = """{
+  "status": "Succeeded",
+  "createdTimeUtc": "2024-03-15T10:29:50Z",
+  "lastUpdatedTimeUtc": "2024-03-15T10:30:00Z",
+  "percentComplete": 100,
+  "error": null,
+  "resourceLocation": "https://api.fabric.microsoft.com/v1/workspaces/a1b2c3d4-e5f6-7890-abcd-ef1234567890/warehouses/d4e5f6a7-b8c9-0123-def0-123456789abc"
+}"""
+
+# LRO poll result when resourceLocation is null (missing)
+WAREHOUSE_OPERATION_SUCCEEDED_NO_LOCATION_PAYLOAD = """{
+  "status": "Succeeded",
+  "createdTimeUtc": "2024-03-15T10:29:50Z",
+  "lastUpdatedTimeUtc": "2024-03-15T10:30:00Z",
+  "percentComplete": 100,
+  "error": null,
+  "resourceLocation": null
+}"""

--- a/tests/unit/services/test_warehouses.py
+++ b/tests/unit/services/test_warehouses.py
@@ -12,7 +12,7 @@ import pytest
 import respx
 from azure.core.credentials import AccessToken, TokenCredential
 
-from fabric_dw.exceptions import NotFound
+from fabric_dw.exceptions import FabricServerError, NotFound
 from fabric_dw.http_client import FabricHttpClient
 from fabric_dw.models import Warehouse, WarehouseKind
 from fabric_dw.services import warehouses
@@ -22,7 +22,10 @@ from tests.fixtures.api_payloads import (
     WAREHOUSE_GET_PAYLOAD,
     WAREHOUSE_LIST_PAGE2_PAYLOAD,
     WAREHOUSE_LIST_PAYLOAD,
+    WAREHOUSE_OPERATION_SUCCEEDED_NO_LOCATION_PAYLOAD,
     WAREHOUSE_OPERATION_SUCCEEDED_PAYLOAD,
+    WAREHOUSE_SQL_ENDPOINTS_PAGE1_PAYLOAD,
+    WAREHOUSE_SQL_ENDPOINTS_PAGE2_PAYLOAD,
     WAREHOUSE_SQL_ENDPOINTS_PAYLOAD,
 )
 
@@ -61,8 +64,9 @@ async def _make_client(rps: int = 10) -> FabricHttpClient:
 
 @pytest.mark.asyncio
 async def test_list_merges_warehouses_and_sql_endpoints() -> None:
-    """list must combine items from both /warehouses and /sqlEndpoints with correct kind."""
+    """list_warehouses must combine items from /warehouses and /sqlEndpoints with correct kind."""
     wh_payload = json.loads(WAREHOUSE_LIST_PAYLOAD)
+    wh_payload.pop("continuationUri", None)  # single-page response
     ep_payload = json.loads(WAREHOUSE_SQL_ENDPOINTS_PAYLOAD)
 
     with respx.mock:
@@ -71,7 +75,7 @@ async def test_list_merges_warehouses_and_sql_endpoints() -> None:
 
         client = await _make_client()
         async with client:
-            result = await warehouses.list(client, _WORKSPACE_ID)
+            result = await warehouses.list_warehouses(client, _WORKSPACE_ID)
 
     assert len(result) == 3  # 2 warehouses + 1 sql endpoint
     kinds = {item.kind for item in result}
@@ -86,7 +90,7 @@ async def test_list_merges_warehouses_and_sql_endpoints() -> None:
 
 @pytest.mark.asyncio
 async def test_list_follows_continuation_uri_for_warehouses() -> None:
-    """list must follow continuationUri for the warehouses endpoint."""
+    """list_warehouses must follow continuationUri for the warehouses endpoint."""
     call_count = 0
 
     def side_effect(request: httpx.Request) -> httpx.Response:
@@ -107,15 +111,44 @@ async def test_list_follows_continuation_uri_for_warehouses() -> None:
 
         client = await _make_client()
         async with client:
-            result = await warehouses.list(client, _WORKSPACE_ID)
+            result = await warehouses.list_warehouses(client, _WORKSPACE_ID)
 
     assert call_count == 2
     assert len(result) == 3  # 2 from page 1 + 1 from page 2 (all warehouses, no endpoints)
 
 
 @pytest.mark.asyncio
+async def test_list_follows_continuation_uri_for_sql_endpoints() -> None:
+    """list_warehouses must follow continuationUri for the sqlEndpoints endpoint."""
+    ep_call_count = 0
+
+    def ep_side_effect(_request: httpx.Request) -> httpx.Response:
+        nonlocal ep_call_count
+        ep_call_count += 1
+        if ep_call_count == 1:
+            return httpx.Response(200, json=json.loads(WAREHOUSE_SQL_ENDPOINTS_PAGE1_PAYLOAD))
+        return httpx.Response(200, json=json.loads(WAREHOUSE_SQL_ENDPOINTS_PAGE2_PAYLOAD))
+
+    with respx.mock(assert_all_called=False) as mock_router:
+        mock_router.get(url__regex=r".*/workspaces/.*/warehouses.*").mock(
+            return_value=httpx.Response(200, json={"value": []})
+        )
+        mock_router.get(url__regex=r".*/workspaces/.*/sqlEndpoints.*").mock(
+            side_effect=ep_side_effect
+        )
+
+        client = await _make_client()
+        async with client:
+            result = await warehouses.list_warehouses(client, _WORKSPACE_ID)
+
+    assert ep_call_count == 2
+    ep_items = [i for i in result if i.kind == WarehouseKind.SQL_ENDPOINT]
+    assert len(ep_items) == 2  # 1 from page 1 + 1 from page 2
+
+
+@pytest.mark.asyncio
 async def test_list_all_items_are_warehouse_instances() -> None:
-    """list must return only Warehouse instances."""
+    """list_warehouses must return only Warehouse instances."""
     wh_payload = json.loads(WAREHOUSE_LIST_PAYLOAD)
     # Remove continuation for simplicity
     wh_payload.pop("continuationUri", None)
@@ -126,7 +159,7 @@ async def test_list_all_items_are_warehouse_instances() -> None:
 
         client = await _make_client()
         async with client:
-            result = await warehouses.list(client, _WORKSPACE_ID)
+            result = await warehouses.list_warehouses(client, _WORKSPACE_ID)
 
     assert all(isinstance(item, Warehouse) for item in result)
 
@@ -138,7 +171,7 @@ async def test_list_all_items_are_warehouse_instances() -> None:
 
 @pytest.mark.asyncio
 async def test_get_returns_populated_warehouse() -> None:
-    """get must return a single populated Warehouse with WAREHOUSE kind."""
+    """get_warehouse must return a single populated Warehouse with WAREHOUSE kind."""
     wh_payload = json.loads(WAREHOUSE_GET_PAYLOAD)
 
     with respx.mock:
@@ -146,7 +179,7 @@ async def test_get_returns_populated_warehouse() -> None:
 
         client = await _make_client()
         async with client:
-            result = await warehouses.get(client, _WORKSPACE_ID, _WAREHOUSE_ID)
+            result = await warehouses.get_warehouse(client, _WORKSPACE_ID, _WAREHOUSE_ID)
 
     assert isinstance(result, Warehouse)
     assert result.id == _WAREHOUSE_ID
@@ -158,7 +191,7 @@ async def test_get_returns_populated_warehouse() -> None:
 
 @pytest.mark.asyncio
 async def test_get_not_found_propagates() -> None:
-    """get must propagate NotFound on a 404 response."""
+    """get_warehouse must propagate NotFound on a 404 response."""
     with respx.mock:
         respx.get(_WAREHOUSE_URL).mock(
             return_value=httpx.Response(404, json={"error": {"code": "ItemNotFound"}})
@@ -167,7 +200,7 @@ async def test_get_not_found_propagates() -> None:
         client = await _make_client()
         async with client:
             with pytest.raises(NotFound):
-                await warehouses.get(client, _WORKSPACE_ID, _WAREHOUSE_ID)
+                await warehouses.get_warehouse(client, _WORKSPACE_ID, _WAREHOUSE_ID)
 
 
 # ---------------------------------------------------------------------------
@@ -284,33 +317,57 @@ async def test_create_with_description() -> None:
 @pytest.mark.asyncio
 async def test_create_invalid_collation_raises_value_error() -> None:
     """create must raise ValueError for unsupported collation before any HTTP call."""
-    client = await _make_client()
-    async with client:
-        with pytest.raises(ValueError, match="collation"):
-            await warehouses.create(
-                client,
-                _WORKSPACE_ID,
-                "SalesWarehouse",
-                collation="SQL_Latin1_General_CP1_CI_AS",
-            )
+    with respx.mock:  # any HTTP call here is a bug
+        client = await _make_client()
+        async with client:
+            with pytest.raises(ValueError, match="collation"):
+                await warehouses.create(
+                    client,
+                    _WORKSPACE_ID,
+                    "SalesWarehouse",
+                    collation="SQL_Latin1_General_CP1_CI_AS",
+                )
 
 
 @pytest.mark.asyncio
 async def test_create_empty_name_raises_value_error() -> None:
     """create must raise ValueError for an empty name before any HTTP call."""
-    client = await _make_client()
-    async with client:
-        with pytest.raises(ValueError, match="name"):
-            await warehouses.create(client, _WORKSPACE_ID, "")
+    with respx.mock:  # any HTTP call here is a bug
+        client = await _make_client()
+        async with client:
+            with pytest.raises(ValueError, match="name"):
+                await warehouses.create(client, _WORKSPACE_ID, "")
 
 
 @pytest.mark.asyncio
 async def test_create_whitespace_only_name_raises_value_error() -> None:
     """create must raise ValueError for a whitespace-only name before any HTTP call."""
-    client = await _make_client()
-    async with client:
-        with pytest.raises(ValueError, match="name"):
-            await warehouses.create(client, _WORKSPACE_ID, "   ")
+    with respx.mock:  # any HTTP call here is a bug
+        client = await _make_client()
+        async with client:
+            with pytest.raises(ValueError, match="name"):
+                await warehouses.create(client, _WORKSPACE_ID, "   ")
+
+
+@pytest.mark.asyncio
+async def test_create_missing_resource_location_raises_fabric_server_error() -> None:
+    """create must raise FabricServerError when LRO completes with null resourceLocation."""
+    op_no_location = json.loads(WAREHOUSE_OPERATION_SUCCEEDED_NO_LOCATION_PAYLOAD)
+
+    with respx.mock:
+        respx.post(_ITEMS_URL).mock(
+            return_value=httpx.Response(
+                202,
+                json={},
+                headers={"Location": _OPERATION_URL},
+            )
+        )
+        respx.get(_OPERATION_URL).mock(return_value=httpx.Response(200, json=op_no_location))
+
+        client = await _make_client()
+        async with client:
+            with pytest.raises(FabricServerError, match="resourceLocation"):
+                await warehouses.create(client, _WORKSPACE_ID, "SalesWarehouse")
 
 
 # ---------------------------------------------------------------------------
@@ -375,10 +432,11 @@ async def test_rename_with_description_includes_it_in_body() -> None:
 @pytest.mark.asyncio
 async def test_rename_empty_name_raises_value_error() -> None:
     """rename must raise ValueError for an empty new_name before any HTTP call."""
-    client = await _make_client()
-    async with client:
-        with pytest.raises(ValueError, match="name"):
-            await warehouses.rename(client, _WORKSPACE_ID, _WAREHOUSE_ID, "")
+    with respx.mock:  # any HTTP call here is a bug
+        client = await _make_client()
+        async with client:
+            with pytest.raises(ValueError, match="name"):
+                await warehouses.rename(client, _WORKSPACE_ID, _WAREHOUSE_ID, "")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/services/test_warehouses.py
+++ b/tests/unit/services/test_warehouses.py
@@ -1,0 +1,427 @@
+"""Tests for fabric_dw.services.warehouses — written BEFORE the implementation (TDD)."""
+
+from __future__ import annotations
+
+import json
+import time
+from unittest.mock import MagicMock
+from uuid import UUID
+
+import httpx
+import pytest
+import respx
+from azure.core.credentials import AccessToken, TokenCredential
+
+from fabric_dw.exceptions import NotFound
+from fabric_dw.http_client import FabricHttpClient
+from fabric_dw.models import Warehouse, WarehouseKind
+from fabric_dw.services import warehouses
+from tests.fixtures.api_payloads import (
+    LAKEHOUSE_GET_PAYLOAD,
+    WAREHOUSE_CREATE_202_PAYLOAD,
+    WAREHOUSE_GET_PAYLOAD,
+    WAREHOUSE_LIST_PAGE2_PAYLOAD,
+    WAREHOUSE_LIST_PAYLOAD,
+    WAREHOUSE_OPERATION_SUCCEEDED_PAYLOAD,
+    WAREHOUSE_SQL_ENDPOINTS_PAYLOAD,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_FAKE_TOKEN = AccessToken(token="fake-token", expires_on=int(time.time()) + 3600)  # noqa: S106
+
+_WORKSPACE_ID = UUID("a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+_WAREHOUSE_ID = UUID("d4e5f6a7-b8c9-0123-def0-123456789abc")
+_SQL_ENDPOINT_ID = UUID("e5f6a7b8-c9d0-1234-ef01-234567890abc")
+
+_BASE = "https://api.fabric.microsoft.com/v1"
+_WAREHOUSES_URL = f"{_BASE}/workspaces/{_WORKSPACE_ID}/warehouses"
+_SQL_ENDPOINTS_URL = f"{_BASE}/workspaces/{_WORKSPACE_ID}/sqlEndpoints"
+_WAREHOUSE_URL = f"{_WAREHOUSES_URL}/{_WAREHOUSE_ID}"
+_ITEMS_URL = f"{_BASE}/workspaces/{_WORKSPACE_ID}/items"
+_OPERATION_URL = f"{_BASE}/operations/op-abc123"
+
+
+def _make_credential(token: AccessToken = _FAKE_TOKEN) -> TokenCredential:
+    cred = MagicMock(spec=TokenCredential)
+    cred.get_token = MagicMock(return_value=token)
+    return cred
+
+
+async def _make_client(rps: int = 10) -> FabricHttpClient:
+    return FabricHttpClient(credential=_make_credential(), rps=rps)
+
+
+# ---------------------------------------------------------------------------
+# list
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_merges_warehouses_and_sql_endpoints() -> None:
+    """list must combine items from both /warehouses and /sqlEndpoints with correct kind."""
+    wh_payload = json.loads(WAREHOUSE_LIST_PAYLOAD)
+    ep_payload = json.loads(WAREHOUSE_SQL_ENDPOINTS_PAYLOAD)
+
+    with respx.mock:
+        respx.get(_WAREHOUSES_URL).mock(return_value=httpx.Response(200, json=wh_payload))
+        respx.get(_SQL_ENDPOINTS_URL).mock(return_value=httpx.Response(200, json=ep_payload))
+
+        client = await _make_client()
+        async with client:
+            result = await warehouses.list(client, _WORKSPACE_ID)
+
+    assert len(result) == 3  # 2 warehouses + 1 sql endpoint
+    kinds = {item.kind for item in result}
+    assert WarehouseKind.WAREHOUSE in kinds
+    assert WarehouseKind.SQL_ENDPOINT in kinds
+
+    wh_items = [i for i in result if i.kind == WarehouseKind.WAREHOUSE]
+    ep_items = [i for i in result if i.kind == WarehouseKind.SQL_ENDPOINT]
+    assert len(wh_items) == 2
+    assert len(ep_items) == 1
+
+
+@pytest.mark.asyncio
+async def test_list_follows_continuation_uri_for_warehouses() -> None:
+    """list must follow continuationUri for the warehouses endpoint."""
+    call_count = 0
+
+    def side_effect(request: httpx.Request) -> httpx.Response:
+        nonlocal call_count
+        url = str(request.url)
+        if "sqlEndpoints" in url:
+            return httpx.Response(200, json={"value": []})
+        call_count += 1
+        if call_count == 1:
+            return httpx.Response(200, json=json.loads(WAREHOUSE_LIST_PAYLOAD))
+        return httpx.Response(200, json=json.loads(WAREHOUSE_LIST_PAGE2_PAYLOAD))
+
+    with respx.mock(assert_all_called=False) as mock_router:
+        mock_router.get(url__regex=r".*/workspaces/.*/warehouses.*").mock(side_effect=side_effect)
+        mock_router.get(url__regex=r".*/workspaces/.*/sqlEndpoints.*").mock(
+            return_value=httpx.Response(200, json={"value": []})
+        )
+
+        client = await _make_client()
+        async with client:
+            result = await warehouses.list(client, _WORKSPACE_ID)
+
+    assert call_count == 2
+    assert len(result) == 3  # 2 from page 1 + 1 from page 2 (all warehouses, no endpoints)
+
+
+@pytest.mark.asyncio
+async def test_list_all_items_are_warehouse_instances() -> None:
+    """list must return only Warehouse instances."""
+    wh_payload = json.loads(WAREHOUSE_LIST_PAYLOAD)
+    # Remove continuation for simplicity
+    wh_payload.pop("continuationUri", None)
+
+    with respx.mock:
+        respx.get(_WAREHOUSES_URL).mock(return_value=httpx.Response(200, json=wh_payload))
+        respx.get(_SQL_ENDPOINTS_URL).mock(return_value=httpx.Response(200, json={"value": []}))
+
+        client = await _make_client()
+        async with client:
+            result = await warehouses.list(client, _WORKSPACE_ID)
+
+    assert all(isinstance(item, Warehouse) for item in result)
+
+
+# ---------------------------------------------------------------------------
+# get
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_returns_populated_warehouse() -> None:
+    """get must return a single populated Warehouse with WAREHOUSE kind."""
+    wh_payload = json.loads(WAREHOUSE_GET_PAYLOAD)
+
+    with respx.mock:
+        respx.get(_WAREHOUSE_URL).mock(return_value=httpx.Response(200, json=wh_payload))
+
+        client = await _make_client()
+        async with client:
+            result = await warehouses.get(client, _WORKSPACE_ID, _WAREHOUSE_ID)
+
+    assert isinstance(result, Warehouse)
+    assert result.id == _WAREHOUSE_ID
+    assert result.name == "SalesWarehouse"
+    assert result.kind == WarehouseKind.WAREHOUSE
+    assert result.connection_string == "saleswarehouse.datawarehouse.fabric.microsoft.com"
+    assert result.collation == "Latin1_General_100_BIN2_UTF8"
+
+
+@pytest.mark.asyncio
+async def test_get_not_found_propagates() -> None:
+    """get must propagate NotFound on a 404 response."""
+    with respx.mock:
+        respx.get(_WAREHOUSE_URL).mock(
+            return_value=httpx.Response(404, json={"error": {"code": "ItemNotFound"}})
+        )
+
+        client = await _make_client()
+        async with client:
+            with pytest.raises(NotFound):
+                await warehouses.get(client, _WORKSPACE_ID, _WAREHOUSE_ID)
+
+
+# ---------------------------------------------------------------------------
+# create
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_with_collation_polls_lro_and_returns_warehouse() -> None:
+    """create must POST with collation, poll the LRO, then GET and return the warehouse."""
+    create_resp = json.loads(WAREHOUSE_CREATE_202_PAYLOAD)
+    op_succeeded = json.loads(WAREHOUSE_OPERATION_SUCCEEDED_PAYLOAD)
+    wh_payload = json.loads(WAREHOUSE_GET_PAYLOAD)
+
+    # The new warehouse ID returned by the LRO
+    new_wh_id = UUID("d4e5f6a7-b8c9-0123-def0-123456789abc")
+    new_wh_url = f"{_WAREHOUSES_URL}/{new_wh_id}"
+
+    with respx.mock:
+        # POST to create
+        post_route = respx.post(_ITEMS_URL).mock(
+            return_value=httpx.Response(
+                202,
+                json=create_resp,
+                headers={"Location": _OPERATION_URL},
+            )
+        )
+        # Poll LRO operation
+        respx.get(_OPERATION_URL).mock(return_value=httpx.Response(200, json=op_succeeded))
+        # Final GET
+        respx.get(new_wh_url).mock(return_value=httpx.Response(200, json=wh_payload))
+
+        client = await _make_client()
+        async with client:
+            result = await warehouses.create(
+                client,
+                _WORKSPACE_ID,
+                "SalesWarehouse",
+                collation="Latin1_General_100_BIN2_UTF8",
+            )
+
+    assert isinstance(result, Warehouse)
+    assert result.id == new_wh_id
+    assert result.kind == WarehouseKind.WAREHOUSE
+
+    # Verify the POST body included creationPayload with collation
+    sent_body = json.loads(post_route.calls[0].request.content)
+    assert sent_body["type"] == "Warehouse"
+    assert sent_body["displayName"] == "SalesWarehouse"
+    assert sent_body["creationPayload"]["defaultCollation"] == "Latin1_General_100_BIN2_UTF8"
+
+
+@pytest.mark.asyncio
+async def test_create_without_collation_omits_creation_payload() -> None:
+    """create without collation must omit creationPayload from the POST body."""
+    op_succeeded = json.loads(WAREHOUSE_OPERATION_SUCCEEDED_PAYLOAD)
+    wh_payload = json.loads(WAREHOUSE_GET_PAYLOAD)
+    new_wh_id = UUID("d4e5f6a7-b8c9-0123-def0-123456789abc")
+    new_wh_url = f"{_WAREHOUSES_URL}/{new_wh_id}"
+
+    with respx.mock:
+        post_route = respx.post(_ITEMS_URL).mock(
+            return_value=httpx.Response(
+                202,
+                json={},
+                headers={"Location": _OPERATION_URL},
+            )
+        )
+        respx.get(_OPERATION_URL).mock(return_value=httpx.Response(200, json=op_succeeded))
+        respx.get(new_wh_url).mock(return_value=httpx.Response(200, json=wh_payload))
+
+        client = await _make_client()
+        async with client:
+            result = await warehouses.create(client, _WORKSPACE_ID, "SalesWarehouse")
+
+    assert isinstance(result, Warehouse)
+    sent_body = json.loads(post_route.calls[0].request.content)
+    assert "creationPayload" not in sent_body
+
+
+@pytest.mark.asyncio
+async def test_create_with_description() -> None:
+    """create with description must include it in the POST body."""
+    op_succeeded = json.loads(WAREHOUSE_OPERATION_SUCCEEDED_PAYLOAD)
+    wh_payload = json.loads(WAREHOUSE_GET_PAYLOAD)
+    new_wh_id = UUID("d4e5f6a7-b8c9-0123-def0-123456789abc")
+    new_wh_url = f"{_WAREHOUSES_URL}/{new_wh_id}"
+
+    with respx.mock:
+        post_route = respx.post(_ITEMS_URL).mock(
+            return_value=httpx.Response(
+                202,
+                json={},
+                headers={"Location": _OPERATION_URL},
+            )
+        )
+        respx.get(_OPERATION_URL).mock(return_value=httpx.Response(200, json=op_succeeded))
+        respx.get(new_wh_url).mock(return_value=httpx.Response(200, json=wh_payload))
+
+        client = await _make_client()
+        async with client:
+            result = await warehouses.create(
+                client,
+                _WORKSPACE_ID,
+                "SalesWarehouse",
+                description="My warehouse",
+            )
+
+    assert isinstance(result, Warehouse)
+    sent_body = json.loads(post_route.calls[0].request.content)
+    assert sent_body["description"] == "My warehouse"
+
+
+@pytest.mark.asyncio
+async def test_create_invalid_collation_raises_value_error() -> None:
+    """create must raise ValueError for unsupported collation before any HTTP call."""
+    client = await _make_client()
+    async with client:
+        with pytest.raises(ValueError, match="collation"):
+            await warehouses.create(
+                client,
+                _WORKSPACE_ID,
+                "SalesWarehouse",
+                collation="SQL_Latin1_General_CP1_CI_AS",
+            )
+
+
+@pytest.mark.asyncio
+async def test_create_empty_name_raises_value_error() -> None:
+    """create must raise ValueError for an empty name before any HTTP call."""
+    client = await _make_client()
+    async with client:
+        with pytest.raises(ValueError, match="name"):
+            await warehouses.create(client, _WORKSPACE_ID, "")
+
+
+@pytest.mark.asyncio
+async def test_create_whitespace_only_name_raises_value_error() -> None:
+    """create must raise ValueError for a whitespace-only name before any HTTP call."""
+    client = await _make_client()
+    async with client:
+        with pytest.raises(ValueError, match="name"):
+            await warehouses.create(client, _WORKSPACE_ID, "   ")
+
+
+# ---------------------------------------------------------------------------
+# rename
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rename_returns_updated_warehouse() -> None:
+    """rename must PATCH and return the updated Warehouse from the response body."""
+    wh_payload = json.loads(WAREHOUSE_GET_PAYLOAD)
+    updated = {**wh_payload, "displayName": "RenamedWarehouse"}
+
+    with respx.mock:
+        patch_route = respx.patch(_WAREHOUSE_URL).mock(
+            return_value=httpx.Response(200, json=updated)
+        )
+
+        client = await _make_client()
+        async with client:
+            result = await warehouses.rename(
+                client, _WORKSPACE_ID, _WAREHOUSE_ID, "RenamedWarehouse"
+            )
+
+    assert isinstance(result, Warehouse)
+    assert result.name == "RenamedWarehouse"
+    assert result.kind == WarehouseKind.WAREHOUSE
+
+    sent_body = json.loads(patch_route.calls[0].request.content)
+    assert sent_body["displayName"] == "RenamedWarehouse"
+    assert "description" not in sent_body
+
+
+@pytest.mark.asyncio
+async def test_rename_with_description_includes_it_in_body() -> None:
+    """rename with description must include it in the PATCH body."""
+    wh_payload = json.loads(WAREHOUSE_GET_PAYLOAD)
+    updated = {**wh_payload, "displayName": "RenamedWarehouse", "description": "New desc"}
+
+    with respx.mock:
+        patch_route = respx.patch(_WAREHOUSE_URL).mock(
+            return_value=httpx.Response(200, json=updated)
+        )
+
+        client = await _make_client()
+        async with client:
+            result = await warehouses.rename(
+                client,
+                _WORKSPACE_ID,
+                _WAREHOUSE_ID,
+                "RenamedWarehouse",
+                description="New desc",
+            )
+
+    assert isinstance(result, Warehouse)
+    assert result.description == "New desc"
+
+    sent_body = json.loads(patch_route.calls[0].request.content)
+    assert sent_body["description"] == "New desc"
+
+
+@pytest.mark.asyncio
+async def test_rename_empty_name_raises_value_error() -> None:
+    """rename must raise ValueError for an empty new_name before any HTTP call."""
+    client = await _make_client()
+    async with client:
+        with pytest.raises(ValueError, match="name"):
+            await warehouses.rename(client, _WORKSPACE_ID, _WAREHOUSE_ID, "")
+
+
+# ---------------------------------------------------------------------------
+# delete
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_204_returns_none() -> None:
+    """delete must return None on 204 No Content."""
+    with respx.mock:
+        respx.delete(_WAREHOUSE_URL).mock(return_value=httpx.Response(204))
+
+        client = await _make_client()
+        async with client:
+            result = await warehouses.delete(client, _WORKSPACE_ID, _WAREHOUSE_ID)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_delete_404_propagates_not_found() -> None:
+    """delete must propagate NotFound on a 404 response."""
+    with respx.mock:
+        respx.delete(_WAREHOUSE_URL).mock(
+            return_value=httpx.Response(404, json={"error": {"code": "ItemNotFound"}})
+        )
+
+        client = await _make_client()
+        async with client:
+            with pytest.raises(NotFound):
+                await warehouses.delete(client, _WORKSPACE_ID, _WAREHOUSE_ID)
+
+
+# ---------------------------------------------------------------------------
+# Fixture sanity: LAKEHOUSE_GET_PAYLOAD has sqlEndpointProperties
+# ---------------------------------------------------------------------------
+
+
+def test_lakehouse_fixture_has_sql_endpoint() -> None:
+    """LAKEHOUSE_GET_PAYLOAD must contain sqlEndpointProperties for SQL_ENDPOINT kind tests."""
+    payload = json.loads(LAKEHOUSE_GET_PAYLOAD)
+    props = payload.get("properties", {})
+    assert "sqlEndpointProperties" in props
+    conn = props["sqlEndpointProperties"]["connectionString"]
+    assert conn == "lakehouse-sql-ep.datawarehouse.fabric.microsoft.com"

--- a/tests/unit/services/test_warehouses.py
+++ b/tests/unit/services/test_warehouses.py
@@ -394,9 +394,8 @@ async def test_delete_204_returns_none() -> None:
 
         client = await _make_client()
         async with client:
-            result = await warehouses.delete(client, _WORKSPACE_ID, _WAREHOUSE_ID)
-
-    assert result is None
+            # delete is typed -> None; just verify no exception is raised
+            await warehouses.delete(client, _WORKSPACE_ID, _WAREHOUSE_ID)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #21

CRUD service for Warehouses and SQL Analytics Endpoints. `create` polls the LRO before returning the populated Warehouse.

## Summary
- `list()` merges `/warehouses` + `/sqlEndpoints` (both paginated) with the correct `WarehouseKind` per endpoint
- `get()` uses the type-specific `/warehouses/{id}` endpoint
- `create()` validates name/collation, POSTs with optional `creationPayload`, polls LRO, returns fully-populated Warehouse
- `rename()` PATCHes the warehouse and returns the updated model
- `delete()` issues DELETE and propagates 404 → `NotFound` via the http_client mapping
- Uses `builtins.list` alias to avoid mypy confusion from shadowing the `list` builtin

## Test plan
- [x] list merges warehouses + sqlEndpoints with correct kind, follows continuationUri
- [x] get returns full Warehouse incl. connection_string
- [x] create polls LRO, returns final Warehouse; collation/empty-name validation raises ValueError before any HTTP call
- [x] create without collation omits `creationPayload` from body
- [x] rename returns updated Warehouse, description omitted when None
- [x] delete 204 + 404 mapping
- [x] ruff / mypy / pytest / pre-commit all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)