### PR TITLE
feat(views): add read command + --from-file body for create/update

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -880,6 +880,39 @@ fabric-dw --yes views drop MyWorkspace SalesWH dbo.vw_recent
 
 ---
 
+### views read
+
+Read up to `--count` rows from a view and emit them as JSON (default), CSV, or Parquet.
+
+CSV and Parquet formats require `--output`. JSON is emitted to stdout by default.
+
+**Synopsis**
+
+```
+fabric-dw views read [OPTIONS] [WORKSPACE] [WAREHOUSE] QUALIFIED_NAME
+```
+
+| Option | Description | Default |
+| --- | --- | --- |
+| `--count N` | Maximum rows to return. | `10` |
+| `--format {json\|csv\|parquet}` | Output format. | `json` |
+| `--output PATH` | Write to file instead of stdout. Required for `csv` and `parquet`. | |
+
+**Example**
+
+```shell
+fabric-dw views read MyWorkspace SalesWH dbo.vw_sales --count 5
+```
+
+```json
+[
+  {"id": 1, "amount": 99.99, "customer_id": 42},
+  ...
+]
+```
+
+---
+
 ## fabric-dw tables
 
 Manage SQL tables on Microsoft Fabric Data Warehouses and SQL Analytics Endpoints.

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -571,6 +571,21 @@ Drop a SQL view.
 
 ---
 
+### read_view
+
+Return up to `count` rows from a view as JSON-serialisable columns and rows.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `item` (`str`) — warehouse or SQL analytics endpoint name or GUID.
+- `qualified_name` (`str`) — dot-separated schema and view name, e.g. `dbo.vw_sales`.
+- `count` (`int`, default `10`) — maximum rows to return.
+
+**Returns:** `{ "columns": list[str], "rows": list[list] }` — column names and row arrays.
+
+---
+
 ## Tables
 
 > **List-source note** — no public REST API exists for enumerating warehouse tables. `list_tables` uses TDS `sys.tables JOIN sys.schemas`.

--- a/src/fabric_dw/cli/commands/views.py
+++ b/src/fabric_dw/cli/commands/views.py
@@ -22,6 +22,7 @@ from fabric_dw.exceptions import FabricError
 from fabric_dw.http_client import FabricHttpClient
 from fabric_dw.services import views as _views_svc
 from fabric_dw.sql import SqlTarget
+from fabric_dw.sql_io import OutputFormat, columns_rows_to_arrow, write_arrow
 
 _log = logging.getLogger(__name__)
 
@@ -60,7 +61,7 @@ def _load_select_body(select: str | None, from_file: str | None) -> str:
         path = Path(from_file)
         if not path.is_file():
             raise click.UsageError(f"File not found: {from_file}")  # noqa: TRY003
-        return path.read_text(encoding="utf-8").strip()
+        return path.read_text(encoding="utf-8-sig").strip()
     if select:
         return select
     raise click.UsageError("Provide --select or --from-file.")  # noqa: TRY003
@@ -101,6 +102,61 @@ async def list_cmd(
                 json_output=ctx.json_output,
                 table_title="Views",
             )
+    except (ValueError, FabricError) as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@views_group.command("read")
+@click.argument("workspace", required=False, default=None)
+@click.argument("item", required=False, default=None)
+@click.argument("qualified_name")
+@click.option("--count", default=10, show_default=True, help="Max rows to return.")
+@click.option(
+    "--format",
+    "fmt",
+    type=click.Choice(list(OutputFormat.ALL), case_sensitive=False),
+    default=OutputFormat.JSON,
+    show_default=True,
+    help="Output format.",
+)
+@click.option("--output", default=None, help="Write to this file instead of stdout.")
+@click.pass_obj
+@_coro
+async def read_cmd(
+    ctx: CliContext,
+    workspace: str | None,
+    item: str | None,
+    qualified_name: str,
+    count: int,
+    fmt: str,
+    output: str | None,
+) -> None:
+    """Read up to COUNT rows from QUALIFIED_NAME (schema.view) on ITEM in WORKSPACE."""
+    ws = resolve_workspace_arg(ctx, workspace)
+    wh = resolve_warehouse_arg(ctx, item)
+    schema, view_name = _parse_qualified_name(qualified_name)
+    output_path = Path(output) if output else None
+
+    if fmt in (OutputFormat.CSV, OutputFormat.PARQUET) and output_path is None:
+        raise click.UsageError(f"--output PATH is required for {fmt!r} format.")  # noqa: TRY003
+
+    try:
+        async with _build_http_client(ctx) as http:
+            ws_id, entry = await _resolve_item(http, ws, wh)
+            if entry.connection_string is None:
+                raise click.ClickException(  # noqa: TRY003
+                    f"Item {entry.display_name!r} has no connection string."
+                )
+            target = SqlTarget(
+                workspace_id=str(ws_id),
+                database=entry.display_name,
+                connection_string=entry.connection_string,
+            )
+            columns, rows = await _views_svc.read_view(
+                target, schema, view_name, count=count, mode=ctx.auth
+            )
+            arrow_table = columns_rows_to_arrow(columns, rows)
+            write_arrow(arrow_table, fmt, output_path)
     except (ValueError, FabricError) as exc:
         raise click.ClickException(str(exc)) from exc
 

--- a/src/fabric_dw/mcp/server.py
+++ b/src/fabric_dw/mcp/server.py
@@ -1060,6 +1060,45 @@ async def list_views(workspace: str, item: str, schema: str | None = None) -> li
 
 
 @mcp.tool()
+async def read_view(
+    workspace: str, item: str, qualified_name: str, count: int = 10
+) -> dict[str, Any]:
+    """Return up to *count* rows from a view as JSON-serialisable columns + rows.
+
+    Args:
+        workspace: Workspace name or GUID.
+        item: Warehouse or SQL endpoint name or GUID.
+        qualified_name: Dot-separated qualified view name, e.g. ``dbo.vw_sales``.
+        count: Maximum number of rows to return (default 10).
+    """
+    schema, _, view_name = qualified_name.partition(".")
+    if not schema or not view_name:
+        raise ToolError(  # noqa: TRY003
+            f"qualified_name must be <schema>.<view>, got {qualified_name!r}"
+        )
+    try:
+        ws_id = await _get_resolver().workspace_id(workspace)
+        entry = await _get_resolver().item(workspace, item)
+        if entry.connection_string is None:
+            msg = f"item {item!r} has no connection string; cannot read views"
+            raise FabricError(msg)  # noqa: TRY301
+        target = SqlTarget(
+            workspace_id=str(ws_id),
+            database=entry.display_name,
+            connection_string=entry.connection_string,
+        )
+        columns, rows = await views_svc.read_view(
+            target, schema, view_name, count=count, mode=_get_auth_mode()
+        )
+    except (ValueError, FabricError) as exc:
+        raise _fabric_err(exc) if isinstance(exc, FabricError) else ToolError(str(exc)) from exc
+    return {
+        "columns": columns,
+        "rows": [[_json_safe_value(v) for v in row] for row in rows],
+    }
+
+
+@mcp.tool()
 async def get_view(workspace: str, item: str, qualified_name: str) -> dict[str, Any]:
     """Fetch the full definition of a view (schema.view).
 

--- a/src/fabric_dw/services/views.py
+++ b/src/fabric_dw/services/views.py
@@ -29,6 +29,7 @@ __all__ = [
     "drop_view",
     "get_view",
     "list_views",
+    "read_view",
     "update_view",
     "validate_identifier",
 ]
@@ -77,6 +78,8 @@ def validate_identifier(name: str) -> str:
 # ---------------------------------------------------------------------------
 # SQL templates
 # ---------------------------------------------------------------------------
+
+_READ_VIEW_SQL = "SELECT TOP ({count}) * FROM [{schema}].[{view}];"
 
 _LIST_VIEWS_SQL = """\
 SELECT
@@ -173,6 +176,60 @@ async def list_views(
                     raise mapped from exc
                 raise
             return [_row_to_view(cols, r) for r in rows]
+
+    return await asyncio.to_thread(_run)
+
+
+async def read_view(
+    target: SqlTarget,
+    schema: str,
+    view_name: str,
+    *,
+    count: int = 10,
+    mode: CredentialMode = CredentialMode.DEFAULT,
+) -> tuple[list[str], list[tuple[object, ...]]]:
+    """Return up to *count* rows from *schema*.*view_name*.
+
+    The result is a ``(columns, rows)`` pair suitable for passing to
+    :mod:`fabric_dw.sql_io` for materialisation via Arrow.
+
+    Args:
+        target: The warehouse or SQL Analytics Endpoint to query.
+        schema: The schema name.  Must pass :func:`validate_identifier`.
+        view_name: The view name.  Must pass :func:`validate_identifier`.
+        count: Maximum number of rows to return (default 10).
+        mode: The credential mode for Entra authentication.
+
+    Returns:
+        A ``(columns, rows)`` tuple where *columns* is a list of column name
+        strings and *rows* is a list of row tuples.
+
+    Raises:
+        ValueError: If *schema* or *view_name* fails identifier validation.
+        NotFound: If the view does not exist (zero rows AND zero columns).
+        PermissionDenied: If the driver reports a permission error.
+    """
+    validate_identifier(schema)
+    validate_identifier(view_name)
+
+    read_sql = _READ_VIEW_SQL.format(count=int(count), schema=schema, view=view_name)
+
+    def _run() -> tuple[list[str], list[tuple[object, ...]]]:
+        with closing(sql.open_connection(target, mode=mode)) as conn:
+            cursor = conn.cursor()
+            try:
+                cursor.execute(read_sql)
+                cols = [c[0] for c in (cursor.description or [])]
+                rows = cursor.fetchall()
+            except Exception as exc:
+                mapped = sql.map_driver_error(exc)
+                if mapped:
+                    raise mapped from exc
+                raise
+            if not cols:
+                msg = f"View [{schema}].[{view_name}] not found"
+                raise NotFound(msg)
+            return cols, list(rows)
 
     return await asyncio.to_thread(_run)
 

--- a/tests/unit/cli/commands/test_views.py
+++ b/tests/unit/cli/commands/test_views.py
@@ -598,6 +598,48 @@ class TestViewsUpdate:
             )
         assert result.exit_code != 0
 
+    def test_update_from_file_strips_utf8_sig_bom(
+        self, runner: CliRunner, cache_env: Path, tmp_path: Path
+    ) -> None:
+        """Files with UTF-8-sig BOM (\xef\xbb\xbf) must be decoded transparently."""
+        _ = cache_env
+        sql_file = tmp_path / "view_update_bom.sql"
+        sql_file.write_bytes(b"\xef\xbb\xbfSELECT id FROM dbo.sales")
+        captured_body: list[str] = []
+
+        async def _capture(
+            _target: object, _schema: object, _view_name: object, body: str, **_kw: object
+        ) -> View:
+            captured_body.append(body)
+            return _make_view(with_definition=True)
+
+        with (
+            patch(
+                "fabric_dw.cli.commands.views._build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.views._resolve_item",
+                new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
+            ),
+            patch("fabric_dw.services.views.update_view", new=_capture),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--yes",
+                    "views",
+                    "update",
+                    WS_GUID,
+                    WH_GUID,
+                    "dbo.vw_sales",
+                    "--from-file",
+                    str(sql_file),
+                ],
+            )
+        assert result.exit_code == 0
+        assert captured_body == ["SELECT id FROM dbo.sales"]
+
 
 # ===========================================================================
 # views drop

--- a/tests/unit/cli/commands/test_views.py
+++ b/tests/unit/cli/commands/test_views.py
@@ -151,6 +151,131 @@ class TestViewsList:
 
 
 # ===========================================================================
+# views read
+# ===========================================================================
+
+
+class TestViewsRead:
+    def test_read_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.views._build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.views._resolve_item",
+                new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.views.read_view",
+                new=AsyncMock(return_value=(["id", "name"], [(1, "Alice")])),
+            ),
+        ):
+            result = runner.invoke(cli, ["views", "read", WS_GUID, WH_GUID, "dbo.vw_sales"])
+        assert result.exit_code == 0
+
+    def test_read_json_output_to_stdout(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.views._build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.views._resolve_item",
+                new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.views.read_view",
+                new=AsyncMock(return_value=(["id"], [(42,)])),
+            ),
+        ):
+            result = runner.invoke(cli, ["views", "read", WS_GUID, WH_GUID, "dbo.vw_sales"])
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed[0]["id"] == 42
+
+    def test_read_csv_requires_output(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        result = runner.invoke(
+            cli, ["views", "read", WS_GUID, WH_GUID, "dbo.vw_sales", "--format", "csv"]
+        )
+        assert result.exit_code != 0
+
+    def test_read_parquet_requires_output(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        result = runner.invoke(
+            cli, ["views", "read", WS_GUID, WH_GUID, "dbo.vw_sales", "--format", "parquet"]
+        )
+        assert result.exit_code != 0
+
+    def test_read_csv_with_output(self, runner: CliRunner, cache_env: Path, tmp_path: Path) -> None:
+        _ = cache_env
+        out_file = tmp_path / "out.csv"
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.views._build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.views._resolve_item",
+                new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.views.read_view",
+                new=AsyncMock(return_value=(["id"], [(1,)])),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "views",
+                    "read",
+                    WS_GUID,
+                    WH_GUID,
+                    "dbo.vw_sales",
+                    "--format",
+                    "csv",
+                    "--output",
+                    str(out_file),
+                ],
+            )
+        assert result.exit_code == 0
+        assert out_file.exists()
+
+    def test_read_bad_qualified_name_exits_nonzero(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        _ = cache_env
+        result = runner.invoke(cli, ["views", "read", WS_GUID, WH_GUID, "nodot"])
+        assert result.exit_code != 0
+
+    def test_read_not_found_returns_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.views._build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.views._resolve_item",
+                new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.views.read_view",
+                new=AsyncMock(side_effect=NotFound("view not found")),
+            ),
+        ):
+            result = runner.invoke(cli, ["views", "read", WS_GUID, WH_GUID, "dbo.vw_missing"])
+        assert result.exit_code != 0
+
+
+# ===========================================================================
 # views get
 # ===========================================================================
 
@@ -328,6 +453,49 @@ class TestViewsCreate:
             ],
         )
         assert result.exit_code != 0
+
+    def test_create_from_file_strips_utf8_sig_bom(
+        self, runner: CliRunner, cache_env: Path, tmp_path: Path
+    ) -> None:
+        """Files with UTF-8-sig BOM (\xef\xbb\xbf) must be decoded transparently."""
+        _ = cache_env
+        sql_file = tmp_path / "view_bom.sql"
+        sql_file.write_bytes(b"\xef\xbb\xbfSELECT id FROM dbo.sales")
+        mock_http = AsyncMock()
+        captured_body: list[str] = []
+
+        async def _capture(
+            _target: object, _schema: object, _view_name: object, body: str, **_kw: object
+        ) -> View:
+            captured_body.append(body)
+            return _make_view(with_definition=True)
+
+        with (
+            patch(
+                "fabric_dw.cli.commands.views._build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.views._resolve_item",
+                new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
+            ),
+            patch("fabric_dw.services.views.create_view", new=_capture),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "views",
+                    "create",
+                    WS_GUID,
+                    WH_GUID,
+                    "--name",
+                    "dbo.vw_sales",
+                    "--from-file",
+                    str(sql_file),
+                ],
+            )
+        assert result.exit_code == 0
+        assert captured_body == ["SELECT id FROM dbo.sales"]
 
     def test_create_permission_denied_returns_nonzero(
         self, runner: CliRunner, cache_env: Path

--- a/tests/unit/mcp/test_server.py
+++ b/tests/unit/mcp/test_server.py
@@ -92,6 +92,19 @@ EXPECTED_TOOL_NAMES: frozenset[str] = frozenset(
         "list_schemas",
         "create_schema",
         "delete_schema",
+        # Views
+        "list_views",
+        "read_view",
+        "get_view",
+        "create_view",
+        "update_view",
+        "drop_view",
+        # Tables
+        "list_tables",
+        "read_table",
+        "create_table",
+        "delete_table",
+        "clear_table",
     }
 )
 
@@ -1229,3 +1242,89 @@ async def test_list_schemas_works_on_sql_endpoint() -> None:
 
     assert isinstance(result, list)
     assert result[0]["name"] == "dbo"
+
+
+@pytest.mark.asyncio
+async def test_read_view_happy_path() -> None:
+    """read_view calls views_svc.read_view and returns {columns, rows}."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = _make_item_entry()
+
+    mock_resolver = AsyncMock()
+    mock_resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_resolver.item = AsyncMock(return_value=item)
+    mock_http = AsyncMock()
+    mock_cache = MagicMock()
+
+    with (
+        patch("fabric_dw.mcp.server._get_http", return_value=mock_http),
+        patch("fabric_dw.mcp.server._get_resolver", return_value=mock_resolver),
+        patch("fabric_dw.mcp.server._get_cache", return_value=mock_cache),
+        patch(
+            "fabric_dw.services.views.read_view",
+            new=AsyncMock(return_value=(["id", "amount"], [(1, 100), (2, 200)])),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "read_view",
+            {"workspace": _WS_NAME, "item": _WH_NAME, "qualified_name": "dbo.vw_sales"},
+        )
+
+    assert isinstance(result, dict)
+    assert result["columns"] == ["id", "amount"]
+    assert result["rows"] == [[1, 100], [2, 200]]
+
+
+@pytest.mark.asyncio
+async def test_read_view_no_connection_string_raises_tool_error() -> None:
+    """read_view raises ToolError when the item has no connection string."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = _make_item_entry(connection_string=None)
+
+    mock_resolver = AsyncMock()
+    mock_resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_resolver.item = AsyncMock(return_value=item)
+    mock_http = AsyncMock()
+    mock_cache = MagicMock()
+
+    with (
+        patch("fabric_dw.mcp.server._get_http", return_value=mock_http),
+        patch("fabric_dw.mcp.server._get_resolver", return_value=mock_resolver),
+        patch("fabric_dw.mcp.server._get_cache", return_value=mock_cache),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "read_view",
+            {"workspace": _WS_NAME, "item": _WH_NAME, "qualified_name": "dbo.vw_sales"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_read_view_bad_qualified_name_raises_tool_error() -> None:
+    """read_view raises ToolError when qualified_name has no dot."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = _make_item_entry()
+
+    mock_resolver = AsyncMock()
+    mock_resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_resolver.item = AsyncMock(return_value=item)
+    mock_http = AsyncMock()
+    mock_cache = MagicMock()
+
+    with (
+        patch("fabric_dw.mcp.server._get_http", return_value=mock_http),
+        patch("fabric_dw.mcp.server._get_resolver", return_value=mock_resolver),
+        patch("fabric_dw.mcp.server._get_cache", return_value=mock_cache),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "read_view",
+            {"workspace": _WS_NAME, "item": _WH_NAME, "qualified_name": "nodot"},
+        )

--- a/tests/unit/services/test_views.py
+++ b/tests/unit/services/test_views.py
@@ -10,7 +10,7 @@ import pytest
 from fabric_dw.exceptions import AuthError, NotFound, PermissionDenied
 from fabric_dw.models import View
 from fabric_dw.services import views
-from fabric_dw.services.views import validate_identifier
+from fabric_dw.services.views import read_view, validate_identifier
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -279,6 +279,103 @@ class TestListViews:
             pytest.raises(RuntimeError, match="network timeout"),
         ):
             await views.list_views(target)
+
+
+# ===========================================================================
+# read_view
+# ===========================================================================
+
+
+class TestReadView:
+    @pytest.mark.asyncio
+    async def test_returns_columns_and_rows(self) -> None:
+        target = _make_target()
+        cols = ["id", "name"]
+        rows: list[tuple[object, ...]] = [(1, "Alice"), (2, "Bob")]
+        conn = _make_conn(rows, cols)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            result_cols, result_rows = await read_view(target, "dbo", "vw_sales")
+        assert result_cols == cols
+        assert list(result_rows) == rows
+
+    @pytest.mark.asyncio
+    async def test_sql_uses_select_top(self) -> None:
+        target = _make_target()
+        conn = _make_conn([(1,)], ["id"])
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await read_view(target, "dbo", "vw_sales", count=5)
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0].upper()
+        assert "SELECT TOP" in call_sql
+        assert "5" in call_sql
+
+    @pytest.mark.asyncio
+    async def test_sql_uses_bracket_quoting(self) -> None:
+        target = _make_target()
+        conn = _make_conn([(1,)], ["id"])
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await read_view(target, "dbo", "vw_sales")
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert "[dbo]" in call_sql
+        assert "[vw_sales]" in call_sql
+
+    @pytest.mark.asyncio
+    async def test_validates_schema_identifier(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await read_view(target, "bad;schema", "vw_sales")
+
+    @pytest.mark.asyncio
+    async def test_validates_view_name_identifier(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await read_view(target, "dbo", "vw--injection")
+
+    @pytest.mark.asyncio
+    async def test_raises_not_found_when_no_columns(self) -> None:
+        target = _make_target()
+        cursor = MagicMock()
+        cursor.description = None
+        cursor.fetchall.return_value = []
+        conn = MagicMock()
+        conn.cursor.return_value = cursor
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(NotFound),
+        ):
+            await read_view(target, "dbo", "vw_nonexistent")
+
+    @pytest.mark.asyncio
+    async def test_maps_permission_denied(self) -> None:
+        target = _make_target()
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.execute.side_effect = Exception("permission was denied on object vw_sales")
+        conn.cursor.return_value = cursor
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(PermissionDenied),
+        ):
+            await read_view(target, "dbo", "vw_sales")
+
+    @pytest.mark.asyncio
+    async def test_closes_connection(self) -> None:
+        target = _make_target()
+        conn = _make_conn([(1,)], ["id"])
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await read_view(target, "dbo", "vw_sales")
+        conn.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_default_count_is_ten(self) -> None:
+        target = _make_target()
+        conn = _make_conn([(1,)], ["id"])
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await read_view(target, "dbo", "vw_sales")
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert "10" in call_sql
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

- Adds `views read <ws> <item> <schema>.<view> [--count N] [--format json|csv|parquet] [--output PATH]` CLI command mirroring `tables read`
- Adds `read_view` MCP tool returning `{columns, rows}`
- Fixes `--from-file` encoding on `views create`/`views update` from `utf-8` to `utf-8-sig` (issue requirement)
- All backed by `sql_io` Arrow infrastructure from PR #212

## Test plan

- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uvx ty==0.0.44 check src tests` — clean
- [x] `uv run pytest tests/unit -q` — 919 passed
- [ ] Integration CI gate (label: `integration`)

Closes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)