### PR TITLE
chore(docker): use astral uv image, simpler Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,18 @@
 # syntax=docker/dockerfile:1
 ARG PYTHON_VERSION=3.13
 
-# --- Build stage ---
-FROM python:${PYTHON_VERSION}-slim AS build
-RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates && rm -rf /var/lib/apt/lists/*
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh
-ENV PATH="/root/.local/bin:${PATH}"
-WORKDIR /src
+# Build stage uses Astral's official uv + python image
+FROM ghcr.io/astral-sh/uv:python${PYTHON_VERSION}-bookworm-slim AS build
+WORKDIR /app
 COPY pyproject.toml uv.lock README.md LICENSE ./
 COPY src/ src/
 RUN uv sync --frozen --no-dev
 RUN uv build --wheel
 
-# --- Runtime stage ---
+# Runtime stage stays minimal — slim Python, pip-install the wheel
 FROM python:${PYTHON_VERSION}-slim AS runtime
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
-COPY --from=build /src/dist/*.whl /tmp/
+COPY --from=build /app/dist/*.whl /tmp/
 RUN pip install --no-cache-dir /tmp/*.whl && rm /tmp/*.whl
-
-ENV FABRIC_AUTH=default \
-    PYTHONUNBUFFERED=1
+ENV FABRIC_AUTH=default PYTHONUNBUFFERED=1
 ENTRYPOINT ["fabric-dw-mcp"]


### PR DESCRIPTION
Closes #127

Swaps the build stage to ghcr.io/astral-sh/uv:python3.13-bookworm-slim per astral's official Docker integration guide. Drops the apt-install + curl-install of uv that the previous Dockerfile did. Runtime stage unchanged.