### PR TITLE
feat(auth): hardcode shared client_id for browser sign-in

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,6 @@ FABRIC_AUTH=default
 # AZURE_TENANT_ID=
 # AZURE_CLIENT_ID=
 # AZURE_CLIENT_SECRET=
+# Override the shared multi-tenant app used for interactive browser sign-in:
+# FABRIC_INTERACTIVE_CLIENT_ID=f666e5ee-2149-4c6a-87eb-13c9e1fdc70d
+# FABRIC_INTERACTIVE_TENANT_ID=

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -4,52 +4,109 @@ title: Authentication
 
 # Authentication
 
-## Quick path — local development
+`fabric-dw` selects a credential source via the `FABRIC_AUTH` environment variable:
 
-1. `az login`
-2. Run the CLI / start the MCP server. Done.
+| `FABRIC_AUTH` value | What it uses |
+| --- | --- |
+| `default` (default) | [`azure-identity` `DefaultAzureCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.defaultazurecredential?WT.mc_id=MVP_310840) — see [credential chain](#fabric_authdefault-defaultazurecredential-chain) below |
+| `interactive` | Browser pop-up — see [interactive sign-in](#interactive-browser-sign-in-zero-setup) below |
+| `sp` | Service-principal — see [service principal](#fabric_authsp-service-principal) below |
 
-## The full picture
+---
 
-With `FABRIC_AUTH=default` the package uses [`DefaultAzureCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.defaultazurecredential?WT.mc_id=MVP_310840). It walks this chain and the first source that returns a token wins:
+## Interactive browser sign-in (zero setup)
 
-### 1. Environment variables — service principal or user
+`FABRIC_AUTH=interactive` (and the default-mode browser fallback) uses a shared multi-tenant app — no registration needed:
 
-`AZURE_CLIENT_ID` + `AZURE_TENANT_ID` + `AZURE_CLIENT_SECRET` for a service principal. See [`EnvironmentCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.environmentcredential?WT.mc_id=MVP_310840).
+| | |
+| --- | --- |
+| Display name | `fabric-dw` |
+| Client ID | `f666e5ee-2149-4c6a-87eb-13c9e1fdc70d` |
+| Sign-in audience | Multi-tenant (`AzureADMultipleOrgs`) |
+| Redirect URI | `http://localhost` |
 
-### 2. Workload Identity — federated, no secret
+On first sign-in:
 
-For GitHub Actions OIDC, AKS federated workloads, etc. See [`WorkloadIdentityCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.workloadidentitycredential?WT.mc_id=MVP_310840).
+- **Non-admin users** — the consent prompt asks for the delegated scopes the app needs (Workspace, Item, Capacity, Tenant.Read, SQL user_impersonation). If your tenant policy requires admin consent for any of them, sign-in will fail until an admin grants it.
+- **Admins** — choose "Consent on behalf of your organization" once; subsequent sign-ins from anyone in the tenant just work.
 
-### 3. Managed Identity — on Azure
+Pre-consent admin URL:
 
-Azure VMs, App Service, Functions, Container Apps, AKS pod identities. See [`ManagedIdentityCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.managedidentitycredential?WT.mc_id=MVP_310840).
+```
+https://login.microsoftonline.com/<YOUR-TENANT-ID>/adminconsent?client_id=f666e5ee-2149-4c6a-87eb-13c9e1fdc70d
+```
 
-### 4. Shared MSAL cache
+### Bring your own app (advanced)
 
-A token written by VS, VS Code, another Azure SDK app on the same machine. See [`SharedTokenCacheCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.sharedtokencachecredential?WT.mc_id=MVP_310840).
+Set `FABRIC_INTERACTIVE_CLIENT_ID` (and optionally `FABRIC_INTERACTIVE_TENANT_ID`) to override the shared default. You then need to register an Entra app in your tenant:
 
-### 5. Azure CLI
+```bash
+az ad app create \
+  --display-name "fabric-dw" \
+  --sign-in-audience AzureADMyOrg \
+  --is-fallback-public-client true \
+  --public-client-redirect-uris http://localhost
+```
 
-`az login`. See [`AzureCliCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.azureclicredential?WT.mc_id=MVP_310840).
+Then grant the same delegated permissions as the shared app:
 
-### 6. Azure Developer CLI
+| API | Permission | Resource app ID |
+| --- | --- | --- |
+| Power BI Service | `Workspace.ReadWrite.All` | `00000009-0000-0000-c000-000000000000` |
+| Power BI Service | `Item.ReadWrite.All` | `00000009-0000-0000-c000-000000000000` |
+| Power BI Service | `Capacity.ReadWrite.All` | `00000009-0000-0000-c000-000000000000` |
+| Power BI Service | `Tenant.Read.All` | `00000009-0000-0000-c000-000000000000` |
+| Azure SQL Database | `user_impersonation` | `022907d3-0f1b-48f7-badc-1ba6abab6d66` |
 
-`azd auth login`. See [`AzureDeveloperCliCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.azuredeveloperclicredential?WT.mc_id=MVP_310840).
+!!! note "Tenant pinning"
+    When `FABRIC_INTERACTIVE_TENANT_ID` is set, `FABRIC_AUTH=interactive` passes it as `tenant_id` to [`InteractiveBrowserCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.interactivebrowsercredential?WT.mc_id=MVP_310840) and the default-mode browser fallback also receives it as `interactive_browser_tenant_id`. Useful when your tenant policy requires a specific tenant context at sign-in time.
 
-### 7. Azure PowerShell
+---
 
-`Connect-AzAccount`. See [`AzurePowerShellCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.azurepowershellcredential?WT.mc_id=MVP_310840).
+## `FABRIC_AUTH=default` — DefaultAzureCredential chain
 
-### 8. Interactive browser — last-resort fallback
+When `FABRIC_AUTH` is `default` (or unset), the package delegates to [`azure-identity`'s `DefaultAzureCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.defaultazurecredential?WT.mc_id=MVP_310840). It walks the following sources **in order** and stops at the first one that returns a usable token:
 
-If everything above failed and you're on a workstation with a browser, you'll be prompted to sign in. See [`InteractiveBrowserCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.interactivebrowsercredential?WT.mc_id=MVP_310840).
+1. **Environment variables** — `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET` / `AZURE_CLIENT_CERTIFICATE_PATH`, `AZURE_TENANT_ID` — see [`EnvironmentCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.environmentcredential?WT.mc_id=MVP_310840)
+2. **Workload Identity** — injected in Kubernetes / AKS workloads — see [`WorkloadIdentityCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.workloadidentitycredential?WT.mc_id=MVP_310840)
+3. **Managed Identity** — Azure VMs, App Service, Container Apps, etc. — see [`ManagedIdentityCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.managedidentitycredential?WT.mc_id=MVP_310840)
+4. **Shared token cache** — the MSAL cache shared between Azure tools — see [`SharedTokenCacheCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.sharedtokencachecredential?WT.mc_id=MVP_310840)
+5. **Azure CLI** — token from `az login` — see [`AzureCliCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.azureclicredential?WT.mc_id=MVP_310840)
+6. **Azure Developer CLI** — token from `azd auth login` — see [`AzureDeveloperCliCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.azuredeveloperclicredential?WT.mc_id=MVP_310840)
+7. **Azure PowerShell** — token from `Connect-AzAccount` — see [`AzurePowerShellCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.azurepowershellcredential?WT.mc_id=MVP_310840)
+8. **Interactive browser** — falls back to browser sign-in using the [shared app](#interactive-browser-sign-in-zero-setup) (or your override via `FABRIC_INTERACTIVE_CLIENT_ID`) — see [`InteractiveBrowserCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.interactivebrowsercredential?WT.mc_id=MVP_310840)
 
-## Two explicit modes
+In practice, the most common source is the Azure CLI. Run [`az login`](https://learn.microsoft.com/cli/azure/reference-index?view=azure-cli-latest&WT.mc_id=MVP_310840#az-login) (or `az login --tenant <tenant-id>`) before using `fabric-dw` and the credential chain picks up your session automatically.
 
-- `FABRIC_AUTH=sp` — [`ClientSecretCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.clientsecretcredential?WT.mc_id=MVP_310840) only. For CI / unattended.
-- `FABRIC_AUTH=interactive` — [`InteractiveBrowserCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.interactivebrowsercredential?WT.mc_id=MVP_310840) only.
+---
+
+## `FABRIC_AUTH=sp` — Service principal
+
+Set the following environment variables:
+
+| Variable | Description |
+| --- | --- |
+| `AZURE_TENANT_ID` | Your Entra tenant ID |
+| `AZURE_CLIENT_ID` | Application (client) ID of your registered app |
+| `AZURE_CLIENT_SECRET` | A client secret for the app |
+
+The package uses [`ClientSecretCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.clientsecretcredential?WT.mc_id=MVP_310840) with these values. The shared `fabric-dw` app is **not** used in SP mode — you must supply your own app registration and secret.
+
+---
+
+## Environment variable reference
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `FABRIC_AUTH` | `default` | Credential mode: `default`, `interactive`, or `sp` |
+| `FABRIC_INTERACTIVE_CLIENT_ID` | `f666e5ee-2149-4c6a-87eb-13c9e1fdc70d` | Override the shared app client ID for browser sign-in |
+| `FABRIC_INTERACTIVE_TENANT_ID` | _(unset)_ | Pin a specific Entra tenant for browser sign-in |
+| `AZURE_TENANT_ID` | _(unset)_ | Required for `FABRIC_AUTH=sp` |
+| `AZURE_CLIENT_ID` | _(unset)_ | Required for `FABRIC_AUTH=sp` |
+| `AZURE_CLIENT_SECRET` | _(unset)_ | Required for `FABRIC_AUTH=sp` |
+
+---
 
 ## Debugging
 
-`AZURE_LOG_LEVEL=debug` makes azure-identity log which credential in the chain it tried and why each failed.
+Set `AZURE_LOG_LEVEL=debug` to make `azure-identity` log which credential in the chain it tried and why each failed.

--- a/src/fabric_dw/auth.py
+++ b/src/fabric_dw/auth.py
@@ -17,6 +17,11 @@ from fabric_dw.exceptions import ConfigError
 FABRIC_SCOPE = "https://analysis.windows.net/powerbi/api/.default"
 SQL_SCOPE = "https://database.windows.net/.default"
 
+#: Shared multi-tenant Entra app for the interactive browser sign-in path.
+#: Users on any tenant can sign in without registering their own app.
+#: Override with the ``FABRIC_INTERACTIVE_CLIENT_ID`` environment variable.
+DEFAULT_INTERACTIVE_CLIENT_ID = "f666e5ee-2149-4c6a-87eb-13c9e1fdc70d"
+
 _CACHE_OPTIONS = TokenCachePersistenceOptions(name="fabric-dw", allow_unencrypted_storage=True)
 
 
@@ -24,6 +29,24 @@ class CredentialMode(StrEnum):
     DEFAULT = "default"
     SERVICE_PRINCIPAL = "sp"
     INTERACTIVE = "interactive"
+
+
+def _resolve_interactive_kwargs() -> dict[str, str]:
+    """Build keyword arguments for the interactive browser credential path.
+
+    Reads ``FABRIC_INTERACTIVE_CLIENT_ID`` (defaults to the shared app) and
+    ``FABRIC_INTERACTIVE_TENANT_ID`` (omitted when not set) from the environment.
+
+    Returns:
+        A dict with at least ``client_id`` and optionally ``tenant_id``.
+    """
+    kwargs: dict[str, str] = {
+        "client_id": os.environ.get("FABRIC_INTERACTIVE_CLIENT_ID", DEFAULT_INTERACTIVE_CLIENT_ID)
+    }
+    tenant = os.environ.get("FABRIC_INTERACTIVE_TENANT_ID")
+    if tenant:
+        kwargs["tenant_id"] = tenant
+    return kwargs
 
 
 def get_credential(mode: CredentialMode = CredentialMode.DEFAULT) -> TokenCredential:
@@ -40,10 +63,15 @@ def get_credential(mode: CredentialMode = CredentialMode.DEFAULT) -> TokenCreden
             AZURE_CLIENT_ID, or AZURE_CLIENT_SECRET are missing from the environment.
     """
     if mode == CredentialMode.DEFAULT:
-        return DefaultAzureCredential(
-            cache_persistence_options=_CACHE_OPTIONS,
-            exclude_interactive_browser_credential=False,
-        )
+        interactive_kwargs = _resolve_interactive_kwargs()
+        dac_kwargs: dict[str, object] = {
+            "cache_persistence_options": _CACHE_OPTIONS,
+            "exclude_interactive_browser_credential": False,
+            "interactive_browser_client_id": interactive_kwargs["client_id"],
+        }
+        if "tenant_id" in interactive_kwargs:
+            dac_kwargs["interactive_browser_tenant_id"] = interactive_kwargs["tenant_id"]
+        return DefaultAzureCredential(**dac_kwargs)
 
     if mode == CredentialMode.SERVICE_PRINCIPAL:
         env_vars = {
@@ -62,7 +90,10 @@ def get_credential(mode: CredentialMode = CredentialMode.DEFAULT) -> TokenCreden
         )
 
     # CredentialMode.INTERACTIVE
-    return InteractiveBrowserCredential(cache_persistence_options=_CACHE_OPTIONS)
+    return InteractiveBrowserCredential(
+        cache_persistence_options=_CACHE_OPTIONS,
+        **_resolve_interactive_kwargs(),
+    )
 
 
 async def get_token(credential: TokenCredential, scope: str) -> AccessToken:

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -194,7 +194,9 @@ def test_default_mode_passes_interactive_browser_client_id(monkeypatch: pytest.M
         assert kwargs.get("interactive_browser_client_id") == DEFAULT_INTERACTIVE_CLIENT_ID
 
 
-def test_default_mode_respects_env_override_for_interactive(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_default_mode_respects_env_override_for_interactive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     custom_id = "deadbeef-0000-0000-0000-000000000002"
     monkeypatch.setenv("FABRIC_INTERACTIVE_CLIENT_ID", custom_id)
     with patch("fabric_dw.auth.DefaultAzureCredential") as mock_dac:
@@ -212,7 +214,9 @@ def test_default_mode_passes_interactive_browser_tenant_id(monkeypatch: pytest.M
         assert kwargs.get("interactive_browser_tenant_id") == "my-tenant-id"
 
 
-def test_default_mode_no_interactive_browser_tenant_id_when_not_set(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_default_mode_no_interactive_browser_tenant_id_when_not_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.delenv("FABRIC_INTERACTIVE_CLIENT_ID", raising=False)
     monkeypatch.delenv("FABRIC_INTERACTIVE_TENANT_ID", raising=False)
     with patch("fabric_dw.auth.DefaultAzureCredential") as mock_dac:

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -12,6 +12,7 @@ from azure.identity import (
 )
 
 from fabric_dw.auth import (
+    DEFAULT_INTERACTIVE_CLIENT_ID,
     FABRIC_SCOPE,
     SQL_SCOPE,
     CredentialMode,
@@ -129,3 +130,109 @@ async def test_get_token_runs_on_non_main_thread() -> None:
 
     assert len(captured_thread_ids) == 1
     assert captured_thread_ids[0] != main_thread_id
+
+
+# ---------------------------------------------------------------------------
+# DEFAULT_INTERACTIVE_CLIENT_ID constant
+# ---------------------------------------------------------------------------
+
+
+def test_default_interactive_client_id_constant() -> None:
+    assert DEFAULT_INTERACTIVE_CLIENT_ID == "f666e5ee-2149-4c6a-87eb-13c9e1fdc70d"
+
+
+# ---------------------------------------------------------------------------
+# Interactive mode — shared client_id + env overrides
+# ---------------------------------------------------------------------------
+
+
+def test_interactive_mode_uses_default_client_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("FABRIC_INTERACTIVE_CLIENT_ID", raising=False)
+    with patch("fabric_dw.auth.InteractiveBrowserCredential") as mock_ibc:
+        get_credential(CredentialMode.INTERACTIVE)
+        _, kwargs = mock_ibc.call_args
+        assert kwargs.get("client_id") == DEFAULT_INTERACTIVE_CLIENT_ID
+
+
+def test_interactive_mode_respects_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    custom_id = "deadbeef-0000-0000-0000-000000000001"
+    monkeypatch.setenv("FABRIC_INTERACTIVE_CLIENT_ID", custom_id)
+    with patch("fabric_dw.auth.InteractiveBrowserCredential") as mock_ibc:
+        get_credential(CredentialMode.INTERACTIVE)
+        _, kwargs = mock_ibc.call_args
+        assert kwargs.get("client_id") == custom_id
+
+
+def test_interactive_mode_uses_tenant_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("FABRIC_INTERACTIVE_CLIENT_ID", raising=False)
+    monkeypatch.setenv("FABRIC_INTERACTIVE_TENANT_ID", "my-tenant-id")
+    with patch("fabric_dw.auth.InteractiveBrowserCredential") as mock_ibc:
+        get_credential(CredentialMode.INTERACTIVE)
+        _, kwargs = mock_ibc.call_args
+        assert kwargs.get("tenant_id") == "my-tenant-id"
+
+
+def test_interactive_mode_no_tenant_id_when_not_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("FABRIC_INTERACTIVE_CLIENT_ID", raising=False)
+    monkeypatch.delenv("FABRIC_INTERACTIVE_TENANT_ID", raising=False)
+    with patch("fabric_dw.auth.InteractiveBrowserCredential") as mock_ibc:
+        get_credential(CredentialMode.INTERACTIVE)
+        _, kwargs = mock_ibc.call_args
+        assert "tenant_id" not in kwargs
+
+
+# ---------------------------------------------------------------------------
+# Default mode — shared client_id forwarded to DefaultAzureCredential
+# ---------------------------------------------------------------------------
+
+
+def test_default_mode_passes_interactive_browser_client_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("FABRIC_INTERACTIVE_CLIENT_ID", raising=False)
+    with patch("fabric_dw.auth.DefaultAzureCredential") as mock_dac:
+        get_credential(CredentialMode.DEFAULT)
+        _, kwargs = mock_dac.call_args
+        assert kwargs.get("interactive_browser_client_id") == DEFAULT_INTERACTIVE_CLIENT_ID
+
+
+def test_default_mode_respects_env_override_for_interactive(monkeypatch: pytest.MonkeyPatch) -> None:
+    custom_id = "deadbeef-0000-0000-0000-000000000002"
+    monkeypatch.setenv("FABRIC_INTERACTIVE_CLIENT_ID", custom_id)
+    with patch("fabric_dw.auth.DefaultAzureCredential") as mock_dac:
+        get_credential(CredentialMode.DEFAULT)
+        _, kwargs = mock_dac.call_args
+        assert kwargs.get("interactive_browser_client_id") == custom_id
+
+
+def test_default_mode_passes_interactive_browser_tenant_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("FABRIC_INTERACTIVE_CLIENT_ID", raising=False)
+    monkeypatch.setenv("FABRIC_INTERACTIVE_TENANT_ID", "my-tenant-id")
+    with patch("fabric_dw.auth.DefaultAzureCredential") as mock_dac:
+        get_credential(CredentialMode.DEFAULT)
+        _, kwargs = mock_dac.call_args
+        assert kwargs.get("interactive_browser_tenant_id") == "my-tenant-id"
+
+
+def test_default_mode_no_interactive_browser_tenant_id_when_not_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("FABRIC_INTERACTIVE_CLIENT_ID", raising=False)
+    monkeypatch.delenv("FABRIC_INTERACTIVE_TENANT_ID", raising=False)
+    with patch("fabric_dw.auth.DefaultAzureCredential") as mock_dac:
+        get_credential(CredentialMode.DEFAULT)
+        _, kwargs = mock_dac.call_args
+        assert "interactive_browser_tenant_id" not in kwargs
+
+
+# ---------------------------------------------------------------------------
+# SP mode — unchanged, shared default does not apply
+# ---------------------------------------------------------------------------
+
+
+def test_sp_mode_does_not_use_interactive_client_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AZURE_TENANT_ID", "test-tenant-id")
+    monkeypatch.setenv("AZURE_CLIENT_ID", "test-client-id")
+    monkeypatch.setenv("AZURE_CLIENT_SECRET", "test-client-secret")
+    monkeypatch.delenv("FABRIC_INTERACTIVE_CLIENT_ID", raising=False)
+    with patch("fabric_dw.auth.ClientSecretCredential") as mock_csc:
+        get_credential(CredentialMode.SERVICE_PRINCIPAL)
+        _, kwargs = mock_csc.call_args
+        assert "interactive_browser_client_id" not in kwargs
+        assert kwargs.get("client_id") == "test-client-id"


### PR DESCRIPTION
Closes #143

The shared multi-tenant app (client id `f666e5ee-2149-4c6a-87eb-13c9e1fdc70d`, sign-in audience `AzureADMultipleOrgs`) is now the default for the interactive-browser path. Users on any tenant get sign-in without registering their own app; admins can pre-consent via the documented URL. `FABRIC_INTERACTIVE_CLIENT_ID` / `FABRIC_INTERACTIVE_TENANT_ID` env vars override the defaults.

## Changes

- `src/fabric_dw/auth.py`: add `DEFAULT_INTERACTIVE_CLIENT_ID` constant and `_resolve_interactive_kwargs()` helper; wire into `InteractiveBrowserCredential` and `DefaultAzureCredential`; SP mode unchanged
- `docs/authentication.md`: rewrite to lead with zero-setup browser sign-in section, admin pre-consent URL, and "bring your own app" subsection
- `.env.example`: document the two new override env vars (commented)
- `tests/unit/test_auth.py`: TDD tests covering default constant, env overrides, tenant override, SP mode isolation

## Test plan

- [x] `uv run pytest tests/unit -q` — 416 passed
- [x] `uv run ruff check .` — no issues
- [x] `uv run ruff format --check .` — no reformats needed
- [x] `uv run mypy src/fabric_dw/auth.py tests/unit/test_auth.py` — no issues
- [x] Docs build clean (`zensical build` — no issues found)
- [x] `grep -q 'f666e5ee-2149-4c6a-87eb-13c9e1fdc70d' docs_build/site/authentication/index.html` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)