### PR TITLE
ci(security): bandit + dependency review

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,32 @@
+name: Security
+on:
+  pull_request:
+  push:
+    branches: [main]
+permissions:
+  contents: read
+  pull-requests: read
+jobs:
+  bandit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v8.2.0
+        with: { enable-cache: true }
+      - run: uvx --quiet bandit -r src/ -ll
+  dependency-review:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+  pip-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v8.2.0
+        with: { enable-cache: true }
+      - run: uv sync --all-extras --frozen
+      - run: uvx --quiet pip-audit


### PR DESCRIPTION
Closes #69. Adds bandit + dependency-review + pip-audit CI gates.

## Summary

- Adds `.github/workflows/security.yml` with three jobs: `bandit`, `dependency-review`, and `pip-audit`
- `bandit` runs on every push and PR, scanning `src/` at medium+ severity (`-ll`)
- `dependency-review` runs on PRs only via `actions/dependency-review-action@v4`
- `pip-audit` scans the locked dependencies for known CVEs on every push and PR

## Test plan

- [ ] Verify `bandit` job passes on current source (local: no issues identified)
- [ ] Verify `pip-audit` job passes on current `uv.lock` (local: no known vulnerabilities found)
- [ ] Verify `dependency-review` job runs on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)