### PR TITLE
feat(services/sql-pools): manage workspace SQL Pools configuration (beta API)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -884,6 +884,107 @@ fabric-dw snapshots roll MyWorkspace SalesWH snap-june-2026 \
 
 ---
 
+## fabric-dw sql-pools
+
+!!! warning "Beta / preview feature"
+    SQL Pools targets a **beta API** that may change before GA.  See [SQL Pools](sql-pools.md) for background on the beta status and destructive PATCH semantics.
+
+Manage custom SQL Pools configuration at the workspace level. Callers must hold the **workspace admin role**.
+
+### sql-pools get
+
+Fetch the current SQL Pools configuration for a workspace.
+
+**Synopsis**
+
+```
+fabric-dw sql-pools get [WORKSPACE]
+```
+
+**Example**
+
+```shell
+fabric-dw sql-pools get MyWorkspace
+```
+
+---
+
+### sql-pools set
+
+Replace the SQL Pools configuration from a JSON file. This is a **destructive PATCH** — any pool not listed in the file is permanently deleted.
+
+**Synopsis**
+
+```
+fabric-dw sql-pools set [WORKSPACE] --from-file POOLS.JSON
+```
+
+| Option | Description |
+| --- | --- |
+| `--from-file PATH` | Path to a JSON file containing the full `SqlPoolsConfiguration` payload. (required) |
+
+**Example**
+
+```shell
+fabric-dw sql-pools set MyWorkspace --from-file pools.json
+```
+
+---
+
+### sql-pools edit
+
+Open the current SQL Pools configuration in `$EDITOR` (or `$VISUAL`, or `vi`/`notepad`), then apply the modified version. Shows a diff and an explicit warning if any pool would be deleted before asking for confirmation.
+
+**Synopsis**
+
+```
+fabric-dw sql-pools edit [WORKSPACE]
+```
+
+**Example**
+
+```shell
+fabric-dw sql-pools edit MyWorkspace
+```
+
+---
+
+### sql-pools enable
+
+Enable custom SQL Pools for a workspace. Preserves the existing pool configuration.
+
+**Synopsis**
+
+```
+fabric-dw sql-pools enable [WORKSPACE]
+```
+
+**Example**
+
+```shell
+fabric-dw sql-pools enable MyWorkspace
+```
+
+---
+
+### sql-pools disable
+
+Disable custom SQL Pools for a workspace without deleting pool definitions. Re-enabling with `sql-pools enable` restores the previously saved configuration.
+
+**Synopsis**
+
+```
+fabric-dw sql-pools disable [WORKSPACE]
+```
+
+**Example**
+
+```shell
+fabric-dw sql-pools disable MyWorkspace
+```
+
+---
+
 ## fabric-dw cache
 
 Manage the local name-to-UUID lookup cache. `fabric-dw` caches workspace and item name-to-GUID mappings to avoid repeated API round-trips. Use these commands if you rename items outside the CLI or need to force a fresh lookup.

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -506,6 +506,64 @@ Drop a SQL view.
 
 ---
 
+## SQL Pools (beta)
+
+!!! warning "Beta / preview feature"
+    The four SQL Pools tools target a **beta / preview** API endpoint.  They may change before GA.  All callers must hold the **workspace admin role**.  See [SQL Pools](sql-pools.md) for full background on the beta status and destructive PATCH semantics.
+
+### get_sql_pools_configuration
+
+Fetch the SQL Pools configuration for a workspace.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+
+**Returns:** `SqlPoolsConfiguration` — object with `customSQLPoolsEnabled` (bool) and `customSQLPools` (list of pool objects; see [SQL Pools](sql-pools.md#field-reference) for the full field reference).
+
+---
+
+### update_sql_pools_configuration
+
+Replace the SQL Pools configuration for a workspace.
+
+!!! danger "Destructive PATCH"
+    Any pool **not** present in `custom_sql_pools` will be permanently deleted.  Supply the full desired pool list every time.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `custom_sql_pools_enabled` (`bool`) — whether custom SQL Pools are active.
+- `custom_sql_pools` (`list[dict]`) — the complete pool list.  Each pool object must include at minimum `name` (str) and `maxResourcePercentage` (int, 1–100).  Optional fields: `isDefault` (bool), `optimizeForReads` (bool), `classifier` (object with `type` str and `value` list[str]).
+
+**Returns:** `SqlPoolsConfiguration` — the fresh configuration after the update.
+
+---
+
+### enable_sql_pools
+
+Enable custom SQL Pools for a workspace without modifying pool definitions.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+
+**Returns:** `SqlPoolsConfiguration` — the updated configuration.
+
+---
+
+### disable_sql_pools
+
+Disable custom SQL Pools for a workspace, preserving the pool configuration. Re-enabling with `enable_sql_pools` restores the previously saved configuration.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+
+**Returns:** `SqlPoolsConfiguration` — the updated configuration.
+
+---
+
 ## Cache
 
 ### clear_cache

--- a/docs/sql-pools.md
+++ b/docs/sql-pools.md
@@ -1,0 +1,174 @@
+---
+title: SQL Pools (beta)
+---
+
+# SQL Pools configuration
+
+!!! warning "Beta / preview feature"
+    The SQL Pools API is currently in **preview**.  It is provided for evaluation
+    and development purposes only and may change before general availability.
+    A mandatory `?beta=true` query parameter is required by the service for every
+    call; this is centralised in the library and will be removed in one place once
+    the API exits preview.
+
+Custom SQL Pools let you partition a workspace's query resources into named
+pools, each with a maximum resource percentage and an optional classifier that
+routes specific application sessions into that pool.
+
+This feature is **workspace-level** — there is no warehouse ID in the path
+despite the `/warehouses/` segment.  The caller must hold the **workspace admin
+role**.
+
+---
+
+## API endpoints
+
+| Operation | Method + Path |
+| --- | --- |
+| Get configuration | `GET /v1/workspaces/{ws}/warehouses/sqlPoolsConfiguration?beta=true` |
+| Update configuration | `PATCH /v1/workspaces/{ws}/warehouses/sqlPoolsConfiguration?beta=true` |
+
+---
+
+## Destructive PATCH semantics
+
+!!! danger "Every PATCH replaces the complete pool list"
+    The PATCH endpoint replaces the named-pool set entirely.  **Any pool NOT
+    included in the request body is permanently deleted.**  There is no merge
+    or partial-update behaviour.
+
+    Always supply the full desired pool list.  Use `sql-pools get` to read the
+    current state before constructing a new payload.
+
+The `enable` and `disable` service functions and CLI commands respect this
+constraint: they fetch the current pool list first and include it unchanged in
+the PATCH body so no pools are accidentally removed.
+
+---
+
+## Safe-edit pattern
+
+Use `sql-pools edit` when you want to interactively modify the configuration
+without manually constructing JSON:
+
+```shell
+fabric-dw sql-pools edit MyWorkspace
+```
+
+The command:
+
+1. Fetches the current configuration.
+2. Opens it in `$VISUAL` (or `$EDITOR`, or `vi`/`notepad`).
+3. On save, computes a unified diff and shows it.
+4. Warns explicitly if any pool would be **deleted** by the change.
+5. Asks for confirmation before applying.
+
+This ensures you always see what will change — and which pools would be removed
+— before committing.
+
+---
+
+## Payload model
+
+```json
+{
+  "customSQLPoolsEnabled": true,
+  "customSQLPools": [
+    {
+      "name": "ETL",
+      "isDefault": false,
+      "maxResourcePercentage": 30,
+      "optimizeForReads": false,
+      "classifier": {
+        "type": "Application Name",
+        "value": ["ETL", "Load", "Pipeline"]
+      }
+    },
+    {
+      "name": "Reporting",
+      "isDefault": false,
+      "maxResourcePercentage": 30,
+      "optimizeForReads": true,
+      "classifier": {
+        "type": "Application Name",
+        "value": ["Reports"]
+      }
+    },
+    {
+      "name": "Default",
+      "isDefault": true,
+      "maxResourcePercentage": 40,
+      "optimizeForReads": false,
+      "classifier": {
+        "type": "Application Name",
+        "value": ["Default"]
+      }
+    }
+  ]
+}
+```
+
+### Field reference
+
+#### `SqlPoolsConfiguration`
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `customSQLPoolsEnabled` | `bool` | Whether custom SQL Pools are active. When `false`, the configuration is preserved and restored on re-enable. |
+| `customSQLPools` | `list[SqlPool]` | The complete pool list. |
+
+#### `SqlPool`
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `name` | `str` | Yes | Friendly name for the pool. |
+| `isDefault` | `bool` | No | At most one pool may be the default. |
+| `maxResourcePercentage` | `int` | Yes | 1–100. Sum across all pools must not exceed 100. |
+| `optimizeForReads` | `bool` | No | Enable enhanced caching for read-heavy workloads. Default `true`. |
+| `classifier` | `SqlPoolClassifier` | No | Routes sessions into this pool. |
+
+#### `SqlPoolClassifier`
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `type` | `str` | Classifier type. Known values: `"Application Name"`, `"Application Name Regex"`. The API treats this as an open enum — additional types may be added. |
+| `value` | `list[str]` | Application names or patterns to match. |
+
+---
+
+## Client-side validation
+
+The library validates the following constraints **before** sending the PATCH
+request, so you get a clear error message without consuming an API call:
+
+- `maxResourcePercentage` must be in the range [1, 100].
+- The sum of `maxResourcePercentage` across all pools must not exceed 100.
+- At most one pool may have `isDefault: true`.
+
+---
+
+## Disable and re-enable behaviour
+
+Setting `customSQLPoolsEnabled: false` does **not** delete pool definitions.
+The service preserves them and restores the full list when you re-enable.
+
+```shell
+# Disable without losing pool config
+fabric-dw sql-pools disable MyWorkspace
+
+# Re-enable — pools come back exactly as they were
+fabric-dw sql-pools enable MyWorkspace
+```
+
+---
+
+## Permissions
+
+All operations require the caller to hold the **workspace admin role**.  A 403
+response is surfaced as a `PermissionDenied` exception in the service layer and
+as a descriptive error message in the CLI and MCP tools.
+
+Required delegated scopes:
+
+- GET: `Workspace.Read.All` or `Workspace.ReadWrite.All`
+- PATCH: `Workspace.ReadWrite.All`

--- a/src/fabric_dw/cli/_main.py
+++ b/src/fabric_dw/cli/_main.py
@@ -17,6 +17,7 @@ from fabric_dw.cli.commands.query_insights import query_insights_group
 from fabric_dw.cli.commands.restore_points import restore_points_group
 from fabric_dw.cli.commands.snapshots import snapshots_group
 from fabric_dw.cli.commands.sql_endpoints import sql_endpoints_group
+from fabric_dw.cli.commands.sql_pools import sql_pools_group
 from fabric_dw.cli.commands.views import views_group
 from fabric_dw.cli.commands.warehouses import warehouses_group
 from fabric_dw.cli.commands.workspaces import workspaces_group
@@ -85,4 +86,5 @@ cli.add_command(queries_group)
 cli.add_command(query_insights_group)
 cli.add_command(restore_points_group)
 cli.add_command(snapshots_group)
+cli.add_command(sql_pools_group)
 cli.add_command(views_group)

--- a/src/fabric_dw/cli/commands/sql_pools.py
+++ b/src/fabric_dw/cli/commands/sql_pools.py
@@ -129,6 +129,8 @@ async def set_cmd(ctx: CliContext, workspace: str | None, from_file: str) -> Non
                 result.model_dump(by_alias=True, mode="json"),
                 json_output=ctx.json_output,
             )
+    except ValueError as exc:
+        raise click.ClickException(f"Invalid configuration: {exc}") from exc  # noqa: TRY003
     except PermissionDenied as exc:
         raise _permission_hint(exc) from exc
     except FabricError as exc:
@@ -148,62 +150,62 @@ async def edit_cmd(ctx: CliContext, workspace: str | None) -> None:
     ws = resolve_workspace_arg(ctx, workspace)
     try:
         async with _build_http_client(ctx) as http:
+            # Resolve the workspace ID once and reuse it for both GET and PATCH
+            # to avoid a TOCTOU issue if the workspace is renamed mid-edit.
             ws_id = await _resolve_workspace(http, ws)
             current = await _svc.get_configuration(http, ws_id)
 
-        current_json = json.dumps(current.model_dump(by_alias=True, mode="json"), indent=2)
+            current_json = json.dumps(current.model_dump(by_alias=True, mode="json"), indent=2)
 
-        editor = os.environ.get("VISUAL") or os.environ.get("EDITOR") or _default_editor()
+            editor = os.environ.get("VISUAL") or os.environ.get("EDITOR") or _default_editor()
 
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".json", delete=False, prefix="fabric-dw-sql-pools-"
-        ) as tmp:
-            tmp.write(current_json)
-            tmp_path = tmp.name
+            with tempfile.NamedTemporaryFile(
+                mode="w", suffix=".json", delete=False, prefix="fabric-dw-sql-pools-"
+            ) as tmp:
+                tmp.write(current_json)
+                tmp_path = tmp.name
 
-        try:
-            subprocess.run([editor, tmp_path], check=True)  # noqa: S603
-            edited_text = Path(tmp_path).read_text()
-        finally:
-            Path(tmp_path).unlink(missing_ok=True)
+            try:
+                subprocess.run([editor, tmp_path], check=True)  # noqa: S603
+                edited_text = Path(tmp_path).read_text()
+            finally:
+                Path(tmp_path).unlink(missing_ok=True)
 
-        if edited_text.strip() == current_json.strip():
-            click.echo("No changes detected. Aborting.")
-            return
+            if edited_text.strip() == current_json.strip():
+                click.echo("No changes detected. Aborting.")
+                return
 
-        try:
-            new_payload = json.loads(edited_text)
-            new_config = SqlPoolsConfiguration.model_validate(new_payload)
-        except (json.JSONDecodeError, ValidationError) as exc:
-            raise click.ClickException(f"Invalid configuration after editing: {exc}") from exc  # noqa: TRY003
+            try:
+                new_payload = json.loads(edited_text)
+                new_config = SqlPoolsConfiguration.model_validate(new_payload)
+            except (json.JSONDecodeError, ValidationError) as exc:
+                raise click.ClickException(f"Invalid configuration after editing: {exc}") from exc  # noqa: TRY003
 
-        current_names = {p.name for p in current.custom_sql_pools}
-        new_names = {p.name for p in new_config.custom_sql_pools}
-        deleted_names = current_names - new_names
+            current_names = {p.name for p in current.custom_sql_pools}
+            new_names = {p.name for p in new_config.custom_sql_pools}
+            deleted_names = current_names - new_names
 
-        diff_lines = list(
-            difflib.unified_diff(
-                current_json.splitlines(keepends=True),
-                edited_text.splitlines(keepends=True),
-                fromfile="current",
-                tofile="new",
+            diff_lines = list(
+                difflib.unified_diff(
+                    current_json.splitlines(keepends=True),
+                    edited_text.splitlines(keepends=True),
+                    fromfile="current",
+                    tofile="new",
+                )
             )
-        )
-        if diff_lines:
-            click.echo("".join(diff_lines))
+            if diff_lines:
+                click.echo("".join(diff_lines))
 
-        if deleted_names:
-            click.echo(
-                f"\nWARNING: The following pools will be DELETED: "
-                f"{', '.join(sorted(deleted_names))}",
-                err=True,
-            )
+            if deleted_names:
+                click.echo(
+                    f"\nWARNING: The following pools will be DELETED: "
+                    f"{', '.join(sorted(deleted_names))}",
+                    err=True,
+                )
 
-        if not confirm("Apply configuration?", yes=ctx.yes):
-            raise click.Abort()  # noqa: TRY301
+            if not confirm("Apply configuration?", yes=ctx.yes):
+                raise click.Abort()  # noqa: TRY301
 
-        async with _build_http_client(ctx) as http:
-            ws_id = await _resolve_workspace(http, ws)
             result = await _svc.update_configuration(http, ws_id, new_config)
             render(
                 result.model_dump(by_alias=True, mode="json"),
@@ -212,6 +214,8 @@ async def edit_cmd(ctx: CliContext, workspace: str | None) -> None:
 
     except click.Abort:
         raise
+    except ValueError as exc:
+        raise click.ClickException(f"Invalid configuration: {exc}") from exc  # noqa: TRY003
     except PermissionDenied as exc:
         raise _permission_hint(exc) from exc
     except FabricError as exc:

--- a/src/fabric_dw/cli/commands/sql_pools.py
+++ b/src/fabric_dw/cli/commands/sql_pools.py
@@ -1,0 +1,274 @@
+"""SQL Pools sub-commands for the fabric-dw CLI.
+
+.. warning::
+   SQL Pools is a **beta / preview** feature.  The underlying API may change
+   before general availability.
+
+.. warning::
+   ``sql-pools set`` and ``sql-pools edit`` use a **destructive PATCH** — any
+   pool *not* listed in the payload will be permanently deleted by the service.
+   Both commands surface this risk explicitly before applying changes.
+"""
+
+from __future__ import annotations
+
+import difflib
+import json
+import logging
+import os
+import subprocess
+import sys
+import tempfile
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from pathlib import Path
+from uuid import UUID
+
+import click
+from pydantic import ValidationError
+
+from fabric_dw import auth as _auth
+from fabric_dw.cache import LookupCache
+from fabric_dw.cli._context import CliContext
+from fabric_dw.cli._render import confirm, render
+from fabric_dw.cli.commands._utils import _coro, resolve_workspace_arg
+from fabric_dw.exceptions import FabricError, PermissionDenied
+from fabric_dw.http_client import FabricHttpClient
+from fabric_dw.models import SqlPoolsConfiguration
+from fabric_dw.resolver import Resolver
+from fabric_dw.services import sql_pools as _svc
+
+_log = logging.getLogger(__name__)
+
+
+@asynccontextmanager
+async def _build_http_client(ctx: CliContext) -> AsyncIterator[FabricHttpClient]:
+    credential = _auth.get_credential(ctx.auth)
+    async with FabricHttpClient(credential) as http:
+        yield http
+
+
+async def _resolve_workspace(http: FabricHttpClient, workspace: str) -> UUID:
+    cache = LookupCache()
+    resolver = Resolver(http=http, cache=cache)
+    return await resolver.workspace_id(workspace)
+
+
+def _permission_hint(exc: PermissionDenied) -> click.ClickException:
+    return click.ClickException(
+        f"{exc}  (Hint: the caller must have the workspace admin role.)"
+    )
+
+
+@click.group("sql-pools")
+def sql_pools_group() -> None:
+    """Manage workspace SQL Pools configuration (beta API)."""
+
+
+@sql_pools_group.command("get")
+@click.argument("workspace", required=False, default=None)
+@click.pass_obj
+@_coro
+async def get_cmd(ctx: CliContext, workspace: str | None) -> None:
+    """Fetch the SQL Pools configuration for WORKSPACE."""
+    ws = resolve_workspace_arg(ctx, workspace)
+    try:
+        async with _build_http_client(ctx) as http:
+            ws_id = await _resolve_workspace(http, ws)
+            config = await _svc.get_configuration(http, ws_id)
+            render(
+                config.model_dump(by_alias=True, mode="json"),
+                json_output=ctx.json_output,
+            )
+    except PermissionDenied as exc:
+        raise _permission_hint(exc) from exc
+    except FabricError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@sql_pools_group.command("set")
+@click.argument("workspace", required=False, default=None)
+@click.option(
+    "--from-file",
+    "from_file",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False, readable=True),
+    help="Path to a JSON file containing the full SqlPoolsConfiguration payload.",
+)
+@click.pass_obj
+@_coro
+async def set_cmd(ctx: CliContext, workspace: str | None, from_file: str) -> None:
+    """Replace the SQL Pools configuration for WORKSPACE from a JSON file.
+
+    \b
+    WARNING: This is a destructive PATCH — any pool NOT listed in the file
+    will be permanently deleted by the Fabric service.
+    """
+    ws = resolve_workspace_arg(ctx, workspace)
+    raw_path = Path(from_file)
+    try:
+        payload = json.loads(raw_path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise click.ClickException(f"Cannot read {from_file}: {exc}") from exc  # noqa: TRY003
+
+    try:
+        config = SqlPoolsConfiguration.model_validate(payload)
+    except ValidationError as exc:
+        raise click.ClickException(f"Invalid configuration: {exc}") from exc  # noqa: TRY003
+
+    click.echo(
+        "WARNING: This is a destructive PATCH. Pools not in the file will be deleted.",
+        err=True,
+    )
+    if not confirm("Apply configuration?", yes=ctx.yes):
+        raise click.Abort()
+
+    try:
+        async with _build_http_client(ctx) as http:
+            ws_id = await _resolve_workspace(http, ws)
+            result = await _svc.update_configuration(http, ws_id, config)
+            render(
+                result.model_dump(by_alias=True, mode="json"),
+                json_output=ctx.json_output,
+            )
+    except PermissionDenied as exc:
+        raise _permission_hint(exc) from exc
+    except FabricError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@sql_pools_group.command("edit")
+@click.argument("workspace", required=False, default=None)
+@click.pass_obj
+@_coro
+async def edit_cmd(ctx: CliContext, workspace: str | None) -> None:
+    """Open the current SQL Pools config in $EDITOR, then apply on save.
+
+    Shows a diff and asks for confirmation before applying if any pool
+    would be deleted (destructive PATCH semantics).
+    """
+    ws = resolve_workspace_arg(ctx, workspace)
+    try:
+        async with _build_http_client(ctx) as http:
+            ws_id = await _resolve_workspace(http, ws)
+            current = await _svc.get_configuration(http, ws_id)
+
+        current_json = json.dumps(
+            current.model_dump(by_alias=True, mode="json"), indent=2
+        )
+
+        editor = os.environ.get("VISUAL") or os.environ.get("EDITOR") or _default_editor()
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False, prefix="fabric-dw-sql-pools-"
+        ) as tmp:
+            tmp.write(current_json)
+            tmp_path = tmp.name
+
+        try:
+            subprocess.run([editor, tmp_path], check=True)  # noqa: S603
+            edited_text = Path(tmp_path).read_text()
+        finally:
+            Path(tmp_path).unlink(missing_ok=True)
+
+        if edited_text.strip() == current_json.strip():
+            click.echo("No changes detected. Aborting.")
+            return
+
+        try:
+            new_payload = json.loads(edited_text)
+            new_config = SqlPoolsConfiguration.model_validate(new_payload)
+        except (json.JSONDecodeError, ValidationError) as exc:
+            raise click.ClickException(f"Invalid configuration after editing: {exc}") from exc  # noqa: TRY003
+
+        current_names = {p.name for p in current.custom_sql_pools}
+        new_names = {p.name for p in new_config.custom_sql_pools}
+        deleted_names = current_names - new_names
+
+        diff_lines = list(
+            difflib.unified_diff(
+                current_json.splitlines(keepends=True),
+                edited_text.splitlines(keepends=True),
+                fromfile="current",
+                tofile="new",
+            )
+        )
+        if diff_lines:
+            click.echo("".join(diff_lines))
+
+        if deleted_names:
+            click.echo(
+                f"\nWARNING: The following pools will be DELETED: "
+                f"{', '.join(sorted(deleted_names))}",
+                err=True,
+            )
+
+        if not confirm("Apply configuration?", yes=ctx.yes):
+            raise click.Abort()  # noqa: TRY301
+
+        async with _build_http_client(ctx) as http:
+            ws_id = await _resolve_workspace(http, ws)
+            result = await _svc.update_configuration(http, ws_id, new_config)
+            render(
+                result.model_dump(by_alias=True, mode="json"),
+                json_output=ctx.json_output,
+            )
+
+    except click.Abort:
+        raise
+    except PermissionDenied as exc:
+        raise _permission_hint(exc) from exc
+    except FabricError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@sql_pools_group.command("enable")
+@click.argument("workspace", required=False, default=None)
+@click.pass_obj
+@_coro
+async def enable_cmd(ctx: CliContext, workspace: str | None) -> None:
+    """Enable custom SQL Pools for WORKSPACE (preserves pool configuration)."""
+    ws = resolve_workspace_arg(ctx, workspace)
+    try:
+        async with _build_http_client(ctx) as http:
+            ws_id = await _resolve_workspace(http, ws)
+            result = await _svc.enable(http, ws_id)
+            render(
+                result.model_dump(by_alias=True, mode="json"),
+                json_output=ctx.json_output,
+            )
+    except PermissionDenied as exc:
+        raise _permission_hint(exc) from exc
+    except FabricError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@sql_pools_group.command("disable")
+@click.argument("workspace", required=False, default=None)
+@click.pass_obj
+@_coro
+async def disable_cmd(ctx: CliContext, workspace: str | None) -> None:
+    """Disable custom SQL Pools for WORKSPACE (preserves pool configuration).
+
+    Re-enabling with 'sql-pools enable' restores the previously saved configuration.
+    """
+    ws = resolve_workspace_arg(ctx, workspace)
+    try:
+        async with _build_http_client(ctx) as http:
+            ws_id = await _resolve_workspace(http, ws)
+            result = await _svc.disable(http, ws_id)
+            render(
+                result.model_dump(by_alias=True, mode="json"),
+                json_output=ctx.json_output,
+            )
+    except PermissionDenied as exc:
+        raise _permission_hint(exc) from exc
+    except FabricError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+def _default_editor() -> str:
+    """Return a sensible default editor when neither $VISUAL nor $EDITOR is set."""
+    if sys.platform == "win32":
+        return "notepad"
+    return "vi"

--- a/src/fabric_dw/cli/commands/sql_pools.py
+++ b/src/fabric_dw/cli/commands/sql_pools.py
@@ -55,9 +55,7 @@ async def _resolve_workspace(http: FabricHttpClient, workspace: str) -> UUID:
 
 
 def _permission_hint(exc: PermissionDenied) -> click.ClickException:
-    return click.ClickException(
-        f"{exc}  (Hint: the caller must have the workspace admin role.)"
-    )
+    return click.ClickException(f"{exc}  (Hint: the caller must have the workspace admin role.)")
 
 
 @click.group("sql-pools")
@@ -153,9 +151,7 @@ async def edit_cmd(ctx: CliContext, workspace: str | None) -> None:
             ws_id = await _resolve_workspace(http, ws)
             current = await _svc.get_configuration(http, ws_id)
 
-        current_json = json.dumps(
-            current.model_dump(by_alias=True, mode="json"), indent=2
-        )
+        current_json = json.dumps(current.model_dump(by_alias=True, mode="json"), indent=2)
 
         editor = os.environ.get("VISUAL") or os.environ.get("EDITOR") or _default_editor()
 

--- a/src/fabric_dw/mcp/server.py
+++ b/src/fabric_dw/mcp/server.py
@@ -31,11 +31,13 @@ from fabric_dw.cache import LookupCache
 from fabric_dw.exceptions import ConfigError, FabricError
 from fabric_dw.http_client import FabricHttpClient
 from fabric_dw.logging import setup_logging
+from fabric_dw.models import SqlPoolsConfiguration
 from fabric_dw.resolver import Resolver
 from fabric_dw.services import audit, queries, snapshots, sql_endpoints, warehouses, workspaces
 from fabric_dw.services import ownership as ownership_svc
 from fabric_dw.services import query_insights as _qi_svc
 from fabric_dw.services import restore as restore_svc
+from fabric_dw.services import sql_pools as sql_pools_svc
 from fabric_dw.services import views as views_svc
 from fabric_dw.sql import SqlTarget
 
@@ -1061,6 +1063,95 @@ async def drop_view(workspace: str, item: str, qualified_name: str) -> dict[str,
     except (ValueError, FabricError) as exc:
         raise _fabric_err(exc) if isinstance(exc, FabricError) else ToolError(str(exc)) from exc
     return {"dropped": True}
+
+
+# ---------------------------------------------------------------------------
+# SQL Pools tools (beta)
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+async def get_sql_pools_configuration(workspace: str) -> dict[str, Any]:
+    """Fetch the SQL Pools configuration for a workspace.
+
+    Requires workspace admin role.  This tool targets a **beta / preview** API
+    endpoint that may change before general availability.
+    """
+    try:
+        ws_id = await _get_resolver().workspace_id(workspace)
+        result = await sql_pools_svc.get_configuration(_get_http(), ws_id)
+    except FabricError as exc:
+        raise _fabric_err(exc) from exc
+    return result.model_dump(by_alias=True, mode="json")
+
+
+@mcp.tool()
+async def update_sql_pools_configuration(
+    workspace: str,
+    custom_sql_pools_enabled: bool,  # noqa: FBT001
+    custom_sql_pools: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Replace the SQL Pools configuration for a workspace.
+
+    **DESTRUCTIVE PATCH**: any pool not present in *custom_sql_pools* will be
+    permanently deleted.  Supply the full desired pool list.
+
+    Requires workspace admin role.  This tool targets a **beta / preview** API.
+
+    Args:
+        workspace: Workspace name or GUID.
+        custom_sql_pools_enabled: Whether custom SQL Pools are active.
+        custom_sql_pools: Full list of pool objects.  Each must have at minimum
+            ``name`` (str) and ``maxResourcePercentage`` (int 1-100).
+            Optional fields: ``isDefault`` (bool), ``optimizeForReads`` (bool),
+            ``classifier`` (object with ``type`` str and ``value`` list[str]).
+    """
+    try:
+        config = SqlPoolsConfiguration.model_validate(
+            {
+                "customSQLPoolsEnabled": custom_sql_pools_enabled,
+                "customSQLPools": custom_sql_pools,
+            }
+        )
+    except Exception as exc:
+        raise ToolError(f"Invalid configuration: {exc}") from exc  # noqa: TRY003
+
+    try:
+        ws_id = await _get_resolver().workspace_id(workspace)
+        result = await sql_pools_svc.update_configuration(_get_http(), ws_id, config)
+    except FabricError as exc:
+        raise _fabric_err(exc) from exc
+    return result.model_dump(by_alias=True, mode="json")
+
+
+@mcp.tool()
+async def enable_sql_pools(workspace: str) -> dict[str, Any]:
+    """Enable custom SQL Pools for a workspace without modifying pool definitions.
+
+    Requires workspace admin role.  This tool targets a **beta / preview** API.
+    """
+    try:
+        ws_id = await _get_resolver().workspace_id(workspace)
+        result = await sql_pools_svc.enable(_get_http(), ws_id)
+    except FabricError as exc:
+        raise _fabric_err(exc) from exc
+    return result.model_dump(by_alias=True, mode="json")
+
+
+@mcp.tool()
+async def disable_sql_pools(workspace: str) -> dict[str, Any]:
+    """Disable custom SQL Pools for a workspace, preserving pool configuration.
+
+    Re-enabling with enable_sql_pools restores the previously saved configuration.
+
+    Requires workspace admin role.  This tool targets a **beta / preview** API.
+    """
+    try:
+        ws_id = await _get_resolver().workspace_id(workspace)
+        result = await sql_pools_svc.disable(_get_http(), ws_id)
+    except FabricError as exc:
+        raise _fabric_err(exc) from exc
+    return result.model_dump(by_alias=True, mode="json")
 
 
 # ---------------------------------------------------------------------------

--- a/src/fabric_dw/models.py
+++ b/src/fabric_dw/models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from enum import StrEnum
-from typing import Literal, cast
+from typing import Annotated, Literal, cast
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
@@ -309,3 +309,74 @@ class View(_FabricBase):
     definition: str | None = None
     created: datetime
     modified: datetime
+
+
+# ---------------------------------------------------------------------------
+# SQL Pools (beta)
+# ---------------------------------------------------------------------------
+
+#: Known classifier type values from the API — open enum; more may be added.
+CLASSIFIER_TYPE_APPLICATION_NAME = "Application Name"
+CLASSIFIER_TYPE_APPLICATION_NAME_REGEX = "Application Name Regex"
+
+
+class SqlPoolClassifier(_FabricBase):
+    """A classifier element that routes sessions to a SQL pool.
+
+    ``type`` is treated as an open string rather than a closed enum because
+    the API explicitly states "Additional classifier element types may be
+    added over time".  Use :data:`CLASSIFIER_TYPE_APPLICATION_NAME` and
+    :data:`CLASSIFIER_TYPE_APPLICATION_NAME_REGEX` for the known values.
+    """
+
+    type: str = Field(alias="type")
+    value: list[str] = Field(default_factory=list, alias="value")
+
+
+class SqlPool(_FabricBase):
+    """A single custom SQL pool element."""
+
+    name: str
+    is_default: bool = Field(default=False, alias="isDefault")
+    max_resource_percentage: Annotated[int, Field(ge=1, le=100)] = Field(
+        alias="maxResourcePercentage"
+    )
+    optimize_for_reads: bool = Field(default=True, alias="optimizeForReads")
+    classifier: SqlPoolClassifier | None = Field(default=None, alias="classifier")
+
+
+class SqlPoolsConfiguration(_FabricBase):
+    """SQL pools configuration for a workspace (beta API)."""
+
+    custom_sql_pools_enabled: bool = Field(alias="customSQLPoolsEnabled")
+    custom_sql_pools: list[SqlPool] = Field(default_factory=list, alias="customSQLPools")
+
+    def validate_for_patch(self) -> None:
+        """Validate constraints that must hold before issuing a PATCH request.
+
+        This is intentionally *not* a Pydantic model validator so that GET
+        responses with server-side state that violates these constraints
+        (e.g. during a beta API drift or a race condition) can still be
+        deserialised without raising.  Call this explicitly before any write
+        operation.
+
+        Raises:
+            ValueError: If the sum of ``maxResourcePercentage`` exceeds 100,
+                or if more than one pool is marked as default.
+        """
+        pools = self.custom_sql_pools
+        if not pools:
+            return
+
+        total = sum(p.max_resource_percentage for p in pools)
+        if total > 100:  # noqa: PLR2004
+            msg = (
+                f"Sum of maxResourcePercentage across all SQL pools is {total}, which exceeds 100."
+            )
+            raise ValueError(msg)
+
+        defaults = [p for p in pools if p.is_default]
+        if len(defaults) > 1:
+            names = ", ".join(p.name for p in defaults)
+            msg = f"Exactly one SQL pool may be marked as default; got {len(defaults)}: {names}"
+            raise ValueError(msg)

--- a/src/fabric_dw/services/sql_pools.py
+++ b/src/fabric_dw/services/sql_pools.py
@@ -1,0 +1,180 @@
+"""Service functions for managing workspace SQL Pools configuration (beta API).
+
+This module targets the beta endpoint::
+
+    GET/PATCH /v1/workspaces/{ws}/warehouses/sqlPoolsConfiguration?beta=true
+
+The endpoint is **workspace-level** — there is no warehouse ID in the path
+despite the ``/warehouses/`` segment.  Callers must hold the workspace admin
+role.
+
+.. warning::
+   The SQL Pools API is currently in beta / preview.  It may change before GA.
+   The ``?beta=true`` query parameter is centralised in :data:`_BETA_PARAMS` so
+   that removing it later is a one-liner.
+
+.. warning::
+   ``update_configuration`` (PATCH) is **destructive**: any pool *not* included
+   in the request body will be permanently deleted.  Always validate before
+   calling or use the client-side helpers that pre-fetch the current state.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from fabric_dw.http_client import FabricHttpClient, HttpBase
+from fabric_dw.models import SqlPoolsConfiguration
+
+__all__ = [
+    "disable",
+    "enable",
+    "get_configuration",
+    "update_configuration",
+]
+
+# The beta query parameter — centralised so removing it later is a one-liner.
+_BETA_PARAMS: dict[str, str] = {"beta": "true"}
+
+
+def _config_path(workspace_id: UUID) -> str:
+    return f"/workspaces/{workspace_id}/warehouses/sqlPoolsConfiguration"
+
+
+async def get_configuration(
+    http: FabricHttpClient,
+    workspace_id: UUID,
+) -> SqlPoolsConfiguration:
+    """Fetch the SQL Pools configuration for a workspace.
+
+    Args:
+        http: An authenticated :class:`~fabric_dw.http_client.FabricHttpClient`.
+        workspace_id: The Fabric workspace UUID.
+
+    Returns:
+        The current :class:`~fabric_dw.models.SqlPoolsConfiguration`.
+
+    Raises:
+        PermissionDenied: If the caller does not have the workspace admin role
+            (HTTP 403).
+    """
+    resp = await http.request(
+        "GET",
+        HttpBase.FABRIC,
+        _config_path(workspace_id),
+        params=_BETA_PARAMS,
+    )
+    return SqlPoolsConfiguration.model_validate(resp.json())
+
+
+async def update_configuration(
+    http: FabricHttpClient,
+    workspace_id: UUID,
+    config: SqlPoolsConfiguration,
+) -> SqlPoolsConfiguration:
+    """Replace the SQL Pools configuration for a workspace.
+
+    .. warning::
+       Any pool **not** included in ``config.custom_sql_pools`` will be
+       **permanently deleted** by the Fabric service.  Pass the full desired
+       pool list every time.
+
+    Client-side validation runs before the PATCH request so constraint
+    violations (sum > 100, multiple defaults) are caught locally without
+    burning an API call.
+
+    Args:
+        http: An authenticated :class:`~fabric_dw.http_client.FabricHttpClient`.
+        workspace_id: The Fabric workspace UUID.
+        config: The full desired :class:`~fabric_dw.models.SqlPoolsConfiguration`.
+            Must pass all model-level validations.
+
+    Returns:
+        The fresh :class:`~fabric_dw.models.SqlPoolsConfiguration` retrieved
+        via a follow-up GET after the PATCH.
+
+    Raises:
+        PermissionDenied: If the caller does not have the workspace admin role
+            (HTTP 403).
+        ValueError: If ``config`` violates client-side constraints (sum > 100,
+            multiple defaults, etc.).
+    """
+    body = config.model_dump(by_alias=True, mode="json", exclude_none=True)
+
+    await http.request(
+        "PATCH",
+        HttpBase.FABRIC,
+        _config_path(workspace_id),
+        json=body,
+        params=_BETA_PARAMS,
+    )
+    return await get_configuration(http, workspace_id)
+
+
+async def enable(
+    http: FabricHttpClient,
+    workspace_id: UUID,
+) -> SqlPoolsConfiguration:
+    """Enable custom SQL Pools for a workspace without modifying the pool list.
+
+    Fetches the current configuration and PATCHes only ``customSQLPoolsEnabled=true``,
+    preserving all existing pools.
+
+    Args:
+        http: An authenticated :class:`~fabric_dw.http_client.FabricHttpClient`.
+        workspace_id: The Fabric workspace UUID.
+
+    Returns:
+        The updated :class:`~fabric_dw.models.SqlPoolsConfiguration`.
+
+    Raises:
+        PermissionDenied: If the caller does not have the workspace admin role
+            (HTTP 403).
+    """
+    current = await get_configuration(http, workspace_id)
+    if current.custom_sql_pools_enabled:
+        return current
+
+    enabled_config = SqlPoolsConfiguration.model_validate(
+        {
+            "customSQLPoolsEnabled": True,
+            "customSQLPools": current.model_dump(by_alias=True, mode="json")["customSQLPools"],
+        }
+    )
+    return await update_configuration(http, workspace_id, enabled_config)
+
+
+async def disable(
+    http: FabricHttpClient,
+    workspace_id: UUID,
+) -> SqlPoolsConfiguration:
+    """Disable custom SQL Pools for a workspace, preserving the pool configuration.
+
+    Per API documentation: "When set to false, the configuration is disabled
+    but preserved.  Re-enabling it restores the previously saved configuration."
+
+    Fetches the current configuration and PATCHes only ``customSQLPoolsEnabled=false``,
+    keeping all pool definitions intact so they can be restored by :func:`enable`.
+
+    Args:
+        http: An authenticated :class:`~fabric_dw.http_client.FabricHttpClient`.
+        workspace_id: The Fabric workspace UUID.
+
+    Returns:
+        The updated :class:`~fabric_dw.models.SqlPoolsConfiguration`.
+
+    Raises:
+        PermissionDenied: If the caller does not have the workspace admin role
+            (HTTP 403).
+    """
+    current = await get_configuration(http, workspace_id)
+    if not current.custom_sql_pools_enabled:
+        return current
+
+    disabled_config = SqlPoolsConfiguration.model_validate(
+        {
+            "customSQLPoolsEnabled": False,
+            "customSQLPools": current.model_dump(by_alias=True, mode="json")["customSQLPools"],
+        }
+    )
+    return await update_configuration(http, workspace_id, disabled_config)

--- a/src/fabric_dw/services/sql_pools.py
+++ b/src/fabric_dw/services/sql_pools.py
@@ -34,7 +34,8 @@ __all__ = [
 ]
 
 # The beta query parameter — centralised so removing it later is a one-liner.
-_BETA_PARAMS: dict[str, str] = {"beta": "true"}
+# Microsoft Learn docs sample uses capital-T "True" for this query parameter.
+_BETA_PARAMS: dict[str, str] = {"beta": "True"}
 
 
 def _config_path(workspace_id: UUID) -> str:
@@ -99,6 +100,7 @@ async def update_configuration(
         ValueError: If ``config`` violates client-side constraints (sum > 100,
             multiple defaults, etc.).
     """
+    config.validate_for_patch()
     body = config.model_dump(by_alias=True, mode="json", exclude_none=True)
 
     await http.request(

--- a/tests/integration/test_services_sql_pools.py
+++ b/tests/integration/test_services_sql_pools.py
@@ -15,18 +15,14 @@ from fabric_dw.services import sql_pools
 pytestmark = pytest.mark.integration
 
 
-async def test_get_configuration_returns_model(
-    http: FabricHttpClient, workspace_id: UUID
-) -> None:
+async def test_get_configuration_returns_model(http: FabricHttpClient, workspace_id: UUID) -> None:
     config = await sql_pools.get_configuration(http, workspace_id)
     assert isinstance(config, SqlPoolsConfiguration)
     assert isinstance(config.custom_sql_pools_enabled, bool)
     assert isinstance(config.custom_sql_pools, list)
 
 
-async def test_enable_disable_roundtrip(
-    http: FabricHttpClient, workspace_id: UUID
-) -> None:
+async def test_enable_disable_roundtrip(http: FabricHttpClient, workspace_id: UUID) -> None:
     original = await sql_pools.get_configuration(http, workspace_id)
 
     try:
@@ -39,9 +35,7 @@ async def test_enable_disable_roundtrip(
         await sql_pools.update_configuration(http, workspace_id, original)
 
 
-async def test_update_configuration_roundtrip(
-    http: FabricHttpClient, workspace_id: UUID
-) -> None:
+async def test_update_configuration_roundtrip(http: FabricHttpClient, workspace_id: UUID) -> None:
     original = await sql_pools.get_configuration(http, workspace_id)
 
     test_config = SqlPoolsConfiguration.model_validate(

--- a/tests/integration/test_services_sql_pools.py
+++ b/tests/integration/test_services_sql_pools.py
@@ -1,0 +1,67 @@
+"""Integration tests for services.sql_pools.
+
+Requires workspace admin rights on FABRIC_TEST_WORKSPACE_ID.
+Run only in environments where admin credentials are available.
+"""
+
+from uuid import UUID
+
+import pytest
+
+from fabric_dw.http_client import FabricHttpClient
+from fabric_dw.models import SqlPoolsConfiguration
+from fabric_dw.services import sql_pools
+
+pytestmark = pytest.mark.integration
+
+
+async def test_get_configuration_returns_model(
+    http: FabricHttpClient, workspace_id: UUID
+) -> None:
+    config = await sql_pools.get_configuration(http, workspace_id)
+    assert isinstance(config, SqlPoolsConfiguration)
+    assert isinstance(config.custom_sql_pools_enabled, bool)
+    assert isinstance(config.custom_sql_pools, list)
+
+
+async def test_enable_disable_roundtrip(
+    http: FabricHttpClient, workspace_id: UUID
+) -> None:
+    original = await sql_pools.get_configuration(http, workspace_id)
+
+    try:
+        disabled = await sql_pools.disable(http, workspace_id)
+        assert disabled.custom_sql_pools_enabled is False
+
+        enabled = await sql_pools.enable(http, workspace_id)
+        assert enabled.custom_sql_pools_enabled is True
+    finally:
+        await sql_pools.update_configuration(http, workspace_id, original)
+
+
+async def test_update_configuration_roundtrip(
+    http: FabricHttpClient, workspace_id: UUID
+) -> None:
+    original = await sql_pools.get_configuration(http, workspace_id)
+
+    test_config = SqlPoolsConfiguration.model_validate(
+        {
+            "customSQLPoolsEnabled": True,
+            "customSQLPools": [
+                {
+                    "name": "pytest-pool",
+                    "isDefault": True,
+                    "maxResourcePercentage": 100,
+                    "optimizeForReads": False,
+                }
+            ],
+        }
+    )
+
+    try:
+        result = await sql_pools.update_configuration(http, workspace_id, test_config)
+        assert isinstance(result, SqlPoolsConfiguration)
+        pool_names = [p.name for p in result.custom_sql_pools]
+        assert "pytest-pool" in pool_names
+    finally:
+        await sql_pools.update_configuration(http, workspace_id, original)

--- a/tests/integration/test_services_sql_pools.py
+++ b/tests/integration/test_services_sql_pools.py
@@ -25,7 +25,25 @@ async def test_get_configuration_returns_model(http: FabricHttpClient, workspace
 async def test_enable_disable_roundtrip(http: FabricHttpClient, workspace_id: UUID) -> None:
     original = await sql_pools.get_configuration(http, workspace_id)
 
+    # The API refuses to set customSQLPoolsEnabled=True when customSQLPools is
+    # empty.  Seed at least one pool so the enable call can succeed.
+    seed_config = SqlPoolsConfiguration.model_validate(
+        {
+            "customSQLPoolsEnabled": True,
+            "customSQLPools": [
+                {
+                    "name": "pytest-roundtrip-pool",
+                    "isDefault": True,
+                    "maxResourcePercentage": 100,
+                    "optimizeForReads": False,
+                }
+            ],
+        }
+    )
+
     try:
+        await sql_pools.update_configuration(http, workspace_id, seed_config)
+
         disabled = await sql_pools.disable(http, workspace_id)
         assert disabled.custom_sql_pools_enabled is False
 

--- a/tests/unit/cli/commands/test_sql_pools.py
+++ b/tests/unit/cli/commands/test_sql_pools.py
@@ -1,0 +1,255 @@
+"""Tests for sql-pools CLI sub-commands."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+from uuid import UUID
+
+import pytest
+from click.testing import CliRunner
+
+from fabric_dw.cli._main import cli
+from fabric_dw.exceptions import PermissionDenied
+from fabric_dw.models import SqlPoolsConfiguration
+
+WS_GUID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+WS_UUID = UUID(WS_GUID)
+
+POOLS_PAYLOAD = {
+    "customSQLPoolsEnabled": True,
+    "customSQLPools": [
+        {
+            "name": "Default",
+            "isDefault": True,
+            "maxResourcePercentage": 100,
+            "optimizeForReads": False,
+        }
+    ],
+}
+
+POOLS_DISABLED_PAYLOAD = {
+    "customSQLPoolsEnabled": False,
+    "customSQLPools": [
+        {
+            "name": "Default",
+            "isDefault": True,
+            "maxResourcePercentage": 100,
+            "optimizeForReads": False,
+        }
+    ],
+}
+
+_CONFIG = SqlPoolsConfiguration.model_validate(POOLS_PAYLOAD)
+_CONFIG_DISABLED = SqlPoolsConfiguration.model_validate(POOLS_DISABLED_PAYLOAD)
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def cache_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    return tmp_path
+
+
+def _make_http_cm(http: object) -> object:
+    @asynccontextmanager
+    async def _cm(_ctx: object) -> AsyncIterator[object]:
+        yield http
+
+    return _cm
+
+
+class TestSqlPoolsGet:
+    def test_get_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql_pools._build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._resolve_workspace",
+                new=AsyncMock(return_value=WS_UUID),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._svc.get_configuration",
+                new=AsyncMock(return_value=_CONFIG),
+            ),
+        ):
+            result = runner.invoke(cli, ["sql-pools", "get", WS_GUID])
+        assert result.exit_code == 0
+
+    def test_get_json_output(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql_pools._build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._resolve_workspace",
+                new=AsyncMock(return_value=WS_UUID),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._svc.get_configuration",
+                new=AsyncMock(return_value=_CONFIG),
+            ),
+        ):
+            result = runner.invoke(cli, ["--json", "sql-pools", "get", WS_GUID])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["customSQLPoolsEnabled"] is True
+        assert len(data["customSQLPools"]) == 1
+
+    def test_get_403_shows_permission_hint(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql_pools._build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._resolve_workspace",
+                new=AsyncMock(return_value=WS_UUID),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._svc.get_configuration",
+                new=AsyncMock(side_effect=PermissionDenied("403")),
+            ),
+        ):
+            result = runner.invoke(cli, ["sql-pools", "get", WS_GUID])
+        assert result.exit_code != 0
+        assert "admin" in result.output.lower()
+
+
+class TestSqlPoolsSet:
+    def test_set_requires_from_file(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        result = runner.invoke(cli, ["sql-pools", "set", WS_GUID])
+        assert result.exit_code != 0
+        assert "from-file" in result.output.lower() or "missing" in result.output.lower()
+
+    def test_set_applies_from_file_with_yes(
+        self, runner: CliRunner, tmp_path: Path, cache_env: Path
+    ) -> None:
+        _ = cache_env
+        pool_file = tmp_path / "pools.json"
+        pool_file.write_text(json.dumps(POOLS_PAYLOAD))
+
+        mock_update = AsyncMock(return_value=_CONFIG)
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql_pools._build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._resolve_workspace",
+                new=AsyncMock(return_value=WS_UUID),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._svc.update_configuration",
+                new=mock_update,
+            ),
+        ):
+            result = runner.invoke(
+                cli, ["-y", "sql-pools", "set", WS_GUID, "--from-file", str(pool_file)]
+            )
+        assert result.exit_code == 0
+        mock_update.assert_awaited_once()
+
+    def test_set_invalid_json_file_exits_nonzero(
+        self, runner: CliRunner, tmp_path: Path, cache_env: Path
+    ) -> None:
+        _ = cache_env
+        bad_file = tmp_path / "bad.json"
+        bad_file.write_text("{not valid json}")
+        result = runner.invoke(
+            cli, ["-y", "sql-pools", "set", WS_GUID, "--from-file", str(bad_file)]
+        )
+        assert result.exit_code != 0
+
+    def test_set_invalid_config_exits_nonzero(
+        self, runner: CliRunner, tmp_path: Path, cache_env: Path
+    ) -> None:
+        _ = cache_env
+        bad_payload = {
+            "customSQLPoolsEnabled": True,
+            "customSQLPools": [
+                {"name": "A", "isDefault": True, "maxResourcePercentage": 101},
+            ],
+        }
+        bad_file = tmp_path / "bad_config.json"
+        bad_file.write_text(json.dumps(bad_payload))
+        result = runner.invoke(
+            cli, ["-y", "sql-pools", "set", WS_GUID, "--from-file", str(bad_file)]
+        )
+        assert result.exit_code != 0
+
+
+class TestSqlPoolsEnable:
+    def test_enable_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql_pools._build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._resolve_workspace",
+                new=AsyncMock(return_value=WS_UUID),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._svc.enable",
+                new=AsyncMock(return_value=_CONFIG),
+            ),
+        ):
+            result = runner.invoke(cli, ["sql-pools", "enable", WS_GUID])
+        assert result.exit_code == 0
+
+    def test_enable_403_shows_permission_hint(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql_pools._build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._resolve_workspace",
+                new=AsyncMock(return_value=WS_UUID),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._svc.enable",
+                new=AsyncMock(side_effect=PermissionDenied("403")),
+            ),
+        ):
+            result = runner.invoke(cli, ["sql-pools", "enable", WS_GUID])
+        assert result.exit_code != 0
+        assert "admin" in result.output.lower()
+
+
+class TestSqlPoolsDisable:
+    def test_disable_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql_pools._build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._resolve_workspace",
+                new=AsyncMock(return_value=WS_UUID),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._svc.disable",
+                new=AsyncMock(return_value=_CONFIG_DISABLED),
+            ),
+        ):
+            result = runner.invoke(cli, ["sql-pools", "disable", WS_GUID])
+        assert result.exit_code == 0

--- a/tests/unit/services/test_sql_pools.py
+++ b/tests/unit/services/test_sql_pools.py
@@ -126,9 +126,7 @@ async def test_get_configuration_returns_model() -> None:
 async def test_get_configuration_disabled_workspace() -> None:
     """get_configuration handles disabled pools (customSQLPoolsEnabled=false)."""
     with respx.mock:
-        respx.get(_CONFIG_URL).mock(
-            return_value=httpx.Response(200, json=POOLS_DISABLED_PAYLOAD)
-        )
+        respx.get(_CONFIG_URL).mock(return_value=httpx.Response(200, json=POOLS_DISABLED_PAYLOAD))
         client = await _make_client()
         async with client:
             result = await sql_pools.get_configuration(client, _WS_ID)

--- a/tests/unit/services/test_sql_pools.py
+++ b/tests/unit/services/test_sql_pools.py
@@ -15,7 +15,7 @@ from azure.core.credentials import AccessToken
 from azure.core.credentials_async import AsyncTokenCredential
 from pydantic import ValidationError
 
-from fabric_dw.exceptions import PermissionDenied
+from fabric_dw.exceptions import NotFound, PermissionDenied
 from fabric_dw.http_client import FabricHttpClient
 from fabric_dw.models import SqlPoolsConfiguration
 from fabric_dw.services import sql_pools
@@ -101,7 +101,7 @@ async def _make_client() -> FabricHttpClient:
 
 @pytest.mark.asyncio
 async def test_get_configuration_returns_model() -> None:
-    """get_configuration should GET the endpoint with ?beta=true and return a model."""
+    """get_configuration should GET the endpoint with ?beta=True and return a model."""
     with respx.mock:
         route = respx.get(_CONFIG_URL).mock(
             return_value=httpx.Response(200, json=POOLS_ENABLED_PAYLOAD)
@@ -111,7 +111,7 @@ async def test_get_configuration_returns_model() -> None:
             result = await sql_pools.get_configuration(client, _WS_ID)
 
     assert route.called
-    assert "beta=true" in str(route.calls[0].request.url)
+    assert "beta=True" in str(route.calls[0].request.url)
     assert isinstance(result, SqlPoolsConfiguration)
     assert result.custom_sql_pools_enabled is True
     assert len(result.custom_sql_pools) == 3
@@ -166,7 +166,7 @@ async def test_update_configuration_patches_full_body() -> None:
             result = await sql_pools.update_configuration(client, _WS_ID, config)
 
     assert patch_route.called
-    assert "beta=true" in str(patch_route.calls[0].request.url)
+    assert "beta=True" in str(patch_route.calls[0].request.url)
 
     sent_body = json.loads(patch_route.calls[0].request.content)
     assert sent_body["customSQLPoolsEnabled"] is True
@@ -292,6 +292,36 @@ async def test_disable_patches_enabled_false_preserving_pools() -> None:
 
 
 @pytest.mark.asyncio
+async def test_enable_propagates_not_found_on_404() -> None:
+    """enable propagates NotFound when get_configuration returns 404.
+
+    There is no fallback that PATCHes an empty configuration — if the workspace
+    configuration endpoint is absent, the error surfaces to the caller.
+    """
+    with respx.mock:
+        respx.get(_CONFIG_URL).mock(return_value=httpx.Response(404, json={"error": "not found"}))
+        client = await _make_client()
+        async with client:
+            with pytest.raises(NotFound):
+                await sql_pools.enable(client, _WS_ID)
+
+
+@pytest.mark.asyncio
+async def test_disable_propagates_not_found_on_404() -> None:
+    """disable propagates NotFound when get_configuration returns 404.
+
+    There is no fallback that PATCHes an empty configuration — if the workspace
+    configuration endpoint is absent, the error surfaces to the caller.
+    """
+    with respx.mock:
+        respx.get(_CONFIG_URL).mock(return_value=httpx.Response(404, json={"error": "not found"}))
+        client = await _make_client()
+        async with client:
+            with pytest.raises(NotFound):
+                await sql_pools.disable(client, _WS_ID)
+
+
+@pytest.mark.asyncio
 async def test_disable_is_no_op_when_already_disabled() -> None:
     """disable should return current config without PATCH when already disabled."""
     with respx.mock:
@@ -309,36 +339,57 @@ async def test_disable_is_no_op_when_already_disabled() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Model validation (client-side constraints)
+# Model validation (client-side constraints via validate_for_patch)
 # ---------------------------------------------------------------------------
 
 
-def test_model_rejects_sum_over_100() -> None:
-    """SqlPoolsConfiguration should raise ValidationError when sum > 100."""
-    with pytest.raises(ValidationError, match="Sum of maxResourcePercentage"):
-        SqlPoolsConfiguration.model_validate(
-            {
-                "customSQLPoolsEnabled": True,
-                "customSQLPools": [
-                    {"name": "A", "isDefault": False, "maxResourcePercentage": 60},
-                    {"name": "B", "isDefault": True, "maxResourcePercentage": 60},
-                ],
-            }
-        )
+def test_validate_for_patch_rejects_sum_over_100() -> None:
+    """validate_for_patch should raise ValueError when sum > 100."""
+    config = SqlPoolsConfiguration.model_validate(
+        {
+            "customSQLPoolsEnabled": True,
+            "customSQLPools": [
+                {"name": "A", "isDefault": False, "maxResourcePercentage": 60},
+                {"name": "B", "isDefault": True, "maxResourcePercentage": 60},
+            ],
+        }
+    )
+    with pytest.raises(ValueError, match="Sum of maxResourcePercentage"):
+        config.validate_for_patch()
 
 
-def test_model_rejects_multiple_defaults() -> None:
-    """SqlPoolsConfiguration should raise ValidationError when > 1 pool is default."""
-    with pytest.raises(ValidationError, match="Exactly one SQL pool may be marked as default"):
-        SqlPoolsConfiguration.model_validate(
-            {
-                "customSQLPoolsEnabled": True,
-                "customSQLPools": [
-                    {"name": "A", "isDefault": True, "maxResourcePercentage": 40},
-                    {"name": "B", "isDefault": True, "maxResourcePercentage": 40},
-                ],
-            }
-        )
+def test_validate_for_patch_rejects_multiple_defaults() -> None:
+    """validate_for_patch should raise ValueError when > 1 pool is default."""
+    config = SqlPoolsConfiguration.model_validate(
+        {
+            "customSQLPoolsEnabled": True,
+            "customSQLPools": [
+                {"name": "A", "isDefault": True, "maxResourcePercentage": 40},
+                {"name": "B", "isDefault": True, "maxResourcePercentage": 40},
+            ],
+        }
+    )
+    with pytest.raises(ValueError, match="Exactly one SQL pool may be marked as default"):
+        config.validate_for_patch()
+
+
+def test_model_validate_does_not_raise_for_invalid_patch_state() -> None:
+    """model_validate should NOT raise for state that violates patch constraints.
+
+    GET responses may contain server-side state that violates client constraints
+    (beta API drift, race conditions).  Deserialisation must not fail.
+    """
+    # sum > 100 — should parse fine via model_validate
+    config = SqlPoolsConfiguration.model_validate(
+        {
+            "customSQLPoolsEnabled": True,
+            "customSQLPools": [
+                {"name": "A", "isDefault": False, "maxResourcePercentage": 60},
+                {"name": "B", "isDefault": True, "maxResourcePercentage": 60},
+            ],
+        }
+    )
+    assert len(config.custom_sql_pools) == 2
 
 
 def test_model_accepts_exactly_one_default() -> None:

--- a/tests/unit/services/test_sql_pools.py
+++ b/tests/unit/services/test_sql_pools.py
@@ -1,0 +1,439 @@
+"""Tests for services.sql_pools — written TDD."""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+from uuid import UUID
+
+import httpx
+import pytest
+import respx
+from azure.core.credentials import AccessToken
+from azure.core.credentials_async import AsyncTokenCredential
+from pydantic import ValidationError
+
+from fabric_dw.exceptions import PermissionDenied
+from fabric_dw.http_client import FabricHttpClient
+from fabric_dw.models import SqlPoolsConfiguration
+from fabric_dw.services import sql_pools
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_WS_ID = UUID("a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+_BASE_URL = "https://api.fabric.microsoft.com/v1"
+_CONFIG_URL = f"{_BASE_URL}/workspaces/{_WS_ID}/warehouses/sqlPoolsConfiguration"
+
+_FAKE_TOKEN = AccessToken(token="fake-token", expires_on=int(time.time()) + 3600)  # noqa: S106
+
+POOLS_ENABLED_PAYLOAD: dict[str, Any] = {
+    "customSQLPoolsEnabled": True,
+    "customSQLPools": [
+        {
+            "name": "ETL",
+            "isDefault": False,
+            "maxResourcePercentage": 30,
+            "optimizeForReads": False,
+            "classifier": {
+                "type": "Application Name",
+                "value": ["ETL", "Load"],
+            },
+        },
+        {
+            "name": "Reporting",
+            "isDefault": False,
+            "maxResourcePercentage": 30,
+            "optimizeForReads": True,
+            "classifier": {
+                "type": "Application Name",
+                "value": ["Reports"],
+            },
+        },
+        {
+            "name": "Default",
+            "isDefault": True,
+            "maxResourcePercentage": 40,
+            "optimizeForReads": False,
+            "classifier": {
+                "type": "Application Name",
+                "value": ["Default"],
+            },
+        },
+    ],
+}
+
+POOLS_DISABLED_PAYLOAD: dict[str, Any] = {
+    "customSQLPoolsEnabled": False,
+    "customSQLPools": [
+        {
+            "name": "Default",
+            "isDefault": True,
+            "maxResourcePercentage": 100,
+            "optimizeForReads": True,
+        }
+    ],
+}
+
+POOLS_EMPTY_PAYLOAD: dict[str, Any] = {
+    "customSQLPoolsEnabled": False,
+    "customSQLPools": [],
+}
+
+
+def _make_credential() -> AsyncTokenCredential:
+    cred = MagicMock(spec=AsyncTokenCredential)
+    cred.get_token = AsyncMock(return_value=_FAKE_TOKEN)
+    return cred
+
+
+async def _make_client() -> FabricHttpClient:
+    return FabricHttpClient(credential=_make_credential(), rps=100)
+
+
+# ---------------------------------------------------------------------------
+# get_configuration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_configuration_returns_model() -> None:
+    """get_configuration should GET the endpoint with ?beta=true and return a model."""
+    with respx.mock:
+        route = respx.get(_CONFIG_URL).mock(
+            return_value=httpx.Response(200, json=POOLS_ENABLED_PAYLOAD)
+        )
+        client = await _make_client()
+        async with client:
+            result = await sql_pools.get_configuration(client, _WS_ID)
+
+    assert route.called
+    assert "beta=true" in str(route.calls[0].request.url)
+    assert isinstance(result, SqlPoolsConfiguration)
+    assert result.custom_sql_pools_enabled is True
+    assert len(result.custom_sql_pools) == 3
+    assert result.custom_sql_pools[0].name == "ETL"
+    assert result.custom_sql_pools[0].max_resource_percentage == 30
+    assert result.custom_sql_pools[0].classifier is not None
+    assert result.custom_sql_pools[0].classifier.type == "Application Name"
+    assert result.custom_sql_pools[0].classifier.value == ["ETL", "Load"]
+
+
+@pytest.mark.asyncio
+async def test_get_configuration_disabled_workspace() -> None:
+    """get_configuration handles disabled pools (customSQLPoolsEnabled=false)."""
+    with respx.mock:
+        respx.get(_CONFIG_URL).mock(
+            return_value=httpx.Response(200, json=POOLS_DISABLED_PAYLOAD)
+        )
+        client = await _make_client()
+        async with client:
+            result = await sql_pools.get_configuration(client, _WS_ID)
+
+    assert result.custom_sql_pools_enabled is False
+    assert len(result.custom_sql_pools) == 1
+
+
+@pytest.mark.asyncio
+async def test_get_configuration_403_raises_permission_denied() -> None:
+    """get_configuration propagates PermissionDenied on 403 with hint."""
+    with respx.mock:
+        respx.get(_CONFIG_URL).mock(return_value=httpx.Response(403, json={"error": "forbidden"}))
+        client = await _make_client()
+        async with client:
+            with pytest.raises(PermissionDenied):
+                await sql_pools.get_configuration(client, _WS_ID)
+
+
+# ---------------------------------------------------------------------------
+# update_configuration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_configuration_patches_full_body() -> None:
+    """update_configuration should PATCH the full config and then GET fresh state."""
+    config = SqlPoolsConfiguration.model_validate(POOLS_ENABLED_PAYLOAD)
+
+    with respx.mock:
+        patch_route = respx.patch(_CONFIG_URL).mock(return_value=httpx.Response(200))
+        get_route = respx.get(_CONFIG_URL).mock(
+            return_value=httpx.Response(200, json=POOLS_ENABLED_PAYLOAD)
+        )
+        client = await _make_client()
+        async with client:
+            result = await sql_pools.update_configuration(client, _WS_ID, config)
+
+    assert patch_route.called
+    assert "beta=true" in str(patch_route.calls[0].request.url)
+
+    sent_body = json.loads(patch_route.calls[0].request.content)
+    assert sent_body["customSQLPoolsEnabled"] is True
+    assert len(sent_body["customSQLPools"]) == 3
+
+    assert get_route.called
+    assert isinstance(result, SqlPoolsConfiguration)
+
+
+@pytest.mark.asyncio
+async def test_update_configuration_destructive_semantics_reflected_in_body() -> None:
+    """Pools absent from the config model must not be in the PATCH body (destructive semantics)."""
+    single_pool_config = SqlPoolsConfiguration.model_validate(
+        {
+            "customSQLPoolsEnabled": True,
+            "customSQLPools": [
+                {
+                    "name": "OnlyPool",
+                    "isDefault": True,
+                    "maxResourcePercentage": 100,
+                    "optimizeForReads": False,
+                }
+            ],
+        }
+    )
+
+    with respx.mock:
+        patch_route = respx.patch(_CONFIG_URL).mock(return_value=httpx.Response(200))
+        respx.get(_CONFIG_URL).mock(return_value=httpx.Response(200, json=POOLS_ENABLED_PAYLOAD))
+        client = await _make_client()
+        async with client:
+            await sql_pools.update_configuration(client, _WS_ID, single_pool_config)
+
+    sent_body = json.loads(patch_route.calls[0].request.content)
+    pool_names = [p["name"] for p in sent_body["customSQLPools"]]
+    assert pool_names == ["OnlyPool"]
+
+
+@pytest.mark.asyncio
+async def test_update_configuration_403_raises_permission_denied() -> None:
+    """update_configuration propagates PermissionDenied on 403."""
+    config = SqlPoolsConfiguration.model_validate(POOLS_ENABLED_PAYLOAD)
+
+    with respx.mock:
+        respx.patch(_CONFIG_URL).mock(return_value=httpx.Response(403, json={"error": "forbidden"}))
+        client = await _make_client()
+        async with client:
+            with pytest.raises(PermissionDenied):
+                await sql_pools.update_configuration(client, _WS_ID, config)
+
+
+# ---------------------------------------------------------------------------
+# enable / disable
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_enable_patches_enabled_true_preserving_pools() -> None:
+    """enable should PATCH customSQLPoolsEnabled=true and keep existing pools."""
+    with respx.mock:
+        get_route = respx.get(_CONFIG_URL).mock(
+            side_effect=[
+                httpx.Response(200, json=POOLS_DISABLED_PAYLOAD),
+                httpx.Response(200, json=POOLS_ENABLED_PAYLOAD),
+            ]
+        )
+        patch_route = respx.patch(_CONFIG_URL).mock(return_value=httpx.Response(200))
+        client = await _make_client()
+        async with client:
+            result = await sql_pools.enable(client, _WS_ID)
+
+    assert patch_route.called
+    sent_body = json.loads(patch_route.calls[0].request.content)
+    assert sent_body["customSQLPoolsEnabled"] is True
+    assert "customSQLPools" in sent_body
+
+    assert get_route.call_count == 2
+    assert isinstance(result, SqlPoolsConfiguration)
+    assert result.custom_sql_pools_enabled is True
+
+
+@pytest.mark.asyncio
+async def test_enable_is_no_op_when_already_enabled() -> None:
+    """enable should return current config without PATCH when already enabled."""
+    with respx.mock:
+        get_route = respx.get(_CONFIG_URL).mock(
+            return_value=httpx.Response(200, json=POOLS_ENABLED_PAYLOAD)
+        )
+        patch_route = respx.patch(_CONFIG_URL).mock(return_value=httpx.Response(200))
+        client = await _make_client()
+        async with client:
+            result = await sql_pools.enable(client, _WS_ID)
+
+    assert get_route.call_count == 1
+    assert not patch_route.called
+    assert result.custom_sql_pools_enabled is True
+
+
+@pytest.mark.asyncio
+async def test_disable_patches_enabled_false_preserving_pools() -> None:
+    """disable should PATCH customSQLPoolsEnabled=false and keep existing pools."""
+    with respx.mock:
+        get_route = respx.get(_CONFIG_URL).mock(
+            side_effect=[
+                httpx.Response(200, json=POOLS_ENABLED_PAYLOAD),
+                httpx.Response(200, json=POOLS_DISABLED_PAYLOAD),
+            ]
+        )
+        patch_route = respx.patch(_CONFIG_URL).mock(return_value=httpx.Response(200))
+        client = await _make_client()
+        async with client:
+            result = await sql_pools.disable(client, _WS_ID)
+
+    assert patch_route.called
+    sent_body = json.loads(patch_route.calls[0].request.content)
+    assert sent_body["customSQLPoolsEnabled"] is False
+    assert "customSQLPools" in sent_body
+    pool_names = [p["name"] for p in sent_body["customSQLPools"]]
+    assert "Default" in pool_names
+
+    assert get_route.call_count == 2
+    assert isinstance(result, SqlPoolsConfiguration)
+
+
+@pytest.mark.asyncio
+async def test_disable_is_no_op_when_already_disabled() -> None:
+    """disable should return current config without PATCH when already disabled."""
+    with respx.mock:
+        get_route = respx.get(_CONFIG_URL).mock(
+            return_value=httpx.Response(200, json=POOLS_DISABLED_PAYLOAD)
+        )
+        patch_route = respx.patch(_CONFIG_URL).mock(return_value=httpx.Response(200))
+        client = await _make_client()
+        async with client:
+            result = await sql_pools.disable(client, _WS_ID)
+
+    assert get_route.call_count == 1
+    assert not patch_route.called
+    assert result.custom_sql_pools_enabled is False
+
+
+# ---------------------------------------------------------------------------
+# Model validation (client-side constraints)
+# ---------------------------------------------------------------------------
+
+
+def test_model_rejects_sum_over_100() -> None:
+    """SqlPoolsConfiguration should raise ValidationError when sum > 100."""
+    with pytest.raises(ValidationError, match="Sum of maxResourcePercentage"):
+        SqlPoolsConfiguration.model_validate(
+            {
+                "customSQLPoolsEnabled": True,
+                "customSQLPools": [
+                    {"name": "A", "isDefault": False, "maxResourcePercentage": 60},
+                    {"name": "B", "isDefault": True, "maxResourcePercentage": 60},
+                ],
+            }
+        )
+
+
+def test_model_rejects_multiple_defaults() -> None:
+    """SqlPoolsConfiguration should raise ValidationError when > 1 pool is default."""
+    with pytest.raises(ValidationError, match="Exactly one SQL pool may be marked as default"):
+        SqlPoolsConfiguration.model_validate(
+            {
+                "customSQLPoolsEnabled": True,
+                "customSQLPools": [
+                    {"name": "A", "isDefault": True, "maxResourcePercentage": 40},
+                    {"name": "B", "isDefault": True, "maxResourcePercentage": 40},
+                ],
+            }
+        )
+
+
+def test_model_accepts_exactly_one_default() -> None:
+    """SqlPoolsConfiguration with exactly one default pool should be valid."""
+    config = SqlPoolsConfiguration.model_validate(
+        {
+            "customSQLPoolsEnabled": True,
+            "customSQLPools": [
+                {"name": "A", "isDefault": False, "maxResourcePercentage": 40},
+                {"name": "B", "isDefault": True, "maxResourcePercentage": 60},
+            ],
+        }
+    )
+    assert config.custom_sql_pools[1].is_default is True
+
+
+def test_model_accepts_no_defaults() -> None:
+    """SqlPoolsConfiguration with zero default pools should be valid."""
+    config = SqlPoolsConfiguration.model_validate(
+        {
+            "customSQLPoolsEnabled": True,
+            "customSQLPools": [
+                {"name": "A", "isDefault": False, "maxResourcePercentage": 50},
+                {"name": "B", "isDefault": False, "maxResourcePercentage": 50},
+            ],
+        }
+    )
+    assert len(config.custom_sql_pools) == 2
+
+
+def test_model_accepts_sum_exactly_100() -> None:
+    """SqlPoolsConfiguration where sum == 100 should be valid."""
+    config = SqlPoolsConfiguration.model_validate(
+        {
+            "customSQLPoolsEnabled": True,
+            "customSQLPools": [
+                {"name": "A", "isDefault": False, "maxResourcePercentage": 50},
+                {"name": "B", "isDefault": True, "maxResourcePercentage": 50},
+            ],
+        }
+    )
+    assert config.custom_sql_pools[0].max_resource_percentage == 50
+
+
+def test_model_rejects_max_resource_percentage_below_1() -> None:
+    """SqlPool should reject maxResourcePercentage < 1."""
+    with pytest.raises(ValidationError):
+        SqlPoolsConfiguration.model_validate(
+            {
+                "customSQLPoolsEnabled": True,
+                "customSQLPools": [
+                    {"name": "A", "isDefault": True, "maxResourcePercentage": 0},
+                ],
+            }
+        )
+
+
+def test_model_rejects_max_resource_percentage_above_100() -> None:
+    """SqlPool should reject maxResourcePercentage > 100."""
+    with pytest.raises(ValidationError):
+        SqlPoolsConfiguration.model_validate(
+            {
+                "customSQLPoolsEnabled": True,
+                "customSQLPools": [
+                    {"name": "A", "isDefault": True, "maxResourcePercentage": 101},
+                ],
+            }
+        )
+
+
+def test_model_accepts_empty_pool_list() -> None:
+    """SqlPoolsConfiguration with empty customSQLPools should be valid."""
+    config = SqlPoolsConfiguration.model_validate(POOLS_EMPTY_PAYLOAD)
+    assert config.custom_sql_pools == []
+
+
+def test_model_handles_open_classifier_type() -> None:
+    """SqlPoolClassifier should accept unknown type values (open enum)."""
+    config = SqlPoolsConfiguration.model_validate(
+        {
+            "customSQLPoolsEnabled": True,
+            "customSQLPools": [
+                {
+                    "name": "X",
+                    "isDefault": True,
+                    "maxResourcePercentage": 100,
+                    "classifier": {
+                        "type": "Future Type Not Yet In SDK",
+                        "value": ["v"],
+                    },
+                }
+            ],
+        }
+    )
+    assert config.custom_sql_pools[0].classifier is not None
+    assert config.custom_sql_pools[0].classifier.type == "Future Type Not Yet In SDK"

--- a/zensical.toml
+++ b/zensical.toml
@@ -19,6 +19,7 @@ nav = [
     { "Authentication" = "authentication.md" },
     { "MCP" = "mcp.md" },
     { "MCP tools" = "mcp-tools.md" },
+    { "SQL Pools (beta)" = "sql-pools.md" },
     { "Shell Completion" = "completion.md" },
     { "Troubleshooting" = "troubleshooting.md" }
   ] },


### PR DESCRIPTION
## Summary

- Adds workspace-level SQL Pools configuration management targeting the beta `GET/PATCH /v1/workspaces/{ws}/warehouses/sqlPoolsConfiguration?beta=true` endpoint
- Service layer: `get_configuration`, `update_configuration`, `enable`, `disable` — all in `src/fabric_dw/services/sql_pools.py`
- Pydantic models `SqlPool`, `SqlPoolClassifier`, `SqlPoolsConfiguration` with client-side validation (sum ≤ 100, at-most-one default, range [1,100]) before PATCH
- CLI subgroup `fabric-dw sql-pools {get|set|edit|enable|disable}` with explicit destructive-PATCH warnings; `edit` opens `$EDITOR` with unified diff + confirmation if pools would be deleted
- Four MCP tools: `get_sql_pools_configuration`, `update_sql_pools_configuration`, `enable_sql_pools`, `disable_sql_pools`
- 29 new unit tests (all green), integration test skeleton guarded by `pytest.mark.integration`
- New docs page `docs/sql-pools.md` explaining beta status, destructive-PATCH semantics, safe-edit pattern, and permission requirements; nav entry added to `zensical.toml`; `docs/cli.md` and `docs/mcp-tools.md` updated

## Test plan

- [ ] `uv run pytest tests/unit/services/test_sql_pools.py tests/unit/cli/commands/test_sql_pools.py` — 29 unit tests pass
- [ ] `uv run ruff check src/ tests/` — no errors
- [ ] `uvx ty check src/` — no errors
- [ ] CI unit suite (label-gated integration tests skipped without real credentials)

Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)