### PR TITLE
fix(warehouses): retry on transient empty-2xx response from create endpoint

### DIFF
--- a/src/fabric_dw/services/warehouses.py
+++ b/src/fabric_dw/services/warehouses.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import logging
 from datetime import UTC, datetime
 from uuid import UUID
 
@@ -10,6 +12,11 @@ from fabric_dw.exceptions import FabricServerError, NotFound, PermissionDenied
 from fabric_dw.http_client import FabricHttpClient, HttpBase
 from fabric_dw.models import Warehouse, WarehouseKind
 from fabric_dw.services.workspaces import SUPPORTED_COLLATIONS
+
+_logger = logging.getLogger("fabric_dw.warehouses")
+
+# Backoff schedule for transient empty-2xx responses (seconds).
+_EMPTY_2XX_BACKOFF = (2, 6, 18)
 
 __all__ = [
     "create",
@@ -143,23 +150,57 @@ async def create(
     if collation is not None:
         body["creationPayload"] = {"defaultCollation": collation}
 
-    resp = await http.request(
-        "POST", HttpBase.FABRIC, f"/workspaces/{workspace_id}/items", json=body
-    )
+    for attempt, backoff in enumerate(
+        [None, *_EMPTY_2XX_BACKOFF], start=0
+    ):  # attempt 0 = initial; attempts 1-3 = retries
+        if backoff is not None:
+            _logger.warning(
+                "create warehouse: 2xx response had no Location header and no usable body "
+                "(attempt %d/3) — waiting %ss before retry (see issue #204)",
+                attempt,
+                backoff,
+            )
+            await asyncio.sleep(backoff)
 
-    location = resp.headers.get("Location")
+        resp = await http.request(
+            "POST", HttpBase.FABRIC, f"/workspaces/{workspace_id}/items", json=body
+        )
 
-    if location is None:
-        # Fabric occasionally returns 201 with the new warehouse directly in the body
-        # (no LRO / no Location header). The body does NOT include properties.connectionString,
-        # so we must do a follow-up GET to return a fully-populated Warehouse.
-        resp_body = resp.json()
-        resp_id = resp_body.get("id")
-        resp_name = resp_body.get("displayName") or resp_body.get("name")
-        if resp_id and resp_name:
-            new_id = UUID(str(resp_id))
-            return await get_warehouse(http, workspace_id, new_id)
-        msg = "create warehouse: response had no Location header and no usable body"
+        location = resp.headers.get("Location")
+
+        if location is None:
+            # Fabric occasionally returns 201 with the new warehouse directly in the body
+            # (no LRO / no Location header). The body does NOT include properties.connectionString,
+            # so we must do a follow-up GET to return a fully-populated Warehouse.
+            resp_body = resp.json()
+            resp_id = resp_body.get("id")
+            resp_name = resp_body.get("displayName") or resp_body.get("name")
+            if resp_id and resp_name:
+                new_id = UUID(str(resp_id))
+                return await get_warehouse(http, workspace_id, new_id)
+
+            # Do not retry on 4xx — those are definitive client errors.
+            if resp.status_code >= 400 and resp.status_code < 500:  # noqa: PLR2004
+                msg = (
+                    f"create warehouse: {resp.status_code} error response "
+                    f"with no Location header and no usable body"
+                )
+                raise FabricServerError(msg)
+
+            # 2xx + no Location + no usable body: transient Fabric data-plane not ready.
+            # Continue the retry loop (will raise below if exhausted).
+            continue
+
+        # Location header present → poll the LRO then fetch the new warehouse.
+        break
+
+    else:
+        # Exhausted all attempts (initial + 3 retries) without a usable response.
+        msg = (
+            "create warehouse: Fabric returned 2xx with no Location header and no usable body "
+            "after 4 attempts. The capacity data plane may not be ready yet. "
+            "See issue #204 for tracking frequency."
+        )
         raise FabricServerError(msg)
 
     # 202 = LRO initiated; poll the operation then fetch the new warehouse

--- a/tests/unit/services/test_warehouses.py
+++ b/tests/unit/services/test_warehouses.py
@@ -422,9 +422,10 @@ async def test_create_no_location_header_and_empty_body_raises_fabric_server_err
 
         client = await _make_client()
         async with client:
-            with patch("asyncio.sleep"):  # skip actual sleeps in unit tests
+            with patch("fabric_dw.services.warehouses.asyncio.sleep") as mock_sleep:
                 with pytest.raises(FabricServerError, match="204"):
                     await warehouses.create(client, _WORKSPACE_ID, "SalesWarehouse")
+        mock_sleep.assert_called()  # retries must have slept
 
     # 1 original + 3 retries = 4 total POST calls
     assert post_route.call_count == 4
@@ -460,8 +461,9 @@ async def test_create_empty_2xx_retries_then_succeeds() -> None:
 
         client = await _make_client()
         async with client:
-            with patch("asyncio.sleep"):  # skip actual sleeps in unit tests
+            with patch("fabric_dw.services.warehouses.asyncio.sleep") as mock_sleep:
                 result = await warehouses.create(client, _WORKSPACE_ID, "SalesWarehouse")
+        mock_sleep.assert_called()  # retries must have slept
 
     assert isinstance(result, Warehouse)
     assert result.id == new_wh_id
@@ -491,7 +493,7 @@ async def test_create_4xx_is_not_retried() -> None:
             # The http_client only raises for 401, 403, 404, 5xx — a bare 400 is returned.
             # warehouses.create will try to parse the body (no Location, no id), but since
             # the status is 4xx the retry must NOT fire.
-            with patch("asyncio.sleep") as mock_sleep:
+            with patch("fabric_dw.services.warehouses.asyncio.sleep") as mock_sleep:
                 with pytest.raises(FabricServerError):
                     await warehouses.create(client, _WORKSPACE_ID, "SalesWarehouse")
 

--- a/tests/unit/services/test_warehouses.py
+++ b/tests/unit/services/test_warehouses.py
@@ -410,16 +410,94 @@ async def test_create_no_location_header_but_body_present_returns_warehouse() ->
 
 @pytest.mark.asyncio
 async def test_create_no_location_header_and_empty_body_raises_fabric_server_error() -> None:
-    """create must raise FabricServerError when no Location header and body is empty."""
+    """create must raise FabricServerError (after exhausting retries) when body is always empty.
+
+    This test mocks 4 consecutive empty-2xx responses (> max 3 retries) and verifies
+    that FabricServerError is raised with a reference to issue #204.
+    """
     with respx.mock:
-        respx.post(_ITEMS_URL).mock(
-            return_value=httpx.Response(202, json={})  # no Location header, empty body
+        post_route = respx.post(_ITEMS_URL).mock(
+            return_value=httpx.Response(202, json={})  # no Location header, empty body, always
         )
 
         client = await _make_client()
         async with client:
-            with pytest.raises(FabricServerError, match="no Location header and no usable body"):
-                await warehouses.create(client, _WORKSPACE_ID, "SalesWarehouse")
+            with patch("asyncio.sleep"):  # skip actual sleeps in unit tests
+                with pytest.raises(FabricServerError, match="204"):
+                    await warehouses.create(client, _WORKSPACE_ID, "SalesWarehouse")
+
+    # 1 original + 3 retries = 4 total POST calls
+    assert post_route.call_count == 4
+
+
+@pytest.mark.asyncio
+async def test_create_empty_2xx_retries_then_succeeds() -> None:
+    """create must retry up to 3 times on 2xx + no Location + no usable body, then succeed.
+
+    Mocks 3 consecutive empty-2xx responses followed by a normal 202+Location response.
+    Verifies 4 total POST attempts and that the returned Warehouse is fully populated.
+    """
+    op_succeeded = json.loads(WAREHOUSE_OPERATION_SUCCEEDED_PAYLOAD)
+    wh_payload = json.loads(WAREHOUSE_GET_PAYLOAD)
+    new_wh_id = UUID("d4e5f6a7-b8c9-0123-def0-123456789abc")
+    new_wh_url = f"{_WAREHOUSES_URL}/{new_wh_id}"
+
+    call_count = 0
+
+    def post_side_effect(_request: httpx.Request) -> httpx.Response:
+        nonlocal call_count
+        call_count += 1
+        if call_count <= 3:
+            # Empty-2xx: no Location header, no usable body
+            return httpx.Response(202, json={})
+        # 4th attempt: normal LRO response
+        return httpx.Response(202, json={}, headers={"Location": _OPERATION_URL})
+
+    with respx.mock:
+        respx.post(_ITEMS_URL).mock(side_effect=post_side_effect)
+        respx.get(_OPERATION_URL).mock(return_value=httpx.Response(200, json=op_succeeded))
+        respx.get(new_wh_url).mock(return_value=httpx.Response(200, json=wh_payload))
+
+        client = await _make_client()
+        async with client:
+            with patch("asyncio.sleep"):  # skip actual sleeps in unit tests
+                result = await warehouses.create(client, _WORKSPACE_ID, "SalesWarehouse")
+
+    assert isinstance(result, Warehouse)
+    assert result.id == new_wh_id
+    assert result.kind == WarehouseKind.WAREHOUSE
+    assert call_count == 4  # 3 empty retries + 1 successful
+
+
+@pytest.mark.asyncio
+async def test_create_4xx_is_not_retried() -> None:
+    """create must NOT retry on 4xx errors — they propagate immediately.
+
+    Mocks a single 400 response and verifies that only 1 POST is made and
+    the exception is raised without any retry.
+    """
+    with respx.mock:
+        post_route = respx.post(_ITEMS_URL).mock(
+            return_value=httpx.Response(
+                400, json={"error": {"code": "InvalidRequest", "message": "bad input"}}
+            )
+        )
+
+        client = await _make_client()
+        async with client:
+            # 400 falls through http_client without raising (no mapping) — the response is returned
+            # and warehouses.create will see an empty/useless body; but the key assertion
+            # is that the retry loop only fires for 2xx+empty-body, not for 4xx.
+            # The http_client only raises for 401, 403, 404, 5xx — a bare 400 is returned.
+            # warehouses.create will try to parse the body (no Location, no id), but since
+            # the status is 4xx the retry must NOT fire.
+            with patch("asyncio.sleep") as mock_sleep:
+                with pytest.raises(FabricServerError):
+                    await warehouses.create(client, _WORKSPACE_ID, "SalesWarehouse")
+
+    # Only 1 POST attempt — no retries
+    assert post_route.call_count == 1
+    mock_sleep.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- `warehouses.create` now retries up to 3 times (backoff 2/6/18 s) when Fabric returns a 2xx response with no `Location` header and no usable body — the transient "capacity just resumed, data plane not ready" case.
- 4xx responses are **never** retried; 5xx behaviour is unchanged (handled by tenacity at HTTP-client layer).
- After exhausting retries, `FabricServerError` is raised with an explicit reference to `#204` for log-frequency tracking.
- Three new unit tests cover: retry-then-succeed (4 POST calls), immediate 4xx propagation (1 POST call, no sleep), and exhausted retries raising with `#204` in the message.

Closes #204

## Test plan

- [x] `uv run pytest tests/unit/services/test_warehouses.py -q` — all 31 tests pass (3 new)
- [x] `uv run pytest tests/unit -q` — all 666 tests pass
- [x] `uv run ruff check src/fabric_dw/services/warehouses.py tests/unit/services/test_warehouses.py`
- [x] `uv run ruff format --check src/fabric_dw/services/warehouses.py tests/unit/services/test_warehouses.py`
- [x] `uvx ty==0.0.44 check src tests`
- [ ] CI integration suite (label-gated, do not merge until green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)