### PR TITLE
docs(nav): rename About section to Contributing

### DIFF
--- a/zensical.toml
+++ b/zensical.toml
@@ -22,7 +22,7 @@ nav = [
     { "Shell Completion" = "completion.md" },
     { "Troubleshooting" = "troubleshooting.md" }
   ] },
-  { "About" = [
+  { "Contributing" = [
     { "Contributing" = "contributing.md" },
     { "Code of Conduct" = "code-of-conduct.md" },
     { "License" = "license.md" },


### PR DESCRIPTION
Renames the nav section label in `zensical.toml` from `"About"` to `"Contributing"`. All four child entries (Contributing, Code of Conduct, License, Security) and their paths are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)