### PR TITLE
ci(integration): client-secret auth for long-running steps

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -91,6 +91,9 @@ jobs:
         env:
           FABRIC_TEST_WORKSPACE_ID: ${{ secrets.FABRIC_TEST_WORKSPACE_ID }}
           FABRIC_AUTH: default
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
         run: |
           uv run python -c "
           import anyio, os
@@ -184,6 +187,9 @@ jobs:
           FABRIC_TEST_WORKSPACE_ID: ${{ secrets.FABRIC_TEST_WORKSPACE_ID }}
           FABRIC_AUTH: default
           FABRIC_TEST_IS_TENANT_ADMIN: "true"
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
         run: |
           if [ -n "${{ inputs.pytest_k }}" ]; then
             echo "Running subset: -k '${{ inputs.pytest_k }}'"
@@ -197,6 +203,9 @@ jobs:
         env:
           FABRIC_TEST_WORKSPACE_ID: ${{ secrets.FABRIC_TEST_WORKSPACE_ID }}
           FABRIC_AUTH: default
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
         run: |
           uv run python -c "
           import anyio, os


### PR DESCRIPTION
## Problem

The integration job uses `FABRIC_AUTH=default`, which calls `DefaultAzureCredential`. CI authenticates via `azure/login@v3` with GitHub OIDC (federated identity / client assertion). OIDC client assertions are valid for only ~5 minutes, but the integration test suite runs ~56 minutes. Mid-run token acquisitions fail with:

```
AADSTS700024: Client assertion is not within its valid time range
```

This cascades into ~26 auth failures across the test run.

## Fix

`DefaultAzureCredential` tries `EnvironmentCredential` first. When `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and `AZURE_CLIENT_SECRET` are all set as environment variables, it selects `ClientSecretCredential`, which refreshes tokens on demand with no assertion time-window limit.

A new repository secret `AZURE_CLIENT_SECRET` holds a client secret for the same service principal already used for OIDC. The three long-running steps that call `get_credential()` / run pytest now receive these three env vars:

- `Pre-test full workspace wipe`
- `Run integration tests`
- `Post-test full workspace wipe`

The `azure/login@v3` step and the capacity resume/suspend steps are unchanged — they use the `az` CLI (short-lived, within the OIDC window) and do not call `get_credential()`.

## Test plan

- [ ] Confirm `AZURE_CLIENT_SECRET` secret is set in the `integration` environment
- [ ] Trigger the workflow via `workflow_dispatch` and verify no `AADSTS700024` errors appear mid-run
- [ ] Confirm token refreshes succeed throughout the full ~56-minute suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)