### PR TITLE
fix(schemas): relax over-strict SQL endpoint guards for CREATE/DROP SCHEMA

### DIFF
--- a/src/fabric_dw/cli/commands/_utils.py
+++ b/src/fabric_dw/cli/commands/_utils.py
@@ -18,7 +18,6 @@ from fabric_dw import auth as _auth
 from fabric_dw.cache import ItemEntry, LookupCache
 from fabric_dw.http_client import FabricHttpClient
 from fabric_dw.identifiers import parse_qualified_name as _parse_qn
-from fabric_dw.models import WarehouseKind
 from fabric_dw.resolver import Resolver
 from fabric_dw.sql import SqlTarget
 
@@ -28,28 +27,16 @@ if TYPE_CHECKING:
 _P = ParamSpec("_P")
 _R = TypeVar("_R")
 
-_SQL_ENDPOINT_READ_ONLY = "SQL Endpoints are read-only; CREATE/DROP SCHEMA not supported"
-
-
 # ---------------------------------------------------------------------------
-# guard_not_sql_endpoint
+# Note on SQL Analytics Endpoint DDL support
 # ---------------------------------------------------------------------------
-
-
-def guard_not_sql_endpoint(entry: ItemEntry) -> None:
-    """Raise ValueError if *entry* is a SQL Analytics Endpoint.
-
-    SQL Analytics Endpoints are read-only; DDL operations are not supported.
-
-    Raises:
-        ValueError: If the resolved item is a SQL Analytics Endpoint.
-    """
-    if entry.kind == WarehouseKind.SQL_ENDPOINT:
-        raise ValueError(_SQL_ENDPOINT_READ_ONLY)
-
-
-# Private alias kept for backward compatibility with existing imports.
-_guard_not_sql_endpoint = guard_not_sql_endpoint
+# CREATE/DROP SCHEMA, CREATE/ALTER/DROP VIEW, and CREATE/ALTER/DROP PROCEDURE
+# are all explicitly supported on SQL Analytics Endpoints per the Microsoft
+# Fabric T-SQL reference (Applies-to: "SQL analytics endpoint in Microsoft
+# Fabric").  Only table DDL and DML (CREATE/DROP/TRUNCATE TABLE, INSERT/
+# UPDATE/DELETE) are Warehouse-only.  No client-side guard is needed for
+# schema or view operations.
+# ---------------------------------------------------------------------------
 
 
 # ---------------------------------------------------------------------------

--- a/src/fabric_dw/cli/commands/schemas.py
+++ b/src/fabric_dw/cli/commands/schemas.py
@@ -10,7 +10,6 @@ from fabric_dw.cli._context import CliContext
 from fabric_dw.cli._render import render
 from fabric_dw.cli.commands._utils import (
     _coro,
-    _guard_not_sql_endpoint,
     build_http_client,
     build_sql_target,
     confirm_destructive,
@@ -67,8 +66,7 @@ async def create_cmd(
     wh = resolve_warehouse_arg(ctx, item)
     try:
         async with build_http_client(ctx) as http:
-            target, entry = await build_sql_target(http, ws, wh)
-            _guard_not_sql_endpoint(entry)
+            target, _entry = await build_sql_target(http, ws, wh)
             s = await _schemas_svc.create_schema(target, name, mode=ctx.auth)
             render(s.model_dump(by_alias=True, mode="json"), json_output=ctx.json_output)
     except (ValueError, FabricError) as exc:
@@ -107,7 +105,6 @@ async def delete_cmd(
     try:
         async with build_http_client(ctx) as http:
             target, entry = await build_sql_target(http, ws, wh)
-            _guard_not_sql_endpoint(entry)
             prompt = f"Drop schema [{name}] from {entry.display_name!r} ({entry.id})?"
             if cascade:
                 prompt = (

--- a/src/fabric_dw/mcp/_helpers.py
+++ b/src/fabric_dw/mcp/_helpers.py
@@ -6,8 +6,6 @@ This module provides utilities imported by every domain tool module:
   to a :class:`~mcp.server.fastmcp.exceptions.ToolError` with structured data.
 - :func:`tool_err` — uniform error funnel mapping FabricError / ValueError /
   Exception to ToolError without inline ternaries.
-- :func:`require_warehouse` — reject SQL Analytics Endpoint items for DDL
-  operations.
 - :func:`parse_qualified_name` — split ``"schema.object"`` strings, raising
   :class:`~mcp.server.fastmcp.exceptions.ToolError` on bad input.
 - :func:`make_sql_target` — build a :class:`~fabric_dw.sql.SqlTarget` from a
@@ -28,7 +26,6 @@ from mcp.server.fastmcp.exceptions import ToolError
 
 from fabric_dw.cache import ItemEntry as _ItemEntry
 from fabric_dw.exceptions import FabricError
-from fabric_dw.models import WarehouseKind
 from fabric_dw.resolver import Resolver
 from fabric_dw.sql import SqlTarget
 from fabric_dw.sql_io import json_safe as _json_safe
@@ -37,7 +34,6 @@ __all__ = [
     "fabric_err",
     "make_sql_target",
     "parse_qualified_name",
-    "require_warehouse",
     "resolve_item",
     "safe_rows",
     "tool_err",
@@ -45,7 +41,9 @@ __all__ = [
 
 _log = logging.getLogger(__name__)
 
-_SQL_ENDPOINT_DDL_ERROR = "SQL Analytics Endpoints are read-only; CREATE/DROP SCHEMA not supported"
+# Note: CREATE/DROP SCHEMA, views, procedures, and functions are all supported
+# on SQL Analytics Endpoints — see T-SQL Applies-to reference for Fabric.
+# No DDL guard is needed for these operations; only table DML/DDL is blocked.
 
 
 def fabric_err(exc: FabricError | Exception) -> ToolError:
@@ -103,24 +101,6 @@ def tool_err(exc: FabricError | Exception) -> ToolError:
     if isinstance(exc, FabricError):
         return fabric_err(exc)
     return ToolError(str(exc))
-
-
-def require_warehouse(entry: _ItemEntry, item: str) -> None:
-    """Raise :class:`ToolError` if *entry* is a SQL Analytics Endpoint.
-
-    DDL operations (CREATE SCHEMA, DROP SCHEMA) are not supported on SQL
-    Analytics Endpoints, which are read-only views over Lakehouse data.
-
-    Args:
-        entry: The resolved item entry.
-        item: The item name/GUID as supplied by the caller (used in the error
-            message).
-
-    Raises:
-        ToolError: If the resolved item is a SQL Analytics Endpoint.
-    """
-    if entry.kind == WarehouseKind.SQL_ENDPOINT:
-        raise ToolError(f"{item!r}: {_SQL_ENDPOINT_DDL_ERROR}")
 
 
 def parse_qualified_name(qualified_name: str, kind: str = "object") -> tuple[str, str]:

--- a/src/fabric_dw/mcp/tools/schemas.py
+++ b/src/fabric_dw/mcp/tools/schemas.py
@@ -16,7 +16,6 @@ from fabric_dw.mcp._guards import (
 )
 from fabric_dw.mcp._helpers import (
     make_sql_target,
-    require_warehouse,
     resolve_item,
     tool_err,
 )
@@ -59,14 +58,14 @@ def register(mcp: FastMCP) -> None:
 
     @mcp.tool(name="create_schema")
     async def create_schema(workspace: str, item: str, name: str) -> dict[str, Any]:
-        """Create a new SQL schema on a warehouse.
+        """Create a new SQL schema on a warehouse or SQL Analytics Endpoint.
 
-        Only Fabric Data Warehouses are supported; SQL Analytics Endpoints are
-        rejected because they are read-only views over Lakehouse data.
+        Both Fabric Data Warehouses and SQL Analytics Endpoints support
+        ``CREATE SCHEMA`` per the Microsoft Fabric T-SQL reference.
 
         Args:
             workspace: Workspace name or GUID.
-            item: Warehouse name or GUID.
+            item: Warehouse or SQL Analytics Endpoint name or GUID.
             name: The schema name.  Must be a valid SQL identifier.
         """
         assert_writes_allowed("create_schema")
@@ -75,7 +74,6 @@ def register(mcp: FastMCP) -> None:
         try:
             ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
             assert_workspace_allowed(workspace, str(ws_id))
-            require_warehouse(entry, item)
             _log.debug("create_schema ws=%s item=%s name=%r", ws_id, entry.id, name)
             target = make_sql_target(ws_id, entry, item)
             result = await schemas_svc.create_schema(target, name, mode=ctx.auth_mode)
@@ -100,12 +98,12 @@ def register(mcp: FastMCP) -> None:
         are permanently deleted along with their data**.  Confirm explicitly with
         the user before calling with ``cascade=True``.
 
-        Only Fabric Data Warehouses are supported; SQL Analytics Endpoints are
-        rejected.
+        Both Fabric Data Warehouses and SQL Analytics Endpoints support
+        ``DROP SCHEMA`` per the Microsoft Fabric T-SQL reference.
 
         Args:
             workspace: Workspace name or GUID.
-            item: Warehouse name or GUID.
+            item: Warehouse or SQL Analytics Endpoint name or GUID.
             name: The schema name to drop.
             cascade: When ``True``, drop all tables and views in the schema first.
                 Defaults to ``False``.
@@ -117,7 +115,6 @@ def register(mcp: FastMCP) -> None:
         try:
             ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
             assert_workspace_allowed(workspace, str(ws_id))
-            require_warehouse(entry, item)
             _log.debug("delete_schema ws=%s item=%s name=%r", ws_id, entry.id, name)
             target = make_sql_target(ws_id, entry, item)
             await schemas_svc.delete_schema(target, name, cascade=cascade, mode=ctx.auth_mode)

--- a/tests/unit/cli/commands/test_schemas.py
+++ b/tests/unit/cli/commands/test_schemas.py
@@ -214,7 +214,8 @@ class TestSchemasCreate:
         parsed = json.loads(result.output)
         assert parsed["name"] == "sales"
 
-    def test_create_sql_endpoint_returns_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
+    def test_create_sql_endpoint_succeeds(self, runner: CliRunner, cache_env: Path) -> None:
+        """CREATE SCHEMA is supported on SQL Analytics Endpoints (Fabric T-SQL reference)."""
         _ = cache_env
         mock_http = AsyncMock()
         with (
@@ -226,9 +227,13 @@ class TestSchemasCreate:
                 "fabric_dw.cli.commands.schemas.build_sql_target",
                 new=AsyncMock(return_value=(_make_sql_target(), _make_sql_endpoint_entry())),
             ),
+            patch(
+                "fabric_dw.services.schemas.create_schema",
+                new=AsyncMock(return_value=_make_schema()),
+            ),
         ):
             result = runner.invoke(cli, ["schemas", "create", WS_GUID, WH_GUID, "sales"])
-        assert result.exit_code != 0
+        assert result.exit_code == 0
 
     def test_create_permission_error_returns_nonzero(
         self, runner: CliRunner, cache_env: Path
@@ -350,7 +355,8 @@ class TestSchemasDelete:
         _, kwargs = mock_delete.call_args
         assert kwargs.get("cascade") is False
 
-    def test_delete_sql_endpoint_returns_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
+    def test_delete_sql_endpoint_succeeds(self, runner: CliRunner, cache_env: Path) -> None:
+        """DROP SCHEMA is supported on SQL Analytics Endpoints (Fabric T-SQL reference)."""
         _ = cache_env
         mock_http = AsyncMock()
         with (
@@ -362,9 +368,14 @@ class TestSchemasDelete:
                 "fabric_dw.cli.commands.schemas.build_sql_target",
                 new=AsyncMock(return_value=(_make_sql_target(), _make_sql_endpoint_entry())),
             ),
+            patch(
+                "fabric_dw.services.schemas.delete_schema",
+                new=AsyncMock(return_value=None),
+            ),
         ):
             result = runner.invoke(cli, ["-y", "schemas", "delete", WS_GUID, WH_GUID, "sales"])
-        assert result.exit_code != 0
+        assert result.exit_code == 0
+        assert "dropped" in result.output
 
     def test_delete_cascade_warns_on_stderr(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env

--- a/tests/unit/mcp/test_server.py
+++ b/tests/unit/mcp/test_server.py
@@ -1158,11 +1158,15 @@ async def test_clear_table_sql_endpoint_raises_tool_error(mock_ctx, ctx_patch) -
 # ---------------------------------------------------------------------------
 
 
-async def test_create_schema_rejects_sql_endpoint(mock_ctx, ctx_patch) -> None:
-    """create_schema must raise ToolError when called against a SQL Analytics Endpoint."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+async def test_create_schema_works_on_sql_endpoint(mock_ctx, ctx_patch) -> None:
+    """create_schema is allowed on SQL Analytics Endpoints.
 
+    CREATE SCHEMA is listed in the Applies-to for 'SQL analytics endpoint in
+    Microsoft Fabric' in the Fabric T-SQL reference — the client-side guard
+    was too strict and has been removed.
+    """
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+    from fabric_dw.models import Schema  # noqa: PLC0415
 
     ep_entry = _make_sql_endpoint_entry()
     mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
@@ -1170,26 +1174,28 @@ async def test_create_schema_rejects_sql_endpoint(mock_ctx, ctx_patch) -> None:
 
     with (
         ctx_patch,
-        pytest.raises(ToolError) as exc_info,
+        patch(
+            "fabric_dw.services.schemas.create_schema",
+            new=AsyncMock(return_value=Schema(name="newschema", principal_id=5)),
+        ),
     ):
-        await mcp._tool_manager.call_tool(
+        result = await mcp._tool_manager.call_tool(
             "create_schema",
             {"workspace": _WS_NAME, "item": "MySqlEndpoint", "name": "newschema"},
         )
 
-    assert "read-only" in str(exc_info.value).lower() or "SQL Analytics Endpoint" in str(
-        exc_info.value
-    )
+    assert result["name"] == "newschema"
 
 
-async def test_delete_schema_rejects_sql_endpoint(mock_ctx, ctx_patch) -> None:
-    """delete_schema must raise ToolError when called against a SQL Analytics Endpoint.
+async def test_delete_schema_works_on_sql_endpoint(mock_ctx, ctx_patch) -> None:
+    """delete_schema is allowed on SQL Analytics Endpoints.
 
-    FABRIC_MCP_ALLOW_DESTRUCTIVE=1 is set so the destructive guard passes and
-    the SQL-endpoint read-only guard fires instead.
+    DROP SCHEMA is listed in the Applies-to for 'SQL analytics endpoint in
+    Microsoft Fabric' in the Fabric T-SQL reference — the client-side guard
+    was too strict and has been removed.
+
+    FABRIC_MCP_ALLOW_DESTRUCTIVE=1 is set so the destructive guard passes.
     """
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
-
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
     ep_entry = _make_sql_endpoint_entry()
@@ -1199,16 +1205,17 @@ async def test_delete_schema_rejects_sql_endpoint(mock_ctx, ctx_patch) -> None:
     with (
         ctx_patch,
         patch.dict(os.environ, {"FABRIC_MCP_ALLOW_DESTRUCTIVE": "1"}),
-        pytest.raises(ToolError) as exc_info,
+        patch(
+            "fabric_dw.services.schemas.delete_schema",
+            new=AsyncMock(return_value=None),
+        ),
     ):
-        await mcp._tool_manager.call_tool(
+        result = await mcp._tool_manager.call_tool(
             "delete_schema",
             {"workspace": _WS_NAME, "item": "MySqlEndpoint", "name": "oldschema"},
         )
 
-    assert "read-only" in str(exc_info.value).lower() or "SQL Analytics Endpoint" in str(
-        exc_info.value
-    )
+    assert result == {"deleted": True}
 
 
 async def test_list_schemas_works_on_sql_endpoint(mock_ctx, ctx_patch) -> None:


### PR DESCRIPTION
## Verified Capability Matrix

Research method: Microsoft Fabric T-SQL reference docs (Applies-to field) + T-SQL surface area article + SQL analytics endpoint feature documentation.

| Operation | DW | SQL Endpoint | Source | Guard action |
|---|---|---|---|---|
| CREATE SCHEMA | ✅ | ✅ | [CREATE SCHEMA Applies-to](https://learn.microsoft.com/sql/t-sql/statements/create-schema-transact-sql) explicitly lists "SQL analytics endpoint in Microsoft Fabric" | **REMOVED** (was too strict) |
| DROP SCHEMA | ✅ | ✅ | [DROP SCHEMA Applies-to](https://learn.microsoft.com/sql/t-sql/statements/drop-schema-transact-sql) explicitly lists "SQL analytics endpoint in Microsoft Fabric" | **REMOVED** (was too strict) |
| CREATE/ALTER/DROP VIEW | ✅ | ✅ | [T-SQL surface area doc](https://learn.microsoft.com/fabric/data-warehouse/tsql-surface-area): "You can also create T-SQL views, functions, and procedures on top of the tables … in the SQL analytics endpoint" | No guard existed — correct |
| CREATE/ALTER/DROP PROCEDURE | ✅ | ✅ | Same T-SQL surface area doc + endpoint feature page | No guard existed — correct |
| CREATE/DROP FUNCTION | ✅ | ✅ (scalar, inlineable) | [Endpoint limitations](https://learn.microsoft.com/fabric/data-engineering/lakehouse-sql-analytics-endpoint#limitations): "Scalar UDFs are supported when inlineable" | No guard existed — correct |
| CREATE TABLE (CTAS) | ✅ | ❌ | T-SQL surface area: "Creating, altering, and dropping tables … only supported in Warehouse" | **KEPT** in `tables.py` |
| DROP TABLE | ✅ | ❌ | Same | **KEPT** in `tables.py` |
| TRUNCATE TABLE | ✅ | ❌ | Same | **KEPT** in `tables.py` |
| INSERT / UPDATE / DELETE | ✅ | ❌ | Same | **KEPT** in `tables.py` |

## What Guards Were Relaxed

- **`guard_not_sql_endpoint` / `_guard_not_sql_endpoint`** removed from `src/fabric_dw/cli/commands/_utils.py` — was only used by schemas CLI
- **`require_warehouse`** removed from `src/fabric_dw/mcp/_helpers.py` — was only used by schemas MCP tools
- Guard calls removed from `cli/commands/schemas.py` create/delete commands
- Guard calls removed from `mcp/tools/schemas.py` create_schema/delete_schema tools
- Docstrings updated to reflect both Warehouses and SQL Analytics Endpoints are supported

## What Guards Were Kept

- `_assert_not_sql_endpoint` in `src/fabric_dw/services/tables.py` — table DDL/DML is correctly Warehouse-only per docs
- `WarehouseKind.SQL_ENDPOINT` check in `cli/commands/warehouses.py` takeover command — takeover of a SQL endpoint is not a meaningful operation

## Tests

- Updated `tests/unit/cli/commands/test_schemas.py`: `test_create_sql_endpoint_returns_nonzero` → `test_create_sql_endpoint_succeeds`, `test_delete_sql_endpoint_returns_nonzero` → `test_delete_sql_endpoint_succeeds`
- Updated `tests/unit/mcp/test_server.py`: replaced `test_create_schema_rejects_sql_endpoint` and `test_delete_schema_rejects_sql_endpoint` with success-path assertions
- `just check` fully green: 1543 passed, lint clean, type clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)