### PR TITLE
feat(release): multi-arch Docker image on ghcr.io

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,83 @@
+name: Docker
+
+on:
+  push:
+    branches: [main]
+    tags: ["v[0-9]+.[0-9]+.[0-9]+"]
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v8.2.0
+        with:
+          enable-cache: true
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Compute version
+        id: ver
+        run: |
+          BASE=$(uv run python -c "import fabric_dw; print(fabric_dw.__version__)")
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            TAG_VER="${GITHUB_REF_NAME#v}"
+            if [[ "$TAG_VER" != "$BASE" ]]; then
+              echo "Tag $TAG_VER does not match fabric_dw.__version__ $BASE" >&2; exit 1
+            fi
+            VERSION="$TAG_VER"
+            CHANNEL="stable"
+          else
+            VERSION="${BASE}.dev${GITHUB_RUN_NUMBER}"
+            CHANNEL="dev"
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "channel=$CHANNEL" >> $GITHUB_OUTPUT
+
+      - name: Override package version
+        run: |
+          sed -i.bak 's|^__version__ = .*|__version__ = "${{ steps.ver.outputs.version }}"|' src/fabric_dw/__init__.py
+          rm src/fabric_dw/__init__.py.bak
+
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build & push (stable)
+        if: steps.ver.outputs.channel == 'stable'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/sdebruyn/fabric-dw:${{ steps.ver.outputs.version }}
+            ghcr.io/sdebruyn/fabric-dw:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build & push (dev)
+        if: steps.ver.outputs.channel == 'dev'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/sdebruyn/fabric-dw:${{ steps.ver.outputs.version }}
+            ghcr.io/sdebruyn/fabric-dw:main
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# syntax=docker/dockerfile:1
+ARG PYTHON_VERSION=3.13
+
+# --- Build stage ---
+FROM python:${PYTHON_VERSION}-slim AS build
+RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates && rm -rf /var/lib/apt/lists/*
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH="/root/.local/bin:${PATH}"
+WORKDIR /src
+COPY pyproject.toml uv.lock README.md LICENSE ./
+COPY src/ src/
+RUN uv sync --frozen --no-dev
+RUN uv build --wheel
+
+# --- Runtime stage ---
+FROM python:${PYTHON_VERSION}-slim AS runtime
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
+COPY --from=build /src/dist/*.whl /tmp/
+RUN pip install --no-cache-dir /tmp/*.whl && rm /tmp/*.whl
+
+ENV FABRIC_AUTH=default \
+    PYTHONUNBUFFERED=1
+ENTRYPOINT ["fabric-dw-mcp"]

--- a/README.md
+++ b/README.md
@@ -29,6 +29,22 @@ pip install fabric-dw
 
 > Note: placeholder release; CLI/MCP under active development. Installation instructions will be updated on first release.
 
+## Run in Docker
+
+```bash
+docker pull ghcr.io/sdebruyn/fabric-dw:latest
+docker run --rm \
+  -e AZURE_CLIENT_ID=… \
+  -e AZURE_TENANT_ID=… \
+  -e AZURE_CLIENT_SECRET=… \
+  -e FABRIC_AUTH=sp \
+  ghcr.io/sdebruyn/fabric-dw --help
+```
+
+Dev images (built from every main merge): `ghcr.io/sdebruyn/fabric-dw:main` or `:<version>.dev<N>`.
+
+Package page: [ghcr.io/sdebruyn/fabric-dw](https://github.com/sdebruyn/fabric-dw-mcp-cli/pkgs/container/fabric-dw)
+
 ## Quick Start
 
 ### CLI


### PR DESCRIPTION
## Summary

- Adds `Dockerfile` (multi-stage: uv build → slim runtime, ENTRYPOINT `fabric-dw-mcp`)
- Adds `.github/workflows/docker.yml`: multi-arch (amd64+arm64) push to `ghcr.io/sdebruyn/fabric-dw` with stable (`<version>` + `latest`) and dev (`<version>.dev<N>` + `main`) tag schemes, version computed identically to `publish.yml`
- Adds "Run in Docker" section to README with pull/run example and mention of dev images

Closes #76