### PR TITLE
chore(lint): fix ruff 0.15.16 violations in unit tests

### DIFF
--- a/tests/unit/cli/commands/test_completion.py
+++ b/tests/unit/cli/commands/test_completion.py
@@ -45,9 +45,7 @@ class TestCompletionInstallPrintOnly:
 class TestCompletionInstallAppendShells:
     """completion install for append-mode shells (bash, zsh)."""
 
-    def test_bash_install_appends_to_rc(
-        self, runner: CliRunner, tmp_path: Path
-    ) -> None:
+    def test_bash_install_appends_to_rc(self, runner: CliRunner, tmp_path: Path) -> None:
         """Installing bash completion writes to ~/.bashrc."""
         rc_file = tmp_path / ".bashrc"
         rc_file.write_text("# existing rc\n")
@@ -68,9 +66,7 @@ class TestCompletionInstallAppendShells:
         content = rc_file.read_text()
         assert mock_script.strip() in content
 
-    def test_zsh_install_appends_to_zshrc(
-        self, runner: CliRunner, tmp_path: Path
-    ) -> None:
+    def test_zsh_install_appends_to_zshrc(self, runner: CliRunner, tmp_path: Path) -> None:
         """Installing zsh completion writes to ~/.zshrc."""
         rc_file = tmp_path / ".zshrc"
         rc_file.write_text("# existing rc\n")
@@ -114,9 +110,7 @@ class TestCompletionInstallAppendShells:
 class TestCompletionInstallWriteShell:
     """completion install for write-mode shells (fish)."""
 
-    def test_fish_install_writes_file(
-        self, runner: CliRunner, tmp_path: Path
-    ) -> None:
+    def test_fish_install_writes_file(self, runner: CliRunner, tmp_path: Path) -> None:
         """Fish completions are written to ~/.config/fish/completions/fabric-dw.fish."""
         mock_script = "# fish completion\ncomplete -c fabric-dw\n"
 
@@ -134,9 +128,7 @@ class TestCompletionInstallWriteShell:
         assert expected_path.exists()
         assert expected_path.read_text() == mock_script
 
-    def test_fish_install_creates_parent_dirs(
-        self, runner: CliRunner, tmp_path: Path
-    ) -> None:
+    def test_fish_install_creates_parent_dirs(self, runner: CliRunner, tmp_path: Path) -> None:
         """Parent directories for fish completion file are created if absent."""
         mock_script = "# fish\n"
 

--- a/tests/unit/cli/commands/test_queries.py
+++ b/tests/unit/cli/commands/test_queries.py
@@ -382,9 +382,7 @@ class TestQueriesFrequent:
             result = runner.invoke(cli, ["queries", "frequent", WS_GUID, WH_GUID])
         assert result.exit_code == 0
 
-    def test_frequent_fabric_error_exits_nonzero(
-        self, runner: CliRunner, cache_env: Path
-    ) -> None:
+    def test_frequent_fabric_error_exits_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
         mock_http = AsyncMock()
         with (

--- a/tests/unit/cli/commands/test_sql_pools.py
+++ b/tests/unit/cli/commands/test_sql_pools.py
@@ -13,7 +13,12 @@ import pytest
 from click.testing import CliRunner
 
 from fabric_dw.cli._main import cli
-from fabric_dw.exceptions import AlreadyExistsError, FabricError, NotFoundError, PermissionDeniedError
+from fabric_dw.exceptions import (
+    AlreadyExistsError,
+    FabricError,
+    NotFoundError,
+    PermissionDeniedError,
+)
 from fabric_dw.models import SqlPool, SqlPoolsConfiguration
 from fabric_dw.sql import SqlTarget
 
@@ -855,9 +860,7 @@ class TestSqlPoolsShowErrors:
 class TestSqlPoolsCreateErrors:
     """create_cmd — ValueError, PermissionDeniedError, FabricError branches (204-209)."""
 
-    def test_create_permission_denied_shows_hint(
-        self, runner: CliRunner, cache_env: Path
-    ) -> None:
+    def test_create_permission_denied_shows_hint(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
         with (
             patch(
@@ -879,9 +882,7 @@ class TestSqlPoolsCreateErrors:
         assert result.exit_code != 0
         assert "admin" in result.output.lower()
 
-    def test_create_fabric_error_exits_nonzero(
-        self, runner: CliRunner, cache_env: Path
-    ) -> None:
+    def test_create_fabric_error_exits_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
         with (
             patch(
@@ -902,9 +903,7 @@ class TestSqlPoolsCreateErrors:
             )
         assert result.exit_code != 0
 
-    def test_create_value_error_exits_nonzero(
-        self, runner: CliRunner, cache_env: Path
-    ) -> None:
+    def test_create_value_error_exits_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
         """ValueError from service surfaces as ClickException (line 205)."""
         _ = cache_env
         with (
@@ -931,9 +930,7 @@ class TestSqlPoolsCreateErrors:
 class TestSqlPoolsUpdateErrors:
     """update_cmd — ValueError, PermissionDeniedError, FabricError branches (285-290)."""
 
-    def test_update_permission_denied_shows_hint(
-        self, runner: CliRunner, cache_env: Path
-    ) -> None:
+    def test_update_permission_denied_shows_hint(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
         with (
             patch(
@@ -956,9 +953,7 @@ class TestSqlPoolsUpdateErrors:
         assert result.exit_code != 0
         assert "admin" in result.output.lower()
 
-    def test_update_fabric_error_exits_nonzero(
-        self, runner: CliRunner, cache_env: Path
-    ) -> None:
+    def test_update_fabric_error_exits_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
         with (
             patch(
@@ -980,9 +975,7 @@ class TestSqlPoolsUpdateErrors:
             )
         assert result.exit_code != 0
 
-    def test_update_value_error_exits_nonzero(
-        self, runner: CliRunner, cache_env: Path
-    ) -> None:
+    def test_update_value_error_exits_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
         """ValueError from service surfaces as ClickException (line 286)."""
         _ = cache_env
         with (
@@ -1034,9 +1027,7 @@ class TestSqlPoolsDeleteAbort:
                 new=AsyncMock(side_effect=FabricError("server error")),
             ),
         ):
-            result = runner.invoke(
-                cli, ["-y", "sql-pools", "delete", WS_GUID, "--name", "Default"]
-            )
+            result = runner.invoke(cli, ["-y", "sql-pools", "delete", WS_GUID, "--name", "Default"])
         assert result.exit_code != 0
 
 

--- a/tests/unit/cli/commands/test_warehouses.py
+++ b/tests/unit/cli/commands/test_warehouses.py
@@ -401,9 +401,7 @@ class TestWarehousesDefaultFallback:
 class TestWarehousesListFabricError:
     """warehouses list — FabricError branch (line 70-71)."""
 
-    def test_list_fabric_error_exits_nonzero(
-        self, runner: CliRunner, cache_env: Path
-    ) -> None:
+    def test_list_fabric_error_exits_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
         mock_http = AsyncMock()
         with (
@@ -423,9 +421,7 @@ class TestWarehousesListFabricError:
 class TestWarehousesCreateError:
     """warehouses create — FabricError branch (lines 120-121)."""
 
-    def test_create_fabric_error_exits_nonzero(
-        self, runner: CliRunner, cache_env: Path
-    ) -> None:
+    def test_create_fabric_error_exits_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
         mock_http = AsyncMock()
         with (
@@ -449,9 +445,7 @@ class TestWarehousesCreateError:
 class TestWarehousesRenameError:
     """warehouses rename — FabricError branch (lines 161-162)."""
 
-    def test_rename_fabric_error_exits_nonzero(
-        self, runner: CliRunner, cache_env: Path
-    ) -> None:
+    def test_rename_fabric_error_exits_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
         mock_http = AsyncMock()
         _cache = LookupCache(path=cache_env / "lookup.json")
@@ -479,9 +473,7 @@ class TestWarehousesRenameError:
 class TestWarehousesDeleteError:
     """warehouses delete — FabricError branch (lines 192-193)."""
 
-    def test_delete_fabric_error_exits_nonzero(
-        self, runner: CliRunner, cache_env: Path
-    ) -> None:
+    def test_delete_fabric_error_exits_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
         mock_http = AsyncMock()
         _cache = LookupCache(path=cache_env / "lookup.json")
@@ -525,9 +517,7 @@ class TestWarehousesTakeoverErrors:
             result = runner.invoke(cli, ["--yes", "warehouses", "takeover", WS_GUID, WH_GUID])
         assert result.exit_code != 0
 
-    def test_takeover_declined_prints_aborted(
-        self, runner: CliRunner, cache_env: Path
-    ) -> None:
+    def test_takeover_declined_prints_aborted(self, runner: CliRunner, cache_env: Path) -> None:
         """Declining confirmation prints 'Aborted.' (lines 220-221)."""
         _ = cache_env
         mock_http = AsyncMock()
@@ -578,7 +568,11 @@ class TestWarehousesPermissions:
 
     def test_permissions_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
-        from fabric_dw.models import ItemAccess, ItemAccessDetail, ItemAccessPrincipal  # noqa: PLC0415
+        from fabric_dw.models import (  # noqa: PLC0415
+            ItemAccess,
+            ItemAccessDetail,
+            ItemAccessPrincipal,
+        )
 
         principal = ItemAccessPrincipal.model_validate(
             {

--- a/tests/unit/cli/test_render.py
+++ b/tests/unit/cli/test_render.py
@@ -10,8 +10,20 @@ from uuid import UUID
 import pytest
 from rich.console import Console
 
-from fabric_dw.cli._render import _cell, confirm, render, render_permissions_table, render_refresh_table
-from fabric_dw.models import ItemAccess, ItemAccessDetail, ItemAccessPrincipal, TableSyncError, TableSyncStatus
+from fabric_dw.cli._render import (
+    _cell,
+    confirm,
+    render,
+    render_permissions_table,
+    render_refresh_table,
+)
+from fabric_dw.models import (
+    ItemAccess,
+    ItemAccessDetail,
+    ItemAccessPrincipal,
+    TableSyncError,
+    TableSyncStatus,
+)
 
 
 class TestRenderJson:
@@ -336,6 +348,7 @@ class TestConfirm:
 # Helpers for render_permissions_table / render_refresh_table tests
 # ---------------------------------------------------------------------------
 
+
 def _make_item_access(
     display_name: str = "Alice",
     upn: str = "alice@example.com",
@@ -388,6 +401,7 @@ class TestRenderPermissionsTable:
         self,
         accesses: list[ItemAccess],
         title: str = "Permissions",
+        *,
         json_output: bool = False,
     ) -> str:
         sio = StringIO()
@@ -464,7 +478,7 @@ class TestRenderPermissionsTable:
         output = sio.getvalue()
         assert aad_id in output
 
-    def test_uses_default_console_when_none_given(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_uses_default_console_when_none_given(self) -> None:
         """When console=None, a fresh Console() is created (no crash)."""
         access = _make_item_access()
         # Should not raise; output goes to stdout (captured)


### PR DESCRIPTION
## Summary

- **E501 (line too long)**: Wrapped long import lines with parentheses in `test_sql_pools.py` and `test_render.py` (2 occurrences exceeded the 100-char limit).
- **FBT001/FBT002 (boolean positional argument)**: In `TestRenderPermissionsTable._render_to_string`, added a bare `*,` separator before `json_output: bool = False` to make it keyword-only. All call sites already used it as keyword-only so no call sites needed updating.
- **ARG002 (unused method argument)**: Removed the `capsys` parameter from `test_uses_default_console_when_none_given` in `test_render.py` — it was never referenced in the method body.
- **I001 (import sort)**: Auto-fixed by `ruff check --fix` across 5 test files.

This unblocks all other PRs that are currently blocked by the failing CI on `main`.

## Test plan

- [x] `uv run ruff check .` — All checks passed
- [x] `uv run ruff format --check .` — 173 files already formatted
- [x] `uv run ty check src tests` — All checks passed
- [x] `uv run pytest tests/unit -q` — 2091 passed in ~19s
- [x] `just check` — Full gate green

🤖 Generated with [Claude Code](https://claude.com/claude-code)