### PR TITLE
fix(ci): suppress bandit B608 on safe system-schema SQL to unblock gate

### DIFF
--- a/src/fabric_dw/services/schemas.py
+++ b/src/fabric_dw/services/schemas.py
@@ -88,7 +88,7 @@ FROM sys.schemas s
 WHERE s.name NOT IN ({_SYSTEM_SCHEMA_PLACEHOLDERS})
   AND s.name NOT LIKE 'db[_]%'
 ORDER BY s.name;
-"""  # noqa: S608 — placeholders are ? params; schema names in _SYSTEM_SCHEMA_PARAMS are hardcoded constants.
+"""  # noqa: S608  # nosec B608 - placeholders are ? params; schema names in _SYSTEM_SCHEMA_PARAMS are hardcoded constants.
 
 _LIST_TABLES_IN_SCHEMA_SQL = """\
 SELECT t.name AS obj_name, 'TABLE' AS obj_type


### PR DESCRIPTION
## Summary

- The bandit security gate (`bandit -r src/ -ll`) was RED on main due to a B608 (hardcoded_sql_expressions) finding on `_LIST_SCHEMAS_SQL` in `src/fabric_dw/services/schemas.py`.
- Bandit does not honour ruff's `# noqa: S608`; it requires its own `# nosec B608` inline suppression matched to the flagged line range.
- The SQL is safe: the f-string interpolates only `_SYSTEM_SCHEMA_PLACEHOLDERS`, which is a string of `?` params built from a hardcoded `frozenset` of system-schema names. No user input reaches the template.
- Fix: added `# nosec B608` to the closing `"""` line of the multiline string (line 91). Bandit checks `# nosec` against the full linerange of multiline strings (lines 83–91), so the suppression on the last line is honoured.
- Kept the existing `# noqa: S608` for ruff compatibility.
- No global disabling of B608; suppression is scoped to this single safe site.

## Test plan

- [ ] `uvx bandit -r src/ -ll` exits 0, Total issues Medium: 0, High: 0
- [ ] `just check` passes (ruff, ty, pytest — 1291 tests)
- [ ] CI security gate passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)