### PR TITLE
fix(release): tag-only PyPI publish, SBOM, provenance, non-root Docker, concurrency guards

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,12 +3,17 @@ name: Docker
 on:
   push:
     branches: [main]
-    tags: ["v[0-9]+.[0-9]+.[0-9]+"]
+    tags: ["v[0-9]+.[0-9]+*"]
+
+concurrency:
+  group: docker-${{ github.ref }}
+  cancel-in-progress: false
 
 permissions:
   contents: read
   packages: write
   id-token: write
+  attestations: write
 
 jobs:
   build-and-push:
@@ -32,15 +37,16 @@ jobs:
         id: docker_tags
         run: |
           VERSION=$(uv run python -c "import fabric_dw; print(fabric_dw.__version__)")
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
           if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
-            echo "tags=ghcr.io/sdebruyn/fabric-dw:$VERSION,ghcr.io/sdebruyn/fabric-dw:latest" >> $GITHUB_OUTPUT
+            echo "tags=ghcr.io/sdebruyn/fabric-dw:${VERSION},ghcr.io/sdebruyn/fabric-dw:latest" >> "${GITHUB_OUTPUT}"
           else
-            echo "tags=ghcr.io/sdebruyn/fabric-dw:$VERSION,ghcr.io/sdebruyn/fabric-dw:main" >> $GITHUB_OUTPUT
+            echo "tags=ghcr.io/sdebruyn/fabric-dw:${VERSION},ghcr.io/sdebruyn/fabric-dw:main" >> "${GITHUB_OUTPUT}"
           fi
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
+        id: buildx
 
       - uses: docker/login-action@v3
         with:
@@ -49,15 +55,27 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build & push
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.docker_tags.outputs.tags }}
-          build-args: SETUPTOOLS_SCM_PRETEND_VERSION=${{ steps.docker_tags.outputs.version }}
+          build-args: |
+            SETUPTOOLS_SCM_PRETEND_VERSION=${{ steps.docker_tags.outputs.version }}
+            VERSION=${{ steps.docker_tags.outputs.version }}
+          provenance: true
+          sbom: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Attest image provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ghcr.io/sdebruyn/fabric-dw
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
 
       - name: Verify image pushed
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,7 +3,7 @@ name: Docker
 on:
   push:
     branches: [main]
-    tags: ["v[0-9]+.[0-9]+*"]
+    tags: ["v[0-9]*"]
 
 concurrency:
   group: docker-${{ github.ref }}
@@ -63,7 +63,6 @@ jobs:
           push: true
           tags: ${{ steps.docker_tags.outputs.tags }}
           build-args: |
-            SETUPTOOLS_SCM_PRETEND_VERSION=${{ steps.docker_tags.outputs.version }}
             VERSION=${{ steps.docker_tags.outputs.version }}
           provenance: true
           sbom: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,12 +2,21 @@ name: Publish
 
 on:
   push:
-    branches: [main]
-    tags: ["v[0-9]+.[0-9]+.[0-9]+"]
+    tags: ["v[0-9]+.[0-9]+*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to publish (e.g. v2026.6.0)"
+        required: true
+
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
 
 permissions:
   contents: write
   id-token: write
+  attestations: write
 
 jobs:
   publish:
@@ -30,6 +39,23 @@ jobs:
 
       - run: uv build
 
+      - name: Generate CycloneDX SBOM
+        run: |
+          uvx cyclonedx-py environment --output-format json --outfile dist/sbom.cdx.json
+          python -c "import json,sys; d=json.load(open('dist/sbom.cdx.json')); print(f'SBOM: {len(d.get(\"components\",[]))} components')"
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom-cyclonedx
+          path: dist/sbom.cdx.json
+          if-no-files-found: error
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: "dist/*.whl,dist/*.tar.gz"
+
       - name: Publish to PyPI (OIDC)
         run: uv publish --trusted-publishing always
 
@@ -40,5 +66,6 @@ jobs:
           files: |
             dist/*.whl
             dist/*.tar.gz
+            dist/sbom.cdx.json
           generate_release_notes: true
           name: ${{ github.ref_name }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish
 
 on:
   push:
-    tags: ["v[0-9]+.[0-9]+*"]
+    tags: ["v[0-9]*"]
   workflow_dispatch:
     inputs:
       tag:
@@ -26,6 +26,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: ${{ inputs.tag || github.ref }}
 
       - uses: astral-sh/setup-uv@v8.2.0
         with:
@@ -54,13 +55,15 @@ jobs:
       - name: Attest build provenance
         uses: actions/attest-build-provenance@v2
         with:
-          subject-path: "dist/*.whl,dist/*.tar.gz"
+          subject-path: |
+            dist/*.whl
+            dist/*.tar.gz
 
       - name: Publish to PyPI (OIDC)
         run: uv publish --trusted-publishing always
 
       - name: Create GitHub Release (tag only)
-        if: github.ref_type == 'tag'
+        if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
         uses: softprops/action-gh-release@v3
         with:
           files: |

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,6 +4,11 @@ on:
     branches: [main]
   pull_request:
     types: [opened, reopened, synchronize]
+
+concurrency:
+  group: release-drafter-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
   pull-requests: read

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -6,7 +6,7 @@ on:
     types: [opened, reopened, synchronize]
 
 concurrency:
-  group: release-drafter-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
 
 concurrency:
-  group: security-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -3,6 +3,11 @@ on:
   pull_request:
   push:
     branches: [main]
+
+concurrency:
+  group: security-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: read

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,8 +41,9 @@ RUN pip install --no-cache-dir /tmp/*.whl && rm /tmp/*.whl
 
 ENV FABRIC_AUTH=default PYTHONUNBUFFERED=1
 
-# Run as non-root for security hardening
-RUN useradd --uid 10001 --no-create-home --shell /sbin/nologin app
+# Run as non-root for security hardening; create home so Path.home() resolves correctly
+RUN useradd --uid 10001 --create-home --home-dir /home/app --shell /usr/sbin/nologin app
+ENV HOME=/home/app
 USER app
 
 # HEALTHCHECK is intentionally omitted: fabric-dw-mcp is a stdio MCP server that

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,17 +4,48 @@ ARG PYTHON_VERSION=3.13
 # Build stage uses Astral's official uv + python image
 FROM ghcr.io/astral-sh/uv:python${PYTHON_VERSION}-trixie-slim AS build
 WORKDIR /app
+
+# VERSION must be supplied via --build-arg; hatch-vcs cannot see .git in the Docker context
+# (the .dockerignore excludes .git intentionally to keep the context small).
+ARG VERSION
+RUN test -n "$VERSION" || (echo "ERROR: pass --build-arg VERSION=x.y.z (hatch-vcs cannot see .git in the Docker context)" && exit 1)
+
 # Global env var (not _FOR_<dist>) because hatch-vcs calls setuptools-scm without dist_name.
-ARG SETUPTOOLS_SCM_PRETEND_VERSION
-ENV SETUPTOOLS_SCM_PRETEND_VERSION=${SETUPTOOLS_SCM_PRETEND_VERSION}
+# SETUPTOOLS_SCM_PRETEND_VERSION_FOR_FABRIC_DW is the dist-specific override for package 'fabric-dw'.
+ENV SETUPTOOLS_SCM_PRETEND_VERSION=${VERSION}
+ENV SETUPTOOLS_SCM_PRETEND_VERSION_FOR_FABRIC_DW=${VERSION}
+
 COPY pyproject.toml uv.lock README.md LICENSE ./
 COPY src/ src/
 RUN uv build --wheel
 
 # Runtime stage stays minimal — slim Python, pip-install the wheel
 FROM python:${PYTHON_VERSION}-slim AS runtime
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
+
+ARG VERSION
+# OCI image labels
+LABEL org.opencontainers.image.title="fabric-dw" \
+      org.opencontainers.image.description="Python CLI + MCP server for administering Microsoft Fabric Data Warehouses and SQL Analytics Endpoints" \
+      org.opencontainers.image.url="https://fdw.debruyn.dev" \
+      org.opencontainers.image.source="https://github.com/sdebruyn/fabric-dw-mcp-cli" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.licenses="MIT"
+
+# Install system dependencies using BuildKit cache mount for faster rebuilds
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends ca-certificates
+
 COPY --from=build /app/dist/*.whl /tmp/
 RUN pip install --no-cache-dir /tmp/*.whl && rm /tmp/*.whl
+
 ENV FABRIC_AUTH=default PYTHONUNBUFFERED=1
+
+# Run as non-root for security hardening
+RUN useradd --uid 10001 --no-create-home --shell /sbin/nologin app
+USER app
+
+# HEALTHCHECK is intentionally omitted: fabric-dw-mcp is a stdio MCP server that
+# communicates over stdin/stdout, not a long-running HTTP/TCP service. There is no
+# socket or port to probe.
 ENTRYPOINT ["fabric-dw-mcp"]


### PR DESCRIPTION
## Summary

- **publish.yml**: publish triggered on version tags only (no more dev-wheel leaks on every main push); CycloneDX SBOM generated and uploaded; `actions/attest-build-provenance` added for dist artifacts; `workflow_dispatch` added for manual re-runs; concurrency guard prevents race on overlapping tag pushes.
- **docker.yml**: concurrency guard added; `provenance: true` + `sbom: true` enabled on `build-push-action`; image digest attested with `actions/attest-build-provenance`; `VERSION` build-arg passed so Dockerfile fail-fast guard works; SC2086 shellcheck warnings fixed.
- **release-drafter.yml / security.yml**: concurrency groups added (`cancel-in-progress: true`).
- **Dockerfile**: `ARG VERSION` with explicit fail-fast `RUN test -n "$VERSION"` guard; both `SETUPTOOLS_SCM_PRETEND_VERSION` and `SETUPTOOLS_SCM_PRETEND_VERSION_FOR_FABRIC_DW` set; OCI image labels added; apt step converted to BuildKit cache-mount; non-root user `app` (uid 10001) created and activated via `USER app`; comment explains HEALTHCHECK omission (stdio MCP server has no TCP port).

## Findings addressed

| File | Finding |
|------|---------|
| `.github/workflows/publish.yml` | `07-pkg-publish-on-every-main-push.md` — trigger changed to tags only |
| `.github/workflows/publish.yml` | `07-pkg-no-sbom-no-sigstore.md` — CycloneDX SBOM + attest-build-provenance added |
| `.github/workflows/publish.yml` | `07-pkg-no-concurrency-guards-on-release-workflows.md` — concurrency group added |
| `.github/workflows/docker.yml` | `07-pkg-no-sbom-no-sigstore.md` — provenance/sbom flags + image attestation added |
| `.github/workflows/docker.yml` | `07-pkg-no-concurrency-guards-on-release-workflows.md` — concurrency group added |
| `.github/workflows/release-drafter.yml` | `07-pkg-no-concurrency-guards-on-release-workflows.md` — concurrency group added |
| `.github/workflows/security.yml` | `07-pkg-no-concurrency-guards-on-release-workflows.md` — concurrency group added |
| `Dockerfile` | `07-pkg-dockerfile-runs-as-root.md` — non-root user added, OCI labels added |
| `Dockerfile` | `07-pkg-dockerfile-apt-no-cache-mount.md` — BuildKit cache-mount added |
| `Dockerfile` | `07-pkg-dockerignore-excludes-git.md` — VERSION build-arg with fail-fast guard + dual SCM env vars |

## Decisions

- **Tag pattern broadened** from `v[0-9]+.[0-9]+.[0-9]+` to `v[0-9]+.[0-9]+*` to match calver pre-releases like `v2026.6.0a0` (the existing tag scheme observed in the repo).
- **SBOM via `cyclonedx-py environment`** — captures the installed runtime environment, which is the most useful SBOM for a wheel distribution.
- **Docker HEALTHCHECK omitted** — `fabric-dw-mcp` is a stdio-based MCP server; there is no port or socket to probe. A comment in the Dockerfile explains this explicitly.
- **`actions/attest-build-provenance` for Docker** — used instead of `cosign` standalone to stay within the GitHub Actions trust model and avoid managing a Rekor/Fulcio key.
- **`.dockerignore` unchanged** — `.git` stays excluded per design spec; the VERSION build-arg approach is the correct fix.

## Validation

- `actionlint 1.7.12`: 0 errors across all 4 modified workflow files (including shellcheck SC2086 fixes in docker.yml).
- `uv run python -c "import yaml..."`: all 6 workflow YAML files parse successfully.
- `just check` (ruff + ty + pytest): 1007 tests passed, 0 lint/type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)