### PR TITLE
ci: integration test workflow with OIDC federated SP login

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,68 @@
+name: Integration tests
+
+on:
+  pull_request:
+    types: [labeled, synchronize]
+  schedule:
+    - cron: "0 3 * * *"
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  integration:
+    if: ${{ github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'integration') }}
+    runs-on: ubuntu-latest
+    environment: integration
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: azure/login@v2
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          allow-no-subscriptions: true
+
+      - uses: astral-sh/setup-uv@v8.2.0
+        with:
+          enable-cache: true
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - run: uv sync --all-extras --frozen
+
+      - name: Run integration tests
+        env:
+          FABRIC_TEST_WORKSPACE_ID: ${{ vars.FABRIC_TEST_WORKSPACE_ID }}
+          FABRIC_AUTH: default
+        run: uv run pytest tests/integration -m integration -v
+
+      - name: Cleanup orphan items
+        if: always()
+        env:
+          FABRIC_TEST_WORKSPACE_ID: ${{ vars.FABRIC_TEST_WORKSPACE_ID }}
+          FABRIC_AUTH: default
+        run: |
+          # Fail the build if any pytest-* items remain after the run
+          uv run python -c "
+          import anyio, os
+          from fabric_dw.auth import get_credential
+          from fabric_dw.http_client import FabricHttpClient
+          from fabric_dw.services import warehouses
+
+          async def main() -> None:
+              ws = os.environ['FABRIC_TEST_WORKSPACE_ID']
+              cred = get_credential()
+              async with FabricHttpClient(cred) as http:
+                  items = await warehouses.list_warehouses(http, ws)
+                  orphans = [w for w in items if w.name.startswith('pytest-')]
+                  if orphans:
+                      names = [w.name for w in orphans]
+                      raise SystemExit(f'orphan test items remain: {names}')
+
+          anyio.run(main)
+          "

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,47 @@
+import os
+import uuid
+from collections.abc import AsyncIterator
+from uuid import UUID
+
+import pytest_asyncio
+
+from fabric_dw.auth import get_credential
+from fabric_dw.http_client import FabricHttpClient
+from fabric_dw.models import Warehouse
+from fabric_dw.services import warehouses
+from fabric_dw.sql_client import FabricSqlClient
+
+
+@pytest_asyncio.fixture
+async def workspace_id() -> UUID:
+    raw = os.environ.get("FABRIC_TEST_WORKSPACE_ID")
+    if not raw:
+        msg = "set FABRIC_TEST_WORKSPACE_ID for integration tests"
+        raise RuntimeError(msg)
+    return UUID(raw)
+
+
+@pytest_asyncio.fixture
+async def http() -> AsyncIterator[FabricHttpClient]:
+    cred = get_credential()
+    async with FabricHttpClient(cred) as client:
+        yield client
+
+
+@pytest_asyncio.fixture
+async def sql() -> AsyncIterator[FabricSqlClient]:
+    async with FabricSqlClient() as client:
+        yield client
+
+
+@pytest_asyncio.fixture
+async def ephemeral_warehouse(
+    http: FabricHttpClient,
+    workspace_id: UUID,
+) -> AsyncIterator[Warehouse]:
+    name = f"pytest-{uuid.uuid4().hex[:8]}-wh"
+    wh = await warehouses.create(http, workspace_id, name)
+    try:
+        yield wh
+    finally:
+        await warehouses.delete(http, workspace_id, wh.id)

--- a/tests/integration/test_smoke.py
+++ b/tests/integration/test_smoke.py
@@ -1,0 +1,17 @@
+from uuid import UUID
+
+import pytest
+
+from fabric_dw.http_client import FabricHttpClient
+from fabric_dw.services import workspaces
+
+pytestmark = pytest.mark.integration
+
+
+async def test_list_workspaces_includes_test_workspace(
+    http: FabricHttpClient,
+    workspace_id: UUID,
+) -> None:
+    items = await workspaces.list_all(http)
+    ids = {w.id for w in items}
+    assert workspace_id in ids


### PR DESCRIPTION
Closes #45

Adds the integration test workflow (label-gated on PRs, nightly on main) using federated SP OIDC. Sets up the minimal conftest fixtures (workspace_id, http, sql, ephemeral_warehouse) and a smoke test that lists workspaces.

Real per-service integration coverage lands in follow-up PRs.

## Test plan
- [x] yamllint clean
- [x] ruff / mypy / pytest tests/unit / pre-commit all green
- [ ] After merge + adding the 'integration' label: the workflow actually authenticates and runs the smoke test green (verified manually by user)