### PR TITLE
ci(unit): enforce 80% coverage gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - run: uv sync --all-extras --frozen
       - run: uv run pytest tests/unit --cov=fabric_dw --cov-report=xml
+      - name: Coverage report
+        run: uv run coverage report
       - uses: actions/upload-artifact@v4
         with:
           name: coverage-${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,3 +85,17 @@ packages = ["fabric_dw"]
 markers = ["integration: hits real Fabric APIs"]
 addopts = "-ra --strict-markers"
 asyncio_mode = "auto"
+
+[tool.coverage.run]
+source = ["fabric_dw"]
+branch = true
+
+[tool.coverage.report]
+fail_under = 80
+show_missing = true
+skip_covered = true
+exclude_lines = [
+    "pragma: no cover",
+    "raise NotImplementedError",
+    "if TYPE_CHECKING:",
+]


### PR DESCRIPTION
Closes #68

Adds `[tool.coverage.report]` with `fail_under = 80` plus a `uv run coverage report` step in the unit CI job. Fails the build if coverage drops below 80%.

Local coverage at time of merge: **83.60%**.

## Test plan
- [x] Local pytest + coverage report shows >= 80% (83.60%)
- [x] CI unit job runs the report step
- [x] pre-commit + CI 5 jobs + integration green