### PR TITLE
feat(cli): shell completion for bash/zsh/fish

### DIFF
--- a/docs/completion.md
+++ b/docs/completion.md
@@ -1,0 +1,73 @@
+# Shell Completion
+
+`fabric-dw` ships with tab-completion for **bash**, **zsh**, and **fish** via
+[Click's built-in shell completion](https://click.palletsprojects.com/en/stable/shell-completion/).
+
+## Quick install
+
+The easiest way to install completion for your shell is the built-in command:
+
+```shell
+fabric-dw completion install bash   # or zsh / fish
+```
+
+This writes the script to the conventional location for your shell and prints
+the command you need to reload it.
+
+Add `--print` to inspect the script before installing:
+
+```shell
+fabric-dw completion install bash --print
+```
+
+## Manual setup
+
+=== "bash"
+
+    Add the following line to `~/.bashrc`:
+
+    ```bash
+    eval "$(_FABRIC_DW_COMPLETE=bash_source fabric-dw)"
+    ```
+
+    Then reload your shell:
+
+    ```bash
+    source ~/.bashrc
+    ```
+
+=== "zsh"
+
+    Add the following line to `~/.zshrc`:
+
+    ```zsh
+    eval "$(_FABRIC_DW_COMPLETE=zsh_source fabric-dw)"
+    ```
+
+    Then reload your shell:
+
+    ```zsh
+    source ~/.zshrc
+    ```
+
+=== "fish"
+
+    Save the completion script to the fish completions directory:
+
+    ```fish
+    _FABRIC_DW_COMPLETE=fish_source fabric-dw | source
+    ```
+
+    For a persistent installation, write it to a file:
+
+    ```fish
+    _FABRIC_DW_COMPLETE=fish_source fabric-dw \
+      > ~/.config/fish/completions/fabric-dw.fish
+    ```
+
+    Fish picks up files in `~/.config/fish/completions/` automatically on the
+    next shell start. To reload immediately:
+
+    ```fish
+    source ~/.config/fish/completions/fabric-dw.fish
+    ```

--- a/src/fabric_dw/cli/_main.py
+++ b/src/fabric_dw/cli/_main.py
@@ -9,6 +9,7 @@ import click
 from fabric_dw.auth import CredentialMode
 from fabric_dw.cli._context import CliContext
 from fabric_dw.cli.commands.cache import cache_group
+from fabric_dw.cli.commands.completion import completion_group
 
 
 @click.group(invoke_without_command=False)
@@ -66,3 +67,4 @@ def cli(
 
 
 cli.add_command(cache_group)
+cli.add_command(completion_group)

--- a/src/fabric_dw/cli/commands/completion.py
+++ b/src/fabric_dw/cli/commands/completion.py
@@ -1,0 +1,94 @@
+"""Completion sub-commands: install shell completion scripts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+from click.shell_completion import BashComplete, FishComplete, ZshComplete
+
+_SUPPORTED_SHELLS = ("bash", "zsh", "fish")
+
+_COMPLETE_VAR = "_FABRIC_DW_COMPLETE"
+_PROG_NAME = "fabric-dw"
+
+
+def _completion_script(shell: str) -> str:
+    """Return the Click-generated completion script for *shell*.
+
+    Uses Click's public ``ShellComplete`` subclasses to generate the
+    source script without spawning a subprocess.
+    """
+    # Import here to avoid a circular import at module load time.
+    from fabric_dw.cli._main import cli  # noqa: PLC0415
+
+    cls_map = {
+        "bash": BashComplete,
+        "zsh": ZshComplete,
+        "fish": FishComplete,
+    }
+    cls = cls_map[shell.lower()]
+    complete = cls(cli, {}, _PROG_NAME, _COMPLETE_VAR)
+    return complete.source()
+
+
+@click.group("completion")
+def completion_group() -> None:
+    """Manage shell completion scripts."""
+
+
+@completion_group.command("install")
+@click.argument("shell", type=click.Choice(_SUPPORTED_SHELLS, case_sensitive=False))
+@click.option(
+    "--print",
+    "print_only",
+    is_flag=True,
+    default=False,
+    help="Print the completion script to stdout instead of installing it.",
+)
+def install(shell: str, print_only: bool) -> None:
+    """Generate and optionally install the completion script for SHELL.
+
+    When --print is given (or no install location can be determined), the
+    script is printed to stdout so you can source it yourself.
+
+    Without --print the script is written to the conventional location:
+
+    \b
+    bash  → appended to ~/.bashrc  (idempotent)
+    zsh   → appended to ~/.zshrc   (idempotent)
+    fish  → written to ~/.config/fish/completions/fabric-dw.fish
+    """
+    shell = shell.lower()
+    script = _completion_script(shell)
+
+    if print_only:
+        click.echo(script, nl=False)
+        return
+
+    home = Path.home()
+
+    if shell == "bash":
+        target = home / ".bashrc"
+        _append_idempotent(target, script)
+        click.echo(f"Completion script appended to {target}. Reload with: source {target}")
+    elif shell == "zsh":
+        target = home / ".zshrc"
+        _append_idempotent(target, script)
+        click.echo(f"Completion script appended to {target}. Reload with: source {target}")
+    elif shell == "fish":
+        target = home / ".config" / "fish" / "completions" / "fabric-dw.fish"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(script)
+        click.echo(f"Completion script written to {target}. Reload with: source {target}")
+
+
+def _append_idempotent(path: Path, script: str) -> None:
+    """Append *script* to *path* only if the script is not already present."""
+    existing = path.read_text() if path.exists() else ""
+    marker = script.strip()
+    if marker and marker in existing:
+        click.echo(f"Completion script already present in {path}. Nothing to do.")
+        return
+    with path.open("a") as fh:
+        fh.write("\n" + script)

--- a/tests/unit/cli/test_completion.py
+++ b/tests/unit/cli/test_completion.py
@@ -1,0 +1,62 @@
+"""Tests for completion sub-commands — written BEFORE the implementation (TDD)."""
+
+from __future__ import annotations
+
+import pytest
+from click.testing import CliRunner
+
+from fabric_dw.cli._main import cli
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+class TestCompletionInstallPrint:
+    """completion install --print outputs a non-empty shell snippet."""
+
+    def test_bash_print_exits_zero(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli, ["completion", "install", "bash", "--print"])
+        assert result.exit_code == 0
+
+    def test_bash_print_contains_complete(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli, ["completion", "install", "bash", "--print"])
+        assert result.exit_code == 0
+        assert "complete" in result.output
+        assert len(result.output.strip()) > 0
+
+    def test_zsh_print_exits_zero(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli, ["completion", "install", "zsh", "--print"])
+        assert result.exit_code == 0
+
+    def test_zsh_print_nonempty(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli, ["completion", "install", "zsh", "--print"])
+        assert result.exit_code == 0
+        assert len(result.output.strip()) > 0
+
+    def test_fish_print_exits_zero(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli, ["completion", "install", "fish", "--print"])
+        assert result.exit_code == 0
+
+    def test_fish_print_contains_complete_c_fabric_dw(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli, ["completion", "install", "fish", "--print"])
+        assert result.exit_code == 0
+        assert "complete" in result.output
+        assert "fabric-dw" in result.output
+
+    def test_unknown_shell_exits_nonzero(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli, ["completion", "install", "powershell"])
+        assert result.exit_code != 0
+
+
+class TestCompletionHelp:
+    """completion --help is well-formed."""
+
+    def test_completion_help_exits_zero(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli, ["completion", "--help"])
+        assert result.exit_code == 0
+
+    def test_completion_install_help_exits_zero(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli, ["completion", "install", "--help"])
+        assert result.exit_code == 0

--- a/zensical.toml
+++ b/zensical.toml
@@ -16,7 +16,8 @@ nav = [
   { "Install" = "install.md" },
   { "Reference" = [
     { "CLI" = "cli.md" },
-    { "MCP" = "mcp.md" }
+    { "MCP" = "mcp.md" },
+    { "Shell Completion" = "completion.md" }
   ] },
   { "Contributing" = "contributing.md" }
 ]


### PR DESCRIPTION
Closes #65

Adds a `fabric-dw completion install [SHELL]` command that prints or installs the Click-generated completion script. Docs page docs/completion.md with copy-paste snippets per shell.

## Changes

- `src/fabric_dw/cli/commands/completion.py` — new `completion` group with `install` command using Click's `BashComplete`/`ZshComplete`/`FishComplete` classes directly
- `src/fabric_dw/cli/_main.py` — registers the `completion_group`
- `docs/completion.md` — copy-paste setup snippets for bash/zsh/fish plus manual eval-based setup
- `zensical.toml` — adds "Shell Completion" page to Reference nav

## Test plan
- [x] `fabric-dw completion install bash --print` produces non-empty script containing `complete`
- [x] `fabric-dw completion install zsh --print` produces non-empty script
- [x] `fabric-dw completion install fish --print` produces script containing `complete` and `fabric-dw`
- [x] `fabric-dw completion install powershell` exits non-zero (unknown shell)
- [x] ruff / mypy / pytest / pre-commit / CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)