### PR TITLE
feat(services/schemas): list/create/delete schemas with --cascade

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1012,6 +1012,82 @@ fabric-dw --yes tables clear MyWorkspace SalesWH dbo.staging_load
 
 ---
 
+## fabric-dw schemas
+
+Manage SQL schemas on Microsoft Fabric Data Warehouses.
+
+> **List-source note** — no public REST API exists for enumerating warehouse schemas. `schemas list` falls back to TDS via `sys.schemas`, filtering out well-known system schemas (`sys`, `INFORMATION_SCHEMA`, `guest`, `db_*` fixed-role schemas). `dbo` is always included because it is user-writable.
+
+> **SQL Analytics Endpoints** — `schemas list` works on both warehouses and SQL Analytics Endpoints. `schemas create` and `schemas delete` are DDL operations and are only supported on Fabric Data Warehouses; they will fail with an error if the resolved item is a SQL Analytics Endpoint.
+
+### schemas list
+
+List all user-defined schemas on a warehouse or SQL Analytics Endpoint. System schemas are excluded.
+
+**Usage**
+
+```shell
+fabric-dw schemas list [OPTIONS] [WORKSPACE] [WAREHOUSE]
+```
+
+**Example**
+
+```shell
+fabric-dw schemas list MyWorkspace SalesWH
+```
+
+```
+ name     principal_id
+ ───────────────────────
+ dbo      1
+ sales    5
+ staging  7
+```
+
+### schemas create
+
+Create a new SQL schema on a warehouse.
+
+**Usage**
+
+```shell
+fabric-dw schemas create [OPTIONS] [WORKSPACE] [WAREHOUSE] NAME
+```
+
+**Example**
+
+```shell
+fabric-dw schemas create MyWorkspace SalesWH reporting
+```
+
+### schemas delete
+
+Drop a schema from a warehouse. You will be asked to confirm unless `--yes` is passed.
+
+Pass `--cascade` to also drop all tables and views inside the schema before dropping the schema itself. **This is a destructive, irreversible operation.**
+
+**Usage**
+
+```shell
+fabric-dw schemas delete [OPTIONS] [WORKSPACE] [WAREHOUSE] NAME
+```
+
+| Option | Description |
+| --- | --- |
+| `--cascade` | Drop all tables and views in the schema first. **WARNING: permanently deletes all contained objects and data.** |
+
+**Example**
+
+```shell
+# Drop an empty schema
+fabric-dw --yes schemas delete MyWorkspace SalesWH staging
+
+# Drop a schema and all its tables/views
+fabric-dw --yes schemas delete MyWorkspace SalesWH staging --cascade
+```
+
+---
+
 ## fabric-dw snapshots
 
 Manage Microsoft Fabric Data Warehouse snapshots.

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -653,6 +653,62 @@ Truncate a SQL table (remove all rows, preserve structure).
 
 ---
 
+## Schemas
+
+> **List-source note** — no public REST API exists for enumerating warehouse schemas. `list_schemas` uses TDS `sys.schemas`, filtering out `sys`, `INFORMATION_SCHEMA`, `guest`, and `db_*` fixed-role schemas. `dbo` is always included because it is user-writable.
+
+> **SQL Analytics Endpoints** — `list_schemas` works on both Fabric Data Warehouses and SQL Analytics Endpoints. `create_schema` and `delete_schema` are DDL operations and are rejected with a `ToolError` when the resolved item is a SQL Analytics Endpoint.
+
+### list_schemas
+
+List user-defined SQL schemas on a warehouse or SQL Analytics Endpoint. System schemas are excluded automatically.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `item` (`str`) — warehouse or SQL Analytics Endpoint name or GUID.
+
+**Returns:** `list[Schema]` — array of schema objects, each with `name` and `principal_id`.
+
+---
+
+### create_schema
+
+Create a new SQL schema on a Fabric Data Warehouse.
+
+**CAUTION**: SQL Analytics Endpoints are read-only — this tool raises a `ToolError` if `item` resolves to a SQL Analytics Endpoint.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `item` (`str`) — warehouse name or GUID.
+- `name` (`str`) — the schema name; must be a valid SQL identifier.
+
+**Returns:** `Schema` — the newly-created schema record with `name` and `principal_id`.
+
+---
+
+### delete_schema
+
+Drop a SQL schema from a Fabric Data Warehouse.
+
+**CAUTION**: This is a destructive, irreversible operation. The schema will be permanently deleted. If the schema still contains tables or views the operation will fail unless `cascade=True`.
+
+**CAUTION**: When `cascade=True`, **all tables and views in the schema are permanently deleted along with their data**. Confirm explicitly with the user before calling with `cascade=True`.
+
+SQL Analytics Endpoints are read-only — this tool raises a `ToolError` if `item` resolves to a SQL Analytics Endpoint.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `item` (`str`) — warehouse name or GUID.
+- `name` (`str`) — the schema name to drop.
+- `cascade` (`bool`, default `False`) — when `True`, drop all tables and views in the schema first.
+
+**Returns:** `{ "deleted": true }` — confirmation.
+
+---
+
 ## SQL Pools (beta)
 
 !!! warning "Beta / preview feature"

--- a/src/fabric_dw/cli/_main.py
+++ b/src/fabric_dw/cli/_main.py
@@ -15,6 +15,7 @@ from fabric_dw.cli.commands.config import config_group
 from fabric_dw.cli.commands.queries import queries_group
 from fabric_dw.cli.commands.query_insights import query_insights_group
 from fabric_dw.cli.commands.restore_points import restore_points_group
+from fabric_dw.cli.commands.schemas import schemas_group
 from fabric_dw.cli.commands.snapshots import snapshots_group
 from fabric_dw.cli.commands.sql import sql_group
 from fabric_dw.cli.commands.sql_endpoints import sql_endpoints_group
@@ -90,5 +91,6 @@ cli.add_command(restore_points_group)
 cli.add_command(snapshots_group)
 cli.add_command(sql_group)
 cli.add_command(sql_pools_group)
+cli.add_command(schemas_group)
 cli.add_command(tables_group)
 cli.add_command(views_group)

--- a/src/fabric_dw/cli/commands/_utils.py
+++ b/src/fabric_dw/cli/commands/_utils.py
@@ -13,6 +13,7 @@ import click
 
 from fabric_dw.cache import ItemEntry, LookupCache
 from fabric_dw.http_client import FabricHttpClient
+from fabric_dw.models import WarehouseKind
 from fabric_dw.resolver import Resolver
 
 if TYPE_CHECKING:
@@ -20,6 +21,20 @@ if TYPE_CHECKING:
 
 _P = ParamSpec("_P")
 _R = TypeVar("_R")
+
+_SQL_ENDPOINT_READ_ONLY = "SQL Endpoints are read-only; CREATE/DROP SCHEMA not supported"
+
+
+def _guard_not_sql_endpoint(entry: ItemEntry) -> None:
+    """Raise ValueError if *entry* is a SQL Analytics Endpoint.
+
+    SQL Analytics Endpoints are read-only; DDL operations are not supported.
+
+    Raises:
+        ValueError: If the resolved item is a SQL Analytics Endpoint.
+    """
+    if entry.kind == WarehouseKind.SQL_ENDPOINT:
+        raise ValueError(_SQL_ENDPOINT_READ_ONLY)
 
 
 def _coro(f: Callable[_P, Coroutine[None, None, _R]]) -> Callable[_P, _R]:

--- a/src/fabric_dw/cli/commands/schemas.py
+++ b/src/fabric_dw/cli/commands/schemas.py
@@ -1,0 +1,180 @@
+"""Schemas sub-commands for the fabric-dw CLI."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+import click
+
+from fabric_dw import auth as _auth
+from fabric_dw.cache import ItemEntry
+from fabric_dw.cli._context import CliContext
+from fabric_dw.cli._render import confirm, render
+from fabric_dw.cli.commands._utils import (
+    _coro,
+    _resolve_item,
+    resolve_warehouse_arg,
+    resolve_workspace_arg,
+)
+from fabric_dw.exceptions import FabricError
+from fabric_dw.http_client import FabricHttpClient
+from fabric_dw.models import WarehouseKind
+from fabric_dw.services import schemas as _schemas_svc
+from fabric_dw.sql import SqlTarget
+
+_SQL_ENDPOINT_READ_ONLY = "SQL Endpoints are read-only; CREATE/DROP SCHEMA not supported"
+
+_log = logging.getLogger(__name__)
+
+
+def _guard_not_sql_endpoint(entry: ItemEntry) -> None:
+    """Raise ValueError if *entry* is a SQL Endpoint.
+
+    SQL Analytics Endpoints are read-only; DDL operations are not supported.
+
+    Raises:
+        ValueError: If the resolved item is a SQL Analytics Endpoint.
+    """
+    if entry.kind == WarehouseKind.SQL_ENDPOINT:
+        raise ValueError(_SQL_ENDPOINT_READ_ONLY)
+
+
+@asynccontextmanager
+async def _build_http_client(ctx: CliContext) -> AsyncIterator[FabricHttpClient]:
+    credential = _auth.get_credential(ctx.auth)
+    async with FabricHttpClient(credential) as http:
+        yield http
+
+
+@click.group("schemas")
+def schemas_group() -> None:
+    """Manage SQL schemas on Fabric warehouses."""
+
+
+@schemas_group.command("list")
+@click.argument("workspace", required=False, default=None)
+@click.argument("item", required=False, default=None)
+@click.pass_obj
+@_coro
+async def list_cmd(ctx: CliContext, workspace: str | None, item: str | None) -> None:
+    """List user-defined schemas on ITEM (warehouse) in WORKSPACE."""
+    ws = resolve_workspace_arg(ctx, workspace)
+    wh = resolve_warehouse_arg(ctx, item)
+    try:
+        async with _build_http_client(ctx) as http:
+            ws_id, entry = await _resolve_item(http, ws, wh)
+            if entry.connection_string is None:
+                raise click.ClickException(  # noqa: TRY003
+                    f"Item {entry.display_name!r} has no connection string."
+                )
+            target = SqlTarget(
+                workspace_id=str(ws_id),
+                database=entry.display_name,
+                connection_string=entry.connection_string,
+            )
+            items = await _schemas_svc.list_schemas(target, mode=ctx.auth)
+            render(
+                [s.model_dump(mode="json") for s in items],
+                json_output=ctx.json_output,
+                table_title="Schemas",
+            )
+    except (ValueError, FabricError) as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@schemas_group.command("create")
+@click.argument("workspace", required=False, default=None)
+@click.argument("item", required=False, default=None)
+@click.argument("name")
+@click.pass_obj
+@_coro
+async def create_cmd(
+    ctx: CliContext,
+    workspace: str | None,
+    item: str | None,
+    name: str,
+) -> None:
+    """Create a new SQL schema NAME on ITEM in WORKSPACE."""
+    ws = resolve_workspace_arg(ctx, workspace)
+    wh = resolve_warehouse_arg(ctx, item)
+    try:
+        async with _build_http_client(ctx) as http:
+            ws_id, entry = await _resolve_item(http, ws, wh)
+            _guard_not_sql_endpoint(entry)
+            if entry.connection_string is None:
+                raise click.ClickException(  # noqa: TRY003
+                    f"Item {entry.display_name!r} has no connection string."
+                )
+            target = SqlTarget(
+                workspace_id=str(ws_id),
+                database=entry.display_name,
+                connection_string=entry.connection_string,
+            )
+            s = await _schemas_svc.create_schema(target, name, mode=ctx.auth)
+            render(s.model_dump(mode="json"), json_output=ctx.json_output)
+    except (ValueError, FabricError) as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@schemas_group.command("delete")
+@click.argument("workspace", required=False, default=None)
+@click.argument("item", required=False, default=None)
+@click.argument("name")
+@click.option(
+    "--cascade",
+    is_flag=True,
+    default=False,
+    help=(
+        "Drop all tables and views in the schema before dropping the schema itself. "
+        "WARNING: This permanently deletes all contained objects and their data."
+    ),
+)
+@click.pass_obj
+@_coro
+async def delete_cmd(
+    ctx: CliContext,
+    workspace: str | None,
+    item: str | None,
+    name: str,
+    cascade: bool,
+) -> None:
+    """Drop schema NAME from ITEM in WORKSPACE.
+
+    Pass --cascade to also drop all tables and views inside the schema first.
+    This is a destructive, irreversible operation.
+    """
+    ws = resolve_workspace_arg(ctx, workspace)
+    wh = resolve_warehouse_arg(ctx, item)
+    try:
+        async with _build_http_client(ctx) as http:
+            ws_id, entry = await _resolve_item(http, ws, wh)
+            _guard_not_sql_endpoint(entry)
+            if entry.connection_string is None:
+                raise click.ClickException(  # noqa: TRY003
+                    f"Item {entry.display_name!r} has no connection string."
+                )
+            if cascade:
+                click.echo(
+                    f"WARNING: --cascade will permanently drop all tables and views "
+                    f"in schema [{name}] on {entry.display_name!r}.",
+                    err=True,
+                )
+            confirmed = confirm(
+                f"Drop schema [{name}] from {entry.display_name!r} ({entry.id})?",
+                yes=ctx.yes,
+            )
+            if not confirmed:
+                raise click.Abort()  # noqa: TRY301
+            target = SqlTarget(
+                workspace_id=str(ws_id),
+                database=entry.display_name,
+                connection_string=entry.connection_string,
+            )
+            await _schemas_svc.delete_schema(target, name, cascade=cascade, mode=ctx.auth)
+            click.echo(f"Schema [{name}] dropped.")
+    except click.Abort:
+        raise
+    except (ValueError, FabricError) as exc:
+        raise click.ClickException(str(exc)) from exc

--- a/src/fabric_dw/cli/commands/schemas.py
+++ b/src/fabric_dw/cli/commands/schemas.py
@@ -9,36 +9,21 @@ from contextlib import asynccontextmanager
 import click
 
 from fabric_dw import auth as _auth
-from fabric_dw.cache import ItemEntry
 from fabric_dw.cli._context import CliContext
 from fabric_dw.cli._render import confirm, render
 from fabric_dw.cli.commands._utils import (
     _coro,
+    _guard_not_sql_endpoint,
     _resolve_item,
     resolve_warehouse_arg,
     resolve_workspace_arg,
 )
 from fabric_dw.exceptions import FabricError
 from fabric_dw.http_client import FabricHttpClient
-from fabric_dw.models import WarehouseKind
 from fabric_dw.services import schemas as _schemas_svc
 from fabric_dw.sql import SqlTarget
 
-_SQL_ENDPOINT_READ_ONLY = "SQL Endpoints are read-only; CREATE/DROP SCHEMA not supported"
-
 _log = logging.getLogger(__name__)
-
-
-def _guard_not_sql_endpoint(entry: ItemEntry) -> None:
-    """Raise ValueError if *entry* is a SQL Endpoint.
-
-    SQL Analytics Endpoints are read-only; DDL operations are not supported.
-
-    Raises:
-        ValueError: If the resolved item is a SQL Analytics Endpoint.
-    """
-    if entry.kind == WarehouseKind.SQL_ENDPOINT:
-        raise ValueError(_SQL_ENDPOINT_READ_ONLY)
 
 
 @asynccontextmanager

--- a/src/fabric_dw/mcp/server.py
+++ b/src/fabric_dw/mcp/server.py
@@ -27,11 +27,12 @@ from mcp.server.fastmcp import FastMCP
 from mcp.server.fastmcp.exceptions import ToolError
 
 from fabric_dw import auth as _auth
+from fabric_dw.cache import ItemEntry as _ItemEntry
 from fabric_dw.cache import LookupCache
 from fabric_dw.exceptions import AlreadyExists, ConfigError, FabricError, NotFound
 from fabric_dw.http_client import FabricHttpClient
 from fabric_dw.logging import setup_logging
-from fabric_dw.models import SqlPool, SqlPoolClassifier
+from fabric_dw.models import SqlPool, SqlPoolClassifier, WarehouseKind
 from fabric_dw.resolver import Resolver
 from fabric_dw.services import audit, queries, snapshots, sql_endpoints, warehouses, workspaces
 from fabric_dw.services import ownership as ownership_svc
@@ -116,6 +117,26 @@ def _fabric_err(exc: FabricError) -> ToolError:
     """Convert a :class:`FabricError` to a :class:`ToolError`."""
     err_type = type(exc).__name__
     return ToolError(f"{err_type}: {exc}")
+
+
+_SQL_ENDPOINT_DDL_ERROR = "SQL Analytics Endpoints are read-only; CREATE/DROP SCHEMA not supported"
+
+
+def _require_warehouse(entry: _ItemEntry, item: str) -> None:
+    """Raise ToolError if *entry* is a SQL Analytics Endpoint.
+
+    DDL operations (CREATE SCHEMA, DROP SCHEMA) are not supported on SQL
+    Analytics Endpoints, which are read-only views over Lakehouse data.
+
+    Args:
+        entry: The resolved item entry.
+        item: The item name/GUID as supplied by the caller (used in the error message).
+
+    Raises:
+        ToolError: If the resolved item is a SQL Analytics Endpoint.
+    """
+    if entry.kind == WarehouseKind.SQL_ENDPOINT:
+        raise ToolError(f"{item!r}: {_SQL_ENDPOINT_DDL_ERROR}")  # noqa: TRY003
 
 
 # ---------------------------------------------------------------------------
@@ -1185,17 +1206,18 @@ async def drop_view(workspace: str, item: str, qualified_name: str) -> dict[str,
 
 @mcp.tool()
 async def list_schemas(workspace: str, item: str) -> list[dict[str, Any]]:
-    """List user-defined SQL schemas on a warehouse.
+    """List user-defined SQL schemas on a warehouse or SQL Analytics Endpoint.
 
     System schemas (``sys``, ``INFORMATION_SCHEMA``, ``db_*`` fixed-role
-    schemas) are excluded.  ``dbo`` is included as it is user-writable.
+    schemas, ``guest``) are excluded.  ``dbo`` is included as it is
+    user-writable.
 
-    Only Fabric Data Warehouses are supported; SQL Analytics Endpoints are
-    rejected.
+    Listing schemas is a read-only operation and works on both Fabric Data
+    Warehouses and SQL Analytics Endpoints.
 
     Args:
         workspace: Workspace name or GUID.
-        item: Warehouse name or GUID.
+        item: Warehouse or SQL Analytics Endpoint name or GUID.
     """
     try:
         ws_id = await _get_resolver().workspace_id(workspace)
@@ -1219,7 +1241,7 @@ async def create_schema(workspace: str, item: str, name: str) -> dict[str, Any]:
     """Create a new SQL schema on a warehouse.
 
     Only Fabric Data Warehouses are supported; SQL Analytics Endpoints are
-    rejected.
+    rejected because they are read-only views over Lakehouse data.
 
     Args:
         workspace: Workspace name or GUID.
@@ -1229,6 +1251,7 @@ async def create_schema(workspace: str, item: str, name: str) -> dict[str, Any]:
     try:
         ws_id = await _get_resolver().workspace_id(workspace)
         entry = await _get_resolver().item(workspace, item)
+        _require_warehouse(entry, item)
         if entry.connection_string is None:
             msg = f"item {item!r} has no connection string; cannot create schemas"
             raise FabricError(msg)  # noqa: TRY301
@@ -1273,6 +1296,7 @@ async def delete_schema(
     try:
         ws_id = await _get_resolver().workspace_id(workspace)
         entry = await _get_resolver().item(workspace, item)
+        _require_warehouse(entry, item)
         if entry.connection_string is None:
             msg = f"item {item!r} has no connection string; cannot delete schemas"
             raise FabricError(msg)  # noqa: TRY301

--- a/src/fabric_dw/mcp/server.py
+++ b/src/fabric_dw/mcp/server.py
@@ -37,6 +37,7 @@ from fabric_dw.services import audit, queries, snapshots, sql_endpoints, warehou
 from fabric_dw.services import ownership as ownership_svc
 from fabric_dw.services import query_insights as _qi_svc
 from fabric_dw.services import restore as restore_svc
+from fabric_dw.services import schemas as schemas_svc
 from fabric_dw.services import sql_exec as _sql_exec_svc
 from fabric_dw.services import sql_pools as sql_pools_svc
 from fabric_dw.services import tables as tables_svc
@@ -1175,6 +1176,115 @@ async def drop_view(workspace: str, item: str, qualified_name: str) -> dict[str,
     except (ValueError, FabricError) as exc:
         raise _fabric_err(exc) if isinstance(exc, FabricError) else ToolError(str(exc)) from exc
     return {"dropped": True}
+
+
+# ---------------------------------------------------------------------------
+# Schema tools
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+async def list_schemas(workspace: str, item: str) -> list[dict[str, Any]]:
+    """List user-defined SQL schemas on a warehouse.
+
+    System schemas (``sys``, ``INFORMATION_SCHEMA``, ``db_*`` fixed-role
+    schemas) are excluded.  ``dbo`` is included as it is user-writable.
+
+    Only Fabric Data Warehouses are supported; SQL Analytics Endpoints are
+    rejected.
+
+    Args:
+        workspace: Workspace name or GUID.
+        item: Warehouse name or GUID.
+    """
+    try:
+        ws_id = await _get_resolver().workspace_id(workspace)
+        entry = await _get_resolver().item(workspace, item)
+        if entry.connection_string is None:
+            msg = f"item {item!r} has no connection string; cannot query schemas"
+            raise FabricError(msg)  # noqa: TRY301
+        target = SqlTarget(
+            workspace_id=str(ws_id),
+            database=entry.display_name,
+            connection_string=entry.connection_string,
+        )
+        result = await schemas_svc.list_schemas(target, mode=_get_auth_mode())
+    except (ValueError, FabricError) as exc:
+        raise _fabric_err(exc) if isinstance(exc, FabricError) else ToolError(str(exc)) from exc
+    return [s.model_dump(mode="json") for s in result]
+
+
+@mcp.tool()
+async def create_schema(workspace: str, item: str, name: str) -> dict[str, Any]:
+    """Create a new SQL schema on a warehouse.
+
+    Only Fabric Data Warehouses are supported; SQL Analytics Endpoints are
+    rejected.
+
+    Args:
+        workspace: Workspace name or GUID.
+        item: Warehouse name or GUID.
+        name: The schema name.  Must be a valid SQL identifier.
+    """
+    try:
+        ws_id = await _get_resolver().workspace_id(workspace)
+        entry = await _get_resolver().item(workspace, item)
+        if entry.connection_string is None:
+            msg = f"item {item!r} has no connection string; cannot create schemas"
+            raise FabricError(msg)  # noqa: TRY301
+        target = SqlTarget(
+            workspace_id=str(ws_id),
+            database=entry.display_name,
+            connection_string=entry.connection_string,
+        )
+        result = await schemas_svc.create_schema(target, name, mode=_get_auth_mode())
+    except (ValueError, FabricError) as exc:
+        raise _fabric_err(exc) if isinstance(exc, FabricError) else ToolError(str(exc)) from exc
+    return result.model_dump(mode="json")
+
+
+@mcp.tool()
+async def delete_schema(
+    workspace: str,
+    item: str,
+    name: str,
+    cascade: bool = False,  # noqa: FBT001, FBT002
+) -> dict[str, Any]:
+    """Drop a SQL schema from a warehouse.
+
+    CAUTION: This is a destructive, irreversible operation.  The schema will
+    be permanently deleted.  If the schema still contains tables or views,
+    the operation will fail unless *cascade* is ``True``.
+
+    CAUTION: When *cascade* is ``True``, **all tables and views in the schema
+    are permanently deleted along with their data**.  Confirm explicitly with
+    the user before calling with ``cascade=True``.
+
+    Only Fabric Data Warehouses are supported; SQL Analytics Endpoints are
+    rejected.
+
+    Args:
+        workspace: Workspace name or GUID.
+        item: Warehouse name or GUID.
+        name: The schema name to drop.
+        cascade: When ``True``, drop all tables and views in the schema first.
+            Defaults to ``False``.
+    """
+    try:
+        ws_id = await _get_resolver().workspace_id(workspace)
+        entry = await _get_resolver().item(workspace, item)
+        if entry.connection_string is None:
+            msg = f"item {item!r} has no connection string; cannot delete schemas"
+            raise FabricError(msg)  # noqa: TRY301
+        target = SqlTarget(
+            workspace_id=str(ws_id),
+            database=entry.display_name,
+            connection_string=entry.connection_string,
+        )
+        await schemas_svc.delete_schema(target, name, cascade=cascade, mode=_get_auth_mode())
+    except (ValueError, FabricError) as exc:
+        raise _fabric_err(exc) if isinstance(exc, FabricError) else ToolError(str(exc)) from exc
+    return {"deleted": True}
 
 
 # ---------------------------------------------------------------------------

--- a/src/fabric_dw/models.py
+++ b/src/fabric_dw/models.py
@@ -332,6 +332,13 @@ class View(_FabricBase):
     modified: datetime
 
 
+class Schema(_FabricBase):
+    """A SQL schema on a Fabric Data Warehouse."""
+
+    name: str
+    principal_id: int | None = None
+
+
 class Table(_FabricBase):
     """A SQL table on a Fabric Data Warehouse or SQL Analytics Endpoint."""
 

--- a/src/fabric_dw/services/schemas.py
+++ b/src/fabric_dw/services/schemas.py
@@ -1,0 +1,357 @@
+"""CRUD operations for SQL schemas on Fabric Data Warehouses.
+
+Public API
+----------
+- :func:`validate_identifier` — re-exported from :mod:`views` (shared validator).
+- :func:`list_schemas`         — list all user-defined schemas via TDS ``sys.schemas``.
+- :func:`create_schema`        — ``CREATE SCHEMA [<name>]``.
+- :func:`delete_schema`        — ``DROP SCHEMA [<name>]``. Optionally cascade-drops
+                                  contained tables and views first.
+
+List-source note
+----------------
+No public REST endpoint exists for enumerating warehouse schemas.  This module
+falls back to TDS via ``sys.schemas``, filtering out well-known system schemas.
+
+System schema filter
+--------------------
+The following schemas are excluded from :func:`list_schemas` results because
+they are maintained by the engine and are not user-editable:
+
+- ``sys`` — SQL Server system catalog schema.
+- ``INFORMATION_SCHEMA`` — ANSI information schema views.
+- ``db_owner``, ``db_accessadmin``, ``db_securityadmin``, ``db_ddladmin``,
+  ``db_backupoperator``, ``db_datareader``, ``db_datawriter``,
+  ``db_denydatareader``, ``db_denydatawriter`` — fixed database role schemas
+  (``db_*`` prefix).
+
+``dbo`` is **not** filtered because it is user-writable and is the default
+schema for warehouse tables.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import closing
+from typing import cast
+
+from fabric_dw import sql
+from fabric_dw.auth import CredentialMode
+from fabric_dw.exceptions import NotFound
+from fabric_dw.models import Schema
+from fabric_dw.services.views import validate_identifier
+from fabric_dw.sql import SqlTarget
+
+__all__ = [
+    "create_schema",
+    "delete_schema",
+    "list_schemas",
+    "validate_identifier",
+]
+
+# ---------------------------------------------------------------------------
+# SQL templates
+# ---------------------------------------------------------------------------
+
+#: System schemas that are never user-editable on Fabric Data Warehouses.
+_SYSTEM_SCHEMAS: frozenset[str] = frozenset(
+    {
+        "sys",
+        "INFORMATION_SCHEMA",
+        "db_owner",
+        "db_accessadmin",
+        "db_securityadmin",
+        "db_ddladmin",
+        "db_backupoperator",
+        "db_datareader",
+        "db_datawriter",
+        "db_denydatareader",
+        "db_denydatawriter",
+    }
+)
+
+_LIST_SCHEMAS_SQL = """\
+SELECT
+    s.name,
+    s.principal_id
+FROM sys.schemas s
+WHERE s.name NOT IN ({placeholders})
+  AND s.name NOT LIKE 'db[_]%'
+ORDER BY s.name;
+"""
+
+_LIST_TABLES_IN_SCHEMA_SQL = """\
+SELECT t.name AS obj_name, 'TABLE' AS obj_type
+FROM sys.tables t
+JOIN sys.schemas s ON s.schema_id = t.schema_id
+WHERE s.name = '{schema}'
+UNION ALL
+SELECT v.name AS obj_name, 'VIEW' AS obj_type
+FROM sys.views v
+JOIN sys.schemas s ON s.schema_id = v.schema_id
+WHERE s.name = '{schema}';
+"""
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _row_to_schema(cols: list[str], row: tuple[object, ...]) -> Schema:
+    """Build a :class:`Schema` from a column-name list and a result row tuple."""
+    data = dict(zip(cols, row, strict=True))
+    name = str(data["name"])
+    raw_pid = data.get("principal_id")
+    principal_id = int(cast("int", raw_pid)) if raw_pid is not None else None
+    return Schema(name=name, principal_id=principal_id)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+async def list_schemas(
+    target: SqlTarget,
+    *,
+    mode: CredentialMode = CredentialMode.DEFAULT,
+) -> list[Schema]:
+    """Return all user-defined schemas on *target*.
+
+    System schemas (``sys``, ``INFORMATION_SCHEMA``, ``db_*`` fixed-role
+    schemas) are excluded.  ``dbo`` is included because it is user-writable.
+
+    Args:
+        target: The warehouse to query.
+        mode: The credential mode for Entra authentication.
+
+    Returns:
+        A (possibly empty) list of :class:`~fabric_dw.models.Schema` instances.
+
+    Raises:
+        PermissionDenied: If the driver reports a permission error.
+        AuthError: If the driver reports an authentication failure.
+    """
+    placeholders = ", ".join(f"'{s}'" for s in sorted(_SYSTEM_SCHEMAS))
+    list_sql = _LIST_SCHEMAS_SQL.format(placeholders=placeholders)
+
+    def _run() -> list[Schema]:
+        with closing(sql.open_connection(target, mode=mode)) as conn:
+            cursor = conn.cursor()
+            try:
+                cursor.execute(list_sql)
+                cols = [c[0] for c in (cursor.description or [])]
+                rows = cursor.fetchall()
+            except Exception as exc:
+                mapped = sql.map_driver_error(exc)
+                if mapped:
+                    raise mapped from exc
+                raise
+            return [_row_to_schema(cols, r) for r in rows]
+
+    return await asyncio.to_thread(_run)
+
+
+async def create_schema(
+    target: SqlTarget,
+    name: str,
+    *,
+    mode: CredentialMode = CredentialMode.DEFAULT,
+) -> Schema:
+    """Create a new schema via ``CREATE SCHEMA [<name>]``.
+
+    Args:
+        target: The warehouse to connect to.
+        name: The schema name.  Must pass :func:`validate_identifier`.
+        mode: The credential mode for Entra authentication.
+
+    Returns:
+        A :class:`~fabric_dw.models.Schema` reflecting the newly-created
+        schema (fetched via ``sys.schemas`` after DDL).
+
+    Raises:
+        ValueError: If *name* fails identifier validation.
+        PermissionDenied: If the driver reports a CREATE SCHEMA permission error.
+    """
+    validate_identifier(name)
+
+    ddl = f"CREATE SCHEMA [{name}]"
+
+    def _run_ddl() -> None:
+        with closing(sql.open_connection(target, mode=mode)) as conn:
+            cursor = conn.cursor()
+            try:
+                cursor.execute(ddl)
+                conn.commit()
+            except Exception as exc:
+                mapped = sql.map_driver_error(exc)
+                if mapped:
+                    raise mapped from exc
+                raise
+
+    await asyncio.to_thread(_run_ddl)
+    return await _fetch_schema(target, name, mode=mode)
+
+
+async def delete_schema(
+    target: SqlTarget,
+    name: str,
+    *,
+    cascade: bool = False,
+    mode: CredentialMode = CredentialMode.DEFAULT,
+) -> None:
+    """Drop a schema via ``DROP SCHEMA [<name>]``.
+
+    If *cascade* is ``True``, all tables and views contained in the schema
+    are dropped first via individual ``DROP TABLE`` / ``DROP VIEW`` statements,
+    then the schema itself is dropped.
+
+    .. caution::
+
+        When *cascade* is ``True``, **all tables and views in the schema are
+        permanently deleted along with their data**.  This operation is
+        irreversible.  Confirm with the user before calling this function with
+        ``cascade=True``.
+
+    Args:
+        target: The warehouse to connect to.
+        name: The schema name.  Must pass :func:`validate_identifier`.
+        cascade: When ``True``, drop all tables and views in the schema
+            before dropping the schema itself.  Defaults to ``False``.
+        mode: The credential mode for Entra authentication.
+
+    Raises:
+        ValueError: If *name* fails identifier validation.
+        PermissionDenied: If the driver reports a DROP SCHEMA permission error.
+    """
+    validate_identifier(name)
+
+    if cascade:
+        await _drop_schema_objects(target, name, mode=mode)
+
+    ddl = f"DROP SCHEMA [{name}]"
+
+    def _run() -> None:
+        with closing(sql.open_connection(target, mode=mode)) as conn:
+            cursor = conn.cursor()
+            try:
+                cursor.execute(ddl)
+                conn.commit()
+            except Exception as exc:
+                mapped = sql.map_driver_error(exc)
+                if mapped:
+                    raise mapped from exc
+                raise
+
+    await asyncio.to_thread(_run)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+async def _fetch_schema(
+    target: SqlTarget,
+    name: str,
+    *,
+    mode: CredentialMode = CredentialMode.DEFAULT,
+) -> Schema:
+    """Fetch a single schema record from sys.schemas to build a :class:`Schema`.
+
+    Args:
+        target: The warehouse to query.
+        name: The schema name (already validated).
+        mode: The credential mode for Entra authentication.
+
+    Returns:
+        A :class:`~fabric_dw.models.Schema` instance.
+
+    Raises:
+        NotFound: If the schema is not found after creation.
+    """
+    # Safe: name passes validate_identifier() before this helper is called.
+    fetch_sql = (
+        f"SELECT s.name, s.principal_id "  # noqa: S608  # nosec B608
+        f"FROM sys.schemas s "
+        f"WHERE s.name = '{name}';"
+    )
+
+    def _run() -> Schema:
+        with closing(sql.open_connection(target, mode=mode)) as conn:
+            cursor = conn.cursor()
+            try:
+                cursor.execute(fetch_sql)
+                cols = [c[0] for c in (cursor.description or [])]
+                rows = cursor.fetchall()
+            except Exception as exc:
+                mapped = sql.map_driver_error(exc)
+                if mapped:
+                    raise mapped from exc
+                raise
+            if not rows:
+                msg = f"Schema [{name}] not found after creation"
+                raise NotFound(msg)
+            return _row_to_schema(cols, rows[0])
+
+    return await asyncio.to_thread(_run)
+
+
+async def _drop_schema_objects(
+    target: SqlTarget,
+    schema_name: str,
+    *,
+    mode: CredentialMode = CredentialMode.DEFAULT,
+) -> None:
+    """Drop all tables and views contained in *schema_name*.
+
+    Enumerates objects via ``sys.tables`` and ``sys.views`` then issues
+    individual ``DROP TABLE`` / ``DROP VIEW`` DDL for each.
+
+    This is a helper for :func:`delete_schema` when ``cascade=True``.
+    The schema name is assumed to have been validated by the caller.
+
+    Args:
+        target: The warehouse to connect to.
+        schema_name: The schema whose objects will be dropped (already validated).
+        mode: The credential mode for Entra authentication.
+    """
+    # Safe: schema_name passes validate_identifier() in delete_schema().
+    list_sql = _LIST_TABLES_IN_SCHEMA_SQL.format(schema=schema_name)
+
+    def _run() -> list[tuple[str, str]]:
+        with closing(sql.open_connection(target, mode=mode)) as conn:
+            cursor = conn.cursor()
+            try:
+                cursor.execute(list_sql)
+                rows = cursor.fetchall()
+            except Exception as exc:
+                mapped = sql.map_driver_error(exc)
+                if mapped:
+                    raise mapped from exc
+                raise
+            return [(str(r[0]), str(r[1])) for r in rows]
+
+    objects = await asyncio.to_thread(_run)
+
+    for obj_name, obj_type in objects:
+        # Object names come from sys.tables/sys.views — bracket-safe catalog names.
+        # Validate anyway to be defensive.
+        validate_identifier(obj_name)
+        ddl_keyword = "TABLE" if obj_type == "TABLE" else "VIEW"
+        ddl = f"DROP {ddl_keyword} [{schema_name}].[{obj_name}]"
+
+        def _run_drop(stmt: str = ddl) -> None:
+            with closing(sql.open_connection(target, mode=mode)) as conn:
+                cursor = conn.cursor()
+                try:
+                    cursor.execute(stmt)
+                    conn.commit()
+                except Exception as exc:
+                    mapped = sql.map_driver_error(exc)
+                    if mapped:
+                        raise mapped from exc
+                    raise
+
+        await asyncio.to_thread(_run_drop)

--- a/src/fabric_dw/services/schemas.py
+++ b/src/fabric_dw/services/schemas.py
@@ -20,6 +20,7 @@ they are maintained by the engine and are not user-editable:
 
 - ``sys`` — SQL Server system catalog schema.
 - ``INFORMATION_SCHEMA`` — ANSI information schema views.
+- ``guest`` — system guest principal schema, not user-editable.
 - ``db_owner``, ``db_accessadmin``, ``db_securityadmin``, ``db_ddladmin``,
   ``db_backupoperator``, ``db_datareader``, ``db_datawriter``,
   ``db_denydatareader``, ``db_denydatawriter`` — fixed database role schemas
@@ -54,10 +55,16 @@ __all__ = [
 # ---------------------------------------------------------------------------
 
 #: System schemas that are never user-editable on Fabric Data Warehouses.
+#:
+#: The explicit ``db_*`` names are kept alongside the ``db[_]%`` LIKE clause in
+#: the query for clarity — they document which fixed-role schemas exist even
+#: though the LIKE pattern already covers them.
 _SYSTEM_SCHEMAS: frozenset[str] = frozenset(
     {
         "sys",
         "INFORMATION_SCHEMA",
+        "guest",  # system guest principal schema
+        # Fixed database-role schemas — also matched by the db[_]% LIKE clause.
         "db_owner",
         "db_accessadmin",
         "db_securityadmin",
@@ -269,9 +276,11 @@ async def _fetch_schema(
         A :class:`~fabric_dw.models.Schema` instance.
 
     Raises:
+        ValueError: If *name* fails identifier validation (belt-and-suspenders).
         NotFound: If the schema is not found after creation.
     """
-    # Safe: name passes validate_identifier() before this helper is called.
+    # Belt-and-suspenders: validate even though callers should have validated already.
+    validate_identifier(name)
     fetch_sql = (
         f"SELECT s.name, s.principal_id "  # noqa: S608  # nosec B608
         f"FROM sys.schemas s "
@@ -311,6 +320,15 @@ async def _drop_schema_objects(
 
     This is a helper for :func:`delete_schema` when ``cascade=True``.
     The schema name is assumed to have been validated by the caller.
+
+    .. note::
+
+        **View-on-view dependency caveat**: objects are dropped in catalog order
+        (the order returned by ``sys.tables``/``sys.views``), without analysing
+        inter-object dependencies.  If the schema contains views that reference
+        other views in the same schema, the drop may fail with a dependency
+        error depending on the order in which the engine returns them.  In that
+        case, re-run the operation or drop the dependent views manually first.
 
     Args:
         target: The warehouse to connect to.

--- a/tests/unit/cli/commands/test_schemas.py
+++ b/tests/unit/cli/commands/test_schemas.py
@@ -1,0 +1,402 @@
+"""Tests for schemas CLI sub-commands."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+from uuid import UUID
+
+import pytest
+from click.testing import CliRunner
+
+from fabric_dw.cache import ItemEntry
+from fabric_dw.cli._main import cli
+from fabric_dw.exceptions import NotFound, PermissionDenied
+from fabric_dw.models import Schema, WarehouseKind
+
+WS_GUID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+WH_GUID = "d4e5f6a7-b8c9-0123-def0-123456789abc"
+WS_UUID = UUID(WS_GUID)
+WH_UUID = UUID(WH_GUID)
+
+_NOW = datetime(2024, 6, 1, 12, 0, 0, tzinfo=UTC)
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def cache_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    return tmp_path
+
+
+def _make_http_cm(http: object) -> object:
+    @asynccontextmanager
+    async def _cm(_ctx: object) -> AsyncIterator[object]:
+        yield http
+
+    return _cm
+
+
+def _make_item_entry() -> ItemEntry:
+    return ItemEntry(
+        id=WH_UUID,
+        kind=WarehouseKind.WAREHOUSE,
+        connection_string="wh.datawarehouse.fabric.microsoft.com",
+        fetched_at=datetime.now(tz=UTC),
+        display_name="SalesWarehouse",
+    )
+
+
+def _make_sql_endpoint_entry() -> ItemEntry:
+    return ItemEntry(
+        id=WH_UUID,
+        kind=WarehouseKind.SQL_ENDPOINT,
+        connection_string="ep.datawarehouse.fabric.microsoft.com",
+        fetched_at=datetime.now(tz=UTC),
+        display_name="SalesEndpoint",
+    )
+
+
+def _make_schema() -> Schema:
+    return Schema(name="sales", principal_id=5)
+
+
+# ===========================================================================
+# schemas list
+# ===========================================================================
+
+
+class TestSchemasList:
+    def test_list_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.schemas._build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.schemas._resolve_item",
+                new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.schemas.list_schemas",
+                new=AsyncMock(return_value=[_make_schema()]),
+            ),
+        ):
+            result = runner.invoke(cli, ["schemas", "list", WS_GUID, WH_GUID])
+        assert result.exit_code == 0
+
+    def test_list_json_output(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.schemas._build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.schemas._resolve_item",
+                new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.schemas.list_schemas",
+                new=AsyncMock(return_value=[_make_schema()]),
+            ),
+        ):
+            result = runner.invoke(cli, ["--json", "schemas", "list", WS_GUID, WH_GUID])
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert isinstance(parsed, list)
+        assert parsed[0]["name"] == "sales"
+
+    def test_list_not_found_returns_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.schemas._build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.schemas._resolve_item",
+                new=AsyncMock(side_effect=NotFound("not found")),
+            ),
+        ):
+            result = runner.invoke(cli, ["schemas", "list", WS_GUID, WH_GUID])
+        assert result.exit_code != 0
+
+    def test_list_permission_error_returns_nonzero(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.schemas._build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.schemas._resolve_item",
+                new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.schemas.list_schemas",
+                new=AsyncMock(side_effect=PermissionDenied("access denied")),
+            ),
+        ):
+            result = runner.invoke(cli, ["schemas", "list", WS_GUID, WH_GUID])
+        assert result.exit_code != 0
+
+
+# ===========================================================================
+# schemas create
+# ===========================================================================
+
+
+class TestSchemasCreate:
+    def test_create_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.schemas._build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.schemas._resolve_item",
+                new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.schemas.create_schema",
+                new=AsyncMock(return_value=_make_schema()),
+            ),
+        ):
+            result = runner.invoke(cli, ["schemas", "create", WS_GUID, WH_GUID, "sales"])
+        assert result.exit_code == 0
+
+    def test_create_json_output_contains_name(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.schemas._build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.schemas._resolve_item",
+                new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.schemas.create_schema",
+                new=AsyncMock(return_value=_make_schema()),
+            ),
+        ):
+            result = runner.invoke(cli, ["--json", "schemas", "create", WS_GUID, WH_GUID, "sales"])
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["name"] == "sales"
+
+    def test_create_sql_endpoint_returns_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.schemas._build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.schemas._resolve_item",
+                new=AsyncMock(return_value=(WS_UUID, _make_sql_endpoint_entry())),
+            ),
+        ):
+            result = runner.invoke(cli, ["schemas", "create", WS_GUID, WH_GUID, "sales"])
+        assert result.exit_code != 0
+
+    def test_create_permission_error_returns_nonzero(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.schemas._build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.schemas._resolve_item",
+                new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.schemas.create_schema",
+                new=AsyncMock(side_effect=PermissionDenied("access denied")),
+            ),
+        ):
+            result = runner.invoke(cli, ["schemas", "create", WS_GUID, WH_GUID, "sales"])
+        assert result.exit_code != 0
+
+
+# ===========================================================================
+# schemas delete
+# ===========================================================================
+
+
+class TestSchemasDelete:
+    def test_delete_exits_zero_with_yes_flag(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.schemas._build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.schemas._resolve_item",
+                new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.schemas.delete_schema",
+                new=AsyncMock(return_value=None),
+            ),
+        ):
+            result = runner.invoke(cli, ["-y", "schemas", "delete", WS_GUID, WH_GUID, "sales"])
+        assert result.exit_code == 0
+        assert "dropped" in result.output
+
+    def test_delete_aborts_without_yes(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.schemas._build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.schemas._resolve_item",
+                new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.schemas.delete_schema",
+                new=AsyncMock(return_value=None),
+            ),
+        ):
+            result = runner.invoke(
+                cli, ["schemas", "delete", WS_GUID, WH_GUID, "sales"], input="n\n"
+            )
+        assert result.exit_code != 0
+
+    def test_delete_cascade_passes_cascade_true(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        mock_delete = AsyncMock(return_value=None)
+        with (
+            patch(
+                "fabric_dw.cli.commands.schemas._build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.schemas._resolve_item",
+                new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
+            ),
+            patch("fabric_dw.services.schemas.delete_schema", new=mock_delete),
+        ):
+            result = runner.invoke(
+                cli,
+                ["-y", "schemas", "delete", WS_GUID, WH_GUID, "sales", "--cascade"],
+            )
+        assert result.exit_code == 0
+        _, kwargs = mock_delete.call_args
+        assert kwargs.get("cascade") is True
+
+    def test_delete_no_cascade_by_default(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        mock_delete = AsyncMock(return_value=None)
+        with (
+            patch(
+                "fabric_dw.cli.commands.schemas._build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.schemas._resolve_item",
+                new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
+            ),
+            patch("fabric_dw.services.schemas.delete_schema", new=mock_delete),
+        ):
+            result = runner.invoke(
+                cli,
+                ["-y", "schemas", "delete", WS_GUID, WH_GUID, "sales"],
+            )
+        assert result.exit_code == 0
+        _, kwargs = mock_delete.call_args
+        assert kwargs.get("cascade") is False
+
+    def test_delete_sql_endpoint_returns_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.schemas._build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.schemas._resolve_item",
+                new=AsyncMock(return_value=(WS_UUID, _make_sql_endpoint_entry())),
+            ),
+        ):
+            result = runner.invoke(cli, ["-y", "schemas", "delete", WS_GUID, WH_GUID, "sales"])
+        assert result.exit_code != 0
+
+    def test_delete_cascade_warns_on_stderr(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.schemas._build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.schemas._resolve_item",
+                new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.schemas.delete_schema",
+                new=AsyncMock(return_value=None),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                ["-y", "schemas", "delete", WS_GUID, WH_GUID, "sales", "--cascade"],
+            )
+        # The cascade warning is emitted to stderr; the command exits cleanly.
+        assert result.exit_code == 0
+
+    def test_delete_permission_error_returns_nonzero(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.schemas._build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.schemas._resolve_item",
+                new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.schemas.delete_schema",
+                new=AsyncMock(side_effect=PermissionDenied("access denied")),
+            ),
+        ):
+            result = runner.invoke(cli, ["-y", "schemas", "delete", WS_GUID, WH_GUID, "sales"])
+        assert result.exit_code != 0

--- a/tests/unit/mcp/test_server.py
+++ b/tests/unit/mcp/test_server.py
@@ -88,6 +88,10 @@ EXPECTED_TOOL_NAMES: frozenset[str] = frozenset(
         "roll_snapshot_timestamp",
         # Cache
         "clear_cache",
+        # Schemas
+        "list_schemas",
+        "create_schema",
+        "delete_schema",
     }
 )
 

--- a/tests/unit/mcp/test_server.py
+++ b/tests/unit/mcp/test_server.py
@@ -145,6 +145,21 @@ def _make_item_entry(
     )
 
 
+def _make_sql_endpoint_entry(
+    *,
+    item_id: UUID = _WH_ID,
+    connection_string: str | None = "ep.fabric.microsoft.com",
+    display_name: str = "MySqlEndpoint",
+) -> ItemEntry:
+    return ItemEntry(
+        id=item_id,
+        kind=WarehouseKind.SQL_ENDPOINT,
+        connection_string=connection_string,
+        fetched_at=datetime.now(tz=UTC),
+        display_name=display_name,
+    )
+
+
 def _make_audit_settings() -> AuditSettings:
     return AuditSettings.model_validate(
         {
@@ -1016,21 +1031,12 @@ async def test_execute_sql_no_connection_string_raises_tool_error() -> None:
 
 
 # ---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
 # SQL Endpoint guard — create_table / delete_table / clear_table via MCP
 # ---------------------------------------------------------------------------
 
 _SE_NAME = "SalesLakehouse"
 _SE_ID = UUID("bbbbbbbb-cccc-dddd-eeee-ffffffffffff")
-
-
-def _make_sql_endpoint_entry() -> ItemEntry:
-    return ItemEntry(
-        id=_SE_ID,
-        kind=WarehouseKind.SQL_ENDPOINT,
-        connection_string="lakehouse.datawarehouse.fabric.microsoft.com",
-        fetched_at=datetime.now(tz=UTC),
-        display_name=_SE_NAME,
-    )
 
 
 @pytest.mark.asyncio
@@ -1042,7 +1048,9 @@ async def test_create_table_sql_endpoint_raises_tool_error() -> None:
 
     mock_resolver = AsyncMock()
     mock_resolver.workspace_id = AsyncMock(return_value=_WS_ID)
-    mock_resolver.item = AsyncMock(return_value=_make_sql_endpoint_entry())
+    mock_resolver.item = AsyncMock(
+        return_value=_make_sql_endpoint_entry(item_id=_SE_ID, display_name=_SE_NAME)
+    )
     mock_http = AsyncMock()
     mock_cache = MagicMock()
 
@@ -1074,7 +1082,9 @@ async def test_delete_table_sql_endpoint_raises_tool_error() -> None:
 
     mock_resolver = AsyncMock()
     mock_resolver.workspace_id = AsyncMock(return_value=_WS_ID)
-    mock_resolver.item = AsyncMock(return_value=_make_sql_endpoint_entry())
+    mock_resolver.item = AsyncMock(
+        return_value=_make_sql_endpoint_entry(item_id=_SE_ID, display_name=_SE_NAME)
+    )
     mock_http = AsyncMock()
     mock_cache = MagicMock()
 
@@ -1101,7 +1111,9 @@ async def test_clear_table_sql_endpoint_raises_tool_error() -> None:
 
     mock_resolver = AsyncMock()
     mock_resolver.workspace_id = AsyncMock(return_value=_WS_ID)
-    mock_resolver.item = AsyncMock(return_value=_make_sql_endpoint_entry())
+    mock_resolver.item = AsyncMock(
+        return_value=_make_sql_endpoint_entry(item_id=_SE_ID, display_name=_SE_NAME)
+    )
     mock_http = AsyncMock()
     mock_cache = MagicMock()
 
@@ -1117,3 +1129,103 @@ async def test_clear_table_sql_endpoint_raises_tool_error() -> None:
         )
 
     assert "read-only" in str(exc_info.value).lower()
+
+
+# ---------------------------------------------------------------------------
+# Schema tool SQL Endpoint guard
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_schema_rejects_sql_endpoint() -> None:
+    """create_schema must raise ToolError when called against a SQL Analytics Endpoint."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    ep_entry = _make_sql_endpoint_entry()
+
+    mock_resolver = AsyncMock()
+    mock_resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_resolver.item = AsyncMock(return_value=ep_entry)
+    mock_http = AsyncMock()
+    mock_cache = MagicMock()
+
+    with (
+        patch("fabric_dw.mcp.server._get_http", return_value=mock_http),
+        patch("fabric_dw.mcp.server._get_resolver", return_value=mock_resolver),
+        patch("fabric_dw.mcp.server._get_cache", return_value=mock_cache),
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "create_schema",
+            {"workspace": _WS_NAME, "item": "MySqlEndpoint", "name": "newschema"},
+        )
+
+    assert "read-only" in str(exc_info.value).lower() or "SQL Analytics Endpoint" in str(
+        exc_info.value
+    )
+
+
+@pytest.mark.asyncio
+async def test_delete_schema_rejects_sql_endpoint() -> None:
+    """delete_schema must raise ToolError when called against a SQL Analytics Endpoint."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    ep_entry = _make_sql_endpoint_entry()
+
+    mock_resolver = AsyncMock()
+    mock_resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_resolver.item = AsyncMock(return_value=ep_entry)
+    mock_http = AsyncMock()
+    mock_cache = MagicMock()
+
+    with (
+        patch("fabric_dw.mcp.server._get_http", return_value=mock_http),
+        patch("fabric_dw.mcp.server._get_resolver", return_value=mock_resolver),
+        patch("fabric_dw.mcp.server._get_cache", return_value=mock_cache),
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "delete_schema",
+            {"workspace": _WS_NAME, "item": "MySqlEndpoint", "name": "oldschema"},
+        )
+
+    assert "read-only" in str(exc_info.value).lower() or "SQL Analytics Endpoint" in str(
+        exc_info.value
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_schemas_works_on_sql_endpoint() -> None:
+    """list_schemas is a read-only operation and must work on SQL Analytics Endpoints."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+    from fabric_dw.models import Schema  # noqa: PLC0415
+
+    ep_entry = _make_sql_endpoint_entry()
+    schemas_result = [Schema(name="dbo", principal_id=1)]
+
+    mock_resolver = AsyncMock()
+    mock_resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_resolver.item = AsyncMock(return_value=ep_entry)
+    mock_http = AsyncMock()
+    mock_cache = MagicMock()
+
+    with (
+        patch("fabric_dw.mcp.server._get_http", return_value=mock_http),
+        patch("fabric_dw.mcp.server._get_resolver", return_value=mock_resolver),
+        patch("fabric_dw.mcp.server._get_cache", return_value=mock_cache),
+        patch(
+            "fabric_dw.services.schemas.list_schemas",
+            new=AsyncMock(return_value=schemas_result),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "list_schemas",
+            {"workspace": _WS_NAME, "item": "MySqlEndpoint"},
+        )
+
+    assert isinstance(result, list)
+    assert result[0]["name"] == "dbo"

--- a/tests/unit/services/test_schemas.py
+++ b/tests/unit/services/test_schemas.py
@@ -145,6 +145,17 @@ class TestListSchemas:
         assert "db[_]%" in call_sql
 
     @pytest.mark.asyncio
+    async def test_sql_excludes_guest_schema(self) -> None:
+        target = _make_target()
+        conn = _make_conn([], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await schemas.list_schemas(target)
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        # 'guest' must appear in the NOT IN clause
+        assert "'guest'" in call_sql
+
+    @pytest.mark.asyncio
     async def test_closes_connection(self) -> None:
         target = _make_target()
         conn = _make_conn([_SCHEMA_ROW_1], _LIST_COLS)
@@ -402,10 +413,16 @@ class TestDeleteSchemaCascade:
         with patch(
             "fabric_dw.sql.open_connection",
             side_effect=[list_conn, drop1_conn, drop2_conn, drop_schema_conn],
-        ):
+        ) as mock_open:
             await schemas.delete_schema(target, "sales", cascade=True)
-        # Should have opened 4 connections total (list + 2 drops + schema drop)
-        assert True  # if we get here without error, the cascade ran
+        # Should have opened 4 connections total: list + DROP TABLE + DROP VIEW + DROP SCHEMA
+        assert mock_open.call_count == 4
+        drop_table_sql_raw: str = drop1_conn.cursor.return_value.execute.call_args[0][0]
+        drop_view_sql_raw: str = drop2_conn.cursor.return_value.execute.call_args[0][0]
+        assert "DROP TABLE" in drop_table_sql_raw.upper()
+        assert "[t1]" in drop_table_sql_raw
+        assert "DROP VIEW" in drop_view_sql_raw.upper()
+        assert "[v1]" in drop_view_sql_raw
 
     @pytest.mark.asyncio
     async def test_cascade_false_does_not_enumerate_objects(self) -> None:

--- a/tests/unit/services/test_schemas.py
+++ b/tests/unit/services/test_schemas.py
@@ -1,0 +1,450 @@
+"""Unit tests for services.schemas — DMV-mock tests."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fabric_dw.exceptions import AuthError, NotFound, PermissionDenied
+from fabric_dw.models import Schema
+from fabric_dw.services import schemas
+from fabric_dw.services.schemas import validate_identifier
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_target() -> MagicMock:
+    return MagicMock()
+
+
+def _make_conn(rows: list[tuple[object, ...]], columns: list[str]) -> MagicMock:
+    cursor = MagicMock()
+    cursor.description = [(c, None) for c in columns]
+    cursor.fetchall.return_value = rows
+    conn = MagicMock()
+    conn.cursor.return_value = cursor
+    return conn
+
+
+def _make_conn_for_ddl() -> MagicMock:
+    cursor = MagicMock()
+    cursor.description = None
+    cursor.fetchall.return_value = []
+    conn = MagicMock()
+    conn.cursor.return_value = cursor
+    return conn
+
+
+# ---------------------------------------------------------------------------
+# Fixture data
+# ---------------------------------------------------------------------------
+
+_LIST_COLS = ["name", "principal_id"]
+_SCHEMA_ROW_1: tuple[object, ...] = ("dbo", 1)
+_SCHEMA_ROW_2: tuple[object, ...] = ("sales", 5)
+_SCHEMA_ROW_SYS: tuple[object, ...] = ("sys", 4)
+
+
+# ===========================================================================
+# validate_identifier — re-exported from views
+# ===========================================================================
+
+
+class TestValidateIdentifierReexport:
+    def test_valid_identifier_passes(self) -> None:
+        assert validate_identifier("my_schema") == "my_schema"
+
+    def test_rejects_injection(self) -> None:
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            validate_identifier("s]; DROP TABLE users--")
+
+
+# ===========================================================================
+# list_schemas
+# ===========================================================================
+
+
+class TestListSchemas:
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_no_rows(self) -> None:
+        target = _make_target()
+        conn = _make_conn([], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            result = await schemas.list_schemas(target)
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_returns_schema_instances(self) -> None:
+        target = _make_target()
+        conn = _make_conn([_SCHEMA_ROW_1], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            result = await schemas.list_schemas(target)
+        assert len(result) == 1
+        assert isinstance(result[0], Schema)
+
+    @pytest.mark.asyncio
+    async def test_parses_fields_correctly(self) -> None:
+        target = _make_target()
+        conn = _make_conn([_SCHEMA_ROW_1], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            result = await schemas.list_schemas(target)
+        s = result[0]
+        assert s.name == "dbo"
+        assert s.principal_id == 1
+
+    @pytest.mark.asyncio
+    async def test_returns_all_rows(self) -> None:
+        target = _make_target()
+        conn = _make_conn([_SCHEMA_ROW_1, _SCHEMA_ROW_2], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            result = await schemas.list_schemas(target)
+        assert len(result) == 2
+
+    @pytest.mark.asyncio
+    async def test_sql_references_sys_schemas(self) -> None:
+        target = _make_target()
+        conn = _make_conn([], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await schemas.list_schemas(target)
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert "sys.schemas" in call_sql
+
+    @pytest.mark.asyncio
+    async def test_sql_excludes_sys_schema(self) -> None:
+        target = _make_target()
+        conn = _make_conn([], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await schemas.list_schemas(target)
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        # The NOT IN clause must include 'sys'
+        assert "'sys'" in call_sql
+
+    @pytest.mark.asyncio
+    async def test_sql_excludes_information_schema(self) -> None:
+        target = _make_target()
+        conn = _make_conn([], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await schemas.list_schemas(target)
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert "'INFORMATION_SCHEMA'" in call_sql
+
+    @pytest.mark.asyncio
+    async def test_sql_excludes_db_prefix_via_like(self) -> None:
+        target = _make_target()
+        conn = _make_conn([], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await schemas.list_schemas(target)
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert "db[_]%" in call_sql
+
+    @pytest.mark.asyncio
+    async def test_closes_connection(self) -> None:
+        target = _make_target()
+        conn = _make_conn([_SCHEMA_ROW_1], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await schemas.list_schemas(target)
+        conn.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_maps_permission_denied(self) -> None:
+        target = _make_target()
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.execute.side_effect = Exception("permission was denied on object sys.schemas")
+        conn.cursor.return_value = cursor
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(PermissionDenied),
+        ):
+            await schemas.list_schemas(target)
+
+    @pytest.mark.asyncio
+    async def test_maps_auth_error(self) -> None:
+        target = _make_target()
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.execute.side_effect = Exception("Authentication failed for user ''")
+        conn.cursor.return_value = cursor
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(AuthError),
+        ):
+            await schemas.list_schemas(target)
+
+    @pytest.mark.asyncio
+    async def test_unrelated_error_propagates(self) -> None:
+        target = _make_target()
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.execute.side_effect = RuntimeError("network timeout")
+        conn.cursor.return_value = cursor
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(RuntimeError, match="network timeout"),
+        ):
+            await schemas.list_schemas(target)
+
+
+# ===========================================================================
+# create_schema
+# ===========================================================================
+
+
+class TestCreateSchema:
+    @pytest.mark.asyncio
+    async def test_emits_create_schema(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_SCHEMA_ROW_1], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            await schemas.create_schema(target, "dbo")
+        cursor = ddl_conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0].upper()
+        assert "CREATE SCHEMA" in call_sql
+
+    @pytest.mark.asyncio
+    async def test_uses_bracket_quoting(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_SCHEMA_ROW_1], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            await schemas.create_schema(target, "dbo")
+        cursor = ddl_conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert "[dbo]" in call_sql
+
+    @pytest.mark.asyncio
+    async def test_returns_schema_object(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_SCHEMA_ROW_1], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            result = await schemas.create_schema(target, "dbo")
+        assert isinstance(result, Schema)
+
+    @pytest.mark.asyncio
+    async def test_commits_after_execute(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_SCHEMA_ROW_1], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            await schemas.create_schema(target, "dbo")
+        ddl_conn.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_validates_name_identifier(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await schemas.create_schema(target, "bad]schema")
+
+    @pytest.mark.asyncio
+    async def test_rejects_injection_in_name(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await schemas.create_schema(target, "x]; DROP TABLE users--")
+
+    @pytest.mark.asyncio
+    async def test_maps_permission_denied(self) -> None:
+        target = _make_target()
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.execute.side_effect = Exception("permission was denied on database")
+        conn.cursor.return_value = cursor
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(PermissionDenied),
+        ):
+            await schemas.create_schema(target, "dbo")
+
+    @pytest.mark.asyncio
+    async def test_fetch_raises_not_found_when_no_rows(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([], _LIST_COLS)
+        with (
+            patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]),
+            pytest.raises(NotFound),
+        ):
+            await schemas.create_schema(target, "dbo")
+
+
+# ===========================================================================
+# delete_schema — no cascade
+# ===========================================================================
+
+
+class TestDeleteSchema:
+    @pytest.mark.asyncio
+    async def test_emits_drop_schema(self) -> None:
+        target = _make_target()
+        conn = _make_conn_for_ddl()
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await schemas.delete_schema(target, "dbo")
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0].upper()
+        assert "DROP SCHEMA" in call_sql
+
+    @pytest.mark.asyncio
+    async def test_uses_bracket_quoting(self) -> None:
+        target = _make_target()
+        conn = _make_conn_for_ddl()
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await schemas.delete_schema(target, "dbo")
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert "[dbo]" in call_sql
+
+    @pytest.mark.asyncio
+    async def test_commits_after_execute(self) -> None:
+        target = _make_target()
+        conn = _make_conn_for_ddl()
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await schemas.delete_schema(target, "dbo")
+        conn.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_closes_connection(self) -> None:
+        target = _make_target()
+        conn = _make_conn_for_ddl()
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await schemas.delete_schema(target, "dbo")
+        conn.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_validates_name_identifier(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await schemas.delete_schema(target, "bad]schema")
+
+    @pytest.mark.asyncio
+    async def test_rejects_injection_in_name(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await schemas.delete_schema(target, "x]; DROP TABLE users--")
+
+    @pytest.mark.asyncio
+    async def test_maps_permission_denied(self) -> None:
+        target = _make_target()
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.execute.side_effect = Exception("permission was denied to drop schema")
+        conn.cursor.return_value = cursor
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(PermissionDenied),
+        ):
+            await schemas.delete_schema(target, "dbo")
+
+    @pytest.mark.asyncio
+    async def test_unrelated_error_propagates(self) -> None:
+        target = _make_target()
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.execute.side_effect = RuntimeError("connection reset")
+        conn.cursor.return_value = cursor
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(RuntimeError, match="connection reset"),
+        ):
+            await schemas.delete_schema(target, "dbo")
+
+
+# ===========================================================================
+# delete_schema — cascade
+# ===========================================================================
+
+
+class TestDeleteSchemaCascade:
+    @pytest.mark.asyncio
+    async def test_cascade_drops_table_then_schema(self) -> None:
+        target = _make_target()
+        list_conn = _make_conn([("orders", "TABLE")], ["obj_name", "obj_type"])
+        drop_table_conn = _make_conn_for_ddl()
+        drop_schema_conn = _make_conn_for_ddl()
+        with patch(
+            "fabric_dw.sql.open_connection",
+            side_effect=[list_conn, drop_table_conn, drop_schema_conn],
+        ):
+            await schemas.delete_schema(target, "sales", cascade=True)
+        cursor = drop_table_conn.cursor.return_value
+        drop_sql: str = cursor.execute.call_args[0][0].upper()
+        assert "DROP TABLE" in drop_sql
+
+    @pytest.mark.asyncio
+    async def test_cascade_drops_view_then_schema(self) -> None:
+        target = _make_target()
+        list_conn = _make_conn([("vw_orders", "VIEW")], ["obj_name", "obj_type"])
+        drop_view_conn = _make_conn_for_ddl()
+        drop_schema_conn = _make_conn_for_ddl()
+        with patch(
+            "fabric_dw.sql.open_connection",
+            side_effect=[list_conn, drop_view_conn, drop_schema_conn],
+        ):
+            await schemas.delete_schema(target, "sales", cascade=True)
+        cursor = drop_view_conn.cursor.return_value
+        drop_sql: str = cursor.execute.call_args[0][0].upper()
+        assert "DROP VIEW" in drop_sql
+
+    @pytest.mark.asyncio
+    async def test_cascade_drops_multiple_objects(self) -> None:
+        target = _make_target()
+        list_conn = _make_conn([("t1", "TABLE"), ("v1", "VIEW")], ["obj_name", "obj_type"])
+        drop1_conn = _make_conn_for_ddl()
+        drop2_conn = _make_conn_for_ddl()
+        drop_schema_conn = _make_conn_for_ddl()
+        with patch(
+            "fabric_dw.sql.open_connection",
+            side_effect=[list_conn, drop1_conn, drop2_conn, drop_schema_conn],
+        ):
+            await schemas.delete_schema(target, "sales", cascade=True)
+        # Should have opened 4 connections total (list + 2 drops + schema drop)
+        assert True  # if we get here without error, the cascade ran
+
+    @pytest.mark.asyncio
+    async def test_cascade_false_does_not_enumerate_objects(self) -> None:
+        target = _make_target()
+        drop_schema_conn = _make_conn_for_ddl()
+        with patch(
+            "fabric_dw.sql.open_connection",
+            side_effect=[drop_schema_conn],
+        ):
+            await schemas.delete_schema(target, "sales", cascade=False)
+        # Only one connection opened (the DROP SCHEMA itself)
+        assert True
+
+    @pytest.mark.asyncio
+    async def test_cascade_empty_schema_drops_schema(self) -> None:
+        target = _make_target()
+        list_conn = _make_conn([], ["obj_name", "obj_type"])
+        drop_schema_conn = _make_conn_for_ddl()
+        with patch(
+            "fabric_dw.sql.open_connection",
+            side_effect=[list_conn, drop_schema_conn],
+        ):
+            await schemas.delete_schema(target, "empty_schema", cascade=True)
+        cursor = drop_schema_conn.cursor.return_value
+        drop_sql: str = cursor.execute.call_args[0][0].upper()
+        assert "DROP SCHEMA" in drop_sql
+
+    @pytest.mark.asyncio
+    async def test_cascade_uses_bracket_quoting_for_objects(self) -> None:
+        target = _make_target()
+        list_conn = _make_conn([("my_table", "TABLE")], ["obj_name", "obj_type"])
+        drop_table_conn = _make_conn_for_ddl()
+        drop_schema_conn = _make_conn_for_ddl()
+        with patch(
+            "fabric_dw.sql.open_connection",
+            side_effect=[list_conn, drop_table_conn, drop_schema_conn],
+        ):
+            await schemas.delete_schema(target, "sales", cascade=True)
+        cursor = drop_table_conn.cursor.return_value
+        drop_sql: str = cursor.execute.call_args[0][0]
+        assert "[sales]" in drop_sql
+        assert "[my_table]" in drop_sql


### PR DESCRIPTION
## Summary

- Add `services/schemas.py` backed by TDS `sys.schemas` with `list_schemas`, `create_schema`, and `delete_schema`
- Add `Schema` model to `models.py`
- Add `cli/commands/schemas.py` with `schemas list`, `schemas create`, and `schemas delete [--cascade]` commands
- Add 3 MCP tools: `list_schemas`, `create_schema`, `delete_schema` (with CAUTION docstring on cascade)
- System schemas (`sys`, `INFORMATION_SCHEMA`, `db_*`) excluded from list via NOT IN + LIKE filter
- `validate_identifier` reused from `services/views`; SQL Analytics Endpoints rejected on DDL commands
- 51 new unit tests (service + CLI + MCP tool registration)

## Test plan

- [ ] `uv run pytest tests/unit -q` passes (950 tests, ignoring unrelated untracked test_permissions.py from other branch)
- [ ] `uv run ruff check .` clean on changed files
- [ ] `uvx ty==0.0.44 check src tests` — no new errors (3 pre-existing errors in permissions code unrelated to this PR)
- [ ] CI integration suite

Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)