### PR TITLE
fix(integration): wipe workspace at run start + valid lakehouse name

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -81,34 +81,44 @@ jobs:
 
       - run: uv sync --frozen
 
-      - name: Pre-test sweep of stale pytest-* items
+      - name: Pre-test full workspace wipe
         env:
           FABRIC_TEST_WORKSPACE_ID: ${{ secrets.FABRIC_TEST_WORKSPACE_ID }}
           FABRIC_AUTH: default
         run: |
           uv run python -c "
           import anyio, os
-          from datetime import datetime, timedelta, UTC
           from fabric_dw.auth import get_credential
-          from fabric_dw.http_client import FabricHttpClient
-          from fabric_dw.services import warehouses, snapshots
+          from fabric_dw.http_client import FabricHttpClient, HttpBase
+
+          async def delete_all(http, ws):
+              for pass_num in range(1, 4):
+                  items = [i async for i in http.iter_paginated(HttpBase.FABRIC, f'/workspaces/{ws}/items')]
+                  if not items:
+                      print(f'Pass {pass_num}: workspace is empty.')
+                      return
+                  print(f'Pass {pass_num}: found {len(items)} item(s) to delete.')
+                  for item in items:
+                      item_id = item.get('id', '')
+                      item_type = item.get('type', '')
+                      item_name = item.get('displayName', '')
+                      print(f'  Deleting {item_type} {item_name!r} ({item_id})')
+                      try:
+                          await http.request('DELETE', HttpBase.FABRIC, f'/workspaces/{ws}/items/{item_id}')
+                      except Exception as exc:
+                          print(f'    skip: {exc}')
+              remaining = [i async for i in http.iter_paginated(HttpBase.FABRIC, f'/workspaces/{ws}/items')]
+              if remaining:
+                  for item in remaining:
+                      print(f'  Residual (undeletable?): {item.get(\"type\")} {item.get(\"displayName\")!r} ({item.get(\"id\")})')
+              else:
+                  print('Workspace is clean.')
 
           async def main() -> None:
               ws = os.environ['FABRIC_TEST_WORKSPACE_ID']
-              cutoff = datetime.now(UTC) - timedelta(hours=1)
               cred = get_credential()
               async with FabricHttpClient(cred) as http:
-                  items = await warehouses.list_warehouses(http, ws)
-                  for w in items:
-                      if w.name.startswith('pytest-') and (w.created_date is None or w.created_date < cutoff):
-                          print(f'Sweeping {w.kind} {w.name} ({w.id})')
-                          try:
-                              if w.kind == 'WarehouseSnapshot':
-                                  await snapshots.delete(http, ws, w.id)
-                              else:
-                                  await warehouses.delete(http, ws, w.id)
-                          except Exception as exc:
-                              print(f'  skip: {exc}')
+                  await delete_all(http, ws)
 
           anyio.run(main)
           "
@@ -119,7 +129,7 @@ jobs:
           FABRIC_AUTH: default
         run: uv run pytest tests/integration -m integration -v
 
-      - name: Post-test sweep of pytest-* items
+      - name: Post-test full workspace wipe
         if: always()
         env:
           FABRIC_TEST_WORKSPACE_ID: ${{ secrets.FABRIC_TEST_WORKSPACE_ID }}
@@ -128,29 +138,36 @@ jobs:
           uv run python -c "
           import anyio, os
           from fabric_dw.auth import get_credential
-          from fabric_dw.http_client import FabricHttpClient
-          from fabric_dw.services import warehouses, snapshots
+          from fabric_dw.http_client import FabricHttpClient, HttpBase
+
+          async def delete_all(http, ws):
+              for pass_num in range(1, 4):
+                  items = [i async for i in http.iter_paginated(HttpBase.FABRIC, f'/workspaces/{ws}/items')]
+                  if not items:
+                      print(f'Pass {pass_num}: workspace is empty.')
+                      return
+                  print(f'Pass {pass_num}: found {len(items)} item(s) to delete.')
+                  for item in items:
+                      item_id = item.get('id', '')
+                      item_type = item.get('type', '')
+                      item_name = item.get('displayName', '')
+                      print(f'  Deleting {item_type} {item_name!r} ({item_id})')
+                      try:
+                          await http.request('DELETE', HttpBase.FABRIC, f'/workspaces/{ws}/items/{item_id}')
+                      except Exception as exc:
+                          print(f'    skip: {exc}')
+              remaining = [i async for i in http.iter_paginated(HttpBase.FABRIC, f'/workspaces/{ws}/items')]
+              if remaining:
+                  for item in remaining:
+                      print(f'  Residual (undeletable?): {item.get(\"type\")} {item.get(\"displayName\")!r} ({item.get(\"id\")})')
+              else:
+                  print('Workspace is clean.')
 
           async def main() -> None:
               ws = os.environ['FABRIC_TEST_WORKSPACE_ID']
               cred = get_credential()
-              failures = []
               async with FabricHttpClient(cred) as http:
-                  items = await warehouses.list_warehouses(http, ws)
-                  for w in items:
-                      if w.name.startswith('pytest-'):
-                          print(f'Deleting {w.kind} {w.name} ({w.id})')
-                          try:
-                              if w.kind == 'WarehouseSnapshot':
-                                  await snapshots.delete(http, ws, w.id)
-                              else:
-                                  await warehouses.delete(http, ws, w.id)
-                          except Exception as exc:
-                              failures.append((w.name, str(exc)))
-                  if failures:
-                      for name, err in failures:
-                          print(f'FAIL: {name}: {err}')
-                      raise SystemExit(1)
+                  await delete_all(http, ws)
 
           anyio.run(main)
           "

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -97,7 +97,7 @@ async def ephemeral_lakehouse(
     The fixture does NOT wait for the SQL endpoint to provision; use
     ``ephemeral_sql_endpoint`` if you need a ready endpoint.
     """
-    name = f"pytest-{uuid.uuid4().hex[:8]}-lh"
+    name = f"pytest_{uuid.uuid4().hex[:8]}_lh"
     body: dict[str, object] = {
         "displayName": name,
         "description": "ephemeral integration-test lakehouse",


### PR DESCRIPTION
## Root causes

### 1 — WorkspaceItemsLimitExceeded
Almost every test was ERRORing at `ephemeral_warehouse` fixture setup because the dedicated integration-test workspace was full of leaked `pytest-*` items from rapid CI runs and interrupted teardowns. The old sweep steps only deleted items **older than 1 hour** and only handled warehouses/snapshots by type — so recent leaks and Lakehouses/SQL-endpoints accumulated until Fabric rejected new item creation with `WorkspaceItemsLimitExceeded`.

### 2 — Invalid Lakehouse DisplayName
`ephemeral_lakehouse` used `name = f"pytest-{uuid.uuid4().hex[:8]}-lh"`. Fabric rejects Lakehouse `displayName` values containing hyphens with `InvalidInput: DisplayName is Invalid for ArtifactType` (letters/digits/underscores only for Lakehouses, unlike Warehouses which accept hyphens).

## Fixes

### Fix 1 — Full workspace wipe (pre- and post-test)
Both sweep steps are replaced with a type-agnostic full workspace wipe:
- Uses `http.iter_paginated(HttpBase.FABRIC, f"/workspaces/{ws}/items")` to list all items (pagination via `continuationUri`/`value`).
- Deletes each item via `DELETE /workspaces/{ws}/items/{itemId}`.
- Runs up to 3 passes to handle dependency ordering (deleting a Lakehouse removes its paired SQL endpoint; a first-pass 400/404 on the endpoint is expected and skipped).
- Individual delete failures are logged and skipped — one undeletable item never blocks the rest.
- Drops the 1-hour cutoff and `pytest-` prefix filter entirely (wipe everything — this is a dedicated integration-test workspace).
- The pre-test wipe **self-heals** the currently item-limit-exceeded workspace on the next run.
- The post-test wipe runs `if: always()` so nothing is left running/costing after the suite.

### Fix 2 — Valid Lakehouse name
`ephemeral_lakehouse` fixture name changed from `pytest-{hex}-lh` → `pytest_{hex}_lh` (hyphens → underscores).

## Validation
- `just check` (ruff lint + ruff format + ty + 1743 unit tests): all green.
- Integration suite cannot be run locally (no Fabric credentials); validated by the post-merge `push`-to-`main` integration run.