### PR TITLE
feat(services/views): CRUD operations for SQL views via TDS

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -649,6 +649,126 @@ fabric-dw --yes restore-points restore MyWorkspace SalesWH 1726617378000
 
 ---
 
+## fabric-dw views
+
+Manage SQL views on Microsoft Fabric Data Warehouses and SQL Analytics Endpoints.
+
+### views list
+
+List all views on a warehouse or SQL Analytics Endpoint. Pass `--schema` to filter to a single schema.
+
+**Synopsis**
+
+```
+fabric-dw views list [OPTIONS] [WORKSPACE] [WAREHOUSE]
+```
+
+| Option | Description |
+| --- | --- |
+| `--schema TEXT` | Only list views in this schema. |
+
+**Example**
+
+```shell
+fabric-dw views list MyWorkspace SalesWH --schema dbo
+```
+
+```
+ schema_name  name         created               modified
+ ------------ ------------ --------------------- ---------------------
+ dbo          vw_sales     2026-01-10T08:00:00Z  2026-06-01T12:00:00Z
+ dbo          vw_monthly   2026-02-01T09:00:00Z  2026-05-15T14:00:00Z
+```
+
+---
+
+### views get
+
+Get the full definition of a single view.
+
+**Synopsis**
+
+```
+fabric-dw views get [WORKSPACE] [WAREHOUSE] QUALIFIED_NAME
+```
+
+`QUALIFIED_NAME` must be a dot-separated `schema.view_name` string, e.g. `dbo.vw_sales`.
+
+**Example**
+
+```shell
+fabric-dw views get MyWorkspace SalesWH dbo.vw_sales
+```
+
+```
+schema_name    dbo
+name           vw_sales
+qualified_name dbo.vw_sales
+created        2026-01-10T08:00:00Z
+modified       2026-06-01T12:00:00Z
+definition     SELECT id, amount FROM dbo.sales
+```
+
+---
+
+### views create
+
+Create a new SQL view.
+
+**Synopsis**
+
+```
+fabric-dw views create [WORKSPACE] [WAREHOUSE] QUALIFIED_NAME SELECT_BODY
+```
+
+`SELECT_BODY` is the verbatim SELECT statement that forms the view body.
+
+**Example**
+
+```shell
+fabric-dw views create MyWorkspace SalesWH dbo.vw_recent \
+  "SELECT id, amount FROM dbo.sales WHERE sale_date >= '2026-01-01'"
+```
+
+---
+
+### views update
+
+Redefine an existing view using `CREATE OR ALTER VIEW`.
+
+**Synopsis**
+
+```
+fabric-dw views update [WORKSPACE] [WAREHOUSE] QUALIFIED_NAME SELECT_BODY
+```
+
+**Example**
+
+```shell
+fabric-dw views update MyWorkspace SalesWH dbo.vw_recent \
+  "SELECT id, amount, region FROM dbo.sales WHERE sale_date >= '2026-01-01'"
+```
+
+---
+
+### views drop
+
+Drop a SQL view. You will be asked to confirm unless `--yes` is passed.
+
+**Synopsis**
+
+```
+fabric-dw views drop [WORKSPACE] [WAREHOUSE] QUALIFIED_NAME
+```
+
+**Example**
+
+```shell
+fabric-dw --yes views drop MyWorkspace SalesWH dbo.vw_recent
+```
+
+---
+
 ## fabric-dw snapshots
 
 Manage Microsoft Fabric Data Warehouse snapshots.

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -432,6 +432,80 @@ Roll a snapshot's timestamp forward, or reset it to the current time.
 
 ---
 
+## SQL Views
+
+### list_views
+
+List SQL views on a warehouse or SQL Analytics Endpoint, optionally filtered to a single schema.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `item` (`str`) — warehouse or SQL analytics endpoint name or GUID.
+- `schema` (`str | null`, optional) — when provided, only views in this schema are returned; must be a valid SQL identifier.
+
+**Returns:** `list[View]` — array of view objects, each with `schema_name`, `name`, `qualified_name`, `created`, `modified`, and `definition` (always `null` for list results).
+
+---
+
+### get_view
+
+Fetch the full definition of a single SQL view.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `item` (`str`) — warehouse or SQL analytics endpoint name or GUID.
+- `qualified_name` (`str`) — dot-separated schema and view name, e.g. `dbo.vw_sales`.
+
+**Returns:** `View` — single view object with `definition` populated from `sys.sql_modules`.
+
+---
+
+### create_view
+
+Create a new SQL view.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `item` (`str`) — warehouse or SQL analytics endpoint name or GUID.
+- `qualified_name` (`str`) — dot-separated schema and view name, e.g. `dbo.vw_sales`.
+- `select_body` (`str`) — the SELECT statement that forms the view body; executed verbatim as DDL.
+
+**Returns:** `View` — the newly-created view object (fetched after DDL, includes `definition`).
+
+---
+
+### update_view
+
+Redefine an existing SQL view using `CREATE OR ALTER VIEW`.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `item` (`str`) — warehouse or SQL analytics endpoint name or GUID.
+- `qualified_name` (`str`) — dot-separated schema and view name, e.g. `dbo.vw_sales`.
+- `select_body` (`str`) — the new SELECT statement; executed verbatim as DDL.
+
+**Returns:** `View` — the updated view object (fetched after DDL, includes `definition`).
+
+---
+
+### drop_view
+
+Drop a SQL view.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `item` (`str`) — warehouse or SQL analytics endpoint name or GUID.
+- `qualified_name` (`str`) — dot-separated schema and view name, e.g. `dbo.vw_sales`.
+
+**Returns:** `{ "dropped": true }` — confirmation.
+
+---
+
 ## Cache
 
 ### clear_cache

--- a/src/fabric_dw/cli/_main.py
+++ b/src/fabric_dw/cli/_main.py
@@ -17,6 +17,7 @@ from fabric_dw.cli.commands.query_insights import query_insights_group
 from fabric_dw.cli.commands.restore_points import restore_points_group
 from fabric_dw.cli.commands.snapshots import snapshots_group
 from fabric_dw.cli.commands.sql_endpoints import sql_endpoints_group
+from fabric_dw.cli.commands.views import views_group
 from fabric_dw.cli.commands.warehouses import warehouses_group
 from fabric_dw.cli.commands.workspaces import workspaces_group
 from fabric_dw.logging import setup_logging
@@ -84,3 +85,4 @@ cli.add_command(queries_group)
 cli.add_command(query_insights_group)
 cli.add_command(restore_points_group)
 cli.add_command(snapshots_group)
+cli.add_command(views_group)

--- a/src/fabric_dw/cli/commands/views.py
+++ b/src/fabric_dw/cli/commands/views.py
@@ -147,7 +147,7 @@ async def get_cmd(
 @click.option("--from-file", default=None, help="Path to a .sql file containing the SELECT body.")
 @click.pass_obj
 @_coro
-async def create_cmd(  # noqa: PLR0913
+async def create_cmd(
     ctx: CliContext,
     workspace: str | None,
     item: str | None,
@@ -186,7 +186,7 @@ async def create_cmd(  # noqa: PLR0913
 @click.option("--from-file", default=None, help="Path to a .sql file containing the SELECT body.")
 @click.pass_obj
 @_coro
-async def update_cmd(  # noqa: PLR0913
+async def update_cmd(
     ctx: CliContext,
     workspace: str | None,
     item: str | None,

--- a/src/fabric_dw/cli/commands/views.py
+++ b/src/fabric_dw/cli/commands/views.py
@@ -1,0 +1,267 @@
+"""Views sub-commands for the fabric-dw CLI."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import click
+
+from fabric_dw import auth as _auth
+from fabric_dw.cli._context import CliContext
+from fabric_dw.cli._render import confirm, render
+from fabric_dw.cli.commands._utils import (
+    _coro,
+    _resolve_item,
+    resolve_warehouse_arg,
+    resolve_workspace_arg,
+)
+from fabric_dw.exceptions import FabricError
+from fabric_dw.http_client import FabricHttpClient
+from fabric_dw.services import views as _views_svc
+from fabric_dw.sql import SqlTarget
+
+_log = logging.getLogger(__name__)
+
+
+@asynccontextmanager
+async def _build_http_client(ctx: CliContext) -> AsyncIterator[FabricHttpClient]:
+    """Build and yield an HTTP client for views commands."""
+    credential = _auth.get_credential(ctx.auth)
+    async with FabricHttpClient(credential) as http:
+        yield http
+
+
+def _parse_qualified_name(qualified_name: str) -> tuple[str, str]:
+    """Split ``<schema>.<view>`` into ``(schema, view)``.
+
+    Raises:
+        click.UsageError: If the string does not contain exactly one dot.
+    """
+    schema, _, view = qualified_name.partition(".")
+    if not schema or not view:
+        raise click.UsageError(  # noqa: TRY003
+            f"Expected <schema>.<view>, got {qualified_name!r}"
+        )
+    return schema, view
+
+
+def _load_select_body(select: str | None, from_file: str | None) -> str:
+    """Return the SELECT body from the inline option or file option.
+
+    Raises:
+        click.UsageError: If neither or both are provided.
+    """
+    if select and from_file:
+        raise click.UsageError("Provide either --select or --from-file, not both.")  # noqa: TRY003
+    if from_file:
+        path = Path(from_file)
+        if not path.is_file():
+            raise click.UsageError(f"File not found: {from_file}")  # noqa: TRY003
+        return path.read_text(encoding="utf-8").strip()
+    if select:
+        return select
+    raise click.UsageError("Provide --select or --from-file.")  # noqa: TRY003
+
+
+@click.group("views")
+def views_group() -> None:
+    """Manage SQL views on Fabric warehouses and SQL Analytics Endpoints."""
+
+
+@views_group.command("list")
+@click.argument("workspace", required=False, default=None)
+@click.argument("item", required=False, default=None)
+@click.option("--schema", default=None, help="Filter by schema name.")
+@click.pass_obj
+@_coro
+async def list_cmd(
+    ctx: CliContext, workspace: str | None, item: str | None, schema: str | None
+) -> None:
+    """List views on ITEM (warehouse or SQL endpoint) in WORKSPACE."""
+    ws = resolve_workspace_arg(ctx, workspace)
+    wh = resolve_warehouse_arg(ctx, item)
+    try:
+        async with _build_http_client(ctx) as http:
+            ws_id, entry = await _resolve_item(http, ws, wh)
+            if entry.connection_string is None:
+                raise click.ClickException(  # noqa: TRY003
+                    f"Item {entry.display_name!r} has no connection string."
+                )
+            target = SqlTarget(
+                workspace_id=str(ws_id),
+                database=entry.display_name,
+                connection_string=entry.connection_string,
+            )
+            items = await _views_svc.list_views(target, schema=schema, mode=ctx.auth)
+            render(
+                [v.model_dump(mode="json") for v in items],
+                json_output=ctx.json_output,
+                table_title="Views",
+            )
+    except (ValueError, FabricError) as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@views_group.command("get")
+@click.argument("workspace", required=False, default=None)
+@click.argument("item", required=False, default=None)
+@click.argument("qualified_name")
+@click.pass_obj
+@_coro
+async def get_cmd(
+    ctx: CliContext,
+    workspace: str | None,
+    item: str | None,
+    qualified_name: str,
+) -> None:
+    """Fetch the full definition of QUALIFIED_NAME (schema.view) on ITEM in WORKSPACE."""
+    ws = resolve_workspace_arg(ctx, workspace)
+    wh = resolve_warehouse_arg(ctx, item)
+    schema, view_name = _parse_qualified_name(qualified_name)
+    try:
+        async with _build_http_client(ctx) as http:
+            ws_id, entry = await _resolve_item(http, ws, wh)
+            if entry.connection_string is None:
+                raise click.ClickException(  # noqa: TRY003
+                    f"Item {entry.display_name!r} has no connection string."
+                )
+            target = SqlTarget(
+                workspace_id=str(ws_id),
+                database=entry.display_name,
+                connection_string=entry.connection_string,
+            )
+            v = await _views_svc.get_view(target, schema, view_name, mode=ctx.auth)
+            render(v.model_dump(mode="json"), json_output=ctx.json_output)
+    except (ValueError, FabricError) as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@views_group.command("create")
+@click.argument("workspace", required=False, default=None)
+@click.argument("item", required=False, default=None)
+@click.option("--name", "qualified_name", required=True, help="Qualified name: schema.view.")
+@click.option("--select", "select_body", default=None, help="Inline SELECT statement.")
+@click.option("--from-file", default=None, help="Path to a .sql file containing the SELECT body.")
+@click.pass_obj
+@_coro
+async def create_cmd(  # noqa: PLR0913
+    ctx: CliContext,
+    workspace: str | None,
+    item: str | None,
+    qualified_name: str,
+    select_body: str | None,
+    from_file: str | None,
+) -> None:
+    """Create a new view QUALIFIED_NAME on ITEM in WORKSPACE."""
+    ws = resolve_workspace_arg(ctx, workspace)
+    wh = resolve_warehouse_arg(ctx, item)
+    schema, view_name = _parse_qualified_name(qualified_name)
+    body = _load_select_body(select_body, from_file)
+    try:
+        async with _build_http_client(ctx) as http:
+            ws_id, entry = await _resolve_item(http, ws, wh)
+            if entry.connection_string is None:
+                raise click.ClickException(  # noqa: TRY003
+                    f"Item {entry.display_name!r} has no connection string."
+                )
+            target = SqlTarget(
+                workspace_id=str(ws_id),
+                database=entry.display_name,
+                connection_string=entry.connection_string,
+            )
+            v = await _views_svc.create_view(target, schema, view_name, body, mode=ctx.auth)
+            render(v.model_dump(mode="json"), json_output=ctx.json_output)
+    except (ValueError, FabricError) as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@views_group.command("update")
+@click.argument("workspace", required=False, default=None)
+@click.argument("item", required=False, default=None)
+@click.argument("qualified_name")
+@click.option("--select", "select_body", default=None, help="Inline SELECT statement.")
+@click.option("--from-file", default=None, help="Path to a .sql file containing the SELECT body.")
+@click.pass_obj
+@_coro
+async def update_cmd(  # noqa: PLR0913
+    ctx: CliContext,
+    workspace: str | None,
+    item: str | None,
+    qualified_name: str,
+    select_body: str | None,
+    from_file: str | None,
+) -> None:
+    """Redefine QUALIFIED_NAME (schema.view) on ITEM in WORKSPACE via CREATE OR ALTER VIEW."""
+    ws = resolve_workspace_arg(ctx, workspace)
+    wh = resolve_warehouse_arg(ctx, item)
+    schema, view_name = _parse_qualified_name(qualified_name)
+    body = _load_select_body(select_body, from_file)
+    try:
+        async with _build_http_client(ctx) as http:
+            ws_id, entry = await _resolve_item(http, ws, wh)
+            if entry.connection_string is None:
+                raise click.ClickException(  # noqa: TRY003
+                    f"Item {entry.display_name!r} has no connection string."
+                )
+            confirmed = confirm(
+                f"Redefine view [{schema}].[{view_name}] on {entry.display_name!r}?",
+                yes=ctx.yes,
+            )
+            if not confirmed:
+                raise click.Abort()  # noqa: TRY301
+            target = SqlTarget(
+                workspace_id=str(ws_id),
+                database=entry.display_name,
+                connection_string=entry.connection_string,
+            )
+            v = await _views_svc.update_view(target, schema, view_name, body, mode=ctx.auth)
+            render(v.model_dump(mode="json"), json_output=ctx.json_output)
+    except click.Abort:
+        raise
+    except (ValueError, FabricError) as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@views_group.command("drop")
+@click.argument("workspace", required=False, default=None)
+@click.argument("item", required=False, default=None)
+@click.argument("qualified_name")
+@click.pass_obj
+@_coro
+async def drop_cmd(
+    ctx: CliContext,
+    workspace: str | None,
+    item: str | None,
+    qualified_name: str,
+) -> None:
+    """Drop QUALIFIED_NAME (schema.view) from ITEM in WORKSPACE."""
+    ws = resolve_workspace_arg(ctx, workspace)
+    wh = resolve_warehouse_arg(ctx, item)
+    schema, view_name = _parse_qualified_name(qualified_name)
+    try:
+        async with _build_http_client(ctx) as http:
+            ws_id, entry = await _resolve_item(http, ws, wh)
+            if entry.connection_string is None:
+                raise click.ClickException(  # noqa: TRY003
+                    f"Item {entry.display_name!r} has no connection string."
+                )
+            confirmed = confirm(
+                f"Drop view [{schema}].[{view_name}] from {entry.display_name!r} ({entry.id})?",
+                yes=ctx.yes,
+            )
+            if not confirmed:
+                raise click.Abort()  # noqa: TRY301
+            target = SqlTarget(
+                workspace_id=str(ws_id),
+                database=entry.display_name,
+                connection_string=entry.connection_string,
+            )
+            await _views_svc.drop_view(target, schema, view_name, mode=ctx.auth)
+            click.echo(f"View [{schema}].[{view_name}] dropped.")
+    except click.Abort:
+        raise
+    except (ValueError, FabricError) as exc:
+        raise click.ClickException(str(exc)) from exc

--- a/src/fabric_dw/mcp/server.py
+++ b/src/fabric_dw/mcp/server.py
@@ -960,6 +960,9 @@ async def create_view(
 ) -> dict[str, Any]:
     """Create a new SQL view.
 
+    CAUTION: ``select_body`` is executed verbatim as DDL. Ensure the body
+    matches the user's intent before calling this tool.
+
     Args:
         workspace: Workspace name or GUID.
         item: Warehouse or SQL endpoint name or GUID.
@@ -995,6 +998,9 @@ async def update_view(
     workspace: str, item: str, qualified_name: str, select_body: str
 ) -> dict[str, Any]:
     """Redefine a SQL view via CREATE OR ALTER VIEW.
+
+    CAUTION: ``select_body`` is executed verbatim as DDL. Ensure the body
+    matches the user's intent before calling this tool.
 
     Args:
         workspace: Workspace name or GUID.

--- a/src/fabric_dw/mcp/server.py
+++ b/src/fabric_dw/mcp/server.py
@@ -36,6 +36,7 @@ from fabric_dw.services import audit, queries, snapshots, sql_endpoints, warehou
 from fabric_dw.services import ownership as ownership_svc
 from fabric_dw.services import query_insights as _qi_svc
 from fabric_dw.services import restore as restore_svc
+from fabric_dw.services import views as views_svc
 from fabric_dw.sql import SqlTarget
 
 __all__ = ["mcp", "run"]
@@ -889,6 +890,171 @@ async def restore_warehouse_in_place(
     except FabricError as exc:
         raise _fabric_err(exc) from exc
     return {"restored": True, "restore_point_id": restore_point_id}
+
+
+# ---------------------------------------------------------------------------
+# Views tools
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+async def list_views(workspace: str, item: str, schema: str | None = None) -> list[dict[str, Any]]:
+    """List SQL views on a warehouse or SQL Analytics Endpoint.
+
+    Args:
+        workspace: Workspace name or GUID.
+        item: Warehouse or SQL endpoint name or GUID.
+        schema: When provided, only views in this schema are returned.
+    """
+    try:
+        ws_id = await _get_resolver().workspace_id(workspace)
+        entry = await _get_resolver().item(workspace, item)
+        if entry.connection_string is None:
+            msg = f"item {item!r} has no connection string; cannot query views"
+            raise FabricError(msg)  # noqa: TRY301
+        target = SqlTarget(
+            workspace_id=str(ws_id),
+            database=entry.display_name,
+            connection_string=entry.connection_string,
+        )
+        result = await views_svc.list_views(target, schema=schema, mode=_get_auth_mode())
+    except (ValueError, FabricError) as exc:
+        raise _fabric_err(exc) if isinstance(exc, FabricError) else ToolError(str(exc)) from exc
+    return [v.model_dump(mode="json") for v in result]
+
+
+@mcp.tool()
+async def get_view(workspace: str, item: str, qualified_name: str) -> dict[str, Any]:
+    """Fetch the full definition of a view (schema.view).
+
+    Args:
+        workspace: Workspace name or GUID.
+        item: Warehouse or SQL endpoint name or GUID.
+        qualified_name: Dot-separated qualified view name, e.g. ``dbo.vw_sales``.
+    """
+    schema, _, view_name = qualified_name.partition(".")
+    if not schema or not view_name:
+        raise ToolError(  # noqa: TRY003
+            f"qualified_name must be <schema>.<view>, got {qualified_name!r}"
+        )
+    try:
+        ws_id = await _get_resolver().workspace_id(workspace)
+        entry = await _get_resolver().item(workspace, item)
+        if entry.connection_string is None:
+            msg = f"item {item!r} has no connection string; cannot query views"
+            raise FabricError(msg)  # noqa: TRY301
+        target = SqlTarget(
+            workspace_id=str(ws_id),
+            database=entry.display_name,
+            connection_string=entry.connection_string,
+        )
+        result = await views_svc.get_view(target, schema, view_name, mode=_get_auth_mode())
+    except (ValueError, FabricError) as exc:
+        raise _fabric_err(exc) if isinstance(exc, FabricError) else ToolError(str(exc)) from exc
+    return result.model_dump(mode="json")
+
+
+@mcp.tool()
+async def create_view(
+    workspace: str, item: str, qualified_name: str, select_body: str
+) -> dict[str, Any]:
+    """Create a new SQL view.
+
+    Args:
+        workspace: Workspace name or GUID.
+        item: Warehouse or SQL endpoint name or GUID.
+        qualified_name: Dot-separated qualified view name, e.g. ``dbo.vw_sales``.
+        select_body: The SELECT statement that forms the view body.
+    """
+    schema, _, view_name = qualified_name.partition(".")
+    if not schema or not view_name:
+        raise ToolError(  # noqa: TRY003
+            f"qualified_name must be <schema>.<view>, got {qualified_name!r}"
+        )
+    try:
+        ws_id = await _get_resolver().workspace_id(workspace)
+        entry = await _get_resolver().item(workspace, item)
+        if entry.connection_string is None:
+            msg = f"item {item!r} has no connection string; cannot create views"
+            raise FabricError(msg)  # noqa: TRY301
+        target = SqlTarget(
+            workspace_id=str(ws_id),
+            database=entry.display_name,
+            connection_string=entry.connection_string,
+        )
+        result = await views_svc.create_view(
+            target, schema, view_name, select_body, mode=_get_auth_mode()
+        )
+    except (ValueError, FabricError) as exc:
+        raise _fabric_err(exc) if isinstance(exc, FabricError) else ToolError(str(exc)) from exc
+    return result.model_dump(mode="json")
+
+
+@mcp.tool()
+async def update_view(
+    workspace: str, item: str, qualified_name: str, select_body: str
+) -> dict[str, Any]:
+    """Redefine a SQL view via CREATE OR ALTER VIEW.
+
+    Args:
+        workspace: Workspace name or GUID.
+        item: Warehouse or SQL endpoint name or GUID.
+        qualified_name: Dot-separated qualified view name, e.g. ``dbo.vw_sales``.
+        select_body: The new SELECT statement.
+    """
+    schema, _, view_name = qualified_name.partition(".")
+    if not schema or not view_name:
+        raise ToolError(  # noqa: TRY003
+            f"qualified_name must be <schema>.<view>, got {qualified_name!r}"
+        )
+    try:
+        ws_id = await _get_resolver().workspace_id(workspace)
+        entry = await _get_resolver().item(workspace, item)
+        if entry.connection_string is None:
+            msg = f"item {item!r} has no connection string; cannot update views"
+            raise FabricError(msg)  # noqa: TRY301
+        target = SqlTarget(
+            workspace_id=str(ws_id),
+            database=entry.display_name,
+            connection_string=entry.connection_string,
+        )
+        result = await views_svc.update_view(
+            target, schema, view_name, select_body, mode=_get_auth_mode()
+        )
+    except (ValueError, FabricError) as exc:
+        raise _fabric_err(exc) if isinstance(exc, FabricError) else ToolError(str(exc)) from exc
+    return result.model_dump(mode="json")
+
+
+@mcp.tool()
+async def drop_view(workspace: str, item: str, qualified_name: str) -> dict[str, Any]:
+    """Drop a SQL view.
+
+    Args:
+        workspace: Workspace name or GUID.
+        item: Warehouse or SQL endpoint name or GUID.
+        qualified_name: Dot-separated qualified view name, e.g. ``dbo.vw_sales``.
+    """
+    schema, _, view_name = qualified_name.partition(".")
+    if not schema or not view_name:
+        raise ToolError(  # noqa: TRY003
+            f"qualified_name must be <schema>.<view>, got {qualified_name!r}"
+        )
+    try:
+        ws_id = await _get_resolver().workspace_id(workspace)
+        entry = await _get_resolver().item(workspace, item)
+        if entry.connection_string is None:
+            msg = f"item {item!r} has no connection string; cannot drop views"
+            raise FabricError(msg)  # noqa: TRY301
+        target = SqlTarget(
+            workspace_id=str(ws_id),
+            database=entry.display_name,
+            connection_string=entry.connection_string,
+        )
+        await views_svc.drop_view(target, schema, view_name, mode=_get_auth_mode())
+    except (ValueError, FabricError) as exc:
+        raise _fabric_err(exc) if isinstance(exc, FabricError) else ToolError(str(exc)) from exc
+    return {"dropped": True}
 
 
 # ---------------------------------------------------------------------------

--- a/src/fabric_dw/models.py
+++ b/src/fabric_dw/models.py
@@ -298,3 +298,14 @@ class SqlPoolInsight(_FabricBase):
     is_optimized_for_reads: bool | None = None
     current_workspace_capacity: str | None = None
     is_pool_under_pressure: bool | None = None
+
+
+class View(_FabricBase):
+    """A SQL view on a Fabric Data Warehouse or SQL Analytics Endpoint."""
+
+    schema_name: str
+    name: str
+    qualified_name: str
+    definition: str | None = None
+    created: datetime
+    modified: datetime

--- a/src/fabric_dw/services/views.py
+++ b/src/fabric_dw/services/views.py
@@ -50,6 +50,11 @@ def validate_identifier(name: str) -> str:
     - ``;`` — statement separator.
     - ``--`` — line comment.
 
+    ASCII identifiers only (regex excludes unicode).  This is a deliberate
+    conservative choice: widening the regex without switching to parameterised
+    queries would reintroduce injection risk.  Use bracket-quoted names with
+    permitted characters only.
+
     Args:
         name: The raw identifier string supplied by the caller.
 
@@ -152,6 +157,7 @@ async def list_views(
         validate_identifier(schema)
 
     schema_filter = f"s.name = '{schema}'" if schema is not None else "1=1"
+    # Safe: schema identifier passes validate_identifier() above.
     list_sql = _LIST_VIEWS_SQL.format(schema_filter=schema_filter)
 
     def _run() -> list[View]:
@@ -197,6 +203,7 @@ async def get_view(
     validate_identifier(schema)
     validate_identifier(view_name)
 
+    # Safe: schema and view_name identifiers pass validate_identifier() above.
     get_sql = _GET_VIEW_SQL.format(schema=schema, view=view_name)
 
     def _run() -> View:

--- a/src/fabric_dw/services/views.py
+++ b/src/fabric_dw/services/views.py
@@ -1,0 +1,349 @@
+"""CRUD operations for SQL views on Fabric Data Warehouses and SQL Analytics Endpoints.
+
+Public API
+----------
+- :func:`validate_identifier` — reject dangerous/malformed SQL identifiers.
+- :func:`list_views`          — list all views (optionally filtered by schema).
+- :func:`get_view`            — fetch a single view with its definition.
+- :func:`create_view`         — issue CREATE VIEW … AS <select_body>.
+- :func:`update_view`         — issue CREATE OR ALTER VIEW … AS <select_body>.
+- :func:`drop_view`           — issue DROP VIEW.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from contextlib import closing
+from datetime import datetime
+from typing import cast
+
+from fabric_dw import sql
+from fabric_dw.auth import CredentialMode
+from fabric_dw.exceptions import NotFound
+from fabric_dw.models import View
+from fabric_dw.sql import SqlTarget
+
+__all__ = [
+    "create_view",
+    "drop_view",
+    "get_view",
+    "list_views",
+    "update_view",
+    "validate_identifier",
+]
+
+# ---------------------------------------------------------------------------
+# Identifier validator
+# ---------------------------------------------------------------------------
+
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,127}$")
+
+
+def validate_identifier(name: str) -> str:
+    """Validate that *name* is a safe SQL identifier segment.
+
+    Accepted pattern: ``[A-Za-z_][A-Za-z0-9_]{0,127}`` (max 128 chars).
+
+    Explicit fast-path rejections before the regex (belt-and-suspenders):
+    - ``]`` — closes a bracket-quoted identifier; enables injection.
+    - ``;`` — statement separator.
+    - ``--`` — line comment.
+
+    Args:
+        name: The raw identifier string supplied by the caller.
+
+    Returns:
+        *name* unchanged if valid.
+
+    Raises:
+        ValueError: If *name* contains dangerous characters or does not match
+            the allowed pattern.
+    """
+    if "]" in name or ";" in name or "--" in name:
+        msg = f"Invalid SQL identifier {name!r}: contains forbidden character(s)"
+        raise ValueError(msg)
+    if not _IDENTIFIER_RE.match(name):
+        msg = f"Invalid SQL identifier {name!r}: must match [A-Za-z_][A-Za-z0-9_]{{0,127}}"
+        raise ValueError(msg)
+    return name
+
+
+# ---------------------------------------------------------------------------
+# SQL templates
+# ---------------------------------------------------------------------------
+
+_LIST_VIEWS_SQL = """\
+SELECT
+    s.name AS schema_name,
+    v.name,
+    v.create_date AS created,
+    v.modify_date AS modified
+FROM sys.views v
+JOIN sys.schemas s ON s.schema_id = v.schema_id
+WHERE ({schema_filter})
+ORDER BY s.name, v.name;
+"""
+
+_GET_VIEW_SQL = """\
+SELECT
+    s.name AS schema_name,
+    v.name,
+    v.create_date AS created,
+    v.modify_date AS modified,
+    m.definition
+FROM sys.views v
+JOIN sys.schemas s ON s.schema_id = v.schema_id
+JOIN sys.sql_modules m ON m.object_id = v.object_id
+WHERE s.name = '{schema}' AND v.name = '{view}';
+"""
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _row_to_view(cols: list[str], row: tuple[object, ...]) -> View:
+    """Build a :class:`View` from a column-name list and a result row tuple."""
+    data = dict(zip(cols, row, strict=True))
+    schema_name = str(data["schema_name"])
+    name = str(data["name"])
+    raw_def = data.get("definition") if "definition" in data else None
+    definition = cast("str | None", raw_def)
+    return View(
+        schema_name=schema_name,
+        name=name,
+        qualified_name=f"{schema_name}.{name}",
+        definition=definition,
+        created=cast(datetime, data["created"]),
+        modified=cast(datetime, data["modified"]),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+async def list_views(
+    target: SqlTarget,
+    *,
+    schema: str | None = None,
+    mode: CredentialMode = CredentialMode.DEFAULT,
+) -> list[View]:
+    """Return all views on *target*, optionally filtered to a single *schema*.
+
+    Args:
+        target: The warehouse or SQL Analytics Endpoint to query.
+        schema: When provided, only views in this schema are returned.
+            Must pass :func:`validate_identifier`.
+        mode: The credential mode for Entra authentication.
+
+    Returns:
+        A (possibly empty) list of :class:`~fabric_dw.models.View` instances.
+
+    Raises:
+        ValueError: If *schema* fails identifier validation.
+        PermissionDenied: If the driver reports a permission error.
+        AuthError: If the driver reports an authentication failure.
+    """
+    if schema is not None:
+        validate_identifier(schema)
+
+    schema_filter = f"s.name = '{schema}'" if schema is not None else "1=1"
+    list_sql = _LIST_VIEWS_SQL.format(schema_filter=schema_filter)
+
+    def _run() -> list[View]:
+        with closing(sql.open_connection(target, mode=mode)) as conn:
+            cursor = conn.cursor()
+            try:
+                cursor.execute(list_sql)
+                cols = [c[0] for c in (cursor.description or [])]
+                rows = cursor.fetchall()
+            except Exception as exc:
+                mapped = sql.map_driver_error(exc)
+                if mapped:
+                    raise mapped from exc
+                raise
+            return [_row_to_view(cols, r) for r in rows]
+
+    return await asyncio.to_thread(_run)
+
+
+async def get_view(
+    target: SqlTarget,
+    schema: str,
+    view_name: str,
+    *,
+    mode: CredentialMode = CredentialMode.DEFAULT,
+) -> View:
+    """Fetch a single view with its ``sys.sql_modules`` definition.
+
+    Args:
+        target: The warehouse to query.
+        schema: The schema name.  Must pass :func:`validate_identifier`.
+        view_name: The view name.  Must pass :func:`validate_identifier`.
+        mode: The credential mode for Entra authentication.
+
+    Returns:
+        A :class:`~fabric_dw.models.View` with ``definition`` populated.
+
+    Raises:
+        ValueError: If *schema* or *view_name* fails identifier validation.
+        NotFound: If no view with that schema/name exists.
+        PermissionDenied: If the driver reports a permission error.
+    """
+    validate_identifier(schema)
+    validate_identifier(view_name)
+
+    get_sql = _GET_VIEW_SQL.format(schema=schema, view=view_name)
+
+    def _run() -> View:
+        with closing(sql.open_connection(target, mode=mode)) as conn:
+            cursor = conn.cursor()
+            try:
+                cursor.execute(get_sql)
+                cols = [c[0] for c in (cursor.description or [])]
+                rows = cursor.fetchall()
+            except Exception as exc:
+                mapped = sql.map_driver_error(exc)
+                if mapped:
+                    raise mapped from exc
+                raise
+            if not rows:
+                msg = f"View [{schema}].[{view_name}] not found"
+                raise NotFound(msg)
+            return _row_to_view(cols, rows[0])
+
+    return await asyncio.to_thread(_run)
+
+
+async def create_view(
+    target: SqlTarget,
+    schema: str,
+    view_name: str,
+    select_body: str,
+    *,
+    mode: CredentialMode = CredentialMode.DEFAULT,
+) -> View:
+    """Create a new view via ``CREATE VIEW [<schema>].[<view>] AS <select_body>``.
+
+    Args:
+        target: The warehouse to connect to.
+        schema: The schema name.  Must pass :func:`validate_identifier`.
+        view_name: The view name.  Must pass :func:`validate_identifier`.
+        select_body: The free-form SELECT statement.  Not validated — the caller
+            owns the SQL (same trust model as ``sql exec``).
+        mode: The credential mode for Entra authentication.
+
+    Returns:
+        The newly-created :class:`~fabric_dw.models.View` (fetched after DDL).
+
+    Raises:
+        ValueError: If *schema* or *view_name* fails identifier validation.
+        PermissionDenied: If the driver reports a CREATE VIEW permission error.
+    """
+    validate_identifier(schema)
+    validate_identifier(view_name)
+
+    ddl = f"CREATE VIEW [{schema}].[{view_name}] AS {select_body}"
+
+    def _run() -> None:
+        with closing(sql.open_connection(target, mode=mode)) as conn:
+            cursor = conn.cursor()
+            try:
+                cursor.execute(ddl)
+                conn.commit()
+            except Exception as exc:
+                mapped = sql.map_driver_error(exc)
+                if mapped:
+                    raise mapped from exc
+                raise
+
+    await asyncio.to_thread(_run)
+    return await get_view(target, schema, view_name, mode=mode)
+
+
+async def update_view(
+    target: SqlTarget,
+    schema: str,
+    view_name: str,
+    select_body: str,
+    *,
+    mode: CredentialMode = CredentialMode.DEFAULT,
+) -> View:
+    """Redefine a view via ``CREATE OR ALTER VIEW [<schema>].[<view>] AS <select_body>``.
+
+    Args:
+        target: The warehouse to connect to.
+        schema: The schema name.  Must pass :func:`validate_identifier`.
+        view_name: The view name.  Must pass :func:`validate_identifier`.
+        select_body: The free-form SELECT statement.  Caller-owned.
+        mode: The credential mode for Entra authentication.
+
+    Returns:
+        The updated :class:`~fabric_dw.models.View` (fetched after DDL).
+
+    Raises:
+        ValueError: If *schema* or *view_name* fails identifier validation.
+        PermissionDenied: If the driver reports an ALTER VIEW permission error.
+    """
+    validate_identifier(schema)
+    validate_identifier(view_name)
+
+    ddl = f"CREATE OR ALTER VIEW [{schema}].[{view_name}] AS {select_body}"
+
+    def _run() -> None:
+        with closing(sql.open_connection(target, mode=mode)) as conn:
+            cursor = conn.cursor()
+            try:
+                cursor.execute(ddl)
+                conn.commit()
+            except Exception as exc:
+                mapped = sql.map_driver_error(exc)
+                if mapped:
+                    raise mapped from exc
+                raise
+
+    await asyncio.to_thread(_run)
+    return await get_view(target, schema, view_name, mode=mode)
+
+
+async def drop_view(
+    target: SqlTarget,
+    schema: str,
+    view_name: str,
+    *,
+    mode: CredentialMode = CredentialMode.DEFAULT,
+) -> None:
+    """Drop a view via ``DROP VIEW [<schema>].[<view>]``.
+
+    Args:
+        target: The warehouse to connect to.
+        schema: The schema name.  Must pass :func:`validate_identifier`.
+        view_name: The view name.  Must pass :func:`validate_identifier`.
+        mode: The credential mode for Entra authentication.
+
+    Raises:
+        ValueError: If *schema* or *view_name* fails identifier validation.
+        PermissionDenied: If the driver reports a DROP VIEW permission error.
+    """
+    validate_identifier(schema)
+    validate_identifier(view_name)
+
+    ddl = f"DROP VIEW [{schema}].[{view_name}]"
+
+    def _run() -> None:
+        with closing(sql.open_connection(target, mode=mode)) as conn:
+            cursor = conn.cursor()
+            try:
+                cursor.execute(ddl)
+                conn.commit()
+            except Exception as exc:
+                mapped = sql.map_driver_error(exc)
+                if mapped:
+                    raise mapped from exc
+                raise
+
+    await asyncio.to_thread(_run)

--- a/tests/unit/cli/commands/test_views.py
+++ b/tests/unit/cli/commands/test_views.py
@@ -1,0 +1,517 @@
+"""Tests for views CLI sub-commands."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+from uuid import UUID
+
+import pytest
+from click.testing import CliRunner
+
+from fabric_dw.cache import ItemEntry
+from fabric_dw.cli._main import cli
+from fabric_dw.exceptions import NotFound, PermissionDenied
+from fabric_dw.models import View, WarehouseKind
+
+WS_GUID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+WH_GUID = "d4e5f6a7-b8c9-0123-def0-123456789abc"
+WS_UUID = UUID(WS_GUID)
+WH_UUID = UUID(WH_GUID)
+
+_NOW = datetime(2024, 6, 1, 12, 0, 0, tzinfo=UTC)
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def cache_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    return tmp_path
+
+
+def _make_http_cm(http: object) -> object:
+    @asynccontextmanager
+    async def _cm(_ctx: object) -> AsyncIterator[object]:
+        yield http
+
+    return _cm
+
+
+def _make_item_entry() -> ItemEntry:
+    return ItemEntry(
+        id=WH_UUID,
+        kind=WarehouseKind.WAREHOUSE,
+        connection_string="wh.datawarehouse.fabric.microsoft.com",
+        fetched_at=datetime.now(tz=UTC),
+        display_name="SalesWarehouse",
+    )
+
+
+def _make_view(*, with_definition: bool = False) -> View:
+    return View(
+        schema_name="dbo",
+        name="vw_sales",
+        qualified_name="dbo.vw_sales",
+        definition="SELECT id FROM dbo.sales" if with_definition else None,
+        created=_NOW,
+        modified=_NOW,
+    )
+
+
+# ===========================================================================
+# views list
+# ===========================================================================
+
+
+class TestViewsList:
+    def test_list_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.views._build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.views._resolve_item",
+                new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.views.list_views",
+                new=AsyncMock(return_value=[_make_view()]),
+            ),
+        ):
+            result = runner.invoke(cli, ["views", "list", WS_GUID, WH_GUID])
+        assert result.exit_code == 0
+
+    def test_list_json_output(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.views._build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.views._resolve_item",
+                new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.views.list_views",
+                new=AsyncMock(return_value=[_make_view()]),
+            ),
+        ):
+            result = runner.invoke(cli, ["--json", "views", "list", WS_GUID, WH_GUID])
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert isinstance(parsed, list)
+
+    def test_list_with_schema_filter(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        mock_list = AsyncMock(return_value=[_make_view()])
+        with (
+            patch(
+                "fabric_dw.cli.commands.views._build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.views._resolve_item",
+                new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
+            ),
+            patch("fabric_dw.services.views.list_views", new=mock_list),
+        ):
+            result = runner.invoke(
+                cli, ["views", "list", WS_GUID, WH_GUID, "--schema", "dbo"]
+            )
+        assert result.exit_code == 0
+        mock_list.assert_awaited_once()
+
+    def test_list_not_found_returns_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.views._build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.views._resolve_item",
+                new=AsyncMock(side_effect=NotFound("not found")),
+            ),
+        ):
+            result = runner.invoke(cli, ["views", "list", WS_GUID, WH_GUID])
+        assert result.exit_code != 0
+
+
+# ===========================================================================
+# views get
+# ===========================================================================
+
+
+class TestViewsGet:
+    def test_get_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.views._build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.views._resolve_item",
+                new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.views.get_view",
+                new=AsyncMock(return_value=_make_view(with_definition=True)),
+            ),
+        ):
+            result = runner.invoke(cli, ["views", "get", WS_GUID, WH_GUID, "dbo.vw_sales"])
+        assert result.exit_code == 0
+
+    def test_get_json_output(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.views._build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.views._resolve_item",
+                new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.views.get_view",
+                new=AsyncMock(return_value=_make_view(with_definition=True)),
+            ),
+        ):
+            result = runner.invoke(
+                cli, ["--json", "views", "get", WS_GUID, WH_GUID, "dbo.vw_sales"]
+            )
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["name"] == "vw_sales"
+
+    def test_get_bad_qualified_name_exits_nonzero(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        _ = cache_env
+        result = runner.invoke(cli, ["views", "get", WS_GUID, WH_GUID, "no_dot_here"])
+        assert result.exit_code != 0
+
+    def test_get_not_found_returns_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.views._build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.views._resolve_item",
+                new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.views.get_view",
+                new=AsyncMock(side_effect=NotFound("not found")),
+            ),
+        ):
+            result = runner.invoke(cli, ["views", "get", WS_GUID, WH_GUID, "dbo.vw_missing"])
+        assert result.exit_code != 0
+
+
+# ===========================================================================
+# views create
+# ===========================================================================
+
+
+class TestViewsCreate:
+    def test_create_with_select_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.views._build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.views._resolve_item",
+                new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.views.create_view",
+                new=AsyncMock(return_value=_make_view(with_definition=True)),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "views",
+                    "create",
+                    WS_GUID,
+                    WH_GUID,
+                    "--name",
+                    "dbo.vw_sales",
+                    "--select",
+                    "SELECT id FROM dbo.sales",
+                ],
+            )
+        assert result.exit_code == 0
+
+    def test_create_with_file(
+        self, runner: CliRunner, cache_env: Path, tmp_path: Path
+    ) -> None:
+        _ = cache_env
+        sql_file = tmp_path / "view.sql"
+        sql_file.write_text("SELECT id FROM dbo.sales")
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.views._build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.views._resolve_item",
+                new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.views.create_view",
+                new=AsyncMock(return_value=_make_view(with_definition=True)),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "views",
+                    "create",
+                    WS_GUID,
+                    WH_GUID,
+                    "--name",
+                    "dbo.vw_sales",
+                    "--from-file",
+                    str(sql_file),
+                ],
+            )
+        assert result.exit_code == 0
+
+    def test_create_no_select_fails(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        result = runner.invoke(
+            cli,
+            ["views", "create", WS_GUID, WH_GUID, "--name", "dbo.vw_sales"],
+        )
+        assert result.exit_code != 0
+
+    def test_create_both_select_and_file_fails(
+        self, runner: CliRunner, cache_env: Path, tmp_path: Path
+    ) -> None:
+        _ = cache_env
+        sql_file = tmp_path / "view.sql"
+        sql_file.write_text("SELECT 1")
+        result = runner.invoke(
+            cli,
+            [
+                "views",
+                "create",
+                WS_GUID,
+                WH_GUID,
+                "--name",
+                "dbo.vw_sales",
+                "--select",
+                "SELECT 1",
+                "--from-file",
+                str(sql_file),
+            ],
+        )
+        assert result.exit_code != 0
+
+    def test_create_permission_denied_returns_nonzero(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.views._build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.views._resolve_item",
+                new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.views.create_view",
+                new=AsyncMock(side_effect=PermissionDenied("no permission")),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "views",
+                    "create",
+                    WS_GUID,
+                    WH_GUID,
+                    "--name",
+                    "dbo.vw_sales",
+                    "--select",
+                    "SELECT 1",
+                ],
+            )
+        assert result.exit_code != 0
+
+
+# ===========================================================================
+# views update
+# ===========================================================================
+
+
+class TestViewsUpdate:
+    def test_update_with_yes_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.views._build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.views._resolve_item",
+                new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.views.update_view",
+                new=AsyncMock(return_value=_make_view(with_definition=True)),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--yes",
+                    "views",
+                    "update",
+                    WS_GUID,
+                    WH_GUID,
+                    "dbo.vw_sales",
+                    "--select",
+                    "SELECT id FROM dbo.sales",
+                ],
+            )
+        assert result.exit_code == 0
+
+    def test_update_declined_aborts(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.views._build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.views._resolve_item",
+                new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "views",
+                    "update",
+                    WS_GUID,
+                    WH_GUID,
+                    "dbo.vw_sales",
+                    "--select",
+                    "SELECT 1",
+                ],
+                input="n\n",
+            )
+        assert result.exit_code != 0
+
+
+# ===========================================================================
+# views drop
+# ===========================================================================
+
+
+class TestViewsDrop:
+    def test_drop_with_yes_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.views._build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.views._resolve_item",
+                new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.views.drop_view",
+                new=AsyncMock(return_value=None),
+            ),
+        ):
+            result = runner.invoke(
+                cli, ["--yes", "views", "drop", WS_GUID, WH_GUID, "dbo.vw_sales"]
+            )
+        assert result.exit_code == 0
+
+    def test_drop_declined_aborts(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.views._build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.views._resolve_item",
+                new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                ["views", "drop", WS_GUID, WH_GUID, "dbo.vw_sales"],
+                input="n\n",
+            )
+        assert result.exit_code != 0
+
+    def test_drop_bad_qualified_name_exits_nonzero(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        _ = cache_env
+        result = runner.invoke(cli, ["views", "drop", WS_GUID, WH_GUID, "no_dot"])
+        assert result.exit_code != 0
+
+    def test_drop_permission_denied_returns_nonzero(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.views._build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.views._resolve_item",
+                new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.views.drop_view",
+                new=AsyncMock(side_effect=PermissionDenied("no permission")),
+            ),
+        ):
+            result = runner.invoke(
+                cli, ["--yes", "views", "drop", WS_GUID, WH_GUID, "dbo.vw_sales"]
+            )
+        assert result.exit_code != 0

--- a/tests/unit/cli/commands/test_views.py
+++ b/tests/unit/cli/commands/test_views.py
@@ -129,9 +129,7 @@ class TestViewsList:
             ),
             patch("fabric_dw.services.views.list_views", new=mock_list),
         ):
-            result = runner.invoke(
-                cli, ["views", "list", WS_GUID, WH_GUID, "--schema", "dbo"]
-            )
+            result = runner.invoke(cli, ["views", "list", WS_GUID, WH_GUID, "--schema", "dbo"])
         assert result.exit_code == 0
         mock_list.assert_awaited_once()
 
@@ -202,9 +200,7 @@ class TestViewsGet:
         parsed = json.loads(result.output)
         assert parsed["name"] == "vw_sales"
 
-    def test_get_bad_qualified_name_exits_nonzero(
-        self, runner: CliRunner, cache_env: Path
-    ) -> None:
+    def test_get_bad_qualified_name_exits_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
         result = runner.invoke(cli, ["views", "get", WS_GUID, WH_GUID, "no_dot_here"])
         assert result.exit_code != 0
@@ -268,9 +264,7 @@ class TestViewsCreate:
             )
         assert result.exit_code == 0
 
-    def test_create_with_file(
-        self, runner: CliRunner, cache_env: Path, tmp_path: Path
-    ) -> None:
+    def test_create_with_file(self, runner: CliRunner, cache_env: Path, tmp_path: Path) -> None:
         _ = cache_env
         sql_file = tmp_path / "view.sql"
         sql_file.write_text("SELECT id FROM dbo.sales")

--- a/tests/unit/services/test_views.py
+++ b/tests/unit/services/test_views.py
@@ -117,6 +117,30 @@ class TestValidateIdentifier:
         with pytest.raises(ValueError, match="Invalid SQL identifier"):
             validate_identifier("schema.view")
 
+    def test_rejects_single_quote(self) -> None:
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            validate_identifier("view'name")
+
+    def test_rejects_opening_bracket(self) -> None:
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            validate_identifier("view[name")
+
+    def test_rejects_newline(self) -> None:
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            validate_identifier("view\nname")
+
+    def test_rejects_null_byte(self) -> None:
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            validate_identifier("view\x00name")
+
+    def test_rejects_hyphen(self) -> None:
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            validate_identifier("view-name")
+
+    def test_allows_single_underscore(self) -> None:
+        """Single underscore matches ^[A-Za-z_][A-Za-z0-9_]{0,127}$ — allowed."""
+        assert validate_identifier("_") == "_"
+
     def test_valid_mixed_case(self) -> None:
         assert validate_identifier("MyView") == "MyView"
 
@@ -196,9 +220,8 @@ class TestListViews:
         with patch("fabric_dw.sql.open_connection", return_value=conn):
             await views.list_views(target, schema="dbo")
         cursor = conn.cursor.return_value
-        call_args = cursor.execute.call_args
-        # schema filter should be passed as an argument or embedded
-        assert call_args is not None
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert "s.name = 'dbo'" in call_sql
 
     @pytest.mark.asyncio
     async def test_schema_filter_validates_identifier(self) -> None:
@@ -462,7 +485,7 @@ class TestUpdateView:
 
         cursor = ddl_conn.cursor.return_value
         call_sql: str = cursor.execute.call_args[0][0].upper()
-        assert "CREATE OR ALTER VIEW" in call_sql or "ALTER VIEW" in call_sql
+        assert "CREATE OR ALTER VIEW" in call_sql
 
     @pytest.mark.asyncio
     async def test_uses_brackets_for_schema_and_name(self) -> None:

--- a/tests/unit/services/test_views.py
+++ b/tests/unit/services/test_views.py
@@ -1,0 +1,620 @@
+"""Tests for services.views — DMV-mock tests + identifier-validator tests (TDD)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fabric_dw.exceptions import AuthError, NotFound, PermissionDenied
+from fabric_dw.models import View
+from fabric_dw.services import views
+from fabric_dw.services.views import validate_identifier
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_target() -> MagicMock:
+    """Return a mock SqlTarget."""
+    return MagicMock()
+
+
+def _make_conn(rows: list[tuple[object, ...]], columns: list[str]) -> MagicMock:
+    """Return a mock connection whose cursor returns the given rows."""
+    cursor = MagicMock()
+    cursor.description = [(c, None) for c in columns]
+    cursor.fetchall.return_value = rows
+    conn = MagicMock()
+    conn.cursor.return_value = cursor
+    return conn
+
+
+def _make_conn_for_ddl() -> MagicMock:
+    """Return a mock connection suitable for DDL statements (no rows returned)."""
+    cursor = MagicMock()
+    cursor.description = None
+    cursor.fetchall.return_value = []
+    conn = MagicMock()
+    conn.cursor.return_value = cursor
+    return conn
+
+
+# ---------------------------------------------------------------------------
+# Fixture data
+# ---------------------------------------------------------------------------
+
+_NOW = datetime(2024, 6, 1, 12, 0, 0, tzinfo=UTC)
+_LATER = datetime(2024, 6, 2, 8, 30, 0, tzinfo=UTC)
+
+_LIST_COLS = ["schema_name", "name", "created", "modified"]
+_GET_COLS = ["schema_name", "name", "created", "modified", "definition"]
+
+_VIEW_ROW_1 = ("dbo", "vw_sales", _NOW, _LATER)
+_VIEW_ROW_2 = ("finance", "vw_monthly", _NOW, _NOW)
+_VIEW_ROW_GET = ("dbo", "vw_sales", _NOW, _LATER, "SELECT id, amount FROM dbo.sales")
+
+
+# ===========================================================================
+# identifier validator tests
+# ===========================================================================
+
+
+class TestValidateIdentifier:
+    def test_simple_valid_identifier(self) -> None:
+        assert validate_identifier("my_view") == "my_view"
+
+    def test_valid_with_letters_digits_underscores(self) -> None:
+        assert validate_identifier("view_123_abc") == "view_123_abc"
+
+    def test_valid_starts_with_underscore(self) -> None:
+        assert validate_identifier("_private") == "_private"
+
+    def test_valid_max_length_128(self) -> None:
+        long_name = "a" * 128
+        assert validate_identifier(long_name) == long_name
+
+    def test_rejects_closing_bracket(self) -> None:
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            validate_identifier("view]name")
+
+    def test_rejects_semicolon(self) -> None:
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            validate_identifier("view;name")
+
+    def test_rejects_double_dash(self) -> None:
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            validate_identifier("view--comment")
+
+    def test_rejects_leading_digit(self) -> None:
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            validate_identifier("1invalid")
+
+    def test_rejects_space(self) -> None:
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            validate_identifier("my view")
+
+    def test_rejects_empty_string(self) -> None:
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            validate_identifier("")
+
+    def test_rejects_too_long(self) -> None:
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            validate_identifier("a" * 129)
+
+    def test_rejects_sql_injection_drop(self) -> None:
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            validate_identifier("x; DROP TABLE users--")
+
+    def test_rejects_bracket_injection(self) -> None:
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            validate_identifier("x] JOIN sys.tables--")
+
+    def test_rejects_dot(self) -> None:
+        """Dots are not allowed in an identifier segment."""
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            validate_identifier("schema.view")
+
+    def test_valid_mixed_case(self) -> None:
+        assert validate_identifier("MyView") == "MyView"
+
+    def test_valid_uppercase(self) -> None:
+        assert validate_identifier("VW_SALES") == "VW_SALES"
+
+
+# ===========================================================================
+# list_views
+# ===========================================================================
+
+
+class TestListViews:
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_no_rows(self) -> None:
+        target = _make_target()
+        conn = _make_conn([], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            result = await views.list_views(target)
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_returns_view_instances(self) -> None:
+        target = _make_target()
+        conn = _make_conn([_VIEW_ROW_1], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            result = await views.list_views(target)
+        assert len(result) == 1
+        assert isinstance(result[0], View)
+
+    @pytest.mark.asyncio
+    async def test_parses_fields_correctly(self) -> None:
+        target = _make_target()
+        conn = _make_conn([_VIEW_ROW_1], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            result = await views.list_views(target)
+        v = result[0]
+        assert v.schema_name == "dbo"
+        assert v.name == "vw_sales"
+        assert v.qualified_name == "dbo.vw_sales"
+        assert v.created == _NOW
+        assert v.modified == _LATER
+        assert v.definition is None
+
+    @pytest.mark.asyncio
+    async def test_returns_all_rows(self) -> None:
+        target = _make_target()
+        conn = _make_conn([_VIEW_ROW_1, _VIEW_ROW_2], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            result = await views.list_views(target)
+        assert len(result) == 2
+
+    @pytest.mark.asyncio
+    async def test_sql_references_sys_views(self) -> None:
+        target = _make_target()
+        conn = _make_conn([], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await views.list_views(target)
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert "sys.views" in call_sql
+
+    @pytest.mark.asyncio
+    async def test_sql_references_sys_schemas(self) -> None:
+        target = _make_target()
+        conn = _make_conn([], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await views.list_views(target)
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert "sys.schemas" in call_sql
+
+    @pytest.mark.asyncio
+    async def test_filters_by_schema_when_provided(self) -> None:
+        target = _make_target()
+        conn = _make_conn([_VIEW_ROW_1], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await views.list_views(target, schema="dbo")
+        cursor = conn.cursor.return_value
+        call_args = cursor.execute.call_args
+        # schema filter should be passed as an argument or embedded
+        assert call_args is not None
+
+    @pytest.mark.asyncio
+    async def test_schema_filter_validates_identifier(self) -> None:
+        target = _make_target()
+        conn = _make_conn([], _LIST_COLS)
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(ValueError, match="Invalid SQL identifier"),
+        ):
+            await views.list_views(target, schema="bad]schema")
+
+    @pytest.mark.asyncio
+    async def test_closes_connection_after_success(self) -> None:
+        target = _make_target()
+        conn = _make_conn([_VIEW_ROW_1], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await views.list_views(target)
+        conn.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_maps_permission_denied(self) -> None:
+        target = _make_target()
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.execute.side_effect = Exception("permission was denied on object sys.views")
+        conn.cursor.return_value = cursor
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(PermissionDenied),
+        ):
+            await views.list_views(target)
+
+    @pytest.mark.asyncio
+    async def test_maps_auth_error(self) -> None:
+        target = _make_target()
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.execute.side_effect = Exception("Authentication failed for user ''")
+        conn.cursor.return_value = cursor
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(AuthError),
+        ):
+            await views.list_views(target)
+
+    @pytest.mark.asyncio
+    async def test_unrelated_error_propagates(self) -> None:
+        target = _make_target()
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.execute.side_effect = RuntimeError("network timeout")
+        conn.cursor.return_value = cursor
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(RuntimeError, match="network timeout"),
+        ):
+            await views.list_views(target)
+
+
+# ===========================================================================
+# get_view
+# ===========================================================================
+
+
+class TestGetView:
+    @pytest.mark.asyncio
+    async def test_returns_view_with_definition(self) -> None:
+        target = _make_target()
+        conn = _make_conn([_VIEW_ROW_GET], _GET_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            result = await views.get_view(target, "dbo", "vw_sales")
+        assert isinstance(result, View)
+        assert result.definition == "SELECT id, amount FROM dbo.sales"
+
+    @pytest.mark.asyncio
+    async def test_parses_all_fields(self) -> None:
+        target = _make_target()
+        conn = _make_conn([_VIEW_ROW_GET], _GET_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            result = await views.get_view(target, "dbo", "vw_sales")
+        assert result.schema_name == "dbo"
+        assert result.name == "vw_sales"
+        assert result.qualified_name == "dbo.vw_sales"
+        assert result.created == _NOW
+        assert result.modified == _LATER
+
+    @pytest.mark.asyncio
+    async def test_sql_includes_sys_sql_modules(self) -> None:
+        target = _make_target()
+        conn = _make_conn([_VIEW_ROW_GET], _GET_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await views.get_view(target, "dbo", "vw_sales")
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert "sys.sql_modules" in call_sql
+
+    @pytest.mark.asyncio
+    async def test_raises_not_found_when_no_rows(self) -> None:
+        target = _make_target()
+        conn = _make_conn([], _GET_COLS)
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(NotFound),
+        ):
+            await views.get_view(target, "dbo", "nonexistent")
+
+    @pytest.mark.asyncio
+    async def test_validates_schema_identifier(self) -> None:
+        target = _make_target()
+        conn = _make_conn([], _GET_COLS)
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(ValueError, match="Invalid SQL identifier"),
+        ):
+            await views.get_view(target, "bad;schema", "vw_sales")
+
+    @pytest.mark.asyncio
+    async def test_validates_view_name_identifier(self) -> None:
+        target = _make_target()
+        conn = _make_conn([], _GET_COLS)
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(ValueError, match="Invalid SQL identifier"),
+        ):
+            await views.get_view(target, "dbo", "vw--injection")
+
+    @pytest.mark.asyncio
+    async def test_closes_connection_after_success(self) -> None:
+        target = _make_target()
+        conn = _make_conn([_VIEW_ROW_GET], _GET_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await views.get_view(target, "dbo", "vw_sales")
+        conn.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_maps_permission_denied(self) -> None:
+        target = _make_target()
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.execute.side_effect = Exception("permission was denied on sys.sql_modules")
+        conn.cursor.return_value = cursor
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(PermissionDenied),
+        ):
+            await views.get_view(target, "dbo", "vw_sales")
+
+
+# ===========================================================================
+# create_view
+# ===========================================================================
+
+
+class TestCreateView:
+    @pytest.mark.asyncio
+    async def test_emits_create_view_ddl(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_VIEW_ROW_GET], _GET_COLS)
+
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            await views.create_view(target, "dbo", "vw_sales", "SELECT id FROM dbo.sales")
+
+        cursor = ddl_conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert "CREATE VIEW" in call_sql.upper()
+        assert "[dbo]" in call_sql
+        assert "[vw_sales]" in call_sql
+
+    @pytest.mark.asyncio
+    async def test_includes_select_body(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_VIEW_ROW_GET], _GET_COLS)
+
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            await views.create_view(target, "dbo", "vw_sales", "SELECT id FROM dbo.sales")
+
+        cursor = ddl_conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert "SELECT id FROM dbo.sales" in call_sql
+
+    @pytest.mark.asyncio
+    async def test_returns_view_object(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_VIEW_ROW_GET], _GET_COLS)
+
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            result = await views.create_view(target, "dbo", "vw_sales", "SELECT id FROM dbo.sales")
+
+        assert isinstance(result, View)
+        assert result.schema_name == "dbo"
+        assert result.name == "vw_sales"
+
+    @pytest.mark.asyncio
+    async def test_validates_schema_identifier(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await views.create_view(target, "bad]schema", "vw_sales", "SELECT 1")
+
+    @pytest.mark.asyncio
+    async def test_validates_view_name_identifier(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await views.create_view(target, "dbo", "vw;drop", "SELECT 1")
+
+    @pytest.mark.asyncio
+    async def test_commits_after_execute(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_VIEW_ROW_GET], _GET_COLS)
+
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            await views.create_view(target, "dbo", "vw_sales", "SELECT id FROM dbo.sales")
+
+        ddl_conn.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_maps_permission_denied_on_ddl(self) -> None:
+        target = _make_target()
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.execute.side_effect = Exception("permission was denied on database")
+        conn.cursor.return_value = cursor
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(PermissionDenied),
+        ):
+            await views.create_view(target, "dbo", "vw_sales", "SELECT 1")
+
+    @pytest.mark.asyncio
+    async def test_rejects_identifier_injection_via_schema(self) -> None:
+        """Bracket injection in schema name must be rejected before SQL is formed."""
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await views.create_view(target, "x]; DROP TABLE users--", "vw_ok", "SELECT 1")
+
+    @pytest.mark.asyncio
+    async def test_rejects_identifier_injection_via_view_name(self) -> None:
+        """Bracket injection in view name must be rejected before SQL is formed."""
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await views.create_view(target, "dbo", "vw_ok] WITH SCHEMABINDING--", "SELECT 1")
+
+
+# ===========================================================================
+# update_view
+# ===========================================================================
+
+
+class TestUpdateView:
+    @pytest.mark.asyncio
+    async def test_emits_create_or_alter_view_ddl(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_VIEW_ROW_GET], _GET_COLS)
+
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            await views.update_view(target, "dbo", "vw_sales", "SELECT id, amount FROM dbo.sales")
+
+        cursor = ddl_conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0].upper()
+        assert "CREATE OR ALTER VIEW" in call_sql or "ALTER VIEW" in call_sql
+
+    @pytest.mark.asyncio
+    async def test_uses_brackets_for_schema_and_name(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_VIEW_ROW_GET], _GET_COLS)
+
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            await views.update_view(target, "dbo", "vw_sales", "SELECT 1")
+
+        cursor = ddl_conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert "[dbo]" in call_sql
+        assert "[vw_sales]" in call_sql
+
+    @pytest.mark.asyncio
+    async def test_returns_view_object(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_VIEW_ROW_GET], _GET_COLS)
+
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            result = await views.update_view(target, "dbo", "vw_sales", "SELECT 1")
+
+        assert isinstance(result, View)
+
+    @pytest.mark.asyncio
+    async def test_validates_schema_identifier(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await views.update_view(target, "bad--schema", "vw_sales", "SELECT 1")
+
+    @pytest.mark.asyncio
+    async def test_validates_view_name_identifier(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await views.update_view(target, "dbo", "vw;injection", "SELECT 1")
+
+    @pytest.mark.asyncio
+    async def test_commits_after_execute(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_VIEW_ROW_GET], _GET_COLS)
+
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            await views.update_view(target, "dbo", "vw_sales", "SELECT 1")
+
+        ddl_conn.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_maps_permission_denied(self) -> None:
+        target = _make_target()
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.execute.side_effect = Exception("permission was denied to alter view")
+        conn.cursor.return_value = cursor
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(PermissionDenied),
+        ):
+            await views.update_view(target, "dbo", "vw_sales", "SELECT 1")
+
+
+# ===========================================================================
+# drop_view
+# ===========================================================================
+
+
+class TestDropView:
+    @pytest.mark.asyncio
+    async def test_emits_drop_view_ddl(self) -> None:
+        target = _make_target()
+        conn = _make_conn_for_ddl()
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await views.drop_view(target, "dbo", "vw_sales")
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0].upper()
+        assert "DROP VIEW" in call_sql
+
+    @pytest.mark.asyncio
+    async def test_uses_brackets_for_schema_and_name(self) -> None:
+        target = _make_target()
+        conn = _make_conn_for_ddl()
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await views.drop_view(target, "dbo", "vw_sales")
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert "[dbo]" in call_sql
+        assert "[vw_sales]" in call_sql
+
+    @pytest.mark.asyncio
+    async def test_commits_after_execute(self) -> None:
+        target = _make_target()
+        conn = _make_conn_for_ddl()
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await views.drop_view(target, "dbo", "vw_sales")
+        conn.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_closes_connection_after_success(self) -> None:
+        target = _make_target()
+        conn = _make_conn_for_ddl()
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await views.drop_view(target, "dbo", "vw_sales")
+        conn.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_validates_schema_identifier(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await views.drop_view(target, "bad]schema", "vw_sales")
+
+    @pytest.mark.asyncio
+    async def test_validates_view_name_identifier(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await views.drop_view(target, "dbo", "vw--bad")
+
+    @pytest.mark.asyncio
+    async def test_maps_permission_denied(self) -> None:
+        target = _make_target()
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.execute.side_effect = Exception("permission was denied to drop view")
+        conn.cursor.return_value = cursor
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(PermissionDenied),
+        ):
+            await views.drop_view(target, "dbo", "vw_sales")
+
+    @pytest.mark.asyncio
+    async def test_rejects_injection_in_schema(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await views.drop_view(target, "x]; DROP TABLE users--", "vw_ok")
+
+    @pytest.mark.asyncio
+    async def test_rejects_injection_in_view_name(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await views.drop_view(target, "dbo", "vw_ok] WHERE 1=1--")
+
+    @pytest.mark.asyncio
+    async def test_unrelated_error_propagates(self) -> None:
+        target = _make_target()
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.execute.side_effect = RuntimeError("connection reset")
+        conn.cursor.return_value = cursor
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(RuntimeError, match="connection reset"),
+        ):
+            await views.drop_view(target, "dbo", "vw_sales")


### PR DESCRIPTION
## Summary

- Adds `services/views.py` with 5 functions: `list_views`, `get_view`, `create_view`, `update_view`, `drop_view`, all backed by TDS DDL and `sys.views`/`sys.sql_modules`/`sys.schemas` metadata reads.
- Adds strict `validate_identifier` (regex `^[A-Za-z_][A-Za-z0-9_]{0,127}$` + explicit rejection of `]`, `;`, `--`) applied to all schema and view name inputs.
- Adds `View` Pydantic model to `models.py`.
- Adds `fabric-dw views {list|get|create|update|drop}` CLI sub-group with `--yes` and `--json` support.
- Adds 5 MCP tools: `list_views`, `get_view`, `create_view`, `update_view`, `drop_view`.
- `create` emits `CREATE VIEW [schema].[view] AS <body>`; `update` emits `CREATE OR ALTER VIEW`.
- `drop` and `update` require interactive confirmation unless `--yes`.
- `select_body` is free-form (caller-owned); only schema/view names are validated.
- 62 new unit tests (TDD) covering identifier validator injection rejections, all 5 service functions, connection close, error mapping, and DDL emission.

## Test plan

- [x] `uv run pytest tests/unit -q` — 512 passed
- [x] `uv run ruff check .` — no errors
- [x] `uv run ruff format --check .` — no reformats needed
- [x] `uvx ty==0.0.44 check src tests` — no diagnostics

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)