### PR TITLE
test(integration): per-service coverage (2/7) — warehouses

### DIFF
--- a/tests/integration/test_services_warehouses.py
+++ b/tests/integration/test_services_warehouses.py
@@ -1,0 +1,42 @@
+import uuid
+
+import pytest
+
+from fabric_dw.exceptions import NotFound
+from fabric_dw.http_client import FabricHttpClient
+from fabric_dw.models import Warehouse
+from fabric_dw.services import warehouses
+
+pytestmark = pytest.mark.integration
+
+
+async def test_ephemeral_warehouse_appears_in_list(
+    http: FabricHttpClient, workspace_id: uuid.UUID, ephemeral_warehouse: Warehouse
+) -> None:
+    items = await warehouses.list_warehouses(http, workspace_id)
+    assert ephemeral_warehouse.id in {w.id for w in items}
+
+
+async def test_get_ephemeral_warehouse(
+    http: FabricHttpClient, workspace_id: uuid.UUID, ephemeral_warehouse: Warehouse
+) -> None:
+    fetched = await warehouses.get_warehouse(http, workspace_id, ephemeral_warehouse.id)
+    assert fetched.id == ephemeral_warehouse.id
+    assert fetched.name == ephemeral_warehouse.name
+    assert fetched.connection_string
+
+
+async def test_rename_ephemeral_warehouse(
+    http: FabricHttpClient, workspace_id: uuid.UUID, ephemeral_warehouse: Warehouse
+) -> None:
+    new_name = f"{ephemeral_warehouse.name}-renamed"
+    updated = await warehouses.rename(http, workspace_id, ephemeral_warehouse.id, new_name)
+    assert updated.name == new_name
+
+
+async def test_delete_nonexistent_warehouse_raises(
+    http: FabricHttpClient, workspace_id: uuid.UUID
+) -> None:
+    bogus = uuid.uuid4()
+    with pytest.raises(NotFound):
+        await warehouses.delete(http, workspace_id, bogus)


### PR DESCRIPTION
Closes #79. Adds 4 integration tests for services.warehouses using the ephemeral_warehouse fixture.

## Summary

- `test_ephemeral_warehouse_appears_in_list`: verifies `list_warehouses` includes the newly created warehouse
- `test_get_ephemeral_warehouse`: verifies `get_warehouse` returns correct `id`, `name`, and `connection_string`
- `test_rename_ephemeral_warehouse`: verifies `rename` updates the display name
- `test_delete_nonexistent_warehouse_raises`: verifies `delete` raises `NotFound` for a bogus UUID

## Test plan

- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run mypy src tests` — no issues
- [x] `uv run pytest tests/unit -q` — 349 passed
- [ ] Integration tests run in CI (requires Azure credentials)

🤖 Generated with [Claude Code](https://claude.com/claude-code)