### PR TITLE
chore(docker): pass version via build-arg; drop .git copy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,4 +14,4 @@ docs_build/
 .pytest_cache
 *.md
 !README.md
-!LICENSE
+.env*

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+.git
+.venv
+.github
+__pycache__
+*.py[cod]
+*.egg-info
+dist/
+build/
+tests/
+docs/
+docs_build/
+.mypy_cache
+.ruff_cache
+.pytest_cache
+*.md
+!README.md
+!LICENSE

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,10 +28,11 @@ jobs:
 
       - run: uv sync --frozen --no-dev
 
-      - name: Compute Docker tags
+      - name: Compute Docker tags and version
         id: docker_tags
         run: |
           VERSION=$(uv run python -c "import fabric_dw; print(fabric_dw.__version__)")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
           if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
             echo "tags=ghcr.io/sdebruyn/fabric-dw:$VERSION,ghcr.io/sdebruyn/fabric-dw:latest" >> $GITHUB_OUTPUT
           else
@@ -54,5 +55,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.docker_tags.outputs.tags }}
+          build-args: SETUPTOOLS_SCM_PRETEND_VERSION_FOR_FABRIC_DW=${{ steps.docker_tags.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,11 @@ ARG PYTHON_VERSION=3.13
 # Build stage uses Astral's official uv + python image
 FROM ghcr.io/astral-sh/uv:python${PYTHON_VERSION}-trixie-slim AS build
 WORKDIR /app
-RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
+ARG SETUPTOOLS_SCM_PRETEND_VERSION_FOR_FABRIC_DW
+ENV SETUPTOOLS_SCM_PRETEND_VERSION_FOR_FABRIC_DW=${SETUPTOOLS_SCM_PRETEND_VERSION_FOR_FABRIC_DW}
 COPY pyproject.toml uv.lock README.md LICENSE ./
 COPY src/ src/
-COPY .git .git
-RUN uv sync --frozen --no-dev && uv build --wheel && rm -rf .git
+RUN uv sync --frozen --no-dev && uv build --wheel
 
 # Runtime stage stays minimal — slim Python, pip-install the wheel
 FROM python:${PYTHON_VERSION}-slim AS runtime


### PR DESCRIPTION
## Summary

- Drop `COPY .git .git` and `rm -rf .git` from the Dockerfile build stage
- Drop `git` from the `apt-get install` in the build stage
- Add `ARG`/`ENV` for `SETUPTOOLS_SCM_PRETEND_VERSION_FOR_FABRIC_DW` so hatch-vcs resolves the version without needing the `.git` directory
- Update `docker.yml` to export the computed version as an output and pass it as `--build-arg` to the Docker build
- Add `.dockerignore` to exclude `.git`, `.venv`, `tests/`, `docs/`, `docs_build/`, and build artefacts from the Docker build context

## Test plan

- [ ] CI Docker workflow builds and pushes the image successfully
- [ ] The built image entrypoint (`fabric-dw-mcp`) starts without errors
- [ ] Image size is unchanged or smaller (no `.git` in build context)

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)