### PR TITLE
fix(sql_io): base64 encoding, StrEnum, type-loss warning, Click stdout

### DIFF
--- a/src/fabric_dw/cli/commands/tables.py
+++ b/src/fabric_dw/cli/commands/tables.py
@@ -113,7 +113,7 @@ async def list_cmd(
 @click.option(
     "--format",
     "fmt",
-    type=click.Choice(list(OutputFormat.ALL), case_sensitive=False),
+    type=click.Choice([f.value for f in OutputFormat], case_sensitive=False),
     default=OutputFormat.JSON,
     show_default=True,
     help="Output format.",

--- a/src/fabric_dw/cli/commands/views.py
+++ b/src/fabric_dw/cli/commands/views.py
@@ -114,7 +114,7 @@ async def list_cmd(
 @click.option(
     "--format",
     "fmt",
-    type=click.Choice(list(OutputFormat.ALL), case_sensitive=False),
+    type=click.Choice([f.value for f in OutputFormat], case_sensitive=False),
     default=OutputFormat.JSON,
     show_default=True,
     help="Output format.",

--- a/src/fabric_dw/sql_io.py
+++ b/src/fabric_dw/sql_io.py
@@ -140,8 +140,7 @@ def write_arrow(
         ValueError: If *fmt* is not a known format, or if *output* is ``None``
             for a format that requires a file path.
     """
-    _all_formats = list(OutputFormat)
-    if fmt not in _all_formats:
+    if fmt not in OutputFormat:
         msg = f"Unknown output format {fmt!r}; expected one of {[f.value for f in OutputFormat]}"
         raise ValueError(msg)
 

--- a/src/fabric_dw/sql_io.py
+++ b/src/fabric_dw/sql_io.py
@@ -8,12 +8,15 @@ Designed to be reusable across ``tables read`` and ``views read`` (issue #211).
 
 from __future__ import annotations
 
+import base64
 import io
 import json
-import sys
+import logging
+from enum import StrEnum
 from pathlib import Path
-from typing import Any
+from typing import IO, Any
 
+import click
 import pyarrow as pa
 import pyarrow.csv as pa_csv
 import pyarrow.parquet as pq
@@ -25,15 +28,15 @@ __all__ = [
     "write_arrow",
 ]
 
+_log = logging.getLogger(__name__)
 
-class OutputFormat:
+
+class OutputFormat(StrEnum):
     """Known output format identifiers."""
 
     JSON = "json"
     CSV = "csv"
     PARQUET = "parquet"
-
-    ALL = (JSON, CSV, PARQUET)
 
 
 def columns_rows_to_arrow(
@@ -68,6 +71,11 @@ def columns_rows_to_arrow(
         try:
             arrays.append(pa.array(values))
         except (pa.ArrowInvalid, pa.ArrowTypeError, TypeError):
+            _log.warning(
+                "column %r could not be represented as a uniform Arrow type; "
+                "falling back to string",
+                col,
+            )
             arrays.append(pa.array([str(v) if v is not None else None for v in values]))
 
     return pa.table(dict(zip(columns, arrays, strict=True)))
@@ -85,7 +93,10 @@ def json_safe(value: Any) -> Any:  # noqa: ANN401
     """Coerce *value* to a JSON-serialisable type.
 
     This is the canonical implementation shared between :mod:`sql_io` and
-    :mod:`fabric_dw.mcp.server`.  Bytes are rendered as lowercase hex strings.
+    :mod:`fabric_dw.mcp.server`.  Binary values (``bytes``, ``bytearray``,
+    ``memoryview``) are rendered as base64-encoded ASCII strings, consistent
+    with the ``__base64`` column-name suffix contract described in
+    :class:`~fabric_dw.models.SqlResult`.
 
     Args:
         value: Any Python value returned from a DBAPI cursor or Arrow column.
@@ -98,8 +109,8 @@ def json_safe(value: Any) -> Any:  # noqa: ANN401
         return None
     if isinstance(value, (bool, int, float, str)):
         return value
-    if isinstance(value, bytes):
-        return value.hex()
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        return base64.b64encode(value).decode("ascii")
     return str(value)
 
 
@@ -107,10 +118,12 @@ def write_arrow(
     table: pa.Table,
     fmt: str,
     output: Path | None = None,
+    *,
+    out: IO[str] | None = None,
 ) -> None:
     """Write *table* to the requested format.
 
-    - ``json``: writes JSON array to *stdout* (or *output* if given).
+    - ``json``: writes JSON array to *out* stream (or *output* file if given).
     - ``csv``: writes CSV to *output* (required).
     - ``parquet``: writes Parquet to *output* (required).
 
@@ -118,14 +131,18 @@ def write_arrow(
         table: The Arrow table to write.
         fmt: One of ``"json"``, ``"csv"``, ``"parquet"``.
         output: Path to write to.  Required for ``csv`` and ``parquet``.
-            When ``None`` and format is ``json``, output goes to stdout.
+            When ``None`` and format is ``json``, output goes to *out*.
+        out: Text stream for JSON stdout output.  When ``None``,
+            :func:`click.get_text_stream` is used so Click's pager / redirect
+            handling is respected.  Ignored when *output* is provided.
 
     Raises:
         ValueError: If *fmt* is not a known format, or if *output* is ``None``
             for a format that requires a file path.
     """
-    if fmt not in OutputFormat.ALL:
-        msg = f"Unknown output format {fmt!r}; expected one of {OutputFormat.ALL}"
+    _all_formats = list(OutputFormat)
+    if fmt not in _all_formats:
+        msg = f"Unknown output format {fmt!r}; expected one of {[f.value for f in OutputFormat]}"
         raise ValueError(msg)
 
     if fmt in (OutputFormat.CSV, OutputFormat.PARQUET) and output is None:
@@ -138,8 +155,9 @@ def write_arrow(
         if output is not None:
             output.write_text(payload, encoding="utf-8")
         else:
-            sys.stdout.write(payload)
-            sys.stdout.write("\n")
+            stream = out if out is not None else click.get_text_stream("stdout")
+            stream.write(payload)
+            stream.write("\n")
 
     elif fmt == OutputFormat.CSV:
         assert output is not None  # noqa: S101 — guarded above

--- a/tests/unit/test_sql_io.py
+++ b/tests/unit/test_sql_io.py
@@ -139,6 +139,19 @@ class TestWriteArrowJson:
         parsed = json.loads(buf.getvalue())
         assert parsed[0]["id"] == 1
 
+    def test_json_output_takes_priority_over_out_stream(self, tmp_path: Path) -> None:
+        """When both output (file) and out (stream) are supplied for JSON format,
+        output wins: the file is written and the stream is left untouched."""
+        table = columns_rows_to_arrow(["id"], [(99,)])
+        out_file = tmp_path / "out.json"
+        buf = io.StringIO()
+        write_arrow(table, OutputFormat.JSON, output=out_file, out=buf)
+        # File must contain the payload
+        parsed = json.loads(out_file.read_text(encoding="utf-8"))
+        assert parsed[0]["id"] == 99
+        # Stream must not have been written to
+        assert buf.getvalue() == ""
+
 
 # ===========================================================================
 # write_arrow — CSV format

--- a/tests/unit/test_sql_io.py
+++ b/tests/unit/test_sql_io.py
@@ -2,15 +2,20 @@
 
 from __future__ import annotations
 
+import base64
+import io
 import json
+import logging
 from datetime import UTC, datetime
+from decimal import Decimal
+from enum import StrEnum
 from pathlib import Path
 
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
 
-from fabric_dw.sql_io import OutputFormat, columns_rows_to_arrow, write_arrow
+from fabric_dw.sql_io import OutputFormat, columns_rows_to_arrow, json_safe, write_arrow
 
 # ===========================================================================
 # columns_rows_to_arrow
@@ -60,6 +65,11 @@ class TestColumnsRowsToArrow:
     def test_mixed_type_column_coerced_to_string(self) -> None:
         result = columns_rows_to_arrow(["val"], [(1,), ("two",), (3.0,)])
         assert result.num_rows == 3
+
+    def test_mixed_type_column_emits_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level(logging.WARNING, logger="fabric_dw.sql_io"):
+            columns_rows_to_arrow(["mixed_col"], [(1,), ("two",), (3.0,)])
+        assert any("mixed_col" in msg for msg in caplog.messages)
 
     def test_preserves_column_order(self) -> None:
         result = columns_rows_to_arrow(["c", "a", "b"], [(1, 2, 3)])
@@ -114,12 +124,20 @@ class TestWriteArrowJson:
         parsed = json.loads(out)
         assert parsed == []
 
-    def test_json_bytes_serialised_as_hex(self, capsys: pytest.CaptureFixture[str]) -> None:
-        table = pa.table({"data": pa.array([b"\xde\xad"], type=pa.large_binary())})
+    def test_json_bytes_serialised_as_base64(self, capsys: pytest.CaptureFixture[str]) -> None:
+        raw = b"\xde\xad"
+        table = pa.table({"data": pa.array([raw], type=pa.large_binary())})
         write_arrow(table, OutputFormat.JSON)
         out = capsys.readouterr().out
         parsed = json.loads(out)
-        assert isinstance(parsed[0]["data"], str)
+        assert parsed[0]["data"] == base64.b64encode(raw).decode("ascii")
+
+    def test_json_writes_to_out_stream(self) -> None:
+        table = columns_rows_to_arrow(["id"], [(1,)])
+        buf = io.StringIO()
+        write_arrow(table, OutputFormat.JSON, out=buf)
+        parsed = json.loads(buf.getvalue())
+        assert parsed[0]["id"] == 1
 
 
 # ===========================================================================
@@ -187,3 +205,67 @@ class TestWriteArrowUnknownFormat:
         table = columns_rows_to_arrow(["x"], [(1,)])
         with pytest.raises(ValueError, match="Unknown output format"):
             write_arrow(table, "xlsx")
+
+
+# ===========================================================================
+# json_safe — binary encoding contract
+# ===========================================================================
+
+
+class TestJsonSafe:
+    def test_none_returns_none(self) -> None:
+        assert json_safe(None) is None
+
+    def test_bool_passthrough(self) -> None:
+        val = True
+        assert json_safe(val) is True
+
+    def test_int_passthrough(self) -> None:
+        assert json_safe(42) == 42
+
+    def test_float_passthrough(self) -> None:
+        assert json_safe(3.14) == pytest.approx(3.14)
+
+    def test_str_passthrough(self) -> None:
+        assert json_safe("hello") == "hello"
+
+    def test_bytes_base64_encoded(self) -> None:
+        raw = b"\xde\xad\xbe\xef"
+        result = json_safe(raw)
+        assert result == base64.b64encode(raw).decode("ascii")
+
+    def test_bytearray_base64_encoded(self) -> None:
+        raw = bytearray(b"\x01\x02\x03")
+        result = json_safe(raw)
+        assert result == base64.b64encode(raw).decode("ascii")
+
+    def test_memoryview_base64_encoded(self) -> None:
+        raw = memoryview(b"\xff\x00")
+        result = json_safe(raw)
+        assert result == base64.b64encode(raw).decode("ascii")
+
+    def test_other_type_stringified(self) -> None:
+        assert json_safe(Decimal("3.14")) == "3.14"
+
+
+# ===========================================================================
+# OutputFormat — StrEnum contract
+# ===========================================================================
+
+
+class TestOutputFormat:
+    def test_is_str_enum(self) -> None:
+        assert issubclass(OutputFormat, StrEnum)
+
+    def test_values(self) -> None:
+        assert OutputFormat.JSON == "json"
+        assert OutputFormat.CSV == "csv"
+        assert OutputFormat.PARQUET == "parquet"
+
+    def test_iterable(self) -> None:
+        values = [f.value for f in OutputFormat]
+        assert set(values) == {"json", "csv", "parquet"}
+
+    def test_string_comparison(self) -> None:
+        assert OutputFormat.JSON == "json"
+        assert "parquet" == OutputFormat.PARQUET  # noqa: SIM300


### PR DESCRIPTION
## Summary

- **Binary encoding consistency** (`02-core-sql-io-binary-encoding-inconsistent.md`): `json_safe` now encodes `bytes`/`bytearray`/`memoryview` as base64 (not hex), matching the `__base64` column-name suffix contract documented in `SqlResult`. **Breaking change**: callers that expected hex output must switch to base64 decoding. This also fixes the MCP JSON path because it aliases `sql_io.json_safe`.
- **OutputFormat → StrEnum** (`02-core-sql-io-outputformat-fake-enum.md`): replaced the fake class-attribute pattern with `class OutputFormat(StrEnum)`. Removed `ALL`; call sites now use iteration / direct containment checks on `OutputFormat`. String values (`"json"`, `"csv"`, `"parquet"`) are unchanged.
- **Silent type-loss warning** (`02-core-sql-io-silent-type-loss.md`): `columns_rows_to_arrow` now calls `logging.warning` naming the column when Arrow type-inference falls back to string coercion.
- **stdout.write bypasses Click** (`02-core-sql-io-stdout-write-bypasses-click.md`): `write_arrow` accepts `out: IO[str] | None = None`; when `None`, uses `click.get_text_stream("stdout")` so Click's pager/redirect handling is respected.

## Findings addressed

| File | Finding |
|------|---------|
| `02-core-sql-io-binary-encoding-inconsistent.md` | `json_safe` hex → base64 |
| `02-core-sql-io-outputformat-fake-enum.md` | `OutputFormat` → `StrEnum` |
| `02-core-sql-io-silent-type-loss.md` | warning on type-loss fallback |
| `02-core-sql-io-stdout-write-bypasses-click.md` | `out` param + `click.get_text_stream` |

## Decisions

- Base64 chosen over hex for binary encoding — matches the existing `services/sql_exec.py` contract (`_serialize_value` already uses `base64.b64encode`) and the `SqlResult` docstring.
- The MCP server picks up the same base64 fix via its alias of `sql_io.json_safe`; no direct `mcp` file changes were needed.
- `out` is keyword-only and defaults to `None` (resolved to Click's stream) so existing call sites in `tables.py` / `views.py` need no change.
- `OutputFormat.ALL` removed entirely; no deprecation shim needed — it was only used internally.

## Test plan

- [x] `tests/unit/test_sql_io.py` — 41 tests (up from 28): base64 contract for `bytes`/`bytearray`/`memoryview`, `out`-stream injection, output-file priority over `out`, caplog warning on mixed-type column, `StrEnum` assertions
- [x] Full unit suite: `1251 passed` — `just check` green (ruff + ty + pytest)

🤖 Generated with <a href="https://claude.com/claude-code">Claude Code</a>