### PR TITLE
feat(sql-endpoints): add --recreate-tables flag + rich refresh table

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -340,16 +340,31 @@ fabric-dw sql-endpoints get MyWorkspace MyLakehouseEP
 
 Refresh metadata for a SQL Analytics Endpoint by triggering a sync from the underlying Lakehouse delta tables. This is a long-running operation (LRO) that is polled to completion.
 
+Results are shown as a Rich table (Table, Status, End Time, Error). Pass `--json` on the root command to emit raw JSON instead.
+
 **Synopsis**
 
 ```
-fabric-dw sql-endpoints refresh WORKSPACE ENDPOINT
+fabric-dw sql-endpoints refresh [--recreate-tables] WORKSPACE ENDPOINT
 ```
+
+**Options**
+
+| Flag | Description |
+|------|-------------|
+| `--recreate-tables` | Drop and recreate all tables during the refresh. Use to resolve inconsistencies or force a clean rebuild. **Destructive** — use with caution. |
 
 **Example**
 
 ```shell
+# Standard refresh — shows a per-table Rich table
 fabric-dw sql-endpoints refresh MyWorkspace MyLakehouseEP
+
+# Force a full table recreate
+fabric-dw sql-endpoints refresh --recreate-tables MyWorkspace MyLakehouseEP
+
+# Emit raw JSON
+fabric-dw --json sql-endpoints refresh MyWorkspace MyLakehouseEP
 ```
 
 ---

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -165,8 +165,9 @@ Refresh metadata for a SQL analytics endpoint by syncing from the underlying Lak
 
 - `workspace` (`str`) — workspace name or GUID.
 - `endpoint` (`str`) — endpoint name or GUID.
+- `recreate_tables` (`bool`, default `False`) — drop and recreate all tables during the refresh. Use to resolve inconsistencies or force a clean rebuild. DESTRUCTIVE — use with caution.
 
-**Returns:** `dict` — the raw LRO completion payload from the Fabric API.
+**Returns:** `list[TableSyncStatus]` — array of per-table sync results, each with `tableName`, `status`, `startDateTime`, `endDateTime`, `lastSuccessfulSyncDateTime`, and `error`.
 
 ---
 

--- a/src/fabric_dw/cli/commands/sql_endpoints.py
+++ b/src/fabric_dw/cli/commands/sql_endpoints.py
@@ -130,8 +130,6 @@ def _render_refresh_table(
             if s.error.message:
                 parts.append(s.error.message)
             error_text = ": ".join(parts)
-            if len(error_text) > _ERROR_MAX_LEN:
-                error_text = error_text[: _ERROR_MAX_LEN - 1] + "…"
 
         table.add_row(
             s.table_name,

--- a/src/fabric_dw/cli/commands/sql_endpoints.py
+++ b/src/fabric_dw/cli/commands/sql_endpoints.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import json as _json
 import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
 import click
+from rich.console import Console
+from rich.table import Table
 
 from fabric_dw import auth as _auth
 from fabric_dw.cache import LookupCache
@@ -15,6 +18,7 @@ from fabric_dw.cli._render import render
 from fabric_dw.cli.commands._utils import _coro, _resolve_item
 from fabric_dw.exceptions import FabricError
 from fabric_dw.http_client import FabricHttpClient
+from fabric_dw.models import TableSyncStatus
 from fabric_dw.resolver import Resolver
 from fabric_dw.services import sql_endpoints as _sql_endpoints_svc
 
@@ -93,21 +97,94 @@ async def get_cmd(ctx: CliContext, workspace: str, endpoint: str) -> None:
         raise click.ClickException(str(exc)) from exc
 
 
+_STATUS_STYLES: dict[str, str] = {
+    "Success": "green",
+    "Failure": "red",
+    "NotRun": "yellow",
+}
+
+_ERROR_MAX_LEN = 60
+
+
+def _render_refresh_table(
+    statuses: list[TableSyncStatus], *, console: Console | None = None
+) -> None:
+    """Render a list of :class:`TableSyncStatus` as a Rich table."""
+    con = console or Console()
+    table = Table(title="Metadata Refresh Results", show_header=True, header_style="bold")
+    table.add_column("Table", no_wrap=True)
+    table.add_column("Status")
+    table.add_column("End Time")
+    table.add_column("Error", max_width=_ERROR_MAX_LEN)
+
+    for s in statuses:
+        status_text = s.status
+        style = _STATUS_STYLES.get(s.status, "")
+        end_dt = s.end_date_time.isoformat() if s.end_date_time else ""
+
+        error_text = ""
+        if s.error:
+            parts = []
+            if s.error.error_code:
+                parts.append(s.error.error_code)
+            if s.error.message:
+                parts.append(s.error.message)
+            error_text = ": ".join(parts)
+            if len(error_text) > _ERROR_MAX_LEN:
+                error_text = error_text[: _ERROR_MAX_LEN - 1] + "…"
+
+        table.add_row(
+            s.table_name,
+            f"[{style}]{status_text}[/{style}]" if style else status_text,
+            end_dt,
+            error_text,
+        )
+
+    con.print(table)
+
+
 @sql_endpoints_group.command("refresh")
 @click.argument("workspace")
 @click.argument("endpoint")
+@click.option(
+    "--recreate-tables",
+    "recreate_tables",
+    is_flag=True,
+    default=False,
+    help=(
+        "Drop and recreate all tables during the refresh. "
+        "Use to resolve inconsistencies or force a clean rebuild. "
+        "DESTRUCTIVE — use with caution."
+    ),
+)
 @click.pass_obj
 @_coro
-async def refresh_cmd(ctx: CliContext, workspace: str, endpoint: str) -> None:
+async def refresh_cmd(
+    ctx: CliContext, workspace: str, endpoint: str, recreate_tables: bool
+) -> None:
     """Refresh metadata for ENDPOINT in WORKSPACE (both accept name or GUID).
 
     Triggers a metadata sync from the underlying Lakehouse delta tables.
     This is a long-running operation (LRO) that is polled to completion.
+
+    By default, results are shown as a Rich table.  Pass --json (on the root
+    command) to emit raw JSON instead.
     """
     try:
         async with _build_clients(ctx) as (http, _):
             ws_id, entry = await _resolve_item(http, workspace, endpoint)
-            result = await _sql_endpoints_svc.refresh_metadata(http, ws_id, entry.id)
-            render(result, json_output=ctx.json_output)
+            statuses = await _sql_endpoints_svc.refresh_metadata(
+                http, ws_id, entry.id, recreate_tables=recreate_tables
+            )
+            if ctx.json_output:
+                click.echo(
+                    _json.dumps(
+                        [s.model_dump(by_alias=True, mode="json") for s in statuses],
+                        indent=2,
+                        default=str,
+                    )
+                )
+            else:
+                _render_refresh_table(statuses)
     except FabricError as exc:
         raise click.ClickException(str(exc)) from exc

--- a/src/fabric_dw/mcp/server.py
+++ b/src/fabric_dw/mcp/server.py
@@ -288,18 +288,32 @@ async def get_sql_endpoint(workspace: str, endpoint: str) -> dict[str, Any]:
 
 
 @mcp.tool()
-async def refresh_sql_endpoint_metadata(workspace: str, endpoint: str) -> dict[str, Any]:
+async def refresh_sql_endpoint_metadata(
+    workspace: str,
+    endpoint: str,
+    recreate_tables: bool = False,  # noqa: FBT001, FBT002
+) -> list[dict[str, Any]]:
     """Refresh metadata for a SQL analytics endpoint (sync from the underlying Lakehouse).
 
     This is a long-running operation (LRO) that is polled to completion.
+    Returns a list of per-table sync results.
+
+    Args:
+        workspace: Workspace name or GUID.
+        endpoint: SQL analytics endpoint name or GUID.
+        recreate_tables: When ``True``, drop and recreate all tables during
+            the refresh.  Use to resolve inconsistencies or force a clean
+            rebuild.  **Destructive** — use with caution.
     """
     try:
         ws_id = await _get_resolver().workspace_id(workspace)
         item = await _get_resolver().item(workspace, endpoint)
-        result = await sql_endpoints.refresh_metadata(_get_http(), ws_id, item.id)
+        statuses = await sql_endpoints.refresh_metadata(
+            _get_http(), ws_id, item.id, recreate_tables=recreate_tables
+        )
     except FabricError as exc:
         raise _fabric_err(exc) from exc
-    return result
+    return [s.model_dump(by_alias=True, mode="json") for s in statuses]
 
 
 # ---------------------------------------------------------------------------

--- a/src/fabric_dw/models.py
+++ b/src/fabric_dw/models.py
@@ -298,6 +298,29 @@ class SqlPoolInsight(_FabricBase):
     is_pool_under_pressure: bool | None = None
 
 
+class TableSyncError(_FabricBase):
+    """Error details for a single table synchronization failure."""
+
+    error_code: str | None = Field(default=None, alias="errorCode")
+    message: str | None = None
+
+
+class TableSyncStatus(_FabricBase):
+    """Per-table result returned by a SQL analytics endpoint metadata refresh.
+
+    Corresponds to the ``TableSyncStatus`` object in the Fabric REST API.
+    """
+
+    table_name: str = Field(alias="tableName")
+    status: str
+    start_date_time: datetime | None = Field(default=None, alias="startDateTime")
+    end_date_time: datetime | None = Field(default=None, alias="endDateTime")
+    last_successful_sync_date_time: datetime | None = Field(
+        default=None, alias="lastSuccessfulSyncDateTime"
+    )
+    error: TableSyncError | None = None
+
+
 class View(_FabricBase):
     """A SQL view on a Fabric Data Warehouse or SQL Analytics Endpoint."""
 

--- a/src/fabric_dw/services/sql_endpoints.py
+++ b/src/fabric_dw/services/sql_endpoints.py
@@ -7,7 +7,7 @@ from uuid import UUID
 
 from fabric_dw.exceptions import NotFound, PermissionDenied
 from fabric_dw.http_client import FabricHttpClient, HttpBase
-from fabric_dw.models import Warehouse, WarehouseKind
+from fabric_dw.models import TableSyncStatus, Warehouse, WarehouseKind
 
 __all__ = [
     "get_endpoint",
@@ -94,31 +94,45 @@ async def get_endpoint(http: FabricHttpClient, workspace_id: UUID, endpoint_id: 
 
 
 async def refresh_metadata(
-    http: FabricHttpClient, workspace_id: UUID, endpoint_id: UUID
-) -> dict[str, Any]:
+    http: FabricHttpClient,
+    workspace_id: UUID,
+    endpoint_id: UUID,
+    *,
+    recreate_tables: bool = False,
+) -> list[TableSyncStatus]:
     """Trigger a metadata refresh for a SQL analytics endpoint.
 
-    Issues ``POST /workspaces/{ws}/sqlEndpoints/{id}/refreshMetadata``, which
-    returns a 202 with a ``Location`` header pointing at a long-running
-    operation (LRO).  The function polls the LRO to completion and returns
-    the final operation body.
+    Issues ``POST /workspaces/{ws}/sqlEndpoints/{id}/refreshMetadata`` with
+    an optional ``recreateTables`` body flag.  The API returns a 202 with a
+    ``Location`` header pointing at a long-running operation (LRO).  The
+    function polls the LRO to completion and parses the per-table results.
 
     Args:
         http: An authenticated :class:`~fabric_dw.http_client.FabricHttpClient`.
         workspace_id: The UUID of the workspace containing the endpoint.
         endpoint_id: The UUID of the SQL analytics endpoint to refresh.
+        recreate_tables: When ``True``, pass ``recreateTables=true`` in the
+            request body, instructing Fabric to drop and recreate all tables
+            during the refresh.  **Destructive** — use with caution.
 
     Returns:
-        The final LRO response body (``{"status": "Succeeded", ...}``).
+        A list of :class:`~fabric_dw.models.TableSyncStatus` objects, one per
+        table, describing the outcome of the refresh.
 
     Raises:
         FabricServerError: If the LRO fails or times out.
         NotFound: If the endpoint does not exist (404).
     """
+    json_body: dict[str, Any] | None = {"recreateTables": True} if recreate_tables else None
+
     resp = await http.request(
         "POST",
         HttpBase.FABRIC,
         f"/workspaces/{workspace_id}/sqlEndpoints/{endpoint_id}/refreshMetadata",
+        json=json_body,
     )
     location: str = resp.headers["Location"]
-    return await http.poll_operation(location)
+    lro_body = await http.poll_operation(location)
+    raw_value: Any = lro_body.get("value", []) if isinstance(lro_body, dict) else []
+    raw_items: list[Any] = raw_value if isinstance(raw_value, list) else []
+    return [TableSyncStatus.model_validate(item) for item in raw_items]

--- a/tests/unit/cli/commands/test_sql_endpoints.py
+++ b/tests/unit/cli/commands/test_sql_endpoints.py
@@ -6,15 +6,18 @@ import json
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime
+from io import StringIO
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import UUID
 
 import pytest
 from click.testing import CliRunner
+from rich.console import Console
 
 from fabric_dw.cache import ItemEntry
 from fabric_dw.cli._main import cli
+from fabric_dw.cli.commands.sql_endpoints import _render_refresh_table
 from fabric_dw.exceptions import NotFound
 from fabric_dw.models import TableSyncStatus, WarehouseKind
 
@@ -401,3 +404,16 @@ class TestEndpointsRefresh:
         ):
             result = runner.invoke(cli, ["sql-endpoints", "refresh", WS_GUID, EP_GUID])
         assert result.exit_code != 0
+
+
+class TestRenderRefreshTable:
+    """Unit tests for the _render_refresh_table helper."""
+
+    def test_empty_list_does_not_crash(self) -> None:
+        """_render_refresh_table([]) must not raise and must render an empty table."""
+        buf = StringIO()
+        con = Console(file=buf, width=120)
+        _render_refresh_table([], console=con)
+        output = buf.getvalue()
+        # The title must still appear even with no rows.
+        assert "Metadata Refresh Results" in output

--- a/tests/unit/cli/commands/test_sql_endpoints.py
+++ b/tests/unit/cli/commands/test_sql_endpoints.py
@@ -16,7 +16,7 @@ from click.testing import CliRunner
 from fabric_dw.cache import ItemEntry
 from fabric_dw.cli._main import cli
 from fabric_dw.exceptions import NotFound
-from fabric_dw.models import WarehouseKind
+from fabric_dw.models import TableSyncStatus, WarehouseKind
 
 WS_GUID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
 EP_GUID = "e5f6a7b8-c9d0-1234-ef01-234567890abc"
@@ -223,30 +223,36 @@ class TestEndpointsGet:
         assert result.exit_code != 0
 
 
+def _make_table_sync_statuses() -> list[TableSyncStatus]:
+    return [
+        TableSyncStatus.model_validate(
+            {
+                "tableName": "Table1",
+                "status": "Success",
+                "startDateTime": "2025-08-08T10:31:22.270Z",
+                "endDateTime": "2025-08-08T10:36:54.965Z",
+                "lastSuccessfulSyncDateTime": "2025-08-08T10:36:54.965Z",
+            }
+        ),
+        TableSyncStatus.model_validate(
+            {
+                "tableName": "Table2",
+                "status": "Failure",
+                "startDateTime": "2025-08-08T10:31:22.270Z",
+                "endDateTime": "2025-08-08T10:43:02.532Z",
+                "error": {"errorCode": "TokenError", "message": "Auth failed"},
+                "lastSuccessfulSyncDateTime": "2025-08-07T10:44:27.263Z",
+            }
+        ),
+    ]
+
+
 class TestEndpointsRefresh:
-    """endpoints refresh — happy path (LRO)."""
+    """endpoints refresh — happy path and error cases."""
 
     def test_refresh_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
         mock_http = AsyncMock()
-        mock_http.request = AsyncMock(
-            return_value=_make_response(
-                202,
-                json.dumps({}),
-            )
-        )
-        mock_http.poll_operation = AsyncMock(
-            return_value={"status": "Succeeded", "percentComplete": 100}
-        )
-
-        _make_response_with_location = MagicMock()
-        _make_response_with_location.status_code = 202
-        _make_response_with_location.json = MagicMock(return_value={})
-        _make_response_with_location.headers = {
-            "Location": "https://api.fabric.microsoft.com/v1/operations/op-123"
-        }
-        _make_response_with_location.text = "{}"
-        mock_http.request = AsyncMock(return_value=_make_response_with_location)
 
         with (
             patch(
@@ -257,9 +263,128 @@ class TestEndpointsRefresh:
                 "fabric_dw.cli.commands.sql_endpoints._resolve_item",
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
             ),
+            patch(
+                "fabric_dw.services.sql_endpoints.refresh_metadata",
+                new=AsyncMock(return_value=_make_table_sync_statuses()),
+            ),
         ):
             result = runner.invoke(cli, ["sql-endpoints", "refresh", WS_GUID, EP_GUID])
         assert result.exit_code == 0
+
+    def test_refresh_default_renders_rich_table(self, runner: CliRunner, cache_env: Path) -> None:
+        """Without --json, the output must contain the table name columns."""
+        _ = cache_env
+        mock_http = AsyncMock()
+
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql_endpoints._build_clients",
+                new=_make_cm(mock_http, None),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_endpoints._resolve_item",
+                new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.sql_endpoints.refresh_metadata",
+                new=AsyncMock(return_value=_make_table_sync_statuses()),
+            ),
+        ):
+            result = runner.invoke(cli, ["sql-endpoints", "refresh", WS_GUID, EP_GUID])
+        assert result.exit_code == 0
+        # Rich table output must not be valid JSON
+        try:
+            json.loads(result.output)
+            is_json = True
+        except (json.JSONDecodeError, ValueError):
+            is_json = False
+        assert not is_json, "Expected Rich table output, got JSON"
+
+    def test_refresh_json_flag_emits_json(self, runner: CliRunner, cache_env: Path) -> None:
+        """With --json, output must be a valid JSON array."""
+        _ = cache_env
+        mock_http = AsyncMock()
+
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql_endpoints._build_clients",
+                new=_make_cm(mock_http, None),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_endpoints._resolve_item",
+                new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.sql_endpoints.refresh_metadata",
+                new=AsyncMock(return_value=_make_table_sync_statuses()),
+            ),
+        ):
+            result = runner.invoke(cli, ["--json", "sql-endpoints", "refresh", WS_GUID, EP_GUID])
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert isinstance(parsed, list)
+        assert len(parsed) == 2
+        assert parsed[0]["tableName"] == "Table1"
+        assert parsed[0]["status"] == "Success"
+
+    def test_refresh_recreate_tables_flag_passed_to_service(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """--recreate-tables must call refresh_metadata with recreate_tables=True."""
+        _ = cache_env
+        mock_http = AsyncMock()
+        mock_refresh = AsyncMock(return_value=_make_table_sync_statuses())
+
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql_endpoints._build_clients",
+                new=_make_cm(mock_http, None),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_endpoints._resolve_item",
+                new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.sql_endpoints.refresh_metadata",
+                new=mock_refresh,
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                ["sql-endpoints", "refresh", "--recreate-tables", WS_GUID, EP_GUID],
+            )
+        assert result.exit_code == 0
+        mock_refresh.assert_called_once()
+        _, kwargs = mock_refresh.call_args
+        assert kwargs.get("recreate_tables") is True
+
+    def test_refresh_no_recreate_tables_default_false(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """Without --recreate-tables, service must be called with recreate_tables=False."""
+        _ = cache_env
+        mock_http = AsyncMock()
+        mock_refresh = AsyncMock(return_value=_make_table_sync_statuses())
+
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql_endpoints._build_clients",
+                new=_make_cm(mock_http, None),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_endpoints._resolve_item",
+                new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.sql_endpoints.refresh_metadata",
+                new=mock_refresh,
+            ),
+        ):
+            result = runner.invoke(cli, ["sql-endpoints", "refresh", WS_GUID, EP_GUID])
+        assert result.exit_code == 0
+        mock_refresh.assert_called_once()
+        _, kwargs = mock_refresh.call_args
+        assert kwargs.get("recreate_tables") is False
 
     def test_refresh_not_found_returns_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env

--- a/tests/unit/mcp/test_server.py
+++ b/tests/unit/mcp/test_server.py
@@ -33,6 +33,7 @@ from fabric_dw.exceptions import NotFound
 from fabric_dw.models import (
     AuditSettings,
     RunningQuery,
+    TableSyncStatus,
     Warehouse,
     WarehouseKind,
     WarehouseSnapshot,
@@ -621,9 +622,33 @@ async def test_get_sql_endpoint_happy_path() -> None:
     assert result["kind"] == "SQLEndpoint"
 
 
+def _make_table_sync_statuses() -> list[TableSyncStatus]:
+    return [
+        TableSyncStatus.model_validate(
+            {
+                "tableName": "Table1",
+                "status": "Success",
+                "startDateTime": "2025-08-08T10:31:22.270Z",
+                "endDateTime": "2025-08-08T10:36:54.965Z",
+                "lastSuccessfulSyncDateTime": "2025-08-08T10:36:54.965Z",
+            }
+        ),
+        TableSyncStatus.model_validate(
+            {
+                "tableName": "Table2",
+                "status": "Failure",
+                "startDateTime": "2025-08-08T10:31:22.270Z",
+                "endDateTime": "2025-08-08T10:43:02.532Z",
+                "error": {"errorCode": "TokenError", "message": "Auth failed"},
+                "lastSuccessfulSyncDateTime": "2025-08-07T10:44:27.263Z",
+            }
+        ),
+    ]
+
+
 @pytest.mark.asyncio
 async def test_refresh_sql_endpoint_metadata_happy_path() -> None:
-    """refresh_sql_endpoint_metadata resolves workspace + endpoint and returns a dict."""
+    """refresh_sql_endpoint_metadata resolves workspace + endpoint and returns a list of dicts."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
     ep_id = UUID("e5f6a7b8-c9d0-1234-ef01-234567890abc")
@@ -635,15 +660,13 @@ async def test_refresh_sql_endpoint_metadata_happy_path() -> None:
     mock_http = AsyncMock()
     mock_cache = MagicMock()
 
-    lro_result = {"status": "Succeeded", "percentComplete": 100}
-
     with (
         patch("fabric_dw.mcp.server._get_http", return_value=mock_http),
         patch("fabric_dw.mcp.server._get_resolver", return_value=mock_resolver),
         patch("fabric_dw.mcp.server._get_cache", return_value=mock_cache),
         patch(
             "fabric_dw.services.sql_endpoints.refresh_metadata",
-            new=AsyncMock(return_value=lro_result),
+            new=AsyncMock(return_value=_make_table_sync_statuses()),
         ),
     ):
         result = await mcp._tool_manager.call_tool(
@@ -651,8 +674,46 @@ async def test_refresh_sql_endpoint_metadata_happy_path() -> None:
             {"workspace": _WS_NAME, "endpoint": "SalesLakehouse"},
         )
 
-    assert isinstance(result, dict)
-    assert result.get("status") == "Succeeded"
+    assert isinstance(result, list)
+    assert len(result) == 2
+    assert result[0]["tableName"] == "Table1"
+    assert result[0]["status"] == "Success"
+    assert result[1]["status"] == "Failure"
+
+
+@pytest.mark.asyncio
+async def test_refresh_sql_endpoint_metadata_recreate_tables() -> None:
+    """refresh_sql_endpoint_metadata passes recreate_tables=True to the service."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    ep_id = UUID("e5f6a7b8-c9d0-1234-ef01-234567890abc")
+    item = _make_item_entry(item_id=ep_id, display_name="SalesLakehouse")
+
+    mock_resolver = AsyncMock()
+    mock_resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_resolver.item = AsyncMock(return_value=item)
+    mock_http = AsyncMock()
+    mock_cache = MagicMock()
+    mock_refresh = AsyncMock(return_value=_make_table_sync_statuses())
+
+    with (
+        patch("fabric_dw.mcp.server._get_http", return_value=mock_http),
+        patch("fabric_dw.mcp.server._get_resolver", return_value=mock_resolver),
+        patch("fabric_dw.mcp.server._get_cache", return_value=mock_cache),
+        patch(
+            "fabric_dw.services.sql_endpoints.refresh_metadata",
+            new=mock_refresh,
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "refresh_sql_endpoint_metadata",
+            {"workspace": _WS_NAME, "endpoint": "SalesLakehouse", "recreate_tables": True},
+        )
+
+    assert isinstance(result, list)
+    mock_refresh.assert_called_once()
+    _, kwargs = mock_refresh.call_args
+    assert kwargs.get("recreate_tables") is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/services/test_sql_endpoints.py
+++ b/tests/unit/services/test_sql_endpoints.py
@@ -16,7 +16,7 @@ from azure.core.credentials_async import AsyncTokenCredential
 
 from fabric_dw.exceptions import FabricServerError, NotFound, PermissionDenied
 from fabric_dw.http_client import FabricHttpClient
-from fabric_dw.models import Warehouse, WarehouseKind, Workspace
+from fabric_dw.models import TableSyncStatus, Warehouse, WarehouseKind, Workspace
 from tests.fixtures.api_payloads import (
     WAREHOUSE_SQL_ENDPOINTS_PAGE1_PAYLOAD,
     WAREHOUSE_SQL_ENDPOINTS_PAGE2_PAYLOAD,
@@ -65,12 +65,31 @@ _ENDPOINT_GET_PAYLOAD: dict[str, Any] = {
     },
 }
 
+_REFRESH_TABLE_RESULTS: list[dict[str, Any]] = [
+    {
+        "tableName": "Table1",
+        "startDateTime": "2025-08-08T10:31:22.270Z",
+        "endDateTime": "2025-08-08T10:36:54.965Z",
+        "status": "Success",
+        "lastSuccessfulSyncDateTime": "2025-08-08T10:36:54.965Z",
+    },
+    {
+        "tableName": "Table2",
+        "startDateTime": "2025-08-08T10:31:22.270Z",
+        "endDateTime": "2025-08-08T10:43:02.532Z",
+        "status": "Failure",
+        "error": {
+            "errorCode": "AdalRetryException",
+            "message": "Token error",
+        },
+        "lastSuccessfulSyncDateTime": "2025-08-07T10:44:27.263Z",
+    },
+]
+
+# The LRO operation GET response wraps results in status/value envelope
 _REFRESH_LRO_SUCCEEDED: dict[str, Any] = {
     "status": "Succeeded",
-    "createdTimeUtc": "2024-03-15T10:29:50Z",
-    "lastUpdatedTimeUtc": "2024-03-15T10:30:00Z",
-    "percentComplete": 100,
-    "error": None,
+    "value": _REFRESH_TABLE_RESULTS,
 }
 
 
@@ -210,8 +229,69 @@ async def test_refresh_metadata_posts_and_polls_lro() -> None:
             result = await refresh_metadata(client, _WORKSPACE_ID, _ENDPOINT_ID)
 
     assert post_route.called
-    assert isinstance(result, dict)
-    assert result.get("status") == "Succeeded"
+    assert isinstance(result, list)
+    assert len(result) == 2
+    assert all(isinstance(s, TableSyncStatus) for s in result)
+    assert result[0].table_name == "Table1"
+    assert result[0].status == "Success"
+    assert result[1].status == "Failure"
+    assert result[1].error is not None
+    assert result[1].error.error_code == "AdalRetryException"
+
+
+@pytest.mark.asyncio
+async def test_refresh_metadata_no_recreate_tables_sends_no_body() -> None:
+    """refresh_metadata without recreate_tables must not send a JSON body."""
+    from fabric_dw.services.sql_endpoints import refresh_metadata  # noqa: PLC0415
+
+    captured_requests: list[httpx.Request] = []
+
+    def post_side_effect(request: httpx.Request) -> httpx.Response:
+        captured_requests.append(request)
+        return httpx.Response(202, json={}, headers={"Location": _OPERATION_URL})
+
+    with respx.mock(assert_all_called=False) as mock_router:
+        mock_router.post(_REFRESH_URL).mock(side_effect=post_side_effect)
+        mock_router.get(_OPERATION_URL).mock(
+            return_value=httpx.Response(200, json=_REFRESH_LRO_SUCCEEDED)
+        )
+
+        client = await _make_client()
+        async with client:
+            await refresh_metadata(client, _WORKSPACE_ID, _ENDPOINT_ID)
+
+    assert len(captured_requests) == 1
+    # No body was sent — content should be empty
+    assert captured_requests[0].content in (b"", b"null")
+
+
+@pytest.mark.asyncio
+async def test_refresh_metadata_recreate_tables_sends_body() -> None:
+    """refresh_metadata with recreate_tables=True must send {recreateTables: true} in the body."""
+    from fabric_dw.services.sql_endpoints import refresh_metadata  # noqa: PLC0415
+
+    captured_requests: list[httpx.Request] = []
+
+    def post_side_effect(request: httpx.Request) -> httpx.Response:
+        captured_requests.append(request)
+        return httpx.Response(202, json={}, headers={"Location": _OPERATION_URL})
+
+    with respx.mock(assert_all_called=False) as mock_router:
+        mock_router.post(_REFRESH_URL).mock(side_effect=post_side_effect)
+        mock_router.get(_OPERATION_URL).mock(
+            return_value=httpx.Response(200, json=_REFRESH_LRO_SUCCEEDED)
+        )
+
+        client = await _make_client()
+        async with client:
+            result = await refresh_metadata(
+                client, _WORKSPACE_ID, _ENDPOINT_ID, recreate_tables=True
+            )
+
+    assert len(captured_requests) == 1
+    body = json.loads(captured_requests[0].content)
+    assert body == {"recreateTables": True}
+    assert isinstance(result, list)
 
 
 @pytest.mark.asyncio
@@ -247,7 +327,8 @@ async def test_refresh_metadata_lro_poll_multiple_times() -> None:
             result = await refresh_metadata(client, _WORKSPACE_ID, _ENDPOINT_ID)
 
     assert poll_count == 3
-    assert result.get("status") == "Succeeded"
+    assert isinstance(result, list)
+    assert len(result) == 2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Add `recreateTables` support to `refresh_metadata` service: passes `{"recreateTables": true}` in the POST request body when `recreate_tables=True` (destructive — drops and recreates all tables)
- Add `--recreate-tables` Click flag to `sql-endpoints refresh` CLI command
- Switch default CLI output from raw JSON to a Rich per-table status table (columns: Table, Status, End Time, Error); root-level `--json` flag still emits raw JSON
- Add `recreate_tables: bool = False` parameter to `refresh_sql_endpoint_metadata` MCP tool
- Add `TableSyncStatus` and `TableSyncError` Pydantic models to type the per-table LRO response (`tableName`, `status`, `startDateTime`, `endDateTime`, `lastSuccessfulSyncDateTime`, `error`)
- Update `docs/cli.md` with new flag docs and output description

Verified against the Fabric REST API spec at https://learn.microsoft.com/en-us/rest/api/fabric/sqlendpoint/items/refresh-sql-endpoint-metadata — `recreateTables` is a request body field (not a query param), and the LRO response envelope wraps table statuses under `{"status": "Succeeded", "value": [...]}`.

Closes #213

## Test plan

- [x] Service unit tests: default (no body sent), `recreate_tables=True` (body with `{"recreateTables": true}`), LRO poll, LRO failure, multi-poll, return type is `list[TableSyncStatus]`
- [x] CLI unit tests: `--recreate-tables` flag passes to service; default output is Rich table (not JSON); `--json` flag emits valid JSON array with `tableName`/`status` keys
- [x] MCP unit tests: happy path returns `list[dict]` with correct fields; `recreate_tables=True` threads through to service
- [x] Full unit suite: 671 passed
- [x] `ruff check`, `ruff format --check`, `ty check` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)