### PR TITLE
feat(services/queries): list current SQL connections via sys.dm_exec_connections

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -475,6 +475,31 @@ fabric-dw queries list MyWorkspace SalesWH
 
 ---
 
+### queries list-connections
+
+List all active SQL connections on a warehouse or SQL Analytics Endpoint. This queries `sys.dm_exec_connections` and shows lower-level connection info (including idle connections) that is not visible in `queries list`.
+
+**Synopsis**
+
+```
+fabric-dw queries list-connections [WORKSPACE] [WAREHOUSE]
+```
+
+**Example**
+
+```shell
+fabric-dw queries list-connections MyWorkspace SalesWH
+```
+
+```
+ session_id  connect_time          client_net_address  auth_scheme  encrypt_option  net_transport
+ ----------  --------------------  ------------------  -----------  --------------  -------------
+ 10          2026-06-08T10:00:00Z  192.168.1.100       NTLM         TRUE            TCP
+ 20          2026-06-08T10:01:00Z  192.168.1.101       KERBEROS     TRUE            TCP
+```
+
+---
+
 ### queries kill
 
 Kill a specific session on a warehouse or SQL Analytics Endpoint. You will be asked to confirm unless `--yes` is passed.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -492,10 +492,10 @@ fabric-dw queries list-connections MyWorkspace SalesWH
 ```
 
 ```
- session_id  connect_time          client_net_address  auth_scheme  encrypt_option  net_transport
- ----------  --------------------  ------------------  -----------  --------------  -------------
- 10          2026-06-08T10:00:00Z  192.168.1.100       NTLM         TRUE            TCP
- 20          2026-06-08T10:01:00Z  192.168.1.101       KERBEROS     TRUE            TCP
+ session_id  connect_time          client_net_address  auth_scheme  encrypt_option  net_transport  most_recent_session_id
+ ----------  --------------------  ------------------  -----------  --------------  -------------  ----------------------
+ 10          2026-06-08T10:00:00Z  192.168.1.100       NTLM         TRUE            TCP            10
+ 20          2026-06-08T10:01:00Z  192.168.1.101       KERBEROS     FALSE           TCP            20
 ```
 
 ---

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -253,6 +253,19 @@ Return all currently-executing queries on a warehouse.
 
 ---
 
+### list_connections
+
+Return all active SQL connections on a warehouse or SQL Analytics Endpoint. Queries `sys.dm_exec_connections`, which includes idle connections not visible via `list_running_queries`.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `warehouse` (`str`) — warehouse name or GUID.
+
+**Returns:** `list[Connection]` — array of connection objects, each with `session_id`, `connect_time`, `client_net_address`, `auth_scheme`, `encrypt_option`, and `net_transport`.
+
+---
+
 ### kill_session
 
 Terminate a session on a warehouse.

--- a/src/fabric_dw/cli/commands/queries.py
+++ b/src/fabric_dw/cli/commands/queries.py
@@ -71,6 +71,39 @@ async def list_cmd(ctx: CliContext, workspace: str | None, warehouse: str | None
         raise click.ClickException(str(exc)) from exc
 
 
+@queries_group.command("list-connections")
+@click.argument("workspace", required=False, default=None)
+@click.argument("warehouse", required=False, default=None)
+@click.pass_obj
+@_coro
+async def list_connections_cmd(
+    ctx: CliContext, workspace: str | None, warehouse: str | None
+) -> None:
+    """List active SQL connections on WAREHOUSE_OR_ENDPOINT in WORKSPACE."""
+    ws = resolve_workspace_arg(ctx, workspace)
+    wh = resolve_warehouse_arg(ctx, warehouse)
+    try:
+        async with _build_http_client(ctx) as http:
+            ws_id, entry = await _resolve_item(http, ws, wh)
+            if entry.connection_string is None:
+                raise click.ClickException(  # noqa: TRY003
+                    f"Warehouse {entry.display_name!r} has no connection string."
+                )
+            target = SqlTarget(
+                workspace_id=str(ws_id),
+                database=entry.display_name,
+                connection_string=entry.connection_string,
+            )
+            items = await _queries_svc.list_connections(target, mode=ctx.auth)
+            render(
+                [c.model_dump(by_alias=True, mode="json") for c in items],
+                json_output=ctx.json_output,
+                table_title="SQL Connections",
+            )
+    except FabricError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
 @queries_group.command("kill")
 @click.argument("workspace", required=False, default=None)
 @click.argument("warehouse", required=False, default=None)

--- a/src/fabric_dw/mcp/server.py
+++ b/src/fabric_dw/mcp/server.py
@@ -375,6 +375,26 @@ async def list_running_queries(workspace: str, warehouse: str) -> list[dict[str,
 
 
 @mcp.tool()
+async def list_connections(workspace: str, warehouse: str) -> list[dict[str, Any]]:
+    """Return all active SQL connections on a warehouse or SQL Analytics Endpoint."""
+    try:
+        ws_id = await _get_resolver().workspace_id(workspace)
+        item = await _get_resolver().item(workspace, warehouse)
+        if item.connection_string is None:
+            msg = f"warehouse {warehouse!r} has no connection string; cannot query DMVs"
+            raise FabricError(msg)  # noqa: TRY301
+        target = SqlTarget(
+            workspace_id=str(ws_id),
+            database=item.display_name,
+            connection_string=item.connection_string,
+        )
+        result = await queries.list_connections(target, mode=_get_auth_mode())
+    except FabricError as exc:
+        raise _fabric_err(exc) from exc
+    return [c.model_dump(by_alias=True, mode="json") for c in result]
+
+
+@mcp.tool()
 async def kill_session(workspace: str, warehouse: str, session_id: int) -> dict[str, Any]:
     """Terminate a session on a warehouse by session_id."""
     try:

--- a/src/fabric_dw/models.py
+++ b/src/fabric_dw/models.py
@@ -132,3 +132,17 @@ class RunningQuery(_FabricBase):
         if v is None:
             return None
         return str(v)
+
+
+class Connection(_FabricBase):
+    """An active SQL connection on a Fabric Data Warehouse or SQL Analytics Endpoint.
+
+    Sourced from ``sys.dm_exec_connections``.
+    """
+
+    session_id: int
+    connect_time: datetime
+    client_net_address: str | None = None
+    auth_scheme: str | None = None
+    encrypt_option: str | None = None
+    net_transport: str | None = None

--- a/src/fabric_dw/models.py
+++ b/src/fabric_dw/models.py
@@ -140,9 +140,10 @@ class Connection(_FabricBase):
     Sourced from ``sys.dm_exec_connections``.
     """
 
-    session_id: int
+    session_id: int | None = None
     connect_time: datetime
     client_net_address: str | None = None
     auth_scheme: str | None = None
     encrypt_option: str | None = None
-    net_transport: str | None = None
+    net_transport: str
+    most_recent_session_id: int | None = None

--- a/src/fabric_dw/services/queries.py
+++ b/src/fabric_dw/services/queries.py
@@ -2,8 +2,9 @@
 
 Public API
 ----------
-- :func:`list_running` — return all currently active queries via DMV JOIN.
-- :func:`kill`         — terminate a session by session_id via KILL.
+- :func:`list_running`     — return all currently active queries via DMV JOIN.
+- :func:`list_connections` — return all active SQL connections via sys.dm_exec_connections.
+- :func:`kill`             — terminate a session by session_id via KILL.
 """
 
 from __future__ import annotations
@@ -88,7 +89,8 @@ SELECT
     client_net_address,
     auth_scheme,
     encrypt_option,
-    net_transport
+    net_transport,
+    most_recent_session_id
 FROM sys.dm_exec_connections
 ORDER BY connect_time;
 """

--- a/src/fabric_dw/services/queries.py
+++ b/src/fabric_dw/services/queries.py
@@ -14,11 +14,12 @@ from contextlib import closing
 from fabric_dw import sql
 from fabric_dw.auth import CredentialMode
 from fabric_dw.exceptions import PermissionDenied
-from fabric_dw.models import RunningQuery
+from fabric_dw.models import Connection, RunningQuery
 from fabric_dw.sql import SqlTarget
 
 __all__ = [
     "kill",
+    "list_connections",
     "list_running",
 ]
 
@@ -76,6 +77,60 @@ async def list_running(
                     raise mapped from exc
                 raise
             return [RunningQuery.model_validate(dict(zip(cols, r, strict=True))) for r in rows]
+
+    return await asyncio.to_thread(_run)
+
+
+_LIST_CONNECTIONS_SQL = """\
+SELECT
+    session_id,
+    connect_time,
+    client_net_address,
+    auth_scheme,
+    encrypt_option,
+    net_transport
+FROM sys.dm_exec_connections
+ORDER BY connect_time;
+"""
+
+
+async def list_connections(
+    target: SqlTarget,
+    *,
+    mode: CredentialMode = CredentialMode.DEFAULT,
+) -> list[Connection]:
+    """Return all active SQL connections on *target*.
+
+    Queries the ``sys.dm_exec_connections`` DMV, which exposes lower-level
+    connection info (including idle connections) that is not visible in
+    ``sys.dm_exec_requests``.  Requires VIEW SERVER STATE permission on the
+    database (Fabric grants this automatically to workspace admins and owners).
+
+    Args:
+        target: The warehouse or SQL Analytics Endpoint to query.
+        mode: The credential mode for Entra authentication.
+
+    Returns:
+        A (possibly empty) list of :class:`~fabric_dw.models.Connection`
+        instances, one per result row.
+
+    Raises:
+        PermissionDenied: If the caller lacks VIEW SERVER STATE.
+    """
+
+    def _run() -> list[Connection]:
+        with closing(sql.open_connection(target, mode=mode)) as conn:
+            cursor = conn.cursor()
+            try:
+                cursor.execute(_LIST_CONNECTIONS_SQL)
+                cols = [c[0] for c in (cursor.description or [])]
+                rows = cursor.fetchall()
+            except Exception as exc:
+                mapped = sql.map_driver_error(exc)
+                if mapped:
+                    raise mapped from exc
+                raise
+            return [Connection.model_validate(dict(zip(cols, r, strict=True))) for r in rows]
 
     return await asyncio.to_thread(_run)
 

--- a/tests/unit/services/test_queries.py
+++ b/tests/unit/services/test_queries.py
@@ -515,8 +515,12 @@ async def test_list_connections_sql_selects_expected_columns() -> None:
     cursor = conn.cursor.return_value
     call_sql: str = cursor.execute.call_args[0][0]
     expected_cols = (
-        "session_id", "connect_time", "client_net_address",
-        "auth_scheme", "encrypt_option", "net_transport",
+        "session_id",
+        "connect_time",
+        "client_net_address",
+        "auth_scheme",
+        "encrypt_option",
+        "net_transport",
     )
     for col in expected_cols:
         assert col in call_sql

--- a/tests/unit/services/test_queries.py
+++ b/tests/unit/services/test_queries.py
@@ -406,6 +406,7 @@ _CONN_COLS = [
     "auth_scheme",
     "encrypt_option",
     "net_transport",
+    "most_recent_session_id",
 ]
 
 _CONN_ROW_1 = (
@@ -415,6 +416,7 @@ _CONN_ROW_1 = (
     "NTLM",
     "TRUE",
     "TCP",
+    10,
 )
 
 _CONN_ROW_2 = (
@@ -424,6 +426,18 @@ _CONN_ROW_2 = (
     "KERBEROS",
     "FALSE",
     "TCP",
+    20,
+)
+
+# Pre-login pooled connection: session_id is NULL (IS NULLABLE per MS docs)
+_CONN_ROW_NULL_SESSION = (
+    None,
+    _NOW,
+    "10.0.0.5",
+    "NTLM",
+    "TRUE",
+    "TCP",
+    99,
 )
 
 
@@ -465,6 +479,7 @@ async def test_list_connections_parses_fields_correctly() -> None:
     assert c.auth_scheme == "NTLM"
     assert c.encrypt_option == "TRUE"
     assert c.net_transport == "TCP"
+    assert c.most_recent_session_id == 10
 
 
 @pytest.mark.asyncio
@@ -521,6 +536,7 @@ async def test_list_connections_sql_selects_expected_columns() -> None:
         "auth_scheme",
         "encrypt_option",
         "net_transport",
+        "most_recent_session_id",
     )
     for col in expected_cols:
         assert col in call_sql
@@ -582,3 +598,45 @@ async def test_list_connections_unrelated_error_propagates() -> None:
         pytest.raises(RuntimeError, match="network timeout"),
     ):
         await queries.list_connections(target)
+
+
+@pytest.mark.asyncio
+async def test_list_connections_handles_null_session_id() -> None:
+    """Pre-login pooled connections return NULL for session_id (IS NULLABLE per MS docs)."""
+    target = _make_target()
+    conn = _make_conn([_CONN_ROW_NULL_SESSION], _CONN_COLS)
+
+    with patch("fabric_dw.sql.open_connection", return_value=conn):
+        result = await queries.list_connections(target)
+
+    assert len(result) == 1
+    assert result[0].session_id is None
+    assert result[0].most_recent_session_id == 99
+
+
+@pytest.mark.asyncio
+async def test_list_connections_parses_most_recent_session_id() -> None:
+    """most_recent_session_id is parsed from the DMV result (disambiguates pooled connections)."""
+    target = _make_target()
+    conn = _make_conn([_CONN_ROW_1, _CONN_ROW_2], _CONN_COLS)
+
+    with patch("fabric_dw.sql.open_connection", return_value=conn):
+        result = await queries.list_connections(target)
+
+    assert result[0].most_recent_session_id == 10
+    assert result[1].most_recent_session_id == 20
+
+
+@pytest.mark.asyncio
+async def test_list_connections_most_recent_session_id_can_be_none() -> None:
+    """most_recent_session_id defaults to None when not present in result row."""
+    target = _make_target()
+    # Use a row without most_recent_session_id to confirm None default
+    cols_without = _CONN_COLS[:-1]  # drop most_recent_session_id
+    row_without = _CONN_ROW_1[:-1]
+    conn = _make_conn([row_without], cols_without)
+
+    with patch("fabric_dw.sql.open_connection", return_value=conn):
+        result = await queries.list_connections(target)
+
+    assert result[0].most_recent_session_id is None

--- a/tests/unit/services/test_queries.py
+++ b/tests/unit/services/test_queries.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from fabric_dw.exceptions import AuthError, PermissionDenied
-from fabric_dw.models import RunningQuery
+from fabric_dw.models import Connection, RunningQuery
 from fabric_dw.services import queries
 
 # ---------------------------------------------------------------------------
@@ -393,3 +393,188 @@ async def test_kill_permission_denied_message_contains_session_id() -> None:
         pytest.raises(PermissionDenied, match="42"),
     ):
         await queries.kill(target, 42)
+
+
+# ---------------------------------------------------------------------------
+# list_connections
+# ---------------------------------------------------------------------------
+
+_CONN_COLS = [
+    "session_id",
+    "connect_time",
+    "client_net_address",
+    "auth_scheme",
+    "encrypt_option",
+    "net_transport",
+]
+
+_CONN_ROW_1 = (
+    10,
+    _NOW,
+    "192.168.1.100",
+    "NTLM",
+    "TRUE",
+    "TCP",
+)
+
+_CONN_ROW_2 = (
+    20,
+    _NOW,
+    None,
+    "KERBEROS",
+    "FALSE",
+    "TCP",
+)
+
+
+@pytest.mark.asyncio
+async def test_list_connections_returns_empty_when_no_rows() -> None:
+    target = _make_target()
+    conn = _make_conn([], _CONN_COLS)
+
+    with patch("fabric_dw.sql.open_connection", return_value=conn):
+        result = await queries.list_connections(target)
+
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_list_connections_returns_connection_instances() -> None:
+    target = _make_target()
+    conn = _make_conn([_CONN_ROW_1], _CONN_COLS)
+
+    with patch("fabric_dw.sql.open_connection", return_value=conn):
+        result = await queries.list_connections(target)
+
+    assert len(result) == 1
+    assert isinstance(result[0], Connection)
+
+
+@pytest.mark.asyncio
+async def test_list_connections_parses_fields_correctly() -> None:
+    target = _make_target()
+    conn = _make_conn([_CONN_ROW_1], _CONN_COLS)
+
+    with patch("fabric_dw.sql.open_connection", return_value=conn):
+        result = await queries.list_connections(target)
+
+    c = result[0]
+    assert c.session_id == 10
+    assert c.connect_time == _NOW
+    assert c.client_net_address == "192.168.1.100"
+    assert c.auth_scheme == "NTLM"
+    assert c.encrypt_option == "TRUE"
+    assert c.net_transport == "TCP"
+
+
+@pytest.mark.asyncio
+async def test_list_connections_handles_null_client_net_address() -> None:
+    target = _make_target()
+    conn = _make_conn([_CONN_ROW_2], _CONN_COLS)
+
+    with patch("fabric_dw.sql.open_connection", return_value=conn):
+        result = await queries.list_connections(target)
+
+    assert result[0].client_net_address is None
+
+
+@pytest.mark.asyncio
+async def test_list_connections_returns_all_rows() -> None:
+    target = _make_target()
+    conn = _make_conn([_CONN_ROW_1, _CONN_ROW_2], _CONN_COLS)
+
+    with patch("fabric_dw.sql.open_connection", return_value=conn):
+        result = await queries.list_connections(target)
+
+    assert len(result) == 2
+    assert result[0].session_id == 10
+    assert result[1].session_id == 20
+
+
+@pytest.mark.asyncio
+async def test_list_connections_sql_references_dm_exec_connections() -> None:
+    target = _make_target()
+    conn = _make_conn([], _CONN_COLS)
+
+    with patch("fabric_dw.sql.open_connection", return_value=conn):
+        await queries.list_connections(target)
+
+    cursor = conn.cursor.return_value
+    call_sql: str = cursor.execute.call_args[0][0]
+    assert "sys.dm_exec_connections" in call_sql
+
+
+@pytest.mark.asyncio
+async def test_list_connections_sql_selects_expected_columns() -> None:
+    target = _make_target()
+    conn = _make_conn([], _CONN_COLS)
+
+    with patch("fabric_dw.sql.open_connection", return_value=conn):
+        await queries.list_connections(target)
+
+    cursor = conn.cursor.return_value
+    call_sql: str = cursor.execute.call_args[0][0]
+    expected_cols = (
+        "session_id", "connect_time", "client_net_address",
+        "auth_scheme", "encrypt_option", "net_transport",
+    )
+    for col in expected_cols:
+        assert col in call_sql
+
+
+@pytest.mark.asyncio
+async def test_list_connections_closes_connection_after_success() -> None:
+    target = _make_target()
+    conn = _make_conn([_CONN_ROW_1], _CONN_COLS)
+
+    with patch("fabric_dw.sql.open_connection", return_value=conn):
+        await queries.list_connections(target)
+
+    conn.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_list_connections_maps_permission_denied() -> None:
+    target = _make_target()
+    conn = MagicMock()
+    cursor = MagicMock()
+    cursor.execute.side_effect = Exception(
+        "permission was denied on object sys.dm_exec_connections"
+    )
+    conn.cursor.return_value = cursor
+
+    with (
+        patch("fabric_dw.sql.open_connection", return_value=conn),
+        pytest.raises(PermissionDenied),
+    ):
+        await queries.list_connections(target)
+
+
+@pytest.mark.asyncio
+async def test_list_connections_maps_auth_error() -> None:
+    target = _make_target()
+    conn = MagicMock()
+    cursor = MagicMock()
+    cursor.execute.side_effect = Exception("Authentication failed for user '' (token)")
+    conn.cursor.return_value = cursor
+
+    with (
+        patch("fabric_dw.sql.open_connection", return_value=conn),
+        pytest.raises(AuthError),
+    ):
+        await queries.list_connections(target)
+
+
+@pytest.mark.asyncio
+async def test_list_connections_unrelated_error_propagates() -> None:
+    target = _make_target()
+    conn = MagicMock()
+    cursor = MagicMock()
+    cursor.execute.side_effect = RuntimeError("network timeout")
+    conn.cursor.return_value = cursor
+
+    with (
+        patch("fabric_dw.sql.open_connection", return_value=conn),
+        pytest.raises(RuntimeError, match="network timeout"),
+    ):
+        await queries.list_connections(target)


### PR DESCRIPTION
## Summary

- Adds `Connection` Pydantic model (`session_id`, `connect_time`, `client_net_address`, `auth_scheme`, `encrypt_option`, `net_transport`) sourced from `sys.dm_exec_connections`.
- Adds `services.queries.list_connections(target, mode)` DMV helper alongside `list_running` and `kill`; follows the same `asyncio.to_thread` + `map_driver_error` pattern.
- Adds CLI subcommand `fabric-dw queries list-connections [WORKSPACE] [WAREHOUSE]` with `--json` support via the shared `render()` helper.
- Adds MCP tool `list_connections(workspace, warehouse)` returning `list[Connection]`.
- 14 new unit tests (TDD) covering empty result, field parsing, nullable columns, SQL shape, connection close, and permission/auth error mapping; all 433 unit tests green.

Closes #175

## Test plan

- [x] `uv run pytest tests/unit` — 433 passed
- [x] `uv run ruff check` — clean
- [x] `uvx ty==0.0.44 check src tests` — clean
- [ ] Integration: `fabric-dw queries list-connections` against a live Fabric warehouse returns at least the caller's own connection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)