### PR TITLE
fix(schemas): cascade on SQL endpoint drops views/procs/functions, skips tables only

### DIFF
--- a/src/fabric_dw/cli/commands/schemas.py
+++ b/src/fabric_dw/cli/commands/schemas.py
@@ -114,7 +114,9 @@ async def delete_cmd(
             if not confirm_destructive(prompt, yes=ctx.yes):
                 click.echo("Aborted.")
                 return
-            await _schemas_svc.delete_schema(target, name, cascade=cascade, mode=ctx.auth)
+            await _schemas_svc.delete_schema(
+                target, name, cascade=cascade, kind=entry.kind, mode=ctx.auth
+            )
             click.echo(f"Schema [{name}] dropped.")
     except (ValueError, FabricError) as exc:
         raise click.ClickException(str(exc)) from exc

--- a/src/fabric_dw/mcp/tools/schemas.py
+++ b/src/fabric_dw/mcp/tools/schemas.py
@@ -117,7 +117,9 @@ def register(mcp: FastMCP) -> None:
             assert_workspace_allowed(workspace, str(ws_id))
             _log.debug("delete_schema ws=%s item=%s name=%r", ws_id, entry.id, name)
             target = make_sql_target(ws_id, entry, item)
-            await schemas_svc.delete_schema(target, name, cascade=cascade, mode=ctx.auth_mode)
+            await schemas_svc.delete_schema(
+                target, name, cascade=cascade, kind=entry.kind, mode=ctx.auth_mode
+            )
         except (ValueError, FabricError) as exc:
             raise tool_err(exc) from exc
         return {"deleted": True}

--- a/src/fabric_dw/services/schemas.py
+++ b/src/fabric_dw/services/schemas.py
@@ -35,9 +35,9 @@ from __future__ import annotations
 import asyncio
 
 from fabric_dw.auth import CredentialMode
-from fabric_dw.exceptions import NotFoundError
+from fabric_dw.exceptions import ItemKindError, NotFoundError
 from fabric_dw.identifiers import quote_identifier, validate_identifier
-from fabric_dw.models import Schema
+from fabric_dw.models import Schema, WarehouseKind
 from fabric_dw.sql import SqlTarget, run_query, run_statements
 
 __all__ = [
@@ -46,6 +46,35 @@ __all__ = [
     "list_schemas",
     "validate_identifier",
 ]
+
+# ---------------------------------------------------------------------------
+# Guards
+# ---------------------------------------------------------------------------
+
+_CASCADE_SQL_ENDPOINT_MSG = (
+    "cascade=True is not supported on SQL Analytics Endpoints: "
+    "DROP TABLE is a Warehouse-only operation. "
+    "Use cascade=False to drop an empty schema, or target a Fabric Data Warehouse."
+)
+
+
+def _assert_cascade_not_sql_endpoint(kind: WarehouseKind, *, cascade: bool) -> None:
+    """Raise :class:`~fabric_dw.exceptions.ItemKindError` when *cascade* is ``True``
+    and the target is a SQL Analytics Endpoint.
+
+    Plain ``DROP SCHEMA`` (cascade=False) is allowed on endpoints.
+
+    Args:
+        kind: The :class:`~fabric_dw.models.WarehouseKind` of the resolved item.
+        cascade: Whether cascade drop was requested.
+
+    Raises:
+        ItemKindError: If *cascade* is ``True`` and *kind* is
+            :attr:`~fabric_dw.models.WarehouseKind.SQL_ENDPOINT`.
+    """
+    if cascade and kind == WarehouseKind.SQL_ENDPOINT:
+        raise ItemKindError(_CASCADE_SQL_ENDPOINT_MSG)
+
 
 # ---------------------------------------------------------------------------
 # SQL templates
@@ -198,6 +227,7 @@ async def delete_schema(
     name: str,
     *,
     cascade: bool = False,
+    kind: WarehouseKind = WarehouseKind.WAREHOUSE,
     mode: CredentialMode = CredentialMode.DEFAULT,
 ) -> None:
     """Drop a schema via ``DROP SCHEMA [<name>]``.
@@ -218,12 +248,19 @@ async def delete_schema(
         name: The schema name.  Must pass :func:`validate_identifier`.
         cascade: When ``True``, drop all tables and views in the schema
             before dropping the schema itself.  Defaults to ``False``.
+        kind: The :class:`~fabric_dw.models.WarehouseKind` of the item.
+            ``cascade=True`` is rejected for SQL Analytics Endpoints because
+            ``DROP TABLE`` is a Warehouse-only operation; ``cascade=False``
+            is still allowed on endpoints.
         mode: The credential mode for Entra authentication.
 
     Raises:
+        ItemKindError: If *cascade* is ``True`` and *kind* is
+            :attr:`~fabric_dw.models.WarehouseKind.SQL_ENDPOINT`.
         ValueError: If *name* fails identifier validation.
         PermissionDeniedError: If the driver reports a DROP SCHEMA permission error.
     """
+    _assert_cascade_not_sql_endpoint(kind, cascade=cascade)
     validate_identifier(name)
 
     if cascade:

--- a/src/fabric_dw/services/schemas.py
+++ b/src/fabric_dw/services/schemas.py
@@ -6,7 +6,8 @@ Public API
 - :func:`list_schemas`         — list all user-defined schemas via TDS ``sys.schemas``.
 - :func:`create_schema`        — ``CREATE SCHEMA [<name>]``.
 - :func:`delete_schema`        — ``DROP SCHEMA [<name>]``. Optionally cascade-drops
-                                  contained tables and views first.
+                                  contained objects (tables, views, procedures, functions)
+                                  first, with target-kind-aware filtering.
 
 List-source note
 ----------------
@@ -28,6 +29,19 @@ they are maintained by the engine and are not user-editable:
 
 ``dbo`` is **not** filtered because it is user-writable and is the default
 schema for warehouse tables.
+
+Cascade behaviour per target kind
+----------------------------------
+When ``cascade=True``:
+
+- **Fabric Data Warehouse** (``WarehouseKind.WAREHOUSE``): drops all contained
+  objects — tables (``U``), views (``V``), stored procedures (``P``), and
+  functions (``FN``/``IF``/``TF``) — before dropping the schema.
+- **SQL Analytics Endpoint** (``WarehouseKind.SQL_ENDPOINT``): drops views,
+  stored procedures, and functions, but **skips tables** because ``DROP TABLE``
+  is a Warehouse-only operation on Fabric.  The schema must therefore contain
+  no tables for the final ``DROP SCHEMA`` to succeed; if it does, the engine
+  will reject the ``DROP SCHEMA`` with a clear error.
 """
 
 from __future__ import annotations
@@ -35,7 +49,7 @@ from __future__ import annotations
 import asyncio
 
 from fabric_dw.auth import CredentialMode
-from fabric_dw.exceptions import ItemKindError, NotFoundError
+from fabric_dw.exceptions import NotFoundError
 from fabric_dw.identifiers import quote_identifier, validate_identifier
 from fabric_dw.models import Schema, WarehouseKind
 from fabric_dw.sql import SqlTarget, run_query, run_statements
@@ -46,35 +60,6 @@ __all__ = [
     "list_schemas",
     "validate_identifier",
 ]
-
-# ---------------------------------------------------------------------------
-# Guards
-# ---------------------------------------------------------------------------
-
-_CASCADE_SQL_ENDPOINT_MSG = (
-    "cascade=True is not supported on SQL Analytics Endpoints: "
-    "DROP TABLE is a Warehouse-only operation. "
-    "Use cascade=False to drop an empty schema, or target a Fabric Data Warehouse."
-)
-
-
-def _assert_cascade_not_sql_endpoint(kind: WarehouseKind, *, cascade: bool) -> None:
-    """Raise :class:`~fabric_dw.exceptions.ItemKindError` when *cascade* is ``True``
-    and the target is a SQL Analytics Endpoint.
-
-    Plain ``DROP SCHEMA`` (cascade=False) is allowed on endpoints.
-
-    Args:
-        kind: The :class:`~fabric_dw.models.WarehouseKind` of the resolved item.
-        cascade: Whether cascade drop was requested.
-
-    Raises:
-        ItemKindError: If *cascade* is ``True`` and *kind* is
-            :attr:`~fabric_dw.models.WarehouseKind.SQL_ENDPOINT`.
-    """
-    if cascade and kind == WarehouseKind.SQL_ENDPOINT:
-        raise ItemKindError(_CASCADE_SQL_ENDPOINT_MSG)
-
 
 # ---------------------------------------------------------------------------
 # SQL templates
@@ -119,23 +104,43 @@ WHERE s.name NOT IN ({_SYSTEM_SCHEMA_PLACEHOLDERS})
 ORDER BY s.name;
 """  # noqa: S608  # nosec B608 - placeholders are ? params; schema names in _SYSTEM_SCHEMA_PARAMS are hardcoded constants.
 
-_LIST_TABLES_IN_SCHEMA_SQL = """\
-SELECT t.name AS obj_name, 'TABLE' AS obj_type
-FROM sys.tables t
-JOIN sys.schemas s ON s.schema_id = t.schema_id
+# Enumerate all droppable user objects in a schema via sys.objects.
+# Object type codes:
+#   U  = USER_TABLE          (DROP TABLE)
+#   V  = VIEW                (DROP VIEW)
+#   P  = SQL_STORED_PROCEDURE (DROP PROCEDURE)
+#   FN = SQL_SCALAR_FUNCTION  (DROP FUNCTION)
+#   IF = SQL_INLINE_TABLE_VALUED_FUNCTION (DROP FUNCTION)
+#   TF = SQL_TABLE_VALUED_FUNCTION        (DROP FUNCTION)
+_LIST_OBJECTS_IN_SCHEMA_SQL = """\
+SELECT o.name AS obj_name, o.type AS obj_type
+FROM sys.objects o
+JOIN sys.schemas s ON s.schema_id = o.schema_id
 WHERE s.name = ?
-UNION ALL
-SELECT v.name AS obj_name, 'VIEW' AS obj_type
-FROM sys.views v
-JOIN sys.schemas s ON s.schema_id = v.schema_id
-WHERE s.name = ?;
-"""
+  AND o.type IN ('U', 'V', 'P', 'FN', 'IF', 'TF')
+ORDER BY o.type, o.name;
+"""  # nosec B608 - schema name is a ? param; type codes are hardcoded constants.
 
 _FETCH_SCHEMA_SQL = """\
 SELECT s.name, s.principal_id
 FROM sys.schemas s
 WHERE s.name = ?;
 """
+
+# Mapping from sys.objects type code to the DDL keyword used in DROP <keyword>.
+_TYPE_TO_DDL_KEYWORD: dict[str, str] = {
+    "U": "TABLE",
+    "V": "VIEW",
+    "P": "PROCEDURE",
+    "FN": "FUNCTION",
+    "IF": "FUNCTION",
+    "TF": "FUNCTION",
+}
+
+# Object types that are NOT droppable on a SQL Analytics Endpoint.
+# DROP TABLE is a Warehouse-only operation on Fabric; tables on an endpoint
+# are read-only projections of the underlying Lakehouse/Warehouse data.
+_ENDPOINT_EXCLUDED_TYPES: frozenset[str] = frozenset({"U"})
 
 
 # ---------------------------------------------------------------------------
@@ -232,39 +237,43 @@ async def delete_schema(
 ) -> None:
     """Drop a schema via ``DROP SCHEMA [<name>]``.
 
-    If *cascade* is ``True``, all tables and views contained in the schema
-    are dropped first via individual ``DROP TABLE`` / ``DROP VIEW`` statements,
-    then the schema itself is dropped.
+    If *cascade* is ``True``, all droppable objects contained in the schema
+    are dropped first, then the schema itself is dropped.  The set of objects
+    dropped depends on *kind*:
+
+    - **Warehouse**: drops tables (``U``), views (``V``), stored procedures
+      (``P``), and functions (``FN``/``IF``/``TF``).
+    - **SQL Analytics Endpoint**: drops views, stored procedures, and
+      functions, but **skips tables** because ``DROP TABLE`` is a
+      Warehouse-only operation on Fabric.  If the schema contains tables, the
+      final ``DROP SCHEMA`` will be rejected by the engine.
 
     .. caution::
 
-        When *cascade* is ``True``, **all tables and views in the schema are
-        permanently deleted along with their data**.  This operation is
-        irreversible.  Confirm with the user before calling this function with
-        ``cascade=True``.
+        When *cascade* is ``True``, **all droppable objects in the schema are
+        permanently deleted**.  This operation is irreversible.  Confirm with
+        the user before calling this function with ``cascade=True``.
 
     Args:
         target: The warehouse to connect to.
         name: The schema name.  Must pass :func:`validate_identifier`.
-        cascade: When ``True``, drop all tables and views in the schema
+        cascade: When ``True``, drop all droppable objects in the schema
             before dropping the schema itself.  Defaults to ``False``.
         kind: The :class:`~fabric_dw.models.WarehouseKind` of the item.
-            ``cascade=True`` is rejected for SQL Analytics Endpoints because
-            ``DROP TABLE`` is a Warehouse-only operation; ``cascade=False``
-            is still allowed on endpoints.
+            Controls which object types are dropped during cascade; tables
+            (type ``U``) are excluded on SQL Analytics Endpoints because
+            ``DROP TABLE`` is Warehouse-only.  Defaults to
+            :attr:`~fabric_dw.models.WarehouseKind.WAREHOUSE`.
         mode: The credential mode for Entra authentication.
 
     Raises:
-        ItemKindError: If *cascade* is ``True`` and *kind* is
-            :attr:`~fabric_dw.models.WarehouseKind.SQL_ENDPOINT`.
         ValueError: If *name* fails identifier validation.
         PermissionDeniedError: If the driver reports a DROP SCHEMA permission error.
     """
-    _assert_cascade_not_sql_endpoint(kind, cascade=cascade)
     validate_identifier(name)
 
     if cascade:
-        await _drop_schema_objects(target, name, mode=mode)
+        await _drop_schema_objects(target, name, kind=kind, mode=mode)
 
     ddl = f"DROP SCHEMA {quote_identifier(name)}"
 
@@ -321,56 +330,83 @@ async def _drop_schema_objects(
     target: SqlTarget,
     schema_name: str,
     *,
+    kind: WarehouseKind = WarehouseKind.WAREHOUSE,
     mode: CredentialMode = CredentialMode.DEFAULT,
 ) -> None:
-    """Drop all tables and views contained in *schema_name*.
+    """Drop droppable objects contained in *schema_name*, respecting *kind*.
 
-    Enumerates objects via ``sys.tables`` and ``sys.views`` then issues all
-    ``DROP TABLE`` / ``DROP VIEW`` DDL statements on a **single** connection,
-    avoiding the N x TCP+TLS handshake overhead of the previous approach.
+    Enumerates objects via ``sys.objects`` (types ``U``, ``V``, ``P``,
+    ``FN``, ``IF``, ``TF``) joined to ``sys.schemas``, then issues the
+    appropriate ``DROP`` statement for each object on a **single** connection.
 
-    This is a helper for :func:`delete_schema` when ``cascade=True``.
-    The schema name is assumed to have been validated by the caller.
+    Target-kind filtering
+    ~~~~~~~~~~~~~~~~~~~~~
+    - **Warehouse** (``WarehouseKind.WAREHOUSE``): all enumerated types are
+      dropped (``DROP TABLE``, ``DROP VIEW``, ``DROP PROCEDURE``,
+      ``DROP FUNCTION``).
+    - **SQL Analytics Endpoint** (``WarehouseKind.SQL_ENDPOINT``): objects of
+      type ``U`` (tables) are **excluded** because ``DROP TABLE`` is a
+      Warehouse-only operation on Fabric.  Views, stored procedures, and
+      functions are still dropped.  If the schema still contains tables after
+      this pass, the subsequent ``DROP SCHEMA`` issued by
+      :func:`delete_schema` will be rejected by the engine with a clear error
+      about remaining objects — this is intentional and acceptable.
 
     .. note::
 
-        **View-on-view dependency caveat**: objects are dropped in catalog order
-        (the order returned by ``sys.tables``/``sys.views``), without analysing
-        inter-object dependencies.  If the schema contains views that reference
-        other views in the same schema, the drop may fail with a dependency
-        error depending on the order in which the engine returns them.  In that
-        case, re-run the operation or drop the dependent views manually first.
+        **Object-dependency caveat**: objects are dropped in the order
+        returned by ``sys.objects`` (by type then name), without analysing
+        inter-object dependencies.  If the schema contains views or functions
+        that reference other views/functions in the same schema, the drop may
+        fail with a dependency error.  In that case, re-run the operation or
+        drop the dependent objects manually first.
 
     Args:
         target: The warehouse to connect to.
         schema_name: The schema whose objects will be dropped (already validated).
+        kind: The :class:`~fabric_dw.models.WarehouseKind` of the item.
+            Controls which object types are eligible for dropping.
         mode: The credential mode for Entra authentication.
     """
 
     def _run() -> list[tuple[str, str]]:
-        # Use schema_name twice: once for sys.tables, once for sys.views (UNION ALL).
         _cols, rows = run_query(
             target,
-            _LIST_TABLES_IN_SCHEMA_SQL,
-            params=[schema_name, schema_name],
+            _LIST_OBJECTS_IN_SCHEMA_SQL,
+            params=[schema_name],
             mode=mode,
         )
-        return [(str(r[0]), str(r[1])) for r in rows]
+        return [(str(r[0]), str(r[1]).strip()) for r in rows]
 
     objects = await asyncio.to_thread(_run)
 
     if not objects:
         return
 
+    # Determine which object types to exclude based on the target kind.
+    excluded_types: frozenset[str] = (
+        _ENDPOINT_EXCLUDED_TYPES if kind == WarehouseKind.SQL_ENDPOINT else frozenset()
+    )
+
     # Build all DROP statements then execute them on ONE connection.
     ddl_statements: list[str] = []
     for obj_name, obj_type in objects:
-        # Object names come from sys.tables/sys.views — catalog names.
+        if obj_type in excluded_types:
+            # Skip objects that cannot be dropped on this target kind.
+            # e.g. tables (U) on SQL Analytics Endpoints.
+            continue
+        ddl_keyword = _TYPE_TO_DDL_KEYWORD.get(obj_type)
+        if ddl_keyword is None:
+            # Unknown type — skip rather than generate invalid SQL.
+            continue
+        # Object names come from sys.objects — catalog names.
         # Validate anyway to be defensive (belt-and-suspenders).
         validate_identifier(obj_name)
-        ddl_keyword = "TABLE" if obj_type == "TABLE" else "VIEW"
         ddl_statements.append(
             f"DROP {ddl_keyword} {quote_identifier(schema_name)}.{quote_identifier(obj_name)}"
         )
+
+    if not ddl_statements:
+        return
 
     await asyncio.to_thread(run_statements, target, ddl_statements, mode=mode)

--- a/tests/unit/cli/commands/test_schemas.py
+++ b/tests/unit/cli/commands/test_schemas.py
@@ -491,3 +491,29 @@ class TestSchemasDelete:
             runner.invoke(cli, ["-y", "schemas", "delete", WS_GUID, WH_GUID, "sales"])
         _, kwargs = mock_delete.call_args
         assert kwargs.get("kind") == WarehouseKind.WAREHOUSE
+
+    def test_delete_passes_sql_endpoint_kind_to_service(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """delete_cmd must forward kind=SQL_ENDPOINT when the entry is a SQL Analytics Endpoint.
+
+        Without this test, a bug that always passed kind=WAREHOUSE would not be caught
+        by the Warehouse-only test above.
+        """
+        _ = cache_env
+        mock_http = AsyncMock()
+        mock_delete = AsyncMock(return_value=None)
+        with (
+            patch(
+                "fabric_dw.cli.commands.schemas.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.schemas.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_sql_endpoint_entry())),
+            ),
+            patch("fabric_dw.services.schemas.delete_schema", new=mock_delete),
+        ):
+            runner.invoke(cli, ["-y", "schemas", "delete", WS_GUID, WH_GUID, "sales"])
+        _, kwargs = mock_delete.call_args
+        assert kwargs.get("kind") == WarehouseKind.SQL_ENDPOINT

--- a/tests/unit/cli/commands/test_schemas.py
+++ b/tests/unit/cli/commands/test_schemas.py
@@ -15,7 +15,7 @@ from click.testing import CliRunner
 
 from fabric_dw.cache import ItemEntry
 from fabric_dw.cli._main import cli
-from fabric_dw.exceptions import ItemKindError, NotFoundError, PermissionDeniedError
+from fabric_dw.exceptions import NotFoundError, PermissionDeniedError
 from fabric_dw.models import Schema, WarehouseKind
 from fabric_dw.sql import SqlTarget
 
@@ -423,10 +423,8 @@ class TestSchemasDelete:
             result = runner.invoke(cli, ["-y", "schemas", "delete", WS_GUID, WH_GUID, "sales"])
         assert result.exit_code != 0
 
-    def test_delete_cascade_sql_endpoint_returns_nonzero(
-        self, runner: CliRunner, cache_env: Path
-    ) -> None:
-        """--cascade on a SQL Analytics Endpoint must be rejected (ItemKindError → nonzero)."""
+    def test_delete_cascade_sql_endpoint_succeeds(self, runner: CliRunner, cache_env: Path) -> None:
+        """--cascade on a SQL Analytics Endpoint must SUCCEED (tables excluded, others dropped)."""
         _ = cache_env
         mock_http = AsyncMock()
         with (
@@ -440,19 +438,15 @@ class TestSchemasDelete:
             ),
             patch(
                 "fabric_dw.services.schemas.delete_schema",
-                new=AsyncMock(
-                    side_effect=ItemKindError(
-                        "cascade=True is not supported on SQL Analytics Endpoints"
-                    )
-                ),
+                new=AsyncMock(return_value=None),
             ),
         ):
             result = runner.invoke(
                 cli,
                 ["-y", "schemas", "delete", WS_GUID, WH_GUID, "sales", "--cascade"],
             )
-        assert result.exit_code != 0
-        assert "cascade" in result.output.lower() or "cascade" in (result.output or "").lower()
+        assert result.exit_code == 0
+        assert "dropped" in result.output
 
     def test_delete_no_cascade_sql_endpoint_succeeds(
         self, runner: CliRunner, cache_env: Path

--- a/tests/unit/cli/commands/test_schemas.py
+++ b/tests/unit/cli/commands/test_schemas.py
@@ -15,7 +15,7 @@ from click.testing import CliRunner
 
 from fabric_dw.cache import ItemEntry
 from fabric_dw.cli._main import cli
-from fabric_dw.exceptions import NotFoundError, PermissionDeniedError
+from fabric_dw.exceptions import ItemKindError, NotFoundError, PermissionDeniedError
 from fabric_dw.models import Schema, WarehouseKind
 from fabric_dw.sql import SqlTarget
 
@@ -422,3 +422,78 @@ class TestSchemasDelete:
         ):
             result = runner.invoke(cli, ["-y", "schemas", "delete", WS_GUID, WH_GUID, "sales"])
         assert result.exit_code != 0
+
+    def test_delete_cascade_sql_endpoint_returns_nonzero(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """--cascade on a SQL Analytics Endpoint must be rejected (ItemKindError → nonzero)."""
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.schemas.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.schemas.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_sql_endpoint_entry())),
+            ),
+            patch(
+                "fabric_dw.services.schemas.delete_schema",
+                new=AsyncMock(
+                    side_effect=ItemKindError(
+                        "cascade=True is not supported on SQL Analytics Endpoints"
+                    )
+                ),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                ["-y", "schemas", "delete", WS_GUID, WH_GUID, "sales", "--cascade"],
+            )
+        assert result.exit_code != 0
+        assert "cascade" in result.output.lower() or "cascade" in (result.output or "").lower()
+
+    def test_delete_no_cascade_sql_endpoint_succeeds(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """DROP SCHEMA without cascade on a SQL Analytics Endpoint must succeed."""
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.schemas.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.schemas.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_sql_endpoint_entry())),
+            ),
+            patch(
+                "fabric_dw.services.schemas.delete_schema",
+                new=AsyncMock(return_value=None),
+            ),
+        ):
+            result = runner.invoke(cli, ["-y", "schemas", "delete", WS_GUID, WH_GUID, "sales"])
+        assert result.exit_code == 0
+        assert "dropped" in result.output
+
+    def test_delete_passes_kind_to_service(self, runner: CliRunner, cache_env: Path) -> None:
+        """delete_cmd must pass entry.kind to the service."""
+        _ = cache_env
+        mock_http = AsyncMock()
+        mock_delete = AsyncMock(return_value=None)
+        with (
+            patch(
+                "fabric_dw.cli.commands.schemas.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.schemas.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch("fabric_dw.services.schemas.delete_schema", new=mock_delete),
+        ):
+            runner.invoke(cli, ["-y", "schemas", "delete", WS_GUID, WH_GUID, "sales"])
+        _, kwargs = mock_delete.call_args
+        assert kwargs.get("kind") == WarehouseKind.WAREHOUSE

--- a/tests/unit/mcp/test_server.py
+++ b/tests/unit/mcp/test_server.py
@@ -1327,6 +1327,33 @@ async def test_delete_schema_passes_kind_to_service(mock_ctx, ctx_patch) -> None
     assert kwargs.get("kind") == WarehouseKind.WAREHOUSE
 
 
+async def test_delete_schema_passes_sql_endpoint_kind_to_service(mock_ctx, ctx_patch) -> None:
+    """delete_schema must forward kind=SQL_ENDPOINT when the entry is a SQL Analytics Endpoint.
+
+    Without this test, a bug that always passed kind=WAREHOUSE would not be caught
+    by the Warehouse-only test above.
+    """
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = _make_sql_endpoint_entry()  # SQL_ENDPOINT kind
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+    mock_delete = AsyncMock(return_value=None)
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_ALLOW_DESTRUCTIVE": "1"}),
+        patch("fabric_dw.services.schemas.delete_schema", new=mock_delete),
+    ):
+        await mcp._tool_manager.call_tool(
+            "delete_schema",
+            {"workspace": _WS_NAME, "item": "MySqlEndpoint", "name": "myschema"},
+        )
+
+    _, kwargs = mock_delete.call_args
+    assert kwargs.get("kind") == WarehouseKind.SQL_ENDPOINT
+
+
 async def test_read_view_happy_path(mock_ctx, ctx_patch) -> None:
     """read_view calls views_svc.read_view and returns {columns, rows}."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415

--- a/tests/unit/mcp/test_server.py
+++ b/tests/unit/mcp/test_server.py
@@ -1244,6 +1244,95 @@ async def test_list_schemas_works_on_sql_endpoint(mock_ctx, ctx_patch) -> None:
     assert result[0]["name"] == "dbo"
 
 
+async def test_delete_schema_cascade_sql_endpoint_raises_tool_error(mock_ctx, ctx_patch) -> None:
+    """delete_schema with cascade=True on a SQL Analytics Endpoint must raise ToolError.
+
+    DROP TABLE is Warehouse-only; the service raises ItemKindError which the MCP
+    tool converts to a ToolError via tool_err().
+    """
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.exceptions import ItemKindError  # noqa: PLC0415
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    ep_entry = _make_sql_endpoint_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=ep_entry)
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_ALLOW_DESTRUCTIVE": "1"}),
+        patch(
+            "fabric_dw.services.schemas.delete_schema",
+            new=AsyncMock(
+                side_effect=ItemKindError(
+                    "cascade=True is not supported on SQL Analytics Endpoints"
+                )
+            ),
+        ),
+        pytest.raises(ToolError, match="cascade=True is not supported"),
+    ):
+        await mcp._tool_manager.call_tool(
+            "delete_schema",
+            {"workspace": _WS_NAME, "item": "MySqlEndpoint", "name": "oldschema", "cascade": True},
+        )
+
+
+async def test_delete_schema_no_cascade_sql_endpoint_succeeds(mock_ctx, ctx_patch) -> None:
+    """delete_schema with cascade=False on a SQL Analytics Endpoint must succeed.
+
+    DROP SCHEMA (without cascade) is valid on endpoints.
+    """
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    ep_entry = _make_sql_endpoint_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=ep_entry)
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_ALLOW_DESTRUCTIVE": "1"}),
+        patch(
+            "fabric_dw.services.schemas.delete_schema",
+            new=AsyncMock(return_value=None),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "delete_schema",
+            {
+                "workspace": _WS_NAME,
+                "item": "MySqlEndpoint",
+                "name": "oldschema",
+                "cascade": False,
+            },
+        )
+
+    assert result == {"deleted": True}
+
+
+async def test_delete_schema_passes_kind_to_service(mock_ctx, ctx_patch) -> None:
+    """delete_schema must forward entry.kind to the service layer."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = _make_item_entry()  # WAREHOUSE kind
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+    mock_delete = AsyncMock(return_value=None)
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_ALLOW_DESTRUCTIVE": "1"}),
+        patch("fabric_dw.services.schemas.delete_schema", new=mock_delete),
+    ):
+        await mcp._tool_manager.call_tool(
+            "delete_schema",
+            {"workspace": _WS_NAME, "item": _WH_NAME, "name": "myschema"},
+        )
+
+    _, kwargs = mock_delete.call_args
+    assert kwargs.get("kind") == WarehouseKind.WAREHOUSE
+
+
 async def test_read_view_happy_path(mock_ctx, ctx_patch) -> None:
     """read_view calls views_svc.read_view and returns {columns, rows}."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415

--- a/tests/unit/mcp/test_server.py
+++ b/tests/unit/mcp/test_server.py
@@ -1244,15 +1244,12 @@ async def test_list_schemas_works_on_sql_endpoint(mock_ctx, ctx_patch) -> None:
     assert result[0]["name"] == "dbo"
 
 
-async def test_delete_schema_cascade_sql_endpoint_raises_tool_error(mock_ctx, ctx_patch) -> None:
-    """delete_schema with cascade=True on a SQL Analytics Endpoint must raise ToolError.
+async def test_delete_schema_cascade_sql_endpoint_succeeds(mock_ctx, ctx_patch) -> None:
+    """delete_schema with cascade=True on a SQL Analytics Endpoint must SUCCEED.
 
-    DROP TABLE is Warehouse-only; the service raises ItemKindError which the MCP
-    tool converts to a ToolError via tool_err().
+    The service drops views/procedures/functions and skips tables (Warehouse-only).
+    No error is raised at the MCP layer.
     """
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
-
-    from fabric_dw.exceptions import ItemKindError  # noqa: PLC0415
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
     ep_entry = _make_sql_endpoint_entry()
@@ -1264,18 +1261,15 @@ async def test_delete_schema_cascade_sql_endpoint_raises_tool_error(mock_ctx, ct
         patch.dict(os.environ, {"FABRIC_MCP_ALLOW_DESTRUCTIVE": "1"}),
         patch(
             "fabric_dw.services.schemas.delete_schema",
-            new=AsyncMock(
-                side_effect=ItemKindError(
-                    "cascade=True is not supported on SQL Analytics Endpoints"
-                )
-            ),
+            new=AsyncMock(return_value=None),
         ),
-        pytest.raises(ToolError, match="cascade=True is not supported"),
     ):
-        await mcp._tool_manager.call_tool(
+        result = await mcp._tool_manager.call_tool(
             "delete_schema",
             {"workspace": _WS_NAME, "item": "MySqlEndpoint", "name": "oldschema", "cascade": True},
         )
+
+    assert result == {"deleted": True}
 
 
 async def test_delete_schema_no_cascade_sql_endpoint_succeeds(mock_ctx, ctx_patch) -> None:

--- a/tests/unit/services/test_schemas.py
+++ b/tests/unit/services/test_schemas.py
@@ -6,8 +6,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from fabric_dw.exceptions import AuthError, NotFoundError, PermissionDeniedError
-from fabric_dw.models import Schema
+from fabric_dw.exceptions import AuthError, ItemKindError, NotFoundError, PermissionDeniedError
+from fabric_dw.models import Schema, WarehouseKind
 from fabric_dw.services import schemas
 from fabric_dw.services.schemas import validate_identifier
 
@@ -449,3 +449,73 @@ class TestDeleteSchemaCascade:
         drop_sql: str = cursor.execute.call_args[0][0]
         assert "[sales]" in drop_sql
         assert "[my_table]" in drop_sql
+
+
+# ===========================================================================
+# delete_schema — SQL Analytics Endpoint cascade guard
+# ===========================================================================
+
+
+class TestDeleteSchemaCascadeEndpointGuard:
+    async def test_cascade_true_on_sql_endpoint_raises_item_kind_error(self) -> None:
+        """cascade=True on a SQL Analytics Endpoint must raise ItemKindError
+        before any SQL is executed (DROP TABLE is Warehouse-only)."""
+        target = _make_target()
+        with (
+            patch("fabric_dw.sql.open_connection") as mock_open,
+            pytest.raises(ItemKindError, match="cascade=True is not supported"),
+        ):
+            await schemas.delete_schema(
+                target, "sales", cascade=True, kind=WarehouseKind.SQL_ENDPOINT
+            )
+        # Guard fires before any connection is opened.
+        mock_open.assert_not_called()
+
+    async def test_cascade_true_error_message_mentions_warehouse(self) -> None:
+        """The error message should suggest using a Warehouse or cascade=False."""
+        target = _make_target()
+        with pytest.raises(ItemKindError, match="Fabric Data Warehouse"):
+            await schemas.delete_schema(
+                target, "sales", cascade=True, kind=WarehouseKind.SQL_ENDPOINT
+            )
+
+    async def test_cascade_false_on_sql_endpoint_is_allowed(self) -> None:
+        """DROP SCHEMA without cascade must succeed on a SQL Analytics Endpoint."""
+        target = _make_target()
+        conn = _make_conn_for_ddl()
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            # Must not raise
+            await schemas.delete_schema(
+                target, "sales", cascade=False, kind=WarehouseKind.SQL_ENDPOINT
+            )
+        cursor = conn.cursor.return_value
+        drop_sql: str = cursor.execute.call_args[0][0].upper()
+        assert "DROP SCHEMA" in drop_sql
+
+    async def test_cascade_true_on_warehouse_is_allowed(self) -> None:
+        """cascade=True on a Warehouse must proceed normally (no guard)."""
+        target = _make_target()
+        list_conn = _make_conn([("orders", "TABLE")], ["obj_name", "obj_type"])
+        drop_objects_conn = _make_conn_for_ddl()
+        drop_schema_conn = _make_conn_for_ddl()
+        with patch(
+            "fabric_dw.sql.open_connection",
+            side_effect=[list_conn, drop_objects_conn, drop_schema_conn],
+        ):
+            # Must not raise
+            await schemas.delete_schema(target, "sales", cascade=True, kind=WarehouseKind.WAREHOUSE)
+        cursor = drop_objects_conn.cursor.return_value
+        drop_sql: str = cursor.execute.call_args[0][0].upper()
+        assert "DROP TABLE" in drop_sql
+
+    async def test_cascade_true_default_kind_is_warehouse(self) -> None:
+        """Default kind=WAREHOUSE means cascade=True works without passing kind."""
+        target = _make_target()
+        list_conn = _make_conn([], ["obj_name", "obj_type"])
+        drop_schema_conn = _make_conn_for_ddl()
+        with patch(
+            "fabric_dw.sql.open_connection",
+            side_effect=[list_conn, drop_schema_conn],
+        ):
+            # Must not raise (kind defaults to WAREHOUSE)
+            await schemas.delete_schema(target, "empty_schema", cascade=True)

--- a/tests/unit/services/test_schemas.py
+++ b/tests/unit/services/test_schemas.py
@@ -397,10 +397,15 @@ class TestDeleteSchemaCascade:
         drop_sql: str = cursor.execute.call_args[0][0].upper()
         assert "DROP PROCEDURE" in drop_sql
 
-    async def test_cascade_drops_function_then_schema(self) -> None:
-        """cascade=True on WAREHOUSE: DROP FUNCTION for scalar functions (type FN)."""
+    @pytest.mark.parametrize("fn_type", ["FN", "IF", "TF"])
+    async def test_cascade_drops_function_for_all_function_types(self, fn_type: str) -> None:
+        """cascade=True on WAREHOUSE: DROP FUNCTION for all function type codes (FN/IF/TF).
+
+        Removing any of the three _TYPE_TO_DDL_KEYWORD entries for function types
+        would cause this parametrised test to fail for that type code.
+        """
         target = _make_target()
-        list_conn = _make_conn([("fn_calc", "FN")], _OBJ_COLS)
+        list_conn = _make_conn([("fn_calc", fn_type)], _OBJ_COLS)
         drop_objects_conn = _make_conn_for_ddl()
         drop_schema_conn = _make_conn_for_ddl()
         with patch(
@@ -549,10 +554,17 @@ class TestDeleteSchemaCascadeEndpoint:
         drop_sql: str = cursor.execute.call_args[0][0].upper()
         assert "DROP PROCEDURE" in drop_sql
 
-    async def test_cascade_endpoint_drops_function(self) -> None:
-        """cascade=True on SQL_ENDPOINT: functions (FN/IF/TF) ARE dropped."""
+    @pytest.mark.parametrize("fn_type", ["FN", "IF", "TF"])
+    async def test_cascade_endpoint_drops_function_for_all_function_types(
+        self, fn_type: str
+    ) -> None:
+        """cascade=True on SQL_ENDPOINT: DROP FUNCTION for all function type codes (FN/IF/TF).
+
+        Removing any of the three _TYPE_TO_DDL_KEYWORD entries for function types
+        would cause this parametrised test to fail for that type code.
+        """
         target = _make_target()
-        list_conn = _make_conn([("fn_calc", "FN")], _OBJ_COLS)
+        list_conn = _make_conn([("fn_calc", fn_type)], _OBJ_COLS)
         drop_objects_conn = _make_conn_for_ddl()
         drop_schema_conn = _make_conn_for_ddl()
         with patch(
@@ -657,3 +669,26 @@ class TestDeleteSchemaCascadeEndpoint:
         assert any("DROP VIEW" in s for s in sqls)
         assert any("DROP PROCEDURE" in s for s in sqls)
         assert any("DROP FUNCTION" in s for s in sqls)
+
+    async def test_cascade_endpoint_space_padded_type_code_excluded(self) -> None:
+        """sys.objects.type is char(2); single-char codes are right-padded (e.g. 'U ').
+
+        The .strip() call in _drop_schema_objects must handle this so that 'U ' is
+        still recognised as a table and excluded on a SQL Analytics Endpoint.
+        Removing .strip() would cause the padded code to bypass the exclusion check
+        and generate a DROP TABLE statement — this test would then catch it.
+        """
+        target = _make_target()
+        # Simulate driver returning space-padded char(2) type code for a table
+        list_conn = _make_conn([("orders", "U ")], _OBJ_COLS)
+        drop_schema_conn = _make_conn_for_ddl()
+        with patch(
+            "fabric_dw.sql.open_connection",
+            side_effect=[list_conn, drop_schema_conn],
+        ) as mock_open:
+            await schemas.delete_schema(
+                target, "sales", cascade=True, kind=WarehouseKind.SQL_ENDPOINT
+            )
+        # 'U ' must be stripped → table excluded → no object-drop connection opened.
+        # Connection count: list (1) + DROP SCHEMA (2) = 2.
+        assert mock_open.call_count == 2

--- a/tests/unit/services/test_schemas.py
+++ b/tests/unit/services/test_schemas.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from fabric_dw.exceptions import AuthError, ItemKindError, NotFoundError, PermissionDeniedError
+from fabric_dw.exceptions import AuthError, NotFoundError, PermissionDeniedError
 from fabric_dw.models import Schema, WarehouseKind
 from fabric_dw.services import schemas
 from fabric_dw.services.schemas import validate_identifier
@@ -46,6 +46,9 @@ _LIST_COLS = ["name", "principal_id"]
 _SCHEMA_ROW_1: tuple[object, ...] = ("dbo", 1)
 _SCHEMA_ROW_2: tuple[object, ...] = ("sales", 5)
 _SCHEMA_ROW_SYS: tuple[object, ...] = ("sys", 4)
+
+# Object rows for cascade tests: (obj_name, obj_type)
+_OBJ_COLS = ["obj_name", "obj_type"]
 
 
 # ===========================================================================
@@ -344,17 +347,15 @@ class TestDeleteSchema:
 
 
 # ===========================================================================
-# delete_schema — cascade
+# delete_schema — cascade (Warehouse: all types)
 # ===========================================================================
 
 
 class TestDeleteSchemaCascade:
     async def test_cascade_drops_table_then_schema(self) -> None:
-        """cascade=True: list → run_statements (DROP TABLE) → DROP SCHEMA.
-        run_statements uses a single connection for all object drops."""
+        """cascade=True on WAREHOUSE: list → run_statements (DROP TABLE) → DROP SCHEMA."""
         target = _make_target()
-        list_conn = _make_conn([("orders", "TABLE")], ["obj_name", "obj_type"])
-        # run_statements uses ONE connection for all object drops
+        list_conn = _make_conn([("orders", "U")], _OBJ_COLS)
         drop_objects_conn = _make_conn_for_ddl()
         drop_schema_conn = _make_conn_for_ddl()
         with patch(
@@ -362,15 +363,14 @@ class TestDeleteSchemaCascade:
             side_effect=[list_conn, drop_objects_conn, drop_schema_conn],
         ):
             await schemas.delete_schema(target, "sales", cascade=True)
-        # drop_objects_conn handles all object drops (here just one table)
         cursor = drop_objects_conn.cursor.return_value
         drop_sql: str = cursor.execute.call_args[0][0].upper()
         assert "DROP TABLE" in drop_sql
 
     async def test_cascade_drops_view_then_schema(self) -> None:
-        """cascade=True: list → run_statements (DROP VIEW) → DROP SCHEMA."""
+        """cascade=True on WAREHOUSE: list → run_statements (DROP VIEW) → DROP SCHEMA."""
         target = _make_target()
-        list_conn = _make_conn([("vw_orders", "VIEW")], ["obj_name", "obj_type"])
+        list_conn = _make_conn([("vw_orders", "V")], _OBJ_COLS)
         drop_objects_conn = _make_conn_for_ddl()
         drop_schema_conn = _make_conn_for_ddl()
         with patch(
@@ -382,17 +382,49 @@ class TestDeleteSchemaCascade:
         drop_sql: str = cursor.execute.call_args[0][0].upper()
         assert "DROP VIEW" in drop_sql
 
+    async def test_cascade_drops_procedure_then_schema(self) -> None:
+        """cascade=True on WAREHOUSE: DROP PROCEDURE for stored procs (type P)."""
+        target = _make_target()
+        list_conn = _make_conn([("usp_load", "P")], _OBJ_COLS)
+        drop_objects_conn = _make_conn_for_ddl()
+        drop_schema_conn = _make_conn_for_ddl()
+        with patch(
+            "fabric_dw.sql.open_connection",
+            side_effect=[list_conn, drop_objects_conn, drop_schema_conn],
+        ):
+            await schemas.delete_schema(target, "sales", cascade=True)
+        cursor = drop_objects_conn.cursor.return_value
+        drop_sql: str = cursor.execute.call_args[0][0].upper()
+        assert "DROP PROCEDURE" in drop_sql
+
+    async def test_cascade_drops_function_then_schema(self) -> None:
+        """cascade=True on WAREHOUSE: DROP FUNCTION for scalar functions (type FN)."""
+        target = _make_target()
+        list_conn = _make_conn([("fn_calc", "FN")], _OBJ_COLS)
+        drop_objects_conn = _make_conn_for_ddl()
+        drop_schema_conn = _make_conn_for_ddl()
+        with patch(
+            "fabric_dw.sql.open_connection",
+            side_effect=[list_conn, drop_objects_conn, drop_schema_conn],
+        ):
+            await schemas.delete_schema(target, "sales", cascade=True)
+        cursor = drop_objects_conn.cursor.return_value
+        drop_sql: str = cursor.execute.call_args[0][0].upper()
+        assert "DROP FUNCTION" in drop_sql
+
     async def test_cascade_drops_multiple_objects(self) -> None:
-        """Multiple objects (t1 TABLE, v1 VIEW) are dropped on ONE connection.
+        """Multiple objects (table + view + proc + function) all dropped on ONE connection.
 
         Connection count:
         - 1: list objects (run_query)
         - 2: ALL DROP statements (run_statements — single connection)
         - 3: DROP SCHEMA (run_query)
-        Total: 3 (not 4 as with the old per-statement approach).
+        Total: 3.
         """
         target = _make_target()
-        list_conn = _make_conn([("t1", "TABLE"), ("v1", "VIEW")], ["obj_name", "obj_type"])
+        list_conn = _make_conn(
+            [("t1", "U"), ("v1", "V"), ("usp_p", "P"), ("fn_f", "FN")], _OBJ_COLS
+        )
         drop_objects_conn = _make_conn_for_ddl()
         drop_schema_conn = _make_conn_for_ddl()
         with patch(
@@ -402,28 +434,30 @@ class TestDeleteSchemaCascade:
             await schemas.delete_schema(target, "sales", cascade=True)
         # 3 connections total: list + all-object-drops + schema-drop
         assert mock_open.call_count == 3
-        # Both DROP statements were executed on the single drop_objects_conn cursor
         cursor = drop_objects_conn.cursor.return_value
-        assert cursor.execute.call_count == 2
+        assert cursor.execute.call_count == 4
         sqls = [str(c[0][0]).upper() for c in cursor.execute.call_args_list]
         assert any("DROP TABLE" in s and "[T1]" in s for s in sqls)
         assert any("DROP VIEW" in s and "[V1]" in s for s in sqls)
+        assert any("DROP PROCEDURE" in s and "[USP_P]" in s for s in sqls)
+        assert any("DROP FUNCTION" in s and "[FN_F]" in s for s in sqls)
 
     async def test_cascade_false_does_not_enumerate_objects(self) -> None:
+        """cascade=False must not enumerate or drop any objects."""
         target = _make_target()
         drop_schema_conn = _make_conn_for_ddl()
         with patch(
             "fabric_dw.sql.open_connection",
             side_effect=[drop_schema_conn],
-        ):
+        ) as mock_open:
             await schemas.delete_schema(target, "sales", cascade=False)
         # Only one connection opened (the DROP SCHEMA itself)
-        assert True
+        assert mock_open.call_count == 1
 
     async def test_cascade_empty_schema_drops_schema(self) -> None:
         """When schema has no objects, skip run_statements and only DROP SCHEMA."""
         target = _make_target()
-        list_conn = _make_conn([], ["obj_name", "obj_type"])
+        list_conn = _make_conn([], _OBJ_COLS)
         drop_schema_conn = _make_conn_for_ddl()
         with patch(
             "fabric_dw.sql.open_connection",
@@ -437,7 +471,7 @@ class TestDeleteSchemaCascade:
     async def test_cascade_uses_bracket_quoting_for_objects(self) -> None:
         """Object DROP statements must use bracket-quoted names."""
         target = _make_target()
-        list_conn = _make_conn([("my_table", "TABLE")], ["obj_name", "obj_type"])
+        list_conn = _make_conn([("my_table", "U")], _OBJ_COLS)
         drop_objects_conn = _make_conn_for_ddl()
         drop_schema_conn = _make_conn_for_ddl()
         with patch(
@@ -450,33 +484,144 @@ class TestDeleteSchemaCascade:
         assert "[sales]" in drop_sql
         assert "[my_table]" in drop_sql
 
-
-# ===========================================================================
-# delete_schema — SQL Analytics Endpoint cascade guard
-# ===========================================================================
-
-
-class TestDeleteSchemaCascadeEndpointGuard:
-    async def test_cascade_true_on_sql_endpoint_raises_item_kind_error(self) -> None:
-        """cascade=True on a SQL Analytics Endpoint must raise ItemKindError
-        before any SQL is executed (DROP TABLE is Warehouse-only)."""
+    async def test_cascade_default_kind_is_warehouse(self) -> None:
+        """Default kind=WAREHOUSE means cascade=True drops tables without passing kind."""
         target = _make_target()
-        with (
-            patch("fabric_dw.sql.open_connection") as mock_open,
-            pytest.raises(ItemKindError, match="cascade=True is not supported"),
+        list_conn = _make_conn([("t1", "U")], _OBJ_COLS)
+        drop_objects_conn = _make_conn_for_ddl()
+        drop_schema_conn = _make_conn_for_ddl()
+        with patch(
+            "fabric_dw.sql.open_connection",
+            side_effect=[list_conn, drop_objects_conn, drop_schema_conn],
+        ):
+            # kind defaults to WAREHOUSE — must drop the table
+            await schemas.delete_schema(target, "sales", cascade=True)
+        cursor = drop_objects_conn.cursor.return_value
+        drop_sql: str = cursor.execute.call_args[0][0].upper()
+        assert "DROP TABLE" in drop_sql
+
+
+# ===========================================================================
+# delete_schema — cascade on SQL Analytics Endpoint (tables excluded)
+# ===========================================================================
+
+
+class TestDeleteSchemaCascadeEndpoint:
+    async def test_cascade_endpoint_drops_view_not_table(self) -> None:
+        """cascade=True on SQL_ENDPOINT: views ARE dropped, tables are NOT.
+
+        Mock returns a mix of a table and a view.  Only DROP VIEW must be issued.
+        """
+        target = _make_target()
+        # Schema contains one table and one view
+        list_conn = _make_conn([("orders", "U"), ("vw_orders", "V")], _OBJ_COLS)
+        drop_objects_conn = _make_conn_for_ddl()
+        drop_schema_conn = _make_conn_for_ddl()
+        with patch(
+            "fabric_dw.sql.open_connection",
+            side_effect=[list_conn, drop_objects_conn, drop_schema_conn],
+        ):
+            # Must not raise — cascade on endpoint is allowed
+            await schemas.delete_schema(
+                target, "sales", cascade=True, kind=WarehouseKind.SQL_ENDPOINT
+            )
+        cursor = drop_objects_conn.cursor.return_value
+        sqls = [str(c[0][0]).upper() for c in cursor.execute.call_args_list]
+        # VIEW must be dropped
+        assert any("DROP VIEW" in s for s in sqls)
+        # TABLE must NOT be dropped
+        assert not any("DROP TABLE" in s for s in sqls)
+
+    async def test_cascade_endpoint_drops_procedure(self) -> None:
+        """cascade=True on SQL_ENDPOINT: stored procedures ARE dropped."""
+        target = _make_target()
+        list_conn = _make_conn([("usp_load", "P")], _OBJ_COLS)
+        drop_objects_conn = _make_conn_for_ddl()
+        drop_schema_conn = _make_conn_for_ddl()
+        with patch(
+            "fabric_dw.sql.open_connection",
+            side_effect=[list_conn, drop_objects_conn, drop_schema_conn],
         ):
             await schemas.delete_schema(
                 target, "sales", cascade=True, kind=WarehouseKind.SQL_ENDPOINT
             )
-        # Guard fires before any connection is opened.
-        mock_open.assert_not_called()
+        cursor = drop_objects_conn.cursor.return_value
+        drop_sql: str = cursor.execute.call_args[0][0].upper()
+        assert "DROP PROCEDURE" in drop_sql
 
-    async def test_cascade_true_error_message_mentions_warehouse(self) -> None:
-        """The error message should suggest using a Warehouse or cascade=False."""
+    async def test_cascade_endpoint_drops_function(self) -> None:
+        """cascade=True on SQL_ENDPOINT: functions (FN/IF/TF) ARE dropped."""
         target = _make_target()
-        with pytest.raises(ItemKindError, match="Fabric Data Warehouse"):
+        list_conn = _make_conn([("fn_calc", "FN")], _OBJ_COLS)
+        drop_objects_conn = _make_conn_for_ddl()
+        drop_schema_conn = _make_conn_for_ddl()
+        with patch(
+            "fabric_dw.sql.open_connection",
+            side_effect=[list_conn, drop_objects_conn, drop_schema_conn],
+        ):
             await schemas.delete_schema(
                 target, "sales", cascade=True, kind=WarehouseKind.SQL_ENDPOINT
+            )
+        cursor = drop_objects_conn.cursor.return_value
+        drop_sql: str = cursor.execute.call_args[0][0].upper()
+        assert "DROP FUNCTION" in drop_sql
+
+    async def test_cascade_endpoint_only_tables_skips_object_drop_connection(self) -> None:
+        """If schema only has tables on an endpoint, no object-drop connection is opened.
+
+        All tables are excluded → ddl_statements is empty → run_statements is not called.
+        Connection count: list (1) + DROP SCHEMA (2) = 2 total.
+        """
+        target = _make_target()
+        list_conn = _make_conn([("orders", "U"), ("customers", "U")], _OBJ_COLS)
+        drop_schema_conn = _make_conn_for_ddl()
+        with patch(
+            "fabric_dw.sql.open_connection",
+            side_effect=[list_conn, drop_schema_conn],
+        ) as mock_open:
+            await schemas.delete_schema(
+                target, "sales", cascade=True, kind=WarehouseKind.SQL_ENDPOINT
+            )
+        # Only 2 connections: list objects + DROP SCHEMA (no object-drop connection)
+        assert mock_open.call_count == 2
+
+    async def test_cascade_endpoint_mixed_objects_drops_only_non_tables(self) -> None:
+        """Mixed schema on endpoint: only non-table objects are dropped."""
+        target = _make_target()
+        list_conn = _make_conn(
+            [("t1", "U"), ("vw1", "V"), ("usp1", "P"), ("fn1", "FN")],
+            _OBJ_COLS,
+        )
+        drop_objects_conn = _make_conn_for_ddl()
+        drop_schema_conn = _make_conn_for_ddl()
+        with patch(
+            "fabric_dw.sql.open_connection",
+            side_effect=[list_conn, drop_objects_conn, drop_schema_conn],
+        ):
+            await schemas.delete_schema(
+                target, "sales", cascade=True, kind=WarehouseKind.SQL_ENDPOINT
+            )
+        cursor = drop_objects_conn.cursor.return_value
+        # 3 DROP statements: VIEW + PROCEDURE + FUNCTION (not TABLE)
+        assert cursor.execute.call_count == 3
+        sqls = [str(c[0][0]).upper() for c in cursor.execute.call_args_list]
+        assert not any("DROP TABLE" in s for s in sqls)
+        assert any("DROP VIEW" in s for s in sqls)
+        assert any("DROP PROCEDURE" in s for s in sqls)
+        assert any("DROP FUNCTION" in s for s in sqls)
+
+    async def test_cascade_true_on_sql_endpoint_does_not_raise(self) -> None:
+        """cascade=True on a SQL_ENDPOINT must NOT raise — the blanket guard is gone."""
+        target = _make_target()
+        list_conn = _make_conn([], _OBJ_COLS)
+        drop_schema_conn = _make_conn_for_ddl()
+        with patch(
+            "fabric_dw.sql.open_connection",
+            side_effect=[list_conn, drop_schema_conn],
+        ):
+            # Must succeed without any exception
+            await schemas.delete_schema(
+                target, "empty_schema", cascade=True, kind=WarehouseKind.SQL_ENDPOINT
             )
 
     async def test_cascade_false_on_sql_endpoint_is_allowed(self) -> None:
@@ -492,30 +637,23 @@ class TestDeleteSchemaCascadeEndpointGuard:
         drop_sql: str = cursor.execute.call_args[0][0].upper()
         assert "DROP SCHEMA" in drop_sql
 
-    async def test_cascade_true_on_warehouse_is_allowed(self) -> None:
-        """cascade=True on a Warehouse must proceed normally (no guard)."""
+    async def test_cascade_true_on_warehouse_drops_all_types(self) -> None:
+        """cascade=True on a Warehouse must drop ALL object types including tables."""
         target = _make_target()
-        list_conn = _make_conn([("orders", "TABLE")], ["obj_name", "obj_type"])
+        list_conn = _make_conn(
+            [("t1", "U"), ("vw1", "V"), ("usp1", "P"), ("fn1", "FN")],
+            _OBJ_COLS,
+        )
         drop_objects_conn = _make_conn_for_ddl()
         drop_schema_conn = _make_conn_for_ddl()
         with patch(
             "fabric_dw.sql.open_connection",
             side_effect=[list_conn, drop_objects_conn, drop_schema_conn],
         ):
-            # Must not raise
             await schemas.delete_schema(target, "sales", cascade=True, kind=WarehouseKind.WAREHOUSE)
         cursor = drop_objects_conn.cursor.return_value
-        drop_sql: str = cursor.execute.call_args[0][0].upper()
-        assert "DROP TABLE" in drop_sql
-
-    async def test_cascade_true_default_kind_is_warehouse(self) -> None:
-        """Default kind=WAREHOUSE means cascade=True works without passing kind."""
-        target = _make_target()
-        list_conn = _make_conn([], ["obj_name", "obj_type"])
-        drop_schema_conn = _make_conn_for_ddl()
-        with patch(
-            "fabric_dw.sql.open_connection",
-            side_effect=[list_conn, drop_schema_conn],
-        ):
-            # Must not raise (kind defaults to WAREHOUSE)
-            await schemas.delete_schema(target, "empty_schema", cascade=True)
+        sqls = [str(c[0][0]).upper() for c in cursor.execute.call_args_list]
+        assert any("DROP TABLE" in s for s in sqls)
+        assert any("DROP VIEW" in s for s in sqls)
+        assert any("DROP PROCEDURE" in s for s in sqls)
+        assert any("DROP FUNCTION" in s for s in sqls)


### PR DESCRIPTION
## Summary

Corrects cascade schema deletion behaviour for SQL Analytics Endpoints.

### Corrected behaviour

| Target kind | `cascade=False` | `cascade=True` |
|---|---|---|
| **Fabric Data Warehouse** | DROP SCHEMA (empty schema only) | DROP TABLE + DROP VIEW + DROP PROCEDURE + DROP FUNCTION, then DROP SCHEMA |
| **SQL Analytics Endpoint** | DROP SCHEMA (empty schema only) | DROP VIEW + DROP PROCEDURE + DROP FUNCTION (**tables skipped**), then DROP SCHEMA |

Tables (`sys.objects` type `U`) are excluded on SQL Analytics Endpoints because `DROP TABLE` is a Warehouse-only operation on Fabric. If the schema still contains tables after dropping other objects, the final `DROP SCHEMA` will be rejected by the engine with a clear error — this is acceptable and expected.

### Implementation details

- **`_drop_schema_objects`** now enumerates objects via `sys.objects` joined to `sys.schemas`, selecting types `U` (table), `V` (view), `P` (stored procedure), `FN`/`IF`/`TF` (functions).
- Issues the correct DDL verb per type: `DROP TABLE` / `DROP VIEW` / `DROP PROCEDURE` / `DROP FUNCTION`.
- On `WarehouseKind.SQL_ENDPOINT`: type `U` objects are excluded from the drop set.
- On `WarehouseKind.WAREHOUSE`: all types are dropped (existing behaviour).
- The `kind` parameter added to `delete_schema` in this PR is retained; CLI and MCP already pass `entry.kind`.
- The blanket `_assert_cascade_not_sql_endpoint` guard and `ItemKindError` raise are **removed** — cascade on endpoints is now allowed.

### Tests updated

- **Service tests** (`TestDeleteSchemaCascadeEndpoint`): assert DROP VIEW / DROP PROCEDURE / DROP FUNCTION are issued on endpoints, DROP TABLE is not; assert all 4 types are dropped on Warehouse.
- **MCP tests**: `test_delete_schema_cascade_sql_endpoint_succeeds` replaces the old raises-ToolError test.
- **CLI tests**: `test_delete_cascade_sql_endpoint_succeeds` replaces the old returns-nonzero test.
- All tests: `just check` green (1560 unit tests pass).