### PR TITLE
ci(integration): run only on dispatch and labeled PRs (stop push-on-main stampede)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -3,8 +3,6 @@ name: Integration tests
 on:
   pull_request:
     types: [labeled, synchronize]
-  push:
-    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -17,7 +15,7 @@ concurrency:
 
 jobs:
   integration:
-    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'integration') }}
+    if: ${{ github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'integration') }}
     runs-on: ubuntu-latest
     environment: integration
     timeout-minutes: 45


### PR DESCRIPTION
## Problem

The integration workflow was triggered on every push to `main` in addition to labeled PRs and manual dispatch. Because the workflow uses a `concurrency` group (`integration-tests`, `cancel-in-progress: false`) that serializes runs by keeping exactly one active and one pending, rapid merges to `main` caused pending integration runs to be dropped — the new push-triggered run would queue as the single allowed pending slot, evicting the run that was already waiting.

## Solution

Remove the `push: branches: [main]` trigger entirely. Integration now runs **only** via:

- Manual `workflow_dispatch` — for on-demand post-merge validation
- Adding the `integration` label to a PR — for pre-merge validation

With no push trigger, the concurrency group works as intended: one run executes, the next waits in the single pending slot, and merges to `main` never generate competing queue entries.

## Diff summary

**`on:` block** — removed `push: branches: [main]`:
```yaml
# before
on:
  pull_request:
    types: [labeled, synchronize]
  push:
    branches: [main]
  workflow_dispatch:

# after
on:
  pull_request:
    types: [labeled, synchronize]
  workflow_dispatch:
```

**`integration` job `if:` condition** — removed `github.event_name == 'push' ||`:
```yaml
# before
if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'integration') }}

# after
if: ${{ github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'integration') }}
```

Everything else (`concurrency`, `permissions`, all steps) is unchanged.

## Test plan

- [ ] Merge a commit to `main` — confirm no integration run is triggered
- [ ] Run `gh workflow run integration.yml` — confirm it queues and runs
- [ ] Add `integration` label to a PR — confirm run is triggered
- [ ] Confirm `concurrency` group serializes correctly with no cancellations

🤖 Generated with [Claude Code](https://claude.com/claude-code)