### PR TITLE
docs(home): show the fdw logo on the docs homepage

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,10 @@
 title: Home
 ---
 
+<p align="center">
+  <img src="assets/logo.svg" alt="fabric-dw" width="180" />
+</p>
+
 # fabric-dw
 
 > Python CLI + MCP server for Microsoft Fabric Data Warehouse administration.


### PR DESCRIPTION
Closes #148

## Summary
- Adds a centered `<img src="assets/logo.svg">` block at the very top of `docs/index.md` (before any heading), matching the README pattern.
- Width set to 180 px per the issue spec (larger than README's 140 px to suit the docs landing page).

## Test plan
- [x] `uv run --only-group docs zensical build` succeeds.
- [x] `docs_build/site/index.html` references `assets/logo.svg`.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)