### PR TITLE
test(integration): add sql_endpoints integration tests + ephemeral_lakehouse fixture

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -104,43 +104,63 @@ async def ephemeral_lakehouse(
         "creationPayload": {"enableSchemas": True},
     }
 
-    resp = await http.request(
-        "POST",
-        HttpBase.FABRIC,
-        f"/workspaces/{workspace_id}/lakehouses",
-        json=body,
-    )
-
-    location = resp.headers.get("Location")
-    if location is not None:
-        # 202 Accepted — poll the LRO then fetch the created item
-        lro_result = await http.poll_operation(location)
-        resource_location = lro_result.get("resourceLocation")
-        if not isinstance(resource_location, str) or not resource_location:
-            pytest.skip(
-                f"create lakehouse LRO completed but no resourceLocation returned: {lro_result}"
-            )
-        lakehouse_id = resource_location.rsplit("/", 1)[-1]
-        get_resp = await http.request(
-            "GET",
-            HttpBase.FABRIC,
-            f"/workspaces/{workspace_id}/lakehouses/{lakehouse_id}",
-        )
-        lakehouse = get_resp.json()
-    else:
-        # 201 Created — body contains the new item directly
-        lakehouse = resp.json()
+    # ``lakehouse_id`` is set as soon as we know the created resource's id so
+    # that the finally block can clean up on every exit path — including any
+    # pytest.skip() that fires after creation but before the yield.
+    lakehouse_id: str | None = None
+    lakehouse: dict[str, object] = {}
 
     try:
+        resp = await http.request(
+            "POST",
+            HttpBase.FABRIC,
+            f"/workspaces/{workspace_id}/lakehouses",
+            json=body,
+        )
+
+        location = resp.headers.get("Location")
+        if location:
+            # 202 Accepted — poll the LRO then fetch the created item
+            lro_result = await http.poll_operation(location)
+            resource_location = lro_result.get("resourceLocation")
+            if isinstance(resource_location, str) and resource_location:
+                lakehouse_id = resource_location.rsplit("/", 1)[-1]
+            else:
+                # resourceLocation may be absent; fall back to GET /result
+                # which returns the created resource directly.
+                result_resp = await http.request(
+                    "GET",
+                    HttpBase.FABRIC,
+                    f"{location}/result",
+                )
+                result_body = result_resp.json()
+                raw_id = result_body.get("id")
+                fallback = result_body.get("resourceLocation", "").rsplit("/", 1)[-1]
+                lakehouse_id = raw_id or fallback or None
+            if not lakehouse_id:
+                pytest.skip(
+                    "create lakehouse LRO completed but could not resolve "
+                    f"lakehouse id: {lro_result}"
+                )
+            get_resp = await http.request(
+                "GET",
+                HttpBase.FABRIC,
+                f"/workspaces/{workspace_id}/lakehouses/{lakehouse_id}",
+            )
+            lakehouse = get_resp.json()
+        else:
+            # 201 Created — body contains the new item directly
+            lakehouse = resp.json()
+            lakehouse_id = lakehouse.get("id") or None  # type: ignore[assignment]
+
         yield lakehouse
     finally:
-        lh_id = lakehouse.get("id")
-        if lh_id:
+        if lakehouse_id:
             with contextlib.suppress(NotFoundError):
                 await http.request(
                     "DELETE",
                     HttpBase.FABRIC,
-                    f"/workspaces/{workspace_id}/lakehouses/{lh_id}",
+                    f"/workspaces/{workspace_id}/lakehouses/{lakehouse_id}",
                 )
 
 
@@ -190,7 +210,13 @@ async def ephemeral_sql_endpoint(
             if not ep_id_raw:
                 pytest.skip(f"SQL endpoint provisioned but id is missing for lakehouse {lh_id}")
             # Construct a Warehouse-shaped dict so we can use model_validate
-            ep_uuid = UUID(str(ep_id_raw))
+            try:
+                ep_uuid = UUID(str(ep_id_raw))
+            except ValueError:
+                pytest.skip(
+                    f"SQL endpoint provisioned but id is not a valid UUID "
+                    f"for lakehouse {lh_id}: {ep_id_raw!r}"
+                )
             wh = Warehouse.model_validate(
                 {
                     "id": str(ep_uuid),

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,4 +1,7 @@
+import asyncio
+import contextlib
 import os
+import time
 import uuid
 from collections.abc import AsyncIterator
 from uuid import UUID
@@ -7,10 +10,16 @@ import pytest
 import pytest_asyncio
 
 from fabric_dw.auth import get_credential
-from fabric_dw.http_client import FabricHttpClient
-from fabric_dw.models import Warehouse, WarehouseSnapshot
+from fabric_dw.exceptions import NotFoundError
+from fabric_dw.http_client import FabricHttpClient, HttpBase
+from fabric_dw.models import Warehouse, WarehouseKind, WarehouseSnapshot
 from fabric_dw.services import snapshots, warehouses
 from fabric_dw.sql import SqlTarget
+
+# Maximum time to wait for a SQL analytics endpoint to provision on a new lakehouse.
+_SQL_ENDPOINT_PROVISION_TIMEOUT_S = 300
+# Polling interval between provisioning status checks.
+_SQL_ENDPOINT_POLL_INTERVAL_S = 5
 
 
 @pytest_asyncio.fixture
@@ -68,3 +77,135 @@ async def ephemeral_sql_target(
         database=ephemeral_warehouse.name,
         connection_string=ephemeral_warehouse.connection_string,
     )
+
+
+@pytest_asyncio.fixture
+async def ephemeral_lakehouse(
+    http: FabricHttpClient,
+    workspace_id: UUID,
+) -> AsyncIterator[dict[str, object]]:
+    """Create a schema-enabled Lakehouse and delete it after the test.
+
+    Yields the raw API response dict from the POST (or the GET after LRO), which
+    contains at minimum ``id``, ``displayName``, and ``workspaceId``.
+
+    The Lakehouse is created with ``creationPayload.enableSchemas=true`` so that
+    the auto-provisioned SQL analytics endpoint is fully functional.  Fabric
+    automatically provisions a paired SQL analytics endpoint alongside every
+    Lakehouse — no extra API call is needed to create it.
+
+    The fixture does NOT wait for the SQL endpoint to provision; use
+    ``ephemeral_sql_endpoint`` if you need a ready endpoint.
+    """
+    name = f"pytest-{uuid.uuid4().hex[:8]}-lh"
+    body: dict[str, object] = {
+        "displayName": name,
+        "description": "ephemeral integration-test lakehouse",
+        "creationPayload": {"enableSchemas": True},
+    }
+
+    resp = await http.request(
+        "POST",
+        HttpBase.FABRIC,
+        f"/workspaces/{workspace_id}/lakehouses",
+        json=body,
+    )
+
+    location = resp.headers.get("Location")
+    if location is not None:
+        # 202 Accepted — poll the LRO then fetch the created item
+        lro_result = await http.poll_operation(location)
+        resource_location = lro_result.get("resourceLocation")
+        if not isinstance(resource_location, str) or not resource_location:
+            pytest.skip(
+                f"create lakehouse LRO completed but no resourceLocation returned: {lro_result}"
+            )
+        lakehouse_id = resource_location.rsplit("/", 1)[-1]
+        get_resp = await http.request(
+            "GET",
+            HttpBase.FABRIC,
+            f"/workspaces/{workspace_id}/lakehouses/{lakehouse_id}",
+        )
+        lakehouse = get_resp.json()
+    else:
+        # 201 Created — body contains the new item directly
+        lakehouse = resp.json()
+
+    try:
+        yield lakehouse
+    finally:
+        lh_id = lakehouse.get("id")
+        if lh_id:
+            with contextlib.suppress(NotFoundError):
+                await http.request(
+                    "DELETE",
+                    HttpBase.FABRIC,
+                    f"/workspaces/{workspace_id}/lakehouses/{lh_id}",
+                )
+
+
+@pytest_asyncio.fixture
+async def ephemeral_sql_endpoint(
+    http: FabricHttpClient,
+    workspace_id: UUID,
+    ephemeral_lakehouse: dict[str, object],
+) -> AsyncIterator[Warehouse]:
+    """Derive the SQL Analytics Endpoint from ``ephemeral_lakehouse`` and wait for it to provision.
+
+    Polls ``GET /workspaces/{ws}/lakehouses/{id}`` until
+    ``properties.sqlEndpointProperties.provisioningStatus`` reaches ``Success``.
+    Skips the test (rather than failing) if provisioning does not complete
+    within ``_SQL_ENDPOINT_PROVISION_TIMEOUT_S`` seconds or if it fails.
+
+    Yields a :class:`~fabric_dw.models.Warehouse` instance typed as
+    ``WarehouseKind.SQL_ENDPOINT`` with the endpoint ID and connection string
+    populated.
+    """
+    lh_id = ephemeral_lakehouse.get("id")
+    if not lh_id:
+        pytest.skip("ephemeral_lakehouse fixture returned no id")
+
+    deadline = time.monotonic() + _SQL_ENDPOINT_PROVISION_TIMEOUT_S
+
+    while True:
+        if time.monotonic() >= deadline:
+            pytest.skip(
+                f"SQL analytics endpoint for lakehouse {lh_id} did not provision within "
+                f"{_SQL_ENDPOINT_PROVISION_TIMEOUT_S}s — skipping endpoint-specific tests"
+            )
+
+        get_resp = await http.request(
+            "GET",
+            HttpBase.FABRIC,
+            f"/workspaces/{workspace_id}/lakehouses/{lh_id}",
+        )
+        lh_body = get_resp.json()
+        props = lh_body.get("properties") or {}
+        sql_ep_props = props.get("sqlEndpointProperties") or {}
+
+        status = sql_ep_props.get("provisioningStatus", "")
+        if status == "Success":
+            ep_id_raw = sql_ep_props.get("id", "")
+            ep_conn = sql_ep_props.get("connectionString", "")
+            if not ep_id_raw:
+                pytest.skip(f"SQL endpoint provisioned but id is missing for lakehouse {lh_id}")
+            # Construct a Warehouse-shaped dict so we can use model_validate
+            ep_uuid = UUID(str(ep_id_raw))
+            wh = Warehouse.model_validate(
+                {
+                    "id": str(ep_uuid),
+                    "displayName": lh_body.get("displayName", ""),
+                    "workspaceId": str(workspace_id),
+                    "kind": WarehouseKind.SQL_ENDPOINT,
+                    "connectionString": ep_conn,
+                }
+            )
+            yield wh
+            return
+
+        if status == "Failed":
+            pytest.skip(
+                f"SQL analytics endpoint provisioning failed for lakehouse {lh_id} — skipping"
+            )
+
+        await asyncio.sleep(_SQL_ENDPOINT_POLL_INTERVAL_S)

--- a/tests/integration/test_services_sql_endpoints.py
+++ b/tests/integration/test_services_sql_endpoints.py
@@ -1,0 +1,151 @@
+"""Integration tests for services.sql_endpoints — runs against a real Fabric environment.
+
+These tests require:
+    FABRIC_TEST_WORKSPACE_ID  — UUID of the target workspace.
+
+## Test organisation
+
+### Read / list / discovery tests  (no Lakehouse required)
+These tests call ``list_endpoints``, ``list_all_workspaces``, and ``get_endpoint``
+against whatever SQL analytics endpoints already exist in the workspace (or confirm
+graceful behaviour when the workspace is empty).  They do NOT depend on the
+``ephemeral_lakehouse`` / ``ephemeral_sql_endpoint`` fixtures.
+
+### Endpoint-specific tests  (require ephemeral_sql_endpoint)
+These tests exercise operations that need a real, provisioned SQL analytics
+endpoint: ``get_endpoint`` (by ID) and ``refresh_metadata``.  They are gated on
+the ``ephemeral_sql_endpoint`` fixture which creates a schema-enabled Lakehouse,
+waits for its SQL endpoint to provision, and tears the Lakehouse down afterwards.
+
+Note: ``refresh_metadata`` with ``recreate_tables=True`` is intentionally NOT
+tested here because it is destructive and could break other items in the
+workspace.  It is covered in unit tests with full LRO mocking.
+"""
+
+from __future__ import annotations
+
+import uuid
+from uuid import UUID
+
+import pytest
+
+from fabric_dw.exceptions import NotFoundError
+from fabric_dw.http_client import FabricHttpClient
+from fabric_dw.models import TableSyncStatus, Warehouse, WarehouseKind
+from fabric_dw.services import sql_endpoints
+
+pytestmark = pytest.mark.integration
+
+# ---------------------------------------------------------------------------
+# Read / list / discovery tests — no ephemeral Lakehouse required
+# ---------------------------------------------------------------------------
+
+
+async def test_list_endpoints_returns_list(http: FabricHttpClient, workspace_id: UUID) -> None:
+    """list_endpoints always returns a list (may be empty)."""
+    items = await sql_endpoints.list_endpoints(http, workspace_id)
+    assert isinstance(items, list)
+
+
+async def test_list_endpoints_all_sql_endpoint_kind(
+    http: FabricHttpClient, workspace_id: UUID
+) -> None:
+    """Every item returned by list_endpoints must have kind == SQL_ENDPOINT."""
+    items = await sql_endpoints.list_endpoints(http, workspace_id)
+    for item in items:
+        assert isinstance(item, Warehouse)
+        assert item.kind == WarehouseKind.SQL_ENDPOINT, (
+            f"expected SQL_ENDPOINT, got {item.kind!r} for item {item.id}"
+        )
+
+
+async def test_list_endpoints_items_have_id_and_name(
+    http: FabricHttpClient, workspace_id: UUID
+) -> None:
+    """Each listed endpoint has a non-empty id and displayName."""
+    items = await sql_endpoints.list_endpoints(http, workspace_id)
+    for item in items:
+        assert item.id, f"endpoint missing id: {item!r}"
+        assert item.name, f"endpoint missing name: {item!r}"
+
+
+async def test_list_all_workspaces_returns_list(http: FabricHttpClient) -> None:
+    """list_all_workspaces scans all workspaces and returns a flat list."""
+    items = await sql_endpoints.list_all_workspaces(http)
+    assert isinstance(items, list)
+    for item in items:
+        assert isinstance(item, Warehouse)
+        assert item.kind == WarehouseKind.SQL_ENDPOINT
+
+
+async def test_get_endpoint_nonexistent_raises_not_found(
+    http: FabricHttpClient, workspace_id: UUID
+) -> None:
+    """get_endpoint raises NotFoundError for a UUID that doesn't exist."""
+    bogus = uuid.uuid4()
+    with pytest.raises(NotFoundError):
+        await sql_endpoints.get_endpoint(http, workspace_id, bogus)
+
+
+# ---------------------------------------------------------------------------
+# Endpoint-specific tests — require a provisioned SQL analytics endpoint
+# ---------------------------------------------------------------------------
+
+
+async def test_get_endpoint_by_id(
+    http: FabricHttpClient,
+    workspace_id: UUID,
+    ephemeral_sql_endpoint: Warehouse,
+) -> None:
+    """get_endpoint fetches the same endpoint we provisioned via the Lakehouse."""
+    fetched = await sql_endpoints.get_endpoint(http, workspace_id, ephemeral_sql_endpoint.id)
+    assert fetched.id == ephemeral_sql_endpoint.id
+    assert fetched.kind == WarehouseKind.SQL_ENDPOINT
+
+
+async def test_get_endpoint_connection_string_populated(
+    http: FabricHttpClient,
+    workspace_id: UUID,
+    ephemeral_sql_endpoint: Warehouse,
+) -> None:
+    """A fully provisioned endpoint must expose a non-empty connection string."""
+    fetched = await sql_endpoints.get_endpoint(http, workspace_id, ephemeral_sql_endpoint.id)
+    assert fetched.connection_string, (
+        f"expected non-empty connection_string for endpoint {fetched.id}"
+    )
+
+
+async def test_endpoint_appears_in_list(
+    http: FabricHttpClient,
+    workspace_id: UUID,
+    ephemeral_sql_endpoint: Warehouse,
+) -> None:
+    """The provisioned endpoint must appear in list_endpoints for the workspace."""
+    items = await sql_endpoints.list_endpoints(http, workspace_id)
+    ids = {item.id for item in items}
+    assert ephemeral_sql_endpoint.id in ids, (
+        f"endpoint {ephemeral_sql_endpoint.id} not found in list_endpoints result: {ids}"
+    )
+
+
+async def test_refresh_metadata_returns_table_sync_statuses(
+    http: FabricHttpClient,
+    workspace_id: UUID,
+    ephemeral_sql_endpoint: Warehouse,
+) -> None:
+    """refresh_metadata (non-destructive) completes and returns a list of TableSyncStatus.
+
+    A brand-new schema-enabled Lakehouse has no Delta tables yet, so the list
+    may be empty — that is acceptable.  We assert shape, not count.
+    """
+    results = await sql_endpoints.refresh_metadata(
+        http,
+        workspace_id,
+        ephemeral_sql_endpoint.id,
+        recreate_tables=False,
+    )
+    assert isinstance(results, list)
+    for entry in results:
+        assert isinstance(entry, TableSyncStatus)
+        assert entry.table_name
+        assert entry.status


### PR DESCRIPTION
## Summary

- Adds `ephemeral_lakehouse` fixture to `tests/integration/conftest.py` that creates a **schema-enabled Lakehouse** (`creationPayload.enableSchemas=true`) via `POST /v1/workspaces/{ws}/lakehouses`, handles both the 201 and 202/LRO Fabric responses, and deletes it in teardown.
- Adds `ephemeral_sql_endpoint` fixture (chained on `ephemeral_lakehouse`) that polls `GET /workspaces/{ws}/lakehouses/{id}` for `properties.sqlEndpointProperties.provisioningStatus == "Success"` (up to 300 s) and yields a `Warehouse(kind=SQL_ENDPOINT)`. Calls `pytest.skip` if provisioning times out or fails — never breaks the suite.
- Adds `tests/integration/test_services_sql_endpoints.py` covering all public functions of `services.sql_endpoints`: `list_endpoints`, `list_all_workspaces`, `get_endpoint`, and `refresh_metadata`.

## Fixture design

| Fixture | Depends on | Purpose |
|---|---|---|
| `ephemeral_lakehouse` | `http`, `workspace_id` | Creates + tears down a schema-enabled Lakehouse |
| `ephemeral_sql_endpoint` | `ephemeral_lakehouse` | Waits for SQL endpoint to provision; skips if not ready |

**Read/list/discovery tests** (`test_list_endpoints_*`, `test_list_all_workspaces_*`, `test_get_endpoint_nonexistent_*`) do **not** use `ephemeral_lakehouse` — they run against whatever endpoints are already in the workspace (possibly none).

**Endpoint-specific tests** (`test_get_endpoint_by_id`, `test_get_endpoint_connection_string_populated`, `test_endpoint_appears_in_list`, `test_refresh_metadata_returns_table_sync_statuses`) use `ephemeral_sql_endpoint`.

## Coverage

| Operation | Covered | Notes |
|---|---|---|
| `list_endpoints` | ✅ 3 tests | kind, id/name shape, may be empty |
| `list_all_workspaces` | ✅ 1 test | returns `list[Warehouse(SQL_ENDPOINT)]` |
| `get_endpoint` | ✅ 2 tests | by ID + connection string; NotFoundError for bogus UUID |
| `refresh_metadata(recreate_tables=False)` | ✅ 1 test | returns `list[TableSyncStatus]` |
| `refresh_metadata(recreate_tables=True)` | ⏭ skipped | Destructive; covered by unit tests with LRO mocking |

## Test plan

- [x] `uv run pytest tests/integration/test_services_sql_endpoints.py --co -q -m integration` — 9 tests collected
- [x] `uv run pytest -m integration --co -q` — 48 total integration tests collected (all new tests included)
- [x] `just check` green (ruff lint + format, ty type-check, 1543 unit tests pass)
- [ ] Real-Fabric execution was **not** verified in this environment (no live Fabric credentials available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)