### PR TITLE
docs: add fdw logo to README and docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+<p align="center">
+  <a href="https://fdw.debruyn.dev">
+    <img src="docs/assets/logo.svg" alt="fabric-dw-mcp-cli" width="140" />
+  </a>
+</p>
+
 # fabric-dw-mcp-cli
 
 > Python CLI and MCP server for administering Microsoft Fabric Data Warehouses and SQL Analytics Endpoints.

--- a/docs/assets/logo.svg
+++ b/docs/assets/logo.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200" role="img" aria-label="fdw">
+  <defs>
+    <radialGradient id="body" cx="0.3" cy="0.2" r="1.08">
+      <stop offset="0" stop-color="#6FDEFB"></stop>
+      <stop offset="0.32" stop-color="#23BBEF"></stop>
+      <stop offset="0.64" stop-color="#0289D7"></stop>
+      <stop offset="1" stop-color="#0E4F88"></stop>
+    </radialGradient>
+  </defs>
+  
+  <path d="M100 60 L146 96 L146 150 L54 150 L54 96 Z" fill="url(#body)" stroke="url(#body)" stroke-width="18" stroke-linejoin="round"></path>
+  
+  <path d="M61 99 L100 68 L139 99" fill="none" stroke="#FFFFFF" stroke-opacity="0.26" stroke-width="7" stroke-linecap="round" stroke-linejoin="round"></path>
+  
+  <path d="M80 112 L96 124 L80 136" fill="none" stroke="#FFFFFF" stroke-width="9" stroke-linecap="round" stroke-linejoin="round"></path>
+  <path d="M104 136 L126 136" stroke="#FFFFFF" stroke-width="9" stroke-linecap="round"></path>
+</svg>

--- a/zensical.toml
+++ b/zensical.toml
@@ -24,6 +24,8 @@ nav = [
 [project.theme]
 custom_dir = "overrides"
 language = "en"
+logo = "assets/logo.svg"
+favicon = "assets/logo.svg"
 features = [
   "content.action.edit",
   "content.code.annotate",
@@ -46,7 +48,6 @@ features = [
 ]
 
 [project.theme.icon]
-logo = "material/cloud-outline"
 repo = "fontawesome/brands/github"
 
 [[project.theme.palette]]


### PR DESCRIPTION
Closes #50

Adds the fdw logo (warehouse silhouette + >_ prompt in OneLake gradient) to:
- README.md top (centered, linked to fdw.debruyn.dev)
- Zensical theme (logo + favicon)

The SVG was generated via Claude Design and lives at docs/assets/logo.svg.

## Test plan
- [x] zensical build still produces docs_build/site/index.html and references the logo
- [x] pre-commit run --all-files green
- [x] Real GitHub Actions CI (5 jobs) green