### PR TITLE
ci: allow manual workflow_dispatch of integration tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -5,6 +5,7 @@ on:
     types: [labeled, synchronize]
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   id-token: write
@@ -16,7 +17,7 @@ concurrency:
 
 jobs:
   integration:
-    if: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'integration') }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'integration') }}
     runs-on: ubuntu-latest
     environment: integration
     timeout-minutes: 45


### PR DESCRIPTION
Adds `workflow_dispatch` so the integration suite can be triggered manually from the Actions tab / `gh workflow run`; the trigger only takes effect once merged to the default branch.