### PR TITLE
docs(auth): show the full DefaultAzureCredential menu, drop az-cli-only narrative

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 - **CLI** — a command-line tool for common DW administration tasks.
 - **MCP server** — a [Model Context Protocol](https://modelcontextprotocol.io) server that exposes DW operations as tools for AI assistants.
 
-Authentication is configured via the `FABRIC_AUTH` environment variable. The default (`FABRIC_AUTH=default`) uses [`azure-identity` `DefaultAzureCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.defaultazurecredential?WT.mc_id=MVP_310840), which walks environment variables, Workload/Managed Identity, and the Azure CLI token cache in order. For most local usage, `az login` is all you need. See the [Authentication](https://fdw.debruyn.dev/install/#authentication) docs for the full credential chain and alternative modes.
+Authentication is configured via the `FABRIC_AUTH` environment variable. The default (`FABRIC_AUTH=default`) uses [`azure-identity` `DefaultAzureCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.defaultazurecredential?WT.mc_id=MVP_310840), which walks environment variables, Workload/Managed Identity, Azure CLI, Azure Developer CLI, Azure PowerShell, and interactive browser in order — any of these will satisfy it. See the [Authentication](https://fdw.debruyn.dev/authentication/) docs for the full chain, all supported sources, and debugging tips.
 
 ## Installation
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,0 +1,55 @@
+---
+title: Authentication
+---
+
+# Authentication
+
+## Quick path — local development
+
+1. `az login`
+2. Run the CLI / start the MCP server. Done.
+
+## The full picture
+
+With `FABRIC_AUTH=default` the package uses [`DefaultAzureCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.defaultazurecredential?WT.mc_id=MVP_310840). It walks this chain and the first source that returns a token wins:
+
+### 1. Environment variables — service principal or user
+
+`AZURE_CLIENT_ID` + `AZURE_TENANT_ID` + `AZURE_CLIENT_SECRET` for a service principal. See [`EnvironmentCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.environmentcredential?WT.mc_id=MVP_310840).
+
+### 2. Workload Identity — federated, no secret
+
+For GitHub Actions OIDC, AKS federated workloads, etc. See [`WorkloadIdentityCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.workloadidentitycredential?WT.mc_id=MVP_310840).
+
+### 3. Managed Identity — on Azure
+
+Azure VMs, App Service, Functions, Container Apps, AKS pod identities. See [`ManagedIdentityCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.managedidentitycredential?WT.mc_id=MVP_310840).
+
+### 4. Shared MSAL cache
+
+A token written by VS, VS Code, another Azure SDK app on the same machine. See [`SharedTokenCacheCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.sharedtokencachecredential?WT.mc_id=MVP_310840).
+
+### 5. Azure CLI
+
+`az login`. See [`AzureCliCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.azureclicredential?WT.mc_id=MVP_310840).
+
+### 6. Azure Developer CLI
+
+`azd auth login`. See [`AzureDeveloperCliCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.azuredeveloperclicredential?WT.mc_id=MVP_310840).
+
+### 7. Azure PowerShell
+
+`Connect-AzAccount`. See [`AzurePowerShellCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.azurepowershellcredential?WT.mc_id=MVP_310840).
+
+### 8. Interactive browser — last-resort fallback
+
+If everything above failed and you're on a workstation with a browser, you'll be prompted to sign in. See [`InteractiveBrowserCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.interactivebrowsercredential?WT.mc_id=MVP_310840).
+
+## Two explicit modes
+
+- `FABRIC_AUTH=sp` — [`ClientSecretCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.clientsecretcredential?WT.mc_id=MVP_310840) only. For CI / unattended.
+- `FABRIC_AUTH=interactive` — [`InteractiveBrowserCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.interactivebrowsercredential?WT.mc_id=MVP_310840) only.
+
+## Debugging
+
+`AZURE_LOG_LEVEL=debug` makes azure-identity log which credential in the chain it tried and why each failed.

--- a/docs/install.md
+++ b/docs/install.md
@@ -7,7 +7,7 @@ title: Install
 ## Prerequisites
 
 - Python 3.11 or later
-- [Azure CLI](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli?WT.mc_id=MVP_310840) — used for authentication (`az login`)
+- An Azure credential. The package picks one up automatically — see [Authentication](authentication.md).
 
 ## Authentication {#authentication}
 
@@ -15,26 +15,11 @@ title: Install
 
 | `FABRIC_AUTH` value | What it uses |
 | --- | --- |
-| `default` (default) | [`azure-identity` `DefaultAzureCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.defaultazurecredential?WT.mc_id=MVP_310840) — see chain below |
+| `default` (default) | [`azure-identity` `DefaultAzureCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.defaultazurecredential?WT.mc_id=MVP_310840) — see [Authentication](authentication.md) for the full chain |
 | `sp` | Service-principal (`AZURE_CLIENT_SECRET`) |
 | `interactive` | Browser pop-up |
 
-### `FABRIC_AUTH=default` — DefaultAzureCredential chain
-
-When `FABRIC_AUTH` is `default` (or unset), the package delegates to [`azure-identity`'s `DefaultAzureCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.defaultazurecredential?WT.mc_id=MVP_310840). It walks the following sources **in order** and stops at the first one that returns a usable token:
-
-1. **Environment variables** — `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET` / `AZURE_CLIENT_CERTIFICATE_PATH`, `AZURE_TENANT_ID`
-2. **Workload Identity** — injected in Kubernetes / AKS workloads
-3. **Managed Identity** — Azure VMs, App Service, Container Apps, etc.
-4. **Shared token cache** — the MSAL cache shared between Azure tools
-5. **Azure CLI** — token from `az login`
-6. **Azure Developer CLI** — token from `azd auth login`
-7. **Azure PowerShell** — token from `Connect-AzAccount`
-
-!!! note "Interactive browser excluded"
-    `fabric-dw` sets `exclude_interactive_browser_credential=True`, so the browser pop-up is **never** triggered by the `default` mode. Use `FABRIC_AUTH=interactive` if you want an interactive login.
-
-In practice, the most common source is the Azure CLI. Run `az login` (or `az login --tenant <tenant-id>`) before using `fabric-dw` and the credential chain picks up your session automatically.
+See [Authentication](authentication.md) for the full credential chain, all supported sources, and debugging tips.
 
 ## Install
 
@@ -57,4 +42,4 @@ You should see the top-level help output listing available commands.
 
 ---
 
-See also the [Troubleshooting](troubleshooting.md) page for common failure modes such as expired `az login` tokens and 403 permission errors.
+See also the [Authentication](authentication.md) page for the full credential chain and the [Troubleshooting](troubleshooting.md) page for common failure modes such as expired tokens and 403 permission errors.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -16,13 +16,11 @@ uvx fabric-dw-mcp
 
 Every client snippet below configures `uvx fabric-dw-mcp` as the entry point, so your AI tool always picks up the latest published version. Pin a version with `uvx fabric-dw-mcp@2026.6.0` if you need reproducibility.
 
-You will also need:
+You will also need an Azure credential the server can use to call the Fabric REST and SQL APIs. Set the `FABRIC_AUTH` environment variable to select a source:
 
-- Azure CLI logged in (`az login`) so the server can call the Fabric REST and SQL APIs as you.
-- Optionally, environment variables to switch auth modes:
-    - `FABRIC_AUTH=default` (default) — delegates to [`azure-identity` `DefaultAzureCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.defaultazurecredential?WT.mc_id=MVP_310840), which tries environment variables, Workload/Managed Identity, and the Azure CLI in order. See [Authentication](install.md#authentication) for the full chain.
-    - `FABRIC_AUTH=sp` plus `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET` for service-principal auth.
-    - `FABRIC_AUTH=interactive` to force browser sign-in.
+- `FABRIC_AUTH=default` (default) — delegates to [`azure-identity` `DefaultAzureCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.defaultazurecredential?WT.mc_id=MVP_310840), which tries environment variables, Workload/Managed Identity, Azure CLI, Azure Developer CLI, Azure PowerShell, and interactive browser in order. See [Authentication](authentication.md) for the full chain.
+- `FABRIC_AUTH=sp` plus `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET` for service-principal auth.
+- `FABRIC_AUTH=interactive` to force browser sign-in.
 
 ## Claude Code
 
@@ -320,7 +318,7 @@ After configuring your client, restart it and ask the assistant to list its avai
 - **Permission denied calling Fabric**: run `az account show` and confirm your account has at least Workspace Contributor on the target Fabric workspace.
 - **`uv: command not found`**: install uv from <https://docs.astral.sh/uv/>.
 - **`uvx: command not found`**: `uvx` ships with uv — install uv and it will be available.
-- **Server hangs at startup**: the server is likely waiting for an Azure CLI token refresh. Run `az login` before starting your assistant.
+- **Server hangs at startup**: the server is likely waiting for a credential to be resolved. Ensure your Azure credential is set up (see [Authentication](authentication.md)) before starting your assistant.
 - **Tools not visible in Copilot Chat**: ensure you are in **Agent** mode, not Ask or Edit mode.
 - **Tools not visible in Continue**: ensure you are in **Agent** mode.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -38,6 +38,8 @@ az login --tenant <tenant-id-or-domain>
 
 Then retry your `fabric-dw` command. The credential chain picks up the refreshed token automatically.
 
+Or use any other source listed in [Authentication](authentication.md). Set `AZURE_LOG_LEVEL=debug` to see which source the chain tried.
+
 ---
 
 ## 403 PermissionDenied on a workspace call

--- a/zensical.toml
+++ b/zensical.toml
@@ -16,6 +16,7 @@ nav = [
   { "Install" = "install.md" },
   { "Reference" = [
     { "CLI" = "cli.md" },
+    { "Authentication" = "authentication.md" },
     { "MCP" = "mcp.md" },
     { "Shell Completion" = "completion.md" },
     { "Troubleshooting" = "troubleshooting.md" }


### PR DESCRIPTION
Closes #138

Replaces the 'Azure CLI required' narrative with a real Authentication page that documents all 8 sources in DefaultAzureCredential's chain plus the two explicit modes. Each source links to its azure-identity reference on MS Learn with MVP tracking.

## Changes

- `docs/authentication.md` — new page with all 8 chain sources, 2 explicit modes, debugging tip
- `docs/install.md` — drops Azure CLI from prerequisites, points to authentication.md
- `README.md` — removes "az login is all you need", links to authentication.md
- `docs/troubleshooting.md` — adds AZURE_LOG_LEVEL=debug hint + link to authentication.md
- `docs/mcp.md` — drops "az login required" claim, links to authentication.md
- `zensical.toml` — adds Authentication to Reference nav group