### PR TITLE
docs: trim favicon padding; enlarge README logo with centered title

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
   </a>
 </p>
 <h1 align="center">fabric-dw</h1>
-<p align="center">Python CLI + MCP server for administering Microsoft Fabric Data Warehouses</p>
 
 > Python CLI and MCP server for administering Microsoft Fabric Data Warehouses and SQL Analytics Endpoints.
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 <p align="center">
   <a href="https://fdw.debruyn.dev">
-    <img src="docs/assets/logo.svg" alt="fabric-dw" width="140" />
+    <img src="docs/assets/logo.svg" alt="fabric-dw logo" width="200" />
   </a>
 </p>
-
-# fabric-dw
+<h1 align="center">fabric-dw</h1>
+<p align="center">Python CLI + MCP server for administering Microsoft Fabric Data Warehouses</p>
 
 > Python CLI and MCP server for administering Microsoft Fabric Data Warehouses and SQL Analytics Endpoints.
 

--- a/docs/assets/logo.svg
+++ b/docs/assets/logo.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200" role="img" aria-label="fdw">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="43 49 114 112" width="200" height="200" role="img" aria-label="fdw">
   <defs>
     <radialGradient id="body" cx="0.3" cy="0.2" r="1.08">
       <stop offset="0" stop-color="#6FDEFB"></stop>


### PR DESCRIPTION
## Summary

- **Favicon padding**: Adjusted `docs/assets/logo.svg` `viewBox` from `0 0 200 200` to `43 49 114 112`, eliminating the large transparent margins. The icon graphic now fills the canvas with ≤5 px margin on each side (verified by pixel bounding box check).
- **README logo**: Increased logo `width` from 140 → 200 px.
- **Centered title**: Replaced `# fabric-dw` (plain Markdown heading) with `<h1 align="center">fabric-dw</h1>` and added a centered tagline `<p align="center">Python CLI + MCP server for administering Microsoft Fabric Data Warehouses</p>` directly below.
- Existing blockquote one-liner and all downstream content are unchanged.

## Test plan

- [ ] Render `docs/assets/logo.svg` at various sizes (16, 32, 48, 200 px) and confirm icon fills the frame with minimal margin.
- [ ] Open `README.md` preview (GitHub or local) and verify logo is larger, title is centered, and tagline appears below it.
- [ ] Verify no badges or other existing content was removed.

Closes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)