### PR TITLE
fix(ci): retry capacity resume on transient state errors

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -31,20 +31,39 @@ jobs:
 
       - name: Resume Fabric capacity
         run: |
-          az resource invoke-action \
-            --ids "${{ vars.FABRIC_TEST_CAPACITY_ID }}" \
-            --action resume
-          # Poll until State=Active (max 5 min)
+          set -e
+          CAPACITY_ID="${{ vars.FABRIC_TEST_CAPACITY_ID }}"
+
+          # Wait for the capacity to leave any transitional state, up to 5 min
           for i in {1..30}; do
-            STATE=$(az resource show --ids "${{ vars.FABRIC_TEST_CAPACITY_ID }}" --query 'properties.state' -o tsv)
-            echo "Capacity state: $STATE"
-            [[ "$STATE" == "Active" ]] && break
+            STATE=$(az resource show --ids "$CAPACITY_ID" --query 'properties.state' -o tsv 2>/dev/null || echo "Unknown")
+            echo "Pre-resume state: $STATE"
+            case "$STATE" in
+              Active)  echo "Already Active, skipping resume"; exit 0 ;;
+              Paused)  break ;;
+              *)       sleep 10 ;;
+            esac
+          done
+
+          # Issue resume, but tolerate transient BadRequest
+          for attempt in {1..6}; do
+            if az resource invoke-action --ids "$CAPACITY_ID" --action resume; then
+              break
+            fi
+            echo "Resume attempt $attempt failed (likely transient), waiting 15s..."
+            sleep 15
+          done
+
+          # Poll until Active, max 5 min
+          for i in {1..30}; do
+            STATE=$(az resource show --ids "$CAPACITY_ID" --query 'properties.state' -o tsv)
+            echo "Post-resume state: $STATE"
+            [[ "$STATE" == "Active" ]] && exit 0
             sleep 10
           done
-          if [[ "$STATE" != "Active" ]]; then
-            echo "Capacity did not become Active within 5 minutes" >&2
-            exit 1
-          fi
+
+          echo "Capacity did not reach Active state within 5 minutes" >&2
+          exit 1
 
       - uses: astral-sh/setup-uv@v8.2.0
         with:
@@ -88,6 +107,36 @@ jobs:
       - name: Suspend Fabric capacity
         if: always()
         run: |
-          az resource invoke-action \
-            --ids "${{ vars.FABRIC_TEST_CAPACITY_ID }}" \
-            --action suspend
+          set -e
+          CAPACITY_ID="${{ vars.FABRIC_TEST_CAPACITY_ID }}"
+
+          # Wait for the capacity to leave any transitional state, up to 5 min
+          for i in {1..30}; do
+            STATE=$(az resource show --ids "$CAPACITY_ID" --query 'properties.state' -o tsv 2>/dev/null || echo "Unknown")
+            echo "Pre-suspend state: $STATE"
+            case "$STATE" in
+              Paused)  echo "Already Paused, skipping suspend"; exit 0 ;;
+              Active)  break ;;
+              *)       sleep 10 ;;
+            esac
+          done
+
+          # Issue suspend, but tolerate transient BadRequest
+          for attempt in {1..6}; do
+            if az resource invoke-action --ids "$CAPACITY_ID" --action suspend; then
+              break
+            fi
+            echo "Suspend attempt $attempt failed (likely transient), waiting 15s..."
+            sleep 15
+          done
+
+          # Poll until Paused, max 5 min
+          for i in {1..30}; do
+            STATE=$(az resource show --ids "$CAPACITY_ID" --query 'properties.state' -o tsv)
+            echo "Post-suspend state: $STATE"
+            [[ "$STATE" == "Paused" ]] && exit 0
+            sleep 10
+          done
+
+          echo "Capacity did not reach Paused state within 5 minutes" >&2
+          exit 1


### PR DESCRIPTION
Closes #100. Wraps capacity resume/suspend in transient-state-tolerant loops so the integration job doesn't fail when a previous run is still mid-transition.

## Changes

- **Resume Fabric capacity**: adds pre-resume poll (waits for `Pausing`/`Resuming` → `Paused`/`Active`), 6-attempt retry loop on `invoke-action`, and post-resume poll until `Active`.
- **Suspend Fabric capacity**: same pattern with `suspend` action and `Paused` as the target state.

## Test plan

- [ ] Workflow YAML lints clean (existing warnings are pre-existing).
- [ ] Unit checks (`ruff`, `mypy`, `pytest tests/unit`) all pass.
- [ ] Integration job runs green on CI.