### PR TITLE
test(mcp): cover sql_pools and queries tool wrappers

### DIFF
--- a/tests/unit/mcp/tools/test_queries.py
+++ b/tests/unit/mcp/tools/test_queries.py
@@ -1,0 +1,983 @@
+"""Unit tests for the queries MCP tool wrappers.
+
+Coverage targets
+----------------
+- _parse_dt helper             (lines 25-32)
+- list_running_queries         (lines 38-51)
+- list_connections             (lines 53-66)
+- kill_session                 (lines 68-82)
+- list_request_history         (lines 84-115)
+- list_session_history         (lines 117-148)
+- list_frequent_queries        (lines 150-181)
+- list_long_running_queries    (lines 183-214)
+
+Each tool is covered for:
+  1. Happy path (service returns expected data -> correct dict/list shape)
+  2. FabricError -> ToolError funnel
+  3. Guard preconditions (READONLY, WORKSPACES allowlist)
+  4. Arg validation / branching (since/until parsing, ValueError from kill)
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, patch
+from uuid import UUID
+
+import pytest
+
+from fabric_dw.exceptions import FabricError
+from fabric_dw.models import (
+    Connection,
+    ExecRequestHistory,
+    ExecSessionHistory,
+    FrequentlyRunQuery,
+    LongRunningQuery,
+    RunningQuery,
+)
+from tests.unit.mcp.conftest import (
+    WH_ID,
+    WH_NAME,
+    WS_ID,
+    WS_NAME,
+    make_item_entry,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_WS_ID = WS_ID
+_WH_ID = WH_ID
+_WS_NAME = WS_NAME
+_WH_NAME = WH_NAME
+
+
+def _make_running_query() -> RunningQuery:
+    return RunningQuery.model_validate(
+        {
+            "session_id": 42,
+            "request_id": "req-1",
+            "status": "running",
+            "start_time": "2026-01-01T12:00:00",
+            "total_elapsed_time": 1000,
+            "login_name": "user@example.com",
+            "command": "SELECT 1",
+            "query_text": None,
+        }
+    )
+
+
+def _make_connection() -> Connection:
+    return Connection.model_validate(
+        {
+            "session_id": 7,
+            "connect_time": "2026-01-01T10:00:00",
+            "net_transport": "TCP",
+        }
+    )
+
+
+def _make_exec_request_history() -> ExecRequestHistory:
+    return ExecRequestHistory.model_validate(
+        {
+            "session_id": 1,
+            "row_count": 5,
+            "status": "Succeeded",
+        }
+    )
+
+
+def _make_exec_session_history() -> ExecSessionHistory:
+    return ExecSessionHistory.model_validate(
+        {
+            "session_id": 99,
+            "connection_id": str(UUID("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")),
+            "session_start_time": "2026-01-01T09:00:00",
+            "total_query_elapsed_time_ms": 500,
+            "last_request_start_time": "2026-01-01T09:00:01",
+            "login_name": "user@example.com",
+            "status": "closed",
+            "is_user_process": True,
+            "prev_error": 0,
+            "group_id": 0,
+            "text_size": 65536,
+            "date_first": 7,
+            "quoted_identifier": True,
+            "arithabort": False,
+            "ansi_null_dflt_on": True,
+            "ansi_defaults": False,
+            "ansi_warnings": True,
+            "ansi_padding": True,
+            "ansi_nulls": True,
+            "concat_null_yields_null": True,
+            "transaction_isolation_level": 2,
+            "lock_timeout": -1,
+            "deadlock_priority": 0,
+            "original_security_id": b"\x00",
+        }
+    )
+
+
+def _make_frequently_run_query() -> FrequentlyRunQuery:
+    return FrequentlyRunQuery.model_validate(
+        {
+            "number_of_runs": 10,
+            "avg_total_elapsed_time_ms": 200,
+            "last_run_total_elapsed_time_ms": 180,
+            "min_run_total_elapsed_time_ms": 100,
+            "max_run_total_elapsed_time_ms": 300,
+            "number_of_successful_runs": 9,
+            "number_of_failed_runs": 1,
+            "number_of_cancelled_runs": 0,
+        }
+    )
+
+
+def _make_long_running_query() -> LongRunningQuery:
+    return LongRunningQuery.model_validate(
+        {
+            "median_total_elapsed_time_ms": 5000,
+            "number_of_runs": 3,
+            "last_run_total_elapsed_time_ms": 6000,
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# list_running_queries
+# ---------------------------------------------------------------------------
+
+
+async def test_list_running_queries_happy_path(mock_ctx, ctx_patch) -> None:
+    """list_running_queries returns list of serialised query dicts."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    query = _make_running_query()
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.queries.list_running",
+            new=AsyncMock(return_value=[query]),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "list_running_queries",
+            {"workspace": _WS_NAME, "warehouse": _WH_NAME},
+        )
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0]["session_id"] == 42
+    assert result[0]["status"] == "running"
+
+
+async def test_list_running_queries_fabric_error(mock_ctx, ctx_patch) -> None:
+    """list_running_queries wraps FabricError as ToolError."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.queries.list_running",
+            new=AsyncMock(side_effect=FabricError("sql error")),
+        ),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "list_running_queries",
+            {"workspace": _WS_NAME, "warehouse": _WH_NAME},
+        )
+
+
+async def test_list_running_queries_workspace_not_allowed(ctx_patch) -> None:
+    """list_running_queries raises ToolError when workspace not in allowlist."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_WORKSPACES": "other-ws"}),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "list_running_queries",
+            {"workspace": _WS_NAME, "warehouse": _WH_NAME},
+        )
+
+
+async def test_list_running_queries_empty(mock_ctx, ctx_patch) -> None:
+    """list_running_queries returns empty list when no queries running."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.queries.list_running",
+            new=AsyncMock(return_value=[]),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "list_running_queries",
+            {"workspace": _WS_NAME, "warehouse": _WH_NAME},
+        )
+
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# list_connections
+# ---------------------------------------------------------------------------
+
+
+async def test_list_connections_happy_path(mock_ctx, ctx_patch) -> None:
+    """list_connections returns list of serialised connection dicts."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    conn = _make_connection()
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.queries.list_connections",
+            new=AsyncMock(return_value=[conn]),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "list_connections",
+            {"workspace": _WS_NAME, "warehouse": _WH_NAME},
+        )
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0]["session_id"] == 7
+    assert result[0]["net_transport"] == "TCP"
+
+
+async def test_list_connections_fabric_error(mock_ctx, ctx_patch) -> None:
+    """list_connections wraps FabricError as ToolError."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.queries.list_connections",
+            new=AsyncMock(side_effect=FabricError("sql error")),
+        ),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "list_connections",
+            {"workspace": _WS_NAME, "warehouse": _WH_NAME},
+        )
+
+
+async def test_list_connections_workspace_not_allowed(ctx_patch) -> None:
+    """list_connections raises ToolError when workspace not in allowlist."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_WORKSPACES": "other-ws"}),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "list_connections",
+            {"workspace": _WS_NAME, "warehouse": _WH_NAME},
+        )
+
+
+# ---------------------------------------------------------------------------
+# kill_session
+# ---------------------------------------------------------------------------
+
+
+async def test_kill_session_happy_path(mock_ctx, ctx_patch) -> None:
+    """kill_session returns killed=True dict."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.queries.kill",
+            new=AsyncMock(return_value=None),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "kill_session",
+            {"workspace": _WS_NAME, "warehouse": _WH_NAME, "session_id": 42},
+        )
+
+    assert result == {"killed": True, "session_id": 42}
+
+
+async def test_kill_session_fabric_error(mock_ctx, ctx_patch) -> None:
+    """kill_session wraps FabricError as ToolError."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.queries.kill",
+            new=AsyncMock(side_effect=FabricError("kill failed")),
+        ),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "kill_session",
+            {"workspace": _WS_NAME, "warehouse": _WH_NAME, "session_id": 42},
+        )
+
+
+async def test_kill_session_value_error(mock_ctx, ctx_patch) -> None:
+    """kill_session wraps ValueError as ToolError."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.queries.kill",
+            new=AsyncMock(side_effect=ValueError("invalid session")),
+        ),
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "kill_session",
+            {"workspace": _WS_NAME, "warehouse": _WH_NAME, "session_id": 99},
+        )
+
+    assert "invalid session" in str(exc_info.value)
+
+
+async def test_kill_session_readonly_blocked(ctx_patch) -> None:
+    """kill_session raises ToolError in read-only mode."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_READONLY": "1"}),
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "kill_session",
+            {"workspace": _WS_NAME, "warehouse": _WH_NAME, "session_id": 5},
+        )
+
+    assert "read-only" in str(exc_info.value).lower()
+
+
+async def test_kill_session_workspace_not_allowed(ctx_patch) -> None:
+    """kill_session raises ToolError when workspace not in allowlist."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_WORKSPACES": "other-ws"}),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "kill_session",
+            {"workspace": _WS_NAME, "warehouse": _WH_NAME, "session_id": 5},
+        )
+
+
+# ---------------------------------------------------------------------------
+# list_request_history
+# ---------------------------------------------------------------------------
+
+
+async def test_list_request_history_happy_path(mock_ctx, ctx_patch) -> None:
+    """list_request_history returns list of serialised history dicts."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    hist = _make_exec_request_history()
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.query_insights.list_request_history",
+            new=AsyncMock(return_value=[hist]),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "list_request_history",
+            {"workspace": _WS_NAME, "warehouse": _WH_NAME},
+        )
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0]["row_count"] == 5
+    assert result[0]["status"] == "Succeeded"
+
+
+async def test_list_request_history_with_since_until(mock_ctx, ctx_patch) -> None:
+    """list_request_history passes parsed datetimes to service."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+    mock_svc = AsyncMock(return_value=[])
+
+    with (
+        ctx_patch,
+        patch("fabric_dw.services.query_insights.list_request_history", new=mock_svc),
+    ):
+        await mcp._tool_manager.call_tool(
+            "list_request_history",
+            {
+                "workspace": _WS_NAME,
+                "warehouse": _WH_NAME,
+                "since": "2026-01-01T00:00:00",
+                "until": "2026-12-31T23:59:59",
+                "limit": 200,
+            },
+        )
+
+    mock_svc.assert_called_once()
+    _, kwargs = mock_svc.call_args
+    assert kwargs["since"] is not None
+    assert kwargs["until"] is not None
+    assert kwargs["limit"] == 200
+
+
+async def test_list_request_history_bad_since(ctx_patch) -> None:
+    """list_request_history raises ToolError on invalid ISO-8601 since."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "list_request_history",
+            {"workspace": _WS_NAME, "warehouse": _WH_NAME, "since": "not-a-date"},
+        )
+
+    assert "ISO-8601" in str(exc_info.value)
+
+
+async def test_list_request_history_bad_until(ctx_patch) -> None:
+    """list_request_history raises ToolError on invalid ISO-8601 until."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "list_request_history",
+            {"workspace": _WS_NAME, "warehouse": _WH_NAME, "until": "bad-ts"},
+        )
+
+    assert "ISO-8601" in str(exc_info.value)
+
+
+async def test_list_request_history_fabric_error(mock_ctx, ctx_patch) -> None:
+    """list_request_history wraps FabricError as ToolError."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.query_insights.list_request_history",
+            new=AsyncMock(side_effect=FabricError("sql error")),
+        ),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "list_request_history",
+            {"workspace": _WS_NAME, "warehouse": _WH_NAME},
+        )
+
+
+async def test_list_request_history_workspace_not_allowed(ctx_patch) -> None:
+    """list_request_history raises ToolError when workspace not in allowlist."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_WORKSPACES": "other-ws"}),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "list_request_history",
+            {"workspace": _WS_NAME, "warehouse": _WH_NAME},
+        )
+
+
+# ---------------------------------------------------------------------------
+# list_session_history
+# ---------------------------------------------------------------------------
+
+
+async def test_list_session_history_happy_path(mock_ctx, ctx_patch) -> None:
+    """list_session_history returns list of serialised session dicts."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    sess = _make_exec_session_history()
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.query_insights.list_session_history",
+            new=AsyncMock(return_value=[sess]),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "list_session_history",
+            {"workspace": _WS_NAME, "warehouse": _WH_NAME},
+        )
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0]["session_id"] == 99
+    assert result[0]["login_name"] == "user@example.com"
+
+
+async def test_list_session_history_with_since_until(mock_ctx, ctx_patch) -> None:
+    """list_session_history passes parsed datetimes to service."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+    mock_svc = AsyncMock(return_value=[])
+
+    with (
+        ctx_patch,
+        patch("fabric_dw.services.query_insights.list_session_history", new=mock_svc),
+    ):
+        await mcp._tool_manager.call_tool(
+            "list_session_history",
+            {
+                "workspace": _WS_NAME,
+                "warehouse": _WH_NAME,
+                "since": "2026-01-01T00:00:00",
+                "until": "2026-06-01T00:00:00",
+            },
+        )
+
+    mock_svc.assert_called_once()
+    _, kwargs = mock_svc.call_args
+    assert kwargs["since"] is not None
+    assert kwargs["until"] is not None
+
+
+async def test_list_session_history_bad_since(ctx_patch) -> None:
+    """list_session_history raises ToolError on invalid ISO-8601 since."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "list_session_history",
+            {"workspace": _WS_NAME, "warehouse": _WH_NAME, "since": "bad-ts"},
+        )
+
+    assert "ISO-8601" in str(exc_info.value)
+
+
+async def test_list_session_history_bad_until(ctx_patch) -> None:
+    """list_session_history raises ToolError on invalid ISO-8601 until."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "list_session_history",
+            {"workspace": _WS_NAME, "warehouse": _WH_NAME, "until": "bad-ts"},
+        )
+
+    assert "ISO-8601" in str(exc_info.value)
+
+
+async def test_list_session_history_fabric_error(mock_ctx, ctx_patch) -> None:
+    """list_session_history wraps FabricError as ToolError."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.query_insights.list_session_history",
+            new=AsyncMock(side_effect=FabricError("sql error")),
+        ),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "list_session_history",
+            {"workspace": _WS_NAME, "warehouse": _WH_NAME},
+        )
+
+
+async def test_list_session_history_workspace_not_allowed(ctx_patch) -> None:
+    """list_session_history raises ToolError when workspace not in allowlist."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_WORKSPACES": "other-ws"}),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "list_session_history",
+            {"workspace": _WS_NAME, "warehouse": _WH_NAME},
+        )
+
+
+# ---------------------------------------------------------------------------
+# list_frequent_queries
+# ---------------------------------------------------------------------------
+
+
+async def test_list_frequent_queries_happy_path(mock_ctx, ctx_patch) -> None:
+    """list_frequent_queries returns list of serialised frequent query dicts."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    fq = _make_frequently_run_query()
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.query_insights.list_frequent_queries",
+            new=AsyncMock(return_value=[fq]),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "list_frequent_queries",
+            {"workspace": _WS_NAME, "warehouse": _WH_NAME},
+        )
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0]["number_of_runs"] == 10
+    assert result[0]["number_of_successful_runs"] == 9
+
+
+async def test_list_frequent_queries_with_since_until(mock_ctx, ctx_patch) -> None:
+    """list_frequent_queries passes parsed datetimes and limit to service."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+    mock_svc = AsyncMock(return_value=[])
+
+    with (
+        ctx_patch,
+        patch("fabric_dw.services.query_insights.list_frequent_queries", new=mock_svc),
+    ):
+        await mcp._tool_manager.call_tool(
+            "list_frequent_queries",
+            {
+                "workspace": _WS_NAME,
+                "warehouse": _WH_NAME,
+                "since": "2026-01-01T00:00:00",
+                "until": "2026-06-01T00:00:00",
+                "limit": 500,
+            },
+        )
+
+    _, kwargs = mock_svc.call_args
+    assert kwargs["since"] is not None
+    assert kwargs["until"] is not None
+    assert kwargs["limit"] == 500
+
+
+async def test_list_frequent_queries_bad_since(ctx_patch) -> None:
+    """list_frequent_queries raises ToolError on invalid ISO-8601 since."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "list_frequent_queries",
+            {"workspace": _WS_NAME, "warehouse": _WH_NAME, "since": "bad"},
+        )
+
+    assert "ISO-8601" in str(exc_info.value)
+
+
+async def test_list_frequent_queries_bad_until(ctx_patch) -> None:
+    """list_frequent_queries raises ToolError on invalid ISO-8601 until."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "list_frequent_queries",
+            {"workspace": _WS_NAME, "warehouse": _WH_NAME, "until": "bad"},
+        )
+
+    assert "ISO-8601" in str(exc_info.value)
+
+
+async def test_list_frequent_queries_fabric_error(mock_ctx, ctx_patch) -> None:
+    """list_frequent_queries wraps FabricError as ToolError."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.query_insights.list_frequent_queries",
+            new=AsyncMock(side_effect=FabricError("sql error")),
+        ),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "list_frequent_queries",
+            {"workspace": _WS_NAME, "warehouse": _WH_NAME},
+        )
+
+
+async def test_list_frequent_queries_workspace_not_allowed(ctx_patch) -> None:
+    """list_frequent_queries raises ToolError when workspace not in allowlist."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_WORKSPACES": "other-ws"}),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "list_frequent_queries",
+            {"workspace": _WS_NAME, "warehouse": _WH_NAME},
+        )
+
+
+# ---------------------------------------------------------------------------
+# list_long_running_queries
+# ---------------------------------------------------------------------------
+
+
+async def test_list_long_running_queries_happy_path(mock_ctx, ctx_patch) -> None:
+    """list_long_running_queries returns list of serialised long-running query dicts."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    lrq = _make_long_running_query()
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.query_insights.list_long_running_queries",
+            new=AsyncMock(return_value=[lrq]),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "list_long_running_queries",
+            {"workspace": _WS_NAME, "warehouse": _WH_NAME},
+        )
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0]["median_total_elapsed_time_ms"] == 5000
+    assert result[0]["number_of_runs"] == 3
+
+
+async def test_list_long_running_queries_with_since_until(mock_ctx, ctx_patch) -> None:
+    """list_long_running_queries passes parsed datetimes and limit to service."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+    mock_svc = AsyncMock(return_value=[])
+
+    with (
+        ctx_patch,
+        patch("fabric_dw.services.query_insights.list_long_running_queries", new=mock_svc),
+    ):
+        await mcp._tool_manager.call_tool(
+            "list_long_running_queries",
+            {
+                "workspace": _WS_NAME,
+                "warehouse": _WH_NAME,
+                "since": "2026-01-01T00:00:00",
+                "until": "2026-06-01T00:00:00",
+                "limit": 250,
+            },
+        )
+
+    _, kwargs = mock_svc.call_args
+    assert kwargs["since"] is not None
+    assert kwargs["until"] is not None
+    assert kwargs["limit"] == 250
+
+
+async def test_list_long_running_queries_bad_since(ctx_patch) -> None:
+    """list_long_running_queries raises ToolError on invalid ISO-8601 since."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "list_long_running_queries",
+            {"workspace": _WS_NAME, "warehouse": _WH_NAME, "since": "bad"},
+        )
+
+    assert "ISO-8601" in str(exc_info.value)
+
+
+async def test_list_long_running_queries_bad_until(ctx_patch) -> None:
+    """list_long_running_queries raises ToolError on invalid ISO-8601 until."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "list_long_running_queries",
+            {"workspace": _WS_NAME, "warehouse": _WH_NAME, "until": "bad"},
+        )
+
+    assert "ISO-8601" in str(exc_info.value)
+
+
+async def test_list_long_running_queries_fabric_error(mock_ctx, ctx_patch) -> None:
+    """list_long_running_queries wraps FabricError as ToolError."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.query_insights.list_long_running_queries",
+            new=AsyncMock(side_effect=FabricError("sql error")),
+        ),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "list_long_running_queries",
+            {"workspace": _WS_NAME, "warehouse": _WH_NAME},
+        )
+
+
+async def test_list_long_running_queries_workspace_not_allowed(ctx_patch) -> None:
+    """list_long_running_queries raises ToolError when workspace not in allowlist."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_WORKSPACES": "other-ws"}),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "list_long_running_queries",
+            {"workspace": _WS_NAME, "warehouse": _WH_NAME},
+        )

--- a/tests/unit/mcp/tools/test_sql_pools.py
+++ b/tests/unit/mcp/tools/test_sql_pools.py
@@ -1,0 +1,1152 @@
+"""Unit tests for the sql_pools MCP tool wrappers.
+
+Coverage targets
+----------------
+- get_sql_pools_configuration  (lines 34-49)
+- list_sql_pools               (lines 51-66)
+- get_sql_pool                 (lines 68-90)
+- create_sql_pool              (lines 92-155)
+- update_sql_pool              (lines 157-207)
+- delete_sql_pool              (lines 209-232)
+- reset_sql_pools              (lines 234-255)
+- enable_sql_pools             (lines 257-273)
+- disable_sql_pools            (lines 275-293)
+- _parse_dt helper             (lines 295-302)
+- list_sql_pool_insights       (lines 304-335)
+
+Each tool is covered for:
+  1. Happy path (service returns expected data -> correct dict/list shape)
+  2. FabricError / subclass -> ToolError funnel
+  3. Guard preconditions (READONLY, ALLOW_DESTRUCTIVE, WORKSPACES allowlist)
+  4. Arg validation / branching (classifier, missing pool after create/update, etc.)
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from fabric_dw.exceptions import AlreadyExistsError, FabricError, NotFoundError
+from fabric_dw.models import (
+    SqlPool,
+    SqlPoolInsight,
+    SqlPoolsConfiguration,
+)
+from tests.unit.mcp.conftest import (
+    WH_ID,
+    WH_NAME,
+    WS_ID,
+    WS_NAME,
+    make_item_entry,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_WS_ID = WS_ID
+_WH_ID = WH_ID
+_WS_NAME = WS_NAME
+_WH_NAME = WH_NAME
+
+
+def _make_pool(
+    name: str = "pool-1",
+    max_pct: int = 30,
+    *,
+    is_default: bool = False,
+) -> SqlPool:
+    return SqlPool.model_validate(
+        {
+            "name": name,
+            "isDefault": is_default,
+            "maxResourcePercentage": max_pct,
+            "optimizeForReads": True,
+        }
+    )
+
+
+def _make_config(
+    *,
+    enabled: bool = True,
+    pools: list[SqlPool] | None = None,
+) -> SqlPoolsConfiguration:
+    pool_list = pools if pools is not None else [_make_pool()]
+    return SqlPoolsConfiguration.model_validate(
+        {
+            "customSQLPoolsEnabled": enabled,
+            "customSQLPools": [p.model_dump(by_alias=True, mode="json") for p in pool_list],
+        }
+    )
+
+
+def _make_pool_insight() -> SqlPoolInsight:
+    return SqlPoolInsight.model_validate(
+        {
+            "sql_pool_name": "pool-1",
+            "timestamp": "2026-01-01T00:00:00",
+            "max_resource_percentage": 30,
+            "is_optimized_for_reads": True,
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# get_sql_pools_configuration
+# ---------------------------------------------------------------------------
+
+
+async def test_get_sql_pools_configuration_happy_path(mock_ctx, ctx_patch) -> None:
+    """get_sql_pools_configuration returns serialised config dict."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    config = _make_config()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.sql_pools.get_configuration",
+            new=AsyncMock(return_value=config),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "get_sql_pools_configuration",
+            {"workspace": _WS_NAME},
+        )
+
+    assert isinstance(result, dict)
+    assert result["customSQLPoolsEnabled"] is True
+    assert len(result["customSQLPools"]) == 1
+
+
+async def test_get_sql_pools_configuration_resolver_fabric_error(mock_ctx, ctx_patch) -> None:
+    """get_sql_pools_configuration wraps FabricError from resolver as ToolError."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.workspace_id = AsyncMock(side_effect=NotFoundError("workspace not found"))
+
+    with (
+        ctx_patch,
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "get_sql_pools_configuration",
+            {"workspace": _WS_NAME},
+        )
+
+
+async def test_get_sql_pools_configuration_workspace_not_allowed(ctx_patch) -> None:
+    """get_sql_pools_configuration raises ToolError when workspace not in allowlist."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_WORKSPACES": "other-ws"}),
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "get_sql_pools_configuration",
+            {"workspace": _WS_NAME},
+        )
+
+    assert "allowlist" in str(exc_info.value).lower()
+
+
+async def test_get_sql_pools_configuration_service_fabric_error(mock_ctx, ctx_patch) -> None:
+    """get_sql_pools_configuration surfaces FabricError from service as ToolError."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.sql_pools.get_configuration",
+            new=AsyncMock(side_effect=FabricError("api error")),
+        ),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "get_sql_pools_configuration",
+            {"workspace": _WS_NAME},
+        )
+
+
+# ---------------------------------------------------------------------------
+# list_sql_pools
+# ---------------------------------------------------------------------------
+
+
+async def test_list_sql_pools_happy_path(mock_ctx, ctx_patch) -> None:
+    """list_sql_pools returns list of pool dicts."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    config = _make_config(pools=[_make_pool("alpha", 40), _make_pool("beta", 30)])
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.sql_pools.get_configuration",
+            new=AsyncMock(return_value=config),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "list_sql_pools",
+            {"workspace": _WS_NAME},
+        )
+
+    assert isinstance(result, list)
+    assert len(result) == 2
+    assert result[0]["name"] == "alpha"
+    assert result[1]["name"] == "beta"
+
+
+async def test_list_sql_pools_fabric_error(mock_ctx, ctx_patch) -> None:
+    """list_sql_pools wraps FabricError as ToolError."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.sql_pools.get_configuration",
+            new=AsyncMock(side_effect=FabricError("boom")),
+        ),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "list_sql_pools",
+            {"workspace": _WS_NAME},
+        )
+
+
+async def test_list_sql_pools_workspace_not_allowed(ctx_patch) -> None:
+    """list_sql_pools raises ToolError when workspace not in allowlist."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_WORKSPACES": "other-ws"}),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "list_sql_pools",
+            {"workspace": _WS_NAME},
+        )
+
+
+# ---------------------------------------------------------------------------
+# get_sql_pool
+# ---------------------------------------------------------------------------
+
+
+async def test_get_sql_pool_happy_path(mock_ctx, ctx_patch) -> None:
+    """get_sql_pool returns the matching pool dict."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    pool = _make_pool("pool-x", 50)
+    config = _make_config(pools=[pool])
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.sql_pools.get_configuration",
+            new=AsyncMock(return_value=config),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "get_sql_pool",
+            {"workspace": _WS_NAME, "pool_name": "pool-x"},
+        )
+
+    assert isinstance(result, dict)
+    assert result["name"] == "pool-x"
+    assert result["maxResourcePercentage"] == 50
+
+
+async def test_get_sql_pool_not_found_in_config(mock_ctx, ctx_patch) -> None:
+    """get_sql_pool raises ToolError when the named pool is absent from config."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    config = _make_config(pools=[_make_pool("other")])
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.sql_pools.get_configuration",
+            new=AsyncMock(return_value=config),
+        ),
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "get_sql_pool",
+            {"workspace": _WS_NAME, "pool_name": "missing-pool"},
+        )
+
+    assert "missing-pool" in str(exc_info.value)
+
+
+async def test_get_sql_pool_fabric_error(mock_ctx, ctx_patch) -> None:
+    """get_sql_pool propagates FabricError as ToolError."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.sql_pools.get_configuration",
+            new=AsyncMock(side_effect=FabricError("api error")),
+        ),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "get_sql_pool",
+            {"workspace": _WS_NAME, "pool_name": "pool-x"},
+        )
+
+
+async def test_get_sql_pool_workspace_not_allowed(ctx_patch) -> None:
+    """get_sql_pool raises ToolError when workspace is not in allowlist."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_WORKSPACES": "other-ws"}),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "get_sql_pool",
+            {"workspace": _WS_NAME, "pool_name": "pool-x"},
+        )
+
+
+# ---------------------------------------------------------------------------
+# create_sql_pool
+# ---------------------------------------------------------------------------
+
+
+async def test_create_sql_pool_happy_path(mock_ctx, ctx_patch) -> None:
+    """create_sql_pool returns the created pool dict and clears negative cache."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    created_pool = _make_pool("new-pool", 20)
+    config = _make_config(pools=[created_pool])
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.sql_pools.create_pool",
+            new=AsyncMock(return_value=config),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "create_sql_pool",
+            {"workspace": _WS_NAME, "name": "new-pool", "max_percent": 20},
+        )
+
+    assert isinstance(result, dict)
+    assert result["name"] == "new-pool"
+    assert result["maxResourcePercentage"] == 20
+    mock_ctx.resolver.clear_negative_cache.assert_called_once()
+
+
+async def test_create_sql_pool_with_classifier(mock_ctx, ctx_patch) -> None:
+    """create_sql_pool passes classifier fields to the service."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    created_pool = SqlPool.model_validate(
+        {
+            "name": "pool-cls",
+            "isDefault": False,
+            "maxResourcePercentage": 25,
+            "optimizeForReads": True,
+            "classifier": {"type": "Application Name", "value": ["MyApp"]},
+        }
+    )
+    config = _make_config(pools=[created_pool])
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_create = AsyncMock(return_value=config)
+
+    with (
+        ctx_patch,
+        patch("fabric_dw.services.sql_pools.create_pool", new=mock_create),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "create_sql_pool",
+            {
+                "workspace": _WS_NAME,
+                "name": "pool-cls",
+                "max_percent": 25,
+                "classifier_type": "Application Name",
+                "classifier_values": ["MyApp"],
+            },
+        )
+
+    assert result["name"] == "pool-cls"
+    mock_create.assert_called_once()
+    # The pool argument is the 3rd positional arg (index 2)
+    pool_arg = mock_create.call_args[0][2]
+    assert pool_arg.classifier is not None
+    assert pool_arg.classifier.type == "Application Name"
+
+
+async def test_create_sql_pool_already_exists(mock_ctx, ctx_patch) -> None:
+    """create_sql_pool raises ToolError (not AlreadyExistsError) when pool exists."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.sql_pools.create_pool",
+            new=AsyncMock(side_effect=AlreadyExistsError("pool exists")),
+        ),
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "create_sql_pool",
+            {"workspace": _WS_NAME, "name": "dupe", "max_percent": 10},
+        )
+
+    assert "pool exists" in str(exc_info.value)
+
+
+async def test_create_sql_pool_fabric_error(mock_ctx, ctx_patch) -> None:
+    """create_sql_pool wraps generic FabricError as ToolError."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.sql_pools.create_pool",
+            new=AsyncMock(side_effect=FabricError("server error")),
+        ),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "create_sql_pool",
+            {"workspace": _WS_NAME, "name": "p", "max_percent": 10},
+        )
+
+
+async def test_create_sql_pool_pool_missing_after_create(mock_ctx, ctx_patch) -> None:
+    """create_sql_pool raises ToolError when pool absent from response (eventual consistency)."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    # Return config without the newly created pool to simulate eventual consistency gap
+    config = _make_config(pools=[_make_pool("other-pool")])
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.sql_pools.create_pool",
+            new=AsyncMock(return_value=config),
+        ),
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "create_sql_pool",
+            {"workspace": _WS_NAME, "name": "new-pool", "max_percent": 10},
+        )
+
+    assert "not found in the API response" in str(exc_info.value)
+
+
+async def test_create_sql_pool_readonly_blocked(ctx_patch) -> None:
+    """create_sql_pool raises ToolError in read-only mode."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_READONLY": "1"}),
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "create_sql_pool",
+            {"workspace": _WS_NAME, "name": "p", "max_percent": 10},
+        )
+
+    assert "read-only" in str(exc_info.value).lower()
+
+
+async def test_create_sql_pool_workspace_not_allowed(ctx_patch) -> None:
+    """create_sql_pool raises ToolError when workspace is not in allowlist."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_WORKSPACES": "other-ws"}),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "create_sql_pool",
+            {"workspace": _WS_NAME, "name": "p", "max_percent": 10},
+        )
+
+
+# ---------------------------------------------------------------------------
+# update_sql_pool
+# ---------------------------------------------------------------------------
+
+
+async def test_update_sql_pool_happy_path(mock_ctx, ctx_patch) -> None:
+    """update_sql_pool returns the updated pool dict."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    updated_pool = _make_pool("pool-1", 60)
+    config = _make_config(pools=[updated_pool])
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.sql_pools.update_pool",
+            new=AsyncMock(return_value=config),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "update_sql_pool",
+            {"workspace": _WS_NAME, "name": "pool-1", "max_percent": 60},
+        )
+
+    assert isinstance(result, dict)
+    assert result["name"] == "pool-1"
+    assert result["maxResourcePercentage"] == 60
+
+
+async def test_update_sql_pool_not_found(mock_ctx, ctx_patch) -> None:
+    """update_sql_pool raises ToolError when pool does not exist."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.sql_pools.update_pool",
+            new=AsyncMock(side_effect=NotFoundError("pool not found")),
+        ),
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "update_sql_pool",
+            {"workspace": _WS_NAME, "name": "ghost", "max_percent": 10},
+        )
+
+    assert "pool not found" in str(exc_info.value)
+
+
+async def test_update_sql_pool_fabric_error(mock_ctx, ctx_patch) -> None:
+    """update_sql_pool wraps FabricError as ToolError."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.sql_pools.update_pool",
+            new=AsyncMock(side_effect=FabricError("server error")),
+        ),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "update_sql_pool",
+            {"workspace": _WS_NAME, "name": "pool-1", "max_percent": 10},
+        )
+
+
+async def test_update_sql_pool_missing_after_update(mock_ctx, ctx_patch) -> None:
+    """update_sql_pool raises ToolError when pool absent from response after update."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    config = _make_config(pools=[_make_pool("other-pool")])
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.sql_pools.update_pool",
+            new=AsyncMock(return_value=config),
+        ),
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "update_sql_pool",
+            {"workspace": _WS_NAME, "name": "pool-1", "max_percent": 10},
+        )
+
+    assert "not found in the API response" in str(exc_info.value)
+
+
+async def test_update_sql_pool_readonly_blocked(ctx_patch) -> None:
+    """update_sql_pool raises ToolError in read-only mode."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_READONLY": "1"}),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "update_sql_pool",
+            {"workspace": _WS_NAME, "name": "pool-1", "max_percent": 50},
+        )
+
+
+# ---------------------------------------------------------------------------
+# delete_sql_pool
+# ---------------------------------------------------------------------------
+
+
+async def test_delete_sql_pool_happy_path(mock_ctx, ctx_patch) -> None:
+    """delete_sql_pool returns deleted=True dict."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_ALLOW_DESTRUCTIVE": "1"}),
+        patch(
+            "fabric_dw.services.sql_pools.delete_pool",
+            new=AsyncMock(return_value=None),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "delete_sql_pool",
+            {"workspace": _WS_NAME, "pool_name": "old-pool"},
+        )
+
+    assert result == {"deleted": True, "pool_name": "old-pool"}
+
+
+async def test_delete_sql_pool_not_found(mock_ctx, ctx_patch) -> None:
+    """delete_sql_pool raises ToolError when pool does not exist."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_ALLOW_DESTRUCTIVE": "1"}),
+        patch(
+            "fabric_dw.services.sql_pools.delete_pool",
+            new=AsyncMock(side_effect=NotFoundError("pool not found")),
+        ),
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "delete_sql_pool",
+            {"workspace": _WS_NAME, "pool_name": "ghost"},
+        )
+
+    assert "pool not found" in str(exc_info.value)
+
+
+async def test_delete_sql_pool_fabric_error(mock_ctx, ctx_patch) -> None:
+    """delete_sql_pool wraps FabricError as ToolError."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_ALLOW_DESTRUCTIVE": "1"}),
+        patch(
+            "fabric_dw.services.sql_pools.delete_pool",
+            new=AsyncMock(side_effect=FabricError("server error")),
+        ),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "delete_sql_pool",
+            {"workspace": _WS_NAME, "pool_name": "p"},
+        )
+
+
+async def test_delete_sql_pool_destructive_disabled(ctx_patch) -> None:
+    """delete_sql_pool raises ToolError when FABRIC_MCP_ALLOW_DESTRUCTIVE is not set."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    env = {k: v for k, v in os.environ.items() if k != "FABRIC_MCP_ALLOW_DESTRUCTIVE"}
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, env, clear=True),
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "delete_sql_pool",
+            {"workspace": _WS_NAME, "pool_name": "p"},
+        )
+
+    assert "destructive" in str(exc_info.value).lower()
+
+
+async def test_delete_sql_pool_readonly_blocked(ctx_patch) -> None:
+    """delete_sql_pool raises ToolError in read-only mode."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_READONLY": "1", "FABRIC_MCP_ALLOW_DESTRUCTIVE": "1"}),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "delete_sql_pool",
+            {"workspace": _WS_NAME, "pool_name": "p"},
+        )
+
+
+# ---------------------------------------------------------------------------
+# reset_sql_pools
+# ---------------------------------------------------------------------------
+
+
+async def test_reset_sql_pools_happy_path(mock_ctx, ctx_patch) -> None:
+    """reset_sql_pools returns serialised config dict with empty pools list."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    config = _make_config(pools=[])
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_ALLOW_DESTRUCTIVE": "1"}),
+        patch(
+            "fabric_dw.services.sql_pools.reset_pools",
+            new=AsyncMock(return_value=config),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "reset_sql_pools",
+            {"workspace": _WS_NAME},
+        )
+
+    assert isinstance(result, dict)
+    assert result["customSQLPools"] == []
+
+
+async def test_reset_sql_pools_fabric_error(mock_ctx, ctx_patch) -> None:
+    """reset_sql_pools wraps FabricError as ToolError."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_ALLOW_DESTRUCTIVE": "1"}),
+        patch(
+            "fabric_dw.services.sql_pools.reset_pools",
+            new=AsyncMock(side_effect=FabricError("server error")),
+        ),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "reset_sql_pools",
+            {"workspace": _WS_NAME},
+        )
+
+
+async def test_reset_sql_pools_destructive_disabled(ctx_patch) -> None:
+    """reset_sql_pools raises ToolError when FABRIC_MCP_ALLOW_DESTRUCTIVE is not set."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    env = {k: v for k, v in os.environ.items() if k != "FABRIC_MCP_ALLOW_DESTRUCTIVE"}
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, env, clear=True),
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "reset_sql_pools",
+            {"workspace": _WS_NAME},
+        )
+
+    assert "destructive" in str(exc_info.value).lower()
+
+
+async def test_reset_sql_pools_readonly_blocked(ctx_patch) -> None:
+    """reset_sql_pools raises ToolError in read-only mode."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_READONLY": "1", "FABRIC_MCP_ALLOW_DESTRUCTIVE": "1"}),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "reset_sql_pools",
+            {"workspace": _WS_NAME},
+        )
+
+
+# ---------------------------------------------------------------------------
+# enable_sql_pools
+# ---------------------------------------------------------------------------
+
+
+async def test_enable_sql_pools_happy_path(mock_ctx, ctx_patch) -> None:
+    """enable_sql_pools returns config dict with enabled=True."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    config = _make_config(enabled=True)
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.sql_pools.enable",
+            new=AsyncMock(return_value=config),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "enable_sql_pools",
+            {"workspace": _WS_NAME},
+        )
+
+    assert isinstance(result, dict)
+    assert result["customSQLPoolsEnabled"] is True
+
+
+async def test_enable_sql_pools_fabric_error(mock_ctx, ctx_patch) -> None:
+    """enable_sql_pools wraps FabricError as ToolError."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.sql_pools.enable",
+            new=AsyncMock(side_effect=FabricError("server error")),
+        ),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "enable_sql_pools",
+            {"workspace": _WS_NAME},
+        )
+
+
+async def test_enable_sql_pools_readonly_blocked(ctx_patch) -> None:
+    """enable_sql_pools raises ToolError in read-only mode."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_READONLY": "1"}),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "enable_sql_pools",
+            {"workspace": _WS_NAME},
+        )
+
+
+async def test_enable_sql_pools_workspace_not_allowed(ctx_patch) -> None:
+    """enable_sql_pools raises ToolError when workspace not in allowlist."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_WORKSPACES": "other-ws"}),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "enable_sql_pools",
+            {"workspace": _WS_NAME},
+        )
+
+
+# ---------------------------------------------------------------------------
+# disable_sql_pools
+# ---------------------------------------------------------------------------
+
+
+async def test_disable_sql_pools_happy_path(mock_ctx, ctx_patch) -> None:
+    """disable_sql_pools returns config dict with enabled=False."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    config = _make_config(enabled=False)
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.sql_pools.disable",
+            new=AsyncMock(return_value=config),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "disable_sql_pools",
+            {"workspace": _WS_NAME},
+        )
+
+    assert isinstance(result, dict)
+    assert result["customSQLPoolsEnabled"] is False
+
+
+async def test_disable_sql_pools_fabric_error(mock_ctx, ctx_patch) -> None:
+    """disable_sql_pools wraps FabricError as ToolError."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.sql_pools.disable",
+            new=AsyncMock(side_effect=FabricError("server error")),
+        ),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "disable_sql_pools",
+            {"workspace": _WS_NAME},
+        )
+
+
+async def test_disable_sql_pools_readonly_blocked(ctx_patch) -> None:
+    """disable_sql_pools raises ToolError in read-only mode."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_READONLY": "1"}),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "disable_sql_pools",
+            {"workspace": _WS_NAME},
+        )
+
+
+async def test_disable_sql_pools_workspace_not_allowed(ctx_patch) -> None:
+    """disable_sql_pools raises ToolError when workspace not in allowlist."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_WORKSPACES": "other-ws"}),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "disable_sql_pools",
+            {"workspace": _WS_NAME},
+        )
+
+
+# ---------------------------------------------------------------------------
+# list_sql_pool_insights
+# ---------------------------------------------------------------------------
+
+
+async def test_list_sql_pool_insights_happy_path(mock_ctx, ctx_patch) -> None:
+    """list_sql_pool_insights returns list of insight dicts."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    insight = _make_pool_insight()
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.query_insights.list_sql_pool_insights",
+            new=AsyncMock(return_value=[insight]),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "list_sql_pool_insights",
+            {"workspace": _WS_NAME, "warehouse": _WH_NAME},
+        )
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0]["sql_pool_name"] == "pool-1"
+
+
+async def test_list_sql_pool_insights_with_since_until(mock_ctx, ctx_patch) -> None:
+    """list_sql_pool_insights passes parsed datetimes to service."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+    mock_svc = AsyncMock(return_value=[])
+
+    with (
+        ctx_patch,
+        patch("fabric_dw.services.query_insights.list_sql_pool_insights", new=mock_svc),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "list_sql_pool_insights",
+            {
+                "workspace": _WS_NAME,
+                "warehouse": _WH_NAME,
+                "since": "2026-01-01T00:00:00",
+                "until": "2026-01-02T00:00:00",
+                "limit": 50,
+            },
+        )
+
+    assert result == []
+    mock_svc.assert_called_once()
+    _, kwargs = mock_svc.call_args
+    assert kwargs["since"] is not None
+    assert kwargs["until"] is not None
+    assert kwargs["limit"] == 50
+
+
+async def test_list_sql_pool_insights_bad_since(ctx_patch) -> None:
+    """list_sql_pool_insights raises ToolError on invalid ISO-8601 since."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "list_sql_pool_insights",
+            {"workspace": _WS_NAME, "warehouse": _WH_NAME, "since": "not-a-date"},
+        )
+
+    assert "ISO-8601" in str(exc_info.value)
+
+
+async def test_list_sql_pool_insights_bad_until(ctx_patch) -> None:
+    """list_sql_pool_insights raises ToolError on invalid ISO-8601 until."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "list_sql_pool_insights",
+            {"workspace": _WS_NAME, "warehouse": _WH_NAME, "until": "bad-date"},
+        )
+
+    assert "ISO-8601" in str(exc_info.value)
+
+
+async def test_list_sql_pool_insights_fabric_error(mock_ctx, ctx_patch) -> None:
+    """list_sql_pool_insights wraps FabricError as ToolError."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.query_insights.list_sql_pool_insights",
+            new=AsyncMock(side_effect=FabricError("sql error")),
+        ),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "list_sql_pool_insights",
+            {"workspace": _WS_NAME, "warehouse": _WH_NAME},
+        )
+
+
+async def test_list_sql_pool_insights_workspace_not_allowed(ctx_patch) -> None:
+    """list_sql_pool_insights raises ToolError when workspace not in allowlist."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_WORKSPACES": "other-ws"}),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "list_sql_pool_insights",
+            {"workspace": _WS_NAME, "warehouse": _WH_NAME},
+        )


### PR DESCRIPTION
## Summary

- Adds 82 unit tests for `fabric_dw/mcp/tools/sql_pools.py` and `fabric_dw/mcp/tools/queries.py`
- Raises `sql_pools.py` coverage from 37% to **99%** (lines 135-136 are an unreachable `except Exception` guard on `SqlPool.model_validate` — Pydantic/FastMCP validates args before the function body runs)
- Raises `queries.py` coverage from 33% to **100%**

## Test plan

- [x] Happy path for every `@mcp.tool` function — mock resolver + service, assert returned dict/list shape
- [x] FabricError / NotFoundError / AlreadyExistsError → ToolError funnel
- [x] Guard axes: `FABRIC_MCP_READONLY`, `FABRIC_MCP_ALLOW_DESTRUCTIVE`, `FABRIC_MCP_WORKSPACES` allowlist
- [x] Arg-validation branches: ISO-8601 `since`/`until` parsing, classifier construction, eventual-consistency guards (pool missing from response after create/update)
- [x] `just check` fully green (ruff + ty + 1837 tests)
- [x] No test exceeds 0.02s (`--durations=10` confirms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)