### PR TITLE
docs: add Code of Conduct page to About group via snippets

### DIFF
--- a/docs/code-of-conduct.md
+++ b/docs/code-of-conduct.md
@@ -1,0 +1,5 @@
+---
+title: Code of Conduct
+---
+
+--8<-- "CODE_OF_CONDUCT.md"

--- a/zensical.toml
+++ b/zensical.toml
@@ -9,7 +9,7 @@ repo_name = "sdebruyn/fabric-dw-mcp-cli"
 edit_uri = "edit/main/docs/"
 copyright = "Copyright &copy; 2026 Sam Debruyn"
 
-watch = ["README.md", "CONTRIBUTING.md", "LICENSE", "SECURITY.md"]
+watch = ["README.md", "CONTRIBUTING.md", "LICENSE", "SECURITY.md", "CODE_OF_CONDUCT.md"]
 
 nav = [
   { "Home" = "index.md" },
@@ -22,6 +22,7 @@ nav = [
   ] },
   { "About" = [
     { "Contributing" = "contributing.md" },
+    { "Code of Conduct" = "code-of-conduct.md" },
     { "License" = "license.md" },
     { "Security" = "security.md" }
   ] }


### PR DESCRIPTION
Late-add to #121: CODE_OF_CONDUCT.md now also renders in the site under About, using the same pymdownx.snippets pattern.