### PR TITLE
feat(services/restore): restore points CRUD + in-place restore

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -493,6 +493,137 @@ fabric-dw --yes queries kill MyWorkspace SalesWH 42
 
 ---
 
+## fabric-dw restore-points
+
+Manage Microsoft Fabric Warehouse restore points.
+
+A restore point captures the state of a warehouse at a point in time. User-defined restore points can be created, renamed, and deleted. System-created restore points are managed automatically by Fabric and cannot be deleted. Restore point IDs are timestamp-based strings (e.g. `"1726617378000"`), not GUIDs.
+
+### restore-points list
+
+List all restore points for a warehouse.
+
+**Synopsis**
+
+```
+fabric-dw restore-points list [WORKSPACE] [WAREHOUSE]
+```
+
+**Example**
+
+```shell
+fabric-dw restore-points list MyWorkspace SalesWH
+```
+
+```
+ id              displayName        creationMode   eventDateTime
+ --------------- ------------------ -------------- ---------------------
+ 1726617378000   Before migration   UserDefined    2024-10-18T22:17:09Z
+```
+
+---
+
+### restore-points get
+
+Get details for a single restore point by ID.
+
+**Synopsis**
+
+```
+fabric-dw restore-points get WORKSPACE WAREHOUSE RESTORE_POINT_ID
+```
+
+**Example**
+
+```shell
+fabric-dw restore-points get MyWorkspace SalesWH 1726617378000
+```
+
+---
+
+### restore-points create
+
+Create a new restore point for a warehouse at the current timestamp.
+
+**Synopsis**
+
+```
+fabric-dw restore-points create [OPTIONS] [WORKSPACE] [WAREHOUSE]
+```
+
+| Option | Description |
+| --- | --- |
+| `--name TEXT` | Optional display name (max 128 chars). |
+| `--description TEXT` | Optional description (max 512 chars). |
+
+**Example**
+
+```shell
+fabric-dw restore-points create MyWorkspace SalesWH \
+  --name "Before migration" \
+  --description "Pre-migration checkpoint"
+```
+
+---
+
+### restore-points rename
+
+Rename a restore point and optionally update its description.
+
+**Synopsis**
+
+```
+fabric-dw restore-points rename [OPTIONS] WORKSPACE WAREHOUSE RESTORE_POINT_ID NEW_NAME
+```
+
+| Option | Description |
+| --- | --- |
+| `--description TEXT` | Optional new description. |
+
+**Example**
+
+```shell
+fabric-dw restore-points rename MyWorkspace SalesWH 1726617378000 "Post-migration backup"
+```
+
+---
+
+### restore-points delete
+
+Delete a user-defined restore point. System-created restore points cannot be deleted. You will be asked to confirm unless `--yes` is passed.
+
+**Synopsis**
+
+```
+fabric-dw restore-points delete WORKSPACE WAREHOUSE RESTORE_POINT_ID
+```
+
+**Example**
+
+```shell
+fabric-dw --yes restore-points delete MyWorkspace SalesWH 1726617378000
+```
+
+---
+
+### restore-points restore
+
+Restore a warehouse in-place to a restore point. **This is a destructive operation** — the warehouse will be unavailable for approximately 10 minutes. You will be asked to confirm unless `--yes` is passed.
+
+**Synopsis**
+
+```
+fabric-dw restore-points restore WORKSPACE WAREHOUSE RESTORE_POINT_ID
+```
+
+**Example**
+
+```shell
+fabric-dw --yes restore-points restore MyWorkspace SalesWH 1726617378000
+```
+
+---
+
 ## fabric-dw snapshots
 
 Manage Microsoft Fabric Data Warehouse snapshots.

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -267,6 +267,96 @@ Terminate a session on a warehouse.
 
 ---
 
+## Restore Points
+
+Restore point IDs are timestamp-based strings (e.g. `"1726617378000"`), not GUIDs. Each `RestorePoint` object has `id`, `displayName`, `description`, `creationMode` (`"UserDefined"` or `"SystemCreated"`), and `eventDateTime`.
+
+### list_restore_points
+
+Return all restore points for a warehouse.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `warehouse` (`str`) — warehouse name or GUID.
+
+**Returns:** `list[RestorePoint]` — array of restore point objects.
+
+---
+
+### get_restore_point
+
+Return a single restore point by ID.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `warehouse` (`str`) — warehouse name or GUID.
+- `restore_point_id` (`str`) — the restore point ID string (e.g. `"1726617378000"`).
+
+**Returns:** `RestorePoint` — the restore point object.
+
+---
+
+### create_restore_point
+
+Create a restore point for a warehouse at the current timestamp.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `warehouse` (`str`) — warehouse name or GUID.
+- `name` (`str | null`, optional) — display name (max 128 chars).
+- `description` (`str | null`, optional) — description (max 512 chars).
+
+**Returns:** `RestorePoint` — the newly-created restore point object.
+
+---
+
+### update_restore_point
+
+Rename and/or update the description of a restore point. At least one of `name` or `description` must be supplied.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `warehouse` (`str`) — warehouse name or GUID.
+- `restore_point_id` (`str`) — the restore point ID string.
+- `name` (`str | null`, optional) — new display name (max 128 chars).
+- `description` (`str | null`, optional) — new description (max 512 chars).
+
+**Returns:** `RestorePoint` — the updated restore point object.
+
+---
+
+### delete_restore_point
+
+Delete a user-defined restore point. System-created restore points cannot be deleted.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `warehouse` (`str`) — warehouse name or GUID.
+- `restore_point_id` (`str`) — the restore point ID string.
+
+**Returns:** `{ "deleted": true, "restore_point_id": str }` — confirmation.
+
+---
+
+### restore_warehouse_in_place
+
+Restore a warehouse in-place to a restore point. **This is a destructive, long-running operation** — the warehouse will be unavailable for approximately 10 minutes while the restore completes.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `warehouse` (`str`) — warehouse name or GUID.
+- `restore_point_id` (`str`) — the restore point ID string to restore to.
+
+**Returns:** `{ "restored": true, "restore_point_id": str }` — confirmation.
+
+---
+
 ## Snapshots
 
 ### list_snapshots

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -32,18 +32,6 @@ Return details for a single workspace.
 
 ---
 
-### get_workspace_collation
-
-Return the default Data Warehouse collation configured for a workspace.
-
-**Parameters:**
-
-- `workspace` (`str`) — workspace name or GUID.
-
-**Returns:** `{ "collation": str }` — the collation name.
-
----
-
 ### set_workspace_collation
 
 Set the default Data Warehouse collation for a workspace.

--- a/src/fabric_dw/cli/_main.py
+++ b/src/fabric_dw/cli/_main.py
@@ -13,6 +13,7 @@ from fabric_dw.cli.commands.cache import cache_group
 from fabric_dw.cli.commands.completion import completion_group
 from fabric_dw.cli.commands.config import config_group
 from fabric_dw.cli.commands.queries import queries_group
+from fabric_dw.cli.commands.restore_points import restore_points_group
 from fabric_dw.cli.commands.snapshots import snapshots_group
 from fabric_dw.cli.commands.sql_endpoints import sql_endpoints_group
 from fabric_dw.cli.commands.warehouses import warehouses_group
@@ -79,4 +80,5 @@ cli.add_command(warehouses_group)
 cli.add_command(sql_endpoints_group)
 cli.add_command(audit_group)
 cli.add_command(queries_group)
+cli.add_command(restore_points_group)
 cli.add_command(snapshots_group)

--- a/src/fabric_dw/cli/commands/restore_points.py
+++ b/src/fabric_dw/cli/commands/restore_points.py
@@ -39,9 +39,7 @@ async def _resolve_ws(http: FabricHttpClient, workspace: str) -> UUID:
     return await resolver.workspace_id(workspace)
 
 
-async def _resolve_wh(
-    http: FabricHttpClient, workspace: str, warehouse: str
-) -> tuple[UUID, UUID]:
+async def _resolve_wh(http: FabricHttpClient, workspace: str, warehouse: str) -> tuple[UUID, UUID]:
     cache = LookupCache()
     resolver = Resolver(http=http, cache=cache)
     ws_id = await resolver.workspace_id(workspace)
@@ -224,9 +222,7 @@ async def restore_cmd(
             if not confirmed:
                 raise click.Abort()  # noqa: TRY301
             await _restore_svc.restore_in_place(http, ws_id, wh_id, restore_point_id)
-            click.echo(
-                f"Warehouse restored to restore point {restore_point_id!r} successfully."
-            )
+            click.echo(f"Warehouse restored to restore point {restore_point_id!r} successfully.")
     except click.Abort:
         raise
     except FabricError as exc:

--- a/src/fabric_dw/cli/commands/restore_points.py
+++ b/src/fabric_dw/cli/commands/restore_points.py
@@ -1,0 +1,233 @@
+"""Restore-points sub-commands for the fabric-dw CLI."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from uuid import UUID
+
+import click
+
+from fabric_dw import auth as _auth
+from fabric_dw.cache import LookupCache
+from fabric_dw.cli._context import CliContext
+from fabric_dw.cli._render import confirm, render
+from fabric_dw.cli.commands._utils import (
+    _coro,
+    resolve_warehouse_arg,
+    resolve_workspace_arg,
+)
+from fabric_dw.exceptions import FabricError
+from fabric_dw.http_client import FabricHttpClient
+from fabric_dw.resolver import Resolver
+from fabric_dw.services import restore as _restore_svc
+
+_log = logging.getLogger(__name__)
+
+
+@asynccontextmanager
+async def _build_http_client(ctx: CliContext) -> AsyncIterator[FabricHttpClient]:
+    credential = _auth.get_credential(ctx.auth)
+    async with FabricHttpClient(credential) as http:
+        yield http
+
+
+async def _resolve_ws(http: FabricHttpClient, workspace: str) -> UUID:
+    cache = LookupCache()
+    resolver = Resolver(http=http, cache=cache)
+    return await resolver.workspace_id(workspace)
+
+
+async def _resolve_wh(
+    http: FabricHttpClient, workspace: str, warehouse: str
+) -> tuple[UUID, UUID]:
+    cache = LookupCache()
+    resolver = Resolver(http=http, cache=cache)
+    ws_id = await resolver.workspace_id(workspace)
+    entry = await resolver.item(workspace, warehouse)
+    return ws_id, entry.id
+
+
+@click.group("restore-points")
+def restore_points_group() -> None:
+    """Manage Microsoft Fabric Warehouse restore points."""
+
+
+@restore_points_group.command("list")
+@click.argument("workspace", required=False, default=None)
+@click.argument("warehouse", required=False, default=None)
+@click.pass_obj
+@_coro
+async def list_cmd(ctx: CliContext, workspace: str | None, warehouse: str | None) -> None:
+    """List all restore points for WAREHOUSE in WORKSPACE."""
+    ws = resolve_workspace_arg(ctx, workspace)
+    wh = resolve_warehouse_arg(ctx, warehouse)
+    try:
+        async with _build_http_client(ctx) as http:
+            ws_id, wh_id = await _resolve_wh(http, ws, wh)
+            items = await _restore_svc.list_points(http, ws_id, wh_id)
+            render(
+                [rp.model_dump(by_alias=True, mode="json") for rp in items],
+                json_output=ctx.json_output,
+                table_title="Restore Points",
+            )
+    except FabricError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@restore_points_group.command("get")
+@click.argument("workspace")
+@click.argument("warehouse")
+@click.argument("restore_point_id")
+@click.pass_obj
+@_coro
+async def get_cmd(
+    ctx: CliContext,
+    workspace: str,
+    warehouse: str,
+    restore_point_id: str,
+) -> None:
+    """Get a restore point by RESTORE_POINT_ID for WAREHOUSE in WORKSPACE."""
+    try:
+        async with _build_http_client(ctx) as http:
+            ws_id, wh_id = await _resolve_wh(http, workspace, warehouse)
+            rp = await _restore_svc.get_point(http, ws_id, wh_id, restore_point_id)
+            render(rp.model_dump(by_alias=True, mode="json"), json_output=ctx.json_output)
+    except FabricError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@restore_points_group.command("create")
+@click.argument("workspace", required=False, default=None)
+@click.argument("warehouse", required=False, default=None)
+@click.option("--name", default=None, help="Optional display name (max 128 chars).")
+@click.option("--description", default=None, help="Optional description (max 512 chars).")
+@click.pass_obj
+@_coro
+async def create_cmd(
+    ctx: CliContext,
+    workspace: str | None,
+    warehouse: str | None,
+    name: str | None,
+    description: str | None,
+) -> None:
+    """Create a restore point for WAREHOUSE in WORKSPACE at the current timestamp."""
+    ws = resolve_workspace_arg(ctx, workspace)
+    wh = resolve_warehouse_arg(ctx, warehouse)
+    try:
+        async with _build_http_client(ctx) as http:
+            ws_id, wh_id = await _resolve_wh(http, ws, wh)
+            rp = await _restore_svc.create_point(
+                http, ws_id, wh_id, name=name, description=description
+            )
+            render(rp.model_dump(by_alias=True, mode="json"), json_output=ctx.json_output)
+    except FabricError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@restore_points_group.command("rename")
+@click.argument("workspace")
+@click.argument("warehouse")
+@click.argument("restore_point_id")
+@click.argument("new_name")
+@click.option("--description", default=None, help="Optional new description.")
+@click.pass_obj
+@_coro
+async def rename_cmd(  # noqa: PLR0913
+    ctx: CliContext,
+    workspace: str,
+    warehouse: str,
+    restore_point_id: str,
+    new_name: str,
+    description: str | None,
+) -> None:
+    """Rename RESTORE_POINT_ID to NEW_NAME on WAREHOUSE in WORKSPACE."""
+    try:
+        async with _build_http_client(ctx) as http:
+            ws_id, wh_id = await _resolve_wh(http, workspace, warehouse)
+            rp = await _restore_svc.update_point(
+                http,
+                ws_id,
+                wh_id,
+                restore_point_id,
+                name=new_name,
+                description=description,
+            )
+            render(rp.model_dump(by_alias=True, mode="json"), json_output=ctx.json_output)
+    except (ValueError, FabricError) as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@restore_points_group.command("delete")
+@click.argument("workspace")
+@click.argument("warehouse")
+@click.argument("restore_point_id")
+@click.pass_obj
+@_coro
+async def delete_cmd(
+    ctx: CliContext,
+    workspace: str,
+    warehouse: str,
+    restore_point_id: str,
+) -> None:
+    """Delete RESTORE_POINT_ID on WAREHOUSE in WORKSPACE.
+
+    Only user-defined restore points can be deleted; system-created points
+    are automatically managed by the service.
+    You will be asked to confirm unless --yes is passed.
+    """
+    try:
+        async with _build_http_client(ctx) as http:
+            ws_id, wh_id = await _resolve_wh(http, workspace, warehouse)
+            confirmed = confirm(
+                f"Delete restore point {restore_point_id!r} on warehouse in {workspace!r}?",
+                yes=ctx.yes,
+            )
+            if not confirmed:
+                raise click.Abort()  # noqa: TRY301
+            await _restore_svc.delete_point(http, ws_id, wh_id, restore_point_id)
+            click.echo(f"Restore point {restore_point_id!r} deleted.")
+    except click.Abort:
+        raise
+    except FabricError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@restore_points_group.command("restore")
+@click.argument("workspace")
+@click.argument("warehouse")
+@click.argument("restore_point_id")
+@click.pass_obj
+@_coro
+async def restore_cmd(
+    ctx: CliContext,
+    workspace: str,
+    warehouse: str,
+    restore_point_id: str,
+) -> None:
+    """Restore WAREHOUSE in-place to RESTORE_POINT_ID in WORKSPACE.
+
+    WARNING: This is a destructive operation. The warehouse will be
+    unavailable for approximately 10 minutes while the restore completes.
+    You will be asked to confirm unless --yes is passed.
+    """
+    try:
+        async with _build_http_client(ctx) as http:
+            ws_id, wh_id = await _resolve_wh(http, workspace, warehouse)
+            confirmed = confirm(
+                f"Restore warehouse in {workspace!r} to restore point "
+                f"{restore_point_id!r}? "
+                f"The warehouse will be unavailable for ~10 minutes.",
+                yes=ctx.yes,
+            )
+            if not confirmed:
+                raise click.Abort()  # noqa: TRY301
+            await _restore_svc.restore_in_place(http, ws_id, wh_id, restore_point_id)
+            click.echo(
+                f"Warehouse restored to restore point {restore_point_id!r} successfully."
+            )
+    except click.Abort:
+        raise
+    except FabricError as exc:
+        raise click.ClickException(str(exc)) from exc

--- a/src/fabric_dw/cli/commands/restore_points.py
+++ b/src/fabric_dw/cli/commands/restore_points.py
@@ -33,12 +33,6 @@ async def _build_http_client(ctx: CliContext) -> AsyncIterator[FabricHttpClient]
         yield http
 
 
-async def _resolve_ws(http: FabricHttpClient, workspace: str) -> UUID:
-    cache = LookupCache()
-    resolver = Resolver(http=http, cache=cache)
-    return await resolver.workspace_id(workspace)
-
-
 async def _resolve_wh(http: FabricHttpClient, workspace: str, warehouse: str) -> tuple[UUID, UUID]:
     cache = LookupCache()
     resolver = Resolver(http=http, cache=cache)

--- a/src/fabric_dw/cli/commands/restore_points.py
+++ b/src/fabric_dw/cli/commands/restore_points.py
@@ -208,19 +208,29 @@ async def restore_cmd(
 
     WARNING: This is a destructive operation. The warehouse will be
     unavailable for approximately 10 minutes while the restore completes.
-    You will be asked to confirm unless --yes is passed.
+    In interactive mode you must type the warehouse name to confirm.
+    Pass --yes to skip the prompt for automation.
     """
     try:
         async with _build_http_client(ctx) as http:
             ws_id, wh_id = await _resolve_wh(http, workspace, warehouse)
-            confirmed = confirm(
-                f"Restore warehouse in {workspace!r} to restore point "
-                f"{restore_point_id!r}? "
-                f"The warehouse will be unavailable for ~10 minutes.",
-                yes=ctx.yes,
-            )
-            if not confirmed:
-                raise click.Abort()  # noqa: TRY301
+            if not ctx.yes:
+                rp = await _restore_svc.get_point(http, ws_id, wh_id, restore_point_id)
+                when = rp.event_date_time.isoformat() if rp.event_date_time else "unknown"
+                click.echo(
+                    f"\nWARNING: This will REPLACE all data in warehouse {warehouse!r} "
+                    f"with the state at restore point {restore_point_id!r} "
+                    f"(created {when}).\n"
+                    f"The warehouse will be UNAVAILABLE for ~10 minutes.\n",
+                    err=True,
+                )
+                typed = click.prompt(
+                    f"To restore warehouse {warehouse!r} to restore point "
+                    f"{restore_point_id!r} (created {when}), "
+                    f"type the warehouse name to confirm"
+                )
+                if typed != warehouse:
+                    raise click.Abort()  # noqa: TRY301
             await _restore_svc.restore_in_place(http, ws_id, wh_id, restore_point_id)
             click.echo(f"Warehouse restored to restore point {restore_point_id!r} successfully.")
     except click.Abort:

--- a/src/fabric_dw/mcp/server.py
+++ b/src/fabric_dw/mcp/server.py
@@ -34,6 +34,7 @@ from fabric_dw.logging import setup_logging
 from fabric_dw.resolver import Resolver
 from fabric_dw.services import audit, queries, snapshots, sql_endpoints, warehouses, workspaces
 from fabric_dw.services import ownership as ownership_svc
+from fabric_dw.services import restore as restore_svc
 from fabric_dw.sql import SqlTarget
 
 __all__ = ["mcp", "run"]
@@ -525,6 +526,154 @@ async def roll_snapshot_timestamp(
     except FabricError as exc:
         raise _fabric_err(exc) from exc
     return {"rolled": True, "snapshot_name": snapshot_name, "new_dt": new_dt}
+
+
+# ---------------------------------------------------------------------------
+# Restore Point tools
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+async def list_restore_points(workspace: str, warehouse: str) -> list[dict[str, Any]]:
+    """Return all restore points for a warehouse."""
+    try:
+        ws_id = await _get_resolver().workspace_id(workspace)
+        item = await _get_resolver().item(workspace, warehouse)
+        result = await restore_svc.list_points(_get_http(), ws_id, item.id)
+    except FabricError as exc:
+        raise _fabric_err(exc) from exc
+    return [rp.model_dump(by_alias=True, mode="json") for rp in result]
+
+
+@mcp.tool()
+async def get_restore_point(
+    workspace: str, warehouse: str, restore_point_id: str
+) -> dict[str, Any]:
+    """Return a single restore point by ID.
+
+    Args:
+        workspace: Workspace name or GUID.
+        warehouse: Warehouse name or GUID.
+        restore_point_id: The restore point ID string (e.g. ``"1726617378000"``).
+    """
+    try:
+        ws_id = await _get_resolver().workspace_id(workspace)
+        item = await _get_resolver().item(workspace, warehouse)
+        result = await restore_svc.get_point(_get_http(), ws_id, item.id, restore_point_id)
+    except FabricError as exc:
+        raise _fabric_err(exc) from exc
+    return result.model_dump(by_alias=True, mode="json")
+
+
+@mcp.tool()
+async def create_restore_point(
+    workspace: str,
+    warehouse: str,
+    name: str | None = None,
+    description: str | None = None,
+) -> dict[str, Any]:
+    """Create a restore point for a warehouse at the current timestamp.
+
+    Args:
+        workspace: Workspace name or GUID.
+        warehouse: Warehouse name or GUID.
+        name: Optional display name (max 128 chars).
+        description: Optional description (max 512 chars).
+    """
+    try:
+        ws_id = await _get_resolver().workspace_id(workspace)
+        item = await _get_resolver().item(workspace, warehouse)
+        result = await restore_svc.create_point(
+            _get_http(), ws_id, item.id, name=name, description=description
+        )
+    except FabricError as exc:
+        raise _fabric_err(exc) from exc
+    return result.model_dump(by_alias=True, mode="json")
+
+
+@mcp.tool()
+async def update_restore_point(
+    workspace: str,
+    warehouse: str,
+    restore_point_id: str,
+    name: str | None = None,
+    description: str | None = None,
+) -> dict[str, Any]:
+    """Rename and/or update the description of a restore point.
+
+    At least one of *name* or *description* must be provided.
+
+    Args:
+        workspace: Workspace name or GUID.
+        warehouse: Warehouse name or GUID.
+        restore_point_id: The restore point ID string.
+        name: New display name (max 128 chars).
+        description: New description (max 512 chars).
+    """
+    try:
+        ws_id = await _get_resolver().workspace_id(workspace)
+        item = await _get_resolver().item(workspace, warehouse)
+        result = await restore_svc.update_point(
+            _get_http(),
+            ws_id,
+            item.id,
+            restore_point_id,
+            name=name,
+            description=description,
+        )
+    except ValueError as exc:
+        raise ToolError(str(exc)) from exc
+    except FabricError as exc:
+        raise _fabric_err(exc) from exc
+    return result.model_dump(by_alias=True, mode="json")
+
+
+@mcp.tool()
+async def delete_restore_point(
+    workspace: str, warehouse: str, restore_point_id: str
+) -> dict[str, Any]:
+    """Delete a user-defined restore point.
+
+    System-created restore points cannot be deleted.
+
+    Args:
+        workspace: Workspace name or GUID.
+        warehouse: Warehouse name or GUID.
+        restore_point_id: The restore point ID string.
+    """
+    try:
+        ws_id = await _get_resolver().workspace_id(workspace)
+        item = await _get_resolver().item(workspace, warehouse)
+        await restore_svc.delete_point(_get_http(), ws_id, item.id, restore_point_id)
+    except FabricError as exc:
+        raise _fabric_err(exc) from exc
+    return {"deleted": True, "restore_point_id": restore_point_id}
+
+
+@mcp.tool()
+async def restore_warehouse_in_place(
+    workspace: str, warehouse: str, restore_point_id: str
+) -> dict[str, Any]:
+    """Restore a warehouse in-place to a restore point.
+
+    WARNING: This is a destructive, long-running operation. The warehouse
+    will be unavailable for approximately 10 minutes while the restore
+    completes.
+
+    Args:
+        workspace: Workspace name or GUID.
+        warehouse: Warehouse name or GUID.
+        restore_point_id: The restore point ID string to restore to.
+    """
+    try:
+        ws_id = await _get_resolver().workspace_id(workspace)
+        item = await _get_resolver().item(workspace, warehouse)
+        await restore_svc.restore_in_place(
+            _get_http(), ws_id, item.id, restore_point_id
+        )
+    except FabricError as exc:
+        raise _fabric_err(exc) from exc
+    return {"restored": True, "restore_point_id": restore_point_id}
 
 
 # ---------------------------------------------------------------------------

--- a/src/fabric_dw/mcp/server.py
+++ b/src/fabric_dw/mcp/server.py
@@ -668,9 +668,7 @@ async def restore_warehouse_in_place(
     try:
         ws_id = await _get_resolver().workspace_id(workspace)
         item = await _get_resolver().item(workspace, warehouse)
-        await restore_svc.restore_in_place(
-            _get_http(), ws_id, item.id, restore_point_id
-        )
+        await restore_svc.restore_in_place(_get_http(), ws_id, item.id, restore_point_id)
     except FabricError as exc:
         raise _fabric_err(exc) from exc
     return {"restored": True, "restore_point_id": restore_point_id}

--- a/src/fabric_dw/models.py
+++ b/src/fabric_dw/models.py
@@ -124,9 +124,7 @@ class RestorePoint(_FabricBase):
         """
         _raw_details = payload.get("creationDetails")
         details: dict[str, object] = (
-            cast("dict[str, object]", _raw_details)
-            if isinstance(_raw_details, dict)
-            else {}
+            cast("dict[str, object]", _raw_details) if isinstance(_raw_details, dict) else {}
         )
         flat: dict[str, object] = {
             "id": payload.get("id"),

--- a/src/fabric_dw/models.py
+++ b/src/fabric_dw/models.py
@@ -96,11 +96,17 @@ class WarehouseSnapshot(_FabricBase):
     snapshot_dt: datetime | None = Field(default=None, alias="snapshotDateTime")
 
 
-class CreationModeType(StrEnum):
-    """Whether the restore point was created by a user or by the system."""
+class CreationModeType:
+    """Known values for the ``creationMode`` field of a :class:`RestorePoint`.
 
-    USER_DEFINED = "UserDefined"
-    SYSTEM_CREATED = "SystemCreated"
+    MS Learn notes that additional creation mode types may be added over time,
+    so this is an **open** set of constants rather than a closed ``StrEnum``.
+    The ``creation_mode`` field on :class:`RestorePoint` is typed as ``str``
+    so that future unknown values pass Pydantic validation without error.
+    """
+
+    USER_DEFINED: str = "UserDefined"
+    SYSTEM_CREATED: str = "SystemCreated"
 
 
 class RestorePoint(_FabricBase):
@@ -112,7 +118,7 @@ class RestorePoint(_FabricBase):
     id: str
     name: str = Field(alias="displayName")
     description: str | None = None
-    creation_mode: CreationModeType = Field(alias="creationMode")
+    creation_mode: str = Field(alias="creationMode")
     event_date_time: datetime | None = Field(default=None, alias="eventDateTime")
 
     @classmethod

--- a/src/fabric_dw/models.py
+++ b/src/fabric_dw/models.py
@@ -101,8 +101,9 @@ class CreationModeType:
 
     MS Learn notes that additional creation mode types may be added over time,
     so this is an **open** set of constants rather than a closed ``StrEnum``.
-    The ``creation_mode`` field on :class:`RestorePoint` is typed as ``str``
-    so that future unknown values pass Pydantic validation without error.
+    The ``creation_mode`` field on :class:`RestorePoint` is typed as ``str | None``
+    so that future unknown values and API responses with null fields pass
+    Pydantic validation without error.
     """
 
     USER_DEFINED: str = "UserDefined"
@@ -113,12 +114,14 @@ class RestorePoint(_FabricBase):
     """A restore point for a Warehouse.
 
     Note: ``id`` is a string timestamp (e.g. ``"1726617378000"``), *not* a UUID.
+    The Fabric API may return ``None`` for ``displayName`` and ``creationMode``
+    on system-created restore points; both fields are therefore optional.
     """
 
     id: str
-    name: str = Field(alias="displayName")
+    name: str | None = Field(default=None, alias="displayName")
     description: str | None = None
-    creation_mode: str = Field(alias="creationMode")
+    creation_mode: str | None = Field(default=None, alias="creationMode")
     event_date_time: datetime | None = Field(default=None, alias="eventDateTime")
 
     @classmethod

--- a/src/fabric_dw/models.py
+++ b/src/fabric_dw/models.py
@@ -96,14 +96,46 @@ class WarehouseSnapshot(_FabricBase):
     snapshot_dt: datetime | None = Field(default=None, alias="snapshotDateTime")
 
 
-class RestorePoint(_FabricBase):
-    """A restore point for a Warehouse."""
+class CreationModeType(StrEnum):
+    """Whether the restore point was created by a user or by the system."""
 
-    id: UUID
-    name: str
+    USER_DEFINED = "UserDefined"
+    SYSTEM_CREATED = "SystemCreated"
+
+
+class RestorePoint(_FabricBase):
+    """A restore point for a Warehouse.
+
+    Note: ``id`` is a string timestamp (e.g. ``"1726617378000"``), *not* a UUID.
+    """
+
+    id: str
+    name: str = Field(alias="displayName")
     description: str | None = None
-    created_at: datetime = Field(alias="createdAt")
-    is_system_created: bool = Field(alias="isSystemCreated")
+    creation_mode: CreationModeType = Field(alias="creationMode")
+    event_date_time: datetime | None = Field(default=None, alias="eventDateTime")
+
+    @classmethod
+    def from_api(cls, payload: dict[str, object]) -> RestorePoint:
+        """Build a RestorePoint from the raw API response dict.
+
+        Flattens ``creationDetails.eventDateTime`` to the top level so the
+        standard Pydantic ``model_validate`` path can handle it.
+        """
+        _raw_details = payload.get("creationDetails")
+        details: dict[str, object] = (
+            cast("dict[str, object]", _raw_details)
+            if isinstance(_raw_details, dict)
+            else {}
+        )
+        flat: dict[str, object] = {
+            "id": payload.get("id"),
+            "displayName": payload.get("displayName"),
+            "description": payload.get("description"),
+            "creationMode": payload.get("creationMode"),
+            "eventDateTime": details.get("eventDateTime"),
+        }
+        return cls.model_validate(flat)
 
 
 class AuditSettings(_FabricBase):

--- a/src/fabric_dw/services/restore.py
+++ b/src/fabric_dw/services/restore.py
@@ -70,8 +70,8 @@ async def get_point(
         The :class:`~fabric_dw.models.RestorePoint`.
 
     Raises:
-        NotFound: If the restore point does not exist or the caller has
-            insufficient permissions.
+        NotFound: If the restore point does not exist.
+        PermissionDenied: If the caller has insufficient permissions.
     """
     resp = await http.request(
         "GET",
@@ -124,6 +124,9 @@ async def create_point(
 
     # 202 Accepted — poll the LRO then fetch the created restore point.
     location: str = resp.headers.get("Location", "")
+    if not location:
+        msg = "Fabric returned 202 for create_point but the Location header is missing"
+        raise ValueError(msg)
     operation_result = await http.poll_operation(location)
 
     # Branch (a): some Fabric LRO responses include resourceId/id in the status
@@ -184,6 +187,7 @@ async def update_point(
     Raises:
         ValueError: If neither *name* nor *description* is supplied.
         NotFound: If the restore point does not exist.
+        PermissionDenied: If the caller has insufficient permissions.
     """
     if name is None and description is None:
         msg = "At least one of name or description must be provided"
@@ -222,8 +226,8 @@ async def delete_point(
         point_id: The restore point ID string.
 
     Raises:
-        NotFound: If the restore point does not exist or the caller has
-            insufficient permissions.
+        NotFound: If the restore point does not exist.
+        PermissionDenied: If the caller has insufficient permissions.
     """
     await http.request(
         "DELETE",
@@ -251,8 +255,8 @@ async def restore_in_place(
         point_id: The restore point ID string.
 
     Raises:
-        NotFound: If the restore point does not exist or the caller has
-            insufficient permissions.
+        NotFound: If the restore point does not exist.
+        PermissionDenied: If the caller has insufficient permissions.
         FabricServerError: If the LRO fails or times out.
     """
     resp = await http.request(
@@ -263,5 +267,8 @@ async def restore_in_place(
 
     if resp.status_code == 202:  # noqa: PLR2004
         location: str = resp.headers.get("Location", "")
+        if not location:
+            msg = "Fabric returned 202 for restore_in_place but the Location header is missing"
+            raise ValueError(msg)
         await http.poll_operation(location)
     # 200 OK means synchronous success — nothing further to do.

--- a/src/fabric_dw/services/restore.py
+++ b/src/fabric_dw/services/restore.py
@@ -132,10 +132,7 @@ async def create_point(
     # As a simpler heuristic, use GET .../restorePoints?continuationToken=… is
     # not needed — the LRO operation result endpoint returns the created point.
     op_id = location.rsplit("/", 1)[-1]
-    resource_id_raw = (
-        operation_result.get("resourceId")
-        or operation_result.get("id")
-    )
+    resource_id_raw = operation_result.get("resourceId") or operation_result.get("id")
     if resource_id_raw:
         # Fetch the freshly created restore point.
         return await get_point(http, workspace_id, warehouse_id, str(resource_id_raw))

--- a/src/fabric_dw/services/restore.py
+++ b/src/fabric_dw/services/restore.py
@@ -1,0 +1,266 @@
+"""Service functions for Microsoft Fabric Warehouse Restore Point operations.
+
+API reference:
+    https://learn.microsoft.com/en-us/rest/api/fabric/warehouse/restore-points
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from fabric_dw.http_client import FabricHttpClient, HttpBase
+from fabric_dw.models import RestorePoint
+
+__all__ = [
+    "create_point",
+    "delete_point",
+    "get_point",
+    "list_points",
+    "restore_in_place",
+    "update_point",
+]
+
+
+def _rp_base(workspace_id: UUID, warehouse_id: UUID) -> str:
+    """Return the base path for restore-point operations."""
+    return f"/workspaces/{workspace_id}/warehouses/{warehouse_id}/restorePoints"
+
+
+async def list_points(
+    http: FabricHttpClient,
+    workspace_id: UUID,
+    warehouse_id: UUID,
+) -> list[RestorePoint]:
+    """Return all restore points for *warehouse_id* in *workspace_id*.
+
+    Uses continuation-URI pagination until all pages are consumed.
+
+    Args:
+        http: An authenticated :class:`~fabric_dw.http_client.FabricHttpClient`.
+        workspace_id: The Fabric workspace UUID.
+        warehouse_id: The Fabric warehouse UUID.
+
+    Returns:
+        A list of :class:`~fabric_dw.models.RestorePoint` instances.
+    """
+    return [
+        RestorePoint.from_api(item)
+        async for item in http.iter_paginated(
+            HttpBase.FABRIC,
+            _rp_base(workspace_id, warehouse_id),
+        )
+    ]
+
+
+async def get_point(
+    http: FabricHttpClient,
+    workspace_id: UUID,
+    warehouse_id: UUID,
+    point_id: str,
+) -> RestorePoint:
+    """Return a single restore point by ID.
+
+    Args:
+        http: An authenticated :class:`~fabric_dw.http_client.FabricHttpClient`.
+        workspace_id: The Fabric workspace UUID.
+        warehouse_id: The Fabric warehouse UUID.
+        point_id: The restore point ID (string, e.g. ``"1726617378000"``).
+
+    Returns:
+        The :class:`~fabric_dw.models.RestorePoint`.
+
+    Raises:
+        NotFound: If the restore point does not exist or the caller has
+            insufficient permissions.
+    """
+    resp = await http.request(
+        "GET",
+        HttpBase.FABRIC,
+        f"{_rp_base(workspace_id, warehouse_id)}/{point_id}",
+    )
+    return RestorePoint.from_api(resp.json())
+
+
+async def create_point(
+    http: FabricHttpClient,
+    workspace_id: UUID,
+    warehouse_id: UUID,
+    *,
+    name: str | None = None,
+    description: str | None = None,
+) -> RestorePoint:
+    """Create a restore point for *warehouse_id* at the current timestamp.
+
+    The API may respond with 201 (synchronous) or 202 + LRO Location header.
+    Both paths are handled: when a 202 is returned the LRO is polled to
+    completion and the resulting restore point is fetched via GET.
+
+    Args:
+        http: An authenticated :class:`~fabric_dw.http_client.FabricHttpClient`.
+        workspace_id: The Fabric workspace UUID.
+        warehouse_id: The Fabric warehouse UUID.
+        name: Optional display name for the restore point (max 128 chars).
+        description: Optional description (max 512 chars).
+
+    Returns:
+        The newly-created :class:`~fabric_dw.models.RestorePoint`.
+    """
+    body: dict[str, object] = {}
+    if name is not None:
+        body["displayName"] = name
+    if description is not None:
+        body["description"] = description
+
+    resp = await http.request(
+        "POST",
+        HttpBase.FABRIC,
+        _rp_base(workspace_id, warehouse_id),
+        json=body or None,
+    )
+
+    if resp.status_code == 201:  # noqa: PLR2004
+        # Synchronous success — body contains the RestorePoint directly.
+        return RestorePoint.from_api(resp.json())
+
+    # 202 Accepted — poll the LRO then fetch the created restore point.
+    location: str = resp.headers.get("Location", "")
+    operation_result = await http.poll_operation(location)
+
+    # Try to extract the restore point ID from the LRO result body.
+    # The LRO result body for restore point creation doesn't contain the
+    # restore point ID; fetch the first point from the list ordered by newest.
+    # As a simpler heuristic, use GET .../restorePoints?continuationToken=… is
+    # not needed — the LRO operation result endpoint returns the created point.
+    op_id = location.rsplit("/", 1)[-1]
+    resource_id_raw = (
+        operation_result.get("resourceId")
+        or operation_result.get("id")
+    )
+    if resource_id_raw:
+        # Fetch the freshly created restore point.
+        return await get_point(http, workspace_id, warehouse_id, str(resource_id_raw))
+
+    # Fall back: try the LRO /result endpoint.
+    lro_result = await http.get_operation_result(op_id)
+    result_id_raw = lro_result.get("id")
+    if result_id_raw:
+        return await get_point(http, workspace_id, warehouse_id, str(result_id_raw))
+
+    # Last resort: return the first UserDefined point by listing all points.
+    # This is safe because creation is serialised (API enforces single in-flight).
+    points = await list_points(http, workspace_id, warehouse_id)
+    if points:
+        return points[0]
+
+    msg = f"Cannot determine new restore point from LRO result: {operation_result}"
+    raise ValueError(msg)
+
+
+async def update_point(
+    http: FabricHttpClient,
+    workspace_id: UUID,
+    warehouse_id: UUID,
+    point_id: str,
+    *,
+    name: str | None = None,
+    description: str | None = None,
+) -> RestorePoint:
+    """Rename and/or re-describe an existing restore point.
+
+    At least one of *name* or *description* must be provided.
+
+    Args:
+        http: An authenticated :class:`~fabric_dw.http_client.FabricHttpClient`.
+        workspace_id: The Fabric workspace UUID.
+        warehouse_id: The Fabric warehouse UUID.
+        point_id: The restore point ID string.
+        name: New display name (max 128 chars).
+        description: New description (max 512 chars).
+
+    Returns:
+        The updated :class:`~fabric_dw.models.RestorePoint`.
+
+    Raises:
+        ValueError: If neither *name* nor *description* is supplied.
+        NotFound: If the restore point does not exist.
+    """
+    if name is None and description is None:
+        msg = "At least one of name or description must be provided"
+        raise ValueError(msg)
+
+    body: dict[str, object] = {}
+    if name is not None:
+        body["displayName"] = name
+    if description is not None:
+        body["description"] = description
+
+    resp = await http.request(
+        "PATCH",
+        HttpBase.FABRIC,
+        f"{_rp_base(workspace_id, warehouse_id)}/{point_id}",
+        json=body,
+    )
+    return RestorePoint.from_api(resp.json())
+
+
+async def delete_point(
+    http: FabricHttpClient,
+    workspace_id: UUID,
+    warehouse_id: UUID,
+    point_id: str,
+) -> None:
+    """Delete a user-defined restore point.
+
+    System-created restore points cannot be deleted (the API will return an
+    error). Only user-defined restore points support deletion.
+
+    Args:
+        http: An authenticated :class:`~fabric_dw.http_client.FabricHttpClient`.
+        workspace_id: The Fabric workspace UUID.
+        warehouse_id: The Fabric warehouse UUID.
+        point_id: The restore point ID string.
+
+    Raises:
+        NotFound: If the restore point does not exist or the caller has
+            insufficient permissions.
+    """
+    await http.request(
+        "DELETE",
+        HttpBase.FABRIC,
+        f"{_rp_base(workspace_id, warehouse_id)}/{point_id}",
+    )
+
+
+async def restore_in_place(
+    http: FabricHttpClient,
+    workspace_id: UUID,
+    warehouse_id: UUID,
+    point_id: str,
+) -> None:
+    """Restore *warehouse_id* in-place to the specified restore point.
+
+    This is a destructive, long-running operation (LRO). The warehouse will
+    be unavailable for approximately 10 minutes while the restore completes.
+    The API may respond synchronously (200) or with 202 + Location for polling.
+
+    Args:
+        http: An authenticated :class:`~fabric_dw.http_client.FabricHttpClient`.
+        workspace_id: The Fabric workspace UUID.
+        warehouse_id: The Fabric warehouse UUID.
+        point_id: The restore point ID string.
+
+    Raises:
+        NotFound: If the restore point does not exist or the caller has
+            insufficient permissions.
+        FabricServerError: If the LRO fails or times out.
+    """
+    resp = await http.request(
+        "POST",
+        HttpBase.FABRIC,
+        f"{_rp_base(workspace_id, warehouse_id)}/{point_id}/restore",
+    )
+
+    if resp.status_code == 202:  # noqa: PLR2004
+        location: str = resp.headers.get("Location", "")
+        await http.poll_operation(location)
+    # 200 OK means synchronous success — nothing further to do.

--- a/src/fabric_dw/services/restore.py
+++ b/src/fabric_dw/services/restore.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from uuid import UUID
 
 from fabric_dw.http_client import FabricHttpClient, HttpBase
-from fabric_dw.models import RestorePoint
+from fabric_dw.models import CreationModeType, RestorePoint
 
 __all__ = [
     "create_point",
@@ -126,31 +126,35 @@ async def create_point(
     location: str = resp.headers.get("Location", "")
     operation_result = await http.poll_operation(location)
 
-    # Try to extract the restore point ID from the LRO result body.
-    # The LRO result body for restore point creation doesn't contain the
-    # restore point ID; fetch the first point from the list ordered by newest.
-    # As a simpler heuristic, use GET .../restorePoints?continuationToken=… is
-    # not needed — the LRO operation result endpoint returns the created point.
-    op_id = location.rsplit("/", 1)[-1]
+    # Branch (a): some Fabric LRO responses include resourceId/id in the status
+    # body — if present, use it to GET the created point directly.
     resource_id_raw = operation_result.get("resourceId") or operation_result.get("id")
     if resource_id_raw:
-        # Fetch the freshly created restore point.
         return await get_point(http, workspace_id, warehouse_id, str(resource_id_raw))
 
-    # Fall back: try the LRO /result endpoint.
+    # Branch (b): fall back to the LRO /result sub-endpoint, which is the
+    # realistic production path for Fabric restore-point creation.
+    op_id = location.rsplit("/", 1)[-1]
     lro_result = await http.get_operation_result(op_id)
     result_id_raw = lro_result.get("id")
     if result_id_raw:
         return await get_point(http, workspace_id, warehouse_id, str(result_id_raw))
 
-    # Last resort: return the first UserDefined point by listing all points.
-    # This is safe because creation is serialised (API enforces single in-flight).
+    # Branch (c) — last resort: list all restore points and return the newest
+    # UserDefined one.  Creation is serialised (the API enforces a single
+    # in-flight create), so the highest ID (lexicographic max of timestamp
+    # strings) among UserDefined points is the one just created.
     points = await list_points(http, workspace_id, warehouse_id)
-    if points:
-        return points[0]
+    user_points = [p for p in points if p.creation_mode == CreationModeType.USER_DEFINED]
+    if user_points:
+        return max(user_points, key=lambda p: p.id)
 
-    msg = f"Cannot determine new restore point from LRO result: {operation_result}"
-    raise ValueError(msg)
+    msg = (
+        "Restore point create succeeded but the created point could not be located: "
+        f"no UserDefined restore points found after LRO completed. "
+        f"LRO result: {operation_result}"
+    )
+    raise RuntimeError(msg)
 
 
 async def update_point(

--- a/src/fabric_dw/services/restore.py
+++ b/src/fabric_dw/services/restore.py
@@ -199,13 +199,15 @@ async def update_point(
     if description is not None:
         body["description"] = description
 
-    resp = await http.request(
+    await http.request(
         "PATCH",
         HttpBase.FABRIC,
         f"{_rp_base(workspace_id, warehouse_id)}/{point_id}",
         json=body,
     )
-    return RestorePoint.from_api(resp.json())
+    # Fabric returns a minimal body on PATCH (often just the ID); GET the full
+    # resource to ensure we return a correctly-populated RestorePoint.
+    return await get_point(http, workspace_id, warehouse_id, point_id)
 
 
 async def delete_point(

--- a/tests/fixtures/api_payloads.py
+++ b/tests/fixtures/api_payloads.py
@@ -71,11 +71,19 @@ WAREHOUSE_SNAPSHOT_PAYLOAD = """{
 }"""
 
 RESTORE_POINT_PAYLOAD = """{
-  "id": "07a8b9c0-d1e2-3456-0123-456789abcdef",
-  "name": "RestorePoint_20240315",
+  "id": "1726617378000",
+  "displayName": "RestorePoint_20240315",
   "description": "Automated restore point before schema migration",
-  "createdAt": "2024-03-15T06:00:00Z",
-  "isSystemCreated": false
+  "creationMode": "UserDefined",
+  "creationDetails": {
+    "eventDateTime": "2024-03-15T06:00:00Z",
+    "eventInitiator": {
+      "id": "f3052d1c-61a9-46fb-8df9-0d78916ae041",
+      "displayName": "Jacob Hancock",
+      "type": "User",
+      "userDetails": {"userPrincipalName": "jacob@contoso.com"}
+    }
+  }
 }"""
 
 # Second page of workspace listing (no continuationUri → last page)

--- a/tests/integration/test_services_restore.py
+++ b/tests/integration/test_services_restore.py
@@ -50,9 +50,7 @@ async def test_create_list_rename_delete_roundtrip(
         assert any(r.id == rp.id for r in listed)
 
         # get — individual fetch
-        fetched = await restore.get_point(
-            http, workspace_id, ephemeral_warehouse.id, rp.id
-        )
+        fetched = await restore.get_point(http, workspace_id, ephemeral_warehouse.id, rp.id)
         assert fetched.id == rp.id
         assert fetched.name == name
 
@@ -69,6 +67,4 @@ async def test_create_list_rename_delete_roundtrip(
 
     finally:
         if rp is not None:
-            await restore.delete_point(
-                http, workspace_id, ephemeral_warehouse.id, rp.id
-            )
+            await restore.delete_point(http, workspace_id, ephemeral_warehouse.id, rp.id)

--- a/tests/integration/test_services_restore.py
+++ b/tests/integration/test_services_restore.py
@@ -1,0 +1,74 @@
+"""Integration tests for services.restore — runs against a real Fabric environment.
+
+These tests require:
+    FABRIC_TEST_WORKSPACE_ID  — UUID of the target workspace.
+
+The ``ephemeral_warehouse`` fixture creates a fresh warehouse and deletes it
+after the test, so the workspace is left clean.
+
+restore_in_place is intentionally NOT tested here because it mutates the
+warehouse for ~10 minutes and would break any concurrent test that touches the
+same warehouse. It is covered in unit tests with full LRO mocking.
+"""
+
+from __future__ import annotations
+
+import uuid
+from uuid import UUID
+
+import pytest
+
+from fabric_dw.http_client import FabricHttpClient
+from fabric_dw.models import RestorePoint, Warehouse
+from fabric_dw.services import restore
+
+pytestmark = pytest.mark.integration
+
+
+async def test_create_list_rename_delete_roundtrip(
+    http: FabricHttpClient,
+    workspace_id: UUID,
+    ephemeral_warehouse: Warehouse,
+) -> None:
+    """Full CRUD round-trip: create → list → rename → delete."""
+    name = f"pytest-rp-{uuid.uuid4().hex[:8]}"
+    rp: RestorePoint | None = None
+
+    try:
+        rp = await restore.create_point(
+            http,
+            workspace_id,
+            ephemeral_warehouse.id,
+            name=name,
+            description="integration test restore point",
+        )
+        assert isinstance(rp, RestorePoint)
+        assert rp.name == name
+
+        # list — the new point should appear
+        listed = await restore.list_points(http, workspace_id, ephemeral_warehouse.id)
+        assert any(r.id == rp.id for r in listed)
+
+        # get — individual fetch
+        fetched = await restore.get_point(
+            http, workspace_id, ephemeral_warehouse.id, rp.id
+        )
+        assert fetched.id == rp.id
+        assert fetched.name == name
+
+        # rename
+        new_name = f"{name}-renamed"
+        updated = await restore.update_point(
+            http,
+            workspace_id,
+            ephemeral_warehouse.id,
+            rp.id,
+            name=new_name,
+        )
+        assert updated.name == new_name
+
+    finally:
+        if rp is not None:
+            await restore.delete_point(
+                http, workspace_id, ephemeral_warehouse.id, rp.id
+            )

--- a/tests/unit/services/test_restore.py
+++ b/tests/unit/services/test_restore.py
@@ -177,9 +177,9 @@ async def test_list_points_follows_pagination() -> None:
         call_count += 1
         return httpx.Response(200, json=page1 if call_count == 1 else page2)
 
-    respx.get(url__regex=rf"https://api\.fabric\.microsoft\.com/v1/workspaces/{_WS_ID}/warehouses/{_WH_ID}/restorePoints(\?.*)?$").mock(
-        side_effect=_side_effect
-    )
+    respx.get(
+        url__regex=rf"https://api\.fabric\.microsoft\.com/v1/workspaces/{_WS_ID}/warehouses/{_WH_ID}/restorePoints(\?.*)?$"
+    ).mock(side_effect=_side_effect)
 
     async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
         result = await restore.list_points(http, _WS_ID, _WH_ID)
@@ -191,9 +191,7 @@ async def test_list_points_follows_pagination() -> None:
 @respx.mock
 async def test_list_points_403_raises_permission_denied() -> None:
     """list_points should propagate PermissionDenied on 403."""
-    respx.get(url__regex=rf"{_RP_LIST_URL}(\?.*)?$").mock(
-        return_value=httpx.Response(403)
-    )
+    respx.get(url__regex=rf"{_RP_LIST_URL}(\?.*)?$").mock(return_value=httpx.Response(403))
 
     async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
         with pytest.raises(PermissionDenied):
@@ -269,9 +267,7 @@ async def test_create_point_sends_correct_body() -> None:
     respx.post(_RP_LIST_URL).mock(side_effect=_capture)
 
     async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
-        await restore.create_point(
-            http, _WS_ID, _WH_ID, name="My RP", description="My desc"
-        )
+        await restore.create_point(http, _WS_ID, _WH_ID, name="My RP", description="My desc")
 
     assert len(captured) == 1
     body = _json.loads(captured[0].content)
@@ -331,9 +327,7 @@ async def test_create_point_lro_202_falls_back_to_result_endpoint() -> None:
         with patch.object(http, "poll_operation", new_callable=AsyncMock) as mock_poll:
             mock_poll.return_value = LRO_SUCCEEDED  # no id in status body
 
-            with patch.object(
-                http, "get_operation_result", new_callable=AsyncMock
-            ) as mock_result:
+            with patch.object(http, "get_operation_result", new_callable=AsyncMock) as mock_result:
                 mock_result.return_value = {"id": _RP_ID}
                 result = await restore.create_point(http, _WS_ID, _WH_ID, name="My RP")
 
@@ -355,9 +349,7 @@ async def test_create_point_lro_202_last_resort_list() -> None:
         with patch.object(http, "poll_operation", new_callable=AsyncMock) as mock_poll:
             mock_poll.return_value = LRO_SUCCEEDED  # no id
 
-            with patch.object(
-                http, "get_operation_result", new_callable=AsyncMock
-            ) as mock_result:
+            with patch.object(http, "get_operation_result", new_callable=AsyncMock) as mock_result:
                 mock_result.return_value = {}  # also no id
                 result = await restore.create_point(http, _WS_ID, _WH_ID)
 
@@ -376,9 +368,7 @@ async def test_update_point_returns_updated_restore_point() -> None:
     respx.patch(_RP_URL).mock(return_value=httpx.Response(200, json=updated_payload))
 
     async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
-        result = await restore.update_point(
-            http, _WS_ID, _WH_ID, _RP_ID, name="Renamed RP"
-        )
+        result = await restore.update_point(http, _WS_ID, _WH_ID, _RP_ID, name="Renamed RP")
 
     assert isinstance(result, RestorePoint)
     assert result.name == "Renamed RP"
@@ -426,6 +416,7 @@ async def test_update_point_description_only() -> None:
 
 def test_update_point_no_args_raises_value_error() -> None:
     """update_point with neither name nor description should raise ValueError."""
+
     async def _run() -> None:
         async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
             with pytest.raises(ValueError, match="At least one"):

--- a/tests/unit/services/test_restore.py
+++ b/tests/unit/services/test_restore.py
@@ -1,0 +1,535 @@
+"""Tests for services.restore — written TDD-first before implementation."""
+
+from __future__ import annotations
+
+import json as _json
+import time
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID
+
+import anyio
+import httpx
+import pytest
+import respx
+from azure.core.credentials import AccessToken
+from azure.core.credentials_async import AsyncTokenCredential
+
+from fabric_dw.exceptions import NotFound, PermissionDenied
+from fabric_dw.http_client import FabricHttpClient
+from fabric_dw.models import CreationModeType, RestorePoint
+from fabric_dw.services import restore
+
+# ---------------------------------------------------------------------------
+# Constants & Fixtures
+# ---------------------------------------------------------------------------
+
+_WS_ID = UUID("a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+_WH_ID = UUID("d4e5f6a7-b8c9-0123-def0-123456789abc")
+
+# Restore point IDs are strings (timestamps), not UUIDs
+_RP_ID = "1726617378000"
+_RP_ID_2 = "1726617379000"
+
+_FAKE_TOKEN = AccessToken(token="fake-token", expires_on=int(time.time()) + 3600)  # noqa: S106
+
+_BASE_URL = "https://api.fabric.microsoft.com/v1"
+_RP_LIST_URL = f"{_BASE_URL}/workspaces/{_WS_ID}/warehouses/{_WH_ID}/restorePoints"
+_RP_URL = f"{_RP_LIST_URL}/{_RP_ID}"
+_RP_URL_2 = f"{_RP_LIST_URL}/{_RP_ID_2}"
+
+_LRO_OP_ID = "0acd697c-1550-43cd-b998-91bfbfbd47c6"
+_LRO_LOCATION = f"{_BASE_URL}/operations/{_LRO_OP_ID}"
+_LRO_RESULT_URL = f"{_BASE_URL}/operations/{_LRO_OP_ID}/result"
+
+# Minimal restore point payload as returned by the API
+RP_PAYLOAD: dict[str, Any] = {
+    "id": _RP_ID,
+    "displayName": "Restore point 1",
+    "description": "Restore point 1 description.",
+    "creationMode": "UserDefined",
+    "creationDetails": {
+        "eventDateTime": "2024-10-18T22:17:09Z",
+        "eventInitiator": {
+            "id": "f3052d1c-61a9-46fb-8df9-0d78916ae041",
+            "displayName": "Jacob Hancock",
+            "type": "User",
+            "userDetails": {"userPrincipalName": "jacob@contoso.com"},
+        },
+    },
+}
+
+RP_PAYLOAD_2: dict[str, Any] = {
+    "id": _RP_ID_2,
+    "displayName": "Restore point 2",
+    "description": "",
+    "creationMode": "SystemCreated",
+    "creationDetails": {
+        "eventDateTime": "2024-10-18T22:17:09Z",
+        "eventInitiator": None,
+    },
+}
+
+RP_LIST_PAYLOAD: dict[str, Any] = {
+    "value": [RP_PAYLOAD, RP_PAYLOAD_2],
+}
+
+LRO_SUCCEEDED: dict[str, Any] = {
+    "status": "Succeeded",
+    "createdTimeUtc": "2024-10-18T22:17:09Z",
+    "lastUpdatedTimeUtc": "2024-10-18T22:17:15Z",
+    "percentComplete": 100,
+    "error": None,
+}
+
+
+def _make_credential() -> AsyncTokenCredential:
+    cred = MagicMock(spec=AsyncTokenCredential)
+    cred.get_token = AsyncMock(return_value=_FAKE_TOKEN)
+    return cred
+
+
+@pytest.fixture(autouse=True)
+def _no_real_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Suppress asyncio.sleep for all restore unit tests."""
+    monkeypatch.setattr("asyncio.sleep", AsyncMock())
+
+
+# ---------------------------------------------------------------------------
+# Model tests
+# ---------------------------------------------------------------------------
+
+
+def test_restore_point_from_api_parses_correctly() -> None:
+    """RestorePoint.from_api should parse the flat API payload."""
+    rp = RestorePoint.from_api(RP_PAYLOAD)
+    assert rp.id == _RP_ID
+    assert rp.name == "Restore point 1"
+    assert rp.description == "Restore point 1 description."
+    assert rp.creation_mode == CreationModeType.USER_DEFINED
+    assert rp.event_date_time is not None
+
+
+def test_restore_point_from_api_system_created() -> None:
+    """RestorePoint.from_api should handle SystemCreated mode and null initiator."""
+    rp = RestorePoint.from_api(RP_PAYLOAD_2)
+    assert rp.id == _RP_ID_2
+    assert rp.creation_mode == CreationModeType.SYSTEM_CREATED
+
+
+def test_restore_point_from_api_missing_creation_details() -> None:
+    """RestorePoint.from_api should handle missing creationDetails gracefully."""
+    payload: dict[str, Any] = {
+        "id": _RP_ID,
+        "displayName": "Test",
+        "description": None,
+        "creationMode": "UserDefined",
+    }
+    rp = RestorePoint.from_api(payload)
+    assert rp.event_date_time is None
+
+
+# ---------------------------------------------------------------------------
+# list_points
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+async def test_list_points_returns_all_items() -> None:
+    """list_points should return all restore points from the paginated list."""
+    respx.get(url__regex=rf"{_RP_LIST_URL}(\?.*)?$").mock(
+        return_value=httpx.Response(200, json=RP_LIST_PAYLOAD)
+    )
+
+    async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
+        result = await restore.list_points(http, _WS_ID, _WH_ID)
+
+    assert len(result) == 2
+    assert all(isinstance(r, RestorePoint) for r in result)
+    assert result[0].id == _RP_ID
+    assert result[1].id == _RP_ID_2
+
+
+@respx.mock
+async def test_list_points_empty() -> None:
+    """list_points should return an empty list when the warehouse has no restore points."""
+    respx.get(url__regex=rf"{_RP_LIST_URL}(\?.*)?$").mock(
+        return_value=httpx.Response(200, json={"value": []})
+    )
+
+    async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
+        result = await restore.list_points(http, _WS_ID, _WH_ID)
+
+    assert result == []
+
+
+@respx.mock
+async def test_list_points_follows_pagination() -> None:
+    """list_points should follow continuationUri across pages."""
+    page2_url = f"{_RP_LIST_URL}?continuationToken=page2"
+    page1: dict[str, Any] = {"value": [RP_PAYLOAD], "continuationUri": page2_url}
+    page2: dict[str, Any] = {"value": [RP_PAYLOAD_2]}
+
+    call_count = 0
+
+    def _side_effect(_req: Any) -> httpx.Response:
+        nonlocal call_count
+        call_count += 1
+        return httpx.Response(200, json=page1 if call_count == 1 else page2)
+
+    respx.get(url__regex=rf"https://api\.fabric\.microsoft\.com/v1/workspaces/{_WS_ID}/warehouses/{_WH_ID}/restorePoints(\?.*)?$").mock(
+        side_effect=_side_effect
+    )
+
+    async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
+        result = await restore.list_points(http, _WS_ID, _WH_ID)
+
+    assert len(result) == 2
+    assert call_count == 2
+
+
+@respx.mock
+async def test_list_points_403_raises_permission_denied() -> None:
+    """list_points should propagate PermissionDenied on 403."""
+    respx.get(url__regex=rf"{_RP_LIST_URL}(\?.*)?$").mock(
+        return_value=httpx.Response(403)
+    )
+
+    async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
+        with pytest.raises(PermissionDenied):
+            await restore.list_points(http, _WS_ID, _WH_ID)
+
+
+# ---------------------------------------------------------------------------
+# get_point
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+async def test_get_point_returns_restore_point() -> None:
+    """get_point should return the RestorePoint with the correct ID."""
+    respx.get(_RP_URL).mock(return_value=httpx.Response(200, json=RP_PAYLOAD))
+
+    async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
+        result = await restore.get_point(http, _WS_ID, _WH_ID, _RP_ID)
+
+    assert isinstance(result, RestorePoint)
+    assert result.id == _RP_ID
+    assert result.name == "Restore point 1"
+
+
+@respx.mock
+async def test_get_point_404_raises_not_found() -> None:
+    """get_point should raise NotFound on 404."""
+    respx.get(_RP_URL).mock(return_value=httpx.Response(404))
+
+    async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
+        with pytest.raises(NotFound):
+            await restore.get_point(http, _WS_ID, _WH_ID, _RP_ID)
+
+
+@respx.mock
+async def test_get_point_403_raises_permission_denied() -> None:
+    """get_point should raise PermissionDenied on 403."""
+    respx.get(_RP_URL).mock(return_value=httpx.Response(403))
+
+    async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
+        with pytest.raises(PermissionDenied):
+            await restore.get_point(http, _WS_ID, _WH_ID, _RP_ID)
+
+
+# ---------------------------------------------------------------------------
+# create_point
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+async def test_create_point_synchronous_201() -> None:
+    """create_point should handle 201 synchronous response directly."""
+    respx.post(_RP_LIST_URL).mock(return_value=httpx.Response(201, json=RP_PAYLOAD))
+
+    async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
+        result = await restore.create_point(
+            http, _WS_ID, _WH_ID, name="Restore point 1", description="desc"
+        )
+
+    assert isinstance(result, RestorePoint)
+    assert result.id == _RP_ID
+
+
+@respx.mock
+async def test_create_point_sends_correct_body() -> None:
+    """create_point should send displayName and description in the request body."""
+    captured: list[Any] = []
+
+    def _capture(request: Any) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(201, json=RP_PAYLOAD)
+
+    respx.post(_RP_LIST_URL).mock(side_effect=_capture)
+
+    async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
+        await restore.create_point(
+            http, _WS_ID, _WH_ID, name="My RP", description="My desc"
+        )
+
+    assert len(captured) == 1
+    body = _json.loads(captured[0].content)
+    assert body["displayName"] == "My RP"
+    assert body["description"] == "My desc"
+
+
+@respx.mock
+async def test_create_point_no_body_when_no_args() -> None:
+    """create_point with no name/description should send empty or no body."""
+    respx.post(_RP_LIST_URL).mock(return_value=httpx.Response(201, json=RP_PAYLOAD))
+
+    async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
+        result = await restore.create_point(http, _WS_ID, _WH_ID)
+
+    assert isinstance(result, RestorePoint)
+
+
+@respx.mock
+async def test_create_point_lro_202_polls_and_fetches() -> None:
+    """create_point should poll LRO on 202, then GET the created restore point."""
+    respx.post(_RP_LIST_URL).mock(
+        return_value=httpx.Response(
+            202,
+            headers={
+                "Location": _LRO_LOCATION,
+                "x-ms-operation-id": _LRO_OP_ID,
+                "Retry-After": "1",
+            },
+        )
+    )
+    respx.get(_RP_URL).mock(return_value=httpx.Response(200, json=RP_PAYLOAD))
+
+    async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
+        with patch.object(http, "poll_operation", new_callable=AsyncMock) as mock_poll:
+            mock_poll.return_value = {**LRO_SUCCEEDED, "id": _RP_ID}
+            result = await restore.create_point(http, _WS_ID, _WH_ID, name="My RP")
+
+    assert isinstance(result, RestorePoint)
+    assert result.id == _RP_ID
+    mock_poll.assert_awaited_once_with(_LRO_LOCATION)
+
+
+@respx.mock
+async def test_create_point_lro_202_falls_back_to_result_endpoint() -> None:
+    """create_point should fall back to LRO result endpoint when status body has no id."""
+    respx.post(_RP_LIST_URL).mock(
+        return_value=httpx.Response(
+            202,
+            headers={"Location": _LRO_LOCATION},
+        )
+    )
+    respx.get(_LRO_RESULT_URL).mock(return_value=httpx.Response(200, json={"id": _RP_ID}))
+    respx.get(_RP_URL).mock(return_value=httpx.Response(200, json=RP_PAYLOAD))
+
+    async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
+        with patch.object(http, "poll_operation", new_callable=AsyncMock) as mock_poll:
+            mock_poll.return_value = LRO_SUCCEEDED  # no id in status body
+
+            with patch.object(
+                http, "get_operation_result", new_callable=AsyncMock
+            ) as mock_result:
+                mock_result.return_value = {"id": _RP_ID}
+                result = await restore.create_point(http, _WS_ID, _WH_ID, name="My RP")
+
+    assert isinstance(result, RestorePoint)
+    assert result.id == _RP_ID
+
+
+@respx.mock
+async def test_create_point_lro_202_last_resort_list() -> None:
+    """create_point falls back to list when LRO result has no id."""
+    respx.post(_RP_LIST_URL).mock(
+        return_value=httpx.Response(202, headers={"Location": _LRO_LOCATION})
+    )
+    respx.get(url__regex=rf"{_RP_LIST_URL}(\?.*)?$").mock(
+        return_value=httpx.Response(200, json={"value": [RP_PAYLOAD]})
+    )
+
+    async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
+        with patch.object(http, "poll_operation", new_callable=AsyncMock) as mock_poll:
+            mock_poll.return_value = LRO_SUCCEEDED  # no id
+
+            with patch.object(
+                http, "get_operation_result", new_callable=AsyncMock
+            ) as mock_result:
+                mock_result.return_value = {}  # also no id
+                result = await restore.create_point(http, _WS_ID, _WH_ID)
+
+    assert isinstance(result, RestorePoint)
+
+
+# ---------------------------------------------------------------------------
+# update_point
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+async def test_update_point_returns_updated_restore_point() -> None:
+    """update_point should PATCH and return the updated RestorePoint."""
+    updated_payload = {**RP_PAYLOAD, "displayName": "Renamed RP"}
+    respx.patch(_RP_URL).mock(return_value=httpx.Response(200, json=updated_payload))
+
+    async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
+        result = await restore.update_point(
+            http, _WS_ID, _WH_ID, _RP_ID, name="Renamed RP"
+        )
+
+    assert isinstance(result, RestorePoint)
+    assert result.name == "Renamed RP"
+
+
+@respx.mock
+async def test_update_point_sends_correct_body() -> None:
+    """update_point should include only the supplied fields in the PATCH body."""
+    captured: list[Any] = []
+
+    def _capture(request: Any) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(200, json=RP_PAYLOAD)
+
+    respx.patch(_RP_URL).mock(side_effect=_capture)
+
+    async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
+        await restore.update_point(
+            http, _WS_ID, _WH_ID, _RP_ID, name="New Name", description="New desc"
+        )
+
+    body = _json.loads(captured[0].content)
+    assert body["displayName"] == "New Name"
+    assert body["description"] == "New desc"
+
+
+@respx.mock
+async def test_update_point_description_only() -> None:
+    """update_point with only description should omit displayName from body."""
+    captured: list[Any] = []
+
+    def _capture(request: Any) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(200, json=RP_PAYLOAD)
+
+    respx.patch(_RP_URL).mock(side_effect=_capture)
+
+    async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
+        await restore.update_point(http, _WS_ID, _WH_ID, _RP_ID, description="New desc")
+
+    body = _json.loads(captured[0].content)
+    assert "displayName" not in body
+    assert body["description"] == "New desc"
+
+
+def test_update_point_no_args_raises_value_error() -> None:
+    """update_point with neither name nor description should raise ValueError."""
+    async def _run() -> None:
+        async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
+            with pytest.raises(ValueError, match="At least one"):
+                await restore.update_point(http, _WS_ID, _WH_ID, _RP_ID)
+
+    anyio.run(_run)
+
+
+@respx.mock
+async def test_update_point_404_raises_not_found() -> None:
+    """update_point should raise NotFound on 404."""
+    respx.patch(_RP_URL).mock(return_value=httpx.Response(404))
+
+    async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
+        with pytest.raises(NotFound):
+            await restore.update_point(http, _WS_ID, _WH_ID, _RP_ID, name="X")
+
+
+# ---------------------------------------------------------------------------
+# delete_point
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+async def test_delete_point_200_returns_none() -> None:
+    """delete_point should issue DELETE and return None on 200."""
+    respx.delete(_RP_URL).mock(return_value=httpx.Response(200))
+
+    async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
+        result = await restore.delete_point(http, _WS_ID, _WH_ID, _RP_ID)
+
+    assert result is None
+
+
+@respx.mock
+async def test_delete_point_404_raises_not_found() -> None:
+    """delete_point should raise NotFound on 404."""
+    respx.delete(_RP_URL).mock(return_value=httpx.Response(404))
+
+    async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
+        with pytest.raises(NotFound):
+            await restore.delete_point(http, _WS_ID, _WH_ID, _RP_ID)
+
+
+@respx.mock
+async def test_delete_point_403_raises_permission_denied() -> None:
+    """delete_point should raise PermissionDenied on 403."""
+    respx.delete(_RP_URL).mock(return_value=httpx.Response(403))
+
+    async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
+        with pytest.raises(PermissionDenied):
+            await restore.delete_point(http, _WS_ID, _WH_ID, _RP_ID)
+
+
+# ---------------------------------------------------------------------------
+# restore_in_place
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+async def test_restore_in_place_synchronous_200() -> None:
+    """restore_in_place should return None on synchronous 200."""
+    respx.post(f"{_RP_URL}/restore").mock(return_value=httpx.Response(200))
+
+    async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
+        result = await restore.restore_in_place(http, _WS_ID, _WH_ID, _RP_ID)
+
+    assert result is None
+
+
+@respx.mock
+async def test_restore_in_place_lro_202_polls_to_completion() -> None:
+    """restore_in_place should poll the LRO when 202 is returned."""
+    respx.post(f"{_RP_URL}/restore").mock(
+        return_value=httpx.Response(
+            202,
+            headers={"Location": _LRO_LOCATION, "Retry-After": "1"},
+        )
+    )
+
+    async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
+        with patch.object(http, "poll_operation", new_callable=AsyncMock) as mock_poll:
+            mock_poll.return_value = LRO_SUCCEEDED
+            result = await restore.restore_in_place(http, _WS_ID, _WH_ID, _RP_ID)
+
+    assert result is None
+    mock_poll.assert_awaited_once_with(_LRO_LOCATION)
+
+
+@respx.mock
+async def test_restore_in_place_404_raises_not_found() -> None:
+    """restore_in_place should raise NotFound on 404."""
+    respx.post(f"{_RP_URL}/restore").mock(return_value=httpx.Response(404))
+
+    async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
+        with pytest.raises(NotFound):
+            await restore.restore_in_place(http, _WS_ID, _WH_ID, _RP_ID)
+
+
+@respx.mock
+async def test_restore_in_place_403_raises_permission_denied() -> None:
+    """restore_in_place should raise PermissionDenied on 403."""
+    respx.post(f"{_RP_URL}/restore").mock(return_value=httpx.Response(403))
+
+    async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
+        with pytest.raises(PermissionDenied):
+            await restore.restore_in_place(http, _WS_ID, _WH_ID, _RP_ID)

--- a/tests/unit/services/test_restore.py
+++ b/tests/unit/services/test_restore.py
@@ -372,9 +372,15 @@ async def test_create_point_lro_202_last_resort_list() -> None:
 
 @respx.mock
 async def test_update_point_returns_updated_restore_point() -> None:
-    """update_point should PATCH and return the updated RestorePoint."""
+    """update_point should PATCH then GET and return the updated RestorePoint.
+
+    Fabric PATCH returns a minimal body (often just the ID), so the service
+    always follows up with a GET to return the full RestorePoint.
+    """
     updated_payload = {**RP_PAYLOAD, "displayName": "Renamed RP"}
-    respx.patch(_RP_URL).mock(return_value=httpx.Response(200, json=updated_payload))
+    # Minimal PATCH response (mirrors real Fabric API behaviour)
+    respx.patch(_RP_URL).mock(return_value=httpx.Response(200, json={"id": _RP_ID}))
+    respx.get(_RP_URL).mock(return_value=httpx.Response(200, json=updated_payload))
 
     async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
         result = await restore.update_point(http, _WS_ID, _WH_ID, _RP_ID, name="Renamed RP")
@@ -390,9 +396,10 @@ async def test_update_point_sends_correct_body() -> None:
 
     def _capture(request: Any) -> httpx.Response:
         captured.append(request)
-        return httpx.Response(200, json=RP_PAYLOAD)
+        return httpx.Response(200, json={"id": _RP_ID})
 
     respx.patch(_RP_URL).mock(side_effect=_capture)
+    respx.get(_RP_URL).mock(return_value=httpx.Response(200, json=RP_PAYLOAD))
 
     async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
         await restore.update_point(
@@ -411,9 +418,10 @@ async def test_update_point_description_only() -> None:
 
     def _capture(request: Any) -> httpx.Response:
         captured.append(request)
-        return httpx.Response(200, json=RP_PAYLOAD)
+        return httpx.Response(200, json={"id": _RP_ID})
 
     respx.patch(_RP_URL).mock(side_effect=_capture)
+    respx.get(_RP_URL).mock(return_value=httpx.Response(200, json=RP_PAYLOAD))
 
     async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
         await restore.update_point(http, _WS_ID, _WH_ID, _RP_ID, description="New desc")

--- a/tests/unit/services/test_restore.py
+++ b/tests/unit/services/test_restore.py
@@ -287,8 +287,13 @@ async def test_create_point_no_body_when_no_args() -> None:
 
 
 @respx.mock
-async def test_create_point_lro_202_polls_and_fetches() -> None:
-    """create_point should poll LRO on 202, then GET the created restore point."""
+async def test_create_point_lro_202_polls_and_fetches_via_result_endpoint() -> None:
+    """create_point should poll LRO on 202, then fetch via the /result endpoint.
+
+    This reflects the realistic Fabric production path: the LRO status body
+    does NOT contain a resource id (branch a is almost never hit in practice);
+    the /result sub-endpoint is the primary fallback (branch b).
+    """
     respx.post(_RP_LIST_URL).mock(
         return_value=httpx.Response(
             202,
@@ -303,12 +308,16 @@ async def test_create_point_lro_202_polls_and_fetches() -> None:
 
     async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
         with patch.object(http, "poll_operation", new_callable=AsyncMock) as mock_poll:
-            mock_poll.return_value = {**LRO_SUCCEEDED, "id": _RP_ID}
-            result = await restore.create_point(http, _WS_ID, _WH_ID, name="My RP")
+            # Realistic status body: no id/resourceId field
+            mock_poll.return_value = LRO_SUCCEEDED
+            with patch.object(http, "get_operation_result", new_callable=AsyncMock) as mock_result:
+                mock_result.return_value = {"id": _RP_ID}
+                result = await restore.create_point(http, _WS_ID, _WH_ID, name="My RP")
 
     assert isinstance(result, RestorePoint)
     assert result.id == _RP_ID
     mock_poll.assert_awaited_once_with(_LRO_LOCATION)
+    mock_result.assert_awaited_once_with(_LRO_OP_ID)
 
 
 @respx.mock

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -143,22 +143,25 @@ class TestWarehouseSnapshot:
 class TestRestorePoint:
     def test_round_trip(self) -> None:
         payload = json.loads(RESTORE_POINT_PAYLOAD)
-        obj = RestorePoint.model_validate(payload)
-        dumped = obj.model_dump(by_alias=True, mode="json", exclude_none=True)
-        assert dumped == payload
+        obj = RestorePoint.from_api(payload)
+        assert obj.id == payload["id"]
+        assert obj.name == payload["displayName"]
+        assert obj.description == payload["description"]
+        assert obj.creation_mode.value == payload["creationMode"]
+        assert obj.event_date_time is not None
 
     def test_extra_fields_ignored(self) -> None:
         payload = json.loads(RESTORE_POINT_PAYLOAD)
         payload_copy = dict(payload)
         payload_copy["unknownProp"] = 42
-        obj = RestorePoint.model_validate(payload_copy)
-        assert obj.name == payload["name"]
+        obj = RestorePoint.from_api(payload_copy)
+        assert obj.name == payload["displayName"]
 
     def test_frozen(self) -> None:
         payload = json.loads(RESTORE_POINT_PAYLOAD)
-        obj = RestorePoint.model_validate(payload)
+        obj = RestorePoint.from_api(payload)
         with pytest.raises(ValidationError):
-            obj.name = "changed"
+            obj.name = "changed"  # type: ignore[misc]
 
 
 class TestAuditSettings:

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -147,7 +147,7 @@ class TestRestorePoint:
         assert obj.id == payload["id"]
         assert obj.name == payload["displayName"]
         assert obj.description == payload["description"]
-        assert obj.creation_mode.value == payload["creationMode"]
+        assert obj.creation_mode == payload["creationMode"]
         assert obj.event_date_time is not None
 
     def test_extra_fields_ignored(self) -> None:


### PR DESCRIPTION
## Summary

- Implements all six Warehouse Restore Points v1 API operations: list, get, create (201 sync + 202 LRO), update (rename/re-describe), delete, and restore-in-place (`POST .../restore`)
- Adds `src/fabric_dw/services/restore.py` with full LRO and pagination handling
- Updates `RestorePoint` model in `models.py` to match the real API shape (string ID, `creationMode`, `eventDateTime`)
- Adds `fabric-dw restore-points {list|get|create|rename|delete|restore}` CLI subgroup
- Adds six MCP tools: `list_restore_points`, `get_restore_point`, `create_restore_point`, `update_restore_point`, `delete_restore_point`, `restore_warehouse_in_place`
- 28 new unit tests (respx-mocked, 100% operation coverage incl. all error paths and LRO fallbacks); integration test covers full CRUD round-trip; restore-in-place intentionally unit-only
- Docs updated: `docs/cli.md` and `docs/mcp-tools.md`

## Test plan

- [ ] `uv run pytest tests/unit/` → 450 passed
- [ ] `uvx ty check src/` → all checks passed
- [ ] `uv run ruff check src/ tests/` → passes on all changed files
- [ ] Integration suite (label-gated): create/list/rename/delete round-trip against a real Fabric warehouse

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)