### PR TITLE
chore: remove CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,0 @@
-# Changelog
-
-The changelog for `fabric-dw` is maintained as **GitHub Releases**.
-
-Each merge to `main` updates a running release draft (via [Release Drafter](.github/release-drafter.yml)), categorised by conventional-commit type. When a version tag is pushed the draft is published as the official release.
-
-Browse the full version history at:
-**<https://github.com/sdebruyn/fabric-dw-mcp-cli/releases>**


### PR DESCRIPTION
## Summary

- Deletes the standalone `CHANGELOG.md` file, which only contained a redirect notice pointing at GitHub Releases anyway.
- The project's changelog is fully maintained via [Release Drafter](https://github.com/sdebruyn/fabric-dw-mcp-cli/blob/main/.github/release-drafter.yml): every PR merged to `main` updates a running release draft, and the draft is published as a GitHub Release when a version tag is pushed.
- No other files referenced `CHANGELOG.md` (confirmed by grep across all `.md`, `.toml`, `.yml`, `.yaml` files), so this is a pure deletion with no follow-up edits needed.

The authoritative version history lives at: https://github.com/sdebruyn/fabric-dw-mcp-cli/releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)