### PR TITLE
refactor(config,auth): TOML writer, strategy registry, public adapter, security docs

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,3 +14,37 @@ We use [GitHub Private Vulnerability Reporting](https://docs.github.com/code-sec
 ## Scope
 
 Bugs that put data, credentials, or workspace state at risk are in scope. Out of scope: bugs in third-party SDKs we depend on (file those upstream), denial-of-service against the Fabric API (file with Microsoft).
+
+## Interactive sign-in Entra application
+
+The interactive browser sign-in path (and the fallback interactive browser step inside `DefaultAzureCredential`) uses a **shared multi-tenant Entra application** by default:
+
+- **Application (client) ID**: `f666e5ee-2149-4c6a-87eb-13c9e1fdc70d`
+
+This application requests delegated (user-context) permissions for the following scopes:
+
+- `https://analysis.windows.net/powerbi/api/.default` — Power BI / Fabric REST API
+- `https://database.windows.net/.default` — Azure SQL / Fabric SQL Analytics Endpoint
+
+### Implications
+
+Because the app is **multi-tenant and shared across all users of this tool**:
+
+1. **Upstream-app trust**: your tenant admin must consent to the app (or the user must do per-user consent if your tenant policy allows it). The audit trail in your Azure AD / Entra audit log will show the *upstream app ID* (`f666e5ee-...`), not a tenant-specific registration — this reduces per-tenant audit granularity.
+2. **Supply-chain risk**: if the shared application is compromised, suspended, or deleted by Microsoft, all users on the default flow will be impacted without a per-tenant fallback.
+3. **No tenant-specific conditional-access policies**: because the app is not registered in your tenant, you cannot target it with tenant-specific conditional-access rules.
+
+### Registering your own Entra application
+
+Tenants that require full audit-trail control or wish to apply custom conditional-access policies should register their own **public-client** Entra application and set the override environment variable:
+
+```bash
+export FABRIC_INTERACTIVE_CLIENT_ID="<your-app-client-id>"
+```
+
+The app must be configured as a public client (mobile & desktop) with the following delegated API permissions:
+
+- **Power BI Service** → `Tenant.Read.All` (or the narrower scopes your workflows require)
+- **Azure SQL Database** → `user_impersonation`
+
+Once registered, set `FABRIC_INTERACTIVE_CLIENT_ID` to your app's client ID. The tool will use it for both the `interactive` and `default` credential modes instead of the shared application.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,10 +21,11 @@ The interactive browser sign-in path (and the fallback interactive browser step 
 
 - **Application (client) ID**: `f666e5ee-2149-4c6a-87eb-13c9e1fdc70d`
 
-This application requests delegated (user-context) permissions for the following scopes:
+This application requests delegated (user-context) permissions for the following scope:
 
 - `https://analysis.windows.net/powerbi/api/.default` — Power BI / Fabric REST API
-- `https://database.windows.net/.default` — Azure SQL / Fabric SQL Analytics Endpoint
+
+> **Note**: The `SQL_SCOPE` constant (`https://database.windows.net/.default`) is defined in `auth.py` for future use when direct Fabric SQL Analytics Endpoint connections are implemented, but it is not yet requested at runtime.
 
 ### Implications
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ dependencies = [
     "anyio>=4",
     "aiohttp>=3.9",
     "pyarrow>=17.0",
+    "tomli-w>=1.0",
 ]
 
 [project.urls]

--- a/src/fabric_dw/auth.py
+++ b/src/fabric_dw/auth.py
@@ -2,9 +2,9 @@
 
 import asyncio
 import os
+from collections.abc import Callable
 from enum import StrEnum
 from types import TracebackType
-from typing import Any
 
 from azure.core.credentials import AccessToken
 from azure.core.credentials_async import AsyncTokenCredential
@@ -26,6 +26,15 @@ DEFAULT_INTERACTIVE_CLIENT_ID = "f666e5ee-2149-4c6a-87eb-13c9e1fdc70d"
 
 _CACHE_OPTIONS = TokenCachePersistenceOptions(name="fabric-dw", allow_unencrypted_storage=True)
 
+__all__ = [
+    "DEFAULT_INTERACTIVE_CLIENT_ID",
+    "FABRIC_SCOPE",
+    "SQL_SCOPE",
+    "CredentialMode",
+    "SyncCredentialAdapter",
+    "get_credential",
+]
+
 
 class CredentialMode(StrEnum):
     DEFAULT = "default"
@@ -33,12 +42,13 @@ class CredentialMode(StrEnum):
     INTERACTIVE = "interactive"
 
 
-class _SyncCredentialAdapter:
+class SyncCredentialAdapter:
     """Adapts a synchronous TokenCredential to the AsyncTokenCredential protocol.
 
     Used because ``azure.identity.aio.InteractiveBrowserCredential`` does not
     exist in azure-identity 1.25.x.  Both ``get_token`` and ``close`` are
-    offloaded to a worker thread so the event loop is never blocked.
+    offloaded to a worker thread via :func:`asyncio.to_thread` so the event
+    loop is never blocked.
 
     Remove this adapter and switch to ``azure.identity.aio.InteractiveBrowserCredential``
     once that ships in a stable release.
@@ -53,7 +63,7 @@ class _SyncCredentialAdapter:
         claims: str | None = None,
         tenant_id: str | None = None,
         enable_cae: bool = False,
-        **kwargs: Any,  # noqa: ANN401, ARG002
+        **kwargs: object,  # noqa: ARG002 — required by AsyncTokenCredential protocol
     ) -> AccessToken:
         return await asyncio.to_thread(
             self._inner.get_token,
@@ -66,7 +76,7 @@ class _SyncCredentialAdapter:
     async def close(self) -> None:
         await asyncio.to_thread(self._inner.close)
 
-    async def __aenter__(self) -> "_SyncCredentialAdapter":
+    async def __aenter__(self) -> "SyncCredentialAdapter":
         return self
 
     async def __aexit__(
@@ -76,6 +86,11 @@ class _SyncCredentialAdapter:
         traceback: TracebackType | None = None,
     ) -> None:
         await self.close()
+
+
+# Keep a private alias so existing internal call sites and any external code
+# that still references the old private name continue to work.
+_SyncCredentialAdapter = SyncCredentialAdapter
 
 
 def _resolve_interactive_kwargs() -> dict[str, str]:
@@ -96,6 +111,59 @@ def _resolve_interactive_kwargs() -> dict[str, str]:
     return kwargs
 
 
+def _make_default_credential() -> AsyncTokenCredential:
+    interactive_kwargs = _resolve_interactive_kwargs()
+    dac_kwargs: dict[str, object] = {
+        "cache_persistence_options": _CACHE_OPTIONS,
+        "exclude_interactive_browser_credential": False,
+        "interactive_browser_client_id": interactive_kwargs["client_id"],
+    }
+    if "tenant_id" in interactive_kwargs:
+        dac_kwargs["interactive_browser_tenant_id"] = interactive_kwargs["tenant_id"]
+    return DefaultAzureCredential(**dac_kwargs)
+
+
+def _make_service_principal_credential() -> AsyncTokenCredential:
+    env_vars = {
+        "AZURE_TENANT_ID": os.environ.get("AZURE_TENANT_ID"),
+        "AZURE_CLIENT_ID": os.environ.get("AZURE_CLIENT_ID"),
+        "AZURE_CLIENT_SECRET": os.environ.get("AZURE_CLIENT_SECRET"),
+    }
+    missing = [name for name, value in env_vars.items() if not value]
+    if missing:
+        raise ConfigError.missing_env_vars(missing)
+
+    # Values are guaranteed non-empty by the missing check above; the dict
+    # lookup and cast are safe — they only reach this point when all three
+    # vars are present and non-empty.
+    return ClientSecretCredential(
+        tenant_id=str(env_vars["AZURE_TENANT_ID"]),
+        client_id=str(env_vars["AZURE_CLIENT_ID"]),
+        client_secret=str(env_vars["AZURE_CLIENT_SECRET"]),
+    )
+
+
+def _make_interactive_credential() -> AsyncTokenCredential:
+    # InteractiveBrowserCredential has no aio variant in this release of
+    # azure-identity; wrap in an adapter that offloads to a worker thread.
+    return SyncCredentialAdapter(
+        InteractiveBrowserCredential(
+            cache_persistence_options=_CACHE_OPTIONS,
+            **_resolve_interactive_kwargs(),
+        )
+    )
+
+
+#: Registry mapping each CredentialMode to a factory that produces the
+#: appropriate AsyncTokenCredential.  To add a new mode, register a new
+#: factory here — no other code needs to change.
+_CREDENTIAL_REGISTRY: dict[CredentialMode, Callable[[], AsyncTokenCredential]] = {
+    CredentialMode.DEFAULT: _make_default_credential,
+    CredentialMode.SERVICE_PRINCIPAL: _make_service_principal_credential,
+    CredentialMode.INTERACTIVE: _make_interactive_credential,
+}
+
+
 def get_credential(mode: CredentialMode = CredentialMode.DEFAULT) -> AsyncTokenCredential:
     """Return an Azure credential for the given mode.
 
@@ -108,39 +176,9 @@ def get_credential(mode: CredentialMode = CredentialMode.DEFAULT) -> AsyncTokenC
     Raises:
         ConfigError: If mode is SERVICE_PRINCIPAL and any of AZURE_TENANT_ID,
             AZURE_CLIENT_ID, or AZURE_CLIENT_SECRET are missing from the environment.
+        ConfigError: If *mode* is not a recognised :class:`CredentialMode`.
     """
-    if mode == CredentialMode.DEFAULT:
-        interactive_kwargs = _resolve_interactive_kwargs()
-        dac_kwargs: dict[str, object] = {
-            "cache_persistence_options": _CACHE_OPTIONS,
-            "exclude_interactive_browser_credential": False,
-            "interactive_browser_client_id": interactive_kwargs["client_id"],
-        }
-        if "tenant_id" in interactive_kwargs:
-            dac_kwargs["interactive_browser_tenant_id"] = interactive_kwargs["tenant_id"]
-        return DefaultAzureCredential(**dac_kwargs)
-
-    if mode == CredentialMode.SERVICE_PRINCIPAL:
-        env_vars = {
-            "AZURE_TENANT_ID": os.environ.get("AZURE_TENANT_ID"),
-            "AZURE_CLIENT_ID": os.environ.get("AZURE_CLIENT_ID"),
-            "AZURE_CLIENT_SECRET": os.environ.get("AZURE_CLIENT_SECRET"),
-        }
-        missing = [name for name, value in env_vars.items() if not value]
-        if missing:
-            raise ConfigError.missing_env_vars(missing)
-
-        return ClientSecretCredential(
-            tenant_id=env_vars["AZURE_TENANT_ID"] or "",
-            client_id=env_vars["AZURE_CLIENT_ID"] or "",
-            client_secret=env_vars["AZURE_CLIENT_SECRET"] or "",
-        )
-
-    # CredentialMode.INTERACTIVE — InteractiveBrowserCredential has no aio variant
-    # in this release of azure-identity; wrap in an adapter that offloads to thread.
-    return _SyncCredentialAdapter(
-        InteractiveBrowserCredential(
-            cache_persistence_options=_CACHE_OPTIONS,
-            **_resolve_interactive_kwargs(),
-        )
-    )
+    factory = _CREDENTIAL_REGISTRY.get(mode)
+    if factory is None:
+        raise ConfigError.unknown_credential_mode(mode)
+    return factory()

--- a/src/fabric_dw/config.py
+++ b/src/fabric_dw/config.py
@@ -127,7 +127,6 @@ def save_config(config: UserConfig, path: Path | None = None) -> None:
         defaults_dict["warehouse"] = config.defaults.warehouse
 
     data: dict[str, object] = {"defaults": defaults_dict}
-    content = tomli_w.dumps(data)
 
     lock = filelock.FileLock(str(resolved) + ".lock", timeout=_LOCK_TIMEOUT)
     with lock:
@@ -138,7 +137,7 @@ def save_config(config: UserConfig, path: Path | None = None) -> None:
         )
         try:
             with os.fdopen(fd, "wb") as fh:
-                fh.write(content.encode())
+                tomli_w.dump(data, fh)
             os.replace(tmp_name, resolved)
         except Exception:
             with contextlib.suppress(OSError):

--- a/src/fabric_dw/config.py
+++ b/src/fabric_dw/config.py
@@ -13,8 +13,9 @@ The TOML shape is intentionally tiny:
     warehouse = "Sales-DW"
 
 Reads are done with :mod:`tomllib` (stdlib, Python 3.11+).
-Writes are hand-generated TOML (no third-party serialiser needed for this
-simple shape) and are atomic: ``tempfile.mkstemp + os.replace``.
+Writes use :mod:`tomli_w` for spec-compliant serialisation (handles newlines,
+control characters, non-BMP unicode, etc.) and are atomic:
+``tempfile.mkstemp + os.replace``.
 The file is protected by a :class:`filelock.FileLock` so concurrent CLI
 invocations do not corrupt each other.
 """
@@ -25,13 +26,12 @@ import contextlib
 import logging
 import os
 import tempfile
+import tomllib
 from dataclasses import dataclass
 from pathlib import Path
 
-if True:  # pragma: no branch  # tomllib is stdlib >= 3.11
-    import tomllib
-
 import filelock
+import tomli_w
 
 __all__ = [
     "Defaults",
@@ -104,8 +104,8 @@ def load_config(path: Path | None = None) -> UserConfig:
     warehouse = defaults_raw.get("warehouse")
     return UserConfig(
         defaults=Defaults(
-            workspace=str(workspace) if isinstance(workspace, str) else None,
-            warehouse=str(warehouse) if isinstance(warehouse, str) else None,
+            workspace=workspace if isinstance(workspace, str) else None,
+            warehouse=warehouse if isinstance(warehouse, str) else None,
         )
     )
 
@@ -114,19 +114,20 @@ def save_config(config: UserConfig, path: Path | None = None) -> None:
     """Atomically write *config* to *path*.
 
     Creates parent directories as needed.
+    Serialises with :mod:`tomli_w` for full TOML-spec compliance (handles
+    newlines, control characters, non-BMP unicode in workspace/warehouse names).
     """
     resolved = path if path is not None else default_path()
     resolved.parent.mkdir(parents=True, exist_ok=True)
 
-    # Hand-write minimal TOML — no third-party serialiser required.
-    lines: list[str] = ["[defaults]\n"]
+    defaults_dict: dict[str, str] = {}
     if config.defaults.workspace is not None:
-        escaped = config.defaults.workspace.replace("\\", "\\\\").replace('"', '\\"')
-        lines.append(f'workspace = "{escaped}"\n')
+        defaults_dict["workspace"] = config.defaults.workspace
     if config.defaults.warehouse is not None:
-        escaped = config.defaults.warehouse.replace("\\", "\\\\").replace('"', '\\"')
-        lines.append(f'warehouse = "{escaped}"\n')
-    content = "".join(lines)
+        defaults_dict["warehouse"] = config.defaults.warehouse
+
+    data: dict[str, object] = {"defaults": defaults_dict}
+    content = tomli_w.dumps(data)
 
     lock = filelock.FileLock(str(resolved) + ".lock", timeout=_LOCK_TIMEOUT)
     with lock:
@@ -136,8 +137,8 @@ def save_config(config: UserConfig, path: Path | None = None) -> None:
             suffix=".toml",
         )
         try:
-            with os.fdopen(fd, "w", encoding="utf-8") as fh:
-                fh.write(content)
+            with os.fdopen(fd, "wb") as fh:
+                fh.write(content.encode())
             os.replace(tmp_name, resolved)
         except Exception:
             with contextlib.suppress(OSError):

--- a/src/fabric_dw/exceptions.py
+++ b/src/fabric_dw/exceptions.py
@@ -37,6 +37,11 @@ class ConfigError(FabricError):
             f"{', '.join(names)}"
         )
 
+    @classmethod
+    def unknown_credential_mode(cls, mode: object) -> "ConfigError":
+        """Create a ConfigError for an unrecognised credential mode."""
+        return cls(f"Unknown credential mode: {mode!r}")
+
 
 class ItemKindError(FabricError):
     """Raised when an operation is not valid for the resolved item kind."""

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -8,11 +8,13 @@ from azure.core.credentials import AccessToken
 from azure.identity.aio import ClientSecretCredential as AsyncClientSecretCredential
 from azure.identity.aio import DefaultAzureCredential as AsyncDefaultAzureCredential
 
+import fabric_dw.auth as auth_module
 from fabric_dw.auth import (
     DEFAULT_INTERACTIVE_CLIENT_ID,
     FABRIC_SCOPE,
     SQL_SCOPE,
     CredentialMode,
+    SyncCredentialAdapter,
     _SyncCredentialAdapter,
     get_credential,
 )
@@ -87,11 +89,11 @@ def test_get_credential_service_principal_raises_config_error_when_all_env_missi
 
 def test_get_credential_interactive_returns_sync_adapter() -> None:
     credential = get_credential(CredentialMode.INTERACTIVE)
-    assert isinstance(credential, _SyncCredentialAdapter)
+    assert isinstance(credential, SyncCredentialAdapter)
 
 
 # ---------------------------------------------------------------------------
-# _SyncCredentialAdapter — get_token and close dispatch via asyncio.to_thread
+# SyncCredentialAdapter — get_token and close dispatch via asyncio.to_thread
 # ---------------------------------------------------------------------------
 
 
@@ -102,7 +104,7 @@ async def test_sync_adapter_get_token_returns_token_from_inner() -> None:
     inner = MagicMock()
     inner.get_token.return_value = expected_token
 
-    adapter = _SyncCredentialAdapter(inner)
+    adapter = SyncCredentialAdapter(inner)
     result = await adapter.get_token(FABRIC_SCOPE)
 
     assert result == expected_token
@@ -124,7 +126,7 @@ async def test_sync_adapter_get_token_runs_in_worker_thread() -> None:
     inner = MagicMock()
     inner.get_token.side_effect = fake_get_token
 
-    adapter = _SyncCredentialAdapter(inner)
+    adapter = SyncCredentialAdapter(inner)
     await adapter.get_token(FABRIC_SCOPE)
 
     assert inner_thread, "inner.get_token was never called"
@@ -136,7 +138,7 @@ async def test_sync_adapter_get_token_dispatches_via_to_thread() -> None:
     """get_token must call asyncio.to_thread with the inner method."""
     inner = MagicMock()
     inner.get_token.return_value = AccessToken("tok", 9999999999)
-    adapter = _SyncCredentialAdapter(inner)
+    adapter = SyncCredentialAdapter(inner)
 
     with patch("fabric_dw.auth.asyncio.to_thread", new_callable=AsyncMock) as mock_to_thread:
         mock_to_thread.return_value = AccessToken("tok", 9999999999)
@@ -154,7 +156,7 @@ async def test_sync_adapter_get_token_dispatches_via_to_thread() -> None:
 async def test_sync_adapter_close_dispatches_via_to_thread() -> None:
     """close() must offload the inner close call to a worker thread."""
     inner = MagicMock()
-    adapter = _SyncCredentialAdapter(inner)
+    adapter = SyncCredentialAdapter(inner)
 
     with patch("fabric_dw.auth.asyncio.to_thread", new_callable=AsyncMock) as mock_to_thread:
         mock_to_thread.return_value = None
@@ -174,7 +176,7 @@ async def test_sync_adapter_close_runs_in_worker_thread() -> None:
     inner = MagicMock()
     inner.close.side_effect = fake_close
 
-    adapter = _SyncCredentialAdapter(inner)
+    adapter = SyncCredentialAdapter(inner)
     await adapter.close()
 
     assert inner_thread, "inner.close was never called"
@@ -289,3 +291,62 @@ def test_sp_mode_does_not_use_interactive_client_id(monkeypatch: pytest.MonkeyPa
         _, kwargs = mock_csc.call_args
         assert "interactive_browser_client_id" not in kwargs
         assert kwargs.get("client_id") == "test-client-id"
+
+
+# ---------------------------------------------------------------------------
+# Registry dispatch — one test per mode
+# ---------------------------------------------------------------------------
+
+
+def test_registry_dispatches_default_mode() -> None:
+    """Registry must dispatch to the default factory for CredentialMode.DEFAULT."""
+    mock_factory = MagicMock(return_value=MagicMock())
+    original = auth_module._CREDENTIAL_REGISTRY[CredentialMode.DEFAULT]
+    try:
+        auth_module._CREDENTIAL_REGISTRY[CredentialMode.DEFAULT] = mock_factory
+        get_credential(CredentialMode.DEFAULT)
+        mock_factory.assert_called_once()
+    finally:
+        auth_module._CREDENTIAL_REGISTRY[CredentialMode.DEFAULT] = original
+
+
+def test_registry_dispatches_service_principal_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Registry must dispatch to the SP factory for CredentialMode.SERVICE_PRINCIPAL."""
+    monkeypatch.setenv("AZURE_TENANT_ID", "t")
+    monkeypatch.setenv("AZURE_CLIENT_ID", "c")
+    monkeypatch.setenv("AZURE_CLIENT_SECRET", "s")
+    mock_factory = MagicMock(return_value=MagicMock())
+    original = auth_module._CREDENTIAL_REGISTRY[CredentialMode.SERVICE_PRINCIPAL]
+    try:
+        auth_module._CREDENTIAL_REGISTRY[CredentialMode.SERVICE_PRINCIPAL] = mock_factory
+        get_credential(CredentialMode.SERVICE_PRINCIPAL)
+        mock_factory.assert_called_once()
+    finally:
+        auth_module._CREDENTIAL_REGISTRY[CredentialMode.SERVICE_PRINCIPAL] = original
+
+
+def test_registry_dispatches_interactive_mode() -> None:
+    """Registry must dispatch to the interactive factory for CredentialMode.INTERACTIVE."""
+    mock_factory = MagicMock(return_value=MagicMock())
+    original = auth_module._CREDENTIAL_REGISTRY[CredentialMode.INTERACTIVE]
+    try:
+        auth_module._CREDENTIAL_REGISTRY[CredentialMode.INTERACTIVE] = mock_factory
+        get_credential(CredentialMode.INTERACTIVE)
+        mock_factory.assert_called_once()
+    finally:
+        auth_module._CREDENTIAL_REGISTRY[CredentialMode.INTERACTIVE] = original
+
+
+# ---------------------------------------------------------------------------
+# SyncCredentialAdapter rename — backward-compat alias
+# ---------------------------------------------------------------------------
+
+
+def test_private_alias_is_same_class() -> None:
+    """_SyncCredentialAdapter must be an alias for SyncCredentialAdapter."""
+    assert _SyncCredentialAdapter is SyncCredentialAdapter
+
+
+def test_sync_adapter_public_name() -> None:
+    """SyncCredentialAdapter must be exported in __all__."""
+    assert "SyncCredentialAdapter" in auth_module.__all__

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -350,3 +350,14 @@ def test_private_alias_is_same_class() -> None:
 def test_sync_adapter_public_name() -> None:
     """SyncCredentialAdapter must be exported in __all__."""
     assert "SyncCredentialAdapter" in auth_module.__all__
+
+
+# ---------------------------------------------------------------------------
+# get_credential unknown mode — new explicit-error contract (registry refactor)
+# ---------------------------------------------------------------------------
+
+
+def test_get_credential_unknown_mode_raises_config_error() -> None:
+    """get_credential must raise ConfigError for a mode not in the registry."""
+    with pytest.raises(ConfigError, match="Unknown credential mode"):
+        get_credential("not-a-real-mode")  # ty: ignore[invalid-argument-type]

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -131,3 +131,60 @@ def test_load_after_clear_returns_empty(tmp_path: Path) -> None:
     clear_config(path)
     cfg = load_config(path)
     assert cfg == UserConfig(defaults=Defaults())
+
+
+# ---------------------------------------------------------------------------
+# TOML round-trip with hostile workspace / warehouse names
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        'Sales "Workspace"',  # embedded double-quote
+        "Back\\slash WS",  # backslash
+        "Line\nBreak WS",  # newline (LF)
+        "Tab\tWS",  # horizontal tab
+        "Control\x00WS",  # null byte (control character)
+        "Unicode ☃ Snowman",  # BMP unicode
+        "Non-BMP \U0001f600 Emoji",  # non-BMP unicode (surrogate pair in UTF-16)
+        '"""triple quotes"""',  # triple double-quote
+        "null\x00byte\x01ctrl",  # multiple control chars
+    ],
+)
+def test_round_trip_hostile_workspace_name(tmp_path: Path, name: str) -> None:
+    """save_config + load_config must survive hostile workspace name strings."""
+    path = tmp_path / "config.toml"
+    cfg = UserConfig(defaults=Defaults(workspace=name))
+    save_config(cfg, path)
+    loaded = load_config(path)
+    assert loaded.defaults.workspace == name
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        'Ware"house',
+        "DW\\backslash",
+        "Line\nBreak-DW",
+    ],
+)
+def test_round_trip_hostile_warehouse_name(tmp_path: Path, name: str) -> None:
+    """save_config + load_config must survive hostile warehouse name strings."""
+    path = tmp_path / "config.toml"
+    cfg = UserConfig(defaults=Defaults(warehouse=name))
+    save_config(cfg, path)
+    loaded = load_config(path)
+    assert loaded.defaults.warehouse == name
+
+
+def test_round_trip_both_hostile(tmp_path: Path) -> None:
+    """Both workspace and warehouse with hostile characters round-trip correctly."""
+    path = tmp_path / "config.toml"
+    ws = 'My "Workspace"\nwith newline'
+    wh = "DW\\slash\ttab"
+    cfg = UserConfig(defaults=Defaults(workspace=ws, warehouse=wh))
+    save_config(cfg, path)
+    loaded = load_config(path)
+    assert loaded.defaults.workspace == ws
+    assert loaded.defaults.warehouse == wh

--- a/uv.lock
+++ b/uv.lock
@@ -607,6 +607,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "rich" },
     { name = "tenacity" },
+    { name = "tomli-w" },
 ]
 
 [package.dev-dependencies]
@@ -639,6 +640,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.9" },
     { name = "rich", specifier = ">=14" },
     { name = "tenacity", specifier = ">=9" },
+    { name = "tomli-w", specifier = ">=1.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -2103,6 +2105,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
     { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
     { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "tomli-w"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **config.py**: Replaces the hand-rolled TOML serialiser with `tomli_w` (new runtime dep `tomli-w>=1.0`) for full TOML-spec compliance — handles newlines, control characters, non-BMP unicode, triple quotes in workspace/warehouse names. Drops the `if True:` pragma wrapper around `tomllib` (plain top-level import). Removes the redundant `str(workspace) if isinstance(workspace, str)` cast.
- **auth.py**: Renames `_SyncCredentialAdapter` → `SyncCredentialAdapter` (public class, backward-compat `_SyncCredentialAdapter` alias kept). Adds `__all__`. Replaces the `get_credential` if/elif chain with a `_CREDENTIAL_REGISTRY` dict mapping `CredentialMode` → factory callable (OCP: new modes need one dict entry). Removes dead `or ""` fallbacks after validated-env check. Tightens `**kwargs: Any` → `**kwargs: object`.
- **exceptions.py**: Adds `ConfigError.unknown_credential_mode()` class method (TRY003 compliance).
- **SECURITY.md**: Adds "Interactive sign-in Entra application" section documenting the shared multi-tenant app ID, delegated scopes, governance implications, and the `FABRIC_INTERACTIVE_CLIENT_ID` override for tenants requiring their own registration.

## Findings addressed

| Finding file | Resolution |
|---|---|
| `02-core-config-hand-rolled-toml-writer.md` | `save_config` now uses `tomli_w.dumps`; all hostile strings pass round-trip tests |
| `02-core-config-if-true-tomllib.md` | `if True:` wrapper removed; `import tomllib` is top-level |
| `02-core-config-redundant-str-cast.md` | `str(workspace) if isinstance(workspace, str)` → `workspace if isinstance(workspace, str)` |
| `02-core-auth-credential-strategy-pattern.md` | `_CREDENTIAL_REGISTRY` dict replaces if/elif chain in `get_credential` |
| `02-core-auth-dead-fallbacks-on-validated-env.md` | `or ""` removed; `str(env_vars[...])` used directly after validated-env check |
| `02-core-auth-private-name-leaked.md` | Class renamed to `SyncCredentialAdapter`; `__all__` added; `**kwargs: object` (no ANN401 noqa needed) |
| `02-core-auth-shared-clientid-undocumented-risk.md` | SECURITY.md section added; `FABRIC_INTERACTIVE_CLIENT_ID` override already present in code |

## Decisions

- `_SyncCredentialAdapter` is kept as a module-level alias (`= SyncCredentialAdapter`) so any callers that reference the old private name continue to work without a deprecation cycle. Tests verify `_SyncCredentialAdapter is SyncCredentialAdapter`.
- `str(env_vars[...])` is used instead of `assert ... is not None` to satisfy the S101 (no-assert-in-prod) ruff rule while still narrowing the type without `or ""`.
- The registry tests mutate `_CREDENTIAL_REGISTRY` directly and restore the original in `finally` blocks (patching the module-level function names does not work because the dict already holds references at import time).
- `**kwargs: object` with a single `noqa: ARG002` is retained on `SyncCredentialAdapter.get_token` — the parameter is required by the `AsyncTokenCredential` protocol but is not consumed in the body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)