### PR TITLE
feat(list): --all-workspaces flag

### DIFF
--- a/src/fabric_dw/cli/commands/endpoints.py
+++ b/src/fabric_dw/cli/commands/endpoints.py
@@ -37,17 +37,36 @@ def endpoints_group() -> None:
 
 
 @endpoints_group.command("list")
-@click.argument("workspace")
+@click.argument("workspace", required=False, default=None)
+@click.option(
+    "-A",
+    "--all-workspaces",
+    "all_workspaces",
+    is_flag=True,
+    default=False,
+    help="Scan all visible workspaces and aggregate results.",
+)
 @click.pass_obj
 @_coro
-async def list_cmd(ctx: CliContext, workspace: str) -> None:
-    """List all SQL analytics endpoints in WORKSPACE (name or GUID)."""
+async def list_cmd(ctx: CliContext, workspace: str | None, all_workspaces: bool) -> None:
+    """List all SQL analytics endpoints in WORKSPACE (name or GUID).
+
+    Pass -A / --all-workspaces to scan every visible workspace instead.
+    WORKSPACE and --all-workspaces are mutually exclusive.
+    """
+    if workspace and all_workspaces:
+        raise click.UsageError("WORKSPACE and --all-workspaces are mutually exclusive.")  # noqa: TRY003
+    if not workspace and not all_workspaces:
+        raise click.UsageError("Provide WORKSPACE or pass --all-workspaces / -A.")  # noqa: TRY003
     try:
         async with _build_clients(ctx) as (http, _):
-            cache = LookupCache()
-            resolver = Resolver(http=http, cache=cache)
-            ws_id = await resolver.workspace_id(workspace)
-            items = await _sql_endpoints_svc.list_endpoints(http, ws_id)
+            if all_workspaces:
+                items = await _sql_endpoints_svc.list_all_workspaces(http)
+            else:
+                cache = LookupCache()
+                resolver = Resolver(http=http, cache=cache)
+                ws_id = await resolver.workspace_id(workspace)  # type: ignore[arg-type]
+                items = await _sql_endpoints_svc.list_endpoints(http, ws_id)
             render(
                 [ep.model_dump(by_alias=True, mode="json") for ep in items],
                 json_output=ctx.json_output,

--- a/src/fabric_dw/cli/commands/warehouses.py
+++ b/src/fabric_dw/cli/commands/warehouses.py
@@ -39,17 +39,36 @@ def warehouses_group() -> None:
 
 
 @warehouses_group.command("list")
-@click.argument("workspace")
+@click.argument("workspace", required=False, default=None)
+@click.option(
+    "-A",
+    "--all-workspaces",
+    "all_workspaces",
+    is_flag=True,
+    default=False,
+    help="Scan all visible workspaces and aggregate results.",
+)
 @click.pass_obj
 @_coro
-async def list_cmd(ctx: CliContext, workspace: str) -> None:
-    """List all warehouses in WORKSPACE (name or GUID)."""
+async def list_cmd(ctx: CliContext, workspace: str | None, all_workspaces: bool) -> None:
+    """List all warehouses in WORKSPACE (name or GUID).
+
+    Pass -A / --all-workspaces to scan every visible workspace instead.
+    WORKSPACE and --all-workspaces are mutually exclusive.
+    """
+    if workspace and all_workspaces:
+        raise click.UsageError("WORKSPACE and --all-workspaces are mutually exclusive.")  # noqa: TRY003
+    if not workspace and not all_workspaces:
+        raise click.UsageError("Provide WORKSPACE or pass --all-workspaces / -A.")  # noqa: TRY003
     try:
         async with _build_clients(ctx) as (http, _):
-            cache = LookupCache()
-            resolver = Resolver(http=http, cache=cache)
-            ws_id = await resolver.workspace_id(workspace)
-            items = await _warehouses_svc.list_warehouses(http, ws_id)
+            if all_workspaces:
+                items = await _warehouses_svc.list_all_workspaces(http)
+            else:
+                cache = LookupCache()
+                resolver = Resolver(http=http, cache=cache)
+                ws_id = await resolver.workspace_id(workspace)  # type: ignore[arg-type]
+                items = await _warehouses_svc.list_warehouses(http, ws_id)
             render(
                 [w.model_dump(by_alias=True, mode="json") for w in items],
                 json_output=ctx.json_output,

--- a/src/fabric_dw/mcp/server.py
+++ b/src/fabric_dw/mcp/server.py
@@ -170,11 +170,18 @@ async def set_workspace_collation(workspace: str, collation: str) -> dict[str, A
 
 
 @mcp.tool()
-async def list_warehouses(workspace: str) -> list[dict[str, Any]]:
-    """List all warehouses and SQL analytics endpoints in a workspace."""
+async def list_warehouses(workspace: str, all_workspaces: bool = False) -> list[dict[str, Any]]:  # noqa: FBT001, FBT002
+    """List all warehouses and SQL analytics endpoints in a workspace.
+
+    When *all_workspaces* is ``True``, ignore *workspace* and aggregate results
+    across every workspace the caller can see.
+    """
     try:
-        ws_id = await _get_resolver().workspace_id(workspace)
-        result = await warehouses.list_warehouses(_get_http(), ws_id)
+        if all_workspaces:
+            result = await warehouses.list_all_workspaces(_get_http())
+        else:
+            ws_id = await _get_resolver().workspace_id(workspace)
+            result = await warehouses.list_warehouses(_get_http(), ws_id)
     except FabricError as exc:
         raise _fabric_err(exc) from exc
     return [wh.model_dump(by_alias=True, mode="json") for wh in result]
@@ -259,11 +266,18 @@ async def takeover_warehouse(workspace: str, warehouse: str) -> dict[str, Any]:
 
 
 @mcp.tool()
-async def list_sql_endpoints(workspace: str) -> list[dict[str, Any]]:
-    """List all SQL analytics endpoints in a workspace."""
+async def list_sql_endpoints(workspace: str, all_workspaces: bool = False) -> list[dict[str, Any]]:  # noqa: FBT001, FBT002
+    """List all SQL analytics endpoints in a workspace.
+
+    When *all_workspaces* is ``True``, ignore *workspace* and aggregate results
+    across every workspace the caller can see.
+    """
     try:
-        ws_id = await _get_resolver().workspace_id(workspace)
-        result = await sql_endpoints.list_endpoints(_get_http(), ws_id)
+        if all_workspaces:
+            result = await sql_endpoints.list_all_workspaces(_get_http())
+        else:
+            ws_id = await _get_resolver().workspace_id(workspace)
+            result = await sql_endpoints.list_endpoints(_get_http(), ws_id)
     except FabricError as exc:
         raise _fabric_err(exc) from exc
     return [ep.model_dump(by_alias=True, mode="json") for ep in result]

--- a/src/fabric_dw/services/sql_endpoints.py
+++ b/src/fabric_dw/services/sql_endpoints.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 from typing import Any
 from uuid import UUID
 
+from fabric_dw.exceptions import NotFound, PermissionDenied
 from fabric_dw.http_client import FabricHttpClient, HttpBase
 from fabric_dw.models import Warehouse, WarehouseKind
 
 __all__ = [
     "get_endpoint",
+    "list_all_workspaces",
     "list_endpoints",
     "refresh_metadata",
 ]
@@ -36,6 +38,34 @@ async def list_endpoints(http: FabricHttpClient, workspace_id: UUID) -> list[War
             HttpBase.FABRIC, f"/workspaces/{workspace_id}/sqlEndpoints"
         )
     ]
+
+
+async def list_all_workspaces(http: FabricHttpClient) -> list[Warehouse]:
+    """Scan every visible workspace and collect its SQL analytics endpoints.
+
+    Iterates all workspaces returned by :func:`~fabric_dw.services.workspaces.list_all`
+    and aggregates their SQL analytics endpoints. Workspaces that raise
+    :class:`~fabric_dw.exceptions.PermissionDenied` or
+    :class:`~fabric_dw.exceptions.NotFound` are silently skipped.
+
+    Args:
+        http: An authenticated :class:`~fabric_dw.http_client.FabricHttpClient`.
+
+    Returns:
+        A flat list of :class:`~fabric_dw.models.Warehouse` instances (with
+        ``kind == SQL_ENDPOINT``) from all accessible workspaces.
+    """
+    from fabric_dw.services import (  # noqa: PLC0415
+        workspaces as _ws,  # avoid circular at module level
+    )
+
+    out: list[Warehouse] = []
+    for ws in await _ws.list_all(http):
+        try:
+            out.extend(await list_endpoints(http, ws.id))
+        except (PermissionDenied, NotFound):
+            continue
+    return out
 
 
 async def get_endpoint(http: FabricHttpClient, workspace_id: UUID, endpoint_id: UUID) -> Warehouse:

--- a/src/fabric_dw/services/warehouses.py
+++ b/src/fabric_dw/services/warehouses.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from uuid import UUID
 
-from fabric_dw.exceptions import FabricServerError
+from fabric_dw.exceptions import FabricServerError, NotFound, PermissionDenied
 from fabric_dw.http_client import FabricHttpClient, HttpBase
 from fabric_dw.models import Warehouse, WarehouseKind
 from fabric_dw.services.workspaces import SUPPORTED_COLLATIONS
@@ -13,6 +13,7 @@ __all__ = [
     "create",
     "delete",
     "get_warehouse",
+    "list_all_workspaces",
     "list_warehouses",
     "rename",
 ]
@@ -46,6 +47,34 @@ async def list_warehouses(http: FabricHttpClient, workspace_id: UUID) -> list[Wa
         )
     ]
     return result
+
+
+async def list_all_workspaces(http: FabricHttpClient) -> list[Warehouse]:
+    """Scan every visible workspace and collect its warehouses.
+
+    Iterates all workspaces returned by :func:`~fabric_dw.services.workspaces.list_all`
+    and aggregates their warehouses. Workspaces that raise
+    :class:`~fabric_dw.exceptions.PermissionDenied` or
+    :class:`~fabric_dw.exceptions.NotFound` are silently skipped.
+
+    Args:
+        http: An authenticated :class:`~fabric_dw.http_client.FabricHttpClient`.
+
+    Returns:
+        A flat list of :class:`~fabric_dw.models.Warehouse` instances from all
+        accessible workspaces.
+    """
+    from fabric_dw.services import (  # noqa: PLC0415
+        workspaces as _ws,  # avoid circular at module level
+    )
+
+    out: list[Warehouse] = []
+    for ws in await _ws.list_all(http):
+        try:
+            out.extend(await list_warehouses(http, ws.id))
+        except (PermissionDenied, NotFound):
+            continue
+    return out
 
 
 async def get_warehouse(

--- a/tests/unit/cli/commands/test_endpoints.py
+++ b/tests/unit/cli/commands/test_endpoints.py
@@ -145,13 +145,16 @@ class TestEndpointsListAllWorkspaces:
     def test_list_with_all_workspaces_flag(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
         from fabric_dw.models import Warehouse, WarehouseKind  # noqa: PLC0415
-        ep = Warehouse.model_validate({
-            "id": EP_GUID,
-            "displayName": "SalesLakehouse",
-            "workspaceId": WS_GUID,
-            "kind": WarehouseKind.SQL_ENDPOINT,
-            "connectionString": "lakehouse-sql-ep.datawarehouse.fabric.microsoft.com",
-        })
+
+        ep = Warehouse.model_validate(
+            {
+                "id": EP_GUID,
+                "displayName": "SalesLakehouse",
+                "workspaceId": WS_GUID,
+                "kind": WarehouseKind.SQL_ENDPOINT,
+                "connectionString": "lakehouse-sql-ep.datawarehouse.fabric.microsoft.com",
+            }
+        )
         mock_http = AsyncMock()
         with (
             patch(
@@ -163,9 +166,12 @@ class TestEndpointsListAllWorkspaces:
                 new=AsyncMock(return_value=[ep]),
             ),
         ):
-            result = runner.invoke(cli, ["endpoints", "list", "-A"])
+            result = runner.invoke(cli, ["--json", "endpoints", "list", "-A"])
         assert result.exit_code == 0
-        assert "workspaceId" in result.output
+        parsed = json.loads(result.output)
+        assert isinstance(parsed, list)
+        assert len(parsed) == 1
+        assert parsed[0]["workspaceId"] == WS_GUID
 
     def test_list_both_workspace_and_all_workspaces_errors(
         self, runner: CliRunner, cache_env: Path

--- a/tests/unit/cli/commands/test_endpoints.py
+++ b/tests/unit/cli/commands/test_endpoints.py
@@ -139,6 +139,47 @@ class TestEndpointsList:
         assert isinstance(parsed, list)
 
 
+class TestEndpointsListAllWorkspaces:
+    """endpoints list --all-workspaces / -A."""
+
+    def test_list_with_all_workspaces_flag(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        from fabric_dw.models import Warehouse, WarehouseKind  # noqa: PLC0415
+        ep = Warehouse.model_validate({
+            "id": EP_GUID,
+            "displayName": "SalesLakehouse",
+            "workspaceId": WS_GUID,
+            "kind": WarehouseKind.SQL_ENDPOINT,
+            "connectionString": "lakehouse-sql-ep.datawarehouse.fabric.microsoft.com",
+        })
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.endpoints._build_clients",
+                new=_make_cm(mock_http, None),
+            ),
+            patch(
+                "fabric_dw.services.sql_endpoints.list_all_workspaces",
+                new=AsyncMock(return_value=[ep]),
+            ),
+        ):
+            result = runner.invoke(cli, ["endpoints", "list", "-A"])
+        assert result.exit_code == 0
+        assert "workspaceId" in result.output
+
+    def test_list_both_workspace_and_all_workspaces_errors(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with patch(
+            "fabric_dw.cli.commands.endpoints._build_clients",
+            new=_make_cm(mock_http, None),
+        ):
+            result = runner.invoke(cli, ["endpoints", "list", WS_GUID, "-A"])
+        assert result.exit_code != 0
+
+
 class TestEndpointsGet:
     """endpoints get — happy path and 404."""
 

--- a/tests/unit/cli/commands/test_warehouses.py
+++ b/tests/unit/cli/commands/test_warehouses.py
@@ -270,25 +270,17 @@ class TestWarehousesListAllWorkspaces:
 
     def test_list_with_all_workspaces_flag(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
-        wh_item = {
-            "id": WH_GUID,
-            "displayName": "SalesWarehouse",
-            "description": "desc",
-            "type": "Warehouse",
-            "workspaceId": WS_GUID,
-            "kind": "Warehouse",
-            "connectionString": "srv.datawarehouse.fabric.microsoft.com",
-            "defaultCollation": None,
-            "createdDate": None,
-        }
         from fabric_dw.models import Warehouse, WarehouseKind  # noqa: PLC0415
-        wh = Warehouse.model_validate({
-            "id": WH_GUID,
-            "displayName": "SalesWarehouse",
-            "workspaceId": WS_GUID,
-            "kind": WarehouseKind.WAREHOUSE,
-            "connectionString": "srv.datawarehouse.fabric.microsoft.com",
-        })
+
+        wh = Warehouse.model_validate(
+            {
+                "id": WH_GUID,
+                "displayName": "SalesWarehouse",
+                "workspaceId": WS_GUID,
+                "kind": WarehouseKind.WAREHOUSE,
+                "connectionString": "srv.datawarehouse.fabric.microsoft.com",
+            }
+        )
         mock_http = AsyncMock()
         with (
             patch(
@@ -300,9 +292,12 @@ class TestWarehousesListAllWorkspaces:
                 new=AsyncMock(return_value=[wh]),
             ),
         ):
-            result = runner.invoke(cli, ["warehouses", "list", "-A"])
+            result = runner.invoke(cli, ["--json", "warehouses", "list", "-A"])
         assert result.exit_code == 0
-        assert "workspaceId" in result.output
+        parsed = json.loads(result.output)
+        assert isinstance(parsed, list)
+        assert len(parsed) == 1
+        assert parsed[0]["workspaceId"] == WS_GUID
 
     def test_list_both_workspace_and_all_workspaces_errors(
         self, runner: CliRunner, cache_env: Path

--- a/tests/unit/cli/commands/test_warehouses.py
+++ b/tests/unit/cli/commands/test_warehouses.py
@@ -265,6 +265,58 @@ class TestWarehousesDelete:
         assert result.exit_code != 0
 
 
+class TestWarehousesListAllWorkspaces:
+    """warehouses list --all-workspaces / -A."""
+
+    def test_list_with_all_workspaces_flag(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        wh_item = {
+            "id": WH_GUID,
+            "displayName": "SalesWarehouse",
+            "description": "desc",
+            "type": "Warehouse",
+            "workspaceId": WS_GUID,
+            "kind": "Warehouse",
+            "connectionString": "srv.datawarehouse.fabric.microsoft.com",
+            "defaultCollation": None,
+            "createdDate": None,
+        }
+        from fabric_dw.models import Warehouse, WarehouseKind  # noqa: PLC0415
+        wh = Warehouse.model_validate({
+            "id": WH_GUID,
+            "displayName": "SalesWarehouse",
+            "workspaceId": WS_GUID,
+            "kind": WarehouseKind.WAREHOUSE,
+            "connectionString": "srv.datawarehouse.fabric.microsoft.com",
+        })
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.warehouses._build_clients",
+                new=_make_cm(mock_http, None),
+            ),
+            patch(
+                "fabric_dw.services.warehouses.list_all_workspaces",
+                new=AsyncMock(return_value=[wh]),
+            ),
+        ):
+            result = runner.invoke(cli, ["warehouses", "list", "-A"])
+        assert result.exit_code == 0
+        assert "workspaceId" in result.output
+
+    def test_list_both_workspace_and_all_workspaces_errors(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with patch(
+            "fabric_dw.cli.commands.warehouses._build_clients",
+            new=_make_cm(mock_http, None),
+        ):
+            result = runner.invoke(cli, ["warehouses", "list", WS_GUID, "-A"])
+        assert result.exit_code != 0
+
+
 class TestWarehousesTakeover:
     """warehouses takeover — happy path and SQL endpoint refusal."""
 

--- a/tests/unit/mcp/test_server.py
+++ b/tests/unit/mcp/test_server.py
@@ -674,3 +674,83 @@ async def test_refresh_sql_endpoint_metadata_happy_path() -> None:
 
     assert isinstance(result, dict)
     assert result.get("status") == "Succeeded"
+
+
+# ---------------------------------------------------------------------------
+# list_warehouses with all_workspaces=True
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_warehouses_all_workspaces() -> None:
+    """list_warehouses with all_workspaces=True dispatches to list_all_workspaces."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    wh = _make_warehouse()
+
+    mock_resolver = AsyncMock()
+    mock_http = AsyncMock()
+    mock_cache = MagicMock()
+
+    with (
+        patch("fabric_dw.mcp.server._get_http", return_value=mock_http),
+        patch("fabric_dw.mcp.server._get_resolver", return_value=mock_resolver),
+        patch("fabric_dw.mcp.server._get_cache", return_value=mock_cache),
+        patch(
+            "fabric_dw.services.warehouses.list_all_workspaces",
+            new=AsyncMock(return_value=[wh]),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "list_warehouses",
+            {"workspace": "", "all_workspaces": True},
+        )
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0]["id"] == str(_WH_ID)
+
+
+# ---------------------------------------------------------------------------
+# list_sql_endpoints with all_workspaces=True
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_sql_endpoints_all_workspaces() -> None:
+    """list_sql_endpoints with all_workspaces=True dispatches to list_all_workspaces."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    ep_id = UUID("e5f6a7b8-c9d0-1234-ef01-234567890abc")
+    ep = Warehouse.model_validate(
+        {
+            "id": str(ep_id),
+            "displayName": "SalesLakehouse",
+            "workspaceId": str(_WS_ID),
+            "kind": WarehouseKind.SQL_ENDPOINT,
+            "connectionString": "lakehouse-sql-ep.datawarehouse.fabric.microsoft.com",
+        }
+    )
+
+    mock_resolver = AsyncMock()
+    mock_http = AsyncMock()
+    mock_cache = MagicMock()
+
+    with (
+        patch("fabric_dw.mcp.server._get_http", return_value=mock_http),
+        patch("fabric_dw.mcp.server._get_resolver", return_value=mock_resolver),
+        patch("fabric_dw.mcp.server._get_cache", return_value=mock_cache),
+        patch(
+            "fabric_dw.services.sql_endpoints.list_all_workspaces",
+            new=AsyncMock(return_value=[ep]),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "list_sql_endpoints",
+            {"workspace": "", "all_workspaces": True},
+        )
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0]["id"] == str(ep_id)
+    assert result[0]["kind"] == "SQLEndpoint"

--- a/tests/unit/services/test_sql_endpoints.py
+++ b/tests/unit/services/test_sql_endpoints.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import time
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import UUID
 
 import httpx
@@ -13,9 +13,9 @@ import pytest
 import respx
 from azure.core.credentials import AccessToken, TokenCredential
 
-from fabric_dw.exceptions import FabricServerError, NotFound
+from fabric_dw.exceptions import FabricServerError, NotFound, PermissionDenied
 from fabric_dw.http_client import FabricHttpClient
-from fabric_dw.models import Warehouse, WarehouseKind
+from fabric_dw.models import Warehouse, WarehouseKind, Workspace
 from tests.fixtures.api_payloads import (
     WAREHOUSE_SQL_ENDPOINTS_PAGE1_PAYLOAD,
     WAREHOUSE_SQL_ENDPOINTS_PAGE2_PAYLOAD,
@@ -276,3 +276,142 @@ async def test_refresh_metadata_lro_failed_raises_fabric_server_error() -> None:
         async with client:
             with pytest.raises(FabricServerError):
                 await refresh_metadata(client, _WORKSPACE_ID, _ENDPOINT_ID)
+
+
+# ---------------------------------------------------------------------------
+# list_all_workspaces (sql_endpoints)
+# ---------------------------------------------------------------------------
+
+
+_EP_WS_A = UUID("aaaaaaaa-0000-0000-0000-000000000001")
+_EP_WS_B = UUID("bbbbbbbb-0000-0000-0000-000000000002")
+_EP_WS_C = UUID("cccccccc-0000-0000-0000-000000000003")
+_EP_A = UUID("aaaaaaaa-1111-0000-0000-000000000001")
+_EP_B = UUID("bbbbbbbb-1111-0000-0000-000000000002")
+_EP_C = UUID("cccccccc-1111-0000-0000-000000000003")
+
+
+def _make_workspace(ws_id: UUID) -> Workspace:
+    return Workspace.model_validate(
+        {
+            "id": str(ws_id),
+            "displayName": f"WS-{ws_id}",
+            "description": None,
+            "capacityId": None,
+        }
+    )
+
+
+def _make_ep(ws_id: UUID, ep_id: UUID) -> Warehouse:
+    return Warehouse.model_validate(
+        {
+            "id": str(ep_id),
+            "displayName": "EP",
+            "workspaceId": str(ws_id),
+            "kind": WarehouseKind.SQL_ENDPOINT,
+            "connectionString": "ep.fabric.microsoft.com",
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_all_workspaces_endpoints_aggregates_across_workspaces() -> None:
+    """list_all_workspaces must collect endpoints from every visible workspace."""
+    from fabric_dw.services.sql_endpoints import list_all_workspaces  # noqa: PLC0415
+
+    ws_a = _make_workspace(_EP_WS_A)
+    ws_b = _make_workspace(_EP_WS_B)
+    ws_c = _make_workspace(_EP_WS_C)
+    ep_a = _make_ep(_EP_WS_A, _EP_A)
+    ep_b = _make_ep(_EP_WS_B, _EP_B)
+    ep_c = _make_ep(_EP_WS_C, _EP_C)
+
+    mock_http = AsyncMock()
+
+    with (
+        patch(
+            "fabric_dw.services.workspaces.list_all",
+            new=AsyncMock(return_value=[ws_a, ws_b, ws_c]),
+        ),
+        patch(
+            "fabric_dw.services.sql_endpoints.list_endpoints",
+            new=AsyncMock(side_effect=[
+                [ep_a],
+                [ep_b],
+                [ep_c],
+            ]),
+        ),
+    ):
+        result = await list_all_workspaces(mock_http)
+
+    assert len(result) == 3
+    ids = {e.id for e in result}
+    assert ids == {_EP_A, _EP_B, _EP_C}
+
+
+@pytest.mark.asyncio
+async def test_list_all_workspaces_endpoints_skips_permission_denied() -> None:
+    """list_all_workspaces must skip workspaces where PermissionDenied is raised."""
+    from fabric_dw.services.sql_endpoints import list_all_workspaces  # noqa: PLC0415
+
+    ws_a = _make_workspace(_EP_WS_A)
+    ws_b = _make_workspace(_EP_WS_B)
+    ws_c = _make_workspace(_EP_WS_C)
+    ep_a = _make_ep(_EP_WS_A, _EP_A)
+    ep_c = _make_ep(_EP_WS_C, _EP_C)
+
+    mock_http = AsyncMock()
+
+    with (
+        patch(
+            "fabric_dw.services.workspaces.list_all",
+            new=AsyncMock(return_value=[ws_a, ws_b, ws_c]),
+        ),
+        patch(
+            "fabric_dw.services.sql_endpoints.list_endpoints",
+            new=AsyncMock(side_effect=[
+                [ep_a],
+                PermissionDenied("no access"),
+                [ep_c],
+            ]),
+        ),
+    ):
+        result = await list_all_workspaces(mock_http)
+
+    assert len(result) == 2
+    ids = {e.id for e in result}
+    assert ids == {_EP_A, _EP_C}
+
+
+@pytest.mark.asyncio
+async def test_list_all_workspaces_endpoints_skips_not_found() -> None:
+    """list_all_workspaces must skip workspaces where NotFound is raised."""
+    from fabric_dw.services.sql_endpoints import list_all_workspaces  # noqa: PLC0415
+
+    ws_a = _make_workspace(_EP_WS_A)
+    ws_b = _make_workspace(_EP_WS_B)
+    ws_c = _make_workspace(_EP_WS_C)
+    ep_a = _make_ep(_EP_WS_A, _EP_A)
+    ep_c = _make_ep(_EP_WS_C, _EP_C)
+
+    mock_http = AsyncMock()
+
+    with (
+        patch(
+            "fabric_dw.services.workspaces.list_all",
+            new=AsyncMock(return_value=[ws_a, ws_b, ws_c]),
+        ),
+        patch(
+            "fabric_dw.services.sql_endpoints.list_endpoints",
+            new=AsyncMock(side_effect=[
+                [ep_a],
+                NotFound("workspace gone"),
+                [ep_c],
+            ]),
+        ),
+    ):
+        result = await list_all_workspaces(mock_http)
+
+    assert len(result) == 2
+    ids = {e.id for e in result}
+    assert ids == {_EP_A, _EP_C}

--- a/tests/unit/services/test_sql_endpoints.py
+++ b/tests/unit/services/test_sql_endpoints.py
@@ -279,7 +279,7 @@ async def test_refresh_metadata_lro_failed_raises_fabric_server_error() -> None:
 
 
 # ---------------------------------------------------------------------------
-# list_all_workspaces (sql_endpoints)
+# list_all_workspaces for sql_endpoints
 # ---------------------------------------------------------------------------
 
 
@@ -335,11 +335,13 @@ async def test_list_all_workspaces_endpoints_aggregates_across_workspaces() -> N
         ),
         patch(
             "fabric_dw.services.sql_endpoints.list_endpoints",
-            new=AsyncMock(side_effect=[
-                [ep_a],
-                [ep_b],
-                [ep_c],
-            ]),
+            new=AsyncMock(
+                side_effect=[
+                    [ep_a],
+                    [ep_b],
+                    [ep_c],
+                ]
+            ),
         ),
     ):
         result = await list_all_workspaces(mock_http)
@@ -369,11 +371,13 @@ async def test_list_all_workspaces_endpoints_skips_permission_denied() -> None:
         ),
         patch(
             "fabric_dw.services.sql_endpoints.list_endpoints",
-            new=AsyncMock(side_effect=[
-                [ep_a],
-                PermissionDenied("no access"),
-                [ep_c],
-            ]),
+            new=AsyncMock(
+                side_effect=[
+                    [ep_a],
+                    PermissionDenied("no access"),
+                    [ep_c],
+                ]
+            ),
         ),
     ):
         result = await list_all_workspaces(mock_http)
@@ -403,11 +407,13 @@ async def test_list_all_workspaces_endpoints_skips_not_found() -> None:
         ),
         patch(
             "fabric_dw.services.sql_endpoints.list_endpoints",
-            new=AsyncMock(side_effect=[
-                [ep_a],
-                NotFound("workspace gone"),
-                [ep_c],
-            ]),
+            new=AsyncMock(
+                side_effect=[
+                    [ep_a],
+                    NotFound("workspace gone"),
+                    [ep_c],
+                ]
+            ),
         ),
     ):
         result = await list_all_workspaces(mock_http)

--- a/tests/unit/services/test_warehouses.py
+++ b/tests/unit/services/test_warehouses.py
@@ -539,11 +539,13 @@ async def test_list_all_workspaces_aggregates_across_workspaces() -> None:
         ),
         patch(
             "fabric_dw.services.warehouses.list_warehouses",
-            new=AsyncMock(side_effect=[
-                [wh_a],
-                [wh_b],
-                [wh_c],
-            ]),
+            new=AsyncMock(
+                side_effect=[
+                    [wh_a],
+                    [wh_b],
+                    [wh_c],
+                ]
+            ),
         ),
     ):
         result = await warehouses.list_all_workspaces(mock_http)
@@ -571,11 +573,13 @@ async def test_list_all_workspaces_skips_permission_denied() -> None:
         ),
         patch(
             "fabric_dw.services.warehouses.list_warehouses",
-            new=AsyncMock(side_effect=[
-                [wh_a],
-                PermissionDenied("no access"),
-                [wh_c],
-            ]),
+            new=AsyncMock(
+                side_effect=[
+                    [wh_a],
+                    PermissionDenied("no access"),
+                    [wh_c],
+                ]
+            ),
         ),
     ):
         result = await warehouses.list_all_workspaces(mock_http)
@@ -603,11 +607,13 @@ async def test_list_all_workspaces_skips_not_found() -> None:
         ),
         patch(
             "fabric_dw.services.warehouses.list_warehouses",
-            new=AsyncMock(side_effect=[
-                [wh_a],
-                NotFound("workspace gone"),
-                [wh_c],
-            ]),
+            new=AsyncMock(
+                side_effect=[
+                    [wh_a],
+                    NotFound("workspace gone"),
+                    [wh_c],
+                ]
+            ),
         ),
     ):
         result = await warehouses.list_all_workspaces(mock_http)

--- a/tests/unit/services/test_warehouses.py
+++ b/tests/unit/services/test_warehouses.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import time
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import UUID
 
 import httpx
@@ -12,9 +12,9 @@ import pytest
 import respx
 from azure.core.credentials import AccessToken, TokenCredential
 
-from fabric_dw.exceptions import FabricServerError, NotFound
+from fabric_dw.exceptions import FabricServerError, NotFound, PermissionDenied
 from fabric_dw.http_client import FabricHttpClient
-from fabric_dw.models import Warehouse, WarehouseKind
+from fabric_dw.models import Warehouse, WarehouseKind, Workspace
 from fabric_dw.services import warehouses
 from tests.fixtures.api_payloads import (
     LAKEHOUSE_GET_PAYLOAD,
@@ -482,3 +482,136 @@ def test_lakehouse_fixture_has_sql_endpoint() -> None:
     assert "sqlEndpointProperties" in props
     conn = props["sqlEndpointProperties"]["connectionString"]
     assert conn == "lakehouse-sql-ep.datawarehouse.fabric.microsoft.com"
+
+
+# ---------------------------------------------------------------------------
+# list_all_workspaces
+# ---------------------------------------------------------------------------
+
+
+def _make_workspace(ws_id: UUID) -> Workspace:
+    return Workspace.model_validate(
+        {
+            "id": str(ws_id),
+            "displayName": f"WS-{ws_id}",
+            "description": None,
+            "capacityId": None,
+        }
+    )
+
+
+def _make_wh(ws_id: UUID, wh_id: UUID) -> Warehouse:
+    return Warehouse.model_validate(
+        {
+            "id": str(wh_id),
+            "displayName": "WH",
+            "workspaceId": str(ws_id),
+            "kind": WarehouseKind.WAREHOUSE,
+            "connectionString": "wh.fabric.microsoft.com",
+        }
+    )
+
+
+_WS_A = UUID("aaaaaaaa-0000-0000-0000-000000000001")
+_WS_B = UUID("bbbbbbbb-0000-0000-0000-000000000002")
+_WS_C = UUID("cccccccc-0000-0000-0000-000000000003")
+_WH_A = UUID("aaaaaaaa-1111-0000-0000-000000000001")
+_WH_B = UUID("bbbbbbbb-1111-0000-0000-000000000002")
+_WH_C = UUID("cccccccc-1111-0000-0000-000000000003")
+
+
+@pytest.mark.asyncio
+async def test_list_all_workspaces_aggregates_across_workspaces() -> None:
+    """list_all_workspaces must collect warehouses from every visible workspace."""
+    ws_a = _make_workspace(_WS_A)
+    ws_b = _make_workspace(_WS_B)
+    ws_c = _make_workspace(_WS_C)
+    wh_a = _make_wh(_WS_A, _WH_A)
+    wh_b = _make_wh(_WS_B, _WH_B)
+    wh_c = _make_wh(_WS_C, _WH_C)
+
+    mock_http = AsyncMock()
+
+    with (
+        patch(
+            "fabric_dw.services.workspaces.list_all",
+            new=AsyncMock(return_value=[ws_a, ws_b, ws_c]),
+        ),
+        patch(
+            "fabric_dw.services.warehouses.list_warehouses",
+            new=AsyncMock(side_effect=[
+                [wh_a],
+                [wh_b],
+                [wh_c],
+            ]),
+        ),
+    ):
+        result = await warehouses.list_all_workspaces(mock_http)
+
+    assert len(result) == 3
+    ids = {w.id for w in result}
+    assert ids == {_WH_A, _WH_B, _WH_C}
+
+
+@pytest.mark.asyncio
+async def test_list_all_workspaces_skips_permission_denied() -> None:
+    """list_all_workspaces must skip workspaces where PermissionDenied is raised."""
+    ws_a = _make_workspace(_WS_A)
+    ws_b = _make_workspace(_WS_B)
+    ws_c = _make_workspace(_WS_C)
+    wh_a = _make_wh(_WS_A, _WH_A)
+    wh_c = _make_wh(_WS_C, _WH_C)
+
+    mock_http = AsyncMock()
+
+    with (
+        patch(
+            "fabric_dw.services.workspaces.list_all",
+            new=AsyncMock(return_value=[ws_a, ws_b, ws_c]),
+        ),
+        patch(
+            "fabric_dw.services.warehouses.list_warehouses",
+            new=AsyncMock(side_effect=[
+                [wh_a],
+                PermissionDenied("no access"),
+                [wh_c],
+            ]),
+        ),
+    ):
+        result = await warehouses.list_all_workspaces(mock_http)
+
+    assert len(result) == 2
+    ids = {w.id for w in result}
+    assert ids == {_WH_A, _WH_C}
+
+
+@pytest.mark.asyncio
+async def test_list_all_workspaces_skips_not_found() -> None:
+    """list_all_workspaces must skip workspaces where NotFound is raised."""
+    ws_a = _make_workspace(_WS_A)
+    ws_b = _make_workspace(_WS_B)
+    ws_c = _make_workspace(_WS_C)
+    wh_a = _make_wh(_WS_A, _WH_A)
+    wh_c = _make_wh(_WS_C, _WH_C)
+
+    mock_http = AsyncMock()
+
+    with (
+        patch(
+            "fabric_dw.services.workspaces.list_all",
+            new=AsyncMock(return_value=[ws_a, ws_b, ws_c]),
+        ),
+        patch(
+            "fabric_dw.services.warehouses.list_warehouses",
+            new=AsyncMock(side_effect=[
+                [wh_a],
+                NotFound("workspace gone"),
+                [wh_c],
+            ]),
+        ),
+    ):
+        result = await warehouses.list_all_workspaces(mock_http)
+
+    assert len(result) == 2
+    ids = {w.id for w in result}
+    assert ids == {_WH_A, _WH_C}


### PR DESCRIPTION
## Summary

- Adds `list_all_workspaces()` to `services/warehouses.py` and `services/sql_endpoints.py` — iterates every visible workspace and aggregates results, silently skipping `PermissionDenied` / `NotFound` workspaces
- Extends `warehouses list` and `endpoints list` CLI commands with `-A` / `--all-workspaces` flag; `WORKSPACE` becomes optional and mutually exclusive with `-A`; table/JSON output includes `workspaceId` column
- Extends `list_warehouses` and `list_sql_endpoints` MCP tools with optional `all_workspaces: bool = false` parameter

Closes #119

## Test plan

- [x] `test_list_all_workspaces_aggregates_across_workspaces` — 3 workspaces, verifies all warehouses collected
- [x] `test_list_all_workspaces_skips_permission_denied` — one workspace raises PermissionDenied, others continue
- [x] `test_list_all_workspaces_skips_not_found` — one workspace raises NotFound, others continue
- [x] Same three tests for `sql_endpoints.list_all_workspaces`
- [x] CLI `warehouses list -A` returns JSON with `workspaceId` column
- [x] CLI `endpoints list -A` returns JSON with `workspaceId` column
- [x] `warehouses list WS -A` exits non-zero (mutual exclusion)
- [x] `endpoints list WS -A` exits non-zero (mutual exclusion)
- [x] MCP `list_warehouses` with `all_workspaces=True` dispatches to `list_all_workspaces`
- [x] MCP `list_sql_endpoints` with `all_workspaces=True` dispatches to `list_all_workspaces`
- [x] All 372 unit tests pass; ruff + mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)