### PR TITLE
chore(packaging): move dev deps to dependency-groups

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
     "ghcr.io/devcontainers/features/azure-cli:1": {},
     "ghcr.io/devcontainers/features/github-cli:1": {}
   },
-  "postCreateCommand": "curl -LsSf https://astral.sh/uv/install.sh | sh && source $HOME/.local/bin/env && uv sync --all-extras && uv run pre-commit install",
+  "postCreateCommand": "curl -LsSf https://astral.sh/uv/install.sh | sh && source $HOME/.local/bin/env && uv sync",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
-      - run: uv sync --all-extras --frozen
+      - run: uv sync --frozen
       - run: uv run ruff check .
       - run: uv run ruff format --check .
 
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
-      - run: uv sync --all-extras --frozen
+      - run: uv sync --frozen
       - run: uv run mypy src tests
 
   unit:
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
-      - run: uv sync --all-extras --frozen
+      - run: uv sync --frozen
       - run: uv run pytest tests/unit --cov=fabric_dw --cov-report=xml
       - name: Coverage report
         run: uv run coverage report

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -73,7 +73,7 @@ jobs:
         with:
           python-version: "3.13"
 
-      - run: uv sync --all-extras --frozen
+      - run: uv sync --frozen
 
       - name: Run integration tests
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,7 +47,7 @@ jobs:
           rm src/fabric_dw/__init__.py.bak
           uv run python -c "import fabric_dw; print('Built version:', fabric_dw.__version__)"
 
-      - run: uv sync --all-extras
+      - run: uv sync --frozen --no-dev
 
       - run: uv build
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -28,5 +28,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v8.2.0
         with: { enable-cache: true }
-      - run: uv sync --all-extras --frozen
+      - run: uv sync --frozen
       - run: uvx --quiet pip-audit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Thank you for your interest in contributing to `fabric-dw-mcp-cli`!
 1. **Install dependencies**
 
    ```bash
-   uv sync --all-extras
+   uv sync
    ```
 
 2. **Install [just](https://github.com/casey/just#installation)** (optional, for convenient local checks)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
 fabric-dw = "fabric_dw.cli:main"
 fabric-dw-mcp = "fabric_dw.mcp.server:run"
 
-[project.optional-dependencies]
+[dependency-groups]
 dev = [
     "pytest",
     "pytest-asyncio",
@@ -45,8 +45,6 @@ dev = [
     "mypy",
     "ruff",
 ]
-
-[dependency-groups]
 docs = ["zensical>=0.0.42"]
 
 [tool.hatch.version]

--- a/uv.lock
+++ b/uv.lock
@@ -507,7 +507,7 @@ dependencies = [
     { name = "tenacity" },
 ]
 
-[package.optional-dependencies]
+[package.dev-dependencies]
 dev = [
     { name = "anyio", extra = ["trio"] },
     { name = "freezegun" },
@@ -519,8 +519,6 @@ dev = [
     { name = "respx" },
     { name = "ruff" },
 ]
-
-[package.dev-dependencies]
 docs = [
     { name = "zensical" },
 ]
@@ -529,28 +527,29 @@ docs = [
 requires-dist = [
     { name = "aiolimiter", specifier = ">=1.2" },
     { name = "anyio", specifier = ">=4" },
-    { name = "anyio", extras = ["trio"], marker = "extra == 'dev'" },
     { name = "azure-identity", specifier = ">=1.19" },
     { name = "click", specifier = ">=8.2" },
     { name = "filelock", specifier = ">=3.16" },
-    { name = "freezegun", marker = "extra == 'dev'", specifier = ">=1.5" },
     { name = "httpx", extras = ["http2"], specifier = ">=0.27" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.0" },
     { name = "mssql-python", specifier = ">=0.13" },
-    { name = "mypy", marker = "extra == 'dev'" },
     { name = "pydantic", specifier = ">=2.9" },
-    { name = "pytest", marker = "extra == 'dev'" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'" },
-    { name = "pytest-cov", marker = "extra == 'dev'" },
-    { name = "pytest-randomly", marker = "extra == 'dev'" },
-    { name = "respx", marker = "extra == 'dev'", specifier = ">=0.21" },
     { name = "rich", specifier = ">=14" },
-    { name = "ruff", marker = "extra == 'dev'" },
     { name = "tenacity", specifier = ">=9" },
 ]
-provides-extras = ["dev"]
 
 [package.metadata.requires-dev]
+dev = [
+    { name = "anyio", extras = ["trio"] },
+    { name = "freezegun", specifier = ">=1.5" },
+    { name = "mypy" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+    { name = "pytest-randomly" },
+    { name = "respx", specifier = ">=0.21" },
+    { name = "ruff" },
+]
 docs = [{ name = "zensical", specifier = ">=0.0.42" }]
 
 [[package]]


### PR DESCRIPTION
Closes #112

Dev deps lived under `[project.optional-dependencies].dev`, which surfaces on PyPI as a `Provides-Extra: dev` line that end users see and may try to install. Moved them to `[dependency-groups].dev` (PEP 735) so they stay dev-only and don't leak into wheel metadata.

Updated every workflow + devcontainer + CONTRIBUTING to drop `--all-extras` since the runtime deps are in `[project] dependencies` and dev is now a group. The publish job uses `--no-dev` to keep the build environment clean.

## Test plan
- [x] `uv sync` (without `--all-extras`) installs ruff/mypy/pytest etc.
- [x] `uv build` produces a wheel with no `Provides-Extra` lines
- [x] All 360 unit tests pass
- [x] ruff check + format pass
- [x] mypy strict pass