### PR TITLE
chore(packaging): restore author email as sam@debruyn.dev

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,8 @@ requires-python = ">=3.11"
 description = "Python CLI + MCP server for administering Microsoft Fabric Data Warehouses and SQL Analytics Endpoints"
 readme = "README.md"
 license = { text = "MIT" }
-authors = [{ name = "Sam Debruyn" }]
-maintainers = [{ name = "Sam Debruyn" }]
+authors = [{ name = "Sam Debruyn", email = "sam@debruyn.dev" }]
+maintainers = [{ name = "Sam Debruyn", email = "sam@debruyn.dev" }]
 keywords = [
     "microsoft-fabric",
     "fabric",


### PR DESCRIPTION
Follow-up to #150 per user clarification on #146. pyproject.toml may carry the email; use the canonical sam@debruyn.dev.

## Changes

- `authors` and `maintainers` in `pyproject.toml` restored with `email = "sam@debruyn.dev"`
- SECURITY.md and CODE_OF_CONDUCT.md unchanged (stay PVR-only)

## Verification

Built wheel METADATA confirms:
```
Author-email: Sam Debruyn <sam@debruyn.dev>
Maintainer-email: Sam Debruyn <sam@debruyn.dev>
```

All 406 unit tests pass, mypy clean.