### PR TITLE
docs(auth): drop Capacity.ReadWrite.All from required permissions

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -45,7 +45,7 @@ If neither of those works for you, read on for the alternatives.
 
 On first sign-in:
 
-- **Non-admin users** — the consent prompt asks for the delegated scopes the app needs (Workspace, Item, Capacity, Tenant.Read, SQL user_impersonation). If your tenant policy requires admin consent for any of them, sign-in will fail until an admin grants it.
+- **Non-admin users** — the consent prompt asks for the delegated scopes the app needs (Workspace, Item, Tenant.Read, SQL user_impersonation). If your tenant policy requires admin consent for any of them, sign-in will fail until an admin grants it.
 - **Admins** — choose "Consent on behalf of your organization" once; subsequent sign-ins from anyone in the tenant just work.
 
 Pre-consent admin URL:
@@ -72,7 +72,6 @@ Then grant the same delegated permissions as the shared app:
 | --- | --- | --- |
 | Power BI Service | `Workspace.ReadWrite.All` | `00000009-0000-0000-c000-000000000000` |
 | Power BI Service | `Item.ReadWrite.All` | `00000009-0000-0000-c000-000000000000` |
-| Power BI Service | `Capacity.ReadWrite.All` | `00000009-0000-0000-c000-000000000000` |
 | Power BI Service | `Tenant.Read.All` | `00000009-0000-0000-c000-000000000000` |
 | Azure SQL Database | `user_impersonation` | `022907d3-0f1b-48f7-badc-1ba6abab6d66` |
 


### PR DESCRIPTION
## Summary

- Removes `Capacity.ReadWrite.All` from the non-admin consent prompt list on line 48 (now reads: Workspace, Item, Tenant.Read, SQL user_impersonation)
- Removes the `Capacity.ReadWrite.All` row from the "Bring your own app" permission table

The codebase never calls any Power BI `/capacities/...` endpoint. The only capacity-related operation (CI resume/pause) goes through Azure ARM, which uses a different scope namespace entirely. The permission was added defensively at app-creation time and is being dropped from the live shared app registration in parallel.

## Test plan

- [ ] Verify `grep -rn "Capacity.ReadWrite.All" docs/ README.md` returns no results
- [ ] Confirm the permission table in `docs/authentication.md` has exactly 4 rows (Workspace.ReadWrite.All, Item.ReadWrite.All, Tenant.Read.All, user_impersonation)
- [ ] Confirm the non-admin consent list no longer mentions "Capacity"
- [ ] Docs build passes (MkDocs lint / link-check steps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #161