### PR TITLE
test(mcp): fix wrong env var making rename_table allowlist test slow + false-green

### DIFF
--- a/tests/unit/mcp/test_server.py
+++ b/tests/unit/mcp/test_server.py
@@ -1675,7 +1675,7 @@ async def test_rename_table_sql_endpoint_raises_tool_error(mock_ctx, ctx_patch) 
 
 
 async def test_rename_table_workspace_allowlist_blocks(mock_ctx, ctx_patch) -> None:
-    """rename_table raises ToolError when workspace is not in FABRIC_MCP_WORKSPACE_ALLOWLIST."""
+    """rename_table raises ToolError when workspace is not in FABRIC_MCP_WORKSPACES."""
     from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
@@ -1685,8 +1685,8 @@ async def test_rename_table_workspace_allowlist_blocks(mock_ctx, ctx_patch) -> N
 
     with (
         ctx_patch,
-        patch.dict(os.environ, {"FABRIC_MCP_WORKSPACE_ALLOWLIST": "other-workspace"}),
-        pytest.raises(ToolError),
+        patch.dict(os.environ, {"FABRIC_MCP_WORKSPACES": "other-workspace"}),
+        pytest.raises(ToolError, match="FABRIC_MCP_WORKSPACES"),
     ):
         await mcp._tool_manager.call_tool(
             "rename_table",


### PR DESCRIPTION
## Summary

- `test_rename_table_workspace_allowlist_blocks` set the env var `FABRIC_MCP_WORKSPACE_ALLOWLIST` (which does not exist), but `_guards.py::assert_workspace_allowed` reads `FABRIC_MCP_WORKSPACES`. The allowlist guard never fired.
- With the guard bypassed, `rename_table` proceeded all the way to a real TDS `sp_rename` call (no SQL mock in this test), which timed out after ~28 seconds and raised `ToolError` for the **wrong reason** — making `pytest.raises(ToolError)` pass as a false-green while taking ~28s.
- Fix: change the env var key to `FABRIC_MCP_WORKSPACES` (matching the sibling tests `test_clone_table_workspace_not_in_allowlist` and `test_rename_view_blocked_by_workspace_allowlist`).
- Added `match="FABRIC_MCP_WORKSPACES"` to `pytest.raises(ToolError, ...)` so the test can only pass when the guard fires for the correct reason — preventing regression.

## Test plan

- [ ] `uv run pytest tests/unit/mcp/test_server.py::test_rename_table_workspace_allowlist_blocks -v --durations=5` — now passes in ~0.08s (was ~28s)
- [ ] `just check` — all 1755 unit tests pass, lint and type checks clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)