### PR TITLE
refactor(mcp): MCP tool-quality improvements — helpers, bounds, logging, cache scope

### DIFF
--- a/src/fabric_dw/mcp/_helpers.py
+++ b/src/fabric_dw/mcp/_helpers.py
@@ -167,7 +167,7 @@ def make_sql_target(ws_id: UUID, entry: _ItemEntry, item: str) -> SqlTarget:
     """
     if entry.connection_string is None:
         raise ToolError(  # noqa: TRY003
-            f"warehouse {item!r} has no connection string; cannot execute SQL"
+            f"item {item!r} has no connection string; cannot execute SQL"
         )
     return SqlTarget(
         workspace_id=str(ws_id),
@@ -199,7 +199,7 @@ async def resolve_item(resolver: Resolver, workspace: str, item: str) -> tuple[U
         ``(workspace_id, entry)`` — both values the tool normally needs.
     """
     ws_id = await resolver.workspace_id(workspace)
-    entry = await resolver.item(workspace, item)
+    entry = await resolver.item(str(ws_id), item)
     return ws_id, entry
 
 

--- a/src/fabric_dw/mcp/_helpers.py
+++ b/src/fabric_dw/mcp/_helpers.py
@@ -3,24 +3,25 @@
 This module provides utilities imported by every domain tool module:
 
 - :func:`fabric_err` — convert a :class:`~fabric_dw.exceptions.FabricError`
-  to a :class:`~mcp.server.fastmcp.exceptions.ToolError`.
+  to a :class:`~mcp.server.fastmcp.exceptions.ToolError` with structured data.
+- :func:`tool_err` — uniform error funnel mapping FabricError / ValueError /
+  Exception to ToolError without inline ternaries.
 - :func:`require_warehouse` — reject SQL Analytics Endpoint items for DDL
   operations.
 - :func:`parse_qualified_name` — split ``"schema.object"`` strings, raising
   :class:`~mcp.server.fastmcp.exceptions.ToolError` on bad input.
 - :func:`make_sql_target` — build a :class:`~fabric_dw.sql.SqlTarget` from a
-  resolved item entry and workspace ID.
-
-NOTE — deduplication deferred to refactor/mcp-tool-quality
------------------------------------------------------------
-The ``SqlTarget`` construction pattern appears in ~20 tools and the qualified-
-name parser in ~9 tools.  Canonical helpers are defined here so future work
-(refactor/mcp-tool-quality) can consolidate callers without touching this PR.
-The domain modules already use these helpers; no further changes are needed.
+  resolved item entry and workspace ID, including the connection-string guard.
+- :func:`resolve_item` — return ``(workspace_id, ItemEntry)`` in one resolver
+  round-trip so tools avoid the double workspace-lookup pattern.
+- :func:`safe_rows` — apply ``json_safe`` to every cell in a row-set in one
+  place, removing duplicated list-comprehensions.
 """
 
 from __future__ import annotations
 
+import logging
+from typing import Any
 from uuid import UUID
 
 from mcp.server.fastmcp.exceptions import ToolError
@@ -28,14 +29,21 @@ from mcp.server.fastmcp.exceptions import ToolError
 from fabric_dw.cache import ItemEntry as _ItemEntry
 from fabric_dw.exceptions import FabricError
 from fabric_dw.models import WarehouseKind
+from fabric_dw.resolver import Resolver
 from fabric_dw.sql import SqlTarget
+from fabric_dw.sql_io import json_safe as _json_safe
 
 __all__ = [
     "fabric_err",
     "make_sql_target",
     "parse_qualified_name",
     "require_warehouse",
+    "resolve_item",
+    "safe_rows",
+    "tool_err",
 ]
+
+_log = logging.getLogger(__name__)
 
 _SQL_ENDPOINT_DDL_ERROR = "SQL Analytics Endpoints are read-only; CREATE/DROP SCHEMA not supported"
 
@@ -43,14 +51,58 @@ _SQL_ENDPOINT_DDL_ERROR = "SQL Analytics Endpoints are read-only; CREATE/DROP SC
 def fabric_err(exc: FabricError | Exception) -> ToolError:
     """Convert a :class:`~fabric_dw.exceptions.FabricError` to a :class:`ToolError`.
 
+    For :class:`FabricError` instances the message is enriched with structured
+    metadata (HTTP status code, request ID, hint) so MCP clients receive all
+    the information they need for diagnostics.  The metadata is appended as a
+    JSON-encoded suffix on a second line so free-text parsers still see a
+    clean first line.
+
     Args:
-        exc: The exception to convert.
+        exc: The exception to convert.  When *exc* is a plain
+            :class:`Exception` (not a :class:`FabricError`), only the message
+            is included.
 
     Returns:
-        A :class:`ToolError` with the exception type and message.
+        A :class:`ToolError` whose message includes the exception type, the
+        formatted exception string (which already contains hint / request_id
+        via :meth:`FabricError.__str__`), and — for :class:`FabricError`
+        instances — a ``|meta|``-prefixed JSON block with ``error_type``,
+        ``status``, and ``request_id`` for machine parsing.
     """
+    import json  # noqa: PLC0415
+
     err_type = type(exc).__name__
-    return ToolError(f"{err_type}: {exc}")
+    msg = f"{err_type}: {exc}"
+    if isinstance(exc, FabricError):
+        meta: dict[str, Any] = {"error_type": err_type}
+        if exc.status is not None:
+            meta["status"] = exc.status
+        if exc.request_id is not None:
+            meta["request_id"] = exc.request_id
+        if exc.hint is not None:
+            meta["hint"] = exc.hint
+        if len(meta) > 1:
+            msg = f"{msg}\n|meta| {json.dumps(meta)}"
+    return ToolError(msg)
+
+
+def tool_err(exc: FabricError | Exception) -> ToolError:
+    """Uniform error funnel: FabricError → structured ToolError, other → ToolError(str).
+
+    Use this in ``except (ValueError, FabricError)`` blocks to replace the
+    verbose inline ternary pattern::
+
+        raise tool_err(exc) from exc
+
+    Args:
+        exc: Any exception from a service call.
+
+    Returns:
+        A :class:`ToolError` appropriate for the exception type.
+    """
+    if isinstance(exc, FabricError):
+        return fabric_err(exc)
+    return ToolError(str(exc))
 
 
 def require_warehouse(entry: _ItemEntry, item: str) -> None:
@@ -94,24 +146,76 @@ def parse_qualified_name(qualified_name: str, kind: str = "object") -> tuple[str
     return schema, name
 
 
-def make_sql_target(ws_id: UUID, entry: _ItemEntry) -> SqlTarget:
+def make_sql_target(ws_id: UUID, entry: _ItemEntry, item: str) -> SqlTarget:
     """Build a :class:`~fabric_dw.sql.SqlTarget` from a resolved item entry.
+
+    Raises :class:`~mcp.server.fastmcp.exceptions.ToolError` directly when
+    *entry* has no connection string, eliminating the ``try: raise FabricError
+    # noqa: TRY301`` anti-pattern in every caller.
 
     Args:
         ws_id: The workspace UUID.
-        entry: The resolved item entry (must have a non-``None``
-            ``connection_string``).
+        entry: The resolved item entry.
+        item: The warehouse/item name as supplied by the caller (used in the
+            error message when the connection string is absent).
 
     Returns:
         A fully populated :class:`~fabric_dw.sql.SqlTarget`.
 
-    Note:
-        Callers should check ``entry.connection_string is None`` before
-        calling and raise an appropriate :class:`~fabric_dw.exceptions.FabricError`
-        if the item has no connection string.
+    Raises:
+        ToolError: When *entry* has no connection string.
     """
+    if entry.connection_string is None:
+        raise ToolError(  # noqa: TRY003
+            f"warehouse {item!r} has no connection string; cannot execute SQL"
+        )
     return SqlTarget(
         workspace_id=str(ws_id),
         database=entry.display_name,
-        connection_string=entry.connection_string or "",
+        connection_string=entry.connection_string,
     )
+
+
+async def resolve_item(resolver: Resolver, workspace: str, item: str) -> tuple[UUID, _ItemEntry]:
+    """Resolve *workspace* + *item* to a ``(workspace_id, ItemEntry)`` pair.
+
+    The resolver's ``item()`` method internally looks up the workspace ID
+    again.  This helper avoids the double workspace-lookup pattern that appears
+    throughout the tool handlers::
+
+        ws_id = await resolver.workspace_id(workspace)  # lookup 1
+        entry = await resolver.item(workspace, item)     # lookup 2 (internal)
+
+    By calling ``workspace_id`` once and exposing the result alongside the
+    entry, callers can pass ``ws_id`` to ``assert_workspace_allowed`` and
+    ``make_sql_target`` without redundant network round-trips.
+
+    Args:
+        resolver: The active :class:`~fabric_dw.resolver.Resolver`.
+        workspace: Workspace name or GUID.
+        item: Item (warehouse, endpoint, …) name or GUID.
+
+    Returns:
+        ``(workspace_id, entry)`` — both values the tool normally needs.
+    """
+    ws_id = await resolver.workspace_id(workspace)
+    entry = await resolver.item(workspace, item)
+    return ws_id, entry
+
+
+def safe_rows(rows: list[Any]) -> list[list[Any]]:
+    """Apply :func:`~fabric_dw.sql_io.json_safe` to every cell in *rows*.
+
+    Centralises the ``[[json_safe(v) for v in row] for row in rows]``
+    pattern that previously appeared in multiple tool modules.
+
+    Args:
+        rows: Raw row data as returned by the SQL execution layer (a list of
+            sequences — lists or tuples depending on the driver).
+
+    Returns:
+        A new list-of-lists with all values converted to JSON-safe types
+        (strings for datetime/Decimal, base64 strings for bytes with
+        ``__base64`` column-name suffix handled by the caller).
+    """
+    return [[_json_safe(v) for v in row] for row in rows]

--- a/src/fabric_dw/mcp/tools/audit.py
+++ b/src/fabric_dw/mcp/tools/audit.py
@@ -2,18 +2,22 @@
 
 from __future__ import annotations
 
-from typing import Any
+import logging
+from typing import Annotated, Any
 
 from mcp.server.fastmcp import FastMCP
 from mcp.server.fastmcp.exceptions import ToolError
+from pydantic import Field
 
 from fabric_dw.exceptions import FabricError
 from fabric_dw.mcp._context import get_context
 from fabric_dw.mcp._guards import assert_workspace_allowed, assert_writes_allowed
-from fabric_dw.mcp._helpers import fabric_err
+from fabric_dw.mcp._helpers import fabric_err, resolve_item
 from fabric_dw.services import audit
 
 __all__ = ["register"]
+
+_log = logging.getLogger(__name__)
 
 
 def register(mcp: FastMCP) -> None:  # noqa: PLR0915
@@ -25,9 +29,9 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         assert_workspace_allowed(workspace)
         ctx = get_context()
         try:
-            ws_id = await ctx.resolver.workspace_id(workspace)
+            ws_id, item = await resolve_item(ctx.resolver, workspace, warehouse)
             assert_workspace_allowed(workspace, str(ws_id))
-            item = await ctx.resolver.item(workspace, warehouse)
+            _log.debug("get_audit_settings ws=%s item=%s", ws_id, item.id)
             result = await audit.get_settings(ctx.http, ws_id, item.id)
         except FabricError as exc:
             raise fabric_err(exc) from exc
@@ -35,16 +39,24 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
 
     @mcp.tool(name="enable_audit")
     async def enable_audit(
-        workspace: str, warehouse: str, retention_days: int = 0
+        workspace: str,
+        warehouse: str,
+        retention_days: Annotated[int, Field(ge=0, le=3650)] = 0,
     ) -> dict[str, Any]:
-        """Enable SQL auditing on a warehouse."""
+        """Enable SQL auditing on a warehouse.
+
+        Args:
+            workspace: Workspace name or GUID.
+            warehouse: Warehouse name or GUID.
+            retention_days: Log retention in days (0-3650; 0 = unlimited). Default 0.
+        """
         assert_writes_allowed("enable_audit")
         assert_workspace_allowed(workspace)
         ctx = get_context()
         try:
-            ws_id = await ctx.resolver.workspace_id(workspace)
+            ws_id, item = await resolve_item(ctx.resolver, workspace, warehouse)
             assert_workspace_allowed(workspace, str(ws_id))
-            item = await ctx.resolver.item(workspace, warehouse)
+            _log.debug("enable_audit ws=%s item=%s retention=%d", ws_id, item.id, retention_days)
             result = await audit.enable(ctx.http, ws_id, item.id, retention_days=retention_days)
         except FabricError as exc:
             raise fabric_err(exc) from exc
@@ -57,9 +69,9 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         assert_workspace_allowed(workspace)
         ctx = get_context()
         try:
-            ws_id = await ctx.resolver.workspace_id(workspace)
+            ws_id, item = await resolve_item(ctx.resolver, workspace, warehouse)
             assert_workspace_allowed(workspace, str(ws_id))
-            item = await ctx.resolver.item(workspace, warehouse)
+            _log.debug("disable_audit ws=%s item=%s", ws_id, item.id)
             result = await audit.disable(ctx.http, ws_id, item.id)
         except FabricError as exc:
             raise fabric_err(exc) from exc
@@ -74,9 +86,11 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         assert_workspace_allowed(workspace)
         ctx = get_context()
         try:
-            ws_id = await ctx.resolver.workspace_id(workspace)
+            ws_id, item = await resolve_item(ctx.resolver, workspace, warehouse)
             assert_workspace_allowed(workspace, str(ws_id))
-            item = await ctx.resolver.item(workspace, warehouse)
+            _log.debug(
+                "set_audit_action_groups ws=%s item=%s groups=%s", ws_id, item.id, action_groups
+            )
             result = await audit.set_action_groups(ctx.http, ws_id, item.id, action_groups)
         except FabricError as exc:
             raise fabric_err(exc) from exc
@@ -100,9 +114,9 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         assert_workspace_allowed(workspace)
         ctx = get_context()
         try:
-            ws_id = await ctx.resolver.workspace_id(workspace)
+            ws_id, item = await resolve_item(ctx.resolver, workspace, warehouse)
             assert_workspace_allowed(workspace, str(ws_id))
-            item = await ctx.resolver.item(workspace, warehouse)
+            _log.debug("add_audit_group ws=%s item=%s group=%r", ws_id, item.id, group)
             result = await audit.add_action_group(ctx.http, ws_id, item.id, group)
         except ValueError as exc:
             raise ToolError(str(exc)) from exc
@@ -128,9 +142,9 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         assert_workspace_allowed(workspace)
         ctx = get_context()
         try:
-            ws_id = await ctx.resolver.workspace_id(workspace)
+            ws_id, item = await resolve_item(ctx.resolver, workspace, warehouse)
             assert_workspace_allowed(workspace, str(ws_id))
-            item = await ctx.resolver.item(workspace, warehouse)
+            _log.debug("remove_audit_group ws=%s item=%s group=%r", ws_id, item.id, group)
             result = await audit.remove_action_group(ctx.http, ws_id, item.id, group)
         except ValueError as exc:
             raise ToolError(str(exc)) from exc
@@ -139,7 +153,11 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         return result.model_dump(by_alias=True, mode="json")
 
     @mcp.tool(name="set_audit_retention")
-    async def set_audit_retention(workspace: str, warehouse: str, days: int) -> dict[str, Any]:
+    async def set_audit_retention(
+        workspace: str,
+        warehouse: str,
+        days: Annotated[int, Field(ge=1, le=3650)],
+    ) -> dict[str, Any]:
         """Update the audit log retention period without changing the audit enabled/disabled state.
 
         Audit must already be enabled; if disabled, enable it first with ``enable_audit``.
@@ -147,15 +165,15 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         Args:
             workspace: Workspace name or GUID.
             warehouse: Warehouse name or GUID.
-            days: Retention period in days (>= 1). The API enforces its own upper bound.
+            days: Retention period in days (1-3650). The API enforces its own upper bound.
         """
         assert_writes_allowed("set_audit_retention")
         assert_workspace_allowed(workspace)
         ctx = get_context()
         try:
-            ws_id = await ctx.resolver.workspace_id(workspace)
+            ws_id, item = await resolve_item(ctx.resolver, workspace, warehouse)
             assert_workspace_allowed(workspace, str(ws_id))
-            item = await ctx.resolver.item(workspace, warehouse)
+            _log.debug("set_audit_retention ws=%s item=%s days=%d", ws_id, item.id, days)
             result = await audit.set_retention(ctx.http, ws_id, item.id, days=days)
         except ValueError as exc:
             raise ToolError(str(exc)) from exc

--- a/src/fabric_dw/mcp/tools/cache.py
+++ b/src/fabric_dw/mcp/tools/cache.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any
+import logging
+from typing import Any, Literal
 
 from mcp.server.fastmcp import FastMCP
 
@@ -10,12 +11,84 @@ from fabric_dw.mcp._context import get_context
 
 __all__ = ["register"]
 
+_log = logging.getLogger(__name__)
+
 
 def register(mcp: FastMCP) -> None:
     """Register cache tools against *mcp*."""
 
     @mcp.tool(name="clear_cache")
-    async def clear_cache() -> dict[str, Any]:
-        """Erase all cached workspace and item name to UUID mappings."""
-        get_context().cache.clear()
-        return {"cleared": True}
+    async def clear_cache(
+        scope: Literal["workspaces", "items", "all"] = "all",
+    ) -> dict[str, Any]:
+        """Erase cached workspace and item name-to-UUID mappings.
+
+        Args:
+            scope: Which portion of the cache to clear.
+
+                - ``"workspaces"`` — clear only workspace name→UUID entries.
+                - ``"items"`` — clear only item (warehouse/endpoint) entries.
+                - ``"all"`` (default) — clear everything, including the
+                  in-memory negative cache on the resolver.
+
+        Returns:
+            A dict with keys ``scope`` (the value used), ``workspaces_cleared``
+            (number of workspace entries removed), ``items_cleared`` (number
+            of item workspace buckets removed), and ``negative_cache_cleared``
+            (``True`` when the resolver's negative cache was also wiped).
+        """
+        _log.info("clear_cache called with scope=%r", scope)
+        ctx = get_context()
+        cache = ctx.cache
+        negative_cache_cleared = False
+
+        # Read current counts before clearing so we can report them.
+        # The LookupCache._read() is an internal helper, so we use the
+        # public JSON representation where possible.  Fall back to 0 on any
+        # access error so the tool never crashes during cleanup.
+        try:
+            with cache._lock:
+                data = cache._read()
+            ws_count = len(data.get("workspaces", {}))
+            items_data: dict[str, Any] = data.get("items", {})
+            items_count = len(items_data)
+        except Exception:  # pragma: no cover
+            ws_count = 0
+            items_count = 0
+
+        if scope == "workspaces":
+            try:
+                with cache._lock:
+                    data = cache._read()
+                    data["workspaces"] = {}
+                    cache._write(data)
+            except Exception as exc:  # pragma: no cover
+                _log.warning("clear_cache(scope=workspaces) failed: %s", exc)
+            items_count = 0  # items not touched
+        elif scope == "items":
+            try:
+                with cache._lock:
+                    data = cache._read()
+                    data["items"] = {}
+                    cache._write(data)
+            except Exception as exc:  # pragma: no cover
+                _log.warning("clear_cache(scope=items) failed: %s", exc)
+            ws_count = 0  # workspaces not touched
+        else:  # "all"
+            cache.clear()
+            ctx.resolver.clear_negative_cache()
+            negative_cache_cleared = True
+
+        _log.info(
+            "clear_cache complete: scope=%r ws=%d items=%d neg=%s",
+            scope,
+            ws_count,
+            items_count,
+            negative_cache_cleared,
+        )
+        return {
+            "scope": scope,
+            "workspaces_cleared": ws_count,
+            "items_cleared": items_count,
+            "negative_cache_cleared": negative_cache_cleared,
+        }

--- a/src/fabric_dw/mcp/tools/queries.py
+++ b/src/fabric_dw/mcp/tools/queries.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from mcp.server.fastmcp import FastMCP
@@ -9,11 +10,12 @@ from mcp.server.fastmcp import FastMCP
 from fabric_dw.exceptions import FabricError
 from fabric_dw.mcp._context import get_context
 from fabric_dw.mcp._guards import assert_workspace_allowed, assert_writes_allowed
-from fabric_dw.mcp._helpers import fabric_err
+from fabric_dw.mcp._helpers import fabric_err, make_sql_target, resolve_item
 from fabric_dw.services import queries
-from fabric_dw.sql import SqlTarget
 
 __all__ = ["register"]
+
+_log = logging.getLogger(__name__)
 
 
 def register(mcp: FastMCP) -> None:
@@ -25,17 +27,10 @@ def register(mcp: FastMCP) -> None:
         assert_workspace_allowed(workspace)
         ctx = get_context()
         try:
-            ws_id = await ctx.resolver.workspace_id(workspace)
+            ws_id, item = await resolve_item(ctx.resolver, workspace, warehouse)
             assert_workspace_allowed(workspace, str(ws_id))
-            item = await ctx.resolver.item(workspace, warehouse)
-            if item.connection_string is None:
-                msg = f"warehouse {warehouse!r} has no connection string; cannot query DMVs"
-                raise FabricError(msg)  # noqa: TRY301
-            target = SqlTarget(
-                workspace_id=str(ws_id),
-                database=item.display_name,
-                connection_string=item.connection_string,
-            )
+            _log.debug("list_running_queries ws=%s item=%s", ws_id, item.id)
+            target = make_sql_target(ws_id, item, warehouse)
             result = await queries.list_running(target, mode=ctx.auth_mode)
         except FabricError as exc:
             raise fabric_err(exc) from exc
@@ -47,17 +42,10 @@ def register(mcp: FastMCP) -> None:
         assert_workspace_allowed(workspace)
         ctx = get_context()
         try:
-            ws_id = await ctx.resolver.workspace_id(workspace)
+            ws_id, item = await resolve_item(ctx.resolver, workspace, warehouse)
             assert_workspace_allowed(workspace, str(ws_id))
-            item = await ctx.resolver.item(workspace, warehouse)
-            if item.connection_string is None:
-                msg = f"warehouse {warehouse!r} has no connection string; cannot query DMVs"
-                raise FabricError(msg)  # noqa: TRY301
-            target = SqlTarget(
-                workspace_id=str(ws_id),
-                database=item.display_name,
-                connection_string=item.connection_string,
-            )
+            _log.debug("list_connections ws=%s item=%s", ws_id, item.id)
+            target = make_sql_target(ws_id, item, warehouse)
             result = await queries.list_connections(target, mode=ctx.auth_mode)
         except FabricError as exc:
             raise fabric_err(exc) from exc
@@ -70,17 +58,10 @@ def register(mcp: FastMCP) -> None:
         assert_workspace_allowed(workspace)
         ctx = get_context()
         try:
-            ws_id = await ctx.resolver.workspace_id(workspace)
+            ws_id, item = await resolve_item(ctx.resolver, workspace, warehouse)
             assert_workspace_allowed(workspace, str(ws_id))
-            item = await ctx.resolver.item(workspace, warehouse)
-            if item.connection_string is None:
-                msg = f"warehouse {warehouse!r} has no connection string; cannot kill sessions"
-                raise FabricError(msg)  # noqa: TRY301
-            target = SqlTarget(
-                workspace_id=str(ws_id),
-                database=item.display_name,
-                connection_string=item.connection_string,
-            )
+            _log.debug("kill_session ws=%s item=%s session=%s", ws_id, item.id, session_id)
+            target = make_sql_target(ws_id, item, warehouse)
             await queries.kill(target, session_id, mode=ctx.auth_mode)
         except FabricError as exc:
             raise fabric_err(exc) from exc

--- a/src/fabric_dw/mcp/tools/queries.py
+++ b/src/fabric_dw/mcp/tools/queries.py
@@ -10,7 +10,7 @@ from mcp.server.fastmcp import FastMCP
 from fabric_dw.exceptions import FabricError
 from fabric_dw.mcp._context import get_context
 from fabric_dw.mcp._guards import assert_workspace_allowed, assert_writes_allowed
-from fabric_dw.mcp._helpers import fabric_err, make_sql_target, resolve_item
+from fabric_dw.mcp._helpers import fabric_err, make_sql_target, resolve_item, tool_err
 from fabric_dw.services import queries
 
 __all__ = ["register"]
@@ -63,6 +63,6 @@ def register(mcp: FastMCP) -> None:
             _log.debug("kill_session ws=%s item=%s session=%s", ws_id, item.id, session_id)
             target = make_sql_target(ws_id, item, warehouse)
             await queries.kill(target, session_id, mode=ctx.auth_mode)
-        except FabricError as exc:
-            raise fabric_err(exc) from exc
+        except (ValueError, FabricError) as exc:
+            raise tool_err(exc) from exc
         return {"killed": True, "session_id": session_id}

--- a/src/fabric_dw/mcp/tools/query_insights.py
+++ b/src/fabric_dw/mcp/tools/query_insights.py
@@ -2,20 +2,23 @@
 
 from __future__ import annotations
 
+import logging
 from datetime import datetime
-from typing import Any
+from typing import Annotated, Any
 
 from mcp.server.fastmcp import FastMCP
 from mcp.server.fastmcp.exceptions import ToolError
+from pydantic import Field
 
 from fabric_dw.exceptions import FabricError
 from fabric_dw.mcp._context import get_context
 from fabric_dw.mcp._guards import assert_workspace_allowed
-from fabric_dw.mcp._helpers import fabric_err
+from fabric_dw.mcp._helpers import fabric_err, make_sql_target, resolve_item
 from fabric_dw.services import query_insights as _qi_svc
-from fabric_dw.sql import SqlTarget
 
 __all__ = ["register"]
+
+_log = logging.getLogger(__name__)
 
 
 def _parse_dt(value: str | None, param: str) -> datetime | None:
@@ -30,23 +33,6 @@ def _parse_dt(value: str | None, param: str) -> datetime | None:
         ) from exc
 
 
-async def _resolve_qi_target(workspace: str, warehouse: str) -> SqlTarget:
-    """Resolve workspace + warehouse to a SqlTarget for Query Insights views."""
-    assert_workspace_allowed(workspace)
-    ctx = get_context()
-    ws_id = await ctx.resolver.workspace_id(workspace)
-    assert_workspace_allowed(workspace, str(ws_id))
-    item = await ctx.resolver.item(workspace, warehouse)
-    if item.connection_string is None:
-        msg = f"item {warehouse!r} has no connection string; cannot query Query Insights DMVs"
-        raise FabricError(msg)
-    return SqlTarget(
-        workspace_id=str(ws_id),
-        database=item.display_name,
-        connection_string=item.connection_string,
-    )
-
-
 def register(mcp: FastMCP) -> None:  # noqa: PLR0915
     """Register query insights tools against *mcp*."""
 
@@ -54,7 +40,7 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
     async def list_request_history(
         workspace: str,
         warehouse: str,
-        limit: int = 100,
+        limit: Annotated[int, Field(ge=1, le=10000)] = 100,
         since: str | None = None,
         until: str | None = None,
     ) -> list[dict[str, Any]]:
@@ -63,15 +49,19 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         Args:
             workspace: Workspace name or GUID.
             warehouse: Warehouse or SQL Analytics Endpoint name or GUID.
-            limit: Maximum rows to return (default 100, cap 10 000).
+            limit: Maximum rows to return (1-10000, default 100).
             since: Optional ISO-8601 lower bound on submit_time.
             until: Optional ISO-8601 upper bound on submit_time.
         """
         since_dt = _parse_dt(since, "since")
         until_dt = _parse_dt(until, "until")
+        assert_workspace_allowed(workspace)
         ctx = get_context()
         try:
-            target = await _resolve_qi_target(workspace, warehouse)
+            ws_id, item = await resolve_item(ctx.resolver, workspace, warehouse)
+            assert_workspace_allowed(workspace, str(ws_id))
+            _log.debug("list_request_history ws=%s item=%s limit=%d", ws_id, item.id, limit)
+            target = make_sql_target(ws_id, item, warehouse)
             result = await _qi_svc.list_request_history(
                 target, limit=limit, since=since_dt, until=until_dt, mode=ctx.auth_mode
             )
@@ -83,7 +73,7 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
     async def list_session_history(
         workspace: str,
         warehouse: str,
-        limit: int = 100,
+        limit: Annotated[int, Field(ge=1, le=10000)] = 100,
         since: str | None = None,
         until: str | None = None,
     ) -> list[dict[str, Any]]:
@@ -92,15 +82,19 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         Args:
             workspace: Workspace name or GUID.
             warehouse: Warehouse or SQL Analytics Endpoint name or GUID.
-            limit: Maximum rows to return (default 100, cap 10 000).
+            limit: Maximum rows to return (1-10000, default 100).
             since: Optional ISO-8601 lower bound on session_start_time.
             until: Optional ISO-8601 upper bound on session_start_time.
         """
         since_dt = _parse_dt(since, "since")
         until_dt = _parse_dt(until, "until")
+        assert_workspace_allowed(workspace)
         ctx = get_context()
         try:
-            target = await _resolve_qi_target(workspace, warehouse)
+            ws_id, item = await resolve_item(ctx.resolver, workspace, warehouse)
+            assert_workspace_allowed(workspace, str(ws_id))
+            _log.debug("list_session_history ws=%s item=%s limit=%d", ws_id, item.id, limit)
+            target = make_sql_target(ws_id, item, warehouse)
             result = await _qi_svc.list_session_history(
                 target, limit=limit, since=since_dt, until=until_dt, mode=ctx.auth_mode
             )
@@ -112,7 +106,7 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
     async def list_frequent_queries(
         workspace: str,
         warehouse: str,
-        limit: int = 100,
+        limit: Annotated[int, Field(ge=1, le=10000)] = 100,
         since: str | None = None,
         until: str | None = None,
     ) -> list[dict[str, Any]]:
@@ -121,15 +115,19 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         Args:
             workspace: Workspace name or GUID.
             warehouse: Warehouse or SQL Analytics Endpoint name or GUID.
-            limit: Maximum rows to return (default 100, cap 10 000).
+            limit: Maximum rows to return (1-10000, default 100).
             since: Optional ISO-8601 lower bound on last_run_start_time.
             until: Optional ISO-8601 upper bound on last_run_start_time.
         """
         since_dt = _parse_dt(since, "since")
         until_dt = _parse_dt(until, "until")
+        assert_workspace_allowed(workspace)
         ctx = get_context()
         try:
-            target = await _resolve_qi_target(workspace, warehouse)
+            ws_id, item = await resolve_item(ctx.resolver, workspace, warehouse)
+            assert_workspace_allowed(workspace, str(ws_id))
+            _log.debug("list_frequent_queries ws=%s item=%s limit=%d", ws_id, item.id, limit)
+            target = make_sql_target(ws_id, item, warehouse)
             result = await _qi_svc.list_frequent_queries(
                 target, limit=limit, since=since_dt, until=until_dt, mode=ctx.auth_mode
             )
@@ -141,7 +139,7 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
     async def list_long_running_queries(
         workspace: str,
         warehouse: str,
-        limit: int = 100,
+        limit: Annotated[int, Field(ge=1, le=10000)] = 100,
         since: str | None = None,
         until: str | None = None,
     ) -> list[dict[str, Any]]:
@@ -150,15 +148,19 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         Args:
             workspace: Workspace name or GUID.
             warehouse: Warehouse or SQL Analytics Endpoint name or GUID.
-            limit: Maximum rows to return (default 100, cap 10 000).
+            limit: Maximum rows to return (1-10000, default 100).
             since: Optional ISO-8601 lower bound on last_run_start_time.
             until: Optional ISO-8601 upper bound on last_run_start_time.
         """
         since_dt = _parse_dt(since, "since")
         until_dt = _parse_dt(until, "until")
+        assert_workspace_allowed(workspace)
         ctx = get_context()
         try:
-            target = await _resolve_qi_target(workspace, warehouse)
+            ws_id, item = await resolve_item(ctx.resolver, workspace, warehouse)
+            assert_workspace_allowed(workspace, str(ws_id))
+            _log.debug("list_long_running_queries ws=%s item=%s limit=%d", ws_id, item.id, limit)
+            target = make_sql_target(ws_id, item, warehouse)
             result = await _qi_svc.list_long_running_queries(
                 target, limit=limit, since=since_dt, until=until_dt, mode=ctx.auth_mode
             )
@@ -170,7 +172,7 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
     async def list_sql_pool_insights(
         workspace: str,
         warehouse: str,
-        limit: int = 100,
+        limit: Annotated[int, Field(ge=1, le=10000)] = 100,
         since: str | None = None,
         until: str | None = None,
     ) -> list[dict[str, Any]]:
@@ -179,15 +181,19 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         Args:
             workspace: Workspace name or GUID.
             warehouse: Warehouse or SQL Analytics Endpoint name or GUID.
-            limit: Maximum rows to return (default 100, cap 10 000).
+            limit: Maximum rows to return (1-10000, default 100).
             since: Optional ISO-8601 lower bound on timestamp.
             until: Optional ISO-8601 upper bound on timestamp.
         """
         since_dt = _parse_dt(since, "since")
         until_dt = _parse_dt(until, "until")
+        assert_workspace_allowed(workspace)
         ctx = get_context()
         try:
-            target = await _resolve_qi_target(workspace, warehouse)
+            ws_id, item = await resolve_item(ctx.resolver, workspace, warehouse)
+            assert_workspace_allowed(workspace, str(ws_id))
+            _log.debug("list_sql_pool_insights ws=%s item=%s limit=%d", ws_id, item.id, limit)
+            target = make_sql_target(ws_id, item, warehouse)
             result = await _qi_svc.list_sql_pool_insights(
                 target, limit=limit, since=since_dt, until=until_dt, mode=ctx.auth_mode
             )

--- a/src/fabric_dw/mcp/tools/restore.py
+++ b/src/fabric_dw/mcp/tools/restore.py
@@ -15,7 +15,7 @@ from fabric_dw.mcp._guards import (
     assert_workspace_allowed,
     assert_writes_allowed,
 )
-from fabric_dw.mcp._helpers import fabric_err, resolve_item
+from fabric_dw.mcp._helpers import fabric_err, resolve_item, tool_err
 from fabric_dw.services import restore as restore_svc
 
 __all__ = ["register"]
@@ -186,6 +186,6 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
                 restore_point_id,
             )
             await restore_svc.restore_in_place(ctx.http, ws_id, item.id, restore_point_id)
-        except FabricError as exc:
-            raise fabric_err(exc) from exc
+        except (ValueError, FabricError) as exc:
+            raise tool_err(exc) from exc
         return {"restored": True, "restore_point_id": restore_point_id}

--- a/src/fabric_dw/mcp/tools/restore.py
+++ b/src/fabric_dw/mcp/tools/restore.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from mcp.server.fastmcp import FastMCP
@@ -14,10 +15,12 @@ from fabric_dw.mcp._guards import (
     assert_workspace_allowed,
     assert_writes_allowed,
 )
-from fabric_dw.mcp._helpers import fabric_err
+from fabric_dw.mcp._helpers import fabric_err, resolve_item
 from fabric_dw.services import restore as restore_svc
 
 __all__ = ["register"]
+
+_log = logging.getLogger(__name__)
 
 
 def register(mcp: FastMCP) -> None:  # noqa: PLR0915
@@ -29,9 +32,9 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         assert_workspace_allowed(workspace)
         ctx = get_context()
         try:
-            ws_id = await ctx.resolver.workspace_id(workspace)
+            ws_id, item = await resolve_item(ctx.resolver, workspace, warehouse)
             assert_workspace_allowed(workspace, str(ws_id))
-            item = await ctx.resolver.item(workspace, warehouse)
+            _log.debug("list_restore_points ws=%s item=%s", ws_id, item.id)
             result = await restore_svc.list_points(ctx.http, ws_id, item.id)
         except FabricError as exc:
             raise fabric_err(exc) from exc
@@ -51,9 +54,9 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         assert_workspace_allowed(workspace)
         ctx = get_context()
         try:
-            ws_id = await ctx.resolver.workspace_id(workspace)
+            ws_id, item = await resolve_item(ctx.resolver, workspace, warehouse)
             assert_workspace_allowed(workspace, str(ws_id))
-            item = await ctx.resolver.item(workspace, warehouse)
+            _log.debug("get_restore_point ws=%s item=%s rp=%r", ws_id, item.id, restore_point_id)
             result = await restore_svc.get_point(ctx.http, ws_id, item.id, restore_point_id)
         except FabricError as exc:
             raise fabric_err(exc) from exc
@@ -78,9 +81,9 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         assert_workspace_allowed(workspace)
         ctx = get_context()
         try:
-            ws_id = await ctx.resolver.workspace_id(workspace)
+            ws_id, item = await resolve_item(ctx.resolver, workspace, warehouse)
             assert_workspace_allowed(workspace, str(ws_id))
-            item = await ctx.resolver.item(workspace, warehouse)
+            _log.debug("create_restore_point ws=%s item=%s name=%r", ws_id, item.id, name)
             result = await restore_svc.create_point(
                 ctx.http, ws_id, item.id, name=name, description=description
             )
@@ -111,9 +114,9 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         assert_workspace_allowed(workspace)
         ctx = get_context()
         try:
-            ws_id = await ctx.resolver.workspace_id(workspace)
+            ws_id, item = await resolve_item(ctx.resolver, workspace, warehouse)
             assert_workspace_allowed(workspace, str(ws_id))
-            item = await ctx.resolver.item(workspace, warehouse)
+            _log.debug("update_restore_point ws=%s item=%s rp=%r", ws_id, item.id, restore_point_id)
             result = await restore_svc.update_point(
                 ctx.http,
                 ws_id,
@@ -146,9 +149,9 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         assert_workspace_allowed(workspace)
         ctx = get_context()
         try:
-            ws_id = await ctx.resolver.workspace_id(workspace)
+            ws_id, item = await resolve_item(ctx.resolver, workspace, warehouse)
             assert_workspace_allowed(workspace, str(ws_id))
-            item = await ctx.resolver.item(workspace, warehouse)
+            _log.debug("delete_restore_point ws=%s item=%s rp=%r", ws_id, item.id, restore_point_id)
             await restore_svc.delete_point(ctx.http, ws_id, item.id, restore_point_id)
         except FabricError as exc:
             raise fabric_err(exc) from exc
@@ -174,9 +177,14 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         assert_workspace_allowed(workspace)
         ctx = get_context()
         try:
-            ws_id = await ctx.resolver.workspace_id(workspace)
+            ws_id, item = await resolve_item(ctx.resolver, workspace, warehouse)
             assert_workspace_allowed(workspace, str(ws_id))
-            item = await ctx.resolver.item(workspace, warehouse)
+            _log.debug(
+                "restore_warehouse_in_place ws=%s item=%s rp=%r",
+                ws_id,
+                item.id,
+                restore_point_id,
+            )
             await restore_svc.restore_in_place(ctx.http, ws_id, item.id, restore_point_id)
         except FabricError as exc:
             raise fabric_err(exc) from exc

--- a/src/fabric_dw/mcp/tools/schemas.py
+++ b/src/fabric_dw/mcp/tools/schemas.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from mcp.server.fastmcp import FastMCP
-from mcp.server.fastmcp.exceptions import ToolError
 
 from fabric_dw.exceptions import FabricError
 from fabric_dw.mcp._context import get_context
@@ -14,14 +14,20 @@ from fabric_dw.mcp._guards import (
     assert_workspace_allowed,
     assert_writes_allowed,
 )
-from fabric_dw.mcp._helpers import fabric_err, require_warehouse
+from fabric_dw.mcp._helpers import (
+    make_sql_target,
+    require_warehouse,
+    resolve_item,
+    tool_err,
+)
 from fabric_dw.services import schemas as schemas_svc
-from fabric_dw.sql import SqlTarget
 
 __all__ = ["register"]
 
+_log = logging.getLogger(__name__)
 
-def register(mcp: FastMCP) -> None:  # noqa: PLR0915
+
+def register(mcp: FastMCP) -> None:
     """Register schema tools against *mcp*."""
 
     @mcp.tool(name="list_schemas")
@@ -42,20 +48,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         assert_workspace_allowed(workspace)
         ctx = get_context()
         try:
-            ws_id = await ctx.resolver.workspace_id(workspace)
+            ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
             assert_workspace_allowed(workspace, str(ws_id))
-            entry = await ctx.resolver.item(workspace, item)
-            if entry.connection_string is None:
-                msg = f"item {item!r} has no connection string; cannot query schemas"
-                raise FabricError(msg)  # noqa: TRY301
-            target = SqlTarget(
-                workspace_id=str(ws_id),
-                database=entry.display_name,
-                connection_string=entry.connection_string,
-            )
+            _log.debug("list_schemas ws=%s item=%s", ws_id, entry.id)
+            target = make_sql_target(ws_id, entry, item)
             result = await schemas_svc.list_schemas(target, mode=ctx.auth_mode)
         except (ValueError, FabricError) as exc:
-            raise fabric_err(exc) if isinstance(exc, FabricError) else ToolError(str(exc)) from exc
+            raise tool_err(exc) from exc
         return [s.model_dump(mode="json") for s in result]
 
     @mcp.tool(name="create_schema")
@@ -74,21 +73,14 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         assert_workspace_allowed(workspace)
         ctx = get_context()
         try:
-            ws_id = await ctx.resolver.workspace_id(workspace)
+            ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
             assert_workspace_allowed(workspace, str(ws_id))
-            entry = await ctx.resolver.item(workspace, item)
             require_warehouse(entry, item)
-            if entry.connection_string is None:
-                msg = f"item {item!r} has no connection string; cannot create schemas"
-                raise FabricError(msg)  # noqa: TRY301
-            target = SqlTarget(
-                workspace_id=str(ws_id),
-                database=entry.display_name,
-                connection_string=entry.connection_string,
-            )
+            _log.debug("create_schema ws=%s item=%s name=%r", ws_id, entry.id, name)
+            target = make_sql_target(ws_id, entry, item)
             result = await schemas_svc.create_schema(target, name, mode=ctx.auth_mode)
         except (ValueError, FabricError) as exc:
-            raise fabric_err(exc) if isinstance(exc, FabricError) else ToolError(str(exc)) from exc
+            raise tool_err(exc) from exc
         return result.model_dump(mode="json")
 
     @mcp.tool(name="delete_schema")
@@ -123,19 +115,12 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         assert_workspace_allowed(workspace)
         ctx = get_context()
         try:
-            ws_id = await ctx.resolver.workspace_id(workspace)
+            ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
             assert_workspace_allowed(workspace, str(ws_id))
-            entry = await ctx.resolver.item(workspace, item)
             require_warehouse(entry, item)
-            if entry.connection_string is None:
-                msg = f"item {item!r} has no connection string; cannot delete schemas"
-                raise FabricError(msg)  # noqa: TRY301
-            target = SqlTarget(
-                workspace_id=str(ws_id),
-                database=entry.display_name,
-                connection_string=entry.connection_string,
-            )
+            _log.debug("delete_schema ws=%s item=%s name=%r", ws_id, entry.id, name)
+            target = make_sql_target(ws_id, entry, item)
             await schemas_svc.delete_schema(target, name, cascade=cascade, mode=ctx.auth_mode)
         except (ValueError, FabricError) as exc:
-            raise fabric_err(exc) if isinstance(exc, FabricError) else ToolError(str(exc)) from exc
+            raise tool_err(exc) from exc
         return {"deleted": True}

--- a/src/fabric_dw/mcp/tools/snapshots.py
+++ b/src/fabric_dw/mcp/tools/snapshots.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from datetime import datetime
 from typing import Any
 
@@ -15,11 +16,12 @@ from fabric_dw.mcp._guards import (
     assert_workspace_allowed,
     assert_writes_allowed,
 )
-from fabric_dw.mcp._helpers import fabric_err
+from fabric_dw.mcp._helpers import fabric_err, make_sql_target, resolve_item
 from fabric_dw.services import snapshots
-from fabric_dw.sql import SqlTarget
 
 __all__ = ["register"]
+
+_log = logging.getLogger(__name__)
 
 
 def register(mcp: FastMCP) -> None:  # noqa: PLR0915
@@ -31,9 +33,9 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         assert_workspace_allowed(workspace)
         ctx = get_context()
         try:
-            ws_id = await ctx.resolver.workspace_id(workspace)
+            ws_id, item = await resolve_item(ctx.resolver, workspace, warehouse)
             assert_workspace_allowed(workspace, str(ws_id))
-            item = await ctx.resolver.item(workspace, warehouse)
+            _log.debug("list_snapshots ws=%s item=%s", ws_id, item.id)
             result = await snapshots.list_snapshots(ctx.http, ws_id, item.id)
         except FabricError as exc:
             raise fabric_err(exc) from exc
@@ -68,9 +70,9 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
                 ) from exc
         ctx = get_context()
         try:
-            ws_id = await ctx.resolver.workspace_id(workspace)
+            ws_id, item = await resolve_item(ctx.resolver, workspace, warehouse)
             assert_workspace_allowed(workspace, str(ws_id))
-            item = await ctx.resolver.item(workspace, warehouse)
+            _log.debug("create_snapshot ws=%s item=%s name=%r", ws_id, item.id, name)
             result = await snapshots.create(
                 ctx.http,
                 ws_id,
@@ -81,6 +83,7 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             )
         except FabricError as exc:
             raise fabric_err(exc) from exc
+        ctx.resolver.clear_negative_cache()
         return result.model_dump(by_alias=True, mode="json")
 
     @mcp.tool(name="rename_snapshot")
@@ -95,9 +98,9 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         assert_workspace_allowed(workspace)
         ctx = get_context()
         try:
-            ws_id = await ctx.resolver.workspace_id(workspace)
+            ws_id, snap_item = await resolve_item(ctx.resolver, workspace, snapshot)
             assert_workspace_allowed(workspace, str(ws_id))
-            snap_item = await ctx.resolver.item(workspace, snapshot)
+            _log.debug("rename_snapshot ws=%s item=%s new=%r", ws_id, snap_item.id, new_name)
             result = await snapshots.rename(
                 ctx.http,
                 ws_id,
@@ -107,6 +110,7 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             )
         except FabricError as exc:
             raise fabric_err(exc) from exc
+        ctx.resolver.clear_negative_cache()
         return result.model_dump(by_alias=True, mode="json")
 
     @mcp.tool(name="delete_snapshot")
@@ -117,9 +121,9 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         assert_workspace_allowed(workspace)
         ctx = get_context()
         try:
-            ws_id = await ctx.resolver.workspace_id(workspace)
+            ws_id, snap_item = await resolve_item(ctx.resolver, workspace, snapshot)
             assert_workspace_allowed(workspace, str(ws_id))
-            snap_item = await ctx.resolver.item(workspace, snapshot)
+            _log.debug("delete_snapshot ws=%s item=%s", ws_id, snap_item.id)
             await snapshots.delete(ctx.http, ws_id, snap_item.id)
         except FabricError as exc:
             raise fabric_err(exc) from exc
@@ -152,17 +156,12 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
                 ) from exc
         ctx = get_context()
         try:
-            ws_id = await ctx.resolver.workspace_id(workspace)
+            ws_id, item = await resolve_item(ctx.resolver, workspace, warehouse)
             assert_workspace_allowed(workspace, str(ws_id))
-            item = await ctx.resolver.item(workspace, warehouse)
-            if item.connection_string is None:
-                msg = f"warehouse {warehouse!r} has no connection string"
-                raise FabricError(msg)  # noqa: TRY301
-            target = SqlTarget(
-                workspace_id=str(ws_id),
-                database=item.display_name,
-                connection_string=item.connection_string,
+            _log.debug(
+                "roll_snapshot_timestamp ws=%s item=%s snap=%r", ws_id, item.id, snapshot_name
             )
+            target = make_sql_target(ws_id, item, warehouse)
             await snapshots.roll_timestamp(target, snapshot_name, parsed_dt, mode=ctx.auth_mode)
         except FabricError as exc:
             raise fabric_err(exc) from exc

--- a/src/fabric_dw/mcp/tools/snapshots.py
+++ b/src/fabric_dw/mcp/tools/snapshots.py
@@ -16,7 +16,7 @@ from fabric_dw.mcp._guards import (
     assert_workspace_allowed,
     assert_writes_allowed,
 )
-from fabric_dw.mcp._helpers import fabric_err, make_sql_target, resolve_item
+from fabric_dw.mcp._helpers import fabric_err, make_sql_target, resolve_item, tool_err
 from fabric_dw.services import snapshots
 
 __all__ = ["register"]
@@ -81,8 +81,8 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
                 description=description,
                 snapshot_dt=parsed_dt,
             )
-        except FabricError as exc:
-            raise fabric_err(exc) from exc
+        except (ValueError, FabricError) as exc:
+            raise tool_err(exc) from exc
         ctx.resolver.clear_negative_cache()
         return result.model_dump(by_alias=True, mode="json")
 
@@ -108,8 +108,8 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
                 new_name=new_name,
                 description=description,
             )
-        except FabricError as exc:
-            raise fabric_err(exc) from exc
+        except (ValueError, FabricError) as exc:
+            raise tool_err(exc) from exc
         ctx.resolver.clear_negative_cache()
         return result.model_dump(by_alias=True, mode="json")
 

--- a/src/fabric_dw/mcp/tools/sql_endpoints.py
+++ b/src/fabric_dw/mcp/tools/sql_endpoints.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 from typing import Any
 
@@ -11,11 +12,13 @@ from mcp.server.fastmcp.exceptions import ToolError
 from fabric_dw.exceptions import FabricError
 from fabric_dw.mcp._context import get_context
 from fabric_dw.mcp._guards import assert_workspace_allowed, assert_writes_allowed
-from fabric_dw.mcp._helpers import fabric_err
+from fabric_dw.mcp._helpers import fabric_err, resolve_item
 from fabric_dw.services import permissions as _permissions_svc
 from fabric_dw.services import sql_endpoints
 
 __all__ = ["register"]
+
+_log = logging.getLogger(__name__)
 
 
 def register(mcp: FastMCP) -> None:  # noqa: PLR0915
@@ -42,10 +45,12 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         ctx = get_context()
         try:
             if all_workspaces:
+                _log.debug("list_sql_endpoints all_workspaces=True")
                 result = await sql_endpoints.list_all_workspaces(ctx.http)
             else:
                 ws_id = await ctx.resolver.workspace_id(workspace)
                 assert_workspace_allowed(workspace, str(ws_id))
+                _log.debug("list_sql_endpoints ws=%s", ws_id)
                 result = await sql_endpoints.list_endpoints(ctx.http, ws_id)
         except FabricError as exc:
             raise fabric_err(exc) from exc
@@ -57,9 +62,9 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         assert_workspace_allowed(workspace)
         ctx = get_context()
         try:
-            ws_id = await ctx.resolver.workspace_id(workspace)
+            ws_id, item = await resolve_item(ctx.resolver, workspace, endpoint)
             assert_workspace_allowed(workspace, str(ws_id))
-            item = await ctx.resolver.item(workspace, endpoint)
+            _log.debug("get_sql_endpoint ws=%s item=%s", ws_id, item.id)
             result = await sql_endpoints.get_endpoint(ctx.http, ws_id, item.id)
         except FabricError as exc:
             raise fabric_err(exc) from exc
@@ -87,9 +92,14 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         assert_workspace_allowed(workspace)
         ctx = get_context()
         try:
-            ws_id = await ctx.resolver.workspace_id(workspace)
+            ws_id, item = await resolve_item(ctx.resolver, workspace, endpoint)
             assert_workspace_allowed(workspace, str(ws_id))
-            item = await ctx.resolver.item(workspace, endpoint)
+            _log.debug(
+                "refresh_sql_endpoint_metadata ws=%s item=%s recreate=%s",
+                ws_id,
+                item.id,
+                recreate_tables,
+            )
             statuses = await sql_endpoints.refresh_metadata(
                 ctx.http, ws_id, item.id, recreate_tables=recreate_tables
             )
@@ -110,9 +120,9 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         assert_workspace_allowed(workspace)
         ctx = get_context()
         try:
-            ws_id = await ctx.resolver.workspace_id(workspace)
+            ws_id, item = await resolve_item(ctx.resolver, workspace, sql_endpoint)
             assert_workspace_allowed(workspace, str(ws_id))
-            item = await ctx.resolver.item(workspace, sql_endpoint)
+            _log.debug("get_sql_endpoint_permissions ws=%s item=%s", ws_id, item.id)
             result = await _permissions_svc.list_item_access(ctx.http, ws_id, item.id)
         except FabricError as exc:
             raise fabric_err(exc) from exc

--- a/src/fabric_dw/mcp/tools/sql_exec.py
+++ b/src/fabric_dw/mcp/tools/sql_exec.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Annotated, Any
 
 from mcp.server.fastmcp import FastMCP
@@ -16,11 +17,12 @@ from fabric_dw.mcp._guards import (
     assert_readonly_sql,
     assert_workspace_allowed,
 )
-from fabric_dw.mcp._helpers import fabric_err
+from fabric_dw.mcp._helpers import fabric_err, make_sql_target, resolve_item
 from fabric_dw.services import sql_exec as _sql_exec_svc
-from fabric_dw.sql import SqlTarget
 
 __all__ = ["register"]
+
+_log = logging.getLogger(__name__)
 
 
 def register(mcp: FastMCP) -> None:
@@ -72,17 +74,10 @@ def register(mcp: FastMCP) -> None:
         assert_workspace_allowed(workspace)
         ctx = get_context()
         try:
-            ws_id = await ctx.resolver.workspace_id(workspace)
+            ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
             assert_workspace_allowed(workspace, str(ws_id))
-            entry = await ctx.resolver.item(workspace, item)
-            if entry.connection_string is None:
-                msg = f"item {item!r} has no connection string; cannot execute SQL"
-                raise FabricError(msg)  # noqa: TRY301
-            target = SqlTarget(
-                workspace_id=str(ws_id),
-                database=entry.display_name,
-                connection_string=entry.connection_string,
-            )
+            _log.debug("execute_sql ws=%s item=%s max_rows=%d", ws_id, entry.id, max_rows)
+            target = make_sql_target(ws_id, entry, item)
             result = await _sql_exec_svc.execute(
                 target, query, mode=ctx.auth_mode, row_limit=max_rows
             )

--- a/src/fabric_dw/mcp/tools/sql_pools.py
+++ b/src/fabric_dw/mcp/tools/sql_pools.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Any
+import logging
+from typing import Annotated, Any
 
 from mcp.server.fastmcp import FastMCP
 from mcp.server.fastmcp.exceptions import ToolError
+from pydantic import Field
 
 from fabric_dw.exceptions import AlreadyExists, FabricError, NotFound
 from fabric_dw.mcp._context import get_context
@@ -19,6 +21,8 @@ from fabric_dw.models import SqlPool, SqlPoolClassifier
 from fabric_dw.services import sql_pools as sql_pools_svc
 
 __all__ = ["register"]
+
+_log = logging.getLogger(__name__)
 
 
 def register(mcp: FastMCP) -> None:  # noqa: PLR0915
@@ -36,6 +40,7 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         try:
             ws_id = await ctx.resolver.workspace_id(workspace)
             assert_workspace_allowed(workspace, str(ws_id))
+            _log.debug("get_sql_pools_configuration ws=%s", ws_id)
             result = await sql_pools_svc.get_configuration(ctx.http, ws_id)
         except FabricError as exc:
             raise fabric_err(exc) from exc
@@ -52,6 +57,7 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         try:
             ws_id = await ctx.resolver.workspace_id(workspace)
             assert_workspace_allowed(workspace, str(ws_id))
+            _log.debug("list_sql_pools ws=%s", ws_id)
             config = await sql_pools_svc.get_configuration(ctx.http, ws_id)
         except FabricError as exc:
             raise fabric_err(exc) from exc
@@ -72,6 +78,7 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         try:
             ws_id = await ctx.resolver.workspace_id(workspace)
             assert_workspace_allowed(workspace, str(ws_id))
+            _log.debug("get_sql_pool ws=%s pool=%r", ws_id, pool_name)
             config = await sql_pools_svc.get_configuration(ctx.http, ws_id)
         except FabricError as exc:
             raise fabric_err(exc) from exc
@@ -84,7 +91,7 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
     async def create_sql_pool(  # noqa: PLR0913
         workspace: str,
         name: str,
-        max_percent: int,
+        max_percent: Annotated[int, Field(ge=1, le=100)],
         is_default: bool = False,  # noqa: FBT001, FBT002
         optimize_for_reads: bool = True,  # noqa: FBT001, FBT002
         classifier_type: str | None = None,
@@ -130,19 +137,26 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         try:
             ws_id = await ctx.resolver.workspace_id(workspace)
             assert_workspace_allowed(workspace, str(ws_id))
+            _log.debug("create_sql_pool ws=%s name=%r max_percent=%d", ws_id, name, max_percent)
             result = await sql_pools_svc.create_pool(ctx.http, ws_id, pool)
         except AlreadyExists as exc:
             raise ToolError(str(exc)) from exc
         except FabricError as exc:
             raise fabric_err(exc) from exc
-        created = next(p for p in result.custom_sql_pools if p.name == name)
+        created = next((p for p in result.custom_sql_pools if p.name == name), None)
+        if created is None:
+            raise ToolError(  # noqa: TRY003
+                f"pool {name!r} was not found in the API response after creation; "
+                "the pool may have been created but is not yet visible (eventual consistency)"
+            )
+        ctx.resolver.clear_negative_cache()
         return created.model_dump(by_alias=True, mode="json")
 
     @mcp.tool(name="update_sql_pool")
     async def update_sql_pool(  # noqa: PLR0913
         workspace: str,
         name: str,
-        max_percent: int | None = None,
+        max_percent: Annotated[int, Field(ge=1, le=100)] | None = None,
         is_default: bool | None = None,  # noqa: FBT001
         optimize_for_reads: bool | None = None,  # noqa: FBT001
         classifier_type: str | None = None,
@@ -167,6 +181,7 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         try:
             ws_id = await ctx.resolver.workspace_id(workspace)
             assert_workspace_allowed(workspace, str(ws_id))
+            _log.debug("update_sql_pool ws=%s name=%r", ws_id, name)
             result = await sql_pools_svc.update_pool(
                 ctx.http,
                 ws_id,
@@ -181,7 +196,12 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             raise ToolError(str(exc)) from exc
         except FabricError as exc:
             raise fabric_err(exc) from exc
-        updated = next(p for p in result.custom_sql_pools if p.name == name)
+        updated = next((p for p in result.custom_sql_pools if p.name == name), None)
+        if updated is None:
+            raise ToolError(  # noqa: TRY003
+                f"pool {name!r} was not found in the API response after update; "
+                "the pool may have been updated but is not yet visible (eventual consistency)"
+            )
         return updated.model_dump(by_alias=True, mode="json")
 
     @mcp.tool(name="delete_sql_pool")
@@ -201,6 +221,7 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         try:
             ws_id = await ctx.resolver.workspace_id(workspace)
             assert_workspace_allowed(workspace, str(ws_id))
+            _log.debug("delete_sql_pool ws=%s pool=%r", ws_id, pool_name)
             await sql_pools_svc.delete_pool(ctx.http, ws_id, pool_name)
         except NotFound as exc:
             raise ToolError(str(exc)) from exc
@@ -225,6 +246,7 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         try:
             ws_id = await ctx.resolver.workspace_id(workspace)
             assert_workspace_allowed(workspace, str(ws_id))
+            _log.debug("reset_sql_pools ws=%s", ws_id)
             result = await sql_pools_svc.reset_pools(ctx.http, ws_id)
         except FabricError as exc:
             raise fabric_err(exc) from exc
@@ -242,6 +264,7 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         try:
             ws_id = await ctx.resolver.workspace_id(workspace)
             assert_workspace_allowed(workspace, str(ws_id))
+            _log.debug("enable_sql_pools ws=%s", ws_id)
             result = await sql_pools_svc.enable(ctx.http, ws_id)
         except FabricError as exc:
             raise fabric_err(exc) from exc
@@ -261,6 +284,7 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         try:
             ws_id = await ctx.resolver.workspace_id(workspace)
             assert_workspace_allowed(workspace, str(ws_id))
+            _log.debug("disable_sql_pools ws=%s", ws_id)
             result = await sql_pools_svc.disable(ctx.http, ws_id)
         except FabricError as exc:
             raise fabric_err(exc) from exc

--- a/src/fabric_dw/mcp/tools/tables.py
+++ b/src/fabric_dw/mcp/tools/tables.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-from typing import Any
+import logging
+from typing import Annotated, Any
 
 from mcp.server.fastmcp import FastMCP
-from mcp.server.fastmcp.exceptions import ToolError
+from pydantic import Field
 
 from fabric_dw.exceptions import FabricError
 from fabric_dw.mcp._context import get_context
@@ -14,12 +15,18 @@ from fabric_dw.mcp._guards import (
     assert_workspace_allowed,
     assert_writes_allowed,
 )
-from fabric_dw.mcp._helpers import fabric_err, parse_qualified_name
+from fabric_dw.mcp._helpers import (
+    make_sql_target,
+    parse_qualified_name,
+    resolve_item,
+    safe_rows,
+    tool_err,
+)
 from fabric_dw.services import tables as tables_svc
-from fabric_dw.sql import SqlTarget
-from fabric_dw.sql_io import json_safe as _json_safe_value
 
 __all__ = ["register"]
+
+_log = logging.getLogger(__name__)
 
 
 def register(mcp: FastMCP) -> None:  # noqa: PLR0915
@@ -39,25 +46,21 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         assert_workspace_allowed(workspace)
         ctx = get_context()
         try:
-            ws_id = await ctx.resolver.workspace_id(workspace)
+            ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
             assert_workspace_allowed(workspace, str(ws_id))
-            entry = await ctx.resolver.item(workspace, item)
-            if entry.connection_string is None:
-                msg = f"item {item!r} has no connection string; cannot query tables"
-                raise FabricError(msg)  # noqa: TRY301
-            target = SqlTarget(
-                workspace_id=str(ws_id),
-                database=entry.display_name,
-                connection_string=entry.connection_string,
-            )
+            _log.debug("list_tables ws=%s item=%s schema=%r", ws_id, entry.id, schema)
+            target = make_sql_target(ws_id, entry, item)
             result = await tables_svc.list_tables(target, schema=schema, mode=ctx.auth_mode)
         except (ValueError, FabricError) as exc:
-            raise fabric_err(exc) if isinstance(exc, FabricError) else ToolError(str(exc)) from exc
+            raise tool_err(exc) from exc
         return [t.model_dump(mode="json") for t in result]
 
     @mcp.tool(name="read_table")
     async def read_table(
-        workspace: str, item: str, qualified_name: str, count: int = 10
+        workspace: str,
+        item: str,
+        qualified_name: str,
+        count: Annotated[int, Field(ge=1, le=10000)] = 10,
     ) -> dict[str, Any]:
         """Return up to *count* rows from a table as JSON-serialisable columns + rows.
 
@@ -65,31 +68,31 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             workspace: Workspace name or GUID.
             item: Warehouse or SQL endpoint name or GUID.
             qualified_name: Dot-separated qualified table name, e.g. ``dbo.sales``.
-            count: Maximum number of rows to return (default 10).
+            count: Maximum number of rows to return (1-10000, default 10).
         """
         schema, table_name = parse_qualified_name(qualified_name, kind="table")
         assert_workspace_allowed(workspace)
         ctx = get_context()
         try:
-            ws_id = await ctx.resolver.workspace_id(workspace)
+            ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
             assert_workspace_allowed(workspace, str(ws_id))
-            entry = await ctx.resolver.item(workspace, item)
-            if entry.connection_string is None:
-                msg = f"item {item!r} has no connection string; cannot read tables"
-                raise FabricError(msg)  # noqa: TRY301
-            target = SqlTarget(
-                workspace_id=str(ws_id),
-                database=entry.display_name,
-                connection_string=entry.connection_string,
+            _log.debug(
+                "read_table ws=%s item=%s table=%s.%s count=%d",
+                ws_id,
+                entry.id,
+                schema,
+                table_name,
+                count,
             )
+            target = make_sql_target(ws_id, entry, item)
             columns, rows = await tables_svc.read_table(
                 target, schema, table_name, count=count, mode=ctx.auth_mode
             )
         except (ValueError, FabricError) as exc:
-            raise fabric_err(exc) if isinstance(exc, FabricError) else ToolError(str(exc)) from exc
+            raise tool_err(exc) from exc
         return {
             "columns": columns,
-            "rows": [[_json_safe_value(v) for v in row] for row in rows],
+            "rows": safe_rows(rows),
         }
 
     @mcp.tool(name="create_table")
@@ -113,22 +116,18 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         assert_workspace_allowed(workspace)
         ctx = get_context()
         try:
-            ws_id = await ctx.resolver.workspace_id(workspace)
+            ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
             assert_workspace_allowed(workspace, str(ws_id))
-            entry = await ctx.resolver.item(workspace, item)
-            if entry.connection_string is None:
-                msg = f"item {item!r} has no connection string; cannot create tables"
-                raise FabricError(msg)  # noqa: TRY301
-            target = SqlTarget(
-                workspace_id=str(ws_id),
-                database=entry.display_name,
-                connection_string=entry.connection_string,
+            _log.debug(
+                "create_table ws=%s item=%s table=%s.%s", ws_id, entry.id, schema, table_name
             )
+            target = make_sql_target(ws_id, entry, item)
             result = await tables_svc.create_table(
                 target, schema, table_name, select_body, kind=entry.kind, mode=ctx.auth_mode
             )
         except (ValueError, FabricError) as exc:
-            raise fabric_err(exc) if isinstance(exc, FabricError) else ToolError(str(exc)) from exc
+            raise tool_err(exc) from exc
+        ctx.resolver.clear_negative_cache()
         return result.model_dump(mode="json")
 
     @mcp.tool(name="delete_table")
@@ -149,22 +148,17 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         assert_workspace_allowed(workspace)
         ctx = get_context()
         try:
-            ws_id = await ctx.resolver.workspace_id(workspace)
+            ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
             assert_workspace_allowed(workspace, str(ws_id))
-            entry = await ctx.resolver.item(workspace, item)
-            if entry.connection_string is None:
-                msg = f"item {item!r} has no connection string; cannot delete tables"
-                raise FabricError(msg)  # noqa: TRY301
-            target = SqlTarget(
-                workspace_id=str(ws_id),
-                database=entry.display_name,
-                connection_string=entry.connection_string,
+            _log.debug(
+                "delete_table ws=%s item=%s table=%s.%s", ws_id, entry.id, schema, table_name
             )
+            target = make_sql_target(ws_id, entry, item)
             await tables_svc.delete_table(
                 target, schema, table_name, kind=entry.kind, mode=ctx.auth_mode
             )
         except (ValueError, FabricError) as exc:
-            raise fabric_err(exc) if isinstance(exc, FabricError) else ToolError(str(exc)) from exc
+            raise tool_err(exc) from exc
         return {"dropped": True}
 
     @mcp.tool(name="clear_table")
@@ -186,20 +180,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         assert_workspace_allowed(workspace)
         ctx = get_context()
         try:
-            ws_id = await ctx.resolver.workspace_id(workspace)
+            ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
             assert_workspace_allowed(workspace, str(ws_id))
-            entry = await ctx.resolver.item(workspace, item)
-            if entry.connection_string is None:
-                msg = f"item {item!r} has no connection string; cannot clear tables"
-                raise FabricError(msg)  # noqa: TRY301
-            target = SqlTarget(
-                workspace_id=str(ws_id),
-                database=entry.display_name,
-                connection_string=entry.connection_string,
-            )
+            _log.debug("clear_table ws=%s item=%s table=%s.%s", ws_id, entry.id, schema, table_name)
+            target = make_sql_target(ws_id, entry, item)
             await tables_svc.clear_table(
                 target, schema, table_name, kind=entry.kind, mode=ctx.auth_mode
             )
         except (ValueError, FabricError) as exc:
-            raise fabric_err(exc) if isinstance(exc, FabricError) else ToolError(str(exc)) from exc
+            raise tool_err(exc) from exc
         return {"truncated": True}

--- a/src/fabric_dw/mcp/tools/views.py
+++ b/src/fabric_dw/mcp/tools/views.py
@@ -2,20 +2,27 @@
 
 from __future__ import annotations
 
-from typing import Any
+import logging
+from typing import Annotated, Any
 
 from mcp.server.fastmcp import FastMCP
-from mcp.server.fastmcp.exceptions import ToolError
+from pydantic import Field
 
 from fabric_dw.exceptions import FabricError
 from fabric_dw.mcp._context import get_context
 from fabric_dw.mcp._guards import assert_workspace_allowed, assert_writes_allowed
-from fabric_dw.mcp._helpers import fabric_err, parse_qualified_name
+from fabric_dw.mcp._helpers import (
+    make_sql_target,
+    parse_qualified_name,
+    resolve_item,
+    safe_rows,
+    tool_err,
+)
 from fabric_dw.services import views as views_svc
-from fabric_dw.sql import SqlTarget
-from fabric_dw.sql_io import json_safe as _json_safe_value
 
 __all__ = ["register"]
+
+_log = logging.getLogger(__name__)
 
 
 def register(mcp: FastMCP) -> None:  # noqa: PLR0915
@@ -35,25 +42,21 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         assert_workspace_allowed(workspace)
         ctx = get_context()
         try:
-            ws_id = await ctx.resolver.workspace_id(workspace)
+            ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
             assert_workspace_allowed(workspace, str(ws_id))
-            entry = await ctx.resolver.item(workspace, item)
-            if entry.connection_string is None:
-                msg = f"item {item!r} has no connection string; cannot query views"
-                raise FabricError(msg)  # noqa: TRY301
-            target = SqlTarget(
-                workspace_id=str(ws_id),
-                database=entry.display_name,
-                connection_string=entry.connection_string,
-            )
+            _log.debug("list_views ws=%s item=%s schema=%r", ws_id, entry.id, schema)
+            target = make_sql_target(ws_id, entry, item)
             result = await views_svc.list_views(target, schema=schema, mode=ctx.auth_mode)
         except (ValueError, FabricError) as exc:
-            raise fabric_err(exc) if isinstance(exc, FabricError) else ToolError(str(exc)) from exc
+            raise tool_err(exc) from exc
         return [v.model_dump(mode="json") for v in result]
 
     @mcp.tool(name="read_view")
     async def read_view(
-        workspace: str, item: str, qualified_name: str, count: int = 10
+        workspace: str,
+        item: str,
+        qualified_name: str,
+        count: Annotated[int, Field(ge=1, le=10000)] = 10,
     ) -> dict[str, Any]:
         """Return up to *count* rows from a view as JSON-serialisable columns + rows.
 
@@ -61,31 +64,31 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             workspace: Workspace name or GUID.
             item: Warehouse or SQL endpoint name or GUID.
             qualified_name: Dot-separated qualified view name, e.g. ``dbo.vw_sales``.
-            count: Maximum number of rows to return (default 10).
+            count: Maximum number of rows to return (1-10000, default 10).
         """
         schema, view_name = parse_qualified_name(qualified_name, kind="view")
         assert_workspace_allowed(workspace)
         ctx = get_context()
         try:
-            ws_id = await ctx.resolver.workspace_id(workspace)
+            ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
             assert_workspace_allowed(workspace, str(ws_id))
-            entry = await ctx.resolver.item(workspace, item)
-            if entry.connection_string is None:
-                msg = f"item {item!r} has no connection string; cannot read views"
-                raise FabricError(msg)  # noqa: TRY301
-            target = SqlTarget(
-                workspace_id=str(ws_id),
-                database=entry.display_name,
-                connection_string=entry.connection_string,
+            _log.debug(
+                "read_view ws=%s item=%s view=%s.%s count=%d",
+                ws_id,
+                entry.id,
+                schema,
+                view_name,
+                count,
             )
+            target = make_sql_target(ws_id, entry, item)
             columns, rows = await views_svc.read_view(
                 target, schema, view_name, count=count, mode=ctx.auth_mode
             )
         except (ValueError, FabricError) as exc:
-            raise fabric_err(exc) if isinstance(exc, FabricError) else ToolError(str(exc)) from exc
+            raise tool_err(exc) from exc
         return {
             "columns": columns,
-            "rows": [[_json_safe_value(v) for v in row] for row in rows],
+            "rows": safe_rows(rows),
         }
 
     @mcp.tool(name="get_view")
@@ -101,20 +104,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         assert_workspace_allowed(workspace)
         ctx = get_context()
         try:
-            ws_id = await ctx.resolver.workspace_id(workspace)
+            ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
             assert_workspace_allowed(workspace, str(ws_id))
-            entry = await ctx.resolver.item(workspace, item)
-            if entry.connection_string is None:
-                msg = f"item {item!r} has no connection string; cannot query views"
-                raise FabricError(msg)  # noqa: TRY301
-            target = SqlTarget(
-                workspace_id=str(ws_id),
-                database=entry.display_name,
-                connection_string=entry.connection_string,
-            )
+            _log.debug("get_view ws=%s item=%s view=%s.%s", ws_id, entry.id, schema, view_name)
+            target = make_sql_target(ws_id, entry, item)
             result = await views_svc.get_view(target, schema, view_name, mode=ctx.auth_mode)
         except (ValueError, FabricError) as exc:
-            raise fabric_err(exc) if isinstance(exc, FabricError) else ToolError(str(exc)) from exc
+            raise tool_err(exc) from exc
         return result.model_dump(mode="json")
 
     @mcp.tool(name="create_view")
@@ -137,22 +133,16 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         assert_workspace_allowed(workspace)
         ctx = get_context()
         try:
-            ws_id = await ctx.resolver.workspace_id(workspace)
+            ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
             assert_workspace_allowed(workspace, str(ws_id))
-            entry = await ctx.resolver.item(workspace, item)
-            if entry.connection_string is None:
-                msg = f"item {item!r} has no connection string; cannot create views"
-                raise FabricError(msg)  # noqa: TRY301
-            target = SqlTarget(
-                workspace_id=str(ws_id),
-                database=entry.display_name,
-                connection_string=entry.connection_string,
-            )
+            _log.debug("create_view ws=%s item=%s view=%s.%s", ws_id, entry.id, schema, view_name)
+            target = make_sql_target(ws_id, entry, item)
             result = await views_svc.create_view(
                 target, schema, view_name, select_body, mode=ctx.auth_mode
             )
         except (ValueError, FabricError) as exc:
-            raise fabric_err(exc) if isinstance(exc, FabricError) else ToolError(str(exc)) from exc
+            raise tool_err(exc) from exc
+        ctx.resolver.clear_negative_cache()
         return result.model_dump(mode="json")
 
     @mcp.tool(name="update_view")
@@ -175,22 +165,15 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         assert_workspace_allowed(workspace)
         ctx = get_context()
         try:
-            ws_id = await ctx.resolver.workspace_id(workspace)
+            ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
             assert_workspace_allowed(workspace, str(ws_id))
-            entry = await ctx.resolver.item(workspace, item)
-            if entry.connection_string is None:
-                msg = f"item {item!r} has no connection string; cannot update views"
-                raise FabricError(msg)  # noqa: TRY301
-            target = SqlTarget(
-                workspace_id=str(ws_id),
-                database=entry.display_name,
-                connection_string=entry.connection_string,
-            )
+            _log.debug("update_view ws=%s item=%s view=%s.%s", ws_id, entry.id, schema, view_name)
+            target = make_sql_target(ws_id, entry, item)
             result = await views_svc.update_view(
                 target, schema, view_name, select_body, mode=ctx.auth_mode
             )
         except (ValueError, FabricError) as exc:
-            raise fabric_err(exc) if isinstance(exc, FabricError) else ToolError(str(exc)) from exc
+            raise tool_err(exc) from exc
         return result.model_dump(mode="json")
 
     @mcp.tool(name="drop_view")
@@ -207,18 +190,11 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         assert_workspace_allowed(workspace)
         ctx = get_context()
         try:
-            ws_id = await ctx.resolver.workspace_id(workspace)
+            ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
             assert_workspace_allowed(workspace, str(ws_id))
-            entry = await ctx.resolver.item(workspace, item)
-            if entry.connection_string is None:
-                msg = f"item {item!r} has no connection string; cannot drop views"
-                raise FabricError(msg)  # noqa: TRY301
-            target = SqlTarget(
-                workspace_id=str(ws_id),
-                database=entry.display_name,
-                connection_string=entry.connection_string,
-            )
+            _log.debug("drop_view ws=%s item=%s view=%s.%s", ws_id, entry.id, schema, view_name)
+            target = make_sql_target(ws_id, entry, item)
             await views_svc.drop_view(target, schema, view_name, mode=ctx.auth_mode)
         except (ValueError, FabricError) as exc:
-            raise fabric_err(exc) if isinstance(exc, FabricError) else ToolError(str(exc)) from exc
+            raise tool_err(exc) from exc
         return {"dropped": True}

--- a/src/fabric_dw/mcp/tools/warehouses.py
+++ b/src/fabric_dw/mcp/tools/warehouses.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 from typing import Any
 
@@ -15,12 +16,14 @@ from fabric_dw.mcp._guards import (
     assert_workspace_allowed,
     assert_writes_allowed,
 )
-from fabric_dw.mcp._helpers import fabric_err
+from fabric_dw.mcp._helpers import fabric_err, resolve_item
 from fabric_dw.services import ownership as ownership_svc
 from fabric_dw.services import permissions as _permissions_svc
 from fabric_dw.services import warehouses
 
 __all__ = ["register"]
+
+_log = logging.getLogger(__name__)
 
 
 def register(mcp: FastMCP) -> None:  # noqa: PLR0915
@@ -47,10 +50,12 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         ctx = get_context()
         try:
             if all_workspaces:
+                _log.debug("list_warehouses all_workspaces=True")
                 result = await warehouses.list_all_workspaces(ctx.http)
             else:
                 ws_id = await ctx.resolver.workspace_id(workspace)
                 assert_workspace_allowed(workspace, str(ws_id))
+                _log.debug("list_warehouses ws=%s", ws_id)
                 result = await warehouses.list_warehouses(ctx.http, ws_id)
         except FabricError as exc:
             raise fabric_err(exc) from exc
@@ -62,9 +67,9 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         assert_workspace_allowed(workspace)
         ctx = get_context()
         try:
-            ws_id = await ctx.resolver.workspace_id(workspace)
+            ws_id, item = await resolve_item(ctx.resolver, workspace, warehouse)
             assert_workspace_allowed(workspace, str(ws_id))
-            item = await ctx.resolver.item(workspace, warehouse)
+            _log.debug("get_warehouse ws=%s item=%s", ws_id, item.id)
             result = await warehouses.get_warehouse(ctx.http, ws_id, item.id)
         except FabricError as exc:
             raise fabric_err(exc) from exc
@@ -84,11 +89,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         try:
             ws_id = await ctx.resolver.workspace_id(workspace)
             assert_workspace_allowed(workspace, str(ws_id))
+            _log.debug("create_warehouse ws=%s name=%r", ws_id, name)
             result = await warehouses.create(
                 ctx.http, ws_id, name, collation=collation, description=description
             )
         except FabricError as exc:
             raise fabric_err(exc) from exc
+        ctx.resolver.clear_negative_cache()
         return result.model_dump(by_alias=True, mode="json")
 
     @mcp.tool(name="rename_warehouse")
@@ -103,14 +110,15 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         assert_workspace_allowed(workspace)
         ctx = get_context()
         try:
-            ws_id = await ctx.resolver.workspace_id(workspace)
+            ws_id, item = await resolve_item(ctx.resolver, workspace, warehouse)
             assert_workspace_allowed(workspace, str(ws_id))
-            item = await ctx.resolver.item(workspace, warehouse)
+            _log.debug("rename_warehouse ws=%s item=%s new=%r", ws_id, item.id, new_name)
             result = await warehouses.rename(
                 ctx.http, ws_id, item.id, new_name, description=description
             )
         except FabricError as exc:
             raise fabric_err(exc) from exc
+        ctx.resolver.clear_negative_cache()
         return result.model_dump(by_alias=True, mode="json")
 
     @mcp.tool(name="delete_warehouse")
@@ -121,9 +129,9 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         assert_workspace_allowed(workspace)
         ctx = get_context()
         try:
-            ws_id = await ctx.resolver.workspace_id(workspace)
+            ws_id, item = await resolve_item(ctx.resolver, workspace, warehouse)
             assert_workspace_allowed(workspace, str(ws_id))
-            item = await ctx.resolver.item(workspace, warehouse)
+            _log.debug("delete_warehouse ws=%s item=%s", ws_id, item.id)
             await warehouses.delete(ctx.http, ws_id, item.id)
         except FabricError as exc:
             raise fabric_err(exc) from exc
@@ -136,9 +144,9 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         assert_workspace_allowed(workspace)
         ctx = get_context()
         try:
-            ws_id = await ctx.resolver.workspace_id(workspace)
+            ws_id, item = await resolve_item(ctx.resolver, workspace, warehouse)
             assert_workspace_allowed(workspace, str(ws_id))
-            item = await ctx.resolver.item(workspace, warehouse)
+            _log.debug("takeover_warehouse ws=%s item=%s", ws_id, item.id)
             await ownership_svc.takeover(ctx.http, ws_id, item.id)
         except FabricError as exc:
             raise fabric_err(exc) from exc
@@ -155,9 +163,9 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         assert_workspace_allowed(workspace)
         ctx = get_context()
         try:
-            ws_id = await ctx.resolver.workspace_id(workspace)
+            ws_id, item = await resolve_item(ctx.resolver, workspace, warehouse)
             assert_workspace_allowed(workspace, str(ws_id))
-            item = await ctx.resolver.item(workspace, warehouse)
+            _log.debug("get_warehouse_permissions ws=%s item=%s", ws_id, item.id)
             result = await _permissions_svc.list_item_access(ctx.http, ws_id, item.id)
         except FabricError as exc:
             raise fabric_err(exc) from exc

--- a/src/fabric_dw/mcp/tools/warehouses.py
+++ b/src/fabric_dw/mcp/tools/warehouses.py
@@ -16,7 +16,7 @@ from fabric_dw.mcp._guards import (
     assert_workspace_allowed,
     assert_writes_allowed,
 )
-from fabric_dw.mcp._helpers import fabric_err, resolve_item
+from fabric_dw.mcp._helpers import fabric_err, resolve_item, tool_err
 from fabric_dw.services import ownership as ownership_svc
 from fabric_dw.services import permissions as _permissions_svc
 from fabric_dw.services import warehouses
@@ -93,8 +93,8 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             result = await warehouses.create(
                 ctx.http, ws_id, name, collation=collation, description=description
             )
-        except FabricError as exc:
-            raise fabric_err(exc) from exc
+        except (ValueError, FabricError) as exc:
+            raise tool_err(exc) from exc
         ctx.resolver.clear_negative_cache()
         return result.model_dump(by_alias=True, mode="json")
 
@@ -116,8 +116,8 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             result = await warehouses.rename(
                 ctx.http, ws_id, item.id, new_name, description=description
             )
-        except FabricError as exc:
-            raise fabric_err(exc) from exc
+        except (ValueError, FabricError) as exc:
+            raise tool_err(exc) from exc
         ctx.resolver.clear_negative_cache()
         return result.model_dump(by_alias=True, mode="json")
 

--- a/src/fabric_dw/mcp/tools/workspaces.py
+++ b/src/fabric_dw/mcp/tools/workspaces.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from mcp.server.fastmcp import FastMCP
@@ -15,6 +16,8 @@ from fabric_dw.services import workspaces
 
 __all__ = ["register"]
 
+_log = logging.getLogger(__name__)
+
 
 def register(mcp: FastMCP) -> None:
     """Register workspace tools against *mcp*."""
@@ -22,6 +25,7 @@ def register(mcp: FastMCP) -> None:
     @mcp.tool(name="list_workspaces")
     async def list_workspaces() -> list[dict[str, Any]]:
         """List all Fabric workspaces the caller has access to."""
+        _log.debug("list_workspaces called")
         ctx = get_context()
         try:
             result = await workspaces.list_all(ctx.http)
@@ -37,6 +41,7 @@ def register(mcp: FastMCP) -> None:
         try:
             ws_id = await ctx.resolver.workspace_id(workspace)
             assert_workspace_allowed(workspace, str(ws_id))
+            _log.debug("get_workspace ws=%s", ws_id)
             result = await workspaces.get(ctx.http, ws_id)
         except FabricError as exc:
             raise fabric_err(exc) from exc
@@ -51,6 +56,7 @@ def register(mcp: FastMCP) -> None:
         try:
             ws_id = await ctx.resolver.workspace_id(workspace)
             assert_workspace_allowed(workspace, str(ws_id))
+            _log.debug("set_workspace_collation ws=%s collation=%r", ws_id, collation)
             await workspaces.set_collation(ctx.http, ws_id, collation)
         except ValueError as exc:
             raise ToolError(str(exc)) from exc

--- a/tests/unit/mcp/conftest.py
+++ b/tests/unit/mcp/conftest.py
@@ -104,6 +104,8 @@ def mock_ctx() -> ServerContext:
     # Sensible defaults so tests that don't care about internals still work.
     mock_resolver.workspace_id = AsyncMock(return_value=WS_ID)
     mock_resolver.item = AsyncMock(return_value=make_item_entry())
+    # clear_negative_cache is a synchronous method on the real Resolver.
+    mock_resolver.clear_negative_cache = MagicMock()
 
     return ServerContext(
         http=mock_http,

--- a/tests/unit/mcp/test_server.py
+++ b/tests/unit/mcp/test_server.py
@@ -512,7 +512,7 @@ async def test_get_audit_settings_happy_path(mock_ctx, ctx_patch) -> None:
     assert isinstance(result, dict)
     assert result["state"] == "Enabled"
     assert result["retentionDays"] == 30
-    mock_ctx.resolver.item.assert_called_once_with(_WS_NAME, _WH_NAME)
+    mock_ctx.resolver.item.assert_called_once_with(str(_WS_ID), _WH_NAME)
 
 
 # ---------------------------------------------------------------------------
@@ -850,7 +850,7 @@ async def test_add_audit_group_happy_path(mock_ctx, ctx_patch) -> None:
 
     assert isinstance(result, dict)
     assert result["state"] == "Enabled"
-    mock_ctx.resolver.item.assert_called_once_with(_WS_NAME, _WH_NAME)
+    mock_ctx.resolver.item.assert_called_once_with(str(_WS_ID), _WH_NAME)
 
 
 @pytest.mark.asyncio
@@ -877,7 +877,7 @@ async def test_remove_audit_group_happy_path(mock_ctx, ctx_patch) -> None:
 
     assert isinstance(result, dict)
     assert result["state"] == "Enabled"
-    mock_ctx.resolver.item.assert_called_once_with(_WS_NAME, _WH_NAME)
+    mock_ctx.resolver.item.assert_called_once_with(str(_WS_ID), _WH_NAME)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/mcp/test_server.py
+++ b/tests/unit/mcp/test_server.py
@@ -317,14 +317,58 @@ async def test_list_workspaces_happy_path(ctx_patch) -> None:
 
 @pytest.mark.asyncio
 async def test_clear_cache_side_effect(mock_ctx, ctx_patch) -> None:
-    """clear_cache must call LookupCache.clear() exactly once."""
+    """clear_cache(scope='all') must call LookupCache.clear() and clear_negative_cache."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
     with ctx_patch:
         result = await mcp._tool_manager.call_tool("clear_cache", {})
 
     mock_ctx.cache.clear.assert_called_once()
-    assert result == {"cleared": True}
+    mock_ctx.resolver.clear_negative_cache.assert_called_once()
+    assert result["scope"] == "all"
+    assert result["negative_cache_cleared"] is True
+
+
+@pytest.mark.asyncio
+async def test_clear_cache_scope_workspaces(mock_ctx, ctx_patch) -> None:
+    """clear_cache(scope='workspaces') must NOT call full clear() or clear_negative_cache."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    # Provide a minimal _read/_write implementation on the mock cache so the
+    # scoped clear can interact with it.
+    mock_ctx.cache._lock = __import__("threading").Lock()
+    mock_ctx.cache._read = lambda: {"version": 1, "workspaces": {"ws1": {}}, "items": {}}
+    mock_ctx.cache._write = lambda _: None
+
+    with ctx_patch:
+        result = await mcp._tool_manager.call_tool("clear_cache", {"scope": "workspaces"})
+
+    mock_ctx.cache.clear.assert_not_called()
+    mock_ctx.resolver.clear_negative_cache.assert_not_called()
+    assert result["scope"] == "workspaces"
+    assert result["negative_cache_cleared"] is False
+
+
+@pytest.mark.asyncio
+async def test_clear_cache_scope_items(mock_ctx, ctx_patch) -> None:
+    """clear_cache(scope='items') must NOT call full clear() or clear_negative_cache."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.cache._lock = __import__("threading").Lock()
+    mock_ctx.cache._read = lambda: {
+        "version": 1,
+        "workspaces": {},
+        "items": {"ws-id": {"item1": {}}},
+    }
+    mock_ctx.cache._write = lambda _: None
+
+    with ctx_patch:
+        result = await mcp._tool_manager.call_tool("clear_cache", {"scope": "items"})
+
+    mock_ctx.cache.clear.assert_not_called()
+    mock_ctx.resolver.clear_negative_cache.assert_not_called()
+    assert result["scope"] == "items"
+    assert result["negative_cache_cleared"] is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/mcp/tools/test_tool_quality.py
+++ b/tests/unit/mcp/tools/test_tool_quality.py
@@ -1,0 +1,665 @@
+"""Tests for MCP tool quality improvements (refactor/mcp-tool-quality).
+
+Coverage
+--------
+1. ``fabric_err`` — structured meta suffix in ToolError message for FabricError.
+2. ``tool_err`` — FabricError → fabric_err, ValueError → plain ToolError.
+3. ``make_sql_target`` — raises ToolError when connection_string is None.
+4. ``resolve_item`` — returns (ws_id, entry) in one call.
+5. ``safe_rows`` — applies json_safe to all cells.
+6. ``parse_qualified_name`` — consistent ToolError on bad input.
+7. Int param bounds — FastMCP rejects out-of-range values.
+8. ``next()`` fallback in create_sql_pool / update_sql_pool.
+9. ``clear_cache`` scope + stats.
+10. ``clear_negative_cache`` called after mutating tool (create_warehouse).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID
+
+import pytest
+from mcp.server.fastmcp.exceptions import ToolError
+
+from fabric_dw import auth as _auth
+from fabric_dw.cache import ItemEntry
+from fabric_dw.exceptions import FabricError
+from fabric_dw.mcp._context import ServerContext
+from fabric_dw.mcp._helpers import (
+    fabric_err,
+    make_sql_target,
+    parse_qualified_name,
+    resolve_item,
+    safe_rows,
+    tool_err,
+)
+from fabric_dw.models import WarehouseKind
+
+# ---------------------------------------------------------------------------
+# Shared constants
+# ---------------------------------------------------------------------------
+
+_WS_ID = UUID("a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+_WH_ID = UUID("d4e5f6a7-b8c9-0123-def0-123456789abc")
+_WS_NAME = "my-workspace"
+_WH_NAME = "my-warehouse"
+_CONN_STRING = "wh.fabric.microsoft.com"
+
+
+def _make_entry(
+    *,
+    connection_string: str | None = _CONN_STRING,
+    kind: WarehouseKind = WarehouseKind.WAREHOUSE,
+) -> ItemEntry:
+    return ItemEntry(
+        id=_WH_ID,
+        kind=kind,
+        connection_string=connection_string,
+        fetched_at=datetime.now(tz=UTC),
+        display_name=_WH_NAME,
+    )
+
+
+def _make_ctx() -> ServerContext:
+    mock_http = AsyncMock()
+    mock_cache = MagicMock()
+    mock_resolver = AsyncMock()
+    mock_resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_resolver.item = AsyncMock(return_value=_make_entry())
+    mock_resolver.clear_negative_cache = MagicMock()
+    return ServerContext(
+        http=mock_http,
+        cache=mock_cache,
+        resolver=mock_resolver,
+        auth_mode=_auth.CredentialMode.DEFAULT,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. fabric_err — structured meta
+# ---------------------------------------------------------------------------
+
+
+class TestFabricErr:
+    def test_plain_exception_no_meta(self) -> None:
+        te = fabric_err(ValueError("bad value"))
+        assert "bad value" in str(te)
+        # No meta block for non-FabricError
+        assert "|meta|" not in str(te)
+
+    def test_fabric_error_without_fields(self) -> None:
+        exc = FabricError("something failed")
+        te = fabric_err(exc)
+        msg = str(te)
+        assert "FabricError" in msg
+        assert "something failed" in msg
+        # No extra meta if no structured fields present
+        assert "|meta|" not in msg
+
+    def test_fabric_error_with_status(self) -> None:
+        exc = FabricError("rate limited", status=429)
+        te = fabric_err(exc)
+        msg = str(te)
+        assert "|meta|" in msg
+        meta_str = msg.split("|meta|", 1)[1].strip()
+        meta = json.loads(meta_str)
+        assert meta["error_type"] == "FabricError"
+        assert meta["status"] == 429
+
+    def test_fabric_error_with_request_id(self) -> None:
+        exc = FabricError("not found", request_id="rid-123")
+        te = fabric_err(exc)
+        msg = str(te)
+        assert "|meta|" in msg
+        meta = json.loads(msg.split("|meta|", 1)[1].strip())
+        assert meta["request_id"] == "rid-123"
+
+    def test_fabric_error_with_hint(self) -> None:
+        exc = FabricError("forbidden", status=403, hint="Grant Viewer role")
+        te = fabric_err(exc)
+        msg = str(te)
+        assert "|meta|" in msg
+        meta = json.loads(msg.split("|meta|", 1)[1].strip())
+        assert meta["hint"] == "Grant Viewer role"
+        assert meta["status"] == 403
+
+    def test_returns_tool_error_type(self) -> None:
+        exc = FabricError("err", status=500)
+        te = fabric_err(exc)
+        assert isinstance(te, ToolError)
+
+
+# ---------------------------------------------------------------------------
+# 2. tool_err — uniform funnel
+# ---------------------------------------------------------------------------
+
+
+class TestToolErr:
+    def test_fabric_error_uses_fabric_err(self) -> None:
+        exc = FabricError("api error", status=404)
+        te = tool_err(exc)
+        assert isinstance(te, ToolError)
+        assert "FabricError" in str(te)
+        assert "api error" in str(te)
+
+    def test_value_error_plain_message(self) -> None:
+        exc = ValueError("bad input")
+        te = tool_err(exc)
+        assert isinstance(te, ToolError)
+        assert "bad input" in str(te)
+        assert "|meta|" not in str(te)
+
+    def test_generic_exception(self) -> None:
+        exc = RuntimeError("unexpected")
+        te = tool_err(exc)
+        assert isinstance(te, ToolError)
+        assert "unexpected" in str(te)
+
+
+# ---------------------------------------------------------------------------
+# 3. make_sql_target — ToolError when connection_string is None
+# ---------------------------------------------------------------------------
+
+
+class TestMakeSqlTarget:
+    def test_raises_tool_error_when_no_connection_string(self) -> None:
+        entry = _make_entry(connection_string=None)
+        with pytest.raises(ToolError, match="has no connection string"):
+            make_sql_target(_WS_ID, entry, "my-warehouse")
+
+    def test_returns_sql_target_with_fields(self) -> None:
+        from fabric_dw.sql import SqlTarget  # noqa: PLC0415
+
+        entry = _make_entry(connection_string=_CONN_STRING)
+        target = make_sql_target(_WS_ID, entry, "my-warehouse")
+        assert isinstance(target, SqlTarget)
+        assert target.connection_string == _CONN_STRING
+        assert target.database == _WH_NAME
+        assert target.workspace_id == str(_WS_ID)
+
+    def test_error_message_includes_item_name(self) -> None:
+        entry = _make_entry(connection_string=None)
+        with pytest.raises(ToolError, match="my-warehouse"):
+            make_sql_target(_WS_ID, entry, "my-warehouse")
+
+
+# ---------------------------------------------------------------------------
+# 4. resolve_item — returns (ws_id, entry) without double lookup
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resolve_item_returns_pair() -> None:
+    mock_resolver = AsyncMock()
+    mock_resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    expected_entry = _make_entry()
+    mock_resolver.item = AsyncMock(return_value=expected_entry)
+
+    ws_id, entry = await resolve_item(mock_resolver, _WS_NAME, _WH_NAME)
+
+    assert ws_id == _WS_ID
+    assert entry is expected_entry
+    mock_resolver.workspace_id.assert_awaited_once_with(_WS_NAME)
+    mock_resolver.item.assert_awaited_once_with(_WS_NAME, _WH_NAME)
+
+
+# ---------------------------------------------------------------------------
+# 5. safe_rows — applies json_safe
+# ---------------------------------------------------------------------------
+
+
+class TestSafeRows:
+    def test_string_passthrough(self) -> None:
+        rows = [["hello", "world"]]
+        result = safe_rows(rows)
+        assert result == [["hello", "world"]]
+
+    def test_converts_decimal_to_string(self) -> None:
+        from decimal import Decimal  # noqa: PLC0415
+
+        rows = [[Decimal("3.14")]]
+        result = safe_rows(rows)
+        assert result == [["3.14"]]
+
+    def test_converts_datetime_to_string(self) -> None:
+        from datetime import datetime  # noqa: PLC0415
+
+        dt = datetime(2024, 1, 15, 12, 0, 0, tzinfo=UTC)
+        rows = [[dt]]
+        result = safe_rows(rows)
+        assert isinstance(result[0][0], str)
+
+    def test_accepts_list_of_tuples(self) -> None:
+        # The service layer may return tuples from the DB driver
+        rows = [("hello", 42)]
+        result = safe_rows(rows)
+        assert result == [["hello", 42]]
+
+    def test_empty_rows(self) -> None:
+        assert safe_rows([]) == []
+
+
+# ---------------------------------------------------------------------------
+# 6. parse_qualified_name — consistent ToolError
+# ---------------------------------------------------------------------------
+
+
+class TestParseQualifiedName:
+    def test_valid_schema_table(self) -> None:
+        schema, name = parse_qualified_name("dbo.my_table", kind="table")
+        assert schema == "dbo"
+        assert name == "my_table"
+
+    def test_valid_view(self) -> None:
+        schema, name = parse_qualified_name("sales.vw_orders", kind="view")
+        assert schema == "sales"
+        assert name == "vw_orders"
+
+    def test_rejects_no_dot(self) -> None:
+        with pytest.raises(ToolError, match="qualified_name must be"):
+            parse_qualified_name("nodot", kind="table")
+
+    def test_rejects_empty_schema(self) -> None:
+        with pytest.raises(ToolError, match="qualified_name must be"):
+            parse_qualified_name(".name", kind="table")
+
+    def test_rejects_empty_name(self) -> None:
+        with pytest.raises(ToolError, match="qualified_name must be"):
+            parse_qualified_name("schema.", kind="table")
+
+    def test_kind_in_error_message(self) -> None:
+        with pytest.raises(ToolError, match="view"):
+            parse_qualified_name("nodot", kind="view")
+
+
+# ---------------------------------------------------------------------------
+# 7. Int param bounds
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_read_table_count_bound_rejection() -> None:
+    """read_table must reject count > 10000 at the FastMCP schema layer."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    ctx = _make_ctx()
+    with (
+        patch("fabric_dw.mcp._context._SERVER_CTX", ctx),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "read_table",
+            {
+                "workspace": _WS_NAME,
+                "item": _WH_NAME,
+                "qualified_name": "dbo.t",
+                "count": 99999,
+            },
+        )
+
+
+@pytest.mark.asyncio
+async def test_read_view_count_bound_rejection() -> None:
+    """read_view must reject count > 10000 at the FastMCP schema layer."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    ctx = _make_ctx()
+    with (
+        patch("fabric_dw.mcp._context._SERVER_CTX", ctx),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "read_view",
+            {
+                "workspace": _WS_NAME,
+                "item": _WH_NAME,
+                "qualified_name": "dbo.v",
+                "count": 99999,
+            },
+        )
+
+
+@pytest.mark.asyncio
+async def test_execute_sql_max_rows_bound_rejection() -> None:
+    """execute_sql must reject max_rows > 10000."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    ctx = _make_ctx()
+    with (
+        patch("fabric_dw.mcp._context._SERVER_CTX", ctx),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "execute_sql",
+            {
+                "workspace": _WS_NAME,
+                "item": _WH_NAME,
+                "query": "SELECT 1",
+                "max_rows": 99999,
+            },
+        )
+
+
+@pytest.mark.asyncio
+async def test_list_request_history_limit_bound_rejection() -> None:
+    """list_request_history must reject limit > 10000."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    ctx = _make_ctx()
+    with (
+        patch("fabric_dw.mcp._context._SERVER_CTX", ctx),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "list_request_history",
+            {
+                "workspace": _WS_NAME,
+                "warehouse": _WH_NAME,
+                "limit": 99999,
+            },
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_sql_pool_max_percent_bound_rejection() -> None:
+    """create_sql_pool must reject max_percent > 100."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    ctx = _make_ctx()
+    with (
+        patch("fabric_dw.mcp._context._SERVER_CTX", ctx),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "create_sql_pool",
+            {
+                "workspace": _WS_NAME,
+                "name": "mypool",
+                "max_percent": 200,
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# 8. next() fallback in create_sql_pool / update_sql_pool
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_sql_pool_next_fallback() -> None:
+    """create_sql_pool raises ToolError (not StopIteration) when pool absent after create."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+    from fabric_dw.models import SqlPoolsConfiguration  # noqa: PLC0415
+
+    ctx = _make_ctx()
+    # Return a config that does NOT include the created pool (eventual consistency simulation)
+    empty_config = SqlPoolsConfiguration.model_validate(
+        {"customSQLPoolsEnabled": True, "customSQLPools": []}
+    )
+    with (
+        patch("fabric_dw.services.sql_pools.create_pool", new=AsyncMock(return_value=empty_config)),
+        patch("fabric_dw.services.sql_pools.get_configuration", new=AsyncMock()),
+        patch("fabric_dw.mcp._context._SERVER_CTX", ctx),
+        patch.dict("os.environ", {}, clear=False),
+        pytest.raises(ToolError, match="eventual consistency"),
+    ):
+        await mcp._tool_manager.call_tool(
+            "create_sql_pool",
+            {
+                "workspace": _WS_NAME,
+                "name": "mypool",
+                "max_percent": 50,
+            },
+        )
+
+
+@pytest.mark.asyncio
+async def test_update_sql_pool_next_fallback() -> None:
+    """update_sql_pool raises ToolError (not StopIteration) when pool absent after update."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+    from fabric_dw.models import SqlPoolsConfiguration  # noqa: PLC0415
+
+    ctx = _make_ctx()
+    empty_config = SqlPoolsConfiguration.model_validate(
+        {"customSQLPoolsEnabled": True, "customSQLPools": []}
+    )
+    with (
+        patch("fabric_dw.services.sql_pools.update_pool", new=AsyncMock(return_value=empty_config)),
+        patch("fabric_dw.mcp._context._SERVER_CTX", ctx),
+        patch.dict("os.environ", {}, clear=False),
+        pytest.raises(ToolError, match="eventual consistency"),
+    ):
+        await mcp._tool_manager.call_tool(
+            "update_sql_pool",
+            {
+                "workspace": _WS_NAME,
+                "name": "mypool",
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# 9. clear_cache scope + stats
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_clear_cache_all_returns_stats() -> None:
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    ctx = _make_ctx()
+    # Provide minimal _read/_write so the pre-clear count is zero.
+    # ctx.cache is a MagicMock; cast to Any to avoid ty spurious attribute errors.
+    from typing import cast as _cast  # noqa: PLC0415
+
+    cache_mock: Any = _cast(Any, ctx.cache)
+    resolver_mock: Any = _cast(Any, ctx.resolver)
+    cache_mock._lock = __import__("threading").Lock()
+    cache_mock._read = lambda: {"version": 1, "workspaces": {}, "items": {}}
+    cache_mock._write = lambda _: None
+
+    with patch("fabric_dw.mcp._context._SERVER_CTX", ctx):
+        result = await mcp._tool_manager.call_tool("clear_cache", {"scope": "all"})
+
+    assert result["scope"] == "all"
+    assert "workspaces_cleared" in result
+    assert "items_cleared" in result
+    assert result["negative_cache_cleared"] is True
+    cache_mock.clear.assert_called_once()
+    resolver_mock.clear_negative_cache.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_clear_cache_workspaces_scope() -> None:
+    from typing import cast as _cast  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    ctx = _make_ctx()
+    cache_mock: Any = _cast(Any, ctx.cache)
+    cache_mock._lock = __import__("threading").Lock()
+    cache_mock._read = lambda: {"version": 1, "workspaces": {"ws1": {}, "ws2": {}}, "items": {}}
+    cache_mock._write = lambda _: None
+
+    with patch("fabric_dw.mcp._context._SERVER_CTX", ctx):
+        result = await mcp._tool_manager.call_tool("clear_cache", {"scope": "workspaces"})
+
+    assert result["scope"] == "workspaces"
+    assert result["workspaces_cleared"] == 2
+    assert result["items_cleared"] == 0
+    assert result["negative_cache_cleared"] is False
+    cache_mock.clear.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_clear_cache_items_scope() -> None:
+    from typing import cast as _cast  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    ctx = _make_ctx()
+    cache_mock: Any = _cast(Any, ctx.cache)
+    cache_mock._lock = __import__("threading").Lock()
+    cache_mock._read = lambda: {
+        "version": 1,
+        "workspaces": {},
+        "items": {"ws-a": {"x": {}}, "ws-b": {"y": {}}},
+    }
+    cache_mock._write = lambda _: None
+
+    with patch("fabric_dw.mcp._context._SERVER_CTX", ctx):
+        result = await mcp._tool_manager.call_tool("clear_cache", {"scope": "items"})
+
+    assert result["scope"] == "items"
+    assert result["workspaces_cleared"] == 0
+    assert result["items_cleared"] == 2
+    assert result["negative_cache_cleared"] is False
+    cache_mock.clear.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 10. clear_negative_cache called after successful create (create_warehouse)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_warehouse_clears_negative_cache() -> None:
+    """create_warehouse must call resolver.clear_negative_cache() on success."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+    from fabric_dw.models import Warehouse, WarehouseKind  # noqa: PLC0415
+
+    ctx = _make_ctx()
+    wh = Warehouse.model_validate(
+        {
+            "id": str(_WH_ID),
+            "displayName": "new-wh",
+            "workspaceId": str(_WS_ID),
+            "kind": WarehouseKind.WAREHOUSE,
+            "connectionString": _CONN_STRING,
+        }
+    )
+    with (
+        patch("fabric_dw.services.warehouses.create", new=AsyncMock(return_value=wh)),
+        patch("fabric_dw.mcp._context._SERVER_CTX", ctx),
+        patch.dict("os.environ", {}, clear=False),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "create_warehouse",
+            {"workspace": _WS_NAME, "name": "new-wh"},
+        )
+
+    from typing import cast as _cast  # noqa: PLC0415
+
+    resolver_mock: Any = _cast(Any, ctx.resolver)
+    assert result["displayName"] == "new-wh"
+    resolver_mock.clear_negative_cache.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_create_table_clears_negative_cache() -> None:
+    """create_table must call resolver.clear_negative_cache() on success."""
+    from typing import cast as _cast  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    ctx = _make_ctx()
+    resolver_mock: Any = _cast(Any, ctx.resolver)
+    # Simulate what tables_svc.create_table returns (a Pydantic model with model_dump)
+    mock_table = MagicMock()
+    mock_table.model_dump.return_value = {"schema": "dbo", "name": "new_table"}
+
+    with (
+        patch("fabric_dw.services.tables.create_table", new=AsyncMock(return_value=mock_table)),
+        patch("fabric_dw.mcp._context._SERVER_CTX", ctx),
+        patch.dict("os.environ", {}, clear=False),
+    ):
+        await mcp._tool_manager.call_tool(
+            "create_table",
+            {
+                "workspace": _WS_NAME,
+                "item": _WH_NAME,
+                "qualified_name": "dbo.new_table",
+                "select_body": "SELECT 1 AS id",
+            },
+        )
+
+    resolver_mock.clear_negative_cache.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_create_view_clears_negative_cache() -> None:
+    """create_view must call resolver.clear_negative_cache() on success."""
+    from typing import cast as _cast  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    ctx = _make_ctx()
+    resolver_mock: Any = _cast(Any, ctx.resolver)
+    mock_view = MagicMock()
+    mock_view.model_dump.return_value = {"schema": "dbo", "name": "new_view"}
+
+    with (
+        patch("fabric_dw.services.views.create_view", new=AsyncMock(return_value=mock_view)),
+        patch("fabric_dw.mcp._context._SERVER_CTX", ctx),
+        patch.dict("os.environ", {}, clear=False),
+    ):
+        await mcp._tool_manager.call_tool(
+            "create_view",
+            {
+                "workspace": _WS_NAME,
+                "item": _WH_NAME,
+                "qualified_name": "dbo.new_view",
+                "select_body": "SELECT 1 AS id",
+            },
+        )
+
+    resolver_mock.clear_negative_cache.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# 11. make_sql_target used instead of TRY301 pattern (no_connection_string path)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_tables_raises_tool_error_on_no_connection() -> None:
+    """list_tables must raise ToolError (not FabricError) when no connection string."""
+    from typing import cast as _cast  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    ctx = _make_ctx()
+    _cast(Any, ctx.resolver).item = AsyncMock(return_value=_make_entry(connection_string=None))
+
+    with (
+        patch("fabric_dw.mcp._context._SERVER_CTX", ctx),
+        pytest.raises(ToolError, match="has no connection string"),
+    ):
+        await mcp._tool_manager.call_tool(
+            "list_tables",
+            {"workspace": _WS_NAME, "item": _WH_NAME},
+        )
+
+
+@pytest.mark.asyncio
+async def test_list_running_queries_raises_tool_error_on_no_connection() -> None:
+    """list_running_queries must raise ToolError when no connection string."""
+    from typing import cast as _cast  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    ctx = _make_ctx()
+    _cast(Any, ctx.resolver).item = AsyncMock(return_value=_make_entry(connection_string=None))
+
+    with (
+        patch("fabric_dw.mcp._context._SERVER_CTX", ctx),
+        pytest.raises(ToolError, match="has no connection string"),
+    ):
+        await mcp._tool_manager.call_tool(
+            "list_running_queries",
+            {"workspace": _WS_NAME, "warehouse": _WH_NAME},
+        )

--- a/tests/unit/mcp/tools/test_tool_quality.py
+++ b/tests/unit/mcp/tools/test_tool_quality.py
@@ -204,7 +204,7 @@ async def test_resolve_item_returns_pair() -> None:
     assert ws_id == _WS_ID
     assert entry is expected_entry
     mock_resolver.workspace_id.assert_awaited_once_with(_WS_NAME)
-    mock_resolver.item.assert_awaited_once_with(_WS_NAME, _WH_NAME)
+    mock_resolver.item.assert_awaited_once_with(str(_WS_ID), _WH_NAME)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Centralised `make_sql_target`, `parse_qualified_name`, `resolve_item`, `safe_rows`, `fabric_err`, `tool_err`, `require_warehouse` into `_helpers.py`, eliminating ~20 inline duplicates across 12 tool modules.
- Added `Annotated[int, Field(ge, le)]` bounds on all unbounded integer params (`count`, `limit`, `retention_days`, `max_percent`, `max_rows`).
- Replaced bare `next(generator)` in `create_sql_pool`/`update_sql_pool` with `next(..., None)` + explicit `ToolError("... eventual consistency")`.
- Added `scope` param and stats dict return to `clear_cache`; scoped clears touch only the requested cache partition.
- Added `_log.debug(...)` to every tool handler with resolved workspace/item IDs; `clear_cache` logs at INFO.
- Mutating tools call `resolver.clear_negative_cache()` after successful writes.
- Uniform error funnel: `FabricError` → `fabric_err()` (with structured `|meta| {json}` suffix); `ValueError` → `ToolError(str(exc))`; combined via `tool_err()`.

## Findings addressed (by filename)

| Finding | Resolution |
|---|---|
| `05-mcp-sqltarget-construction-duplication` | `make_sql_target()` helper in `_helpers.py` |
| `05-mcp-qualified-name-parser-duplication` | `parse_qualified_name()` helper in `_helpers.py` |
| `05-mcp-try-raise-from-try-antipattern` | `make_sql_target` raises `ToolError` before try-block; zero `TRY301` noqa's remain |
| `05-mcp-inconsistent-except-valueerror` | Uniform `tool_err()` / `fabric_err()` in all handlers |
| `05-mcp-inconsistent-error-terminology` | Centralised helpers produce consistent messages |
| `05-mcp-fabric-err-no-structured-data` | `fabric_err()` emits `\|meta\| {json}` with status/request_id/hint |
| `05-mcp-dict-return-types-lose-schema` | `model_dump(mode="json")` retained for MCP protocol compat |
| `05-mcp-no-bounds-on-int-params` | `Annotated[int, Field(ge, le)]` on all int params |
| `05-mcp-next-without-fallback` | Safe `next(..., None)` + ToolError("eventual consistency") |
| `05-mcp-no-logging-in-tools` | `_log.debug(...)` in every handler |
| `05-mcp-resolver-item-double-lookup` | `resolve_item()` helper returns `(ws_id, entry)` |
| `05-mcp-json-safe-value-duplication` | `safe_rows()` in `_helpers.py` |
| `05-mcp-large-tool-handlers` | Shared helpers reduce per-handler LOC; sql_pool restructured |
| `05-mcp-clear-cache-no-granularity` | `scope` param + stats return |
| `05-mcp-streaming-resultsets-in-memory` | Bounded `count`/`max_rows` via `Annotated[int, Field(ge=1, le=10000)]` |

## Decisions

- `dict[str, Any]` return types kept: FastMCP serialises them fine and changing to `list[Model]` would be a separate PR touching the public MCP tool schema.
- `05-mcp-monolithic-god-module` and `05-mcp-module-singletons-race` were addressed in the prior PR #248 (per-domain tool modules + `ServerContext`); this PR builds on that split.
- `05-mcp-no-lifecycle-shutdown` and `05-mcp-no-di-environ-in-factories` are out-of-scope (covered by prior refactors).

## Security

All `_guards.py` calls (`assert_readonly_sql` / `assert_writes_allowed` / `assert_destructive_allowed` / `assert_workspace_allowed`) and `max_rows`/`row_limit` caps are preserved. grep count: **222** call-sites in `src/fabric_dw/mcp/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)