### PR TITLE
ci: upload coverage and test results to Codecov + README badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,13 +69,24 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: uv sync --frozen
-      - run: uv run pytest tests/unit --cov --cov-report=xml --cov-report=term
+      - run: uv run pytest tests/unit --cov --cov-branch --cov-report=xml --cov-report=term --junitxml=junit.xml -o junit_family=legacy
       - name: Enforce coverage threshold
         run: uv run coverage report --fail-under=80
       - uses: actions/upload-artifact@v7
         with:
           name: coverage-${{ matrix.python-version }}
           path: coverage.xml
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: python-${{ matrix.python-version }}
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: python-${{ matrix.python-version }}
       # Upload coverage to GitHub Code Quality (public preview).
       # Only runs on Python 3.13 to avoid duplicate uploads across matrix entries.
       # Fork-PR guard: skip on PRs from forks (they lack write permissions).

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 
 <p align="center">
   <a href="https://github.com/sdebruyn/fabric-dw-mcp-cli/actions/workflows/ci.yml"><img src="https://github.com/sdebruyn/fabric-dw-mcp-cli/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://codecov.io/gh/sdebruyn/fabric-dw-mcp-cli"><img src="https://codecov.io/gh/sdebruyn/fabric-dw-mcp-cli/graph/badge.svg" alt="codecov"></a>
   <a href="https://pypi.org/project/fabric-dw/"><img src="https://img.shields.io/pypi/v/fabric-dw" alt="PyPI version"></a>
   <a href="https://pypi.org/project/fabric-dw/"><img src="https://img.shields.io/pypi/pyversions/fabric-dw" alt="Python versions"></a>
   <a href="LICENSE"><img src="https://img.shields.io/github/license/sdebruyn/fabric-dw-mcp-cli" alt="License"></a>


### PR DESCRIPTION
## Summary

- **pytest step updated**: adds `--cov-branch`, `--junitxml=junit.xml`, and `-o junit_family=legacy` to the existing invocation — tests still run exactly once per matrix entry.
- **Codecov coverage upload**: `codecov/codecov-action@v5` runs after the artifact upload on every matrix entry, flagged with `python-${{ matrix.python-version }}` so per-version uploads are distinguished.
- **Codecov test-results upload**: `codecov/test-results-action@v1` runs with `if: ${{ !cancelled() }}` (reports even on test failure) on every matrix entry, same flags.
- **GitHub Code Quality step preserved**: the existing `actions/upload-code-coverage@v1` step is unchanged — both coverage tools coexist.
- **README badge**: Codecov badge added alongside the CI/PyPI badges at the top of `README.md`.

## Manual steps required

Before coverage uploads will succeed, the maintainer must:

1. **Add a repository secret `CODECOV_TOKEN`**: Go to **Settings → Secrets and variables → Actions → New repository secret**. Name it exactly `CODECOV_TOKEN`. Do **not** use an environment secret — the `unit` job has no `environment:` block. Obtain the token from [codecov.io](https://codecov.io) after linking the repo.
2. **Link the repo on codecov.io**: Sign in at [codecov.io](https://codecov.io) with GitHub, find `sdebruyn/fabric-dw-mcp-cli`, and activate it. The upload token will be shown there.

The README badge will show "unknown" until the first successful upload. The existing GitHub Code Quality upload (`actions/upload-code-coverage@v1`, guarded to Python 3.13) remains active and unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)