### PR TITLE
chore: speed up Cloudflare Pages docs build

### DIFF
--- a/docs_build/cloudflare_pages.sh
+++ b/docs_build/cloudflare_pages.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 #   PYTHON_VERSION=3.13.3       — pins to the version pre-cached in CF's V3
 #                                 build image so pyenv never compiles from source
 #                                 (~95 s saved).  The repo's .python-version
-#                                 (3.13) is still read by local uv/pyenv for dev.
+#                                 (3.13) is still read by local tooling (uv, pyenv) for dev.
 pip install --quiet --upgrade "zensical>=0.0.42"
 
 zensical build

--- a/docs_build/cloudflare_pages.sh
+++ b/docs_build/cloudflare_pages.sh
@@ -1,8 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Cloudflare Pages already runs `pip install .` on this project; we only need
-# zensical itself to build the docs site.
+# Required CF dashboard env vars (Settings → Environment variables):
+#   SKIP_DEPENDENCY_INSTALL=1   — prevents CF from running `pip install .`,
+#                                 which would pull in all runtime deps the docs
+#                                 build doesn't need (~17 s saved).
+#   PYTHON_VERSION=3.13.3       — pins to the version pre-cached in CF's V3
+#                                 build image so pyenv never compiles from source
+#                                 (~95 s saved).  The repo's .python-version
+#                                 (3.13) is still read by local uv/pyenv for dev.
 pip install --quiet --upgrade "zensical>=0.0.42"
 
 zensical build


### PR DESCRIPTION
## Summary

- Replaces the stale comment in `docs_build/cloudflare_pages.sh` with documentation of two required CF dashboard env vars that together cut build time from ~140 s to ~30 s.
- No code or dependency changes; the script logic itself is unchanged.

## Root cause

| Phase | Time | Cause |
|---|---|---|
| pyenv compile | ~95 s | Repo `.python-version = 3.13` caused CF to `python-build` the latest 3.13.x (3.13.12) because only 3.13.3 is pre-cached in the V3 image |
| `pip install .` | ~17 s | CF auto-detects `pyproject.toml` and installs all runtime deps (mssql-python 27 MB, azure-identity, httpx, pydantic, mcp, …) the docs build never uses |
| zensical + upload | ~19 s | Unavoidable |

## Required dashboard changes

In **Cloudflare Pages → fabric-dw → Settings → Environment variables**, add (apply to both Production and Preview):

| Variable | Value | Why |
|---|---|---|
| `PYTHON_VERSION` | `3.13.3` | Pins to the exact version pre-cached in CF's V3 build image — no source compilation. The repo's `.python-version` (still `3.13`) continues to be used by local uv/pyenv for dev. |
| `SKIP_DEPENDENCY_INSTALL` | `1` | Prevents CF from auto-running `pip install .` on detecting `pyproject.toml`. The script installs only `zensical` itself, which is all the docs build needs. |

Both settings are documented as header comments in `docs_build/cloudflare_pages.sh`.

### Verification

- `PYTHON_VERSION`: [CF docs — Language support and tools](https://developers.cloudflare.com/pages/configuration/language-support-and-tools/) confirms `PYTHON_VERSION` overrides `.python-version`; V3 default is `3.13.3` (pre-cached).
- `SKIP_DEPENDENCY_INSTALL`: same page confirms accepted values are `1` or `true`.
- `zensical` requires `>=3.10`, so `3.13.3` is compatible.

## Test plan

- [ ] Set the two env vars in the CF dashboard (see above).
- [ ] Trigger a new Pages deploy (push any commit or retry latest).
- [ ] Confirm build completes in <40 s with no pyenv compile step in the log.
- [ ] Confirm docs site renders correctly at https://fdw.debruyn.dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #160