### PR TITLE
fix(tests): eliminate RuntimeWarning coroutine-never-awaited leaks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,7 @@ docstring-code-format = true
 markers = ["integration: hits real Fabric APIs"]
 addopts = "-ra --strict-markers -m 'not integration'"
 asyncio_mode = "auto"
+filterwarnings = ["error::RuntimeWarning"]
 
 [tool.coverage.run]
 source_pkgs = ["fabric_dw"]

--- a/tests/unit/cli/commands/test_audit.py
+++ b/tests/unit/cli/commands/test_audit.py
@@ -15,8 +15,8 @@ from click.testing import CliRunner
 
 from fabric_dw.cache import ItemEntry
 from fabric_dw.cli._main import cli
-from fabric_dw.exceptions import NotFoundError
-from fabric_dw.models import WarehouseKind
+from fabric_dw.exceptions import FabricError, NotFoundError
+from fabric_dw.models import AuditSettings, WarehouseKind
 from tests.fixtures.api_payloads import AUDIT_SETTINGS_PAYLOAD
 
 WS_GUID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
@@ -156,7 +156,8 @@ class TestAuditEnable:
         _ = cache_env
         mock_http = AsyncMock()
         mock_http.request = AsyncMock(return_value=_make_response(200, AUDIT_SETTINGS_PAYLOAD))
-        mock_enable = AsyncMock()
+        audit_settings = AuditSettings.model_validate(json.loads(AUDIT_SETTINGS_PAYLOAD))
+        mock_enable = AsyncMock(return_value=audit_settings)
         with (
             patch(
                 "fabric_dw.cli.commands.audit.build_http_client",
@@ -301,6 +302,10 @@ class TestAuditSetRetention:
             patch(
                 "fabric_dw.cli.commands.audit._resolve_item",
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.cli.commands.audit._audit_svc.set_retention",
+                new=AsyncMock(side_effect=FabricError("retentionDays value is out of range")),
             ),
         ):
             result = runner.invoke(


### PR DESCRIPTION
## Summary

Closes #256

Two tests in `tests/unit/cli/commands/test_audit.py` left `AsyncMock` coroutines unawaited, producing `RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited`. Because CPython's garbage collector can collect a zombie coroutine at any point after the creating test finishes, the warning surfaced non-deterministically in whichever test happened to run next — making the root cause hard to trace.

### Root causes

**`test_enable_with_unlimited_flag_exits_zero`**
`mock_enable = AsyncMock()` had no `return_value`, so `await _audit_svc.enable(...)` returned `mock_enable.return_value` — itself an `AsyncMock`. Calling `obj.model_dump(by_alias=True, mode="json")` on an `AsyncMock` produces a coroutine (every attribute access on `AsyncMock` auto-creates child `AsyncMock`s; calling one creates a coroutine). That coroutine was passed to `render()` but never awaited.

Fix: set `mock_enable.return_value = AuditSettings.model_validate(json.loads(AUDIT_SETTINGS_PAYLOAD))` so `obj.model_dump()` is a plain synchronous dict call.

**`test_set_retention_out_of_range_returns_nonzero`**
`mock_http.request` was not set explicitly, so the service code received the default `AsyncMock` result as `resp`. Calling `resp.json()` on an `AsyncMock` creates a coroutine that `AuditSettings.model_validate()` can't parse — triggering a `ValidationError` that produced the expected non-zero exit as an accidental side effect. The unawaited `resp.json()` coroutine was the leak.

Fix: patch `_audit_svc.set_retention` directly with `side_effect=FabricError(...)` to properly simulate the API rejecting an out-of-range value. No HTTP call is made, no coroutine is leaked, and the assertion remains valid.

### Regression guard

Added `filterwarnings = ["error::RuntimeWarning"]` to `[tool.pytest.ini_options]` in `pyproject.toml`. The full unit suite (1528 tests) is clean under this filter. Future tests that accidentally leave coroutines unawaited will fail immediately instead of leaking silently.

## Test plan

- [x] `uv run pytest tests/unit -W error::RuntimeWarning -q` — 1528 passed, 0 warnings
- [x] `just check` — ruff, ruff format, ty, pytest all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)