### PR TITLE
chore(tests): strip redundant asyncio markers, shared helpers, deselect integration by default

### DIFF
--- a/justfile
+++ b/justfile
@@ -24,7 +24,7 @@ cov-html:
     uv run pytest tests/unit --cov --cov-report=html
 
 integration:
-    uv run pytest tests/integration -q
+    uv run pytest tests/integration -q -m integration
 
 build:
     uv build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,7 +130,7 @@ select = [
 
 [tool.pytest.ini_options]
 markers = ["integration: hits real Fabric APIs"]
-addopts = "-ra --strict-markers"
+addopts = "-ra --strict-markers -m 'not integration'"
 asyncio_mode = "auto"
 
 [tool.coverage.run]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -3,6 +3,7 @@ import uuid
 from collections.abc import AsyncIterator
 from uuid import UUID
 
+import pytest
 import pytest_asyncio
 
 from fabric_dw.auth import get_credential
@@ -16,8 +17,10 @@ from fabric_dw.sql import SqlTarget
 async def workspace_id() -> UUID:
     raw = os.environ.get("FABRIC_TEST_WORKSPACE_ID")
     if not raw:
-        msg = "set FABRIC_TEST_WORKSPACE_ID for integration tests"
-        raise RuntimeError(msg)
+        pytest.skip(
+            "set FABRIC_TEST_WORKSPACE_ID to run integration tests",
+            allow_module_level=True,
+        )
     return UUID(raw)
 
 

--- a/tests/unit/mcp/test_contract.py
+++ b/tests/unit/mcp/test_contract.py
@@ -104,7 +104,6 @@ def _make_workspace() -> Workspace:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_list_tools_returns_expected_count(contract_ctx) -> None:
     """list_tools() via the MCP protocol returns all 65 registered tools.
 
@@ -127,7 +126,6 @@ async def test_list_tools_returns_expected_count(contract_ctx) -> None:
     )
 
 
-@pytest.mark.asyncio
 async def test_list_tools_contains_read_tool(contract_ctx) -> None:
     """The tool roster must include the 'list_workspaces' read tool."""
     from mcp.shared.memory import create_connected_server_and_client_session  # noqa: PLC0415
@@ -142,7 +140,6 @@ async def test_list_tools_contains_read_tool(contract_ctx) -> None:
     assert "list_workspaces" in tool_names
 
 
-@pytest.mark.asyncio
 async def test_list_tools_contains_destructive_tool(contract_ctx) -> None:
     """The tool roster must include the guarded 'delete_restore_point' tool."""
     from mcp.shared.memory import create_connected_server_and_client_session  # noqa: PLC0415
@@ -162,7 +159,6 @@ async def test_list_tools_contains_destructive_tool(contract_ctx) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_call_tool_list_workspaces_round_trips(contract_ctx) -> None:
     """Calling list_workspaces via MCP protocol returns serialised workspace data.
 
@@ -204,7 +200,6 @@ async def test_call_tool_list_workspaces_round_trips(contract_ctx) -> None:
     assert str(WS_ID) in json.dumps(workspace_data)
 
 
-@pytest.mark.asyncio
 async def test_call_tool_list_workspaces_empty_returns_list(contract_ctx) -> None:
     """list_workspaces with no workspaces returns a successful result."""
     from mcp.shared.memory import create_connected_server_and_client_session  # noqa: PLC0415
@@ -227,7 +222,6 @@ async def test_call_tool_list_workspaces_empty_returns_list(contract_ctx) -> Non
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_destructive_tool_blocked_without_env_flag(
     contract_ctx, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -264,7 +258,6 @@ async def test_destructive_tool_blocked_without_env_flag(
     )
 
 
-@pytest.mark.asyncio
 async def test_destructive_tool_allowed_with_env_flag(
     contract_ctx, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/mcp/test_security.py
+++ b/tests/unit/mcp/test_security.py
@@ -424,7 +424,6 @@ class TestAssertWorkspaceAllowed:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_execute_sql_max_rows_truncation() -> None:
     """execute_sql slices rows to max_rows and sets truncated=True."""
     from datetime import UTC, datetime  # noqa: PLC0415
@@ -476,7 +475,6 @@ async def test_execute_sql_max_rows_truncation() -> None:
     assert len(result["rows"]) == 10
 
 
-@pytest.mark.asyncio
 async def test_execute_sql_no_truncation_when_under_limit() -> None:
     """execute_sql sets truncated=False when rows fit within max_rows."""
     from datetime import UTC, datetime  # noqa: PLC0415
@@ -533,7 +531,6 @@ async def test_execute_sql_no_truncation_when_under_limit() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_execute_sql_blocked_by_readonly_mode() -> None:
     """execute_sql raises ToolError when FABRIC_MCP_READONLY is set and query is DROP."""
     from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
@@ -550,7 +547,6 @@ async def test_execute_sql_blocked_by_readonly_mode() -> None:
         )
 
 
-@pytest.mark.asyncio
 async def test_execute_sql_allowed_in_readonly_mode_for_select() -> None:
     """execute_sql SELECT queries pass the readonly gate."""
     from datetime import UTC, datetime  # noqa: PLC0415
@@ -602,7 +598,6 @@ async def test_execute_sql_allowed_in_readonly_mode_for_select() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_delete_warehouse_blocked_without_destructive_flag() -> None:
     """delete_warehouse raises ToolError when FABRIC_MCP_ALLOW_DESTRUCTIVE is not set."""
     from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
@@ -621,7 +616,6 @@ async def test_delete_warehouse_blocked_without_destructive_flag() -> None:
         )
 
 
-@pytest.mark.asyncio
 async def test_delete_snapshot_blocked_without_destructive_flag() -> None:
     """delete_snapshot raises ToolError when FABRIC_MCP_ALLOW_DESTRUCTIVE is not set."""
     from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
@@ -639,7 +633,6 @@ async def test_delete_snapshot_blocked_without_destructive_flag() -> None:
         )
 
 
-@pytest.mark.asyncio
 async def test_reset_sql_pools_blocked_without_destructive_flag() -> None:
     """reset_sql_pools raises ToolError when FABRIC_MCP_ALLOW_DESTRUCTIVE is not set."""
     from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
@@ -662,7 +655,6 @@ async def test_reset_sql_pools_blocked_without_destructive_flag() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_get_workspace_blocked_by_workspace_allowlist() -> None:
     """get_workspace raises ToolError when workspace not in FABRIC_MCP_WORKSPACES."""
     from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
@@ -679,7 +671,6 @@ async def test_get_workspace_blocked_by_workspace_allowlist() -> None:
         )
 
 
-@pytest.mark.asyncio
 async def test_list_warehouses_all_workspaces_blocked_when_allowlist_set() -> None:
     """list_warehouses(all_workspaces=True) raises ToolError when FABRIC_MCP_WORKSPACES is set."""
     from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
@@ -696,7 +687,6 @@ async def test_list_warehouses_all_workspaces_blocked_when_allowlist_set() -> No
         )
 
 
-@pytest.mark.asyncio
 async def test_list_sql_endpoints_all_workspaces_blocked_when_allowlist_set() -> None:
     """list_sql_endpoints(all_workspaces=True) raises ToolError when allowlist is set."""
     from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415

--- a/tests/unit/mcp/test_server.py
+++ b/tests/unit/mcp/test_server.py
@@ -291,7 +291,6 @@ def test_tools_registered() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_list_workspaces_happy_path(ctx_patch) -> None:
     """list_workspaces returns a list of serialised workspace dicts."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
@@ -315,7 +314,6 @@ async def test_list_workspaces_happy_path(ctx_patch) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_clear_cache_side_effect(mock_ctx, ctx_patch) -> None:
     """clear_cache(scope='all') must call LookupCache.clear() and clear_negative_cache."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
@@ -329,7 +327,6 @@ async def test_clear_cache_side_effect(mock_ctx, ctx_patch) -> None:
     assert result["negative_cache_cleared"] is True
 
 
-@pytest.mark.asyncio
 async def test_clear_cache_scope_workspaces(mock_ctx, ctx_patch) -> None:
     """clear_cache(scope='workspaces') must NOT call full clear() or clear_negative_cache."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
@@ -349,7 +346,6 @@ async def test_clear_cache_scope_workspaces(mock_ctx, ctx_patch) -> None:
     assert result["negative_cache_cleared"] is False
 
 
-@pytest.mark.asyncio
 async def test_clear_cache_scope_items(mock_ctx, ctx_patch) -> None:
     """clear_cache(scope='items') must NOT call full clear() or clear_negative_cache."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
@@ -376,7 +372,6 @@ async def test_clear_cache_scope_items(mock_ctx, ctx_patch) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_fabric_error_becomes_tool_error(ctx_patch) -> None:
     """A FabricError raised by the service layer must become a ToolError."""
     from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
@@ -404,7 +399,6 @@ async def test_fabric_error_becomes_tool_error(ctx_patch) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_get_workspace_happy_path(mock_ctx, ctx_patch) -> None:
     """get_workspace resolves the name via Resolver and returns a dict."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
@@ -428,7 +422,6 @@ async def test_get_workspace_happy_path(mock_ctx, ctx_patch) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_list_warehouses_happy_path(mock_ctx, ctx_patch) -> None:
     """list_warehouses resolves workspace and returns list of warehouse dicts."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
@@ -487,7 +480,6 @@ def test_run_accepts_http_transport() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_get_audit_settings_happy_path(mock_ctx, ctx_patch) -> None:
     """get_audit_settings resolves workspace + warehouse and returns a dict."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
@@ -520,7 +512,6 @@ async def test_get_audit_settings_happy_path(mock_ctx, ctx_patch) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_list_running_queries_happy_path(mock_ctx, ctx_patch) -> None:
     """list_running_queries returns list of dicts from the SQL service."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
@@ -551,7 +542,6 @@ async def test_list_running_queries_happy_path(mock_ctx, ctx_patch) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_not_found_error_becomes_tool_error(mock_ctx, ctx_patch) -> None:
     """NotFound (a FabricError subclass) must become a ToolError."""
     from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
@@ -572,7 +562,6 @@ async def test_not_found_error_becomes_tool_error(mock_ctx, ctx_patch) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_create_snapshot_bad_datetime_becomes_tool_error(ctx_patch) -> None:
     """create_snapshot raises ToolError when snapshot_dt is not ISO-8601."""
     from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
@@ -596,7 +585,6 @@ async def test_create_snapshot_bad_datetime_becomes_tool_error(ctx_patch) -> Non
     assert "ISO-8601" in str(exc_info.value)
 
 
-@pytest.mark.asyncio
 async def test_roll_snapshot_timestamp_bad_datetime_becomes_tool_error(
     ctx_patch,
 ) -> None:
@@ -627,7 +615,6 @@ async def test_roll_snapshot_timestamp_bad_datetime_becomes_tool_error(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_list_sql_endpoints_happy_path(mock_ctx, ctx_patch) -> None:
     """list_sql_endpoints resolves workspace and returns list of SQL endpoint dicts."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
@@ -659,7 +646,6 @@ async def test_list_sql_endpoints_happy_path(mock_ctx, ctx_patch) -> None:
     assert result[0]["kind"] == "SQLEndpoint"
 
 
-@pytest.mark.asyncio
 async def test_get_sql_endpoint_happy_path(mock_ctx, ctx_patch) -> None:
     """get_sql_endpoint resolves workspace + endpoint and returns a dict."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
@@ -695,7 +681,6 @@ async def test_get_sql_endpoint_happy_path(mock_ctx, ctx_patch) -> None:
     assert result["kind"] == "SQLEndpoint"
 
 
-@pytest.mark.asyncio
 async def test_refresh_sql_endpoint_metadata_happy_path(mock_ctx, ctx_patch) -> None:
     """refresh_sql_endpoint_metadata resolves workspace + endpoint and returns a list of dicts."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
@@ -724,7 +709,6 @@ async def test_refresh_sql_endpoint_metadata_happy_path(mock_ctx, ctx_patch) -> 
     assert result[1]["status"] == "Failure"
 
 
-@pytest.mark.asyncio
 async def test_refresh_sql_endpoint_metadata_recreate_tables(mock_ctx, ctx_patch) -> None:
     """refresh_sql_endpoint_metadata passes recreate_tables=True to the service."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
@@ -758,7 +742,6 @@ async def test_refresh_sql_endpoint_metadata_recreate_tables(mock_ctx, ctx_patch
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_list_warehouses_all_workspaces(ctx_patch) -> None:
     """list_warehouses with all_workspaces=True dispatches to list_all_workspaces."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
@@ -787,7 +770,6 @@ async def test_list_warehouses_all_workspaces(ctx_patch) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_list_sql_endpoints_all_workspaces(ctx_patch) -> None:
     """list_sql_endpoints with all_workspaces=True dispatches to list_all_workspaces."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
@@ -826,7 +808,6 @@ async def test_list_sql_endpoints_all_workspaces(ctx_patch) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_add_audit_group_happy_path(mock_ctx, ctx_patch) -> None:
     """add_audit_group resolves workspace + warehouse and returns a dict."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
@@ -853,7 +834,6 @@ async def test_add_audit_group_happy_path(mock_ctx, ctx_patch) -> None:
     mock_ctx.resolver.item.assert_called_once_with(str(_WS_ID), _WH_NAME)
 
 
-@pytest.mark.asyncio
 async def test_remove_audit_group_happy_path(mock_ctx, ctx_patch) -> None:
     """remove_audit_group resolves workspace + warehouse and returns a dict."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
@@ -885,7 +865,6 @@ async def test_remove_audit_group_happy_path(mock_ctx, ctx_patch) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_set_audit_retention_happy_path(mock_ctx, ctx_patch) -> None:
     """set_audit_retention resolves workspace + warehouse and returns updated AuditSettings."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
@@ -918,7 +897,6 @@ async def test_set_audit_retention_happy_path(mock_ctx, ctx_patch) -> None:
     assert result["state"] == "Enabled"
 
 
-@pytest.mark.asyncio
 async def test_set_audit_retention_value_error_becomes_tool_error(mock_ctx, ctx_patch) -> None:
     """set_audit_retention converts ValueError (disabled audit or out-of-range) to ToolError."""
     from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
@@ -950,7 +928,6 @@ async def test_set_audit_retention_value_error_becomes_tool_error(mock_ctx, ctx_
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_execute_sql_happy_path(mock_ctx, ctx_patch) -> None:
     """execute_sql calls sql_exec.execute and returns a dict with columns/rows/rowcount."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
@@ -979,7 +956,6 @@ async def test_execute_sql_happy_path(mock_ctx, ctx_patch) -> None:
     assert result["rowcount"] == 2
 
 
-@pytest.mark.asyncio
 async def test_execute_sql_no_connection_string_raises_tool_error(mock_ctx, ctx_patch) -> None:
     """execute_sql raises ToolError when the item has no connection string."""
     from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
@@ -1005,7 +981,6 @@ async def test_execute_sql_no_connection_string_raises_tool_error(mock_ctx, ctx_
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_get_warehouse_permissions_happy_path(mock_ctx, ctx_patch) -> None:
     """get_warehouse_permissions returns a list of serialised ItemAccess dicts."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
@@ -1032,7 +1007,6 @@ async def test_get_warehouse_permissions_happy_path(mock_ctx, ctx_patch) -> None
     assert result[0]["principal"]["displayName"] == "Jacob Hancock"
 
 
-@pytest.mark.asyncio
 async def test_get_sql_endpoint_permissions_happy_path(mock_ctx, ctx_patch) -> None:
     """get_sql_endpoint_permissions returns a list of serialised ItemAccess dicts."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
@@ -1059,7 +1033,6 @@ async def test_get_sql_endpoint_permissions_happy_path(mock_ctx, ctx_patch) -> N
     assert result[0]["principal"]["type"] == "User"
 
 
-@pytest.mark.asyncio
 async def test_get_warehouse_permissions_permission_denied_becomes_tool_error(
     mock_ctx, ctx_patch
 ) -> None:
@@ -1094,7 +1067,6 @@ _SE_NAME = "SalesLakehouse"
 _SE_ID = UUID("bbbbbbbb-cccc-dddd-eeee-ffffffffffff")
 
 
-@pytest.mark.asyncio
 async def test_create_table_sql_endpoint_raises_tool_error(mock_ctx, ctx_patch) -> None:
     """create_table must raise ToolError when the item is a SQL Endpoint."""
     from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
@@ -1123,7 +1095,6 @@ async def test_create_table_sql_endpoint_raises_tool_error(mock_ctx, ctx_patch) 
     assert "read-only" in str(exc_info.value).lower()
 
 
-@pytest.mark.asyncio
 async def test_delete_table_sql_endpoint_raises_tool_error(mock_ctx, ctx_patch) -> None:
     """delete_table must raise ToolError when the item is a SQL Endpoint.
 
@@ -1152,7 +1123,6 @@ async def test_delete_table_sql_endpoint_raises_tool_error(mock_ctx, ctx_patch) 
     assert "read-only" in str(exc_info.value).lower()
 
 
-@pytest.mark.asyncio
 async def test_clear_table_sql_endpoint_raises_tool_error(mock_ctx, ctx_patch) -> None:
     """clear_table must raise ToolError when the item is a SQL Endpoint.
 
@@ -1186,7 +1156,6 @@ async def test_clear_table_sql_endpoint_raises_tool_error(mock_ctx, ctx_patch) -
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_create_schema_rejects_sql_endpoint(mock_ctx, ctx_patch) -> None:
     """create_schema must raise ToolError when called against a SQL Analytics Endpoint."""
     from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
@@ -1211,7 +1180,6 @@ async def test_create_schema_rejects_sql_endpoint(mock_ctx, ctx_patch) -> None:
     )
 
 
-@pytest.mark.asyncio
 async def test_delete_schema_rejects_sql_endpoint(mock_ctx, ctx_patch) -> None:
     """delete_schema must raise ToolError when called against a SQL Analytics Endpoint.
 
@@ -1241,7 +1209,6 @@ async def test_delete_schema_rejects_sql_endpoint(mock_ctx, ctx_patch) -> None:
     )
 
 
-@pytest.mark.asyncio
 async def test_list_schemas_works_on_sql_endpoint(mock_ctx, ctx_patch) -> None:
     """list_schemas is a read-only operation and must work on SQL Analytics Endpoints."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
@@ -1268,7 +1235,6 @@ async def test_list_schemas_works_on_sql_endpoint(mock_ctx, ctx_patch) -> None:
     assert result[0]["name"] == "dbo"
 
 
-@pytest.mark.asyncio
 async def test_read_view_happy_path(mock_ctx, ctx_patch) -> None:
     """read_view calls views_svc.read_view and returns {columns, rows}."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
@@ -1294,7 +1260,6 @@ async def test_read_view_happy_path(mock_ctx, ctx_patch) -> None:
     assert result["rows"] == [[1, 100], [2, 200]]
 
 
-@pytest.mark.asyncio
 async def test_read_view_no_connection_string_raises_tool_error(mock_ctx, ctx_patch) -> None:
     """read_view raises ToolError when the item has no connection string."""
     from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
@@ -1315,7 +1280,6 @@ async def test_read_view_no_connection_string_raises_tool_error(mock_ctx, ctx_pa
         )
 
 
-@pytest.mark.asyncio
 async def test_read_view_bad_qualified_name_raises_tool_error(mock_ctx, ctx_patch) -> None:
     """read_view raises ToolError when qualified_name has no dot."""
     from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415

--- a/tests/unit/mcp/tools/test_tool_quality.py
+++ b/tests/unit/mcp/tools/test_tool_quality.py
@@ -192,7 +192,6 @@ class TestMakeSqlTarget:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_resolve_item_returns_pair() -> None:
     mock_resolver = AsyncMock()
     mock_resolver.workspace_id = AsyncMock(return_value=_WS_ID)
@@ -281,7 +280,6 @@ class TestParseQualifiedName:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_read_table_count_bound_rejection() -> None:
     """read_table must reject count > 10000 at the FastMCP schema layer."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
@@ -302,7 +300,6 @@ async def test_read_table_count_bound_rejection() -> None:
         )
 
 
-@pytest.mark.asyncio
 async def test_read_view_count_bound_rejection() -> None:
     """read_view must reject count > 10000 at the FastMCP schema layer."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
@@ -323,7 +320,6 @@ async def test_read_view_count_bound_rejection() -> None:
         )
 
 
-@pytest.mark.asyncio
 async def test_execute_sql_max_rows_bound_rejection() -> None:
     """execute_sql must reject max_rows > 10000."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
@@ -344,7 +340,6 @@ async def test_execute_sql_max_rows_bound_rejection() -> None:
         )
 
 
-@pytest.mark.asyncio
 async def test_list_request_history_limit_bound_rejection() -> None:
     """list_request_history must reject limit > 10000."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
@@ -364,7 +359,6 @@ async def test_list_request_history_limit_bound_rejection() -> None:
         )
 
 
-@pytest.mark.asyncio
 async def test_create_sql_pool_max_percent_bound_rejection() -> None:
     """create_sql_pool must reject max_percent > 100."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
@@ -389,7 +383,6 @@ async def test_create_sql_pool_max_percent_bound_rejection() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_create_sql_pool_next_fallback() -> None:
     """create_sql_pool raises ToolError (not StopIteration) when pool absent after create."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
@@ -417,7 +410,6 @@ async def test_create_sql_pool_next_fallback() -> None:
         )
 
 
-@pytest.mark.asyncio
 async def test_update_sql_pool_next_fallback() -> None:
     """update_sql_pool raises ToolError (not StopIteration) when pool absent after update."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
@@ -447,7 +439,6 @@ async def test_update_sql_pool_next_fallback() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_clear_cache_all_returns_stats() -> None:
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -473,7 +464,6 @@ async def test_clear_cache_all_returns_stats() -> None:
     resolver_mock.clear_negative_cache.assert_called_once()
 
 
-@pytest.mark.asyncio
 async def test_clear_cache_workspaces_scope() -> None:
     from typing import cast as _cast  # noqa: PLC0415
 
@@ -495,7 +485,6 @@ async def test_clear_cache_workspaces_scope() -> None:
     cache_mock.clear.assert_not_called()
 
 
-@pytest.mark.asyncio
 async def test_clear_cache_items_scope() -> None:
     from typing import cast as _cast  # noqa: PLC0415
 
@@ -526,7 +515,6 @@ async def test_clear_cache_items_scope() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_create_warehouse_clears_negative_cache() -> None:
     """create_warehouse must call resolver.clear_negative_cache() on success."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
@@ -559,7 +547,6 @@ async def test_create_warehouse_clears_negative_cache() -> None:
     resolver_mock.clear_negative_cache.assert_called_once()
 
 
-@pytest.mark.asyncio
 async def test_create_table_clears_negative_cache() -> None:
     """create_table must call resolver.clear_negative_cache() on success."""
     from typing import cast as _cast  # noqa: PLC0415
@@ -590,7 +577,6 @@ async def test_create_table_clears_negative_cache() -> None:
     resolver_mock.clear_negative_cache.assert_called_once()
 
 
-@pytest.mark.asyncio
 async def test_create_view_clears_negative_cache() -> None:
     """create_view must call resolver.clear_negative_cache() on success."""
     from typing import cast as _cast  # noqa: PLC0415
@@ -625,7 +611,6 @@ async def test_create_view_clears_negative_cache() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_list_tables_raises_tool_error_on_no_connection() -> None:
     """list_tables must raise ToolError (not FabricError) when no connection string."""
     from typing import cast as _cast  # noqa: PLC0415
@@ -645,7 +630,6 @@ async def test_list_tables_raises_tool_error_on_no_connection() -> None:
         )
 
 
-@pytest.mark.asyncio
 async def test_list_running_queries_raises_tool_error_on_no_connection() -> None:
     """list_running_queries must raise ToolError when no connection string."""
     from typing import cast as _cast  # noqa: PLC0415

--- a/tests/unit/services/_helpers.py
+++ b/tests/unit/services/_helpers.py
@@ -1,0 +1,40 @@
+"""Shared test helpers for tests/unit/services/.
+
+These helpers are *not* pytest fixtures — they are plain module-level
+callables imported directly by each service test module.  This avoids
+duplicate definitions while preserving the calling convention used by
+every test (``client = await _make_client()`` followed by
+``async with client:``).
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+from azure.core.credentials import AccessToken
+from azure.core.credentials_async import AsyncTokenCredential
+
+from fabric_dw.http_client import FabricHttpClient
+
+# A long-lived fake token shared across all service unit tests.  The
+# ``expires_on`` is set 1 h into the future so token-refresh logic is
+# not triggered during normal test runs.
+_FAKE_TOKEN = AccessToken(token="fake-token", expires_on=int(time.time()) + 3600)  # noqa: S106
+
+
+def _make_credential(token: AccessToken = _FAKE_TOKEN) -> AsyncTokenCredential:
+    """Return a mock ``AsyncTokenCredential`` that yields *token*."""
+    cred = MagicMock(spec=AsyncTokenCredential)
+    cred.get_token = AsyncMock(return_value=token)
+    return cred
+
+
+async def _make_client(rps: int = 100) -> FabricHttpClient:
+    """Return a ``FabricHttpClient`` backed by a fake credential.
+
+    The *rps* default is 100 (generous) so that rate-limiting does not
+    slow down unit tests.  Pass a smaller value when testing throttling
+    behaviour explicitly.
+    """
+    return FabricHttpClient(credential=_make_credential(), rps=rps)

--- a/tests/unit/services/test_audit.py
+++ b/tests/unit/services/test_audit.py
@@ -3,21 +3,17 @@
 from __future__ import annotations
 
 import json
-import time
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
 from uuid import UUID
 
 import httpx
 import pytest
 import respx
-from azure.core.credentials import AccessToken
-from azure.core.credentials_async import AsyncTokenCredential
 
 from fabric_dw.exceptions import PermissionDenied
-from fabric_dw.http_client import FabricHttpClient
 from fabric_dw.models import AuditSettings
 from fabric_dw.services import audit
+from tests.unit.services._helpers import _make_client
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -44,25 +40,12 @@ AUDIT_SETTINGS_DISABLED_PAYLOAD: dict[str, Any] = {
     "auditActionsAndGroups": [],
 }
 
-_FAKE_TOKEN = AccessToken(token="fake-token", expires_on=int(time.time()) + 3600)  # noqa: S106
-
-
-def _make_credential() -> AsyncTokenCredential:
-    cred = MagicMock(spec=AsyncTokenCredential)
-    cred.get_token = AsyncMock(return_value=_FAKE_TOKEN)
-    return cred
-
-
-async def _make_client() -> FabricHttpClient:
-    return FabricHttpClient(credential=_make_credential(), rps=100)
-
 
 # ---------------------------------------------------------------------------
 # get_settings
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_get_settings_returns_audit_settings() -> None:
     """get_settings should GET /settings/sqlAudit and return AuditSettings."""
     with respx.mock:
@@ -80,7 +63,6 @@ async def test_get_settings_returns_audit_settings() -> None:
     ]
 
 
-@pytest.mark.asyncio
 async def test_get_settings_403_raises_permission_denied() -> None:
     """get_settings should propagate PermissionDenied on 403."""
     with respx.mock:
@@ -96,7 +78,6 @@ async def test_get_settings_403_raises_permission_denied() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_enable_patches_with_enabled_state_and_retention() -> None:
     """enable should PATCH with state=Enabled and retentionDays, then GET and return fresh state."""
     get_response = AUDIT_SETTINGS_PAYLOAD.copy()
@@ -119,7 +100,6 @@ async def test_enable_patches_with_enabled_state_and_retention() -> None:
     assert result.retention_days == 7
 
 
-@pytest.mark.asyncio
 async def test_enable_default_retention_is_zero() -> None:
     """enable with default retention_days=0 (unlimited) should send retentionDays=0."""
     with respx.mock:
@@ -133,7 +113,6 @@ async def test_enable_default_retention_is_zero() -> None:
     assert sent_body == {"state": "Enabled", "retentionDays": 0}
 
 
-@pytest.mark.asyncio
 async def test_enable_negative_retention_raises_value_error() -> None:
     """enable should raise ValueError if retention_days < 0."""
     client = await _make_client()
@@ -142,7 +121,6 @@ async def test_enable_negative_retention_raises_value_error() -> None:
             await audit.enable(client, _WS_ID, _WH_ID, retention_days=-1)
 
 
-@pytest.mark.asyncio
 async def test_enable_403_raises_permission_denied() -> None:
     """enable should propagate PermissionDenied on 403 from PATCH."""
     with respx.mock:
@@ -158,7 +136,6 @@ async def test_enable_403_raises_permission_denied() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_disable_patches_with_disabled_state() -> None:
     """disable should PATCH with state=Disabled, then GET and return fresh state."""
     with respx.mock:
@@ -179,7 +156,6 @@ async def test_disable_patches_with_disabled_state() -> None:
     assert result.state == "Disabled"
 
 
-@pytest.mark.asyncio
 async def test_disable_403_raises_permission_denied() -> None:
     """disable should propagate PermissionDenied on 403 from PATCH."""
     with respx.mock:
@@ -195,7 +171,6 @@ async def test_disable_403_raises_permission_denied() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_set_action_groups_patches_with_enabled_state_and_groups() -> None:
     """set_action_groups should PATCH with state=Enabled + auditActionsAndGroups, then GET."""
     groups = ["BATCH_COMPLETED_GROUP", "FAILED_DATABASE_AUTHENTICATION_GROUP"]
@@ -218,7 +193,6 @@ async def test_set_action_groups_patches_with_enabled_state_and_groups() -> None
     assert result.action_groups == groups
 
 
-@pytest.mark.asyncio
 async def test_set_action_groups_empty_list_is_valid() -> None:
     """set_action_groups with an empty list should be accepted (clears all groups)."""
     with respx.mock:
@@ -233,7 +207,6 @@ async def test_set_action_groups_empty_list_is_valid() -> None:
     assert isinstance(result, AuditSettings)
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "bad_group",
     [
@@ -252,7 +225,6 @@ async def test_set_action_groups_invalid_name_raises_value_error(bad_group: str)
             await audit.set_action_groups(client, _WS_ID, _WH_ID, [bad_group])
 
 
-@pytest.mark.asyncio
 async def test_set_action_groups_403_raises_permission_denied() -> None:
     """set_action_groups should propagate PermissionDenied on 403 from PATCH."""
     with respx.mock:
@@ -263,7 +235,6 @@ async def test_set_action_groups_403_raises_permission_denied() -> None:
                 await audit.set_action_groups(client, _WS_ID, _WH_ID, ["BATCH_COMPLETED_GROUP"])
 
 
-@pytest.mark.asyncio
 async def test_set_action_groups_works_on_fresh_warehouse() -> None:
     """set_action_groups via PATCH works on freshly-created warehouses without a prior enable().
 
@@ -289,7 +260,6 @@ async def test_set_action_groups_works_on_fresh_warehouse() -> None:
     assert result.action_groups == groups
 
 
-@pytest.mark.asyncio
 async def test_set_action_groups_ensure_enabled_false_omits_state() -> None:
     """set_action_groups with ensure_enabled=False should NOT include state=Enabled in the PATCH."""
     groups = ["BATCH_COMPLETED_GROUP"]
@@ -312,7 +282,6 @@ async def test_set_action_groups_ensure_enabled_false_omits_state() -> None:
     assert isinstance(result, AuditSettings)
 
 
-@pytest.mark.asyncio
 async def test_set_action_groups_ensure_enabled_true_default_includes_state() -> None:
     """set_action_groups default (ensure_enabled=True) includes state=Enabled in the PATCH."""
     groups = ["BATCH_COMPLETED_GROUP"]
@@ -334,7 +303,6 @@ async def test_set_action_groups_ensure_enabled_true_default_includes_state() ->
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_add_action_group_adds_missing_group() -> None:
     """add_action_group should GET current groups, append the new one, then PATCH."""
     new_group = "FAILED_DATABASE_AUTHENTICATION_GROUP"
@@ -367,7 +335,6 @@ async def test_add_action_group_adds_missing_group() -> None:
     assert new_group in result.action_groups
 
 
-@pytest.mark.asyncio
 async def test_add_action_group_idempotent_when_already_present() -> None:
     """add_action_group should not PATCH if the group is already present."""
     existing_group = "BATCH_COMPLETED_GROUP"
@@ -386,7 +353,6 @@ async def test_add_action_group_idempotent_when_already_present() -> None:
     assert existing_group in result.action_groups
 
 
-@pytest.mark.asyncio
 async def test_add_action_group_disabled_raises_value_error() -> None:
     """add_action_group should raise ValueError when audit is disabled."""
     disabled = AUDIT_SETTINGS_DISABLED_PAYLOAD.copy()
@@ -399,7 +365,6 @@ async def test_add_action_group_disabled_raises_value_error() -> None:
                 await audit.add_action_group(client, _WS_ID, _WH_ID, "BATCH_COMPLETED_GROUP")
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "bad_group",
     [
@@ -416,7 +381,6 @@ async def test_add_action_group_invalid_name_raises_value_error(bad_group: str) 
             await audit.add_action_group(client, _WS_ID, _WH_ID, bad_group)
 
 
-@pytest.mark.asyncio
 async def test_add_action_group_403_raises_permission_denied() -> None:
     """add_action_group should propagate PermissionDenied on 403 from GET."""
     with respx.mock:
@@ -432,7 +396,6 @@ async def test_add_action_group_403_raises_permission_denied() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_remove_action_group_removes_present_group() -> None:
     """remove_action_group should GET current groups, remove the target, then PATCH."""
     group_to_remove = "SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP"
@@ -460,7 +423,6 @@ async def test_remove_action_group_removes_present_group() -> None:
     assert isinstance(result, AuditSettings)
 
 
-@pytest.mark.asyncio
 async def test_remove_action_group_idempotent_when_not_present() -> None:
     """remove_action_group should not PATCH if the group is not present."""
     absent_group = "FAILED_DATABASE_AUTHENTICATION_GROUP"
@@ -478,7 +440,6 @@ async def test_remove_action_group_idempotent_when_not_present() -> None:
     assert isinstance(result, AuditSettings)
 
 
-@pytest.mark.asyncio
 async def test_remove_action_group_disabled_raises_value_error() -> None:
     """remove_action_group should raise ValueError when audit is disabled."""
     disabled = AUDIT_SETTINGS_DISABLED_PAYLOAD.copy()
@@ -491,7 +452,6 @@ async def test_remove_action_group_disabled_raises_value_error() -> None:
                 await audit.remove_action_group(client, _WS_ID, _WH_ID, "BATCH_COMPLETED_GROUP")
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "bad_group",
     [
@@ -508,7 +468,6 @@ async def test_remove_action_group_invalid_name_raises_value_error(bad_group: st
             await audit.remove_action_group(client, _WS_ID, _WH_ID, bad_group)
 
 
-@pytest.mark.asyncio
 async def test_remove_action_group_403_raises_permission_denied() -> None:
     """remove_action_group should propagate PermissionDenied on 403 from GET."""
     with respx.mock:
@@ -524,7 +483,6 @@ async def test_remove_action_group_403_raises_permission_denied() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_set_retention_patches_with_retention_days_only() -> None:
     """set_retention should PATCH with only retentionDays (no state), then GET and return fresh."""
     updated = AUDIT_SETTINGS_PAYLOAD.copy()
@@ -547,7 +505,6 @@ async def test_set_retention_patches_with_retention_days_only() -> None:
     assert result.retention_days == 90
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("days", [0, -1, -100])
 async def test_set_retention_out_of_range_raises_value_error(days: int) -> None:
     """set_retention should raise ValueError when days < 1."""
@@ -557,7 +514,6 @@ async def test_set_retention_out_of_range_raises_value_error(days: int) -> None:
             await audit.set_retention(client, _WS_ID, _WH_ID, days=days)
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("days", [1, 3650])
 async def test_set_retention_boundary_values_are_accepted(days: int) -> None:
     """set_retention should accept boundary values: 1 (minimum) and 3650 (large plausible value).
@@ -577,7 +533,6 @@ async def test_set_retention_boundary_values_are_accepted(days: int) -> None:
     assert result.retention_days == days
 
 
-@pytest.mark.asyncio
 async def test_set_retention_disabled_audit_sends_patch_to_server() -> None:
     """set_retention no longer pre-checks audit state; it sends PATCH and lets the server decide.
 
@@ -599,7 +554,6 @@ async def test_set_retention_disabled_audit_sends_patch_to_server() -> None:
     assert isinstance(result, AuditSettings)
 
 
-@pytest.mark.asyncio
 async def test_set_retention_403_raises_permission_denied() -> None:
     """set_retention should propagate PermissionDenied on 403 from PATCH."""
     with respx.mock:

--- a/tests/unit/services/test_concurrency.py
+++ b/tests/unit/services/test_concurrency.py
@@ -38,21 +38,18 @@ def _raising(exc: BaseException) -> Callable[[], Awaitable[int]]:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_empty_input_returns_empty_list() -> None:
     """bounded_gather with no factories must return an empty list."""
     result = await bounded_gather([])
     assert result == []
 
 
-@pytest.mark.asyncio
 async def test_single_factory_returns_single_result() -> None:
     """A single factory must return a one-element list."""
     result = await bounded_gather([_const(42)])
     assert result == [42]
 
 
-@pytest.mark.asyncio
 async def test_output_preserves_input_order() -> None:
     """Results must appear in the same order as the input factories."""
     factories = [_const(i) for i in range(10)]
@@ -60,7 +57,6 @@ async def test_output_preserves_input_order() -> None:
     assert result == list(range(10))
 
 
-@pytest.mark.asyncio
 async def test_all_factories_called() -> None:
     """Every factory must be invoked exactly once."""
     called: list[int] = []
@@ -80,7 +76,6 @@ async def test_all_factories_called() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_concurrency_cap_not_exceeded() -> None:
     """At most *concurrency* factories may run simultaneously."""
     max_concurrent = 0
@@ -101,7 +96,6 @@ async def test_concurrency_cap_not_exceeded() -> None:
     assert max_concurrent <= cap
 
 
-@pytest.mark.asyncio
 async def test_concurrency_cap_of_one_runs_serially() -> None:
     """concurrency=1 must result in strictly serial execution."""
     order: list[str] = []
@@ -123,7 +117,6 @@ async def test_concurrency_cap_of_one_runs_serially() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_parallel_execution_all_started_before_first_completes() -> None:
     """All factories are started before the first one completes (when concurrency allows)."""
     n = 5
@@ -156,7 +149,6 @@ async def test_parallel_execution_all_started_before_first_completes() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_exception_propagates_when_return_exceptions_false() -> None:
     """An exception must propagate and be raised when return_exceptions=False."""
     boom = ValueError("boom")
@@ -164,7 +156,6 @@ async def test_exception_propagates_when_return_exceptions_false() -> None:
         await bounded_gather([_const(1), _raising(boom), _const(3)], return_exceptions=False)
 
 
-@pytest.mark.asyncio
 async def test_exception_in_result_when_return_exceptions_true() -> None:
     """When return_exceptions=True exceptions appear in the result list."""
     boom = RuntimeError("oops")
@@ -174,7 +165,6 @@ async def test_exception_in_result_when_return_exceptions_true() -> None:
     assert result[2] == 3
 
 
-@pytest.mark.asyncio
 async def test_multiple_exceptions_all_captured_when_return_exceptions_true() -> None:
     """All exceptions are captured when return_exceptions=True."""
     err_a = ValueError("a")
@@ -187,7 +177,6 @@ async def test_multiple_exceptions_all_captured_when_return_exceptions_true() ->
     assert result[2] is err_b
 
 
-@pytest.mark.asyncio
 async def test_all_tasks_done_after_exception_with_return_exceptions_false() -> None:
     """All tasks must be done (completed or cancelled) after bounded_gather raises.
 
@@ -232,7 +221,6 @@ async def test_all_tasks_done_after_exception_with_return_exceptions_false() -> 
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_return_exceptions_false_returns_plain_list() -> None:
     """return_exceptions=False (default) returns a plain list of values."""
     result = await bounded_gather([_const(1), _const(2)], return_exceptions=False)
@@ -241,7 +229,6 @@ async def test_return_exceptions_false_returns_plain_list() -> None:
     assert all(not isinstance(v, BaseException) for v in result)
 
 
-@pytest.mark.asyncio
 async def test_return_exceptions_true_literal_annotation() -> None:
     """Passing Literal[True] for return_exceptions works at runtime."""
     flag: Literal[True] = True

--- a/tests/unit/services/test_lro.py
+++ b/tests/unit/services/test_lro.py
@@ -2,35 +2,18 @@
 
 from __future__ import annotations
 
-import time
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
-import pytest
-from azure.core.credentials import AccessToken
-from azure.core.credentials_async import AsyncTokenCredential
-
-from fabric_dw.http_client import FabricHttpClient
 from fabric_dw.services._lro import (
     LRO_DETAIL_WAIT_S,
     LRO_MAX_DETAIL_RETRIES,
     extract_operation_id,
     resolve_lro_item_id,
 )
-
-_FAKE_TOKEN = AccessToken(token="fake-token", expires_on=int(time.time()) + 3600)  # noqa: S106
+from tests.unit.services._helpers import _make_client
 
 _OP_ID = "abc-def-123"
 _LOCATION = f"https://api.fabric.microsoft.com/v1/operations/{_OP_ID}"
-
-
-def _make_credential() -> AsyncTokenCredential:
-    cred = MagicMock(spec=AsyncTokenCredential)
-    cred.get_token = AsyncMock(return_value=_FAKE_TOKEN)
-    return cred
-
-
-async def _make_client() -> FabricHttpClient:
-    return FabricHttpClient(credential=_make_credential(), rps=100)
 
 
 # ---------------------------------------------------------------------------
@@ -70,7 +53,6 @@ def test_extract_operation_id_simple_path() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_resolve_lro_item_id_path_a_resourceid() -> None:
     """resolve_lro_item_id returns the id from resourceId in the status body (Path A)."""
     client = await _make_client()
@@ -83,7 +65,6 @@ async def test_resolve_lro_item_id_path_a_resourceid() -> None:
     assert result == "res-123"
 
 
-@pytest.mark.asyncio
 async def test_resolve_lro_item_id_path_a_id() -> None:
     """resolve_lro_item_id returns the id from 'id' in the status body (Path A fallback)."""
     client = await _make_client()
@@ -96,7 +77,6 @@ async def test_resolve_lro_item_id_path_a_id() -> None:
     assert result == "item-456"
 
 
-@pytest.mark.asyncio
 async def test_resolve_lro_item_id_path_a_custom_keys() -> None:
     """resolve_lro_item_id checks custom result_id_keys in order."""
     client = await _make_client()
@@ -115,7 +95,6 @@ async def test_resolve_lro_item_id_path_a_custom_keys() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_resolve_lro_item_id_path_b_result_endpoint() -> None:
     """resolve_lro_item_id falls back to /result endpoint when status body has no id."""
     client = await _make_client()
@@ -132,7 +111,6 @@ async def test_resolve_lro_item_id_path_b_result_endpoint() -> None:
     mock_result.assert_awaited_once_with(_OP_ID)
 
 
-@pytest.mark.asyncio
 async def test_resolve_lro_item_id_returns_none_when_both_paths_fail() -> None:
     """resolve_lro_item_id returns None when neither Path A nor Path B yields an id."""
     client = await _make_client()
@@ -148,7 +126,6 @@ async def test_resolve_lro_item_id_returns_none_when_both_paths_fail() -> None:
     assert result is None
 
 
-@pytest.mark.asyncio
 async def test_resolve_lro_item_id_path_a_takes_priority_over_path_b() -> None:
     """Path A (status body) should be checked before Path B (/result endpoint)."""
     client = await _make_client()

--- a/tests/unit/services/test_ownership.py
+++ b/tests/unit/services/test_ownership.py
@@ -2,25 +2,21 @@
 
 from __future__ import annotations
 
-import time
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
 from uuid import UUID
 
 import pytest
 import respx
-from azure.core.credentials import AccessToken
-from azure.core.credentials_async import AsyncTokenCredential
 
 from fabric_dw.exceptions import NotFound, PermissionDenied
 from fabric_dw.http_client import FabricHttpClient
 from fabric_dw.services.ownership import takeover
+from tests.unit.services._helpers import _make_credential
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
-_FAKE_TOKEN = AccessToken(token="fake-token", expires_on=int(time.time()) + 3600)  # noqa: S106
 
 _WORKSPACE_ID = UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
 _WAREHOUSE_ID = UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
@@ -29,13 +25,6 @@ _EXPECTED_URL = (
     f"https://api.powerbi.com/v1.0/myorg"
     f"/groups/{_WORKSPACE_ID}/datawarehouses/{_WAREHOUSE_ID}/takeover"
 )
-
-
-def _make_credential(token: AccessToken = _FAKE_TOKEN) -> AsyncTokenCredential:
-    """Build a mock credential that returns *token*."""
-    cred = MagicMock(spec=AsyncTokenCredential)
-    cred.get_token = AsyncMock(return_value=token)
-    return cred
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/services/test_permissions.py
+++ b/tests/unit/services/test_permissions.py
@@ -3,18 +3,13 @@
 from __future__ import annotations
 
 import json
-import time
-from unittest.mock import AsyncMock, MagicMock
 from uuid import UUID
 
 import httpx
 import pytest
 import respx
-from azure.core.credentials import AccessToken
-from azure.core.credentials_async import AsyncTokenCredential
 
 from fabric_dw.exceptions import NotFound, PermissionDenied
-from fabric_dw.http_client import FabricHttpClient
 from fabric_dw.models import ItemAccess, PrincipalType
 from fabric_dw.services import permissions
 from tests.fixtures.api_payloads import (
@@ -22,12 +17,11 @@ from tests.fixtures.api_payloads import (
     ITEM_ACCESS_DETAILS_PAGE2_PAYLOAD,
     ITEM_ACCESS_DETAILS_PAYLOAD,
 )
+from tests.unit.services._helpers import _make_client
 
 # ---------------------------------------------------------------------------
-# Helpers
+# Constants
 # ---------------------------------------------------------------------------
-
-_FAKE_TOKEN = AccessToken(token="fake-token", expires_on=int(time.time()) + 3600)  # noqa: S106
 
 _BASE = "https://api.fabric.microsoft.com/v1"
 _WORKSPACE_ID = UUID("a1b2c3d4-e5f6-7890-abcd-ef1234567890")
@@ -39,22 +33,11 @@ _ACCESS_URL = (
 )
 
 
-def _make_credential(token: AccessToken = _FAKE_TOKEN) -> AsyncTokenCredential:
-    cred = MagicMock(spec=AsyncTokenCredential)
-    cred.get_token = AsyncMock(return_value=token)
-    return cred
-
-
-async def _make_client(rps: int = 10) -> FabricHttpClient:
-    return FabricHttpClient(credential=_make_credential(), rps=rps)
-
-
 # ---------------------------------------------------------------------------
 # list_item_access — happy path (single page)
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_list_item_access_returns_all_principals() -> None:
     """list_item_access must return one ItemAccess per principal in the response."""
     payload = json.loads(ITEM_ACCESS_DETAILS_PAYLOAD)
@@ -70,7 +53,6 @@ async def test_list_item_access_returns_all_principals() -> None:
     assert all(isinstance(item, ItemAccess) for item in result)
 
 
-@pytest.mark.asyncio
 async def test_list_item_access_user_principal_fields() -> None:
     """User principal must have display_name, type=User, and user_principal_name populated."""
     payload = json.loads(ITEM_ACCESS_DETAILS_PAYLOAD)
@@ -91,7 +73,6 @@ async def test_list_item_access_user_principal_fields() -> None:
     assert user.group_type is None
 
 
-@pytest.mark.asyncio
 async def test_list_item_access_group_principal_fields() -> None:
     """Group principal must have group_type populated from groupDetails."""
     payload = json.loads(ITEM_ACCESS_DETAILS_PAYLOAD)
@@ -111,7 +92,6 @@ async def test_list_item_access_group_principal_fields() -> None:
     assert group.user_principal_name is None
 
 
-@pytest.mark.asyncio
 async def test_list_item_access_service_principal_fields() -> None:
     """ServicePrincipal principal must have aad_app_id populated from servicePrincipalDetails."""
     payload = json.loads(ITEM_ACCESS_DETAILS_PAYLOAD)
@@ -131,7 +111,6 @@ async def test_list_item_access_service_principal_fields() -> None:
     assert sp.user_principal_name is None
 
 
-@pytest.mark.asyncio
 async def test_list_item_access_permissions_populated() -> None:
     """ItemAccess.item_access_details must have permissions and additional_permissions."""
     payload = json.loads(ITEM_ACCESS_DETAILS_PAYLOAD)
@@ -155,7 +134,6 @@ async def test_list_item_access_permissions_populated() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_list_item_access_empty_response_returns_empty_list() -> None:
     """list_item_access must return an empty list when accessDetails is empty."""
     with respx.mock:
@@ -173,7 +151,6 @@ async def test_list_item_access_empty_response_returns_empty_list() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_list_item_access_follows_continuation_uri() -> None:
     """list_item_access must follow continuationUri to fetch all pages."""
     page1 = json.loads(ITEM_ACCESS_DETAILS_PAGE1_PAYLOAD)
@@ -202,7 +179,6 @@ async def test_list_item_access_follows_continuation_uri() -> None:
     assert len(result) == 2  # 1 from page 1 + 1 from page 2
 
 
-@pytest.mark.asyncio
 async def test_list_item_access_pagination_returns_all_items_as_item_access() -> None:
     """All items from all pages must be ItemAccess instances."""
     page1 = json.loads(ITEM_ACCESS_DETAILS_PAGE1_PAYLOAD)
@@ -231,7 +207,6 @@ async def test_list_item_access_pagination_returns_all_items_as_item_access() ->
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_list_item_access_403_raises_permission_denied_with_hint() -> None:
     """list_item_access must raise PermissionDenied with admin-role hint on 403."""
     with respx.mock:
@@ -245,7 +220,6 @@ async def test_list_item_access_403_raises_permission_denied_with_hint() -> None
                 await permissions.list_item_access(client, _WORKSPACE_ID, _ITEM_ID)
 
 
-@pytest.mark.asyncio
 async def test_list_item_access_404_raises_not_found() -> None:
     """list_item_access must propagate NotFound on 404."""
     with respx.mock:

--- a/tests/unit/services/test_queries.py
+++ b/tests/unit/services/test_queries.py
@@ -76,7 +76,6 @@ _ROW_2_TUPLE = (
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_list_running_returns_empty_when_no_rows() -> None:
     target = _make_target()
     conn = _make_conn([], _COLS)
@@ -87,7 +86,6 @@ async def test_list_running_returns_empty_when_no_rows() -> None:
     assert result == []
 
 
-@pytest.mark.asyncio
 async def test_list_running_returns_running_query_instances() -> None:
     target = _make_target()
     conn = _make_conn([_ROW_1_TUPLE], _COLS)
@@ -99,7 +97,6 @@ async def test_list_running_returns_running_query_instances() -> None:
     assert isinstance(result[0], RunningQuery)
 
 
-@pytest.mark.asyncio
 async def test_list_running_parses_fields_correctly() -> None:
     target = _make_target()
     conn = _make_conn([_ROW_1_TUPLE], _COLS)
@@ -118,7 +115,6 @@ async def test_list_running_parses_fields_correctly() -> None:
     assert q.query_text == "SELECT TOP 10 * FROM dbo.sales"
 
 
-@pytest.mark.asyncio
 async def test_list_running_handles_null_query_text() -> None:
     target = _make_target()
     conn = _make_conn([_ROW_2_TUPLE], _COLS)
@@ -129,7 +125,6 @@ async def test_list_running_handles_null_query_text() -> None:
     assert result[0].query_text is None
 
 
-@pytest.mark.asyncio
 async def test_list_running_returns_all_rows() -> None:
     target = _make_target()
     conn = _make_conn([_ROW_1_TUPLE, _ROW_2_TUPLE], _COLS)
@@ -142,7 +137,6 @@ async def test_list_running_returns_all_rows() -> None:
     assert result[1].session_id == 99
 
 
-@pytest.mark.asyncio
 async def test_list_running_sql_references_dm_exec_sessions() -> None:
     target = _make_target()
     conn = _make_conn([], _COLS)
@@ -155,7 +149,6 @@ async def test_list_running_sql_references_dm_exec_sessions() -> None:
     assert "sys.dm_exec_sessions" in call_sql
 
 
-@pytest.mark.asyncio
 async def test_list_running_sql_references_dm_exec_requests() -> None:
     target = _make_target()
     conn = _make_conn([], _COLS)
@@ -168,7 +161,6 @@ async def test_list_running_sql_references_dm_exec_requests() -> None:
     assert "sys.dm_exec_requests" in call_sql
 
 
-@pytest.mark.asyncio
 async def test_list_running_sql_filters_by_status() -> None:
     target = _make_target()
     conn = _make_conn([], _COLS)
@@ -181,7 +173,6 @@ async def test_list_running_sql_filters_by_status() -> None:
     assert "r.status IN" in call_sql
 
 
-@pytest.mark.asyncio
 async def test_list_running_closes_connection_after_success() -> None:
     target = _make_target()
     conn = _make_conn([_ROW_1_TUPLE], _COLS)
@@ -192,7 +183,6 @@ async def test_list_running_closes_connection_after_success() -> None:
     conn.close.assert_called_once()
 
 
-@pytest.mark.asyncio
 async def test_list_running_maps_permission_denied() -> None:
     """cursor.execute raising a 'permission was denied' fragment → PermissionDenied."""
     target = _make_target()
@@ -208,7 +198,6 @@ async def test_list_running_maps_permission_denied() -> None:
         await queries.list_running(target)
 
 
-@pytest.mark.asyncio
 async def test_list_running_maps_auth_error() -> None:
     """cursor.execute raising an auth fragment → AuthError."""
     target = _make_target()
@@ -224,7 +213,6 @@ async def test_list_running_maps_auth_error() -> None:
         await queries.list_running(target)
 
 
-@pytest.mark.asyncio
 async def test_list_running_unrelated_error_propagates() -> None:
     """Non-mapped driver errors propagate unchanged."""
     target = _make_target()
@@ -245,7 +233,6 @@ async def test_list_running_unrelated_error_propagates() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_kill_issues_kill_statement() -> None:
     target = _make_target()
     conn = MagicMock()
@@ -260,7 +247,6 @@ async def test_kill_issues_kill_statement() -> None:
     assert "42" in call_sql
 
 
-@pytest.mark.asyncio
 async def test_kill_commits_after_execute() -> None:
     target = _make_target()
     conn = MagicMock()
@@ -273,7 +259,6 @@ async def test_kill_commits_after_execute() -> None:
     conn.commit.assert_called_once()
 
 
-@pytest.mark.asyncio
 async def test_kill_closes_connection_after_success() -> None:
     target = _make_target()
     conn = MagicMock()
@@ -286,7 +271,6 @@ async def test_kill_closes_connection_after_success() -> None:
     conn.close.assert_called_once()
 
 
-@pytest.mark.asyncio
 async def test_kill_returns_none_on_success() -> None:
     target = _make_target()
     conn = MagicMock()
@@ -302,7 +286,6 @@ async def test_kill_returns_none_on_success() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_kill_raises_value_error_for_zero() -> None:
     target = _make_target()
     conn = MagicMock()
@@ -316,7 +299,6 @@ async def test_kill_raises_value_error_for_zero() -> None:
     conn.cursor.assert_not_called()
 
 
-@pytest.mark.asyncio
 async def test_kill_raises_value_error_for_negative() -> None:
     target = _make_target()
     conn = MagicMock()
@@ -330,7 +312,6 @@ async def test_kill_raises_value_error_for_negative() -> None:
     conn.cursor.assert_not_called()
 
 
-@pytest.mark.asyncio
 async def test_kill_raises_value_error_for_large_negative() -> None:
     target = _make_target()
     conn = MagicMock()
@@ -349,7 +330,6 @@ async def test_kill_raises_value_error_for_large_negative() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_kill_maps_permission_denied_from_cursor() -> None:
     target = _make_target()
     conn = MagicMock()
@@ -364,7 +344,6 @@ async def test_kill_maps_permission_denied_from_cursor() -> None:
         await queries.kill(target, 42)
 
 
-@pytest.mark.asyncio
 async def test_kill_maps_auth_error_to_permission_denied() -> None:
     """kill should map AuthError → PermissionDenied."""
     target = _make_target()
@@ -380,7 +359,6 @@ async def test_kill_maps_auth_error_to_permission_denied() -> None:
         await queries.kill(target, 42)
 
 
-@pytest.mark.asyncio
 async def test_kill_permission_denied_message_contains_session_id() -> None:
     target = _make_target()
     conn = MagicMock()
@@ -441,7 +419,6 @@ _CONN_ROW_NULL_SESSION = (
 )
 
 
-@pytest.mark.asyncio
 async def test_list_connections_returns_empty_when_no_rows() -> None:
     target = _make_target()
     conn = _make_conn([], _CONN_COLS)
@@ -452,7 +429,6 @@ async def test_list_connections_returns_empty_when_no_rows() -> None:
     assert result == []
 
 
-@pytest.mark.asyncio
 async def test_list_connections_returns_connection_instances() -> None:
     target = _make_target()
     conn = _make_conn([_CONN_ROW_1], _CONN_COLS)
@@ -464,7 +440,6 @@ async def test_list_connections_returns_connection_instances() -> None:
     assert isinstance(result[0], Connection)
 
 
-@pytest.mark.asyncio
 async def test_list_connections_parses_fields_correctly() -> None:
     target = _make_target()
     conn = _make_conn([_CONN_ROW_1], _CONN_COLS)
@@ -482,7 +457,6 @@ async def test_list_connections_parses_fields_correctly() -> None:
     assert c.most_recent_session_id == 10
 
 
-@pytest.mark.asyncio
 async def test_list_connections_handles_null_client_net_address() -> None:
     target = _make_target()
     conn = _make_conn([_CONN_ROW_2], _CONN_COLS)
@@ -493,7 +467,6 @@ async def test_list_connections_handles_null_client_net_address() -> None:
     assert result[0].client_net_address is None
 
 
-@pytest.mark.asyncio
 async def test_list_connections_returns_all_rows() -> None:
     target = _make_target()
     conn = _make_conn([_CONN_ROW_1, _CONN_ROW_2], _CONN_COLS)
@@ -506,7 +479,6 @@ async def test_list_connections_returns_all_rows() -> None:
     assert result[1].session_id == 20
 
 
-@pytest.mark.asyncio
 async def test_list_connections_sql_references_dm_exec_connections() -> None:
     target = _make_target()
     conn = _make_conn([], _CONN_COLS)
@@ -519,7 +491,6 @@ async def test_list_connections_sql_references_dm_exec_connections() -> None:
     assert "sys.dm_exec_connections" in call_sql
 
 
-@pytest.mark.asyncio
 async def test_list_connections_sql_selects_expected_columns() -> None:
     target = _make_target()
     conn = _make_conn([], _CONN_COLS)
@@ -542,7 +513,6 @@ async def test_list_connections_sql_selects_expected_columns() -> None:
         assert col in call_sql
 
 
-@pytest.mark.asyncio
 async def test_list_connections_closes_connection_after_success() -> None:
     target = _make_target()
     conn = _make_conn([_CONN_ROW_1], _CONN_COLS)
@@ -553,7 +523,6 @@ async def test_list_connections_closes_connection_after_success() -> None:
     conn.close.assert_called_once()
 
 
-@pytest.mark.asyncio
 async def test_list_connections_maps_permission_denied() -> None:
     target = _make_target()
     conn = MagicMock()
@@ -570,7 +539,6 @@ async def test_list_connections_maps_permission_denied() -> None:
         await queries.list_connections(target)
 
 
-@pytest.mark.asyncio
 async def test_list_connections_maps_auth_error() -> None:
     target = _make_target()
     conn = MagicMock()
@@ -585,7 +553,6 @@ async def test_list_connections_maps_auth_error() -> None:
         await queries.list_connections(target)
 
 
-@pytest.mark.asyncio
 async def test_list_connections_unrelated_error_propagates() -> None:
     target = _make_target()
     conn = MagicMock()
@@ -600,7 +567,6 @@ async def test_list_connections_unrelated_error_propagates() -> None:
         await queries.list_connections(target)
 
 
-@pytest.mark.asyncio
 async def test_list_connections_handles_null_session_id() -> None:
     """Pre-login pooled connections return NULL for session_id (IS NULLABLE per MS docs)."""
     target = _make_target()
@@ -614,7 +580,6 @@ async def test_list_connections_handles_null_session_id() -> None:
     assert result[0].most_recent_session_id == 99
 
 
-@pytest.mark.asyncio
 async def test_list_connections_parses_most_recent_session_id() -> None:
     """most_recent_session_id is parsed from the DMV result (disambiguates pooled connections)."""
     target = _make_target()
@@ -627,7 +592,6 @@ async def test_list_connections_parses_most_recent_session_id() -> None:
     assert result[1].most_recent_session_id == 20
 
 
-@pytest.mark.asyncio
 async def test_list_connections_most_recent_session_id_can_be_none() -> None:
     """most_recent_session_id defaults to None when not present in result row."""
     target = _make_target()
@@ -647,7 +611,6 @@ async def test_list_connections_most_recent_session_id_can_be_none() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_list_running_sql_uses_inner_join() -> None:
     """The SQL must use INNER JOIN (not LEFT JOIN) so that the WHERE predicate
     on the right-side table is semantically correct rather than implied.
@@ -670,7 +633,6 @@ async def test_list_running_sql_uses_inner_join() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_kill_sql_contains_bare_integer() -> None:
     """KILL statement must embed a bare integer, not a quoted or f-string value."""
     target = _make_target()
@@ -686,7 +648,6 @@ async def test_kill_sql_contains_bare_integer() -> None:
     assert call_sql.strip() == "KILL 123"
 
 
-@pytest.mark.asyncio
 async def test_kill_sql_session_id_is_integer_not_string() -> None:
     """The embedded session_id must be a plain integer (not a quoted string)."""
     target = _make_target()

--- a/tests/unit/services/test_query_insights.py
+++ b/tests/unit/services/test_query_insights.py
@@ -81,7 +81,6 @@ _REQ_HIST_ROW = (
 )
 
 
-@pytest.mark.asyncio
 async def test_list_request_history_returns_empty_when_no_rows() -> None:
     target = _make_target()
     conn = _make_conn([], _REQ_HIST_COLS)
@@ -90,7 +89,6 @@ async def test_list_request_history_returns_empty_when_no_rows() -> None:
     assert result == []
 
 
-@pytest.mark.asyncio
 async def test_list_request_history_returns_model_instances() -> None:
     target = _make_target()
     conn = _make_conn([_REQ_HIST_ROW], _REQ_HIST_COLS)
@@ -100,7 +98,6 @@ async def test_list_request_history_returns_model_instances() -> None:
     assert isinstance(result[0], ExecRequestHistory)
 
 
-@pytest.mark.asyncio
 async def test_list_request_history_parses_fields() -> None:
     target = _make_target()
     conn = _make_conn([_REQ_HIST_ROW], _REQ_HIST_COLS)
@@ -113,7 +110,6 @@ async def test_list_request_history_parses_fields() -> None:
     assert row.total_elapsed_time_ms == 1500
 
 
-@pytest.mark.asyncio
 async def test_list_request_history_sql_references_exec_requests_history() -> None:
     target = _make_target()
     conn = _make_conn([], _REQ_HIST_COLS)
@@ -124,7 +120,6 @@ async def test_list_request_history_sql_references_exec_requests_history() -> No
     assert "queryinsights.exec_requests_history" in call_sql
 
 
-@pytest.mark.asyncio
 async def test_list_request_history_sql_has_top_clause() -> None:
     target = _make_target()
     conn = _make_conn([], _REQ_HIST_COLS)
@@ -135,7 +130,6 @@ async def test_list_request_history_sql_has_top_clause() -> None:
     assert "TOP (50)" in call_sql
 
 
-@pytest.mark.asyncio
 async def test_list_request_history_default_limit_100() -> None:
     target = _make_target()
     conn = _make_conn([], _REQ_HIST_COLS)
@@ -146,7 +140,6 @@ async def test_list_request_history_default_limit_100() -> None:
     assert "TOP (100)" in call_sql
 
 
-@pytest.mark.asyncio
 async def test_list_request_history_limit_clamped_to_10000() -> None:
     target = _make_target()
     conn = _make_conn([], _REQ_HIST_COLS)
@@ -157,7 +150,6 @@ async def test_list_request_history_limit_clamped_to_10000() -> None:
     assert "TOP (10000)" in call_sql
 
 
-@pytest.mark.asyncio
 async def test_list_request_history_since_adds_where_clause() -> None:
     target = _make_target()
     conn = _make_conn([], _REQ_HIST_COLS)
@@ -170,7 +162,6 @@ async def test_list_request_history_since_adds_where_clause() -> None:
     assert "submit_time" in call_sql
 
 
-@pytest.mark.asyncio
 async def test_list_request_history_until_adds_where_clause() -> None:
     target = _make_target()
     conn = _make_conn([], _REQ_HIST_COLS)
@@ -182,7 +173,6 @@ async def test_list_request_history_until_adds_where_clause() -> None:
     assert "WHERE" in call_sql
 
 
-@pytest.mark.asyncio
 async def test_list_request_history_maps_permission_denied() -> None:
     target = _make_target()
     conn = MagicMock()
@@ -196,7 +186,6 @@ async def test_list_request_history_maps_permission_denied() -> None:
         await query_insights.list_request_history(target)
 
 
-@pytest.mark.asyncio
 async def test_list_request_history_permission_denied_message_has_docs_link() -> None:
     target = _make_target()
     conn = MagicMock()
@@ -210,7 +199,6 @@ async def test_list_request_history_permission_denied_message_has_docs_link() ->
         await query_insights.list_request_history(target)
 
 
-@pytest.mark.asyncio
 async def test_list_request_history_maps_auth_error() -> None:
     target = _make_target()
     conn = MagicMock()
@@ -224,7 +212,6 @@ async def test_list_request_history_maps_auth_error() -> None:
         await query_insights.list_request_history(target)
 
 
-@pytest.mark.asyncio
 async def test_list_request_history_closes_connection() -> None:
     target = _make_target()
     conn = _make_conn([_REQ_HIST_ROW], _REQ_HIST_COLS)
@@ -277,7 +264,6 @@ _SESS_HIST_ROW = (
 )
 
 
-@pytest.mark.asyncio
 async def test_list_session_history_returns_empty_when_no_rows() -> None:
     target = _make_target()
     conn = _make_conn([], _SESS_HIST_COLS)
@@ -286,7 +272,6 @@ async def test_list_session_history_returns_empty_when_no_rows() -> None:
     assert result == []
 
 
-@pytest.mark.asyncio
 async def test_list_session_history_returns_model_instances() -> None:
     target = _make_target()
     conn = _make_conn([_SESS_HIST_ROW], _SESS_HIST_COLS)
@@ -296,7 +281,6 @@ async def test_list_session_history_returns_model_instances() -> None:
     assert isinstance(result[0], ExecSessionHistory)
 
 
-@pytest.mark.asyncio
 async def test_list_session_history_sql_references_view() -> None:
     target = _make_target()
     conn = _make_conn([], _SESS_HIST_COLS)
@@ -307,7 +291,6 @@ async def test_list_session_history_sql_references_view() -> None:
     assert "queryinsights.exec_sessions_history" in call_sql
 
 
-@pytest.mark.asyncio
 async def test_list_session_history_top_default_100() -> None:
     target = _make_target()
     conn = _make_conn([], _SESS_HIST_COLS)
@@ -318,7 +301,6 @@ async def test_list_session_history_top_default_100() -> None:
     assert "TOP (100)" in call_sql
 
 
-@pytest.mark.asyncio
 async def test_list_session_history_maps_permission_denied() -> None:
     target = _make_target()
     conn = MagicMock()
@@ -332,7 +314,6 @@ async def test_list_session_history_maps_permission_denied() -> None:
         await query_insights.list_session_history(target)
 
 
-@pytest.mark.asyncio
 async def test_list_session_history_since_adds_where() -> None:
     target = _make_target()
     conn = _make_conn([], _SESS_HIST_COLS)
@@ -366,7 +347,6 @@ _FREQ_ROW = (
 )
 
 
-@pytest.mark.asyncio
 async def test_list_frequent_queries_returns_empty_when_no_rows() -> None:
     target = _make_target()
     conn = _make_conn([], _FREQ_COLS)
@@ -375,7 +355,6 @@ async def test_list_frequent_queries_returns_empty_when_no_rows() -> None:
     assert result == []
 
 
-@pytest.mark.asyncio
 async def test_list_frequent_queries_returns_model_instances() -> None:
     target = _make_target()
     conn = _make_conn([_FREQ_ROW], _FREQ_COLS)
@@ -385,7 +364,6 @@ async def test_list_frequent_queries_returns_model_instances() -> None:
     assert isinstance(result[0], FrequentlyRunQuery)
 
 
-@pytest.mark.asyncio
 async def test_list_frequent_queries_parses_fields() -> None:
     target = _make_target()
     conn = _make_conn([_FREQ_ROW], _FREQ_COLS)
@@ -396,7 +374,6 @@ async def test_list_frequent_queries_parses_fields() -> None:
     assert row.avg_total_elapsed_time_ms == 1500
 
 
-@pytest.mark.asyncio
 async def test_list_frequent_queries_sql_references_view() -> None:
     target = _make_target()
     conn = _make_conn([], _FREQ_COLS)
@@ -407,7 +384,6 @@ async def test_list_frequent_queries_sql_references_view() -> None:
     assert "queryinsights.frequently_run_queries" in call_sql
 
 
-@pytest.mark.asyncio
 async def test_list_frequent_queries_top_default_100() -> None:
     target = _make_target()
     conn = _make_conn([], _FREQ_COLS)
@@ -418,7 +394,6 @@ async def test_list_frequent_queries_top_default_100() -> None:
     assert "TOP (100)" in call_sql
 
 
-@pytest.mark.asyncio
 async def test_list_frequent_queries_maps_permission_denied() -> None:
     target = _make_target()
     conn = MagicMock()
@@ -432,7 +407,6 @@ async def test_list_frequent_queries_maps_permission_denied() -> None:
         await query_insights.list_frequent_queries(target)
 
 
-@pytest.mark.asyncio
 async def test_list_frequent_queries_since_adds_where() -> None:
     target = _make_target()
     conn = _make_conn([], _FREQ_COLS)
@@ -461,7 +435,6 @@ _LONG_ROW = (
 )
 
 
-@pytest.mark.asyncio
 async def test_list_long_running_returns_empty_when_no_rows() -> None:
     target = _make_target()
     conn = _make_conn([], _LONG_COLS)
@@ -470,7 +443,6 @@ async def test_list_long_running_returns_empty_when_no_rows() -> None:
     assert result == []
 
 
-@pytest.mark.asyncio
 async def test_list_long_running_returns_model_instances() -> None:
     target = _make_target()
     conn = _make_conn([_LONG_ROW], _LONG_COLS)
@@ -480,7 +452,6 @@ async def test_list_long_running_returns_model_instances() -> None:
     assert isinstance(result[0], LongRunningQuery)
 
 
-@pytest.mark.asyncio
 async def test_list_long_running_parses_fields() -> None:
     target = _make_target()
     conn = _make_conn([_LONG_ROW], _LONG_COLS)
@@ -491,7 +462,6 @@ async def test_list_long_running_parses_fields() -> None:
     assert row.number_of_runs == 5
 
 
-@pytest.mark.asyncio
 async def test_list_long_running_sql_references_view() -> None:
     target = _make_target()
     conn = _make_conn([], _LONG_COLS)
@@ -502,7 +472,6 @@ async def test_list_long_running_sql_references_view() -> None:
     assert "queryinsights.long_running_queries" in call_sql
 
 
-@pytest.mark.asyncio
 async def test_list_long_running_top_default_100() -> None:
     target = _make_target()
     conn = _make_conn([], _LONG_COLS)
@@ -513,7 +482,6 @@ async def test_list_long_running_top_default_100() -> None:
     assert "TOP (100)" in call_sql
 
 
-@pytest.mark.asyncio
 async def test_list_long_running_maps_permission_denied() -> None:
     target = _make_target()
     conn = MagicMock()
@@ -527,7 +495,6 @@ async def test_list_long_running_maps_permission_denied() -> None:
         await query_insights.list_long_running_queries(target)
 
 
-@pytest.mark.asyncio
 async def test_list_long_running_since_adds_where() -> None:
     target = _make_target()
     conn = _make_conn([], _LONG_COLS)
@@ -555,7 +522,6 @@ _POOL_ROW = (
 )
 
 
-@pytest.mark.asyncio
 async def test_list_sql_pool_insights_returns_empty_when_no_rows() -> None:
     target = _make_target()
     conn = _make_conn([], _POOL_COLS)
@@ -564,7 +530,6 @@ async def test_list_sql_pool_insights_returns_empty_when_no_rows() -> None:
     assert result == []
 
 
-@pytest.mark.asyncio
 async def test_list_sql_pool_insights_returns_model_instances() -> None:
     target = _make_target()
     conn = _make_conn([_POOL_ROW], _POOL_COLS)
@@ -574,7 +539,6 @@ async def test_list_sql_pool_insights_returns_model_instances() -> None:
     assert isinstance(result[0], SqlPoolInsight)
 
 
-@pytest.mark.asyncio
 async def test_list_sql_pool_insights_parses_fields() -> None:
     target = _make_target()
     conn = _make_conn([_POOL_ROW], _POOL_COLS)
@@ -586,7 +550,6 @@ async def test_list_sql_pool_insights_parses_fields() -> None:
     assert row.is_pool_under_pressure is False
 
 
-@pytest.mark.asyncio
 async def test_list_sql_pool_insights_sql_references_view() -> None:
     target = _make_target()
     conn = _make_conn([], _POOL_COLS)
@@ -597,7 +560,6 @@ async def test_list_sql_pool_insights_sql_references_view() -> None:
     assert "queryinsights.sql_pool_insights" in call_sql
 
 
-@pytest.mark.asyncio
 async def test_list_sql_pool_insights_top_default_100() -> None:
     target = _make_target()
     conn = _make_conn([], _POOL_COLS)
@@ -608,7 +570,6 @@ async def test_list_sql_pool_insights_top_default_100() -> None:
     assert "TOP (100)" in call_sql
 
 
-@pytest.mark.asyncio
 async def test_list_sql_pool_insights_maps_permission_denied() -> None:
     target = _make_target()
     conn = MagicMock()
@@ -622,7 +583,6 @@ async def test_list_sql_pool_insights_maps_permission_denied() -> None:
         await query_insights.list_sql_pool_insights(target)
 
 
-@pytest.mark.asyncio
 async def test_list_sql_pool_insights_since_adds_where() -> None:
     target = _make_target()
     conn = _make_conn([], _POOL_COLS)
@@ -634,7 +594,6 @@ async def test_list_sql_pool_insights_since_adds_where() -> None:
     assert "timestamp" in call_sql
 
 
-@pytest.mark.asyncio
 async def test_list_sql_pool_insights_closes_connection() -> None:
     target = _make_target()
     conn = _make_conn([_POOL_ROW], _POOL_COLS)
@@ -648,7 +607,6 @@ async def test_list_sql_pool_insights_closes_connection() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_limit_clamped_min_1() -> None:
     """Negative or zero limit is treated as 1."""
     target = _make_target()
@@ -660,7 +618,6 @@ async def test_limit_clamped_min_1() -> None:
     assert "TOP (1)" in call_sql
 
 
-@pytest.mark.asyncio
 async def test_limit_clamped_max_10000_for_frequent() -> None:
     target = _make_target()
     conn = _make_conn([], _FREQ_COLS)
@@ -676,7 +633,6 @@ async def test_limit_clamped_max_10000_for_frequent() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_request_history_since_and_until_produce_and_clause() -> None:
     target = _make_target()
     conn = _make_conn([], _REQ_HIST_COLS)

--- a/tests/unit/services/test_restore.py
+++ b/tests/unit/services/test_restore.py
@@ -3,22 +3,20 @@
 from __future__ import annotations
 
 import json as _json
-import time
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 from uuid import UUID
 
 import anyio
 import httpx
 import pytest
 import respx
-from azure.core.credentials import AccessToken
-from azure.core.credentials_async import AsyncTokenCredential
 
 from fabric_dw.exceptions import NotFound, PermissionDenied
 from fabric_dw.http_client import FabricHttpClient
 from fabric_dw.models import CreationModeType, RestorePoint
 from fabric_dw.services import restore
+from tests.unit.services._helpers import _make_credential
 
 # ---------------------------------------------------------------------------
 # Constants & Fixtures
@@ -31,7 +29,6 @@ _WH_ID = UUID("d4e5f6a7-b8c9-0123-def0-123456789abc")
 _RP_ID = "1726617378000"
 _RP_ID_2 = "1726617379000"
 
-_FAKE_TOKEN = AccessToken(token="fake-token", expires_on=int(time.time()) + 3600)  # noqa: S106
 
 _BASE_URL = "https://api.fabric.microsoft.com/v1"
 _RP_LIST_URL = f"{_BASE_URL}/workspaces/{_WS_ID}/warehouses/{_WH_ID}/restorePoints"
@@ -81,12 +78,6 @@ LRO_SUCCEEDED: dict[str, Any] = {
     "percentComplete": 100,
     "error": None,
 }
-
-
-def _make_credential() -> AsyncTokenCredential:
-    cred = MagicMock(spec=AsyncTokenCredential)
-    cred.get_token = AsyncMock(return_value=_FAKE_TOKEN)
-    return cred
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/services/test_schemas.py
+++ b/tests/unit/services/test_schemas.py
@@ -68,7 +68,6 @@ class TestValidateIdentifierReexport:
 
 
 class TestListSchemas:
-    @pytest.mark.asyncio
     async def test_returns_empty_when_no_rows(self) -> None:
         target = _make_target()
         conn = _make_conn([], _LIST_COLS)
@@ -76,7 +75,6 @@ class TestListSchemas:
             result = await schemas.list_schemas(target)
         assert result == []
 
-    @pytest.mark.asyncio
     async def test_returns_schema_instances(self) -> None:
         target = _make_target()
         conn = _make_conn([_SCHEMA_ROW_1], _LIST_COLS)
@@ -85,7 +83,6 @@ class TestListSchemas:
         assert len(result) == 1
         assert isinstance(result[0], Schema)
 
-    @pytest.mark.asyncio
     async def test_parses_fields_correctly(self) -> None:
         target = _make_target()
         conn = _make_conn([_SCHEMA_ROW_1], _LIST_COLS)
@@ -95,7 +92,6 @@ class TestListSchemas:
         assert s.name == "dbo"
         assert s.principal_id == 1
 
-    @pytest.mark.asyncio
     async def test_returns_all_rows(self) -> None:
         target = _make_target()
         conn = _make_conn([_SCHEMA_ROW_1, _SCHEMA_ROW_2], _LIST_COLS)
@@ -103,7 +99,6 @@ class TestListSchemas:
             result = await schemas.list_schemas(target)
         assert len(result) == 2
 
-    @pytest.mark.asyncio
     async def test_sql_references_sys_schemas(self) -> None:
         target = _make_target()
         conn = _make_conn([], _LIST_COLS)
@@ -113,7 +108,6 @@ class TestListSchemas:
         call_sql: str = cursor.execute.call_args[0][0]
         assert "sys.schemas" in call_sql
 
-    @pytest.mark.asyncio
     async def test_sql_excludes_sys_schema(self) -> None:
         target = _make_target()
         conn = _make_conn([], _LIST_COLS)
@@ -127,7 +121,6 @@ class TestListSchemas:
         params = call_args[0][1] if len(call_args[0]) > 1 else []
         assert "sys" in list(params)
 
-    @pytest.mark.asyncio
     async def test_sql_excludes_information_schema(self) -> None:
         target = _make_target()
         conn = _make_conn([], _LIST_COLS)
@@ -138,7 +131,6 @@ class TestListSchemas:
         params = call_args[0][1] if len(call_args[0]) > 1 else []
         assert "INFORMATION_SCHEMA" in list(params)
 
-    @pytest.mark.asyncio
     async def test_sql_excludes_db_prefix_via_like(self) -> None:
         target = _make_target()
         conn = _make_conn([], _LIST_COLS)
@@ -148,7 +140,6 @@ class TestListSchemas:
         call_sql: str = cursor.execute.call_args[0][0]
         assert "db[_]%" in call_sql
 
-    @pytest.mark.asyncio
     async def test_sql_excludes_guest_schema(self) -> None:
         target = _make_target()
         conn = _make_conn([], _LIST_COLS)
@@ -160,7 +151,6 @@ class TestListSchemas:
         # 'guest' must appear in the NOT IN params
         assert "guest" in list(params)
 
-    @pytest.mark.asyncio
     async def test_closes_connection(self) -> None:
         target = _make_target()
         conn = _make_conn([_SCHEMA_ROW_1], _LIST_COLS)
@@ -168,7 +158,6 @@ class TestListSchemas:
             await schemas.list_schemas(target)
         conn.close.assert_called_once()
 
-    @pytest.mark.asyncio
     async def test_maps_permission_denied(self) -> None:
         target = _make_target()
         conn = MagicMock()
@@ -181,7 +170,6 @@ class TestListSchemas:
         ):
             await schemas.list_schemas(target)
 
-    @pytest.mark.asyncio
     async def test_maps_auth_error(self) -> None:
         target = _make_target()
         conn = MagicMock()
@@ -194,7 +182,6 @@ class TestListSchemas:
         ):
             await schemas.list_schemas(target)
 
-    @pytest.mark.asyncio
     async def test_unrelated_error_propagates(self) -> None:
         target = _make_target()
         conn = MagicMock()
@@ -214,7 +201,6 @@ class TestListSchemas:
 
 
 class TestCreateSchema:
-    @pytest.mark.asyncio
     async def test_emits_create_schema(self) -> None:
         target = _make_target()
         ddl_conn = _make_conn_for_ddl()
@@ -225,7 +211,6 @@ class TestCreateSchema:
         call_sql: str = cursor.execute.call_args[0][0].upper()
         assert "CREATE SCHEMA" in call_sql
 
-    @pytest.mark.asyncio
     async def test_uses_bracket_quoting(self) -> None:
         target = _make_target()
         ddl_conn = _make_conn_for_ddl()
@@ -236,7 +221,6 @@ class TestCreateSchema:
         call_sql: str = cursor.execute.call_args[0][0]
         assert "[dbo]" in call_sql
 
-    @pytest.mark.asyncio
     async def test_returns_schema_object(self) -> None:
         target = _make_target()
         ddl_conn = _make_conn_for_ddl()
@@ -245,7 +229,6 @@ class TestCreateSchema:
             result = await schemas.create_schema(target, "dbo")
         assert isinstance(result, Schema)
 
-    @pytest.mark.asyncio
     async def test_commits_after_execute(self) -> None:
         target = _make_target()
         ddl_conn = _make_conn_for_ddl()
@@ -254,19 +237,16 @@ class TestCreateSchema:
             await schemas.create_schema(target, "dbo")
         ddl_conn.commit.assert_called_once()
 
-    @pytest.mark.asyncio
     async def test_validates_name_identifier(self) -> None:
         target = _make_target()
         with pytest.raises(ValueError, match="Invalid SQL identifier"):
             await schemas.create_schema(target, "bad]schema")
 
-    @pytest.mark.asyncio
     async def test_rejects_injection_in_name(self) -> None:
         target = _make_target()
         with pytest.raises(ValueError, match="Invalid SQL identifier"):
             await schemas.create_schema(target, "x]; DROP TABLE users--")
 
-    @pytest.mark.asyncio
     async def test_maps_permission_denied(self) -> None:
         target = _make_target()
         conn = MagicMock()
@@ -279,7 +259,6 @@ class TestCreateSchema:
         ):
             await schemas.create_schema(target, "dbo")
 
-    @pytest.mark.asyncio
     async def test_fetch_raises_not_found_when_no_rows(self) -> None:
         target = _make_target()
         ddl_conn = _make_conn_for_ddl()
@@ -297,7 +276,6 @@ class TestCreateSchema:
 
 
 class TestDeleteSchema:
-    @pytest.mark.asyncio
     async def test_emits_drop_schema(self) -> None:
         target = _make_target()
         conn = _make_conn_for_ddl()
@@ -307,7 +285,6 @@ class TestDeleteSchema:
         call_sql: str = cursor.execute.call_args[0][0].upper()
         assert "DROP SCHEMA" in call_sql
 
-    @pytest.mark.asyncio
     async def test_uses_bracket_quoting(self) -> None:
         target = _make_target()
         conn = _make_conn_for_ddl()
@@ -317,7 +294,6 @@ class TestDeleteSchema:
         call_sql: str = cursor.execute.call_args[0][0]
         assert "[dbo]" in call_sql
 
-    @pytest.mark.asyncio
     async def test_commits_after_execute(self) -> None:
         target = _make_target()
         conn = _make_conn_for_ddl()
@@ -325,7 +301,6 @@ class TestDeleteSchema:
             await schemas.delete_schema(target, "dbo")
         conn.commit.assert_called_once()
 
-    @pytest.mark.asyncio
     async def test_closes_connection(self) -> None:
         target = _make_target()
         conn = _make_conn_for_ddl()
@@ -333,19 +308,16 @@ class TestDeleteSchema:
             await schemas.delete_schema(target, "dbo")
         conn.close.assert_called_once()
 
-    @pytest.mark.asyncio
     async def test_validates_name_identifier(self) -> None:
         target = _make_target()
         with pytest.raises(ValueError, match="Invalid SQL identifier"):
             await schemas.delete_schema(target, "bad]schema")
 
-    @pytest.mark.asyncio
     async def test_rejects_injection_in_name(self) -> None:
         target = _make_target()
         with pytest.raises(ValueError, match="Invalid SQL identifier"):
             await schemas.delete_schema(target, "x]; DROP TABLE users--")
 
-    @pytest.mark.asyncio
     async def test_maps_permission_denied(self) -> None:
         target = _make_target()
         conn = MagicMock()
@@ -358,7 +330,6 @@ class TestDeleteSchema:
         ):
             await schemas.delete_schema(target, "dbo")
 
-    @pytest.mark.asyncio
     async def test_unrelated_error_propagates(self) -> None:
         target = _make_target()
         conn = MagicMock()
@@ -378,7 +349,6 @@ class TestDeleteSchema:
 
 
 class TestDeleteSchemaCascade:
-    @pytest.mark.asyncio
     async def test_cascade_drops_table_then_schema(self) -> None:
         """cascade=True: list → run_statements (DROP TABLE) → DROP SCHEMA.
         run_statements uses a single connection for all object drops."""
@@ -397,7 +367,6 @@ class TestDeleteSchemaCascade:
         drop_sql: str = cursor.execute.call_args[0][0].upper()
         assert "DROP TABLE" in drop_sql
 
-    @pytest.mark.asyncio
     async def test_cascade_drops_view_then_schema(self) -> None:
         """cascade=True: list → run_statements (DROP VIEW) → DROP SCHEMA."""
         target = _make_target()
@@ -413,7 +382,6 @@ class TestDeleteSchemaCascade:
         drop_sql: str = cursor.execute.call_args[0][0].upper()
         assert "DROP VIEW" in drop_sql
 
-    @pytest.mark.asyncio
     async def test_cascade_drops_multiple_objects(self) -> None:
         """Multiple objects (t1 TABLE, v1 VIEW) are dropped on ONE connection.
 
@@ -441,7 +409,6 @@ class TestDeleteSchemaCascade:
         assert any("DROP TABLE" in s and "[T1]" in s for s in sqls)
         assert any("DROP VIEW" in s and "[V1]" in s for s in sqls)
 
-    @pytest.mark.asyncio
     async def test_cascade_false_does_not_enumerate_objects(self) -> None:
         target = _make_target()
         drop_schema_conn = _make_conn_for_ddl()
@@ -453,7 +420,6 @@ class TestDeleteSchemaCascade:
         # Only one connection opened (the DROP SCHEMA itself)
         assert True
 
-    @pytest.mark.asyncio
     async def test_cascade_empty_schema_drops_schema(self) -> None:
         """When schema has no objects, skip run_statements and only DROP SCHEMA."""
         target = _make_target()
@@ -468,7 +434,6 @@ class TestDeleteSchemaCascade:
         drop_sql: str = cursor.execute.call_args[0][0].upper()
         assert "DROP SCHEMA" in drop_sql
 
-    @pytest.mark.asyncio
     async def test_cascade_uses_bracket_quoting_for_objects(self) -> None:
         """Object DROP statements must use bracket-quoted names."""
         target = _make_target()

--- a/tests/unit/services/test_snapshots.py
+++ b/tests/unit/services/test_snapshots.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json as _json
-import time
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -13,8 +12,6 @@ from uuid import UUID
 import httpx
 import pytest
 import respx
-from azure.core.credentials import AccessToken
-from azure.core.credentials_async import AsyncTokenCredential
 
 from fabric_dw.cache import ItemEntry, LookupCache
 from fabric_dw.exceptions import NotFound, PermissionDenied
@@ -22,6 +19,7 @@ from fabric_dw.http_client import FabricHttpClient
 from fabric_dw.models import WarehouseKind, WarehouseSnapshot
 from fabric_dw.services import snapshots
 from fabric_dw.sql import SqlTarget
+from tests.unit.services._helpers import _make_credential
 
 # ---------------------------------------------------------------------------
 # Constants & Fixtures
@@ -32,7 +30,6 @@ _PARENT_WH_ID = UUID("d4e5f6a7-b8c9-0123-def0-123456789abc")
 _SNAP_ID = UUID("f6a7b8c9-d0e1-2345-f012-34567890abcd")
 _OTHER_WH_ID = UUID("11111111-2222-3333-4444-555555555555")
 
-_FAKE_TOKEN = AccessToken(token="fake-token", expires_on=int(time.time()) + 3600)  # noqa: S106
 
 _BASE_URL = "https://api.fabric.microsoft.com/v1"
 _ITEMS_URL = f"{_BASE_URL}/workspaces/{_WS_ID}/items"
@@ -128,12 +125,6 @@ WAREHOUSE_SNAPSHOT_CREATE_OPERATION_PAYLOAD: dict[str, Any] = {
 }
 
 _LRO_LOCATION = f"{_BASE_URL}/operations/op-abc-123"
-
-
-def _make_credential() -> AsyncTokenCredential:
-    cred = MagicMock(spec=AsyncTokenCredential)
-    cred.get_token = AsyncMock(return_value=_FAKE_TOKEN)
-    return cred
 
 
 def _make_sql_target() -> SqlTarget:
@@ -726,7 +717,6 @@ _RENAME_TYPED_RESP: dict[str, object] = {
 }
 
 
-@pytest.mark.asyncio
 async def test_rename_evicts_old_name_and_inserts_new_name(tmp_path: Path) -> None:
     """rename with cache must evict old name and populate new name."""
     cache, _entry = _make_snap_cache_entry(tmp_path)
@@ -757,7 +747,6 @@ async def test_rename_evicts_old_name_and_inserts_new_name(tmp_path: Path) -> No
     assert renamed_entry.display_name == "RenamedSnapshot"
 
 
-@pytest.mark.asyncio
 async def test_rename_without_cache_does_not_raise(tmp_path: Path) -> None:
     """rename without cache= must still complete successfully."""
     _ = tmp_path
@@ -780,7 +769,6 @@ async def test_rename_without_cache_does_not_raise(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_delete_evicts_name_from_cache(tmp_path: Path) -> None:
     """delete with cache= must evict both the name entry and the GUID entry."""
     cache, _entry = _make_snap_cache_entry(tmp_path)
@@ -804,7 +792,6 @@ async def test_delete_evicts_name_from_cache(tmp_path: Path) -> None:
     assert cache.get_item(_WS_ID, str(_SNAP_ID)) is None
 
 
-@pytest.mark.asyncio
 async def test_delete_without_cache_does_not_raise(tmp_path: Path) -> None:
     """delete without cache= must still complete successfully."""
     _ = tmp_path

--- a/tests/unit/services/test_sql_endpoints.py
+++ b/tests/unit/services/test_sql_endpoints.py
@@ -4,19 +4,15 @@ from __future__ import annotations
 
 import json
 import logging
-import time
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 from uuid import UUID
 
 import httpx
 import pytest
 import respx
-from azure.core.credentials import AccessToken
-from azure.core.credentials_async import AsyncTokenCredential
 
 from fabric_dw.exceptions import FabricServerError, NotFound, PermissionDenied
-from fabric_dw.http_client import FabricHttpClient
 from fabric_dw.models import TableSyncStatus, Warehouse, WarehouseKind, Workspace
 from fabric_dw.services.sql_endpoints import list_all_workspaces
 from tests.fixtures.api_payloads import (
@@ -24,12 +20,11 @@ from tests.fixtures.api_payloads import (
     WAREHOUSE_SQL_ENDPOINTS_PAGE2_PAYLOAD,
     WAREHOUSE_SQL_ENDPOINTS_PAYLOAD,
 )
+from tests.unit.services._helpers import _make_client
 
 # ---------------------------------------------------------------------------
-# Helpers
+# Constants
 # ---------------------------------------------------------------------------
-
-_FAKE_TOKEN = AccessToken(token="fake-token", expires_on=int(time.time()) + 3600)  # noqa: S106
 
 _WORKSPACE_ID = UUID("a1b2c3d4-e5f6-7890-abcd-ef1234567890")
 _ENDPOINT_ID = UUID("e5f6a7b8-c9d0-1234-ef01-234567890abc")
@@ -39,16 +34,6 @@ _SQL_ENDPOINTS_URL = f"{_BASE}/workspaces/{_WORKSPACE_ID}/sqlEndpoints"
 _ENDPOINT_URL = f"{_SQL_ENDPOINTS_URL}/{_ENDPOINT_ID}"
 _REFRESH_URL = f"{_ENDPOINT_URL}/refreshMetadata"
 _OPERATION_URL = f"{_BASE}/operations/op-refresh-123"
-
-
-def _make_credential(token: AccessToken = _FAKE_TOKEN) -> AsyncTokenCredential:
-    cred = MagicMock(spec=AsyncTokenCredential)
-    cred.get_token = AsyncMock(return_value=token)
-    return cred
-
-
-async def _make_client(rps: int = 10) -> FabricHttpClient:
-    return FabricHttpClient(credential=_make_credential(), rps=rps)
 
 
 # Single SQL endpoint GET payload
@@ -100,7 +85,6 @@ _REFRESH_LRO_SUCCEEDED: dict[str, Any] = {
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_list_endpoints_returns_sql_endpoint_items() -> None:
     """list_endpoints must return only SQL_ENDPOINT-kind Warehouse items."""
     from fabric_dw.services.sql_endpoints import list_endpoints  # noqa: PLC0415
@@ -120,7 +104,6 @@ async def test_list_endpoints_returns_sql_endpoint_items() -> None:
     assert all(ep.kind == WarehouseKind.SQL_ENDPOINT for ep in result)
 
 
-@pytest.mark.asyncio
 async def test_list_endpoints_follows_pagination() -> None:
     """list_endpoints must follow continuationUri across pages."""
     from fabric_dw.services.sql_endpoints import list_endpoints  # noqa: PLC0415
@@ -146,7 +129,6 @@ async def test_list_endpoints_follows_pagination() -> None:
     assert all(ep.kind == WarehouseKind.SQL_ENDPOINT for ep in result)
 
 
-@pytest.mark.asyncio
 async def test_list_endpoints_empty_workspace_returns_empty_list() -> None:
     """list_endpoints must return an empty list when there are no SQL endpoints."""
     from fabric_dw.services.sql_endpoints import list_endpoints  # noqa: PLC0415
@@ -166,7 +148,6 @@ async def test_list_endpoints_empty_workspace_returns_empty_list() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_get_endpoint_returns_populated_warehouse() -> None:
     """get_endpoint must return a single populated Warehouse with SQL_ENDPOINT kind."""
     from fabric_dw.services.sql_endpoints import get_endpoint  # noqa: PLC0415
@@ -186,7 +167,6 @@ async def test_get_endpoint_returns_populated_warehouse() -> None:
     assert result.workspace_id == _WORKSPACE_ID
 
 
-@pytest.mark.asyncio
 async def test_get_endpoint_404_propagates_not_found() -> None:
     """get_endpoint must propagate NotFound on a 404 response."""
     from fabric_dw.services.sql_endpoints import get_endpoint  # noqa: PLC0415
@@ -209,7 +189,6 @@ async def test_get_endpoint_404_propagates_not_found() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_refresh_metadata_posts_and_polls_lro() -> None:
     """refresh_metadata must POST to /refreshMetadata and poll the LRO to completion."""
     from fabric_dw.services.sql_endpoints import refresh_metadata  # noqa: PLC0415
@@ -241,7 +220,6 @@ async def test_refresh_metadata_posts_and_polls_lro() -> None:
     assert result[1].error.error_code == "AdalRetryException"
 
 
-@pytest.mark.asyncio
 async def test_refresh_metadata_no_recreate_tables_sends_no_body() -> None:
     """refresh_metadata without recreate_tables must not send a JSON body."""
     from fabric_dw.services.sql_endpoints import refresh_metadata  # noqa: PLC0415
@@ -267,7 +245,6 @@ async def test_refresh_metadata_no_recreate_tables_sends_no_body() -> None:
     assert captured_requests[0].content in (b"", b"null")
 
 
-@pytest.mark.asyncio
 async def test_refresh_metadata_recreate_tables_sends_body() -> None:
     """refresh_metadata with recreate_tables=True must send {recreateTables: true} in the body."""
     from fabric_dw.services.sql_endpoints import refresh_metadata  # noqa: PLC0415
@@ -296,7 +273,6 @@ async def test_refresh_metadata_recreate_tables_sends_body() -> None:
     assert isinstance(result, list)
 
 
-@pytest.mark.asyncio
 async def test_refresh_metadata_lro_poll_multiple_times() -> None:
     """refresh_metadata must poll the LRO until it succeeds (multi-poll path)."""
     from fabric_dw.services.sql_endpoints import refresh_metadata  # noqa: PLC0415
@@ -333,7 +309,6 @@ async def test_refresh_metadata_lro_poll_multiple_times() -> None:
     assert len(result) == 2
 
 
-@pytest.mark.asyncio
 async def test_refresh_metadata_lro_failed_raises_fabric_server_error() -> None:
     """refresh_metadata must raise FabricServerError when LRO status is 'Failed'."""
     from fabric_dw.services.sql_endpoints import refresh_metadata  # noqa: PLC0415
@@ -398,7 +373,6 @@ def _make_ep(ws_id: UUID, ep_id: UUID) -> Warehouse:
     )
 
 
-@pytest.mark.asyncio
 async def test_list_all_workspaces_endpoints_aggregates_across_workspaces() -> None:
     """list_all_workspaces must collect endpoints from every visible workspace."""
     ws_a = _make_workspace(_EP_WS_A)
@@ -433,7 +407,6 @@ async def test_list_all_workspaces_endpoints_aggregates_across_workspaces() -> N
     assert ids == {_EP_A, _EP_B, _EP_C}
 
 
-@pytest.mark.asyncio
 async def test_list_all_workspaces_endpoints_skips_permission_denied(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -472,7 +445,6 @@ async def test_list_all_workspaces_endpoints_skips_permission_denied(
     assert any("skipped 1 of 3" in r.message for r in caplog.records)
 
 
-@pytest.mark.asyncio
 async def test_list_all_workspaces_endpoints_skips_not_found(
     caplog: pytest.LogCaptureFixture,
 ) -> None:

--- a/tests/unit/services/test_sql_exec.py
+++ b/tests/unit/services/test_sql_exec.py
@@ -55,7 +55,6 @@ def _make_no_result_conn(*, rowcount: int = 1) -> MagicMock:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_execute_select_returns_sql_result() -> None:
     target = _make_target()
     conn = _make_conn([(1, "hello"), (2, "world")], ["id", "name"])
@@ -66,7 +65,6 @@ async def test_execute_select_returns_sql_result() -> None:
     assert isinstance(result, SqlResult)
 
 
-@pytest.mark.asyncio
 async def test_execute_select_columns_and_rows() -> None:
     target = _make_target()
     conn = _make_conn([(42, "foo")], ["col_a", "col_b"])
@@ -78,7 +76,6 @@ async def test_execute_select_columns_and_rows() -> None:
     assert result.rows == [[42, "foo"]]
 
 
-@pytest.mark.asyncio
 async def test_execute_select_empty_rows() -> None:
     target = _make_target()
     conn = _make_conn([], ["col_a", "col_b"])
@@ -90,7 +87,6 @@ async def test_execute_select_empty_rows() -> None:
     assert result.rows == []
 
 
-@pytest.mark.asyncio
 async def test_execute_select_rowcount_falls_back_to_len_rows() -> None:
     """When driver returns rowcount=-1 for SELECT, we use len(rows)."""
     target = _make_target()
@@ -102,7 +98,6 @@ async def test_execute_select_rowcount_falls_back_to_len_rows() -> None:
     assert result.rowcount == 3
 
 
-@pytest.mark.asyncio
 async def test_execute_select_rowcount_from_driver_when_positive() -> None:
     """When driver returns a positive rowcount, use it directly."""
     target = _make_target()
@@ -119,7 +114,6 @@ async def test_execute_select_rowcount_from_driver_when_positive() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_execute_insert_no_rows_returns_empty() -> None:
     target = _make_target()
     conn = _make_no_result_conn(rowcount=3)
@@ -132,7 +126,6 @@ async def test_execute_insert_no_rows_returns_empty() -> None:
     assert result.rowcount == 3
 
 
-@pytest.mark.asyncio
 async def test_execute_dml_closes_connection() -> None:
     target = _make_target()
     conn = _make_no_result_conn()
@@ -148,7 +141,6 @@ async def test_execute_dml_closes_connection() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_execute_alter_no_rows_returns_empty() -> None:
     target = _make_target()
     conn = _make_no_result_conn(rowcount=0)
@@ -165,7 +157,6 @@ async def test_execute_alter_no_rows_returns_empty() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_execute_datetime_column_serialised_to_iso() -> None:
     dt = datetime(2024, 6, 1, 12, 0, 0, tzinfo=UTC)
     target = _make_target()
@@ -177,7 +168,6 @@ async def test_execute_datetime_column_serialised_to_iso() -> None:
     assert result.rows[0][0] == dt.isoformat()
 
 
-@pytest.mark.asyncio
 async def test_execute_decimal_column_serialised_to_string() -> None:
     target = _make_target()
     conn = _make_conn([(Decimal("3.14"),)], ["price"])
@@ -188,7 +178,6 @@ async def test_execute_decimal_column_serialised_to_string() -> None:
     assert result.rows[0][0] == "3.14"
 
 
-@pytest.mark.asyncio
 async def test_execute_bytes_column_base64_encoded() -> None:
     raw = b"\x00\x01\x02\x03"
     target = _make_target()
@@ -201,7 +190,6 @@ async def test_execute_bytes_column_base64_encoded() -> None:
     assert result.rows[0][0] == expected_b64
 
 
-@pytest.mark.asyncio
 async def test_execute_bytes_column_name_gets_base64_suffix() -> None:
     target = _make_target()
     conn = _make_conn([(b"\xff",)], ["hash_val"])
@@ -212,7 +200,6 @@ async def test_execute_bytes_column_name_gets_base64_suffix() -> None:
     assert result.columns == ["hash_val__base64"]
 
 
-@pytest.mark.asyncio
 async def test_execute_non_binary_column_name_unchanged() -> None:
     target = _make_target()
     conn = _make_conn([(42,)], ["score"])
@@ -228,7 +215,6 @@ async def test_execute_non_binary_column_name_unchanged() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_execute_syntax_error_propagates() -> None:
     """Non-mapped driver errors are raised as-is."""
     target = _make_target()
@@ -244,7 +230,6 @@ async def test_execute_syntax_error_propagates() -> None:
         await sql_exec.execute(target, "SLECT 1")
 
 
-@pytest.mark.asyncio
 async def test_execute_permission_denied_raises_permission_denied() -> None:
     target = _make_target()
     conn = MagicMock()
@@ -259,7 +244,6 @@ async def test_execute_permission_denied_raises_permission_denied() -> None:
         await sql_exec.execute(target, "SELECT * FROM SensitiveTable")
 
 
-@pytest.mark.asyncio
 async def test_execute_permission_denied_message_contains_hint() -> None:
     """PermissionDenied message must mention a documentation hint."""
     target = _make_target()
@@ -275,7 +259,6 @@ async def test_execute_permission_denied_message_contains_hint() -> None:
         await sql_exec.execute(target, "SELECT * FROM X")
 
 
-@pytest.mark.asyncio
 async def test_execute_auth_error_raises_auth_error() -> None:
     """Authentication failures (expired/missing token) are re-raised as AuthError."""
     target = _make_target()
@@ -291,7 +274,6 @@ async def test_execute_auth_error_raises_auth_error() -> None:
         await sql_exec.execute(target, "SELECT 1")
 
 
-@pytest.mark.asyncio
 async def test_execute_perm_denied_driver_raises_permission_denied() -> None:
     """SQL permission-denial errors are re-raised as PermissionDenied."""
     target = _make_target()
@@ -312,7 +294,6 @@ async def test_execute_perm_denied_driver_raises_permission_denied() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_execute_multi_statement_returns_last_result_set() -> None:
     """When the cursor has multiple result sets, the last one is returned."""
     target = _make_target()
@@ -342,7 +323,6 @@ async def test_execute_multi_statement_returns_last_result_set() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_execute_closes_connection_after_success() -> None:
     target = _make_target()
     conn = _make_conn([(1,)], ["n"])
@@ -353,7 +333,6 @@ async def test_execute_closes_connection_after_success() -> None:
     conn.close.assert_called_once()
 
 
-@pytest.mark.asyncio
 async def test_execute_closes_connection_on_error() -> None:
     """Connection must be closed even when cursor.execute raises."""
     target = _make_target()
@@ -376,7 +355,6 @@ async def test_execute_closes_connection_on_error() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_binary_null_first_row_detected_via_later_rows() -> None:
     """If the first row has NULL for a binary column, later rows with bytes
     must still cause the column to be tagged.  The old first-row-only heuristic
@@ -391,7 +369,6 @@ async def test_binary_null_first_row_detected_via_later_rows() -> None:
     assert result.columns == ["blob__base64"]
 
 
-@pytest.mark.asyncio
 async def test_binary_all_null_rows_not_tagged() -> None:
     """A column that is NULL in every row is not binary and must not be tagged."""
     target = _make_target()
@@ -403,7 +380,6 @@ async def test_binary_all_null_rows_not_tagged() -> None:
     assert result.columns == ["blob"]
 
 
-@pytest.mark.asyncio
 async def test_binary_type_code_in_description_tags_column() -> None:
     """When cursor.description carries a type_code whose __name__ contains
     'binary', the column is tagged without scanning any row."""

--- a/tests/unit/services/test_sql_pools.py
+++ b/tests/unit/services/test_sql_pools.py
@@ -3,22 +3,18 @@
 from __future__ import annotations
 
 import json
-import time
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
 from uuid import UUID
 
 import httpx
 import pytest
 import respx
-from azure.core.credentials import AccessToken
-from azure.core.credentials_async import AsyncTokenCredential
 from pydantic import ValidationError
 
 from fabric_dw.exceptions import AlreadyExists, NotFound, PermissionDenied
-from fabric_dw.http_client import FabricHttpClient
 from fabric_dw.models import SqlPool, SqlPoolsConfiguration
 from fabric_dw.services import sql_pools
+from tests.unit.services._helpers import _make_client
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -27,8 +23,6 @@ from fabric_dw.services import sql_pools
 _WS_ID = UUID("a1b2c3d4-e5f6-7890-abcd-ef1234567890")
 _BASE_URL = "https://api.fabric.microsoft.com/v1"
 _CONFIG_URL = f"{_BASE_URL}/workspaces/{_WS_ID}/warehouses/sqlPoolsConfiguration"
-
-_FAKE_TOKEN = AccessToken(token="fake-token", expires_on=int(time.time()) + 3600)  # noqa: S106
 
 POOLS_ENABLED_PAYLOAD: dict[str, Any] = {
     "customSQLPoolsEnabled": True,
@@ -84,22 +78,11 @@ POOLS_EMPTY_PAYLOAD: dict[str, Any] = {
 }
 
 
-def _make_credential() -> AsyncTokenCredential:
-    cred = MagicMock(spec=AsyncTokenCredential)
-    cred.get_token = AsyncMock(return_value=_FAKE_TOKEN)
-    return cred
-
-
-async def _make_client() -> FabricHttpClient:
-    return FabricHttpClient(credential=_make_credential(), rps=100)
-
-
 # ---------------------------------------------------------------------------
 # get_configuration
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_get_configuration_returns_model() -> None:
     """get_configuration should GET the endpoint with ?beta=True and return a model."""
     with respx.mock:
@@ -122,7 +105,6 @@ async def test_get_configuration_returns_model() -> None:
     assert result.custom_sql_pools[0].classifier.value == ["ETL", "Load"]
 
 
-@pytest.mark.asyncio
 async def test_get_configuration_disabled_workspace() -> None:
     """get_configuration handles disabled pools (customSQLPoolsEnabled=false)."""
     with respx.mock:
@@ -135,7 +117,6 @@ async def test_get_configuration_disabled_workspace() -> None:
     assert len(result.custom_sql_pools) == 1
 
 
-@pytest.mark.asyncio
 async def test_get_configuration_403_raises_permission_denied() -> None:
     """get_configuration propagates PermissionDenied on 403 with hint."""
     with respx.mock:
@@ -151,7 +132,6 @@ async def test_get_configuration_403_raises_permission_denied() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_update_configuration_patches_full_body() -> None:
     """update_configuration should PATCH the full config and then GET fresh state."""
     config = SqlPoolsConfiguration.model_validate(POOLS_ENABLED_PAYLOAD)
@@ -176,7 +156,6 @@ async def test_update_configuration_patches_full_body() -> None:
     assert isinstance(result, SqlPoolsConfiguration)
 
 
-@pytest.mark.asyncio
 async def test_update_configuration_destructive_semantics_reflected_in_body() -> None:
     """Pools absent from the config model must not be in the PATCH body (destructive semantics)."""
     single_pool_config = SqlPoolsConfiguration.model_validate(
@@ -205,7 +184,6 @@ async def test_update_configuration_destructive_semantics_reflected_in_body() ->
     assert pool_names == ["OnlyPool"]
 
 
-@pytest.mark.asyncio
 async def test_update_configuration_403_raises_permission_denied() -> None:
     """update_configuration propagates PermissionDenied on 403."""
     config = SqlPoolsConfiguration.model_validate(POOLS_ENABLED_PAYLOAD)
@@ -223,7 +201,6 @@ async def test_update_configuration_403_raises_permission_denied() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_enable_patches_enabled_true_preserving_pools() -> None:
     """enable should PATCH customSQLPoolsEnabled=true and keep existing pools."""
     with respx.mock:
@@ -248,7 +225,6 @@ async def test_enable_patches_enabled_true_preserving_pools() -> None:
     assert result.custom_sql_pools_enabled is True
 
 
-@pytest.mark.asyncio
 async def test_enable_is_no_op_when_already_enabled() -> None:
     """enable should return current config without PATCH when already enabled."""
     with respx.mock:
@@ -265,7 +241,6 @@ async def test_enable_is_no_op_when_already_enabled() -> None:
     assert result.custom_sql_pools_enabled is True
 
 
-@pytest.mark.asyncio
 async def test_disable_patches_enabled_false_preserving_pools() -> None:
     """disable should PATCH customSQLPoolsEnabled=false and keep existing pools."""
     with respx.mock:
@@ -291,7 +266,6 @@ async def test_disable_patches_enabled_false_preserving_pools() -> None:
     assert isinstance(result, SqlPoolsConfiguration)
 
 
-@pytest.mark.asyncio
 async def test_enable_propagates_not_found_on_404() -> None:
     """enable propagates NotFound when get_configuration returns 404.
 
@@ -306,7 +280,6 @@ async def test_enable_propagates_not_found_on_404() -> None:
                 await sql_pools.enable(client, _WS_ID)
 
 
-@pytest.mark.asyncio
 async def test_disable_propagates_not_found_on_404() -> None:
     """disable propagates NotFound when get_configuration returns 404.
 
@@ -321,7 +294,6 @@ async def test_disable_propagates_not_found_on_404() -> None:
                 await sql_pools.disable(client, _WS_ID)
 
 
-@pytest.mark.asyncio
 async def test_disable_is_no_op_when_already_disabled() -> None:
     """disable should return current config without PATCH when already disabled."""
     with respx.mock:
@@ -515,7 +487,6 @@ _POOLS_WITH_HEADROOM: dict[str, object] = {
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_create_pool_appends_and_patches() -> None:
     """create_pool should GET, append the new pool, and PATCH the full list."""
     new_pool = SqlPool.model_validate(
@@ -546,7 +517,6 @@ async def test_create_pool_appends_and_patches() -> None:
     assert len(pool_names) == 3  # 2 original + 1 new
 
 
-@pytest.mark.asyncio
 async def test_create_pool_raises_already_exists_on_duplicate() -> None:
     """create_pool should raise AlreadyExists when the pool name already exists."""
     duplicate_pool = SqlPool.model_validate(
@@ -564,7 +534,6 @@ async def test_create_pool_raises_already_exists_on_duplicate() -> None:
                 await sql_pools.create_pool(client, _WS_ID, duplicate_pool)
 
 
-@pytest.mark.asyncio
 async def test_create_pool_single_classifier_value() -> None:
     """create_pool should handle a classifier with a single value list."""
     new_pool = SqlPool.model_validate(
@@ -592,7 +561,6 @@ async def test_create_pool_single_classifier_value() -> None:
     assert new["classifier"]["value"] == ["OnlyApp"]
 
 
-@pytest.mark.asyncio
 async def test_create_pool_multiple_classifier_values() -> None:
     """create_pool should preserve multiple classifier values."""
     new_pool = SqlPool.model_validate(
@@ -625,7 +593,6 @@ async def test_create_pool_multiple_classifier_values() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_update_pool_raises_not_found_for_missing_name() -> None:
     """update_pool should raise NotFound when the pool name does not exist."""
     with respx.mock:
@@ -638,7 +605,6 @@ async def test_update_pool_raises_not_found_for_missing_name() -> None:
                 )
 
 
-@pytest.mark.asyncio
 async def test_update_pool_partial_update_preserves_other_fields() -> None:
     """update_pool should preserve omitted fields unchanged."""
     with respx.mock:
@@ -661,7 +627,6 @@ async def test_update_pool_partial_update_preserves_other_fields() -> None:
     assert etl["classifier"]["value"] == ["ETL", "Load"]
 
 
-@pytest.mark.asyncio
 async def test_update_pool_toggle_is_default() -> None:
     """update_pool can toggle the is_default flag."""
     base_payload: dict[str, object] = {
@@ -690,7 +655,6 @@ async def test_update_pool_toggle_is_default() -> None:
     assert pool_b["isDefault"] is False
 
 
-@pytest.mark.asyncio
 async def test_update_pool_classifier_both_fields() -> None:
     """update_pool replaces classifier type and values when both are supplied."""
     with respx.mock:
@@ -722,7 +686,6 @@ async def test_update_pool_classifier_both_fields() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_delete_pool_removes_named_pool() -> None:
     """delete_pool should GET, drop the named pool, and PATCH."""
     with respx.mock:
@@ -743,7 +706,6 @@ async def test_delete_pool_removes_named_pool() -> None:
     assert len(pool_names) == 2
 
 
-@pytest.mark.asyncio
 async def test_delete_pool_raises_not_found_for_missing_name() -> None:
     """delete_pool should raise NotFound when the pool name does not exist."""
     with respx.mock:
@@ -759,7 +721,6 @@ async def test_delete_pool_raises_not_found_for_missing_name() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_reset_pools_patches_empty_list_preserving_enabled_flag() -> None:
     """reset_pools should PATCH with empty customSQLPools and preserve enabled state."""
     with respx.mock:
@@ -779,7 +740,6 @@ async def test_reset_pools_patches_empty_list_preserving_enabled_flag() -> None:
     assert sent_body["customSQLPoolsEnabled"] is True
 
 
-@pytest.mark.asyncio
 async def test_reset_pools_preserves_disabled_state() -> None:
     """reset_pools keeps customSQLPoolsEnabled=false when the workspace is disabled."""
     with respx.mock:
@@ -799,7 +759,6 @@ async def test_reset_pools_preserves_disabled_state() -> None:
     assert sent_body["customSQLPoolsEnabled"] is False
 
 
-@pytest.mark.asyncio
 async def test_reset_pools_404_returns_none_without_patch() -> None:
     """reset_pools returns None when the workspace has no SQL pools config (never provisioned).
 
@@ -825,7 +784,6 @@ async def test_reset_pools_404_returns_none_without_patch() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_update_pool_classifier_type_without_values_raises() -> None:
     """update_pool raises ValueError when classifier_type is given but classifier_values is not."""
     with respx.mock:
@@ -838,7 +796,6 @@ async def test_update_pool_classifier_type_without_values_raises() -> None:
                 )
 
 
-@pytest.mark.asyncio
 async def test_update_pool_classifier_values_without_type_raises() -> None:
     """update_pool raises ValueError when classifier_values is given but classifier_type is not."""
     with respx.mock:

--- a/tests/unit/services/test_tables.py
+++ b/tests/unit/services/test_tables.py
@@ -136,7 +136,6 @@ class TestRejectNonSelect:
 
 
 class TestListTables:
-    @pytest.mark.asyncio
     async def test_returns_empty_when_no_rows(self) -> None:
         target = _make_target()
         conn = _make_conn([], _LIST_COLS)
@@ -144,7 +143,6 @@ class TestListTables:
             result = await tables.list_tables(target)
         assert result == []
 
-    @pytest.mark.asyncio
     async def test_returns_table_instances(self) -> None:
         target = _make_target()
         conn = _make_conn([_TABLE_ROW_1], _LIST_COLS)
@@ -153,7 +151,6 @@ class TestListTables:
         assert len(result) == 1
         assert isinstance(result[0], Table)
 
-    @pytest.mark.asyncio
     async def test_parses_fields_correctly(self) -> None:
         target = _make_target()
         conn = _make_conn([_TABLE_ROW_1], _LIST_COLS)
@@ -166,7 +163,6 @@ class TestListTables:
         assert t.created == _NOW
         assert t.modified == _LATER
 
-    @pytest.mark.asyncio
     async def test_returns_all_rows(self) -> None:
         target = _make_target()
         conn = _make_conn([_TABLE_ROW_1, _TABLE_ROW_2], _LIST_COLS)
@@ -174,7 +170,6 @@ class TestListTables:
             result = await tables.list_tables(target)
         assert len(result) == 2
 
-    @pytest.mark.asyncio
     async def test_sql_references_sys_tables(self) -> None:
         target = _make_target()
         conn = _make_conn([], _LIST_COLS)
@@ -184,7 +179,6 @@ class TestListTables:
         call_sql: str = cursor.execute.call_args[0][0]
         assert "sys.tables" in call_sql
 
-    @pytest.mark.asyncio
     async def test_sql_references_sys_schemas(self) -> None:
         target = _make_target()
         conn = _make_conn([], _LIST_COLS)
@@ -194,7 +188,6 @@ class TestListTables:
         call_sql: str = cursor.execute.call_args[0][0]
         assert "sys.schemas" in call_sql
 
-    @pytest.mark.asyncio
     async def test_filters_by_schema_when_provided(self) -> None:
         target = _make_target()
         conn = _make_conn([_TABLE_ROW_1], _LIST_COLS)
@@ -209,7 +202,6 @@ class TestListTables:
         assert params is not None
         assert "dbo" in list(params)
 
-    @pytest.mark.asyncio
     async def test_schema_filter_validates_identifier(self) -> None:
         target = _make_target()
         conn = _make_conn([], _LIST_COLS)
@@ -219,7 +211,6 @@ class TestListTables:
         ):
             await tables.list_tables(target, schema="bad]schema")
 
-    @pytest.mark.asyncio
     async def test_closes_connection(self) -> None:
         target = _make_target()
         conn = _make_conn([_TABLE_ROW_1], _LIST_COLS)
@@ -227,7 +218,6 @@ class TestListTables:
             await tables.list_tables(target)
         conn.close.assert_called_once()
 
-    @pytest.mark.asyncio
     async def test_maps_permission_denied(self) -> None:
         target = _make_target()
         conn = MagicMock()
@@ -240,7 +230,6 @@ class TestListTables:
         ):
             await tables.list_tables(target)
 
-    @pytest.mark.asyncio
     async def test_maps_auth_error(self) -> None:
         target = _make_target()
         conn = MagicMock()
@@ -253,7 +242,6 @@ class TestListTables:
         ):
             await tables.list_tables(target)
 
-    @pytest.mark.asyncio
     async def test_unrelated_error_propagates(self) -> None:
         target = _make_target()
         conn = MagicMock()
@@ -273,7 +261,6 @@ class TestListTables:
 
 
 class TestReadTable:
-    @pytest.mark.asyncio
     async def test_returns_columns_and_rows(self) -> None:
         target = _make_target()
         cols = ["id", "name"]
@@ -284,7 +271,6 @@ class TestReadTable:
         assert result_cols == cols
         assert list(result_rows) == rows
 
-    @pytest.mark.asyncio
     async def test_sql_uses_select_top(self) -> None:
         target = _make_target()
         conn = _make_conn([(1,)], ["id"])
@@ -295,7 +281,6 @@ class TestReadTable:
         assert "SELECT TOP" in call_sql
         assert "5" in call_sql
 
-    @pytest.mark.asyncio
     async def test_sql_uses_bracket_quoting(self) -> None:
         target = _make_target()
         conn = _make_conn([(1,)], ["id"])
@@ -306,19 +291,16 @@ class TestReadTable:
         assert "[dbo]" in call_sql
         assert "[sales]" in call_sql
 
-    @pytest.mark.asyncio
     async def test_validates_schema_identifier(self) -> None:
         target = _make_target()
         with pytest.raises(ValueError, match="Invalid SQL identifier"):
             await tables.read_table(target, "bad;schema", "sales")
 
-    @pytest.mark.asyncio
     async def test_validates_table_name_identifier(self) -> None:
         target = _make_target()
         with pytest.raises(ValueError, match="Invalid SQL identifier"):
             await tables.read_table(target, "dbo", "table--injection")
 
-    @pytest.mark.asyncio
     async def test_raises_not_found_when_no_columns(self) -> None:
         target = _make_target()
         cursor = MagicMock()
@@ -332,7 +314,6 @@ class TestReadTable:
         ):
             await tables.read_table(target, "dbo", "nonexistent")
 
-    @pytest.mark.asyncio
     async def test_maps_permission_denied(self) -> None:
         target = _make_target()
         conn = MagicMock()
@@ -345,7 +326,6 @@ class TestReadTable:
         ):
             await tables.read_table(target, "dbo", "sales")
 
-    @pytest.mark.asyncio
     async def test_closes_connection(self) -> None:
         target = _make_target()
         conn = _make_conn([(1,)], ["id"])
@@ -360,7 +340,6 @@ class TestReadTable:
 
 
 class TestCreateTable:
-    @pytest.mark.asyncio
     async def test_emits_create_table_as_select(self) -> None:
         target = _make_target()
         ddl_conn = _make_conn_for_ddl()
@@ -373,7 +352,6 @@ class TestCreateTable:
         assert "[DBO]" in call_sql
         assert "[SALES]" in call_sql
 
-    @pytest.mark.asyncio
     async def test_includes_select_body(self) -> None:
         target = _make_target()
         ddl_conn = _make_conn_for_ddl()
@@ -384,7 +362,6 @@ class TestCreateTable:
         call_sql: str = cursor.execute.call_args[0][0]
         assert "SELECT id FROM src.raw" in call_sql
 
-    @pytest.mark.asyncio
     async def test_returns_table_object(self) -> None:
         target = _make_target()
         ddl_conn = _make_conn_for_ddl()
@@ -393,7 +370,6 @@ class TestCreateTable:
             result = await tables.create_table(target, "dbo", "sales", "SELECT 1 AS id")
         assert isinstance(result, Table)
 
-    @pytest.mark.asyncio
     async def test_commits_after_execute(self) -> None:
         target = _make_target()
         ddl_conn = _make_conn_for_ddl()
@@ -402,13 +378,11 @@ class TestCreateTable:
             await tables.create_table(target, "dbo", "sales", "SELECT 1")
         ddl_conn.commit.assert_called_once()
 
-    @pytest.mark.asyncio
     async def test_rejects_non_select_body(self) -> None:
         target = _make_target()
         with pytest.raises(ValueError, match="must begin with SELECT or WITH"):
             await tables.create_table(target, "dbo", "sales", "INSERT INTO foo SELECT 1")
 
-    @pytest.mark.asyncio
     async def test_accepts_cte_body(self) -> None:
         target = _make_target()
         ddl_conn = _make_conn_for_ddl()
@@ -422,19 +396,16 @@ class TestCreateTable:
             )
         assert isinstance(result, Table)
 
-    @pytest.mark.asyncio
     async def test_validates_schema_identifier(self) -> None:
         target = _make_target()
         with pytest.raises(ValueError, match="Invalid SQL identifier"):
             await tables.create_table(target, "bad]schema", "sales", "SELECT 1")
 
-    @pytest.mark.asyncio
     async def test_validates_table_name_identifier(self) -> None:
         target = _make_target()
         with pytest.raises(ValueError, match="Invalid SQL identifier"):
             await tables.create_table(target, "dbo", "sales;drop", "SELECT 1")
 
-    @pytest.mark.asyncio
     async def test_maps_permission_denied(self) -> None:
         target = _make_target()
         conn = MagicMock()
@@ -447,7 +418,6 @@ class TestCreateTable:
         ):
             await tables.create_table(target, "dbo", "sales", "SELECT 1")
 
-    @pytest.mark.asyncio
     async def test_rejects_injection_in_schema(self) -> None:
         target = _make_target()
         with pytest.raises(ValueError, match="Invalid SQL identifier"):
@@ -460,7 +430,6 @@ class TestCreateTable:
 
 
 class TestDeleteTable:
-    @pytest.mark.asyncio
     async def test_emits_drop_table(self) -> None:
         target = _make_target()
         conn = _make_conn_for_ddl()
@@ -470,7 +439,6 @@ class TestDeleteTable:
         call_sql: str = cursor.execute.call_args[0][0].upper()
         assert "DROP TABLE" in call_sql
 
-    @pytest.mark.asyncio
     async def test_uses_brackets(self) -> None:
         target = _make_target()
         conn = _make_conn_for_ddl()
@@ -481,7 +449,6 @@ class TestDeleteTable:
         assert "[dbo]" in call_sql
         assert "[sales]" in call_sql
 
-    @pytest.mark.asyncio
     async def test_commits_after_execute(self) -> None:
         target = _make_target()
         conn = _make_conn_for_ddl()
@@ -489,7 +456,6 @@ class TestDeleteTable:
             await tables.delete_table(target, "dbo", "sales")
         conn.commit.assert_called_once()
 
-    @pytest.mark.asyncio
     async def test_closes_connection(self) -> None:
         target = _make_target()
         conn = _make_conn_for_ddl()
@@ -497,19 +463,16 @@ class TestDeleteTable:
             await tables.delete_table(target, "dbo", "sales")
         conn.close.assert_called_once()
 
-    @pytest.mark.asyncio
     async def test_validates_schema_identifier(self) -> None:
         target = _make_target()
         with pytest.raises(ValueError, match="Invalid SQL identifier"):
             await tables.delete_table(target, "bad]schema", "sales")
 
-    @pytest.mark.asyncio
     async def test_validates_table_name_identifier(self) -> None:
         target = _make_target()
         with pytest.raises(ValueError, match="Invalid SQL identifier"):
             await tables.delete_table(target, "dbo", "sales--bad")
 
-    @pytest.mark.asyncio
     async def test_maps_permission_denied(self) -> None:
         target = _make_target()
         conn = MagicMock()
@@ -522,19 +485,16 @@ class TestDeleteTable:
         ):
             await tables.delete_table(target, "dbo", "sales")
 
-    @pytest.mark.asyncio
     async def test_rejects_injection_in_schema(self) -> None:
         target = _make_target()
         with pytest.raises(ValueError, match="Invalid SQL identifier"):
             await tables.delete_table(target, "x]; DROP TABLE users--", "ok")
 
-    @pytest.mark.asyncio
     async def test_rejects_injection_in_table_name(self) -> None:
         target = _make_target()
         with pytest.raises(ValueError, match="Invalid SQL identifier"):
             await tables.delete_table(target, "dbo", "ok] WHERE 1=1--")
 
-    @pytest.mark.asyncio
     async def test_unrelated_error_propagates(self) -> None:
         target = _make_target()
         conn = MagicMock()
@@ -554,7 +514,6 @@ class TestDeleteTable:
 
 
 class TestClearTable:
-    @pytest.mark.asyncio
     async def test_emits_truncate_table(self) -> None:
         target = _make_target()
         conn = _make_conn_for_ddl()
@@ -564,7 +523,6 @@ class TestClearTable:
         call_sql: str = cursor.execute.call_args[0][0].upper()
         assert "TRUNCATE TABLE" in call_sql
 
-    @pytest.mark.asyncio
     async def test_uses_brackets(self) -> None:
         target = _make_target()
         conn = _make_conn_for_ddl()
@@ -575,7 +533,6 @@ class TestClearTable:
         assert "[dbo]" in call_sql
         assert "[sales]" in call_sql
 
-    @pytest.mark.asyncio
     async def test_commits_after_execute(self) -> None:
         target = _make_target()
         conn = _make_conn_for_ddl()
@@ -583,7 +540,6 @@ class TestClearTable:
             await tables.clear_table(target, "dbo", "sales")
         conn.commit.assert_called_once()
 
-    @pytest.mark.asyncio
     async def test_closes_connection(self) -> None:
         target = _make_target()
         conn = _make_conn_for_ddl()
@@ -591,19 +547,16 @@ class TestClearTable:
             await tables.clear_table(target, "dbo", "sales")
         conn.close.assert_called_once()
 
-    @pytest.mark.asyncio
     async def test_validates_schema_identifier(self) -> None:
         target = _make_target()
         with pytest.raises(ValueError, match="Invalid SQL identifier"):
             await tables.clear_table(target, "bad;schema", "sales")
 
-    @pytest.mark.asyncio
     async def test_validates_table_name_identifier(self) -> None:
         target = _make_target()
         with pytest.raises(ValueError, match="Invalid SQL identifier"):
             await tables.clear_table(target, "dbo", "sales]injection")
 
-    @pytest.mark.asyncio
     async def test_maps_permission_denied(self) -> None:
         target = _make_target()
         conn = MagicMock()
@@ -616,7 +569,6 @@ class TestClearTable:
         ):
             await tables.clear_table(target, "dbo", "sales")
 
-    @pytest.mark.asyncio
     async def test_unrelated_error_propagates(self) -> None:
         target = _make_target()
         conn = MagicMock()
@@ -638,7 +590,6 @@ class TestClearTable:
 class TestSqlEndpointGuard:
     """Verify that create/delete/clear reject SQL Endpoint items before any I/O."""
 
-    @pytest.mark.asyncio
     async def test_create_table_rejects_sql_endpoint(self) -> None:
         target = _make_target()
         with pytest.raises(ItemKindError, match="read-only"):
@@ -650,7 +601,6 @@ class TestSqlEndpointGuard:
                 kind=WarehouseKind.SQL_ENDPOINT,
             )
 
-    @pytest.mark.asyncio
     async def test_delete_table_rejects_sql_endpoint(self) -> None:
         target = _make_target()
         with pytest.raises(ItemKindError, match="read-only"):
@@ -661,7 +611,6 @@ class TestSqlEndpointGuard:
                 kind=WarehouseKind.SQL_ENDPOINT,
             )
 
-    @pytest.mark.asyncio
     async def test_clear_table_rejects_sql_endpoint(self) -> None:
         target = _make_target()
         with pytest.raises(ItemKindError, match="read-only"):
@@ -672,7 +621,6 @@ class TestSqlEndpointGuard:
                 kind=WarehouseKind.SQL_ENDPOINT,
             )
 
-    @pytest.mark.asyncio
     async def test_create_table_warehouse_allowed(self) -> None:
         """WarehouseKind.WAREHOUSE must not be blocked by the guard."""
         target = _make_target()
@@ -688,7 +636,6 @@ class TestSqlEndpointGuard:
             )
         assert isinstance(result, Table)
 
-    @pytest.mark.asyncio
     async def test_guard_fires_before_identifier_validation(self) -> None:
         """ItemKindError must be raised even when schema/table identifiers are invalid."""
         target = _make_target()

--- a/tests/unit/services/test_views.py
+++ b/tests/unit/services/test_views.py
@@ -154,7 +154,6 @@ class TestValidateIdentifier:
 
 
 class TestListViews:
-    @pytest.mark.asyncio
     async def test_returns_empty_when_no_rows(self) -> None:
         target = _make_target()
         conn = _make_conn([], _LIST_COLS)
@@ -162,7 +161,6 @@ class TestListViews:
             result = await views.list_views(target)
         assert result == []
 
-    @pytest.mark.asyncio
     async def test_returns_view_instances(self) -> None:
         target = _make_target()
         conn = _make_conn([_VIEW_ROW_1], _LIST_COLS)
@@ -171,7 +169,6 @@ class TestListViews:
         assert len(result) == 1
         assert isinstance(result[0], View)
 
-    @pytest.mark.asyncio
     async def test_parses_fields_correctly(self) -> None:
         target = _make_target()
         conn = _make_conn([_VIEW_ROW_1], _LIST_COLS)
@@ -185,7 +182,6 @@ class TestListViews:
         assert v.modified == _LATER
         assert v.definition is None
 
-    @pytest.mark.asyncio
     async def test_returns_all_rows(self) -> None:
         target = _make_target()
         conn = _make_conn([_VIEW_ROW_1, _VIEW_ROW_2], _LIST_COLS)
@@ -193,7 +189,6 @@ class TestListViews:
             result = await views.list_views(target)
         assert len(result) == 2
 
-    @pytest.mark.asyncio
     async def test_sql_references_sys_views(self) -> None:
         target = _make_target()
         conn = _make_conn([], _LIST_COLS)
@@ -203,7 +198,6 @@ class TestListViews:
         call_sql: str = cursor.execute.call_args[0][0]
         assert "sys.views" in call_sql
 
-    @pytest.mark.asyncio
     async def test_sql_references_sys_schemas(self) -> None:
         target = _make_target()
         conn = _make_conn([], _LIST_COLS)
@@ -213,7 +207,6 @@ class TestListViews:
         call_sql: str = cursor.execute.call_args[0][0]
         assert "sys.schemas" in call_sql
 
-    @pytest.mark.asyncio
     async def test_filters_by_schema_when_provided(self) -> None:
         target = _make_target()
         conn = _make_conn([_VIEW_ROW_1], _LIST_COLS)
@@ -227,7 +220,6 @@ class TestListViews:
         params = call_args[0][1] if len(call_args[0]) > 1 else []
         assert "dbo" in list(params)
 
-    @pytest.mark.asyncio
     async def test_schema_filter_validates_identifier(self) -> None:
         target = _make_target()
         conn = _make_conn([], _LIST_COLS)
@@ -237,7 +229,6 @@ class TestListViews:
         ):
             await views.list_views(target, schema="bad]schema")
 
-    @pytest.mark.asyncio
     async def test_closes_connection_after_success(self) -> None:
         target = _make_target()
         conn = _make_conn([_VIEW_ROW_1], _LIST_COLS)
@@ -245,7 +236,6 @@ class TestListViews:
             await views.list_views(target)
         conn.close.assert_called_once()
 
-    @pytest.mark.asyncio
     async def test_maps_permission_denied(self) -> None:
         target = _make_target()
         conn = MagicMock()
@@ -258,7 +248,6 @@ class TestListViews:
         ):
             await views.list_views(target)
 
-    @pytest.mark.asyncio
     async def test_maps_auth_error(self) -> None:
         target = _make_target()
         conn = MagicMock()
@@ -271,7 +260,6 @@ class TestListViews:
         ):
             await views.list_views(target)
 
-    @pytest.mark.asyncio
     async def test_unrelated_error_propagates(self) -> None:
         target = _make_target()
         conn = MagicMock()
@@ -291,7 +279,6 @@ class TestListViews:
 
 
 class TestReadView:
-    @pytest.mark.asyncio
     async def test_returns_columns_and_rows(self) -> None:
         target = _make_target()
         cols = ["id", "name"]
@@ -302,7 +289,6 @@ class TestReadView:
         assert result_cols == cols
         assert list(result_rows) == rows
 
-    @pytest.mark.asyncio
     async def test_sql_uses_select_top(self) -> None:
         target = _make_target()
         conn = _make_conn([(1,)], ["id"])
@@ -313,7 +299,6 @@ class TestReadView:
         assert "SELECT TOP" in call_sql
         assert "5" in call_sql
 
-    @pytest.mark.asyncio
     async def test_sql_uses_bracket_quoting(self) -> None:
         target = _make_target()
         conn = _make_conn([(1,)], ["id"])
@@ -324,19 +309,16 @@ class TestReadView:
         assert "[dbo]" in call_sql
         assert "[vw_sales]" in call_sql
 
-    @pytest.mark.asyncio
     async def test_validates_schema_identifier(self) -> None:
         target = _make_target()
         with pytest.raises(ValueError, match="Invalid SQL identifier"):
             await read_view(target, "bad;schema", "vw_sales")
 
-    @pytest.mark.asyncio
     async def test_validates_view_name_identifier(self) -> None:
         target = _make_target()
         with pytest.raises(ValueError, match="Invalid SQL identifier"):
             await read_view(target, "dbo", "vw--injection")
 
-    @pytest.mark.asyncio
     async def test_raises_not_found_when_no_columns(self) -> None:
         target = _make_target()
         cursor = MagicMock()
@@ -350,7 +332,6 @@ class TestReadView:
         ):
             await read_view(target, "dbo", "vw_nonexistent")
 
-    @pytest.mark.asyncio
     async def test_maps_permission_denied(self) -> None:
         target = _make_target()
         conn = MagicMock()
@@ -363,7 +344,6 @@ class TestReadView:
         ):
             await read_view(target, "dbo", "vw_sales")
 
-    @pytest.mark.asyncio
     async def test_closes_connection(self) -> None:
         target = _make_target()
         conn = _make_conn([(1,)], ["id"])
@@ -371,7 +351,6 @@ class TestReadView:
             await read_view(target, "dbo", "vw_sales")
         conn.close.assert_called_once()
 
-    @pytest.mark.asyncio
     async def test_default_count_is_ten(self) -> None:
         target = _make_target()
         conn = _make_conn([(1,)], ["id"])
@@ -388,7 +367,6 @@ class TestReadView:
 
 
 class TestGetView:
-    @pytest.mark.asyncio
     async def test_returns_view_with_definition(self) -> None:
         target = _make_target()
         conn = _make_conn([_VIEW_ROW_GET], _GET_COLS)
@@ -397,7 +375,6 @@ class TestGetView:
         assert isinstance(result, View)
         assert result.definition == "SELECT id, amount FROM dbo.sales"
 
-    @pytest.mark.asyncio
     async def test_parses_all_fields(self) -> None:
         target = _make_target()
         conn = _make_conn([_VIEW_ROW_GET], _GET_COLS)
@@ -409,7 +386,6 @@ class TestGetView:
         assert result.created == _NOW
         assert result.modified == _LATER
 
-    @pytest.mark.asyncio
     async def test_sql_includes_sys_sql_modules(self) -> None:
         target = _make_target()
         conn = _make_conn([_VIEW_ROW_GET], _GET_COLS)
@@ -419,7 +395,6 @@ class TestGetView:
         call_sql: str = cursor.execute.call_args[0][0]
         assert "sys.sql_modules" in call_sql
 
-    @pytest.mark.asyncio
     async def test_raises_not_found_when_no_rows(self) -> None:
         target = _make_target()
         conn = _make_conn([], _GET_COLS)
@@ -429,7 +404,6 @@ class TestGetView:
         ):
             await views.get_view(target, "dbo", "nonexistent")
 
-    @pytest.mark.asyncio
     async def test_validates_schema_identifier(self) -> None:
         target = _make_target()
         conn = _make_conn([], _GET_COLS)
@@ -439,7 +413,6 @@ class TestGetView:
         ):
             await views.get_view(target, "bad;schema", "vw_sales")
 
-    @pytest.mark.asyncio
     async def test_validates_view_name_identifier(self) -> None:
         target = _make_target()
         conn = _make_conn([], _GET_COLS)
@@ -449,7 +422,6 @@ class TestGetView:
         ):
             await views.get_view(target, "dbo", "vw--injection")
 
-    @pytest.mark.asyncio
     async def test_closes_connection_after_success(self) -> None:
         target = _make_target()
         conn = _make_conn([_VIEW_ROW_GET], _GET_COLS)
@@ -457,7 +429,6 @@ class TestGetView:
             await views.get_view(target, "dbo", "vw_sales")
         conn.close.assert_called_once()
 
-    @pytest.mark.asyncio
     async def test_maps_permission_denied(self) -> None:
         target = _make_target()
         conn = MagicMock()
@@ -477,7 +448,6 @@ class TestGetView:
 
 
 class TestCreateView:
-    @pytest.mark.asyncio
     async def test_emits_create_view_ddl(self) -> None:
         target = _make_target()
         ddl_conn = _make_conn_for_ddl()
@@ -492,7 +462,6 @@ class TestCreateView:
         assert "[dbo]" in call_sql
         assert "[vw_sales]" in call_sql
 
-    @pytest.mark.asyncio
     async def test_includes_select_body(self) -> None:
         target = _make_target()
         ddl_conn = _make_conn_for_ddl()
@@ -505,7 +474,6 @@ class TestCreateView:
         call_sql: str = cursor.execute.call_args[0][0]
         assert "SELECT id FROM dbo.sales" in call_sql
 
-    @pytest.mark.asyncio
     async def test_returns_view_object(self) -> None:
         target = _make_target()
         ddl_conn = _make_conn_for_ddl()
@@ -518,19 +486,16 @@ class TestCreateView:
         assert result.schema_name == "dbo"
         assert result.name == "vw_sales"
 
-    @pytest.mark.asyncio
     async def test_validates_schema_identifier(self) -> None:
         target = _make_target()
         with pytest.raises(ValueError, match="Invalid SQL identifier"):
             await views.create_view(target, "bad]schema", "vw_sales", "SELECT 1")
 
-    @pytest.mark.asyncio
     async def test_validates_view_name_identifier(self) -> None:
         target = _make_target()
         with pytest.raises(ValueError, match="Invalid SQL identifier"):
             await views.create_view(target, "dbo", "vw;drop", "SELECT 1")
 
-    @pytest.mark.asyncio
     async def test_commits_after_execute(self) -> None:
         target = _make_target()
         ddl_conn = _make_conn_for_ddl()
@@ -541,7 +506,6 @@ class TestCreateView:
 
         ddl_conn.commit.assert_called_once()
 
-    @pytest.mark.asyncio
     async def test_maps_permission_denied_on_ddl(self) -> None:
         target = _make_target()
         conn = MagicMock()
@@ -554,14 +518,12 @@ class TestCreateView:
         ):
             await views.create_view(target, "dbo", "vw_sales", "SELECT 1")
 
-    @pytest.mark.asyncio
     async def test_rejects_identifier_injection_via_schema(self) -> None:
         """Bracket injection in schema name must be rejected before SQL is formed."""
         target = _make_target()
         with pytest.raises(ValueError, match="Invalid SQL identifier"):
             await views.create_view(target, "x]; DROP TABLE users--", "vw_ok", "SELECT 1")
 
-    @pytest.mark.asyncio
     async def test_rejects_identifier_injection_via_view_name(self) -> None:
         """Bracket injection in view name must be rejected before SQL is formed."""
         target = _make_target()
@@ -575,7 +537,6 @@ class TestCreateView:
 
 
 class TestUpdateView:
-    @pytest.mark.asyncio
     async def test_emits_create_or_alter_view_ddl(self) -> None:
         target = _make_target()
         ddl_conn = _make_conn_for_ddl()
@@ -588,7 +549,6 @@ class TestUpdateView:
         call_sql: str = cursor.execute.call_args[0][0].upper()
         assert "CREATE OR ALTER VIEW" in call_sql
 
-    @pytest.mark.asyncio
     async def test_uses_brackets_for_schema_and_name(self) -> None:
         target = _make_target()
         ddl_conn = _make_conn_for_ddl()
@@ -602,7 +562,6 @@ class TestUpdateView:
         assert "[dbo]" in call_sql
         assert "[vw_sales]" in call_sql
 
-    @pytest.mark.asyncio
     async def test_returns_view_object(self) -> None:
         target = _make_target()
         ddl_conn = _make_conn_for_ddl()
@@ -613,19 +572,16 @@ class TestUpdateView:
 
         assert isinstance(result, View)
 
-    @pytest.mark.asyncio
     async def test_validates_schema_identifier(self) -> None:
         target = _make_target()
         with pytest.raises(ValueError, match="Invalid SQL identifier"):
             await views.update_view(target, "bad--schema", "vw_sales", "SELECT 1")
 
-    @pytest.mark.asyncio
     async def test_validates_view_name_identifier(self) -> None:
         target = _make_target()
         with pytest.raises(ValueError, match="Invalid SQL identifier"):
             await views.update_view(target, "dbo", "vw;injection", "SELECT 1")
 
-    @pytest.mark.asyncio
     async def test_commits_after_execute(self) -> None:
         target = _make_target()
         ddl_conn = _make_conn_for_ddl()
@@ -636,7 +592,6 @@ class TestUpdateView:
 
         ddl_conn.commit.assert_called_once()
 
-    @pytest.mark.asyncio
     async def test_maps_permission_denied(self) -> None:
         target = _make_target()
         conn = MagicMock()
@@ -656,7 +611,6 @@ class TestUpdateView:
 
 
 class TestDropView:
-    @pytest.mark.asyncio
     async def test_emits_drop_view_ddl(self) -> None:
         target = _make_target()
         conn = _make_conn_for_ddl()
@@ -666,7 +620,6 @@ class TestDropView:
         call_sql: str = cursor.execute.call_args[0][0].upper()
         assert "DROP VIEW" in call_sql
 
-    @pytest.mark.asyncio
     async def test_uses_brackets_for_schema_and_name(self) -> None:
         target = _make_target()
         conn = _make_conn_for_ddl()
@@ -677,7 +630,6 @@ class TestDropView:
         assert "[dbo]" in call_sql
         assert "[vw_sales]" in call_sql
 
-    @pytest.mark.asyncio
     async def test_commits_after_execute(self) -> None:
         target = _make_target()
         conn = _make_conn_for_ddl()
@@ -685,7 +637,6 @@ class TestDropView:
             await views.drop_view(target, "dbo", "vw_sales")
         conn.commit.assert_called_once()
 
-    @pytest.mark.asyncio
     async def test_closes_connection_after_success(self) -> None:
         target = _make_target()
         conn = _make_conn_for_ddl()
@@ -693,19 +644,16 @@ class TestDropView:
             await views.drop_view(target, "dbo", "vw_sales")
         conn.close.assert_called_once()
 
-    @pytest.mark.asyncio
     async def test_validates_schema_identifier(self) -> None:
         target = _make_target()
         with pytest.raises(ValueError, match="Invalid SQL identifier"):
             await views.drop_view(target, "bad]schema", "vw_sales")
 
-    @pytest.mark.asyncio
     async def test_validates_view_name_identifier(self) -> None:
         target = _make_target()
         with pytest.raises(ValueError, match="Invalid SQL identifier"):
             await views.drop_view(target, "dbo", "vw--bad")
 
-    @pytest.mark.asyncio
     async def test_maps_permission_denied(self) -> None:
         target = _make_target()
         conn = MagicMock()
@@ -718,19 +666,16 @@ class TestDropView:
         ):
             await views.drop_view(target, "dbo", "vw_sales")
 
-    @pytest.mark.asyncio
     async def test_rejects_injection_in_schema(self) -> None:
         target = _make_target()
         with pytest.raises(ValueError, match="Invalid SQL identifier"):
             await views.drop_view(target, "x]; DROP TABLE users--", "vw_ok")
 
-    @pytest.mark.asyncio
     async def test_rejects_injection_in_view_name(self) -> None:
         target = _make_target()
         with pytest.raises(ValueError, match="Invalid SQL identifier"):
             await views.drop_view(target, "dbo", "vw_ok] WHERE 1=1--")
 
-    @pytest.mark.asyncio
     async def test_unrelated_error_propagates(self) -> None:
         target = _make_target()
         conn = MagicMock()

--- a/tests/unit/services/test_warehouses.py
+++ b/tests/unit/services/test_warehouses.py
@@ -4,21 +4,17 @@ from __future__ import annotations
 
 import json
 import logging
-import time
 from datetime import UTC, datetime
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 from uuid import UUID
 
 import httpx
 import pytest
 import respx
-from azure.core.credentials import AccessToken
-from azure.core.credentials_async import AsyncTokenCredential
 
 from fabric_dw.cache import ItemEntry, LookupCache
 from fabric_dw.exceptions import FabricServerError, NotFound, PermissionDenied
-from fabric_dw.http_client import FabricHttpClient
 from fabric_dw.models import Warehouse, WarehouseKind, Workspace
 from fabric_dw.services import warehouses
 from tests.fixtures.api_payloads import (
@@ -33,12 +29,11 @@ from tests.fixtures.api_payloads import (
     WAREHOUSE_SQL_ENDPOINTS_PAGE2_PAYLOAD,
     WAREHOUSE_SQL_ENDPOINTS_PAYLOAD,
 )
+from tests.unit.services._helpers import _make_client
 
 # ---------------------------------------------------------------------------
-# Helpers
+# Constants
 # ---------------------------------------------------------------------------
-
-_FAKE_TOKEN = AccessToken(token="fake-token", expires_on=int(time.time()) + 3600)  # noqa: S106
 
 _WORKSPACE_ID = UUID("a1b2c3d4-e5f6-7890-abcd-ef1234567890")
 _WAREHOUSE_ID = UUID("d4e5f6a7-b8c9-0123-def0-123456789abc")
@@ -52,22 +47,11 @@ _ITEMS_URL = f"{_BASE}/workspaces/{_WORKSPACE_ID}/items"
 _OPERATION_URL = f"{_BASE}/operations/op-abc123"
 
 
-def _make_credential(token: AccessToken = _FAKE_TOKEN) -> AsyncTokenCredential:
-    cred = MagicMock(spec=AsyncTokenCredential)
-    cred.get_token = AsyncMock(return_value=token)
-    return cred
-
-
-async def _make_client(rps: int = 10) -> FabricHttpClient:
-    return FabricHttpClient(credential=_make_credential(), rps=rps)
-
-
 # ---------------------------------------------------------------------------
 # list
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_list_merges_warehouses_and_sql_endpoints() -> None:
     """list_warehouses must combine items from /warehouses and /sqlEndpoints with correct kind."""
     wh_payload = json.loads(WAREHOUSE_LIST_PAYLOAD)
@@ -93,7 +77,6 @@ async def test_list_merges_warehouses_and_sql_endpoints() -> None:
     assert len(ep_items) == 1
 
 
-@pytest.mark.asyncio
 async def test_list_follows_continuation_uri_for_warehouses() -> None:
     """list_warehouses must follow continuationUri for the warehouses endpoint."""
     call_count = 0
@@ -122,7 +105,6 @@ async def test_list_follows_continuation_uri_for_warehouses() -> None:
     assert len(result) == 3  # 2 from page 1 + 1 from page 2 (all warehouses, no endpoints)
 
 
-@pytest.mark.asyncio
 async def test_list_follows_continuation_uri_for_sql_endpoints() -> None:
     """list_warehouses must follow continuationUri for the sqlEndpoints endpoint."""
     ep_call_count = 0
@@ -151,7 +133,6 @@ async def test_list_follows_continuation_uri_for_sql_endpoints() -> None:
     assert len(ep_items) == 2  # 1 from page 1 + 1 from page 2
 
 
-@pytest.mark.asyncio
 async def test_list_all_items_are_warehouse_instances() -> None:
     """list_warehouses must return only Warehouse instances."""
     wh_payload = json.loads(WAREHOUSE_LIST_PAYLOAD)
@@ -174,7 +155,6 @@ async def test_list_all_items_are_warehouse_instances() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_get_returns_populated_warehouse() -> None:
     """get_warehouse must return a single populated Warehouse with WAREHOUSE kind."""
     wh_payload = json.loads(WAREHOUSE_GET_PAYLOAD)
@@ -194,7 +174,6 @@ async def test_get_returns_populated_warehouse() -> None:
     assert result.collation == "Latin1_General_100_BIN2_UTF8"
 
 
-@pytest.mark.asyncio
 async def test_get_not_found_propagates() -> None:
     """get_warehouse must propagate NotFound on a 404 response."""
     with respx.mock:
@@ -213,7 +192,6 @@ async def test_get_not_found_propagates() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_create_with_collation_polls_lro_and_returns_warehouse() -> None:
     """create must POST with collation, poll the LRO, then GET and return the warehouse."""
     create_resp = json.loads(WAREHOUSE_CREATE_202_PAYLOAD)
@@ -258,7 +236,6 @@ async def test_create_with_collation_polls_lro_and_returns_warehouse() -> None:
     assert sent_body["creationPayload"]["defaultCollation"] == "Latin1_General_100_BIN2_UTF8"
 
 
-@pytest.mark.asyncio
 async def test_create_without_collation_omits_creation_payload() -> None:
     """create without collation must omit creationPayload from the POST body."""
     op_succeeded = json.loads(WAREHOUSE_OPERATION_SUCCEEDED_PAYLOAD)
@@ -286,7 +263,6 @@ async def test_create_without_collation_omits_creation_payload() -> None:
     assert "creationPayload" not in sent_body
 
 
-@pytest.mark.asyncio
 async def test_create_with_description() -> None:
     """create with description must include it in the POST body."""
     op_succeeded = json.loads(WAREHOUSE_OPERATION_SUCCEEDED_PAYLOAD)
@@ -319,7 +295,6 @@ async def test_create_with_description() -> None:
     assert sent_body["description"] == "My warehouse"
 
 
-@pytest.mark.asyncio
 async def test_create_invalid_collation_raises_value_error() -> None:
     """create must raise ValueError for unsupported collation before any HTTP call."""
     with respx.mock:  # any HTTP call here is a bug
@@ -334,7 +309,6 @@ async def test_create_invalid_collation_raises_value_error() -> None:
                 )
 
 
-@pytest.mark.asyncio
 async def test_create_empty_name_raises_value_error() -> None:
     """create must raise ValueError for an empty name before any HTTP call."""
     with respx.mock:  # any HTTP call here is a bug
@@ -344,7 +318,6 @@ async def test_create_empty_name_raises_value_error() -> None:
                 await warehouses.create(client, _WORKSPACE_ID, "")
 
 
-@pytest.mark.asyncio
 async def test_create_whitespace_only_name_raises_value_error() -> None:
     """create must raise ValueError for a whitespace-only name before any HTTP call."""
     with respx.mock:  # any HTTP call here is a bug
@@ -354,7 +327,6 @@ async def test_create_whitespace_only_name_raises_value_error() -> None:
                 await warehouses.create(client, _WORKSPACE_ID, "   ")
 
 
-@pytest.mark.asyncio
 async def test_create_missing_resource_location_raises_fabric_server_error() -> None:
     """create must raise FabricServerError when LRO completes with null resourceLocation."""
     op_no_location = json.loads(WAREHOUSE_OPERATION_SUCCEEDED_NO_LOCATION_PAYLOAD)
@@ -375,7 +347,6 @@ async def test_create_missing_resource_location_raises_fabric_server_error() -> 
                 await warehouses.create(client, _WORKSPACE_ID, "SalesWarehouse")
 
 
-@pytest.mark.asyncio
 async def test_create_no_location_header_but_body_present_returns_warehouse() -> None:
     """create must do a follow-up GET when 201 body is present (no Location header).
 
@@ -409,7 +380,6 @@ async def test_create_no_location_header_but_body_present_returns_warehouse() ->
     assert result.connection_string == "saleswarehouse.datawarehouse.fabric.microsoft.com"
 
 
-@pytest.mark.asyncio
 async def test_create_no_location_header_and_empty_body_raises_fabric_server_error() -> None:
     """create must raise FabricServerError (after exhausting retries) when body is always empty.
 
@@ -432,7 +402,6 @@ async def test_create_no_location_header_and_empty_body_raises_fabric_server_err
     assert post_route.call_count == 4
 
 
-@pytest.mark.asyncio
 async def test_create_empty_2xx_retries_then_succeeds() -> None:
     """create must retry up to 3 times on 2xx + no Location + no usable body, then succeed.
 
@@ -472,7 +441,6 @@ async def test_create_empty_2xx_retries_then_succeeds() -> None:
     assert call_count == 4  # 3 empty retries + 1 successful
 
 
-@pytest.mark.asyncio
 async def test_create_4xx_is_not_retried() -> None:
     """create must NOT retry on 4xx errors — they propagate immediately.
 
@@ -503,7 +471,6 @@ async def test_create_4xx_is_not_retried() -> None:
     mock_sleep.assert_not_called()
 
 
-@pytest.mark.asyncio
 async def test_create_existing_path_with_location_header_still_works() -> None:
     """create must still work correctly (LRO poll + final GET) when a Location header is present."""
     op_succeeded = json.loads(WAREHOUSE_OPERATION_SUCCEEDED_PAYLOAD)
@@ -536,7 +503,6 @@ async def test_create_existing_path_with_location_header_still_works() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_rename_returns_updated_warehouse() -> None:
     """rename must PATCH and return the updated Warehouse from the response body."""
     wh_payload = json.loads(WAREHOUSE_GET_PAYLOAD)
@@ -562,7 +528,6 @@ async def test_rename_returns_updated_warehouse() -> None:
     assert "description" not in sent_body
 
 
-@pytest.mark.asyncio
 async def test_rename_with_description_includes_it_in_body() -> None:
     """rename with description must include it in the PATCH body."""
     wh_payload = json.loads(WAREHOUSE_GET_PAYLOAD)
@@ -590,7 +555,6 @@ async def test_rename_with_description_includes_it_in_body() -> None:
     assert sent_body["description"] == "New desc"
 
 
-@pytest.mark.asyncio
 async def test_rename_empty_name_raises_value_error() -> None:
     """rename must raise ValueError for an empty new_name before any HTTP call."""
     with respx.mock:  # any HTTP call here is a bug
@@ -605,7 +569,6 @@ async def test_rename_empty_name_raises_value_error() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_delete_204_returns_none() -> None:
     """delete must return None on 204 No Content."""
     with respx.mock:
@@ -617,7 +580,6 @@ async def test_delete_204_returns_none() -> None:
             await warehouses.delete(client, _WORKSPACE_ID, _WAREHOUSE_ID)
 
 
-@pytest.mark.asyncio
 async def test_delete_404_propagates_not_found() -> None:
     """delete must propagate NotFound on a 404 response."""
     with respx.mock:
@@ -681,7 +643,6 @@ _WH_B = UUID("bbbbbbbb-1111-0000-0000-000000000002")
 _WH_C = UUID("cccccccc-1111-0000-0000-000000000003")
 
 
-@pytest.mark.asyncio
 async def test_list_all_workspaces_aggregates_across_workspaces() -> None:
     """list_all_workspaces must collect warehouses from every visible workspace."""
     ws_a = _make_workspace(_WS_A)
@@ -716,7 +677,6 @@ async def test_list_all_workspaces_aggregates_across_workspaces() -> None:
     assert ids == {_WH_A, _WH_B, _WH_C}
 
 
-@pytest.mark.asyncio
 async def test_list_all_workspaces_skips_permission_denied(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -757,7 +717,6 @@ async def test_list_all_workspaces_skips_permission_denied(
     assert any("skipped 1 of 3" in r.message for r in caplog.records)
 
 
-@pytest.mark.asyncio
 async def test_list_all_workspaces_skips_not_found(caplog: pytest.LogCaptureFixture) -> None:
     """list_all_workspaces must skip workspaces where NotFound is raised and warn."""
     ws_a = _make_workspace(_WS_A)
@@ -813,7 +772,6 @@ def _make_item_entry_for_cache(tmp_path: Path) -> tuple[LookupCache, ItemEntry]:
     return cache, entry
 
 
-@pytest.mark.asyncio
 async def test_rename_evicts_old_name_and_inserts_new_name(tmp_path: Path) -> None:
     """rename with cache must evict old name and populate new name."""
     cache, _entry = _make_item_entry_for_cache(tmp_path)
@@ -841,7 +799,6 @@ async def test_rename_evicts_old_name_and_inserts_new_name(tmp_path: Path) -> No
     assert renamed_entry.display_name == "RenamedWarehouse"
 
 
-@pytest.mark.asyncio
 async def test_rename_without_cache_does_not_raise(tmp_path: Path) -> None:
     """rename without cache= must still complete successfully."""
     _ = tmp_path
@@ -865,7 +822,6 @@ async def test_rename_without_cache_does_not_raise(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_delete_evicts_name_from_cache(tmp_path: Path) -> None:
     """delete with cache= must evict both the name entry and the GUID entry."""
     cache, _entry = _make_item_entry_for_cache(tmp_path)
@@ -887,7 +843,6 @@ async def test_delete_evicts_name_from_cache(tmp_path: Path) -> None:
     assert cache.get_item(_WORKSPACE_ID, str(_WAREHOUSE_ID)) is None
 
 
-@pytest.mark.asyncio
 async def test_delete_without_cache_does_not_raise(tmp_path: Path) -> None:
     """delete without cache= must still complete successfully."""
     _ = tmp_path

--- a/tests/unit/services/test_workspaces.py
+++ b/tests/unit/services/test_workspaces.py
@@ -3,18 +3,13 @@
 from __future__ import annotations
 
 import json
-import time
-from unittest.mock import AsyncMock, MagicMock
 from uuid import UUID
 
 import httpx
 import pytest
 import respx
-from azure.core.credentials import AccessToken
-from azure.core.credentials_async import AsyncTokenCredential
 
 from fabric_dw.exceptions import FabricError
-from fabric_dw.http_client import FabricHttpClient
 from fabric_dw.models import Workspace
 from fabric_dw.services import workspaces
 from tests.fixtures.api_payloads import (
@@ -22,12 +17,11 @@ from tests.fixtures.api_payloads import (
     WORKSPACE_LIST_PAGE2_PAYLOAD,
     WORKSPACE_LIST_PAYLOAD,
 )
+from tests.unit.services._helpers import _make_client
 
 # ---------------------------------------------------------------------------
-# Helpers
+# Constants
 # ---------------------------------------------------------------------------
-
-_FAKE_TOKEN = AccessToken(token="fake-token", expires_on=int(time.time()) + 3600)  # noqa: S106
 
 _WORKSPACE_ID = UUID("a1b2c3d4-e5f6-7890-abcd-ef1234567890")
 _CONTINUATION_URL = (
@@ -35,22 +29,11 @@ _CONTINUATION_URL = (
 )
 
 
-def _make_credential(token: AccessToken = _FAKE_TOKEN) -> AsyncTokenCredential:
-    cred = MagicMock(spec=AsyncTokenCredential)
-    cred.get_token = AsyncMock(return_value=token)
-    return cred
-
-
-async def _make_client(rps: int = 10) -> FabricHttpClient:
-    return FabricHttpClient(credential=_make_credential(), rps=rps)
-
-
 # ---------------------------------------------------------------------------
 # list_all
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_list_all_follows_continuation_uri() -> None:
     """list_all must follow continuationUri for ≥2 pages and return all workspaces."""
     call_count = 0
@@ -80,7 +63,6 @@ async def test_list_all_follows_continuation_uri() -> None:
     assert "MLWorkspace" in names
 
 
-@pytest.mark.asyncio
 async def test_list_all_returns_workspace_instances() -> None:
     """list_all items must be validated Workspace model instances."""
     payload = json.loads(WORKSPACE_LIST_PAYLOAD)
@@ -108,7 +90,6 @@ async def test_list_all_returns_workspace_instances() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_get_returns_populated_workspace() -> None:
     """get must return a single populated Workspace for the given workspace_id."""
     ws_id = _WORKSPACE_ID
@@ -134,7 +115,6 @@ async def test_get_returns_populated_workspace() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_set_collation_happy_path_returns_none() -> None:
     """set_collation must return None on a successful PATCH (200/202)."""
     ws_id = _WORKSPACE_ID
@@ -150,7 +130,6 @@ async def test_set_collation_happy_path_returns_none() -> None:
     # set_collation returns None implicitly on success; no assertion needed beyond no exception
 
 
-@pytest.mark.asyncio
 async def test_set_collation_202_happy_path() -> None:
     """set_collation must also return None on 202 (accepted)."""
     ws_id = _WORKSPACE_ID
@@ -166,7 +145,6 @@ async def test_set_collation_202_happy_path() -> None:
     # set_collation returns None implicitly on success; no assertion needed beyond no exception
 
 
-@pytest.mark.asyncio
 async def test_set_collation_400_raises_fabric_error_with_portal_link() -> None:
     """set_collation must raise FabricError mentioning the portal on a 400 response."""
     ws_id = _WORKSPACE_ID
@@ -183,7 +161,6 @@ async def test_set_collation_400_raises_fabric_error_with_portal_link() -> None:
                 await workspaces.set_collation(client, ws_id, "Latin1_General_100_BIN2_UTF8")
 
 
-@pytest.mark.asyncio
 async def test_set_collation_invalid_value_raises_value_error() -> None:
     """set_collation must raise ValueError for unsupported collation strings."""
     ws_id = _WORKSPACE_ID

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -97,7 +97,6 @@ def test_get_credential_interactive_returns_sync_adapter() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_sync_adapter_get_token_returns_token_from_inner() -> None:
     """get_token must return the token produced by the inner sync credential."""
     expected_token = AccessToken("my-access-token", 9999999999)
@@ -113,7 +112,6 @@ async def test_sync_adapter_get_token_returns_token_from_inner() -> None:
     )
 
 
-@pytest.mark.asyncio
 async def test_sync_adapter_get_token_runs_in_worker_thread() -> None:
     """get_token must offload the inner call to a worker thread, not the test thread."""
     test_thread = threading.current_thread()
@@ -133,7 +131,6 @@ async def test_sync_adapter_get_token_runs_in_worker_thread() -> None:
     assert inner_thread[0] is not test_thread, "get_token must run in a worker thread"
 
 
-@pytest.mark.asyncio
 async def test_sync_adapter_get_token_dispatches_via_to_thread() -> None:
     """get_token must call asyncio.to_thread with the inner method."""
     inner = MagicMock()
@@ -152,7 +149,6 @@ async def test_sync_adapter_get_token_dispatches_via_to_thread() -> None:
         )
 
 
-@pytest.mark.asyncio
 async def test_sync_adapter_close_dispatches_via_to_thread() -> None:
     """close() must offload the inner close call to a worker thread."""
     inner = MagicMock()
@@ -164,7 +160,6 @@ async def test_sync_adapter_close_dispatches_via_to_thread() -> None:
         mock_to_thread.assert_called_once_with(inner.close)
 
 
-@pytest.mark.asyncio
 async def test_sync_adapter_close_runs_in_worker_thread() -> None:
     """close() must execute inner.close in a worker thread, not the test thread."""
     test_thread = threading.current_thread()

--- a/tests/unit/test_http_client.py
+++ b/tests/unit/test_http_client.py
@@ -68,7 +68,6 @@ def test_parse_retry_after_http_date() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_rps_limiter_timing() -> None:
     """6 requests at 2 RPS complete in ~2.0s.
 
@@ -100,7 +99,6 @@ async def test_rps_limiter_timing() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_429_retry_after_honored() -> None:
     """A 429 with Retry-After: 1 should retry once and succeed; elapsed >= ~0.9 s."""
     call_count = 0
@@ -126,7 +124,6 @@ async def test_429_retry_after_honored() -> None:
     assert elapsed >= 0.9, f"Retry-After not honored: {elapsed:.2f}s"
 
 
-@pytest.mark.asyncio
 async def test_429_raises_after_five_in_a_row() -> None:
     """Exactly 5 consecutive 429 responses must trigger RateLimitedError (_MAX_429_RETRIES = 5).
 
@@ -156,7 +153,6 @@ async def test_429_raises_after_five_in_a_row() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_401_raises_auth_error() -> None:
     """HTTP 401 should raise AuthError."""
     with respx.mock:
@@ -169,7 +165,6 @@ async def test_401_raises_auth_error() -> None:
                 await client.request("GET", HttpBase.FABRIC, "/items")
 
 
-@pytest.mark.asyncio
 async def test_403_raises_permission_denied() -> None:
     """HTTP 403 should raise PermissionDenied."""
     with respx.mock:
@@ -182,7 +177,6 @@ async def test_403_raises_permission_denied() -> None:
                 await client.request("GET", HttpBase.FABRIC, "/items")
 
 
-@pytest.mark.asyncio
 async def test_404_raises_not_found() -> None:
     """HTTP 404 should raise NotFound."""
     with respx.mock:
@@ -200,7 +194,6 @@ async def test_404_raises_not_found() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_500_retried_then_raises() -> None:
     """HTTP 500 should be retried (tenacity) and finally raise FabricServerError."""
     with respx.mock:
@@ -218,7 +211,6 @@ async def test_500_retried_then_raises() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_iter_paginated_follows_continuation_uri() -> None:
     """iter_paginated should follow continuationUri across pages and yield all items."""
     page1 = {
@@ -251,7 +243,6 @@ async def test_iter_paginated_follows_continuation_uri() -> None:
         assert call_count == 2
 
 
-@pytest.mark.asyncio
 async def test_iter_paginated_single_page() -> None:
     """iter_paginated should yield all items from a single-page response."""
     page: dict[str, Any] = {"value": [{"id": "x"}, {"id": "y"}]}
@@ -268,7 +259,6 @@ async def test_iter_paginated_single_page() -> None:
     assert items == [{"id": "x"}, {"id": "y"}]
 
 
-@pytest.mark.asyncio
 async def test_iter_paginated_two_pages_follows_continuation_uri() -> None:
     """iter_paginated should follow continuationUri and yield items from both pages."""
     continuation_url = "https://api.fabric.microsoft.com/v1/items?continuation=abc"
@@ -300,7 +290,6 @@ async def test_iter_paginated_two_pages_follows_continuation_uri() -> None:
     assert call_count == 2
 
 
-@pytest.mark.asyncio
 async def test_iter_paginated_empty_value_list() -> None:
     """iter_paginated should yield nothing when the value list is empty."""
     with respx.mock:
@@ -315,7 +304,6 @@ async def test_iter_paginated_empty_value_list() -> None:
     assert items == []
 
 
-@pytest.mark.asyncio
 async def test_iter_paginated_custom_key() -> None:
     """iter_paginated with key='someOtherKey' must yield items from that key, not from 'value'.
 
@@ -344,7 +332,6 @@ async def test_iter_paginated_custom_key() -> None:
     assert items == [{"id": 1}], f"Expected only id=1 from 'someOtherKey'; got {items}"
 
 
-@pytest.mark.asyncio
 async def test_iter_paginated_params_only_on_first_request() -> None:
     """params must be sent on the first request only, not on continuation requests.
 
@@ -402,7 +389,6 @@ async def test_iter_paginated_params_only_on_first_request() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_poll_operation_succeeded() -> None:
     """poll_operation should return the body when status == 'Succeeded'."""
     poll_count = 0
@@ -434,7 +420,6 @@ async def test_poll_operation_succeeded() -> None:
         assert poll_count == 2
 
 
-@pytest.mark.asyncio
 async def test_poll_operation_failed_raises() -> None:
     """poll_operation should raise FabricServerError when status == 'Failed'."""
     with respx.mock:
@@ -448,7 +433,6 @@ async def test_poll_operation_failed_raises() -> None:
                 await client.poll_operation("https://api.fabric.microsoft.com/v1/operations/op-456")
 
 
-@pytest.mark.asyncio
 async def test_poll_operation_timeout_raises() -> None:
     """poll_operation should raise FabricServerError when timeout_s is exceeded.
 
@@ -474,7 +458,6 @@ async def test_poll_operation_timeout_raises() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_get_operation_result_returns_body() -> None:
     """get_operation_result should GET /operations/{op_id}/result and return the body.
 
@@ -500,7 +483,6 @@ async def test_get_operation_result_returns_body() -> None:
     assert result == expected
 
 
-@pytest.mark.asyncio
 async def test_get_operation_result_not_found_propagates() -> None:
     """get_operation_result should propagate NotFound when the result endpoint returns 404."""
     op_id = "no-such-op"
@@ -520,7 +502,6 @@ async def test_get_operation_result_not_found_propagates() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_request_params_int_value_serialized() -> None:
     """request() must accept int param values and serialize them correctly (e.g. ?top=100)."""
     captured_url: str | None = None
@@ -548,7 +529,6 @@ async def test_request_params_int_value_serialized() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_concurrent_requests_fetch_token_once() -> None:
     """Five concurrent requests before any token is fetched must call get_token exactly once."""
     cred = MagicMock(spec=AsyncTokenCredential)
@@ -577,7 +557,6 @@ async def test_concurrent_requests_fetch_token_once() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_debug_log_emitted_on_request(caplog: pytest.LogCaptureFixture) -> None:
     """A successful request at DEBUG must emit a log record from fabric_dw.http.
 
@@ -611,7 +590,6 @@ async def test_debug_log_emitted_on_request(caplog: pytest.LogCaptureFixture) ->
     assert "fake-token" not in msg
 
 
-@pytest.mark.asyncio
 async def test_debug_log_contains_elapsed_ms(caplog: pytest.LogCaptureFixture) -> None:
     """Log record should contain elapsed_ms as a numeric attribute or in message."""
     with respx.mock:
@@ -642,7 +620,6 @@ async def test_debug_log_contains_elapsed_ms(caplog: pytest.LogCaptureFixture) -
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_status_mapping_fills_exception_attributes() -> None:
     """Error exceptions must carry status, request_id, and body attributes."""
     req_id = "test-req-id-001"
@@ -667,7 +644,6 @@ async def test_status_mapping_fills_exception_attributes() -> None:
     assert err.body.get("error") is not None
 
 
-@pytest.mark.asyncio
 async def test_auth_error_carries_status() -> None:
     """AuthError must have status=401."""
     with respx.mock:
@@ -682,7 +658,6 @@ async def test_auth_error_carries_status() -> None:
     assert exc_info.value.status == 401
 
 
-@pytest.mark.asyncio
 async def test_server_error_carries_status() -> None:
     """FabricServerError must have status=500."""
     with respx.mock:
@@ -697,7 +672,6 @@ async def test_server_error_carries_status() -> None:
     assert exc_info.value.status == 500
 
 
-@pytest.mark.asyncio
 async def test_rate_limited_error_carries_status() -> None:
     """RateLimitedError raised after consecutive 429s must carry status=429."""
 
@@ -751,7 +725,6 @@ def test_fabric_error_str_with_hint_and_request_id() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_429_deadline_aggregated_for_concurrent_requests() -> None:
     """Two concurrent 429s with Retry-After values aggregate to the MAX deadline.
 
@@ -790,7 +763,6 @@ async def test_429_deadline_aggregated_for_concurrent_requests() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_429_deadline_single_request_honors_retry_after() -> None:
     """429 with Retry-After: 1 sets _pause_until and waits before retry."""
     call_count = 0
@@ -821,7 +793,6 @@ async def test_429_deadline_single_request_honors_retry_after() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_debug_log_includes_request_id_when_present(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -872,7 +843,6 @@ def test_constructor_parameters_are_stored() -> None:
     assert client._token_refresh_buffer == 600.0
 
 
-@pytest.mark.asyncio
 async def test_timeout_wired_into_http_client() -> None:
     """The timeout parameter must be forwarded to the underlying httpx.AsyncClient."""
     cred = _make_credential()
@@ -887,7 +857,6 @@ async def test_timeout_wired_into_http_client() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_poll_operation_jitter_within_bounds() -> None:
     """poll_operation sleep must add the jitter produced by random.uniform.
 
@@ -947,7 +916,6 @@ async def test_poll_operation_jitter_within_bounds() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_429_with_garbage_retry_after_falls_back_and_succeeds() -> None:
     """A malformed Retry-After value must NOT raise ValueError.
 
@@ -975,7 +943,6 @@ async def test_429_with_garbage_retry_after_falls_back_and_succeeds() -> None:
     assert call_count == 2
 
 
-@pytest.mark.asyncio
 async def test_429_garbage_retry_after_emits_warning(caplog: pytest.LogCaptureFixture) -> None:
     """A malformed Retry-After must emit a WARNING log with the raw header value."""
     call_count = 0
@@ -1009,7 +976,6 @@ async def test_429_garbage_retry_after_emits_warning(caplog: pytest.LogCaptureFi
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_send_once_deadline_sleep_happens_before_get_token() -> None:
     """_send_once must sleep for the pause deadline BEFORE calling _get_token.
 
@@ -1074,7 +1040,6 @@ async def test_send_once_deadline_sleep_happens_before_get_token() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_send_once_re_sleeps_when_pause_until_extended_mid_sleep() -> None:
     """_send_once must re-check _pause_until after waking and sleep again if extended.
 

--- a/tests/unit/test_resolver.py
+++ b/tests/unit/test_resolver.py
@@ -132,7 +132,6 @@ def _sql_endpoint_list_item(item_id: str, name: str) -> dict[str, object]:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_workspace_id_guid_no_api_call(tmp_path: Path) -> None:
     resolver, client, _ = _make_resolver(tmp_path)
     with respx.mock:
@@ -148,7 +147,6 @@ async def test_workspace_id_guid_no_api_call(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_workspace_id_name_hits_api(tmp_path: Path) -> None:
     resolver, client, _ = _make_resolver(tmp_path)
     with respx.mock:
@@ -162,7 +160,6 @@ async def test_workspace_id_name_hits_api(tmp_path: Path) -> None:
     assert result == WS_UUID
 
 
-@pytest.mark.asyncio
 async def test_workspace_id_name_cached_after_first_call(tmp_path: Path) -> None:
     resolver, client, _cache = _make_resolver(tmp_path)
     with respx.mock:
@@ -180,7 +177,6 @@ async def test_workspace_id_name_cached_after_first_call(tmp_path: Path) -> None
     assert first == second == WS_UUID
 
 
-@pytest.mark.asyncio
 async def test_workspace_id_name_not_found(tmp_path: Path) -> None:
     resolver, client, _ = _make_resolver(tmp_path)
     with respx.mock:
@@ -192,7 +188,6 @@ async def test_workspace_id_name_not_found(tmp_path: Path) -> None:
                 await resolver.workspace_id("NonExistentWorkspace")
 
 
-@pytest.mark.asyncio
 async def test_workspace_id_name_multiple_matches_raises_fabric_error(tmp_path: Path) -> None:
     resolver, client, _ = _make_resolver(tmp_path)
     with respx.mock:
@@ -204,7 +199,6 @@ async def test_workspace_id_name_multiple_matches_raises_fabric_error(tmp_path: 
                 await resolver.workspace_id("Ambiguous")
 
 
-@pytest.mark.asyncio
 async def test_workspace_id_multiple_matches_error_mentions_all_ids(tmp_path: Path) -> None:
     resolver, client, _ = _make_resolver(tmp_path)
     with respx.mock:
@@ -224,7 +218,6 @@ async def test_workspace_id_multiple_matches_error_mentions_all_ids(tmp_path: Pa
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_item_guid_fetches_detail_endpoint(tmp_path: Path) -> None:
     resolver, client, _ = _make_resolver(tmp_path)
     generic_payload = _warehouse_detail_payload(ITEM_GUID, WS_GUID, "SalesWarehouse")
@@ -243,7 +236,6 @@ async def test_item_guid_fetches_detail_endpoint(tmp_path: Path) -> None:
     assert result.connection_string == "mywarehouse.datawarehouse.fabric.microsoft.com"
 
 
-@pytest.mark.asyncio
 async def test_item_guid_sql_endpoint_connection_string(tmp_path: Path) -> None:
     resolver, client, _ = _make_resolver(tmp_path)
     generic_payload = _sql_endpoint_detail_payload(ITEM_GUID, WS_GUID, "MySQLEndpoint")
@@ -264,7 +256,6 @@ async def test_item_guid_sql_endpoint_connection_string(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_item_name_pages_items_and_fetches_detail(tmp_path: Path) -> None:
     resolver, client, _ = _make_resolver(tmp_path)
     list_payload = _items_list_payload(
@@ -285,7 +276,6 @@ async def test_item_name_pages_items_and_fetches_detail(tmp_path: Path) -> None:
     assert result.connection_string == "mywarehouse.datawarehouse.fabric.microsoft.com"
 
 
-@pytest.mark.asyncio
 async def test_item_name_case_insensitive_match(tmp_path: Path) -> None:
     resolver, client, _ = _make_resolver(tmp_path)
     list_payload = _items_list_payload(
@@ -304,7 +294,6 @@ async def test_item_name_case_insensitive_match(tmp_path: Path) -> None:
     assert result.id == ITEM_UUID
 
 
-@pytest.mark.asyncio
 async def test_item_name_not_found(tmp_path: Path) -> None:
     resolver, client, _ = _make_resolver(tmp_path)
     # Return a list with no matching items
@@ -318,7 +307,6 @@ async def test_item_name_not_found(tmp_path: Path) -> None:
                 await resolver.item(WS_GUID, "NonExistentWarehouse")
 
 
-@pytest.mark.asyncio
 async def test_item_name_cached_after_first_call(tmp_path: Path) -> None:
     resolver, client, _ = _make_resolver(tmp_path)
     list_payload = _items_list_payload(
@@ -345,7 +333,6 @@ async def test_item_name_cached_after_first_call(tmp_path: Path) -> None:
     assert first.id == second.id
 
 
-@pytest.mark.asyncio
 async def test_item_name_sql_endpoint(tmp_path: Path) -> None:
     resolver, client, _ = _make_resolver(tmp_path)
     list_payload = _items_list_payload(
@@ -365,7 +352,6 @@ async def test_item_name_sql_endpoint(tmp_path: Path) -> None:
     assert result.connection_string == "mysqlep.datawarehouse.fabric.microsoft.com"
 
 
-@pytest.mark.asyncio
 async def test_item_name_workspace_resolved_first(tmp_path: Path) -> None:
     """When workspace is given as a name, it gets resolved via PBI first."""
     resolver, client, _ = _make_resolver(tmp_path)
@@ -395,7 +381,6 @@ async def test_item_name_workspace_resolved_first(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_workspace_id_name_with_single_quote_escaped(tmp_path: Path) -> None:
     """Workspace names containing a single quote are properly OData-escaped."""
     resolver, client, _ = _make_resolver(tmp_path)
@@ -416,7 +401,6 @@ async def test_workspace_id_name_with_single_quote_escaped(tmp_path: Path) -> No
     assert "O%27%27Brien" in called_request.url.query.decode()
 
 
-@pytest.mark.asyncio
 async def test_workspace_id_name_with_double_apostrophe_escaped(tmp_path: Path) -> None:
     """Names with consecutive apostrophes are double-escaped correctly."""
     resolver, client, _ = _make_resolver(tmp_path)
@@ -444,7 +428,6 @@ _FABRIC_SQL_ENDPOINT_URL = (
 )
 
 
-@pytest.mark.asyncio
 async def test_item_guid_second_call_hits_cache_not_api(tmp_path: Path) -> None:
     """GUID input: first call hits API, second call within TTL hits cache (no extra HTTP)."""
     resolver, client, _ = _make_resolver(tmp_path)
@@ -471,7 +454,6 @@ async def test_item_guid_second_call_hits_cache_not_api(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_item_guid_warehouse_uses_type_specific_endpoint(tmp_path: Path) -> None:
     """Warehouse items: detail fetch uses /warehouses/{id}, not generic /items/{id}."""
     resolver, client, _ = _make_resolver(tmp_path)
@@ -492,7 +474,6 @@ async def test_item_guid_warehouse_uses_type_specific_endpoint(tmp_path: Path) -
     assert warehouse_route.call_count == 1
 
 
-@pytest.mark.asyncio
 async def test_item_guid_sql_endpoint_uses_type_specific_endpoint(tmp_path: Path) -> None:
     """SQLEndpoint items: detail fetch uses /sqlEndpoints/{id}, not generic /items/{id}."""
     resolver, client, _ = _make_resolver(tmp_path)
@@ -513,7 +494,6 @@ async def test_item_guid_sql_endpoint_uses_type_specific_endpoint(tmp_path: Path
     assert sql_route.call_count == 1
 
 
-@pytest.mark.asyncio
 async def test_item_guid_snapshot_uses_generic_endpoint_only(tmp_path: Path) -> None:
     """WarehouseSnapshot: no type-specific endpoint; uses generic /items/{id} only."""
     resolver, client, _ = _make_resolver(tmp_path)
@@ -540,7 +520,6 @@ async def test_item_guid_snapshot_uses_generic_endpoint_only(tmp_path: Path) -> 
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_item_guid_unknown_type_raises_fabric_error(tmp_path: Path) -> None:
     """An unsupported item type (e.g. Lakehouse) must raise FabricError, not silently default."""
     resolver, client, _ = _make_resolver(tmp_path)
@@ -562,7 +541,6 @@ async def test_item_guid_unknown_type_raises_fabric_error(tmp_path: Path) -> Non
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_workspace_negative_cache_avoids_second_api_call(tmp_path: Path) -> None:
     """Second lookup of a missing workspace must not hit the API (negative cache)."""
     resolver, client, _ = _make_resolver(tmp_path)
@@ -580,7 +558,6 @@ async def test_workspace_negative_cache_avoids_second_api_call(tmp_path: Path) -
     assert route.call_count == 1, "negative cache must suppress the second API call"
 
 
-@pytest.mark.asyncio
 async def test_workspace_negative_cache_clears_on_success(tmp_path: Path) -> None:
     """After a successful lookup the negative cache entry must be cleared.
 
@@ -617,7 +594,6 @@ async def test_workspace_negative_cache_clears_on_success(tmp_path: Path) -> Non
     assert result == WS_UUID
 
 
-@pytest.mark.asyncio
 async def test_item_negative_cache_avoids_second_api_call(tmp_path: Path) -> None:
     """Second lookup of a missing item must not page through items again."""
     resolver, client, _ = _make_resolver(tmp_path)
@@ -651,7 +627,6 @@ def test_odata_escape_rejects_oversized_value() -> None:
         _odata_escape(too_long)
 
 
-@pytest.mark.asyncio
 async def test_workspace_id_oversized_name_raises_fabric_error(tmp_path: Path) -> None:
     """workspace_id must raise FabricError (not ValueError) for names exceeding _ODATA_MAX_LEN."""
     resolver, client, _ = _make_resolver(tmp_path)
@@ -666,7 +641,6 @@ async def test_workspace_id_oversized_name_raises_fabric_error(tmp_path: Path) -
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_item_name_passes_type_param_to_items_api(tmp_path: Path) -> None:
     """item() with item_type kwarg must send type= query param to the items API."""
     resolver, client, _ = _make_resolver(tmp_path)
@@ -690,7 +664,6 @@ async def test_item_name_passes_type_param_to_items_api(tmp_path: Path) -> None:
     assert "type=Warehouse" in str(called_url) or "type" in called_url.params
 
 
-@pytest.mark.asyncio
 async def test_item_name_no_type_param_when_item_type_not_provided(tmp_path: Path) -> None:
     """item() without item_type must not send a type= param to the items API."""
     resolver, client, _ = _make_resolver(tmp_path)
@@ -716,7 +689,6 @@ async def test_item_name_no_type_param_when_item_type_not_provided(tmp_path: Pat
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_fetch_item_detail_uses_put_items(tmp_path: Path) -> None:
     """_fetch_item_detail must call put_items (not two separate put_item calls)."""
     resolver, client, cache = _make_resolver(tmp_path)
@@ -757,7 +729,6 @@ def test_negative_ttl_is_five_seconds() -> None:
     )
 
 
-@pytest.mark.asyncio
 async def test_negative_cache_expired_entry_pruned_on_check(tmp_path: Path) -> None:
     """_negative_check must prune expired entries to keep the dict bounded."""
     resolver, client, _ = _make_resolver(tmp_path)
@@ -775,7 +746,6 @@ async def test_negative_cache_expired_entry_pruned_on_check(tmp_path: Path) -> N
     assert ("workspace", "ghost") not in resolver._negative
 
 
-@pytest.mark.asyncio
 async def test_clear_negative_cache_empties_all_entries(tmp_path: Path) -> None:
     """clear_negative_cache() must discard all in-memory negative entries."""
     resolver, client, _ = _make_resolver(tmp_path)
@@ -793,7 +763,6 @@ async def test_clear_negative_cache_empties_all_entries(tmp_path: Path) -> None:
     assert len(resolver._negative) == 0
 
 
-@pytest.mark.asyncio
 async def test_item_fetch_clears_workspace_negative_entries(tmp_path: Path) -> None:
     """After _fetch_item_detail succeeds, negative entries for that workspace are cleared."""
     resolver, client, _ = _make_resolver(tmp_path)


### PR DESCRIPTION
## Summary

- **`06-tests-mark-asyncio-redundant`**: Removed 387 redundant `@pytest.mark.asyncio` decorators across 22 test files. `asyncio_mode = "auto"` in `pyproject.toml` already makes them dead noise. Also removed one now-unused `import pytest` in `test_lro.py`.
- **`06-tests-no-shared-conftest-helpers-duplicated`**: Created `tests/unit/services/_helpers.py` with shared `_FAKE_TOKEN`, `_make_credential`, and `_make_client`. Updated 9 service test files (`test_workspaces`, `test_audit`, `test_warehouses`, `test_sql_endpoints`, `test_permissions`, `test_lro`, `test_sql_pools`, `test_snapshots`, `test_restore`, `test_ownership`) to import from the shared module, removing ~200+ duplicated lines. Cleaned up now-unused imports (`time`, `AccessToken`, `AsyncTokenCredential`, `MagicMock`, `FabricHttpClient`) in each file.
- **`06-tests-integration-default-not-deselected`**: Added `-m 'not integration'` to `addopts` in `[tool.pytest.ini_options]`. Bare `pytest` now deselects the 39 integration tests. Updated `just integration` to pass `-m integration` so integration tests are still selectable when explicitly requested.
- **`06-tests-integration-conftest-hard-fail`**: Replaced `raise RuntimeError(...)` in `tests/integration/conftest.py` `workspace_id` fixture with `pytest.skip(..., allow_module_level=True)` so local devs without Fabric creds get SKIP not ERROR.

## Decisions

- Used a plain module `tests/unit/services/_helpers.py` instead of pytest fixtures because the existing calling convention (`client = await _make_client()` + `async with client:`) is uniform across all tests and would require invasive rewrites to convert to fixtures. The shared module achieves the DRY goal with minimal test-body churn.
- Unified `_make_client` rps default to `100` (more permissive) since the variation between files (`10` vs `100`) was incidental and all tests pass with either value.
- The `just integration` recipe now explicitly passes `-m integration` to override `addopts`; no `--override-ini` needed since `-m` arguments compose (the recipe-level flag narrows to integration-only within the path constraint).

## Test results

- Baseline: **1528 passed** before changes
- After changes: **1528 passed** — identical count, no tests silently disabled
- Coverage: **86.74%** (gate: 80%) — unchanged
- `just check` (ruff lint + ruff format + ty type-check + pytest tests/unit): fully green

🤖 Generated with [Claude Code](https://claude.com/claude-code)