### PR TITLE
fix(render): omit all-NULL columns from Rich table output

### DIFF
--- a/src/fabric_dw/cli/_render.py
+++ b/src/fabric_dw/cli/_render.py
@@ -83,7 +83,13 @@ def _cell(value: object) -> str:
 
 
 def _render_table(rows: Sequence[object], *, console: Console, title: str | None) -> None:
-    """Render a list of dicts as a Rich Table."""
+    """Render a list of dicts as a Rich Table.
+
+    Columns whose value is ``None`` in **every** row are omitted from the
+    output — they only clutter list views (e.g. ``definition`` for
+    ``procedures list``).  A column that is non-null in at least one row is
+    kept, and any null cells in that column still render as ``[dim]NULL[/dim]``.
+    """
     table = Table(title=title, show_header=True, header_style="bold")
 
     if not rows:
@@ -93,21 +99,38 @@ def _render_table(rows: Sequence[object], *, console: Console, title: str | None
     # Collect all column names in insertion order (union of all keys)
     columns: list[str] = []
     seen: set[str] = set()
+    # Normalise each row to dict[str, object] once so we can reuse below.
+    norm_rows: list[dict[str, object] | object] = []
     for row in rows:
         if isinstance(row, dict):
             row_dict: dict[str, object] = {str(k): v for k, v in row.items()}
+            norm_rows.append(row_dict)
             for key in row_dict:
                 if key not in seen:
                     columns.append(key)
                     seen.add(key)
+        else:
+            norm_rows.append(row)
 
-    for col in columns:
+    # Drop columns where every dict-row's value is None (or the key is absent).
+    # Non-dict rows (scalars) are never counted as "having" any column value, so
+    # a column is only kept if at least one dict-row provides a non-None value.
+    all_null: set[str] = {
+        col
+        for col in columns
+        if all(
+            (isinstance(r, dict) and r.get(col) is None) or not isinstance(r, dict)
+            for r in norm_rows
+        )
+    }
+    visible_columns = [col for col in columns if col not in all_null]
+
+    for col in visible_columns:
         table.add_column(col)
 
-    for row in rows:
+    for row in norm_rows:
         if isinstance(row, dict):
-            row_dict = {str(k): v for k, v in row.items()}
-            table.add_row(*[_cell(row_dict.get(col, "")) for col in columns])
+            table.add_row(*[_cell(row.get(col, "")) for col in visible_columns])
         else:
             table.add_row(_cell(row))
 

--- a/tests/unit/cli/test_render.py
+++ b/tests/unit/cli/test_render.py
@@ -119,7 +119,10 @@ class TestNullRendering:
         return sio.getvalue()
 
     def test_none_in_table_cell_renders_null(self) -> None:
-        data = [{"id": "abc", "score": None}]
+        # Use two rows so the 'score' column is not all-null (it has a non-None
+        # value in the second row), meaning it is kept and the None cell renders
+        # as NULL.
+        data = [{"id": "abc", "score": None}, {"id": "def", "score": 42}]
         output = self._render_to_string(data)
         assert "NULL" in output
         assert "None" not in output
@@ -164,11 +167,130 @@ class TestSparseRowRendering:
         assert "NULL" not in output
 
     def test_explicit_none_renders_as_null(self) -> None:
-        """A row dict with an explicit None value renders as NULL, not blank."""
-        data = [{"id": "abc", "score": None}]
+        """A row dict with an explicit None value renders as NULL, not blank.
+
+        Two rows are used so that the 'score' column has at least one non-None
+        value and is therefore not dropped by the all-null pruning logic.
+        """
+        data = [{"id": "abc", "score": None}, {"id": "def", "score": 99}]
         output = self._render_to_string(data)
         assert "NULL" in output
         assert "None" not in output
+
+
+class TestOmitAllNullColumns:
+    """_render_table omits columns that are None in every row (human table only)."""
+
+    def _render_to_string(self, data: object, table_title: str | None = None) -> str:
+        sio = StringIO()
+        console = Console(file=sio, width=200, highlight=False, no_color=True)
+        render(data, json_output=False, console=console, table_title=table_title)
+        return sio.getvalue()
+
+    # ------------------------------------------------------------------
+    # 1. Column that is None in EVERY row → omitted from the table
+    # ------------------------------------------------------------------
+
+    def test_all_null_column_is_absent_from_table(self) -> None:
+        """A column where every row's value is None must not appear in output."""
+        data = [
+            {"name": "proc_a", "schema": "dbo", "definition": None},
+            {"name": "proc_b", "schema": "dbo", "definition": None},
+        ]
+        output = self._render_to_string(data)
+        assert "name" in output
+        assert "schema" in output
+        # "definition" column header and NULL cell must both be absent
+        assert "definition" not in output
+
+    def test_all_null_column_values_absent_too(self) -> None:
+        """When a column is dropped entirely, neither its header nor NULL appears."""
+        data = [
+            {"qualified_name": "dbo.proc_a", "definition": None},
+            {"qualified_name": "dbo.proc_b", "definition": None},
+        ]
+        output = self._render_to_string(data)
+        assert "qualified_name" in output
+        # definition not in output (neither as header nor as NULL cell)
+        assert "definition" not in output
+        # NULL should not appear at all since the only None column was dropped
+        assert "NULL" not in output
+
+    # ------------------------------------------------------------------
+    # 2. Column that is None in SOME but not all rows → kept, nulls rendered
+    # ------------------------------------------------------------------
+
+    def test_partial_null_column_is_kept(self) -> None:
+        """A column with at least one non-None value must be present in output."""
+        data = [
+            {"name": "proc_a", "schema": "dbo", "definition": "CREATE PROC ..."},
+            {"name": "proc_b", "schema": "dbo", "definition": None},
+        ]
+        output = self._render_to_string(data)
+        assert "definition" in output
+
+    def test_partial_null_column_null_cells_render_as_null(self) -> None:
+        """Null cells in a kept column still render as NULL."""
+        data = [
+            {"name": "proc_a", "definition": "CREATE PROC ..."},
+            {"name": "proc_b", "definition": None},
+        ]
+        output = self._render_to_string(data)
+        assert "NULL" in output
+
+    def test_partial_null_column_non_null_value_shown(self) -> None:
+        """Non-null value in a partially-null column is still rendered."""
+        data = [
+            {"name": "proc_a", "definition": "CREATE PROC ..."},
+            {"name": "proc_b", "definition": None},
+        ]
+        output = self._render_to_string(data)
+        assert "CREATE PROC" in output
+
+    # ------------------------------------------------------------------
+    # 3. JSON output still emits all fields including all-null columns
+    # ------------------------------------------------------------------
+
+    def test_json_output_retains_all_null_column(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """json_output=True must never drop any field, even if all values are None."""
+        data = [
+            {"name": "proc_a", "definition": None},
+            {"name": "proc_b", "definition": None},
+        ]
+        render(data, json_output=True)
+        captured = capsys.readouterr()
+        parsed: list[dict[str, object]] = json.loads(captured.out)
+        assert "definition" in parsed[0]
+        assert parsed[0]["definition"] is None
+        assert "definition" in parsed[1]
+        assert parsed[1]["definition"] is None
+
+    # ------------------------------------------------------------------
+    # 4. Edge cases
+    # ------------------------------------------------------------------
+
+    def test_empty_rows_not_affected(self) -> None:
+        """An empty list renders without error (empty table, no columns)."""
+        output = self._render_to_string([])
+        assert output is not None
+
+    def test_non_null_columns_preserved_when_some_columns_dropped(self) -> None:
+        """Only all-null columns are dropped; other columns remain intact."""
+        data = [
+            {"id": "1", "name": "foo", "extra": None},
+            {"id": "2", "name": "bar", "extra": None},
+        ]
+        output = self._render_to_string(data)
+        assert "id" in output
+        assert "name" in output
+        assert "extra" not in output
+
+    def test_single_row_all_null_column_dropped(self) -> None:
+        """Even with a single row, an all-None column is dropped."""
+        data = [{"name": "view_a", "definition": None}]
+        output = self._render_to_string(data)
+        assert "name" in output
+        assert "definition" not in output
 
 
 class TestConfirm:


### PR DESCRIPTION
## Summary

- In `_render_table` (`src/fabric_dw/cli/_render.py`), after collecting the union of column names, any column whose value is `None` (or absent) in **every** row is now dropped before building the Rich Table.
- This generically de-clutters all `list` command output — e.g. `procedures list` and `views list` no longer show a `definition` column full of `NULL`; that field is only populated by the single-item `get` endpoint.
- A column with at least one non-null value across rows is kept; null cells in kept columns still render as `[dim]NULL[/dim]`.

## Scope / non-changes

- **JSON output (`json_output=True`) is completely untouched** — all fields including all-null ones are emitted as before; machine consumers rely on the full schema.
- **`_render_panel`** (single-item `get` output) is also untouched — `definition: NULL` continues to appear when inspecting a single stored procedure or view.
- Empty-rows behaviour (no rows → empty table) is preserved.

## Tests added (`tests/unit/cli/test_render.py`)

New `TestOmitAllNullColumns` class with 9 tests covering:
1. All-null column absent from rendered table (header and cell both gone)
2. All-null column dropped → no `NULL` text visible at all in that table
3. Partial-null column kept when at least one row is non-null
4. Partial-null column's null cells still render as `NULL`
5. Non-null value in a partially-null column still shown
6. `json_output=True` retains all-null fields unchanged
7. Empty row list still works
8. Non-null columns unaffected when some columns are dropped
9. Single-row all-null column dropped

Two pre-existing tests that used a single-row `{…, score: None}` fixture (which is legitimately all-null in one row) were updated to use two-row fixtures so the `score` column has a non-null value and the NULL-rendering behaviour they intended to exercise is still covered.

## Validation

`just check` (ruff + ty + pytest with 80% coverage threshold) is fully green: 1752 tests passed, 87.77% total coverage.

Addresses the reviewer finding from #281.

🤖 Generated with [Claude Code](https://claude.com/claude-code)