### PR TITLE
chore(security): use GitHub Private Vulnerability Reporting

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -36,7 +36,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at [claude.sam@debruyn.dev](mailto:claude.sam@debruyn.dev). All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the maintainers via [GitHub Private Vulnerability Reporting](https://github.com/sdebruyn/fabric-dw-mcp-cli/security/advisories/new). All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,24 +1,16 @@
-# Security Policy
+# Security
 
-## Supported Versions
+We use [GitHub Private Vulnerability Reporting](https://docs.github.com/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability?WT.mc_id=MVP_310840) for security disclosures.
 
-Only the latest minor release receives security fixes.
+**To report a vulnerability**: [open a private advisory](https://github.com/sdebruyn/fabric-dw-mcp-cli/security/advisories/new). GitHub will deliver it directly and privately to the maintainers — no public issue or email needed.
 
-| Version | Supported          |
-| ------- | ------------------ |
-| latest  | :white_check_mark: |
-| older   | :x:                |
+## Supported versions
 
-## Reporting a Vulnerability
+| Version | Supported |
+| --- | --- |
+| Latest stable | yes |
+| Anything older | no |
 
-Please **do not** open a public GitHub issue for security vulnerabilities.
+## Scope
 
-Instead, report them by email to [claude.sam@debruyn.dev](mailto:claude.sam@debruyn.dev).
-
-Include as much detail as possible:
-
-- A description of the vulnerability and its potential impact
-- Steps to reproduce or proof-of-concept
-- Affected versions
-
-You can expect an acknowledgement within 72 hours. We will keep you informed as we work on a fix and coordinate disclosure.
+Bugs that put data, credentials, or workspace state at risk are in scope. Out of scope: bugs in third-party SDKs we depend on (file those upstream), denial-of-service against the Fabric API (file with Microsoft).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,8 @@ requires-python = ">=3.11"
 description = "Python CLI + MCP server for administering Microsoft Fabric Data Warehouses and SQL Analytics Endpoints"
 readme = "README.md"
 license = { text = "MIT" }
-authors = [{ name = "Sam Debruyn", email = "claude.sam@debruyn.dev" }]
-maintainers = [{ name = "Sam Debruyn", email = "claude.sam@debruyn.dev" }]
+authors = [{ name = "Sam Debruyn" }]
+maintainers = [{ name = "Sam Debruyn" }]
 keywords = [
     "microsoft-fabric",
     "fabric",


### PR DESCRIPTION
Closes #146

## Summary

- Replace `claude.sam@debruyn.dev` in `SECURITY.md` with PVR-based instructions pointing at the GitHub advisory workflow
- Replace the enforcement email in `CODE_OF_CONDUCT.md` with a link to the same PVR advisory channel
- Drop `email` field from `authors` and `maintainers` in `pyproject.toml`

## Verification

- `grep` for hardcoded emails returns nothing
- `just check` (ruff, mypy, 406 unit tests) all green
- Docs build succeeds and `security/index.html` contains PVR link
- Wheel `METADATA` contains no `Author-Email` or `Maintainer-Email` field