### PR TITLE
test(snapshots): add roll_timestamp integration test

### DIFF
--- a/tests/integration/test_services_snapshots.py
+++ b/tests/integration/test_services_snapshots.py
@@ -1,11 +1,13 @@
 import uuid
+from datetime import UTC, datetime, timedelta
 from uuid import UUID
 
 import pytest
 
 from fabric_dw.http_client import FabricHttpClient
-from fabric_dw.models import Warehouse
+from fabric_dw.models import Warehouse, WarehouseSnapshot
 from fabric_dw.services import snapshots
+from fabric_dw.sql import SqlTarget
 
 pytestmark = pytest.mark.integration
 
@@ -24,3 +26,31 @@ async def test_create_list_rename_delete_roundtrip(
         assert renamed.name == new_name
     finally:
         await snapshots.delete(http, workspace_id, snap.id)
+
+
+async def test_roll_timestamp_updates_snapshot(
+    http: FabricHttpClient,
+    workspace_id: UUID,
+    ephemeral_snapshot: WarehouseSnapshot,
+    ephemeral_sql_target: SqlTarget,
+) -> None:
+    """roll_timestamp advances the snapshot's timestamp to the requested datetime."""
+    # Choose a target datetime a short distance in the past so it falls within the
+    # parent warehouse's retention window and is safely distinct from the original.
+    new_dt = datetime.now(tz=UTC).replace(microsecond=0) - timedelta(minutes=5)
+
+    await snapshots.roll_timestamp(
+        ephemeral_sql_target,
+        ephemeral_snapshot.name,
+        new_dt,
+    )
+
+    # Re-fetch the snapshot via the typed API to confirm the change is visible.
+    listed = await snapshots.list_snapshots(
+        http, workspace_id, ephemeral_snapshot.parent_warehouse_id
+    )
+    updated = next((s for s in listed if s.id == ephemeral_snapshot.id), None)
+    assert updated is not None, "snapshot not found after roll_timestamp"
+    assert updated.snapshot_dt is not None, "snapshot_dt should be set after roll_timestamp"
+    # The API stores the timestamp without sub-second precision; compare at second granularity.
+    assert updated.snapshot_dt.replace(tzinfo=UTC, microsecond=0) == new_dt


### PR DESCRIPTION
## Summary
- Fills the `snapshots.roll_timestamp` integration-test gap identified in #262
- Adds `test_roll_timestamp_updates_snapshot` to `tests/integration/test_services_snapshots.py`
- Reuses existing `ephemeral_snapshot` and `ephemeral_sql_target` conftest fixtures — no conftest changes
- Asserts that after calling `roll_timestamp` with an explicit datetime, `list_snapshots` returns the updated `snapshot_dt` (second-level precision comparison matching the API's storage format)

## Test plan
- [ ] `uv run pytest tests/integration/test_services_snapshots.py --co -q -m integration` collects both tests
- [ ] `just check` green (ruff, ruff format, ty, 1543 unit tests)
- [ ] Real-Fabric execution NOT verified here (requires `FABRIC_TEST_WORKSPACE_ID` env var and live credentials)

fills snapshots.roll_timestamp integration gap from #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)