### PR TITLE
chore(lint): rename exception classes + align lint policy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,15 +112,30 @@ select = [
     "C4", "DTZ", "ARG", "PT", "TRY", "LOG", "S", "FBT", "RET", "PIE",
     "TID", "ICN", "T20", "ERA", "PERF", "FURB",
 ]
+ignore = [
+    # TRY003: the project favours descriptive inline exception messages over an
+    # exception-message-constants module. Suppressing globally removes ~30 inline noqa comments.
+    "TRY003",
+    # D/DOC: docstring rules are intentionally deferred until the public API stabilises.
+    # Re-evaluate when the service and MCP layers solidify. Enable D419 (empty docstring)
+    # at minimum once the deferral is lifted.
+]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**" = ["ANN", "S101", "PLR2004", "TRY003", "FBT001"]
+# ANN: test functions do not require full type annotations.
+# S101: pytest asserts are intentional.
+# PLR2004: test fixtures use concrete numeric values that are inherent to the test spec
+#   (retention_days=14, page_size=10, etc.) — these are not magic numbers in the
+#   refactoring sense. HTTP status codes in src/ use http.HTTPStatus instead.
+"tests/**" = ["ANN", "S101", "PLR2004"]
+# PLR0913: service functions have many parameters by design (workspace_id, client, etc.).
 "src/fabric_dw/services/**" = ["PLR0913"]
-# Click injects bool flags via decorators; FBT001 is a false-positive for Click commands.
-# PLR0913 fires on commands with --limit/--since/--until; suppress at the CLI layer.
+# FBT001: Click injects bool flags via decorators; positional-bool check is a false-positive.
+# PLR0913: CLI commands grow many options (--limit/--since/--until/etc.); suppress at CLI layer.
 "src/fabric_dw/cli/**" = ["FBT001", "PLR0913"]
 
 [tool.ruff.format]
+docstring-code-format = true
 
 [tool.ty]
 # ty 0.0.44 is in alpha; no meaningful strictness settings are stable yet.

--- a/src/fabric_dw/cache.py
+++ b/src/fabric_dw/cache.py
@@ -8,19 +8,17 @@ JSON shape::
 
     {
         "version": 1,
-        "workspaces": {
-            "<name_lower>": {"id": "<guid>", "fetched_at": "<iso8601>"}
-        },
+        "workspaces": {"<name_lower>": {"id": "<guid>", "fetched_at": "<iso8601>"}},
         "items": {
             "<ws_uuid>": {
                 "<name_lower_or_guid_lower>": {
                     "id": "<guid>",
                     "kind": "<WarehouseKind>",
                     "connection_string": "<str | null>",
-                    "fetched_at": "<iso8601>"
+                    "fetched_at": "<iso8601>",
                 }
             }
-        }
+        },
     }
 
 Names are stripped of leading/trailing whitespace and lower-cased at the

--- a/src/fabric_dw/cli/commands/_utils.py
+++ b/src/fabric_dw/cli/commands/_utils.py
@@ -159,9 +159,7 @@ async def build_sql_target(
     """
     ws_id, entry = await resolve_item(http, workspace, item)
     if entry.connection_string is None:
-        raise click.ClickException(  # noqa: TRY003
-            f"Item {entry.display_name!r} has no connection string."
-        )
+        raise click.ClickException(f"Item {entry.display_name!r} has no connection string.")
     target = SqlTarget(
         workspace_id=str(ws_id),
         database=entry.display_name,
@@ -191,9 +189,7 @@ def parse_qualified_name(qualified_name: str, *, kind: str = "object") -> tuple[
     try:
         return _parse_qn(qualified_name)
     except ValueError:
-        raise click.UsageError(  # noqa: TRY003
-            f"Expected <schema>.{kind}, got {qualified_name!r}"
-        ) from None
+        raise click.UsageError(f"Expected <schema>.{kind}, got {qualified_name!r}") from None
 
 
 def load_select_body(select: str | None, from_file: str | None) -> str:
@@ -203,15 +199,15 @@ def load_select_body(select: str | None, from_file: str | None) -> str:
         click.UsageError: If neither or both are provided, or file is missing.
     """
     if select and from_file:
-        raise click.UsageError("Provide either --select or --from-file, not both.")  # noqa: TRY003
+        raise click.UsageError("Provide either --select or --from-file, not both.")
     if from_file:
         path = Path(from_file)
         if not path.is_file():
-            raise click.UsageError(f"File not found: {from_file}")  # noqa: TRY003
+            raise click.UsageError(f"File not found: {from_file}")
         return path.read_text(encoding="utf-8-sig").strip()
     if select:
         return select
-    raise click.UsageError("Provide --select or --from-file.")  # noqa: TRY003
+    raise click.UsageError("Provide --select or --from-file.")
 
 
 # ---------------------------------------------------------------------------
@@ -234,7 +230,7 @@ def parse_iso_datetime(value: str, param_name: str, *, assume_utc: bool = True) 
     try:
         dt = datetime.fromisoformat(value)
     except ValueError as exc:
-        raise click.UsageError(  # noqa: TRY003
+        raise click.UsageError(
             f"invalid {param_name} {value!r}: expected ISO-8601 (e.g. 2024-01-01T00:00:00)"
         ) from exc
     if assume_utc:
@@ -243,7 +239,7 @@ def parse_iso_datetime(value: str, param_name: str, *, assume_utc: bool = True) 
     _DT_YEAR_MAX = 2100  # noqa: N806
     # Sanity range check: reject obviously wrong years (e.g. epoch 0 or year 9999).
     if not (_DT_YEAR_MIN <= dt.year <= _DT_YEAR_MAX):
-        raise click.UsageError(  # noqa: TRY003
+        raise click.UsageError(
             f"invalid {param_name} {value!r}: year {dt.year} is out of the expected range "
             "(2000-2100). Check the timestamp."
         )
@@ -314,7 +310,7 @@ def resolve_workspace_arg(ctx: CliContext, value: str | None) -> str:
     cfg_val = ctx.config.defaults.workspace
     if cfg_val is not None:
         return cfg_val
-    raise click.UsageError(  # noqa: TRY003
+    raise click.UsageError(
         "no workspace specified; pass as argument or run 'fabric-dw config set workspace ...'"
     )
 
@@ -335,7 +331,7 @@ def resolve_warehouse_arg(ctx: CliContext, value: str | None) -> str:
     cfg_val = ctx.config.defaults.warehouse
     if cfg_val is not None:
         return cfg_val
-    raise click.UsageError(  # noqa: TRY003
+    raise click.UsageError(
         "no warehouse specified; pass as argument or run 'fabric-dw config set warehouse ...'"
     )
 
@@ -361,8 +357,6 @@ def validate_workspace_or_all_workspaces(workspace: str | None, all_workspaces: 
         click.UsageError: If both or neither are provided.
     """
     if workspace and all_workspaces:
-        raise click.UsageError("WORKSPACE and --all-workspaces are mutually exclusive.")  # noqa: TRY003
+        raise click.UsageError("WORKSPACE and --all-workspaces are mutually exclusive.")
     if not workspace and not all_workspaces:
-        raise click.UsageError(  # noqa: TRY003
-            "Provide WORKSPACE or pass --all-workspaces / -A."
-        )
+        raise click.UsageError("Provide WORKSPACE or pass --all-workspaces / -A.")

--- a/src/fabric_dw/cli/commands/audit.py
+++ b/src/fabric_dw/cli/commands/audit.py
@@ -76,9 +76,9 @@ async def enable_cmd(
     Omitting both --retention-days and --unlimited defaults to unlimited retention.
     """
     if retention_days is not None and unlimited:
-        raise click.UsageError("--retention-days and --unlimited are mutually exclusive.")  # noqa: TRY003
+        raise click.UsageError("--retention-days and --unlimited are mutually exclusive.")
     if retention_days is not None and retention_days < 1:
-        raise click.UsageError("--retention-days must be >= 1; use --unlimited for no limit.")  # noqa: TRY003
+        raise click.UsageError("--retention-days must be >= 1; use --unlimited for no limit.")
     # Map to service value: 0 means unlimited.
     effective_days: int = 0
     if retention_days is not None:

--- a/src/fabric_dw/cli/commands/sql.py
+++ b/src/fabric_dw/cli/commands/sql.py
@@ -72,9 +72,9 @@ async def exec_cmd(
     for machine-readable JSON ({columns: [...], rows: [...], rowcount: N}).
     """
     if query_text is not None and query_file is not None:
-        raise click.UsageError("Use -q/--query OR -f/--file, not both.")  # noqa: TRY003
+        raise click.UsageError("Use -q/--query OR -f/--file, not both.")
     if query_text is None and query_file is None:
-        raise click.UsageError("Provide a query via -q/--query or -f/--file.")  # noqa: TRY003
+        raise click.UsageError("Provide a query via -q/--query or -f/--file.")
 
     if query_file is not None:
         query_text = Path(query_file).read_text(encoding="utf-8-sig")

--- a/src/fabric_dw/cli/commands/sql_pools.py
+++ b/src/fabric_dw/cli/commands/sql_pools.py
@@ -19,14 +19,19 @@ from fabric_dw.cli.commands._utils import (
     resolve_workspace_arg,
     resolve_workspace_id,
 )
-from fabric_dw.exceptions import AlreadyExists, FabricError, NotFound, PermissionDenied
+from fabric_dw.exceptions import (
+    AlreadyExistsError,
+    FabricError,
+    NotFoundError,
+    PermissionDeniedError,
+)
 from fabric_dw.models import SqlPool, SqlPoolClassifier
 from fabric_dw.services import sql_pools as _svc
 
 _log = logging.getLogger(__name__)
 
 
-def _permission_hint(exc: PermissionDenied) -> click.ClickException:
+def _permission_hint(exc: PermissionDeniedError) -> click.ClickException:
     return click.ClickException(f"{exc}  (Hint: the caller must have the workspace admin role.)")
 
 
@@ -55,7 +60,7 @@ async def get_cmd(ctx: CliContext, workspace: str | None) -> None:
                 config.model_dump(by_alias=True, mode="json"),
                 json_output=ctx.json_output,
             )
-    except PermissionDenied as exc:
+    except PermissionDeniedError as exc:
         raise _permission_hint(exc) from exc
     except FabricError as exc:
         raise click.ClickException(str(exc)) from exc
@@ -79,7 +84,7 @@ async def list_cmd(ctx: CliContext, workspace: str | None) -> None:
             config = await _svc.get_configuration(http, ws_id)
             pools = [p.model_dump(by_alias=True, mode="json") for p in config.custom_sql_pools]
             render(pools, json_output=ctx.json_output)
-    except PermissionDenied as exc:
+    except PermissionDeniedError as exc:
         raise _permission_hint(exc) from exc
     except FabricError as exc:
         raise click.ClickException(str(exc)) from exc
@@ -102,16 +107,14 @@ async def show_cmd(ctx: CliContext, workspace: str | None, name: str) -> None:
         async with build_http_client(ctx) as http:
             ws_id = await resolve_workspace_id(http, ws)
             config = await _svc.get_configuration(http, ws_id)
-            pool = next((p for p in config.custom_sql_pools if p.name == name), None)
-            if pool is None:
-                raise click.ClickException(f"pool {name!r} not found")  # noqa: TRY003, TRY301
-            render(pool.model_dump(by_alias=True, mode="json"), json_output=ctx.json_output)
-    except click.ClickException:
-        raise
-    except PermissionDenied as exc:
+    except PermissionDeniedError as exc:
         raise _permission_hint(exc) from exc
     except FabricError as exc:
         raise click.ClickException(str(exc)) from exc
+    pool = next((p for p in config.custom_sql_pools if p.name == name), None)
+    if pool is None:
+        raise click.ClickException(f"pool {name!r} not found")
+    render(pool.model_dump(by_alias=True, mode="json"), json_output=ctx.json_output)
 
 
 # ---------------------------------------------------------------------------
@@ -191,11 +194,11 @@ async def create_cmd(
             ws_id = await resolve_workspace_id(http, ws)
             result = await _svc.create_pool(http, ws_id, pool)
             render(result.model_dump(by_alias=True, mode="json"), json_output=ctx.json_output)
-    except AlreadyExists as exc:
+    except AlreadyExistsError as exc:
         raise click.ClickException(str(exc)) from exc
     except ValueError as exc:
-        raise click.ClickException(f"Invalid pool configuration: {exc}") from exc  # noqa: TRY003
-    except PermissionDenied as exc:
+        raise click.ClickException(f"Invalid pool configuration: {exc}") from exc
+    except PermissionDeniedError as exc:
         raise _permission_hint(exc) from exc
     except FabricError as exc:
         raise click.ClickException(str(exc)) from exc
@@ -272,11 +275,11 @@ async def update_cmd(
                 classifier_values=cv,
             )
             render(result.model_dump(by_alias=True, mode="json"), json_output=ctx.json_output)
-    except NotFound as exc:
+    except NotFoundError as exc:
         raise click.ClickException(str(exc)) from exc
     except ValueError as exc:
-        raise click.ClickException(f"Invalid pool configuration: {exc}") from exc  # noqa: TRY003
-    except PermissionDenied as exc:
+        raise click.ClickException(f"Invalid pool configuration: {exc}") from exc
+    except PermissionDeniedError as exc:
         raise _permission_hint(exc) from exc
     except FabricError as exc:
         raise click.ClickException(str(exc)) from exc
@@ -303,9 +306,9 @@ async def delete_cmd(ctx: CliContext, workspace: str | None, name: str) -> None:
             ws_id = await resolve_workspace_id(http, ws)
             result = await _svc.delete_pool(http, ws_id, name)
             render(result.model_dump(by_alias=True, mode="json"), json_output=ctx.json_output)
-    except NotFound as exc:
+    except NotFoundError as exc:
         raise click.ClickException(str(exc)) from exc
-    except PermissionDenied as exc:
+    except PermissionDeniedError as exc:
         raise _permission_hint(exc) from exc
     except FabricError as exc:
         raise click.ClickException(str(exc)) from exc
@@ -331,7 +334,7 @@ async def enable_cmd(ctx: CliContext, workspace: str | None) -> None:
                 result.model_dump(by_alias=True, mode="json"),
                 json_output=ctx.json_output,
             )
-    except PermissionDenied as exc:
+    except PermissionDeniedError as exc:
         raise _permission_hint(exc) from exc
     except FabricError as exc:
         raise click.ClickException(str(exc)) from exc
@@ -355,7 +358,7 @@ async def disable_cmd(ctx: CliContext, workspace: str | None) -> None:
                 result.model_dump(by_alias=True, mode="json"),
                 json_output=ctx.json_output,
             )
-    except PermissionDenied as exc:
+    except PermissionDeniedError as exc:
         raise _permission_hint(exc) from exc
     except FabricError as exc:
         raise click.ClickException(str(exc)) from exc
@@ -384,7 +387,7 @@ async def reset_cmd(ctx: CliContext, workspace: str | None) -> None:
                 click.echo("Workspace has no SQL pools configuration (never provisioned).")
             else:
                 render(result.model_dump(by_alias=True, mode="json"), json_output=ctx.json_output)
-    except PermissionDenied as exc:
+    except PermissionDeniedError as exc:
         raise _permission_hint(exc) from exc
     except FabricError as exc:
         raise click.ClickException(str(exc)) from exc

--- a/src/fabric_dw/cli/commands/tables.py
+++ b/src/fabric_dw/cli/commands/tables.py
@@ -88,8 +88,7 @@ async def read_cmd(
     output_path = Path(output) if output else None
 
     if fmt in (OutputFormat.CSV, OutputFormat.PARQUET) and output_path is None:
-        raise click.UsageError(f"--output PATH is required for {fmt!r} format.")  # noqa: TRY003
-
+        raise click.UsageError(f"--output PATH is required for {fmt!r} format.")
     try:
         async with build_http_client(ctx) as http:
             target, _entry = await build_sql_target(http, ws, wh)

--- a/src/fabric_dw/cli/commands/views.py
+++ b/src/fabric_dw/cli/commands/views.py
@@ -87,8 +87,7 @@ async def read_cmd(
     output_path = Path(output) if output else None
 
     if fmt in (OutputFormat.CSV, OutputFormat.PARQUET) and output_path is None:
-        raise click.UsageError(f"--output PATH is required for {fmt!r} format.")  # noqa: TRY003
-
+        raise click.UsageError(f"--output PATH is required for {fmt!r} format.")
     try:
         async with build_http_client(ctx) as http:
             target, _entry = await build_sql_target(http, ws, wh)

--- a/src/fabric_dw/cli/commands/warehouses.py
+++ b/src/fabric_dw/cli/commands/warehouses.py
@@ -208,23 +208,23 @@ async def takeover_cmd(ctx: CliContext, workspace: str | None, warehouse: str | 
     try:
         async with build_http_client(ctx) as http:
             ws_id, entry = await _resolve_item(http, ws, wh)
-            if entry.kind == WarehouseKind.SQL_ENDPOINT:
-                raise click.UsageError(  # noqa: TRY003, TRY301
-                    "takeover is not supported for SQL Analytics Endpoints"
-                )
-            confirmed = confirm(
-                f"Take over warehouse {entry.display_name!r} ({entry.id})?",
-                yes=ctx.yes,
-            )
-            if not confirmed:
-                click.echo("Aborted.")
-                return
-            await _ownership_svc.takeover(http, ws_id, entry.id)
-            click.echo(f"Ownership of warehouse {entry.display_name!r} ({entry.id}) taken.")
-    except click.UsageError:
-        raise
     except FabricError as exc:
         raise click.ClickException(str(exc)) from exc
+    if entry.kind == WarehouseKind.SQL_ENDPOINT:
+        raise click.UsageError("takeover is not supported for SQL Analytics Endpoints")
+    confirmed = confirm(
+        f"Take over warehouse {entry.display_name!r} ({entry.id})?",
+        yes=ctx.yes,
+    )
+    if not confirmed:
+        click.echo("Aborted.")
+        return
+    try:
+        async with build_http_client(ctx) as http:
+            await _ownership_svc.takeover(http, ws_id, entry.id)
+    except FabricError as exc:
+        raise click.ClickException(str(exc)) from exc
+    click.echo(f"Ownership of warehouse {entry.display_name!r} ({entry.id}) taken.")
 
 
 @warehouses_group.command("permissions")

--- a/src/fabric_dw/cli/commands/workspaces.py
+++ b/src/fabric_dw/cli/commands/workspaces.py
@@ -72,17 +72,19 @@ async def set_collation_cmd(ctx: CliContext, workspace: str | None, collation: s
     try:
         async with build_http_client(ctx) as http:
             ws_id = await resolve_workspace_id(http, ws)
-            confirmed = confirm(
-                f"Set collation to {collation!r} for workspace {ws_id}?",
-                yes=ctx.yes,
-            )
-            if not confirmed:
-                raise click.Abort()  # noqa: TRY301
+    except FabricError as exc:
+        raise click.ClickException(str(exc)) from exc
+    confirmed = confirm(
+        f"Set collation to {collation!r} for workspace {ws_id}?",
+        yes=ctx.yes,
+    )
+    if not confirmed:
+        raise click.Abort()
+    try:
+        async with build_http_client(ctx) as http:
             await _workspaces_svc.set_collation(http, ws_id, collation)
-            click.echo(f"Collation set to {collation!r}.")
-    except click.Abort:
-        raise
     except ValueError as exc:
         raise click.ClickException(str(exc)) from exc
     except FabricError as exc:
         raise click.ClickException(str(exc)) from exc
+    click.echo(f"Collation set to {collation!r}.")

--- a/src/fabric_dw/config.py
+++ b/src/fabric_dw/config.py
@@ -159,7 +159,7 @@ def set_default(key: str, value: str | None, path: Path | None = None) -> None:
     """
     allowed = {"workspace", "warehouse"}
     if key not in allowed:
-        raise ValueError(f"Unknown config key {key!r}; must be one of {sorted(allowed)}")  # noqa: TRY003
+        raise ValueError(f"Unknown config key {key!r}; must be one of {sorted(allowed)}")
     cfg = load_config(path)
     current = cfg.defaults
     new_defaults = Defaults(

--- a/src/fabric_dw/exceptions.py
+++ b/src/fabric_dw/exceptions.py
@@ -36,11 +36,11 @@ class AuthError(FabricError):
     """Raised on HTTP 401 - authentication token missing or invalid."""
 
 
-class PermissionDenied(FabricError):  # noqa: N818
+class PermissionDeniedError(FabricError):
     """Raised on HTTP 403 - caller lacks the required permission."""
 
 
-class NotFound(FabricError):  # noqa: N818
+class NotFoundError(FabricError):
     """Raised on HTTP 404 - requested resource does not exist."""
 
 
@@ -52,7 +52,7 @@ class FabricServerError(FabricError):
     """Raised on persistent 5xx errors or a failed LRO operation."""
 
 
-class AlreadyExists(FabricError):  # noqa: N818
+class AlreadyExistsError(FabricError):
     """Raised when a resource with the given name already exists."""
 
 
@@ -75,3 +75,9 @@ class ConfigError(FabricError):
 
 class ItemKindError(FabricError):
     """Raised when an operation is not valid for the resolved item kind."""
+
+
+# Deprecated aliases — remove after next release.
+PermissionDenied = PermissionDeniedError
+NotFound = NotFoundError
+AlreadyExists = AlreadyExistsError

--- a/src/fabric_dw/http_client.py
+++ b/src/fabric_dw/http_client.py
@@ -4,7 +4,7 @@ Provides:
 - Global rate-limiting via aiolimiter (default 2 RPS).
 - 429 Retry-After handling with a monotonic deadline (``_pause_until``).
 - 5xx retry with tenacity exponential back-off (max 3 attempts).
-- Standard error mapping (401 -> AuthError, 403 -> PermissionDenied, 404 -> NotFound).
+- Standard error mapping (401 -> AuthError, 403 -> PermissionDeniedError, 404 -> NotFoundError).
 - continuationUri pagination.
 - LRO (202 + Location) polling with jitter.
 
@@ -42,8 +42,8 @@ from fabric_dw.exceptions import (
     AuthError,
     FabricError,
     FabricServerError,
-    NotFound,
-    PermissionDenied,
+    NotFoundError,
+    PermissionDeniedError,
     RateLimitedError,
 )
 from fabric_dw.logging import redact_auth_header
@@ -66,8 +66,8 @@ _TOKEN_REFRESH_BUFFER: float = 300.0  # seconds before expiry to refresh
 # Status code → exception class mapping (4xx errors only; 5xx handled separately)
 _STATUS_TO_EXC: dict[int, type[FabricError]] = {
     http.HTTPStatus.UNAUTHORIZED: AuthError,
-    http.HTTPStatus.FORBIDDEN: PermissionDenied,
-    http.HTTPStatus.NOT_FOUND: NotFound,
+    http.HTTPStatus.FORBIDDEN: PermissionDeniedError,
+    http.HTTPStatus.NOT_FOUND: NotFoundError,
 }
 
 
@@ -208,8 +208,8 @@ class FabricHttpClient:
 
         Raises:
             AuthError: On 401.
-            PermissionDenied: On 403.
-            NotFound: On 404.
+            PermissionDeniedError: On 403.
+            NotFoundError: On 404.
             RateLimitedError: After exactly ``max_429_retries`` consecutive 429 responses.
             FabricServerError: On persistent 5xx errors.
         """
@@ -264,7 +264,7 @@ class FabricHttpClient:
             if resp.status_code == http.HTTPStatus.TOO_MANY_REQUESTS:
                 consecutive_429 += 1
                 if consecutive_429 >= self._max_429_retries:
-                    raise RateLimitedError(  # noqa: TRY003
+                    raise RateLimitedError(
                         f"Received 429 {consecutive_429} consecutive times for {url}",
                         status=429,
                         request_id=resp.headers.get("x-ms-request-id"),
@@ -371,7 +371,7 @@ class FabricHttpClient:
 
         exc_class = _STATUS_TO_EXC.get(status)
         if exc_class is not None:
-            raise exc_class(  # noqa: TRY003
+            raise exc_class(
                 f"HTTP {status} for {url}: {resp.text}",
                 status=status,
                 request_id=request_id,
@@ -379,7 +379,7 @@ class FabricHttpClient:
             )
 
         if status >= http.HTTPStatus.INTERNAL_SERVER_ERROR:
-            raise FabricServerError(  # noqa: TRY003
+            raise FabricServerError(
                 f"Server error {status} for {url}: {resp.text}",
                 status=status,
                 request_id=request_id,
@@ -447,7 +447,7 @@ class FabricHttpClient:
             The result body, e.g. ``{"id": "...", "type": "WarehouseSnapshot", ...}``.
 
         Raises:
-            NotFound: If the result is not available (404).
+            NotFoundError: If the result is not available (404).
             FabricServerError: On 5xx errors.
         """
         result_url = f"{HttpBase.FABRIC}/operations/{operation_id}/result"
@@ -477,9 +477,7 @@ class FabricHttpClient:
 
         while True:
             if _time.monotonic() >= deadline:
-                raise FabricServerError(  # noqa: TRY003
-                    f"LRO timed out after {timeout_s}s for {location}"
-                )
+                raise FabricServerError(f"LRO timed out after {timeout_s}s for {location}")
 
             resp = await self._request_with_retry("GET", location)
             body: dict[str, object] = resp.json()
@@ -488,9 +486,7 @@ class FabricHttpClient:
             if status == "Succeeded":
                 return body
             if status == "Failed":
-                raise FabricServerError(  # noqa: TRY003
-                    f"LRO failed for {location}: {body.get('error', body)}"
-                )
+                raise FabricServerError(f"LRO failed for {location}: {body.get('error', body)}")
 
             # Not finished yet - honour Retry-After or fall back to default, with jitter
             retry_after_raw = resp.headers.get("Retry-After")

--- a/src/fabric_dw/mcp/_context.py
+++ b/src/fabric_dw/mcp/_context.py
@@ -79,7 +79,7 @@ def get_context() -> ServerContext:
             or after shutdown).
     """
     if _SERVER_CTX is None:
-        raise RuntimeError(  # noqa: TRY003
+        raise RuntimeError(
             "ServerContext is not initialised — get_context() called outside the server lifespan"
         )
     return _SERVER_CTX
@@ -109,7 +109,7 @@ def build_context(environ: Mapping[str, str] | None = None) -> ServerContext:
     try:
         mode = _auth.CredentialMode(raw_mode)
     except ValueError as exc:
-        raise ConfigError(  # noqa: TRY003
+        raise ConfigError(
             f"invalid FABRIC_AUTH value {raw_mode!r}; "
             f"expected one of {[m.value for m in _auth.CredentialMode]}"
         ) from exc

--- a/src/fabric_dw/mcp/_guards.py
+++ b/src/fabric_dw/mcp/_guards.py
@@ -201,7 +201,7 @@ def assert_readonly_sql(statement: str) -> None:
 
     # Reject unbalanced block-comment delimiters left after stripping.
     if "/*" in sanitised or "*/" in sanitised:
-        raise ToolError(  # noqa: TRY003
+        raise ToolError(
             "read-only mode (FABRIC_MCP_READONLY) blocks statements with unbalanced block comments"
         )
 
@@ -209,15 +209,13 @@ def assert_readonly_sql(statement: str) -> None:
 
     # Reject multi-statement batches: a ';' followed by non-whitespace.
     if re.search(r";\s*\S", sanitised):
-        raise ToolError(  # noqa: TRY003
-            "read-only mode (FABRIC_MCP_READONLY) blocks multi-statement batches"
-        )
+        raise ToolError("read-only mode (FABRIC_MCP_READONLY) blocks multi-statement batches")
 
     tokens = _TOKEN_RE.findall(sanitised)
     first_token = tokens[0].upper() if tokens else ""
 
     if first_token not in _ALLOWED_FIRST_TOKENS:
-        raise ToolError(  # noqa: TRY003
+        raise ToolError(
             f"read-only mode (FABRIC_MCP_READONLY) blocks non-SELECT statements "
             f"(got {first_token!r})"
         )
@@ -225,7 +223,7 @@ def assert_readonly_sql(statement: str) -> None:
     # Scan every token for forbidden keywords.
     for tok in tokens:
         if tok.upper() in _FORBIDDEN_TOKENS:
-            raise ToolError(  # noqa: TRY003
+            raise ToolError(
                 f"read-only mode (FABRIC_MCP_READONLY) blocks statements containing "
                 f"forbidden keyword {tok.upper()!r}"
             )
@@ -311,6 +309,6 @@ def assert_workspace_allowed(workspace_arg: str, resolved_id: str | None = None)
         candidates.add(resolved_id.strip().lower())
 
     if candidates.isdisjoint(allowed):
-        raise ToolError(  # noqa: TRY003
+        raise ToolError(
             f"workspace {workspace_arg!r} is not in the FABRIC_MCP_WORKSPACES allowlist"
         )

--- a/src/fabric_dw/mcp/_helpers.py
+++ b/src/fabric_dw/mcp/_helpers.py
@@ -120,7 +120,7 @@ def require_warehouse(entry: _ItemEntry, item: str) -> None:
         ToolError: If the resolved item is a SQL Analytics Endpoint.
     """
     if entry.kind == WarehouseKind.SQL_ENDPOINT:
-        raise ToolError(f"{item!r}: {_SQL_ENDPOINT_DDL_ERROR}")  # noqa: TRY003
+        raise ToolError(f"{item!r}: {_SQL_ENDPOINT_DDL_ERROR}")
 
 
 def parse_qualified_name(qualified_name: str, kind: str = "object") -> tuple[str, str]:
@@ -140,9 +140,7 @@ def parse_qualified_name(qualified_name: str, kind: str = "object") -> tuple[str
     """
     schema, _, name = qualified_name.partition(".")
     if not schema or not name:
-        raise ToolError(  # noqa: TRY003
-            f"qualified_name must be <schema>.<{kind}>, got {qualified_name!r}"
-        )
+        raise ToolError(f"qualified_name must be <schema>.<{kind}>, got {qualified_name!r}")
     return schema, name
 
 
@@ -166,9 +164,7 @@ def make_sql_target(ws_id: UUID, entry: _ItemEntry, item: str) -> SqlTarget:
         ToolError: When *entry* has no connection string.
     """
     if entry.connection_string is None:
-        raise ToolError(  # noqa: TRY003
-            f"item {item!r} has no connection string; cannot execute SQL"
-        )
+        raise ToolError(f"item {item!r} has no connection string; cannot execute SQL")
     return SqlTarget(
         workspace_id=str(ws_id),
         database=entry.display_name,
@@ -184,7 +180,7 @@ async def resolve_item(resolver: Resolver, workspace: str, item: str) -> tuple[U
     throughout the tool handlers::
 
         ws_id = await resolver.workspace_id(workspace)  # lookup 1
-        entry = await resolver.item(workspace, item)     # lookup 2 (internal)
+        entry = await resolver.item(workspace, item)  # lookup 2 (internal)
 
     By calling ``workspace_id`` once and exposing the result alongside the
     entry, callers can pass ``ws_id`` to ``assert_workspace_allowed`` and

--- a/src/fabric_dw/mcp/tools/query_insights.py
+++ b/src/fabric_dw/mcp/tools/query_insights.py
@@ -28,9 +28,7 @@ def _parse_dt(value: str | None, param: str) -> datetime | None:
     try:
         return datetime.fromisoformat(value)
     except ValueError as exc:
-        raise ToolError(  # noqa: TRY003
-            f"invalid {param} {value!r}: expected ISO-8601"
-        ) from exc
+        raise ToolError(f"invalid {param} {value!r}: expected ISO-8601") from exc
 
 
 def register(mcp: FastMCP) -> None:  # noqa: PLR0915

--- a/src/fabric_dw/mcp/tools/snapshots.py
+++ b/src/fabric_dw/mcp/tools/snapshots.py
@@ -65,9 +65,7 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             try:
                 parsed_dt = datetime.fromisoformat(snapshot_dt)
             except ValueError as exc:
-                raise ToolError(  # noqa: TRY003
-                    f"invalid snapshot_dt {snapshot_dt!r}: expected ISO-8601"
-                ) from exc
+                raise ToolError(f"invalid snapshot_dt {snapshot_dt!r}: expected ISO-8601") from exc
         ctx = get_context()
         try:
             ws_id, item = await resolve_item(ctx.resolver, workspace, warehouse)
@@ -151,9 +149,7 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             try:
                 parsed_dt = datetime.fromisoformat(new_dt)
             except ValueError as exc:
-                raise ToolError(  # noqa: TRY003
-                    f"invalid new_dt {new_dt!r}: expected ISO-8601"
-                ) from exc
+                raise ToolError(f"invalid new_dt {new_dt!r}: expected ISO-8601") from exc
         ctx = get_context()
         try:
             ws_id, item = await resolve_item(ctx.resolver, workspace, warehouse)

--- a/src/fabric_dw/mcp/tools/sql_endpoints.py
+++ b/src/fabric_dw/mcp/tools/sql_endpoints.py
@@ -36,7 +36,7 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         """
         _workspaces_allowlist = os.environ.get("FABRIC_MCP_WORKSPACES", "").strip()
         if all_workspaces and _workspaces_allowlist:
-            raise ToolError(  # noqa: TRY003
+            raise ToolError(
                 "all_workspaces=True is not permitted when FABRIC_MCP_WORKSPACES is configured; "
                 "specify an individual workspace instead"
             )

--- a/src/fabric_dw/mcp/tools/sql_pools.py
+++ b/src/fabric_dw/mcp/tools/sql_pools.py
@@ -9,7 +9,7 @@ from mcp.server.fastmcp import FastMCP
 from mcp.server.fastmcp.exceptions import ToolError
 from pydantic import Field
 
-from fabric_dw.exceptions import AlreadyExists, FabricError, NotFound
+from fabric_dw.exceptions import AlreadyExistsError, FabricError, NotFoundError
 from fabric_dw.mcp._context import get_context
 from fabric_dw.mcp._guards import (
     assert_destructive_allowed,
@@ -84,7 +84,7 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             raise fabric_err(exc) from exc
         pool = next((p for p in config.custom_sql_pools if p.name == pool_name), None)
         if pool is None:
-            raise ToolError(f"pool {pool_name!r} not found")  # noqa: TRY003
+            raise ToolError(f"pool {pool_name!r} not found")
         return pool.model_dump(by_alias=True, mode="json")
 
     @mcp.tool(name="create_sql_pool")
@@ -131,7 +131,7 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
                 }
             )
         except Exception as exc:
-            raise ToolError(f"Invalid pool: {exc}") from exc  # noqa: TRY003
+            raise ToolError(f"Invalid pool: {exc}") from exc
 
         ctx = get_context()
         try:
@@ -139,13 +139,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             assert_workspace_allowed(workspace, str(ws_id))
             _log.debug("create_sql_pool ws=%s name=%r max_percent=%d", ws_id, name, max_percent)
             result = await sql_pools_svc.create_pool(ctx.http, ws_id, pool)
-        except AlreadyExists as exc:
+        except AlreadyExistsError as exc:
             raise ToolError(str(exc)) from exc
         except FabricError as exc:
             raise fabric_err(exc) from exc
         created = next((p for p in result.custom_sql_pools if p.name == name), None)
         if created is None:
-            raise ToolError(  # noqa: TRY003
+            raise ToolError(
                 f"pool {name!r} was not found in the API response after creation; "
                 "the pool may have been created but is not yet visible (eventual consistency)"
             )
@@ -192,13 +192,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
                 classifier_type=classifier_type,
                 classifier_values=classifier_values,
             )
-        except NotFound as exc:
+        except NotFoundError as exc:
             raise ToolError(str(exc)) from exc
         except FabricError as exc:
             raise fabric_err(exc) from exc
         updated = next((p for p in result.custom_sql_pools if p.name == name), None)
         if updated is None:
-            raise ToolError(  # noqa: TRY003
+            raise ToolError(
                 f"pool {name!r} was not found in the API response after update; "
                 "the pool may have been updated but is not yet visible (eventual consistency)"
             )
@@ -223,7 +223,7 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             assert_workspace_allowed(workspace, str(ws_id))
             _log.debug("delete_sql_pool ws=%s pool=%r", ws_id, pool_name)
             await sql_pools_svc.delete_pool(ctx.http, ws_id, pool_name)
-        except NotFound as exc:
+        except NotFoundError as exc:
             raise ToolError(str(exc)) from exc
         except FabricError as exc:
             raise fabric_err(exc) from exc

--- a/src/fabric_dw/mcp/tools/warehouses.py
+++ b/src/fabric_dw/mcp/tools/warehouses.py
@@ -41,7 +41,7 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         """
         _workspaces_allowlist = os.environ.get("FABRIC_MCP_WORKSPACES", "").strip()
         if all_workspaces and _workspaces_allowlist:
-            raise ToolError(  # noqa: TRY003
+            raise ToolError(
                 "all_workspaces=True is not permitted when FABRIC_MCP_WORKSPACES is configured; "
                 "specify an individual workspace instead"
             )

--- a/src/fabric_dw/models.py
+++ b/src/fabric_dw/models.py
@@ -465,7 +465,8 @@ class SqlPoolsConfiguration(_FabricBase):
             return
 
         total = sum(p.max_resource_percentage for p in pools)
-        if total > 100:  # noqa: PLR2004
+        max_resource_percentage = 100
+        if total > max_resource_percentage:
             msg = (
                 f"Sum of maxResourcePercentage across all SQL pools is {total}, which exceeds 100."
             )

--- a/src/fabric_dw/resolver.py
+++ b/src/fabric_dw/resolver.py
@@ -19,7 +19,7 @@ from typing import Any, NamedTuple
 from uuid import UUID
 
 from fabric_dw.cache import ItemEntry, LookupCache
-from fabric_dw.exceptions import FabricError, NotFound
+from fabric_dw.exceptions import FabricError, NotFoundError
 from fabric_dw.http_client import FabricHttpClient, HttpBase
 from fabric_dw.models import WarehouseKind
 
@@ -118,9 +118,9 @@ class Resolver:
 
     In addition to the persistent filesystem cache (``LookupCache``), each
     ``Resolver`` instance keeps an **in-memory** negative cache.  When a
-    workspace or item lookup raises ``NotFound``, the failed key is recorded
+    workspace or item lookup raises ``NotFoundError``, the failed key is recorded
     with a monotonic timestamp; subsequent lookups within ``_NEGATIVE_TTL``
-    seconds re-raise ``NotFound`` without hitting the API.
+    seconds re-raise ``NotFoundError`` without hitting the API.
 
     The negative cache is intentionally *not* persisted.  "Not found" is a
     transient condition (the resource may be created moments later), and
@@ -137,12 +137,12 @@ class Resolver:
         self._negative: dict[tuple[str, str], float] = {}
 
     def _negative_check(self, scope: str, key: str) -> None:
-        """Raise NotFound immediately if *key* is in the negative cache and still fresh."""
+        """Raise NotFoundError immediately if *key* is in the negative cache and still fresh."""
         ts = self._negative.get((scope, key))
         if ts is not None:
             age = time.monotonic() - ts
             if age < _NEGATIVE_TTL:
-                raise NotFound(f"{scope}/{key!r} not found")  # noqa: TRY003
+                raise NotFoundError(f"{scope}/{key!r} not found")
             # Entry has expired; prune it now to keep the dict bounded.
             del self._negative[(scope, key)]
 
@@ -184,7 +184,7 @@ class Resolver:
             The workspace UUID.
 
         Raises:
-            NotFound: If no workspace matches *value*.
+            NotFoundError: If no workspace matches *value*.
             FabricError: If *value* matches more than one workspace.
         """
         value = value.strip()
@@ -213,13 +213,11 @@ class Resolver:
 
         if not results:
             self._negative_record("workspace", value.lower())
-            raise NotFound(f"workspace {value!r} not found")  # noqa: TRY003
+            raise NotFoundError(f"workspace {value!r} not found")
 
         if len(results) > 1:
             ids = ", ".join(str(r.get("id", "?")) for r in results)
-            raise FabricError(  # noqa: TRY003
-                f"workspace name {value!r} is ambiguous: ids = {ids}"
-            )
+            raise FabricError(f"workspace name {value!r} is ambiguous: ids = {ids}")
 
         ws_id = UUID(str(results[0]["id"]))
         self._cache.put_workspace(value, ws_id)
@@ -246,7 +244,7 @@ class Resolver:
             The resolved ItemEntry with ``connection_string`` populated.
 
         Raises:
-            NotFound: If the item is not found in the workspace.
+            NotFoundError: If the item is not found in the workspace.
         """
         value = value.strip()
         ws_id = await self.workspace_id(workspace)
@@ -261,7 +259,7 @@ class Resolver:
             self._negative_check(ws_key, value.lower())
             try:
                 result = await self._fetch_item_detail(ws_id, item_uuid)
-            except NotFound:
+            except NotFoundError:
                 self._negative_record(ws_key, value.lower())
                 raise
             self._negative_clear(ws_key, value.lower())
@@ -296,14 +294,14 @@ class Resolver:
             item_id = UUID(str(raw_item["id"]))
             try:
                 result = await self._fetch_item_detail(ws_id, item_id)
-            except NotFound:
+            except NotFoundError:
                 self._negative_record(ws_key, value.lower())
                 raise
             self._negative_clear(ws_key, value.lower())
             return result
 
         self._negative_record(ws_key, value.lower())
-        raise NotFound(f"item {value!r} not found in workspace {ws_id}")  # noqa: TRY003
+        raise NotFoundError(f"item {value!r} not found in workspace {ws_id}")
 
     async def _fetch_item_detail(self, workspace_id: UUID, item_id: UUID) -> ItemEntry:
         """Fetch a single item's full detail, build ItemEntry, cache and return it.
@@ -327,7 +325,7 @@ class Resolver:
         item_type = str(generic_payload.get("type", ""))
 
         if item_type not in _ITEM_TYPE_INFO:
-            raise FabricError(  # noqa: TRY003
+            raise FabricError(
                 f"item {item_id} has unsupported type {item_type!r}; "
                 "expected Warehouse, SQLEndpoint or WarehouseSnapshot"
             )

--- a/src/fabric_dw/services/audit.py
+++ b/src/fabric_dw/services/audit.py
@@ -52,8 +52,8 @@ async def get_settings(
         The current :class:`~fabric_dw.models.AuditSettings`.
 
     Raises:
-        PermissionDenied: If the caller lacks the required permission (HTTP 403).
-        NotFound: If the warehouse does not exist (HTTP 404).
+        PermissionDeniedError: If the caller lacks the required permission (HTTP 403).
+        NotFoundError: If the warehouse does not exist (HTTP 404).
     """
     path = _audit_path(workspace_id, warehouse_id)
     resp = await http.request("GET", HttpBase.FABRIC, path)
@@ -81,7 +81,7 @@ async def enable(
 
     Raises:
         ValueError: If *retention_days* is negative.
-        PermissionDenied: If the caller lacks the required permission (HTTP 403).
+        PermissionDeniedError: If the caller lacks the required permission (HTTP 403).
     """
     if retention_days < 0:
         msg = f"retention_days must be >= 0; got {retention_days}"
@@ -114,7 +114,7 @@ async def disable(
         The fresh :class:`~fabric_dw.models.AuditSettings` after the update.
 
     Raises:
-        PermissionDenied: If the caller lacks the required permission (HTTP 403).
+        PermissionDeniedError: If the caller lacks the required permission (HTTP 403).
     """
     path = _audit_path(workspace_id, warehouse_id)
     await http.request("PATCH", HttpBase.FABRIC, path, json={"state": "Disabled"})
@@ -150,7 +150,7 @@ async def set_retention(
 
     Raises:
         ValueError: If *days* is less than 1.
-        PermissionDenied: If the caller lacks the required permission (HTTP 403).
+        PermissionDeniedError: If the caller lacks the required permission (HTTP 403).
     """
     if days < 1:
         msg = f"days must be >= 1; got {days}"
@@ -192,7 +192,7 @@ async def set_action_groups(
 
     Raises:
         ValueError: If any name in *action_groups* does not match ``^[A-Z0-9_]+$``.
-        PermissionDenied: If the caller lacks the required permission (HTTP 403).
+        PermissionDeniedError: If the caller lacks the required permission (HTTP 403).
     """
     for name in action_groups:
         if not _ACTION_GROUP_RE.match(name):
@@ -261,8 +261,8 @@ async def add_action_group(
         ValueError: If *group* does not match ``^[A-Z0-9_]+$``.
         ValueError: If auditing is currently disabled (``state == "Disabled"``).
             Enable auditing first with :func:`enable`.
-        PermissionDenied: If the caller lacks the required permission (HTTP 403).
-        NotFound: If the warehouse does not exist (HTTP 404).
+        PermissionDeniedError: If the caller lacks the required permission (HTTP 403).
+        NotFoundError: If the warehouse does not exist (HTTP 404).
     """
     if not _ACTION_GROUP_RE.match(group):
         msg = (
@@ -331,8 +331,8 @@ async def remove_action_group(
         ValueError: If *group* does not match ``^[A-Z0-9_]+$``.
         ValueError: If auditing is currently disabled (``state == "Disabled"``).
             Enable auditing first with :func:`enable`.
-        PermissionDenied: If the caller lacks the required permission (HTTP 403).
-        NotFound: If the warehouse does not exist (HTTP 404).
+        PermissionDeniedError: If the caller lacks the required permission (HTTP 403).
+        NotFoundError: If the warehouse does not exist (HTTP 404).
     """
     if not _ACTION_GROUP_RE.match(group):
         msg = (

--- a/src/fabric_dw/services/ownership.py
+++ b/src/fabric_dw/services/ownership.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from uuid import UUID
 
-from fabric_dw.exceptions import PermissionDenied
+from fabric_dw.exceptions import PermissionDeniedError
 from fabric_dw.http_client import FabricHttpClient, HttpBase
 
 __all__ = ["takeover"]
@@ -25,16 +25,16 @@ async def takeover(http: FabricHttpClient, workspace_id: UUID, warehouse_id: UUI
         warehouse_id: The GUID of the Warehouse item to take over.
 
     Raises:
-        PermissionDenied: If the caller does not have Admin/Member/Contributor
+        PermissionDeniedError: If the caller does not have Admin/Member/Contributor
             role on the workspace (HTTP 403).
-        NotFound: If the workspace or warehouse does not exist (HTTP 404).
+        NotFoundError: If the workspace or warehouse does not exist (HTTP 404).
     """
     # TODO: CLI/MCP layer should refuse SQLEndpoint kind before calling this.
     path = f"/groups/{workspace_id}/datawarehouses/{warehouse_id}/takeover"
 
     try:
         await http.request("POST", HttpBase.POWERBI, path, json=None)
-    except PermissionDenied as exc:
-        raise PermissionDenied(  # noqa: TRY003
+    except PermissionDeniedError as exc:
+        raise PermissionDeniedError(
             "takeover requires Admin/Member/Contributor role on the workspace"
         ) from exc

--- a/src/fabric_dw/services/permissions.py
+++ b/src/fabric_dw/services/permissions.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 from uuid import UUID
 
-from fabric_dw.exceptions import PermissionDenied
+from fabric_dw.exceptions import PermissionDeniedError
 from fabric_dw.http_client import FabricHttpClient, HttpBase
 from fabric_dw.models import ItemAccess
 
@@ -51,8 +51,8 @@ async def list_item_access(
         A list of :class:`~fabric_dw.models.ItemAccess` objects, one per principal.
 
     Raises:
-        PermissionDenied: If the caller is not a Fabric Administrator (HTTP 403).
-        NotFound: If the workspace or item does not exist (HTTP 404).
+        PermissionDeniedError: If the caller is not a Fabric Administrator (HTTP 403).
+        NotFoundError: If the workspace or item does not exist (HTTP 404).
     """
     # The optional ?type= query param is intentionally omitted: Warehouse and
     # SQLEndpoint items do not filter by type, and omitting it returns all principals.
@@ -63,5 +63,5 @@ async def list_item_access(
             ItemAccess.from_api(raw)
             async for raw in http.iter_paginated(HttpBase.FABRIC, path, key=_ACCESS_DETAILS_KEY)
         ]
-    except PermissionDenied as exc:
-        raise PermissionDenied(_ADMIN_HINT) from exc
+    except PermissionDeniedError as exc:
+        raise PermissionDeniedError(_ADMIN_HINT) from exc

--- a/src/fabric_dw/services/queries.py
+++ b/src/fabric_dw/services/queries.py
@@ -14,7 +14,7 @@ from contextlib import closing
 
 from fabric_dw import sql
 from fabric_dw.auth import CredentialMode
-from fabric_dw.exceptions import AuthError, PermissionDenied
+from fabric_dw.exceptions import AuthError, PermissionDeniedError
 from fabric_dw.models import Connection, RunningQuery
 from fabric_dw.sql import SqlTarget, run_query
 
@@ -113,7 +113,7 @@ async def list_connections(
         instances, one per result row.
 
     Raises:
-        PermissionDenied: If the caller lacks VIEW SERVER STATE.
+        PermissionDeniedError: If the caller lacks VIEW SERVER STATE.
     """
 
     def _run() -> list[Connection]:
@@ -138,7 +138,7 @@ async def kill(
 
     Raises:
         ValueError: If *session_id* is not a positive integer (i.e. <= 0).
-        PermissionDenied: If the driver raises a permission or auth error
+        PermissionDeniedError: If the driver raises a permission or auth error
             (KILL requires Monitor or Admin permission on Fabric DW).
     """
     if session_id <= 0:
@@ -160,13 +160,13 @@ async def kill(
                 mapped = sql.map_driver_error(exc)
                 if mapped:
                     msg = f"Permission denied when trying to KILL session {session_id}: {mapped}"
-                    raise PermissionDenied(
+                    raise PermissionDeniedError(
                         msg,
                         hint="KILL requires Monitor or Admin permission on Fabric DW.",
                     ) from exc
-                if isinstance(exc, (PermissionDenied, AuthError)):
+                if isinstance(exc, (PermissionDeniedError, AuthError)):
                     msg = f"Permission denied when trying to KILL session {session_id}: {exc}"
-                    raise PermissionDenied(msg) from exc
+                    raise PermissionDeniedError(msg) from exc
                 raise
 
     await asyncio.to_thread(_run)

--- a/src/fabric_dw/services/query_insights.py
+++ b/src/fabric_dw/services/query_insights.py
@@ -11,7 +11,7 @@ Public API
 All functions accept an optional *limit* (default 100, cap 10 000) and
 ISO-8601 *since* / *until* window where the view has a datetime column to
 filter on.  A 403 driver error is surfaced as
-:class:`~fabric_dw.exceptions.PermissionDenied` with a documentation link.
+:class:`~fabric_dw.exceptions.PermissionDeniedError` with a documentation link.
 """
 
 from __future__ import annotations
@@ -21,7 +21,7 @@ from datetime import datetime
 from typing import Any
 
 from fabric_dw.auth import CredentialMode
-from fabric_dw.exceptions import PermissionDenied
+from fabric_dw.exceptions import PermissionDeniedError
 from fabric_dw.models import (
     ExecRequestHistory,
     ExecSessionHistory,
@@ -193,8 +193,8 @@ def _execute_sql(
     """Execute *sql_text* synchronously and return rows as list of dicts."""
     try:
         cols, rows = run_query(target, sql_text, mode=mode)
-    except PermissionDenied as exc:
-        raise PermissionDenied(str(exc), hint=_PERMISSION_DENIED_DOCS) from exc
+    except PermissionDeniedError as exc:
+        raise PermissionDeniedError(str(exc), hint=_PERMISSION_DENIED_DOCS) from exc
     return [dict(zip(cols, r, strict=True)) for r in rows]
 
 
@@ -257,7 +257,7 @@ async def list_request_history(
         ordered by ``submit_time`` descending.
 
     Raises:
-        PermissionDenied: If the caller lacks Contributor or above permission.
+        PermissionDeniedError: If the caller lacks Contributor or above permission.
     """
     clamped = _clamp_limit(limit)
     where_fragment = _build_where(since=since, until=until, column="submit_time")
@@ -334,7 +334,7 @@ async def list_session_history(
         ordered by ``session_start_time`` descending.
 
     Raises:
-        PermissionDenied: If the caller lacks Contributor or above permission.
+        PermissionDeniedError: If the caller lacks Contributor or above permission.
     """
     clamped = _clamp_limit(limit)
     where_fragment = _build_where(since=since, until=until, column="session_start_time")
@@ -389,7 +389,7 @@ async def list_frequent_queries(
         ordered by ``number_of_runs`` descending.
 
     Raises:
-        PermissionDenied: If the caller lacks Contributor or above permission.
+        PermissionDeniedError: If the caller lacks Contributor or above permission.
     """
     clamped = _clamp_limit(limit)
     where_fragment = _build_where(since=since, until=until, column="last_run_start_time")
@@ -439,7 +439,7 @@ async def list_long_running_queries(
         ordered by ``median_total_elapsed_time_ms`` descending.
 
     Raises:
-        PermissionDenied: If the caller lacks Contributor or above permission.
+        PermissionDeniedError: If the caller lacks Contributor or above permission.
     """
     clamped = _clamp_limit(limit)
     where_fragment = _build_where(since=since, until=until, column="last_run_start_time")
@@ -488,7 +488,7 @@ async def list_sql_pool_insights(
         ordered by ``timestamp`` descending.
 
     Raises:
-        PermissionDenied: If the caller lacks Contributor or above permission.
+        PermissionDeniedError: If the caller lacks Contributor or above permission.
     """
     clamped = _clamp_limit(limit)
     where_fragment = _build_where(since=since, until=until, column="timestamp")

--- a/src/fabric_dw/services/restore.py
+++ b/src/fabric_dw/services/restore.py
@@ -76,8 +76,8 @@ async def get_point(
         The :class:`~fabric_dw.models.RestorePoint`.
 
     Raises:
-        NotFound: If the restore point does not exist.
-        PermissionDenied: If the caller has insufficient permissions.
+        NotFoundError: If the restore point does not exist.
+        PermissionDeniedError: If the caller has insufficient permissions.
     """
     resp = await http.request(
         "GET",
@@ -186,8 +186,8 @@ async def update_point(
 
     Raises:
         ValueError: If neither *name* nor *description* is supplied.
-        NotFound: If the restore point does not exist.
-        PermissionDenied: If the caller has insufficient permissions.
+        NotFoundError: If the restore point does not exist.
+        PermissionDeniedError: If the caller has insufficient permissions.
     """
     if name is None and description is None:
         msg = "At least one of name or description must be provided"
@@ -224,8 +224,8 @@ async def delete_point(
         point_id: The restore point ID string.
 
     Raises:
-        NotFound: If the restore point does not exist.
-        PermissionDenied: If the caller has insufficient permissions.
+        NotFoundError: If the restore point does not exist.
+        PermissionDeniedError: If the caller has insufficient permissions.
     """
     await http.request(
         "DELETE",
@@ -253,8 +253,8 @@ async def restore_in_place(
         point_id: The restore point ID string.
 
     Raises:
-        NotFound: If the restore point does not exist.
-        PermissionDenied: If the caller has insufficient permissions.
+        NotFoundError: If the restore point does not exist.
+        PermissionDeniedError: If the caller has insufficient permissions.
         FabricServerError: If the LRO fails or times out.
     """
     resp = await http.request(

--- a/src/fabric_dw/services/schemas.py
+++ b/src/fabric_dw/services/schemas.py
@@ -35,7 +35,7 @@ from __future__ import annotations
 import asyncio
 
 from fabric_dw.auth import CredentialMode
-from fabric_dw.exceptions import NotFound
+from fabric_dw.exceptions import NotFoundError
 from fabric_dw.identifiers import quote_identifier, validate_identifier
 from fabric_dw.models import Schema
 from fabric_dw.sql import SqlTarget, run_query, run_statements
@@ -146,7 +146,7 @@ async def list_schemas(
         A (possibly empty) list of :class:`~fabric_dw.models.Schema` instances.
 
     Raises:
-        PermissionDenied: If the driver reports a permission error.
+        PermissionDeniedError: If the driver reports a permission error.
         AuthError: If the driver reports an authentication failure.
     """
 
@@ -181,7 +181,7 @@ async def create_schema(
 
     Raises:
         ValueError: If *name* fails identifier validation.
-        PermissionDenied: If the driver reports a CREATE SCHEMA permission error.
+        PermissionDeniedError: If the driver reports a CREATE SCHEMA permission error.
     """
     validate_identifier(name)
     ddl = f"CREATE SCHEMA {quote_identifier(name)}"
@@ -222,7 +222,7 @@ async def delete_schema(
 
     Raises:
         ValueError: If *name* fails identifier validation.
-        PermissionDenied: If the driver reports a DROP SCHEMA permission error.
+        PermissionDeniedError: If the driver reports a DROP SCHEMA permission error.
     """
     validate_identifier(name)
 
@@ -260,7 +260,7 @@ async def _fetch_schema(
 
     Raises:
         ValueError: If *name* fails identifier validation (belt-and-suspenders).
-        NotFound: If the schema is not found after creation.
+        NotFoundError: If the schema is not found after creation.
     """
     # Belt-and-suspenders: validate even though callers should have validated already.
     validate_identifier(name)
@@ -274,7 +274,7 @@ async def _fetch_schema(
         )
         if not rows:
             msg = f"Schema [{name}] not found after creation"
-            raise NotFound(msg)
+            raise NotFoundError(msg)
         return _row_to_schema(cols, rows[0])
 
     return await asyncio.to_thread(_run)

--- a/src/fabric_dw/services/snapshots.py
+++ b/src/fabric_dw/services/snapshots.py
@@ -286,7 +286,7 @@ async def delete(
         name: The display name of the snapshot; used to evict the name-keyed entry.
 
     Raises:
-        NotFound: If the snapshot does not exist (HTTP 404).
+        NotFoundError: If the snapshot does not exist (HTTP 404).
     """
     await http.request(
         "DELETE",
@@ -324,7 +324,7 @@ async def roll_timestamp(
 
     Raises:
         ValueError: If *snapshot_name* contains any forbidden character.
-        PermissionDenied: If the driver reports a permission failure.
+        PermissionDeniedError: If the driver reports a permission failure.
     """
     _validate_snapshot_name(snapshot_name, param="snapshot_name")
 

--- a/src/fabric_dw/services/sql_endpoints.py
+++ b/src/fabric_dw/services/sql_endpoints.py
@@ -6,7 +6,7 @@ import logging
 from typing import Any
 from uuid import UUID
 
-from fabric_dw.exceptions import NotFound, PermissionDenied
+from fabric_dw.exceptions import NotFoundError, PermissionDeniedError
 from fabric_dw.http_client import FabricHttpClient, HttpBase
 from fabric_dw.models import TableSyncStatus, Warehouse, WarehouseKind
 from fabric_dw.services._concurrency import bounded_gather
@@ -51,8 +51,8 @@ async def list_all_workspaces(http: FabricHttpClient) -> list[Warehouse]:
     Iterates all workspaces returned by :func:`~fabric_dw.services.workspaces.list_all`
     and aggregates their SQL analytics endpoints using bounded concurrency (up to
     8 workspaces in parallel).  Workspaces that raise
-    :class:`~fabric_dw.exceptions.PermissionDenied` or
-    :class:`~fabric_dw.exceptions.NotFound` are skipped with a per-workspace
+    :class:`~fabric_dw.exceptions.PermissionDeniedError` or
+    :class:`~fabric_dw.exceptions.NotFoundError` are skipped with a per-workspace
     warning; a summary warning is logged after the scan.
 
     Args:
@@ -73,7 +73,7 @@ async def list_all_workspaces(http: FabricHttpClient) -> list[Warehouse]:
     out: list[Warehouse] = []
     skipped = 0
     for ws, result in zip(workspaces, raw, strict=True):
-        if isinstance(result, (PermissionDenied, NotFound)):
+        if isinstance(result, (PermissionDeniedError, NotFoundError)):
             _log.warning("skipping workspace %s: %s", ws.name, result)
             skipped += 1
         elif isinstance(result, BaseException):
@@ -102,7 +102,7 @@ async def get_endpoint(http: FabricHttpClient, workspace_id: UUID, endpoint_id: 
         ``kind == WarehouseKind.SQL_ENDPOINT``.
 
     Raises:
-        NotFound: If the endpoint does not exist (404).
+        NotFoundError: If the endpoint does not exist (404).
     """
     resp = await http.request(
         "GET",
@@ -140,7 +140,7 @@ async def refresh_metadata(
 
     Raises:
         FabricServerError: If the LRO fails or times out.
-        NotFound: If the endpoint does not exist (404).
+        NotFoundError: If the endpoint does not exist (404).
     """
     json_body: dict[str, Any] | None = {"recreateTables": True} if recreate_tables else None
 

--- a/src/fabric_dw/services/sql_exec.py
+++ b/src/fabric_dw/services/sql_exec.py
@@ -15,7 +15,7 @@ from decimal import Decimal
 
 from fabric_dw import sql
 from fabric_dw.auth import CredentialMode
-from fabric_dw.exceptions import PermissionDenied
+from fabric_dw.exceptions import PermissionDeniedError
 from fabric_dw.models import SqlResult
 from fabric_dw.sql import SqlTarget
 
@@ -159,7 +159,7 @@ async def execute(
     Raises:
         AuthError: If the driver raises an authentication failure (expired or
             missing token).
-        PermissionDenied: If the driver raises a SQL permission-denial error.
+        PermissionDeniedError: If the driver raises a SQL permission-denial error.
             The exception message contains a hint pointing to the
             documentation for the required permissions.
         Exception: Any other driver error is propagated unchanged.
@@ -174,8 +174,8 @@ async def execute(
                 except Exception as exc:
                     mapped = sql.map_driver_error(exc)
                     if mapped is not None:
-                        if isinstance(mapped, PermissionDenied):
-                            raise PermissionDenied(
+                        if isinstance(mapped, PermissionDeniedError):
+                            raise PermissionDeniedError(
                                 str(mapped),
                                 hint=(
                                     "The caller must have at least READ permission on the "

--- a/src/fabric_dw/services/sql_pools.py
+++ b/src/fabric_dw/services/sql_pools.py
@@ -25,7 +25,7 @@ import types
 from collections.abc import Mapping
 from uuid import UUID
 
-from fabric_dw.exceptions import AlreadyExists, NotFound
+from fabric_dw.exceptions import AlreadyExistsError, NotFoundError
 from fabric_dw.http_client import FabricHttpClient, HttpBase
 from fabric_dw.models import SqlPool, SqlPoolsConfiguration
 
@@ -64,7 +64,7 @@ async def get_configuration(
         The current :class:`~fabric_dw.models.SqlPoolsConfiguration`.
 
     Raises:
-        PermissionDenied: If the caller does not have the workspace admin role
+        PermissionDeniedError: If the caller does not have the workspace admin role
             (HTTP 403).
     """
     resp = await http.request(
@@ -103,7 +103,7 @@ async def update_configuration(
         via a follow-up GET after the PATCH.
 
     Raises:
-        PermissionDenied: If the caller does not have the workspace admin role
+        PermissionDeniedError: If the caller does not have the workspace admin role
             (HTTP 403).
         ValueError: If ``config`` violates client-side constraints (sum > 100,
             multiple defaults, etc.).
@@ -143,7 +143,7 @@ async def enable(
         The updated :class:`~fabric_dw.models.SqlPoolsConfiguration`.
 
     Raises:
-        PermissionDenied: If the caller does not have the workspace admin role
+        PermissionDeniedError: If the caller does not have the workspace admin role
             (HTTP 403).
     """
     current = await get_configuration(http, workspace_id)
@@ -184,7 +184,7 @@ async def disable(
         The updated :class:`~fabric_dw.models.SqlPoolsConfiguration`.
 
     Raises:
-        PermissionDenied: If the caller does not have the workspace admin role
+        PermissionDeniedError: If the caller does not have the workspace admin role
             (HTTP 403).
     """
     current = await get_configuration(http, workspace_id)
@@ -208,7 +208,7 @@ async def create_pool(
     """Add a new pool to the workspace SQL Pools configuration.
 
     Fetches the current pool list, appends the new pool, and PATCHes the full
-    list back.  Raises :class:`~fabric_dw.exceptions.AlreadyExists` if a pool
+    list back.  Raises :class:`~fabric_dw.exceptions.AlreadyExistsError` if a pool
     with the same name already exists.
 
     Note:
@@ -226,13 +226,13 @@ async def create_pool(
         The updated :class:`~fabric_dw.models.SqlPoolsConfiguration`.
 
     Raises:
-        AlreadyExists: If a pool with ``pool.name`` already exists.
-        PermissionDenied: If the caller does not have the workspace admin role.
+        AlreadyExistsError: If a pool with ``pool.name`` already exists.
+        PermissionDeniedError: If the caller does not have the workspace admin role.
     """
     current = await get_configuration(http, workspace_id)
     if any(p.name == pool.name for p in current.custom_sql_pools):
         msg = f"pool {pool.name!r} already exists; use update to modify it"
-        raise AlreadyExists(msg)
+        raise AlreadyExistsError(msg)
     new_pools = [*current.custom_sql_pools, pool]
     new_config = SqlPoolsConfiguration.model_validate(
         {
@@ -295,8 +295,8 @@ async def update_pool(
     Raises:
         ValueError: If exactly one of *classifier_type* / *classifier_values*
             is supplied without the other.
-        NotFound: If no pool named *name* exists.
-        PermissionDenied: If the caller does not have the workspace admin role.
+        NotFoundError: If no pool named *name* exists.
+        PermissionDeniedError: If the caller does not have the workspace admin role.
     """
     if (classifier_type is None) != (classifier_values is None):
         msg = "classifier_type and classifier_values must be provided together (or neither)"
@@ -305,7 +305,7 @@ async def update_pool(
     existing = next((p for p in current.custom_sql_pools if p.name == name), None)
     if existing is None:
         msg = f"pool {name!r} not found; use create to add it"
-        raise NotFound(msg)
+        raise NotFoundError(msg)
 
     raw = existing.model_dump(by_alias=True, mode="json")
     if max_resource_percentage is not None:
@@ -341,7 +341,7 @@ async def delete_pool(
     """Remove a pool from the workspace SQL Pools configuration.
 
     Fetches the current pool list, drops the named pool, and PATCHes the
-    remaining list back.  Raises :class:`~fabric_dw.exceptions.NotFound` if no
+    remaining list back.  Raises :class:`~fabric_dw.exceptions.NotFoundError` if no
     pool with that name exists.
 
     Note:
@@ -359,13 +359,13 @@ async def delete_pool(
         The updated :class:`~fabric_dw.models.SqlPoolsConfiguration`.
 
     Raises:
-        NotFound: If no pool named ``name`` exists.
-        PermissionDenied: If the caller does not have the workspace admin role.
+        NotFoundError: If no pool named ``name`` exists.
+        PermissionDeniedError: If the caller does not have the workspace admin role.
     """
     current = await get_configuration(http, workspace_id)
     if not any(p.name == name for p in current.custom_sql_pools):
         msg = f"pool {name!r} not found"
-        raise NotFound(msg)
+        raise NotFoundError(msg)
     new_pools = [p for p in current.custom_sql_pools if p.name != name]
     new_config = SqlPoolsConfiguration.model_validate(
         {
@@ -399,11 +399,11 @@ async def reset_pools(
         provisioned — GET returned 404).
 
     Raises:
-        PermissionDenied: If the caller does not have the workspace admin role.
+        PermissionDeniedError: If the caller does not have the workspace admin role.
     """
     try:
         current = await get_configuration(http, workspace_id)
-    except NotFound:
+    except NotFoundError:
         return None
     new_config = SqlPoolsConfiguration.model_validate(
         {

--- a/src/fabric_dw/services/tables.py
+++ b/src/fabric_dw/services/tables.py
@@ -25,7 +25,7 @@ from datetime import datetime
 from typing import cast
 
 from fabric_dw.auth import CredentialMode
-from fabric_dw.exceptions import ItemKindError, NotFound
+from fabric_dw.exceptions import ItemKindError, NotFoundError
 from fabric_dw.identifiers import quote_identifier, validate_identifier
 from fabric_dw.models import Table, WarehouseKind
 from fabric_dw.sql import SqlTarget, run_query
@@ -159,7 +159,7 @@ async def list_tables(
 
     Raises:
         ValueError: If *schema* fails identifier validation.
-        PermissionDenied: If the driver reports a permission error.
+        PermissionDeniedError: If the driver reports a permission error.
         AuthError: If the driver reports an authentication failure.
     """
     if schema is not None:
@@ -212,8 +212,8 @@ async def read_table(
 
     Raises:
         ValueError: If *schema* or *table_name* fails identifier validation.
-        NotFound: If the table does not exist (zero rows AND zero columns).
-        PermissionDenied: If the driver reports a permission error.
+        NotFoundError: If the table does not exist (zero rows AND zero columns).
+        PermissionDeniedError: If the driver reports a permission error.
     """
     validate_identifier(schema)
     validate_identifier(table_name)
@@ -228,7 +228,7 @@ async def read_table(
         cols, rows = run_query(target, read_sql, mode=mode)
         if not cols:
             msg = f"Table [{schema}].[{table_name}] not found"
-            raise NotFound(msg)
+            raise NotFoundError(msg)
         return cols, list(rows)
 
     return await asyncio.to_thread(_run)
@@ -264,7 +264,7 @@ async def create_table(
         ItemKindError: If *kind* is :attr:`~fabric_dw.models.WarehouseKind.SQL_ENDPOINT`.
         ValueError: If *schema* or *table_name* fails identifier validation, or
             if *select_body* does not start with SELECT or WITH (CTE).
-        PermissionDenied: If the driver reports a CREATE TABLE permission error.
+        PermissionDeniedError: If the driver reports a CREATE TABLE permission error.
     """
     _assert_not_sql_endpoint(kind)
     validate_identifier(schema)
@@ -301,7 +301,7 @@ async def delete_table(
     Raises:
         ItemKindError: If *kind* is :attr:`~fabric_dw.models.WarehouseKind.SQL_ENDPOINT`.
         ValueError: If *schema* or *table_name* fails identifier validation.
-        PermissionDenied: If the driver reports a DROP TABLE permission error.
+        PermissionDeniedError: If the driver reports a DROP TABLE permission error.
     """
     _assert_not_sql_endpoint(kind)
     validate_identifier(schema)
@@ -336,7 +336,7 @@ async def clear_table(
     Raises:
         ItemKindError: If *kind* is :attr:`~fabric_dw.models.WarehouseKind.SQL_ENDPOINT`.
         ValueError: If *schema* or *table_name* fails identifier validation.
-        PermissionDenied: If the driver reports a TRUNCATE TABLE permission error.
+        PermissionDeniedError: If the driver reports a TRUNCATE TABLE permission error.
     """
     _assert_not_sql_endpoint(kind)
     validate_identifier(schema)
@@ -374,7 +374,7 @@ async def _fetch_table(
         A :class:`~fabric_dw.models.Table` instance.
 
     Raises:
-        NotFound: If the table is not found after creation.
+        NotFoundError: If the table is not found after creation.
     """
 
     def _run() -> Table:
@@ -386,7 +386,7 @@ async def _fetch_table(
         )
         if not rows:
             msg = f"Table [{schema}].[{table_name}] not found after creation"
-            raise NotFound(msg)
+            raise NotFoundError(msg)
         return _row_to_table(cols, rows[0])
 
     return await asyncio.to_thread(_run)

--- a/src/fabric_dw/services/views.py
+++ b/src/fabric_dw/services/views.py
@@ -17,7 +17,7 @@ from datetime import datetime
 from typing import cast
 
 from fabric_dw.auth import CredentialMode
-from fabric_dw.exceptions import NotFound
+from fabric_dw.exceptions import NotFoundError
 from fabric_dw.identifiers import quote_identifier, validate_identifier
 from fabric_dw.models import View
 from fabric_dw.sql import SqlTarget, run_query
@@ -111,7 +111,7 @@ async def list_views(
 
     Raises:
         ValueError: If *schema* fails identifier validation.
-        PermissionDenied: If the driver reports a permission error.
+        PermissionDeniedError: If the driver reports a permission error.
         AuthError: If the driver reports an authentication failure.
     """
     if schema is not None:
@@ -167,8 +167,8 @@ async def read_view(
 
     Raises:
         ValueError: If *schema* or *view_name* fails identifier validation.
-        NotFound: If the view does not exist (zero rows AND zero columns).
-        PermissionDenied: If the driver reports a permission error.
+        NotFoundError: If the view does not exist (zero rows AND zero columns).
+        PermissionDeniedError: If the driver reports a permission error.
     """
     validate_identifier(schema)
     validate_identifier(view_name)
@@ -185,7 +185,7 @@ async def read_view(
         cols, rows = run_query(target, read_sql, mode=mode)
         if not cols:
             msg = f"View [{schema}].[{view_name}] not found"
-            raise NotFound(msg)
+            raise NotFoundError(msg)
         return cols, list(rows)
 
     return await asyncio.to_thread(_run)
@@ -211,8 +211,8 @@ async def get_view(
 
     Raises:
         ValueError: If *schema* or *view_name* fails identifier validation.
-        NotFound: If no view with that schema/name exists.
-        PermissionDenied: If the driver reports a permission error.
+        NotFoundError: If no view with that schema/name exists.
+        PermissionDeniedError: If the driver reports a permission error.
     """
     validate_identifier(schema)
     validate_identifier(view_name)
@@ -226,7 +226,7 @@ async def get_view(
         )
         if not rows:
             msg = f"View [{schema}].[{view_name}] not found"
-            raise NotFound(msg)
+            raise NotFoundError(msg)
         return _row_to_view(cols, rows[0])
 
     return await asyncio.to_thread(_run)
@@ -255,7 +255,7 @@ async def create_view(
 
     Raises:
         ValueError: If *schema* or *view_name* fails identifier validation.
-        PermissionDenied: If the driver reports a CREATE VIEW permission error.
+        PermissionDeniedError: If the driver reports a CREATE VIEW permission error.
     """
     validate_identifier(schema)
     validate_identifier(view_name)
@@ -291,7 +291,7 @@ async def update_view(
 
     Raises:
         ValueError: If *schema* or *view_name* fails identifier validation.
-        PermissionDenied: If the driver reports an ALTER VIEW permission error.
+        PermissionDeniedError: If the driver reports an ALTER VIEW permission error.
     """
     validate_identifier(schema)
     validate_identifier(view_name)
@@ -325,7 +325,7 @@ async def drop_view(
 
     Raises:
         ValueError: If *schema* or *view_name* fails identifier validation.
-        PermissionDenied: If the driver reports a DROP VIEW permission error.
+        PermissionDeniedError: If the driver reports a DROP VIEW permission error.
     """
     validate_identifier(schema)
     validate_identifier(view_name)

--- a/src/fabric_dw/services/warehouses.py
+++ b/src/fabric_dw/services/warehouses.py
@@ -9,7 +9,7 @@ from datetime import UTC, datetime
 from uuid import UUID
 
 from fabric_dw.cache import ItemEntry, LookupCache
-from fabric_dw.exceptions import FabricServerError, NotFound, PermissionDenied
+from fabric_dw.exceptions import FabricServerError, NotFoundError, PermissionDeniedError
 from fabric_dw.http_client import FabricHttpClient, HttpBase
 from fabric_dw.models import Warehouse, WarehouseKind
 from fabric_dw.services._concurrency import bounded_gather
@@ -71,8 +71,8 @@ async def list_all_workspaces(http: FabricHttpClient) -> list[Warehouse]:
     Iterates all workspaces returned by :func:`~fabric_dw.services.workspaces.list_all`
     and aggregates their warehouses using bounded concurrency (up to 8 workspaces
     in parallel).  Workspaces that raise
-    :class:`~fabric_dw.exceptions.PermissionDenied` or
-    :class:`~fabric_dw.exceptions.NotFound` are skipped with a per-workspace
+    :class:`~fabric_dw.exceptions.PermissionDeniedError` or
+    :class:`~fabric_dw.exceptions.NotFoundError` are skipped with a per-workspace
     warning; a summary warning is logged after the scan.
 
     Args:
@@ -93,7 +93,7 @@ async def list_all_workspaces(http: FabricHttpClient) -> list[Warehouse]:
     out: list[Warehouse] = []
     skipped = 0
     for ws, result in zip(workspaces, raw, strict=True):
-        if isinstance(result, (PermissionDenied, NotFound)):
+        if isinstance(result, (PermissionDeniedError, NotFoundError)):
             _logger.warning("skipping workspace %s: %s", ws.name, result)
             skipped += 1
         elif isinstance(result, BaseException):
@@ -331,7 +331,7 @@ async def delete(
         ``None`` on success (204 No Content).
 
     Raises:
-        NotFound: If the warehouse does not exist (404).
+        NotFoundError: If the warehouse does not exist (404).
     """
     await http.request(
         "DELETE",

--- a/src/fabric_dw/services/workspaces.py
+++ b/src/fabric_dw/services/workspaces.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import http as http_module
 from uuid import UUID
 
-from fabric_dw.exceptions import FabricError, NotFound
+from fabric_dw.exceptions import FabricError, NotFoundError
 from fabric_dw.http_client import FabricHttpClient, HttpBase
 from fabric_dw.models import Workspace
 
@@ -97,12 +98,16 @@ async def set_collation(
             f"/workspaces/{workspace_id}",
             json={"defaultDataWarehouseCollation": collation},
         )
-    except NotFound as exc:
+    except NotFoundError as exc:
         raise FabricError(portal_msg) from exc
     except FabricError:
         raise
 
     # http_client returns non-error responses (including 400) without raising;
     # treat any remaining 4xx as a portal-redirect case.
-    if 400 <= resp.status_code < 500:  # noqa: PLR2004
+    if (
+        http_module.HTTPStatus.BAD_REQUEST
+        <= resp.status_code
+        < http_module.HTTPStatus.INTERNAL_SERVER_ERROR
+    ):
         raise FabricError(portal_msg)

--- a/src/fabric_dw/sql.py
+++ b/src/fabric_dw/sql.py
@@ -22,7 +22,7 @@ from dataclasses import dataclass
 from typing import Any, Literal, Protocol
 
 from fabric_dw.auth import CredentialMode
-from fabric_dw.exceptions import AuthError, PermissionDenied
+from fabric_dw.exceptions import AuthError, PermissionDeniedError
 
 # ---------------------------------------------------------------------------
 # Lazy driver import — @functools.cache avoids the module-level global and the
@@ -233,13 +233,13 @@ def map_driver_error(exc: BaseException) -> Exception | None:
 
     Permission-denied is checked before auth-failure in both strategies so a
     message containing both fragments resolves to
-    :class:`~fabric_dw.exceptions.PermissionDenied`.
+    :class:`~fabric_dw.exceptions.PermissionDeniedError`.
 
     Args:
         exc: The raw exception raised by the driver.
 
     Returns:
-        A :class:`~fabric_dw.exceptions.PermissionDenied` or
+        A :class:`~fabric_dw.exceptions.PermissionDeniedError` or
         :class:`~fabric_dw.exceptions.AuthError` instance if the error message
         matches a known fragment or error number, otherwise ``None``.
     """
@@ -251,14 +251,14 @@ def map_driver_error(exc: BaseException) -> Exception | None:
             if raw_num:
                 err_num = int(raw_num)
                 if err_num in _PERMISSION_DENIED_ERROR_NUMBERS:
-                    return PermissionDenied(str(exc))
+                    return PermissionDeniedError(str(exc))
                 if err_num in _AUTH_FAILED_ERROR_NUMBERS:
                     return AuthError(str(exc))
 
     # --- Strategy 2: message-fragment fallback (locale-dependent, documented) ---
     msg = str(exc).lower()
     if any(fragment in msg for fragment in _PERMISSION_DENIED_FRAGMENTS):
-        return PermissionDenied(str(exc))
+        return PermissionDeniedError(str(exc))
     if any(fragment in msg for fragment in _AUTH_FAILED_FRAGMENTS):
         return AuthError(str(exc))
     return None
@@ -311,7 +311,7 @@ def run_query(  # noqa: PLR0913
         strings and *rows* is a list of row tuples.
 
     Raises:
-        PermissionDenied: If the driver reports a permission error.
+        PermissionDeniedError: If the driver reports a permission error.
         AuthError: If the driver reports an authentication failure.
         Exception: Any other driver error is propagated unchanged.
     """
@@ -363,7 +363,7 @@ def run_statements(
         mode: The credential mode for Entra authentication.
 
     Raises:
-        PermissionDenied: If the driver reports a permission error on any statement.
+        PermissionDeniedError: If the driver reports a permission error on any statement.
         AuthError: If the driver reports an authentication failure.
         Exception: Any other driver error is propagated unchanged.
     """

--- a/tests/integration/test_services_permissions.py
+++ b/tests/integration/test_services_permissions.py
@@ -15,7 +15,7 @@ from uuid import UUID
 
 import pytest
 
-from fabric_dw.exceptions import PermissionDenied
+from fabric_dw.exceptions import PermissionDeniedError
 from fabric_dw.http_client import FabricHttpClient
 from fabric_dw.models import ItemAccess, Warehouse
 from fabric_dw.services import permissions
@@ -72,7 +72,7 @@ async def test_list_item_access_non_admin_raises_permission_denied(
     workspace_id: UUID,
     ephemeral_warehouse: Warehouse,
 ) -> None:
-    """list_item_access must raise PermissionDenied (with admin hint) when not an admin.
+    """list_item_access must raise PermissionDeniedError (with admin hint) when not an admin.
 
     This test is expected to run even without admin access; it just verifies
     the error is surfaced correctly.  If the caller IS an admin the test is
@@ -81,5 +81,5 @@ async def test_list_item_access_non_admin_raises_permission_denied(
     if _IS_ADMIN:
         pytest.skip("caller has admin access; cannot test non-admin path")
 
-    with pytest.raises(PermissionDenied, match="Fabric Administrator"):
+    with pytest.raises(PermissionDeniedError, match="Fabric Administrator"):
         await permissions.list_item_access(http, workspace_id, ephemeral_warehouse.id)

--- a/tests/integration/test_services_sql_pools.py
+++ b/tests/integration/test_services_sql_pools.py
@@ -10,7 +10,7 @@ from uuid import UUID
 
 import pytest
 
-from fabric_dw.exceptions import AlreadyExists, NotFound
+from fabric_dw.exceptions import AlreadyExistsError, NotFoundError
 from fabric_dw.http_client import FabricHttpClient
 from fabric_dw.models import SqlPool, SqlPoolsConfiguration
 from fabric_dw.services import sql_pools
@@ -82,8 +82,8 @@ async def test_create_update_delete_roundtrip(http: FabricHttpClient, workspace_
         assert created.max_resource_percentage == 10
         assert created.optimize_for_reads is True
 
-        # Duplicate name must raise AlreadyExists
-        with pytest.raises(AlreadyExists):
+        # Duplicate name must raise AlreadyExistsError
+        with pytest.raises(AlreadyExistsError):
             await sql_pools.create_pool(http, workspace_id, new_pool)
 
         # Update
@@ -101,8 +101,8 @@ async def test_create_update_delete_roundtrip(http: FabricHttpClient, workspace_
         after_delete = await sql_pools.delete_pool(http, workspace_id, pool_name)
         assert not any(p.name == pool_name for p in after_delete.custom_sql_pools)
 
-        # Missing name must raise NotFound
-        with pytest.raises(NotFound):
+        # Missing name must raise NotFoundError
+        with pytest.raises(NotFoundError):
             await sql_pools.delete_pool(http, workspace_id, pool_name)
 
     finally:

--- a/tests/integration/test_services_tables.py
+++ b/tests/integration/test_services_tables.py
@@ -13,7 +13,7 @@ import contextlib
 
 import pytest
 
-from fabric_dw.exceptions import NotFound
+from fabric_dw.exceptions import NotFoundError
 from fabric_dw.models import Table
 from fabric_dw.services import tables
 from fabric_dw.sql import SqlTarget
@@ -55,5 +55,5 @@ async def test_create_read_clear_delete_roundtrip(ephemeral_sql_target: SqlTarge
         with contextlib.suppress(Exception):
             await tables.delete_table(ephemeral_sql_target, schema, table_name)
 
-    with pytest.raises((NotFound, Exception)):
+    with pytest.raises((NotFoundError, Exception)):
         await tables.read_table(ephemeral_sql_target, schema, table_name)

--- a/tests/integration/test_services_warehouses.py
+++ b/tests/integration/test_services_warehouses.py
@@ -2,7 +2,7 @@ import uuid
 
 import pytest
 
-from fabric_dw.exceptions import NotFound
+from fabric_dw.exceptions import NotFoundError
 from fabric_dw.http_client import FabricHttpClient
 from fabric_dw.models import Warehouse
 from fabric_dw.services import warehouses
@@ -38,5 +38,5 @@ async def test_delete_nonexistent_warehouse_raises(
     http: FabricHttpClient, workspace_id: uuid.UUID
 ) -> None:
     bogus = uuid.uuid4()
-    with pytest.raises(NotFound):
+    with pytest.raises(NotFoundError):
         await warehouses.delete(http, workspace_id, bogus)

--- a/tests/unit/cli/commands/test_audit.py
+++ b/tests/unit/cli/commands/test_audit.py
@@ -15,7 +15,7 @@ from click.testing import CliRunner
 
 from fabric_dw.cache import ItemEntry
 from fabric_dw.cli._main import cli
-from fabric_dw.exceptions import NotFound
+from fabric_dw.exceptions import NotFoundError
 from fabric_dw.models import WarehouseKind
 from tests.fixtures.api_payloads import AUDIT_SETTINGS_PAYLOAD
 
@@ -103,7 +103,7 @@ class TestAuditGet:
             ),
             patch(
                 "fabric_dw.cli.commands.audit._resolve_item",
-                new=AsyncMock(side_effect=NotFound("not found")),
+                new=AsyncMock(side_effect=NotFoundError("not found")),
             ),
         ):
             result = runner.invoke(cli, ["audit", "get", WS_GUID, WH_GUID])

--- a/tests/unit/cli/commands/test_queries.py
+++ b/tests/unit/cli/commands/test_queries.py
@@ -15,7 +15,7 @@ from click.testing import CliRunner
 
 from fabric_dw.cache import ItemEntry
 from fabric_dw.cli._main import cli
-from fabric_dw.exceptions import NotFound, PermissionDenied
+from fabric_dw.exceptions import NotFoundError, PermissionDeniedError
 from fabric_dw.models import RunningQuery, WarehouseKind
 from fabric_dw.sql import SqlTarget
 
@@ -134,7 +134,7 @@ class TestQueriesList:
             ),
             patch(
                 "fabric_dw.cli.commands.queries.build_sql_target",
-                new=AsyncMock(side_effect=NotFound("not found")),
+                new=AsyncMock(side_effect=NotFoundError("not found")),
             ),
         ):
             result = runner.invoke(cli, ["queries", "list", WS_GUID, WH_GUID])
@@ -198,7 +198,7 @@ class TestQueriesKill:
             ),
             patch(
                 "fabric_dw.services.queries.kill",
-                new=AsyncMock(side_effect=PermissionDenied("no permission")),
+                new=AsyncMock(side_effect=PermissionDeniedError("no permission")),
             ),
         ):
             result = runner.invoke(cli, ["--yes", "queries", "kill", WS_GUID, WH_GUID, "42"])

--- a/tests/unit/cli/commands/test_query_insights.py
+++ b/tests/unit/cli/commands/test_query_insights.py
@@ -15,7 +15,7 @@ from click.testing import CliRunner
 
 from fabric_dw.cache import ItemEntry
 from fabric_dw.cli._main import cli
-from fabric_dw.exceptions import NotFound, PermissionDenied
+from fabric_dw.exceptions import NotFoundError, PermissionDeniedError
 from fabric_dw.models import (
     ExecRequestHistory,
     ExecSessionHistory,
@@ -213,7 +213,7 @@ class TestRequestHistory:
             ),
             patch(
                 "fabric_dw.cli.commands.query_insights.build_sql_target",
-                new=AsyncMock(side_effect=NotFound("not found")),
+                new=AsyncMock(side_effect=NotFoundError("not found")),
             ),
         ):
             result = runner.invoke(cli, ["query-insights", "request-history", WS_GUID, WH_GUID])
@@ -233,7 +233,7 @@ class TestRequestHistory:
             ),
             patch(
                 "fabric_dw.services.query_insights.list_request_history",
-                new=AsyncMock(side_effect=PermissionDenied("no permission")),
+                new=AsyncMock(side_effect=PermissionDeniedError("no permission")),
             ),
         ):
             result = runner.invoke(cli, ["query-insights", "request-history", WS_GUID, WH_GUID])

--- a/tests/unit/cli/commands/test_restore_points.py
+++ b/tests/unit/cli/commands/test_restore_points.py
@@ -20,7 +20,7 @@ from click.testing import CliRunner
 
 from fabric_dw.cache import ItemEntry
 from fabric_dw.cli._main import cli
-from fabric_dw.exceptions import FabricError, NotFound, PermissionDenied
+from fabric_dw.exceptions import FabricError, NotFoundError, PermissionDeniedError
 from fabric_dw.models import RestorePoint, WarehouseKind
 
 # ---------------------------------------------------------------------------
@@ -170,7 +170,7 @@ class TestRestorePointsList:
             ),
             patch(
                 "fabric_dw.cli.commands.restore_points.resolve_item",
-                new=AsyncMock(side_effect=NotFound("warehouse not found")),
+                new=AsyncMock(side_effect=NotFoundError("warehouse not found")),
             ),
         ):
             result = runner.invoke(cli, ["restore-points", "list", WS_GUID, WH_GUID])
@@ -186,7 +186,7 @@ class TestRestorePointsList:
             ),
             patch(
                 "fabric_dw.cli.commands.restore_points.resolve_item",
-                new=AsyncMock(side_effect=PermissionDenied("forbidden")),
+                new=AsyncMock(side_effect=PermissionDeniedError("forbidden")),
             ),
         ):
             result = runner.invoke(cli, ["restore-points", "list", WS_GUID, WH_GUID])
@@ -261,7 +261,7 @@ class TestRestorePointsGet:
             ),
             patch(
                 "fabric_dw.services.restore.get_point",
-                new=AsyncMock(side_effect=NotFound("restore point not found")),
+                new=AsyncMock(side_effect=NotFoundError("restore point not found")),
             ),
         ):
             result = runner.invoke(cli, ["restore-points", "get", WS_GUID, WH_GUID, RP_ID])

--- a/tests/unit/cli/commands/test_schemas.py
+++ b/tests/unit/cli/commands/test_schemas.py
@@ -15,7 +15,7 @@ from click.testing import CliRunner
 
 from fabric_dw.cache import ItemEntry
 from fabric_dw.cli._main import cli
-from fabric_dw.exceptions import NotFound, PermissionDenied
+from fabric_dw.exceptions import NotFoundError, PermissionDeniedError
 from fabric_dw.models import Schema, WarehouseKind
 from fabric_dw.sql import SqlTarget
 
@@ -137,7 +137,7 @@ class TestSchemasList:
             ),
             patch(
                 "fabric_dw.cli.commands.schemas.build_sql_target",
-                new=AsyncMock(side_effect=NotFound("not found")),
+                new=AsyncMock(side_effect=NotFoundError("not found")),
             ),
         ):
             result = runner.invoke(cli, ["schemas", "list", WS_GUID, WH_GUID])
@@ -159,7 +159,7 @@ class TestSchemasList:
             ),
             patch(
                 "fabric_dw.services.schemas.list_schemas",
-                new=AsyncMock(side_effect=PermissionDenied("access denied")),
+                new=AsyncMock(side_effect=PermissionDeniedError("access denied")),
             ),
         ):
             result = runner.invoke(cli, ["schemas", "list", WS_GUID, WH_GUID])
@@ -246,7 +246,7 @@ class TestSchemasCreate:
             ),
             patch(
                 "fabric_dw.services.schemas.create_schema",
-                new=AsyncMock(side_effect=PermissionDenied("access denied")),
+                new=AsyncMock(side_effect=PermissionDeniedError("access denied")),
             ),
         ):
             result = runner.invoke(cli, ["schemas", "create", WS_GUID, WH_GUID, "sales"])
@@ -406,7 +406,7 @@ class TestSchemasDelete:
             ),
             patch(
                 "fabric_dw.services.schemas.delete_schema",
-                new=AsyncMock(side_effect=PermissionDenied("access denied")),
+                new=AsyncMock(side_effect=PermissionDeniedError("access denied")),
             ),
         ):
             result = runner.invoke(cli, ["-y", "schemas", "delete", WS_GUID, WH_GUID, "sales"])

--- a/tests/unit/cli/commands/test_snapshots.py
+++ b/tests/unit/cli/commands/test_snapshots.py
@@ -15,7 +15,7 @@ from click.testing import CliRunner
 
 from fabric_dw.cache import ItemEntry, LookupCache
 from fabric_dw.cli._main import cli
-from fabric_dw.exceptions import NotFound, PermissionDenied
+from fabric_dw.exceptions import NotFoundError, PermissionDeniedError
 from fabric_dw.models import WarehouseKind
 from fabric_dw.sql import SqlTarget
 
@@ -138,7 +138,7 @@ class TestSnapshotsList:
             ),
             patch(
                 "fabric_dw.cli.commands.snapshots._resolve_item",
-                new=AsyncMock(side_effect=NotFound("not found")),
+                new=AsyncMock(side_effect=NotFoundError("not found")),
             ),
         ):
             result = runner.invoke(cli, ["snapshots", "list", WS_GUID, WH_GUID])
@@ -403,7 +403,7 @@ class TestSnapshotsRoll:
             ),
             patch(
                 "fabric_dw.services.snapshots.roll_timestamp",
-                new=AsyncMock(side_effect=PermissionDenied("no permission")),
+                new=AsyncMock(side_effect=PermissionDeniedError("no permission")),
             ),
         ):
             result = runner.invoke(

--- a/tests/unit/cli/commands/test_sql.py
+++ b/tests/unit/cli/commands/test_sql.py
@@ -16,7 +16,7 @@ from click.testing import CliRunner
 
 from fabric_dw.cache import ItemEntry
 from fabric_dw.cli._main import cli
-from fabric_dw.exceptions import NotFound, PermissionDenied
+from fabric_dw.exceptions import NotFoundError, PermissionDeniedError
 from fabric_dw.models import SqlResult, WarehouseKind
 from fabric_dw.sql import SqlTarget
 
@@ -320,7 +320,7 @@ class TestSqlExecErrors:
             ),
             patch(
                 "fabric_dw.services.sql_exec.execute",
-                new=AsyncMock(side_effect=PermissionDenied("no perms")),
+                new=AsyncMock(side_effect=PermissionDeniedError("no perms")),
             ),
         ):
             result = runner.invoke(
@@ -339,7 +339,7 @@ class TestSqlExecErrors:
             ),
             patch(
                 "fabric_dw.cli.commands.sql.build_sql_target",
-                new=AsyncMock(side_effect=NotFound("not found")),
+                new=AsyncMock(side_effect=NotFoundError("not found")),
             ),
         ):
             result = runner.invoke(

--- a/tests/unit/cli/commands/test_sql_endpoints.py
+++ b/tests/unit/cli/commands/test_sql_endpoints.py
@@ -18,7 +18,7 @@ from rich.console import Console
 from fabric_dw.cache import ItemEntry
 from fabric_dw.cli._main import cli
 from fabric_dw.cli._render import render_refresh_table as _render_refresh_table
-from fabric_dw.exceptions import NotFound
+from fabric_dw.exceptions import NotFoundError
 from fabric_dw.models import TableSyncStatus, WarehouseKind
 
 WS_GUID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
@@ -219,7 +219,7 @@ class TestEndpointsGet:
             ),
             patch(
                 "fabric_dw.cli.commands.sql_endpoints._resolve_item",
-                new=AsyncMock(side_effect=NotFound("endpoint not found")),
+                new=AsyncMock(side_effect=NotFoundError("endpoint not found")),
             ),
         ):
             result = runner.invoke(cli, ["sql-endpoints", "get", WS_GUID, EP_GUID])
@@ -399,7 +399,7 @@ class TestEndpointsRefresh:
             ),
             patch(
                 "fabric_dw.cli.commands.sql_endpoints._resolve_item",
-                new=AsyncMock(side_effect=NotFound("endpoint not found")),
+                new=AsyncMock(side_effect=NotFoundError("endpoint not found")),
             ),
         ):
             result = runner.invoke(cli, ["sql-endpoints", "refresh", WS_GUID, EP_GUID])

--- a/tests/unit/cli/commands/test_sql_pools.py
+++ b/tests/unit/cli/commands/test_sql_pools.py
@@ -13,7 +13,7 @@ import pytest
 from click.testing import CliRunner
 
 from fabric_dw.cli._main import cli
-from fabric_dw.exceptions import AlreadyExists, NotFound, PermissionDenied
+from fabric_dw.exceptions import AlreadyExistsError, NotFoundError, PermissionDeniedError
 from fabric_dw.models import SqlPool, SqlPoolsConfiguration
 
 WS_GUID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
@@ -148,7 +148,7 @@ class TestSqlPoolsGet:
             ),
             patch(
                 "fabric_dw.cli.commands.sql_pools._svc.get_configuration",
-                new=AsyncMock(side_effect=PermissionDenied("403")),
+                new=AsyncMock(side_effect=PermissionDeniedError("403")),
             ),
         ):
             result = runner.invoke(cli, ["sql-pools", "get", WS_GUID])
@@ -335,7 +335,7 @@ class TestSqlPoolsCreate:
             ),
             patch(
                 "fabric_dw.cli.commands.sql_pools._svc.create_pool",
-                new=AsyncMock(side_effect=AlreadyExists("pool 'Default' already exists")),
+                new=AsyncMock(side_effect=AlreadyExistsError("pool 'Default' already exists")),
             ),
         ):
             result = runner.invoke(
@@ -435,7 +435,7 @@ class TestSqlPoolsUpdate:
             ),
             patch(
                 "fabric_dw.cli.commands.sql_pools._svc.update_pool",
-                new=AsyncMock(side_effect=NotFound("pool 'NoPool' not found")),
+                new=AsyncMock(side_effect=NotFoundError("pool 'NoPool' not found")),
             ),
         ):
             result = runner.invoke(
@@ -558,7 +558,7 @@ class TestSqlPoolsDelete:
             ),
             patch(
                 "fabric_dw.cli.commands.sql_pools._svc.delete_pool",
-                new=AsyncMock(side_effect=NotFound("pool 'NoPool' not found")),
+                new=AsyncMock(side_effect=NotFoundError("pool 'NoPool' not found")),
             ),
         ):
             result = runner.invoke(
@@ -580,7 +580,7 @@ class TestSqlPoolsDelete:
             ),
             patch(
                 "fabric_dw.cli.commands.sql_pools._svc.delete_pool",
-                new=AsyncMock(side_effect=PermissionDenied("403")),
+                new=AsyncMock(side_effect=PermissionDeniedError("403")),
             ),
         ):
             result = runner.invoke(
@@ -624,7 +624,7 @@ class TestSqlPoolsEnable:
             ),
             patch(
                 "fabric_dw.cli.commands.sql_pools._svc.enable",
-                new=AsyncMock(side_effect=PermissionDenied("403")),
+                new=AsyncMock(side_effect=PermissionDeniedError("403")),
             ),
         ):
             result = runner.invoke(cli, ["sql-pools", "enable", WS_GUID])
@@ -688,7 +688,7 @@ class TestSqlPoolsReset:
             ),
             patch(
                 "fabric_dw.cli.commands.sql_pools._svc.reset_pools",
-                new=AsyncMock(side_effect=PermissionDenied("403")),
+                new=AsyncMock(side_effect=PermissionDeniedError("403")),
             ),
         ):
             result = runner.invoke(cli, ["-y", "sql-pools", "reset", WS_GUID])

--- a/tests/unit/cli/commands/test_tables.py
+++ b/tests/unit/cli/commands/test_tables.py
@@ -15,7 +15,7 @@ from click.testing import CliRunner
 
 from fabric_dw.cache import ItemEntry
 from fabric_dw.cli._main import cli
-from fabric_dw.exceptions import NotFound, PermissionDenied
+from fabric_dw.exceptions import NotFoundError, PermissionDeniedError
 from fabric_dw.models import Table, WarehouseKind
 from fabric_dw.sql import SqlTarget
 
@@ -164,7 +164,7 @@ class TestTablesList:
             ),
             patch(
                 "fabric_dw.cli.commands.tables.build_sql_target",
-                new=AsyncMock(side_effect=NotFound("not found")),
+                new=AsyncMock(side_effect=NotFoundError("not found")),
             ),
         ):
             result = runner.invoke(cli, ["tables", "list", WS_GUID, WH_GUID])
@@ -289,7 +289,7 @@ class TestTablesRead:
             ),
             patch(
                 "fabric_dw.services.tables.read_table",
-                new=AsyncMock(side_effect=NotFound("table not found")),
+                new=AsyncMock(side_effect=NotFoundError("table not found")),
             ),
         ):
             result = runner.invoke(cli, ["tables", "read", WS_GUID, WH_GUID, "dbo.missing"])
@@ -415,7 +415,7 @@ class TestTablesCreate:
             ),
             patch(
                 "fabric_dw.services.tables.create_table",
-                new=AsyncMock(side_effect=PermissionDenied("no permission")),
+                new=AsyncMock(side_effect=PermissionDeniedError("no permission")),
             ),
         ):
             result = runner.invoke(
@@ -570,7 +570,7 @@ class TestTablesDelete:
             ),
             patch(
                 "fabric_dw.services.tables.delete_table",
-                new=AsyncMock(side_effect=PermissionDenied("no permission")),
+                new=AsyncMock(side_effect=PermissionDeniedError("no permission")),
             ),
         ):
             result = runner.invoke(
@@ -693,7 +693,7 @@ class TestTablesClear:
             ),
             patch(
                 "fabric_dw.services.tables.clear_table",
-                new=AsyncMock(side_effect=PermissionDenied("no permission")),
+                new=AsyncMock(side_effect=PermissionDeniedError("no permission")),
             ),
         ):
             result = runner.invoke(cli, ["--yes", "tables", "clear", WS_GUID, WH_GUID, "dbo.sales"])

--- a/tests/unit/cli/commands/test_views.py
+++ b/tests/unit/cli/commands/test_views.py
@@ -15,7 +15,7 @@ from click.testing import CliRunner
 
 from fabric_dw.cache import ItemEntry
 from fabric_dw.cli._main import cli
-from fabric_dw.exceptions import NotFound, PermissionDenied
+from fabric_dw.exceptions import NotFoundError, PermissionDeniedError
 from fabric_dw.models import View, WarehouseKind
 from fabric_dw.sql import SqlTarget
 
@@ -152,7 +152,7 @@ class TestViewsList:
             ),
             patch(
                 "fabric_dw.cli.commands.views.build_sql_target",
-                new=AsyncMock(side_effect=NotFound("not found")),
+                new=AsyncMock(side_effect=NotFoundError("not found")),
             ),
         ):
             result = runner.invoke(cli, ["views", "list", WS_GUID, WH_GUID])
@@ -277,7 +277,7 @@ class TestViewsRead:
             ),
             patch(
                 "fabric_dw.services.views.read_view",
-                new=AsyncMock(side_effect=NotFound("view not found")),
+                new=AsyncMock(side_effect=NotFoundError("view not found")),
             ),
         ):
             result = runner.invoke(cli, ["views", "read", WS_GUID, WH_GUID, "dbo.vw_missing"])
@@ -353,7 +353,7 @@ class TestViewsGet:
             ),
             patch(
                 "fabric_dw.services.views.get_view",
-                new=AsyncMock(side_effect=NotFound("not found")),
+                new=AsyncMock(side_effect=NotFoundError("not found")),
             ),
         ):
             result = runner.invoke(cli, ["views", "get", WS_GUID, WH_GUID, "dbo.vw_missing"])
@@ -522,7 +522,7 @@ class TestViewsCreate:
             ),
             patch(
                 "fabric_dw.services.views.create_view",
-                new=AsyncMock(side_effect=PermissionDenied("no permission")),
+                new=AsyncMock(side_effect=PermissionDeniedError("no permission")),
             ),
         ):
             result = runner.invoke(
@@ -725,7 +725,7 @@ class TestViewsDrop:
             ),
             patch(
                 "fabric_dw.services.views.drop_view",
-                new=AsyncMock(side_effect=PermissionDenied("no permission")),
+                new=AsyncMock(side_effect=PermissionDeniedError("no permission")),
             ),
         ):
             result = runner.invoke(

--- a/tests/unit/cli/commands/test_warehouses.py
+++ b/tests/unit/cli/commands/test_warehouses.py
@@ -15,7 +15,7 @@ from click.testing import CliRunner
 
 from fabric_dw.cache import ItemEntry, LookupCache
 from fabric_dw.cli._main import cli
-from fabric_dw.exceptions import NotFound
+from fabric_dw.exceptions import NotFoundError
 from fabric_dw.models import WarehouseKind
 from tests.fixtures.api_payloads import (
     WAREHOUSE_CREATE_202_PAYLOAD,
@@ -146,7 +146,7 @@ class TestWarehousesGet:
             ),
             patch(
                 "fabric_dw.cli.commands.warehouses._resolve_item",
-                new=AsyncMock(side_effect=NotFound("not found")),
+                new=AsyncMock(side_effect=NotFoundError("not found")),
             ),
         ):
             result = runner.invoke(cli, ["warehouses", "get", WS_GUID, WH_GUID])

--- a/tests/unit/cli/commands/test_workspaces.py
+++ b/tests/unit/cli/commands/test_workspaces.py
@@ -13,7 +13,7 @@ import pytest
 from click.testing import CliRunner
 
 from fabric_dw.cli._main import cli
-from fabric_dw.exceptions import NotFound
+from fabric_dw.exceptions import NotFoundError
 from tests.fixtures.api_payloads import WORKSPACE_GET_PAYLOAD
 
 WS_GUID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
@@ -174,7 +174,7 @@ class TestWorkspacesGet:
     def test_get_not_found_returns_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
         mock_http = AsyncMock()
-        mock_http.request = AsyncMock(side_effect=NotFound("not found"))
+        mock_http.request = AsyncMock(side_effect=NotFoundError("not found"))
         with patch(
             "fabric_dw.cli.commands.workspaces.build_http_client",
             new=_make_cm(mock_http, None),

--- a/tests/unit/mcp/test_server.py
+++ b/tests/unit/mcp/test_server.py
@@ -24,7 +24,7 @@ from uuid import UUID
 import pytest
 
 from fabric_dw.cache import ItemEntry
-from fabric_dw.exceptions import NotFound, PermissionDenied
+from fabric_dw.exceptions import NotFoundError, PermissionDeniedError
 from fabric_dw.models import (
     AuditSettings,
     ItemAccess,
@@ -378,7 +378,7 @@ async def test_fabric_error_becomes_tool_error(ctx_patch) -> None:
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
-    not_found_error = NotFound("workspace 'x' not found")
+    not_found_error = NotFoundError("workspace 'x' not found")
 
     with (
         ctx_patch,
@@ -391,7 +391,7 @@ async def test_fabric_error_becomes_tool_error(ctx_patch) -> None:
         await mcp._tool_manager.call_tool("list_workspaces", {})
 
     err = exc_info.value
-    assert "NotFound" in str(err) or "not found" in str(err).lower()
+    assert "NotFoundError" in str(err) or "not found" in str(err).lower()
 
 
 # ---------------------------------------------------------------------------
@@ -538,17 +538,19 @@ async def test_list_running_queries_happy_path(mock_ctx, ctx_patch) -> None:
 
 
 # ---------------------------------------------------------------------------
-# 12. NotFound error becomes ToolError
+# 12. NotFoundError error becomes ToolError
 # ---------------------------------------------------------------------------
 
 
 async def test_not_found_error_becomes_tool_error(mock_ctx, ctx_patch) -> None:
-    """NotFound (a FabricError subclass) must become a ToolError."""
+    """NotFoundError (a FabricError subclass) must become a ToolError."""
     from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
-    mock_ctx.resolver.workspace_id = AsyncMock(side_effect=NotFound("workspace 'boom' not found"))
+    mock_ctx.resolver.workspace_id = AsyncMock(
+        side_effect=NotFoundError("workspace 'boom' not found")
+    )
 
     with (
         ctx_patch,
@@ -1036,7 +1038,7 @@ async def test_get_sql_endpoint_permissions_happy_path(mock_ctx, ctx_patch) -> N
 async def test_get_warehouse_permissions_permission_denied_becomes_tool_error(
     mock_ctx, ctx_patch
 ) -> None:
-    """get_warehouse_permissions wraps PermissionDenied into ToolError."""
+    """get_warehouse_permissions wraps PermissionDeniedError into ToolError."""
     from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
@@ -1049,7 +1051,7 @@ async def test_get_warehouse_permissions_permission_denied_becomes_tool_error(
         ctx_patch,
         patch(
             "fabric_dw.services.permissions.list_item_access",
-            new=AsyncMock(side_effect=PermissionDenied("Fabric Administrator")),
+            new=AsyncMock(side_effect=PermissionDeniedError("Fabric Administrator")),
         ),
         pytest.raises(ToolError),
     ):

--- a/tests/unit/services/test_audit.py
+++ b/tests/unit/services/test_audit.py
@@ -10,7 +10,7 @@ import httpx
 import pytest
 import respx
 
-from fabric_dw.exceptions import PermissionDenied
+from fabric_dw.exceptions import PermissionDeniedError
 from fabric_dw.models import AuditSettings
 from fabric_dw.services import audit
 from tests.unit.services._helpers import _make_client
@@ -64,12 +64,12 @@ async def test_get_settings_returns_audit_settings() -> None:
 
 
 async def test_get_settings_403_raises_permission_denied() -> None:
-    """get_settings should propagate PermissionDenied on 403."""
+    """get_settings should propagate PermissionDeniedError on 403."""
     with respx.mock:
         respx.get(_AUDIT_URL).mock(return_value=httpx.Response(403, json={"error": "forbidden"}))
         client = await _make_client()
         async with client:
-            with pytest.raises(PermissionDenied):
+            with pytest.raises(PermissionDeniedError):
                 await audit.get_settings(client, _WS_ID, _WH_ID)
 
 
@@ -122,12 +122,12 @@ async def test_enable_negative_retention_raises_value_error() -> None:
 
 
 async def test_enable_403_raises_permission_denied() -> None:
-    """enable should propagate PermissionDenied on 403 from PATCH."""
+    """enable should propagate PermissionDeniedError on 403 from PATCH."""
     with respx.mock:
         respx.patch(_AUDIT_URL).mock(return_value=httpx.Response(403, json={"error": "forbidden"}))
         client = await _make_client()
         async with client:
-            with pytest.raises(PermissionDenied):
+            with pytest.raises(PermissionDeniedError):
                 await audit.enable(client, _WS_ID, _WH_ID)
 
 
@@ -157,12 +157,12 @@ async def test_disable_patches_with_disabled_state() -> None:
 
 
 async def test_disable_403_raises_permission_denied() -> None:
-    """disable should propagate PermissionDenied on 403 from PATCH."""
+    """disable should propagate PermissionDeniedError on 403 from PATCH."""
     with respx.mock:
         respx.patch(_AUDIT_URL).mock(return_value=httpx.Response(403, json={"error": "forbidden"}))
         client = await _make_client()
         async with client:
-            with pytest.raises(PermissionDenied):
+            with pytest.raises(PermissionDeniedError):
                 await audit.disable(client, _WS_ID, _WH_ID)
 
 
@@ -226,12 +226,12 @@ async def test_set_action_groups_invalid_name_raises_value_error(bad_group: str)
 
 
 async def test_set_action_groups_403_raises_permission_denied() -> None:
-    """set_action_groups should propagate PermissionDenied on 403 from PATCH."""
+    """set_action_groups should propagate PermissionDeniedError on 403 from PATCH."""
     with respx.mock:
         respx.patch(_AUDIT_URL).mock(return_value=httpx.Response(403, json={"error": "forbidden"}))
         client = await _make_client()
         async with client:
-            with pytest.raises(PermissionDenied):
+            with pytest.raises(PermissionDeniedError):
                 await audit.set_action_groups(client, _WS_ID, _WH_ID, ["BATCH_COMPLETED_GROUP"])
 
 
@@ -382,12 +382,12 @@ async def test_add_action_group_invalid_name_raises_value_error(bad_group: str) 
 
 
 async def test_add_action_group_403_raises_permission_denied() -> None:
-    """add_action_group should propagate PermissionDenied on 403 from GET."""
+    """add_action_group should propagate PermissionDeniedError on 403 from GET."""
     with respx.mock:
         respx.get(_AUDIT_URL).mock(return_value=httpx.Response(403, json={"error": "forbidden"}))
         client = await _make_client()
         async with client:
-            with pytest.raises(PermissionDenied):
+            with pytest.raises(PermissionDeniedError):
                 await audit.add_action_group(client, _WS_ID, _WH_ID, "BATCH_COMPLETED_GROUP")
 
 
@@ -469,12 +469,12 @@ async def test_remove_action_group_invalid_name_raises_value_error(bad_group: st
 
 
 async def test_remove_action_group_403_raises_permission_denied() -> None:
-    """remove_action_group should propagate PermissionDenied on 403 from GET."""
+    """remove_action_group should propagate PermissionDeniedError on 403 from GET."""
     with respx.mock:
         respx.get(_AUDIT_URL).mock(return_value=httpx.Response(403, json={"error": "forbidden"}))
         client = await _make_client()
         async with client:
-            with pytest.raises(PermissionDenied):
+            with pytest.raises(PermissionDeniedError):
                 await audit.remove_action_group(client, _WS_ID, _WH_ID, "BATCH_COMPLETED_GROUP")
 
 
@@ -555,12 +555,12 @@ async def test_set_retention_disabled_audit_sends_patch_to_server() -> None:
 
 
 async def test_set_retention_403_raises_permission_denied() -> None:
-    """set_retention should propagate PermissionDenied on 403 from PATCH."""
+    """set_retention should propagate PermissionDeniedError on 403 from PATCH."""
     with respx.mock:
         # GET succeeds (audit enabled), PATCH returns 403
         respx.get(_AUDIT_URL).mock(return_value=httpx.Response(200, json=AUDIT_SETTINGS_PAYLOAD))
         respx.patch(_AUDIT_URL).mock(return_value=httpx.Response(403, json={"error": "forbidden"}))
         client = await _make_client()
         async with client:
-            with pytest.raises(PermissionDenied):
+            with pytest.raises(PermissionDeniedError):
                 await audit.set_retention(client, _WS_ID, _WH_ID, days=30)

--- a/tests/unit/services/test_ownership.py
+++ b/tests/unit/services/test_ownership.py
@@ -8,7 +8,7 @@ from uuid import UUID
 import pytest
 import respx
 
-from fabric_dw.exceptions import NotFound, PermissionDenied
+from fabric_dw.exceptions import NotFoundError, PermissionDeniedError
 from fabric_dw.http_client import FabricHttpClient
 from fabric_dw.services.ownership import takeover
 from tests.unit.services._helpers import _make_credential
@@ -61,21 +61,21 @@ async def test_takeover_204_returns_none() -> None:
 
 @respx.mock
 async def test_takeover_403_raises_permission_denied() -> None:
-    """A 403 response should raise PermissionDenied with a helpful message."""
+    """A 403 response should raise PermissionDeniedError with a helpful message."""
     respx.post(_EXPECTED_URL).mock(return_value=respx.MockResponse(403))
 
     async with FabricHttpClient(credential=_make_credential(), rps=10) as http:
-        with pytest.raises(PermissionDenied, match="Admin/Member/Contributor"):
+        with pytest.raises(PermissionDeniedError, match="Admin/Member/Contributor"):
             await takeover(http, _WORKSPACE_ID, _WAREHOUSE_ID)
 
 
 @respx.mock
 async def test_takeover_404_raises_not_found() -> None:
-    """A 404 response should raise NotFound."""
+    """A 404 response should raise NotFoundError."""
     respx.post(_EXPECTED_URL).mock(return_value=respx.MockResponse(404))
 
     async with FabricHttpClient(credential=_make_credential(), rps=10) as http:
-        with pytest.raises(NotFound):
+        with pytest.raises(NotFoundError):
             await takeover(http, _WORKSPACE_ID, _WAREHOUSE_ID)
 
 

--- a/tests/unit/services/test_permissions.py
+++ b/tests/unit/services/test_permissions.py
@@ -9,7 +9,7 @@ import httpx
 import pytest
 import respx
 
-from fabric_dw.exceptions import NotFound, PermissionDenied
+from fabric_dw.exceptions import NotFoundError, PermissionDeniedError
 from fabric_dw.models import ItemAccess, PrincipalType
 from fabric_dw.services import permissions
 from tests.fixtures.api_payloads import (
@@ -208,7 +208,7 @@ async def test_list_item_access_pagination_returns_all_items_as_item_access() ->
 
 
 async def test_list_item_access_403_raises_permission_denied_with_hint() -> None:
-    """list_item_access must raise PermissionDenied with admin-role hint on 403."""
+    """list_item_access must raise PermissionDeniedError with admin-role hint on 403."""
     with respx.mock:
         respx.get(_ACCESS_URL).mock(
             return_value=httpx.Response(403, json={"errorCode": "Forbidden"})
@@ -216,12 +216,12 @@ async def test_list_item_access_403_raises_permission_denied_with_hint() -> None
 
         client = await _make_client()
         async with client:
-            with pytest.raises(PermissionDenied, match="Fabric Administrator"):
+            with pytest.raises(PermissionDeniedError, match="Fabric Administrator"):
                 await permissions.list_item_access(client, _WORKSPACE_ID, _ITEM_ID)
 
 
 async def test_list_item_access_404_raises_not_found() -> None:
-    """list_item_access must propagate NotFound on 404."""
+    """list_item_access must propagate NotFoundError on 404."""
     with respx.mock:
         respx.get(_ACCESS_URL).mock(
             return_value=httpx.Response(404, json={"errorCode": "ItemNotFound"})
@@ -229,5 +229,5 @@ async def test_list_item_access_404_raises_not_found() -> None:
 
         client = await _make_client()
         async with client:
-            with pytest.raises(NotFound):
+            with pytest.raises(NotFoundError):
                 await permissions.list_item_access(client, _WORKSPACE_ID, _ITEM_ID)

--- a/tests/unit/services/test_queries.py
+++ b/tests/unit/services/test_queries.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from fabric_dw.exceptions import AuthError, PermissionDenied
+from fabric_dw.exceptions import AuthError, PermissionDeniedError
 from fabric_dw.models import Connection, RunningQuery
 from fabric_dw.services import queries
 
@@ -184,7 +184,7 @@ async def test_list_running_closes_connection_after_success() -> None:
 
 
 async def test_list_running_maps_permission_denied() -> None:
-    """cursor.execute raising a 'permission was denied' fragment → PermissionDenied."""
+    """cursor.execute raising a 'permission was denied' fragment → PermissionDeniedError."""
     target = _make_target()
     conn = MagicMock()
     cursor = MagicMock()
@@ -193,7 +193,7 @@ async def test_list_running_maps_permission_denied() -> None:
 
     with (
         patch("fabric_dw.sql.open_connection", return_value=conn),
-        pytest.raises(PermissionDenied),
+        pytest.raises(PermissionDeniedError),
     ):
         await queries.list_running(target)
 
@@ -339,13 +339,13 @@ async def test_kill_maps_permission_denied_from_cursor() -> None:
 
     with (
         patch("fabric_dw.sql.open_connection", return_value=conn),
-        pytest.raises(PermissionDenied),
+        pytest.raises(PermissionDeniedError),
     ):
         await queries.kill(target, 42)
 
 
 async def test_kill_maps_auth_error_to_permission_denied() -> None:
-    """kill should map AuthError → PermissionDenied."""
+    """kill should map AuthError → PermissionDeniedError."""
     target = _make_target()
     conn = MagicMock()
     cursor = MagicMock()
@@ -354,7 +354,7 @@ async def test_kill_maps_auth_error_to_permission_denied() -> None:
 
     with (
         patch("fabric_dw.sql.open_connection", return_value=conn),
-        pytest.raises(PermissionDenied),
+        pytest.raises(PermissionDeniedError),
     ):
         await queries.kill(target, 42)
 
@@ -368,7 +368,7 @@ async def test_kill_permission_denied_message_contains_session_id() -> None:
 
     with (
         patch("fabric_dw.sql.open_connection", return_value=conn),
-        pytest.raises(PermissionDenied, match="42"),
+        pytest.raises(PermissionDeniedError, match="42"),
     ):
         await queries.kill(target, 42)
 
@@ -534,7 +534,7 @@ async def test_list_connections_maps_permission_denied() -> None:
 
     with (
         patch("fabric_dw.sql.open_connection", return_value=conn),
-        pytest.raises(PermissionDenied),
+        pytest.raises(PermissionDeniedError),
     ):
         await queries.list_connections(target)
 

--- a/tests/unit/services/test_query_insights.py
+++ b/tests/unit/services/test_query_insights.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from fabric_dw.exceptions import AuthError, PermissionDenied
+from fabric_dw.exceptions import AuthError, PermissionDeniedError
 from fabric_dw.models import (
     ExecRequestHistory,
     ExecSessionHistory,
@@ -181,7 +181,7 @@ async def test_list_request_history_maps_permission_denied() -> None:
     conn.cursor.return_value = cursor
     with (
         patch("fabric_dw.sql.open_connection", return_value=conn),
-        pytest.raises(PermissionDenied),
+        pytest.raises(PermissionDeniedError),
     ):
         await query_insights.list_request_history(target)
 
@@ -194,7 +194,7 @@ async def test_list_request_history_permission_denied_message_has_docs_link() ->
     conn.cursor.return_value = cursor
     with (
         patch("fabric_dw.sql.open_connection", return_value=conn),
-        pytest.raises(PermissionDenied, match="query-insights"),
+        pytest.raises(PermissionDeniedError, match="query-insights"),
     ):
         await query_insights.list_request_history(target)
 
@@ -309,7 +309,7 @@ async def test_list_session_history_maps_permission_denied() -> None:
     conn.cursor.return_value = cursor
     with (
         patch("fabric_dw.sql.open_connection", return_value=conn),
-        pytest.raises(PermissionDenied),
+        pytest.raises(PermissionDeniedError),
     ):
         await query_insights.list_session_history(target)
 
@@ -402,7 +402,7 @@ async def test_list_frequent_queries_maps_permission_denied() -> None:
     conn.cursor.return_value = cursor
     with (
         patch("fabric_dw.sql.open_connection", return_value=conn),
-        pytest.raises(PermissionDenied),
+        pytest.raises(PermissionDeniedError),
     ):
         await query_insights.list_frequent_queries(target)
 
@@ -490,7 +490,7 @@ async def test_list_long_running_maps_permission_denied() -> None:
     conn.cursor.return_value = cursor
     with (
         patch("fabric_dw.sql.open_connection", return_value=conn),
-        pytest.raises(PermissionDenied),
+        pytest.raises(PermissionDeniedError),
     ):
         await query_insights.list_long_running_queries(target)
 
@@ -578,7 +578,7 @@ async def test_list_sql_pool_insights_maps_permission_denied() -> None:
     conn.cursor.return_value = cursor
     with (
         patch("fabric_dw.sql.open_connection", return_value=conn),
-        pytest.raises(PermissionDenied),
+        pytest.raises(PermissionDeniedError),
     ):
         await query_insights.list_sql_pool_insights(target)
 

--- a/tests/unit/services/test_restore.py
+++ b/tests/unit/services/test_restore.py
@@ -12,7 +12,7 @@ import httpx
 import pytest
 import respx
 
-from fabric_dw.exceptions import NotFound, PermissionDenied
+from fabric_dw.exceptions import NotFoundError, PermissionDeniedError
 from fabric_dw.http_client import FabricHttpClient
 from fabric_dw.models import CreationModeType, RestorePoint
 from fabric_dw.services import restore
@@ -181,11 +181,11 @@ async def test_list_points_follows_pagination() -> None:
 
 @respx.mock
 async def test_list_points_403_raises_permission_denied() -> None:
-    """list_points should propagate PermissionDenied on 403."""
+    """list_points should propagate PermissionDeniedError on 403."""
     respx.get(url__regex=rf"{_RP_LIST_URL}(\?.*)?$").mock(return_value=httpx.Response(403))
 
     async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
-        with pytest.raises(PermissionDenied):
+        with pytest.raises(PermissionDeniedError):
             await restore.list_points(http, _WS_ID, _WH_ID)
 
 
@@ -209,21 +209,21 @@ async def test_get_point_returns_restore_point() -> None:
 
 @respx.mock
 async def test_get_point_404_raises_not_found() -> None:
-    """get_point should raise NotFound on 404."""
+    """get_point should raise NotFoundError on 404."""
     respx.get(_RP_URL).mock(return_value=httpx.Response(404))
 
     async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
-        with pytest.raises(NotFound):
+        with pytest.raises(NotFoundError):
             await restore.get_point(http, _WS_ID, _WH_ID, _RP_ID)
 
 
 @respx.mock
 async def test_get_point_403_raises_permission_denied() -> None:
-    """get_point should raise PermissionDenied on 403."""
+    """get_point should raise PermissionDeniedError on 403."""
     respx.get(_RP_URL).mock(return_value=httpx.Response(403))
 
     async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
-        with pytest.raises(PermissionDenied):
+        with pytest.raises(PermissionDeniedError):
             await restore.get_point(http, _WS_ID, _WH_ID, _RP_ID)
 
 
@@ -435,11 +435,11 @@ def test_update_point_no_args_raises_value_error() -> None:
 
 @respx.mock
 async def test_update_point_404_raises_not_found() -> None:
-    """update_point should raise NotFound on 404."""
+    """update_point should raise NotFoundError on 404."""
     respx.patch(_RP_URL).mock(return_value=httpx.Response(404))
 
     async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
-        with pytest.raises(NotFound):
+        with pytest.raises(NotFoundError):
             await restore.update_point(http, _WS_ID, _WH_ID, _RP_ID, name="X")
 
 
@@ -461,21 +461,21 @@ async def test_delete_point_200_returns_none() -> None:
 
 @respx.mock
 async def test_delete_point_404_raises_not_found() -> None:
-    """delete_point should raise NotFound on 404."""
+    """delete_point should raise NotFoundError on 404."""
     respx.delete(_RP_URL).mock(return_value=httpx.Response(404))
 
     async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
-        with pytest.raises(NotFound):
+        with pytest.raises(NotFoundError):
             await restore.delete_point(http, _WS_ID, _WH_ID, _RP_ID)
 
 
 @respx.mock
 async def test_delete_point_403_raises_permission_denied() -> None:
-    """delete_point should raise PermissionDenied on 403."""
+    """delete_point should raise PermissionDeniedError on 403."""
     respx.delete(_RP_URL).mock(return_value=httpx.Response(403))
 
     async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
-        with pytest.raises(PermissionDenied):
+        with pytest.raises(PermissionDeniedError):
             await restore.delete_point(http, _WS_ID, _WH_ID, _RP_ID)
 
 
@@ -516,19 +516,19 @@ async def test_restore_in_place_lro_202_polls_to_completion() -> None:
 
 @respx.mock
 async def test_restore_in_place_404_raises_not_found() -> None:
-    """restore_in_place should raise NotFound on 404."""
+    """restore_in_place should raise NotFoundError on 404."""
     respx.post(f"{_RP_URL}/restore").mock(return_value=httpx.Response(404))
 
     async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
-        with pytest.raises(NotFound):
+        with pytest.raises(NotFoundError):
             await restore.restore_in_place(http, _WS_ID, _WH_ID, _RP_ID)
 
 
 @respx.mock
 async def test_restore_in_place_403_raises_permission_denied() -> None:
-    """restore_in_place should raise PermissionDenied on 403."""
+    """restore_in_place should raise PermissionDeniedError on 403."""
     respx.post(f"{_RP_URL}/restore").mock(return_value=httpx.Response(403))
 
     async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
-        with pytest.raises(PermissionDenied):
+        with pytest.raises(PermissionDeniedError):
             await restore.restore_in_place(http, _WS_ID, _WH_ID, _RP_ID)

--- a/tests/unit/services/test_schemas.py
+++ b/tests/unit/services/test_schemas.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from fabric_dw.exceptions import AuthError, NotFound, PermissionDenied
+from fabric_dw.exceptions import AuthError, NotFoundError, PermissionDeniedError
 from fabric_dw.models import Schema
 from fabric_dw.services import schemas
 from fabric_dw.services.schemas import validate_identifier
@@ -166,7 +166,7 @@ class TestListSchemas:
         conn.cursor.return_value = cursor
         with (
             patch("fabric_dw.sql.open_connection", return_value=conn),
-            pytest.raises(PermissionDenied),
+            pytest.raises(PermissionDeniedError),
         ):
             await schemas.list_schemas(target)
 
@@ -255,7 +255,7 @@ class TestCreateSchema:
         conn.cursor.return_value = cursor
         with (
             patch("fabric_dw.sql.open_connection", return_value=conn),
-            pytest.raises(PermissionDenied),
+            pytest.raises(PermissionDeniedError),
         ):
             await schemas.create_schema(target, "dbo")
 
@@ -265,7 +265,7 @@ class TestCreateSchema:
         fetch_conn = _make_conn([], _LIST_COLS)
         with (
             patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]),
-            pytest.raises(NotFound),
+            pytest.raises(NotFoundError),
         ):
             await schemas.create_schema(target, "dbo")
 
@@ -326,7 +326,7 @@ class TestDeleteSchema:
         conn.cursor.return_value = cursor
         with (
             patch("fabric_dw.sql.open_connection", return_value=conn),
-            pytest.raises(PermissionDenied),
+            pytest.raises(PermissionDeniedError),
         ):
             await schemas.delete_schema(target, "dbo")
 

--- a/tests/unit/services/test_snapshots.py
+++ b/tests/unit/services/test_snapshots.py
@@ -14,7 +14,7 @@ import pytest
 import respx
 
 from fabric_dw.cache import ItemEntry, LookupCache
-from fabric_dw.exceptions import NotFound, PermissionDenied
+from fabric_dw.exceptions import NotFoundError, PermissionDeniedError
 from fabric_dw.http_client import FabricHttpClient
 from fabric_dw.models import WarehouseKind, WarehouseSnapshot
 from fabric_dw.services import snapshots
@@ -535,11 +535,11 @@ async def test_delete_204_returns_none() -> None:
 
 @respx.mock
 async def test_delete_404_raises_not_found() -> None:
-    """delete should propagate NotFound on 404."""
+    """delete should propagate NotFoundError on 404."""
     respx.delete(f"{_ITEMS_URL}/{_SNAP_ID}").mock(return_value=httpx.Response(404))
 
     async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
-        with pytest.raises(NotFound):
+        with pytest.raises(NotFoundError):
             await snapshots.delete(http, _WS_ID, _SNAP_ID)
 
 
@@ -661,7 +661,7 @@ async def test_roll_timestamp_name_injection_newline() -> None:
 
 
 async def test_roll_timestamp_maps_permission_error() -> None:
-    """roll_timestamp should map driver permission failures to PermissionDenied."""
+    """roll_timestamp should map driver permission failures to PermissionDeniedError."""
     target = _make_sql_target()
     conn = MagicMock()
     cursor = MagicMock()
@@ -670,7 +670,7 @@ async def test_roll_timestamp_maps_permission_error() -> None:
 
     with (
         patch("fabric_dw.sql.open_connection", return_value=conn),
-        pytest.raises(PermissionDenied),
+        pytest.raises(PermissionDeniedError),
     ):
         await snapshots.roll_timestamp(target, "MySnapshot")
 

--- a/tests/unit/services/test_sql_endpoints.py
+++ b/tests/unit/services/test_sql_endpoints.py
@@ -12,7 +12,7 @@ import httpx
 import pytest
 import respx
 
-from fabric_dw.exceptions import FabricServerError, NotFound, PermissionDenied
+from fabric_dw.exceptions import FabricServerError, NotFoundError, PermissionDeniedError
 from fabric_dw.models import TableSyncStatus, Warehouse, WarehouseKind, Workspace
 from fabric_dw.services.sql_endpoints import list_all_workspaces
 from tests.fixtures.api_payloads import (
@@ -168,7 +168,7 @@ async def test_get_endpoint_returns_populated_warehouse() -> None:
 
 
 async def test_get_endpoint_404_propagates_not_found() -> None:
-    """get_endpoint must propagate NotFound on a 404 response."""
+    """get_endpoint must propagate NotFoundError on a 404 response."""
     from fabric_dw.services.sql_endpoints import get_endpoint  # noqa: PLC0415
 
     with respx.mock:
@@ -180,7 +180,7 @@ async def test_get_endpoint_404_propagates_not_found() -> None:
 
         client = await _make_client()
         async with client:
-            with pytest.raises(NotFound):
+            with pytest.raises(NotFoundError):
                 await get_endpoint(client, _WORKSPACE_ID, _ENDPOINT_ID)
 
 
@@ -410,7 +410,7 @@ async def test_list_all_workspaces_endpoints_aggregates_across_workspaces() -> N
 async def test_list_all_workspaces_endpoints_skips_permission_denied(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """list_all_workspaces must skip workspaces where PermissionDenied is raised and warn."""
+    """list_all_workspaces must skip workspaces where PermissionDeniedError is raised and warn."""
     ws_a = _make_workspace(_EP_WS_A)
     ws_b = _make_workspace(_EP_WS_B)
     ws_c = _make_workspace(_EP_WS_C)
@@ -430,7 +430,7 @@ async def test_list_all_workspaces_endpoints_skips_permission_denied(
             new=AsyncMock(
                 side_effect=[
                     [ep_a],
-                    PermissionDenied("no access"),
+                    PermissionDeniedError("no access"),
                     [ep_c],
                 ]
             ),
@@ -448,7 +448,7 @@ async def test_list_all_workspaces_endpoints_skips_permission_denied(
 async def test_list_all_workspaces_endpoints_skips_not_found(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """list_all_workspaces must skip workspaces where NotFound is raised and warn."""
+    """list_all_workspaces must skip workspaces where NotFoundError is raised and warn."""
     ws_a = _make_workspace(_EP_WS_A)
     ws_b = _make_workspace(_EP_WS_B)
     ws_c = _make_workspace(_EP_WS_C)
@@ -468,7 +468,7 @@ async def test_list_all_workspaces_endpoints_skips_not_found(
             new=AsyncMock(
                 side_effect=[
                     [ep_a],
-                    NotFound("workspace gone"),
+                    NotFoundError("workspace gone"),
                     [ep_c],
                 ]
             ),

--- a/tests/unit/services/test_sql_exec.py
+++ b/tests/unit/services/test_sql_exec.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from fabric_dw.exceptions import AuthError, PermissionDenied
+from fabric_dw.exceptions import AuthError, PermissionDeniedError
 from fabric_dw.models import SqlResult
 from fabric_dw.services import sql_exec
 
@@ -239,13 +239,13 @@ async def test_execute_permission_denied_raises_permission_denied() -> None:
 
     with (
         patch("fabric_dw.sql.open_connection", return_value=conn),
-        pytest.raises(PermissionDenied),
+        pytest.raises(PermissionDeniedError),
     ):
         await sql_exec.execute(target, "SELECT * FROM SensitiveTable")
 
 
 async def test_execute_permission_denied_message_contains_hint() -> None:
-    """PermissionDenied message must mention a documentation hint."""
+    """PermissionDeniedError message must mention a documentation hint."""
     target = _make_target()
     conn = MagicMock()
     cursor = MagicMock()
@@ -254,7 +254,7 @@ async def test_execute_permission_denied_message_contains_hint() -> None:
 
     with (
         patch("fabric_dw.sql.open_connection", return_value=conn),
-        pytest.raises(PermissionDenied, match="Hint"),
+        pytest.raises(PermissionDeniedError, match="Hint"),
     ):
         await sql_exec.execute(target, "SELECT * FROM X")
 
@@ -275,7 +275,7 @@ async def test_execute_auth_error_raises_auth_error() -> None:
 
 
 async def test_execute_perm_denied_driver_raises_permission_denied() -> None:
-    """SQL permission-denial errors are re-raised as PermissionDenied."""
+    """SQL permission-denial errors are re-raised as PermissionDeniedError."""
     target = _make_target()
     conn = MagicMock()
     cursor = MagicMock()
@@ -284,7 +284,7 @@ async def test_execute_perm_denied_driver_raises_permission_denied() -> None:
 
     with (
         patch("fabric_dw.sql.open_connection", return_value=conn),
-        pytest.raises(PermissionDenied),
+        pytest.raises(PermissionDeniedError),
     ):
         await sql_exec.execute(target, "SELECT * FROM SensitiveTable")
 

--- a/tests/unit/services/test_sql_pools.py
+++ b/tests/unit/services/test_sql_pools.py
@@ -11,7 +11,7 @@ import pytest
 import respx
 from pydantic import ValidationError
 
-from fabric_dw.exceptions import AlreadyExists, NotFound, PermissionDenied
+from fabric_dw.exceptions import AlreadyExistsError, NotFoundError, PermissionDeniedError
 from fabric_dw.models import SqlPool, SqlPoolsConfiguration
 from fabric_dw.services import sql_pools
 from tests.unit.services._helpers import _make_client
@@ -118,12 +118,12 @@ async def test_get_configuration_disabled_workspace() -> None:
 
 
 async def test_get_configuration_403_raises_permission_denied() -> None:
-    """get_configuration propagates PermissionDenied on 403 with hint."""
+    """get_configuration propagates PermissionDeniedError on 403 with hint."""
     with respx.mock:
         respx.get(_CONFIG_URL).mock(return_value=httpx.Response(403, json={"error": "forbidden"}))
         client = await _make_client()
         async with client:
-            with pytest.raises(PermissionDenied):
+            with pytest.raises(PermissionDeniedError):
                 await sql_pools.get_configuration(client, _WS_ID)
 
 
@@ -185,14 +185,14 @@ async def test_update_configuration_destructive_semantics_reflected_in_body() ->
 
 
 async def test_update_configuration_403_raises_permission_denied() -> None:
-    """update_configuration propagates PermissionDenied on 403."""
+    """update_configuration propagates PermissionDeniedError on 403."""
     config = SqlPoolsConfiguration.model_validate(POOLS_ENABLED_PAYLOAD)
 
     with respx.mock:
         respx.patch(_CONFIG_URL).mock(return_value=httpx.Response(403, json={"error": "forbidden"}))
         client = await _make_client()
         async with client:
-            with pytest.raises(PermissionDenied):
+            with pytest.raises(PermissionDeniedError):
                 await sql_pools.update_configuration(client, _WS_ID, config)
 
 
@@ -267,7 +267,7 @@ async def test_disable_patches_enabled_false_preserving_pools() -> None:
 
 
 async def test_enable_propagates_not_found_on_404() -> None:
-    """enable propagates NotFound when get_configuration returns 404.
+    """enable propagates NotFoundError when get_configuration returns 404.
 
     There is no fallback that PATCHes an empty configuration — if the workspace
     configuration endpoint is absent, the error surfaces to the caller.
@@ -276,12 +276,12 @@ async def test_enable_propagates_not_found_on_404() -> None:
         respx.get(_CONFIG_URL).mock(return_value=httpx.Response(404, json={"error": "not found"}))
         client = await _make_client()
         async with client:
-            with pytest.raises(NotFound):
+            with pytest.raises(NotFoundError):
                 await sql_pools.enable(client, _WS_ID)
 
 
 async def test_disable_propagates_not_found_on_404() -> None:
-    """disable propagates NotFound when get_configuration returns 404.
+    """disable propagates NotFoundError when get_configuration returns 404.
 
     There is no fallback that PATCHes an empty configuration — if the workspace
     configuration endpoint is absent, the error surfaces to the caller.
@@ -290,7 +290,7 @@ async def test_disable_propagates_not_found_on_404() -> None:
         respx.get(_CONFIG_URL).mock(return_value=httpx.Response(404, json={"error": "not found"}))
         client = await _make_client()
         async with client:
-            with pytest.raises(NotFound):
+            with pytest.raises(NotFoundError):
                 await sql_pools.disable(client, _WS_ID)
 
 
@@ -518,7 +518,7 @@ async def test_create_pool_appends_and_patches() -> None:
 
 
 async def test_create_pool_raises_already_exists_on_duplicate() -> None:
-    """create_pool should raise AlreadyExists when the pool name already exists."""
+    """create_pool should raise AlreadyExistsError when the pool name already exists."""
     duplicate_pool = SqlPool.model_validate(
         {
             "name": "ETL",
@@ -530,7 +530,7 @@ async def test_create_pool_raises_already_exists_on_duplicate() -> None:
         respx.get(_CONFIG_URL).mock(return_value=httpx.Response(200, json=POOLS_ENABLED_PAYLOAD))
         client = await _make_client()
         async with client:
-            with pytest.raises(AlreadyExists, match="ETL"):
+            with pytest.raises(AlreadyExistsError, match="ETL"):
                 await sql_pools.create_pool(client, _WS_ID, duplicate_pool)
 
 
@@ -594,12 +594,12 @@ async def test_create_pool_multiple_classifier_values() -> None:
 
 
 async def test_update_pool_raises_not_found_for_missing_name() -> None:
-    """update_pool should raise NotFound when the pool name does not exist."""
+    """update_pool should raise NotFoundError when the pool name does not exist."""
     with respx.mock:
         respx.get(_CONFIG_URL).mock(return_value=httpx.Response(200, json=POOLS_ENABLED_PAYLOAD))
         client = await _make_client()
         async with client:
-            with pytest.raises(NotFound, match="NonExistent"):
+            with pytest.raises(NotFoundError, match="NonExistent"):
                 await sql_pools.update_pool(
                     client, _WS_ID, "NonExistent", max_resource_percentage=50
                 )
@@ -707,12 +707,12 @@ async def test_delete_pool_removes_named_pool() -> None:
 
 
 async def test_delete_pool_raises_not_found_for_missing_name() -> None:
-    """delete_pool should raise NotFound when the pool name does not exist."""
+    """delete_pool should raise NotFoundError when the pool name does not exist."""
     with respx.mock:
         respx.get(_CONFIG_URL).mock(return_value=httpx.Response(200, json=POOLS_ENABLED_PAYLOAD))
         client = await _make_client()
         async with client:
-            with pytest.raises(NotFound, match="DoesNotExist"):
+            with pytest.raises(NotFoundError, match="DoesNotExist"):
                 await sql_pools.delete_pool(client, _WS_ID, "DoesNotExist")
 
 

--- a/tests/unit/services/test_tables.py
+++ b/tests/unit/services/test_tables.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from fabric_dw.exceptions import AuthError, ItemKindError, NotFound, PermissionDenied
+from fabric_dw.exceptions import AuthError, ItemKindError, NotFoundError, PermissionDeniedError
 from fabric_dw.models import Table, WarehouseKind
 from fabric_dw.services import tables
 from fabric_dw.services.tables import validate_identifier
@@ -226,7 +226,7 @@ class TestListTables:
         conn.cursor.return_value = cursor
         with (
             patch("fabric_dw.sql.open_connection", return_value=conn),
-            pytest.raises(PermissionDenied),
+            pytest.raises(PermissionDeniedError),
         ):
             await tables.list_tables(target)
 
@@ -310,7 +310,7 @@ class TestReadTable:
         conn.cursor.return_value = cursor
         with (
             patch("fabric_dw.sql.open_connection", return_value=conn),
-            pytest.raises(NotFound),
+            pytest.raises(NotFoundError),
         ):
             await tables.read_table(target, "dbo", "nonexistent")
 
@@ -322,7 +322,7 @@ class TestReadTable:
         conn.cursor.return_value = cursor
         with (
             patch("fabric_dw.sql.open_connection", return_value=conn),
-            pytest.raises(PermissionDenied),
+            pytest.raises(PermissionDeniedError),
         ):
             await tables.read_table(target, "dbo", "sales")
 
@@ -414,7 +414,7 @@ class TestCreateTable:
         conn.cursor.return_value = cursor
         with (
             patch("fabric_dw.sql.open_connection", return_value=conn),
-            pytest.raises(PermissionDenied),
+            pytest.raises(PermissionDeniedError),
         ):
             await tables.create_table(target, "dbo", "sales", "SELECT 1")
 
@@ -481,7 +481,7 @@ class TestDeleteTable:
         conn.cursor.return_value = cursor
         with (
             patch("fabric_dw.sql.open_connection", return_value=conn),
-            pytest.raises(PermissionDenied),
+            pytest.raises(PermissionDeniedError),
         ):
             await tables.delete_table(target, "dbo", "sales")
 
@@ -565,7 +565,7 @@ class TestClearTable:
         conn.cursor.return_value = cursor
         with (
             patch("fabric_dw.sql.open_connection", return_value=conn),
-            pytest.raises(PermissionDenied),
+            pytest.raises(PermissionDeniedError),
         ):
             await tables.clear_table(target, "dbo", "sales")
 

--- a/tests/unit/services/test_views.py
+++ b/tests/unit/services/test_views.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from fabric_dw.exceptions import AuthError, NotFound, PermissionDenied
+from fabric_dw.exceptions import AuthError, NotFoundError, PermissionDeniedError
 from fabric_dw.models import View
 from fabric_dw.services import views
 from fabric_dw.services.views import read_view, validate_identifier
@@ -244,7 +244,7 @@ class TestListViews:
         conn.cursor.return_value = cursor
         with (
             patch("fabric_dw.sql.open_connection", return_value=conn),
-            pytest.raises(PermissionDenied),
+            pytest.raises(PermissionDeniedError),
         ):
             await views.list_views(target)
 
@@ -328,7 +328,7 @@ class TestReadView:
         conn.cursor.return_value = cursor
         with (
             patch("fabric_dw.sql.open_connection", return_value=conn),
-            pytest.raises(NotFound),
+            pytest.raises(NotFoundError),
         ):
             await read_view(target, "dbo", "vw_nonexistent")
 
@@ -340,7 +340,7 @@ class TestReadView:
         conn.cursor.return_value = cursor
         with (
             patch("fabric_dw.sql.open_connection", return_value=conn),
-            pytest.raises(PermissionDenied),
+            pytest.raises(PermissionDeniedError),
         ):
             await read_view(target, "dbo", "vw_sales")
 
@@ -400,7 +400,7 @@ class TestGetView:
         conn = _make_conn([], _GET_COLS)
         with (
             patch("fabric_dw.sql.open_connection", return_value=conn),
-            pytest.raises(NotFound),
+            pytest.raises(NotFoundError),
         ):
             await views.get_view(target, "dbo", "nonexistent")
 
@@ -437,7 +437,7 @@ class TestGetView:
         conn.cursor.return_value = cursor
         with (
             patch("fabric_dw.sql.open_connection", return_value=conn),
-            pytest.raises(PermissionDenied),
+            pytest.raises(PermissionDeniedError),
         ):
             await views.get_view(target, "dbo", "vw_sales")
 
@@ -514,7 +514,7 @@ class TestCreateView:
         conn.cursor.return_value = cursor
         with (
             patch("fabric_dw.sql.open_connection", return_value=conn),
-            pytest.raises(PermissionDenied),
+            pytest.raises(PermissionDeniedError),
         ):
             await views.create_view(target, "dbo", "vw_sales", "SELECT 1")
 
@@ -600,7 +600,7 @@ class TestUpdateView:
         conn.cursor.return_value = cursor
         with (
             patch("fabric_dw.sql.open_connection", return_value=conn),
-            pytest.raises(PermissionDenied),
+            pytest.raises(PermissionDeniedError),
         ):
             await views.update_view(target, "dbo", "vw_sales", "SELECT 1")
 
@@ -662,7 +662,7 @@ class TestDropView:
         conn.cursor.return_value = cursor
         with (
             patch("fabric_dw.sql.open_connection", return_value=conn),
-            pytest.raises(PermissionDenied),
+            pytest.raises(PermissionDeniedError),
         ):
             await views.drop_view(target, "dbo", "vw_sales")
 

--- a/tests/unit/services/test_warehouses.py
+++ b/tests/unit/services/test_warehouses.py
@@ -14,7 +14,7 @@ import pytest
 import respx
 
 from fabric_dw.cache import ItemEntry, LookupCache
-from fabric_dw.exceptions import FabricServerError, NotFound, PermissionDenied
+from fabric_dw.exceptions import FabricServerError, NotFoundError, PermissionDeniedError
 from fabric_dw.models import Warehouse, WarehouseKind, Workspace
 from fabric_dw.services import warehouses
 from tests.fixtures.api_payloads import (
@@ -175,7 +175,7 @@ async def test_get_returns_populated_warehouse() -> None:
 
 
 async def test_get_not_found_propagates() -> None:
-    """get_warehouse must propagate NotFound on a 404 response."""
+    """get_warehouse must propagate NotFoundError on a 404 response."""
     with respx.mock:
         respx.get(_WAREHOUSE_URL).mock(
             return_value=httpx.Response(404, json={"error": {"code": "ItemNotFound"}})
@@ -183,7 +183,7 @@ async def test_get_not_found_propagates() -> None:
 
         client = await _make_client()
         async with client:
-            with pytest.raises(NotFound):
+            with pytest.raises(NotFoundError):
                 await warehouses.get_warehouse(client, _WORKSPACE_ID, _WAREHOUSE_ID)
 
 
@@ -581,7 +581,7 @@ async def test_delete_204_returns_none() -> None:
 
 
 async def test_delete_404_propagates_not_found() -> None:
-    """delete must propagate NotFound on a 404 response."""
+    """delete must propagate NotFoundError on a 404 response."""
     with respx.mock:
         respx.delete(_WAREHOUSE_URL).mock(
             return_value=httpx.Response(404, json={"error": {"code": "ItemNotFound"}})
@@ -589,7 +589,7 @@ async def test_delete_404_propagates_not_found() -> None:
 
         client = await _make_client()
         async with client:
-            with pytest.raises(NotFound):
+            with pytest.raises(NotFoundError):
                 await warehouses.delete(client, _WORKSPACE_ID, _WAREHOUSE_ID)
 
 
@@ -680,7 +680,7 @@ async def test_list_all_workspaces_aggregates_across_workspaces() -> None:
 async def test_list_all_workspaces_skips_permission_denied(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """list_all_workspaces must skip workspaces where PermissionDenied is raised and warn."""
+    """list_all_workspaces must skip workspaces where PermissionDeniedError is raised and warn."""
     ws_a = _make_workspace(_WS_A)
     ws_b = _make_workspace(_WS_B)
     ws_c = _make_workspace(_WS_C)
@@ -700,7 +700,7 @@ async def test_list_all_workspaces_skips_permission_denied(
             new=AsyncMock(
                 side_effect=[
                     [wh_a],
-                    PermissionDenied("no access"),
+                    PermissionDeniedError("no access"),
                     [wh_c],
                 ]
             ),
@@ -718,7 +718,7 @@ async def test_list_all_workspaces_skips_permission_denied(
 
 
 async def test_list_all_workspaces_skips_not_found(caplog: pytest.LogCaptureFixture) -> None:
-    """list_all_workspaces must skip workspaces where NotFound is raised and warn."""
+    """list_all_workspaces must skip workspaces where NotFoundError is raised and warn."""
     ws_a = _make_workspace(_WS_A)
     ws_b = _make_workspace(_WS_B)
     ws_c = _make_workspace(_WS_C)
@@ -738,7 +738,7 @@ async def test_list_all_workspaces_skips_not_found(caplog: pytest.LogCaptureFixt
             new=AsyncMock(
                 side_effect=[
                     [wh_a],
-                    NotFound("workspace gone"),
+                    NotFoundError("workspace gone"),
                     [wh_c],
                 ]
             ),

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -12,14 +12,14 @@ from __future__ import annotations
 import pytest
 
 from fabric_dw.exceptions import (
-    AlreadyExists,
+    AlreadyExistsError,
     AuthError,
     ConfigError,
     FabricError,
     FabricServerError,
     ItemKindError,
-    NotFound,
-    PermissionDenied,
+    NotFoundError,
+    PermissionDeniedError,
     RateLimitedError,
 )
 
@@ -137,11 +137,11 @@ class TestSubclasses:
         "exc_cls",
         [
             AuthError,
-            PermissionDenied,
-            NotFound,
+            PermissionDeniedError,
+            NotFoundError,
             RateLimitedError,
             FabricServerError,
-            AlreadyExists,
+            AlreadyExistsError,
             ItemKindError,
         ],
     )
@@ -153,11 +153,11 @@ class TestSubclasses:
         "exc_cls",
         [
             AuthError,
-            PermissionDenied,
-            NotFound,
+            PermissionDeniedError,
+            NotFoundError,
             RateLimitedError,
             FabricServerError,
-            AlreadyExists,
+            AlreadyExistsError,
             ItemKindError,
         ],
     )
@@ -177,11 +177,11 @@ class TestSubclasses:
         "exc_cls",
         [
             AuthError,
-            PermissionDenied,
-            NotFound,
+            PermissionDeniedError,
+            NotFoundError,
             RateLimitedError,
             FabricServerError,
-            AlreadyExists,
+            AlreadyExistsError,
             ItemKindError,
         ],
     )
@@ -193,11 +193,11 @@ class TestSubclasses:
         "exc_cls",
         [
             AuthError,
-            PermissionDenied,
-            NotFound,
+            PermissionDeniedError,
+            NotFoundError,
             RateLimitedError,
             FabricServerError,
-            AlreadyExists,
+            AlreadyExistsError,
             ItemKindError,
         ],
     )

--- a/tests/unit/test_http_client.py
+++ b/tests/unit/test_http_client.py
@@ -20,8 +20,8 @@ from fabric_dw.exceptions import (
     AuthError,
     FabricError,
     FabricServerError,
-    NotFound,
-    PermissionDenied,
+    NotFoundError,
+    PermissionDeniedError,
     RateLimitedError,
 )
 from fabric_dw.http_client import FabricHttpClient, HttpBase, _parse_retry_after
@@ -166,26 +166,26 @@ async def test_401_raises_auth_error() -> None:
 
 
 async def test_403_raises_permission_denied() -> None:
-    """HTTP 403 should raise PermissionDenied."""
+    """HTTP 403 should raise PermissionDeniedError."""
     with respx.mock:
         respx.get("https://api.fabric.microsoft.com/v1/items").mock(
             return_value=httpx.Response(403, json={"error": "forbidden"})
         )
         client = await _get_client()
         async with client:
-            with pytest.raises(PermissionDenied):
+            with pytest.raises(PermissionDeniedError):
                 await client.request("GET", HttpBase.FABRIC, "/items")
 
 
 async def test_404_raises_not_found() -> None:
-    """HTTP 404 should raise NotFound."""
+    """HTTP 404 should raise NotFoundError."""
     with respx.mock:
         respx.get("https://api.fabric.microsoft.com/v1/items").mock(
             return_value=httpx.Response(404, json={"error": "not found"})
         )
         client = await _get_client()
         async with client:
-            with pytest.raises(NotFound):
+            with pytest.raises(NotFoundError):
                 await client.request("GET", HttpBase.FABRIC, "/items")
 
 
@@ -484,7 +484,7 @@ async def test_get_operation_result_returns_body() -> None:
 
 
 async def test_get_operation_result_not_found_propagates() -> None:
-    """get_operation_result should propagate NotFound when the result endpoint returns 404."""
+    """get_operation_result should propagate NotFoundError when the result endpoint returns 404."""
     op_id = "no-such-op"
     result_url = f"https://api.fabric.microsoft.com/v1/operations/{op_id}/result"
 
@@ -493,7 +493,7 @@ async def test_get_operation_result_not_found_propagates() -> None:
 
         client = await _get_client()
         async with client:
-            with pytest.raises(NotFound):
+            with pytest.raises(NotFoundError):
                 await client.get_operation_result(op_id)
 
 
@@ -634,7 +634,7 @@ async def test_status_mapping_fills_exception_attributes() -> None:
         )
         client = await _get_client()
         async with client:
-            with pytest.raises(NotFound) as exc_info:
+            with pytest.raises(NotFoundError) as exc_info:
                 await client.request("GET", HttpBase.FABRIC, "/items")
 
     err = exc_info.value

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -693,7 +693,9 @@ class TestRestorePointFlatteningParametric:
         ],
         ids=["nested", "already_flat", "no_details", "empty_details"],
     )
-    def test_event_date_time_resolved(self, payload: dict, expected_event_dt_is_none: bool) -> None:
+    def test_event_date_time_resolved(
+        self, payload: dict, *, expected_event_dt_is_none: bool
+    ) -> None:
         obj = RestorePoint.model_validate(payload)
         if expected_event_dt_is_none:
             assert obj.event_date_time is None

--- a/tests/unit/test_resolver.py
+++ b/tests/unit/test_resolver.py
@@ -14,7 +14,7 @@ from azure.core.credentials import AccessToken
 from azure.core.credentials_async import AsyncTokenCredential
 
 from fabric_dw.cache import LookupCache
-from fabric_dw.exceptions import FabricError, NotFound
+from fabric_dw.exceptions import FabricError, NotFoundError
 from fabric_dw.http_client import FabricHttpClient
 from fabric_dw.models import WarehouseKind
 from fabric_dw.resolver import (
@@ -184,7 +184,7 @@ async def test_workspace_id_name_not_found(tmp_path: Path) -> None:
             return_value=httpx.Response(200, json=_pbi_empty_response())
         )
         async with client:
-            with pytest.raises(NotFound, match="workspace"):
+            with pytest.raises(NotFoundError, match="workspace"):
                 await resolver.workspace_id("NonExistentWorkspace")
 
 
@@ -303,7 +303,7 @@ async def test_item_name_not_found(tmp_path: Path) -> None:
     with respx.mock:
         respx.get(_FABRIC_ITEMS_URL).mock(return_value=httpx.Response(200, json=list_payload))
         async with client:
-            with pytest.raises(NotFound):
+            with pytest.raises(NotFoundError):
                 await resolver.item(WS_GUID, "NonExistentWarehouse")
 
 
@@ -537,7 +537,7 @@ async def test_item_guid_unknown_type_raises_fabric_error(tmp_path: Path) -> Non
 
 
 # ---------------------------------------------------------------------------
-# Negative cache: repeated NotFound avoids API call
+# Negative cache: repeated NotFoundError avoids API call
 # ---------------------------------------------------------------------------
 
 
@@ -549,10 +549,10 @@ async def test_workspace_negative_cache_avoids_second_api_call(tmp_path: Path) -
             return_value=httpx.Response(200, json=_pbi_empty_response())
         )
         async with client:
-            with pytest.raises(NotFound):
+            with pytest.raises(NotFoundError):
                 await resolver.workspace_id("GhostWorkspace")
             # Second call: negative cache should fire before the HTTP route
-            with pytest.raises(NotFound):
+            with pytest.raises(NotFoundError):
                 await resolver.workspace_id("GhostWorkspace")
     # The real API should only have been called once
     assert route.call_count == 1, "negative cache must suppress the second API call"
@@ -572,7 +572,7 @@ async def test_workspace_negative_cache_clears_on_success(tmp_path: Path) -> Non
             return_value=httpx.Response(200, json=_pbi_empty_response())
         )
         async with client:
-            with pytest.raises(NotFound):
+            with pytest.raises(NotFoundError):
                 await resolver.workspace_id("GhostWorkspace")
 
         # Verify the entry was recorded
@@ -604,10 +604,10 @@ async def test_item_negative_cache_avoids_second_api_call(tmp_path: Path) -> Non
             return_value=httpx.Response(200, json=list_payload)
         )
         async with client:
-            with pytest.raises(NotFound):
+            with pytest.raises(NotFoundError):
                 await resolver.item(WS_GUID, "GhostItem")
             # Second call: negative cache should fire before hitting the list endpoint
-            with pytest.raises(NotFound):
+            with pytest.raises(NotFoundError):
                 await resolver.item(WS_GUID, "GhostItem")
     assert route.call_count == 1, "negative cache must suppress the second items-list call"
 
@@ -739,7 +739,7 @@ async def test_negative_cache_expired_entry_pruned_on_check(tmp_path: Path) -> N
             return_value=httpx.Response(200, json=_pbi_group_response(WS_GUID, "ghost"))
         )
         async with client:
-            # Should NOT raise NotFound (entry is expired), and must prune it
+            # Should NOT raise NotFoundError (entry is expired), and must prune it
             result = await resolver.workspace_id("ghost")
     assert result == WS_UUID
     # Expired entry must have been pruned
@@ -754,9 +754,9 @@ async def test_clear_negative_cache_empties_all_entries(tmp_path: Path) -> None:
             return_value=httpx.Response(200, json=_pbi_empty_response())
         )
         async with client:
-            with pytest.raises(NotFound):
+            with pytest.raises(NotFoundError):
                 await resolver.workspace_id("Ghost1")
-            with pytest.raises(NotFound):
+            with pytest.raises(NotFoundError):
                 await resolver.workspace_id("Ghost2")
     assert len(resolver._negative) == 2
     resolver.clear_negative_cache()

--- a/tests/unit/test_sql.py
+++ b/tests/unit/test_sql.py
@@ -10,7 +10,7 @@ import pytest
 
 import fabric_dw.sql as _sql_module
 from fabric_dw.auth import CredentialMode
-from fabric_dw.exceptions import AuthError, PermissionDenied
+from fabric_dw.exceptions import AuthError, PermissionDeniedError
 from fabric_dw.sql import (
     SqlTarget,
     build_connection_string,
@@ -275,12 +275,12 @@ class TestMapDriverError:
     def test_permission_denied_fragment_returns_permission_denied(self) -> None:
         exc = Exception("The principal does not have permission was denied on object X")
         result = map_driver_error(exc)
-        assert isinstance(result, PermissionDenied)
+        assert isinstance(result, PermissionDeniedError)
 
     def test_denied_the_right_to_fragment_returns_permission_denied(self) -> None:
         exc = Exception("denied the right to execute")
         result = map_driver_error(exc)
-        assert isinstance(result, PermissionDenied)
+        assert isinstance(result, PermissionDeniedError)
 
     def test_auth_failed_fragment_returns_auth_error(self) -> None:
         exc = Exception("Authentication failed for user '' (token-based)")
@@ -302,12 +302,12 @@ class TestMapDriverError:
         # Permission-denied check must come first (as in the issue spec).
         exc = Exception("permission was denied authentication failed")
         result = map_driver_error(exc)
-        assert isinstance(result, PermissionDenied)
+        assert isinstance(result, PermissionDeniedError)
 
     def test_case_insensitive_matching(self) -> None:
         exc = Exception("PERMISSION WAS DENIED on the object")
         result = map_driver_error(exc)
-        assert isinstance(result, PermissionDenied)
+        assert isinstance(result, PermissionDeniedError)
 
     def test_result_message_contains_original(self) -> None:
         original_msg = "permission was denied on SELECT"
@@ -327,22 +327,22 @@ class TestMapDriverError:
         return exc  # type: ignore[return-value]
 
     def test_native_error_229_returns_permission_denied(self) -> None:
-        """Error number 229 (SELECT permission denied) → PermissionDenied."""
+        """Error number 229 (SELECT permission denied) → PermissionDeniedError."""
         exc = self._make_driver_exc("some driver error", "Error: 229 SELECT permission denied")
         result = map_driver_error(exc)
-        assert isinstance(result, PermissionDenied)
+        assert isinstance(result, PermissionDeniedError)
 
     def test_native_error_230_returns_permission_denied(self) -> None:
-        """Error number 230 (INSERT permission denied) → PermissionDenied."""
+        """Error number 230 (INSERT permission denied) → PermissionDeniedError."""
         exc = self._make_driver_exc("some driver error", "(230) INSERT permission denied")
         result = map_driver_error(exc)
-        assert isinstance(result, PermissionDenied)
+        assert isinstance(result, PermissionDeniedError)
 
     def test_native_error_297_returns_permission_denied(self) -> None:
-        """Error number 297 (execute permission denied) → PermissionDenied."""
+        """Error number 297 (execute permission denied) → PermissionDeniedError."""
         exc = self._make_driver_exc("some driver error", "Error: 297 execute permission denied")
         result = map_driver_error(exc)
-        assert isinstance(result, PermissionDenied)
+        assert isinstance(result, PermissionDeniedError)
 
     def test_native_error_18456_returns_auth_error(self) -> None:
         """Error number 18456 (login failed) → AuthError."""
@@ -354,13 +354,13 @@ class TestMapDriverError:
         """Native error 229 beats an auth fragment in the message string."""
         exc = self._make_driver_exc("authentication failed error", "Error: 229 permission")
         result = map_driver_error(exc)
-        assert isinstance(result, PermissionDenied)
+        assert isinstance(result, PermissionDeniedError)
 
     def test_unrecognised_native_error_falls_through_to_fragment(self) -> None:
         """An unrecognised native error number falls through to fragment matching."""
         exc = self._make_driver_exc("permission was denied for this object", "Error: 9999 unknown")
         result = map_driver_error(exc)
-        assert isinstance(result, PermissionDenied)
+        assert isinstance(result, PermissionDeniedError)
 
 
 # ---------------------------------------------------------------------------
@@ -448,7 +448,7 @@ class TestRunQuery:
         mock_cursor.execute.side_effect = Exception("permission was denied on object X")
         _patch_mssql(monkeypatch, mock_mssql)
 
-        with pytest.raises(PermissionDenied):
+        with pytest.raises(PermissionDeniedError):
             run_query(_make_target(), "SELECT * FROM X")
 
     def test_auth_error_fragment_mapped(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -526,7 +526,7 @@ class TestRunStatements:
         mock_cursor.execute.side_effect = Exception("permission was denied")
         _patch_mssql(monkeypatch, mock_mssql)
 
-        with pytest.raises(PermissionDenied):
+        with pytest.raises(PermissionDeniedError):
             run_statements(_make_target(), ["DROP TABLE [dbo].[t]"])
 
         mock_conn.close.assert_called_once()


### PR DESCRIPTION
## Summary

- **Exception rename (N818)**: `PermissionDenied` → `PermissionDeniedError`, `NotFound` → `NotFoundError`, `AlreadyExists` → `AlreadyExistsError` across 57 source + test files. Backward-compat aliases added to `exceptions.py` (marked deprecated, remove after next release).
- **TRY003 global ignore**: added `"TRY003"` to `[tool.ruff.lint].ignore` with rationale comment (project favours descriptive inline messages). Stripped ~40 `# noqa: TRY003` comments.
- **TRY301 fixes**: refactored three CLI commands (`sql_pools show`, `warehouses takeover`, `workspaces set-collation`) to split try blocks — async Fabric calls in the first try, validation/interaction after — eliminating the raise-in-try-triggers-same-except anti-pattern.
- **per-file-ignores tightened**: removed `TRY003` (now global) and `FBT001` from `tests/**`; kept `PLR2004` with rationale comment (test fixtures use concrete numeric test values, not refactorable magic numbers); fixed the one `FBT001` hit in `test_models.py` (keyword-only arg). Added rationale comments to all per-file-ignores.
- **Empty `[tool.ruff.format]` block**: added `docstring-code-format = true`.
- **Docstring rules deferred**: added comment in `pyproject.toml` deferring `D`/`DOC` rules until the public API stabilises.
- **PLR2004 in src**: replaced `100` percent cap with named local var; used `http.HTTPStatus` in `services/workspaces.py` to eliminate the two PLR2004 suppressions.

## Findings addressed

| Review file | Status |
|---|---|
| `02-core-exceptions-naming-noqa-n818.md` | Fixed — renamed + backward aliases |
| `01-arch-noqa-density-as-design-signal.md` | Fixed — TRY003 global, TRY301 restructured |
| `04-cli-noqa-suppressions-pattern.md` | Fixed — TRY003 comments stripped |
| `07-pkg-per-file-ignores-too-broad.md` | Fixed — tightened with rationale |
| `07-pkg-empty-ruff-format-block.md` | Fixed — `docstring-code-format = true` |
| `07-pkg-no-docstring-rules.md` | Fixed — decision documented |

## Decisions

- **TRY003**: global ignore preferred over helper wrapper. The codebase has ~40 inline messages; introducing a message-constants module would be premature.
- **PLR2004 in tests**: kept in `per-file-ignores`. 167 violations — all legitimate test values (retention days, page sizes, years). HTTP status codes in `src/` use `http.HTTPStatus` instead.
- **Backward aliases**: `PermissionDenied = PermissionDeniedError` etc. are exported from `exceptions.py` for one release. Pre-1.0 alpha, but cheap insurance for any external callers.
- **TRY301 non-trivial cases**: none left — all three remaining ones were trivially restructurable by splitting the try block.
- **docstring-code-format**: added to the previously-empty `[tool.ruff.format]` block.

## Lint policy now in effect

```
select  = E W F I N UP B SIM ANN RUF PL C4 DTZ ARG PT TRY LOG S FBT RET PIE TID ICN T20 ERA PERF FURB
ignore  = TRY003, (D/DOC deferred)
tests   = ANN S101 PLR2004
services = PLR0913
cli     = FBT001 PLR0913
```

## Test plan

- [x] `just check` fully green: ruff lint + format + ty + pytest (1528 passed, 86.69% coverage)
- [x] Zero bare `PermissionDenied`/`NotFound`/`AlreadyExists` references in code (only aliases in `exceptions.py`)
- [x] Zero `# noqa: TRY003` or `# noqa: N818` remaining
- [x] Backward aliases present and exported

🤖 Generated with [Claude Code](https://claude.com/claude-code)