### PR TITLE
test(mcp): cover restore and snapshots tool wrappers

### DIFF
--- a/tests/unit/mcp/tools/test_restore.py
+++ b/tests/unit/mcp/tools/test_restore.py
@@ -1,0 +1,717 @@
+"""Unit tests for the MCP restore-point tool wrappers.
+
+Coverage targets
+----------------
+``src/fabric_dw/mcp/tools/restore.py``
+
+Tool list
+~~~~~~~~~
+* ``list_restore_points``    — happy path, FabricError → ToolError, workspace guard
+* ``get_restore_point``      — happy path, FabricError → ToolError, workspace guard
+* ``create_restore_point``   — happy path, FabricError → ToolError, readonly guard
+* ``update_restore_point``   — happy path, ValueError → ToolError, FabricError → ToolError,
+  readonly guard
+* ``delete_restore_point``   — happy path, FabricError → ToolError, readonly + destructive guard
+* ``restore_warehouse_in_place`` — happy path, FabricError → ToolError, readonly + destructive
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from mcp.server.fastmcp.exceptions import ToolError
+
+from fabric_dw.exceptions import FabricError, NotFoundError
+from fabric_dw.models import RestorePoint
+from tests.unit.mcp.conftest import (
+    WH_NAME,
+    WS_ID,
+    WS_NAME,
+    make_item_entry,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_RP_ID = "1726617378000"
+_RP_ID_2 = "1726617490000"
+
+
+def _make_restore_point(
+    rp_id: str = _RP_ID,
+    *,
+    name: str | None = "rp-1",
+    creation_mode: str | None = "UserDefined",
+) -> RestorePoint:
+    return RestorePoint.model_validate(
+        {
+            "id": rp_id,
+            "displayName": name,
+            "creationMode": creation_mode,
+            "eventDateTime": "2026-01-01T00:00:00",
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# list_restore_points
+# ---------------------------------------------------------------------------
+
+
+async def test_list_restore_points_happy_path(mock_ctx, ctx_patch) -> None:
+    """list_restore_points returns a list of serialised RestorePoint dicts."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    rp = _make_restore_point()
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.restore.list_points",
+            new=AsyncMock(return_value=[rp]),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "list_restore_points",
+            {"workspace": WS_NAME, "warehouse": WH_NAME},
+        )
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0]["id"] == _RP_ID
+    assert result[0]["displayName"] == "rp-1"
+
+
+async def test_list_restore_points_fabric_error_becomes_tool_error(mock_ctx, ctx_patch) -> None:
+    """list_restore_points converts FabricError to ToolError."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.restore.list_points",
+            new=AsyncMock(side_effect=NotFoundError("warehouse not found")),
+        ),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "list_restore_points",
+            {"workspace": WS_NAME, "warehouse": WH_NAME},
+        )
+
+
+async def test_list_restore_points_workspace_guard(ctx_patch) -> None:
+    """list_restore_points raises ToolError when workspace is not in the allowlist."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_WORKSPACES": "other-workspace"}),
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "list_restore_points",
+            {"workspace": WS_NAME, "warehouse": WH_NAME},
+        )
+
+    assert "allowlist" in str(exc_info.value).lower()
+
+
+async def test_list_restore_points_multiple(mock_ctx, ctx_patch) -> None:
+    """list_restore_points serialises every RestorePoint in the result list."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    rp1 = _make_restore_point(_RP_ID)
+    rp2 = _make_restore_point(_RP_ID_2, name=None, creation_mode="SystemCreated")
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.restore.list_points",
+            new=AsyncMock(return_value=[rp1, rp2]),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "list_restore_points",
+            {"workspace": WS_NAME, "warehouse": WH_NAME},
+        )
+
+    assert len(result) == 2
+    assert result[1]["id"] == _RP_ID_2
+    assert result[1]["creationMode"] == "SystemCreated"
+
+
+# ---------------------------------------------------------------------------
+# get_restore_point
+# ---------------------------------------------------------------------------
+
+
+async def test_get_restore_point_happy_path(mock_ctx, ctx_patch) -> None:
+    """get_restore_point returns a single serialised RestorePoint dict."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    rp = _make_restore_point()
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.restore.get_point",
+            new=AsyncMock(return_value=rp),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "get_restore_point",
+            {"workspace": WS_NAME, "warehouse": WH_NAME, "restore_point_id": _RP_ID},
+        )
+
+    assert isinstance(result, dict)
+    assert result["id"] == _RP_ID
+    assert result["displayName"] == "rp-1"
+
+
+async def test_get_restore_point_fabric_error_becomes_tool_error(mock_ctx, ctx_patch) -> None:
+    """get_restore_point converts FabricError to ToolError."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.restore.get_point",
+            new=AsyncMock(side_effect=NotFoundError("restore point not found")),
+        ),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "get_restore_point",
+            {"workspace": WS_NAME, "warehouse": WH_NAME, "restore_point_id": _RP_ID},
+        )
+
+
+async def test_get_restore_point_workspace_guard(ctx_patch) -> None:
+    """get_restore_point raises ToolError when workspace is not in the allowlist."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_WORKSPACES": "other-workspace"}),
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "get_restore_point",
+            {"workspace": WS_NAME, "warehouse": WH_NAME, "restore_point_id": _RP_ID},
+        )
+
+    assert "allowlist" in str(exc_info.value).lower()
+
+
+# ---------------------------------------------------------------------------
+# create_restore_point
+# ---------------------------------------------------------------------------
+
+
+async def test_create_restore_point_happy_path(mock_ctx, ctx_patch) -> None:
+    """create_restore_point returns a serialised RestorePoint dict."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    rp = _make_restore_point()
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.restore.create_point",
+            new=AsyncMock(return_value=rp),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "create_restore_point",
+            {"workspace": WS_NAME, "warehouse": WH_NAME},
+        )
+
+    assert isinstance(result, dict)
+    assert result["id"] == _RP_ID
+
+
+async def test_create_restore_point_with_name_and_description(mock_ctx, ctx_patch) -> None:
+    """create_restore_point forwards name and description to the service."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    rp = _make_restore_point(name="my-rp")
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+    mock_create = AsyncMock(return_value=rp)
+
+    with (
+        ctx_patch,
+        patch("fabric_dw.services.restore.create_point", new=mock_create),
+    ):
+        await mcp._tool_manager.call_tool(
+            "create_restore_point",
+            {
+                "workspace": WS_NAME,
+                "warehouse": WH_NAME,
+                "name": "my-rp",
+                "description": "test description",
+            },
+        )
+
+    mock_create.assert_called_once()
+    _, kwargs = mock_create.call_args
+    assert kwargs.get("name") == "my-rp"
+    assert kwargs.get("description") == "test description"
+
+
+async def test_create_restore_point_readonly_blocked(ctx_patch) -> None:
+    """create_restore_point raises ToolError in FABRIC_MCP_READONLY=1 mode."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_READONLY": "1"}),
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "create_restore_point",
+            {"workspace": WS_NAME, "warehouse": WH_NAME},
+        )
+
+    assert "read-only" in str(exc_info.value).lower()
+
+
+async def test_create_restore_point_fabric_error_becomes_tool_error(mock_ctx, ctx_patch) -> None:
+    """create_restore_point converts FabricError to ToolError."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.restore.create_point",
+            new=AsyncMock(side_effect=FabricError("service failure")),
+        ),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "create_restore_point",
+            {"workspace": WS_NAME, "warehouse": WH_NAME},
+        )
+
+
+async def test_create_restore_point_workspace_guard(ctx_patch) -> None:
+    """create_restore_point raises ToolError when workspace is not in the allowlist."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_WORKSPACES": "other-workspace"}),
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "create_restore_point",
+            {"workspace": WS_NAME, "warehouse": WH_NAME},
+        )
+
+    assert "allowlist" in str(exc_info.value).lower()
+
+
+# ---------------------------------------------------------------------------
+# update_restore_point
+# ---------------------------------------------------------------------------
+
+
+async def test_update_restore_point_happy_path(mock_ctx, ctx_patch) -> None:
+    """update_restore_point returns a serialised RestorePoint dict."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    rp = _make_restore_point(name="updated-rp")
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.restore.update_point",
+            new=AsyncMock(return_value=rp),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "update_restore_point",
+            {
+                "workspace": WS_NAME,
+                "warehouse": WH_NAME,
+                "restore_point_id": _RP_ID,
+                "name": "updated-rp",
+            },
+        )
+
+    assert isinstance(result, dict)
+    assert result["id"] == _RP_ID
+    assert result["displayName"] == "updated-rp"
+
+
+async def test_update_restore_point_value_error_becomes_tool_error(mock_ctx, ctx_patch) -> None:
+    """update_restore_point wraps ValueError (no name/description) into ToolError."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.restore.update_point",
+            new=AsyncMock(
+                side_effect=ValueError("At least one of name or description must be provided")
+            ),
+        ),
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "update_restore_point",
+            {
+                "workspace": WS_NAME,
+                "warehouse": WH_NAME,
+                "restore_point_id": _RP_ID,
+            },
+        )
+
+    assert "name or description" in str(exc_info.value).lower()
+
+
+async def test_update_restore_point_fabric_error_becomes_tool_error(mock_ctx, ctx_patch) -> None:
+    """update_restore_point converts FabricError to ToolError."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.restore.update_point",
+            new=AsyncMock(side_effect=NotFoundError("restore point not found")),
+        ),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "update_restore_point",
+            {
+                "workspace": WS_NAME,
+                "warehouse": WH_NAME,
+                "restore_point_id": _RP_ID,
+                "name": "new-name",
+            },
+        )
+
+
+async def test_update_restore_point_readonly_blocked(ctx_patch) -> None:
+    """update_restore_point raises ToolError in FABRIC_MCP_READONLY=1 mode."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_READONLY": "1"}),
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "update_restore_point",
+            {
+                "workspace": WS_NAME,
+                "warehouse": WH_NAME,
+                "restore_point_id": _RP_ID,
+                "name": "new-name",
+            },
+        )
+
+    assert "read-only" in str(exc_info.value).lower()
+
+
+async def test_update_restore_point_workspace_guard(ctx_patch) -> None:
+    """update_restore_point raises ToolError when workspace is not in the allowlist."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_WORKSPACES": "other-workspace"}),
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "update_restore_point",
+            {
+                "workspace": WS_NAME,
+                "warehouse": WH_NAME,
+                "restore_point_id": _RP_ID,
+                "name": "new-name",
+            },
+        )
+
+    assert "allowlist" in str(exc_info.value).lower()
+
+
+# ---------------------------------------------------------------------------
+# delete_restore_point
+# ---------------------------------------------------------------------------
+
+
+async def test_delete_restore_point_happy_path(mock_ctx, ctx_patch) -> None:
+    """delete_restore_point returns a deletion-confirmed dict."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_ALLOW_DESTRUCTIVE": "1"}),
+        patch(
+            "fabric_dw.services.restore.delete_point",
+            new=AsyncMock(return_value=None),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "delete_restore_point",
+            {"workspace": WS_NAME, "warehouse": WH_NAME, "restore_point_id": _RP_ID},
+        )
+
+    assert result == {"deleted": True, "restore_point_id": _RP_ID}
+
+
+async def test_delete_restore_point_readonly_blocked(ctx_patch) -> None:
+    """delete_restore_point raises ToolError in FABRIC_MCP_READONLY=1 mode."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_READONLY": "1", "FABRIC_MCP_ALLOW_DESTRUCTIVE": "1"}),
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "delete_restore_point",
+            {"workspace": WS_NAME, "warehouse": WH_NAME, "restore_point_id": _RP_ID},
+        )
+
+    assert "read-only" in str(exc_info.value).lower()
+
+
+async def test_delete_restore_point_destructive_guard(ctx_patch) -> None:
+    """delete_restore_point raises ToolError when FABRIC_MCP_ALLOW_DESTRUCTIVE is unset."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {}, clear=False),
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "delete_restore_point",
+            {"workspace": WS_NAME, "warehouse": WH_NAME, "restore_point_id": _RP_ID},
+        )
+
+    assert "destructive" in str(exc_info.value).lower()
+
+
+async def test_delete_restore_point_fabric_error_becomes_tool_error(mock_ctx, ctx_patch) -> None:
+    """delete_restore_point converts FabricError to ToolError."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_ALLOW_DESTRUCTIVE": "1"}),
+        patch(
+            "fabric_dw.services.restore.delete_point",
+            new=AsyncMock(side_effect=NotFoundError("restore point not found")),
+        ),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "delete_restore_point",
+            {"workspace": WS_NAME, "warehouse": WH_NAME, "restore_point_id": _RP_ID},
+        )
+
+
+async def test_delete_restore_point_workspace_guard(ctx_patch) -> None:
+    """delete_restore_point raises ToolError when workspace is not in the allowlist."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        patch.dict(
+            os.environ,
+            {"FABRIC_MCP_WORKSPACES": "other-workspace", "FABRIC_MCP_ALLOW_DESTRUCTIVE": "1"},
+        ),
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "delete_restore_point",
+            {"workspace": WS_NAME, "warehouse": WH_NAME, "restore_point_id": _RP_ID},
+        )
+
+    assert "allowlist" in str(exc_info.value).lower()
+
+
+# ---------------------------------------------------------------------------
+# restore_warehouse_in_place
+# ---------------------------------------------------------------------------
+
+
+async def test_restore_warehouse_in_place_happy_path(mock_ctx, ctx_patch) -> None:
+    """restore_warehouse_in_place returns a restoration-confirmed dict."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_ALLOW_DESTRUCTIVE": "1"}),
+        patch(
+            "fabric_dw.services.restore.restore_in_place",
+            new=AsyncMock(return_value=None),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "restore_warehouse_in_place",
+            {"workspace": WS_NAME, "warehouse": WH_NAME, "restore_point_id": _RP_ID},
+        )
+
+    assert result == {"restored": True, "restore_point_id": _RP_ID}
+
+
+async def test_restore_warehouse_in_place_readonly_blocked(ctx_patch) -> None:
+    """restore_warehouse_in_place raises ToolError in FABRIC_MCP_READONLY=1 mode."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_READONLY": "1", "FABRIC_MCP_ALLOW_DESTRUCTIVE": "1"}),
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "restore_warehouse_in_place",
+            {"workspace": WS_NAME, "warehouse": WH_NAME, "restore_point_id": _RP_ID},
+        )
+
+    assert "read-only" in str(exc_info.value).lower()
+
+
+async def test_restore_warehouse_in_place_destructive_guard(ctx_patch) -> None:
+    """restore_warehouse_in_place raises ToolError when destructive tools are disabled."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "restore_warehouse_in_place",
+            {"workspace": WS_NAME, "warehouse": WH_NAME, "restore_point_id": _RP_ID},
+        )
+
+    assert "destructive" in str(exc_info.value).lower()
+
+
+async def test_restore_warehouse_in_place_fabric_error_becomes_tool_error(
+    mock_ctx, ctx_patch
+) -> None:
+    """restore_warehouse_in_place converts FabricError to ToolError."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_ALLOW_DESTRUCTIVE": "1"}),
+        patch(
+            "fabric_dw.services.restore.restore_in_place",
+            new=AsyncMock(side_effect=FabricError("restore failed")),
+        ),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "restore_warehouse_in_place",
+            {"workspace": WS_NAME, "warehouse": WH_NAME, "restore_point_id": _RP_ID},
+        )
+
+
+async def test_restore_warehouse_in_place_value_error_becomes_tool_error(
+    mock_ctx, ctx_patch
+) -> None:
+    """restore_warehouse_in_place wraps ValueError into ToolError via tool_err."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_ALLOW_DESTRUCTIVE": "1"}),
+        patch(
+            "fabric_dw.services.restore.restore_in_place",
+            new=AsyncMock(side_effect=ValueError("cannot restore: operation already in flight")),
+        ),
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "restore_warehouse_in_place",
+            {"workspace": WS_NAME, "warehouse": WH_NAME, "restore_point_id": _RP_ID},
+        )
+
+    assert "operation already in flight" in str(exc_info.value).lower()
+
+
+async def test_restore_warehouse_in_place_workspace_guard(ctx_patch) -> None:
+    """restore_warehouse_in_place raises ToolError when workspace is not in the allowlist."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        patch.dict(
+            os.environ,
+            {"FABRIC_MCP_WORKSPACES": "other-workspace", "FABRIC_MCP_ALLOW_DESTRUCTIVE": "1"},
+        ),
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "restore_warehouse_in_place",
+            {"workspace": WS_NAME, "warehouse": WH_NAME, "restore_point_id": _RP_ID},
+        )
+
+    assert "allowlist" in str(exc_info.value).lower()

--- a/tests/unit/mcp/tools/test_snapshots.py
+++ b/tests/unit/mcp/tools/test_snapshots.py
@@ -1,0 +1,717 @@
+"""Unit tests for the MCP snapshot tool wrappers.
+
+Coverage targets
+----------------
+``src/fabric_dw/mcp/tools/snapshots.py``
+
+Tool list
+~~~~~~~~~
+* ``list_snapshots``         — happy path, FabricError → ToolError, workspace guard
+* ``create_snapshot``        — happy path, bad datetime, FabricError/ValueError → ToolError,
+  readonly guard
+* ``rename_snapshot``        — happy path, FabricError/ValueError → ToolError, readonly guard
+* ``delete_snapshot``        — happy path, FabricError → ToolError, readonly + destructive guard
+* ``roll_snapshot_timestamp`` — happy path, bad datetime, FabricError → ToolError, readonly guard
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime
+from unittest.mock import AsyncMock, patch
+from uuid import UUID
+
+import pytest
+from mcp.server.fastmcp.exceptions import ToolError
+
+from fabric_dw.exceptions import FabricError, NotFoundError
+from fabric_dw.models import WarehouseSnapshot
+from tests.unit.mcp.conftest import (
+    SNAP_ID,
+    WH_ID,
+    WH_NAME,
+    WS_ID,
+    WS_NAME,
+    make_item_entry,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_SNAP_NAME = "snap-1"
+_SNAP_DT = "2026-01-01T00:00:00"
+
+
+def _make_snapshot(
+    snap_id: UUID = SNAP_ID,
+    *,
+    name: str = _SNAP_NAME,
+    parent_wh_id: UUID = WH_ID,
+) -> WarehouseSnapshot:
+    return WarehouseSnapshot.model_validate(
+        {
+            "id": str(snap_id),
+            "displayName": name,
+            "parentWarehouseId": str(parent_wh_id),
+            "snapshotDateTime": _SNAP_DT,
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# list_snapshots
+# ---------------------------------------------------------------------------
+
+
+async def test_list_snapshots_happy_path(mock_ctx, ctx_patch) -> None:
+    """list_snapshots returns a list of serialised WarehouseSnapshot dicts."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    snap = _make_snapshot()
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.snapshots.list_snapshots",
+            new=AsyncMock(return_value=[snap]),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "list_snapshots",
+            {"workspace": WS_NAME, "warehouse": WH_NAME},
+        )
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0]["id"] == str(SNAP_ID)
+    assert result[0]["displayName"] == _SNAP_NAME
+
+
+async def test_list_snapshots_fabric_error_becomes_tool_error(mock_ctx, ctx_patch) -> None:
+    """list_snapshots converts FabricError to ToolError."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.snapshots.list_snapshots",
+            new=AsyncMock(side_effect=NotFoundError("warehouse not found")),
+        ),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "list_snapshots",
+            {"workspace": WS_NAME, "warehouse": WH_NAME},
+        )
+
+
+async def test_list_snapshots_workspace_guard(ctx_patch) -> None:
+    """list_snapshots raises ToolError when workspace is not in the allowlist."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_WORKSPACES": "other-workspace"}),
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "list_snapshots",
+            {"workspace": WS_NAME, "warehouse": WH_NAME},
+        )
+
+    assert "allowlist" in str(exc_info.value).lower()
+
+
+async def test_list_snapshots_empty(mock_ctx, ctx_patch) -> None:
+    """list_snapshots returns an empty list when no snapshots exist."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.snapshots.list_snapshots",
+            new=AsyncMock(return_value=[]),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "list_snapshots",
+            {"workspace": WS_NAME, "warehouse": WH_NAME},
+        )
+
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# create_snapshot
+# ---------------------------------------------------------------------------
+
+
+async def test_create_snapshot_happy_path(mock_ctx, ctx_patch) -> None:
+    """create_snapshot returns a serialised WarehouseSnapshot dict."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    snap = _make_snapshot()
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.snapshots.create",
+            new=AsyncMock(return_value=snap),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "create_snapshot",
+            {"workspace": WS_NAME, "warehouse": WH_NAME, "name": _SNAP_NAME},
+        )
+
+    assert isinstance(result, dict)
+    assert result["id"] == str(SNAP_ID)
+    assert result["displayName"] == _SNAP_NAME
+
+
+async def test_create_snapshot_with_datetime(mock_ctx, ctx_patch) -> None:
+    """create_snapshot passes a parsed datetime to the service when snapshot_dt is supplied."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    snap = _make_snapshot()
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+    mock_create = AsyncMock(return_value=snap)
+
+    with (
+        ctx_patch,
+        patch("fabric_dw.services.snapshots.create", new=mock_create),
+    ):
+        await mcp._tool_manager.call_tool(
+            "create_snapshot",
+            {
+                "workspace": WS_NAME,
+                "warehouse": WH_NAME,
+                "name": _SNAP_NAME,
+                "snapshot_dt": "2026-03-01T12:00:00",
+            },
+        )
+
+    mock_create.assert_called_once()
+    _, kwargs = mock_create.call_args
+    assert kwargs.get("snapshot_dt") is not None
+    assert isinstance(kwargs["snapshot_dt"], datetime)
+
+
+async def test_create_snapshot_bad_datetime_becomes_tool_error(ctx_patch) -> None:
+    """create_snapshot raises ToolError when snapshot_dt is not a valid ISO-8601 string."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "create_snapshot",
+            {
+                "workspace": WS_NAME,
+                "warehouse": WH_NAME,
+                "name": _SNAP_NAME,
+                "snapshot_dt": "not-a-date",
+            },
+        )
+
+    assert "ISO-8601" in str(exc_info.value)
+
+
+async def test_create_snapshot_readonly_blocked(ctx_patch) -> None:
+    """create_snapshot raises ToolError in FABRIC_MCP_READONLY=1 mode."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_READONLY": "1"}),
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "create_snapshot",
+            {"workspace": WS_NAME, "warehouse": WH_NAME, "name": _SNAP_NAME},
+        )
+
+    assert "read-only" in str(exc_info.value).lower()
+
+
+async def test_create_snapshot_fabric_error_becomes_tool_error(mock_ctx, ctx_patch) -> None:
+    """create_snapshot converts FabricError to ToolError via tool_err."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.snapshots.create",
+            new=AsyncMock(side_effect=FabricError("create failed")),
+        ),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "create_snapshot",
+            {"workspace": WS_NAME, "warehouse": WH_NAME, "name": _SNAP_NAME},
+        )
+
+
+async def test_create_snapshot_value_error_becomes_tool_error(mock_ctx, ctx_patch) -> None:
+    """create_snapshot converts ValueError to ToolError via tool_err."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.snapshots.create",
+            new=AsyncMock(side_effect=ValueError("name must be a non-empty string")),
+        ),
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "create_snapshot",
+            {"workspace": WS_NAME, "warehouse": WH_NAME, "name": ""},
+        )
+
+    assert "non-empty" in str(exc_info.value).lower()
+
+
+async def test_create_snapshot_clears_negative_cache(mock_ctx, ctx_patch) -> None:
+    """create_snapshot calls resolver.clear_negative_cache() after success."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    snap = _make_snapshot()
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.snapshots.create",
+            new=AsyncMock(return_value=snap),
+        ),
+    ):
+        await mcp._tool_manager.call_tool(
+            "create_snapshot",
+            {"workspace": WS_NAME, "warehouse": WH_NAME, "name": _SNAP_NAME},
+        )
+
+    mock_ctx.resolver.clear_negative_cache.assert_called_once()
+
+
+async def test_create_snapshot_workspace_guard(ctx_patch) -> None:
+    """create_snapshot raises ToolError when workspace is not in the allowlist."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_WORKSPACES": "other-workspace"}),
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "create_snapshot",
+            {"workspace": WS_NAME, "warehouse": WH_NAME, "name": _SNAP_NAME},
+        )
+
+    assert "allowlist" in str(exc_info.value).lower()
+
+
+# ---------------------------------------------------------------------------
+# rename_snapshot
+# ---------------------------------------------------------------------------
+
+
+async def test_rename_snapshot_happy_path(mock_ctx, ctx_patch) -> None:
+    """rename_snapshot returns a serialised WarehouseSnapshot dict with the new name."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    snap = _make_snapshot(name="snap-renamed")
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.snapshots.rename",
+            new=AsyncMock(return_value=snap),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "rename_snapshot",
+            {"workspace": WS_NAME, "snapshot": _SNAP_NAME, "new_name": "snap-renamed"},
+        )
+
+    assert isinstance(result, dict)
+    assert result["displayName"] == "snap-renamed"
+
+
+async def test_rename_snapshot_readonly_blocked(ctx_patch) -> None:
+    """rename_snapshot raises ToolError in FABRIC_MCP_READONLY=1 mode."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_READONLY": "1"}),
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "rename_snapshot",
+            {"workspace": WS_NAME, "snapshot": _SNAP_NAME, "new_name": "snap-renamed"},
+        )
+
+    assert "read-only" in str(exc_info.value).lower()
+
+
+async def test_rename_snapshot_fabric_error_becomes_tool_error(mock_ctx, ctx_patch) -> None:
+    """rename_snapshot converts FabricError to ToolError via tool_err."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.snapshots.rename",
+            new=AsyncMock(side_effect=NotFoundError("snapshot not found")),
+        ),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "rename_snapshot",
+            {"workspace": WS_NAME, "snapshot": _SNAP_NAME, "new_name": "snap-renamed"},
+        )
+
+
+async def test_rename_snapshot_value_error_becomes_tool_error(mock_ctx, ctx_patch) -> None:
+    """rename_snapshot converts ValueError to ToolError via tool_err."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.snapshots.rename",
+            new=AsyncMock(side_effect=ValueError("new_name must be a non-empty string")),
+        ),
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "rename_snapshot",
+            {"workspace": WS_NAME, "snapshot": _SNAP_NAME, "new_name": ""},
+        )
+
+    assert "non-empty" in str(exc_info.value).lower()
+
+
+async def test_rename_snapshot_clears_negative_cache(mock_ctx, ctx_patch) -> None:
+    """rename_snapshot calls resolver.clear_negative_cache() after success."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    snap = _make_snapshot(name="snap-renamed")
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.snapshots.rename",
+            new=AsyncMock(return_value=snap),
+        ),
+    ):
+        await mcp._tool_manager.call_tool(
+            "rename_snapshot",
+            {"workspace": WS_NAME, "snapshot": _SNAP_NAME, "new_name": "snap-renamed"},
+        )
+
+    mock_ctx.resolver.clear_negative_cache.assert_called_once()
+
+
+async def test_rename_snapshot_workspace_guard(ctx_patch) -> None:
+    """rename_snapshot raises ToolError when workspace is not in the allowlist."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_WORKSPACES": "other-workspace"}),
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "rename_snapshot",
+            {"workspace": WS_NAME, "snapshot": _SNAP_NAME, "new_name": "snap-renamed"},
+        )
+
+    assert "allowlist" in str(exc_info.value).lower()
+
+
+# ---------------------------------------------------------------------------
+# delete_snapshot
+# ---------------------------------------------------------------------------
+
+
+async def test_delete_snapshot_happy_path(mock_ctx, ctx_patch) -> None:
+    """delete_snapshot returns a deletion-confirmed dict with the snapshot id."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry(item_id=SNAP_ID, display_name=_SNAP_NAME)
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_ALLOW_DESTRUCTIVE": "1"}),
+        patch(
+            "fabric_dw.services.snapshots.delete",
+            new=AsyncMock(return_value=None),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "delete_snapshot",
+            {"workspace": WS_NAME, "snapshot": _SNAP_NAME},
+        )
+
+    assert result["deleted"] is True
+    assert result["snapshot_id"] == str(SNAP_ID)
+
+
+async def test_delete_snapshot_readonly_blocked(ctx_patch) -> None:
+    """delete_snapshot raises ToolError in FABRIC_MCP_READONLY=1 mode."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_READONLY": "1", "FABRIC_MCP_ALLOW_DESTRUCTIVE": "1"}),
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "delete_snapshot",
+            {"workspace": WS_NAME, "snapshot": _SNAP_NAME},
+        )
+
+    assert "read-only" in str(exc_info.value).lower()
+
+
+async def test_delete_snapshot_destructive_guard(ctx_patch) -> None:
+    """delete_snapshot raises ToolError when FABRIC_MCP_ALLOW_DESTRUCTIVE is unset."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "delete_snapshot",
+            {"workspace": WS_NAME, "snapshot": _SNAP_NAME},
+        )
+
+    assert "destructive" in str(exc_info.value).lower()
+
+
+async def test_delete_snapshot_fabric_error_becomes_tool_error(mock_ctx, ctx_patch) -> None:
+    """delete_snapshot converts FabricError to ToolError."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry(item_id=SNAP_ID, display_name=_SNAP_NAME)
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_ALLOW_DESTRUCTIVE": "1"}),
+        patch(
+            "fabric_dw.services.snapshots.delete",
+            new=AsyncMock(side_effect=NotFoundError("snapshot not found")),
+        ),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "delete_snapshot",
+            {"workspace": WS_NAME, "snapshot": _SNAP_NAME},
+        )
+
+
+async def test_delete_snapshot_workspace_guard(ctx_patch) -> None:
+    """delete_snapshot raises ToolError when workspace is not in the allowlist."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        patch.dict(
+            os.environ,
+            {"FABRIC_MCP_WORKSPACES": "other-workspace", "FABRIC_MCP_ALLOW_DESTRUCTIVE": "1"},
+        ),
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "delete_snapshot",
+            {"workspace": WS_NAME, "snapshot": _SNAP_NAME},
+        )
+
+    assert "allowlist" in str(exc_info.value).lower()
+
+
+# ---------------------------------------------------------------------------
+# roll_snapshot_timestamp
+# ---------------------------------------------------------------------------
+
+
+async def test_roll_snapshot_timestamp_happy_path(mock_ctx, ctx_patch) -> None:
+    """roll_snapshot_timestamp returns a roll-confirmed dict."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.snapshots.roll_timestamp",
+            new=AsyncMock(return_value=None),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "roll_snapshot_timestamp",
+            {"workspace": WS_NAME, "warehouse": WH_NAME, "snapshot_name": _SNAP_NAME},
+        )
+
+    assert result["rolled"] is True
+    assert result["snapshot_name"] == _SNAP_NAME
+    assert result["new_dt"] is None
+
+
+async def test_roll_snapshot_timestamp_with_datetime(mock_ctx, ctx_patch) -> None:
+    """roll_snapshot_timestamp passes a parsed datetime to the service when new_dt is supplied."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+    mock_roll = AsyncMock(return_value=None)
+
+    with (
+        ctx_patch,
+        patch("fabric_dw.services.snapshots.roll_timestamp", new=mock_roll),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "roll_snapshot_timestamp",
+            {
+                "workspace": WS_NAME,
+                "warehouse": WH_NAME,
+                "snapshot_name": _SNAP_NAME,
+                "new_dt": "2026-06-01T09:00:00",
+            },
+        )
+
+    mock_roll.assert_called_once()
+    args, _kwargs = mock_roll.call_args
+    # second positional arg is snapshot_name, third is new_dt
+    assert args[1] == _SNAP_NAME
+    assert isinstance(args[2], datetime)
+    assert result["new_dt"] == "2026-06-01T09:00:00"
+
+
+async def test_roll_snapshot_timestamp_bad_datetime_becomes_tool_error(ctx_patch) -> None:
+    """roll_snapshot_timestamp raises ToolError when new_dt is not valid ISO-8601."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "roll_snapshot_timestamp",
+            {
+                "workspace": WS_NAME,
+                "warehouse": WH_NAME,
+                "snapshot_name": _SNAP_NAME,
+                "new_dt": "not-a-date",
+            },
+        )
+
+    assert "ISO-8601" in str(exc_info.value)
+
+
+async def test_roll_snapshot_timestamp_readonly_blocked(ctx_patch) -> None:
+    """roll_snapshot_timestamp raises ToolError in FABRIC_MCP_READONLY=1 mode."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_READONLY": "1"}),
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "roll_snapshot_timestamp",
+            {"workspace": WS_NAME, "warehouse": WH_NAME, "snapshot_name": _SNAP_NAME},
+        )
+
+    assert "read-only" in str(exc_info.value).lower()
+
+
+async def test_roll_snapshot_timestamp_fabric_error_becomes_tool_error(mock_ctx, ctx_patch) -> None:
+    """roll_snapshot_timestamp converts FabricError to ToolError."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.snapshots.roll_timestamp",
+            new=AsyncMock(side_effect=FabricError("SQL execution failed")),
+        ),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "roll_snapshot_timestamp",
+            {"workspace": WS_NAME, "warehouse": WH_NAME, "snapshot_name": _SNAP_NAME},
+        )
+
+
+async def test_roll_snapshot_timestamp_workspace_guard(ctx_patch) -> None:
+    """roll_snapshot_timestamp raises ToolError when workspace is not in the allowlist."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_WORKSPACES": "other-workspace"}),
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "roll_snapshot_timestamp",
+            {"workspace": WS_NAME, "warehouse": WH_NAME, "snapshot_name": _SNAP_NAME},
+        )
+
+    assert "allowlist" in str(exc_info.value).lower()


### PR DESCRIPTION
## Summary

- Add `tests/unit/mcp/tools/test_restore.py` — 28 tests covering all six restore-point MCP tools: `list_restore_points`, `get_restore_point`, `create_restore_point`, `update_restore_point`, `delete_restore_point`, `restore_warehouse_in_place`
- Add `tests/unit/mcp/tools/test_snapshots.py` — 29 tests covering all five snapshot MCP tools: `list_snapshots`, `create_snapshot`, `rename_snapshot`, `delete_snapshot`, `roll_snapshot_timestamp`
- Each tool has: happy-path assertion on dict shape, FabricError/ValueError → ToolError funnel, readonly guard (`FABRIC_MCP_READONLY`), destructive guard (`FABRIC_MCP_ALLOW_DESTRUCTIVE`) where applicable, workspace allowlist guard (`FABRIC_MCP_WORKSPACES`), and ISO-8601 datetime parsing validation for tools that accept datetime args

## Coverage result

| Module | Before | After |
|--------|--------|-------|
| `mcp/tools/restore.py` | 38% | **100%** |
| `mcp/tools/snapshots.py` | 45% | **100%** |

## Test plan

- [x] `uv run pytest tests/unit/mcp/tools/test_restore.py tests/unit/mcp/tools/test_snapshots.py -q` — 57 passed
- [x] `just check` (ruff lint + ruff format + ty check + pytest 1812 tests) — all green
- [x] `--durations=10` shows no multi-second tests (all < 0.05 s each)
- [x] No real network or SQL calls — everything mocked via `ctx_patch` fixture

🤖 Generated with [Claude Code](https://claude.com/claude-code)