### PR TITLE
feat(procedures): CRUD for stored procedures on DW and SQL Analytics Endpoint

### DIFF
--- a/src/fabric_dw/cli/_main.py
+++ b/src/fabric_dw/cli/_main.py
@@ -12,6 +12,7 @@ from fabric_dw.cli.commands.audit import audit_group
 from fabric_dw.cli.commands.cache import cache_group
 from fabric_dw.cli.commands.completion import completion_group
 from fabric_dw.cli.commands.config import config_group
+from fabric_dw.cli.commands.procedures import procedures_group
 from fabric_dw.cli.commands.queries import queries_group
 from fabric_dw.cli.commands.query_insights import query_insights_group
 from fabric_dw.cli.commands.restore_points import restore_points_group
@@ -94,3 +95,4 @@ cli.add_command(sql_pools_group)
 cli.add_command(schemas_group)
 cli.add_command(tables_group)
 cli.add_command(views_group)
+cli.add_command(procedures_group)

--- a/src/fabric_dw/cli/commands/procedures.py
+++ b/src/fabric_dw/cli/commands/procedures.py
@@ -1,0 +1,186 @@
+"""Procedures sub-commands for the fabric-dw CLI."""
+
+from __future__ import annotations
+
+import logging
+
+import click
+
+from fabric_dw.cli._context import CliContext
+from fabric_dw.cli._render import confirm, render
+from fabric_dw.cli.commands._utils import (
+    _coro,
+    build_http_client,
+    build_sql_target,
+    load_select_body,
+    parse_qualified_name,
+    resolve_warehouse_arg,
+    resolve_workspace_arg,
+)
+from fabric_dw.exceptions import FabricError
+from fabric_dw.services import procedures as _procs_svc
+
+_log = logging.getLogger(__name__)
+
+
+@click.group("procedures")
+def procedures_group() -> None:
+    """Manage stored procedures on Fabric warehouses and SQL Analytics Endpoints."""
+
+
+@procedures_group.command("list")
+@click.argument("workspace", required=False, default=None)
+@click.argument("item", required=False, default=None)
+@click.option("--schema", default=None, help="Filter by schema name.")
+@click.pass_obj
+@_coro
+async def list_cmd(
+    ctx: CliContext, workspace: str | None, item: str | None, schema: str | None
+) -> None:
+    """List stored procedures on ITEM (warehouse or SQL endpoint) in WORKSPACE."""
+    ws = resolve_workspace_arg(ctx, workspace)
+    wh = resolve_warehouse_arg(ctx, item)
+    try:
+        async with build_http_client(ctx) as http:
+            target, _entry = await build_sql_target(http, ws, wh)
+            items = await _procs_svc.list_procedures(target, schema=schema, mode=ctx.auth)
+            render(
+                [p.model_dump(by_alias=True, mode="json") for p in items],
+                json_output=ctx.json_output,
+                table_title="Stored Procedures",
+            )
+    except (ValueError, FabricError) as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@procedures_group.command("get")
+@click.argument("workspace", required=False, default=None)
+@click.argument("item", required=False, default=None)
+@click.argument("qualified_name")
+@click.pass_obj
+@_coro
+async def get_cmd(
+    ctx: CliContext,
+    workspace: str | None,
+    item: str | None,
+    qualified_name: str,
+) -> None:
+    """Fetch the full definition of QUALIFIED_NAME (schema.proc) on ITEM in WORKSPACE."""
+    ws = resolve_workspace_arg(ctx, workspace)
+    wh = resolve_warehouse_arg(ctx, item)
+    schema, proc_name = parse_qualified_name(qualified_name, kind="procedure")
+    try:
+        async with build_http_client(ctx) as http:
+            target, _entry = await build_sql_target(http, ws, wh)
+            p = await _procs_svc.get_procedure(target, schema, proc_name, mode=ctx.auth)
+            render(p.model_dump(by_alias=True, mode="json"), json_output=ctx.json_output)
+    except (ValueError, FabricError) as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@procedures_group.command("create")
+@click.argument("workspace", required=False, default=None)
+@click.argument("item", required=False, default=None)
+@click.option("--name", "qualified_name", required=True, help="Qualified name: schema.proc.")
+@click.option("--body", "body", default=None, help="Inline procedure body.")
+@click.option(
+    "--from-file", default=None, help="Path to a .sql file containing the procedure body."
+)
+@click.pass_obj
+@_coro
+async def create_cmd(
+    ctx: CliContext,
+    workspace: str | None,
+    item: str | None,
+    qualified_name: str,
+    body: str | None,
+    from_file: str | None,
+) -> None:
+    """Create a new stored procedure QUALIFIED_NAME on ITEM in WORKSPACE."""
+    ws = resolve_workspace_arg(ctx, workspace)
+    wh = resolve_warehouse_arg(ctx, item)
+    schema, proc_name = parse_qualified_name(qualified_name, kind="procedure")
+    proc_body = load_select_body(body, from_file)
+    try:
+        async with build_http_client(ctx) as http:
+            target, _entry = await build_sql_target(http, ws, wh)
+            p = await _procs_svc.create_procedure(
+                target, schema, proc_name, proc_body, mode=ctx.auth
+            )
+            render(p.model_dump(by_alias=True, mode="json"), json_output=ctx.json_output)
+    except (ValueError, FabricError) as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@procedures_group.command("update")
+@click.argument("workspace", required=False, default=None)
+@click.argument("item", required=False, default=None)
+@click.argument("qualified_name")
+@click.option("--body", "body", default=None, help="Inline procedure body.")
+@click.option(
+    "--from-file", default=None, help="Path to a .sql file containing the procedure body."
+)
+@click.pass_obj
+@_coro
+async def update_cmd(
+    ctx: CliContext,
+    workspace: str | None,
+    item: str | None,
+    qualified_name: str,
+    body: str | None,
+    from_file: str | None,
+) -> None:
+    """Redefine QUALIFIED_NAME (schema.proc) on ITEM in WORKSPACE via CREATE OR ALTER PROCEDURE."""
+    ws = resolve_workspace_arg(ctx, workspace)
+    wh = resolve_warehouse_arg(ctx, item)
+    schema, proc_name = parse_qualified_name(qualified_name, kind="procedure")
+    proc_body = load_select_body(body, from_file)
+    try:
+        async with build_http_client(ctx) as http:
+            target, entry = await build_sql_target(http, ws, wh)
+            confirmed = confirm(
+                f"Redefine procedure [{schema}].[{proc_name}] on {entry.display_name!r}?",
+                yes=ctx.yes,
+            )
+            if not confirmed:
+                click.echo("Aborted.")
+                return
+            p = await _procs_svc.update_procedure(
+                target, schema, proc_name, proc_body, mode=ctx.auth
+            )
+            render(p.model_dump(by_alias=True, mode="json"), json_output=ctx.json_output)
+    except (ValueError, FabricError) as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@procedures_group.command("drop")
+@click.argument("workspace", required=False, default=None)
+@click.argument("item", required=False, default=None)
+@click.argument("qualified_name")
+@click.pass_obj
+@_coro
+async def drop_cmd(
+    ctx: CliContext,
+    workspace: str | None,
+    item: str | None,
+    qualified_name: str,
+) -> None:
+    """Drop QUALIFIED_NAME (schema.proc) from ITEM in WORKSPACE."""
+    ws = resolve_workspace_arg(ctx, workspace)
+    wh = resolve_warehouse_arg(ctx, item)
+    schema, proc_name = parse_qualified_name(qualified_name, kind="procedure")
+    try:
+        async with build_http_client(ctx) as http:
+            target, entry = await build_sql_target(http, ws, wh)
+            confirmed = confirm(
+                f"Drop procedure [{schema}].[{proc_name}] from"
+                f" {entry.display_name!r} ({entry.id})?",
+                yes=ctx.yes,
+            )
+            if not confirmed:
+                click.echo("Aborted.")
+                return
+            await _procs_svc.drop_procedure(target, schema, proc_name, mode=ctx.auth)
+            click.echo(f"Procedure [{schema}].[{proc_name}] dropped.")
+    except (ValueError, FabricError) as exc:
+        raise click.ClickException(str(exc)) from exc

--- a/src/fabric_dw/mcp/server.py
+++ b/src/fabric_dw/mcp/server.py
@@ -18,12 +18,12 @@ is closed by its ``__aexit__`` (no standalone ``aclose()`` call needed).
 
 Context access
 --------------
-All 68 tool functions call :func:`~fabric_dw.mcp._context.get_context` to
+All 73 tool functions call :func:`~fabric_dw.mcp._context.get_context` to
 obtain the shared :class:`~fabric_dw.mcp._context.ServerContext`.  The sentinel
 pattern (module-level ``ServerContext | None``) was chosen over injecting a
 ``Context`` parameter into every tool because FastMCP's lifespan context is
 not ergonomically accessible from tool functions without either adding a
-``Context`` import to all 68 tools or using fragile ``request_context``
+``Context`` import to all 73 tools or using fragile ``request_context``
 internals.  The sentinel is safe for streamable-HTTP concurrency because it is
 **read-only** after startup — tools only call ``get_context()``; they never
 re-assign the global.

--- a/src/fabric_dw/mcp/tools/__init__.py
+++ b/src/fabric_dw/mcp/tools/__init__.py
@@ -16,6 +16,7 @@ Domains
 - :mod:`.snapshots` — warehouse snapshot CRUD, roll timestamp
 - :mod:`.restore` — restore points CRUD, in-place restore
 - :mod:`.views` — SQL view listing, reading, CRUD
+- :mod:`.procedures` — stored procedure listing and CRUD
 - :mod:`.schemas` — SQL schema listing and DDL
 - :mod:`.tables` — SQL table listing, reading, DDL
 - :mod:`.sql_pools` — SQL Pools beta API
@@ -29,6 +30,7 @@ from mcp.server.fastmcp import FastMCP
 from fabric_dw.mcp.tools import (
     audit,
     cache,
+    procedures,
     queries,
     query_insights,
     restore,
@@ -56,6 +58,7 @@ _DOMAINS = [
     snapshots,
     restore,
     views,
+    procedures,
     schemas,
     tables,
     sql_pools,

--- a/src/fabric_dw/mcp/tools/procedures.py
+++ b/src/fabric_dw/mcp/tools/procedures.py
@@ -1,0 +1,186 @@
+"""MCP tools for stored procedure operations."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+from fabric_dw.exceptions import FabricError
+from fabric_dw.mcp._context import get_context
+from fabric_dw.mcp._guards import (
+    assert_destructive_allowed,
+    assert_workspace_allowed,
+    assert_writes_allowed,
+)
+from fabric_dw.mcp._helpers import (
+    make_sql_target,
+    parse_qualified_name,
+    resolve_item,
+    tool_err,
+)
+from fabric_dw.services import procedures as procedures_svc
+
+__all__ = ["register"]
+
+_log = logging.getLogger(__name__)
+
+
+def register(mcp: FastMCP) -> None:  # noqa: PLR0915
+    """Register stored procedure tools against *mcp*."""
+
+    @mcp.tool(name="list_procedures")
+    async def list_procedures(
+        workspace: str, item: str, schema: str | None = None
+    ) -> list[dict[str, Any]]:
+        """List stored procedures on a warehouse or SQL Analytics Endpoint.
+
+        Stored procedures are supported on both Fabric Data Warehouses and
+        SQL Analytics Endpoints.
+
+        Args:
+            workspace: Workspace name or GUID.
+            item: Warehouse or SQL endpoint name or GUID.
+            schema: When provided, only procedures in this schema are returned.
+        """
+        assert_workspace_allowed(workspace)
+        ctx = get_context()
+        try:
+            ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
+            assert_workspace_allowed(workspace, str(ws_id))
+            _log.debug("list_procedures ws=%s item=%s schema=%r", ws_id, entry.id, schema)
+            target = make_sql_target(ws_id, entry, item)
+            result = await procedures_svc.list_procedures(target, schema=schema, mode=ctx.auth_mode)
+        except (ValueError, FabricError) as exc:
+            raise tool_err(exc) from exc
+        return [p.model_dump(mode="json") for p in result]
+
+    @mcp.tool(name="get_procedure")
+    async def get_procedure(workspace: str, item: str, qualified_name: str) -> dict[str, Any]:
+        """Fetch the full definition of a stored procedure (schema.proc).
+
+        Stored procedures are supported on both Fabric Data Warehouses and
+        SQL Analytics Endpoints.
+
+        Args:
+            workspace: Workspace name or GUID.
+            item: Warehouse or SQL endpoint name or GUID.
+            qualified_name: Dot-separated qualified procedure name, e.g. ``dbo.usp_load``.
+        """
+        schema, proc_name = parse_qualified_name(qualified_name, kind="procedure")
+        assert_workspace_allowed(workspace)
+        ctx = get_context()
+        try:
+            ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
+            assert_workspace_allowed(workspace, str(ws_id))
+            _log.debug("get_procedure ws=%s item=%s proc=%s.%s", ws_id, entry.id, schema, proc_name)
+            target = make_sql_target(ws_id, entry, item)
+            result = await procedures_svc.get_procedure(
+                target, schema, proc_name, mode=ctx.auth_mode
+            )
+        except (ValueError, FabricError) as exc:
+            raise tool_err(exc) from exc
+        return result.model_dump(mode="json")
+
+    @mcp.tool(name="create_procedure")
+    async def create_procedure(
+        workspace: str, item: str, qualified_name: str, body: str
+    ) -> dict[str, Any]:
+        """Create a new stored procedure.
+
+        Stored procedures are supported on both Fabric Data Warehouses and
+        SQL Analytics Endpoints.
+
+        CAUTION: ``body`` is executed verbatim as DDL. Ensure the body
+        matches the user's intent before calling this tool.
+
+        Args:
+            workspace: Workspace name or GUID.
+            item: Warehouse or SQL endpoint name or GUID.
+            qualified_name: Dot-separated qualified procedure name, e.g. ``dbo.usp_load``.
+            body: The procedure body (the AS … section).
+        """
+        schema, proc_name = parse_qualified_name(qualified_name, kind="procedure")
+        assert_writes_allowed("create_procedure")
+        assert_workspace_allowed(workspace)
+        ctx = get_context()
+        try:
+            ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
+            assert_workspace_allowed(workspace, str(ws_id))
+            _log.debug(
+                "create_procedure ws=%s item=%s proc=%s.%s", ws_id, entry.id, schema, proc_name
+            )
+            target = make_sql_target(ws_id, entry, item)
+            result = await procedures_svc.create_procedure(
+                target, schema, proc_name, body, mode=ctx.auth_mode
+            )
+        except (ValueError, FabricError) as exc:
+            raise tool_err(exc) from exc
+        ctx.resolver.clear_negative_cache()
+        return result.model_dump(mode="json")
+
+    @mcp.tool(name="update_procedure")
+    async def update_procedure(
+        workspace: str, item: str, qualified_name: str, body: str
+    ) -> dict[str, Any]:
+        """Redefine a stored procedure via CREATE OR ALTER PROCEDURE.
+
+        Stored procedures are supported on both Fabric Data Warehouses and
+        SQL Analytics Endpoints.
+
+        CAUTION: ``body`` is executed verbatim as DDL. Ensure the body
+        matches the user's intent before calling this tool.
+
+        Args:
+            workspace: Workspace name or GUID.
+            item: Warehouse or SQL endpoint name or GUID.
+            qualified_name: Dot-separated qualified procedure name, e.g. ``dbo.usp_load``.
+            body: The new procedure body (the AS … section).
+        """
+        schema, proc_name = parse_qualified_name(qualified_name, kind="procedure")
+        assert_writes_allowed("update_procedure")
+        assert_workspace_allowed(workspace)
+        ctx = get_context()
+        try:
+            ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
+            assert_workspace_allowed(workspace, str(ws_id))
+            _log.debug(
+                "update_procedure ws=%s item=%s proc=%s.%s", ws_id, entry.id, schema, proc_name
+            )
+            target = make_sql_target(ws_id, entry, item)
+            result = await procedures_svc.update_procedure(
+                target, schema, proc_name, body, mode=ctx.auth_mode
+            )
+        except (ValueError, FabricError) as exc:
+            raise tool_err(exc) from exc
+        return result.model_dump(mode="json")
+
+    @mcp.tool(name="drop_procedure")
+    async def drop_procedure(workspace: str, item: str, qualified_name: str) -> dict[str, Any]:
+        """Drop a stored procedure.
+
+        Stored procedures are supported on both Fabric Data Warehouses and
+        SQL Analytics Endpoints.
+
+        Args:
+            workspace: Workspace name or GUID.
+            item: Warehouse or SQL endpoint name or GUID.
+            qualified_name: Dot-separated qualified procedure name, e.g. ``dbo.usp_load``.
+        """
+        schema, proc_name = parse_qualified_name(qualified_name, kind="procedure")
+        assert_writes_allowed("drop_procedure")
+        assert_destructive_allowed()
+        assert_workspace_allowed(workspace)
+        ctx = get_context()
+        try:
+            ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
+            assert_workspace_allowed(workspace, str(ws_id))
+            _log.debug(
+                "drop_procedure ws=%s item=%s proc=%s.%s", ws_id, entry.id, schema, proc_name
+            )
+            target = make_sql_target(ws_id, entry, item)
+            await procedures_svc.drop_procedure(target, schema, proc_name, mode=ctx.auth_mode)
+        except (ValueError, FabricError) as exc:
+            raise tool_err(exc) from exc
+        return {"dropped": True}

--- a/src/fabric_dw/models.py
+++ b/src/fabric_dw/models.py
@@ -390,6 +390,17 @@ class View(_FabricBase):
     modified: datetime
 
 
+class StoredProcedure(_FabricBase):
+    """A stored procedure on a Fabric Data Warehouse or SQL Analytics Endpoint."""
+
+    schema_name: str
+    name: str
+    qualified_name: str
+    definition: str | None = None
+    created: datetime
+    modified: datetime
+
+
 class Schema(_FabricBase):
     """A SQL schema on a Fabric Data Warehouse."""
 

--- a/src/fabric_dw/services/procedures.py
+++ b/src/fabric_dw/services/procedures.py
@@ -1,0 +1,300 @@
+"""CRUD operations for stored procedures on Fabric Data Warehouses and SQL Analytics Endpoints.
+
+Public API
+----------
+- :func:`validate_identifier` — re-exported from :mod:`fabric_dw.identifiers`.
+- :func:`list_procedures`     — list all stored procedures (optionally filtered by schema).
+- :func:`get_procedure`       — fetch a single procedure with its definition.
+- :func:`create_procedure`    — issue CREATE PROCEDURE … AS <body>.
+- :func:`update_procedure`    — issue CREATE OR ALTER PROCEDURE … AS <body>.
+- :func:`drop_procedure`      — issue DROP PROCEDURE.
+
+Note: Stored procedures are supported on **both** Fabric Data Warehouses and
+SQL Analytics Endpoints — no endpoint guard is applied here.  See Microsoft
+documentation: DROP PROCEDURE and ALTER PROCEDURE both list
+"SQL analytics endpoint in Microsoft Fabric" and "Warehouse in Microsoft Fabric"
+in their "Applies to" lists.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from typing import cast
+
+from fabric_dw.auth import CredentialMode
+from fabric_dw.exceptions import NotFoundError
+from fabric_dw.identifiers import quote_identifier, validate_identifier
+from fabric_dw.models import StoredProcedure
+from fabric_dw.sql import SqlTarget, run_query
+
+__all__ = [
+    "create_procedure",
+    "drop_procedure",
+    "get_procedure",
+    "list_procedures",
+    "update_procedure",
+    "validate_identifier",
+]
+
+# ---------------------------------------------------------------------------
+# SQL templates
+# ---------------------------------------------------------------------------
+
+_LIST_PROCEDURES_SQL = """\
+SELECT
+    s.name AS schema_name,
+    p.name,
+    p.create_date AS created,
+    p.modify_date AS modified
+FROM sys.procedures p
+JOIN sys.schemas s ON s.schema_id = p.schema_id
+WHERE ({schema_filter})
+ORDER BY s.name, p.name;
+"""
+
+_GET_PROCEDURE_SQL = """\
+SELECT
+    s.name AS schema_name,
+    p.name,
+    p.create_date AS created,
+    p.modify_date AS modified,
+    m.definition
+FROM sys.procedures p
+JOIN sys.schemas s ON s.schema_id = p.schema_id
+JOIN sys.sql_modules m ON m.object_id = p.object_id
+WHERE s.name = ? AND p.name = ?;
+"""
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _row_to_procedure(cols: list[str], row: tuple[object, ...]) -> StoredProcedure:
+    """Build a :class:`StoredProcedure` from a column-name list and a result row tuple."""
+    data = dict(zip(cols, row, strict=True))
+    schema_name = str(data["schema_name"])
+    name = str(data["name"])
+    raw_def = data.get("definition") if "definition" in data else None
+    definition = cast("str | None", raw_def)
+    return StoredProcedure(
+        schema_name=schema_name,
+        name=name,
+        qualified_name=f"{schema_name}.{name}",
+        definition=definition,
+        created=cast(datetime, data["created"]),
+        modified=cast(datetime, data["modified"]),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+async def list_procedures(
+    target: SqlTarget,
+    *,
+    schema: str | None = None,
+    mode: CredentialMode = CredentialMode.DEFAULT,
+) -> list[StoredProcedure]:
+    """Return all stored procedures on *target*, optionally filtered to a single *schema*.
+
+    Supported on both Fabric Data Warehouses and SQL Analytics Endpoints.
+
+    Args:
+        target: The warehouse or SQL Analytics Endpoint to query.
+        schema: When provided, only procedures in this schema are returned.
+            Must pass :func:`validate_identifier`.
+        mode: The credential mode for Entra authentication.
+
+    Returns:
+        A (possibly empty) list of :class:`~fabric_dw.models.StoredProcedure` instances.
+
+    Raises:
+        ValueError: If *schema* fails identifier validation.
+        PermissionDeniedError: If the driver reports a permission error.
+        AuthError: If the driver reports an authentication failure.
+    """
+    if schema is not None:
+        validate_identifier(schema)
+
+    if schema is not None:
+        schema_filter = "s.name = ?"
+        filter_params: list[object] = [schema]
+    else:
+        schema_filter = "1=1"
+        filter_params = []
+
+    list_sql = _LIST_PROCEDURES_SQL.format(schema_filter=schema_filter)
+
+    def _run() -> list[StoredProcedure]:
+        cols, rows = run_query(
+            target,
+            list_sql,
+            params=filter_params or None,
+            mode=mode,
+        )
+        return [_row_to_procedure(cols, r) for r in rows]
+
+    return await asyncio.to_thread(_run)
+
+
+async def get_procedure(
+    target: SqlTarget,
+    schema: str,
+    procedure_name: str,
+    *,
+    mode: CredentialMode = CredentialMode.DEFAULT,
+) -> StoredProcedure:
+    """Fetch a single stored procedure with its ``sys.sql_modules`` definition.
+
+    Supported on both Fabric Data Warehouses and SQL Analytics Endpoints.
+
+    Args:
+        target: The warehouse or SQL Analytics Endpoint to query.
+        schema: The schema name.  Must pass :func:`validate_identifier`.
+        procedure_name: The procedure name.  Must pass :func:`validate_identifier`.
+        mode: The credential mode for Entra authentication.
+
+    Returns:
+        A :class:`~fabric_dw.models.StoredProcedure` with ``definition`` populated.
+
+    Raises:
+        ValueError: If *schema* or *procedure_name* fails identifier validation.
+        NotFoundError: If no procedure with that schema/name exists.
+        PermissionDeniedError: If the driver reports a permission error.
+    """
+    validate_identifier(schema)
+    validate_identifier(procedure_name)
+
+    def _run() -> StoredProcedure:
+        cols, rows = run_query(
+            target,
+            _GET_PROCEDURE_SQL,
+            params=[schema, procedure_name],
+            mode=mode,
+        )
+        if not rows:
+            msg = f"Procedure [{schema}].[{procedure_name}] not found"
+            raise NotFoundError(msg)
+        return _row_to_procedure(cols, rows[0])
+
+    return await asyncio.to_thread(_run)
+
+
+async def create_procedure(
+    target: SqlTarget,
+    schema: str,
+    procedure_name: str,
+    body: str,
+    *,
+    mode: CredentialMode = CredentialMode.DEFAULT,
+) -> StoredProcedure:
+    """Create a new stored procedure via ``CREATE PROCEDURE [<schema>].[<proc>] AS <body>``.
+
+    Supported on both Fabric Data Warehouses and SQL Analytics Endpoints.
+
+    Args:
+        target: The warehouse or SQL Analytics Endpoint to connect to.
+        schema: The schema name.  Must pass :func:`validate_identifier`.
+        procedure_name: The procedure name.  Must pass :func:`validate_identifier`.
+        body: The free-form procedure body.  Not validated — the caller owns
+            the SQL (same trust model as ``sql exec``).
+        mode: The credential mode for Entra authentication.
+
+    Returns:
+        The newly-created :class:`~fabric_dw.models.StoredProcedure` (fetched after DDL).
+
+    Raises:
+        ValueError: If *schema* or *procedure_name* fails identifier validation.
+        PermissionDeniedError: If the driver reports a CREATE PROCEDURE permission error.
+    """
+    validate_identifier(schema)
+    validate_identifier(procedure_name)
+
+    ddl = (
+        f"CREATE PROCEDURE {quote_identifier(schema)}.{quote_identifier(procedure_name)} AS {body}"
+    )
+
+    def _run() -> None:
+        run_query(target, ddl, mode=mode, commit=True, fetch="none")
+
+    await asyncio.to_thread(_run)
+    return await get_procedure(target, schema, procedure_name, mode=mode)
+
+
+async def update_procedure(
+    target: SqlTarget,
+    schema: str,
+    procedure_name: str,
+    body: str,
+    *,
+    mode: CredentialMode = CredentialMode.DEFAULT,
+) -> StoredProcedure:
+    """Redefine a stored procedure via ``CREATE OR ALTER PROCEDURE … AS <body>``.
+
+    Supported on both Fabric Data Warehouses and SQL Analytics Endpoints.
+
+    Args:
+        target: The warehouse or SQL Analytics Endpoint to connect to.
+        schema: The schema name.  Must pass :func:`validate_identifier`.
+        procedure_name: The procedure name.  Must pass :func:`validate_identifier`.
+        body: The free-form procedure body.  Caller-owned.
+        mode: The credential mode for Entra authentication.
+
+    Returns:
+        The updated :class:`~fabric_dw.models.StoredProcedure` (fetched after DDL).
+
+    Raises:
+        ValueError: If *schema* or *procedure_name* fails identifier validation.
+        PermissionDeniedError: If the driver reports an ALTER PROCEDURE permission error.
+    """
+    validate_identifier(schema)
+    validate_identifier(procedure_name)
+
+    ddl = (
+        f"CREATE OR ALTER PROCEDURE"
+        f" {quote_identifier(schema)}.{quote_identifier(procedure_name)}"
+        f" AS {body}"
+    )
+
+    def _run() -> None:
+        run_query(target, ddl, mode=mode, commit=True, fetch="none")
+
+    await asyncio.to_thread(_run)
+    return await get_procedure(target, schema, procedure_name, mode=mode)
+
+
+async def drop_procedure(
+    target: SqlTarget,
+    schema: str,
+    procedure_name: str,
+    *,
+    mode: CredentialMode = CredentialMode.DEFAULT,
+) -> None:
+    """Drop a stored procedure via ``DROP PROCEDURE [<schema>].[<proc>]``.
+
+    Supported on both Fabric Data Warehouses and SQL Analytics Endpoints.
+
+    Args:
+        target: The warehouse or SQL Analytics Endpoint to connect to.
+        schema: The schema name.  Must pass :func:`validate_identifier`.
+        procedure_name: The procedure name.  Must pass :func:`validate_identifier`.
+        mode: The credential mode for Entra authentication.
+
+    Raises:
+        ValueError: If *schema* or *procedure_name* fails identifier validation.
+        PermissionDeniedError: If the driver reports a DROP PROCEDURE permission error.
+    """
+    validate_identifier(schema)
+    validate_identifier(procedure_name)
+
+    ddl = f"DROP PROCEDURE {quote_identifier(schema)}.{quote_identifier(procedure_name)}"
+
+    def _run() -> None:
+        run_query(target, ddl, mode=mode, commit=True, fetch="none")
+
+    await asyncio.to_thread(_run)

--- a/tests/integration/test_services_procedures.py
+++ b/tests/integration/test_services_procedures.py
@@ -1,0 +1,193 @@
+"""Integration tests for services.procedures — requires real Fabric credentials.
+
+Run with: pytest -m integration tests/integration/test_services_procedures.py
+
+Fixture note: uses ``ephemeral_sql_target`` from conftest.  The target points at
+a freshly-created warehouse for each test session; all procedures created here are
+cleaned up inside each test via try/finally.
+
+Note on scope: stored procedures are supported on **both** Fabric Data Warehouses
+and SQL Analytics Endpoints.  The ``ephemeral_sql_target`` fixture points at a
+warehouse; a separate ``ephemeral_sql_target``-equivalent for an endpoint is not
+set up here because endpoint tests require a Lakehouse, which is out of scope.
+The service itself has no endpoint guard.
+"""
+
+from __future__ import annotations
+
+import contextlib
+
+import pytest
+
+from fabric_dw.exceptions import NotFoundError
+from fabric_dw.models import StoredProcedure
+from fabric_dw.services import procedures
+from fabric_dw.sql import SqlTarget
+
+pytestmark = pytest.mark.integration
+
+
+async def test_list_procedures_returns_list(ephemeral_sql_target: SqlTarget) -> None:
+    """list_procedures on a fresh warehouse must return an empty (or non-empty) list."""
+    result = await procedures.list_procedures(ephemeral_sql_target)
+    assert isinstance(result, list)
+
+
+async def test_create_procedure_returns_procedure_object(
+    ephemeral_sql_target: SqlTarget,
+) -> None:
+    """create_procedure must return a StoredProcedure with the correct schema/name."""
+    schema = "dbo"
+    proc_name = "pytest_procs_create"
+    body = "BEGIN SELECT 1 AS id, 'hello' AS greeting END"
+
+    try:
+        created = await procedures.create_procedure(ephemeral_sql_target, schema, proc_name, body)
+        assert isinstance(created, StoredProcedure)
+        assert created.schema_name == schema
+        assert created.name == proc_name
+        assert created.qualified_name == f"{schema}.{proc_name}"
+        assert created.definition is not None
+        assert "SELECT" in created.definition.upper()
+    finally:
+        with contextlib.suppress(Exception):
+            await procedures.drop_procedure(ephemeral_sql_target, schema, proc_name)
+
+
+async def test_list_procedures_includes_created_procedure(
+    ephemeral_sql_target: SqlTarget,
+) -> None:
+    """A newly created procedure must appear in list_procedures results."""
+    schema = "dbo"
+    proc_name = "pytest_procs_list"
+    body = "BEGIN SELECT 42 AS answer END"
+
+    try:
+        await procedures.create_procedure(ephemeral_sql_target, schema, proc_name, body)
+
+        all_procs = await procedures.list_procedures(ephemeral_sql_target)
+        names = {p.name for p in all_procs}
+        assert proc_name in names
+
+        # Also verify schema filter narrows correctly
+        dbo_procs = await procedures.list_procedures(ephemeral_sql_target, schema=schema)
+        dbo_names = {p.name for p in dbo_procs}
+        assert proc_name in dbo_names
+
+        # A schema that doesn't exist should return empty
+        other_procs = await procedures.list_procedures(
+            ephemeral_sql_target, schema="nonexistent_schema_x"
+        )
+        assert other_procs == []
+    finally:
+        with contextlib.suppress(Exception):
+            await procedures.drop_procedure(ephemeral_sql_target, schema, proc_name)
+
+
+async def test_get_procedure_returns_definition(ephemeral_sql_target: SqlTarget) -> None:
+    """get_procedure must return the StoredProcedure with its definition populated."""
+    schema = "dbo"
+    proc_name = "pytest_procs_get"
+    body = "BEGIN SELECT 99 AS magic_number END"
+
+    try:
+        await procedures.create_procedure(ephemeral_sql_target, schema, proc_name, body)
+
+        fetched = await procedures.get_procedure(ephemeral_sql_target, schema, proc_name)
+        assert isinstance(fetched, StoredProcedure)
+        assert fetched.schema_name == schema
+        assert fetched.name == proc_name
+        assert fetched.definition is not None
+        assert "magic_number" in fetched.definition.lower()
+    finally:
+        with contextlib.suppress(Exception):
+            await procedures.drop_procedure(ephemeral_sql_target, schema, proc_name)
+
+
+async def test_get_procedure_raises_not_found_for_missing_procedure(
+    ephemeral_sql_target: SqlTarget,
+) -> None:
+    """get_procedure must raise NotFoundError when the procedure does not exist."""
+    with pytest.raises(NotFoundError):
+        await procedures.get_procedure(ephemeral_sql_target, "dbo", "pytest_procs_does_not_exist")
+
+
+async def test_update_procedure_changes_definition(ephemeral_sql_target: SqlTarget) -> None:
+    """update_procedure must redefine the procedure and return the updated definition."""
+    schema = "dbo"
+    proc_name = "pytest_procs_update"
+    original_body = "BEGIN SELECT 1 AS version END"
+    updated_body = "BEGIN SELECT 2 AS version, 'updated' AS status END"
+
+    try:
+        await procedures.create_procedure(ephemeral_sql_target, schema, proc_name, original_body)
+
+        updated = await procedures.update_procedure(
+            ephemeral_sql_target, schema, proc_name, updated_body
+        )
+        assert isinstance(updated, StoredProcedure)
+        assert updated.definition is not None
+        assert "status" in updated.definition.lower()
+    finally:
+        with contextlib.suppress(Exception):
+            await procedures.drop_procedure(ephemeral_sql_target, schema, proc_name)
+
+
+async def test_drop_procedure_removes_procedure(ephemeral_sql_target: SqlTarget) -> None:
+    """drop_procedure must remove the procedure so it no longer appears in list_procedures."""
+    schema = "dbo"
+    proc_name = "pytest_procs_drop"
+    body = "BEGIN SELECT 0 AS placeholder END"
+
+    await procedures.create_procedure(ephemeral_sql_target, schema, proc_name, body)
+
+    # Confirm it exists before dropping
+    before = await procedures.list_procedures(ephemeral_sql_target)
+    assert any(p.name == proc_name for p in before)
+
+    await procedures.drop_procedure(ephemeral_sql_target, schema, proc_name)
+
+    # Must not appear in listing after drop
+    after = await procedures.list_procedures(ephemeral_sql_target)
+    assert not any(p.name == proc_name for p in after)
+
+    # get_procedure must raise NotFoundError
+    with pytest.raises(NotFoundError):
+        await procedures.get_procedure(ephemeral_sql_target, schema, proc_name)
+
+
+async def test_create_procedure_full_roundtrip(ephemeral_sql_target: SqlTarget) -> None:
+    """End-to-end: create -> list -> get (definition contains body) -> update (definition
+    changes) -> drop.
+    """
+    schema = "dbo"
+    proc_name = "pytest_procs_roundtrip"
+    v1_body = "BEGIN SELECT 1 AS n END"
+    v2_body = "BEGIN SELECT 2 AS n, 'v2' AS label END"
+
+    try:
+        # --- create ---
+        created = await procedures.create_procedure(
+            ephemeral_sql_target, schema, proc_name, v1_body
+        )
+        assert created.name == proc_name
+
+        # --- list ---
+        all_procs = await procedures.list_procedures(ephemeral_sql_target)
+        assert any(p.name == proc_name for p in all_procs)
+
+        # --- get (definition contains body) ---
+        fetched = await procedures.get_procedure(ephemeral_sql_target, schema, proc_name)
+        assert fetched.definition is not None
+        assert "SELECT" in fetched.definition.upper()
+
+        # --- update (definition changes) ---
+        updated = await procedures.update_procedure(
+            ephemeral_sql_target, schema, proc_name, v2_body
+        )
+        assert updated.definition is not None
+        assert "label" in updated.definition.lower()
+
+    finally:
+        with contextlib.suppress(Exception):
+            await procedures.drop_procedure(ephemeral_sql_target, schema, proc_name)

--- a/tests/unit/cli/commands/test_procedures.py
+++ b/tests/unit/cli/commands/test_procedures.py
@@ -1,0 +1,643 @@
+"""Tests for procedures CLI sub-commands."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+from uuid import UUID
+
+import pytest
+from click.testing import CliRunner
+
+from fabric_dw.cache import ItemEntry
+from fabric_dw.cli._main import cli
+from fabric_dw.exceptions import NotFoundError, PermissionDeniedError
+from fabric_dw.models import StoredProcedure, WarehouseKind
+from fabric_dw.sql import SqlTarget
+
+WS_GUID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+WH_GUID = "d4e5f6a7-b8c9-0123-def0-123456789abc"
+WS_UUID = UUID(WS_GUID)
+WH_UUID = UUID(WH_GUID)
+
+_NOW = datetime(2024, 6, 1, 12, 0, 0, tzinfo=UTC)
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def cache_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    return tmp_path
+
+
+def _make_sql_target() -> SqlTarget:
+    return SqlTarget(
+        workspace_id=WS_GUID,
+        database="SalesWarehouse",
+        connection_string="wh.datawarehouse.fabric.microsoft.com",
+    )
+
+
+def _make_http_cm(http: object) -> object:
+    @asynccontextmanager
+    async def _cm(_ctx: object) -> AsyncIterator[object]:
+        yield http
+
+    return _cm
+
+
+def _make_item_entry(*, kind: WarehouseKind = WarehouseKind.WAREHOUSE) -> ItemEntry:
+    return ItemEntry(
+        id=WH_UUID,
+        kind=kind,
+        connection_string="wh.datawarehouse.fabric.microsoft.com",
+        fetched_at=datetime.now(tz=UTC),
+        display_name="SalesWarehouse",
+    )
+
+
+def _make_proc(*, with_definition: bool = False) -> StoredProcedure:
+    return StoredProcedure(
+        schema_name="dbo",
+        name="usp_load",
+        qualified_name="dbo.usp_load",
+        definition="BEGIN SELECT 1 END" if with_definition else None,
+        created=_NOW,
+        modified=_NOW,
+    )
+
+
+# ===========================================================================
+# procedures list
+# ===========================================================================
+
+
+class TestProceduresList:
+    def test_list_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.procedures.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.procedures.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.procedures.list_procedures",
+                new=AsyncMock(return_value=[_make_proc()]),
+            ),
+        ):
+            result = runner.invoke(cli, ["procedures", "list", WS_GUID, WH_GUID])
+        assert result.exit_code == 0
+
+    def test_list_json_output(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.procedures.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.procedures.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.procedures.list_procedures",
+                new=AsyncMock(return_value=[_make_proc()]),
+            ),
+        ):
+            result = runner.invoke(cli, ["--json", "procedures", "list", WS_GUID, WH_GUID])
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert isinstance(parsed, list)
+
+    def test_list_with_schema_filter(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        mock_list = AsyncMock(return_value=[_make_proc()])
+        with (
+            patch(
+                "fabric_dw.cli.commands.procedures.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.procedures.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch("fabric_dw.services.procedures.list_procedures", new=mock_list),
+        ):
+            result = runner.invoke(cli, ["procedures", "list", WS_GUID, WH_GUID, "--schema", "dbo"])
+        assert result.exit_code == 0
+        mock_list.assert_awaited_once()
+
+    def test_list_not_found_returns_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.procedures.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.procedures.build_sql_target",
+                new=AsyncMock(side_effect=NotFoundError("not found")),
+            ),
+        ):
+            result = runner.invoke(cli, ["procedures", "list", WS_GUID, WH_GUID])
+        assert result.exit_code != 0
+
+    def test_list_works_on_sql_endpoint(self, runner: CliRunner, cache_env: Path) -> None:
+        """list on a SQL Analytics Endpoint must succeed — no DW-only guard."""
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.procedures.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.procedures.build_sql_target",
+                new=AsyncMock(
+                    return_value=(
+                        _make_sql_target(),
+                        _make_item_entry(kind=WarehouseKind.SQL_ENDPOINT),
+                    )
+                ),
+            ),
+            patch(
+                "fabric_dw.services.procedures.list_procedures",
+                new=AsyncMock(return_value=[]),
+            ),
+        ):
+            result = runner.invoke(cli, ["procedures", "list", WS_GUID, WH_GUID])
+        assert result.exit_code == 0
+
+
+# ===========================================================================
+# procedures get
+# ===========================================================================
+
+
+class TestProceduresGet:
+    def test_get_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.procedures.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.procedures.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.procedures.get_procedure",
+                new=AsyncMock(return_value=_make_proc(with_definition=True)),
+            ),
+        ):
+            result = runner.invoke(cli, ["procedures", "get", WS_GUID, WH_GUID, "dbo.usp_load"])
+        assert result.exit_code == 0
+
+    def test_get_json_output(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.procedures.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.procedures.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.procedures.get_procedure",
+                new=AsyncMock(return_value=_make_proc(with_definition=True)),
+            ),
+        ):
+            result = runner.invoke(
+                cli, ["--json", "procedures", "get", WS_GUID, WH_GUID, "dbo.usp_load"]
+            )
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["name"] == "usp_load"
+
+    def test_get_bad_qualified_name_exits_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        result = runner.invoke(cli, ["procedures", "get", WS_GUID, WH_GUID, "no_dot_here"])
+        assert result.exit_code != 0
+
+    def test_get_not_found_returns_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.procedures.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.procedures.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.procedures.get_procedure",
+                new=AsyncMock(side_effect=NotFoundError("not found")),
+            ),
+        ):
+            result = runner.invoke(cli, ["procedures", "get", WS_GUID, WH_GUID, "dbo.usp_missing"])
+        assert result.exit_code != 0
+
+
+# ===========================================================================
+# procedures create
+# ===========================================================================
+
+
+class TestProceduresCreate:
+    def test_create_with_body_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.procedures.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.procedures.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.procedures.create_procedure",
+                new=AsyncMock(return_value=_make_proc(with_definition=True)),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "procedures",
+                    "create",
+                    WS_GUID,
+                    WH_GUID,
+                    "--name",
+                    "dbo.usp_load",
+                    "--body",
+                    "BEGIN SELECT 1 END",
+                ],
+            )
+        assert result.exit_code == 0
+
+    def test_create_with_file(self, runner: CliRunner, cache_env: Path, tmp_path: Path) -> None:
+        _ = cache_env
+        sql_file = tmp_path / "proc.sql"
+        sql_file.write_text("BEGIN SELECT 1 END")
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.procedures.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.procedures.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.procedures.create_procedure",
+                new=AsyncMock(return_value=_make_proc(with_definition=True)),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "procedures",
+                    "create",
+                    WS_GUID,
+                    WH_GUID,
+                    "--name",
+                    "dbo.usp_load",
+                    "--from-file",
+                    str(sql_file),
+                ],
+            )
+        assert result.exit_code == 0
+
+    def test_create_no_body_fails(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        result = runner.invoke(
+            cli,
+            ["procedures", "create", WS_GUID, WH_GUID, "--name", "dbo.usp_load"],
+        )
+        assert result.exit_code != 0
+
+    def test_create_both_body_and_file_fails(
+        self, runner: CliRunner, cache_env: Path, tmp_path: Path
+    ) -> None:
+        _ = cache_env
+        sql_file = tmp_path / "proc.sql"
+        sql_file.write_text("BEGIN END")
+        result = runner.invoke(
+            cli,
+            [
+                "procedures",
+                "create",
+                WS_GUID,
+                WH_GUID,
+                "--name",
+                "dbo.usp_load",
+                "--body",
+                "BEGIN END",
+                "--from-file",
+                str(sql_file),
+            ],
+        )
+        assert result.exit_code != 0
+
+    def test_create_from_file_strips_utf8_sig_bom(
+        self, runner: CliRunner, cache_env: Path, tmp_path: Path
+    ) -> None:
+        """Files with UTF-8-sig BOM must be decoded transparently."""
+        _ = cache_env
+        sql_file = tmp_path / "proc_bom.sql"
+        sql_file.write_bytes(b"\xef\xbb\xbfBEGIN SELECT 1 END")
+        mock_http = AsyncMock()
+        captured_body: list[str] = []
+
+        async def _capture(
+            _target: object,
+            _schema: object,
+            _proc_name: object,
+            body: str,
+            **_kw: object,
+        ) -> StoredProcedure:
+            captured_body.append(body)
+            return _make_proc(with_definition=True)
+
+        with (
+            patch(
+                "fabric_dw.cli.commands.procedures.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.procedures.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch("fabric_dw.services.procedures.create_procedure", new=_capture),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "procedures",
+                    "create",
+                    WS_GUID,
+                    WH_GUID,
+                    "--name",
+                    "dbo.usp_load",
+                    "--from-file",
+                    str(sql_file),
+                ],
+            )
+        assert result.exit_code == 0
+        assert captured_body == ["BEGIN SELECT 1 END"]
+
+    def test_create_permission_denied_returns_nonzero(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.procedures.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.procedures.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.procedures.create_procedure",
+                new=AsyncMock(side_effect=PermissionDeniedError("no permission")),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "procedures",
+                    "create",
+                    WS_GUID,
+                    WH_GUID,
+                    "--name",
+                    "dbo.usp_load",
+                    "--body",
+                    "BEGIN END",
+                ],
+            )
+        assert result.exit_code != 0
+
+
+# ===========================================================================
+# procedures update
+# ===========================================================================
+
+
+class TestProceduresUpdate:
+    def test_update_with_yes_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.procedures.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.procedures.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.procedures.update_procedure",
+                new=AsyncMock(return_value=_make_proc(with_definition=True)),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--yes",
+                    "procedures",
+                    "update",
+                    WS_GUID,
+                    WH_GUID,
+                    "dbo.usp_load",
+                    "--body",
+                    "BEGIN SELECT 2 END",
+                ],
+            )
+        assert result.exit_code == 0
+
+    def test_update_declined_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
+        """Declining update is a clean no-op (exit 0)."""
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.procedures.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.procedures.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "procedures",
+                    "update",
+                    WS_GUID,
+                    WH_GUID,
+                    "dbo.usp_load",
+                    "--body",
+                    "BEGIN END",
+                ],
+                input="n\n",
+            )
+        assert result.exit_code == 0
+        assert "Aborted." in result.output
+
+    def test_update_from_file_strips_utf8_sig_bom(
+        self, runner: CliRunner, cache_env: Path, tmp_path: Path
+    ) -> None:
+        """Files with UTF-8-sig BOM must be decoded transparently."""
+        _ = cache_env
+        sql_file = tmp_path / "proc_update_bom.sql"
+        sql_file.write_bytes(b"\xef\xbb\xbfBEGIN SELECT 2 END")
+        captured_body: list[str] = []
+
+        async def _capture(
+            _target: object,
+            _schema: object,
+            _proc_name: object,
+            body: str,
+            **_kw: object,
+        ) -> StoredProcedure:
+            captured_body.append(body)
+            return _make_proc(with_definition=True)
+
+        with (
+            patch(
+                "fabric_dw.cli.commands.procedures.build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.procedures.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch("fabric_dw.services.procedures.update_procedure", new=_capture),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--yes",
+                    "procedures",
+                    "update",
+                    WS_GUID,
+                    WH_GUID,
+                    "dbo.usp_load",
+                    "--from-file",
+                    str(sql_file),
+                ],
+            )
+        assert result.exit_code == 0
+        assert captured_body == ["BEGIN SELECT 2 END"]
+
+
+# ===========================================================================
+# procedures drop
+# ===========================================================================
+
+
+class TestProceduresDrop:
+    def test_drop_with_yes_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.procedures.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.procedures.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.procedures.drop_procedure",
+                new=AsyncMock(return_value=None),
+            ),
+        ):
+            result = runner.invoke(
+                cli, ["--yes", "procedures", "drop", WS_GUID, WH_GUID, "dbo.usp_load"]
+            )
+        assert result.exit_code == 0
+
+    def test_drop_declined_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
+        """Declining drop is a clean no-op (exit 0)."""
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.procedures.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.procedures.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                ["procedures", "drop", WS_GUID, WH_GUID, "dbo.usp_load"],
+                input="n\n",
+            )
+        assert result.exit_code == 0
+        assert "Aborted." in result.output
+
+    def test_drop_bad_qualified_name_exits_nonzero(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        _ = cache_env
+        result = runner.invoke(cli, ["procedures", "drop", WS_GUID, WH_GUID, "no_dot"])
+        assert result.exit_code != 0
+
+    def test_drop_permission_denied_returns_nonzero(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.procedures.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.procedures.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.procedures.drop_procedure",
+                new=AsyncMock(side_effect=PermissionDeniedError("no permission")),
+            ),
+        ):
+            result = runner.invoke(
+                cli, ["--yes", "procedures", "drop", WS_GUID, WH_GUID, "dbo.usp_load"]
+            )
+        assert result.exit_code != 0

--- a/tests/unit/mcp/test_contract.py
+++ b/tests/unit/mcp/test_contract.py
@@ -46,7 +46,7 @@ from tests.unit.mcp.conftest import WS_ID, WS_NAME, make_item_entry
 # Expected tool count (sync with test_server.EXPECTED_TOOL_NAMES)
 # ---------------------------------------------------------------------------
 
-_EXPECTED_TOOL_COUNT = 68  # as documented in server.py docstring
+_EXPECTED_TOOL_COUNT = 73  # as documented in server.py docstring
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/mcp/test_procedures.py
+++ b/tests/unit/mcp/test_procedures.py
@@ -1,0 +1,446 @@
+"""Unit tests for MCP procedures tools.
+
+Tests cover:
+- Happy path for list/get/create/update/drop
+- readonly guard blocks create/update/drop
+- destructive guard blocks drop
+- workspace allowlist enforcement
+- No endpoint rejection — procedures work on both DW and SQL endpoint
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+from uuid import UUID
+
+import pytest
+
+from fabric_dw.cache import ItemEntry
+from fabric_dw.models import StoredProcedure, WarehouseKind
+
+# ---------------------------------------------------------------------------
+# Shared constants
+# ---------------------------------------------------------------------------
+
+_WS_ID = UUID("a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+_WH_ID = UUID("d4e5f6a7-b8c9-0123-def0-123456789abc")
+_WS_NAME = "my-workspace"
+_WH_NAME = "my-warehouse"
+_NOW = datetime(2024, 6, 1, 12, 0, 0, tzinfo=UTC)
+
+
+def _make_item_entry(
+    *,
+    kind: WarehouseKind = WarehouseKind.WAREHOUSE,
+    connection_string: str | None = "wh.fabric.microsoft.com",
+) -> ItemEntry:
+    return ItemEntry(
+        id=_WH_ID,
+        kind=kind,
+        connection_string=connection_string,
+        fetched_at=datetime.now(tz=UTC),
+        display_name=_WH_NAME,
+    )
+
+
+def _make_proc(*, with_definition: bool = True) -> StoredProcedure:
+    return StoredProcedure(
+        schema_name="dbo",
+        name="usp_load",
+        qualified_name="dbo.usp_load",
+        definition="BEGIN SELECT 1 AS id END" if with_definition else None,
+        created=_NOW,
+        modified=_NOW,
+    )
+
+
+# ===========================================================================
+# list_procedures
+# ===========================================================================
+
+
+async def test_list_procedures_happy_path(mock_ctx, ctx_patch) -> None:
+    """list_procedures calls procedures_svc.list_procedures and returns serialised list."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = _make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.procedures.list_procedures",
+            new=AsyncMock(return_value=[_make_proc()]),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "list_procedures",
+            {"workspace": _WS_NAME, "item": _WH_NAME},
+        )
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0]["name"] == "usp_load"
+
+
+async def test_list_procedures_with_schema_filter(mock_ctx, ctx_patch) -> None:
+    """list_procedures passes schema filter to the service."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = _make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+    mock_list = AsyncMock(return_value=[])
+
+    with (
+        ctx_patch,
+        patch("fabric_dw.services.procedures.list_procedures", new=mock_list),
+    ):
+        await mcp._tool_manager.call_tool(
+            "list_procedures",
+            {"workspace": _WS_NAME, "item": _WH_NAME, "schema": "dbo"},
+        )
+
+    mock_list.assert_awaited_once()
+    _, kwargs = mock_list.call_args
+    assert kwargs.get("schema") == "dbo"
+
+
+async def test_list_procedures_on_sql_endpoint_no_error(mock_ctx, ctx_patch) -> None:
+    """list_procedures must NOT raise a ToolError for SQL Analytics Endpoint items.
+
+    This asserts the absence of a DW-only guard: procedures work on both
+    Fabric Data Warehouses and SQL Analytics Endpoints.
+    """
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    # Use a SQL endpoint item
+    item = _make_item_entry(kind=WarehouseKind.SQL_ENDPOINT)
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.procedures.list_procedures",
+            new=AsyncMock(return_value=[]),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "list_procedures",
+            {"workspace": _WS_NAME, "item": _WH_NAME},
+        )
+
+    assert isinstance(result, list)
+
+
+async def test_list_procedures_workspace_allowlist_blocks(
+    mock_ctx, ctx_patch, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """list_procedures raises ToolError when workspace is not in the allowlist."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    monkeypatch.setenv("FABRIC_MCP_WORKSPACES", "other-workspace")
+    item = _make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with ctx_patch, pytest.raises(ToolError):
+        await mcp._tool_manager.call_tool(
+            "list_procedures",
+            {"workspace": _WS_NAME, "item": _WH_NAME},
+        )
+
+
+# ===========================================================================
+# get_procedure
+# ===========================================================================
+
+
+async def test_get_procedure_happy_path(mock_ctx, ctx_patch) -> None:
+    """get_procedure returns the procedure dict with definition."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = _make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.procedures.get_procedure",
+            new=AsyncMock(return_value=_make_proc()),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "get_procedure",
+            {"workspace": _WS_NAME, "item": _WH_NAME, "qualified_name": "dbo.usp_load"},
+        )
+
+    assert isinstance(result, dict)
+    assert result["name"] == "usp_load"
+    assert result["definition"] is not None
+
+
+async def test_get_procedure_bad_qualified_name_raises_tool_error(mock_ctx, ctx_patch) -> None:
+    """get_procedure raises ToolError when qualified_name has no dot."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = _make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with ctx_patch, pytest.raises(ToolError):
+        await mcp._tool_manager.call_tool(
+            "get_procedure",
+            {"workspace": _WS_NAME, "item": _WH_NAME, "qualified_name": "nodot"},
+        )
+
+
+# ===========================================================================
+# create_procedure
+# ===========================================================================
+
+
+async def test_create_procedure_happy_path(mock_ctx, ctx_patch) -> None:
+    """create_procedure returns the newly created procedure."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = _make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.procedures.create_procedure",
+            new=AsyncMock(return_value=_make_proc()),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "create_procedure",
+            {
+                "workspace": _WS_NAME,
+                "item": _WH_NAME,
+                "qualified_name": "dbo.usp_load",
+                "body": "BEGIN SELECT 1 END",
+            },
+        )
+
+    assert isinstance(result, dict)
+    assert result["name"] == "usp_load"
+
+
+async def test_create_procedure_blocked_in_readonly(
+    mock_ctx, ctx_patch, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """create_procedure raises ToolError when FABRIC_MCP_READONLY is set."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    monkeypatch.setenv("FABRIC_MCP_READONLY", "1")
+    item = _make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with ctx_patch, pytest.raises(ToolError, match="read-only"):
+        await mcp._tool_manager.call_tool(
+            "create_procedure",
+            {
+                "workspace": _WS_NAME,
+                "item": _WH_NAME,
+                "qualified_name": "dbo.usp_load",
+                "body": "BEGIN END",
+            },
+        )
+
+
+async def test_create_procedure_on_sql_endpoint_no_error(mock_ctx, ctx_patch) -> None:
+    """create_procedure must NOT raise for SQL Analytics Endpoint — no DW-only guard."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = _make_item_entry(kind=WarehouseKind.SQL_ENDPOINT)
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.procedures.create_procedure",
+            new=AsyncMock(return_value=_make_proc()),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "create_procedure",
+            {
+                "workspace": _WS_NAME,
+                "item": _WH_NAME,
+                "qualified_name": "dbo.usp_load",
+                "body": "BEGIN SELECT 1 END",
+            },
+        )
+
+    assert isinstance(result, dict)
+
+
+# ===========================================================================
+# update_procedure
+# ===========================================================================
+
+
+async def test_update_procedure_happy_path(mock_ctx, ctx_patch) -> None:
+    """update_procedure returns the updated procedure."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = _make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.procedures.update_procedure",
+            new=AsyncMock(return_value=_make_proc()),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "update_procedure",
+            {
+                "workspace": _WS_NAME,
+                "item": _WH_NAME,
+                "qualified_name": "dbo.usp_load",
+                "body": "BEGIN SELECT 2 END",
+            },
+        )
+
+    assert isinstance(result, dict)
+    assert result["name"] == "usp_load"
+
+
+async def test_update_procedure_blocked_in_readonly(
+    mock_ctx, ctx_patch, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """update_procedure raises ToolError when FABRIC_MCP_READONLY is set."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    monkeypatch.setenv("FABRIC_MCP_READONLY", "1")
+    item = _make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with ctx_patch, pytest.raises(ToolError, match="read-only"):
+        await mcp._tool_manager.call_tool(
+            "update_procedure",
+            {
+                "workspace": _WS_NAME,
+                "item": _WH_NAME,
+                "qualified_name": "dbo.usp_load",
+                "body": "BEGIN END",
+            },
+        )
+
+
+# ===========================================================================
+# drop_procedure
+# ===========================================================================
+
+
+async def test_drop_procedure_happy_path(
+    mock_ctx, ctx_patch, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """drop_procedure returns {dropped: True} when FABRIC_MCP_ALLOW_DESTRUCTIVE is set."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    monkeypatch.setenv("FABRIC_MCP_ALLOW_DESTRUCTIVE", "1")
+    item = _make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.procedures.drop_procedure",
+            new=AsyncMock(return_value=None),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "drop_procedure",
+            {"workspace": _WS_NAME, "item": _WH_NAME, "qualified_name": "dbo.usp_load"},
+        )
+
+    assert result == {"dropped": True}
+
+
+async def test_drop_procedure_blocked_without_destructive_flag(
+    mock_ctx, ctx_patch, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """drop_procedure raises ToolError when FABRIC_MCP_ALLOW_DESTRUCTIVE is not set."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    monkeypatch.delenv("FABRIC_MCP_ALLOW_DESTRUCTIVE", raising=False)
+    item = _make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with ctx_patch, pytest.raises(ToolError, match="destructive"):
+        await mcp._tool_manager.call_tool(
+            "drop_procedure",
+            {"workspace": _WS_NAME, "item": _WH_NAME, "qualified_name": "dbo.usp_load"},
+        )
+
+
+async def test_drop_procedure_blocked_in_readonly(
+    mock_ctx, ctx_patch, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """drop_procedure raises ToolError when FABRIC_MCP_READONLY is set."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    monkeypatch.setenv("FABRIC_MCP_READONLY", "1")
+    item = _make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with ctx_patch, pytest.raises(ToolError, match="read-only"):
+        await mcp._tool_manager.call_tool(
+            "drop_procedure",
+            {"workspace": _WS_NAME, "item": _WH_NAME, "qualified_name": "dbo.usp_load"},
+        )
+
+
+async def test_drop_procedure_on_sql_endpoint_no_error(
+    mock_ctx, ctx_patch, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """drop_procedure must NOT raise for SQL Analytics Endpoint — no DW-only guard."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    monkeypatch.setenv("FABRIC_MCP_ALLOW_DESTRUCTIVE", "1")
+    item = _make_item_entry(kind=WarehouseKind.SQL_ENDPOINT)
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.procedures.drop_procedure",
+            new=AsyncMock(return_value=None),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "drop_procedure",
+            {"workspace": _WS_NAME, "item": _WH_NAME, "qualified_name": "dbo.usp_load"},
+        )
+
+    assert result == {"dropped": True}

--- a/tests/unit/mcp/test_server.py
+++ b/tests/unit/mcp/test_server.py
@@ -109,6 +109,12 @@ EXPECTED_TOOL_NAMES: frozenset[str] = frozenset(
         "update_view",
         "drop_view",
         "rename_view",
+        # Stored Procedures
+        "list_procedures",
+        "get_procedure",
+        "create_procedure",
+        "update_procedure",
+        "drop_procedure",
         # Tables
         "list_tables",
         "read_table",

--- a/tests/unit/services/test_procedures.py
+++ b/tests/unit/services/test_procedures.py
@@ -1,0 +1,551 @@
+"""Tests for services.procedures — DMV-mock tests + identifier-validator tests (TDD)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fabric_dw.exceptions import AuthError, NotFoundError, PermissionDeniedError
+from fabric_dw.models import StoredProcedure
+from fabric_dw.services import procedures
+from fabric_dw.services.procedures import validate_identifier
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_target() -> MagicMock:
+    """Return a mock SqlTarget."""
+    return MagicMock()
+
+
+def _make_conn(rows: list[tuple[object, ...]], columns: list[str]) -> MagicMock:
+    """Return a mock connection whose cursor returns the given rows."""
+    cursor = MagicMock()
+    cursor.description = [(c, None) for c in columns]
+    cursor.fetchall.return_value = rows
+    conn = MagicMock()
+    conn.cursor.return_value = cursor
+    return conn
+
+
+def _make_conn_for_ddl() -> MagicMock:
+    """Return a mock connection suitable for DDL statements (no rows returned)."""
+    cursor = MagicMock()
+    cursor.description = None
+    cursor.fetchall.return_value = []
+    conn = MagicMock()
+    conn.cursor.return_value = cursor
+    return conn
+
+
+# ---------------------------------------------------------------------------
+# Fixture data
+# ---------------------------------------------------------------------------
+
+_NOW = datetime(2024, 6, 1, 12, 0, 0, tzinfo=UTC)
+_LATER = datetime(2024, 6, 2, 8, 30, 0, tzinfo=UTC)
+
+_LIST_COLS = ["schema_name", "name", "created", "modified"]
+_GET_COLS = ["schema_name", "name", "created", "modified", "definition"]
+
+_PROC_ROW_1 = ("dbo", "usp_load", _NOW, _LATER)
+_PROC_ROW_2 = ("finance", "usp_monthly", _NOW, _NOW)
+_PROC_ROW_GET = ("dbo", "usp_load", _NOW, _LATER, "BEGIN SELECT 1 AS id END")
+
+
+# ===========================================================================
+# identifier validator re-export
+# ===========================================================================
+
+
+class TestValidateIdentifier:
+    def test_simple_valid_identifier(self) -> None:
+        assert validate_identifier("my_proc") == "my_proc"
+
+    def test_rejects_semicolon(self) -> None:
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            validate_identifier("proc;injection")
+
+    def test_rejects_bracket(self) -> None:
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            validate_identifier("proc]name")
+
+
+# ===========================================================================
+# list_procedures
+# ===========================================================================
+
+
+class TestListProcedures:
+    async def test_returns_empty_when_no_rows(self) -> None:
+        target = _make_target()
+        conn = _make_conn([], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            result = await procedures.list_procedures(target)
+        assert result == []
+
+    async def test_returns_procedure_instances(self) -> None:
+        target = _make_target()
+        conn = _make_conn([_PROC_ROW_1], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            result = await procedures.list_procedures(target)
+        assert len(result) == 1
+        assert isinstance(result[0], StoredProcedure)
+
+    async def test_parses_fields_correctly(self) -> None:
+        target = _make_target()
+        conn = _make_conn([_PROC_ROW_1], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            result = await procedures.list_procedures(target)
+        p = result[0]
+        assert p.schema_name == "dbo"
+        assert p.name == "usp_load"
+        assert p.qualified_name == "dbo.usp_load"
+        assert p.created == _NOW
+        assert p.modified == _LATER
+        assert p.definition is None
+
+    async def test_returns_all_rows(self) -> None:
+        target = _make_target()
+        conn = _make_conn([_PROC_ROW_1, _PROC_ROW_2], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            result = await procedures.list_procedures(target)
+        assert len(result) == 2
+
+    async def test_sql_references_sys_procedures(self) -> None:
+        target = _make_target()
+        conn = _make_conn([], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await procedures.list_procedures(target)
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert "sys.procedures" in call_sql
+
+    async def test_sql_references_sys_schemas(self) -> None:
+        target = _make_target()
+        conn = _make_conn([], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await procedures.list_procedures(target)
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert "sys.schemas" in call_sql
+
+    async def test_filters_by_schema_when_provided(self) -> None:
+        target = _make_target()
+        conn = _make_conn([_PROC_ROW_1], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await procedures.list_procedures(target, schema="dbo")
+        cursor = conn.cursor.return_value
+        call_args = cursor.execute.call_args
+        call_sql: str = call_args[0][0]
+        assert "s.name = ?" in call_sql
+        params = call_args[0][1] if len(call_args[0]) > 1 else []
+        assert "dbo" in list(params)
+
+    async def test_schema_filter_validates_identifier(self) -> None:
+        target = _make_target()
+        conn = _make_conn([], _LIST_COLS)
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(ValueError, match="Invalid SQL identifier"),
+        ):
+            await procedures.list_procedures(target, schema="bad]schema")
+
+    async def test_closes_connection_after_success(self) -> None:
+        target = _make_target()
+        conn = _make_conn([_PROC_ROW_1], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await procedures.list_procedures(target)
+        conn.close.assert_called_once()
+
+    async def test_maps_permission_denied(self) -> None:
+        target = _make_target()
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.execute.side_effect = Exception("permission was denied on object sys.procedures")
+        conn.cursor.return_value = cursor
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(PermissionDeniedError),
+        ):
+            await procedures.list_procedures(target)
+
+    async def test_maps_auth_error(self) -> None:
+        target = _make_target()
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.execute.side_effect = Exception("Authentication failed for user ''")
+        conn.cursor.return_value = cursor
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(AuthError),
+        ):
+            await procedures.list_procedures(target)
+
+    async def test_unrelated_error_propagates(self) -> None:
+        target = _make_target()
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.execute.side_effect = RuntimeError("network timeout")
+        conn.cursor.return_value = cursor
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(RuntimeError, match="network timeout"),
+        ):
+            await procedures.list_procedures(target)
+
+    async def test_no_endpoint_guard_raises(self) -> None:
+        """list_procedures must NOT raise for SQL Analytics Endpoint targets.
+
+        This test asserts the absence of a DW-only guard: the service must
+        accept any SqlTarget regardless of target kind.
+        """
+        from fabric_dw.sql import SqlTarget  # noqa: PLC0415
+
+        # Build a target that looks like a SQL endpoint (kind is not checked at service level)
+        endpoint_target = SqlTarget(
+            workspace_id="a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            database="MyLakehouse",
+            connection_string="ep.datawarehouse.fabric.microsoft.com",
+        )
+        conn = _make_conn([], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            # Must not raise — no endpoint guard
+            result = await procedures.list_procedures(endpoint_target)
+        assert isinstance(result, list)
+
+
+# ===========================================================================
+# get_procedure
+# ===========================================================================
+
+
+class TestGetProcedure:
+    async def test_returns_procedure_with_definition(self) -> None:
+        target = _make_target()
+        conn = _make_conn([_PROC_ROW_GET], _GET_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            result = await procedures.get_procedure(target, "dbo", "usp_load")
+        assert isinstance(result, StoredProcedure)
+        assert result.definition == "BEGIN SELECT 1 AS id END"
+
+    async def test_parses_all_fields(self) -> None:
+        target = _make_target()
+        conn = _make_conn([_PROC_ROW_GET], _GET_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            result = await procedures.get_procedure(target, "dbo", "usp_load")
+        assert result.schema_name == "dbo"
+        assert result.name == "usp_load"
+        assert result.qualified_name == "dbo.usp_load"
+        assert result.created == _NOW
+        assert result.modified == _LATER
+
+    async def test_sql_includes_sys_sql_modules(self) -> None:
+        target = _make_target()
+        conn = _make_conn([_PROC_ROW_GET], _GET_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await procedures.get_procedure(target, "dbo", "usp_load")
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert "sys.sql_modules" in call_sql
+
+    async def test_raises_not_found_when_no_rows(self) -> None:
+        target = _make_target()
+        conn = _make_conn([], _GET_COLS)
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(NotFoundError),
+        ):
+            await procedures.get_procedure(target, "dbo", "nonexistent")
+
+    async def test_validates_schema_identifier(self) -> None:
+        target = _make_target()
+        conn = _make_conn([], _GET_COLS)
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(ValueError, match="Invalid SQL identifier"),
+        ):
+            await procedures.get_procedure(target, "bad;schema", "usp_load")
+
+    async def test_validates_procedure_name_identifier(self) -> None:
+        target = _make_target()
+        conn = _make_conn([], _GET_COLS)
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(ValueError, match="Invalid SQL identifier"),
+        ):
+            await procedures.get_procedure(target, "dbo", "usp--injection")
+
+    async def test_closes_connection_after_success(self) -> None:
+        target = _make_target()
+        conn = _make_conn([_PROC_ROW_GET], _GET_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await procedures.get_procedure(target, "dbo", "usp_load")
+        conn.close.assert_called_once()
+
+    async def test_maps_permission_denied(self) -> None:
+        target = _make_target()
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.execute.side_effect = Exception("permission was denied on sys.sql_modules")
+        conn.cursor.return_value = cursor
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(PermissionDeniedError),
+        ):
+            await procedures.get_procedure(target, "dbo", "usp_load")
+
+
+# ===========================================================================
+# create_procedure
+# ===========================================================================
+
+
+class TestCreateProcedure:
+    async def test_emits_create_procedure_ddl(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_PROC_ROW_GET], _GET_COLS)
+
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            await procedures.create_procedure(target, "dbo", "usp_load", "BEGIN SELECT 1 END")
+
+        cursor = ddl_conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert "CREATE PROCEDURE" in call_sql.upper()
+        assert "[dbo]" in call_sql
+        assert "[usp_load]" in call_sql
+
+    async def test_includes_body(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_PROC_ROW_GET], _GET_COLS)
+
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            await procedures.create_procedure(target, "dbo", "usp_load", "BEGIN SELECT 1 END")
+
+        cursor = ddl_conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert "BEGIN SELECT 1 END" in call_sql
+
+    async def test_returns_procedure_object(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_PROC_ROW_GET], _GET_COLS)
+
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            result = await procedures.create_procedure(
+                target, "dbo", "usp_load", "BEGIN SELECT 1 END"
+            )
+
+        assert isinstance(result, StoredProcedure)
+        assert result.schema_name == "dbo"
+        assert result.name == "usp_load"
+
+    async def test_validates_schema_identifier(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await procedures.create_procedure(target, "bad]schema", "usp_load", "BEGIN END")
+
+    async def test_validates_procedure_name_identifier(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await procedures.create_procedure(target, "dbo", "usp;drop", "BEGIN END")
+
+    async def test_commits_after_execute(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_PROC_ROW_GET], _GET_COLS)
+
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            await procedures.create_procedure(target, "dbo", "usp_load", "BEGIN SELECT 1 END")
+
+        ddl_conn.commit.assert_called_once()
+
+    async def test_maps_permission_denied_on_ddl(self) -> None:
+        target = _make_target()
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.execute.side_effect = Exception("permission was denied on database")
+        conn.cursor.return_value = cursor
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(PermissionDeniedError),
+        ):
+            await procedures.create_procedure(target, "dbo", "usp_load", "BEGIN END")
+
+    async def test_rejects_identifier_injection_via_schema(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await procedures.create_procedure(
+                target, "x]; DROP TABLE users--", "usp_ok", "BEGIN END"
+            )
+
+    async def test_rejects_identifier_injection_via_proc_name(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await procedures.create_procedure(
+                target, "dbo", "usp_ok] WITH EXECUTE AS OWNER--", "BEGIN END"
+            )
+
+
+# ===========================================================================
+# update_procedure
+# ===========================================================================
+
+
+class TestUpdateProcedure:
+    async def test_emits_create_or_alter_procedure_ddl(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_PROC_ROW_GET], _GET_COLS)
+
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            await procedures.update_procedure(target, "dbo", "usp_load", "BEGIN SELECT 2 END")
+
+        cursor = ddl_conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0].upper()
+        assert "CREATE OR ALTER PROCEDURE" in call_sql
+
+    async def test_uses_brackets_for_schema_and_name(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_PROC_ROW_GET], _GET_COLS)
+
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            await procedures.update_procedure(target, "dbo", "usp_load", "BEGIN END")
+
+        cursor = ddl_conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert "[dbo]" in call_sql
+        assert "[usp_load]" in call_sql
+
+    async def test_returns_procedure_object(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_PROC_ROW_GET], _GET_COLS)
+
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            result = await procedures.update_procedure(target, "dbo", "usp_load", "BEGIN END")
+
+        assert isinstance(result, StoredProcedure)
+
+    async def test_validates_schema_identifier(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await procedures.update_procedure(target, "bad--schema", "usp_load", "BEGIN END")
+
+    async def test_validates_procedure_name_identifier(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await procedures.update_procedure(target, "dbo", "usp;injection", "BEGIN END")
+
+    async def test_commits_after_execute(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_PROC_ROW_GET], _GET_COLS)
+
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            await procedures.update_procedure(target, "dbo", "usp_load", "BEGIN END")
+
+        ddl_conn.commit.assert_called_once()
+
+    async def test_maps_permission_denied(self) -> None:
+        target = _make_target()
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.execute.side_effect = Exception("permission was denied to alter procedure")
+        conn.cursor.return_value = cursor
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(PermissionDeniedError),
+        ):
+            await procedures.update_procedure(target, "dbo", "usp_load", "BEGIN END")
+
+
+# ===========================================================================
+# drop_procedure
+# ===========================================================================
+
+
+class TestDropProcedure:
+    async def test_emits_drop_procedure_ddl(self) -> None:
+        target = _make_target()
+        conn = _make_conn_for_ddl()
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await procedures.drop_procedure(target, "dbo", "usp_load")
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0].upper()
+        assert "DROP PROCEDURE" in call_sql
+
+    async def test_uses_brackets_for_schema_and_name(self) -> None:
+        target = _make_target()
+        conn = _make_conn_for_ddl()
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await procedures.drop_procedure(target, "dbo", "usp_load")
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert "[dbo]" in call_sql
+        assert "[usp_load]" in call_sql
+
+    async def test_commits_after_execute(self) -> None:
+        target = _make_target()
+        conn = _make_conn_for_ddl()
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await procedures.drop_procedure(target, "dbo", "usp_load")
+        conn.commit.assert_called_once()
+
+    async def test_closes_connection_after_success(self) -> None:
+        target = _make_target()
+        conn = _make_conn_for_ddl()
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await procedures.drop_procedure(target, "dbo", "usp_load")
+        conn.close.assert_called_once()
+
+    async def test_validates_schema_identifier(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await procedures.drop_procedure(target, "bad]schema", "usp_load")
+
+    async def test_validates_procedure_name_identifier(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await procedures.drop_procedure(target, "dbo", "usp--bad")
+
+    async def test_maps_permission_denied(self) -> None:
+        target = _make_target()
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.execute.side_effect = Exception("permission was denied to drop procedure")
+        conn.cursor.return_value = cursor
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(PermissionDeniedError),
+        ):
+            await procedures.drop_procedure(target, "dbo", "usp_load")
+
+    async def test_rejects_injection_in_schema(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await procedures.drop_procedure(target, "x]; DROP TABLE users--", "usp_ok")
+
+    async def test_rejects_injection_in_procedure_name(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await procedures.drop_procedure(target, "dbo", "usp_ok] WHERE 1=1--")
+
+    async def test_unrelated_error_propagates(self) -> None:
+        target = _make_target()
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.execute.side_effect = RuntimeError("connection reset")
+        conn.cursor.return_value = cursor
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(RuntimeError, match="connection reset"),
+        ):
+            await procedures.drop_procedure(target, "dbo", "usp_load")


### PR DESCRIPTION
## Summary

- Adds full CRUD for stored procedures, mirroring the views feature exactly
- **No DW-only guard**: `CREATE/ALTER/DROP PROCEDURE` are confirmed supported on both Fabric Data Warehouses and SQL Analytics Endpoints (verified via Microsoft Learn docs — both appear in the "Applies to" lists for all three DDL statements)
- `CREATE OR ALTER PROCEDURE` is used for updates (confirmed supported on Fabric targets)

## Files added/changed

**New files:**
- `src/fabric_dw/services/procedures.py` — service layer (`list_procedures`, `get_procedure`, `create_procedure`, `update_procedure`, `drop_procedure`)
- `src/fabric_dw/cli/commands/procedures.py` — CLI group with list/get/create/update/drop sub-commands; `--body`/`--from-file` like views; confirm prompt for update/drop
- `src/fabric_dw/mcp/tools/procedures.py` — 5 MCP tools with `assert_writes_allowed` (create/update/drop), `assert_destructive_allowed` (drop), `assert_workspace_allowed` (all); **no endpoint guard**
- `tests/unit/services/test_procedures.py` — SQL shape, bracket quoting, `CREATE OR ALTER`, `DROP`, identifier validation, NotFoundError
- `tests/unit/cli/commands/test_procedures.py` — happy path, `--from-file`, BOM stripping, confirm prompt, error cases; includes assertion that SQL endpoint target does NOT raise
- `tests/unit/mcp/test_procedures.py` — readonly blocks writes, destructive gate on drop, workspace allowlist; explicit assertions that SQL endpoint items are NOT rejected
- `tests/integration/test_services_procedures.py` — label-gated (`pytestmark = pytest.mark.integration`); create→list→get (definition contains body)→update (definition changes)→drop roundtrip; self-cleaning

**Modified files:**
- `src/fabric_dw/models.py` — adds `StoredProcedure` model
- `src/fabric_dw/cli/_main.py` — registers `procedures_group`
- `src/fabric_dw/mcp/tools/__init__.py` — registers `procedures` domain module
- `src/fabric_dw/mcp/server.py` — updates tool count in docstring (65 → 70)
- `tests/unit/mcp/test_server.py` — adds 5 procedure tool names to `EXPECTED_TOOL_NAMES`
- `tests/unit/mcp/test_contract.py` — updates `_EXPECTED_TOOL_COUNT` from 65 → 70

## Test results

`just check` (lint + ty + unit) green: **1630 passed**.  
Integration tests require real Fabric credentials — NOT verified here (by design).

## No DW-only guard

The service, CLI, and MCP tools apply **no** `require_warehouse()` / endpoint guard. Microsoft documentation for `DROP PROCEDURE`, `ALTER PROCEDURE`, and the Fabric T-SQL surface area page all list "SQL analytics endpoint in Microsoft Fabric" alongside "Warehouse in Microsoft Fabric" as supported targets. Unit tests contain explicit assertions confirming SQL endpoint items are accepted without error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)