### PR TITLE
refactor(models): StrEnum, model_validator flattening, registry, as_props helper

### DIFF
--- a/src/fabric_dw/models.py
+++ b/src/fabric_dw/models.py
@@ -659,8 +659,6 @@ class WarehouseSnapshotApiPayload(_FabricBase):
     parent_warehouse_id: str | None = Field(default=None, alias="parentWarehouseId")
     snapshot_date_time: str | None = Field(default=None, alias="snapshotDateTime")
 
-    model_config = ConfigDict(extra="ignore", frozen=False, populate_by_name=True)
-
     @classmethod
     def props_from_item(cls, item: dict[str, object]) -> WarehouseSnapshotApiPayload:
         """Parse the ``properties`` sub-object of a snapshot API item response.

--- a/src/fabric_dw/models.py
+++ b/src/fabric_dw/models.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from datetime import datetime
 from enum import StrEnum
-from typing import Annotated, Literal, cast
+from typing import Annotated, Any, Literal, cast
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
@@ -50,41 +51,65 @@ class Warehouse(_FabricBase):
     collation: str | None = Field(default=None, alias="defaultCollation")
     created_date: datetime | None = Field(default=None, alias="createdDate")
 
+    @model_validator(mode="before")
+    @classmethod
+    def _flatten_api_payload(cls, data: object) -> object:
+        """Flatten nested ``properties`` to top-level Pydantic fields.
+
+        Picks up the connection string from the correct nested path depending
+        on the ``kind`` field (WAREHOUSE uses ``properties.connectionString``;
+        SQL_ENDPOINT uses ``properties.sqlEndpointProperties.connectionString``).
+
+        If ``data`` is already a flat dict (e.g. already processed or assembled
+        manually), the properties-flattening is skipped so the standard
+        Pydantic constructor path keeps working.
+        """
+        if not isinstance(data, dict):
+            return data
+        d = cast("_AnyDict", data)
+        if "properties" not in d:
+            # Already flat (or manually constructed without properties key).
+            return d
+
+        props = d.get("properties")
+        props_dict: dict[str, Any] = props if isinstance(props, dict) else {}
+
+        kind_val = d.get("kind")
+        conn_string: Any = None
+        if kind_val in {WarehouseKind.WAREHOUSE, WarehouseKind.WAREHOUSE.value}:
+            conn_string = props_dict.get("connectionString")
+        elif kind_val in {WarehouseKind.SQL_ENDPOINT, WarehouseKind.SQL_ENDPOINT.value}:
+            sql_ep = props_dict.get("sqlEndpointProperties")
+            sql_ep_dict: dict[str, Any] = sql_ep if isinstance(sql_ep, dict) else {}
+            conn_string = sql_ep_dict.get("connectionString")
+        # For SNAPSHOT kind or unknown kinds, conn_string stays None.
+
+        return {
+            **d,
+            "connectionString": d.get("connectionString", conn_string),
+            "defaultCollation": d.get("defaultCollation", props_dict.get("defaultCollation")),
+            "createdDate": d.get("createdDate", props_dict.get("createdDate")),
+        }
+
     @classmethod
     def from_api(cls, payload: dict[str, object], kind: WarehouseKind) -> Warehouse:
         """Build a Warehouse from a raw API response dict.
 
+        .. deprecated::
+            Prefer ``Warehouse.model_validate({**payload, "kind": kind})`` directly.
+            This shim delegates to :meth:`model_validate` and is kept for
+            backward compatibility with existing call sites.
+
         Picks up the connection string from the correct nested properties path
         depending on whether the item is a WAREHOUSE or SQL_ENDPOINT.
-        """
-        _raw_props = payload.get("properties")
-        props: dict[str, object] = (
-            cast("dict[str, object]", _raw_props) if isinstance(_raw_props, dict) else {}
-        )
 
-        if kind == WarehouseKind.WAREHOUSE:
-            conn_string = props.get("connectionString")
-        elif kind == WarehouseKind.SQL_ENDPOINT:
-            _raw_sql_ep = props.get("sqlEndpointProperties")
-            sql_ep: dict[str, object] = (
-                cast("dict[str, object]", _raw_sql_ep) if isinstance(_raw_sql_ep, dict) else {}
-            )
-            conn_string = sql_ep.get("connectionString")
-        else:
+        Raises:
+            ValueError: If *kind* is :attr:`WarehouseKind.SNAPSHOT`.
+        """
+        if kind == WarehouseKind.SNAPSHOT:
             msg = f"from_api does not support kind={kind}"
             raise ValueError(msg)
-
-        flat: dict[str, object] = {
-            "id": payload.get("id"),
-            "displayName": payload.get("displayName"),
-            "description": payload.get("description"),
-            "workspaceId": payload.get("workspaceId"),
-            "kind": kind,
-            "connectionString": conn_string,
-            "defaultCollation": props.get("defaultCollation"),
-            "createdDate": props.get("createdDate"),
-        }
-        return cls.model_validate(flat)
+        return cls.model_validate({**payload, "kind": kind})
 
 
 class WarehouseSnapshot(_FabricBase):
@@ -96,18 +121,18 @@ class WarehouseSnapshot(_FabricBase):
     snapshot_dt: datetime | None = Field(default=None, alias="snapshotDateTime")
 
 
-class CreationModeType:
+class CreationModeType(StrEnum):
     """Known values for the ``creationMode`` field of a :class:`RestorePoint`.
 
-    MS Learn notes that additional creation mode types may be added over time,
-    so this is an **open** set of constants rather than a closed ``StrEnum``.
-    The ``creation_mode`` field on :class:`RestorePoint` is typed as ``str | None``
-    so that future unknown values and API responses with null fields pass
-    Pydantic validation without error.
+    This is an **open** enum — MS Learn notes that additional creation mode
+    types may be added over time.  The ``creation_mode`` field on
+    :class:`RestorePoint` is typed as ``str | None`` so that future unknown
+    values and API responses with null fields pass Pydantic validation without
+    error.  Use these constants when you need to compare against known values.
     """
 
-    USER_DEFINED: str = "UserDefined"
-    SYSTEM_CREATED: str = "SystemCreated"
+    USER_DEFINED = "UserDefined"
+    SYSTEM_CREATED = "SystemCreated"
 
 
 class RestorePoint(_FabricBase):
@@ -124,25 +149,34 @@ class RestorePoint(_FabricBase):
     creation_mode: str | None = Field(default=None, alias="creationMode")
     event_date_time: datetime | None = Field(default=None, alias="eventDateTime")
 
+    @model_validator(mode="before")
+    @classmethod
+    def _flatten_creation_details(cls, data: object) -> object:
+        """Flatten ``creationDetails.eventDateTime`` to the top level.
+
+        If ``eventDateTime`` is already present at the top level (e.g. when
+        calling :meth:`model_validate` directly on an already-flat dict), the
+        existing value is preserved.
+        """
+        if not isinstance(data, dict):
+            return data
+        d = cast("_AnyDict", data)
+        if "eventDateTime" in d or "creationDetails" not in d:
+            return d
+        details = d.get("creationDetails")
+        details_dict: dict[str, Any] = details if isinstance(details, dict) else {}
+        return {**d, "eventDateTime": details_dict.get("eventDateTime")}
+
     @classmethod
     def from_api(cls, payload: dict[str, object]) -> RestorePoint:
         """Build a RestorePoint from the raw API response dict.
 
-        Flattens ``creationDetails.eventDateTime`` to the top level so the
-        standard Pydantic ``model_validate`` path can handle it.
+        .. deprecated::
+            Prefer ``RestorePoint.model_validate(payload)`` directly.
+            This shim delegates to :meth:`model_validate` and is kept for
+            backward compatibility with existing call sites.
         """
-        _raw_details = payload.get("creationDetails")
-        details: dict[str, object] = (
-            cast("dict[str, object]", _raw_details) if isinstance(_raw_details, dict) else {}
-        )
-        flat: dict[str, object] = {
-            "id": payload.get("id"),
-            "displayName": payload.get("displayName"),
-            "description": payload.get("description"),
-            "creationMode": payload.get("creationMode"),
-            "eventDateTime": details.get("eventDateTime"),
-        }
-        return cls.model_validate(flat)
+        return cls.model_validate(payload)
 
 
 class AuditSettings(_FabricBase):
@@ -189,24 +223,36 @@ class Connection(_FabricBase):
 
 
 class ExecRequestHistory(_FabricBase):
-    """A completed SQL request from ``queryinsights.exec_requests_history``."""
+    """A completed SQL request from ``queryinsights.exec_requests_history``.
 
+    .. note::
+        This model is an intentional 1-to-1 projection of the DMV / queryinsights
+        view columns.  **Do not restructure into sub-models** — that would
+        destabilise the query_insights service and the CLI rendering layer.
+        Adding a new column?  Append it in the appropriate group below.
+    """
+
+    # --- identifiers ---
     distributed_statement_id: UUID | None = None
-    database_name: str | None = None
+    session_id: int | None = None
+    connection_id: UUID | None = None
+    batch_id: UUID | None = None
+    root_batch_id: UUID | None = None
+
+    # --- timing ---
     submit_time: datetime | None = None
     start_time: datetime | None = None
     end_time: datetime | None = None
+    total_elapsed_time_ms: int | None = None
+
+    # --- details ---
+    database_name: str | None = None
     is_distributed: int | None = None
     statement_type: str | None = None
-    total_elapsed_time_ms: int | None = None
     login_name: str | None = None
     row_count: int
     status: str | None = None
-    session_id: int | None = None
-    connection_id: UUID | None = None
     program_name: str | None = None
-    batch_id: UUID | None = None
-    root_batch_id: UUID | None = None
     query_hash: str | None = None
     label: str | None = None
     result_cache_hit: int | None = None
@@ -220,19 +266,31 @@ class ExecRequestHistory(_FabricBase):
 
 
 class ExecSessionHistory(_FabricBase):
-    """A completed session from ``queryinsights.exec_sessions_history``."""
+    """A completed session from ``queryinsights.exec_sessions_history``.
 
+    .. note::
+        This model is an intentional 1-to-1 projection of the DMV / queryinsights
+        view columns.  **Do not restructure into sub-models** — that would
+        destabilise the query_insights service and the CLI rendering layer.
+        Adding a new column?  Append it in the appropriate group below.
+    """
+
+    # --- identifiers ---
     session_id: int
     connection_id: UUID
+
+    # --- timing ---
     session_start_time: datetime
     session_end_time: datetime | None = None
+    total_query_elapsed_time_ms: int
+    last_request_start_time: datetime
+    last_request_end_time: datetime | None = None
+
+    # --- details ---
     program_name: str | None = None
     login_name: str
     status: str
     context_info: bytes | None = None
-    total_query_elapsed_time_ms: int
-    last_request_start_time: datetime
-    last_request_end_time: datetime | None = None
     is_user_process: bool
     prev_error: int
     group_id: int
@@ -367,7 +425,7 @@ class SqlPoolClassifier(_FabricBase):
     :data:`CLASSIFIER_TYPE_APPLICATION_NAME_REGEX` for the known values.
     """
 
-    type: str = Field(alias="type")
+    type: str
     value: list[str] = Field(default_factory=list, alias="value")
 
 
@@ -438,6 +496,52 @@ class PrincipalType(StrEnum):
     ENTIRE_TENANT = "EntireTenant"
 
 
+_AnyDict = dict[str, Any]
+_Flattener = Callable[[_AnyDict], _AnyDict]
+
+
+def _flatten_user(data: _AnyDict) -> _AnyDict:
+    """Extract ``userPrincipalName`` from the ``userDetails`` sub-object."""
+    user_details = data.get("userDetails")
+    if isinstance(user_details, dict):
+        return {**data, "user_principal_name": user_details.get("userPrincipalName")}
+    return data
+
+
+def _flatten_group(data: _AnyDict) -> _AnyDict:
+    """Extract ``groupType`` from the ``groupDetails`` sub-object."""
+    group_details = data.get("groupDetails")
+    if isinstance(group_details, dict):
+        return {**data, "group_type": group_details.get("groupType")}
+    return data
+
+
+def _flatten_service_principal(data: _AnyDict) -> _AnyDict:
+    """Extract ``aadAppId`` from the ``servicePrincipalDetails`` sub-object."""
+    sp_details = data.get("servicePrincipalDetails")
+    if isinstance(sp_details, dict):
+        return {**data, "aad_app_id": sp_details.get("aadAppId")}
+    return data
+
+
+def _flatten_noop(data: _AnyDict) -> _AnyDict:
+    """No-op flattener — for principal types with no scalar sub-fields to extract."""
+    return data
+
+
+#: Registry mapping principal type strings to their flattening function.
+#: Unknown principal types fall back to :func:`_flatten_noop` so parsing never
+#: crashes when Microsoft adds a new variant.
+_PRINCIPAL_FLATTENERS: dict[str, _Flattener] = {
+    PrincipalType.USER: _flatten_user,
+    PrincipalType.GROUP: _flatten_group,
+    PrincipalType.SERVICE_PRINCIPAL: _flatten_service_principal,
+    # ServicePrincipalProfile and EntireTenant: identity carried by top-level fields only.
+    PrincipalType.SERVICE_PRINCIPAL_PROFILE: _flatten_noop,
+    PrincipalType.ENTIRE_TENANT: _flatten_noop,
+}
+
+
 class ItemAccessPrincipal(_FabricBase):
     """Minimal representation of a principal in an item access record.
 
@@ -464,32 +568,18 @@ class ItemAccessPrincipal(_FabricBase):
     @model_validator(mode="before")
     @classmethod
     def _flatten_detail(cls, data: object) -> object:
-        """Flatten the type-specific detail sub-object to the top level."""
+        """Flatten the type-specific detail sub-object to the top level.
+
+        Dispatches to the appropriate flattener in :data:`_PRINCIPAL_FLATTENERS`
+        keyed by the principal ``type`` string.  Unknown principal types fall
+        back to a no-op so parsing never raises on new API variants.
+        """
         if not isinstance(data, dict):
             return data
-
-        flat = dict(data)
-        principal_type = flat.get("type", "")
-
-        if principal_type == PrincipalType.USER:
-            user_details = flat.get("userDetails")
-            if isinstance(user_details, dict):
-                flat["user_principal_name"] = user_details.get("userPrincipalName")
-
-        elif principal_type == PrincipalType.GROUP:
-            group_details = flat.get("groupDetails")
-            if isinstance(group_details, dict):
-                flat["group_type"] = group_details.get("groupType")
-
-        elif principal_type == PrincipalType.SERVICE_PRINCIPAL:
-            sp_details = flat.get("servicePrincipalDetails")
-            if isinstance(sp_details, dict):
-                flat["aad_app_id"] = sp_details.get("aadAppId")
-
-        # ServicePrincipalProfile: no scalar sub-fields to extract (profile
-        # identity is carried by the top-level id/displayName only).
-
-        return flat
+        d = cast("_AnyDict", data)
+        principal_type = str(d.get("type", ""))
+        flattener = _PRINCIPAL_FLATTENERS.get(principal_type, _flatten_noop)
+        return flattener(d)
 
 
 class ItemAccessDetail(_FabricBase):
@@ -532,3 +622,50 @@ class SqlResult(_FabricBase):
     columns: list[str] = Field(default_factory=list)
     rows: list[list[object]] = Field(default_factory=list)
     rowcount: int = -1
+
+
+# ---------------------------------------------------------------------------
+# API payload helpers — boundary validation for raw HTTP response bodies
+# ---------------------------------------------------------------------------
+
+
+def as_props(raw: object) -> _AnyDict:
+    """Return *raw* as a dict if it is one, else an empty dict.
+
+    Use this at the API boundary instead of ``cast(...)`` + ``isinstance``
+    to validate that a nested ``properties`` value is a plain dict.
+
+    Args:
+        raw: The value to coerce (typically ``response.get("properties")``).
+
+    Returns:
+        The original dict if *raw* is a :class:`dict`, otherwise ``{}``.
+    """
+    return cast("_AnyDict", raw) if isinstance(raw, dict) else {}
+
+
+class WarehouseSnapshotApiPayload(_FabricBase):
+    """Typed wrapper for the raw API response body of a warehouse-snapshot item.
+
+    Used by :mod:`fabric_dw.services.snapshots` to validate/type-narrow the
+    nested ``properties`` object returned by the
+    ``GET /workspaces/{ws}/warehouseSnapshots`` and
+    ``GET /workspaces/{ws}/warehouseSnapshots/{id}`` endpoints, avoiding
+    reflexive ``cast(...)`` calls at each call site.
+    """
+
+    id: str | None = None
+    display_name: str | None = Field(default=None, alias="displayName")
+    parent_warehouse_id: str | None = Field(default=None, alias="parentWarehouseId")
+    snapshot_date_time: str | None = Field(default=None, alias="snapshotDateTime")
+
+    model_config = ConfigDict(extra="ignore", frozen=False, populate_by_name=True)
+
+    @classmethod
+    def props_from_item(cls, item: dict[str, object]) -> WarehouseSnapshotApiPayload:
+        """Parse the ``properties`` sub-object of a snapshot API item response.
+
+        Returns a :class:`WarehouseSnapshotApiPayload` populated from the
+        ``properties`` dict, or an empty instance if the key is absent.
+        """
+        return cls.model_validate(as_props(item.get("properties")))

--- a/src/fabric_dw/services/snapshots.py
+++ b/src/fabric_dw/services/snapshots.py
@@ -4,13 +4,12 @@ from __future__ import annotations
 
 import asyncio
 from datetime import UTC, datetime
-from typing import cast
 from uuid import UUID
 
 from fabric_dw.auth import CredentialMode
 from fabric_dw.cache import ItemEntry, LookupCache
 from fabric_dw.http_client import FabricHttpClient, HttpBase
-from fabric_dw.models import WarehouseKind, WarehouseSnapshot
+from fabric_dw.models import WarehouseKind, WarehouseSnapshot, WarehouseSnapshotApiPayload, as_props
 from fabric_dw.services._helpers import compact
 from fabric_dw.services._lro import LRO_DETAIL_WAIT_S, LRO_MAX_DETAIL_RETRIES, resolve_lro_item_id
 from fabric_dw.sql import SqlTarget, run_query
@@ -51,15 +50,12 @@ def _snapshot_from_typed_api(item: dict[str, object]) -> WarehouseSnapshot:
     ``parentWarehouseId`` and ``snapshotDateTime`` nested under ``properties``
     (not ``creationPayload``).
     """
-    _raw_props = item.get("properties")
-    props: dict[str, object] = (
-        cast("dict[str, object]", _raw_props) if isinstance(_raw_props, dict) else {}
-    )
+    props = WarehouseSnapshotApiPayload.props_from_item(item)
     flat: dict[str, object] = {
         "id": item.get("id"),
         "displayName": item.get("displayName"),
-        "parentWarehouseId": props.get("parentWarehouseId"),
-        "snapshotDateTime": props.get("snapshotDateTime"),
+        "parentWarehouseId": props.parent_warehouse_id,
+        "snapshotDateTime": props.snapshot_date_time,
     }
     return WarehouseSnapshot.model_validate(flat)
 
@@ -89,11 +85,7 @@ async def list_snapshots(
         HttpBase.FABRIC,
         f"/workspaces/{workspace_id}/warehouseSnapshots",
     ):
-        _raw_props = item.get("properties")
-        props: dict[str, object] = (
-            cast("dict[str, object]", _raw_props) if isinstance(_raw_props, dict) else {}
-        )
-        raw_parent_id = props.get("parentWarehouseId")
+        raw_parent_id = WarehouseSnapshotApiPayload.props_from_item(item).parent_warehouse_id
         if raw_parent_id and UUID(str(raw_parent_id)) == parent_warehouse_id:
             out.append(_snapshot_from_typed_api(item))
     return out
@@ -177,23 +169,16 @@ async def create(
     for _attempt in range(LRO_MAX_DETAIL_RETRIES):
         typed_resp = await http.request("GET", HttpBase.FABRIC, _typed_detail_path)
         typed_body = typed_resp.json()
-        _raw_props = typed_body.get("properties")
-        _props: dict[str, object] = (
-            cast("dict[str, object]", _raw_props) if isinstance(_raw_props, dict) else {}
-        )
-        if _props.get("parentWarehouseId") is not None:
+        if WarehouseSnapshotApiPayload.props_from_item(typed_body).parent_warehouse_id is not None:
             break
         if _attempt < LRO_MAX_DETAIL_RETRIES - 1:
             await asyncio.sleep(LRO_DETAIL_WAIT_S)
     else:
         # parentWarehouseId still absent after all retries — inject the value we sent.
-        _raw_props2 = typed_body.get("properties")
-        _props2: dict[str, object] = (
-            cast("dict[str, object]", _raw_props2) if isinstance(_raw_props2, dict) else {}
-        )
+        existing_props = as_props(typed_body.get("properties"))
         typed_body = dict(typed_body)
         typed_body["properties"] = {
-            **_props2,
+            **existing_props,
             "parentWarehouseId": str(parent_warehouse_id),
         }
 
@@ -242,11 +227,7 @@ async def rename(
     _typed_path = f"/workspaces/{workspace_id}/warehouseSnapshots/{snapshot_id}"
     current_resp = await http.request("GET", HttpBase.FABRIC, _typed_path)
     current: dict[str, object] = current_resp.json()
-    _raw_props = current.get("properties")
-    props: dict[str, object] = (
-        cast("dict[str, object]", _raw_props) if isinstance(_raw_props, dict) else {}
-    )
-    parent_wh_id = props.get("parentWarehouseId")
+    parent_wh_id = WarehouseSnapshotApiPayload.props_from_item(current).parent_warehouse_id
 
     patch_body: dict[str, object] = {
         **compact({"description": description}),

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -2,21 +2,30 @@
 
 import json
 from copy import deepcopy
+from typing import ClassVar
 
 import pytest
 from pydantic import ValidationError
 
 from fabric_dw.models import (
     AuditSettings,
+    CreationModeType,
+    ItemAccess,
+    ItemAccessPrincipal,
+    PrincipalType,
     RestorePoint,
     RunningQuery,
+    SqlPoolClassifier,
     Warehouse,
     WarehouseKind,
     WarehouseSnapshot,
+    WarehouseSnapshotApiPayload,
     Workspace,
+    as_props,
 )
 from tests.fixtures.api_payloads import (
     AUDIT_SETTINGS_PAYLOAD,
+    ITEM_ACCESS_DETAILS_PAYLOAD,
     LAKEHOUSE_GET_PAYLOAD,
     RESTORE_POINT_PAYLOAD,
     WAREHOUSE_GET_PAYLOAD,
@@ -275,3 +284,294 @@ class TestRunningQuery:
         }
         obj = RunningQuery.model_validate(payload)
         assert obj.request_id is None
+
+
+class TestCreationModeType:
+    """CreationModeType is now a proper StrEnum."""
+
+    def test_is_str_enum(self) -> None:
+        assert issubclass(CreationModeType, str)
+
+    def test_user_defined_value(self) -> None:
+        assert CreationModeType.USER_DEFINED == "UserDefined"
+
+    def test_system_created_value(self) -> None:
+        assert CreationModeType.SYSTEM_CREATED == "SystemCreated"
+
+    def test_compare_with_raw_string(self) -> None:
+        """StrEnum compares equal to its string value — open-enum pattern works."""
+        assert CreationModeType.USER_DEFINED == "UserDefined"
+        assert CreationModeType.SYSTEM_CREATED == "SystemCreated"
+
+    @pytest.mark.parametrize("mode_str", ["UserDefined", "SystemCreated"])
+    def test_restore_point_known_values_pass_through(self, mode_str: str) -> None:
+        """Known creationMode values round-trip via RestorePoint.creation_mode."""
+        payload = {
+            "id": "1726617378000",
+            "creationMode": mode_str,
+        }
+        obj = RestorePoint.model_validate(payload)
+        assert obj.creation_mode == mode_str
+
+    def test_restore_point_unknown_value_pass_through(self) -> None:
+        """Unknown creationMode values pass through without error (open enum)."""
+        payload = {
+            "id": "1726617378000",
+            "creationMode": "FutureNewMode",
+        }
+        obj = RestorePoint.model_validate(payload)
+        assert obj.creation_mode == "FutureNewMode"
+
+    def test_restore_point_null_creation_mode(self) -> None:
+        """Null creationMode is accepted (system-created restore points)."""
+        payload = {"id": "1726617378000", "creationMode": None}
+        obj = RestorePoint.model_validate(payload)
+        assert obj.creation_mode is None
+
+
+class TestWarehouseModelValidator:
+    """Warehouse flattening via model_validator(mode='before') and from_api shim."""
+
+    def test_model_validate_warehouse_kind(self) -> None:
+        payload = json.loads(WAREHOUSE_GET_PAYLOAD)
+        obj = Warehouse.model_validate({**payload, "kind": WarehouseKind.WAREHOUSE})
+        assert obj.kind == WarehouseKind.WAREHOUSE
+        assert obj.connection_string == payload["properties"]["connectionString"]
+
+    def test_model_validate_sql_endpoint_kind(self) -> None:
+        payload = json.loads(LAKEHOUSE_GET_PAYLOAD)
+        obj = Warehouse.model_validate({**payload, "kind": WarehouseKind.SQL_ENDPOINT})
+        assert obj.kind == WarehouseKind.SQL_ENDPOINT
+        expected = payload["properties"]["sqlEndpointProperties"]["connectionString"]
+        assert obj.connection_string == expected
+
+    def test_model_validate_collation_and_created_date(self) -> None:
+        payload = json.loads(WAREHOUSE_GET_PAYLOAD)
+        obj = Warehouse.model_validate({**payload, "kind": WarehouseKind.WAREHOUSE})
+        assert obj.collation == payload["properties"]["defaultCollation"]
+        assert obj.created_date is not None
+
+    def test_from_api_shim_warehouse(self) -> None:
+        payload = json.loads(WAREHOUSE_GET_PAYLOAD)
+        obj = Warehouse.from_api(payload, kind=WarehouseKind.WAREHOUSE)
+        assert obj.connection_string == payload["properties"]["connectionString"]
+
+    def test_from_api_shim_sql_endpoint(self) -> None:
+        payload = json.loads(LAKEHOUSE_GET_PAYLOAD)
+        obj = Warehouse.from_api(payload, kind=WarehouseKind.SQL_ENDPOINT)
+        expected = payload["properties"]["sqlEndpointProperties"]["connectionString"]
+        assert obj.connection_string == expected
+
+    def test_from_api_shim_snapshot_raises(self) -> None:
+        payload = json.loads(WAREHOUSE_GET_PAYLOAD)
+        with pytest.raises(ValueError, match="from_api does not support kind="):
+            Warehouse.from_api(payload, kind=WarehouseKind.SNAPSHOT)
+
+    def test_model_validate_and_from_api_consistent(self) -> None:
+        """model_validate and from_api shim return equivalent objects."""
+        payload = json.loads(WAREHOUSE_GET_PAYLOAD)
+        via_validator = Warehouse.model_validate({**payload, "kind": WarehouseKind.WAREHOUSE})
+        via_shim = Warehouse.from_api(payload, kind=WarehouseKind.WAREHOUSE)
+        assert via_validator == via_shim
+
+
+class TestRestorePointModelValidator:
+    """RestorePoint flattening via model_validator(mode='before') and from_api shim."""
+
+    def test_model_validate_flattens_event_date_time(self) -> None:
+        payload = json.loads(RESTORE_POINT_PAYLOAD)
+        obj = RestorePoint.model_validate(payload)
+        assert obj.event_date_time is not None
+
+    def test_from_api_shim_delegates_to_model_validate(self) -> None:
+        payload = json.loads(RESTORE_POINT_PAYLOAD)
+        obj = RestorePoint.from_api(payload)
+        assert obj.id == payload["id"]
+        assert obj.event_date_time is not None
+
+    def test_model_validate_and_from_api_consistent(self) -> None:
+        """model_validate and from_api shim return equivalent objects."""
+        payload = json.loads(RESTORE_POINT_PAYLOAD)
+        via_validator = RestorePoint.model_validate(payload)
+        via_shim = RestorePoint.from_api(payload)
+        assert via_validator == via_shim
+
+    def test_already_flat_dict_not_double_flattened(self) -> None:
+        """Providing eventDateTime at top-level skips the creationDetails lookup."""
+        flat = {
+            "id": "1726617378000",
+            "eventDateTime": "2024-03-15T06:00:00Z",
+        }
+        obj = RestorePoint.model_validate(flat)
+        assert obj.event_date_time is not None
+
+    def test_missing_creation_details_returns_none_event_date(self) -> None:
+        """Missing creationDetails results in event_date_time=None (graceful)."""
+        payload = {"id": "1726617378000", "displayName": "TestRP"}
+        obj = RestorePoint.model_validate(payload)
+        assert obj.event_date_time is None
+
+
+class TestItemAccessPrincipalRegistry:
+    """ItemAccessPrincipal flattener registry covers all known types + unknown fallback."""
+
+    def _user_payload(self) -> dict:
+        return {
+            "id": "f3052d1c-61a9-46fb-8df9-0d78916ae041",
+            "displayName": "Jacob Hancock",
+            "type": "User",
+            "userDetails": {"userPrincipalName": "jacob@example.com"},
+        }
+
+    def _group_payload(self) -> dict:
+        return {
+            "id": "c7db8e03-c8cb-4d4c-9f64-1dcd327c9d3c",
+            "displayName": "TestSecurityGroup",
+            "type": "Group",
+            "groupDetails": {"groupType": "SecurityGroup"},
+        }
+
+    def _sp_payload(self) -> dict:
+        return {
+            "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            "displayName": "MyServicePrincipal",
+            "type": "ServicePrincipal",
+            "servicePrincipalDetails": {"aadAppId": "b2c3d4e5-f6a7-8901-bcde-f01234567891"},
+        }
+
+    def test_user_flattened(self) -> None:
+        obj = ItemAccessPrincipal.model_validate(self._user_payload())
+        assert obj.user_principal_name == "jacob@example.com"
+        assert obj.group_type is None
+        assert obj.aad_app_id is None
+
+    def test_group_flattened(self) -> None:
+        obj = ItemAccessPrincipal.model_validate(self._group_payload())
+        assert obj.group_type == "SecurityGroup"
+        assert obj.user_principal_name is None
+        assert obj.aad_app_id is None
+
+    def test_service_principal_flattened(self) -> None:
+        obj = ItemAccessPrincipal.model_validate(self._sp_payload())
+        assert str(obj.aad_app_id) == "b2c3d4e5-f6a7-8901-bcde-f01234567891"
+        assert obj.user_principal_name is None
+        assert obj.group_type is None
+
+    def test_service_principal_profile_no_crash(self) -> None:
+        """ServicePrincipalProfile has no sub-fields — should parse without error."""
+        payload = {
+            "id": "11111111-1111-1111-1111-111111111111",
+            "displayName": "My SPP",
+            "type": PrincipalType.SERVICE_PRINCIPAL_PROFILE,
+        }
+        obj = ItemAccessPrincipal.model_validate(payload)
+        assert str(obj.type) == PrincipalType.SERVICE_PRINCIPAL_PROFILE
+
+    def test_entire_tenant_no_crash(self) -> None:
+        """EntireTenant principal parses without error."""
+        payload = {
+            "id": "22222222-2222-2222-2222-222222222222",
+            "displayName": None,
+            "type": PrincipalType.ENTIRE_TENANT,
+        }
+        obj = ItemAccessPrincipal.model_validate(payload)
+        assert str(obj.type) == PrincipalType.ENTIRE_TENANT
+
+    def test_unknown_principal_type_no_crash(self) -> None:
+        """Unknown principal type falls back to noop flattener — no crash."""
+        payload = {
+            "id": "33333333-3333-3333-3333-333333333333",
+            "displayName": "Mystery",
+            "type": "FutureNewPrincipalType",
+        }
+        obj = ItemAccessPrincipal.model_validate(payload)
+        assert obj.type == "FutureNewPrincipalType"
+        assert obj.user_principal_name is None
+        assert obj.group_type is None
+        assert obj.aad_app_id is None
+
+    def test_all_known_principal_types_from_fixture(self) -> None:
+        """Full ItemAccess fixture round-trips all three common principal types."""
+        raw = json.loads(ITEM_ACCESS_DETAILS_PAYLOAD)
+        access_list = [ItemAccess.model_validate(entry) for entry in raw["accessDetails"]]
+        types = {str(a.principal.type) for a in access_list}
+        assert types == {"User", "Group", "ServicePrincipal"}
+
+
+class TestSqlPoolClassifierAlias:
+    """Dropped redundant alias on SqlPoolClassifier.type — serialisation unchanged."""
+
+    def test_type_field_serialises_as_type(self) -> None:
+        obj = SqlPoolClassifier.model_validate({"type": "Application Name", "value": ["MyApp"]})
+        dumped = obj.model_dump(by_alias=True, mode="json")
+        assert dumped["type"] == "Application Name"
+
+    def test_type_field_without_alias_still_works(self) -> None:
+        obj = SqlPoolClassifier(type="Application Name Regex")
+        assert obj.type == "Application Name Regex"
+
+    def test_round_trip_by_alias(self) -> None:
+        payload = {"type": "Application Name", "value": ["Alpha", "Beta"]}
+        obj = SqlPoolClassifier.model_validate(payload)
+        dumped = obj.model_dump(by_alias=True, mode="json")
+        assert dumped == payload
+
+
+class TestAsProps:
+    """as_props boundary helper."""
+
+    def test_dict_passed_through(self) -> None:
+        d = {"foo": 1, "bar": "baz"}
+        assert as_props(d) is d
+
+    def test_none_returns_empty(self) -> None:
+        assert as_props(None) == {}
+
+    def test_string_returns_empty(self) -> None:
+        assert as_props("not a dict") == {}
+
+    def test_list_returns_empty(self) -> None:
+        assert as_props([1, 2, 3]) == {}
+
+    def test_nested_api_props_extraction(self) -> None:
+        item = {"id": "abc", "properties": {"parentWarehouseId": "def"}}
+        props = as_props(item.get("properties"))
+        assert props["parentWarehouseId"] == "def"
+
+
+class TestWarehouseSnapshotApiPayload:
+    """WarehouseSnapshotApiPayload boundary model for snapshot API responses."""
+
+    _TYPED_ITEM: ClassVar[dict] = {
+        "id": "f6a7b8c9-d0e1-2345-f012-34567890abcd",
+        "displayName": "MySalesSnapshot",
+        "properties": {
+            "parentWarehouseId": "d4e5f6a7-b8c9-0123-def0-123456789abc",
+            "snapshotDateTime": "2024-03-15T08:00:00Z",
+        },
+    }
+
+    def test_props_from_item_extracts_parent_id(self) -> None:
+        props = WarehouseSnapshotApiPayload.props_from_item(self._TYPED_ITEM)
+        assert props.parent_warehouse_id == "d4e5f6a7-b8c9-0123-def0-123456789abc"
+
+    def test_props_from_item_extracts_snapshot_datetime(self) -> None:
+        props = WarehouseSnapshotApiPayload.props_from_item(self._TYPED_ITEM)
+        assert props.snapshot_date_time == "2024-03-15T08:00:00Z"
+
+    def test_props_from_item_missing_properties_returns_empty(self) -> None:
+        item: dict = {"id": "abc", "displayName": "Test"}
+        props = WarehouseSnapshotApiPayload.props_from_item(item)
+        assert props.parent_warehouse_id is None
+        assert props.snapshot_date_time is None
+
+    def test_props_from_item_non_dict_properties_returns_empty(self) -> None:
+        item: dict = {"id": "abc", "properties": "unexpected_string"}
+        props = WarehouseSnapshotApiPayload.props_from_item(item)
+        assert props.parent_warehouse_id is None
+
+    def test_extra_fields_ignored(self) -> None:
+        item = dict(self._TYPED_ITEM)
+        item["properties"] = {**item["properties"], "unknownFutureField": "value"}  # type: ignore[index]
+        props = WarehouseSnapshotApiPayload.props_from_item(item)
+        assert props.parent_warehouse_id is not None


### PR DESCRIPTION
## Summary

- **CreationModeType fake class → StrEnum** (`02-core-models-creation-mode-fake-class.md`): replaced class-with-attrs with `class CreationModeType(StrEnum)`. `RestorePoint.creation_mode` stays typed `str | None` for open-enum passthrough.
- **Unify flatten pattern** (`02-core-models-from-api-vs-model-validator.md`): `Warehouse` and `RestorePoint` now use `@model_validator(mode="before")` for API payload flattening. Thin `from_api()` shims kept for all 9 existing call sites in services — no call-site churn needed.
- **Flatten registry** (`02-core-models-flatten-detail-hardcoded.md`): replaced `if/elif` in `ItemAccessPrincipal._flatten_detail` with `_PRINCIPAL_FLATTENERS: dict[str, _Flattener]`. Unknown types fall back to `_flatten_noop` — never crashes on new API variants.
- **Redundant alias drop** (`02-core-models-redundant-alias-eq-name.md`): removed `Field(alias="type")` from `SqlPoolClassifier.type` where field name already equals alias.
- **God-models: document + group** (`02-core-models-god-models-30-fields.md`): added explicit docstring noting intentional 1:1 DMV projection and added comment banners (identifiers / timing / details) to `ExecRequestHistory` and `ExecSessionHistory`. Sub-model split deliberately declined — would destabilise `query_insights` service and CLI rendering.
- **cast-over-validation** (`03-services-cast-over-validation.md`): introduced `as_props(raw) -> dict` helper and `WarehouseSnapshotApiPayload` boundary model. Replaced all `cast("dict[str, object]", _raw_props) if isinstance(...) else {}` calls in `snapshots.py`. `schemas.py` / `tables.py` / `views.py` had no such pattern on latest main.

## Decisions

- `from_api()` shims kept (not removed) because 9 call sites across `warehouses.py`, `sql_endpoints.py`, `restore.py`, `permissions.py` use them. Migration to direct `model_validate` is deferred to a follow-up.
- `WarehouseSnapshotApiPayload` introduced as a real boundary model because `properties` is accessed in 4+ distinct places in `snapshots.py`. `as_props()` helper introduced for single-use dict coercion at other boundaries.
- `cast` is still imported in `models.py` — used in `mode="before"` validators to narrow `dict[Unknown, Unknown]` → `_AnyDict` for `ty` compatibility (invariant generics). This is a type annotation tool cast, not the API-boundary anti-pattern from the review.

## Test results

- 1275 tests pass (was 1235 before); 40 new tests added to `tests/unit/test_models.py`
- `just check` (ruff + ty + pytest) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)