### PR TITLE
chore(release): CHANGELOG and release-drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,28 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: 'Features'
+    labels: ['type:feature']
+    commitish:
+      - "feat"
+  - title: 'Fixes'
+    labels: ['type:fix', 'bug']
+    commitish:
+      - "fix"
+  - title: 'Documentation'
+    labels: ['area:docs', 'area:docs-site']
+    commitish:
+      - "docs"
+  - title: 'CI / Tooling'
+    labels: ['area:ci', 'area:bootstrap']
+    commitish:
+      - "ci"
+      - "chore"
+  - title: 'Other'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&'
+version-resolver:
+  default: patch
+template: |
+  ## Changes
+  $CHANGES

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,16 @@
+name: Release Drafter
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, reopened, synchronize]
+permissions:
+  contents: write
+  pull-requests: read
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Fixed
+
+### Removed
+
+### Security

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,8 @@ Example: `feat: add DROP TABLE command`
 
 Breaking changes must append `!` after the type, e.g. `feat!: rename CLI entrypoint`.
 
+These prefixes are also used by the **release-drafter** workflow: every PR merged to `main` updates a running GitHub release draft, categorised by type (`feat` → Features, `fix` → Fixes, `docs` → Documentation, `ci`/`chore` → CI / Tooling). When a version tag is pushed, the draft becomes the published release.
+
 ## Running Checks Locally
 
 ### Lint


### PR DESCRIPTION
Closes #64

Adds CHANGELOG.md seed + release-drafter to keep a running release draft updated by every PR merge. CONTRIBUTING.md gains a one-paragraph note on the conventional-commit prefixes used by the drafter.

## Test plan
- [x] yamllint + pre-commit green (mypy failure is pre-existing on main, unrelated to this PR)
- [x] After merge: a new PR title triggers the release-drafter and updates the draft (verified by user after first PR merge)