### PR TITLE
chore(dx): add devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,26 @@
+{
+  "name": "fabric-dw",
+  "image": "mcr.microsoft.com/devcontainers/python:1-3.13-bookworm",
+  "features": {
+    "ghcr.io/devcontainers/features/azure-cli:1": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  "postCreateCommand": "curl -LsSf https://astral.sh/uv/install.sh | sh && source $HOME/.local/bin/env && uv sync --all-extras && uv run pre-commit install",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "charliermarsh.ruff",
+        "ms-python.python",
+        "ms-python.mypy-type-checker",
+        "tamasfe.even-better-toml",
+        "GitHub.copilot",
+        "GitHub.copilot-chat"
+      ],
+      "settings": {
+        "python.defaultInterpreterPath": "/usr/local/bin/python",
+        "[python]": { "editor.defaultFormatter": "charliermarsh.ruff" }
+      }
+    }
+  },
+  "remoteUser": "vscode"
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,8 @@ Thank you for your interest in contributing to `fabric-dw-mcp-cli`!
 
 ## Dev Setup
 
+> **Recommended:** open the repo in [GitHub Codespaces](https://codespaces.new/sdebruyn/fabric-dw-mcp-cli) or VS Code with the Remote-Containers extension — the devcontainer handles all of steps 1–2 automatically.
+
 1. **Install dependencies**
 
    ```bash

--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ fabric-dw --help
 }
 ```
 
+## Develop in a container
+
+Open the repo in [GitHub Codespaces](https://github.com/codespaces) or VS Code's Remote-Containers extension — the devcontainer pre-installs Python 3.13, uv, Azure CLI, and the GitHub CLI.
+
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/sdebruyn/fabric-dw-mcp-cli)
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for dev setup, branch flow, and how to run tests locally.


### PR DESCRIPTION
Closes #66

Adds a devcontainer using mcr.microsoft.com/devcontainers/python:1-3.13-bookworm with uv (installed via official install script), azure-cli, gh, and the Ruff/Python VS Code extensions. README and CONTRIBUTING updated.

Note: `ghcr.io/astral-sh/uv:1` does not exist as a devcontainer feature — uv is installed via `curl -LsSf https://astral.sh/uv/install.sh | sh` in `postCreateCommand` instead.

## Test plan
- [x] devcontainer.json parses as JSON
- [x] pre-commit green (mypy failure is pre-existing on main, unrelated to this change)
- [ ] Open in Codespaces actually works (user-verified)