### PR TITLE
refactor(http): expose iter_paginated for cross-module pagination

### DIFF
--- a/src/fabric_dw/http_client.py
+++ b/src/fabric_dw/http_client.py
@@ -268,7 +268,7 @@ class FabricHttpClient:
         *,
         key: str = "value",
         params: dict[str, str] | None = None,
-    ) -> AsyncIterator[dict[str, Any]]:
+    ) -> AsyncIterator[dict[str, object]]:
         """Iterate over all items across paginated responses.
 
         Follows the ``continuationUri`` field in each page until it is absent.
@@ -289,7 +289,7 @@ class FabricHttpClient:
             # continuationUri is always a full URL; use _request_with_retry directly
             resp = await self._request_with_retry("GET", url, params=params if first else None)
             first = False
-            data: dict[str, Any] = resp.json()
+            data: dict[str, object] = resp.json()
             raw_items = data.get(key, [])
             if isinstance(raw_items, list):
                 for item in raw_items:

--- a/src/fabric_dw/http_client.py
+++ b/src/fabric_dw/http_client.py
@@ -261,7 +261,14 @@ class FabricHttpClient:
     # Pagination
     # ------------------------------------------------------------------
 
-    async def iter_paginated(self, base: HttpBase, path: str) -> AsyncIterator[dict[str, object]]:
+    async def iter_paginated(
+        self,
+        base: HttpBase,
+        path: str,
+        *,
+        key: str = "value",
+        params: dict[str, str] | None = None,
+    ) -> AsyncIterator[dict[str, Any]]:
         """Iterate over all items across paginated responses.
 
         Follows the ``continuationUri`` field in each page until it is absent.
@@ -269,19 +276,23 @@ class FabricHttpClient:
         Args:
             base: Base URL enum value (used only for the first request).
             path: Initial path to request.
+            key: JSON key whose list value contains the items (default ``"value"``).
+            params: Optional query parameters for the first request only.
 
         Yields:
-            Individual items from the ``value`` array in each page.
+            Individual items from the *key* array in each page.
         """
         url: str | None = f"{base}{path}"
+        first = True
 
         while url is not None:
             # continuationUri is always a full URL; use _request_with_retry directly
-            resp = await self._request_with_retry("GET", url)
-            data: dict[str, object] = resp.json()
-            value = data.get("value", [])
-            if isinstance(value, list):
-                for item in value:
+            resp = await self._request_with_retry("GET", url, params=params if first else None)
+            first = False
+            data: dict[str, Any] = resp.json()
+            raw_items = data.get(key, [])
+            if isinstance(raw_items, list):
+                for item in raw_items:
                     if isinstance(item, dict):
                         yield {str(k): v for k, v in item.items()}
 

--- a/src/fabric_dw/services/permissions.py
+++ b/src/fabric_dw/services/permissions.py
@@ -12,7 +12,6 @@ Reference:
 
 from __future__ import annotations
 
-from typing import cast
 from uuid import UUID
 
 from fabric_dw.exceptions import PermissionDenied
@@ -52,30 +51,11 @@ async def list_item_access(
     # The optional ?type= query param is intentionally omitted: Warehouse and
     # SQLEndpoint items do not filter by type, and omitting it returns all principals.
     path = f"/admin/workspaces/{workspace_id}/items/{item_id}/users"
-    results: list[ItemAccess] = []
-
-    # The admin endpoint uses the same continuationUri pagination pattern as
-    # other Fabric list endpoints, but the items are in "accessDetails" rather
-    # than "value".  We implement manual pagination here instead of using
-    # iter_paginated (which looks for "value").
-    url: str | None = f"{HttpBase.FABRIC}{path}"
 
     try:
-        while url is not None:
-            resp = await http._request_with_retry("GET", url)  # type: ignore[attr-defined]
-            data = cast("dict[str, object]", resp.json())
-
-            raw_items = data.get("accessDetails", [])
-            if isinstance(raw_items, list):
-                results.extend(
-                    ItemAccess.from_api({str(k): v for k, v in raw.items()})
-                    for raw in raw_items
-                    if isinstance(raw, dict)
-                )
-
-            cont = data.get("continuationUri")
-            url = cont if isinstance(cont, str) else None
+        return [
+            ItemAccess.from_api(raw)
+            async for raw in http.iter_paginated(HttpBase.FABRIC, path, key="accessDetails")
+        ]
     except PermissionDenied as exc:
         raise PermissionDenied(_ADMIN_HINT) from exc
-
-    return results

--- a/tests/unit/test_http_client.py
+++ b/tests/unit/test_http_client.py
@@ -249,6 +249,70 @@ async def test_iter_paginated_follows_continuation_uri() -> None:
         assert call_count == 2
 
 
+@pytest.mark.asyncio
+async def test_iter_paginated_single_page() -> None:
+    """iter_paginated should yield all items from a single-page response."""
+    page: dict[str, Any] = {"value": [{"id": "x"}, {"id": "y"}]}
+
+    with respx.mock:
+        respx.get("https://api.fabric.microsoft.com/v1/items").mock(
+            return_value=httpx.Response(200, json=page)
+        )
+
+        client = await _get_client()
+        async with client:
+            items = [item async for item in client.iter_paginated(HttpBase.FABRIC, "/items")]
+
+    assert items == [{"id": "x"}, {"id": "y"}]
+
+
+@pytest.mark.asyncio
+async def test_iter_paginated_two_pages_follows_continuation_uri() -> None:
+    """iter_paginated should follow continuationUri and yield items from both pages."""
+    continuation_url = "https://api.fabric.microsoft.com/v1/items?continuation=abc"
+    page1: dict[str, Any] = {
+        "value": [{"id": "1"}],
+        "continuationUri": continuation_url,
+    }
+    page2: dict[str, Any] = {"value": [{"id": "2"}, {"id": "3"}]}
+
+    call_count = 0
+
+    def side_effect(request: httpx.Request) -> httpx.Response:
+        nonlocal call_count
+        call_count += 1
+        if "continuation" in str(request.url):
+            return httpx.Response(200, json=page2)
+        return httpx.Response(200, json=page1)
+
+    with respx.mock(assert_all_called=False) as mock_router:
+        mock_router.get(url__regex=r"https://api\.fabric\.microsoft\.com/v1/items.*").mock(
+            side_effect=side_effect
+        )
+
+        client = await _get_client()
+        async with client:
+            items = [item async for item in client.iter_paginated(HttpBase.FABRIC, "/items")]
+
+    assert items == [{"id": "1"}, {"id": "2"}, {"id": "3"}]
+    assert call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_iter_paginated_empty_value_list() -> None:
+    """iter_paginated should yield nothing when the value list is empty."""
+    with respx.mock:
+        respx.get("https://api.fabric.microsoft.com/v1/items").mock(
+            return_value=httpx.Response(200, json={"value": []})
+        )
+
+        client = await _get_client()
+        async with client:
+            items = [item async for item in client.iter_paginated(HttpBase.FABRIC, "/items")]
+
+    assert items == []
+
+
 # ---------------------------------------------------------------------------
 # LRO polling
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_http_client.py
+++ b/tests/unit/test_http_client.py
@@ -313,6 +313,88 @@ async def test_iter_paginated_empty_value_list() -> None:
     assert items == []
 
 
+@pytest.mark.asyncio
+async def test_iter_paginated_custom_key() -> None:
+    """iter_paginated with key='someOtherKey' must yield items from that key, not from 'value'.
+
+    The response body contains both 'someOtherKey' (with id=1) and 'value' (with id=99).
+    Only the item from 'someOtherKey' should be yielded.
+    """
+    page: dict[str, Any] = {
+        "someOtherKey": [{"id": 1}],
+        "value": [{"id": 99}],
+    }
+
+    with respx.mock:
+        respx.get("https://api.fabric.microsoft.com/v1/items").mock(
+            return_value=httpx.Response(200, json=page)
+        )
+
+        client = await _get_client()
+        async with client:
+            items = [
+                item
+                async for item in client.iter_paginated(
+                    HttpBase.FABRIC, "/items", key="someOtherKey"
+                )
+            ]
+
+    assert items == [{"id": 1}], f"Expected only id=1 from 'someOtherKey'; got {items}"
+
+
+@pytest.mark.asyncio
+async def test_iter_paginated_params_only_on_first_request() -> None:
+    """params must be sent on the first request only, not on continuation requests.
+
+    Mock two responses:
+    - First: contains continuationUri.
+    - Second: no continuationUri.
+    Verify via captured request URLs/params that the first call includes params={"x": "y"}
+    and the second call (continuation URL) does NOT include those params.
+    """
+    continuation_url = "https://api.fabric.microsoft.com/v1/items?continuation=tok"
+    page1: dict[str, Any] = {
+        "value": [{"id": "first"}],
+        "continuationUri": continuation_url,
+    }
+    page2: dict[str, Any] = {"value": [{"id": "second"}]}
+
+    captured_requests: list[httpx.Request] = []
+
+    def side_effect(request: httpx.Request) -> httpx.Response:
+        captured_requests.append(request)
+        if "continuation" in str(request.url):
+            return httpx.Response(200, json=page2)
+        return httpx.Response(200, json=page1)
+
+    with respx.mock(assert_all_called=False) as mock_router:
+        mock_router.get(url__regex=r"https://api\.fabric\.microsoft\.com/v1/items.*").mock(
+            side_effect=side_effect
+        )
+
+        client = await _get_client()
+        async with client:
+            items = [
+                item
+                async for item in client.iter_paginated(
+                    HttpBase.FABRIC, "/items", params={"x": "y"}
+                )
+            ]
+
+    assert items == [{"id": "first"}, {"id": "second"}]
+    assert len(captured_requests) == 2, f"Expected 2 requests; got {len(captured_requests)}"
+
+    first_url = str(captured_requests[0].url)
+    second_url = str(captured_requests[1].url)
+
+    # First request must contain the custom param
+    assert "x=y" in first_url, f"Expected 'x=y' in first request URL; got {first_url}"
+    # Second request (continuation) must NOT contain the custom param
+    assert "x=y" not in second_url, (
+        f"Params must not be forwarded to continuation URL; second URL: {second_url}"
+    )
+
+
 # ---------------------------------------------------------------------------
 # LRO polling
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add `key` and `params` keyword args to `FabricHttpClient.iter_paginated` so callers can target non-`"value"` list keys (e.g. `"accessDetails"`)
- Refactor `services/permissions.py` to use the helper, eliminating the manual pagination loop and the `# type: ignore[attr-defined]` suppression
- Add three unit tests: `test_iter_paginated_single_page`, `test_iter_paginated_two_pages_follows_continuation_uri`, `test_iter_paginated_empty_value_list`

## Test plan

- [x] `uv run ruff check .` — all checks passed
- [x] `uv run ruff format --check .` — 118 files already formatted
- [x] `uv run pytest tests/unit/test_http_client.py tests/unit/services/test_permissions.py -q` — 32 passed

Closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)