### PR TITLE
feat(tables): add zero-copy table clone (CREATE TABLE AS CLONE OF)

### DIFF
--- a/src/fabric_dw/cli/commands/tables.py
+++ b/src/fabric_dw/cli/commands/tables.py
@@ -15,6 +15,7 @@ from fabric_dw.cli.commands._utils import (
     build_sql_target,
     confirm_destructive,
     load_select_body,
+    parse_iso_datetime,
     parse_qualified_name,
     resolve_warehouse_arg,
     resolve_workspace_arg,
@@ -195,5 +196,59 @@ async def clear_cmd(
                 target, schema, table_name, kind=entry.kind, mode=ctx.auth
             )
             click.echo(f"Table [{schema}].[{table_name}] truncated.")
+    except (ValueError, FabricError) as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@tables_group.command("clone")
+@click.argument("workspace", required=False, default=None)
+@click.argument("item", required=False, default=None)
+@click.option("--source", required=True, help="Qualified source table: schema.table.")
+@click.option(
+    "--name", "new_table", required=True, help="Qualified name for the clone: schema.table."
+)
+@click.option(
+    "--at",
+    "at_str",
+    default=None,
+    help=(
+        "Optional point-in-time (UTC) for a historical clone, "
+        "e.g. 2024-05-20T14:00:00. Must be within the data-retention window."
+    ),
+)
+@click.pass_obj
+@_coro
+async def clone_cmd(
+    ctx: CliContext,
+    workspace: str | None,
+    item: str | None,
+    source: str,
+    new_table: str,
+    at_str: str | None,
+) -> None:
+    """Clone SOURCE table as a zero-copy clone named NAME on ITEM in WORKSPACE.
+
+    Creates a new table using ``CREATE TABLE … AS CLONE OF …``.  The optional
+    ``--at`` timestamp must be within the warehouse data-retention window (UTC).
+    Only supported on Fabric Data Warehouses (not SQL Analytics Endpoints).
+    """
+    ws = resolve_workspace_arg(ctx, workspace)
+    wh = resolve_warehouse_arg(ctx, item)
+    # Validate both qualified names eagerly so bad input is reported before any I/O.
+    parse_qualified_name(source, kind="table")
+    parse_qualified_name(new_table, kind="table")
+    at = parse_iso_datetime(at_str, "--at") if at_str is not None else None
+    try:
+        async with build_http_client(ctx) as http:
+            target, entry = await build_sql_target(http, ws, wh)
+            t = await _tables_svc.clone_table(
+                target,
+                source,
+                new_table,
+                at=at,
+                kind=entry.kind,
+                mode=ctx.auth,
+            )
+            render(t.model_dump(by_alias=True, mode="json"), json_output=ctx.json_output)
     except (ValueError, FabricError) as exc:
         raise click.ClickException(str(exc)) from exc

--- a/src/fabric_dw/mcp/server.py
+++ b/src/fabric_dw/mcp/server.py
@@ -18,12 +18,12 @@ is closed by its ``__aexit__`` (no standalone ``aclose()`` call needed).
 
 Context access
 --------------
-All 65 tool functions call :func:`~fabric_dw.mcp._context.get_context` to
+All 66 tool functions call :func:`~fabric_dw.mcp._context.get_context` to
 obtain the shared :class:`~fabric_dw.mcp._context.ServerContext`.  The sentinel
 pattern (module-level ``ServerContext | None``) was chosen over injecting a
 ``Context`` parameter into every tool because FastMCP's lifespan context is
 not ergonomically accessible from tool functions without either adding a
-``Context`` import to all 65 tools or using fragile ``request_context``
+``Context`` import to all 66 tools or using fragile ``request_context``
 internals.  The sentinel is safe for streamable-HTTP concurrency because it is
 **read-only** after startup — tools only call ``get_context()``; they never
 re-assign the global.

--- a/src/fabric_dw/mcp/tools/tables.py
+++ b/src/fabric_dw/mcp/tools/tables.py
@@ -225,7 +225,7 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
                 from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
 
                 raise ToolError(
-                    f"invalid --at timestamp {at!r}: expected ISO-8601 (e.g. 2024-01-01T00:00:00)"
+                    f"invalid at timestamp {at!r}: expected ISO-8601 (e.g. 2024-01-01T00:00:00)"
                 ) from exc
             at_dt = at_dt.replace(tzinfo=UTC) if at_dt.tzinfo is None else at_dt.astimezone(UTC)
 

--- a/src/fabric_dw/mcp/tools/tables.py
+++ b/src/fabric_dw/mcp/tools/tables.py
@@ -214,8 +214,6 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
                 window (30 days by default).  When omitted, the clone reflects the
                 current state of the source table.
         """
-        parse_qualified_name(source, kind="table")
-        parse_qualified_name(new_table, kind="table")
         assert_writes_allowed("clone_table")
         assert_workspace_allowed(workspace)
 

--- a/src/fabric_dw/mcp/tools/tables.py
+++ b/src/fabric_dw/mcp/tools/tables.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import UTC, datetime
 from typing import Annotated, Any
 
 from mcp.server.fastmcp import FastMCP
@@ -190,3 +191,68 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         except (ValueError, FabricError) as exc:
             raise tool_err(exc) from exc
         return {"truncated": True}
+
+    @mcp.tool(name="clone_table")
+    async def clone_table(
+        workspace: str,
+        item: str,
+        source: str,
+        new_table: str,
+        at: str | None = None,
+    ) -> dict[str, Any]:
+        """Create a zero-copy clone of a table using ``CREATE TABLE … AS CLONE OF …``.
+
+        Only supported on Fabric Data Warehouses (not SQL Analytics Endpoints).
+
+        Args:
+            workspace: Workspace name or GUID.
+            item: Warehouse name or GUID.
+            source: Qualified source table name, e.g. ``dbo.sales``.
+            new_table: Qualified name for the new cloned table, e.g. ``dbo.sales_clone``.
+            at: Optional ISO-8601 UTC timestamp for a point-in-time clone,
+                e.g. ``2024-05-20T14:00:00``.  Must be within the data-retention
+                window (30 days by default).  When omitted, the clone reflects the
+                current state of the source table.
+        """
+        parse_qualified_name(source, kind="table")
+        parse_qualified_name(new_table, kind="table")
+        assert_writes_allowed("clone_table")
+        assert_workspace_allowed(workspace)
+
+        at_dt: datetime | None = None
+        if at is not None:
+            try:
+                at_dt = datetime.fromisoformat(at)
+            except ValueError as exc:
+                from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+                raise ToolError(
+                    f"invalid --at timestamp {at!r}: expected ISO-8601 (e.g. 2024-01-01T00:00:00)"
+                ) from exc
+            at_dt = at_dt.replace(tzinfo=UTC) if at_dt.tzinfo is None else at_dt.astimezone(UTC)
+
+        ctx = get_context()
+        try:
+            ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
+            assert_workspace_allowed(workspace, str(ws_id))
+            _log.debug(
+                "clone_table ws=%s item=%s source=%s new_table=%s at=%s",
+                ws_id,
+                entry.id,
+                source,
+                new_table,
+                at,
+            )
+            target = make_sql_target(ws_id, entry, item)
+            result = await tables_svc.clone_table(
+                target,
+                source,
+                new_table,
+                at=at_dt,
+                kind=entry.kind,
+                mode=ctx.auth_mode,
+            )
+        except (ValueError, FabricError) as exc:
+            raise tool_err(exc) from exc
+        ctx.resolver.clear_negative_cache()
+        return result.model_dump(mode="json")

--- a/src/fabric_dw/services/tables.py
+++ b/src/fabric_dw/services/tables.py
@@ -303,7 +303,7 @@ async def clone_table(
 
     The ``AT`` timestamp — when provided — is a :class:`~datetime.datetime`
     that has already been parsed and validated at the CLI/MCP boundary.  It is
-    formatted to a fixed safe literal (``YYYY-MM-DDTHH:MM:SSS.mmm``) so no
+    formatted to a fixed safe literal (``YYYY-MM-DDTHH:MM:SS.mmm``) so no
     raw user string is ever interpolated into the DDL.
 
     Args:

--- a/src/fabric_dw/services/tables.py
+++ b/src/fabric_dw/services/tables.py
@@ -6,6 +6,7 @@ Public API
 - :func:`list_tables`          — list all tables via TDS ``sys.tables JOIN sys.schemas``.
 - :func:`read_table`           — ``SELECT TOP (N) * FROM [schema].[table]``.
 - :func:`create_table`         — ``CREATE TABLE … AS <select_body>`` (CTAS).
+- :func:`clone_table`          — ``CREATE TABLE … AS CLONE OF …`` (zero-copy clone).
 - :func:`delete_table`         — ``DROP TABLE [schema].[table]``.
 - :func:`clear_table`          — ``TRUNCATE TABLE [schema].[table]``.
 
@@ -26,12 +27,13 @@ from typing import cast
 
 from fabric_dw.auth import CredentialMode
 from fabric_dw.exceptions import ItemKindError, NotFoundError
-from fabric_dw.identifiers import quote_identifier, validate_identifier
+from fabric_dw.identifiers import parse_qualified_name, quote_identifier, validate_identifier
 from fabric_dw.models import Table, WarehouseKind
 from fabric_dw.sql import SqlTarget, run_query
 
 __all__ = [
     "clear_table",
+    "clone_table",
     "create_table",
     "delete_table",
     "list_tables",
@@ -278,6 +280,81 @@ async def create_table(
 
     await asyncio.to_thread(_run_ddl)
     return await _fetch_table(target, schema, table_name, mode=mode)
+
+
+async def clone_table(
+    target: SqlTarget,
+    source: str,
+    new_table: str,
+    *,
+    at: datetime | None = None,
+    kind: WarehouseKind = WarehouseKind.WAREHOUSE,
+    mode: CredentialMode = CredentialMode.DEFAULT,
+) -> Table:
+    """Create a zero-copy clone of *source* table as *new_table*.
+
+    Executes ``CREATE TABLE [new_schema].[new_table] AS CLONE OF
+    [src_schema].[src_table]`` (with an optional ``AT '<timestamp>'`` suffix).
+
+    Both *source* and *new_table* are dot-separated qualified names
+    (``schema.table``).  Every identifier component is validated via
+    :func:`validate_identifier` and bracket-quoted via :func:`quote_identifier`
+    before being embedded in the DDL string.
+
+    The ``AT`` timestamp — when provided — is a :class:`~datetime.datetime`
+    that has already been parsed and validated at the CLI/MCP boundary.  It is
+    formatted to a fixed safe literal (``YYYY-MM-DDTHH:MM:SSS.mmm``) so no
+    raw user string is ever interpolated into the DDL.
+
+    Args:
+        target: The warehouse to connect to.
+        source: Qualified source table name (``schema.table``).
+            Both parts must pass :func:`validate_identifier`.
+        new_table: Qualified name for the new cloned table (``schema.table``).
+            Both parts must pass :func:`validate_identifier`.
+        at: Optional point-in-time (UTC) for a historical clone.
+            When provided, the ``AT '<literal>'`` clause is appended.
+        kind: The :class:`~fabric_dw.models.WarehouseKind` of the item.
+            SQL Endpoint items are rejected with :class:`~fabric_dw.exceptions.ItemKindError`.
+        mode: The credential mode for Entra authentication.
+
+    Returns:
+        A :class:`~fabric_dw.models.Table` reflecting the newly-cloned table
+        (fetched via ``sys.tables`` after DDL).
+
+    Raises:
+        ItemKindError: If *kind* is :attr:`~fabric_dw.models.WarehouseKind.SQL_ENDPOINT`.
+        ValueError: If any identifier component fails validation, or if *source*
+            or *new_table* are not dot-separated qualified names.
+        PermissionDeniedError: If the driver reports a CREATE TABLE permission error.
+    """
+    _assert_not_sql_endpoint(kind)
+
+    src_schema, src_name = parse_qualified_name(source)
+    new_schema, new_name = parse_qualified_name(new_table)
+
+    validate_identifier(src_schema)
+    validate_identifier(src_name)
+    validate_identifier(new_schema)
+    validate_identifier(new_name)
+
+    src_q = f"{quote_identifier(src_schema)}.{quote_identifier(src_name)}"
+    new_q = f"{quote_identifier(new_schema)}.{quote_identifier(new_name)}"
+
+    ddl = f"CREATE TABLE {new_q} AS CLONE OF {src_q}"
+    if at is not None:
+        # Format the datetime as a millisecond-precision UTC literal.
+        # The AT clause does not support bound parameters in T-SQL DDL, so we
+        # embed a fixed-format literal derived from the already-validated datetime
+        # object — never an arbitrary user string.
+        at_literal = at.strftime("%Y-%m-%dT%H:%M:%S.") + f"{at.microsecond // 1000:03d}"
+        ddl = f"{ddl} AT '{at_literal}'"
+
+    def _run_ddl() -> None:
+        run_query(target, ddl, mode=mode, commit=True, fetch="none")
+
+    await asyncio.to_thread(_run_ddl)
+    return await _fetch_table(target, new_schema, new_name, mode=mode)
 
 
 async def delete_table(

--- a/tests/integration/test_services_tables.py
+++ b/tests/integration/test_services_tables.py
@@ -107,7 +107,7 @@ async def test_clone_table_creates_identical_rows(ephemeral_sql_target: SqlTarge
             ephemeral_sql_target, schema, clone_name, count=100
         )
         assert src_cols == cln_cols
-        assert len(cln_rows) == len(src_rows)
+        assert cln_rows == src_rows
     finally:
         with contextlib.suppress(Exception):
             await tables.delete_table(ephemeral_sql_target, schema, source_name)

--- a/tests/integration/test_services_tables.py
+++ b/tests/integration/test_services_tables.py
@@ -10,6 +10,7 @@ cleaned up in the roundtrip test itself.
 from __future__ import annotations
 
 import contextlib
+from datetime import UTC, datetime
 
 import pytest
 
@@ -57,3 +58,87 @@ async def test_create_read_clear_delete_roundtrip(ephemeral_sql_target: SqlTarge
 
     with pytest.raises((NotFoundError, Exception)):
         await tables.read_table(ephemeral_sql_target, schema, table_name)
+
+
+async def test_clone_table_creates_identical_rows(ephemeral_sql_target: SqlTarget) -> None:
+    """clone_table (plain, no AT) creates a clone with the same rows as the source."""
+    schema = "dbo"
+    source_name = "pytest_clone_source"
+    clone_name = "pytest_clone_copy"
+    select_body = "SELECT 1 AS id, 'hello' AS greeting"
+
+    try:
+        # Create the source table.
+        await tables.create_table(ephemeral_sql_target, schema, source_name, select_body)
+
+        # Clone it without a point-in-time.
+        cloned = await tables.clone_table(
+            ephemeral_sql_target, f"{schema}.{source_name}", f"{schema}.{clone_name}"
+        )
+        assert isinstance(cloned, Table)
+        assert cloned.schema_name == schema
+        assert cloned.name == clone_name
+
+        # Verify the clone is visible and contains the same data.
+        all_tables = await tables.list_tables(ephemeral_sql_target, schema=schema)
+        names = {t.name for t in all_tables}
+        assert clone_name in names
+
+        src_cols, src_rows = await tables.read_table(
+            ephemeral_sql_target, schema, source_name, count=100
+        )
+        cln_cols, cln_rows = await tables.read_table(
+            ephemeral_sql_target, schema, clone_name, count=100
+        )
+        assert src_cols == cln_cols
+        assert len(cln_rows) == len(src_rows)
+    finally:
+        with contextlib.suppress(Exception):
+            await tables.delete_table(ephemeral_sql_target, schema, source_name)
+        with contextlib.suppress(Exception):
+            await tables.delete_table(ephemeral_sql_target, schema, clone_name)
+
+
+async def test_clone_table_at_point_in_time(ephemeral_sql_target: SqlTarget) -> None:
+    """clone_table with AT timestamp clones the table at the specified point in time.
+
+    A fresh table will have existed for only a few seconds, so the AT timestamp
+    is captured immediately after creation and used for the clone.  If the
+    engine rejects the timestamp because the table has no history at that
+    instant (some engines require at least one committed version *before* the
+    AT time), the test is skipped with a clear reason rather than failing.
+    """
+    schema = "dbo"
+    source_name = "pytest_clone_at_source"
+    clone_name = "pytest_clone_at_copy"
+    select_body = "SELECT 42 AS value"
+
+    try:
+        await tables.create_table(ephemeral_sql_target, schema, source_name, select_body)
+
+        # Capture a timestamp a moment after creation.
+        at_dt = datetime.now(tz=UTC)
+
+        try:
+            cloned = await tables.clone_table(
+                ephemeral_sql_target,
+                f"{schema}.{source_name}",
+                f"{schema}.{clone_name}",
+                at=at_dt,
+            )
+        except Exception as exc:
+            # A freshly-created table may have no committed history older than
+            # the AT timestamp; skip gracefully rather than marking the whole
+            # test as a hard failure.
+            pytest.skip(
+                f"Point-in-time clone not feasible on a freshly created table "
+                f"(no history at {at_dt.isoformat()}): {exc}"
+            )
+
+        assert isinstance(cloned, Table)
+        assert cloned.name == clone_name
+    finally:
+        with contextlib.suppress(Exception):
+            await tables.delete_table(ephemeral_sql_target, schema, source_name)
+        with contextlib.suppress(Exception):
+            await tables.delete_table(ephemeral_sql_target, schema, clone_name)

--- a/tests/integration/test_services_tables.py
+++ b/tests/integration/test_services_tables.py
@@ -14,12 +14,28 @@ from datetime import UTC, datetime
 
 import pytest
 
-from fabric_dw.exceptions import NotFoundError
+from fabric_dw.exceptions import FabricError, NotFoundError
 from fabric_dw.models import Table
 from fabric_dw.services import tables
 from fabric_dw.sql import SqlTarget
 
 pytestmark = pytest.mark.integration
+
+# Fragments that indicate the SQL engine rejected an AT timestamp because the
+# table has no committed history at the requested point in time.  These are
+# expected and trigger a pytest.skip rather than a test failure.
+_CLONE_AT_SKIP_FRAGMENTS = (
+    ("clone", "point in time"),
+    ("no version",),
+    ("history",),
+    ("at time",),
+)
+
+
+def _is_clone_at_unavailable(exc: BaseException) -> bool:
+    """Return True when *exc* is a SQL engine rejection of an AT timestamp."""
+    msg = str(exc).lower()
+    return any(all(frag in msg for frag in frags) for frags in _CLONE_AT_SKIP_FRAGMENTS)
 
 
 async def test_list_tables_returns_list(ephemeral_sql_target: SqlTarget) -> None:
@@ -128,8 +144,12 @@ async def test_clone_table_at_point_in_time(ephemeral_sql_target: SqlTarget) -> 
             )
         except Exception as exc:
             # A freshly-created table may have no committed history older than
-            # the AT timestamp; skip gracefully rather than marking the whole
-            # test as a hard failure.
+            # the AT timestamp; the engine raises a SQL error when the AT time
+            # predates any committed version.  Skip only for those expected
+            # SQL/driver rejections; re-raise Python-level bugs (TypeError etc.)
+            # so regressions are not silently hidden.
+            if not isinstance(exc, FabricError) and not _is_clone_at_unavailable(exc):
+                raise
             pytest.skip(
                 f"Point-in-time clone not feasible on a freshly created table "
                 f"(no history at {at_dt.isoformat()}): {exc}"

--- a/tests/unit/cli/commands/test_tables.py
+++ b/tests/unit/cli/commands/test_tables.py
@@ -791,7 +791,15 @@ class TestTablesClone:
             ),
             patch(
                 "fabric_dw.services.tables.clone_table",
-                new=AsyncMock(return_value=_make_table()),
+                new=AsyncMock(
+                    return_value=Table(
+                        schema_name="dbo",
+                        name="sales_clone",
+                        qualified_name="dbo.sales_clone",
+                        created=_NOW,
+                        modified=_NOW,
+                    )
+                ),
             ),
         ):
             result = runner.invoke(
@@ -810,7 +818,7 @@ class TestTablesClone:
             )
         assert result.exit_code == 0
         parsed = json.loads(result.output)
-        assert parsed["name"] == "sales"
+        assert parsed["name"] == "sales_clone"
 
     def test_clone_with_at_timestamp(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env

--- a/tests/unit/cli/commands/test_tables.py
+++ b/tests/unit/cli/commands/test_tables.py
@@ -737,3 +737,295 @@ class TestTablesClear:
             result = runner.invoke(cli, ["--yes", "tables", "clear", WS_GUID, SE_GUID, "dbo.sales"])
         assert result.exit_code != 0
         assert "read-only" in result.output
+
+
+# ===========================================================================
+# tables clone
+# ===========================================================================
+
+
+class TestTablesClone:
+    def test_clone_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.tables.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.tables.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.tables.clone_table",
+                new=AsyncMock(return_value=_make_table()),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "tables",
+                    "clone",
+                    WS_GUID,
+                    WH_GUID,
+                    "--source",
+                    "dbo.source_tbl",
+                    "--name",
+                    "dbo.sales_clone",
+                ],
+            )
+        assert result.exit_code == 0
+
+    def test_clone_json_output(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.tables.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.tables.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.tables.clone_table",
+                new=AsyncMock(return_value=_make_table()),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--json",
+                    "tables",
+                    "clone",
+                    WS_GUID,
+                    WH_GUID,
+                    "--source",
+                    "dbo.source_tbl",
+                    "--name",
+                    "dbo.sales_clone",
+                ],
+            )
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["name"] == "sales"
+
+    def test_clone_with_at_timestamp(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        mock_clone = AsyncMock(return_value=_make_table())
+        with (
+            patch(
+                "fabric_dw.cli.commands.tables.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.tables.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch("fabric_dw.services.tables.clone_table", new=mock_clone),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "tables",
+                    "clone",
+                    WS_GUID,
+                    WH_GUID,
+                    "--source",
+                    "dbo.source_tbl",
+                    "--name",
+                    "dbo.sales_clone",
+                    "--at",
+                    "2024-05-20T14:00:00",
+                ],
+            )
+        assert result.exit_code == 0
+        _, kwargs = mock_clone.call_args
+        assert kwargs["at"] is not None
+
+    def test_clone_bad_at_timestamp_exits_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        result = runner.invoke(
+            cli,
+            [
+                "tables",
+                "clone",
+                WS_GUID,
+                WH_GUID,
+                "--source",
+                "dbo.source_tbl",
+                "--name",
+                "dbo.sales_clone",
+                "--at",
+                "not-a-date",
+            ],
+        )
+        assert result.exit_code != 0
+
+    def test_clone_missing_source_exits_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        result = runner.invoke(
+            cli,
+            [
+                "tables",
+                "clone",
+                WS_GUID,
+                WH_GUID,
+                "--name",
+                "dbo.sales_clone",
+            ],
+        )
+        assert result.exit_code != 0
+
+    def test_clone_missing_name_exits_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        result = runner.invoke(
+            cli,
+            [
+                "tables",
+                "clone",
+                WS_GUID,
+                WH_GUID,
+                "--source",
+                "dbo.source_tbl",
+            ],
+        )
+        assert result.exit_code != 0
+
+    def test_clone_bad_source_qualified_name_exits_nonzero(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        _ = cache_env
+        result = runner.invoke(
+            cli,
+            [
+                "tables",
+                "clone",
+                WS_GUID,
+                WH_GUID,
+                "--source",
+                "nodot",
+                "--name",
+                "dbo.sales_clone",
+            ],
+        )
+        assert result.exit_code != 0
+
+    def test_clone_bad_name_qualified_name_exits_nonzero(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        _ = cache_env
+        result = runner.invoke(
+            cli,
+            [
+                "tables",
+                "clone",
+                WS_GUID,
+                WH_GUID,
+                "--source",
+                "dbo.source_tbl",
+                "--name",
+                "nodot",
+            ],
+        )
+        assert result.exit_code != 0
+
+    def test_clone_sql_endpoint_rejected(self, runner: CliRunner, cache_env: Path) -> None:
+        """SQL Endpoint items must be rejected before issuing DDL."""
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.tables.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.tables.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_sql_endpoint_entry())),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "tables",
+                    "clone",
+                    WS_GUID,
+                    SE_GUID,
+                    "--source",
+                    "dbo.source_tbl",
+                    "--name",
+                    "dbo.sales_clone",
+                ],
+            )
+        assert result.exit_code != 0
+        assert "read-only" in result.output
+
+    def test_clone_warehouse_item_allowed(self, runner: CliRunner, cache_env: Path) -> None:
+        """Warehouse items should not be blocked by the SQL Endpoint guard."""
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.tables.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.tables.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.tables.clone_table",
+                new=AsyncMock(return_value=_make_table()),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "tables",
+                    "clone",
+                    WS_GUID,
+                    WH_GUID,
+                    "--source",
+                    "dbo.source_tbl",
+                    "--name",
+                    "dbo.sales_clone",
+                ],
+            )
+        assert result.exit_code == 0
+
+    def test_clone_permission_denied_returns_nonzero(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.tables.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.tables.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.tables.clone_table",
+                new=AsyncMock(side_effect=PermissionDeniedError("no permission")),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "tables",
+                    "clone",
+                    WS_GUID,
+                    WH_GUID,
+                    "--source",
+                    "dbo.source_tbl",
+                    "--name",
+                    "dbo.sales_clone",
+                ],
+            )
+        assert result.exit_code != 0

--- a/tests/unit/mcp/test_contract.py
+++ b/tests/unit/mcp/test_contract.py
@@ -46,7 +46,7 @@ from tests.unit.mcp.conftest import WS_ID, WS_NAME, make_item_entry
 # Expected tool count (sync with test_server.EXPECTED_TOOL_NAMES)
 # ---------------------------------------------------------------------------
 
-_EXPECTED_TOOL_COUNT = 65  # as documented in server.py docstring
+_EXPECTED_TOOL_COUNT = 66  # as documented in server.py docstring
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/mcp/test_server.py
+++ b/tests/unit/mcp/test_server.py
@@ -18,6 +18,7 @@ that has mocked service objects.
 from __future__ import annotations
 
 import os
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, patch
 from uuid import UUID
 
@@ -29,6 +30,7 @@ from fabric_dw.models import (
     AuditSettings,
     ItemAccess,
     RunningQuery,
+    Table,
     TableSyncStatus,
     Warehouse,
     WarehouseKind,
@@ -110,6 +112,7 @@ EXPECTED_TOOL_NAMES: frozenset[str] = frozenset(
         "list_tables",
         "read_table",
         "create_table",
+        "clone_table",
         "delete_table",
         "clear_table",
         # Restore Points
@@ -1148,6 +1151,151 @@ async def test_clear_table_sql_endpoint_raises_tool_error(mock_ctx, ctx_patch) -
         await mcp._tool_manager.call_tool(
             "clear_table",
             {"workspace": _WS_NAME, "item": _SE_NAME, "qualified_name": "dbo.sales"},
+        )
+
+    assert "read-only" in str(exc_info.value).lower()
+
+
+def _make_clone_table() -> Table:
+    _now = datetime(2024, 6, 1, 12, 0, 0, tzinfo=UTC)
+    return Table(
+        schema_name="dbo",
+        name="sales_clone",
+        qualified_name="dbo.sales_clone",
+        created=_now,
+        modified=_now,
+    )
+
+
+async def test_clone_table_happy_path(mock_ctx, ctx_patch) -> None:
+    """clone_table resolves workspace + item and returns a Table dict."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=_make_item_entry())
+    mock_clone = AsyncMock(return_value=_make_clone_table())
+
+    with (
+        ctx_patch,
+        patch("fabric_dw.services.tables.clone_table", new=mock_clone),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "clone_table",
+            {
+                "workspace": _WS_NAME,
+                "item": _WH_NAME,
+                "source": "dbo.sales",
+                "new_table": "dbo.sales_clone",
+            },
+        )
+
+    assert isinstance(result, dict)
+    assert result["name"] == "sales_clone"
+    mock_clone.assert_called_once()
+    _, kwargs = mock_clone.call_args
+    assert kwargs.get("at") is None
+
+
+async def test_clone_table_with_at_timestamp(mock_ctx, ctx_patch) -> None:
+    """clone_table passes a parsed datetime to the service when --at is supplied."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=_make_item_entry())
+    mock_clone = AsyncMock(return_value=_make_clone_table())
+
+    with (
+        ctx_patch,
+        patch("fabric_dw.services.tables.clone_table", new=mock_clone),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "clone_table",
+            {
+                "workspace": _WS_NAME,
+                "item": _WH_NAME,
+                "source": "dbo.sales",
+                "new_table": "dbo.sales_clone",
+                "at": "2024-05-20T14:00:00",
+            },
+        )
+
+    assert isinstance(result, dict)
+    mock_clone.assert_called_once()
+    _, kwargs = mock_clone.call_args
+    assert kwargs.get("at") is not None
+
+
+async def test_clone_table_readonly_mode_blocked(ctx_patch) -> None:
+    """clone_table must raise ToolError in readonly mode (FABRIC_MCP_READONLY=1)."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_READONLY": "1"}),
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "clone_table",
+            {
+                "workspace": _WS_NAME,
+                "item": _WH_NAME,
+                "source": "dbo.sales",
+                "new_table": "dbo.sales_clone",
+            },
+        )
+
+    assert "read-only" in str(exc_info.value).lower()
+
+
+async def test_clone_table_workspace_not_in_allowlist(ctx_patch) -> None:
+    """clone_table must raise ToolError when workspace is not in FABRIC_MCP_WORKSPACES."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_WORKSPACES": "other-workspace"}),
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "clone_table",
+            {
+                "workspace": _WS_NAME,
+                "item": _WH_NAME,
+                "source": "dbo.sales",
+                "new_table": "dbo.sales_clone",
+            },
+        )
+
+    assert "allowlist" in str(exc_info.value).lower()
+
+
+async def test_clone_table_sql_endpoint_raises_tool_error(mock_ctx, ctx_patch) -> None:
+    """clone_table must raise ToolError when the item is a SQL Endpoint."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_ctx.resolver.item = AsyncMock(
+        return_value=_make_sql_endpoint_entry(item_id=_SE_ID, display_name=_SE_NAME)
+    )
+
+    with (
+        ctx_patch,
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "clone_table",
+            {
+                "workspace": _WS_NAME,
+                "item": _SE_NAME,
+                "source": "dbo.sales",
+                "new_table": "dbo.sales_clone",
+            },
         )
 
     assert "read-only" in str(exc_info.value).lower()

--- a/tests/unit/services/test_tables.py
+++ b/tests/unit/services/test_tables.py
@@ -647,3 +647,156 @@ class TestSqlEndpointGuard:
                 "SELECT 1",
                 kind=WarehouseKind.SQL_ENDPOINT,
             )
+
+
+# ===========================================================================
+# clone_table
+# ===========================================================================
+
+
+class TestCloneTable:
+    async def test_emits_create_table_as_clone_of(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_TABLE_ROW_1], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            await tables.clone_table(target, "dbo.source_tbl", "dbo.sales")
+        cursor = ddl_conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0].upper()
+        assert "CREATE TABLE" in call_sql
+        assert "CLONE OF" in call_sql
+
+    async def test_bracket_quotes_all_identifiers(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_TABLE_ROW_1], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            await tables.clone_table(target, "dbo.source_tbl", "dbo.sales")
+        cursor = ddl_conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert "[dbo].[sales]" in call_sql
+        assert "[dbo].[source_tbl]" in call_sql
+
+    async def test_cross_schema_clone_quotes_correctly(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_row: tuple[object, ...] = ("staging", "copy_tbl", _NOW, _NOW)
+        fetch_conn = _make_conn([fetch_row], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            await tables.clone_table(target, "dbo.source_tbl", "staging.copy_tbl")
+        cursor = ddl_conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert "[staging].[copy_tbl]" in call_sql
+        assert "[dbo].[source_tbl]" in call_sql
+
+    async def test_no_at_clause_without_timestamp(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_TABLE_ROW_1], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            await tables.clone_table(target, "dbo.source_tbl", "dbo.sales")
+        cursor = ddl_conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0].upper()
+        assert " AT " not in call_sql
+
+    async def test_at_clause_appended_when_provided(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_TABLE_ROW_1], _LIST_COLS)
+        at_dt = datetime(2024, 5, 20, 14, 0, 0, tzinfo=UTC)
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            await tables.clone_table(target, "dbo.source_tbl", "dbo.sales", at=at_dt)
+        cursor = ddl_conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert "AT '2024-05-20T14:00:00.000'" in call_sql
+
+    async def test_at_clause_formats_milliseconds(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_TABLE_ROW_1], _LIST_COLS)
+        # 123456 microseconds → 123 milliseconds in the literal
+        at_dt = datetime(2024, 5, 20, 14, 0, 0, 123456, tzinfo=UTC)
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            await tables.clone_table(target, "dbo.source_tbl", "dbo.sales", at=at_dt)
+        cursor = ddl_conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert "AT '2024-05-20T14:00:00.123'" in call_sql
+
+    async def test_returns_table_object(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_TABLE_ROW_1], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            result = await tables.clone_table(target, "dbo.source_tbl", "dbo.sales")
+        assert isinstance(result, Table)
+
+    async def test_commits_after_execute(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_TABLE_ROW_1], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            await tables.clone_table(target, "dbo.source_tbl", "dbo.sales")
+        ddl_conn.commit.assert_called_once()
+
+    async def test_rejects_sql_endpoint(self) -> None:
+        target = _make_target()
+        with pytest.raises(ItemKindError, match="read-only"):
+            await tables.clone_table(
+                target,
+                "dbo.source_tbl",
+                "dbo.sales",
+                kind=WarehouseKind.SQL_ENDPOINT,
+            )
+
+    async def test_endpoint_guard_fires_before_io(self) -> None:
+        """Guard fires without touching the network even if identifiers are invalid."""
+        target = _make_target()
+        with pytest.raises(ItemKindError):
+            await tables.clone_table(
+                target,
+                "bad]schema.src",
+                "dbo.sales",
+                kind=WarehouseKind.SQL_ENDPOINT,
+            )
+
+    async def test_validates_source_schema_identifier(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await tables.clone_table(target, "bad]schema.src", "dbo.sales")
+
+    async def test_validates_source_table_identifier(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await tables.clone_table(target, "dbo.src--bad", "dbo.sales")
+
+    async def test_validates_new_schema_identifier(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await tables.clone_table(target, "dbo.src", "bad]schema.sales")
+
+    async def test_validates_new_table_identifier(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await tables.clone_table(target, "dbo.src", "dbo.sales;drop")
+
+    async def test_rejects_missing_dot_in_source(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match=r"substring not found|qualified"):
+            await tables.clone_table(target, "nodot", "dbo.sales")
+
+    async def test_rejects_missing_dot_in_new_table(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match=r"substring not found|qualified"):
+            await tables.clone_table(target, "dbo.src", "nodot")
+
+    async def test_maps_permission_denied(self) -> None:
+        target = _make_target()
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.execute.side_effect = Exception("permission was denied on database")
+        conn.cursor.return_value = cursor
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(PermissionDeniedError),
+        ):
+            await tables.clone_table(target, "dbo.source_tbl", "dbo.sales")


### PR DESCRIPTION
## Summary

- Adds `tables clone` CLI command: `fabric-dw tables clone [WORKSPACE] [ITEM] --source schema.src --name schema.dst [--at ISO-timestamp]`
- Adds `clone_table` MCP tool gated with `assert_writes_allowed` (not destructive — mirrors `create_table` gating)
- Adds `clone_table` service function in `services/tables.py`

## Design

**T-SQL syntax (verified against [Microsoft Learn](https://learn.microsoft.com/en-us/fabric/data-warehouse/tutorial-clone-table)):**
```sql
-- Current state clone:
CREATE TABLE [dbo].[sales_clone] AS CLONE OF [dbo].[sales];

-- Point-in-time clone (AT literal, within data-retention window):
CREATE TABLE [dbo].[sales_clone] AS CLONE OF [dbo].[sales] AT '2024-05-20T14:00:00.000';
```

**Injection safety:** The `AT` clause cannot use bound parameters in T-SQL DDL. The implementation accepts a `datetime` object (already parsed/validated at CLI or MCP boundary) and formats it to a fixed-format millisecond-precision literal via `at.strftime("%Y-%m-%dT%H:%M:%S.") + f"{at.microsecond // 1000:03d}"`. No raw user string is ever interpolated.

**DW-only guard:** Reuses the existing `_assert_not_sql_endpoint(kind)` guard (raises `ItemKindError`), identical to `create_table` / `delete_table` / `clear_table`.

**Return type:** Re-fetches the new table from `sys.tables` post-DDL and returns a `Table` model — same convention as `create_table`.

## Files changed

| File | Change |
|------|--------|
| `src/fabric_dw/services/tables.py` | `clone_table()` service function |
| `src/fabric_dw/cli/commands/tables.py` | `clone` sub-command |
| `src/fabric_dw/mcp/tools/tables.py` | `clone_table` MCP tool |
| `src/fabric_dw/mcp/server.py` | Tool count docstring (65→66) |
| `tests/unit/services/test_tables.py` | `TestCloneTable` — 17 unit tests |
| `tests/unit/cli/commands/test_tables.py` | `TestTablesClone` — 11 unit tests |
| `tests/unit/mcp/test_server.py` | 5 MCP tool tests + `clone_table` in `EXPECTED_TOOL_NAMES` |
| `tests/unit/mcp/test_contract.py` | Tool count 65→66 |
| `tests/integration/test_services_tables.py` | 2 integration tests (label-gated, real Fabric) |

## Test plan

- [x] `just check` fully green (lint + ty + 1576 unit tests)
- [x] Integration tests collect correctly under `-m integration`
- [ ] Real-Fabric integration tests NOT verified here (no Fabric creds in CI without label)

🤖 Generated with [Claude Code](https://claude.com/claude-code)