### PR TITLE
ci(integration): permanently purge recoverable (soft-deleted) items in wipe

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -92,12 +92,35 @@ jobs:
           from fabric_dw.auth import get_credential
           from fabric_dw.http_client import FabricHttpClient, HttpBase
 
+          async def purge_recycle_bin(http, ws):
+              for pass_num in range(1, 4):
+                  items = [i async for i in http.iter_paginated(HttpBase.FABRIC, f'/workspaces/{ws}/recoverableItems')]
+                  if not items:
+                      print(f'Recoverable pass {pass_num}: recycle bin is empty.')
+                      return
+                  print(f'Recoverable pass {pass_num}: found {len(items)} item(s) to purge.')
+                  for item in items:
+                      item_id = item.get('id', '')
+                      item_type = item.get('type', '')
+                      item_name = item.get('displayName', '')
+                      print(f'  Purging {item_type} {item_name!r} ({item_id})')
+                      try:
+                          await http.request('DELETE', HttpBase.FABRIC, f'/workspaces/{ws}/recoverableItems/{item_id}')
+                      except Exception as exc:
+                          print(f'    skip: {exc}')
+              residual = [i async for i in http.iter_paginated(HttpBase.FABRIC, f'/workspaces/{ws}/recoverableItems')]
+              if residual:
+                  for item in residual:
+                      print(f'  Residual recoverable: {item.get(\"type\")} {item.get(\"displayName\")!r} ({item.get(\"id\")})')
+              else:
+                  print('Recycle bin clean.')
+
           async def delete_all(http, ws):
               for pass_num in range(1, 4):
                   items = [i async for i in http.iter_paginated(HttpBase.FABRIC, f'/workspaces/{ws}/items')]
                   if not items:
                       print(f'Pass {pass_num}: workspace is empty.')
-                      return
+                      break
                   print(f'Pass {pass_num}: found {len(items)} item(s) to delete.')
                   for item in items:
                       item_id = item.get('id', '')
@@ -114,6 +137,7 @@ jobs:
                       print(f'  Residual (undeletable?): {item.get(\"type\")} {item.get(\"displayName\")!r} ({item.get(\"id\")})')
               else:
                   print('Workspace is clean.')
+              await purge_recycle_bin(http, ws)
 
           async def main() -> None:
               ws = os.environ['FABRIC_TEST_WORKSPACE_ID']
@@ -141,12 +165,35 @@ jobs:
           from fabric_dw.auth import get_credential
           from fabric_dw.http_client import FabricHttpClient, HttpBase
 
+          async def purge_recycle_bin(http, ws):
+              for pass_num in range(1, 4):
+                  items = [i async for i in http.iter_paginated(HttpBase.FABRIC, f'/workspaces/{ws}/recoverableItems')]
+                  if not items:
+                      print(f'Recoverable pass {pass_num}: recycle bin is empty.')
+                      return
+                  print(f'Recoverable pass {pass_num}: found {len(items)} item(s) to purge.')
+                  for item in items:
+                      item_id = item.get('id', '')
+                      item_type = item.get('type', '')
+                      item_name = item.get('displayName', '')
+                      print(f'  Purging {item_type} {item_name!r} ({item_id})')
+                      try:
+                          await http.request('DELETE', HttpBase.FABRIC, f'/workspaces/{ws}/recoverableItems/{item_id}')
+                      except Exception as exc:
+                          print(f'    skip: {exc}')
+              residual = [i async for i in http.iter_paginated(HttpBase.FABRIC, f'/workspaces/{ws}/recoverableItems')]
+              if residual:
+                  for item in residual:
+                      print(f'  Residual recoverable: {item.get(\"type\")} {item.get(\"displayName\")!r} ({item.get(\"id\")})')
+              else:
+                  print('Recycle bin clean.')
+
           async def delete_all(http, ws):
               for pass_num in range(1, 4):
                   items = [i async for i in http.iter_paginated(HttpBase.FABRIC, f'/workspaces/{ws}/items')]
                   if not items:
                       print(f'Pass {pass_num}: workspace is empty.')
-                      return
+                      break
                   print(f'Pass {pass_num}: found {len(items)} item(s) to delete.')
                   for item in items:
                       item_id = item.get('id', '')
@@ -163,6 +210,7 @@ jobs:
                       print(f'  Residual (undeletable?): {item.get(\"type\")} {item.get(\"displayName\")!r} ({item.get(\"id\")})')
               else:
                   print('Workspace is clean.')
+              await purge_recycle_bin(http, ws)
 
           async def main() -> None:
               ws = os.environ['FABRIC_TEST_WORKSPACE_ID']


### PR DESCRIPTION
## Problem

Soft-deleted (recoverable) Fabric items count toward the per-workspace item limit but are **not** returned by `GET /workspaces/{ws}/items`. As a result, repeated integration-test runs can exhaust the workspace item limit even after the wipe step deletes all active items — because each deletion moves the item into the recycle bin rather than removing it immediately.

## Solution

Extend both the **Pre-test** and **Post-test** full workspace wipe steps to also drain the recycle bin after deleting active items.

### Verified REST API endpoints (from [Microsoft Learn — Recover or permanently delete items (preview)](https://learn.microsoft.com/en-us/fabric/admin/item-recovery))

| Operation | Method & path |
|---|---|
| List recoverable items | `GET https://api.fabric.microsoft.com/v1/workspaces/{workspaceId}/recoverableItems` |
| Permanently delete one | `DELETE https://api.fabric.microsoft.com/v1/workspaces/{workspaceId}/recoverableItems/{itemId}` |

Response shape follows the standard Fabric pagination envelope (`value` array + `continuationUri`), so `http.iter_paginated(HttpBase.FABRIC, f'/workspaces/{ws}/recoverableItems')` works with the default `key="value"`. The item id field is `id` (same as active items). Permanent delete requires **Workspace Admin** permissions.

## Changes

- Added `purge_recycle_bin(http, ws)` helper (identical in both steps — kept in sync).
- After active-item deletion completes, `delete_all` calls `purge_recycle_bin`, which loops up to 3 passes over `recoverableItems`, permanently deleting each.
- Changed the early-exit in `delete_all`'s active-deletion loop from `return` to `break` so execution continues to `purge_recycle_bin` even when the workspace is found empty on the first pass.
- Each DELETE is wrapped in `try/except` with `skip: {exc}` logging — a persistently un-deletable item is logged as residual and does not cause an infinite loop; the loop cap of 3 passes guarantees termination.
- Prints: `Recoverable pass N: found M item(s) to purge`, `Purging {type} {name!r} ({id})`, and either `Recycle bin clean.` or a list of residual items.

## Requirements

The CI service principal must have **Workspace Admin** role on the integration test workspace (required by the permanent-delete endpoint).

## Termination argument

Each pass either finds 0 items (exits early) or deletes ≥1 item, reducing the total count. Because the loop cap is 3 and failures are skipped (not retried), the loop always terminates. Items that repeatedly fail to delete are logged as residual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)