### PR TITLE
fix(http,warehouses): surface 4xx bodies + correct warehouse create endpoint

### DIFF
--- a/src/fabric_dw/exceptions.py
+++ b/src/fabric_dw/exceptions.py
@@ -52,6 +52,15 @@ class FabricServerError(FabricError):
     """Raised on persistent 5xx errors or a failed LRO operation."""
 
 
+class BadRequestError(FabricError):
+    """Raised on HTTP 400 - the request body or parameters were invalid.
+
+    The ``body`` attribute contains the parsed Fabric error JSON (errorCode /
+    message) when available, giving callers visibility into the exact reason the
+    request was rejected.
+    """
+
+
 class AlreadyExistsError(FabricError):
     """Raised when a resource with the given name already exists."""
 

--- a/src/fabric_dw/http_client.py
+++ b/src/fabric_dw/http_client.py
@@ -40,6 +40,7 @@ from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_ex
 from fabric_dw import auth
 from fabric_dw.exceptions import (
     AuthError,
+    BadRequestError,
     FabricError,
     FabricServerError,
     NotFoundError,
@@ -352,7 +353,9 @@ class FabricHttpClient:
     def _map_status(self, resp: httpx.Response, url: str) -> None:
         """Raise a typed ``FabricError`` subclass for error status codes.
 
-        Uses ``_STATUS_TO_EXC`` for known 4xx codes; raises ``FabricServerError``
+        Uses ``_STATUS_TO_EXC`` for known 4xx codes (401, 403, 404); raises
+        ``BadRequestError`` for any other 4xx (including 400) so that Fabric
+        error details are never silently discarded; raises ``FabricServerError``
         for any 5xx response.  JSON body is parsed best-effort (parse errors
         are silently swallowed).  The ``x-ms-request-id`` header is captured
         for all raised exceptions.
@@ -372,6 +375,16 @@ class FabricHttpClient:
         exc_class = _STATUS_TO_EXC.get(status)
         if exc_class is not None:
             raise exc_class(
+                f"HTTP {status} for {url}: {resp.text}",
+                status=status,
+                request_id=request_id,
+                body=body,
+            )
+
+        if http.HTTPStatus.BAD_REQUEST <= status < http.HTTPStatus.INTERNAL_SERVER_ERROR:
+            # Unmapped 4xx — surface the full Fabric error body so callers can see
+            # the errorCode/message (e.g. InvalidItemType, WorkspaceItemsLimitExceeded).
+            raise BadRequestError(
                 f"HTTP {status} for {url}: {resp.text}",
                 status=status,
                 request_id=request_id,

--- a/src/fabric_dw/services/warehouses.py
+++ b/src/fabric_dw/services/warehouses.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import http as _http
 import logging
 from datetime import UTC, datetime
 from uuid import UUID
@@ -21,9 +20,6 @@ _logger = logging.getLogger("fabric_dw.warehouses")
 
 # Backoff schedule for transient empty-2xx responses (seconds).
 _EMPTY_2XX_BACKOFF = (2, 6, 18)
-
-_HTTP_400_BAD_REQUEST = _http.HTTPStatus.BAD_REQUEST
-_HTTP_500_INTERNAL_SERVER_ERROR = _http.HTTPStatus.INTERNAL_SERVER_ERROR
 
 __all__ = [
     "create",
@@ -167,11 +163,10 @@ async def create(
 
     body: dict[str, object] = {
         **compact({"description": description}),
-        "type": "Warehouse",
         "displayName": name,
     }
     if collation is not None:
-        body["creationPayload"] = {"defaultCollation": collation}
+        body["creationPayload"] = {"collationType": collation}
 
     for attempt, backoff in enumerate(
         [None, *_EMPTY_2XX_BACKOFF], start=0
@@ -185,8 +180,11 @@ async def create(
             )
             await asyncio.sleep(backoff)
 
+        # Use the type-specific endpoint (POST /workspaces/{id}/warehouses).
+        # Any 4xx is raised by the HTTP client as BadRequestError before reaching here,
+        # so the only non-202/201 responses that arrive are genuine 2xx with missing data.
         resp = await http.request(
-            "POST", HttpBase.FABRIC, f"/workspaces/{workspace_id}/items", json=body
+            "POST", HttpBase.FABRIC, f"/workspaces/{workspace_id}/warehouses", json=body
         )
 
         location = resp.headers.get("Location")
@@ -201,17 +199,6 @@ async def create(
             if resp_id and resp_name:
                 new_id = UUID(str(resp_id))
                 return await get_warehouse(http, workspace_id, new_id)
-
-            # Do not retry on 4xx — those are definitive client errors.
-            if (
-                resp.status_code >= _HTTP_400_BAD_REQUEST
-                and resp.status_code < _HTTP_500_INTERNAL_SERVER_ERROR
-            ):
-                msg = (
-                    f"create warehouse: {resp.status_code} error response "
-                    f"with no Location header and no usable body"
-                )
-                raise FabricServerError(msg)
 
             # 2xx + no Location + no usable body: transient Fabric data-plane not ready.
             # Continue the retry loop (will raise below if exhausted).

--- a/src/fabric_dw/services/workspaces.py
+++ b/src/fabric_dw/services/workspaces.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
-import http as http_module
 from uuid import UUID
 
-from fabric_dw.exceptions import FabricError, NotFoundError
+from fabric_dw.exceptions import BadRequestError, FabricError, NotFoundError
 from fabric_dw.http_client import FabricHttpClient, HttpBase
 from fabric_dw.models import Workspace
 
@@ -92,22 +91,15 @@ async def set_collation(
     )
 
     try:
-        resp = await http.request(
+        await http.request(
             "PATCH",
             HttpBase.FABRIC,
             f"/workspaces/{workspace_id}",
             json={"defaultDataWarehouseCollation": collation},
         )
-    except NotFoundError as exc:
+    except (NotFoundError, BadRequestError) as exc:
+        # The v1 API may not expose defaultDataWarehouseCollation on all tenants yet.
+        # Surface a portal link so the user knows the manual fallback path.
         raise FabricError(portal_msg) from exc
     except FabricError:
         raise
-
-    # http_client returns non-error responses (including 400) without raising;
-    # treat any remaining 4xx as a portal-redirect case.
-    if (
-        http_module.HTTPStatus.BAD_REQUEST
-        <= resp.status_code
-        < http_module.HTTPStatus.INTERNAL_SERVER_ERROR
-    ):
-        raise FabricError(portal_msg)

--- a/tests/unit/services/test_warehouses.py
+++ b/tests/unit/services/test_warehouses.py
@@ -14,7 +14,12 @@ import pytest
 import respx
 
 from fabric_dw.cache import ItemEntry, LookupCache
-from fabric_dw.exceptions import FabricServerError, NotFoundError, PermissionDeniedError
+from fabric_dw.exceptions import (
+    BadRequestError,
+    FabricServerError,
+    NotFoundError,
+    PermissionDeniedError,
+)
 from fabric_dw.models import Warehouse, WarehouseKind, Workspace
 from fabric_dw.services import warehouses
 from tests.fixtures.api_payloads import (
@@ -43,7 +48,6 @@ _BASE = "https://api.fabric.microsoft.com/v1"
 _WAREHOUSES_URL = f"{_BASE}/workspaces/{_WORKSPACE_ID}/warehouses"
 _SQL_ENDPOINTS_URL = f"{_BASE}/workspaces/{_WORKSPACE_ID}/sqlEndpoints"
 _WAREHOUSE_URL = f"{_WAREHOUSES_URL}/{_WAREHOUSE_ID}"
-_ITEMS_URL = f"{_BASE}/workspaces/{_WORKSPACE_ID}/items"
 _OPERATION_URL = f"{_BASE}/operations/op-abc123"
 
 
@@ -204,7 +208,7 @@ async def test_create_with_collation_polls_lro_and_returns_warehouse() -> None:
 
     with respx.mock:
         # POST to create
-        post_route = respx.post(_ITEMS_URL).mock(
+        post_route = respx.post(_WAREHOUSES_URL).mock(
             return_value=httpx.Response(
                 202,
                 json=create_resp,
@@ -231,9 +235,9 @@ async def test_create_with_collation_polls_lro_and_returns_warehouse() -> None:
 
     # Verify the POST body included creationPayload with collation
     sent_body = json.loads(post_route.calls[0].request.content)
-    assert sent_body["type"] == "Warehouse"
+    assert "type" not in sent_body  # type-specific endpoint — no type field needed
     assert sent_body["displayName"] == "SalesWarehouse"
-    assert sent_body["creationPayload"]["defaultCollation"] == "Latin1_General_100_BIN2_UTF8"
+    assert sent_body["creationPayload"]["collationType"] == "Latin1_General_100_BIN2_UTF8"
 
 
 async def test_create_without_collation_omits_creation_payload() -> None:
@@ -244,7 +248,7 @@ async def test_create_without_collation_omits_creation_payload() -> None:
     new_wh_url = f"{_WAREHOUSES_URL}/{new_wh_id}"
 
     with respx.mock:
-        post_route = respx.post(_ITEMS_URL).mock(
+        post_route = respx.post(_WAREHOUSES_URL).mock(
             return_value=httpx.Response(
                 202,
                 json={},
@@ -271,7 +275,7 @@ async def test_create_with_description() -> None:
     new_wh_url = f"{_WAREHOUSES_URL}/{new_wh_id}"
 
     with respx.mock:
-        post_route = respx.post(_ITEMS_URL).mock(
+        post_route = respx.post(_WAREHOUSES_URL).mock(
             return_value=httpx.Response(
                 202,
                 json={},
@@ -332,7 +336,7 @@ async def test_create_missing_resource_location_raises_fabric_server_error() -> 
     op_no_location = json.loads(WAREHOUSE_OPERATION_SUCCEEDED_NO_LOCATION_PAYLOAD)
 
     with respx.mock:
-        respx.post(_ITEMS_URL).mock(
+        respx.post(_WAREHOUSES_URL).mock(
             return_value=httpx.Response(
                 202,
                 json={},
@@ -361,7 +365,7 @@ async def test_create_no_location_header_but_body_present_returns_warehouse() ->
     new_wh_url = f"{_WAREHOUSES_URL}/{new_wh_id}"
 
     with respx.mock:
-        respx.post(_ITEMS_URL).mock(
+        respx.post(_WAREHOUSES_URL).mock(
             # 201, no Location header, body contains id + displayName
             return_value=httpx.Response(201, json=body)
         )
@@ -387,7 +391,7 @@ async def test_create_no_location_header_and_empty_body_raises_fabric_server_err
     that FabricServerError is raised with a reference to issue #204.
     """
     with respx.mock:
-        post_route = respx.post(_ITEMS_URL).mock(
+        post_route = respx.post(_WAREHOUSES_URL).mock(
             return_value=httpx.Response(202, json={})  # no Location header, empty body, always
         )
 
@@ -425,7 +429,7 @@ async def test_create_empty_2xx_retries_then_succeeds() -> None:
         return httpx.Response(202, json={}, headers={"Location": _OPERATION_URL})
 
     with respx.mock:
-        respx.post(_ITEMS_URL).mock(side_effect=post_side_effect)
+        respx.post(_WAREHOUSES_URL).mock(side_effect=post_side_effect)
         respx.get(_OPERATION_URL).mock(return_value=httpx.Response(200, json=op_succeeded))
         respx.get(new_wh_url).mock(return_value=httpx.Response(200, json=wh_payload))
 
@@ -442,33 +446,33 @@ async def test_create_empty_2xx_retries_then_succeeds() -> None:
 
 
 async def test_create_4xx_is_not_retried() -> None:
-    """create must NOT retry on 4xx errors — they propagate immediately.
+    """create must NOT retry on 4xx errors — they propagate immediately as BadRequestError.
 
+    The HTTP client now raises BadRequestError for unmapped 4xx (including 400)
+    before the response even reaches warehouses.create, so the retry loop never fires.
     Mocks a single 400 response and verifies that only 1 POST is made and
-    the exception is raised without any retry.
+    BadRequestError (with the Fabric error body) is raised without any retry.
     """
     with respx.mock:
-        post_route = respx.post(_ITEMS_URL).mock(
+        post_route = respx.post(_WAREHOUSES_URL).mock(
             return_value=httpx.Response(
-                400, json={"error": {"code": "InvalidRequest", "message": "bad input"}}
+                400, json={"errorCode": "InvalidItemType", "message": "bad input"}
             )
         )
 
         client = await _make_client()
         async with client:
-            # 400 falls through http_client without raising (no mapping) — the response is returned
-            # and warehouses.create will see an empty/useless body; but the key assertion
-            # is that the retry loop only fires for 2xx+empty-body, not for 4xx.
-            # The http_client only raises for 401, 403, 404, 5xx — a bare 400 is returned.
-            # warehouses.create will try to parse the body (no Location, no id), but since
-            # the status is 4xx the retry must NOT fire.
             with patch("fabric_dw.services.warehouses.asyncio.sleep") as mock_sleep:
-                with pytest.raises(FabricServerError):
+                with pytest.raises(BadRequestError) as exc_info:
                     await warehouses.create(client, _WORKSPACE_ID, "SalesWarehouse")
 
     # Only 1 POST attempt — no retries
     assert post_route.call_count == 1
     mock_sleep.assert_not_called()
+    # The error body (Fabric error detail) must be surfaced
+    assert exc_info.value.status == 400
+    assert exc_info.value.body is not None
+    assert exc_info.value.body.get("errorCode") == "InvalidItemType"
 
 
 async def test_create_existing_path_with_location_header_still_works() -> None:
@@ -479,7 +483,7 @@ async def test_create_existing_path_with_location_header_still_works() -> None:
     new_wh_url = f"{_WAREHOUSES_URL}/{new_wh_id}"
 
     with respx.mock:
-        respx.post(_ITEMS_URL).mock(
+        respx.post(_WAREHOUSES_URL).mock(
             return_value=httpx.Response(
                 202,
                 json={},

--- a/tests/unit/test_http_client.py
+++ b/tests/unit/test_http_client.py
@@ -18,6 +18,7 @@ from freezegun import freeze_time
 
 from fabric_dw.exceptions import (
     AuthError,
+    BadRequestError,
     FabricError,
     FabricServerError,
     NotFoundError,
@@ -1079,3 +1080,95 @@ async def test_send_once_re_sleeps_when_pause_until_extended_mid_sleep() -> None
     assert len(sleep_durations) >= 2, (
         f"Expected >=2 sleeps (original + extended deadline); got {sleep_durations}"
     )
+
+
+# ---------------------------------------------------------------------------
+# 4xx body surfacing (BadRequestError for unmapped 4xx)
+# ---------------------------------------------------------------------------
+
+
+async def test_400_raises_bad_request_error_with_json_body() -> None:
+    """HTTP 400 must raise BadRequestError and include the parsed JSON error body.
+
+    Before this fix, 400 passed through _map_status silently, causing the Fabric
+    errorCode/message to be discarded.  Now the body is surfaced on the exception.
+    """
+    error_payload = {
+        "errorCode": "InvalidItemType",
+        "message": "The item type 'Warehouse' is not valid for this endpoint.",
+        "requestId": "req-abc-123",
+    }
+    with respx.mock:
+        respx.post("https://api.fabric.microsoft.com/v1/items").mock(
+            return_value=httpx.Response(400, json=error_payload)
+        )
+        client = await _get_client()
+        async with client:
+            with pytest.raises(BadRequestError) as exc_info:
+                await client.request("POST", HttpBase.FABRIC, "/items", json={"x": 1})
+
+    err = exc_info.value
+    assert err.status == 400
+    assert err.body is not None
+    assert err.body.get("errorCode") == "InvalidItemType"
+    assert "InvalidItemType" in str(err)
+
+
+async def test_400_raises_bad_request_error_with_plain_text_body() -> None:
+    """HTTP 400 with a non-JSON body must still raise BadRequestError (body=None)."""
+    with respx.mock:
+        respx.get("https://api.fabric.microsoft.com/v1/items").mock(
+            return_value=httpx.Response(400, text="Bad Request")
+        )
+        client = await _get_client()
+        async with client:
+            with pytest.raises(BadRequestError) as exc_info:
+                await client.request("GET", HttpBase.FABRIC, "/items")
+
+    assert exc_info.value.status == 400
+    assert exc_info.value.body is None  # non-JSON body → body not parsed
+
+
+async def test_422_raises_bad_request_error() -> None:
+    """Any unmapped 4xx (e.g. 422) must raise BadRequestError, not pass through silently."""
+    with respx.mock:
+        respx.post("https://api.fabric.microsoft.com/v1/items").mock(
+            return_value=httpx.Response(422, json={"errorCode": "ValidationFailed"})
+        )
+        client = await _get_client()
+        async with client:
+            with pytest.raises(BadRequestError) as exc_info:
+                await client.request("POST", HttpBase.FABRIC, "/items", json={})
+
+    assert exc_info.value.status == 422
+
+
+async def test_bad_request_error_includes_request_id_header() -> None:
+    """BadRequestError must capture x-ms-request-id when present in the response headers."""
+    with respx.mock:
+        respx.get("https://api.fabric.microsoft.com/v1/items").mock(
+            return_value=httpx.Response(
+                400,
+                json={"errorCode": "SomeError"},
+                headers={"x-ms-request-id": "req-id-xyz"},
+            )
+        )
+        client = await _get_client()
+        async with client:
+            with pytest.raises(BadRequestError) as exc_info:
+                await client.request("GET", HttpBase.FABRIC, "/items")
+
+    assert exc_info.value.request_id == "req-id-xyz"
+    assert "req-id-xyz" in str(exc_info.value)
+
+
+async def test_401_still_raises_auth_error_not_bad_request() -> None:
+    """HTTP 401 must still raise AuthError (mapped in _STATUS_TO_EXC), not BadRequestError."""
+    with respx.mock:
+        respx.get("https://api.fabric.microsoft.com/v1/items").mock(
+            return_value=httpx.Response(401, json={"error": "unauthorized"})
+        )
+        client = await _get_client()
+        async with client:
+            with pytest.raises(AuthError):
+                await client.request("GET", HttpBase.FABRIC, "/items")


### PR DESCRIPTION
## Root-cause analysis

Nearly all integration tests ERROR at setup because `warehouses.create` raises `FabricServerError: create warehouse: 400 error response with no Location header and no usable body`. Two bugs compound to produce this opaque failure:

**Bug 1 — Wrong endpoint and payload (primary cause of the 400)**

The code was calling `POST /workspaces/{id}/items` with `{"type":"Warehouse","displayName":...}`. The current Microsoft Learn REST API reference ([Items - Create Warehouse](https://learn.microsoft.com/en-us/rest/api/fabric/warehouse/items/create-warehouse?tabs=HTTP)) specifies a **dedicated endpoint**:

```
POST https://api.fabric.microsoft.com/v1/workspaces/{workspaceId}/warehouses
```

The generic `/items` endpoint with `type=Warehouse` appears to be either deprecated or no longer valid, explaining the 400. Additionally, the collation key in `creationPayload` was `defaultCollation` in old docs but is now `collationType` per the current `WarehouseCreationPayload` schema.

**Bug 2 — 4xx body masking (amplified the confusion)**

`_map_status` in `http_client.py` only handled 401, 403, 404, and 5xx. A bare 400 passed through silently, returning the response object to `warehouses.create`, which then inspected the response, found no `Location` header and no usable `id/displayName`, checked the status code, and raised an opaque `FabricServerError` — discarding the actual Fabric `errorCode`/`message` from the response body.

## Microsoft Learn API verification

- Verified via `microsoft_docs_fetch` on the official REST reference: the create-warehouse endpoint is **`POST /workspaces/{workspaceId}/warehouses`**.
- No `type` field in the request body (it's implicit from the typed endpoint).
- `creationPayload` schema is `WarehouseCreationPayload` with field `collationType` (not `defaultCollation`).
- Source: https://learn.microsoft.com/en-us/rest/api/fabric/warehouse/items/create-warehouse?tabs=HTTP

## Changes

**`src/fabric_dw/exceptions.py`** — new `BadRequestError(FabricError)` for HTTP 400/other unmapped 4xx.

**`src/fabric_dw/http_client.py`** — `_map_status` now raises `BadRequestError` for any unmapped 4xx (400–499 excluding 401/403/404), surfacing the full Fabric error body (`errorCode`, `message`, `requestId`) on the exception.

**`src/fabric_dw/services/warehouses.py`**:
- Endpoint: `POST /workspaces/{id}/warehouses` (was `/workspaces/{id}/items`)
- Payload: no `"type"` field; collation key is `"collationType"` (was `"defaultCollation"`)
- Removed dead 4xx status-check (http_client now raises before that code runs)

**`src/fabric_dw/services/workspaces.py`** — `set_collation` now catches `BadRequestError` (in addition to `NotFoundError`) and surfaces the portal-link hint; removed dead post-response status check.

**`tests/unit/test_http_client.py`** — 5 new tests covering: 400 with JSON body surfaces `BadRequestError` with `body`/`status`/`request_id`, 400 with plain-text body (`body=None`), 422 raises `BadRequestError`, `x-ms-request-id` captured, 401 still raises `AuthError` (not `BadRequestError`).

**`tests/unit/services/test_warehouses.py`** — updated to use `_WAREHOUSES_URL` POST target, `collationType` assertion, `"type"` not in body, `BadRequestError` raised on 400.

## test_reset_pools FAILED

This failure (`reset_pools did not clear the configuration within 60s`) is **not a code bug**. The code is correct: `reset_pools` PATCHes an empty pool list and polls `get_configuration` for up to 60 seconds. The failure occurred because the Fabric beta SQL Pools API did not reflect the PATCH within the 60-second window (known eventual-consistency issue, tracked in issue #205). The test is already marked with a comment about this. No code change is needed; this was coincidental flakiness in the same failing run.

## What still needs a real integration CI run to confirm

- Whether the 400 was purely due to the wrong endpoint/payload (now fixed), or partly environmental (capacity quota). The improved error surfacing will show the Fabric `errorCode` on the next run, making this unambiguous.
- This PR does **not** claim the integration suite is fixed end-to-end — it claims the masking bug is fixed and the endpoint/payload bug is corrected. Add the `integration` label to trigger the label-gated suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)