### PR TITLE
feat(sql-pools): replace JSON-blob CLI with Azure-CLI-style sub-resource commands

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1055,13 +1055,13 @@ fabric-dw snapshots roll MyWorkspace SalesWH snap-june-2026 \
 ## fabric-dw sql-pools
 
 !!! warning "Beta / preview feature"
-    Manages workspace SQL Pools (currently in preview; the API may change before GA).
+    Manages workspace SQL Pools (currently in preview; the API may change before GA).  Callers must hold the **workspace admin role**.
 
-Manage custom SQL Pools configuration at the workspace level. Callers must hold the **workspace admin role**.
+Manage custom SQL Pools at the workspace level with sub-resource commands that mirror the Azure CLI style.
 
 ### sql-pools get
 
-Fetch the current SQL Pools configuration for a workspace.
+Fetch the full SQL Pools configuration (enabled flag + pool list) for a workspace.
 
 **Synopsis**
 
@@ -1077,42 +1077,125 @@ fabric-dw sql-pools get MyWorkspace
 
 ---
 
-### sql-pools set
+### sql-pools list
 
-Replace the SQL Pools configuration from a JSON file. This is a **destructive PATCH** — any pool not listed in the file is permanently deleted.
+List all SQL pools in a workspace.
 
 **Synopsis**
 
 ```
-fabric-dw sql-pools set [WORKSPACE] --from-file POOLS.JSON
+fabric-dw sql-pools list [WORKSPACE]
 ```
-
-| Option | Description |
-| --- | --- |
-| `--from-file PATH` | Path to a JSON file containing the full `SqlPoolsConfiguration` payload. (required) |
 
 **Example**
 
 ```shell
-fabric-dw sql-pools set MyWorkspace --from-file pools.json
+fabric-dw sql-pools list MyWorkspace
 ```
 
 ---
 
-### sql-pools edit
+### sql-pools show
 
-Open the current SQL Pools configuration in `$EDITOR` (or `$VISUAL`, or `vi`/`notepad`), then apply the modified version. Shows a diff and an explicit warning if any pool would be deleted before asking for confirmation.
+Show details for a single SQL pool.
 
 **Synopsis**
 
 ```
-fabric-dw sql-pools edit [WORKSPACE]
+fabric-dw sql-pools show [WORKSPACE] --name POOL
 ```
+
+| Option | Description |
+| --- | --- |
+| `--name TEXT` | Pool name to show. (required) |
 
 **Example**
 
 ```shell
-fabric-dw sql-pools edit MyWorkspace
+fabric-dw sql-pools show MyWorkspace --name ETL
+```
+
+---
+
+### sql-pools create
+
+Add a new SQL pool to a workspace.
+
+**Synopsis**
+
+```
+fabric-dw sql-pools create [OPTIONS] [WORKSPACE]
+```
+
+| Option | Description |
+| --- | --- |
+| `--name TEXT` | Pool name. (required) |
+| `--max-percent INTEGER` | Max resource percentage (1–100). (required) |
+| `--default` / `--no-default` | Mark as default pool. Default: `--no-default`. |
+| `--optimize-for-reads` / `--no-optimize-for-reads` | Enable read optimisation. Default: `--optimize-for-reads`. |
+| `--classifier-type TEXT` | Classifier type (e.g. `Application Name`). |
+| `--classifier-value TEXT` | Classifier value. Repeat for multiple values. |
+
+**Example**
+
+```shell
+fabric-dw sql-pools create MyWorkspace \
+  --name ETL \
+  --max-percent 30 \
+  --no-optimize-for-reads \
+  --classifier-type "Application Name" \
+  --classifier-value "ETL" \
+  --classifier-value "Load"
+```
+
+---
+
+### sql-pools update
+
+Update an existing SQL pool. Only the flags you provide are changed; all other fields are preserved.
+
+**Synopsis**
+
+```
+fabric-dw sql-pools update [OPTIONS] [WORKSPACE]
+```
+
+| Option | Description |
+| --- | --- |
+| `--name TEXT` | Pool name to update. (required) |
+| `--max-percent INTEGER` | New max resource percentage. |
+| `--default` / `--no-default` | Set or clear the default flag. |
+| `--optimize-for-reads` / `--no-optimize-for-reads` | Enable or disable read optimisation. |
+| `--classifier-type TEXT` | New classifier type. |
+| `--classifier-value TEXT` | New classifier value(s). Replaces all existing values. |
+
+**Example**
+
+```shell
+fabric-dw sql-pools update MyWorkspace --name ETL --max-percent 40
+```
+
+---
+
+### sql-pools delete
+
+Remove a SQL pool from a workspace. You will be asked to confirm unless `--yes` is passed.
+
+**Synopsis**
+
+```
+fabric-dw sql-pools delete [OPTIONS] [WORKSPACE]
+```
+
+| Option | Description |
+| --- | --- |
+| `--name TEXT` | Pool name to delete. (required) |
+| `--yes` | Skip confirmation prompt. |
+
+**Example**
+
+```shell
+fabric-dw --yes sql-pools delete MyWorkspace --name ETL
 ```
 
 ---
@@ -1149,6 +1232,28 @@ fabric-dw sql-pools disable [WORKSPACE]
 
 ```shell
 fabric-dw sql-pools disable MyWorkspace
+```
+
+---
+
+### sql-pools reset
+
+Clear all SQL pools for a workspace. The enabled/disabled state is preserved. You will be asked to confirm unless `--yes` is passed.
+
+**Synopsis**
+
+```
+fabric-dw sql-pools reset [OPTIONS] [WORKSPACE]
+```
+
+| Option | Description |
+| --- | --- |
+| `--yes` | Skip confirmation prompt. |
+
+**Example**
+
+```shell
+fabric-dw --yes sql-pools reset MyWorkspace
 ```
 
 ---

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -619,11 +619,11 @@ Truncate a SQL table (remove all rows, preserve structure).
 ## SQL Pools (beta)
 
 !!! warning "Beta / preview feature"
-    The four SQL Pools tools manage the workspace SQL Pools configuration (currently in preview; the API may change before GA). All callers must hold the **workspace admin role**.
+    The SQL Pools tools manage the workspace SQL Pools configuration (currently in preview; the API may change before GA). All callers must hold the **workspace admin role**.
 
 ### get_sql_pools_configuration
 
-Fetch the SQL Pools configuration for a workspace.
+Fetch the full SQL Pools configuration (enabled flag + pool list) for a workspace.
 
 **Parameters:**
 
@@ -633,20 +633,89 @@ Fetch the SQL Pools configuration for a workspace.
 
 ---
 
-### update_sql_pools_configuration
+### list_sql_pools
 
-Replace the SQL Pools configuration for a workspace.
-
-!!! danger "Destructive PATCH"
-    Any pool **not** present in `custom_sql_pools` will be permanently deleted.  Supply the full desired pool list every time.
+Return the list of SQL pools for a workspace.
 
 **Parameters:**
 
 - `workspace` (`str`) — workspace name or GUID.
-- `custom_sql_pools_enabled` (`bool`) — whether custom SQL Pools are active.
-- `custom_sql_pools` (`list[dict]`) — the complete pool list.  Each pool object must include at minimum `name` (str) and `maxResourcePercentage` (int, 1–100).  Optional fields: `isDefault` (bool), `optimizeForReads` (bool), `classifier` (object with `type` str and `value` list[str]).
 
-**Returns:** `SqlPoolsConfiguration` — the fresh configuration after the update.
+**Returns:** `list[SqlPool]` — array of pool objects, each with `name`, `isDefault`, `maxResourcePercentage`, `optimizeForReads`, and optional `classifier`.
+
+---
+
+### get_sql_pool
+
+Return details for a single SQL pool by name.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `pool_name` (`str`) — pool name.
+
+**Returns:** `SqlPool` — single pool object (fields as above).
+
+---
+
+### create_sql_pool
+
+Add a new SQL pool to a workspace.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `name` (`str`) — pool name (must be unique within the workspace).
+- `max_percent` (`int`) — max resource percentage (1–100).
+- `is_default` (`bool`, default `false`) — whether this is the default pool.
+- `optimize_for_reads` (`bool`, default `true`) — enable read optimisation.
+- `classifier_type` (`str | null`, optional) — classifier type (e.g. `"Application Name"`).
+- `classifier_values` (`list[str] | null`, optional) — classifier value list.
+
+**Returns:** `SqlPool` — the newly-created pool object.
+
+---
+
+### update_sql_pool
+
+Update an existing SQL pool.  Only the parameters you supply are changed; all other fields are preserved.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `name` (`str`) — name of the pool to update.
+- `max_percent` (`int | null`, optional) — new max resource percentage.
+- `is_default` (`bool | null`, optional) — set or clear the default flag.
+- `optimize_for_reads` (`bool | null`, optional) — enable or disable read optimisation.
+- `classifier_type` (`str | null`, optional) — new classifier type.
+- `classifier_values` (`list[str] | null`, optional) — new classifier value list (replaces all existing values).
+
+**Returns:** `SqlPool` — the updated pool object.
+
+---
+
+### delete_sql_pool
+
+Delete an SQL pool from a workspace.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `pool_name` (`str`) — name of the pool to delete.
+
+**Returns:** `{ "deleted": true, "pool_name": str }` — confirmation.
+
+---
+
+### reset_sql_pools
+
+Clear all SQL pools for a workspace.  The `customSQLPoolsEnabled` flag is preserved.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+
+**Returns:** `SqlPoolsConfiguration` — the updated configuration (with an empty pool list).
 
 ---
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -69,7 +69,7 @@ The equivalent `.mcp.json` snippet (project scope, `default` auth):
 }
 ```
 
-After adding, verify with `/mcp` inside a Claude Code session. You should see 22 tools including `list_workspaces`, `get_warehouse`, `kill_session`, and `clear_cache`.
+After adding, verify with `/mcp` inside a Claude Code session. You should see 27 tools including `list_workspaces`, `get_warehouse`, `kill_session`, and `clear_cache`.
 
 ## Cursor
 
@@ -311,7 +311,7 @@ Codex picks up config changes on the next invocation; no explicit reload is need
 
 ## Verifying
 
-After configuring your client, restart it and ask the assistant to list its available tools. You should see entries like `list_workspaces`, `get_warehouse`, `kill_session`, `clear_cache`, and 18 others (22 tools total).
+After configuring your client, restart it and ask the assistant to list its available tools. You should see entries like `list_workspaces`, `get_warehouse`, `kill_session`, `clear_cache`, and 23 others (27 tools total).
 
 ## Troubleshooting
 

--- a/src/fabric_dw/cli/commands/sql_pools.py
+++ b/src/fabric_dw/cli/commands/sql_pools.py
@@ -3,38 +3,25 @@
 .. warning::
    SQL Pools is a **beta / preview** feature.  The underlying API may change
    before general availability.
-
-.. warning::
-   ``sql-pools set`` and ``sql-pools edit`` use a **destructive PATCH** — any
-   pool *not* listed in the payload will be permanently deleted by the service.
-   Both commands surface this risk explicitly before applying changes.
 """
 
 from __future__ import annotations
 
-import difflib
-import json
 import logging
-import os
-import subprocess
-import sys
-import tempfile
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from pathlib import Path
 from uuid import UUID
 
 import click
-from pydantic import ValidationError
 
 from fabric_dw import auth as _auth
 from fabric_dw.cache import LookupCache
 from fabric_dw.cli._context import CliContext
 from fabric_dw.cli._render import confirm, render
 from fabric_dw.cli.commands._utils import _coro, resolve_workspace_arg
-from fabric_dw.exceptions import FabricError, PermissionDenied
+from fabric_dw.exceptions import AlreadyExists, FabricError, NotFound, PermissionDenied
 from fabric_dw.http_client import FabricHttpClient
-from fabric_dw.models import SqlPoolsConfiguration
+from fabric_dw.models import SqlPool, SqlPoolClassifier
 from fabric_dw.resolver import Resolver
 from fabric_dw.services import sql_pools as _svc
 
@@ -63,6 +50,11 @@ def sql_pools_group() -> None:
     """Manage workspace SQL Pools configuration (beta API)."""
 
 
+# ---------------------------------------------------------------------------
+# get
+# ---------------------------------------------------------------------------
+
+
 @sql_pools_group.command("get")
 @click.argument("workspace", required=False, default=None)
 @click.pass_obj
@@ -84,142 +76,259 @@ async def get_cmd(ctx: CliContext, workspace: str | None) -> None:
         raise click.ClickException(str(exc)) from exc
 
 
-@sql_pools_group.command("set")
+# ---------------------------------------------------------------------------
+# list
+# ---------------------------------------------------------------------------
+
+
+@sql_pools_group.command("list")
 @click.argument("workspace", required=False, default=None)
+@click.pass_obj
+@_coro
+async def list_cmd(ctx: CliContext, workspace: str | None) -> None:
+    """List all SQL pools in WORKSPACE."""
+    ws = resolve_workspace_arg(ctx, workspace)
+    try:
+        async with _build_http_client(ctx) as http:
+            ws_id = await _resolve_workspace(http, ws)
+            config = await _svc.get_configuration(http, ws_id)
+            pools = [p.model_dump(by_alias=True, mode="json") for p in config.custom_sql_pools]
+            render(pools, json_output=ctx.json_output)
+    except PermissionDenied as exc:
+        raise _permission_hint(exc) from exc
+    except FabricError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+# ---------------------------------------------------------------------------
+# show
+# ---------------------------------------------------------------------------
+
+
+@sql_pools_group.command("show")
+@click.argument("workspace", required=False, default=None)
+@click.option("--name", required=True, help="Name of the pool to show.")
+@click.pass_obj
+@_coro
+async def show_cmd(ctx: CliContext, workspace: str | None, name: str) -> None:
+    """Show details for a single SQL pool in WORKSPACE."""
+    ws = resolve_workspace_arg(ctx, workspace)
+    try:
+        async with _build_http_client(ctx) as http:
+            ws_id = await _resolve_workspace(http, ws)
+            config = await _svc.get_configuration(http, ws_id)
+            pool = next((p for p in config.custom_sql_pools if p.name == name), None)
+            if pool is None:
+                raise click.ClickException(f"pool {name!r} not found")  # noqa: TRY003, TRY301
+            render(pool.model_dump(by_alias=True, mode="json"), json_output=ctx.json_output)
+    except click.ClickException:
+        raise
+    except PermissionDenied as exc:
+        raise _permission_hint(exc) from exc
+    except FabricError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+# ---------------------------------------------------------------------------
+# create
+# ---------------------------------------------------------------------------
+
+
+@sql_pools_group.command("create")
+@click.argument("workspace", required=False, default=None)
+@click.option("--name", required=True, help="Pool name.")
 @click.option(
-    "--from-file",
-    "from_file",
+    "--max-percent",
+    "max_percent",
     required=True,
-    type=click.Path(exists=True, dir_okay=False, readable=True),
-    help="Path to a JSON file containing the full SqlPoolsConfiguration payload.",
+    type=int,
+    help="Max resource percentage (1-100).",
+)
+@click.option(
+    "--default/--no-default",
+    "is_default",
+    default=False,
+    show_default=True,
+    help="Mark pool as default.",
+)
+@click.option(
+    "--optimize-for-reads/--no-optimize-for-reads",
+    "optimize_for_reads",
+    default=True,
+    show_default=True,
+    help="Enable read optimisation.",
+)
+@click.option(
+    "--classifier-type",
+    "classifier_type",
+    default=None,
+    help="Classifier type (e.g. 'Application Name').",
+)
+@click.option(
+    "--classifier-value",
+    "classifier_values",
+    multiple=True,
+    help="Classifier value(s). Repeat for multiple values.",
 )
 @click.pass_obj
 @_coro
-async def set_cmd(ctx: CliContext, workspace: str | None, from_file: str) -> None:
-    """Replace the SQL Pools configuration for WORKSPACE from a JSON file.
-
-    \b
-    WARNING: This is a destructive PATCH — any pool NOT listed in the file
-    will be permanently deleted by the Fabric service.
-    """
+async def create_cmd(
+    ctx: CliContext,
+    workspace: str | None,
+    name: str,
+    max_percent: int,
+    is_default: bool,
+    optimize_for_reads: bool,
+    classifier_type: str | None,
+    classifier_values: tuple[str, ...],
+) -> None:
+    """Add a new SQL pool to WORKSPACE."""
     ws = resolve_workspace_arg(ctx, workspace)
-    raw_path = Path(from_file)
-    try:
-        payload = json.loads(raw_path.read_text())
-    except (OSError, json.JSONDecodeError) as exc:
-        raise click.ClickException(f"Cannot read {from_file}: {exc}") from exc  # noqa: TRY003
 
-    try:
-        config = SqlPoolsConfiguration.model_validate(payload)
-    except ValidationError as exc:
-        raise click.ClickException(f"Invalid configuration: {exc}") from exc  # noqa: TRY003
+    classifier: SqlPoolClassifier | None = None
+    if classifier_type is not None:
+        classifier = SqlPoolClassifier.model_validate(
+            {"type": classifier_type, "value": list(classifier_values)}
+        )
 
-    click.echo(
-        "WARNING: This is a destructive PATCH. Pools not in the file will be deleted.",
-        err=True,
+    pool = SqlPool.model_validate(
+        {
+            "name": name,
+            "isDefault": is_default,
+            "maxResourcePercentage": max_percent,
+            "optimizeForReads": optimize_for_reads,
+            "classifier": classifier.model_dump(by_alias=True, mode="json") if classifier else None,
+        }
     )
-    if not confirm("Apply configuration?", yes=ctx.yes):
-        raise click.Abort()
 
     try:
         async with _build_http_client(ctx) as http:
             ws_id = await _resolve_workspace(http, ws)
-            result = await _svc.update_configuration(http, ws_id, config)
-            render(
-                result.model_dump(by_alias=True, mode="json"),
-                json_output=ctx.json_output,
-            )
+            result = await _svc.create_pool(http, ws_id, pool)
+            render(result.model_dump(by_alias=True, mode="json"), json_output=ctx.json_output)
+    except AlreadyExists as exc:
+        raise click.ClickException(str(exc)) from exc
     except ValueError as exc:
-        raise click.ClickException(f"Invalid configuration: {exc}") from exc  # noqa: TRY003
+        raise click.ClickException(f"Invalid pool configuration: {exc}") from exc  # noqa: TRY003
     except PermissionDenied as exc:
         raise _permission_hint(exc) from exc
     except FabricError as exc:
         raise click.ClickException(str(exc)) from exc
 
 
-@sql_pools_group.command("edit")
+# ---------------------------------------------------------------------------
+# update
+# ---------------------------------------------------------------------------
+
+
+@sql_pools_group.command("update")
 @click.argument("workspace", required=False, default=None)
+@click.option("--name", required=True, help="Name of the pool to update.")
+@click.option(
+    "--max-percent",
+    "max_percent",
+    default=None,
+    type=int,
+    help="New max resource percentage (1-100).",
+)
+@click.option(
+    "--default/--no-default",
+    "is_default",
+    default=None,
+    help="Set or clear the default flag.",
+)
+@click.option(
+    "--optimize-for-reads/--no-optimize-for-reads",
+    "optimize_for_reads",
+    default=None,
+    help="Enable or disable read optimisation.",
+)
+@click.option(
+    "--classifier-type",
+    "classifier_type",
+    default=None,
+    help="New classifier type.",
+)
+@click.option(
+    "--classifier-value",
+    "classifier_values",
+    multiple=True,
+    help="New classifier value(s). Repeat for multiple values. Replaces all existing values.",
+)
 @click.pass_obj
 @_coro
-async def edit_cmd(ctx: CliContext, workspace: str | None) -> None:
-    """Open the current SQL Pools config in $EDITOR, then apply on save.
+async def update_cmd(
+    ctx: CliContext,
+    workspace: str | None,
+    name: str,
+    max_percent: int | None,
+    is_default: bool | None,
+    optimize_for_reads: bool | None,
+    classifier_type: str | None,
+    classifier_values: tuple[str, ...],
+) -> None:
+    """Update an existing SQL pool in WORKSPACE.
 
-    Shows a diff and asks for confirmation before applying if any pool
-    would be deleted (destructive PATCH semantics).
+    Only the flags you provide are changed; all other fields are preserved.
     """
     ws = resolve_workspace_arg(ctx, workspace)
+    cv: list[str] | None = list(classifier_values) if classifier_values else None
     try:
         async with _build_http_client(ctx) as http:
-            # Resolve the workspace ID once and reuse it for both GET and PATCH
-            # to avoid a TOCTOU issue if the workspace is renamed mid-edit.
             ws_id = await _resolve_workspace(http, ws)
-            current = await _svc.get_configuration(http, ws_id)
-
-            current_json = json.dumps(current.model_dump(by_alias=True, mode="json"), indent=2)
-
-            editor = os.environ.get("VISUAL") or os.environ.get("EDITOR") or _default_editor()
-
-            with tempfile.NamedTemporaryFile(
-                mode="w", suffix=".json", delete=False, prefix="fabric-dw-sql-pools-"
-            ) as tmp:
-                tmp.write(current_json)
-                tmp_path = tmp.name
-
-            try:
-                subprocess.run([editor, tmp_path], check=True)  # noqa: S603
-                edited_text = Path(tmp_path).read_text()
-            finally:
-                Path(tmp_path).unlink(missing_ok=True)
-
-            if edited_text.strip() == current_json.strip():
-                click.echo("No changes detected. Aborting.")
-                return
-
-            try:
-                new_payload = json.loads(edited_text)
-                new_config = SqlPoolsConfiguration.model_validate(new_payload)
-            except (json.JSONDecodeError, ValidationError) as exc:
-                raise click.ClickException(f"Invalid configuration after editing: {exc}") from exc  # noqa: TRY003
-
-            current_names = {p.name for p in current.custom_sql_pools}
-            new_names = {p.name for p in new_config.custom_sql_pools}
-            deleted_names = current_names - new_names
-
-            diff_lines = list(
-                difflib.unified_diff(
-                    current_json.splitlines(keepends=True),
-                    edited_text.splitlines(keepends=True),
-                    fromfile="current",
-                    tofile="new",
-                )
+            result = await _svc.update_pool(
+                http,
+                ws_id,
+                name,
+                max_resource_percentage=max_percent,
+                is_default=is_default,
+                optimize_for_reads=optimize_for_reads,
+                classifier_type=classifier_type,
+                classifier_values=cv,
             )
-            if diff_lines:
-                click.echo("".join(diff_lines))
-
-            if deleted_names:
-                click.echo(
-                    f"\nWARNING: The following pools will be DELETED: "
-                    f"{', '.join(sorted(deleted_names))}",
-                    err=True,
-                )
-
-            if not confirm("Apply configuration?", yes=ctx.yes):
-                raise click.Abort()  # noqa: TRY301
-
-            result = await _svc.update_configuration(http, ws_id, new_config)
-            render(
-                result.model_dump(by_alias=True, mode="json"),
-                json_output=ctx.json_output,
-            )
-
-    except click.Abort:
-        raise
+            render(result.model_dump(by_alias=True, mode="json"), json_output=ctx.json_output)
+    except NotFound as exc:
+        raise click.ClickException(str(exc)) from exc
     except ValueError as exc:
-        raise click.ClickException(f"Invalid configuration: {exc}") from exc  # noqa: TRY003
+        raise click.ClickException(f"Invalid pool configuration: {exc}") from exc  # noqa: TRY003
     except PermissionDenied as exc:
         raise _permission_hint(exc) from exc
     except FabricError as exc:
         raise click.ClickException(str(exc)) from exc
+
+
+# ---------------------------------------------------------------------------
+# delete
+# ---------------------------------------------------------------------------
+
+
+@sql_pools_group.command("delete")
+@click.argument("workspace", required=False, default=None)
+@click.option("--name", required=True, help="Name of the pool to delete.")
+@click.option("--yes", "yes", is_flag=True, default=False, help="Skip confirmation prompt.")
+@click.pass_obj
+@_coro
+async def delete_cmd(ctx: CliContext, workspace: str | None, name: str, yes: bool) -> None:
+    """Remove an SQL pool from WORKSPACE."""
+    ws = resolve_workspace_arg(ctx, workspace)
+    if not yes and not ctx.yes and not confirm(f"Delete pool {name!r}?", yes=False):
+        raise click.Abort()
+    try:
+        async with _build_http_client(ctx) as http:
+            ws_id = await _resolve_workspace(http, ws)
+            result = await _svc.delete_pool(http, ws_id, name)
+            render(result.model_dump(by_alias=True, mode="json"), json_output=ctx.json_output)
+    except NotFound as exc:
+        raise click.ClickException(str(exc)) from exc
+    except PermissionDenied as exc:
+        raise _permission_hint(exc) from exc
+    except FabricError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+# ---------------------------------------------------------------------------
+# enable / disable
+# ---------------------------------------------------------------------------
 
 
 @sql_pools_group.command("enable")
@@ -267,8 +376,27 @@ async def disable_cmd(ctx: CliContext, workspace: str | None) -> None:
         raise click.ClickException(str(exc)) from exc
 
 
-def _default_editor() -> str:
-    """Return a sensible default editor when neither $VISUAL nor $EDITOR is set."""
-    if sys.platform == "win32":
-        return "notepad"
-    return "vi"
+# ---------------------------------------------------------------------------
+# reset
+# ---------------------------------------------------------------------------
+
+
+@sql_pools_group.command("reset")
+@click.argument("workspace", required=False, default=None)
+@click.option("--yes", "yes", is_flag=True, default=False, help="Skip confirmation prompt.")
+@click.pass_obj
+@_coro
+async def reset_cmd(ctx: CliContext, workspace: str | None, yes: bool) -> None:
+    """Clear all SQL pools for WORKSPACE (preserves enabled/disabled state)."""
+    ws = resolve_workspace_arg(ctx, workspace)
+    if not yes and not ctx.yes and not confirm("Clear all SQL pools?", yes=False):
+        raise click.Abort()
+    try:
+        async with _build_http_client(ctx) as http:
+            ws_id = await _resolve_workspace(http, ws)
+            result = await _svc.reset_pools(http, ws_id)
+            render(result.model_dump(by_alias=True, mode="json"), json_output=ctx.json_output)
+    except PermissionDenied as exc:
+        raise _permission_hint(exc) from exc
+    except FabricError as exc:
+        raise click.ClickException(str(exc)) from exc

--- a/src/fabric_dw/exceptions.py
+++ b/src/fabric_dw/exceptions.py
@@ -22,6 +22,10 @@ class FabricServerError(FabricError):
     """Raised on persistent 5xx errors or a failed LRO operation."""
 
 
+class AlreadyExists(FabricError):  # noqa: N818
+    """Raised when a resource with the given name already exists."""
+
+
 class ConfigError(FabricError):
     """Raised when required configuration is missing or invalid."""
 

--- a/src/fabric_dw/mcp/server.py
+++ b/src/fabric_dw/mcp/server.py
@@ -1474,6 +1474,10 @@ async def reset_sql_pools(workspace: str) -> dict[str, Any]:
     """Clear all SQL pools for a workspace, preserving the enabled/disabled state.
 
     Requires workspace admin role.  This tool targets a **beta / preview** API.
+
+    CAUTION: this permanently removes ALL pool definitions in the workspace. The
+    configuration's enabled-state is preserved, but every pool is wiped. Use only
+    when the user explicitly requests a reset.
     """
     try:
         ws_id = await _get_resolver().workspace_id(workspace)

--- a/src/fabric_dw/mcp/server.py
+++ b/src/fabric_dw/mcp/server.py
@@ -28,10 +28,10 @@ from mcp.server.fastmcp.exceptions import ToolError
 
 from fabric_dw import auth as _auth
 from fabric_dw.cache import LookupCache
-from fabric_dw.exceptions import ConfigError, FabricError
+from fabric_dw.exceptions import AlreadyExists, ConfigError, FabricError, NotFound
 from fabric_dw.http_client import FabricHttpClient
 from fabric_dw.logging import setup_logging
-from fabric_dw.models import SqlPoolsConfiguration
+from fabric_dw.models import SqlPool, SqlPoolClassifier
 from fabric_dw.resolver import Resolver
 from fabric_dw.services import audit, queries, snapshots, sql_endpoints, warehouses, workspaces
 from fabric_dw.services import ownership as ownership_svc
@@ -1303,7 +1303,7 @@ async def clear_table(workspace: str, item: str, qualified_name: str) -> dict[st
 
 @mcp.tool()
 async def get_sql_pools_configuration(workspace: str) -> dict[str, Any]:
-    """Fetch the SQL Pools configuration for a workspace.
+    """Fetch the full SQL Pools configuration (enabled flag + pool list) for a workspace.
 
     Requires workspace admin role.  This tool targets a **beta / preview** API
     endpoint that may change before general availability.
@@ -1317,39 +1317,167 @@ async def get_sql_pools_configuration(workspace: str) -> dict[str, Any]:
 
 
 @mcp.tool()
-async def update_sql_pools_configuration(
-    workspace: str,
-    custom_sql_pools_enabled: bool,  # noqa: FBT001
-    custom_sql_pools: list[dict[str, Any]],
-) -> dict[str, Any]:
-    """Replace the SQL Pools configuration for a workspace.
-
-    **DESTRUCTIVE PATCH**: any pool not present in *custom_sql_pools* will be
-    permanently deleted.  Supply the full desired pool list.
+async def list_sql_pools(workspace: str) -> list[dict[str, Any]]:
+    """Return the list of custom SQL pools for a workspace.
 
     Requires workspace admin role.  This tool targets a **beta / preview** API.
+    """
+    try:
+        ws_id = await _get_resolver().workspace_id(workspace)
+        config = await sql_pools_svc.get_configuration(_get_http(), ws_id)
+    except FabricError as exc:
+        raise _fabric_err(exc) from exc
+    return [p.model_dump(by_alias=True, mode="json") for p in config.custom_sql_pools]
+
+
+@mcp.tool()
+async def get_sql_pool(workspace: str, pool_name: str) -> dict[str, Any]:
+    """Return details for a single SQL pool by name.
 
     Args:
         workspace: Workspace name or GUID.
-        custom_sql_pools_enabled: Whether custom SQL Pools are active.
-        custom_sql_pools: Full list of pool objects.  Each must have at minimum
-            ``name`` (str) and ``maxResourcePercentage`` (int 1-100).
-            Optional fields: ``isDefault`` (bool), ``optimizeForReads`` (bool),
-            ``classifier`` (object with ``type`` str and ``value`` list[str]).
+        pool_name: The pool name.
+
+    Requires workspace admin role.  This tool targets a **beta / preview** API.
     """
     try:
-        config = SqlPoolsConfiguration.model_validate(
+        ws_id = await _get_resolver().workspace_id(workspace)
+        config = await sql_pools_svc.get_configuration(_get_http(), ws_id)
+    except FabricError as exc:
+        raise _fabric_err(exc) from exc
+    pool = next((p for p in config.custom_sql_pools if p.name == pool_name), None)
+    if pool is None:
+        raise ToolError(f"pool {pool_name!r} not found")  # noqa: TRY003
+    return pool.model_dump(by_alias=True, mode="json")
+
+
+@mcp.tool()
+async def create_sql_pool(  # noqa: PLR0913
+    workspace: str,
+    name: str,
+    max_percent: int,
+    is_default: bool = False,  # noqa: FBT001, FBT002
+    optimize_for_reads: bool = True,  # noqa: FBT001, FBT002
+    classifier_type: str | None = None,
+    classifier_values: list[str] | None = None,
+) -> dict[str, Any]:
+    """Add a new custom SQL pool to a workspace.
+
+    Args:
+        workspace: Workspace name or GUID.
+        name: Pool name (must be unique within the workspace).
+        max_percent: Max resource percentage (1-100).
+        is_default: Whether this pool is the default pool. Defaults to false.
+        optimize_for_reads: Enable read optimisation. Defaults to true.
+        classifier_type: Classifier type (e.g. ``"Application Name"``).
+        classifier_values: List of classifier values (e.g. application names).
+
+    Requires workspace admin role.  This tool targets a **beta / preview** API.
+    """
+    classifier: SqlPoolClassifier | None = None
+    if classifier_type is not None:
+        classifier = SqlPoolClassifier.model_validate(
+            {"type": classifier_type, "value": classifier_values or []}
+        )
+
+    try:
+        pool = SqlPool.model_validate(
             {
-                "customSQLPoolsEnabled": custom_sql_pools_enabled,
-                "customSQLPools": custom_sql_pools,
+                "name": name,
+                "isDefault": is_default,
+                "maxResourcePercentage": max_percent,
+                "optimizeForReads": optimize_for_reads,
+                "classifier": (
+                    classifier.model_dump(by_alias=True, mode="json") if classifier else None
+                ),
             }
         )
     except Exception as exc:
-        raise ToolError(f"Invalid configuration: {exc}") from exc  # noqa: TRY003
+        raise ToolError(f"Invalid pool: {exc}") from exc  # noqa: TRY003
 
     try:
         ws_id = await _get_resolver().workspace_id(workspace)
-        result = await sql_pools_svc.update_configuration(_get_http(), ws_id, config)
+        result = await sql_pools_svc.create_pool(_get_http(), ws_id, pool)
+    except AlreadyExists as exc:
+        raise ToolError(str(exc)) from exc
+    except FabricError as exc:
+        raise _fabric_err(exc) from exc
+    created = next(p for p in result.custom_sql_pools if p.name == name)
+    return created.model_dump(by_alias=True, mode="json")
+
+
+@mcp.tool()
+async def update_sql_pool(  # noqa: PLR0913
+    workspace: str,
+    name: str,
+    max_percent: int | None = None,
+    is_default: bool | None = None,  # noqa: FBT001
+    optimize_for_reads: bool | None = None,  # noqa: FBT001
+    classifier_type: str | None = None,
+    classifier_values: list[str] | None = None,
+) -> dict[str, Any]:
+    """Update an existing SQL pool.  Only the parameters you supply are changed.
+
+    Args:
+        workspace: Workspace name or GUID.
+        name: Name of the pool to update.
+        max_percent: New max resource percentage (1-100), or omit to keep current.
+        is_default: Set or clear the default flag, or omit to keep current.
+        optimize_for_reads: Enable/disable read optimisation, or omit to keep current.
+        classifier_type: New classifier type, or omit to keep current.
+        classifier_values: New classifier value list, or omit to keep current.
+
+    Requires workspace admin role.  This tool targets a **beta / preview** API.
+    """
+    try:
+        ws_id = await _get_resolver().workspace_id(workspace)
+        result = await sql_pools_svc.update_pool(
+            _get_http(),
+            ws_id,
+            name,
+            max_resource_percentage=max_percent,
+            is_default=is_default,
+            optimize_for_reads=optimize_for_reads,
+            classifier_type=classifier_type,
+            classifier_values=classifier_values,
+        )
+    except NotFound as exc:
+        raise ToolError(str(exc)) from exc
+    except FabricError as exc:
+        raise _fabric_err(exc) from exc
+    updated = next(p for p in result.custom_sql_pools if p.name == name)
+    return updated.model_dump(by_alias=True, mode="json")
+
+
+@mcp.tool()
+async def delete_sql_pool(workspace: str, pool_name: str) -> dict[str, Any]:
+    """Delete an SQL pool from a workspace.
+
+    Args:
+        workspace: Workspace name or GUID.
+        pool_name: Name of the pool to delete.
+
+    Requires workspace admin role.  This tool targets a **beta / preview** API.
+    """
+    try:
+        ws_id = await _get_resolver().workspace_id(workspace)
+        await sql_pools_svc.delete_pool(_get_http(), ws_id, pool_name)
+    except NotFound as exc:
+        raise ToolError(str(exc)) from exc
+    except FabricError as exc:
+        raise _fabric_err(exc) from exc
+    return {"deleted": True, "pool_name": pool_name}
+
+
+@mcp.tool()
+async def reset_sql_pools(workspace: str) -> dict[str, Any]:
+    """Clear all SQL pools for a workspace, preserving the enabled/disabled state.
+
+    Requires workspace admin role.  This tool targets a **beta / preview** API.
+    """
+    try:
+        ws_id = await _get_resolver().workspace_id(workspace)
+        result = await sql_pools_svc.reset_pools(_get_http(), ws_id)
     except FabricError as exc:
         raise _fabric_err(exc) from exc
     return result.model_dump(by_alias=True, mode="json")

--- a/src/fabric_dw/services/sql_pools.py
+++ b/src/fabric_dw/services/sql_pools.py
@@ -23,14 +23,19 @@ from __future__ import annotations
 
 from uuid import UUID
 
+from fabric_dw.exceptions import AlreadyExists, NotFound
 from fabric_dw.http_client import FabricHttpClient, HttpBase
-from fabric_dw.models import SqlPoolsConfiguration
+from fabric_dw.models import SqlPool, SqlPoolsConfiguration
 
 __all__ = [
+    "create_pool",
+    "delete_pool",
     "disable",
     "enable",
     "get_configuration",
+    "reset_pools",
     "update_configuration",
+    "update_pool",
 ]
 
 # The beta query parameter — centralised so removing it later is a one-liner.
@@ -180,3 +185,178 @@ async def disable(
         }
     )
     return await update_configuration(http, workspace_id, disabled_config)
+
+
+async def create_pool(
+    http: FabricHttpClient,
+    workspace_id: UUID,
+    pool: SqlPool,
+) -> SqlPoolsConfiguration:
+    """Add a new pool to the workspace SQL Pools configuration.
+
+    Fetches the current pool list, appends the new pool, and PATCHes the full
+    list back.  Raises :class:`~fabric_dw.exceptions.AlreadyExists` if a pool
+    with the same name already exists.
+
+    Args:
+        http: An authenticated :class:`~fabric_dw.http_client.FabricHttpClient`.
+        workspace_id: The Fabric workspace UUID.
+        pool: The new :class:`~fabric_dw.models.SqlPool` to create.
+
+    Returns:
+        The updated :class:`~fabric_dw.models.SqlPoolsConfiguration`.
+
+    Raises:
+        AlreadyExists: If a pool with ``pool.name`` already exists.
+        PermissionDenied: If the caller does not have the workspace admin role.
+    """
+    current = await get_configuration(http, workspace_id)
+    if any(p.name == pool.name for p in current.custom_sql_pools):
+        msg = f"pool {pool.name!r} already exists; use update to modify it"
+        raise AlreadyExists(msg)
+    new_pools = [*current.custom_sql_pools, pool]
+    new_config = SqlPoolsConfiguration.model_validate(
+        {
+            "customSQLPoolsEnabled": current.custom_sql_pools_enabled,
+            "customSQLPools": [p.model_dump(by_alias=True, mode="json") for p in new_pools],
+        }
+    )
+    return await update_configuration(http, workspace_id, new_config)
+
+
+async def update_pool(
+    http: FabricHttpClient,
+    workspace_id: UUID,
+    name: str,
+    *,
+    max_resource_percentage: int | None = None,
+    is_default: bool | None = None,
+    optimize_for_reads: bool | None = None,
+    classifier_type: str | None = None,
+    classifier_values: list[str] | None = None,
+) -> SqlPoolsConfiguration:
+    """Update an existing pool in the workspace SQL Pools configuration.
+
+    Fetches the current pool list, finds the named pool, applies only the
+    provided field overrides, then PATCHes the full list back.  Fields not
+    supplied are left unchanged.
+
+    Args:
+        http: An authenticated :class:`~fabric_dw.http_client.FabricHttpClient`.
+        workspace_id: The Fabric workspace UUID.
+        name: The name of the pool to update.
+        max_resource_percentage: New max-resource-percentage (1-100), or ``None`` to keep.
+        is_default: New default flag, or ``None`` to keep.
+        optimize_for_reads: New optimize-for-reads flag, or ``None`` to keep.
+        classifier_type: New classifier type string, or ``None`` to keep.
+        classifier_values: New classifier value list, or ``None`` to keep.
+
+    Returns:
+        The updated :class:`~fabric_dw.models.SqlPoolsConfiguration`.
+
+    Raises:
+        NotFound: If no pool named ``name`` exists.
+        PermissionDenied: If the caller does not have the workspace admin role.
+    """
+    current = await get_configuration(http, workspace_id)
+    existing = next((p for p in current.custom_sql_pools if p.name == name), None)
+    if existing is None:
+        msg = f"pool {name!r} not found; use create to add it"
+        raise NotFound(msg)
+
+    raw = existing.model_dump(by_alias=True, mode="json")
+    if max_resource_percentage is not None:
+        raw["maxResourcePercentage"] = max_resource_percentage
+    if is_default is not None:
+        raw["isDefault"] = is_default
+    if optimize_for_reads is not None:
+        raw["optimizeForReads"] = optimize_for_reads
+    if classifier_type is not None or classifier_values is not None:
+        existing_cls = raw.get("classifier") or {}
+        updated_cls = {
+            "type": (
+                classifier_type if classifier_type is not None else existing_cls.get("type", "")
+            ),
+            "value": (
+                classifier_values
+                if classifier_values is not None
+                else existing_cls.get("value", [])
+            ),
+        }
+        raw["classifier"] = updated_cls
+
+    new_pool = SqlPool.model_validate(raw)
+    new_pools = [new_pool if p.name == name else p for p in current.custom_sql_pools]
+    new_config = SqlPoolsConfiguration.model_validate(
+        {
+            "customSQLPoolsEnabled": current.custom_sql_pools_enabled,
+            "customSQLPools": [p.model_dump(by_alias=True, mode="json") for p in new_pools],
+        }
+    )
+    return await update_configuration(http, workspace_id, new_config)
+
+
+async def delete_pool(
+    http: FabricHttpClient,
+    workspace_id: UUID,
+    name: str,
+) -> SqlPoolsConfiguration:
+    """Remove a pool from the workspace SQL Pools configuration.
+
+    Fetches the current pool list, drops the named pool, and PATCHes the
+    remaining list back.  Raises :class:`~fabric_dw.exceptions.NotFound` if no
+    pool with that name exists.
+
+    Args:
+        http: An authenticated :class:`~fabric_dw.http_client.FabricHttpClient`.
+        workspace_id: The Fabric workspace UUID.
+        name: The name of the pool to delete.
+
+    Returns:
+        The updated :class:`~fabric_dw.models.SqlPoolsConfiguration`.
+
+    Raises:
+        NotFound: If no pool named ``name`` exists.
+        PermissionDenied: If the caller does not have the workspace admin role.
+    """
+    current = await get_configuration(http, workspace_id)
+    if not any(p.name == name for p in current.custom_sql_pools):
+        msg = f"pool {name!r} not found"
+        raise NotFound(msg)
+    new_pools = [p for p in current.custom_sql_pools if p.name != name]
+    new_config = SqlPoolsConfiguration.model_validate(
+        {
+            "customSQLPoolsEnabled": current.custom_sql_pools_enabled,
+            "customSQLPools": [p.model_dump(by_alias=True, mode="json") for p in new_pools],
+        }
+    )
+    return await update_configuration(http, workspace_id, new_config)
+
+
+async def reset_pools(
+    http: FabricHttpClient,
+    workspace_id: UUID,
+) -> SqlPoolsConfiguration:
+    """Clear all custom pools for a workspace, preserving the enabled flag.
+
+    Fetches the current configuration, replaces ``customSQLPools`` with an
+    empty list, and PATCHes.  ``customSQLPoolsEnabled`` is left unchanged.
+
+    Args:
+        http: An authenticated :class:`~fabric_dw.http_client.FabricHttpClient`.
+        workspace_id: The Fabric workspace UUID.
+
+    Returns:
+        The updated :class:`~fabric_dw.models.SqlPoolsConfiguration`.
+
+    Raises:
+        PermissionDenied: If the caller does not have the workspace admin role.
+    """
+    current = await get_configuration(http, workspace_id)
+    new_config = SqlPoolsConfiguration.model_validate(
+        {
+            "customSQLPoolsEnabled": current.custom_sql_pools_enabled,
+            "customSQLPools": [],
+        }
+    )
+    return await update_configuration(http, workspace_id, new_config)

--- a/src/fabric_dw/services/sql_pools.py
+++ b/src/fabric_dw/services/sql_pools.py
@@ -198,6 +198,10 @@ async def create_pool(
     list back.  Raises :class:`~fabric_dw.exceptions.AlreadyExists` if a pool
     with the same name already exists.
 
+    Note: not locked. Two simultaneous create_pool calls with the same name
+    will both pass the duplicate check and the second's PATCH will overwrite
+    the first.
+
     Args:
         http: An authenticated :class:`~fabric_dw.http_client.FabricHttpClient`.
         workspace_id: The Fabric workspace UUID.
@@ -241,6 +245,10 @@ async def update_pool(
     provided field overrides, then PATCHes the full list back.  Fields not
     supplied are left unchanged.
 
+    Note: setting is_default=True does NOT automatically clear is_default on
+    other pools. The caller must explicitly unset it on the previous default
+    if the API rejects multiple defaults.
+
     Args:
         http: An authenticated :class:`~fabric_dw.http_client.FabricHttpClient`.
         workspace_id: The Fabric workspace UUID.
@@ -255,9 +263,15 @@ async def update_pool(
         The updated :class:`~fabric_dw.models.SqlPoolsConfiguration`.
 
     Raises:
+        ValueError: If exactly one of ``classifier_type`` / ``classifier_values``
+            is supplied without the other (both must be provided together, or
+            neither).
         NotFound: If no pool named ``name`` exists.
         PermissionDenied: If the caller does not have the workspace admin role.
     """
+    if (classifier_type is None) != (classifier_values is None):
+        msg = "classifier_type and classifier_values must be provided together (or neither)"
+        raise ValueError(msg)
     current = await get_configuration(http, workspace_id)
     existing = next((p for p in current.custom_sql_pools if p.name == name), None)
     if existing is None:
@@ -342,17 +356,28 @@ async def reset_pools(
     Fetches the current configuration, replaces ``customSQLPools`` with an
     empty list, and PATCHes.  ``customSQLPoolsEnabled`` is left unchanged.
 
+    If the workspace has never been provisioned (GET returns 404), the
+    endpoint is already in the desired empty state.  A sentinel
+    ``SqlPoolsConfiguration(custom_sql_pools_enabled=False, custom_sql_pools=[])``
+    is returned without making a PATCH request.
+
     Args:
         http: An authenticated :class:`~fabric_dw.http_client.FabricHttpClient`.
         workspace_id: The Fabric workspace UUID.
 
     Returns:
-        The updated :class:`~fabric_dw.models.SqlPoolsConfiguration`.
+        The updated :class:`~fabric_dw.models.SqlPoolsConfiguration` (or the
+        sentinel configuration when the workspace was not provisioned).
 
     Raises:
         PermissionDenied: If the caller does not have the workspace admin role.
     """
-    current = await get_configuration(http, workspace_id)
+    try:
+        current = await get_configuration(http, workspace_id)
+    except NotFound:
+        return SqlPoolsConfiguration.model_validate(
+            {"customSQLPoolsEnabled": False, "customSQLPools": []}
+        )
     new_config = SqlPoolsConfiguration.model_validate(
         {
             "customSQLPoolsEnabled": current.custom_sql_pools_enabled,

--- a/tests/integration/test_services_sql_pools.py
+++ b/tests/integration/test_services_sql_pools.py
@@ -8,8 +8,9 @@ from uuid import UUID
 
 import pytest
 
+from fabric_dw.exceptions import AlreadyExists, NotFound
 from fabric_dw.http_client import FabricHttpClient
-from fabric_dw.models import SqlPoolsConfiguration
+from fabric_dw.models import SqlPool, SqlPoolsConfiguration
 from fabric_dw.services import sql_pools
 
 pytestmark = pytest.mark.integration
@@ -53,15 +54,69 @@ async def test_enable_disable_roundtrip(http: FabricHttpClient, workspace_id: UU
         await sql_pools.update_configuration(http, workspace_id, original)
 
 
-async def test_update_configuration_roundtrip(http: FabricHttpClient, workspace_id: UUID) -> None:
+async def test_create_update_delete_roundtrip(http: FabricHttpClient, workspace_id: UUID) -> None:
+    """Integration test: create → update → delete roundtrip for a single pool."""
     original = await sql_pools.get_configuration(http, workspace_id)
 
-    test_config = SqlPoolsConfiguration.model_validate(
+    pool_name = "pytest-integration-pool"
+
+    try:
+        # Create
+        new_pool = SqlPool.model_validate(
+            {
+                "name": pool_name,
+                "isDefault": False,
+                "maxResourcePercentage": 10,
+                "optimizeForReads": True,
+                "classifier": {
+                    "type": "Application Name",
+                    "value": ["pytest-app"],
+                },
+            }
+        )
+        after_create = await sql_pools.create_pool(http, workspace_id, new_pool)
+        created = next((p for p in after_create.custom_sql_pools if p.name == pool_name), None)
+        assert created is not None
+        assert created.max_resource_percentage == 10
+        assert created.optimize_for_reads is True
+
+        # Duplicate name must raise AlreadyExists
+        with pytest.raises(AlreadyExists):
+            await sql_pools.create_pool(http, workspace_id, new_pool)
+
+        # Update
+        after_update = await sql_pools.update_pool(
+            http, workspace_id, pool_name, max_resource_percentage=20, optimize_for_reads=False
+        )
+        updated = next((p for p in after_update.custom_sql_pools if p.name == pool_name), None)
+        assert updated is not None
+        assert updated.max_resource_percentage == 20
+        assert updated.optimize_for_reads is False
+        assert updated.classifier is not None
+        assert updated.classifier.value == ["pytest-app"]
+
+        # Delete
+        after_delete = await sql_pools.delete_pool(http, workspace_id, pool_name)
+        assert not any(p.name == pool_name for p in after_delete.custom_sql_pools)
+
+        # Missing name must raise NotFound
+        with pytest.raises(NotFound):
+            await sql_pools.delete_pool(http, workspace_id, pool_name)
+
+    finally:
+        await sql_pools.update_configuration(http, workspace_id, original)
+
+
+async def test_reset_pools(http: FabricHttpClient, workspace_id: UUID) -> None:
+    """reset_pools clears all pools while preserving the enabled flag."""
+    original = await sql_pools.get_configuration(http, workspace_id)
+
+    seed_config = SqlPoolsConfiguration.model_validate(
         {
             "customSQLPoolsEnabled": True,
             "customSQLPools": [
                 {
-                    "name": "pytest-pool",
+                    "name": "pytest-reset-pool",
                     "isDefault": True,
                     "maxResourcePercentage": 100,
                     "optimizeForReads": False,
@@ -71,9 +126,10 @@ async def test_update_configuration_roundtrip(http: FabricHttpClient, workspace_
     )
 
     try:
-        result = await sql_pools.update_configuration(http, workspace_id, test_config)
-        assert isinstance(result, SqlPoolsConfiguration)
-        pool_names = [p.name for p in result.custom_sql_pools]
-        assert "pytest-pool" in pool_names
+        await sql_pools.update_configuration(http, workspace_id, seed_config)
+
+        after_reset = await sql_pools.reset_pools(http, workspace_id)
+        assert after_reset.custom_sql_pools == []
+        assert after_reset.custom_sql_pools_enabled is True
     finally:
         await sql_pools.update_configuration(http, workspace_id, original)

--- a/tests/unit/cli/commands/test_sql_pools.py
+++ b/tests/unit/cli/commands/test_sql_pools.py
@@ -1,4 +1,4 @@
-"""Tests for sql-pools CLI sub-commands."""
+"""Tests for sql-pools CLI sub-commands (Azure-CLI-style sub-resource interface)."""
 
 from __future__ import annotations
 
@@ -13,8 +13,8 @@ import pytest
 from click.testing import CliRunner
 
 from fabric_dw.cli._main import cli
-from fabric_dw.exceptions import PermissionDenied
-from fabric_dw.models import SqlPoolsConfiguration
+from fabric_dw.exceptions import AlreadyExists, NotFound, PermissionDenied
+from fabric_dw.models import SqlPool, SqlPoolsConfiguration
 
 WS_GUID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
 WS_UUID = UUID(WS_GUID)
@@ -43,8 +43,35 @@ POOLS_DISABLED_PAYLOAD = {
     ],
 }
 
+POOLS_EMPTY_PAYLOAD = {
+    "customSQLPoolsEnabled": True,
+    "customSQLPools": [],
+}
+
+MULTI_POOL_PAYLOAD = {
+    "customSQLPoolsEnabled": True,
+    "customSQLPools": [
+        {
+            "name": "ETL",
+            "isDefault": False,
+            "maxResourcePercentage": 40,
+            "optimizeForReads": False,
+            "classifier": {"type": "Application Name", "value": ["ETL"]},
+        },
+        {
+            "name": "Reporting",
+            "isDefault": True,
+            "maxResourcePercentage": 60,
+            "optimizeForReads": True,
+            "classifier": {"type": "Application Name", "value": ["Reports"]},
+        },
+    ],
+}
+
 _CONFIG = SqlPoolsConfiguration.model_validate(POOLS_PAYLOAD)
 _CONFIG_DISABLED = SqlPoolsConfiguration.model_validate(POOLS_DISABLED_PAYLOAD)
+_CONFIG_EMPTY = SqlPoolsConfiguration.model_validate(POOLS_EMPTY_PAYLOAD)
+_CONFIG_MULTI = SqlPoolsConfiguration.model_validate(MULTI_POOL_PAYLOAD)
 
 
 @pytest.fixture
@@ -129,20 +156,242 @@ class TestSqlPoolsGet:
         assert "admin" in result.output.lower()
 
 
-class TestSqlPoolsSet:
-    def test_set_requires_from_file(self, runner: CliRunner, cache_env: Path) -> None:
+class TestSqlPoolsList:
+    def test_list_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
-        result = runner.invoke(cli, ["sql-pools", "set", WS_GUID])
-        assert result.exit_code != 0
-        assert "from-file" in result.output.lower() or "missing" in result.output.lower()
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql_pools._build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._resolve_workspace",
+                new=AsyncMock(return_value=WS_UUID),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._svc.get_configuration",
+                new=AsyncMock(return_value=_CONFIG_MULTI),
+            ),
+        ):
+            result = runner.invoke(cli, ["sql-pools", "list", WS_GUID])
+        assert result.exit_code == 0
 
-    def test_set_applies_from_file_with_yes(
-        self, runner: CliRunner, tmp_path: Path, cache_env: Path
+    def test_list_json_shows_pool_array(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql_pools._build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._resolve_workspace",
+                new=AsyncMock(return_value=WS_UUID),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._svc.get_configuration",
+                new=AsyncMock(return_value=_CONFIG_MULTI),
+            ),
+        ):
+            result = runner.invoke(cli, ["--json", "sql-pools", "list", WS_GUID])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert isinstance(data, list)
+        assert len(data) == 2
+        names = [p["name"] for p in data]
+        assert "ETL" in names
+        assert "Reporting" in names
+
+
+class TestSqlPoolsShow:
+    def test_show_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql_pools._build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._resolve_workspace",
+                new=AsyncMock(return_value=WS_UUID),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._svc.get_configuration",
+                new=AsyncMock(return_value=_CONFIG_MULTI),
+            ),
+        ):
+            result = runner.invoke(cli, ["sql-pools", "show", WS_GUID, "--name", "ETL"])
+        assert result.exit_code == 0
+
+    def test_show_missing_pool_exits_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql_pools._build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._resolve_workspace",
+                new=AsyncMock(return_value=WS_UUID),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._svc.get_configuration",
+                new=AsyncMock(return_value=_CONFIG_MULTI),
+            ),
+        ):
+            result = runner.invoke(cli, ["sql-pools", "show", WS_GUID, "--name", "DoesNotExist"])
+        assert result.exit_code != 0
+
+
+class TestSqlPoolsCreate:
+    def test_create_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_create = AsyncMock(return_value=_CONFIG)
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql_pools._build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._resolve_workspace",
+                new=AsyncMock(return_value=WS_UUID),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._svc.create_pool",
+                new=mock_create,
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "sql-pools",
+                    "create",
+                    WS_GUID,
+                    "--name",
+                    "NewPool",
+                    "--max-percent",
+                    "30",
+                    "--classifier-type",
+                    "Application Name",
+                    "--classifier-value",
+                    "App1",
+                ],
+            )
+        assert result.exit_code == 0
+        mock_create.assert_awaited_once()
+
+    def test_create_with_multiple_classifier_values(
+        self, runner: CliRunner, cache_env: Path
     ) -> None:
         _ = cache_env
-        pool_file = tmp_path / "pools.json"
-        pool_file.write_text(json.dumps(POOLS_PAYLOAD))
+        mock_create = AsyncMock(return_value=_CONFIG)
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql_pools._build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._resolve_workspace",
+                new=AsyncMock(return_value=WS_UUID),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._svc.create_pool",
+                new=mock_create,
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "sql-pools",
+                    "create",
+                    WS_GUID,
+                    "--name",
+                    "NewPool",
+                    "--max-percent",
+                    "30",
+                    "--classifier-type",
+                    "Application Name",
+                    "--classifier-value",
+                    "App1",
+                    "--classifier-value",
+                    "App2",
+                ],
+            )
+        assert result.exit_code == 0
+        call_args = mock_create.call_args
+        pool: SqlPool = call_args.args[2]
+        assert pool.classifier is not None
+        assert pool.classifier.value == ["App1", "App2"]
 
+    def test_create_already_exists_exits_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql_pools._build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._resolve_workspace",
+                new=AsyncMock(return_value=WS_UUID),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._svc.create_pool",
+                new=AsyncMock(side_effect=AlreadyExists("pool 'Default' already exists")),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "sql-pools",
+                    "create",
+                    WS_GUID,
+                    "--name",
+                    "Default",
+                    "--max-percent",
+                    "100",
+                ],
+            )
+        assert result.exit_code != 0
+        assert "already exists" in result.output.lower() or "Default" in result.output
+
+    def test_create_with_default_flag(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_create = AsyncMock(return_value=_CONFIG)
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql_pools._build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._resolve_workspace",
+                new=AsyncMock(return_value=WS_UUID),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._svc.create_pool",
+                new=mock_create,
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "sql-pools",
+                    "create",
+                    WS_GUID,
+                    "--name",
+                    "Defaults",
+                    "--max-percent",
+                    "100",
+                    "--default",
+                ],
+            )
+        assert result.exit_code == 0
+        call_args = mock_create.call_args
+        pool: SqlPool = call_args.args[2]
+        assert pool.is_default is True
+
+
+class TestSqlPoolsUpdate:
+    def test_update_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
         mock_update = AsyncMock(return_value=_CONFIG)
         with (
             patch(
@@ -154,43 +403,192 @@ class TestSqlPoolsSet:
                 new=AsyncMock(return_value=WS_UUID),
             ),
             patch(
-                "fabric_dw.cli.commands.sql_pools._svc.update_configuration",
+                "fabric_dw.cli.commands.sql_pools._svc.update_pool",
                 new=mock_update,
             ),
         ):
             result = runner.invoke(
-                cli, ["-y", "sql-pools", "set", WS_GUID, "--from-file", str(pool_file)]
+                cli,
+                [
+                    "sql-pools",
+                    "update",
+                    WS_GUID,
+                    "--name",
+                    "Default",
+                    "--max-percent",
+                    "50",
+                ],
             )
         assert result.exit_code == 0
         mock_update.assert_awaited_once()
 
-    def test_set_invalid_json_file_exits_nonzero(
-        self, runner: CliRunner, tmp_path: Path, cache_env: Path
-    ) -> None:
+    def test_update_not_found_exits_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
-        bad_file = tmp_path / "bad.json"
-        bad_file.write_text("{not valid json}")
-        result = runner.invoke(
-            cli, ["-y", "sql-pools", "set", WS_GUID, "--from-file", str(bad_file)]
-        )
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql_pools._build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._resolve_workspace",
+                new=AsyncMock(return_value=WS_UUID),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._svc.update_pool",
+                new=AsyncMock(side_effect=NotFound("pool 'NoPool' not found")),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "sql-pools",
+                    "update",
+                    WS_GUID,
+                    "--name",
+                    "NoPool",
+                    "--max-percent",
+                    "50",
+                ],
+            )
         assert result.exit_code != 0
 
-    def test_set_invalid_config_exits_nonzero(
-        self, runner: CliRunner, tmp_path: Path, cache_env: Path
+    def test_update_partial_flags_passed_correctly(
+        self, runner: CliRunner, cache_env: Path
     ) -> None:
         _ = cache_env
-        bad_payload = {
-            "customSQLPoolsEnabled": True,
-            "customSQLPools": [
-                {"name": "A", "isDefault": True, "maxResourcePercentage": 101},
-            ],
-        }
-        bad_file = tmp_path / "bad_config.json"
-        bad_file.write_text(json.dumps(bad_payload))
-        result = runner.invoke(
-            cli, ["-y", "sql-pools", "set", WS_GUID, "--from-file", str(bad_file)]
-        )
+        mock_update = AsyncMock(return_value=_CONFIG)
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql_pools._build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._resolve_workspace",
+                new=AsyncMock(return_value=WS_UUID),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._svc.update_pool",
+                new=mock_update,
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "sql-pools",
+                    "update",
+                    WS_GUID,
+                    "--name",
+                    "Default",
+                    "--no-optimize-for-reads",
+                ],
+            )
+        assert result.exit_code == 0
+        _, kwargs = mock_update.call_args
+        assert kwargs.get("optimize_for_reads") is False
+        assert kwargs.get("max_resource_percentage") is None
+
+    def test_update_with_is_default_toggle(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_update = AsyncMock(return_value=_CONFIG)
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql_pools._build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._resolve_workspace",
+                new=AsyncMock(return_value=WS_UUID),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._svc.update_pool",
+                new=mock_update,
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "sql-pools",
+                    "update",
+                    WS_GUID,
+                    "--name",
+                    "Default",
+                    "--no-default",
+                ],
+            )
+        assert result.exit_code == 0
+        _, kwargs = mock_update.call_args
+        assert kwargs.get("is_default") is False
+
+
+class TestSqlPoolsDelete:
+    def test_delete_exits_zero_with_yes(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_delete = AsyncMock(return_value=_CONFIG_EMPTY)
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql_pools._build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._resolve_workspace",
+                new=AsyncMock(return_value=WS_UUID),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._svc.delete_pool",
+                new=mock_delete,
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                ["-y", "sql-pools", "delete", WS_GUID, "--name", "Default"],
+            )
+        assert result.exit_code == 0
+        mock_delete.assert_awaited_once()
+
+    def test_delete_not_found_exits_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql_pools._build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._resolve_workspace",
+                new=AsyncMock(return_value=WS_UUID),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._svc.delete_pool",
+                new=AsyncMock(side_effect=NotFound("pool 'NoPool' not found")),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                ["-y", "sql-pools", "delete", WS_GUID, "--name", "NoPool"],
+            )
         assert result.exit_code != 0
+
+    def test_delete_403_shows_permission_hint(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql_pools._build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._resolve_workspace",
+                new=AsyncMock(return_value=WS_UUID),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._svc.delete_pool",
+                new=AsyncMock(side_effect=PermissionDenied("403")),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                ["-y", "sql-pools", "delete", WS_GUID, "--name", "Default"],
+            )
+        assert result.exit_code != 0
+        assert "admin" in result.output.lower()
 
 
 class TestSqlPoolsEnable:
@@ -253,3 +651,46 @@ class TestSqlPoolsDisable:
         ):
             result = runner.invoke(cli, ["sql-pools", "disable", WS_GUID])
         assert result.exit_code == 0
+
+
+class TestSqlPoolsReset:
+    def test_reset_exits_zero_with_yes(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_reset = AsyncMock(return_value=_CONFIG_EMPTY)
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql_pools._build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._resolve_workspace",
+                new=AsyncMock(return_value=WS_UUID),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._svc.reset_pools",
+                new=mock_reset,
+            ),
+        ):
+            result = runner.invoke(cli, ["-y", "sql-pools", "reset", WS_GUID])
+        assert result.exit_code == 0
+        mock_reset.assert_awaited_once()
+
+    def test_reset_403_shows_permission_hint(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql_pools._build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._resolve_workspace",
+                new=AsyncMock(return_value=WS_UUID),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._svc.reset_pools",
+                new=AsyncMock(side_effect=PermissionDenied("403")),
+            ),
+        ):
+            result = runner.invoke(cli, ["-y", "sql-pools", "reset", WS_GUID])
+        assert result.exit_code != 0
+        assert "admin" in result.output.lower()

--- a/tests/unit/services/test_sql_pools.py
+++ b/tests/unit/services/test_sql_pools.py
@@ -15,9 +15,9 @@ from azure.core.credentials import AccessToken
 from azure.core.credentials_async import AsyncTokenCredential
 from pydantic import ValidationError
 
-from fabric_dw.exceptions import NotFound, PermissionDenied
+from fabric_dw.exceptions import AlreadyExists, NotFound, PermissionDenied
 from fabric_dw.http_client import FabricHttpClient
-from fabric_dw.models import SqlPoolsConfiguration
+from fabric_dw.models import SqlPool, SqlPoolsConfiguration
 from fabric_dw.services import sql_pools
 
 # ---------------------------------------------------------------------------
@@ -486,3 +486,308 @@ def test_model_handles_open_classifier_type() -> None:
     )
     assert config.custom_sql_pools[0].classifier is not None
     assert config.custom_sql_pools[0].classifier.type == "Future Type Not Yet In SDK"
+
+
+# Pool payload with headroom for adding another pool (total = 80%)
+_POOLS_WITH_HEADROOM: dict[str, object] = {
+    "customSQLPoolsEnabled": True,
+    "customSQLPools": [
+        {
+            "name": "ETL",
+            "isDefault": False,
+            "maxResourcePercentage": 40,
+            "optimizeForReads": False,
+            "classifier": {"type": "Application Name", "value": ["ETL", "Load"]},
+        },
+        {
+            "name": "Reporting",
+            "isDefault": True,
+            "maxResourcePercentage": 40,
+            "optimizeForReads": True,
+            "classifier": {"type": "Application Name", "value": ["Reports"]},
+        },
+    ],
+}
+
+
+# ---------------------------------------------------------------------------
+# create_pool
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_pool_appends_and_patches() -> None:
+    """create_pool should GET, append the new pool, and PATCH the full list."""
+    new_pool = SqlPool.model_validate(
+        {
+            "name": "NewPool",
+            "isDefault": False,
+            "maxResourcePercentage": 20,
+            "optimizeForReads": True,
+            "classifier": {"type": "Application Name", "value": ["App1"]},
+        }
+    )
+    with respx.mock:
+        respx.get(_CONFIG_URL).mock(
+            side_effect=[
+                httpx.Response(200, json=_POOLS_WITH_HEADROOM),
+                httpx.Response(200, json=_POOLS_WITH_HEADROOM),
+            ]
+        )
+        patch_route = respx.patch(_CONFIG_URL).mock(return_value=httpx.Response(200))
+        client = await _make_client()
+        async with client:
+            await sql_pools.create_pool(client, _WS_ID, new_pool)
+
+    assert patch_route.called
+    sent_body = json.loads(patch_route.calls[0].request.content)
+    pool_names = [p["name"] for p in sent_body["customSQLPools"]]
+    assert "NewPool" in pool_names
+    assert len(pool_names) == 3  # 2 original + 1 new
+
+
+@pytest.mark.asyncio
+async def test_create_pool_raises_already_exists_on_duplicate() -> None:
+    """create_pool should raise AlreadyExists when the pool name already exists."""
+    duplicate_pool = SqlPool.model_validate(
+        {
+            "name": "ETL",
+            "isDefault": False,
+            "maxResourcePercentage": 10,
+        }
+    )
+    with respx.mock:
+        respx.get(_CONFIG_URL).mock(return_value=httpx.Response(200, json=POOLS_ENABLED_PAYLOAD))
+        client = await _make_client()
+        async with client:
+            with pytest.raises(AlreadyExists, match="ETL"):
+                await sql_pools.create_pool(client, _WS_ID, duplicate_pool)
+
+
+@pytest.mark.asyncio
+async def test_create_pool_single_classifier_value() -> None:
+    """create_pool should handle a classifier with a single value list."""
+    new_pool = SqlPool.model_validate(
+        {
+            "name": "SingleValPool",
+            "isDefault": False,
+            "maxResourcePercentage": 10,
+            "classifier": {"type": "Application Name", "value": ["OnlyApp"]},
+        }
+    )
+    with respx.mock:
+        respx.get(_CONFIG_URL).mock(
+            side_effect=[
+                httpx.Response(200, json=_POOLS_WITH_HEADROOM),
+                httpx.Response(200, json=_POOLS_WITH_HEADROOM),
+            ]
+        )
+        patch_route = respx.patch(_CONFIG_URL).mock(return_value=httpx.Response(200))
+        client = await _make_client()
+        async with client:
+            await sql_pools.create_pool(client, _WS_ID, new_pool)
+
+    sent_body = json.loads(patch_route.calls[0].request.content)
+    new = next(p for p in sent_body["customSQLPools"] if p["name"] == "SingleValPool")
+    assert new["classifier"]["value"] == ["OnlyApp"]
+
+
+@pytest.mark.asyncio
+async def test_create_pool_multiple_classifier_values() -> None:
+    """create_pool should preserve multiple classifier values."""
+    new_pool = SqlPool.model_validate(
+        {
+            "name": "MultiValPool",
+            "isDefault": False,
+            "maxResourcePercentage": 10,
+            "classifier": {"type": "Application Name", "value": ["App1", "App2", "App3"]},
+        }
+    )
+    with respx.mock:
+        respx.get(_CONFIG_URL).mock(
+            side_effect=[
+                httpx.Response(200, json=_POOLS_WITH_HEADROOM),
+                httpx.Response(200, json=_POOLS_WITH_HEADROOM),
+            ]
+        )
+        patch_route = respx.patch(_CONFIG_URL).mock(return_value=httpx.Response(200))
+        client = await _make_client()
+        async with client:
+            await sql_pools.create_pool(client, _WS_ID, new_pool)
+
+    sent_body = json.loads(patch_route.calls[0].request.content)
+    new = next(p for p in sent_body["customSQLPools"] if p["name"] == "MultiValPool")
+    assert new["classifier"]["value"] == ["App1", "App2", "App3"]
+
+
+# ---------------------------------------------------------------------------
+# update_pool
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_pool_raises_not_found_for_missing_name() -> None:
+    """update_pool should raise NotFound when the pool name does not exist."""
+    with respx.mock:
+        respx.get(_CONFIG_URL).mock(return_value=httpx.Response(200, json=POOLS_ENABLED_PAYLOAD))
+        client = await _make_client()
+        async with client:
+            with pytest.raises(NotFound, match="NonExistent"):
+                await sql_pools.update_pool(
+                    client, _WS_ID, "NonExistent", max_resource_percentage=50
+                )
+
+
+@pytest.mark.asyncio
+async def test_update_pool_partial_update_preserves_other_fields() -> None:
+    """update_pool should preserve omitted fields unchanged."""
+    with respx.mock:
+        respx.get(_CONFIG_URL).mock(
+            side_effect=[
+                httpx.Response(200, json=_POOLS_WITH_HEADROOM),
+                httpx.Response(200, json=_POOLS_WITH_HEADROOM),
+            ]
+        )
+        patch_route = respx.patch(_CONFIG_URL).mock(return_value=httpx.Response(200))
+        client = await _make_client()
+        async with client:
+            await sql_pools.update_pool(client, _WS_ID, "ETL", max_resource_percentage=50)
+
+    sent_body = json.loads(patch_route.calls[0].request.content)
+    etl = next(p for p in sent_body["customSQLPools"] if p["name"] == "ETL")
+    assert etl["maxResourcePercentage"] == 50
+    assert etl["isDefault"] is False
+    assert etl["optimizeForReads"] is False
+    assert etl["classifier"]["value"] == ["ETL", "Load"]
+
+
+@pytest.mark.asyncio
+async def test_update_pool_toggle_is_default() -> None:
+    """update_pool can toggle the is_default flag."""
+    base_payload: dict[str, object] = {
+        "customSQLPoolsEnabled": True,
+        "customSQLPools": [
+            {"name": "A", "isDefault": False, "maxResourcePercentage": 50},
+            {"name": "B", "isDefault": False, "maxResourcePercentage": 50},
+        ],
+    }
+    with respx.mock:
+        respx.get(_CONFIG_URL).mock(
+            side_effect=[
+                httpx.Response(200, json=base_payload),
+                httpx.Response(200, json=base_payload),
+            ]
+        )
+        patch_route = respx.patch(_CONFIG_URL).mock(return_value=httpx.Response(200))
+        client = await _make_client()
+        async with client:
+            await sql_pools.update_pool(client, _WS_ID, "A", is_default=True)
+
+    sent_body = json.loads(patch_route.calls[0].request.content)
+    pool_a = next(p for p in sent_body["customSQLPools"] if p["name"] == "A")
+    pool_b = next(p for p in sent_body["customSQLPools"] if p["name"] == "B")
+    assert pool_a["isDefault"] is True
+    assert pool_b["isDefault"] is False
+
+
+@pytest.mark.asyncio
+async def test_update_pool_classifier_values_only() -> None:
+    """update_pool replaces classifier values while preserving classifier type."""
+    with respx.mock:
+        respx.get(_CONFIG_URL).mock(
+            side_effect=[
+                httpx.Response(200, json=POOLS_ENABLED_PAYLOAD),
+                httpx.Response(200, json=POOLS_ENABLED_PAYLOAD),
+            ]
+        )
+        patch_route = respx.patch(_CONFIG_URL).mock(return_value=httpx.Response(200))
+        client = await _make_client()
+        async with client:
+            await sql_pools.update_pool(client, _WS_ID, "ETL", classifier_values=["NewApp"])
+
+    sent_body = json.loads(patch_route.calls[0].request.content)
+    etl = next(p for p in sent_body["customSQLPools"] if p["name"] == "ETL")
+    assert etl["classifier"]["value"] == ["NewApp"]
+    assert etl["classifier"]["type"] == "Application Name"
+
+
+# ---------------------------------------------------------------------------
+# delete_pool
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_pool_removes_named_pool() -> None:
+    """delete_pool should GET, drop the named pool, and PATCH."""
+    with respx.mock:
+        respx.get(_CONFIG_URL).mock(
+            side_effect=[
+                httpx.Response(200, json=POOLS_ENABLED_PAYLOAD),
+                httpx.Response(200, json=POOLS_ENABLED_PAYLOAD),
+            ]
+        )
+        patch_route = respx.patch(_CONFIG_URL).mock(return_value=httpx.Response(200))
+        client = await _make_client()
+        async with client:
+            await sql_pools.delete_pool(client, _WS_ID, "ETL")
+
+    sent_body = json.loads(patch_route.calls[0].request.content)
+    pool_names = [p["name"] for p in sent_body["customSQLPools"]]
+    assert "ETL" not in pool_names
+    assert len(pool_names) == 2
+
+
+@pytest.mark.asyncio
+async def test_delete_pool_raises_not_found_for_missing_name() -> None:
+    """delete_pool should raise NotFound when the pool name does not exist."""
+    with respx.mock:
+        respx.get(_CONFIG_URL).mock(return_value=httpx.Response(200, json=POOLS_ENABLED_PAYLOAD))
+        client = await _make_client()
+        async with client:
+            with pytest.raises(NotFound, match="DoesNotExist"):
+                await sql_pools.delete_pool(client, _WS_ID, "DoesNotExist")
+
+
+# ---------------------------------------------------------------------------
+# reset_pools
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reset_pools_patches_empty_list_preserving_enabled_flag() -> None:
+    """reset_pools should PATCH with empty customSQLPools and preserve enabled state."""
+    with respx.mock:
+        respx.get(_CONFIG_URL).mock(
+            side_effect=[
+                httpx.Response(200, json=POOLS_ENABLED_PAYLOAD),
+                httpx.Response(200, json=POOLS_EMPTY_PAYLOAD),
+            ]
+        )
+        patch_route = respx.patch(_CONFIG_URL).mock(return_value=httpx.Response(200))
+        client = await _make_client()
+        async with client:
+            await sql_pools.reset_pools(client, _WS_ID)
+
+    sent_body = json.loads(patch_route.calls[0].request.content)
+    assert sent_body["customSQLPools"] == []
+    assert sent_body["customSQLPoolsEnabled"] is True
+
+
+@pytest.mark.asyncio
+async def test_reset_pools_preserves_disabled_state() -> None:
+    """reset_pools keeps customSQLPoolsEnabled=false when the workspace is disabled."""
+    with respx.mock:
+        respx.get(_CONFIG_URL).mock(
+            side_effect=[
+                httpx.Response(200, json=POOLS_DISABLED_PAYLOAD),
+                httpx.Response(200, json=POOLS_EMPTY_PAYLOAD),
+            ]
+        )
+        patch_route = respx.patch(_CONFIG_URL).mock(return_value=httpx.Response(200))
+        client = await _make_client()
+        async with client:
+            await sql_pools.reset_pools(client, _WS_ID)
+
+    sent_body = json.loads(patch_route.calls[0].request.content)
+    assert sent_body["customSQLPools"] == []
+    assert sent_body["customSQLPoolsEnabled"] is False

--- a/tests/unit/services/test_sql_pools.py
+++ b/tests/unit/services/test_sql_pools.py
@@ -691,8 +691,8 @@ async def test_update_pool_toggle_is_default() -> None:
 
 
 @pytest.mark.asyncio
-async def test_update_pool_classifier_values_only() -> None:
-    """update_pool replaces classifier values while preserving classifier type."""
+async def test_update_pool_classifier_both_fields() -> None:
+    """update_pool replaces classifier type and values when both are supplied."""
     with respx.mock:
         respx.get(_CONFIG_URL).mock(
             side_effect=[
@@ -703,7 +703,13 @@ async def test_update_pool_classifier_values_only() -> None:
         patch_route = respx.patch(_CONFIG_URL).mock(return_value=httpx.Response(200))
         client = await _make_client()
         async with client:
-            await sql_pools.update_pool(client, _WS_ID, "ETL", classifier_values=["NewApp"])
+            await sql_pools.update_pool(
+                client,
+                _WS_ID,
+                "ETL",
+                classifier_type="Application Name",
+                classifier_values=["NewApp"],
+            )
 
     sent_body = json.loads(patch_route.calls[0].request.content)
     etl = next(p for p in sent_body["customSQLPools"] if p["name"] == "ETL")
@@ -791,3 +797,51 @@ async def test_reset_pools_preserves_disabled_state() -> None:
     sent_body = json.loads(patch_route.calls[0].request.content)
     assert sent_body["customSQLPools"] == []
     assert sent_body["customSQLPoolsEnabled"] is False
+
+
+@pytest.mark.asyncio
+async def test_reset_pools_404_returns_sentinel_without_patch() -> None:
+    """reset_pools returns an empty sentinel config when the workspace 404s (never provisioned)."""
+    with respx.mock:
+        get_route = respx.get(_CONFIG_URL).mock(
+            return_value=httpx.Response(404, json={"error": "not found"})
+        )
+        patch_route = respx.patch(_CONFIG_URL).mock(return_value=httpx.Response(200))
+        client = await _make_client()
+        async with client:
+            result = await sql_pools.reset_pools(client, _WS_ID)
+
+    assert get_route.call_count == 1
+    assert not patch_route.called
+    assert isinstance(result, SqlPoolsConfiguration)
+    assert result.custom_sql_pools_enabled is False
+    assert result.custom_sql_pools == []
+
+
+# ---------------------------------------------------------------------------
+# update_pool — classifier partial validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_pool_classifier_type_without_values_raises() -> None:
+    """update_pool raises ValueError when classifier_type is given but classifier_values is not."""
+    with respx.mock:
+        respx.get(_CONFIG_URL).mock(return_value=httpx.Response(200, json=POOLS_ENABLED_PAYLOAD))
+        client = await _make_client()
+        async with client:
+            with pytest.raises(ValueError, match="classifier_type and classifier_values"):
+                await sql_pools.update_pool(
+                    client, _WS_ID, "ETL", classifier_type="Application Name"
+                )
+
+
+@pytest.mark.asyncio
+async def test_update_pool_classifier_values_without_type_raises() -> None:
+    """update_pool raises ValueError when classifier_values is given but classifier_type is not."""
+    with respx.mock:
+        respx.get(_CONFIG_URL).mock(return_value=httpx.Response(200, json=POOLS_ENABLED_PAYLOAD))
+        client = await _make_client()
+        async with client:
+            with pytest.raises(ValueError, match="classifier_type and classifier_values"):
+                await sql_pools.update_pool(client, _WS_ID, "ETL", classifier_values=["App1"])


### PR DESCRIPTION
## Summary

- Drops `sql-pools set --from-file` and `sql-pools edit`; adds `list`, `show`, `create`, `update`, `delete`, and `reset` sub-commands that accept flat flags (mirrors Azure CLI style).
- Adds `AlreadyExists` exception; adds four new service-layer compositions: `create_pool`, `update_pool`, `delete_pool`, `reset_pools`.
- Replaces bulk `update_sql_pools_configuration` MCP tool with eight granular tools: `list_sql_pools`, `get_sql_pool`, `create_sql_pool`, `update_sql_pool`, `delete_sql_pool`, `reset_sql_pools`, `enable_sql_pools`, `disable_sql_pools`.
- Updates `docs/cli.md` and `docs/mcp-tools.md` with new command/tool reference.

## Test plan

- [x] Unit tests for all four new service compositions (create/update/delete/reset), including `AlreadyExists` on duplicate, `NotFound` on missing name, partial-update field preservation, single and multiple classifier values, `is_default` toggling.
- [x] Unit tests for all new CLI sub-commands using `CliRunner`.
- [x] Integration test: `create → update → delete` roundtrip (also covers `AlreadyExists` and `NotFound` after delete).
- [x] Integration test: `reset_pools` clears list, preserves enabled flag.
- [x] `uv run ruff check .` — clean.
- [x] `uv run ruff format --check .` — clean.
- [x] `uvx ty==0.0.44 check src tests` — clean.
- [x] `uv run pytest tests/unit -q` — 689 passed.

> **Note:** The integration suite may fail on query-insights tests (bug #195, PR #197 in flight). SQL-pools integration tests require workspace admin credentials.

Closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)