### PR TITLE
refactor(http): enrich exceptions, split _do_request, fix 429 race, extras in JSON log

### DIFF
--- a/src/fabric_dw/exceptions.py
+++ b/src/fabric_dw/exceptions.py
@@ -1,5 +1,35 @@
 class FabricError(Exception):
-    """Base error for all fabric-dw errors."""
+    """Base error for all fabric-dw errors.
+
+    Attributes:
+        status:     HTTP status code that triggered this error, or None.
+        request_id: Value of the ``x-ms-request-id`` response header, or None.
+        body:       Best-effort parsed JSON response body, or None.
+        hint:       Optional human-readable remediation hint.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status: int | None = None,
+        request_id: str | None = None,
+        body: dict[str, object] | None = None,
+        hint: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.status = status
+        self.request_id = request_id
+        self.body = body
+        self.hint = hint
+
+    def __str__(self) -> str:
+        msg = super().__str__()
+        if self.hint:
+            msg = f"{msg}\nHint: {self.hint}"
+        if self.request_id:
+            msg = f"{msg} (request-id: {self.request_id})"
+        return msg
 
 
 class AuthError(FabricError):

--- a/src/fabric_dw/http_client.py
+++ b/src/fabric_dw/http_client.py
@@ -309,9 +309,14 @@ class FabricHttpClient:
 
         # Honour the 429 pause deadline (aggregated across all concurrent callers).
         # This must happen before token fetch so the token is always fresh at send time.
-        now = _time.monotonic()
-        if self._pause_until > now:
-            await asyncio.sleep(self._pause_until - now)
+        # Use a while loop so that if another coroutine extends _pause_until while we
+        # are sleeping, we re-check and sleep again rather than waking up early.
+        while True:
+            now = _time.monotonic()
+            remaining = self._pause_until - now
+            if remaining <= 0:
+                break
+            await asyncio.sleep(remaining)
 
         # Fetch token outside the limiter to avoid wasting RPS budget on refresh.
         token = await self._get_token()

--- a/src/fabric_dw/http_client.py
+++ b/src/fabric_dw/http_client.py
@@ -2,18 +2,29 @@
 
 Provides:
 - Global rate-limiting via aiolimiter (default 2 RPS).
-- 429 Retry-After handling with a shared asyncio pause gate.
+- 429 Retry-After handling with a monotonic deadline (``_pause_until``).
 - 5xx retry with tenacity exponential back-off (max 3 attempts).
 - Standard error mapping (401 -> AuthError, 403 -> PermissionDenied, 404 -> NotFound).
 - continuationUri pagination.
-- LRO (202 + Location) polling.
+- LRO (202 + Location) polling with jitter.
+
+Retry arithmetic
+~~~~~~~~~~~~~~~~
+Tenacity wraps ``_request_with_retry`` and retries on ``FabricServerError``
+(5xx) up to 3 attempts with exponential back-off.  Inside each attempt,
+``_do_request`` executes a 429-loop of up to ``max_429_retries`` iterations.
+Worst-case total attempts = 3 tenacity attempts x 5 429-retries = 15 sends.
+In practice the 429-loop resets its counter on any non-429 response, so the
+two mechanisms are largely independent.
 """
 
 from __future__ import annotations
 
 import asyncio
 import datetime
+import http
 import logging
+import random
 import time as _time
 from collections.abc import AsyncIterator, Mapping
 from email.utils import parsedate_to_datetime
@@ -29,6 +40,7 @@ from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_ex
 from fabric_dw import auth
 from fabric_dw.exceptions import (
     AuthError,
+    FabricError,
     FabricServerError,
     NotFound,
     PermissionDenied,
@@ -44,9 +56,19 @@ __all__ = [
     "_parse_retry_after",
 ]
 
-_MAX_429_RETRIES = 5
-_DEFAULT_POLL_INTERVAL = 2.0
-_TOKEN_REFRESH_BUFFER = 300  # seconds before expiry to refresh
+# Module-level defaults (used as constructor defaults)
+_DEFAULT_RPS: int = 2
+_DEFAULT_TIMEOUT: float = 30.0
+_MAX_429_RETRIES: int = 5
+_DEFAULT_POLL_INTERVAL: float = 2.0
+_TOKEN_REFRESH_BUFFER: float = 300.0  # seconds before expiry to refresh
+
+# Status code → exception class mapping (4xx errors only; 5xx handled separately)
+_STATUS_TO_EXC: dict[int, type[FabricError]] = {
+    http.HTTPStatus.UNAUTHORIZED: AuthError,
+    http.HTTPStatus.FORBIDDEN: PermissionDenied,
+    http.HTTPStatus.NOT_FOUND: NotFound,
+}
 
 
 class HttpBase(StrEnum):
@@ -88,20 +110,51 @@ class FabricHttpClient:
 
         async with FabricHttpClient(credential) as client:
             resp = await client.request("GET", HttpBase.FABRIC, "/workspaces")
+
+    Retry arithmetic
+    ~~~~~~~~~~~~~~~~
+    Tenacity wraps ``_request_with_retry`` and retries on ``FabricServerError``
+    (5xx) up to 3 attempts.  Inside each tenacity attempt, ``_do_request`` runs
+    a 429-loop of up to ``max_429_retries`` iterations.  Worst-case total sends
+    = 3 x ``max_429_retries`` (default 15).  The 429 counter resets on any
+    non-429 response, so both mechanisms are largely independent in practice.
+
+    Args:
+        credential:          Azure credential used to fetch bearer tokens.
+        rps:                 Maximum requests per second (default 2).
+        timeout:             HTTP request timeout in seconds (default 30.0).
+        max_429_retries:     Maximum consecutive 429 responses before raising
+                             ``RateLimitedError`` (default 5).
+        poll_interval:       Default LRO polling interval in seconds (default 2.0).
+        token_refresh_buffer: Seconds before token expiry at which a refresh is
+                             triggered (default 300.0).
     """
 
-    def __init__(self, credential: AsyncTokenCredential, rps: int = 2) -> None:
+    def __init__(  # noqa: PLR0913
+        self,
+        credential: AsyncTokenCredential,
+        rps: int = _DEFAULT_RPS,
+        *,
+        timeout: float = _DEFAULT_TIMEOUT,
+        max_429_retries: int = _MAX_429_RETRIES,
+        poll_interval: float = _DEFAULT_POLL_INTERVAL,
+        token_refresh_buffer: float = _TOKEN_REFRESH_BUFFER,
+    ) -> None:
         self._credential = credential
         self._limiter = AsyncLimiter(max_rate=rps, time_period=1)
         self._http: httpx.AsyncClient | None = None
         self._token: AccessToken | None = None
         self._token_lock = asyncio.Lock()
-        # Pause gate: set when idle, clear when sleeping for a 429
-        self._pause_event = asyncio.Event()
-        self._pause_event.set()
+        self._timeout = timeout
+        self._max_429_retries = max_429_retries
+        self._poll_interval = poll_interval
+        self._token_refresh_buffer = token_refresh_buffer
+        # Monotonic deadline: sleep until this time before each send.
+        # 0.0 means "no pause needed".
+        self._pause_until: float = 0.0
 
     async def __aenter__(self) -> FabricHttpClient:
-        self._http = httpx.AsyncClient(http2=True, timeout=30)
+        self._http = httpx.AsyncClient(http2=True, timeout=self._timeout)
         return self
 
     async def __aexit__(self, *_exc: object) -> None:
@@ -121,7 +174,10 @@ class FabricHttpClient:
         the same time.
         """
         async with self._token_lock:
-            if self._token is None or self._token.expires_on - _time.time() < _TOKEN_REFRESH_BUFFER:
+            if (
+                self._token is None
+                or self._token.expires_on - _time.time() < self._token_refresh_buffer
+            ):
                 self._token = await self._credential.get_token(auth.FABRIC_SCOPE)
         return self._token.token
 
@@ -154,7 +210,7 @@ class FabricHttpClient:
             AuthError: On 401.
             PermissionDenied: On 403.
             NotFound: On 404.
-            RateLimitedError: When the server returns 429 more than _MAX_429_RETRIES times.
+            RateLimitedError: When the server returns 429 more than max_429_retries times.
             FabricServerError: On persistent 5xx errors.
         """
         url = f"{base}{path}"
@@ -185,7 +241,17 @@ class FabricHttpClient:
         json: object = None,
         params: Mapping[str, Any] | None = None,
     ) -> httpx.Response:
-        """Execute a request with rate limiting and 429 handling."""
+        """Execute a request with rate limiting and 429 handling.
+
+        Delegates to:
+        - ``_send_once``: waits for the pause deadline, acquires the rate
+          limiter, and performs the actual HTTP send.
+        - ``_map_status``: maps error status codes to typed exceptions.
+
+        On 429: updates the shared monotonic deadline and retries up to
+        ``_max_429_retries`` consecutive times before raising
+        ``RateLimitedError``.
+        """
         if self._http is None:
             msg = "Client must be used as an async context manager"
             raise RuntimeError(msg)
@@ -193,69 +259,117 @@ class FabricHttpClient:
         consecutive_429 = 0
 
         while True:
-            # Wait if another coroutine is paused for 429
-            await self._pause_event.wait()
+            resp = await self._send_once(method, url, json=json, params=params)
 
-            # Acquire rate-limit token
-            async with self._limiter:
-                token = await self._get_token()
-                headers = {"Authorization": f"Bearer {token}"}
-
-                t0 = _time.monotonic()
-                resp = await self._http.request(
-                    method,
-                    url,
-                    headers=headers,
-                    json=json,
-                    params=params,
-                )
-                elapsed_ms = (_time.monotonic() - t0) * 1000
-
-            if _logger.isEnabledFor(logging.DEBUG):
-                safe_headers = redact_auth_header(dict(headers))
-                _logger.debug(
-                    "%s %s -> %d elapsed_ms=%.1f headers=%r",
-                    method,
-                    url,
-                    resp.status_code,
-                    elapsed_ms,
-                    safe_headers,
-                )
-
-            if resp.status_code == 429:  # noqa: PLR2004
+            if resp.status_code == http.HTTPStatus.TOO_MANY_REQUESTS:
                 consecutive_429 += 1
-                if consecutive_429 >= _MAX_429_RETRIES:
+                if consecutive_429 >= self._max_429_retries:
                     raise RateLimitedError(  # noqa: TRY003
-                        f"Received 429 {consecutive_429} consecutive times for {url}"
+                        f"Received 429 {consecutive_429} consecutive times for {url}",
+                        status=429,
+                        request_id=resp.headers.get("x-ms-request-id"),
                     )
 
                 retry_after_raw = resp.headers.get("Retry-After", "1")
                 wait_s = _parse_retry_after(retry_after_raw)
 
-                # Pause all other concurrent callers while we sleep
-                self._pause_event.clear()
-                try:
-                    await asyncio.sleep(wait_s)
-                finally:
-                    self._pause_event.set()
-
+                # Aggregate concurrent 429s: keep the latest (furthest) deadline.
+                deadline = _time.monotonic() + wait_s
+                self._pause_until = max(self._pause_until, deadline)
                 continue
 
             # Reset counter on non-429
             consecutive_429 = 0
-
-            if resp.status_code == 401:  # noqa: PLR2004
-                raise AuthError(f"Authentication failed for {url}: {resp.text}")  # noqa: TRY003
-            if resp.status_code == 403:  # noqa: PLR2004
-                raise PermissionDenied(f"Permission denied for {url}: {resp.text}")  # noqa: TRY003
-            if resp.status_code == 404:  # noqa: PLR2004
-                raise NotFound(f"Resource not found: {url}: {resp.text}")  # noqa: TRY003
-            if resp.status_code >= 500:  # noqa: PLR2004
-                raise FabricServerError(  # noqa: TRY003
-                    f"Server error {resp.status_code} for {url}: {resp.text}"
-                )
-
+            self._map_status(resp, url)
             return resp
+
+    async def _send_once(
+        self,
+        method: str,
+        url: str,
+        *,
+        json: object = None,
+        params: Mapping[str, Any] | None = None,
+    ) -> httpx.Response:
+        """Fetch token, wait for any pause deadline, acquire the limiter, and send.
+
+        Token fetch happens BEFORE acquiring the rate-limiter slot so that a
+        cache-miss token refresh does not consume RPS budget.
+        """
+        assert self._http is not None  # noqa: S101 — enforced by _do_request
+
+        # Fetch token outside the limiter to avoid wasting RPS budget on refresh.
+        token = await self._get_token()
+
+        # Honour the 429 pause deadline (aggregated across all concurrent callers).
+        now = _time.monotonic()
+        if self._pause_until > now:
+            await asyncio.sleep(self._pause_until - now)
+
+        headers = {"Authorization": f"Bearer {token}"}
+
+        async with self._limiter:
+            t0 = _time.monotonic()
+            resp = await self._http.request(
+                method,
+                url,
+                headers=headers,
+                json=json,
+                params=params,
+            )
+            elapsed_ms = (_time.monotonic() - t0) * 1000
+
+        if _logger.isEnabledFor(logging.DEBUG):
+            safe_headers = redact_auth_header(dict(headers))
+            request_id = resp.headers.get("x-ms-request-id")
+            _logger.debug(
+                "%s %s -> %d elapsed_ms=%.1f headers=%r",
+                method,
+                url,
+                resp.status_code,
+                elapsed_ms,
+                safe_headers,
+                extra={"request_id": request_id} if request_id else {},
+            )
+
+        return resp
+
+    def _map_status(self, resp: httpx.Response, url: str) -> None:
+        """Raise a typed ``FabricError`` subclass for error status codes.
+
+        Uses ``_STATUS_TO_EXC`` for known 4xx codes; raises ``FabricServerError``
+        for any 5xx response.  JSON body is parsed best-effort (parse errors
+        are silently swallowed).  The ``x-ms-request-id`` header is captured
+        for all raised exceptions.
+        """
+        status = resp.status_code
+        request_id = resp.headers.get("x-ms-request-id")
+
+        # Best-effort JSON body parse
+        body: dict[str, object] | None = None
+        try:
+            parsed = resp.json()
+            if isinstance(parsed, dict):
+                body = parsed
+        except Exception:  # noqa: S110
+            pass
+
+        exc_class = _STATUS_TO_EXC.get(status)
+        if exc_class is not None:
+            raise exc_class(  # noqa: TRY003
+                f"HTTP {status} for {url}: {resp.text}",
+                status=status,
+                request_id=request_id,
+                body=body,
+            )
+
+        if status >= http.HTTPStatus.INTERNAL_SERVER_ERROR:
+            raise FabricServerError(  # noqa: TRY003
+                f"Server error {status} for {url}: {resp.text}",
+                status=status,
+                request_id=request_id,
+                body=body,
+            )
 
     # ------------------------------------------------------------------
     # Pagination
@@ -363,9 +477,10 @@ class FabricHttpClient:
                     f"LRO failed for {location}: {body.get('error', body)}"
                 )
 
-            # Not finished yet - honour Retry-After or fall back to default
+            # Not finished yet - honour Retry-After or fall back to default, with jitter
             retry_after_raw = resp.headers.get("Retry-After")
-            wait_s = (
-                _parse_retry_after(retry_after_raw) if retry_after_raw else _DEFAULT_POLL_INTERVAL
+            base_wait = (
+                _parse_retry_after(retry_after_raw) if retry_after_raw else self._poll_interval
             )
+            wait_s = base_wait + random.uniform(0, base_wait * 0.25)  # noqa: S311
             await asyncio.sleep(wait_s)

--- a/src/fabric_dw/http_client.py
+++ b/src/fabric_dw/http_client.py
@@ -210,7 +210,7 @@ class FabricHttpClient:
             AuthError: On 401.
             PermissionDenied: On 403.
             NotFound: On 404.
-            RateLimitedError: When the server returns 429 more than max_429_retries times.
+            RateLimitedError: After exactly ``max_429_retries`` consecutive 429 responses.
             FabricServerError: On persistent 5xx errors.
         """
         url = f"{base}{path}"
@@ -271,7 +271,14 @@ class FabricHttpClient:
                     )
 
                 retry_after_raw = resp.headers.get("Retry-After", "1")
-                wait_s = _parse_retry_after(retry_after_raw)
+                try:
+                    wait_s = _parse_retry_after(retry_after_raw)
+                except ValueError:
+                    _logger.warning(
+                        "Malformed Retry-After header %r; falling back to 1.0s",
+                        retry_after_raw,
+                    )
+                    wait_s = 1.0
 
                 # Aggregate concurrent 429s: keep the latest (furthest) deadline.
                 deadline = _time.monotonic() + wait_s
@@ -291,20 +298,23 @@ class FabricHttpClient:
         json: object = None,
         params: Mapping[str, Any] | None = None,
     ) -> httpx.Response:
-        """Fetch token, wait for any pause deadline, acquire the limiter, and send.
+        """Wait for any pause deadline, fetch token, acquire the limiter, and send.
 
-        Token fetch happens BEFORE acquiring the rate-limiter slot so that a
-        cache-miss token refresh does not consume RPS budget.
+        The pause-deadline wait happens first so that the token is fetched (and
+        potentially refreshed) immediately before use, regardless of how long the
+        429-induced pause was.  Token fetch happens BEFORE acquiring the
+        rate-limiter slot so that a cache-miss refresh does not consume RPS budget.
         """
         assert self._http is not None  # noqa: S101 — enforced by _do_request
 
-        # Fetch token outside the limiter to avoid wasting RPS budget on refresh.
-        token = await self._get_token()
-
         # Honour the 429 pause deadline (aggregated across all concurrent callers).
+        # This must happen before token fetch so the token is always fresh at send time.
         now = _time.monotonic()
         if self._pause_until > now:
             await asyncio.sleep(self._pause_until - now)
+
+        # Fetch token outside the limiter to avoid wasting RPS budget on refresh.
+        token = await self._get_token()
 
         headers = {"Authorization": f"Bearer {token}"}
 

--- a/src/fabric_dw/logging.py
+++ b/src/fabric_dw/logging.py
@@ -17,12 +17,30 @@ __all__ = [
 
 _SENTINEL = object()
 
+# Build the set of "standard" LogRecord attribute names by inspecting a fresh
+# instance, then add the keys that are added during formatting.
+_STANDARD_LOGRECORD_ATTRS: frozenset[str] = frozenset(
+    logging.LogRecord(
+        name="",
+        level=logging.DEBUG,
+        pathname="",
+        lineno=0,
+        msg="",
+        args=(),
+        exc_info=None,
+    ).__dict__.keys()
+) | {"message", "asctime"}
+
 
 class _JsonFormatter(logging.Formatter):
     """Minimal JSON log formatter.
 
     Each record is emitted as a single-line JSON object with the keys:
     ``level``, ``name``, ``msg``, and ``time`` (ISO-8601 UTC).
+
+    Any extra fields passed via ``extra={...}`` to the logging call are
+    merged into the payload without overwriting the core keys.  Values that
+    are not JSON-serialisable are coerced to ``str``.
     """
 
     def format(self, record: logging.LogRecord) -> str:
@@ -34,7 +52,14 @@ class _JsonFormatter(logging.Formatter):
             "msg": message,
             "time": self.formatTime(record, self.datefmt),
         }
-        return json.dumps(payload)
+
+        # Merge extra= fields without overwriting core keys.
+        extras = {k: v for k, v in record.__dict__.items() if k not in _STANDARD_LOGRECORD_ATTRS}
+        for key, value in extras.items():
+            if key not in payload:
+                payload[key] = value
+
+        return json.dumps(payload, default=str)
 
     def formatTime(self, record: logging.LogRecord, datefmt: str | None = None) -> str:  # noqa: N802
         # Always emit UTC ISO-8601

--- a/tests/unit/test_http_client.py
+++ b/tests/unit/test_http_client.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
+import unittest.mock
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -17,6 +18,7 @@ from freezegun import freeze_time
 
 from fabric_dw.exceptions import (
     AuthError,
+    FabricError,
     FabricServerError,
     NotFound,
     PermissionDenied,
@@ -633,3 +635,297 @@ async def test_debug_log_contains_elapsed_ms(caplog: pytest.LogCaptureFixture) -
         or "ms" in record.getMessage()
     )
     assert has_elapsed, f"No elapsed info in log record: {record.getMessage()}"
+
+
+# ---------------------------------------------------------------------------
+# Exception context attributes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_status_mapping_fills_exception_attributes() -> None:
+    """Error exceptions must carry status, request_id, and body attributes."""
+    req_id = "test-req-id-001"
+
+    with respx.mock:
+        respx.get("https://api.fabric.microsoft.com/v1/items").mock(
+            return_value=httpx.Response(
+                404,
+                headers={"x-ms-request-id": req_id},
+                json={"error": {"code": "ItemNotFound", "message": "not found"}},
+            )
+        )
+        client = await _get_client()
+        async with client:
+            with pytest.raises(NotFound) as exc_info:
+                await client.request("GET", HttpBase.FABRIC, "/items")
+
+    err = exc_info.value
+    assert err.status == 404
+    assert err.request_id == req_id
+    assert isinstance(err.body, dict)
+    assert err.body.get("error") is not None
+
+
+@pytest.mark.asyncio
+async def test_auth_error_carries_status() -> None:
+    """AuthError must have status=401."""
+    with respx.mock:
+        respx.get("https://api.fabric.microsoft.com/v1/items").mock(
+            return_value=httpx.Response(401, json={"error": "unauthorized"})
+        )
+        client = await _get_client()
+        async with client:
+            with pytest.raises(AuthError) as exc_info:
+                await client.request("GET", HttpBase.FABRIC, "/items")
+
+    assert exc_info.value.status == 401
+
+
+@pytest.mark.asyncio
+async def test_server_error_carries_status() -> None:
+    """FabricServerError must have status=500."""
+    with respx.mock:
+        respx.get("https://api.fabric.microsoft.com/v1/items").mock(
+            return_value=httpx.Response(500, json={"error": "boom"})
+        )
+        client = await _get_client()
+        async with client:
+            with pytest.raises(FabricServerError) as exc_info:
+                await client.request("GET", HttpBase.FABRIC, "/items")
+
+    assert exc_info.value.status == 500
+
+
+@pytest.mark.asyncio
+async def test_rate_limited_error_carries_status() -> None:
+    """RateLimitedError raised after consecutive 429s must carry status=429."""
+
+    def side_effect(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(429, headers={"Retry-After": "0"}, json={})
+
+    with respx.mock:
+        respx.get("https://api.fabric.microsoft.com/v1/items").mock(side_effect=side_effect)
+
+        client = await _get_client(rps=10)
+        async with client:
+            with pytest.raises(RateLimitedError) as exc_info:
+                await client.request("GET", HttpBase.FABRIC, "/items")
+
+    assert exc_info.value.status == 429
+
+
+# ---------------------------------------------------------------------------
+# FabricError __str__ with hint and request_id
+# ---------------------------------------------------------------------------
+
+
+def test_fabric_error_str_no_extras() -> None:
+    """FabricError without hint/request_id returns the plain message."""
+    err = FabricError("plain message")
+    assert str(err) == "plain message"
+
+
+def test_fabric_error_str_with_hint() -> None:
+    """FabricError with hint appends it on a new line."""
+    err = FabricError("base msg", hint="try again later")
+    assert str(err) == "base msg\nHint: try again later"
+
+
+def test_fabric_error_str_with_request_id() -> None:
+    """FabricError with request_id appends it."""
+    err = FabricError("base msg", request_id="abc-123")
+    assert str(err) == "base msg (request-id: abc-123)"
+
+
+def test_fabric_error_str_with_hint_and_request_id() -> None:
+    """FabricError with both hint and request_id includes both."""
+    err = FabricError("base msg", hint="do X", request_id="rid-42")
+    text = str(err)
+    assert "Hint: do X" in text
+    assert "request-id: rid-42" in text
+
+
+# ---------------------------------------------------------------------------
+# 429 deadline aggregation (concurrent)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_429_deadline_aggregated_for_concurrent_requests() -> None:
+    """Two concurrent 429s with Retry-After values aggregate to the MAX deadline.
+
+    Both requests see a 429 first. After sleeping the maximum Retry-After,
+    both succeed. The total elapsed time must be >= the longer Retry-After.
+    """
+    call_count = 0
+
+    def side_effect(_request: httpx.Request) -> httpx.Response:
+        nonlocal call_count
+        call_count += 1
+        if call_count <= 2:
+            # First two calls return 429 with 1 second Retry-After
+            return httpx.Response(429, headers={"Retry-After": "1"}, json={})
+        return httpx.Response(200, json={"value": []})
+
+    with respx.mock:
+        respx.get("https://api.fabric.microsoft.com/v1/items").mock(side_effect=side_effect)
+
+        client = FabricHttpClient(credential=_make_credential(), rps=10)
+        async with client:
+            start = time.monotonic()
+            results = await asyncio.gather(
+                client.request("GET", HttpBase.FABRIC, "/items"),
+                client.request("GET", HttpBase.FABRIC, "/items"),
+            )
+            elapsed = time.monotonic() - start
+
+    assert all(r.status_code == 200 for r in results)
+    # Must have waited at least 1 second for the Retry-After
+    assert elapsed >= 0.9, f"Retry-After not honored: {elapsed:.2f}s"
+
+
+# ---------------------------------------------------------------------------
+# 429 honours Retry-After via deadline (single request)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_429_deadline_single_request_honors_retry_after() -> None:
+    """429 with Retry-After: 1 sets _pause_until and waits before retry."""
+    call_count = 0
+
+    def side_effect(_request: httpx.Request) -> httpx.Response:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return httpx.Response(429, headers={"Retry-After": "1"}, json={})
+        return httpx.Response(200, json={"ok": True})
+
+    with respx.mock:
+        respx.get("https://api.fabric.microsoft.com/v1/items").mock(side_effect=side_effect)
+
+        client = FabricHttpClient(credential=_make_credential(), rps=10)
+        async with client:
+            start = time.monotonic()
+            resp = await client.request("GET", HttpBase.FABRIC, "/items")
+            elapsed = time.monotonic() - start
+
+    assert resp.status_code == 200
+    assert call_count == 2
+    assert elapsed >= 0.9, f"Pause deadline not honored: {elapsed:.2f}s"
+
+
+# ---------------------------------------------------------------------------
+# Correlation id in debug log
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_debug_log_includes_request_id_when_present(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """When x-ms-request-id is in the response, it must appear in the log extra."""
+    req_id = "fabric-req-id-xyz"
+
+    with respx.mock:
+        respx.get("https://api.fabric.microsoft.com/v1/items").mock(
+            return_value=httpx.Response(
+                200,
+                headers={"x-ms-request-id": req_id},
+                json={},
+            )
+        )
+
+        client = await _get_client(rps=10)
+        async with client:
+            with caplog.at_level(logging.DEBUG, logger="fabric_dw.http"):
+                await client.request("GET", HttpBase.FABRIC, "/items")
+
+    fabric_records = [r for r in caplog.records if r.name == "fabric_dw.http"]
+    assert len(fabric_records) >= 1
+    record = fabric_records[0]
+    # request_id should be available as an extra attribute on the log record
+    assert hasattr(record, "request_id"), f"request_id not in log record: {record.__dict__}"
+    assert record.request_id == req_id
+
+
+# ---------------------------------------------------------------------------
+# Configurability: constructor parameters
+# ---------------------------------------------------------------------------
+
+
+def test_constructor_parameters_are_stored() -> None:
+    """FabricHttpClient stores custom constructor parameters."""
+    cred = _make_credential()
+    client = FabricHttpClient(
+        credential=cred,
+        rps=5,
+        timeout=60.0,
+        max_429_retries=3,
+        poll_interval=5.0,
+        token_refresh_buffer=600.0,
+    )
+    assert client._timeout == 60.0
+    assert client._max_429_retries == 3
+    assert client._poll_interval == 5.0
+    assert client._token_refresh_buffer == 600.0
+
+
+@pytest.mark.asyncio
+async def test_timeout_wired_into_http_client() -> None:
+    """The timeout parameter must be forwarded to the underlying httpx.AsyncClient."""
+    cred = _make_credential()
+    client = FabricHttpClient(credential=cred, timeout=42.0)
+    async with client:
+        assert client._http is not None
+        assert client._http.timeout.read == 42.0
+
+
+# ---------------------------------------------------------------------------
+# poll_operation jitter
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_poll_operation_jitter_within_bounds() -> None:
+    """poll_operation sleep must include jitter in [0, interval * 0.25] range.
+
+    Monkeypatches asyncio.sleep to capture the actual sleep durations and
+    verifies that at least one sleep is > the base interval (i.e. has jitter)
+    when multiple polls occur.
+    """
+    poll_count = 0
+    sleep_durations: list[float] = []
+
+    original_sleep = asyncio.sleep
+
+    async def mock_sleep(seconds: float) -> None:
+        sleep_durations.append(seconds)
+        # Use a tiny actual sleep so the test doesn't hang
+        await original_sleep(0)
+
+    def side_effect(_request: httpx.Request) -> httpx.Response:
+        nonlocal poll_count
+        poll_count += 1
+        if poll_count < 4:
+            return httpx.Response(202, headers={"Retry-After": "1"}, json={"status": "Running"})
+        return httpx.Response(200, json={"status": "Succeeded"})
+
+    with respx.mock:
+        respx.get("https://api.fabric.microsoft.com/v1/operations/op-jitter").mock(
+            side_effect=side_effect
+        )
+
+        client = FabricHttpClient(credential=_make_credential(), rps=10, poll_interval=2.0)
+        async with client:
+            with unittest.mock.patch("asyncio.sleep", side_effect=mock_sleep):
+                await client.poll_operation(
+                    "https://api.fabric.microsoft.com/v1/operations/op-jitter"
+                )
+
+    # Each sleep should be base_wait + jitter where base_wait=1 (from Retry-After: 1)
+    # jitter is in [0, 0.25], so sleep must be in [1.0, 1.25]
+    assert len(sleep_durations) >= 3, f"Expected at least 3 sleeps; got {len(sleep_durations)}"
+    for dur in sleep_durations:
+        assert 1.0 <= dur <= 1.26, f"Sleep {dur:.3f} outside expected [1.0, 1.25] range"

--- a/tests/unit/test_http_client.py
+++ b/tests/unit/test_http_client.py
@@ -889,11 +889,12 @@ async def test_timeout_wired_into_http_client() -> None:
 
 @pytest.mark.asyncio
 async def test_poll_operation_jitter_within_bounds() -> None:
-    """poll_operation sleep must include jitter in [0, interval * 0.25] range.
+    """poll_operation sleep must add the jitter produced by random.uniform.
 
-    Monkeypatches asyncio.sleep to capture the actual sleep durations and
-    verifies that at least one sleep is > the base interval (i.e. has jitter)
-    when multiple polls occur.
+    Patches random.uniform to a fixed non-zero value (0.15) so the test is
+    deterministic: each sleep must equal exactly base_wait + 0.15 where
+    base_wait=1.0 (from Retry-After: 1).  This proves the code applies jitter
+    rather than only checking that it falls within a probabilistic range.
     """
     poll_count = 0
     sleep_durations: list[float] = []
@@ -912,6 +913,10 @@ async def test_poll_operation_jitter_within_bounds() -> None:
             return httpx.Response(202, headers={"Retry-After": "1"}, json={"status": "Running"})
         return httpx.Response(200, json={"status": "Succeeded"})
 
+    # Patch random.uniform to a fixed non-zero value so jitter is deterministic.
+    # base_wait=1.0 (Retry-After: 1), jitter_max=1.0*0.25=0.25, fixed jitter=0.15
+    _fixed_jitter = 0.15
+
     with respx.mock:
         respx.get("https://api.fabric.microsoft.com/v1/operations/op-jitter").mock(
             side_effect=side_effect
@@ -919,16 +924,22 @@ async def test_poll_operation_jitter_within_bounds() -> None:
 
         client = FabricHttpClient(credential=_make_credential(), rps=10, poll_interval=2.0)
         async with client:
-            with unittest.mock.patch("asyncio.sleep", side_effect=mock_sleep):
+            with (
+                unittest.mock.patch("asyncio.sleep", side_effect=mock_sleep),
+                unittest.mock.patch(
+                    "fabric_dw.http_client.random.uniform", return_value=_fixed_jitter
+                ),
+            ):
                 await client.poll_operation(
                     "https://api.fabric.microsoft.com/v1/operations/op-jitter"
                 )
 
-    # Each sleep should be base_wait + jitter where base_wait=1 (from Retry-After: 1)
-    # jitter is in [0, 0.25], so sleep must be in [1.0, 1.25]
+    # Each sleep must be exactly base_wait (1.0) + fixed jitter (0.15) = 1.15
     assert len(sleep_durations) >= 3, f"Expected at least 3 sleeps; got {len(sleep_durations)}"
     for dur in sleep_durations:
-        assert 1.0 <= dur <= 1.26, f"Sleep {dur:.3f} outside expected [1.0, 1.25] range"
+        assert dur == pytest.approx(1.0 + _fixed_jitter), (
+            f"Sleep {dur:.3f} != expected {1.0 + _fixed_jitter:.3f}; jitter may not be applied"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -1055,4 +1066,51 @@ async def test_send_once_deadline_sleep_happens_before_get_token() -> None:
     assert first_sleep_idx < second_token_idx, (
         f"Deadline sleep ({first_sleep_idx}) must precede second get_token ({second_token_idx}); "
         f"log={event_log}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# _pause_until extended mid-sleep triggers a second sleep (while-loop guard)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_once_re_sleeps_when_pause_until_extended_mid_sleep() -> None:
+    """_send_once must re-check _pause_until after waking and sleep again if extended.
+
+    Regression for the original single-if implementation: if a concurrent coroutine
+    extends _pause_until while this coroutine is sleeping, the while loop must
+    detect the remaining time and sleep again rather than proceeding immediately.
+    """
+    sleep_durations: list[float] = []
+    original_sleep = asyncio.sleep
+
+    call_count = 0
+
+    async def mock_sleep(seconds: float) -> None:
+        nonlocal call_count
+        sleep_durations.append(seconds)
+        # On the first deadline sleep, extend _pause_until by an extra 0.1s
+        # to simulate a concurrent coroutine updating the shared deadline.
+        if len(sleep_durations) == 1 and seconds > 0:
+            client._pause_until = client._pause_until + 0.1
+        await original_sleep(0)  # Don't actually wait in tests
+
+    with respx.mock:
+        respx.get("https://api.fabric.microsoft.com/v1/items").mock(
+            return_value=httpx.Response(200, json={"ok": True})
+        )
+
+        client = FabricHttpClient(credential=_make_credential(), rps=10)
+        async with client:
+            # Pre-set a deadline in the future so _send_once will enter the while loop
+            client._pause_until = time.monotonic() + 0.05
+            with unittest.mock.patch("asyncio.sleep", side_effect=mock_sleep):
+                resp = await client.request("GET", HttpBase.FABRIC, "/items")
+
+    assert resp.status_code == 200
+    # The while loop must have produced at least 2 deadline sleeps:
+    # once for the original deadline, once after _pause_until was extended.
+    assert len(sleep_durations) >= 2, (
+        f"Expected >=2 sleeps (original + extended deadline); got {sleep_durations}"
     )

--- a/tests/unit/test_http_client.py
+++ b/tests/unit/test_http_client.py
@@ -929,3 +929,130 @@ async def test_poll_operation_jitter_within_bounds() -> None:
     assert len(sleep_durations) >= 3, f"Expected at least 3 sleeps; got {len(sleep_durations)}"
     for dur in sleep_durations:
         assert 1.0 <= dur <= 1.26, f"Sleep {dur:.3f} outside expected [1.0, 1.25] range"
+
+
+# ---------------------------------------------------------------------------
+# Garbage Retry-After header (regression: must not crash)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_429_with_garbage_retry_after_falls_back_and_succeeds() -> None:
+    """A malformed Retry-After value must NOT raise ValueError.
+
+    The 429 loop must catch the parse error, fall back to 1.0s,
+    log a warning, and then retry — succeeding on the next response.
+    """
+    call_count = 0
+
+    def side_effect(_request: httpx.Request) -> httpx.Response:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return httpx.Response(429, headers={"Retry-After": "garbage"}, json={})
+        return httpx.Response(200, json={"ok": True})
+
+    with respx.mock:
+        respx.get("https://api.fabric.microsoft.com/v1/items").mock(side_effect=side_effect)
+
+        client = FabricHttpClient(credential=_make_credential(), rps=10)
+        async with client:
+            resp = await client.request("GET", HttpBase.FABRIC, "/items")
+
+    # Must succeed (no ValueError propagated)
+    assert resp.status_code == 200
+    assert call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_429_garbage_retry_after_emits_warning(caplog: pytest.LogCaptureFixture) -> None:
+    """A malformed Retry-After must emit a WARNING log with the raw header value."""
+    call_count = 0
+
+    def side_effect(_request: httpx.Request) -> httpx.Response:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return httpx.Response(429, headers={"Retry-After": "soon"}, json={})
+        return httpx.Response(200, json={})
+
+    with respx.mock:
+        respx.get("https://api.fabric.microsoft.com/v1/items").mock(side_effect=side_effect)
+
+        client = FabricHttpClient(credential=_make_credential(), rps=10)
+        async with client:
+            with caplog.at_level(logging.WARNING, logger="fabric_dw.http"):
+                await client.request("GET", HttpBase.FABRIC, "/items")
+
+    warning_records = [
+        r for r in caplog.records if r.levelno == logging.WARNING and r.name == "fabric_dw.http"
+    ]
+    assert len(warning_records) >= 1, f"No WARNING emitted; records={caplog.records}"
+    assert "soon" in warning_records[0].getMessage(), (
+        f"Raw header value not in warning: {warning_records[0].getMessage()}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Token fetch ordering: deadline wait BEFORE token fetch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_once_deadline_sleep_happens_before_get_token() -> None:
+    """_send_once must sleep for the pause deadline BEFORE calling _get_token.
+
+    We monkeypatch _send_once internals by tracking call order via a shared
+    event log: asyncio.sleep records when it's called; _get_token records
+    when it's called.  The sleep entry must precede the get_token entry.
+    """
+    event_log: list[str] = []
+
+    original_get_token = FabricHttpClient._get_token  # type: ignore[attr-defined]
+    original_sleep = asyncio.sleep
+
+    async def tracking_get_token(self: FabricHttpClient) -> str:
+        event_log.append("get_token")
+        return await original_get_token(self)
+
+    async def tracking_sleep(seconds: float) -> None:
+        if seconds > 0:
+            event_log.append(f"sleep:{seconds:.2f}")
+        await original_sleep(0)  # Don't actually wait in tests
+
+    call_count = 0
+
+    def side_effect(_request: httpx.Request) -> httpx.Response:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return httpx.Response(429, headers={"Retry-After": "0.05"}, json={})
+        return httpx.Response(200, json={"ok": True})
+
+    with respx.mock:
+        respx.get("https://api.fabric.microsoft.com/v1/items").mock(side_effect=side_effect)
+
+        client = FabricHttpClient(credential=_make_credential(), rps=10)
+        async with client:
+            with (
+                unittest.mock.patch.object(FabricHttpClient, "_get_token", tracking_get_token),
+                unittest.mock.patch("asyncio.sleep", side_effect=tracking_sleep),
+            ):
+                resp = await client.request("GET", HttpBase.FABRIC, "/items")
+
+    assert resp.status_code == 200
+    assert call_count == 2
+
+    # Verify ordering: the deadline sleep must appear BEFORE the second get_token call
+    sleep_events = [e for e in event_log if e.startswith("sleep:")]
+    token_events = [e for e in event_log if e == "get_token"]
+
+    assert len(sleep_events) >= 1, f"Expected at least one deadline sleep; log={event_log}"
+    assert len(token_events) >= 2, f"Expected >=2 get_token calls in log={event_log}"
+
+    first_sleep_idx = next(i for i, e in enumerate(event_log) if e.startswith("sleep:"))
+    second_token_idx = [i for i, e in enumerate(event_log) if e == "get_token"][1]
+    assert first_sleep_idx < second_token_idx, (
+        f"Deadline sleep ({first_sleep_idx}) must precede second get_token ({second_token_idx}); "
+        f"log={event_log}"
+    )

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -72,3 +72,84 @@ class TestRedactAuthHeader:
         result = redact_auth_header(headers)
         # Non-bearer tokens are left as-is (only Bearer is a concern for this codebase)
         assert result["Authorization"] == "Basic dXNlcjpwYXNz"
+
+
+class TestJsonFormatterExtraFields:
+    """Tests for extra= field propagation in _JsonFormatter."""
+
+    def _make_record(self, msg: str = "hello", extra: dict | None = None) -> logging.LogRecord:
+        logger = logging.getLogger("fabric_dw.test_extra")
+        return logger.makeRecord(
+            name="fabric_dw.test_extra",
+            level=logging.DEBUG,
+            fn="test_file.py",
+            lno=1,
+            msg=msg,
+            args=(),
+            exc_info=None,
+            extra=extra,
+        )
+
+    def test_extra_string_field_included(self) -> None:
+        """A string extra field must appear in the formatted JSON output."""
+        formatter = _JsonFormatter()
+        record = self._make_record(extra={"workspace_id": "ws-abc"})
+        parsed = json.loads(formatter.format(record))
+        assert "workspace_id" in parsed, f"workspace_id missing from {parsed}"
+        assert parsed["workspace_id"] == "ws-abc"
+
+    def test_extra_int_field_included(self) -> None:
+        """An integer extra field must appear in the formatted JSON output."""
+        formatter = _JsonFormatter()
+        record = self._make_record(extra={"count": 42})
+        parsed = json.loads(formatter.format(record))
+        assert parsed.get("count") == 42
+
+    def test_extra_non_standard_field_named_level_does_not_overwrite_core_key(self) -> None:
+        """An extra field named 'level' that is NOT a standard LogRecord attr must not
+        overwrite the core 'level' key in the JSON payload.
+
+        We use a custom attribute name that happens to collide with a payload key but
+        is not in _STANDARD_LOGRECORD_ATTRS.  We simulate this by injecting a key that
+        is definitely not standard and checking that core keys are preserved.
+        """
+        formatter = _JsonFormatter()
+        # Inject a non-standard attribute that would collide with 'level' if the guard
+        # were missing.  We use '_custom_level' since 'level' is a payload key we compute.
+        # The real protection: extras loop does `if key not in payload`.
+        record = self._make_record(msg="real message", extra={"workspace_id": "ws-123"})
+        parsed = json.loads(formatter.format(record))
+        # Core keys must retain their proper values
+        assert parsed["level"] == "DEBUG"
+        assert parsed["msg"] == "real message"
+        # The extra must appear
+        assert parsed.get("workspace_id") == "ws-123"
+
+    def test_non_serialisable_extra_coerced_to_str(self) -> None:
+        """Non-JSON-serialisable extra values must be coerced to str, not raise."""
+        formatter = _JsonFormatter()
+
+        class Unserializable:
+            def __repr__(self) -> str:
+                return "Unserializable()"
+
+        record = self._make_record(extra={"obj": Unserializable()})
+        # Must not raise
+        output = formatter.format(record)
+        parsed = json.loads(output)
+        assert "obj" in parsed
+        assert isinstance(parsed["obj"], str)
+
+    def test_no_extra_fields_still_valid_json(self) -> None:
+        """A record with no extra fields still produces valid JSON with core keys."""
+        formatter = _JsonFormatter()
+        record = self._make_record()
+        parsed = json.loads(formatter.format(record))
+        assert set(parsed.keys()) >= {"level", "name", "msg", "time"}
+
+    def test_extra_request_id_lands_in_json(self) -> None:
+        """The request_id extra used by http_client must appear in JSON output."""
+        formatter = _JsonFormatter()
+        record = self._make_record(extra={"request_id": "fabric-req-id-001"})
+        parsed = json.loads(formatter.format(record))
+        assert parsed.get("request_id") == "fabric-req-id-001"

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -106,24 +106,22 @@ class TestJsonFormatterExtraFields:
         assert parsed.get("count") == 42
 
     def test_extra_non_standard_field_named_level_does_not_overwrite_core_key(self) -> None:
-        """An extra field named 'level' that is NOT a standard LogRecord attr must not
-        overwrite the core 'level' key in the JSON payload.
+        """An extra field named 'level' must not overwrite the core 'level' payload key.
 
-        We use a custom attribute name that happens to collide with a payload key but
-        is not in _STANDARD_LOGRECORD_ATTRS.  We simulate this by injecting a key that
-        is definitely not standard and checking that core keys are preserved.
+        'level' is NOT in _STANDARD_LOGRECORD_ATTRS (only 'levelname' is), so it
+        reaches the extras merge loop.  The guard ``if key not in payload`` must
+        prevent it from clobbering the real level value derived from levelname.
         """
         formatter = _JsonFormatter()
-        # Inject a non-standard attribute that would collide with 'level' if the guard
-        # were missing.  We use '_custom_level' since 'level' is a payload key we compute.
-        # The real protection: extras loop does `if key not in payload`.
-        record = self._make_record(msg="real message", extra={"workspace_id": "ws-123"})
+        # Inject a colliding 'level' key via extra — this is NOT a standard LogRecord
+        # attribute, so the extras loop will encounter it.  The guard must block it.
+        record = self._make_record(msg="real message", extra={"level": "EVIL"})
         parsed = json.loads(formatter.format(record))
-        # Core keys must retain their proper values
-        assert parsed["level"] == "DEBUG"
+        # Core key must retain the real level, not "EVIL"
+        assert parsed["level"] == "DEBUG", (
+            f"Guard failed: level was overwritten to {parsed['level']!r}"
+        )
         assert parsed["msg"] == "real message"
-        # The extra must appear
-        assert parsed.get("workspace_id") == "ws-123"
 
     def test_non_serialisable_extra_coerced_to_str(self) -> None:
         """Non-JSON-serialisable extra values must be coerced to str, not raise."""


### PR DESCRIPTION
## Summary

- **`exceptions.py`**: `FabricError` gains keyword-only `status`, `request_id`, `body`, `hint` attributes. `__str__` appends `\nHint: {hint}` and ` (request-id: …)` when set. All subclasses remain unchanged and existing call sites still compile (new params are optional).
- **`http_client.py`**: `_do_request` split into `_send_once` (token fetch → deadline wait → limiter → send) and `_map_status` (dict lookup + 5xx branch with enriched exceptions). `_pause_event` race replaced by `_pause_until: float` monotonic deadline aggregated with `max()` across concurrent 429s. Token fetch moved before the rate-limiter. `_STATUS_TO_EXC` dict + `http.HTTPStatus` constants eliminate the `PLR2004` `noqa` chain. Magic numbers promoted to constructor kwargs (`rps`, `timeout`, `max_429_retries`, `poll_interval`, `token_refresh_buffer`); `timeout` wired into `httpx.AsyncClient`. `x-ms-request-id` logged at DEBUG level via `extra=`. `poll_operation` adds jitter (`base + uniform(0, base * 0.25)`). Class/method docstrings document the tenacity × 429-loop retry arithmetic.
- **`logging.py`**: `_JsonFormatter` computes `_STANDARD_LOGRECORD_ATTRS` from a fresh `LogRecord` instance, then merges non-standard keys from `record.__dict__` into the JSON payload without overwriting core keys. `json.dumps(default=str)` handles non-serialisable values.

## Findings addressed

| Finding file | Fix |
|---|---|
| `02-core-exceptions-no-context-data.md` | `FabricError` keyword-only `status`, `request_id`, `body`, `hint`; subclasses pass through unchanged |
| `02-core-http-client-do-request-mixes-concerns.md` | `_do_request` → `_send_once` + `_map_status` |
| `02-core-http-client-pause-event-race.md` | `_pause_event` replaced by `_pause_until` monotonic deadline with `max()` aggregation |
| `02-core-http-client-token-fetch-inside-limiter.md` | `_get_token()` called before `async with self._limiter:` in `_send_once` |
| `02-core-http-client-status-chain-instead-of-map.md` | `_STATUS_TO_EXC: dict[int, type[FabricError]]` + `http.HTTPStatus` constants |
| `02-core-http-client-magic-numbers.md` | All five defaults promoted to constructor kwargs with module-level constant defaults |
| `02-core-http-client-no-correlation-id.md` | `x-ms-request-id` captured in `_send_once` DEBUG log via `extra={"request_id": …}` |
| `02-core-http-client-no-jitter.md` | `poll_operation` sleep = `base_wait + random.uniform(0, base_wait * 0.25)` |
| `02-core-logging-no-extra-fields-no-context.md` | `_JsonFormatter` merges `extra=` fields via `_STANDARD_LOGRECORD_ATTRS` filter |

## Decisions

- `_pause_until` is a plain `float` (no lock) because asyncio is single-threaded; concurrent coroutines race to `max()` but the GIL makes the float write atomic.
- `contextvars` support (trace_id from the review) deferred: the current `extra=` propagation already covers the `request_id` case; a context-var filter can be added in a follow-up without touching the formatter signature.
- Jitter uses `random.uniform` (stdlib, non-crypto); `S311` suppressed with `# noqa` since this is not a security-sensitive use.
- `except Exception: pass` in `_map_status` body-parse gets `# noqa: S110` (same intent as the original `BLE001`).

## Test results

```
1027 passed, 1 warning in 14.53s
```

ruff check ✓ · ruff format --check ✓ · ty check ✓ · pytest tests/unit ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)