### PR TITLE
test(cli): cover completion, render helpers, and command edge branches

### DIFF
--- a/tests/unit/cli/commands/test_completion.py
+++ b/tests/unit/cli/commands/test_completion.py
@@ -1,0 +1,198 @@
+"""Tests for completion CLI sub-commands."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from fabric_dw.cli._main import cli
+from fabric_dw.cli.commands.completion import _append_idempotent, _completion_script
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+class TestCompletionInstallPrintOnly:
+    """completion install --print emits script to stdout, no file written."""
+
+    def test_print_bash_exits_zero(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli, ["completion", "install", "--print", "bash"])
+        assert result.exit_code == 0
+
+    def test_print_zsh_exits_zero(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli, ["completion", "install", "--print", "zsh"])
+        assert result.exit_code == 0
+
+    def test_print_fish_exits_zero(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli, ["completion", "install", "--print", "fish"])
+        assert result.exit_code == 0
+
+    def test_print_bash_emits_script(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli, ["completion", "install", "--print", "bash"])
+        # Click generates a bash completion script; it should contain some shell code
+        assert len(result.output) > 0
+
+    def test_unsupported_shell_exits_nonzero(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli, ["completion", "install", "--print", "powershell"])
+        assert result.exit_code != 0
+
+
+class TestCompletionInstallAppendShells:
+    """completion install for append-mode shells (bash, zsh)."""
+
+    def test_bash_install_appends_to_rc(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """Installing bash completion writes to ~/.bashrc."""
+        rc_file = tmp_path / ".bashrc"
+        rc_file.write_text("# existing rc\n")
+
+        mock_script = "# bash completion script\n_FABRIC_DW_COMPLETE=bash_source fabric-dw\n"
+
+        with (
+            patch("fabric_dw.cli.commands.completion.Path.home", return_value=tmp_path),
+            patch(
+                "fabric_dw.cli.commands.completion._completion_script",
+                return_value=mock_script,
+            ),
+        ):
+            result = runner.invoke(cli, ["completion", "install", "bash"])
+
+        assert result.exit_code == 0
+        assert "appended" in result.output.lower() or "Reload" in result.output
+        content = rc_file.read_text()
+        assert mock_script.strip() in content
+
+    def test_zsh_install_appends_to_zshrc(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """Installing zsh completion writes to ~/.zshrc."""
+        rc_file = tmp_path / ".zshrc"
+        rc_file.write_text("# existing rc\n")
+
+        mock_script = "# zsh completion script\n_FABRIC_DW_COMPLETE=zsh_source fabric-dw\n"
+
+        with (
+            patch("fabric_dw.cli.commands.completion.Path.home", return_value=tmp_path),
+            patch(
+                "fabric_dw.cli.commands.completion._completion_script",
+                return_value=mock_script,
+            ),
+        ):
+            result = runner.invoke(cli, ["completion", "install", "zsh"])
+
+        assert result.exit_code == 0
+        content = rc_file.read_text()
+        assert mock_script.strip() in content
+
+    def test_bash_install_idempotent_when_script_already_present(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """Re-running install when the script is already in ~/.bashrc does nothing."""
+        mock_script = "# bash completion script\n_FABRIC_DW_COMPLETE=bash_source fabric-dw\n"
+        rc_file = tmp_path / ".bashrc"
+        rc_file.write_text("# existing rc\n" + mock_script)
+
+        with (
+            patch("fabric_dw.cli.commands.completion.Path.home", return_value=tmp_path),
+            patch(
+                "fabric_dw.cli.commands.completion._completion_script",
+                return_value=mock_script,
+            ),
+        ):
+            result = runner.invoke(cli, ["completion", "install", "bash"])
+
+        assert result.exit_code == 0
+        assert "already present" in result.output.lower()
+
+
+class TestCompletionInstallWriteShell:
+    """completion install for write-mode shells (fish)."""
+
+    def test_fish_install_writes_file(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """Fish completions are written to ~/.config/fish/completions/fabric-dw.fish."""
+        mock_script = "# fish completion\ncomplete -c fabric-dw\n"
+
+        with (
+            patch("fabric_dw.cli.commands.completion.Path.home", return_value=tmp_path),
+            patch(
+                "fabric_dw.cli.commands.completion._completion_script",
+                return_value=mock_script,
+            ),
+        ):
+            result = runner.invoke(cli, ["completion", "install", "fish"])
+
+        assert result.exit_code == 0
+        expected_path = tmp_path / ".config" / "fish" / "completions" / "fabric-dw.fish"
+        assert expected_path.exists()
+        assert expected_path.read_text() == mock_script
+
+    def test_fish_install_creates_parent_dirs(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """Parent directories for fish completion file are created if absent."""
+        mock_script = "# fish\n"
+
+        with (
+            patch("fabric_dw.cli.commands.completion.Path.home", return_value=tmp_path),
+            patch(
+                "fabric_dw.cli.commands.completion._completion_script",
+                return_value=mock_script,
+            ),
+        ):
+            runner.invoke(cli, ["completion", "install", "fish"])
+
+        parent = tmp_path / ".config" / "fish" / "completions"
+        assert parent.is_dir()
+
+
+class TestAppendIdempotent:
+    """Unit tests for the _append_idempotent helper."""
+
+    def test_appends_when_file_does_not_exist(self, tmp_path: Path) -> None:
+        target = tmp_path / ".bashrc"
+        _append_idempotent(target, "# script\n")
+        assert "# script" in target.read_text()
+
+    def test_appends_when_script_not_in_file(self, tmp_path: Path) -> None:
+        target = tmp_path / ".bashrc"
+        target.write_text("# existing\n")
+        _append_idempotent(target, "# newscript\n")
+        content = target.read_text()
+        assert "# existing" in content
+        assert "# newscript" in content
+
+    def test_does_not_append_when_already_present(self, tmp_path: Path) -> None:
+        script = "# completion\n_COMPLETE=bash_source prog\n"
+        target = tmp_path / ".bashrc"
+        target.write_text("# existing\n" + script)
+        _append_idempotent(target, script)
+        content = target.read_text()
+        # Script should appear only once
+        assert content.count(script.strip()) == 1
+
+
+class TestCompletionScript:
+    """Unit tests for _completion_script helper."""
+
+    def test_returns_string_for_bash(self) -> None:
+        script = _completion_script("bash")
+        assert isinstance(script, str)
+        assert len(script) > 0
+
+    def test_returns_string_for_zsh(self) -> None:
+        script = _completion_script("zsh")
+        assert isinstance(script, str)
+        assert len(script) > 0
+
+    def test_returns_string_for_fish(self) -> None:
+        script = _completion_script("fish")
+        assert isinstance(script, str)
+        assert len(script) > 0

--- a/tests/unit/cli/commands/test_queries.py
+++ b/tests/unit/cli/commands/test_queries.py
@@ -15,7 +15,7 @@ from click.testing import CliRunner
 
 from fabric_dw.cache import ItemEntry
 from fabric_dw.cli._main import cli
-from fabric_dw.exceptions import NotFoundError, PermissionDeniedError
+from fabric_dw.exceptions import FabricError, NotFoundError, PermissionDeniedError
 from fabric_dw.models import RunningQuery, WarehouseKind
 from fabric_dw.sql import SqlTarget
 
@@ -248,4 +248,196 @@ class TestQueriesDefaultFallback:
         monkeypatch.delenv("FABRIC_DW_DEFAULT_WORKSPACE", raising=False)
         monkeypatch.delenv("FABRIC_DW_DEFAULT_WAREHOUSE", raising=False)
         result = runner.invoke(cli, ["queries", "list"])
+        assert result.exit_code != 0
+
+
+class TestQueriesListConnections:
+    """queries list-connections — happy path + FabricError (lines 89-101)."""
+
+    def test_list_connections_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.queries.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.queries.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.queries.list_connections",
+                new=AsyncMock(return_value=[]),
+            ),
+        ):
+            result = runner.invoke(cli, ["queries", "list-connections", WS_GUID, WH_GUID])
+        assert result.exit_code == 0
+
+    def test_list_connections_fabric_error_exits_nonzero(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.queries.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.queries.build_sql_target",
+                new=AsyncMock(side_effect=FabricError("server error")),
+            ),
+        ):
+            result = runner.invoke(cli, ["queries", "list-connections", WS_GUID, WH_GUID])
+        assert result.exit_code != 0
+
+
+class TestQueriesRequestHistory:
+    """queries request-history — happy path."""
+
+    def test_request_history_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.queries.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.queries.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.query_insights.list_request_history",
+                new=AsyncMock(return_value=[]),
+            ),
+        ):
+            result = runner.invoke(cli, ["queries", "request-history", WS_GUID, WH_GUID])
+        assert result.exit_code == 0
+
+
+class TestQueriesSessionHistory:
+    """queries session-history — happy path + FabricError (lines 210-211)."""
+
+    def test_session_history_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.queries.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.queries.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.query_insights.list_session_history",
+                new=AsyncMock(return_value=[]),
+            ),
+        ):
+            result = runner.invoke(cli, ["queries", "session-history", WS_GUID, WH_GUID])
+        assert result.exit_code == 0
+
+    def test_session_history_fabric_error_exits_nonzero(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.queries.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.queries.build_sql_target",
+                new=AsyncMock(side_effect=FabricError("server error")),
+            ),
+        ):
+            result = runner.invoke(cli, ["queries", "session-history", WS_GUID, WH_GUID])
+        assert result.exit_code != 0
+
+
+class TestQueriesFrequent:
+    """queries frequent — happy path + FabricError (lines 251-252)."""
+
+    def test_frequent_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.queries.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.queries.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.query_insights.list_frequent_queries",
+                new=AsyncMock(return_value=[]),
+            ),
+        ):
+            result = runner.invoke(cli, ["queries", "frequent", WS_GUID, WH_GUID])
+        assert result.exit_code == 0
+
+    def test_frequent_fabric_error_exits_nonzero(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.queries.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.queries.build_sql_target",
+                new=AsyncMock(side_effect=FabricError("server error")),
+            ),
+        ):
+            result = runner.invoke(cli, ["queries", "frequent", WS_GUID, WH_GUID])
+        assert result.exit_code != 0
+
+
+class TestQueriesLongRunning:
+    """queries long-running — happy path + FabricError (lines 292-293)."""
+
+    def test_long_running_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.queries.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.queries.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.query_insights.list_long_running_queries",
+                new=AsyncMock(return_value=[]),
+            ),
+        ):
+            result = runner.invoke(cli, ["queries", "long-running", WS_GUID, WH_GUID])
+        assert result.exit_code == 0
+
+    def test_long_running_fabric_error_exits_nonzero(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.queries.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.queries.build_sql_target",
+                new=AsyncMock(side_effect=FabricError("server error")),
+            ),
+        ):
+            result = runner.invoke(cli, ["queries", "long-running", WS_GUID, WH_GUID])
         assert result.exit_code != 0

--- a/tests/unit/cli/commands/test_sql_pools.py
+++ b/tests/unit/cli/commands/test_sql_pools.py
@@ -13,8 +13,9 @@ import pytest
 from click.testing import CliRunner
 
 from fabric_dw.cli._main import cli
-from fabric_dw.exceptions import AlreadyExistsError, NotFoundError, PermissionDeniedError
+from fabric_dw.exceptions import AlreadyExistsError, FabricError, NotFoundError, PermissionDeniedError
 from fabric_dw.models import SqlPool, SqlPoolsConfiguration
+from fabric_dw.sql import SqlTarget
 
 WS_GUID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
 WS_UUID = UUID(WS_GUID)
@@ -694,3 +695,489 @@ class TestSqlPoolsReset:
             result = runner.invoke(cli, ["-y", "sql-pools", "reset", WS_GUID])
         assert result.exit_code != 0
         assert "admin" in result.output.lower()
+
+    def test_reset_declined_prints_aborted(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        result = runner.invoke(cli, ["sql-pools", "reset", WS_GUID], input="n\n")
+        assert result.exit_code == 0
+        assert "Aborted." in result.output
+
+    def test_reset_none_result_prints_message(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql_pools.build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools.resolve_workspace_id",
+                new=AsyncMock(return_value=WS_UUID),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._svc.reset_pools",
+                new=AsyncMock(return_value=None),
+            ),
+        ):
+            result = runner.invoke(cli, ["-y", "sql-pools", "reset", WS_GUID])
+        assert result.exit_code == 0
+        assert "never provisioned" in result.output.lower() or "no SQL pools" in result.output
+
+    def test_reset_fabric_error_exits_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql_pools.build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools.resolve_workspace_id",
+                new=AsyncMock(return_value=WS_UUID),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._svc.reset_pools",
+                new=AsyncMock(side_effect=FabricError("server error")),
+            ),
+        ):
+            result = runner.invoke(cli, ["-y", "sql-pools", "reset", WS_GUID])
+        assert result.exit_code != 0
+
+
+class TestSqlPoolsGetFabricError:
+    """get_cmd — FabricError branch (line 70-71)."""
+
+    def test_get_fabric_error_exits_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql_pools.build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools.resolve_workspace_id",
+                new=AsyncMock(return_value=WS_UUID),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._svc.get_configuration",
+                new=AsyncMock(side_effect=FabricError("server error")),
+            ),
+        ):
+            result = runner.invoke(cli, ["sql-pools", "get", WS_GUID])
+        assert result.exit_code != 0
+        assert "server error" in result.output
+
+
+class TestSqlPoolsListErrors:
+    """list_cmd — PermissionDeniedError and FabricError branches (lines 92-95)."""
+
+    def test_list_403_shows_permission_hint(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql_pools.build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools.resolve_workspace_id",
+                new=AsyncMock(return_value=WS_UUID),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._svc.get_configuration",
+                new=AsyncMock(side_effect=PermissionDeniedError("403")),
+            ),
+        ):
+            result = runner.invoke(cli, ["sql-pools", "list", WS_GUID])
+        assert result.exit_code != 0
+        assert "admin" in result.output.lower()
+
+    def test_list_fabric_error_exits_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql_pools.build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools.resolve_workspace_id",
+                new=AsyncMock(return_value=WS_UUID),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._svc.get_configuration",
+                new=AsyncMock(side_effect=FabricError("server error")),
+            ),
+        ):
+            result = runner.invoke(cli, ["sql-pools", "list", WS_GUID])
+        assert result.exit_code != 0
+
+
+class TestSqlPoolsShowErrors:
+    """show_cmd — PermissionDeniedError and FabricError branches (lines 115-118)."""
+
+    def test_show_403_shows_permission_hint(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql_pools.build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools.resolve_workspace_id",
+                new=AsyncMock(return_value=WS_UUID),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._svc.get_configuration",
+                new=AsyncMock(side_effect=PermissionDeniedError("403")),
+            ),
+        ):
+            result = runner.invoke(cli, ["sql-pools", "show", WS_GUID, "--name", "Default"])
+        assert result.exit_code != 0
+        assert "admin" in result.output.lower()
+
+    def test_show_fabric_error_exits_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql_pools.build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools.resolve_workspace_id",
+                new=AsyncMock(return_value=WS_UUID),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._svc.get_configuration",
+                new=AsyncMock(side_effect=FabricError("server error")),
+            ),
+        ):
+            result = runner.invoke(cli, ["sql-pools", "show", WS_GUID, "--name", "Default"])
+        assert result.exit_code != 0
+
+
+class TestSqlPoolsCreateErrors:
+    """create_cmd — ValueError, PermissionDeniedError, FabricError branches (204-209)."""
+
+    def test_create_permission_denied_shows_hint(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        _ = cache_env
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql_pools.build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools.resolve_workspace_id",
+                new=AsyncMock(return_value=WS_UUID),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._svc.create_pool",
+                new=AsyncMock(side_effect=PermissionDeniedError("403")),
+            ),
+        ):
+            result = runner.invoke(
+                cli, ["sql-pools", "create", WS_GUID, "--name", "NewPool", "--max-percent", "50"]
+            )
+        assert result.exit_code != 0
+        assert "admin" in result.output.lower()
+
+    def test_create_fabric_error_exits_nonzero(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        _ = cache_env
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql_pools.build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools.resolve_workspace_id",
+                new=AsyncMock(return_value=WS_UUID),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._svc.create_pool",
+                new=AsyncMock(side_effect=FabricError("server error")),
+            ),
+        ):
+            result = runner.invoke(
+                cli, ["sql-pools", "create", WS_GUID, "--name", "NewPool", "--max-percent", "50"]
+            )
+        assert result.exit_code != 0
+
+    def test_create_value_error_exits_nonzero(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """ValueError from service surfaces as ClickException (line 205)."""
+        _ = cache_env
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql_pools.build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools.resolve_workspace_id",
+                new=AsyncMock(return_value=WS_UUID),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._svc.create_pool",
+                new=AsyncMock(side_effect=ValueError("bad config")),
+            ),
+        ):
+            result = runner.invoke(
+                cli, ["sql-pools", "create", WS_GUID, "--name", "NewPool", "--max-percent", "50"]
+            )
+        assert result.exit_code != 0
+        assert "Invalid pool configuration" in result.output
+
+
+class TestSqlPoolsUpdateErrors:
+    """update_cmd — ValueError, PermissionDeniedError, FabricError branches (285-290)."""
+
+    def test_update_permission_denied_shows_hint(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        _ = cache_env
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql_pools.build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools.resolve_workspace_id",
+                new=AsyncMock(return_value=WS_UUID),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._svc.update_pool",
+                new=AsyncMock(side_effect=PermissionDeniedError("403")),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                ["sql-pools", "update", WS_GUID, "--name", "Default", "--max-percent", "50"],
+            )
+        assert result.exit_code != 0
+        assert "admin" in result.output.lower()
+
+    def test_update_fabric_error_exits_nonzero(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        _ = cache_env
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql_pools.build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools.resolve_workspace_id",
+                new=AsyncMock(return_value=WS_UUID),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._svc.update_pool",
+                new=AsyncMock(side_effect=FabricError("server error")),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                ["sql-pools", "update", WS_GUID, "--name", "Default", "--max-percent", "50"],
+            )
+        assert result.exit_code != 0
+
+    def test_update_value_error_exits_nonzero(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """ValueError from service surfaces as ClickException (line 286)."""
+        _ = cache_env
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql_pools.build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools.resolve_workspace_id",
+                new=AsyncMock(return_value=WS_UUID),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._svc.update_pool",
+                new=AsyncMock(side_effect=ValueError("bad config")),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                ["sql-pools", "update", WS_GUID, "--name", "Default", "--max-percent", "50"],
+            )
+        assert result.exit_code != 0
+        assert "Invalid pool configuration" in result.output
+
+
+class TestSqlPoolsDeleteAbort:
+    """delete_cmd — abort (no-confirm) branch (lines 307-308)."""
+
+    def test_delete_declined_prints_aborted(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        result = runner.invoke(
+            cli, ["sql-pools", "delete", WS_GUID, "--name", "Default"], input="n\n"
+        )
+        assert result.exit_code == 0
+        assert "Aborted." in result.output
+
+    def test_delete_fabric_error_exits_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql_pools.build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools.resolve_workspace_id",
+                new=AsyncMock(return_value=WS_UUID),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._svc.delete_pool",
+                new=AsyncMock(side_effect=FabricError("server error")),
+            ),
+        ):
+            result = runner.invoke(
+                cli, ["-y", "sql-pools", "delete", WS_GUID, "--name", "Default"]
+            )
+        assert result.exit_code != 0
+
+
+class TestSqlPoolsEnableFabricError:
+    """enable_cmd — FabricError branch (line 344-345)."""
+
+    def test_enable_fabric_error_exits_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql_pools.build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools.resolve_workspace_id",
+                new=AsyncMock(return_value=WS_UUID),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._svc.enable",
+                new=AsyncMock(side_effect=FabricError("server error")),
+            ),
+        ):
+            result = runner.invoke(cli, ["sql-pools", "enable", WS_GUID])
+        assert result.exit_code != 0
+
+
+class TestSqlPoolsDisableErrors:
+    """disable_cmd — PermissionDeniedError and FabricError branches (lines 366-369)."""
+
+    def test_disable_403_shows_permission_hint(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql_pools.build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools.resolve_workspace_id",
+                new=AsyncMock(return_value=WS_UUID),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._svc.disable",
+                new=AsyncMock(side_effect=PermissionDeniedError("403")),
+            ),
+        ):
+            result = runner.invoke(cli, ["sql-pools", "disable", WS_GUID])
+        assert result.exit_code != 0
+        assert "admin" in result.output.lower()
+
+    def test_disable_fabric_error_exits_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql_pools.build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools.resolve_workspace_id",
+                new=AsyncMock(return_value=WS_UUID),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._svc.disable",
+                new=AsyncMock(side_effect=FabricError("server error")),
+            ),
+        ):
+            result = runner.invoke(cli, ["sql-pools", "disable", WS_GUID])
+        assert result.exit_code != 0
+
+
+class TestSqlPoolsInsights:
+    """insights_cmd — happy path + FabricError branch (lines 461-462)."""
+
+    def _make_sql_target(self) -> SqlTarget:
+        return SqlTarget(
+            workspace_id=WS_GUID,
+            database="SalesWarehouse",
+            connection_string="wh.datawarehouse.fabric.microsoft.com",
+        )
+
+    def test_insights_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql_pools.build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools.build_sql_target",
+                new=AsyncMock(return_value=(self._make_sql_target(), AsyncMock())),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._qi_svc.list_sql_pool_insights",
+                new=AsyncMock(return_value=[]),
+            ),
+        ):
+            result = runner.invoke(cli, ["sql-pools", "insights", WS_GUID, WS_GUID])
+        assert result.exit_code == 0
+
+    def test_insights_with_since_and_until(self, runner: CliRunner, cache_env: Path) -> None:
+        """Passes --since and --until to exercise the _parse_iso line 410."""
+        _ = cache_env
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql_pools.build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools.build_sql_target",
+                new=AsyncMock(return_value=(self._make_sql_target(), AsyncMock())),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._qi_svc.list_sql_pool_insights",
+                new=AsyncMock(return_value=[]),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "sql-pools",
+                    "insights",
+                    WS_GUID,
+                    WS_GUID,
+                    "--since",
+                    "2024-01-01T00:00:00",
+                    "--until",
+                    "2024-12-31T23:59:59",
+                ],
+            )
+        assert result.exit_code == 0
+
+    def test_insights_fabric_error_exits_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql_pools.build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools.build_sql_target",
+                new=AsyncMock(side_effect=FabricError("server error")),
+            ),
+        ):
+            result = runner.invoke(cli, ["sql-pools", "insights", WS_GUID, WS_GUID])
+        assert result.exit_code != 0

--- a/tests/unit/cli/commands/test_warehouses.py
+++ b/tests/unit/cli/commands/test_warehouses.py
@@ -15,7 +15,7 @@ from click.testing import CliRunner
 
 from fabric_dw.cache import ItemEntry, LookupCache
 from fabric_dw.cli._main import cli
-from fabric_dw.exceptions import NotFoundError
+from fabric_dw.exceptions import FabricError, NotFoundError
 from fabric_dw.models import WarehouseKind
 from tests.fixtures.api_payloads import (
     WAREHOUSE_CREATE_202_PAYLOAD,
@@ -395,6 +395,243 @@ class TestWarehousesDefaultFallback:
         monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
         monkeypatch.delenv("FABRIC_DW_DEFAULT_WORKSPACE", raising=False)
         result = runner.invoke(cli, ["warehouses", "list"])
+        assert result.exit_code != 0
+
+
+class TestWarehousesListFabricError:
+    """warehouses list — FabricError branch (line 70-71)."""
+
+    def test_list_fabric_error_exits_nonzero(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.warehouses.build_http_client",
+                new=_make_cm(mock_http, None),
+            ),
+            patch(
+                "fabric_dw.resolver.Resolver.workspace_id",
+                new=AsyncMock(side_effect=FabricError("server error")),
+            ),
+        ):
+            result = runner.invoke(cli, ["warehouses", "list", WS_GUID])
+        assert result.exit_code != 0
+
+
+class TestWarehousesCreateError:
+    """warehouses create — FabricError branch (lines 120-121)."""
+
+    def test_create_fabric_error_exits_nonzero(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.warehouses.build_http_client",
+                new=_make_cm(mock_http, None),
+            ),
+            patch(
+                "fabric_dw.resolver.Resolver.workspace_id",
+                new=AsyncMock(return_value=WS_UUID),
+            ),
+            patch(
+                "fabric_dw.services.warehouses.create",
+                new=AsyncMock(side_effect=FabricError("server error")),
+            ),
+        ):
+            result = runner.invoke(cli, ["warehouses", "create", WS_GUID, "NewWarehouse"])
+        assert result.exit_code != 0
+
+
+class TestWarehousesRenameError:
+    """warehouses rename — FabricError branch (lines 161-162)."""
+
+    def test_rename_fabric_error_exits_nonzero(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        _cache = LookupCache(path=cache_env / "lookup.json")
+        with (
+            patch(
+                "fabric_dw.cli.commands.warehouses.build_http_client",
+                new=_make_cm(mock_http, None),
+            ),
+            patch(
+                "fabric_dw.cli.commands.warehouses._resolve_item_with_cache",
+                new=AsyncMock(return_value=(WS_UUID, _make_item_entry(), _cache)),
+            ),
+            patch(
+                "fabric_dw.services.warehouses.rename",
+                new=AsyncMock(side_effect=FabricError("server error")),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                ["--yes", "warehouses", "rename", WS_GUID, WH_GUID, "NewName"],
+            )
+        assert result.exit_code != 0
+
+
+class TestWarehousesDeleteError:
+    """warehouses delete — FabricError branch (lines 192-193)."""
+
+    def test_delete_fabric_error_exits_nonzero(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        _cache = LookupCache(path=cache_env / "lookup.json")
+        with (
+            patch(
+                "fabric_dw.cli.commands.warehouses.build_http_client",
+                new=_make_cm(mock_http, None),
+            ),
+            patch(
+                "fabric_dw.cli.commands.warehouses._resolve_item_with_cache",
+                new=AsyncMock(return_value=(WS_UUID, _make_item_entry(), _cache)),
+            ),
+            patch(
+                "fabric_dw.services.warehouses.delete",
+                new=AsyncMock(side_effect=FabricError("server error")),
+            ),
+        ):
+            result = runner.invoke(cli, ["--yes", "warehouses", "delete", WS_GUID, WH_GUID])
+        assert result.exit_code != 0
+
+
+class TestWarehousesTakeoverErrors:
+    """warehouses takeover — FabricError and abort branches (lines 211-212, 220-221, 225-226)."""
+
+    def test_takeover_resolve_fabric_error_exits_nonzero(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """FabricError during _resolve_item (line 211-212)."""
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.warehouses.build_http_client",
+                new=_make_cm(mock_http, None),
+            ),
+            patch(
+                "fabric_dw.cli.commands.warehouses._resolve_item",
+                new=AsyncMock(side_effect=FabricError("resolve error")),
+            ),
+        ):
+            result = runner.invoke(cli, ["--yes", "warehouses", "takeover", WS_GUID, WH_GUID])
+        assert result.exit_code != 0
+
+    def test_takeover_declined_prints_aborted(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """Declining confirmation prints 'Aborted.' (lines 220-221)."""
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.warehouses.build_http_client",
+                new=_make_cm(mock_http, None),
+            ),
+            patch(
+                "fabric_dw.cli.commands.warehouses._resolve_item",
+                new=AsyncMock(return_value=(WS_UUID, _make_item_entry(WarehouseKind.WAREHOUSE))),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                ["warehouses", "takeover", WS_GUID, WH_GUID],
+                input="n\n",
+            )
+        assert result.exit_code == 0
+        assert "Aborted." in result.output
+
+    def test_takeover_fabric_error_after_confirm_exits_nonzero(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """FabricError from ownership service (lines 225-226)."""
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.warehouses.build_http_client",
+                new=_make_cm(mock_http, None),
+            ),
+            patch(
+                "fabric_dw.cli.commands.warehouses._resolve_item",
+                new=AsyncMock(return_value=(WS_UUID, _make_item_entry(WarehouseKind.WAREHOUSE))),
+            ),
+            patch(
+                "fabric_dw.services.ownership.takeover",
+                new=AsyncMock(side_effect=FabricError("takeover failed")),
+            ),
+        ):
+            result = runner.invoke(cli, ["--yes", "warehouses", "takeover", WS_GUID, WH_GUID])
+        assert result.exit_code != 0
+
+
+class TestWarehousesPermissions:
+    """warehouses permissions — happy path + FabricError (lines 241-251)."""
+
+    def test_permissions_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        from fabric_dw.models import ItemAccess, ItemAccessDetail, ItemAccessPrincipal  # noqa: PLC0415
+
+        principal = ItemAccessPrincipal.model_validate(
+            {
+                "id": str(WH_UUID),
+                "displayName": "Alice",
+                "type": "User",
+                "userDetails": {"userPrincipalName": "alice@example.com"},
+            }
+        )
+        detail = ItemAccessDetail.model_validate(
+            {"permissions": ["Read"], "additionalPermissions": []}
+        )
+        access = ItemAccess.model_validate(
+            {
+                "principal": principal.model_dump(by_alias=True, mode="json"),
+                "itemAccessDetails": detail.model_dump(by_alias=True, mode="json"),
+            }
+        )
+
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.warehouses.build_http_client",
+                new=_make_cm(mock_http, None),
+            ),
+            patch(
+                "fabric_dw.cli.commands.warehouses._resolve_item",
+                new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.permissions.list_item_access",
+                new=AsyncMock(return_value=[access]),
+            ),
+        ):
+            result = runner.invoke(cli, ["warehouses", "permissions", WS_GUID, WH_GUID])
+        assert result.exit_code == 0
+
+    def test_permissions_fabric_error_exits_nonzero(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.warehouses.build_http_client",
+                new=_make_cm(mock_http, None),
+            ),
+            patch(
+                "fabric_dw.cli.commands.warehouses._resolve_item",
+                new=AsyncMock(side_effect=FabricError("server error")),
+            ),
+        ):
+            result = runner.invoke(cli, ["warehouses", "permissions", WS_GUID, WH_GUID])
         assert result.exit_code != 0
 
 

--- a/tests/unit/cli/test_render.py
+++ b/tests/unit/cli/test_render.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import json
+from datetime import UTC, datetime
 from io import StringIO
+from uuid import UUID
 
 import pytest
 from rich.console import Console
 
-from fabric_dw.cli._render import _cell, confirm, render
+from fabric_dw.cli._render import _cell, confirm, render, render_permissions_table, render_refresh_table
+from fabric_dw.models import ItemAccess, ItemAccessDetail, ItemAccessPrincipal, TableSyncError, TableSyncStatus
 
 
 class TestRenderJson:
@@ -293,9 +296,259 @@ class TestOmitAllNullColumns:
         assert "definition" not in output
 
 
+class TestNonDictListRows:
+    """_render_table handles list rows that are not dicts (lines 113, 135)."""
+
+    def _render_to_string(self, data: object) -> str:
+        sio = StringIO()
+        console = Console(file=sio, width=200, highlight=False, no_color=True)
+        render(data, json_output=False, console=console)
+        return sio.getvalue()
+
+    def test_list_of_scalars_renders_without_error(self) -> None:
+        """A list of plain strings renders as a single-column table."""
+        output = self._render_to_string(["alpha", "beta", "gamma"])
+        assert "alpha" in output
+        assert "beta" in output
+        assert "gamma" in output
+
+    def test_list_of_ints_renders_without_error(self) -> None:
+        output = self._render_to_string([1, 2, 3])
+        assert "1" in output
+        assert "2" in output
+
+    def test_mixed_dict_and_scalar_rows_renders_without_error(self) -> None:
+        """Mixed rows: dict first (adds columns), then scalar (renders via _cell)."""
+        # Non-dict rows appended at line 113; rendered at line 135
+        output = self._render_to_string([{"name": "foo"}, "bar"])
+        assert output is not None
+
+
 class TestConfirm:
     """confirm() helper returns True when yes=True without prompting."""
 
     def test_yes_flag_skips_prompt(self) -> None:
         result = confirm("Are you sure?", yes=True)
         assert result is True
+
+
+# ---------------------------------------------------------------------------
+# Helpers for render_permissions_table / render_refresh_table tests
+# ---------------------------------------------------------------------------
+
+def _make_item_access(
+    display_name: str = "Alice",
+    upn: str = "alice@example.com",
+    principal_type: str = "User",
+    permissions: list[str] | None = None,
+    additional_permissions: list[str] | None = None,
+) -> ItemAccess:
+    principal = ItemAccessPrincipal.model_validate(
+        {
+            "id": str(UUID("12345678-1234-5678-1234-567812345678")),
+            "displayName": display_name,
+            "type": principal_type,
+            "userDetails": {"userPrincipalName": upn},
+        }
+    )
+    detail = ItemAccessDetail.model_validate(
+        {
+            "permissions": permissions or ["Read"],
+            "additionalPermissions": additional_permissions or [],
+        }
+    )
+    return ItemAccess.model_validate(
+        {
+            "principal": principal.model_dump(by_alias=True, mode="json"),
+            "itemAccessDetails": detail.model_dump(by_alias=True, mode="json"),
+        }
+    )
+
+
+def _make_table_sync_status(
+    table_name: str = "dbo.Sales",
+    status: str = "Success",
+    end_date_time: datetime | None = None,
+    error: TableSyncError | None = None,
+) -> TableSyncStatus:
+    return TableSyncStatus.model_validate(
+        {
+            "tableName": table_name,
+            "status": status,
+            "endDateTime": end_date_time.isoformat() if end_date_time else None,
+            "error": error.model_dump(by_alias=True, mode="json") if error else None,
+        }
+    )
+
+
+class TestRenderPermissionsTable:
+    """render_permissions_table renders ItemAccess records correctly."""
+
+    def _render_to_string(
+        self,
+        accesses: list[ItemAccess],
+        title: str = "Permissions",
+        json_output: bool = False,
+    ) -> str:
+        sio = StringIO()
+        console = Console(file=sio, width=200, highlight=False, no_color=True)
+        render_permissions_table(accesses, title=title, json_output=json_output, console=console)
+        return sio.getvalue()
+
+    def test_renders_display_name(self) -> None:
+        access = _make_item_access(display_name="Alice Smith")
+        output = self._render_to_string([access])
+        assert "Alice Smith" in output
+
+    def test_renders_upn(self) -> None:
+        access = _make_item_access(upn="alice@example.com")
+        output = self._render_to_string([access])
+        assert "alice@example.com" in output
+
+    def test_renders_principal_type(self) -> None:
+        access = _make_item_access(principal_type="User")
+        output = self._render_to_string([access])
+        assert "User" in output
+
+    def test_renders_permissions(self) -> None:
+        access = _make_item_access(permissions=["Read", "Write"])
+        output = self._render_to_string([access])
+        assert "Read" in output
+        assert "Write" in output
+
+    def test_renders_additional_permissions(self) -> None:
+        access = _make_item_access(additional_permissions=["Execute"])
+        output = self._render_to_string([access])
+        assert "Execute" in output
+
+    def test_renders_table_title(self) -> None:
+        access = _make_item_access()
+        output = self._render_to_string([access], title="Warehouse Permissions")
+        assert "Warehouse" in output or "Permissions" in output
+
+    def test_empty_list_renders_without_error(self) -> None:
+        output = self._render_to_string([])
+        assert output is not None
+
+    def test_json_output_emits_valid_json(self, capsys: pytest.CaptureFixture[str]) -> None:
+        access = _make_item_access(display_name="Bob", permissions=["Read"])
+        render_permissions_table([access], title="Test", json_output=True)
+        captured = capsys.readouterr()
+        parsed = json.loads(captured.out)
+        assert isinstance(parsed, list)
+        assert len(parsed) == 1
+
+    def test_service_principal_uses_aad_app_id(self) -> None:
+        """Service principal: identity column shows AAD app ID, not UPN."""
+        aad_id = "aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+        principal = ItemAccessPrincipal.model_validate(
+            {
+                "id": str(UUID("12345678-1234-5678-1234-567812345678")),
+                "displayName": "MyApp",
+                "type": "ServicePrincipal",
+                "servicePrincipalDetails": {"aadAppId": aad_id},
+            }
+        )
+        detail = ItemAccessDetail.model_validate(
+            {"permissions": ["Read"], "additionalPermissions": []}
+        )
+        access = ItemAccess.model_validate(
+            {
+                "principal": principal.model_dump(by_alias=True, mode="json"),
+                "itemAccessDetails": detail.model_dump(by_alias=True, mode="json"),
+            }
+        )
+        sio = StringIO()
+        console = Console(file=sio, width=200, highlight=False, no_color=True)
+        render_permissions_table([access], title="Test", console=console)
+        output = sio.getvalue()
+        assert aad_id in output
+
+    def test_uses_default_console_when_none_given(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """When console=None, a fresh Console() is created (no crash)."""
+        access = _make_item_access()
+        # Should not raise; output goes to stdout (captured)
+        render_permissions_table([access], title="Test", console=None)
+
+
+class TestRenderRefreshTable:
+    """render_refresh_table renders TableSyncStatus records correctly."""
+
+    def _render_to_string(self, statuses: list[TableSyncStatus]) -> str:
+        sio = StringIO()
+        console = Console(file=sio, width=200, highlight=False, no_color=True)
+        render_refresh_table(statuses, console=console)
+        return sio.getvalue()
+
+    def test_renders_table_name(self) -> None:
+        s = _make_table_sync_status(table_name="dbo.Orders")
+        output = self._render_to_string([s])
+        assert "dbo.Orders" in output
+
+    def test_renders_success_status(self) -> None:
+        s = _make_table_sync_status(status="Success")
+        output = self._render_to_string([s])
+        assert "Success" in output
+
+    def test_renders_failure_status(self) -> None:
+        s = _make_table_sync_status(status="Failure")
+        output = self._render_to_string([s])
+        assert "Failure" in output
+
+    def test_renders_notrun_status(self) -> None:
+        s = _make_table_sync_status(status="NotRun")
+        output = self._render_to_string([s])
+        assert "NotRun" in output
+
+    def test_renders_unknown_status_without_style(self) -> None:
+        """An unknown status value does not raise — just renders as plain text."""
+        s = _make_table_sync_status(status="InProgress")
+        output = self._render_to_string([s])
+        assert "InProgress" in output
+
+    def test_renders_end_time(self) -> None:
+        dt = datetime(2024, 3, 15, 10, 30, 0, tzinfo=UTC)
+        s = _make_table_sync_status(end_date_time=dt)
+        output = self._render_to_string([s])
+        assert "2024" in output
+
+    def test_renders_error_code_and_message(self) -> None:
+        error = TableSyncError.model_validate(
+            {"errorCode": "ERR001", "message": "Something went wrong"}
+        )
+        s = _make_table_sync_status(status="Failure", error=error)
+        output = self._render_to_string([s])
+        assert "ERR001" in output
+        assert "Something went wrong" in output
+
+    def test_renders_error_code_only(self) -> None:
+        error = TableSyncError.model_validate({"errorCode": "ERR002", "message": None})
+        s = _make_table_sync_status(status="Failure", error=error)
+        output = self._render_to_string([s])
+        assert "ERR002" in output
+
+    def test_renders_error_message_only(self) -> None:
+        error = TableSyncError.model_validate({"errorCode": None, "message": "Something failed"})
+        s = _make_table_sync_status(status="Failure", error=error)
+        output = self._render_to_string([s])
+        assert "Something failed" in output
+
+    def test_renders_no_error(self) -> None:
+        s = _make_table_sync_status(status="Success", error=None)
+        output = self._render_to_string([s])
+        assert "Success" in output
+
+    def test_empty_list_renders_without_error(self) -> None:
+        output = self._render_to_string([])
+        assert output is not None
+
+    def test_uses_default_console_when_none_given(self) -> None:
+        """When console=None, a fresh Console() is created (no crash)."""
+        s = _make_table_sync_status()
+        # Should not raise
+        render_refresh_table([s], console=None)
+
+    def test_title_appears_in_output(self) -> None:
+        s = _make_table_sync_status()
+        output = self._render_to_string([s])
+        assert "Metadata Refresh Results" in output


### PR DESCRIPTION
## Summary

- Add `tests/unit/cli/commands/test_completion.py` (new file): covers `completion install` for all three shells (bash/zsh/fish), `--print` mode, idempotent-append, fish directory creation, `_append_idempotent` helper, and unsupported-shell rejection.
- Extend `tests/unit/cli/test_render.py`: add `TestRenderPermissionsTable`, `TestRenderRefreshTable`, and `TestNonDictListRows` to cover previously-missing lines 113, 135, 166-190, and the `console=None` branches.
- Extend `tests/unit/cli/commands/test_sql_pools.py`: add error/abort branch tests for all sub-commands (`get`, `list`, `show`, `create`, `update`, `delete`, `enable`, `disable`, `reset`, `insights`) covering `FabricError`, `PermissionDeniedError`, `ValueError`, and no-confirm abort paths. Adds `insights` happy-path + `--since`/`--until` to cover `_parse_iso` line 410.
- Extend `tests/unit/cli/commands/test_warehouses.py`: cover `FabricError` branches in `list`, `create`, `rename`, `delete`, takeover error + abort + second-http-block FabricError, and the `permissions` happy-path + FabricError.
- Extend `tests/unit/cli/commands/test_queries.py`: add `list-connections`, `session-history`, `frequent`, and `long-running` happy-path + `FabricError` tests.

## Coverage before → after (CLI files only)

| File | Before | After |
|---|---|---|
| `completion.py` | 56% | 100% |
| `_render.py` | 79% | 100% |
| `sql_pools.py` | 81% | 100% |
| `warehouses.py` | 84% | 100% |
| `queries.py` | 90% | 100% |

## Test plan

- [x] `just check` (lint + types + all tests): green
- [x] No real network calls; no test takes more than 0.02s
- [x] `--durations=10` shows max 0.02s per test

🤖 Generated with [Claude Code](https://claude.com/claude-code)