### PR TITLE
test(integration): per-service coverage (5/7) — snapshots

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -7,8 +7,8 @@ import pytest_asyncio
 
 from fabric_dw.auth import get_credential
 from fabric_dw.http_client import FabricHttpClient
-from fabric_dw.models import Warehouse
-from fabric_dw.services import warehouses
+from fabric_dw.models import Warehouse, WarehouseSnapshot
+from fabric_dw.services import snapshots, warehouses
 from fabric_dw.sql_client import FabricSqlClient, SqlTarget
 
 
@@ -45,6 +45,20 @@ async def ephemeral_warehouse(
         yield wh
     finally:
         await warehouses.delete(http, workspace_id, wh.id)
+
+
+@pytest_asyncio.fixture
+async def ephemeral_snapshot(
+    http: FabricHttpClient,
+    workspace_id: UUID,
+    ephemeral_warehouse: Warehouse,
+) -> AsyncIterator[WarehouseSnapshot]:
+    name = f"pytest-{uuid.uuid4().hex[:8]}-snap"
+    snap = await snapshots.create(http, workspace_id, ephemeral_warehouse.id, name)
+    try:
+        yield snap
+    finally:
+        await snapshots.delete(http, workspace_id, snap.id)
 
 
 @pytest_asyncio.fixture

--- a/tests/integration/test_services_snapshots.py
+++ b/tests/integration/test_services_snapshots.py
@@ -1,0 +1,26 @@
+import uuid
+from uuid import UUID
+
+import pytest
+
+from fabric_dw.http_client import FabricHttpClient
+from fabric_dw.models import Warehouse
+from fabric_dw.services import snapshots
+
+pytestmark = pytest.mark.integration
+
+
+async def test_create_list_rename_delete_roundtrip(
+    http: FabricHttpClient, workspace_id: UUID, ephemeral_warehouse: Warehouse
+) -> None:
+    name = f"pytest-snap-{uuid.uuid4().hex[:8]}"
+    snap = await snapshots.create(http, workspace_id, ephemeral_warehouse.id, name)
+    try:
+        listed = await snapshots.list_snapshots(http, workspace_id, ephemeral_warehouse.id)
+        assert snap.id in {s.id for s in listed}
+
+        new_name = f"{name}-renamed"
+        renamed = await snapshots.rename(http, workspace_id, snap.id, new_name=new_name)
+        assert renamed.name == new_name
+    finally:
+        await snapshots.delete(http, workspace_id, snap.id)


### PR DESCRIPTION
Closes #84. Adds integration test for services.snapshots covering create→list→rename→delete on an ephemeral warehouse.

## Summary
- New `tests/integration/test_services_snapshots.py` with a roundtrip test: create snapshot, verify it appears in `list_snapshots`, rename it, clean up via delete
- Adds `ephemeral_snapshot` fixture to `tests/integration/conftest.py` mirroring `ephemeral_warehouse` for use by future snapshot tests

## Test plan
- [ ] `uv run ruff check .` — passes
- [ ] `uv run ruff format --check .` — passes
- [ ] `uv run mypy src tests` — passes
- [ ] `uv run pytest tests/unit -q` — 349 passed
- [ ] Integration test exercises the full snapshot lifecycle against a real Fabric workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)