### PR TITLE
fix(ci): integration workflow reads OIDC IDs from secrets, not vars

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -25,8 +25,8 @@ jobs:
 
       - uses: azure/login@v2
         with:
-          client-id: ${{ vars.AZURE_CLIENT_ID }}
-          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
       - name: Resume Fabric capacity
@@ -58,14 +58,14 @@ jobs:
 
       - name: Run integration tests
         env:
-          FABRIC_TEST_WORKSPACE_ID: ${{ vars.FABRIC_TEST_WORKSPACE_ID }}
+          FABRIC_TEST_WORKSPACE_ID: ${{ secrets.FABRIC_TEST_WORKSPACE_ID }}
           FABRIC_AUTH: default
         run: uv run pytest tests/integration -m integration -v
 
       - name: Cleanup orphan items
         if: always()
         env:
-          FABRIC_TEST_WORKSPACE_ID: ${{ vars.FABRIC_TEST_WORKSPACE_ID }}
+          FABRIC_TEST_WORKSPACE_ID: ${{ secrets.FABRIC_TEST_WORKSPACE_ID }}
           FABRIC_AUTH: default
         run: |
           # Fail the build if any pytest-* warehouses remain


### PR DESCRIPTION
Closes #81

AZURE_CLIENT_ID, AZURE_TENANT_ID and FABRIC_TEST_WORKSPACE_ID are stored as environment secrets; the workflow was reading them as vars (different namespace), which returned empty strings and broke azure/login on every PR. Switched those three to secrets.* refs. AZURE_SUBSCRIPTION_ID and FABRIC_TEST_CAPACITY_ID stay as vars (they are repo variables).