### PR TITLE
feat(cli/cache): drop show and invalidate, keep clear

### DIFF
--- a/src/fabric_dw/cli/commands/cache.py
+++ b/src/fabric_dw/cli/commands/cache.py
@@ -1,59 +1,17 @@
-"""Cache sub-commands: show, clear, invalidate."""
+"""Cache sub-commands: clear."""
 
 from __future__ import annotations
 
-import logging
-from collections.abc import Callable, Coroutine
-from functools import wraps
-from typing import ParamSpec, TypeVar
-from uuid import UUID
-
-import anyio
 import click
 
-from fabric_dw import auth as _auth
 from fabric_dw.cache import LookupCache
 from fabric_dw.cli._context import CliContext
-from fabric_dw.cli._render import confirm, render
-from fabric_dw.http_client import FabricHttpClient
-from fabric_dw.resolver import GUID_RE, Resolver
-
-_P = ParamSpec("_P")
-_R = TypeVar("_R")
-
-_log = logging.getLogger(__name__)
-
-
-def _coro(f: Callable[_P, Coroutine[None, None, _R]]) -> Callable[_P, _R]:
-    """Wrap an async Click command so it runs via anyio.run.
-
-    ``anyio.run`` does not support keyword arguments, so we wrap the call
-    in a no-argument async closure.
-    """
-
-    @wraps(f)
-    def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R:
-        async def _inner() -> _R:
-            return await f(*args, **kwargs)
-
-        return anyio.run(_inner)
-
-    return wrapper
+from fabric_dw.cli._render import confirm
 
 
 @click.group("cache")
 def cache_group() -> None:
     """Manage the local name-to-UUID lookup cache."""
-
-
-@cache_group.command("show")
-@click.pass_obj
-def show(ctx: CliContext) -> None:
-    """Print the current cache contents."""
-    cache = LookupCache()
-    # Read raw JSON shape from the cache file
-    raw = cache._read()  # pylint: disable=protected-access
-    render(raw, json_output=ctx.json_output, table_title="Cache")
 
 
 @cache_group.command("clear")
@@ -66,29 +24,3 @@ def clear(ctx: CliContext) -> None:
         click.echo("Cache cleared.")
     else:
         click.echo("Aborted.")
-
-
-@cache_group.command("invalidate")
-@click.argument("workspace")
-@click.pass_obj
-@_coro
-async def invalidate(ctx: CliContext, workspace: str) -> None:
-    """Invalidate cache entries for WORKSPACE (name or GUID).
-
-    If WORKSPACE is already a GUID, the resolver is bypassed and the
-    workspace entry is removed directly.  If it is a name, the resolver
-    is used to look up the GUID (hitting the cache or the Fabric API).
-    """
-    if GUID_RE.match(workspace):
-        ws_uuid = UUID(workspace)
-    else:
-        # Name path: need to resolve via Resolver (requires HTTP client)
-        credential = _auth.get_credential(ctx.auth)
-        async with FabricHttpClient(credential) as http:
-            cache = LookupCache()
-            resolver = Resolver(http=http, cache=cache)
-            ws_uuid = await resolver.workspace_id(workspace)
-
-    cache = LookupCache()
-    cache.invalidate_workspace(ws_uuid)
-    click.echo(f"Invalidated cache for workspace {ws_uuid}.")

--- a/tests/unit/cli/test_cache.py
+++ b/tests/unit/cli/test_cache.py
@@ -1,4 +1,4 @@
-"""Tests for cache sub-commands — written BEFORE the implementation (TDD)."""
+"""Tests for cache sub-commands."""
 
 from __future__ import annotations
 
@@ -25,43 +25,6 @@ def cache_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     """Redirect XDG_CACHE_HOME to a temp dir so cache files are isolated."""
     monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
     return tmp_path
-
-
-class TestCacheShow:
-    """cache show prints the current cache contents."""
-
-    def test_show_empty_cache_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
-        _ = cache_env  # ensure XDG_CACHE_HOME is redirected
-        result = runner.invoke(cli, ["cache", "show"])
-        assert result.exit_code == 0
-
-    def test_show_empty_cache_json_flag(self, runner: CliRunner, cache_env: Path) -> None:
-        _ = cache_env  # ensure XDG_CACHE_HOME is redirected
-        result = runner.invoke(cli, ["--json", "cache", "show"])
-        assert result.exit_code == 0
-        # With --json, output must be parseable JSON
-        parsed = json.loads(result.output)
-        assert isinstance(parsed, dict)
-
-    def test_show_displays_cache_structure(self, runner: CliRunner, cache_env: Path) -> None:
-        # Pre-populate cache
-        cache_file = cache_env / "fabric-dw" / "lookup.json"
-        cache_file.parent.mkdir(parents=True, exist_ok=True)
-        cache_file.write_text(
-            json.dumps(
-                {
-                    "version": 1,
-                    "workspaces": {
-                        "myws": {"id": WS_GUID, "fetched_at": "2026-01-01T00:00:00+00:00"}
-                    },
-                    "items": {},
-                }
-            )
-        )
-        result = runner.invoke(cli, ["--json", "cache", "show"])
-        assert result.exit_code == 0
-        parsed = json.loads(result.output)
-        assert "workspaces" in parsed
 
 
 class TestCacheClear:
@@ -109,37 +72,3 @@ class TestCacheClear:
         data = json.loads(cache_file.read_text())
         # Cache should still have the workspace entry
         assert "myws" in data["workspaces"]
-
-
-class TestCacheInvalidate:
-    """cache invalidate removes a workspace entry from the cache."""
-
-    def test_invalidate_guid_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
-        _ = cache_env  # ensure XDG_CACHE_HOME is redirected
-        result = runner.invoke(cli, ["cache", "invalidate", WS_GUID])
-        assert result.exit_code == 0
-
-    def test_invalidate_guid_removes_workspace(self, runner: CliRunner, cache_env: Path) -> None:
-        cache_file = cache_env / "fabric-dw" / "lookup.json"
-        cache_file.parent.mkdir(parents=True, exist_ok=True)
-        cache_file.write_text(
-            json.dumps(
-                {
-                    "version": 1,
-                    "workspaces": {
-                        "myws": {"id": WS_GUID, "fetched_at": "2026-01-01T00:00:00+00:00"}
-                    },
-                    "items": {WS_GUID: {"someitem": {"id": "x", "kind": "Warehouse"}}},
-                }
-            )
-        )
-        runner.invoke(cli, ["cache", "invalidate", WS_GUID])
-        data = json.loads(cache_file.read_text())
-        assert "myws" not in data["workspaces"]
-        assert WS_GUID not in data.get("items", {})
-
-    def test_invalidate_missing_guid_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
-        _ = cache_env  # ensure XDG_CACHE_HOME is redirected
-        # GUID not in cache — should still exit cleanly
-        result = runner.invoke(cli, ["cache", "invalidate", WS_GUID])
-        assert result.exit_code == 0


### PR DESCRIPTION
Closes #106

Per the user, only `fabric-dw cache clear` is useful at the CLI surface. MCP tools `clear_cache` and `invalidate_workspace_cache` stay unchanged.

## Test plan
- [x] cache show / cache invalidate removed; cache clear unchanged
- [x] ruff / mypy / pytest / CI 5 jobs + integration green
- [x] MCP server tool list unchanged