### PR TITLE
ci(integration): sleep 30s after capacity reaches Active

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -56,7 +56,7 @@ jobs:
             sleep 15
           done
 
-          # Poll until Active, max 5 min
+          # Poll until Active, then sleep 30s for data-plane warm-up (max ~5.5 min)
           for i in {1..30}; do
             STATE=$(az resource show --ids "$CAPACITY_ID" --query 'properties.state' -o tsv)
             echo "Post-resume state: $STATE"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -60,7 +60,11 @@ jobs:
           for i in {1..30}; do
             STATE=$(az resource show --ids "$CAPACITY_ID" --query 'properties.state' -o tsv)
             echo "Post-resume state: $STATE"
-            [[ "$STATE" == "Active" ]] && exit 0
+            if [[ "$STATE" == "Active" ]]; then
+              echo "Capacity is Active; sleeping 30s for Fabric data-plane to settle..."
+              sleep 30
+              exit 0
+            fi
             sleep 10
           done
 


### PR DESCRIPTION
## Summary

- ARM reports `Active` ~35s after capacity resume, but Fabric data-plane endpoints (warehouse creation etc.) still return empty 2xx bodies for ~1–2 min after
- Adds an unconditional `sleep 30` after the polling loop confirms `state=Active`, giving the data-plane time to settle before the workflow proceeds
- The "Already Active, skipping resume" fast-path is **not** affected — no sleep when capacity was already up

## Change

`[[ "$STATE" == "Active" ]] && exit 0` is replaced with an explicit `if` branch that prints a message, sleeps 30s, then exits 0.

## Test plan

- [ ] CI lint/type/unit checks pass on this PR
- [ ] Next integration run: confirm the Resume step takes ~30s longer and that warehouse-creation calls no longer return empty bodies

Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)