### PR TITLE
feat(auth): include browser credential in default chain

### DIFF
--- a/src/fabric_dw/auth.py
+++ b/src/fabric_dw/auth.py
@@ -42,7 +42,7 @@ def get_credential(mode: CredentialMode = CredentialMode.DEFAULT) -> TokenCreden
     if mode == CredentialMode.DEFAULT:
         return DefaultAzureCredential(
             cache_persistence_options=_CACHE_OPTIONS,
-            exclude_interactive_browser_credential=True,
+            exclude_interactive_browser_credential=False,
         )
 
     if mode == CredentialMode.SERVICE_PRINCIPAL:

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -1,7 +1,7 @@
 """Tests for fabric_dw.auth — written before implementation (TDD)."""
 
 import threading
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from azure.core.credentials import AccessToken
@@ -37,6 +37,14 @@ def test_get_credential_default_returns_default_azure_credential() -> None:
 def test_get_credential_default_is_default_argument() -> None:
     credential = get_credential()
     assert isinstance(credential, DefaultAzureCredential)
+
+
+def test_get_credential_default_includes_interactive_browser() -> None:
+    """DefaultAzureCredential must NOT exclude the interactive browser credential."""
+    with patch("fabric_dw.auth.DefaultAzureCredential") as mock_dac:
+        get_credential(CredentialMode.DEFAULT)
+        _, kwargs = mock_dac.call_args
+        assert kwargs.get("exclude_interactive_browser_credential") is False
 
 
 def test_get_credential_service_principal_returns_client_secret_credential(


### PR DESCRIPTION
Closes #133

## Summary

- Changes `exclude_interactive_browser_credential=True` → `False` in `DefaultAzureCredential` so the default auth chain ends with an interactive browser fallback
- Users without `az login` (and no other credential source) now get a browser sign-in prompt instead of a hard failure
- Headless environments (CI, Docker, MCP server with no UI) are detected by azure-identity itself and the browser step is skipped cleanly
- Users can set `FABRIC_AUTH=sp` to disable interactive entirely for unattended scenarios

## Test plan

- [x] New unit test `test_get_credential_default_includes_interactive_browser` mocks `DefaultAzureCredential` and asserts `exclude_interactive_browser_credential=False`
- [x] All 14 existing unit tests pass
- [x] `ruff check`, `ruff format --check`, `mypy` all green locally

## PR #131 coordination

PR #131 (`docs: explain FABRIC_AUTH=default + add MVP tracking`) does not exist in the repository — it was either never opened or already closed. No conflicting doc changes found; the "interactive browser credential is intentionally excluded" text does not appear anywhere in `README.md` or `docs/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)