### PR TITLE
docs: render CONTRIBUTING/LICENSE/SECURITY in the site via snippets

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -2,6 +2,4 @@
 title: Contributing
 ---
 
-# Contributing
-
-Contributions are welcome. Please read [CONTRIBUTING.md](https://github.com/sdebruyn/fabric-dw-mcp-cli/blob/main/CONTRIBUTING.md) for dev setup, branch flow, and how to run tests locally, and [CODE_OF_CONDUCT.md](https://github.com/sdebruyn/fabric-dw-mcp-cli/blob/main/CODE_OF_CONDUCT.md) for community standards.
+--8<-- "CONTRIBUTING.md"

--- a/docs/license.md
+++ b/docs/license.md
@@ -1,0 +1,5 @@
+---
+title: License
+---
+
+--8<-- "LICENSE"

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,5 @@
+---
+title: Security
+---
+
+--8<-- "SECURITY.md"

--- a/zensical.toml
+++ b/zensical.toml
@@ -9,7 +9,7 @@ repo_name = "sdebruyn/fabric-dw-mcp-cli"
 edit_uri = "edit/main/docs/"
 copyright = "Copyright &copy; 2026 Sam Debruyn"
 
-watch = ["README.md", "CONTRIBUTING.md"]
+watch = ["README.md", "CONTRIBUTING.md", "LICENSE", "SECURITY.md"]
 
 nav = [
   { "Home" = "index.md" },
@@ -20,7 +20,11 @@ nav = [
     { "Shell Completion" = "completion.md" },
     { "Troubleshooting" = "troubleshooting.md" }
   ] },
-  { "Contributing" = "contributing.md" }
+  { "About" = [
+    { "Contributing" = "contributing.md" },
+    { "License" = "license.md" },
+    { "Security" = "security.md" }
+  ] }
 ]
 
 [project.theme]
@@ -114,6 +118,7 @@ pygments_lang_class = true
 [project.markdown_extensions.pymdownx.smartsymbols]
 [project.markdown_extensions.pymdownx.snippets]
 check_paths = true
+base_path = ["."]
 [project.markdown_extensions.pymdownx.superfences]
 custom_fences = [
   { name = "mermaid", class = "mermaid", format = "pymdownx.superfences.fence_code_format" }


### PR DESCRIPTION
Closes #121

Uses `pymdownx.snippets` to include the three repo-root files (`CONTRIBUTING.md`, `LICENSE`, `SECURITY.md`) into Zensical pages. No content duplication; the GitHub copy stays the single source of truth.

### Changes

- `docs/contributing.md` — replaced link-out with `--8<-- "CONTRIBUTING.md"` snippet include
- `docs/license.md` (new) — plain include of `LICENSE`
- `docs/security.md` (new) — plain include of `SECURITY.md`
- `zensical.toml` — added `base_path = ["."]` to `pymdownx.snippets` config; updated nav to group the three pages under "About"; added `LICENSE` and `SECURITY.md` to the `watch` list

### Verification

All three pages build successfully and contain the actual content of the root files. All 360 unit tests pass.