### PR TITLE
fix(render): show SQL NULL distinctly in --table output

### DIFF
--- a/src/fabric_dw/cli/_render.py
+++ b/src/fabric_dw/cli/_render.py
@@ -53,6 +53,17 @@ def render(
         click.echo(repr(data))
 
 
+def _cell(value: object) -> str:
+    """Convert a cell value to a Rich-markup string.
+
+    ``None`` is rendered as ``[dim]NULL[/dim]`` so SQL NULLs are visually
+    distinct from the literal string ``'None'``.
+    """
+    if value is None:
+        return "[dim]NULL[/dim]"
+    return str(value)
+
+
 def _render_table(rows: Sequence[object], *, console: Console, title: str | None) -> None:
     """Render a list of dicts as a Rich Table."""
     table = Table(title=title, show_header=True, header_style="bold")
@@ -78,16 +89,16 @@ def _render_table(rows: Sequence[object], *, console: Console, title: str | None
     for row in rows:
         if isinstance(row, dict):
             row_dict = {str(k): v for k, v in row.items()}
-            table.add_row(*[str(row_dict.get(col, "")) for col in columns])
+            table.add_row(*[_cell(row_dict.get(col)) for col in columns])
         else:
-            table.add_row(str(row))
+            table.add_row(_cell(row))
 
     console.print(table)
 
 
 def _render_panel(data: dict[str, object], *, console: Console, title: str | None) -> None:
     """Render a single dict as a Rich Panel with key: value lines."""
-    lines = "\n".join(f"[bold]{k}[/bold]: {v}" for k, v in data.items())
+    lines = "\n".join(f"[bold]{k}[/bold]: {_cell(v)}" for k, v in data.items())
     panel = Panel(lines, title=title)
     console.print(panel)
 

--- a/src/fabric_dw/cli/_render.py
+++ b/src/fabric_dw/cli/_render.py
@@ -89,7 +89,7 @@ def _render_table(rows: Sequence[object], *, console: Console, title: str | None
     for row in rows:
         if isinstance(row, dict):
             row_dict = {str(k): v for k, v in row.items()}
-            table.add_row(*[_cell(row_dict.get(col)) for col in columns])
+            table.add_row(*[_cell(row_dict.get(col, "")) for col in columns])
         else:
             table.add_row(_cell(row))
 

--- a/tests/unit/cli/test_render.py
+++ b/tests/unit/cli/test_render.py
@@ -143,6 +143,32 @@ class TestNullRendering:
         data = [{"label": "None"}]
         output = self._render_to_string(data)
         assert "None" in output
+        assert "NULL" not in output
+
+
+class TestSparseRowRendering:
+    """Rows missing a key render as blank; only explicit None renders as NULL."""
+
+    def _render_to_string(self, data: object) -> str:
+        sio = StringIO()
+        console = Console(file=sio, width=120, highlight=False, no_color=True)
+        render(data, json_output=False, console=console)
+        return sio.getvalue()
+
+    def test_missing_key_renders_as_blank_not_null(self) -> None:
+        """A row dict that has no entry for a column renders the cell blank, not NULL."""
+        # Row 1 has both keys; row 2 is missing 'score' → should be blank
+        data = [{"id": "abc", "score": 42}, {"id": "def"}]
+        output = self._render_to_string(data)
+        # The column exists (inferred from row 1) but row 2's cell must NOT say NULL
+        assert "NULL" not in output
+
+    def test_explicit_none_renders_as_null(self) -> None:
+        """A row dict with an explicit None value renders as NULL, not blank."""
+        data = [{"id": "abc", "score": None}]
+        output = self._render_to_string(data)
+        assert "NULL" in output
+        assert "None" not in output
 
 
 class TestConfirm:

--- a/tests/unit/cli/test_render.py
+++ b/tests/unit/cli/test_render.py
@@ -8,7 +8,7 @@ from io import StringIO
 import pytest
 from rich.console import Console
 
-from fabric_dw.cli._render import confirm, render
+from fabric_dw.cli._render import _cell, confirm, render
 
 
 class TestRenderJson:
@@ -90,6 +90,59 @@ class TestRenderTable:
         output = self._render_to_string([])
         # Should produce something (empty table) without crashing
         assert output is not None
+
+
+class TestCellHelper:
+    """_cell() converts values to Rich-markup strings for table cells."""
+
+    def test_none_renders_as_dim_null(self) -> None:
+        assert _cell(None) == "[dim]NULL[/dim]"
+
+    def test_string_value_is_unchanged(self) -> None:
+        assert _cell("hello") == "hello"
+
+    def test_integer_value_is_stringified(self) -> None:
+        assert _cell(42) == "42"
+
+    def test_literal_string_none_is_not_affected(self) -> None:
+        # The actual string "None" must NOT be changed — only Python None
+        assert _cell("None") == "None"
+
+
+class TestNullRendering:
+    """NULL values in table and panel output are rendered as dim 'NULL', not 'None'."""
+
+    def _render_to_string(self, data: object) -> str:
+        sio = StringIO()
+        console = Console(file=sio, width=120, highlight=False, no_color=True)
+        render(data, json_output=False, console=console)
+        return sio.getvalue()
+
+    def test_none_in_table_cell_renders_null(self) -> None:
+        data = [{"id": "abc", "score": None}]
+        output = self._render_to_string(data)
+        assert "NULL" in output
+        assert "None" not in output
+
+    def test_none_in_panel_value_renders_null(self) -> None:
+        data = {"id": "abc", "score": None}
+        output = self._render_to_string(data)
+        assert "NULL" in output
+        assert "None" not in output
+
+    def test_none_in_json_output_stays_null(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """JSON serialisation must NOT be affected — null stays null."""
+        data = [{"id": "abc", "score": None}]
+        render(data, json_output=True)
+        captured = capsys.readouterr()
+        parsed = json.loads(captured.out)
+        assert parsed[0]["score"] is None
+
+    def test_literal_string_none_not_changed_in_table(self) -> None:
+        """A real string value 'None' must pass through unchanged."""
+        data = [{"label": "None"}]
+        output = self._render_to_string(data)
+        assert "None" in output
 
 
 class TestConfirm:


### PR DESCRIPTION
## Summary

- Adds a `_cell()` helper in `src/fabric_dw/cli/_render.py` that converts `None` to `[dim]NULL[/dim]` and all other values via `str()`
- `_render_table` and `_render_panel` both use `_cell()`, so the fix covers both output paths
- JSON serialisation is untouched — `null` stays `null`

## Test plan

- `TestCellHelper` — unit tests for `_cell()` directly, including asserting the literal string `"None"` is NOT affected
- `TestNullRendering` — integration-style render tests covering table cells, panel values, JSON passthrough, and literal-`"None"` preservation
- All 665 unit tests pass; ruff + ty clean

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)