### PR TITLE
ci(integration): raise timeout + add pytest_k dispatch filter

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -6,6 +6,11 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      pytest_k:
+        description: "Optional pytest -k expression to run a subset (empty = full suite)"
+        required: false
+        default: ""
 
 permissions:
   id-token: write
@@ -20,7 +25,7 @@ jobs:
     if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'integration') }}
     runs-on: ubuntu-latest
     environment: integration
-    timeout-minutes: 45
+    timeout-minutes: 150
     steps:
       - uses: actions/checkout@v6
         with:
@@ -179,7 +184,13 @@ jobs:
           FABRIC_TEST_WORKSPACE_ID: ${{ secrets.FABRIC_TEST_WORKSPACE_ID }}
           FABRIC_AUTH: default
           FABRIC_TEST_IS_TENANT_ADMIN: "true"
-        run: uv run pytest tests/integration -m integration -v
+        run: |
+          if [ -n "${{ inputs.pytest_k }}" ]; then
+            echo "Running subset: -k '${{ inputs.pytest_k }}'"
+            uv run pytest tests/integration -m integration -v -k "${{ inputs.pytest_k }}"
+          else
+            uv run pytest tests/integration -m integration -v
+          fi
 
       - name: Post-test full workspace wipe
         if: always()


### PR DESCRIPTION
## Summary

- **Raise job timeout to 150 minutes** (was 45 min): The integration suite now legitimately runs ~90+ minutes because each test hits a fresh Fabric SQL warehouse with a cold data-plane — the warm-up from `sleep 120` after capacity resume plus per-test SQL endpoint warm-up (~40–60 s each) pushes the full suite well past the old 45-minute ceiling, causing spurious CI kills.
- **Add optional `pytest_k` dispatch input**: When triggering the workflow manually (`workflow_dispatch`), callers can now pass a `-k` expression (e.g. `test_create_warehouse`) to run only a subset of tests. On `push` and `pull_request` events, `inputs.pytest_k` is empty so the `else` branch runs the full suite — behaviour is unchanged for those triggers.

## Test plan

- [ ] Confirm YAML parses cleanly (`python3 -c "import yaml; yaml.safe_load(open(...))"` passes)
- [ ] Trigger workflow manually with a `pytest_k` value and verify only matching tests run
- [ ] Trigger via push or PR label and verify full suite runs (no `-k` flag injected)
- [ ] Confirm job no longer times out for a full suite run that previously took ~90 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)