### PR TITLE
refactor(mcp): drop invalidate_workspace_cache tool

### DIFF
--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -353,17 +353,5 @@ Erase all cached workspace and item name-to-UUID mappings.
 
 ---
 
-### invalidate_workspace_cache
-
-Remove all cached entries for a specific workspace.
-
-**Parameters:**
-
-- `workspace` (`str`) — workspace name or GUID.
-
-**Returns:** `{ "invalidated": true, "workspace_id": str }` — confirmation with the workspace GUID.
-
----
-
 !!! note "Name-or-GUID resolution"
-    All `workspace`, `warehouse`, `endpoint`, and `snapshot` parameters accept either the item's display name or its GUID. The resolver translates names to GUIDs automatically and caches the mapping locally. Use [`clear_cache`](#clear_cache) or [`invalidate_workspace_cache`](#invalidate_workspace_cache) to force a fresh lookup after renaming items outside this tool. See the [CLI reference](cli.md) for further details on name resolution and cache behaviour.
+    All `workspace`, `warehouse`, `endpoint`, and `snapshot` parameters accept either the item's display name or its GUID. The resolver translates names to GUIDs automatically and caches the mapping locally. Use [`clear_cache`](#clear_cache) to force a fresh lookup after renaming items outside this tool. See the [CLI reference](cli.md) for further details on name resolution and cache behaviour.

--- a/src/fabric_dw/cache.py
+++ b/src/fabric_dw/cache.py
@@ -242,18 +242,3 @@ class LookupCache:
         with self._lock:
             self._path.parent.mkdir(parents=True, exist_ok=True)
             self._write(self._empty())
-
-    def invalidate_workspace(self, workspace_id: UUID) -> None:
-        """Remove *workspace_id* and all items cached under it."""
-        ws_id_str = str(workspace_id)
-        with self._lock:
-            data = self._read()
-            # Remove workspace entry whose id field matches
-            workspaces: dict[str, Any] = data.get("workspaces", {})
-            to_remove = [k for k, v in workspaces.items() if v.get("id") == ws_id_str]
-            for key in to_remove:
-                del workspaces[key]
-            # Drop all items under this workspace
-            items: dict[str, Any] = data.get("items", {})
-            items.pop(ws_id_str, None)
-            self._write(data)

--- a/src/fabric_dw/mcp/server.py
+++ b/src/fabric_dw/mcp/server.py
@@ -550,17 +550,6 @@ async def clear_cache() -> dict[str, Any]:
     return {"cleared": True}
 
 
-@mcp.tool()
-async def invalidate_workspace_cache(workspace: str) -> dict[str, Any]:
-    """Remove cache entries for a specific workspace (name or GUID)."""
-    try:
-        ws_id = await _get_resolver().workspace_id(workspace)
-    except FabricError as exc:
-        raise _fabric_err(exc) from exc
-    _get_cache().invalidate_workspace(ws_id)
-    return {"invalidated": True, "workspace_id": str(ws_id)}
-
-
 # ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------

--- a/tests/unit/mcp/test_server.py
+++ b/tests/unit/mcp/test_server.py
@@ -77,7 +77,6 @@ EXPECTED_TOOL_NAMES: frozenset[str] = frozenset(
         "roll_snapshot_timestamp",
         # Cache
         "clear_cache",
-        "invalidate_workspace_cache",
     }
 )
 
@@ -292,34 +291,6 @@ async def test_get_workspace_happy_path() -> None:
     assert isinstance(result, dict)
     assert result["id"] == str(_WS_ID)
     mock_resolver.workspace_id.assert_called_once_with(_WS_NAME)
-
-
-# ---------------------------------------------------------------------------
-# 6. invalidate_workspace_cache
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_invalidate_workspace_cache() -> None:
-    """invalidate_workspace_cache resolves the workspace and calls cache.invalidate_workspace."""
-    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
-
-    mock_resolver = AsyncMock()
-    mock_resolver.workspace_id = AsyncMock(return_value=_WS_ID)
-    mock_http = AsyncMock()
-    mock_cache = MagicMock()
-
-    with (
-        patch("fabric_dw.mcp.server._get_http", return_value=mock_http),
-        patch("fabric_dw.mcp.server._get_resolver", return_value=mock_resolver),
-        patch("fabric_dw.mcp.server._get_cache", return_value=mock_cache),
-    ):
-        result = await mcp._tool_manager.call_tool(
-            "invalidate_workspace_cache", {"workspace": _WS_NAME}
-        )
-
-    mock_cache.invalidate_workspace.assert_called_once_with(_WS_ID)
-    assert result == {"invalidated": True, "workspace_id": str(_WS_ID)}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -181,46 +181,6 @@ def test_clear_then_get_returns_none(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# invalidate_workspace
-# ---------------------------------------------------------------------------
-
-
-def test_invalidate_workspace_removes_entry(tmp_path: Path) -> None:
-    cache = _make_cache(tmp_path)
-    cache.put_workspace("ws", WS_ID)
-    cache.invalidate_workspace(WS_ID)
-    assert cache.get_workspace("ws") is None
-
-
-def test_invalidate_workspace_removes_items_under_it(tmp_path: Path) -> None:
-    cache = _make_cache(tmp_path)
-    cache.put_workspace("ws", WS_ID)
-    cache.put_item(WS_ID, "item1", _make_item_entry())
-    cache.invalidate_workspace(WS_ID)
-    assert cache.get_item(WS_ID, "item1") is None
-
-
-def test_invalidate_workspace_leaves_other_workspaces(tmp_path: Path) -> None:
-    cache = _make_cache(tmp_path)
-    cache.put_workspace("ws1", WS_ID)
-    cache.put_workspace("ws2", WS_ID_2)
-    cache.put_item(WS_ID_2, "item2", _make_item_entry())
-    cache.invalidate_workspace(WS_ID)
-    # ws2 and its items should still be reachable
-    assert cache.get_workspace("ws2") is not None
-    assert cache.get_item(WS_ID_2, "item2") is not None
-
-
-def test_invalidate_workspace_only_targets_matching_uuid(tmp_path: Path) -> None:
-    cache = _make_cache(tmp_path)
-    cache.put_workspace("ws1", WS_ID)
-    cache.put_workspace("ws2", WS_ID_2)
-    cache.invalidate_workspace(WS_ID)
-    # ws2 survives
-    assert cache.get_workspace("ws2") is not None
-
-
-# ---------------------------------------------------------------------------
 # Concurrent writes (file locking)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Removes the `invalidate_workspace_cache` MCP tool from `server.py`
- Deletes `LookupCache.invalidate_workspace()` from `cache.py` — it had no callers other than the now-removed tool
- Removes all unit tests for the deleted tool and method (4 cache tests, 1 server test)
- Removes the tool entry from `docs/mcp-tools.md` and updates the note in that page to drop the reference to the removed tool

`clear_cache` remains the sole cache-control surface exposed via MCP.

## Test plan

- [x] `uv run ruff check .` — passes
- [x] `uv run ruff format --check .` — passes
- [x] `uv run mypy src tests` — passes
- [x] `uv run pytest tests/unit -q` — 411 passed

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)