### PR TITLE
test(integration): per-service coverage (4/7) — queries

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -9,7 +9,7 @@ from fabric_dw.auth import get_credential
 from fabric_dw.http_client import FabricHttpClient
 from fabric_dw.models import Warehouse
 from fabric_dw.services import warehouses
-from fabric_dw.sql_client import FabricSqlClient
+from fabric_dw.sql_client import FabricSqlClient, SqlTarget
 
 
 @pytest_asyncio.fixture
@@ -45,3 +45,15 @@ async def ephemeral_warehouse(
         yield wh
     finally:
         await warehouses.delete(http, workspace_id, wh.id)
+
+
+@pytest_asyncio.fixture
+async def ephemeral_sql_target(
+    workspace_id: UUID, ephemeral_warehouse: Warehouse
+) -> AsyncIterator[SqlTarget]:
+    assert ephemeral_warehouse.connection_string
+    yield SqlTarget(
+        workspace_id=str(workspace_id),
+        database=ephemeral_warehouse.name,
+        connection_string=ephemeral_warehouse.connection_string,
+    )

--- a/tests/integration/test_services_queries.py
+++ b/tests/integration/test_services_queries.py
@@ -1,0 +1,22 @@
+import pytest
+
+from fabric_dw.services import queries
+from fabric_dw.sql_client import FabricSqlClient, SqlTarget
+
+pytestmark = pytest.mark.integration
+
+
+async def test_list_running_returns_a_list(
+    sql: FabricSqlClient, ephemeral_sql_target: SqlTarget
+) -> None:
+    running = await queries.list_running(sql, ephemeral_sql_target)
+    assert isinstance(running, list)
+
+
+async def test_kill_invalid_session_id_raises(
+    sql: FabricSqlClient, ephemeral_sql_target: SqlTarget
+) -> None:
+    with pytest.raises(ValueError, match="session_id must be a positive integer"):
+        await queries.kill(sql, ephemeral_sql_target, 0)
+    with pytest.raises(ValueError, match="session_id must be a positive integer"):
+        await queries.kill(sql, ephemeral_sql_target, -1)


### PR DESCRIPTION
Closes #83. Adds integration tests for services.queries (list_running smoke + kill validation). Adds ephemeral_sql_target fixture if missing.

## Summary
- Adds `ephemeral_sql_target` fixture to `tests/integration/conftest.py`, derived from `ephemeral_warehouse`
- Adds `tests/integration/test_services_queries.py` with two tests:
  - `test_list_running_returns_a_list`: smoke test that `list_running` returns a list
  - `test_kill_invalid_session_id_raises`: validates that `kill` raises `ValueError` for non-positive session IDs

## Test plan
- [ ] Unit checks pass: `ruff check`, `ruff format --check`, `mypy`, `pytest tests/unit`
- [ ] Integration CI green (runs against ephemeral Fabric warehouse)