### PR TITLE
chore(release): adopt hatch-vcs for git-tag-based versioning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: astral-sh/setup-uv@v8.2.0
         with:
           enable-cache: true
@@ -34,6 +36,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: astral-sh/setup-uv@v8.2.0
         with:
           enable-cache: true
@@ -51,6 +55,8 @@ jobs:
         python-version: ["3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: astral-sh/setup-uv@v8.2.0
         with:
           enable-cache: true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,7 +14,9 @@ jobs:
   build-and-push:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - uses: astral-sh/setup-uv@v8.2.0
         with:
@@ -24,28 +26,17 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Compute version
-        id: ver
-        run: |
-          BASE=$(uv run python -c "import fabric_dw; print(fabric_dw.__version__)")
-          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
-            TAG_VER="${GITHUB_REF_NAME#v}"
-            if [[ "$TAG_VER" != "$BASE" ]]; then
-              echo "Tag $TAG_VER does not match fabric_dw.__version__ $BASE" >&2; exit 1
-            fi
-            VERSION="$TAG_VER"
-            CHANNEL="stable"
-          else
-            VERSION="${BASE}.dev${GITHUB_RUN_NUMBER}"
-            CHANNEL="dev"
-          fi
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "channel=$CHANNEL" >> $GITHUB_OUTPUT
+      - run: uv sync --frozen --no-dev
 
-      - name: Override package version
+      - name: Compute Docker tags
+        id: docker_tags
         run: |
-          sed -i.bak 's|^__version__ = .*|__version__ = "${{ steps.ver.outputs.version }}"|' src/fabric_dw/__init__.py
-          rm src/fabric_dw/__init__.py.bak
+          VERSION=$(uv run python -c "import fabric_dw; print(fabric_dw.__version__)")
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            echo "tags=ghcr.io/sdebruyn/fabric-dw:$VERSION,ghcr.io/sdebruyn/fabric-dw:latest" >> $GITHUB_OUTPUT
+          else
+            echo "tags=ghcr.io/sdebruyn/fabric-dw:$VERSION,ghcr.io/sdebruyn/fabric-dw:main" >> $GITHUB_OUTPUT
+          fi
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
@@ -56,28 +47,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build & push (stable)
-        if: steps.ver.outputs.channel == 'stable'
+      - name: Build & push
         uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: |
-            ghcr.io/sdebruyn/fabric-dw:${{ steps.ver.outputs.version }}
-            ghcr.io/sdebruyn/fabric-dw:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Build & push (dev)
-        if: steps.ver.outputs.channel == 'dev'
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            ghcr.io/sdebruyn/fabric-dw:${{ steps.ver.outputs.version }}
-            ghcr.io/sdebruyn/fabric-dw:main
+          tags: ${{ steps.docker_tags.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -22,6 +22,8 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - uses: azure/login@v2
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,27 +26,6 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Compute version
-        id: ver
-        run: |
-          BASE=$(uv run python -c "import fabric_dw; print(fabric_dw.__version__)")
-          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
-            TAG_VER="${GITHUB_REF_NAME#v}"
-            if [[ "$TAG_VER" != "$BASE" ]]; then
-              echo "Tag $TAG_VER does not match fabric_dw.__version__ $BASE" >&2; exit 1
-            fi
-            VERSION="$TAG_VER"
-          else
-            VERSION="${BASE}.dev${GITHUB_RUN_NUMBER}"
-          fi
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-
-      - name: Override version for build
-        run: |
-          sed -i.bak 's|^__version__ = .*|__version__ = "${{ steps.ver.outputs.version }}"|' src/fabric_dw/__init__.py
-          rm src/fabric_dw/__init__.py.bak
-          uv run python -c "import fabric_dw; print('Built version:', fabric_dw.__version__)"
-
       - run: uv sync --frozen --no-dev
 
       - run: uv build

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: astral-sh/setup-uv@v8.2.0
         with: { enable-cache: true }
       - run: uvx --quiet bandit -r src/ -ll
@@ -19,6 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: actions/dependency-review-action@v5
         with:
           fail-on-severity: high
@@ -26,6 +30,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: astral-sh/setup-uv@v8.2.0
         with: { enable-cache: true }
       - run: uv sync --frozen

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Python
 __pycache__/
+src/fabric_dw/_version.py
 *.py[cod]
 *$py.class
 *.so

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
@@ -87,7 +87,11 @@ dev = [
 docs = ["zensical>=0.0.42"]
 
 [tool.hatch.version]
-path = "src/fabric_dw/__init__.py"
+source = "vcs"
+raw-options = { local_scheme = "no-local-version" }
+
+[tool.hatch.build.hooks.vcs]
+version-file = "src/fabric_dw/_version.py"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/fabric_dw"]

--- a/src/fabric_dw/__init__.py
+++ b/src/fabric_dw/__init__.py
@@ -1,1 +1,5 @@
-__version__ = "2026.6.0a0"
+"""fabric-dw — Python CLI + MCP server for Microsoft Fabric Data Warehouse."""
+
+from fabric_dw._version import __version__
+
+__all__ = ["__version__"]


### PR DESCRIPTION
Closes #154

Replaces the hand-bumped `__version__` + sed-override flow with hatch-vcs. Version is now derived from git tags at build time.

## Changes

- `pyproject.toml`: add `hatch-vcs` to `[build-system].requires`; switch `[tool.hatch.version]` to `source = "vcs"`; add `[tool.hatch.build.hooks.vcs]` to write `_version.py`.
- `src/fabric_dw/__init__.py`: import `__version__` from `_version.py` instead of hardcoding it.
- `.gitignore`: ignore the generated `src/fabric_dw/_version.py`.
- All workflow `actions/checkout` steps: add `fetch-depth: 0` so hatch-vcs can walk tag history.
- `publish.yml`: remove "Compute version" + "Override version for build" sed steps — hatch-vcs handles version at build time.
- `docker.yml`: remove "Compute version" + "Override package version" sed steps; add "Compute Docker tags" step that reads `fabric_dw.__version__` post-install; consolidate stable/dev into a single build-push step using the computed tags.

## After merge — Sam action required

Push the baseline tag once so hatch-vcs has a starting point that matches the current PyPI release:

```bash
git fetch origin
git tag v2026.6.0a0 origin/main
git push origin v2026.6.0a0
```

Subsequent main pushes will then publish `2026.6.0a1.devN` and so on. Without that baseline tag, the first dev push would compute version `0.1.devN` and PyPI would refuse it.