### PR TITLE
feat(services/permissions): list item access details (admin API)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -286,6 +286,39 @@ fabric-dw warehouses takeover MyWorkspace SalesWH
 
 ---
 
+### warehouses permissions
+
+List all principals (users, groups, service principals) with access to a warehouse, including their effective permissions. Requires **Fabric Administrator** role.
+
+**Synopsis**
+
+```
+fabric-dw [--json] warehouses permissions [WORKSPACE] [WAREHOUSE]
+```
+
+| Option | Description |
+| --- | --- |
+| `--json` | Emit raw JSON instead of a Rich table. Pass on the root command. |
+
+**Example**
+
+```shell
+# Tabular output
+fabric-dw warehouses permissions MyWorkspace SalesWH
+
+# Raw JSON
+fabric-dw --json warehouses permissions MyWorkspace SalesWH
+```
+
+```
+ Display Name    UPN / App ID             Type    Permissions    Additional Permissions
+ --------------- ------------------------ ------- -------------- ----------------------
+ Alice           alice@contoso.com        User    Read, Write
+ DataPipeline    00000000-0000-...        ServicePrincipal  Read
+```
+
+---
+
 ## fabric-dw sql-endpoints
 
 Manage Microsoft Fabric SQL Analytics Endpoints.
@@ -365,6 +398,39 @@ fabric-dw sql-endpoints refresh --recreate-tables MyWorkspace MyLakehouseEP
 
 # Emit raw JSON
 fabric-dw --json sql-endpoints refresh MyWorkspace MyLakehouseEP
+```
+
+---
+
+### sql-endpoints permissions
+
+List all principals (users, groups, service principals) with access to a SQL Analytics Endpoint, including their effective permissions. Requires **Fabric Administrator** role.
+
+**Synopsis**
+
+```
+fabric-dw [--json] sql-endpoints permissions [WORKSPACE] ENDPOINT
+```
+
+| Option | Description |
+| --- | --- |
+| `--json` | Emit raw JSON instead of a Rich table. Pass on the root command. |
+
+**Example**
+
+```shell
+# Tabular output
+fabric-dw sql-endpoints permissions MyWorkspace MyLakehouseEP
+
+# Raw JSON
+fabric-dw --json sql-endpoints permissions MyWorkspace MyLakehouseEP
+```
+
+```
+ Display Name    UPN / App ID             Type    Permissions    Additional Permissions
+ --------------- ------------------------ ------- -------------- ----------------------
+ Alice           alice@contoso.com        User    Read, Write
+ DataPipeline    00000000-0000-...        ServicePrincipal  Read
 ```
 
 ---

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -129,6 +129,21 @@ Take ownership of a Warehouse. Not supported for SQL analytics endpoints.
 
 ---
 
+### get_warehouse_permissions
+
+Return all principals (users, groups, service principals) with access to a Warehouse, including their effective permissions.
+
+> **Note:** Requires **Fabric Administrator** role (`Tenant.Read.All` or `Tenant.ReadWrite.All` scope). See [Microsoft Fabric admin documentation](https://learn.microsoft.com/en-us/fabric/admin/microsoft-fabric-admin) for how to request the role.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `warehouse` (`str`) — warehouse name or GUID.
+
+**Returns:** `list[ItemAccess]` — array of access records, each with `principal` (containing `id`, `displayName`, `type`, and type-specific fields such as `userPrincipalName` or `aadAppId`) and `itemAccessDetails` (containing `type`, `permissions`, and `additionalPermissions`).
+
+---
+
 ## SQL analytics endpoints
 
 ### list_sql_endpoints
@@ -168,6 +183,21 @@ Refresh metadata for a SQL analytics endpoint by syncing from the underlying Lak
 - `recreate_tables` (`bool`, default `False`) — drop and recreate all tables during the refresh. Use to resolve inconsistencies or force a clean rebuild. DESTRUCTIVE — use with caution.
 
 **Returns:** `list[TableSyncStatus]` — array of per-table sync results, each with `tableName`, `status`, `startDateTime`, `endDateTime`, `lastSuccessfulSyncDateTime`, and `error`.
+
+---
+
+### get_sql_endpoint_permissions
+
+Return all principals (users, groups, service principals) with access to a SQL Analytics Endpoint, including their effective permissions.
+
+> **Note:** Requires **Fabric Administrator** role (`Tenant.Read.All` or `Tenant.ReadWrite.All` scope). See [Microsoft Fabric admin documentation](https://learn.microsoft.com/en-us/fabric/admin/microsoft-fabric-admin) for how to request the role.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `sql_endpoint` (`str`) — SQL analytics endpoint name or GUID.
+
+**Returns:** `list[ItemAccess]` — array of access records, each with `principal` (containing `id`, `displayName`, `type`, and type-specific fields such as `userPrincipalName` or `aadAppId`) and `itemAccessDetails` (containing `type`, `permissions`, and `additionalPermissions`).
 
 ---
 

--- a/src/fabric_dw/cli/commands/_utils.py
+++ b/src/fabric_dw/cli/commands/_utils.py
@@ -3,16 +3,19 @@
 from __future__ import annotations
 
 import os
-from collections.abc import Callable, Coroutine
+from collections.abc import Callable, Coroutine, Sequence
 from functools import wraps
 from typing import TYPE_CHECKING, ParamSpec, TypeVar
 from uuid import UUID
 
 import anyio
 import click
+from rich.console import Console
+from rich.table import Table
 
 from fabric_dw.cache import ItemEntry, LookupCache
 from fabric_dw.http_client import FabricHttpClient
+from fabric_dw.models import ItemAccess
 from fabric_dw.resolver import Resolver
 
 if TYPE_CHECKING:
@@ -84,6 +87,39 @@ def resolve_workspace_arg(ctx: CliContext, value: str | None) -> str:
     raise click.UsageError(  # noqa: TRY003
         "no workspace specified; pass as argument or run 'fabric-dw config set workspace ...'"
     )
+
+
+def render_permissions_table(
+    accesses: Sequence[ItemAccess],
+    *,
+    title: str,
+    console: Console | None = None,
+) -> None:
+    """Render a sequence of :class:`~fabric_dw.models.ItemAccess` as a Rich table.
+
+    Args:
+        accesses: The list of item access records to display.
+        title: Table title shown in the Rich header.
+        console: Optional Rich console; defaults to a new :class:`~rich.console.Console`.
+    """
+    con = console or Console()
+    table = Table(title=title, show_header=True, header_style="bold")
+    table.add_column("Display Name", no_wrap=True)
+    table.add_column("UPN / App ID")
+    table.add_column("Type")
+    table.add_column("Permissions")
+    table.add_column("Additional Permissions")
+
+    for entry in accesses:
+        p = entry.principal
+        display = p.display_name or ""
+        identity = p.user_principal_name or (str(p.aad_app_id) if p.aad_app_id else "")
+        ptype = p.type
+        perms = ", ".join(entry.item_access_details.permissions)
+        additional = ", ".join(entry.item_access_details.additional_permissions)
+        table.add_row(display, identity, ptype, perms, additional)
+
+    con.print(table)
 
 
 def resolve_warehouse_arg(ctx: CliContext, value: str | None) -> str:

--- a/src/fabric_dw/cli/commands/sql_endpoints.py
+++ b/src/fabric_dw/cli/commands/sql_endpoints.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json as _json
 import logging
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Sequence
 from contextlib import asynccontextmanager
 
 import click
@@ -15,11 +15,16 @@ from fabric_dw import auth as _auth
 from fabric_dw.cache import LookupCache
 from fabric_dw.cli._context import CliContext
 from fabric_dw.cli._render import render
-from fabric_dw.cli.commands._utils import _coro, _resolve_item
+from fabric_dw.cli.commands._utils import (
+    _coro,
+    _resolve_item,
+    resolve_workspace_arg,
+)
 from fabric_dw.exceptions import FabricError
 from fabric_dw.http_client import FabricHttpClient
-from fabric_dw.models import TableSyncStatus
+from fabric_dw.models import ItemAccess, TableSyncStatus
 from fabric_dw.resolver import Resolver
+from fabric_dw.services import permissions as _permissions_svc
 from fabric_dw.services import sql_endpoints as _sql_endpoints_svc
 
 _log = logging.getLogger(__name__)
@@ -184,5 +189,59 @@ async def refresh_cmd(
                 )
             else:
                 _render_refresh_table(statuses)
+    except FabricError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+def _render_permissions_table(
+    accesses: Sequence[ItemAccess], *, console: Console | None = None
+) -> None:
+    """Render a sequence of :class:`~fabric_dw.models.ItemAccess` as a Rich table."""
+    con = console or Console()
+    table = Table(title="SQL Analytics Endpoint Permissions", show_header=True, header_style="bold")
+    table.add_column("Display Name", no_wrap=True)
+    table.add_column("UPN / App ID")
+    table.add_column("Type")
+    table.add_column("Permissions")
+    table.add_column("Additional")
+
+    for entry in accesses:
+        p = entry.principal
+        display = p.display_name or ""
+        identity = p.user_principal_name or (str(p.aad_app_id) if p.aad_app_id else "")
+        ptype = p.type
+        perms = ", ".join(entry.item_access_details.permissions)
+        additional = ", ".join(entry.item_access_details.additional_permissions)
+        table.add_row(display, identity, ptype, perms, additional)
+
+    con.print(table)
+
+
+@sql_endpoints_group.command("permissions")
+@click.argument("workspace", required=False, default=None)
+@click.argument("endpoint")
+@click.pass_obj
+@_coro
+async def permissions_cmd(ctx: CliContext, workspace: str | None, endpoint: str) -> None:
+    """List principals with access to ENDPOINT in WORKSPACE (both accept name or GUID).
+
+    Requires Fabric Administrator role.
+    See https://learn.microsoft.com/en-us/fabric/admin/microsoft-fabric-admin for details.
+    """
+    ws = resolve_workspace_arg(ctx, workspace)
+    try:
+        async with _build_clients(ctx) as (http, _):
+            ws_id, entry = await _resolve_item(http, ws, endpoint)
+            items = await _permissions_svc.list_item_access(http, ws_id, entry.id)
+            if ctx.json_output:
+                click.echo(
+                    _json.dumps(
+                        [a.model_dump(by_alias=True, mode="json") for a in items],
+                        indent=2,
+                        default=str,
+                    )
+                )
+            else:
+                _render_permissions_table(items)
     except FabricError as exc:
         raise click.ClickException(str(exc)) from exc

--- a/src/fabric_dw/cli/commands/sql_endpoints.py
+++ b/src/fabric_dw/cli/commands/sql_endpoints.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json as _json
 import logging
-from collections.abc import AsyncIterator, Sequence
+from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
 import click
@@ -18,11 +18,12 @@ from fabric_dw.cli._render import render
 from fabric_dw.cli.commands._utils import (
     _coro,
     _resolve_item,
+    render_permissions_table,
     resolve_workspace_arg,
 )
 from fabric_dw.exceptions import FabricError
 from fabric_dw.http_client import FabricHttpClient
-from fabric_dw.models import ItemAccess, TableSyncStatus
+from fabric_dw.models import TableSyncStatus
 from fabric_dw.resolver import Resolver
 from fabric_dw.services import permissions as _permissions_svc
 from fabric_dw.services import sql_endpoints as _sql_endpoints_svc
@@ -193,30 +194,6 @@ async def refresh_cmd(
         raise click.ClickException(str(exc)) from exc
 
 
-def _render_permissions_table(
-    accesses: Sequence[ItemAccess], *, console: Console | None = None
-) -> None:
-    """Render a sequence of :class:`~fabric_dw.models.ItemAccess` as a Rich table."""
-    con = console or Console()
-    table = Table(title="SQL Analytics Endpoint Permissions", show_header=True, header_style="bold")
-    table.add_column("Display Name", no_wrap=True)
-    table.add_column("UPN / App ID")
-    table.add_column("Type")
-    table.add_column("Permissions")
-    table.add_column("Additional")
-
-    for entry in accesses:
-        p = entry.principal
-        display = p.display_name or ""
-        identity = p.user_principal_name or (str(p.aad_app_id) if p.aad_app_id else "")
-        ptype = p.type
-        perms = ", ".join(entry.item_access_details.permissions)
-        additional = ", ".join(entry.item_access_details.additional_permissions)
-        table.add_row(display, identity, ptype, perms, additional)
-
-    con.print(table)
-
-
 @sql_endpoints_group.command("permissions")
 @click.argument("workspace", required=False, default=None)
 @click.argument("endpoint")
@@ -242,6 +219,6 @@ async def permissions_cmd(ctx: CliContext, workspace: str | None, endpoint: str)
                     )
                 )
             else:
-                _render_permissions_table(items)
+                render_permissions_table(items, title="SQL Analytics Endpoint Permissions")
     except FabricError as exc:
         raise click.ClickException(str(exc)) from exc

--- a/src/fabric_dw/cli/commands/warehouses.py
+++ b/src/fabric_dw/cli/commands/warehouses.py
@@ -4,12 +4,10 @@ from __future__ import annotations
 
 import json as _json
 import logging
-from collections.abc import AsyncIterator, Sequence
+from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
 import click
-from rich.console import Console
-from rich.table import Table
 
 from fabric_dw import auth as _auth
 from fabric_dw.cache import LookupCache
@@ -19,12 +17,13 @@ from fabric_dw.cli.commands._utils import (
     _coro,
     _resolve_item,
     _resolve_item_with_cache,
+    render_permissions_table,
     resolve_warehouse_arg,
     resolve_workspace_arg,
 )
 from fabric_dw.exceptions import FabricError
 from fabric_dw.http_client import FabricHttpClient
-from fabric_dw.models import ItemAccess, WarehouseKind
+from fabric_dw.models import WarehouseKind
 from fabric_dw.resolver import Resolver
 from fabric_dw.services import ownership as _ownership_svc
 from fabric_dw.services import permissions as _permissions_svc
@@ -249,30 +248,6 @@ async def takeover_cmd(ctx: CliContext, workspace: str | None, warehouse: str | 
         raise click.ClickException(str(exc)) from exc
 
 
-def _render_permissions_table(
-    accesses: Sequence[ItemAccess], *, console: Console | None = None
-) -> None:
-    """Render a sequence of :class:`~fabric_dw.models.ItemAccess` as a Rich table."""
-    con = console or Console()
-    table = Table(title="Warehouse Permissions", show_header=True, header_style="bold")
-    table.add_column("Display Name", no_wrap=True)
-    table.add_column("UPN / App ID")
-    table.add_column("Type")
-    table.add_column("Permissions")
-    table.add_column("Additional")
-
-    for entry in accesses:
-        p = entry.principal
-        display = p.display_name or ""
-        identity = p.user_principal_name or (str(p.aad_app_id) if p.aad_app_id else "")
-        ptype = p.type
-        perms = ", ".join(entry.item_access_details.permissions)
-        additional = ", ".join(entry.item_access_details.additional_permissions)
-        table.add_row(display, identity, ptype, perms, additional)
-
-    con.print(table)
-
-
 @warehouses_group.command("permissions")
 @click.argument("workspace", required=False, default=None)
 @click.argument("warehouse", required=False, default=None)
@@ -299,6 +274,6 @@ async def permissions_cmd(ctx: CliContext, workspace: str | None, warehouse: str
                     )
                 )
             else:
-                _render_permissions_table(items)
+                render_permissions_table(items, title="Warehouse Permissions")
     except FabricError as exc:
         raise click.ClickException(str(exc)) from exc

--- a/src/fabric_dw/cli/commands/warehouses.py
+++ b/src/fabric_dw/cli/commands/warehouses.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import json as _json
 import logging
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Sequence
 from contextlib import asynccontextmanager
 
 import click
+from rich.console import Console
+from rich.table import Table
 
 from fabric_dw import auth as _auth
 from fabric_dw.cache import LookupCache
@@ -21,9 +24,10 @@ from fabric_dw.cli.commands._utils import (
 )
 from fabric_dw.exceptions import FabricError
 from fabric_dw.http_client import FabricHttpClient
-from fabric_dw.models import WarehouseKind
+from fabric_dw.models import ItemAccess, WarehouseKind
 from fabric_dw.resolver import Resolver
 from fabric_dw.services import ownership as _ownership_svc
+from fabric_dw.services import permissions as _permissions_svc
 from fabric_dw.services import warehouses as _warehouses_svc
 
 _log = logging.getLogger(__name__)
@@ -241,5 +245,60 @@ async def takeover_cmd(ctx: CliContext, workspace: str | None, warehouse: str | 
         raise
     except click.UsageError:
         raise
+    except FabricError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+def _render_permissions_table(
+    accesses: Sequence[ItemAccess], *, console: Console | None = None
+) -> None:
+    """Render a sequence of :class:`~fabric_dw.models.ItemAccess` as a Rich table."""
+    con = console or Console()
+    table = Table(title="Warehouse Permissions", show_header=True, header_style="bold")
+    table.add_column("Display Name", no_wrap=True)
+    table.add_column("UPN / App ID")
+    table.add_column("Type")
+    table.add_column("Permissions")
+    table.add_column("Additional")
+
+    for entry in accesses:
+        p = entry.principal
+        display = p.display_name or ""
+        identity = p.user_principal_name or (str(p.aad_app_id) if p.aad_app_id else "")
+        ptype = p.type
+        perms = ", ".join(entry.item_access_details.permissions)
+        additional = ", ".join(entry.item_access_details.additional_permissions)
+        table.add_row(display, identity, ptype, perms, additional)
+
+    con.print(table)
+
+
+@warehouses_group.command("permissions")
+@click.argument("workspace", required=False, default=None)
+@click.argument("warehouse", required=False, default=None)
+@click.pass_obj
+@_coro
+async def permissions_cmd(ctx: CliContext, workspace: str | None, warehouse: str | None) -> None:
+    """List principals with access to WAREHOUSE in WORKSPACE (both accept name or GUID).
+
+    Requires Fabric Administrator role.
+    See https://learn.microsoft.com/en-us/fabric/admin/microsoft-fabric-admin for details.
+    """
+    ws = resolve_workspace_arg(ctx, workspace)
+    wh = resolve_warehouse_arg(ctx, warehouse)
+    try:
+        async with _build_clients(ctx) as (http, _):
+            ws_id, entry = await _resolve_item(http, ws, wh)
+            items = await _permissions_svc.list_item_access(http, ws_id, entry.id)
+            if ctx.json_output:
+                click.echo(
+                    _json.dumps(
+                        [a.model_dump(by_alias=True, mode="json") for a in items],
+                        indent=2,
+                        default=str,
+                    )
+                )
+            else:
+                _render_permissions_table(items)
     except FabricError as exc:
         raise click.ClickException(str(exc)) from exc

--- a/src/fabric_dw/mcp/server.py
+++ b/src/fabric_dw/mcp/server.py
@@ -35,6 +35,7 @@ from fabric_dw.models import SqlPool, SqlPoolClassifier
 from fabric_dw.resolver import Resolver
 from fabric_dw.services import audit, queries, snapshots, sql_endpoints, warehouses, workspaces
 from fabric_dw.services import ownership as ownership_svc
+from fabric_dw.services import permissions as _permissions_svc
 from fabric_dw.services import query_insights as _qi_svc
 from fabric_dw.services import restore as restore_svc
 from fabric_dw.services import sql_exec as _sql_exec_svc
@@ -252,6 +253,23 @@ async def takeover_warehouse(workspace: str, warehouse: str) -> dict[str, Any]:
     return {"taken_over": True, "warehouse_id": str(item.id)}
 
 
+@mcp.tool()
+async def get_warehouse_permissions(workspace: str, warehouse: str) -> list[dict[str, Any]]:
+    """Return principals with access to a Warehouse item.
+
+    Requires Fabric Administrator role (admin API).
+
+    See https://learn.microsoft.com/en-us/fabric/admin/microsoft-fabric-admin for details.
+    """
+    try:
+        ws_id = await _get_resolver().workspace_id(workspace)
+        item = await _get_resolver().item(workspace, warehouse)
+        result = await _permissions_svc.list_item_access(_get_http(), ws_id, item.id)
+    except FabricError as exc:
+        raise _fabric_err(exc) from exc
+    return [a.model_dump(by_alias=True, mode="json") for a in result]
+
+
 # ---------------------------------------------------------------------------
 # SQL Endpoint tools
 # ---------------------------------------------------------------------------
@@ -314,6 +332,23 @@ async def refresh_sql_endpoint_metadata(
     except FabricError as exc:
         raise _fabric_err(exc) from exc
     return [s.model_dump(by_alias=True, mode="json") for s in statuses]
+
+
+@mcp.tool()
+async def get_sql_endpoint_permissions(workspace: str, sql_endpoint: str) -> list[dict[str, Any]]:
+    """Return principals with access to a SQL Analytics Endpoint item.
+
+    Requires Fabric Administrator role (admin API).
+
+    See https://learn.microsoft.com/en-us/fabric/admin/microsoft-fabric-admin for details.
+    """
+    try:
+        ws_id = await _get_resolver().workspace_id(workspace)
+        item = await _get_resolver().item(workspace, sql_endpoint)
+        result = await _permissions_svc.list_item_access(_get_http(), ws_id, item.id)
+    except FabricError as exc:
+        raise _fabric_err(exc) from exc
+    return [a.model_dump(by_alias=True, mode="json") for a in result]
 
 
 # ---------------------------------------------------------------------------

--- a/src/fabric_dw/models.py
+++ b/src/fabric_dw/models.py
@@ -479,6 +479,9 @@ class ItemAccessPrincipal(_FabricBase):
             if isinstance(sp_details, dict):
                 flat["aad_app_id"] = sp_details.get("aadAppId")
 
+        # ServicePrincipalProfile: no scalar sub-fields to extract (profile
+        # identity is carried by the top-level id/displayName only).
+
         return flat
 
 

--- a/src/fabric_dw/models.py
+++ b/src/fabric_dw/models.py
@@ -7,7 +7,7 @@ from enum import StrEnum
 from typing import Annotated, Literal, cast
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
 class _FabricBase(BaseModel):
@@ -411,6 +411,95 @@ class SqlPoolsConfiguration(_FabricBase):
             names = ", ".join(p.name for p in defaults)
             msg = f"Exactly one SQL pool may be marked as default; got {len(defaults)}: {names}"
             raise ValueError(msg)
+
+
+# ---------------------------------------------------------------------------
+# Item access details (admin API)
+# ---------------------------------------------------------------------------
+
+
+class PrincipalType(StrEnum):
+    """The type of the principal returned by the item access details API.
+
+    Note: additional types may be added by Microsoft over time.
+    """
+
+    USER = "User"
+    GROUP = "Group"
+    SERVICE_PRINCIPAL = "ServicePrincipal"
+    SERVICE_PRINCIPAL_PROFILE = "ServicePrincipalProfile"
+    ENTIRE_TENANT = "EntireTenant"
+
+
+class ItemAccessPrincipal(_FabricBase):
+    """Minimal representation of a principal in an item access record.
+
+    Covers all five principal variants (User, Group, ServicePrincipal,
+    ServicePrincipalProfile, EntireTenant).  Type-specific detail fields
+    (``userPrincipalName``, ``aadAppId``, ``groupType``) are surfaced as
+    optional top-level attributes so that consumers do not need to traverse
+    nested detail sub-objects.
+    """
+
+    id: UUID
+    display_name: str | None = Field(default=None, alias="displayName")
+    type: str  # open string — new values may appear
+
+    # User-specific
+    user_principal_name: str | None = None
+
+    # Group-specific
+    group_type: str | None = None
+
+    # ServicePrincipal-specific
+    aad_app_id: UUID | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _flatten_detail(cls, data: object) -> object:
+        """Flatten the type-specific detail sub-object to the top level."""
+        if not isinstance(data, dict):
+            return data
+
+        flat = dict(data)
+        principal_type = flat.get("type", "")
+
+        if principal_type == PrincipalType.USER:
+            user_details = flat.get("userDetails")
+            if isinstance(user_details, dict):
+                flat["user_principal_name"] = user_details.get("userPrincipalName")
+
+        elif principal_type == PrincipalType.GROUP:
+            group_details = flat.get("groupDetails")
+            if isinstance(group_details, dict):
+                flat["group_type"] = group_details.get("groupType")
+
+        elif principal_type == PrincipalType.SERVICE_PRINCIPAL:
+            sp_details = flat.get("servicePrincipalDetails")
+            if isinstance(sp_details, dict):
+                flat["aad_app_id"] = sp_details.get("aadAppId")
+
+        return flat
+
+
+class ItemAccessDetail(_FabricBase):
+    """Item-level permission details for a single principal."""
+
+    item_type: str | None = Field(default=None, alias="type")
+    permissions: list[str] = Field(default_factory=list)
+    additional_permissions: list[str] = Field(default_factory=list, alias="additionalPermissions")
+
+
+class ItemAccess(_FabricBase):
+    """Combined principal + permission record from the admin item-access API."""
+
+    principal: ItemAccessPrincipal
+    item_access_details: ItemAccessDetail = Field(alias="itemAccessDetails")
+
+    @classmethod
+    def from_api(cls, raw: dict[str, object]) -> ItemAccess:
+        """Build an :class:`ItemAccess` from a raw ``accessDetails`` element."""
+        return cls.model_validate(raw)
 
 
 class SqlResult(_FabricBase):

--- a/src/fabric_dw/services/permissions.py
+++ b/src/fabric_dw/services/permissions.py
@@ -49,6 +49,8 @@ async def list_item_access(
         PermissionDenied: If the caller is not a Fabric Administrator (HTTP 403).
         NotFound: If the workspace or item does not exist (HTTP 404).
     """
+    # The optional ?type= query param is intentionally omitted: Warehouse and
+    # SQLEndpoint items do not filter by type, and omitting it returns all principals.
     path = f"/admin/workspaces/{workspace_id}/items/{item_id}/users"
     results: list[ItemAccess] = []
 

--- a/src/fabric_dw/services/permissions.py
+++ b/src/fabric_dw/services/permissions.py
@@ -1,0 +1,79 @@
+"""Item access details service for Microsoft Fabric (admin API).
+
+Wraps the admin endpoint ``GET /v1/admin/workspaces/{workspaceId}/items/{itemId}/users``
+to return the list of principals (users, groups, service principals) that have
+access to a given item, along with their effective permissions.
+
+Caller must be a Fabric Administrator (Tenant.Read.All or Tenant.ReadWrite.All scope).
+
+Reference:
+    https://learn.microsoft.com/en-us/rest/api/fabric/admin/items/list-item-access-details
+"""
+
+from __future__ import annotations
+
+from typing import cast
+from uuid import UUID
+
+from fabric_dw.exceptions import PermissionDenied
+from fabric_dw.http_client import FabricHttpClient, HttpBase
+from fabric_dw.models import ItemAccess
+
+__all__ = ["list_item_access"]
+
+_ADMIN_HINT = (
+    "This endpoint requires Fabric Administrator role. "
+    "See https://learn.microsoft.com/en-us/fabric/admin/microsoft-fabric-admin"
+    "?WT.mc_id=MVP_310840 for how to request it."
+)
+
+
+async def list_item_access(
+    http: FabricHttpClient,
+    workspace_id: UUID,
+    item_id: UUID,
+) -> list[ItemAccess]:
+    """Return the list of principals with access to *item_id* in *workspace_id*.
+
+    Follows ``continuationUri`` pagination until all pages are consumed.
+
+    Args:
+        http: Authenticated Fabric HTTP client.
+        workspace_id: GUID of the Fabric workspace.
+        item_id: GUID of the item (Warehouse or SQL Endpoint).
+
+    Returns:
+        A list of :class:`~fabric_dw.models.ItemAccess` objects, one per principal.
+
+    Raises:
+        PermissionDenied: If the caller is not a Fabric Administrator (HTTP 403).
+        NotFound: If the workspace or item does not exist (HTTP 404).
+    """
+    path = f"/admin/workspaces/{workspace_id}/items/{item_id}/users"
+    results: list[ItemAccess] = []
+
+    # The admin endpoint uses the same continuationUri pagination pattern as
+    # other Fabric list endpoints, but the items are in "accessDetails" rather
+    # than "value".  We implement manual pagination here instead of using
+    # iter_paginated (which looks for "value").
+    url: str | None = f"{HttpBase.FABRIC}{path}"
+
+    try:
+        while url is not None:
+            resp = await http._request_with_retry("GET", url)  # type: ignore[attr-defined]
+            data = cast("dict[str, object]", resp.json())
+
+            raw_items = data.get("accessDetails", [])
+            if isinstance(raw_items, list):
+                results.extend(
+                    ItemAccess.from_api({str(k): v for k, v in raw.items()})
+                    for raw in raw_items
+                    if isinstance(raw, dict)
+                )
+
+            cont = data.get("continuationUri")
+            url = cont if isinstance(cont, str) else None
+    except PermissionDenied as exc:
+        raise PermissionDenied(_ADMIN_HINT) from exc
+
+    return results

--- a/tests/fixtures/api_payloads.py
+++ b/tests/fixtures/api_payloads.py
@@ -279,3 +279,97 @@ WAREHOUSE_OPERATION_SUCCEEDED_NO_LOCATION_PAYLOAD = """{
   "error": null,
   "resourceLocation": null
 }"""
+
+# Item access details — single-page response with User, Group, ServicePrincipal entries
+ITEM_ACCESS_DETAILS_PAYLOAD = """{
+  "accessDetails": [
+    {
+      "principal": {
+        "id": "f3052d1c-61a9-46fb-8df9-0d78916ae041",
+        "displayName": "Jacob Hancock",
+        "type": "User",
+        "userDetails": {
+          "userPrincipalName": "jacob@example.com"
+        }
+      },
+      "itemAccessDetails": {
+        "type": "Warehouse",
+        "permissions": ["Read", "Write"],
+        "additionalPermissions": ["ReadAll"]
+      }
+    },
+    {
+      "principal": {
+        "id": "c7db8e03-c8cb-4d4c-9f64-1dcd327c9d3c",
+        "displayName": "TestSecurityGroup",
+        "type": "Group",
+        "groupDetails": {
+          "groupType": "SecurityGroup"
+        }
+      },
+      "itemAccessDetails": {
+        "type": "Warehouse",
+        "permissions": ["Read"],
+        "additionalPermissions": []
+      }
+    },
+    {
+      "principal": {
+        "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+        "displayName": "MyServicePrincipal",
+        "type": "ServicePrincipal",
+        "servicePrincipalDetails": {
+          "aadAppId": "b2c3d4e5-f6a7-8901-bcde-f01234567891"
+        }
+      },
+      "itemAccessDetails": {
+        "type": "Warehouse",
+        "permissions": ["Read", "Reshare"],
+        "additionalPermissions": []
+      }
+    }
+  ]
+}"""
+
+# Item access details — page 1 of 2 (with continuationUri)
+ITEM_ACCESS_DETAILS_PAGE1_PAYLOAD = """{
+  "accessDetails": [
+    {
+      "principal": {
+        "id": "f3052d1c-61a9-46fb-8df9-0d78916ae041",
+        "displayName": "Jacob Hancock",
+        "type": "User",
+        "userDetails": {
+          "userPrincipalName": "jacob@example.com"
+        }
+      },
+      "itemAccessDetails": {
+        "type": "Warehouse",
+        "permissions": ["Read"],
+        "additionalPermissions": []
+      }
+    }
+  ],
+  "continuationUri": "https://api.fabric.microsoft.com/v1/admin/workspaces/a1b2c3d4-e5f6-7890-abcd-ef1234567890/items/d4e5f6a7-b8c9-0123-def0-123456789abc/users?continuationToken=page2token"
+}"""
+
+# Item access details — page 2 of 2 (no continuationUri)
+ITEM_ACCESS_DETAILS_PAGE2_PAYLOAD = """{
+  "accessDetails": [
+    {
+      "principal": {
+        "id": "c7db8e03-c8cb-4d4c-9f64-1dcd327c9d3c",
+        "displayName": "Eric Solomon",
+        "type": "User",
+        "userDetails": {
+          "userPrincipalName": "eric@example.com"
+        }
+      },
+      "itemAccessDetails": {
+        "type": "Warehouse",
+        "permissions": ["Read", "Reshare"],
+        "additionalPermissions": ["ReadAll"]
+      }
+    }
+  ]
+}"""

--- a/tests/integration/test_services_permissions.py
+++ b/tests/integration/test_services_permissions.py
@@ -1,0 +1,85 @@
+"""Integration tests for fabric_dw.services.permissions (admin API).
+
+These tests require:
+- FABRIC_TEST_WORKSPACE_ID set to a workspace the caller can see.
+- The caller must be a Fabric Administrator to call the admin endpoint.
+
+Tests that require admin access are marked with ``skip_if_not_admin``
+and are gated behind the ``integration`` pytest mark.
+"""
+
+from __future__ import annotations
+
+import os
+from uuid import UUID
+
+import pytest
+
+from fabric_dw.exceptions import PermissionDenied
+from fabric_dw.http_client import FabricHttpClient
+from fabric_dw.models import ItemAccess, Warehouse
+from fabric_dw.services import permissions
+
+pytestmark = pytest.mark.integration
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+#: Set to True when the test environment is known to have Fabric Admin access.
+_IS_ADMIN = os.environ.get("FABRIC_TEST_IS_ADMIN", "").lower() in {"1", "true", "yes"}
+
+skip_if_not_admin = pytest.mark.skipif(
+    not _IS_ADMIN,
+    reason="FABRIC_TEST_IS_ADMIN not set; skipping admin-only test",
+)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@skip_if_not_admin
+async def test_list_item_access_returns_list(
+    http: FabricHttpClient,
+    workspace_id: UUID,
+    ephemeral_warehouse: Warehouse,
+) -> None:
+    """list_item_access must return a list of ItemAccess for a real warehouse."""
+    result = await permissions.list_item_access(http, workspace_id, ephemeral_warehouse.id)
+
+    assert isinstance(result, list)
+    assert all(isinstance(item, ItemAccess) for item in result)
+
+
+@skip_if_not_admin
+async def test_list_item_access_principals_have_required_fields(
+    http: FabricHttpClient,
+    workspace_id: UUID,
+    ephemeral_warehouse: Warehouse,
+) -> None:
+    """Every returned principal must have id, display_name, and type."""
+    result = await permissions.list_item_access(http, workspace_id, ephemeral_warehouse.id)
+
+    for item in result:
+        assert item.principal.id is not None
+        assert item.principal.type is not None
+
+
+async def test_list_item_access_non_admin_raises_permission_denied(
+    http: FabricHttpClient,
+    workspace_id: UUID,
+    ephemeral_warehouse: Warehouse,
+) -> None:
+    """list_item_access must raise PermissionDenied (with admin hint) when not an admin.
+
+    This test is expected to run even without admin access; it just verifies
+    the error is surfaced correctly.  If the caller IS an admin the test is
+    skipped so it does not accidentally pass for the wrong reason.
+    """
+    if _IS_ADMIN:
+        pytest.skip("caller has admin access; cannot test non-admin path")
+
+    with pytest.raises(PermissionDenied, match="Fabric Administrator"):
+        await permissions.list_item_access(http, workspace_id, ephemeral_warehouse.id)

--- a/tests/unit/mcp/test_server.py
+++ b/tests/unit/mcp/test_server.py
@@ -29,9 +29,10 @@ from uuid import UUID
 import pytest
 
 from fabric_dw.cache import ItemEntry
-from fabric_dw.exceptions import NotFound
+from fabric_dw.exceptions import NotFound, PermissionDenied
 from fabric_dw.models import (
     AuditSettings,
+    ItemAccess,
     RunningQuery,
     TableSyncStatus,
     Warehouse,
@@ -88,6 +89,9 @@ EXPECTED_TOOL_NAMES: frozenset[str] = frozenset(
         "roll_snapshot_timestamp",
         # Cache
         "clear_cache",
+        # Permissions (admin API)
+        "get_warehouse_permissions",
+        "get_sql_endpoint_permissions",
     }
 )
 
@@ -1008,4 +1012,124 @@ async def test_execute_sql_no_connection_string_raises_tool_error() -> None:
         await mcp._tool_manager.call_tool(
             "execute_sql",
             {"workspace": _WS_NAME, "item": _WH_NAME, "query": "SELECT 1"},
+        )
+
+
+# ---------------------------------------------------------------------------
+# Permissions tools
+# ---------------------------------------------------------------------------
+
+
+def _make_item_access() -> ItemAccess:
+    return ItemAccess.model_validate(
+        {
+            "principal": {
+                "id": str(_WH_ID),
+                "displayName": "Jacob Hancock",
+                "type": "User",
+                "userDetails": {"userPrincipalName": "jacob@example.com"},
+            },
+            "itemAccessDetails": {
+                "type": "Warehouse",
+                "permissions": ["Read", "Write"],
+                "additionalPermissions": ["ReadAll"],
+            },
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_warehouse_permissions_happy_path() -> None:
+    """get_warehouse_permissions returns a list of serialised ItemAccess dicts."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    access = _make_item_access()
+    item = _make_item_entry()
+
+    mock_resolver = AsyncMock()
+    mock_resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_resolver.item = AsyncMock(return_value=item)
+    mock_http = AsyncMock()
+    mock_cache = MagicMock()
+
+    with (
+        patch("fabric_dw.mcp.server._get_http", return_value=mock_http),
+        patch("fabric_dw.mcp.server._get_resolver", return_value=mock_resolver),
+        patch("fabric_dw.mcp.server._get_cache", return_value=mock_cache),
+        patch(
+            "fabric_dw.services.permissions.list_item_access",
+            new=AsyncMock(return_value=[access]),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "get_warehouse_permissions",
+            {"workspace": _WS_NAME, "warehouse": _WH_NAME},
+        )
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0]["principal"]["displayName"] == "Jacob Hancock"
+
+
+@pytest.mark.asyncio
+async def test_get_sql_endpoint_permissions_happy_path() -> None:
+    """get_sql_endpoint_permissions returns a list of serialised ItemAccess dicts."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    access = _make_item_access()
+    item = _make_item_entry()
+
+    mock_resolver = AsyncMock()
+    mock_resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_resolver.item = AsyncMock(return_value=item)
+    mock_http = AsyncMock()
+    mock_cache = MagicMock()
+
+    with (
+        patch("fabric_dw.mcp.server._get_http", return_value=mock_http),
+        patch("fabric_dw.mcp.server._get_resolver", return_value=mock_resolver),
+        patch("fabric_dw.mcp.server._get_cache", return_value=mock_cache),
+        patch(
+            "fabric_dw.services.permissions.list_item_access",
+            new=AsyncMock(return_value=[access]),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "get_sql_endpoint_permissions",
+            {"workspace": _WS_NAME, "sql_endpoint": _WH_NAME},
+        )
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0]["principal"]["type"] == "User"
+
+
+@pytest.mark.asyncio
+async def test_get_warehouse_permissions_permission_denied_becomes_tool_error() -> None:
+    """get_warehouse_permissions wraps PermissionDenied into ToolError."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = _make_item_entry()
+
+    mock_resolver = AsyncMock()
+    mock_resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_resolver.item = AsyncMock(return_value=item)
+    mock_http = AsyncMock()
+    mock_cache = MagicMock()
+
+    with (
+        patch("fabric_dw.mcp.server._get_http", return_value=mock_http),
+        patch("fabric_dw.mcp.server._get_resolver", return_value=mock_resolver),
+        patch("fabric_dw.mcp.server._get_cache", return_value=mock_cache),
+        patch(
+            "fabric_dw.services.permissions.list_item_access",
+            new=AsyncMock(side_effect=PermissionDenied("Fabric Administrator")),
+        ),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "get_warehouse_permissions",
+            {"workspace": _WS_NAME, "warehouse": _WH_NAME},
         )

--- a/tests/unit/services/test_permissions.py
+++ b/tests/unit/services/test_permissions.py
@@ -1,0 +1,259 @@
+"""Tests for fabric_dw.services.permissions — written BEFORE the implementation (TDD)."""
+
+from __future__ import annotations
+
+import json
+import time
+from unittest.mock import AsyncMock, MagicMock
+from uuid import UUID
+
+import httpx
+import pytest
+import respx
+from azure.core.credentials import AccessToken
+from azure.core.credentials_async import AsyncTokenCredential
+
+from fabric_dw.exceptions import NotFound, PermissionDenied
+from fabric_dw.http_client import FabricHttpClient
+from fabric_dw.models import ItemAccess, PrincipalType
+from fabric_dw.services import permissions
+from tests.fixtures.api_payloads import (
+    ITEM_ACCESS_DETAILS_PAGE1_PAYLOAD,
+    ITEM_ACCESS_DETAILS_PAGE2_PAYLOAD,
+    ITEM_ACCESS_DETAILS_PAYLOAD,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_FAKE_TOKEN = AccessToken(token="fake-token", expires_on=int(time.time()) + 3600)  # noqa: S106
+
+_BASE = "https://api.fabric.microsoft.com/v1"
+_WORKSPACE_ID = UUID("a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+_ITEM_ID = UUID("d4e5f6a7-b8c9-0123-def0-123456789abc")
+
+_ACCESS_URL = (
+    f"{_BASE}/admin/workspaces/a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+    "/items/d4e5f6a7-b8c9-0123-def0-123456789abc/users"
+)
+
+
+def _make_credential(token: AccessToken = _FAKE_TOKEN) -> AsyncTokenCredential:
+    cred = MagicMock(spec=AsyncTokenCredential)
+    cred.get_token = AsyncMock(return_value=token)
+    return cred
+
+
+async def _make_client(rps: int = 10) -> FabricHttpClient:
+    return FabricHttpClient(credential=_make_credential(), rps=rps)
+
+
+# ---------------------------------------------------------------------------
+# list_item_access — happy path (single page)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_item_access_returns_all_principals() -> None:
+    """list_item_access must return one ItemAccess per principal in the response."""
+    payload = json.loads(ITEM_ACCESS_DETAILS_PAYLOAD)
+
+    with respx.mock:
+        respx.get(_ACCESS_URL).mock(return_value=httpx.Response(200, json=payload))
+
+        client = await _make_client()
+        async with client:
+            result = await permissions.list_item_access(client, _WORKSPACE_ID, _ITEM_ID)
+
+    assert len(result) == 3
+    assert all(isinstance(item, ItemAccess) for item in result)
+
+
+@pytest.mark.asyncio
+async def test_list_item_access_user_principal_fields() -> None:
+    """User principal must have display_name, type=User, and user_principal_name populated."""
+    payload = json.loads(ITEM_ACCESS_DETAILS_PAYLOAD)
+
+    with respx.mock:
+        respx.get(_ACCESS_URL).mock(return_value=httpx.Response(200, json=payload))
+
+        client = await _make_client()
+        async with client:
+            result = await permissions.list_item_access(client, _WORKSPACE_ID, _ITEM_ID)
+
+    user_items = [r for r in result if r.principal.type == PrincipalType.USER]
+    assert len(user_items) == 1
+    user = user_items[0].principal
+    assert user.display_name == "Jacob Hancock"
+    assert user.user_principal_name == "jacob@example.com"
+    assert user.aad_app_id is None
+    assert user.group_type is None
+
+
+@pytest.mark.asyncio
+async def test_list_item_access_group_principal_fields() -> None:
+    """Group principal must have group_type populated from groupDetails."""
+    payload = json.loads(ITEM_ACCESS_DETAILS_PAYLOAD)
+
+    with respx.mock:
+        respx.get(_ACCESS_URL).mock(return_value=httpx.Response(200, json=payload))
+
+        client = await _make_client()
+        async with client:
+            result = await permissions.list_item_access(client, _WORKSPACE_ID, _ITEM_ID)
+
+    group_items = [r for r in result if r.principal.type == PrincipalType.GROUP]
+    assert len(group_items) == 1
+    group = group_items[0].principal
+    assert group.display_name == "TestSecurityGroup"
+    assert group.group_type == "SecurityGroup"
+    assert group.user_principal_name is None
+
+
+@pytest.mark.asyncio
+async def test_list_item_access_service_principal_fields() -> None:
+    """ServicePrincipal principal must have aad_app_id populated from servicePrincipalDetails."""
+    payload = json.loads(ITEM_ACCESS_DETAILS_PAYLOAD)
+
+    with respx.mock:
+        respx.get(_ACCESS_URL).mock(return_value=httpx.Response(200, json=payload))
+
+        client = await _make_client()
+        async with client:
+            result = await permissions.list_item_access(client, _WORKSPACE_ID, _ITEM_ID)
+
+    sp_items = [r for r in result if r.principal.type == PrincipalType.SERVICE_PRINCIPAL]
+    assert len(sp_items) == 1
+    sp = sp_items[0].principal
+    assert sp.display_name == "MyServicePrincipal"
+    assert sp.aad_app_id == UUID("b2c3d4e5-f6a7-8901-bcde-f01234567891")
+    assert sp.user_principal_name is None
+
+
+@pytest.mark.asyncio
+async def test_list_item_access_permissions_populated() -> None:
+    """ItemAccess.item_access_details must have permissions and additional_permissions."""
+    payload = json.loads(ITEM_ACCESS_DETAILS_PAYLOAD)
+
+    with respx.mock:
+        respx.get(_ACCESS_URL).mock(return_value=httpx.Response(200, json=payload))
+
+        client = await _make_client()
+        async with client:
+            result = await permissions.list_item_access(client, _WORKSPACE_ID, _ITEM_ID)
+
+    user_entry = next(r for r in result if r.principal.type == PrincipalType.USER)
+    assert "Read" in user_entry.item_access_details.permissions
+    assert "Write" in user_entry.item_access_details.permissions
+    assert "ReadAll" in user_entry.item_access_details.additional_permissions
+    assert user_entry.item_access_details.item_type == "Warehouse"
+
+
+# ---------------------------------------------------------------------------
+# list_item_access — empty response
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_item_access_empty_response_returns_empty_list() -> None:
+    """list_item_access must return an empty list when accessDetails is empty."""
+    with respx.mock:
+        respx.get(_ACCESS_URL).mock(return_value=httpx.Response(200, json={"accessDetails": []}))
+
+        client = await _make_client()
+        async with client:
+            result = await permissions.list_item_access(client, _WORKSPACE_ID, _ITEM_ID)
+
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# list_item_access — pagination
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_item_access_follows_continuation_uri() -> None:
+    """list_item_access must follow continuationUri to fetch all pages."""
+    page1 = json.loads(ITEM_ACCESS_DETAILS_PAGE1_PAYLOAD)
+    page2 = json.loads(ITEM_ACCESS_DETAILS_PAGE2_PAYLOAD)
+
+    call_count = 0
+
+    def side_effect(request: httpx.Request) -> httpx.Response:
+        nonlocal call_count
+        call_count += 1
+        url = str(request.url)
+        if "continuationToken" in url:
+            return httpx.Response(200, json=page2)
+        return httpx.Response(200, json=page1)
+
+    with respx.mock(assert_all_called=False) as router:
+        router.get(url__regex=r".*/admin/workspaces/.*/items/.*/users.*").mock(
+            side_effect=side_effect
+        )
+
+        client = await _make_client()
+        async with client:
+            result = await permissions.list_item_access(client, _WORKSPACE_ID, _ITEM_ID)
+
+    assert call_count == 2
+    assert len(result) == 2  # 1 from page 1 + 1 from page 2
+
+
+@pytest.mark.asyncio
+async def test_list_item_access_pagination_returns_all_items_as_item_access() -> None:
+    """All items from all pages must be ItemAccess instances."""
+    page1 = json.loads(ITEM_ACCESS_DETAILS_PAGE1_PAYLOAD)
+    page2 = json.loads(ITEM_ACCESS_DETAILS_PAGE2_PAYLOAD)
+
+    def side_effect(request: httpx.Request) -> httpx.Response:
+        url = str(request.url)
+        if "continuationToken" in url:
+            return httpx.Response(200, json=page2)
+        return httpx.Response(200, json=page1)
+
+    with respx.mock(assert_all_called=False) as router:
+        router.get(url__regex=r".*/admin/workspaces/.*/items/.*/users.*").mock(
+            side_effect=side_effect
+        )
+
+        client = await _make_client()
+        async with client:
+            result = await permissions.list_item_access(client, _WORKSPACE_ID, _ITEM_ID)
+
+    assert all(isinstance(item, ItemAccess) for item in result)
+
+
+# ---------------------------------------------------------------------------
+# list_item_access — error handling
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_item_access_403_raises_permission_denied_with_hint() -> None:
+    """list_item_access must raise PermissionDenied with admin-role hint on 403."""
+    with respx.mock:
+        respx.get(_ACCESS_URL).mock(
+            return_value=httpx.Response(403, json={"errorCode": "Forbidden"})
+        )
+
+        client = await _make_client()
+        async with client:
+            with pytest.raises(PermissionDenied, match="Fabric Administrator"):
+                await permissions.list_item_access(client, _WORKSPACE_ID, _ITEM_ID)
+
+
+@pytest.mark.asyncio
+async def test_list_item_access_404_raises_not_found() -> None:
+    """list_item_access must propagate NotFound on 404."""
+    with respx.mock:
+        respx.get(_ACCESS_URL).mock(
+            return_value=httpx.Response(404, json={"errorCode": "ItemNotFound"})
+        )
+
+        client = await _make_client()
+        async with client:
+            with pytest.raises(NotFound):
+                await permissions.list_item_access(client, _WORKSPACE_ID, _ITEM_ID)


### PR DESCRIPTION
## Summary

- Adds `services/permissions.py::list_item_access` wrapping `GET /v1/admin/workspaces/{workspaceId}/items/{itemId}/users` with `continuationUri` pagination and a 403→`PermissionDenied` hint
- Adds `ItemAccess`, `ItemAccessPrincipal`, `ItemAccessDetail`, `PrincipalType` Pydantic models with principal-type flattening via `model_validator(mode="before")`
- CLI: `warehouses permissions <ws> <warehouse>` and `sql-endpoints permissions <ws> <endpoint>` with Rich table output (or `--json`)
- MCP tools: `get_warehouse_permissions` and `get_sql_endpoint_permissions`

## Test plan

- [x] `uv run ruff check .` — passes
- [x] `uv run ruff format --check .` — passes
- [x] `uvx ty==0.0.44 check src tests` — passes
- [x] `uv run pytest tests/unit -q` — 912 passed
- [ ] Integration suite passes (label-gated)

Closes #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)