### PR TITLE
ci(integration): bump post-resume sleep to 120s

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -56,13 +56,13 @@ jobs:
             sleep 15
           done
 
-          # Poll until Active, then sleep 30s for data-plane warm-up (max ~5.5 min)
+          # Poll until Active, then sleep 120s for data-plane warm-up (max ~7 min)
           for i in {1..30}; do
             STATE=$(az resource show --ids "$CAPACITY_ID" --query 'properties.state' -o tsv)
             echo "Post-resume state: $STATE"
             if [[ "$STATE" == "Active" ]]; then
-              echo "Capacity is Active; sleeping 30s for Fabric data-plane to settle..."
-              sleep 30
+              echo "Capacity is Active; sleeping 120s for Fabric data-plane to settle..."
+              sleep 120
               exit 0
             fi
             sleep 10


### PR DESCRIPTION
## Summary
- Bumps the post-resume Fabric capacity sleep from 30s to 120s
- Updates the inline comment from "max ~5.5 min" to "max ~7 min"
- Updates the diagnostic echo text to reflect 120s

## Motivation
PR #207 added 30s sleep. Observed: capacity went Active at 17:05:52 and warehouse-create still failed at 17:07:09 — 77s after Active. 30s is insufficient; 120s provides a safe margin for the Fabric data-plane to fully settle.

## Workflow-only exception
This is a workflow self-modification PR; the `integration` label is intentionally omitted per project convention.

Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)