### PR TITLE
ci: calver-tag release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v8.2.0
+        with:
+          enable-cache: true
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Verify tag matches package version
+        run: |
+          uv sync --all-extras
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          PKG_VERSION=$(uv run python -c "import fabric_dw; print(fabric_dw.__version__)")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "Tag $TAG_VERSION does not match fabric_dw.__version__ $PKG_VERSION" >&2
+            exit 1
+          fi
+
+      - name: Build wheel and sdist
+        run: uv build
+
+      - name: Create GitHub Release with assets
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            dist/*.whl
+            dist/*.tar.gz
+          generate_release_notes: true
+          name: ${{ github.ref_name }}


### PR DESCRIPTION
Closes #46

Push of a v-prefixed calver tag (e.g. v2026.6.0) builds wheel + sdist via uv, verifies the tag matches fabric_dw.__version__, and creates a GitHub Release with auto-generated notes and both artefacts attached. No PyPI yet.

## Test plan
- [x] yamllint clean
- [x] CI green
- [ ] After merge: tagging v2026.6.0 actually produces a release with artefacts (user-verifies)