### PR TITLE
fix(docker): make hatch-vcs honour pretend-version build-arg in build stage

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -58,3 +58,7 @@ jobs:
           build-args: SETUPTOOLS_SCM_PRETEND_VERSION=${{ steps.docker_tags.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Verify image pushed
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
+        run: docker manifest inspect ghcr.io/sdebruyn/fabric-dw:${{ steps.docker_tags.outputs.version }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -55,6 +55,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.docker_tags.outputs.tags }}
-          build-args: SETUPTOOLS_SCM_PRETEND_VERSION_FOR_FABRIC_DW=${{ steps.docker_tags.outputs.version }}
+          build-args: SETUPTOOLS_SCM_PRETEND_VERSION=${{ steps.docker_tags.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,11 @@ ARG PYTHON_VERSION=3.13
 # Build stage uses Astral's official uv + python image
 FROM ghcr.io/astral-sh/uv:python${PYTHON_VERSION}-trixie-slim AS build
 WORKDIR /app
-ARG SETUPTOOLS_SCM_PRETEND_VERSION_FOR_FABRIC_DW
-ENV SETUPTOOLS_SCM_PRETEND_VERSION_FOR_FABRIC_DW=${SETUPTOOLS_SCM_PRETEND_VERSION_FOR_FABRIC_DW}
+ARG SETUPTOOLS_SCM_PRETEND_VERSION
+ENV SETUPTOOLS_SCM_PRETEND_VERSION=${SETUPTOOLS_SCM_PRETEND_VERSION}
 COPY pyproject.toml uv.lock README.md LICENSE ./
 COPY src/ src/
-RUN uv sync --frozen --no-dev && uv build --wheel
+RUN uv build --wheel
 
 # Runtime stage stays minimal — slim Python, pip-install the wheel
 FROM python:${PYTHON_VERSION}-slim AS runtime

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ ARG PYTHON_VERSION=3.13
 # Build stage uses Astral's official uv + python image
 FROM ghcr.io/astral-sh/uv:python${PYTHON_VERSION}-trixie-slim AS build
 WORKDIR /app
+# Global env var (not _FOR_<dist>) because hatch-vcs calls setuptools-scm without dist_name.
 ARG SETUPTOOLS_SCM_PRETEND_VERSION
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=${SETUPTOOLS_SCM_PRETEND_VERSION}
 COPY pyproject.toml uv.lock README.md LICENSE ./


### PR DESCRIPTION
## Summary

- `hatch-vcs` calls `setuptools_scm.get_version()` without passing `dist_name`, so the dist-specific env var `SETUPTOOLS_SCM_PRETEND_VERSION_FOR_FABRIC_DW` is never consulted — only the generic `SETUPTOOLS_SCM_PRETEND_VERSION` is checked. Switching to the generic form fixes the `LookupError`.
- Drops the redundant `uv sync --frozen --no-dev` step from the build stage: the build stage's only output is a wheel that the runtime stage installs via `pip`, so the sync venv is thrown away and its editable-install path (`hatchling.build.build_editable`) is what triggers the same error on every `main` push.

Closes #223

## Test plan

- [x] Reproduced the failure locally by simulating the Docker build context (no `.git`, no `_version.py`) with `SETUPTOOLS_SCM_PRETEND_VERSION_FOR_FABRIC_DW` set — confirmed it fails
- [x] Confirmed `SETUPTOOLS_SCM_PRETEND_VERSION=99.0.0 uv build --wheel` succeeds in the same simulated context, producing `fabric_dw-99.0.0-py3-none-any.whl`
- [ ] CI Docker workflow passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)