### PR TITLE
feat(services/sql_endpoints): list, get, refresh metadata

### DIFF
--- a/src/fabric_dw/cli/_main.py
+++ b/src/fabric_dw/cli/_main.py
@@ -11,6 +11,7 @@ from fabric_dw.cli._context import CliContext
 from fabric_dw.cli.commands.audit import audit_group
 from fabric_dw.cli.commands.cache import cache_group
 from fabric_dw.cli.commands.completion import completion_group
+from fabric_dw.cli.commands.endpoints import endpoints_group
 from fabric_dw.cli.commands.queries import queries_group
 from fabric_dw.cli.commands.snapshots import snapshots_group
 from fabric_dw.cli.commands.warehouses import warehouses_group
@@ -73,6 +74,7 @@ cli.add_command(cache_group)
 cli.add_command(completion_group)
 cli.add_command(workspaces_group)
 cli.add_command(warehouses_group)
+cli.add_command(endpoints_group)
 cli.add_command(audit_group)
 cli.add_command(queries_group)
 cli.add_command(snapshots_group)

--- a/src/fabric_dw/cli/commands/endpoints.py
+++ b/src/fabric_dw/cli/commands/endpoints.py
@@ -1,0 +1,93 @@
+"""SQL Analytics Endpoint sub-commands for the fabric-dw CLI."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+import click
+
+from fabric_dw import auth as _auth
+from fabric_dw.cache import LookupCache
+from fabric_dw.cli._context import CliContext
+from fabric_dw.cli._render import render
+from fabric_dw.cli.commands._utils import _coro, _resolve_item
+from fabric_dw.exceptions import FabricError
+from fabric_dw.http_client import FabricHttpClient
+from fabric_dw.resolver import Resolver
+from fabric_dw.services import sql_endpoints as _sql_endpoints_svc
+
+_log = logging.getLogger(__name__)
+
+
+@asynccontextmanager
+async def _build_clients(
+    ctx: CliContext,
+) -> AsyncIterator[tuple[FabricHttpClient, None]]:
+    """Build and yield an HTTP client for endpoint commands."""
+    credential = _auth.get_credential(ctx.auth)
+    async with FabricHttpClient(credential) as http:
+        yield http, None
+
+
+@click.group("endpoints")
+def endpoints_group() -> None:
+    """Manage Microsoft Fabric SQL Analytics Endpoints."""
+
+
+@endpoints_group.command("list")
+@click.argument("workspace")
+@click.pass_obj
+@_coro
+async def list_cmd(ctx: CliContext, workspace: str) -> None:
+    """List all SQL analytics endpoints in WORKSPACE (name or GUID)."""
+    try:
+        async with _build_clients(ctx) as (http, _):
+            cache = LookupCache()
+            resolver = Resolver(http=http, cache=cache)
+            ws_id = await resolver.workspace_id(workspace)
+            items = await _sql_endpoints_svc.list_endpoints(http, ws_id)
+            render(
+                [ep.model_dump(by_alias=True, mode="json") for ep in items],
+                json_output=ctx.json_output,
+                table_title="SQL Analytics Endpoints",
+            )
+    except FabricError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@endpoints_group.command("get")
+@click.argument("workspace")
+@click.argument("endpoint")
+@click.pass_obj
+@_coro
+async def get_cmd(ctx: CliContext, workspace: str, endpoint: str) -> None:
+    """Get details for ENDPOINT in WORKSPACE (both accept name or GUID)."""
+    try:
+        async with _build_clients(ctx) as (http, _):
+            ws_id, entry = await _resolve_item(http, workspace, endpoint)
+            obj = await _sql_endpoints_svc.get_endpoint(http, ws_id, entry.id)
+            render(obj.model_dump(by_alias=True, mode="json"), json_output=ctx.json_output)
+    except FabricError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@endpoints_group.command("refresh")
+@click.argument("workspace")
+@click.argument("endpoint")
+@click.pass_obj
+@_coro
+async def refresh_cmd(ctx: CliContext, workspace: str, endpoint: str) -> None:
+    """Refresh metadata for ENDPOINT in WORKSPACE (both accept name or GUID).
+
+    Triggers a metadata sync from the underlying Lakehouse delta tables.
+    This is a long-running operation (LRO) that is polled to completion.
+    """
+    try:
+        async with _build_clients(ctx) as (http, _):
+            ws_id, entry = await _resolve_item(http, workspace, endpoint)
+            result = await _sql_endpoints_svc.refresh_metadata(http, ws_id, entry.id)
+            render(result, json_output=ctx.json_output)
+    except FabricError as exc:
+        raise click.ClickException(str(exc)) from exc

--- a/src/fabric_dw/mcp/server.py
+++ b/src/fabric_dw/mcp/server.py
@@ -32,7 +32,7 @@ from fabric_dw.exceptions import ConfigError, FabricError
 from fabric_dw.http_client import FabricHttpClient
 from fabric_dw.logging import setup_logging
 from fabric_dw.resolver import Resolver
-from fabric_dw.services import audit, queries, snapshots, warehouses, workspaces
+from fabric_dw.services import audit, queries, snapshots, sql_endpoints, warehouses, workspaces
 from fabric_dw.services import ownership as ownership_svc
 from fabric_dw.sql_client import FabricSqlClient, SqlTarget
 
@@ -251,6 +251,49 @@ async def takeover_warehouse(workspace: str, warehouse: str) -> dict[str, Any]:
     except FabricError as exc:
         raise _fabric_err(exc) from exc
     return {"taken_over": True, "warehouse_id": str(item.id)}
+
+
+# ---------------------------------------------------------------------------
+# SQL Endpoint tools
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+async def list_sql_endpoints(workspace: str) -> list[dict[str, Any]]:
+    """List all SQL analytics endpoints in a workspace."""
+    try:
+        ws_id = await _get_resolver().workspace_id(workspace)
+        result = await sql_endpoints.list_endpoints(_get_http(), ws_id)
+    except FabricError as exc:
+        raise _fabric_err(exc) from exc
+    return [ep.model_dump(by_alias=True, mode="json") for ep in result]
+
+
+@mcp.tool()
+async def get_sql_endpoint(workspace: str, endpoint: str) -> dict[str, Any]:
+    """Return details for a single SQL analytics endpoint (name or GUID)."""
+    try:
+        ws_id = await _get_resolver().workspace_id(workspace)
+        item = await _get_resolver().item(workspace, endpoint)
+        result = await sql_endpoints.get_endpoint(_get_http(), ws_id, item.id)
+    except FabricError as exc:
+        raise _fabric_err(exc) from exc
+    return result.model_dump(by_alias=True, mode="json")
+
+
+@mcp.tool()
+async def refresh_sql_endpoint_metadata(workspace: str, endpoint: str) -> dict[str, Any]:
+    """Refresh metadata for a SQL analytics endpoint (sync from the underlying Lakehouse).
+
+    This is a long-running operation (LRO) that is polled to completion.
+    """
+    try:
+        ws_id = await _get_resolver().workspace_id(workspace)
+        item = await _get_resolver().item(workspace, endpoint)
+        result = await sql_endpoints.refresh_metadata(_get_http(), ws_id, item.id)
+    except FabricError as exc:
+        raise _fabric_err(exc) from exc
+    return result
 
 
 # ---------------------------------------------------------------------------

--- a/src/fabric_dw/services/sql_endpoints.py
+++ b/src/fabric_dw/services/sql_endpoints.py
@@ -1,0 +1,94 @@
+"""Service functions for Microsoft Fabric SQL Analytics Endpoint operations."""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from fabric_dw.http_client import FabricHttpClient, HttpBase
+from fabric_dw.models import Warehouse, WarehouseKind
+
+__all__ = [
+    "get_endpoint",
+    "list_endpoints",
+    "refresh_metadata",
+]
+
+
+async def list_endpoints(http: FabricHttpClient, workspace_id: UUID) -> list[Warehouse]:
+    """Return all SQL analytics endpoints in a workspace.
+
+    Pages through ``GET /workspaces/{ws}/sqlEndpoints`` and returns each item
+    parsed as a :class:`~fabric_dw.models.Warehouse` with
+    ``kind=SQL_ENDPOINT``.
+
+    Args:
+        http: An authenticated :class:`~fabric_dw.http_client.FabricHttpClient`.
+        workspace_id: The UUID of the workspace to query.
+
+    Returns:
+        A list of :class:`~fabric_dw.models.Warehouse` instances with
+        ``kind == WarehouseKind.SQL_ENDPOINT``.
+    """
+    return [
+        Warehouse.from_api(item, kind=WarehouseKind.SQL_ENDPOINT)
+        async for item in http.iter_paginated(
+            HttpBase.FABRIC, f"/workspaces/{workspace_id}/sqlEndpoints"
+        )
+    ]
+
+
+async def get_endpoint(http: FabricHttpClient, workspace_id: UUID, endpoint_id: UUID) -> Warehouse:
+    """Fetch a single SQL analytics endpoint by ID.
+
+    Uses ``GET /workspaces/{ws}/sqlEndpoints/{id}``.
+
+    Args:
+        http: An authenticated :class:`~fabric_dw.http_client.FabricHttpClient`.
+        workspace_id: The UUID of the workspace containing the endpoint.
+        endpoint_id: The UUID of the SQL analytics endpoint to retrieve.
+
+    Returns:
+        A populated :class:`~fabric_dw.models.Warehouse` instance with
+        ``kind == WarehouseKind.SQL_ENDPOINT``.
+
+    Raises:
+        NotFound: If the endpoint does not exist (404).
+    """
+    resp = await http.request(
+        "GET",
+        HttpBase.FABRIC,
+        f"/workspaces/{workspace_id}/sqlEndpoints/{endpoint_id}",
+    )
+    return Warehouse.from_api(resp.json(), kind=WarehouseKind.SQL_ENDPOINT)
+
+
+async def refresh_metadata(
+    http: FabricHttpClient, workspace_id: UUID, endpoint_id: UUID
+) -> dict[str, Any]:
+    """Trigger a metadata refresh for a SQL analytics endpoint.
+
+    Issues ``POST /workspaces/{ws}/sqlEndpoints/{id}/refreshMetadata``, which
+    returns a 202 with a ``Location`` header pointing at a long-running
+    operation (LRO).  The function polls the LRO to completion and returns
+    the final operation body.
+
+    Args:
+        http: An authenticated :class:`~fabric_dw.http_client.FabricHttpClient`.
+        workspace_id: The UUID of the workspace containing the endpoint.
+        endpoint_id: The UUID of the SQL analytics endpoint to refresh.
+
+    Returns:
+        The final LRO response body (``{"status": "Succeeded", ...}``).
+
+    Raises:
+        FabricServerError: If the LRO fails or times out.
+        NotFound: If the endpoint does not exist (404).
+    """
+    resp = await http.request(
+        "POST",
+        HttpBase.FABRIC,
+        f"/workspaces/{workspace_id}/sqlEndpoints/{endpoint_id}/refreshMetadata",
+    )
+    location: str = resp.headers["Location"]
+    return await http.poll_operation(location)

--- a/tests/unit/cli/commands/test_endpoints.py
+++ b/tests/unit/cli/commands/test_endpoints.py
@@ -53,12 +53,13 @@ def _make_item_entry(kind: WarehouseKind = WarehouseKind.SQL_ENDPOINT) -> ItemEn
     )
 
 
-def _async_iter(items: list[object]):  # type: ignore[no-untyped-def]
-    async def _gen():  # type: ignore[no-untyped-def]
-        for item in items:
-            yield item
+async def _async_iter_coro(items: list[object]):  # type: ignore[no-untyped-def]
+    for item in items:
+        yield item
 
-    return _gen()
+
+def _async_iter(items: list[object]):  # type: ignore[no-untyped-def]
+    return _async_iter_coro(items)
 
 
 def _make_response(status_code: int, text: str) -> MagicMock:

--- a/tests/unit/cli/commands/test_endpoints.py
+++ b/tests/unit/cli/commands/test_endpoints.py
@@ -1,0 +1,230 @@
+"""Tests for endpoints CLI sub-commands — written BEFORE the implementation (TDD)."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID
+
+import pytest
+from click.testing import CliRunner
+
+from fabric_dw.cache import ItemEntry
+from fabric_dw.cli._main import cli
+from fabric_dw.exceptions import NotFound
+from fabric_dw.models import WarehouseKind
+
+WS_GUID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+EP_GUID = "e5f6a7b8-c9d0-1234-ef01-234567890abc"
+WS_UUID = UUID(WS_GUID)
+EP_UUID = UUID(EP_GUID)
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def cache_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    return tmp_path
+
+
+def _make_cm(http: object, sql: object) -> object:
+    @asynccontextmanager
+    async def _cm(_ctx: object) -> AsyncIterator[tuple[object, object]]:
+        yield http, sql
+
+    return _cm
+
+
+def _make_item_entry(kind: WarehouseKind = WarehouseKind.SQL_ENDPOINT) -> ItemEntry:
+    return ItemEntry(
+        id=EP_UUID,
+        kind=kind,
+        connection_string="lakehouse-sql-ep.datawarehouse.fabric.microsoft.com",
+        fetched_at=datetime.now(tz=UTC),
+        display_name="SalesLakehouse",
+    )
+
+
+def _async_iter(items: list[object]):  # type: ignore[no-untyped-def]
+    async def _gen():  # type: ignore[no-untyped-def]
+        for item in items:
+            yield item
+
+    return _gen()
+
+
+def _make_response(status_code: int, text: str) -> MagicMock:
+    mock_resp = MagicMock()
+    mock_resp.status_code = status_code
+    mock_resp.json = MagicMock(return_value=json.loads(text) if text and text.strip() else {})
+    mock_resp.headers = {}
+    mock_resp.text = text
+    return mock_resp
+
+
+_ENDPOINT_JSON = json.dumps(
+    {
+        "id": EP_GUID,
+        "displayName": "SalesLakehouse",
+        "description": "SQL endpoint for sales lakehouse",
+        "workspaceId": WS_GUID,
+        "kind": "SQLEndpoint",
+        "connectionString": "lakehouse-sql-ep.datawarehouse.fabric.microsoft.com",
+        "defaultCollation": None,
+        "createdDate": None,
+    }
+)
+
+
+class TestEndpointsList:
+    """endpoints list — happy path."""
+
+    def test_list_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        mock_http.iter_paginated = MagicMock(return_value=_async_iter([]))
+        with (
+            patch(
+                "fabric_dw.cli.commands.endpoints._build_clients",
+                new=_make_cm(mock_http, None),
+            ),
+            patch(
+                "fabric_dw.cli.commands.endpoints.Resolver.workspace_id",
+                new=AsyncMock(return_value=WS_UUID),
+            ),
+        ):
+            result = runner.invoke(cli, ["endpoints", "list", WS_GUID])
+        assert result.exit_code == 0
+
+    def test_list_json_output(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        ep_item = {
+            "id": EP_GUID,
+            "displayName": "SalesLakehouse",
+            "description": "SQL endpoint",
+            "type": "SQLEndpoint",
+            "workspaceId": WS_GUID,
+            "properties": {
+                "sqlEndpointProperties": {
+                    "connectionString": "lakehouse-sql-ep.datawarehouse.fabric.microsoft.com",
+                    "id": "f6a7b8c9-d0e1-2345-f012-34567890abcd",
+                    "provisioningStatus": "Success",
+                }
+            },
+        }
+        mock_http = AsyncMock()
+        mock_http.iter_paginated = MagicMock(return_value=_async_iter([ep_item]))
+        with (
+            patch(
+                "fabric_dw.cli.commands.endpoints._build_clients",
+                new=_make_cm(mock_http, None),
+            ),
+            patch(
+                "fabric_dw.cli.commands.endpoints.Resolver.workspace_id",
+                new=AsyncMock(return_value=WS_UUID),
+            ),
+        ):
+            result = runner.invoke(cli, ["--json", "endpoints", "list", WS_GUID])
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert isinstance(parsed, list)
+
+
+class TestEndpointsGet:
+    """endpoints get — happy path and 404."""
+
+    def test_get_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        mock_http.request = AsyncMock(return_value=_make_response(200, _ENDPOINT_JSON))
+        with (
+            patch(
+                "fabric_dw.cli.commands.endpoints._build_clients",
+                new=_make_cm(mock_http, None),
+            ),
+            patch(
+                "fabric_dw.cli.commands.endpoints._resolve_item",
+                new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
+            ),
+        ):
+            result = runner.invoke(cli, ["endpoints", "get", WS_GUID, EP_GUID])
+        assert result.exit_code == 0
+
+    def test_get_not_found_returns_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.endpoints._build_clients",
+                new=_make_cm(mock_http, None),
+            ),
+            patch(
+                "fabric_dw.cli.commands.endpoints._resolve_item",
+                new=AsyncMock(side_effect=NotFound("endpoint not found")),
+            ),
+        ):
+            result = runner.invoke(cli, ["endpoints", "get", WS_GUID, EP_GUID])
+        assert result.exit_code != 0
+
+
+class TestEndpointsRefresh:
+    """endpoints refresh — happy path (LRO)."""
+
+    def test_refresh_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        mock_http.request = AsyncMock(
+            return_value=_make_response(
+                202,
+                json.dumps({}),
+            )
+        )
+        mock_http.poll_operation = AsyncMock(
+            return_value={"status": "Succeeded", "percentComplete": 100}
+        )
+
+        _make_response_with_location = MagicMock()
+        _make_response_with_location.status_code = 202
+        _make_response_with_location.json = MagicMock(return_value={})
+        _make_response_with_location.headers = {
+            "Location": "https://api.fabric.microsoft.com/v1/operations/op-123"
+        }
+        _make_response_with_location.text = "{}"
+        mock_http.request = AsyncMock(return_value=_make_response_with_location)
+
+        with (
+            patch(
+                "fabric_dw.cli.commands.endpoints._build_clients",
+                new=_make_cm(mock_http, None),
+            ),
+            patch(
+                "fabric_dw.cli.commands.endpoints._resolve_item",
+                new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
+            ),
+        ):
+            result = runner.invoke(cli, ["endpoints", "refresh", WS_GUID, EP_GUID])
+        assert result.exit_code == 0
+
+    def test_refresh_not_found_returns_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.endpoints._build_clients",
+                new=_make_cm(mock_http, None),
+            ),
+            patch(
+                "fabric_dw.cli.commands.endpoints._resolve_item",
+                new=AsyncMock(side_effect=NotFound("endpoint not found")),
+            ),
+        ):
+            result = runner.invoke(cli, ["endpoints", "refresh", WS_GUID, EP_GUID])
+        assert result.exit_code != 0

--- a/tests/unit/mcp/test_server.py
+++ b/tests/unit/mcp/test_server.py
@@ -567,10 +567,10 @@ async def test_list_sql_endpoints_happy_path() -> None:
     """list_sql_endpoints resolves workspace and returns list of SQL endpoint dicts."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
-    _EP_ID = UUID("e5f6a7b8-c9d0-1234-ef01-234567890abc")
+    ep_id = UUID("e5f6a7b8-c9d0-1234-ef01-234567890abc")
     ep = Warehouse.model_validate(
         {
-            "id": str(_EP_ID),
+            "id": str(ep_id),
             "displayName": "SalesLakehouse",
             "workspaceId": str(_WS_ID),
             "kind": WarehouseKind.SQL_ENDPOINT,
@@ -592,13 +592,11 @@ async def test_list_sql_endpoints_happy_path() -> None:
             new=AsyncMock(return_value=[ep]),
         ),
     ):
-        result = await mcp._tool_manager.call_tool(
-            "list_sql_endpoints", {"workspace": _WS_NAME}
-        )
+        result = await mcp._tool_manager.call_tool("list_sql_endpoints", {"workspace": _WS_NAME})
 
     assert isinstance(result, list)
     assert len(result) == 1
-    assert result[0]["id"] == str(_EP_ID)
+    assert result[0]["id"] == str(ep_id)
     assert result[0]["kind"] == "SQLEndpoint"
 
 
@@ -607,17 +605,17 @@ async def test_get_sql_endpoint_happy_path() -> None:
     """get_sql_endpoint resolves workspace + endpoint and returns a dict."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
-    _EP_ID = UUID("e5f6a7b8-c9d0-1234-ef01-234567890abc")
+    ep_id = UUID("e5f6a7b8-c9d0-1234-ef01-234567890abc")
     ep = Warehouse.model_validate(
         {
-            "id": str(_EP_ID),
+            "id": str(ep_id),
             "displayName": "SalesLakehouse",
             "workspaceId": str(_WS_ID),
             "kind": WarehouseKind.SQL_ENDPOINT,
             "connectionString": "lakehouse-sql-ep.datawarehouse.fabric.microsoft.com",
         }
     )
-    item = _make_item_entry(item_id=_EP_ID, display_name="SalesLakehouse")
+    item = _make_item_entry(item_id=ep_id, display_name="SalesLakehouse")
 
     mock_resolver = AsyncMock()
     mock_resolver.workspace_id = AsyncMock(return_value=_WS_ID)
@@ -640,7 +638,7 @@ async def test_get_sql_endpoint_happy_path() -> None:
         )
 
     assert isinstance(result, dict)
-    assert result["id"] == str(_EP_ID)
+    assert result["id"] == str(ep_id)
     assert result["kind"] == "SQLEndpoint"
 
 
@@ -649,8 +647,8 @@ async def test_refresh_sql_endpoint_metadata_happy_path() -> None:
     """refresh_sql_endpoint_metadata resolves workspace + endpoint and returns a dict."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
-    _EP_ID = UUID("e5f6a7b8-c9d0-1234-ef01-234567890abc")
-    item = _make_item_entry(item_id=_EP_ID, display_name="SalesLakehouse")
+    ep_id = UUID("e5f6a7b8-c9d0-1234-ef01-234567890abc")
+    item = _make_item_entry(item_id=ep_id, display_name="SalesLakehouse")
 
     mock_resolver = AsyncMock()
     mock_resolver.workspace_id = AsyncMock(return_value=_WS_ID)

--- a/tests/unit/mcp/test_server.py
+++ b/tests/unit/mcp/test_server.py
@@ -57,6 +57,10 @@ EXPECTED_TOOL_NAMES: frozenset[str] = frozenset(
         "rename_warehouse",
         "delete_warehouse",
         "takeover_warehouse",
+        # SQL Endpoints
+        "list_sql_endpoints",
+        "get_sql_endpoint",
+        "refresh_sql_endpoint_metadata",
         # Audit
         "get_audit_settings",
         "enable_audit",
@@ -551,3 +555,124 @@ async def test_roll_snapshot_timestamp_bad_datetime_becomes_tool_error() -> None
         )
 
     assert "ISO-8601" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# SQL Endpoint tools
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_sql_endpoints_happy_path() -> None:
+    """list_sql_endpoints resolves workspace and returns list of SQL endpoint dicts."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    _EP_ID = UUID("e5f6a7b8-c9d0-1234-ef01-234567890abc")
+    ep = Warehouse.model_validate(
+        {
+            "id": str(_EP_ID),
+            "displayName": "SalesLakehouse",
+            "workspaceId": str(_WS_ID),
+            "kind": WarehouseKind.SQL_ENDPOINT,
+            "connectionString": "lakehouse-sql-ep.datawarehouse.fabric.microsoft.com",
+        }
+    )
+
+    mock_resolver = AsyncMock()
+    mock_resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_http = AsyncMock()
+    mock_cache = MagicMock()
+
+    with (
+        patch("fabric_dw.mcp.server._get_http", return_value=mock_http),
+        patch("fabric_dw.mcp.server._get_resolver", return_value=mock_resolver),
+        patch("fabric_dw.mcp.server._get_cache", return_value=mock_cache),
+        patch(
+            "fabric_dw.services.sql_endpoints.list_endpoints",
+            new=AsyncMock(return_value=[ep]),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "list_sql_endpoints", {"workspace": _WS_NAME}
+        )
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0]["id"] == str(_EP_ID)
+    assert result[0]["kind"] == "SQLEndpoint"
+
+
+@pytest.mark.asyncio
+async def test_get_sql_endpoint_happy_path() -> None:
+    """get_sql_endpoint resolves workspace + endpoint and returns a dict."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    _EP_ID = UUID("e5f6a7b8-c9d0-1234-ef01-234567890abc")
+    ep = Warehouse.model_validate(
+        {
+            "id": str(_EP_ID),
+            "displayName": "SalesLakehouse",
+            "workspaceId": str(_WS_ID),
+            "kind": WarehouseKind.SQL_ENDPOINT,
+            "connectionString": "lakehouse-sql-ep.datawarehouse.fabric.microsoft.com",
+        }
+    )
+    item = _make_item_entry(item_id=_EP_ID, display_name="SalesLakehouse")
+
+    mock_resolver = AsyncMock()
+    mock_resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_resolver.item = AsyncMock(return_value=item)
+    mock_http = AsyncMock()
+    mock_cache = MagicMock()
+
+    with (
+        patch("fabric_dw.mcp.server._get_http", return_value=mock_http),
+        patch("fabric_dw.mcp.server._get_resolver", return_value=mock_resolver),
+        patch("fabric_dw.mcp.server._get_cache", return_value=mock_cache),
+        patch(
+            "fabric_dw.services.sql_endpoints.get_endpoint",
+            new=AsyncMock(return_value=ep),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "get_sql_endpoint",
+            {"workspace": _WS_NAME, "endpoint": "SalesLakehouse"},
+        )
+
+    assert isinstance(result, dict)
+    assert result["id"] == str(_EP_ID)
+    assert result["kind"] == "SQLEndpoint"
+
+
+@pytest.mark.asyncio
+async def test_refresh_sql_endpoint_metadata_happy_path() -> None:
+    """refresh_sql_endpoint_metadata resolves workspace + endpoint and returns a dict."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    _EP_ID = UUID("e5f6a7b8-c9d0-1234-ef01-234567890abc")
+    item = _make_item_entry(item_id=_EP_ID, display_name="SalesLakehouse")
+
+    mock_resolver = AsyncMock()
+    mock_resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_resolver.item = AsyncMock(return_value=item)
+    mock_http = AsyncMock()
+    mock_cache = MagicMock()
+
+    lro_result = {"status": "Succeeded", "percentComplete": 100}
+
+    with (
+        patch("fabric_dw.mcp.server._get_http", return_value=mock_http),
+        patch("fabric_dw.mcp.server._get_resolver", return_value=mock_resolver),
+        patch("fabric_dw.mcp.server._get_cache", return_value=mock_cache),
+        patch(
+            "fabric_dw.services.sql_endpoints.refresh_metadata",
+            new=AsyncMock(return_value=lro_result),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "refresh_sql_endpoint_metadata",
+            {"workspace": _WS_NAME, "endpoint": "SalesLakehouse"},
+        )
+
+    assert isinstance(result, dict)
+    assert result.get("status") == "Succeeded"

--- a/tests/unit/services/test_sql_endpoints.py
+++ b/tests/unit/services/test_sql_endpoints.py
@@ -1,0 +1,282 @@
+"""Tests for fabric_dw.services.sql_endpoints — written BEFORE the implementation (TDD)."""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+from uuid import UUID
+
+import httpx
+import pytest
+import respx
+from azure.core.credentials import AccessToken, TokenCredential
+
+from fabric_dw.exceptions import FabricServerError, NotFound
+from fabric_dw.http_client import FabricHttpClient
+from fabric_dw.models import Warehouse, WarehouseKind
+from tests.fixtures.api_payloads import (
+    WAREHOUSE_SQL_ENDPOINTS_PAGE1_PAYLOAD,
+    WAREHOUSE_SQL_ENDPOINTS_PAGE2_PAYLOAD,
+    WAREHOUSE_SQL_ENDPOINTS_PAYLOAD,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_FAKE_TOKEN = AccessToken(token="fake-token", expires_on=int(time.time()) + 3600)  # noqa: S106
+
+_WORKSPACE_ID = UUID("a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+_ENDPOINT_ID = UUID("e5f6a7b8-c9d0-1234-ef01-234567890abc")
+
+_BASE = "https://api.fabric.microsoft.com/v1"
+_SQL_ENDPOINTS_URL = f"{_BASE}/workspaces/{_WORKSPACE_ID}/sqlEndpoints"
+_ENDPOINT_URL = f"{_SQL_ENDPOINTS_URL}/{_ENDPOINT_ID}"
+_REFRESH_URL = f"{_ENDPOINT_URL}/refreshMetadata"
+_OPERATION_URL = f"{_BASE}/operations/op-refresh-123"
+
+
+def _make_credential(token: AccessToken = _FAKE_TOKEN) -> TokenCredential:
+    cred = MagicMock(spec=TokenCredential)
+    cred.get_token = MagicMock(return_value=token)
+    return cred
+
+
+async def _make_client(rps: int = 10) -> FabricHttpClient:
+    return FabricHttpClient(credential=_make_credential(), rps=rps)
+
+
+# Single SQL endpoint GET payload
+_ENDPOINT_GET_PAYLOAD: dict[str, Any] = {
+    "id": str(_ENDPOINT_ID),
+    "displayName": "SalesLakehouse",
+    "description": "SQL endpoint for sales lakehouse",
+    "type": "SQLEndpoint",
+    "workspaceId": str(_WORKSPACE_ID),
+    "properties": {
+        "sqlEndpointProperties": {
+            "connectionString": "lakehouse-sql-ep.datawarehouse.fabric.microsoft.com",
+            "id": "f6a7b8c9-d0e1-2345-f012-34567890abcd",
+            "provisioningStatus": "Success",
+        }
+    },
+}
+
+_REFRESH_LRO_SUCCEEDED: dict[str, Any] = {
+    "status": "Succeeded",
+    "createdTimeUtc": "2024-03-15T10:29:50Z",
+    "lastUpdatedTimeUtc": "2024-03-15T10:30:00Z",
+    "percentComplete": 100,
+    "error": None,
+}
+
+
+# ---------------------------------------------------------------------------
+# list_endpoints
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_endpoints_returns_sql_endpoint_items() -> None:
+    """list_endpoints must return only SQL_ENDPOINT-kind Warehouse items."""
+    from fabric_dw.services.sql_endpoints import list_endpoints  # noqa: PLC0415
+
+    ep_payload = json.loads(WAREHOUSE_SQL_ENDPOINTS_PAYLOAD)
+
+    with respx.mock:
+        respx.get(_SQL_ENDPOINTS_URL).mock(return_value=httpx.Response(200, json=ep_payload))
+
+        client = await _make_client()
+        async with client:
+            result = await list_endpoints(client, _WORKSPACE_ID)
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert all(isinstance(ep, Warehouse) for ep in result)
+    assert all(ep.kind == WarehouseKind.SQL_ENDPOINT for ep in result)
+
+
+@pytest.mark.asyncio
+async def test_list_endpoints_follows_pagination() -> None:
+    """list_endpoints must follow continuationUri across pages."""
+    from fabric_dw.services.sql_endpoints import list_endpoints  # noqa: PLC0415
+
+    call_count = 0
+
+    def side_effect(_request: httpx.Request) -> httpx.Response:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return httpx.Response(200, json=json.loads(WAREHOUSE_SQL_ENDPOINTS_PAGE1_PAYLOAD))
+        return httpx.Response(200, json=json.loads(WAREHOUSE_SQL_ENDPOINTS_PAGE2_PAYLOAD))
+
+    with respx.mock(assert_all_called=False) as mock_router:
+        mock_router.get(url__regex=r".*/sqlEndpoints.*").mock(side_effect=side_effect)
+
+        client = await _make_client()
+        async with client:
+            result = await list_endpoints(client, _WORKSPACE_ID)
+
+    assert call_count == 2
+    assert len(result) == 2
+    assert all(ep.kind == WarehouseKind.SQL_ENDPOINT for ep in result)
+
+
+@pytest.mark.asyncio
+async def test_list_endpoints_empty_workspace_returns_empty_list() -> None:
+    """list_endpoints must return an empty list when there are no SQL endpoints."""
+    from fabric_dw.services.sql_endpoints import list_endpoints  # noqa: PLC0415
+
+    with respx.mock:
+        respx.get(_SQL_ENDPOINTS_URL).mock(
+            return_value=httpx.Response(200, json={"value": []})
+        )
+
+        client = await _make_client()
+        async with client:
+            result = await list_endpoints(client, _WORKSPACE_ID)
+
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# get_endpoint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_endpoint_returns_populated_warehouse() -> None:
+    """get_endpoint must return a single populated Warehouse with SQL_ENDPOINT kind."""
+    from fabric_dw.services.sql_endpoints import get_endpoint  # noqa: PLC0415
+
+    with respx.mock:
+        respx.get(_ENDPOINT_URL).mock(
+            return_value=httpx.Response(200, json=_ENDPOINT_GET_PAYLOAD)
+        )
+
+        client = await _make_client()
+        async with client:
+            result = await get_endpoint(client, _WORKSPACE_ID, _ENDPOINT_ID)
+
+    assert isinstance(result, Warehouse)
+    assert result.id == _ENDPOINT_ID
+    assert result.name == "SalesLakehouse"
+    assert result.kind == WarehouseKind.SQL_ENDPOINT
+    assert result.connection_string == "lakehouse-sql-ep.datawarehouse.fabric.microsoft.com"
+    assert result.workspace_id == _WORKSPACE_ID
+
+
+@pytest.mark.asyncio
+async def test_get_endpoint_404_propagates_not_found() -> None:
+    """get_endpoint must propagate NotFound on a 404 response."""
+    from fabric_dw.services.sql_endpoints import get_endpoint  # noqa: PLC0415
+
+    with respx.mock:
+        respx.get(_ENDPOINT_URL).mock(
+            return_value=httpx.Response(
+                404, json={"error": {"code": "ItemNotFound", "message": "not found"}}
+            )
+        )
+
+        client = await _make_client()
+        async with client:
+            with pytest.raises(NotFound):
+                await get_endpoint(client, _WORKSPACE_ID, _ENDPOINT_ID)
+
+
+# ---------------------------------------------------------------------------
+# refresh_metadata
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_refresh_metadata_posts_and_polls_lro() -> None:
+    """refresh_metadata must POST to /refreshMetadata and poll the LRO to completion."""
+    from fabric_dw.services.sql_endpoints import refresh_metadata  # noqa: PLC0415
+
+    with respx.mock:
+        post_route = respx.post(_REFRESH_URL).mock(
+            return_value=httpx.Response(
+                202,
+                json={},
+                headers={"Location": _OPERATION_URL},
+            )
+        )
+        respx.get(_OPERATION_URL).mock(
+            return_value=httpx.Response(200, json=_REFRESH_LRO_SUCCEEDED)
+        )
+
+        client = await _make_client()
+        async with client:
+            result = await refresh_metadata(client, _WORKSPACE_ID, _ENDPOINT_ID)
+
+    assert post_route.called
+    assert isinstance(result, dict)
+    assert result.get("status") == "Succeeded"
+
+
+@pytest.mark.asyncio
+async def test_refresh_metadata_lro_poll_multiple_times() -> None:
+    """refresh_metadata must poll the LRO until it succeeds (multi-poll path)."""
+    from fabric_dw.services.sql_endpoints import refresh_metadata  # noqa: PLC0415
+
+    poll_count = 0
+
+    def lro_side_effect(_request: httpx.Request) -> httpx.Response:
+        nonlocal poll_count
+        poll_count += 1
+        if poll_count < 3:
+            return httpx.Response(
+                200,
+                json={"status": "Running", "percentComplete": poll_count * 30},
+                headers={"Retry-After": "0"},
+            )
+        return httpx.Response(200, json=_REFRESH_LRO_SUCCEEDED)
+
+    with respx.mock(assert_all_called=False) as mock_router:
+        mock_router.post(_REFRESH_URL).mock(
+            return_value=httpx.Response(
+                202,
+                json={},
+                headers={"Location": _OPERATION_URL},
+            )
+        )
+        mock_router.get(_OPERATION_URL).mock(side_effect=lro_side_effect)
+
+        client = await _make_client()
+        async with client:
+            result = await refresh_metadata(client, _WORKSPACE_ID, _ENDPOINT_ID)
+
+    assert poll_count == 3
+    assert result.get("status") == "Succeeded"
+
+
+@pytest.mark.asyncio
+async def test_refresh_metadata_lro_failed_raises_fabric_server_error() -> None:
+    """refresh_metadata must raise FabricServerError when LRO status is 'Failed'."""
+    from fabric_dw.services.sql_endpoints import refresh_metadata  # noqa: PLC0415
+
+    with respx.mock:
+        respx.post(_REFRESH_URL).mock(
+            return_value=httpx.Response(
+                202,
+                json={},
+                headers={"Location": _OPERATION_URL},
+            )
+        )
+        respx.get(_OPERATION_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "status": "Failed",
+                    "error": {"code": "RefreshFailed", "message": "Refresh failed"},
+                },
+            )
+        )
+
+        client = await _make_client()
+        async with client:
+            with pytest.raises(FabricServerError):
+                await refresh_metadata(client, _WORKSPACE_ID, _ENDPOINT_ID)

--- a/tests/unit/services/test_sql_endpoints.py
+++ b/tests/unit/services/test_sql_endpoints.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import time
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 from uuid import UUID
 
 import httpx
@@ -130,9 +130,7 @@ async def test_list_endpoints_empty_workspace_returns_empty_list() -> None:
     from fabric_dw.services.sql_endpoints import list_endpoints  # noqa: PLC0415
 
     with respx.mock:
-        respx.get(_SQL_ENDPOINTS_URL).mock(
-            return_value=httpx.Response(200, json={"value": []})
-        )
+        respx.get(_SQL_ENDPOINTS_URL).mock(return_value=httpx.Response(200, json={"value": []}))
 
         client = await _make_client()
         async with client:
@@ -152,9 +150,7 @@ async def test_get_endpoint_returns_populated_warehouse() -> None:
     from fabric_dw.services.sql_endpoints import get_endpoint  # noqa: PLC0415
 
     with respx.mock:
-        respx.get(_ENDPOINT_URL).mock(
-            return_value=httpx.Response(200, json=_ENDPOINT_GET_PAYLOAD)
-        )
+        respx.get(_ENDPOINT_URL).mock(return_value=httpx.Response(200, json=_ENDPOINT_GET_PAYLOAD))
 
         client = await _make_client()
         async with client:


### PR DESCRIPTION
## Summary

Closes #88. Adds services/sql_endpoints (list/get/refresh-metadata), CLI sub-group fabric-dw endpoints, and three MCP tools.

- `src/fabric_dw/services/sql_endpoints.py`: `list_endpoints` (paginated), `get_endpoint`, `refresh_metadata` (LRO-polled)
- `src/fabric_dw/cli/commands/endpoints.py`: `fabric-dw endpoints list/get/refresh` sub-group, registered in `_main.py`
- `src/fabric_dw/mcp/server.py`: `list_sql_endpoints`, `get_sql_endpoint`, `refresh_sql_endpoint_metadata` MCP tools

## Test plan

- [x] `tests/unit/services/test_sql_endpoints.py` — respx-mocked; list (happy + pagination + empty), get (happy + 404), refresh (happy + multi-poll + LRO failed)
- [x] `tests/unit/cli/commands/test_endpoints.py` — list/get/refresh CLI commands (happy + 404)
- [x] `tests/unit/mcp/test_server.py` — asserts all three new tool names registered + happy-path call tests
- [x] All 366 unit tests pass; ruff check/format + mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)