### PR TITLE
chore(docker): bump base from bookworm to trixie

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "fabric-dw",
-  "image": "ghcr.io/astral-sh/uv:python3.13-bookworm",
+  "image": "ghcr.io/astral-sh/uv:python3.13-trixie",
   "features": {
     "ghcr.io/devcontainers/features/azure-cli:1": {},
     "ghcr.io/devcontainers/features/github-cli:1": {},

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,13 @@
 ARG PYTHON_VERSION=3.13
 
 # Build stage uses Astral's official uv + python image
-FROM ghcr.io/astral-sh/uv:python${PYTHON_VERSION}-bookworm-slim AS build
+FROM ghcr.io/astral-sh/uv:python${PYTHON_VERSION}-trixie-slim AS build
 WORKDIR /app
+RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
 COPY pyproject.toml uv.lock README.md LICENSE ./
 COPY src/ src/
-RUN uv sync --frozen --no-dev
-RUN uv build --wheel
+COPY .git .git
+RUN uv sync --frozen --no-dev && uv build --wheel && rm -rf .git
 
 # Runtime stage stays minimal — slim Python, pip-install the wheel
 FROM python:${PYTHON_VERSION}-slim AS runtime


### PR DESCRIPTION
## Summary

- Switch build stage from `ghcr.io/astral-sh/uv:python3.13-bookworm-slim` to `python3.13-trixie-slim`
- Switch devcontainer image from `python3.13-bookworm` to `python3.13-trixie`
- Install `git` in the build stage and copy `.git` so `hatch-vcs` can resolve the version from tags during `uv sync`; `.git` is removed after the wheel is built (the CI Docker workflow was already failing for this reason with bookworm)

## Image size

`278 MB` (runtime stage, `python:3.13-slim` on linux/arm64)

## Test plan

- [x] `docker build -t fabric-dw-test .` succeeds locally
- [x] `docker run --rm --entrypoint fabric-dw fabric-dw-test --help` prints CLI help
- [x] `docker run --rm fabric-dw-test --help` prints MCP server help

Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)