### PR TITLE
chore(devcontainer): use astral uv image instead of curl-install

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,11 +1,12 @@
 {
   "name": "fabric-dw",
-  "image": "mcr.microsoft.com/devcontainers/python:1-3.13-bookworm",
+  "image": "ghcr.io/astral-sh/uv:python3.13-bookworm",
   "features": {
     "ghcr.io/devcontainers/features/azure-cli:1": {},
-    "ghcr.io/devcontainers/features/github-cli:1": {}
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers/features/common-utils:2": { "username": "vscode" }
   },
-  "postCreateCommand": "curl -LsSf https://astral.sh/uv/install.sh | sh && source $HOME/.local/bin/env && uv sync",
+  "postCreateCommand": "uv sync",
   "customizations": {
     "vscode": {
       "extensions": [


### PR DESCRIPTION
Closes #132

Mirrors #128 (Dockerfile cleanup): devcontainer base is now `ghcr.io/astral-sh/uv:python3.13-bookworm` with uv pre-installed. `postCreateCommand` simplified to `uv sync`.

`common-utils:2` feature added with `username: vscode` to create the non-root `vscode` user — the Astral image is minimal and does not ship one by default.