### PR TITLE
fix(sql): wrap cursor.execute permission errors as PermissionDenied

### DIFF
--- a/src/fabric_dw/services/queries.py
+++ b/src/fabric_dw/services/queries.py
@@ -87,6 +87,6 @@ async def kill(sql: FabricSqlClient, target: SqlTarget, session_id: int) -> None
     stmt = _build_kill_sql(session_id)
     try:
         await sql.execute_nonquery(target, stmt)
-    except AuthError as exc:
+    except (AuthError, PermissionDenied) as exc:
         msg = f"Permission denied when trying to KILL session {session_id}: {exc}"
         raise PermissionDenied(msg) from exc

--- a/src/fabric_dw/sql_client.py
+++ b/src/fabric_dw/sql_client.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 from typing import Any, Protocol
 
 from fabric_dw.auth import CredentialMode
-from fabric_dw.exceptions import AuthError
+from fabric_dw.exceptions import AuthError, PermissionDenied
 
 # Thin indirection that lets tests monkeypatch ``_mssql`` without the native
 # extension being imported at module-load time (the .so may not be loadable in
@@ -28,9 +28,6 @@ def _get_mssql() -> types.ModuleType:
 
 
 # Sentinel strings that signal Entra auth failures in driver error messages.
-# NOTE: These fragments are only checked during connection-time failures
-# (_get_connection). Errors raised by cursor.execute() after a successful
-# connection (e.g. token expiry mid-session) propagate unwrapped.
 _AUTH_ERROR_FRAGMENTS = (
     "login failed",
     "token",
@@ -39,6 +36,13 @@ _AUTH_ERROR_FRAGMENTS = (
     "access denied",
     "invalid authorization",
     "28000",
+)
+
+# Sentinel strings that signal SQL permission-denial failures in driver error messages.
+_PERMISSION_DENIED_FRAGMENTS = (
+    "permission was denied",
+    "cannot grant",
+    "denied the right to",
 )
 
 # Mapping from CredentialMode to the ActiveDirectory auth type suffix.
@@ -116,6 +120,21 @@ def _is_auth_error(exc: BaseException) -> bool:
     return any(fragment in msg for fragment in _AUTH_ERROR_FRAGMENTS)
 
 
+def _classify_driver_error(exc: Exception) -> Exception | None:
+    """Return a mapped exception for known driver error categories, or ``None``.
+
+    Checks the error message against known fragment sets and returns the
+    appropriate high-level exception type.  Returns ``None`` when the error
+    does not match any known category (caller should re-raise unchanged).
+    """
+    msg = str(exc).lower()
+    if any(fragment in msg for fragment in _PERMISSION_DENIED_FRAGMENTS):
+        return PermissionDenied(str(exc))
+    if any(fragment in msg for fragment in _AUTH_ERROR_FRAGMENTS):
+        return AuthError(str(exc))
+    return None
+
+
 @dataclass(frozen=True)
 class SqlTarget:
     """Identifies a specific Fabric warehouse to connect to.
@@ -177,8 +196,9 @@ class FabricSqlClient:
                 try:
                     conn: _Connection = await asyncio.to_thread(_get_mssql().connect, cs)
                 except Exception as exc:
-                    if _is_auth_error(exc):
-                        raise AuthError(str(exc)) from exc
+                    mapped = _classify_driver_error(exc)
+                    if mapped is not None:
+                        raise mapped from exc
                     raise
                 self._cache[key] = conn
             return self._cache[key]
@@ -210,7 +230,13 @@ class FabricSqlClient:
 
         def _run() -> list[dict[str, Any]]:
             cursor = conn.cursor()
-            cursor.execute(sql, params)
+            try:
+                cursor.execute(sql, params)
+            except Exception as exc:
+                mapped = _classify_driver_error(exc)
+                if mapped is not None:
+                    raise mapped from exc
+                raise
             description: list[tuple[str, Any]] = cursor.description or []
             columns = [col[0] for col in description]
             rows: list[tuple[Any, ...]] = cursor.fetchall() or []
@@ -243,7 +269,13 @@ class FabricSqlClient:
 
         def _run() -> int:
             cursor = conn.cursor()
-            cursor.execute(sql, params)
+            try:
+                cursor.execute(sql, params)
+            except Exception as exc:
+                mapped = _classify_driver_error(exc)
+                if mapped is not None:
+                    raise mapped from exc
+                raise
             rowcount: int = cursor.rowcount
             conn.commit()
             return rowcount

--- a/tests/unit/services/test_queries.py
+++ b/tests/unit/services/test_queries.py
@@ -281,3 +281,13 @@ async def test_kill_permission_denied_message_contains_session_id() -> None:
 
     with pytest.raises(PermissionDenied, match="42"):
         await queries.kill(sql, _TARGET, 42)
+
+
+@pytest.mark.asyncio
+async def test_kill_maps_permission_denied_from_execute_nonquery_to_permission_denied() -> None:
+    """kill should re-raise PermissionDenied from execute_nonquery as PermissionDenied."""
+    sql = _make_sql()
+    sql.execute_nonquery.side_effect = PermissionDenied("permission was denied on the object KILL")
+
+    with pytest.raises(PermissionDenied):
+        await queries.kill(sql, _TARGET, 42)

--- a/tests/unit/test_sql_client.py
+++ b/tests/unit/test_sql_client.py
@@ -485,3 +485,51 @@ class TestAuthErrorMapping:
         client = FabricSqlClient()
         with pytest.raises(RuntimeError):
             await client.execute(_make_target(), "SELECT 1")
+
+
+# ---------------------------------------------------------------------------
+# execute / execute_nonquery — cursor.execute error mapping
+# ---------------------------------------------------------------------------
+
+
+class TestCursorExecuteErrorMapping:
+    async def test_execute_nonquery_permission_denied_from_cursor_execute(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """cursor.execute raising 'permission was denied' → PermissionDenied."""
+        from fabric_dw.exceptions import PermissionDenied
+
+        mock_mssql, _conn, mock_cursor = _make_mock_mssql()
+        driver_exc = Exception("The server principal does not have permission was denied on the object")
+        mock_cursor.execute.side_effect = driver_exc
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        client = FabricSqlClient()
+        with pytest.raises(PermissionDenied):
+            await client.execute_nonquery(_make_target(), "KILL '42'")
+
+    async def test_execute_cursor_auth_error_raises_auth_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """cursor.execute raising 'authentication failed' → AuthError."""
+        mock_mssql, _conn, mock_cursor = _make_mock_mssql()
+        driver_exc = Exception("Authentication failed for user '' (token-based)")
+        mock_cursor.execute.side_effect = driver_exc
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        client = FabricSqlClient()
+        with pytest.raises(AuthError):
+            await client.execute(_make_target(), "SELECT 1")
+
+    async def test_cursor_execute_unrelated_error_propagates_unchanged(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A driver exception that doesn't match any fragments propagates as-is."""
+        mock_mssql, _conn, mock_cursor = _make_mock_mssql()
+        driver_exc = RuntimeError("deadlock detected")
+        mock_cursor.execute.side_effect = driver_exc
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        client = FabricSqlClient()
+        with pytest.raises(RuntimeError, match="deadlock detected"):
+            await client.execute(_make_target(), "SELECT 1")

--- a/tests/unit/test_sql_client.py
+++ b/tests/unit/test_sql_client.py
@@ -9,7 +9,7 @@ import pytest
 
 import fabric_dw.sql_client as _sql_client_module
 from fabric_dw.auth import CredentialMode
-from fabric_dw.exceptions import AuthError
+from fabric_dw.exceptions import AuthError, PermissionDenied
 from fabric_dw.sql_client import FabricSqlClient, SqlTarget
 
 # ---------------------------------------------------------------------------
@@ -497,10 +497,10 @@ class TestCursorExecuteErrorMapping:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """cursor.execute raising 'permission was denied' → PermissionDenied."""
-        from fabric_dw.exceptions import PermissionDenied
-
         mock_mssql, _conn, mock_cursor = _make_mock_mssql()
-        driver_exc = Exception("The server principal does not have permission was denied on the object")
+        driver_exc = Exception(
+            "The server principal does not have permission was denied on the object"
+        )
         mock_cursor.execute.side_effect = driver_exc
         _patch_mssql(monkeypatch, mock_mssql)
 


### PR DESCRIPTION
Closes #37

Extends sql_client's driver-error classification so cursor.execute permission failures are also caught and surfaced as PermissionDenied, not propagated as raw driver exceptions. Updates queries.kill to catch the new exception type.

## Changes

- Added `_PERMISSION_DENIED_FRAGMENTS` tuple for permission-denial message detection
- Replaced `_is_auth_error` usage in `_get_connection` with new `_classify_driver_error` helper
- `_classify_driver_error` returns `PermissionDenied` for permission fragments, `AuthError` for auth fragments, or `None` to propagate unchanged
- Wrapped `cursor.execute` in both `execute()` and `execute_nonquery()` with the classifier
- Updated `queries.kill` to catch `(AuthError, PermissionDenied)` instead of just `AuthError`

## Test plan
- [x] New unit tests for `execute_nonquery` permission-denied path (`cursor.execute` raises → `PermissionDenied`)
- [x] New unit test for `execute` auth-error path (`cursor.execute` raises → `AuthError`)
- [x] New unit test for unrelated driver errors propagating unchanged
- [x] `queries.kill` test for `PermissionDenied` bubble-up from `execute_nonquery`
- [x] ruff / mypy / pytest / pre-commit all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)