### PR TITLE
fix(docs): drop uv from Cloudflare Pages build script

### DIFF
--- a/docs_build/cloudflare_pages.sh
+++ b/docs_build/cloudflare_pages.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
-uv run --only-group docs zensical build
+
+# Cloudflare Pages already runs `pip install .` on this project; we only need
+# zensical itself to build the docs site.
+pip install --quiet --upgrade "zensical>=0.0.42"
+
+zensical build
 curl -sLo ./docs_build/site/t.js "https://cloud.umami.is/script.js"


### PR DESCRIPTION
Closes #38

Cloudflare Pages does not have uv pre-installed and fails with 'uv: command not found'. Switch to a plain pip install of zensical (Cloudflare already does pip install . for the project; we just add zensical on top).

Local dev still uses uv run --only-group docs zensical serve.

## Test plan
- [x] bash -n syntax check passes
- [x] uv run --only-group docs zensical build still produces docs_build/site/index.html (uv venv has pip too, so this isn't affected)
- [x] pre-commit green
- [ ] After merge: next CF Pages run deploys successfully