### PR TITLE
test(audit): add integration coverage for add/remove_action_group

### DIFF
--- a/tests/integration/test_services_audit.py
+++ b/tests/integration/test_services_audit.py
@@ -62,3 +62,150 @@ async def test_set_retention_rejects_disabled_audit(
     await audit.disable(http, workspace_id, ephemeral_warehouse.id)
     with pytest.raises(ValueError, match="disabled"):
         await audit.set_retention(http, workspace_id, ephemeral_warehouse.id, days=30)
+
+
+async def test_add_action_group_appears_in_settings(
+    http: FabricHttpClient, workspace_id: UUID, ephemeral_warehouse: Warehouse
+) -> None:
+    # Ensure auditing is enabled so add_action_group is permitted.
+    await audit.enable(http, workspace_id, ephemeral_warehouse.id)
+    # Start from a known baseline: one group only.
+    await audit.set_action_groups(
+        http,
+        workspace_id,
+        ephemeral_warehouse.id,
+        ["BATCH_COMPLETED_GROUP"],
+        ensure_enabled=True,
+    )
+
+    updated = await audit.add_action_group(
+        http, workspace_id, ephemeral_warehouse.id, "SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP"
+    )
+
+    assert "SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP" in updated.action_groups
+    assert "BATCH_COMPLETED_GROUP" in updated.action_groups
+
+
+async def test_add_action_group_is_idempotent(
+    http: FabricHttpClient, workspace_id: UUID, ephemeral_warehouse: Warehouse
+) -> None:
+    await audit.enable(http, workspace_id, ephemeral_warehouse.id)
+    await audit.set_action_groups(
+        http,
+        workspace_id,
+        ephemeral_warehouse.id,
+        ["BATCH_COMPLETED_GROUP"],
+        ensure_enabled=True,
+    )
+
+    first = await audit.add_action_group(
+        http, workspace_id, ephemeral_warehouse.id, "BATCH_COMPLETED_GROUP"
+    )
+    second = await audit.add_action_group(
+        http, workspace_id, ephemeral_warehouse.id, "BATCH_COMPLETED_GROUP"
+    )
+
+    assert first.action_groups == second.action_groups
+    assert first.action_groups.count("BATCH_COMPLETED_GROUP") == 1
+
+
+async def test_add_action_group_rejects_disabled_audit(
+    http: FabricHttpClient, workspace_id: UUID, ephemeral_warehouse: Warehouse
+) -> None:
+    await audit.disable(http, workspace_id, ephemeral_warehouse.id)
+    with pytest.raises(ValueError, match="disabled"):
+        await audit.add_action_group(
+            http, workspace_id, ephemeral_warehouse.id, "BATCH_COMPLETED_GROUP"
+        )
+
+
+async def test_add_action_group_rejects_invalid_name(
+    http: FabricHttpClient, workspace_id: UUID, ephemeral_warehouse: Warehouse
+) -> None:
+    with pytest.raises(ValueError, match="bad_group"):
+        await audit.add_action_group(http, workspace_id, ephemeral_warehouse.id, "bad_group")
+
+
+async def test_remove_action_group_no_longer_in_settings(
+    http: FabricHttpClient, workspace_id: UUID, ephemeral_warehouse: Warehouse
+) -> None:
+    await audit.enable(http, workspace_id, ephemeral_warehouse.id)
+    await audit.set_action_groups(
+        http,
+        workspace_id,
+        ephemeral_warehouse.id,
+        ["BATCH_COMPLETED_GROUP", "SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP"],
+        ensure_enabled=True,
+    )
+
+    updated = await audit.remove_action_group(
+        http, workspace_id, ephemeral_warehouse.id, "SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP"
+    )
+
+    assert "SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP" not in updated.action_groups
+    # Other groups must be preserved.
+    assert "BATCH_COMPLETED_GROUP" in updated.action_groups
+
+
+async def test_remove_action_group_is_idempotent(
+    http: FabricHttpClient, workspace_id: UUID, ephemeral_warehouse: Warehouse
+) -> None:
+    await audit.enable(http, workspace_id, ephemeral_warehouse.id)
+    await audit.set_action_groups(
+        http,
+        workspace_id,
+        ephemeral_warehouse.id,
+        ["BATCH_COMPLETED_GROUP"],
+        ensure_enabled=True,
+    )
+
+    first = await audit.remove_action_group(
+        http, workspace_id, ephemeral_warehouse.id, "SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP"
+    )
+    second = await audit.remove_action_group(
+        http, workspace_id, ephemeral_warehouse.id, "SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP"
+    )
+
+    assert first.action_groups == second.action_groups
+
+
+async def test_add_then_remove_action_group_roundtrip(
+    http: FabricHttpClient, workspace_id: UUID, ephemeral_warehouse: Warehouse
+) -> None:
+    """End-to-end: add a group then remove it — net effect is no change."""
+    await audit.enable(http, workspace_id, ephemeral_warehouse.id)
+    baseline = await audit.set_action_groups(
+        http,
+        workspace_id,
+        ephemeral_warehouse.id,
+        ["BATCH_COMPLETED_GROUP"],
+        ensure_enabled=True,
+    )
+
+    after_add = await audit.add_action_group(
+        http, workspace_id, ephemeral_warehouse.id, "SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP"
+    )
+    assert "SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP" in after_add.action_groups
+
+    after_remove = await audit.remove_action_group(
+        http, workspace_id, ephemeral_warehouse.id, "SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP"
+    )
+    assert "SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP" not in after_remove.action_groups
+    assert after_remove.action_groups == baseline.action_groups
+
+
+async def test_remove_action_group_rejects_disabled_audit(
+    http: FabricHttpClient, workspace_id: UUID, ephemeral_warehouse: Warehouse
+) -> None:
+    await audit.disable(http, workspace_id, ephemeral_warehouse.id)
+    with pytest.raises(ValueError, match="disabled"):
+        await audit.remove_action_group(
+            http, workspace_id, ephemeral_warehouse.id, "BATCH_COMPLETED_GROUP"
+        )
+
+
+async def test_remove_action_group_rejects_invalid_name(
+    http: FabricHttpClient, workspace_id: UUID, ephemeral_warehouse: Warehouse
+) -> None:
+    with pytest.raises(ValueError, match="bad_group"):
+        await audit.remove_action_group(http, workspace_id, ephemeral_warehouse.id, "bad_group")


### PR DESCRIPTION
## Summary

- Fills the audit `add_action_group` and `remove_action_group` integration test gap identified in #262
- Adds 9 new integration tests covering: group appears after add, group absent after remove, idempotency for both ops, disabled-state rejection, invalid-name rejection, and a full add→remove roundtrip

## Test plan

- `uv run pytest tests/integration/test_services_audit.py --co -q` — deselected by default (label-gated, requires real Fabric)
- `uv run pytest -m integration --co -q` — all 15 audit tests collected
- `uv run pytest tests/unit -q` — 1543 passed, unaffected
- `just check` — ruff, ty, and unit suite all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)