### PR TITLE
test(integration): add list_connections end-to-end coverage

### DIFF
--- a/tests/integration/test_services_queries.py
+++ b/tests/integration/test_services_queries.py
@@ -1,5 +1,6 @@
 import pytest
 
+from fabric_dw.models import Connection
 from fabric_dw.services import queries
 from fabric_dw.sql import SqlTarget
 
@@ -16,3 +17,26 @@ async def test_kill_invalid_session_id_raises(ephemeral_sql_target: SqlTarget) -
         await queries.kill(ephemeral_sql_target, 0)
     with pytest.raises(ValueError, match="session_id must be a positive integer"):
         await queries.kill(ephemeral_sql_target, -1)
+
+
+async def test_list_connections_returns_connection_models(
+    ephemeral_sql_target: SqlTarget,
+) -> None:
+    """list_connections returns a non-empty list of Connection instances.
+
+    Issuing this query creates at least one active connection (the current
+    session), so the result list must be non-empty and every element must be
+    a fully-validated Connection model with the expected scalar fields.
+    """
+    connections = await queries.list_connections(ephemeral_sql_target)
+
+    assert isinstance(connections, list)
+    assert len(connections) >= 1, "expected at least the current session in dm_exec_connections"
+
+    for conn in connections:
+        assert isinstance(conn, Connection)
+        # net_transport is NOT NULL in the DMV schema — verify it is always populated
+        assert isinstance(conn.net_transport, str)
+        assert conn.net_transport != ""
+        # connect_time is NOT NULL in the DMV schema — verify it is always populated
+        assert conn.connect_time is not None


### PR DESCRIPTION
## Summary

- Fills the `queries.list_connections` integration-test gap identified in #262
- Adds `test_list_connections_returns_connection_models` to `tests/integration/test_services_queries.py`
- Asserts the call returns a non-empty list of `Connection` model instances with non-nullable DMV fields (`net_transport`, `connect_time`) populated — genuine assertion, not vacuous

## Test plan

- [ ] `uv run pytest tests/integration/test_services_queries.py -m integration --co -q` collects 3 tests including the new one
- [ ] `just check` passes (ruff + ty + 1543 unit tests)
- [ ] Real-Fabric run: set `FABRIC_TEST_WORKSPACE_ID` and run `just integration` — NOT verified here (no live Fabric available in CI for this worktree)

🤖 Generated with [Claude Code](https://claude.com/claude-code)