### PR TITLE
refactor(resolver): use iter_paginated for continuation pages

### DIFF
--- a/src/fabric_dw/resolver.py
+++ b/src/fabric_dw/resolver.py
@@ -111,14 +111,14 @@ class Resolver:
             return cached.id
 
         # 3. Power BI OData filter — escape single quotes per OData spec
-        resp = await self._http.request(
-            "GET",
-            HttpBase.POWERBI,
-            "/groups",
-            params={"$filter": f"name eq '{_odata_escape(value)}'"},
-        )
-        body: dict[str, Any] = resp.json()
-        results: list[dict[str, Any]] = body.get("value", [])
+        results: list[dict[str, object]] = [
+            item
+            async for item in self._http.iter_paginated(
+                HttpBase.POWERBI,
+                "/groups",
+                params={"$filter": f"name eq '{_odata_escape(value)}'"},
+            )
+        ]
 
         if not results:
             raise NotFound(f"workspace {value!r} not found")  # noqa: TRY003

--- a/tests/unit/test_resolver.py
+++ b/tests/unit/test_resolver.py
@@ -213,6 +213,44 @@ async def test_workspace_id_multiple_matches_error_mentions_all_ids(tmp_path: Pa
 
 
 # ---------------------------------------------------------------------------
+# workspace_id: continuation pages are followed
+# ---------------------------------------------------------------------------
+
+# A continuation URL that uses a distinct path segment so respx can
+# differentiate it from the first-page URL (which carries a $filter param
+# that respx ignores when matching by default).
+_PBI_GROUPS_CONT_URL = "https://api.powerbi.com/v1.0/myorg/groups/continuation/abc123"
+
+
+@pytest.mark.asyncio
+async def test_workspace_id_follows_continuation_pages(tmp_path: Path) -> None:
+    """workspace_id collects items across multiple continuation pages.
+
+    Simulates an API that returns an empty first page with a continuationUri,
+    and the actual result on the second page.  This proves that iter_paginated
+    is used (single-shot body.get() would return an empty list and raise NotFound).
+    """
+    resolver, client, _ = _make_resolver(tmp_path)
+
+    # Page 1 is empty but carries a continuationUri.
+    # Page 2 contains the matching workspace.
+    page1_response: dict[str, object] = {
+        "value": [],
+        "continuationUri": _PBI_GROUPS_CONT_URL,
+    }
+    page2_response: dict[str, object] = {
+        "value": [{"id": WS_GUID, "name": "AnalyticsWorkspace", "type": "Workspace"}],
+        "continuationUri": None,
+    }
+    with respx.mock:
+        respx.get(_PBI_GROUPS_URL).mock(return_value=httpx.Response(200, json=page1_response))
+        respx.get(_PBI_GROUPS_CONT_URL).mock(return_value=httpx.Response(200, json=page2_response))
+        async with client:
+            result = await resolver.workspace_id("AnalyticsWorkspace")
+    assert result == WS_UUID
+
+
+# ---------------------------------------------------------------------------
 # item: GUID input fetches detail directly
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Replace the one-shot `request()` + `body.get("value", [])` call in `Resolver.workspace_id` with `self._http.iter_paginated(HttpBase.POWERBI, "/groups", params={"$filter": ...})`, making workspace lookup consistent with how `item()` and the rest of the codebase pages through results.
- Add `test_workspace_id_follows_continuation_pages`: verifies that when the Power BI `/groups` endpoint returns an empty first page with a `continuationUri`, the resolver follows it and finds the workspace on the second page (a case that the old single-shot code would silently fail as `NotFound`).

Closes #233

## Test plan

- [x] `uv run ruff check .` — all checks passed
- [x] `uv run ruff format --check .` — all files already formatted
- [x] `uvx ty==0.0.44 check src tests` — all checks passed
- [x] `uv run pytest tests/unit/test_resolver.py tests/unit/services -q` — 517 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)