### PR TITLE
feat(auth): self-refreshing GitHub OIDC credential

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -91,6 +91,8 @@ jobs:
         env:
           FABRIC_TEST_WORKSPACE_ID: ${{ secrets.FABRIC_TEST_WORKSPACE_ID }}
           FABRIC_AUTH: default
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
         run: |
           uv run python -c "
           import anyio, os
@@ -184,6 +186,8 @@ jobs:
           FABRIC_TEST_WORKSPACE_ID: ${{ secrets.FABRIC_TEST_WORKSPACE_ID }}
           FABRIC_AUTH: default
           FABRIC_TEST_IS_TENANT_ADMIN: "true"
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
         run: |
           if [ -n "${{ inputs.pytest_k }}" ]; then
             echo "Running subset: -k '${{ inputs.pytest_k }}'"
@@ -197,6 +201,8 @@ jobs:
         env:
           FABRIC_TEST_WORKSPACE_ID: ${{ secrets.FABRIC_TEST_WORKSPACE_ID }}
           FABRIC_AUTH: default
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
         run: |
           uv run python -c "
           import anyio, os

--- a/src/fabric_dw/auth.py
+++ b/src/fabric_dw/auth.py
@@ -6,13 +6,18 @@ from collections.abc import Callable
 from enum import StrEnum
 from types import TracebackType
 
+import httpx
 from azure.core.credentials import AccessToken
 from azure.core.credentials_async import AsyncTokenCredential
 from azure.identity import (
     InteractiveBrowserCredential,
     TokenCachePersistenceOptions,
 )
-from azure.identity.aio import ClientSecretCredential, DefaultAzureCredential
+from azure.identity.aio import (
+    ClientAssertionCredential,
+    ClientSecretCredential,
+    DefaultAzureCredential,
+)
 
 from fabric_dw.exceptions import ConfigError
 
@@ -25,6 +30,9 @@ SQL_SCOPE = "https://database.windows.net/.default"
 DEFAULT_INTERACTIVE_CLIENT_ID = "f666e5ee-2149-4c6a-87eb-13c9e1fdc70d"
 
 _CACHE_OPTIONS = TokenCachePersistenceOptions(name="fabric-dw", allow_unencrypted_storage=True)
+
+_GITHUB_OIDC_AUDIENCE = "api://AzureADTokenExchange"
+_GITHUB_OIDC_TIMEOUT = 10  # seconds
 
 __all__ = [
     "DEFAULT_INTERACTIVE_CLIENT_ID",
@@ -111,7 +119,90 @@ def _resolve_interactive_kwargs() -> dict[str, str]:
     return kwargs
 
 
+def _is_github_actions_oidc() -> bool:
+    """Return True when GitHub Actions OIDC env vars are present.
+
+    Both ``ACTIONS_ID_TOKEN_REQUEST_URL`` and ``ACTIONS_ID_TOKEN_REQUEST_TOKEN``
+    must be set (non-empty) for the OIDC endpoint to be usable.
+    """
+    return bool(
+        os.environ.get("ACTIONS_ID_TOKEN_REQUEST_URL")
+        and os.environ.get("ACTIONS_ID_TOKEN_REQUEST_TOKEN")
+    )
+
+
+def _fetch_github_oidc_jwt() -> str:
+    """Fetch a fresh GitHub Actions OIDC JWT.
+
+    This is a *synchronous* callable because ``azure.identity.aio.ClientAssertionCredential``
+    expects ``func: Callable[[], str]`` (sync) in azure-identity 1.25.x.  It is
+    invoked by azure-identity on every token acquisition (not on every HTTP
+    request), so the blocking GET is acceptable.
+
+    Returns:
+        The OIDC JWT string from the GitHub token endpoint.
+
+    Raises:
+        ConfigError: If the required environment variables are missing or the
+            OIDC endpoint returns a non-2xx response.
+    """
+    request_url = os.environ.get("ACTIONS_ID_TOKEN_REQUEST_URL")
+    request_token = os.environ.get("ACTIONS_ID_TOKEN_REQUEST_TOKEN")
+    if not request_url or not request_token:
+        raise ConfigError(
+            "GitHub Actions OIDC environment variables are not set. "
+            "Ensure the workflow has 'permissions: id-token: write' and that "
+            "ACTIONS_ID_TOKEN_REQUEST_URL and ACTIONS_ID_TOKEN_REQUEST_TOKEN are available."
+        )
+
+    url = f"{request_url}&audience={_GITHUB_OIDC_AUDIENCE}"
+    try:
+        response = httpx.get(
+            url,
+            headers={"Authorization": f"Bearer {request_token}"},
+            timeout=_GITHUB_OIDC_TIMEOUT,
+        )
+        response.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        raise ConfigError(
+            f"GitHub OIDC token endpoint returned HTTP {exc.response.status_code}. URL: {url}"
+        ) from exc
+    except httpx.RequestError as exc:
+        raise ConfigError(f"Failed to reach GitHub OIDC token endpoint: {exc}. URL: {url}") from exc
+
+    return str(response.json()["value"])
+
+
+def _make_github_oidc_credential() -> AsyncTokenCredential:
+    """Build a self-refreshing ClientAssertionCredential backed by GitHub OIDC.
+
+    Each time azure-identity needs to acquire or refresh an access token it
+    calls *func* to obtain a fresh client assertion.  Because a GitHub OIDC
+    JWT is only valid for ~5 minutes, fetching a new one on every call prevents
+    ``AADSTS700024: Client assertion is not within its valid time range`` errors
+    that would otherwise terminate long-running CI jobs.
+
+    Raises:
+        ConfigError: If AZURE_TENANT_ID or AZURE_CLIENT_ID are missing.
+    """
+    missing = [name for name in ("AZURE_TENANT_ID", "AZURE_CLIENT_ID") if not os.environ.get(name)]
+    if missing:
+        raise ConfigError(
+            f"GitHub Actions OIDC credential requires {', '.join(missing)} "
+            f"to be set in the environment."
+        )
+
+    return ClientAssertionCredential(
+        tenant_id=os.environ["AZURE_TENANT_ID"],
+        client_id=os.environ["AZURE_CLIENT_ID"],
+        func=_fetch_github_oidc_jwt,
+    )
+
+
 def _make_default_credential() -> AsyncTokenCredential:
+    if _is_github_actions_oidc():
+        return _make_github_oidc_credential()
+
     interactive_kwargs = _resolve_interactive_kwargs()
     dac_kwargs: dict[str, object] = {
         "cache_persistence_options": _CACHE_OPTIONS,

--- a/src/fabric_dw/auth.py
+++ b/src/fabric_dw/auth.py
@@ -5,16 +5,19 @@ import os
 from collections.abc import Callable
 from enum import StrEnum
 from types import TracebackType
+from typing import Protocol
 
 import httpx
 from azure.core.credentials import AccessToken
 from azure.core.credentials_async import AsyncTokenCredential
 from azure.identity import (
+    ClientAssertionCredential as SyncClientAssertionCredential,
+)
+from azure.identity import (
     InteractiveBrowserCredential,
     TokenCachePersistenceOptions,
 )
 from azure.identity.aio import (
-    ClientAssertionCredential,
     ClientSecretCredential,
     DefaultAzureCredential,
 )
@@ -50,19 +53,36 @@ class CredentialMode(StrEnum):
     INTERACTIVE = "interactive"
 
 
+class _CloseableTokenCredential(Protocol):
+    """A synchronous token credential that also supports close()."""
+
+    def get_token(
+        self,
+        *scopes: str,
+        claims: str | None = None,
+        tenant_id: str | None = None,
+        enable_cae: bool = False,
+        **kwargs: object,
+    ) -> AccessToken: ...
+
+    def close(self) -> None: ...
+
+
 class SyncCredentialAdapter:
     """Adapts a synchronous TokenCredential to the AsyncTokenCredential protocol.
 
     Used because ``azure.identity.aio.InteractiveBrowserCredential`` does not
-    exist in azure-identity 1.25.x.  Both ``get_token`` and ``close`` are
-    offloaded to a worker thread via :func:`asyncio.to_thread` so the event
-    loop is never blocked.
+    exist in azure-identity 1.25.x, and because ``azure.identity.aio.ClientAssertionCredential``
+    invokes its ``func`` callback bare on the event loop (no ``asyncio.to_thread`` wrapping)
+    in azure-identity 1.25.x.  Wrapping a synchronous credential here ensures that both
+    ``get_token`` and ``close`` are offloaded to a worker thread via
+    :func:`asyncio.to_thread` so the event loop is never blocked.
 
-    Remove this adapter and switch to ``azure.identity.aio.InteractiveBrowserCredential``
-    once that ships in a stable release.
+    Remove the ``InteractiveBrowserCredential`` usage of this adapter and switch to
+    ``azure.identity.aio.InteractiveBrowserCredential`` once that ships in a stable release.
     """
 
-    def __init__(self, inner: InteractiveBrowserCredential) -> None:
+    def __init__(self, inner: _CloseableTokenCredential) -> None:
         self._inner = inner
 
     async def get_token(
@@ -134,10 +154,13 @@ def _is_github_actions_oidc() -> bool:
 def _fetch_github_oidc_jwt() -> str:
     """Fetch a fresh GitHub Actions OIDC JWT.
 
-    This is a *synchronous* callable because ``azure.identity.aio.ClientAssertionCredential``
-    expects ``func: Callable[[], str]`` (sync) in azure-identity 1.25.x.  It is
-    invoked by azure-identity on every token acquisition (not on every HTTP
-    request), so the blocking GET is acceptable.
+    This is a *synchronous* callable because ``azure.identity.ClientAssertionCredential``
+    (sync variant) expects ``func: Callable[[], str]``.  The whole credential is wrapped
+    in :class:`SyncCredentialAdapter`, which offloads ``get_token`` (and therefore this
+    function) to a worker thread via :func:`asyncio.to_thread`, keeping the event loop free.
+
+    It is invoked by azure-identity on every token acquisition (not on every HTTP
+    request), so the blocking GET runs safely off the event loop.
 
     Returns:
         The OIDC JWT string from the GitHub token endpoint.
@@ -155,7 +178,11 @@ def _fetch_github_oidc_jwt() -> str:
             "ACTIONS_ID_TOKEN_REQUEST_URL and ACTIONS_ID_TOKEN_REQUEST_TOKEN are available."
         )
 
-    url = f"{request_url}&audience={_GITHUB_OIDC_AUDIENCE}"
+    # Build the final URL by appending audience= to any existing query params.
+    # Using httpx.URL.copy_add_param preserves params already in the URL
+    # (e.g. api-version=2.0 that GitHub always includes), whereas passing
+    # params= to httpx.get() would replace the entire query string.
+    url = httpx.URL(request_url).copy_add_param("audience", _GITHUB_OIDC_AUDIENCE)
     try:
         response = httpx.get(
             url,
@@ -165,10 +192,10 @@ def _fetch_github_oidc_jwt() -> str:
         response.raise_for_status()
     except httpx.HTTPStatusError as exc:
         raise ConfigError(
-            f"GitHub OIDC token endpoint returned HTTP {exc.response.status_code}. URL: {url}"
+            f"GitHub OIDC token endpoint returned HTTP {exc.response.status_code}."
         ) from exc
     except httpx.RequestError as exc:
-        raise ConfigError(f"Failed to reach GitHub OIDC token endpoint: {exc}. URL: {url}") from exc
+        raise ConfigError(f"Failed to reach GitHub OIDC token endpoint: {exc}.") from exc
 
     return str(response.json()["value"])
 
@@ -176,11 +203,17 @@ def _fetch_github_oidc_jwt() -> str:
 def _make_github_oidc_credential() -> AsyncTokenCredential:
     """Build a self-refreshing ClientAssertionCredential backed by GitHub OIDC.
 
-    Each time azure-identity needs to acquire or refresh an access token it
-    calls *func* to obtain a fresh client assertion.  Because a GitHub OIDC
-    JWT is only valid for ~5 minutes, fetching a new one on every call prevents
-    ``AADSTS700024: Client assertion is not within its valid time range`` errors
-    that would otherwise terminate long-running CI jobs.
+    Uses the *synchronous* ``azure.identity.ClientAssertionCredential`` wrapped in
+    :class:`SyncCredentialAdapter`.  This ensures that the blocking ``_fetch_github_oidc_jwt``
+    HTTP call runs in a worker thread (via :func:`asyncio.to_thread`) rather than on the
+    event loop — the aio variant calls its ``func`` bare on the event loop in azure-identity
+    1.25.x.
+
+    Each time azure-identity needs to acquire or refresh an access token it calls *func*
+    to obtain a fresh client assertion.  Because a GitHub OIDC JWT is only valid for ~5
+    minutes, fetching a new one on every call prevents
+    ``AADSTS700024: Client assertion is not within its valid time range`` errors that
+    would otherwise terminate long-running CI jobs.
 
     Raises:
         ConfigError: If AZURE_TENANT_ID or AZURE_CLIENT_ID are missing.
@@ -192,10 +225,12 @@ def _make_github_oidc_credential() -> AsyncTokenCredential:
             f"to be set in the environment."
         )
 
-    return ClientAssertionCredential(
-        tenant_id=os.environ["AZURE_TENANT_ID"],
-        client_id=os.environ["AZURE_CLIENT_ID"],
-        func=_fetch_github_oidc_jwt,
+    return SyncCredentialAdapter(
+        SyncClientAssertionCredential(
+            tenant_id=os.environ["AZURE_TENANT_ID"],
+            client_id=os.environ["AZURE_CLIENT_ID"],
+            func=_fetch_github_oidc_jwt,
+        )
     )
 
 

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -7,7 +7,7 @@ import httpx
 import pytest
 import respx
 from azure.core.credentials import AccessToken
-from azure.identity.aio import ClientAssertionCredential
+from azure.identity import ClientAssertionCredential as SyncClientAssertionCredential
 from azure.identity.aio import ClientSecretCredential as AsyncClientSecretCredential
 from azure.identity.aio import DefaultAzureCredential as AsyncDefaultAzureCredential
 
@@ -420,8 +420,13 @@ def test_is_github_actions_oidc_false_when_both_missing(monkeypatch: pytest.Monk
 def test_fetch_github_oidc_jwt_returns_value_from_response(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """_fetch_github_oidc_jwt must GET the OIDC endpoint and return the JWT."""
-    request_url = "https://pipelines.actions.githubusercontent.com/oidc/token"
+    """_fetch_github_oidc_jwt must GET the OIDC endpoint and return the JWT.
+
+    Uses a realistic GitHub Actions URL that already contains a query string
+    (api-version=2.0) to verify robust URL parameter handling.
+    """
+    # Real GitHub Actions URLs always include ?api-version=2.0
+    request_url = "https://pipelines.actions.githubusercontent.com/serviceHosts/abc/_apis/distributedtask/hubs/Gates/plans/def/jobs/ghi/idtoken?api-version=2.0"
     runner_token = "gha-runner-token-abc"  # noqa: S105
     expected_jwt = "eyJhbGciOiJSUzI1NiJ9.fake.jwt"
 
@@ -429,51 +434,60 @@ def test_fetch_github_oidc_jwt_returns_value_from_response(
     monkeypatch.setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", runner_token)
 
     with respx.mock:
-        route = respx.get(f"{request_url}&audience=api://AzureADTokenExchange").mock(
-            return_value=httpx.Response(200, json={"value": expected_jwt})
-        )
+        # The audience param must be appended alongside the existing api-version param
+        route = respx.get(
+            "https://pipelines.actions.githubusercontent.com/serviceHosts/abc/_apis/distributedtask/hubs/Gates/plans/def/jobs/ghi/idtoken",
+            params={"api-version": "2.0", "audience": "api://AzureADTokenExchange"},
+        ).mock(return_value=httpx.Response(200, json={"value": expected_jwt}))
         result = auth_module._fetch_github_oidc_jwt()
 
     assert result == expected_jwt
     assert route.called
     sent_request = route.calls.last.request
     assert sent_request.headers["authorization"] == f"Bearer {runner_token}"
-
-
-def test_fetch_github_oidc_jwt_sends_correct_audience(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """_fetch_github_oidc_jwt must append audience=api://AzureADTokenExchange."""
-    request_url = "https://pipelines.actions.githubusercontent.com/oidc/token?base=1"
-    monkeypatch.setenv("ACTIONS_ID_TOKEN_REQUEST_URL", request_url)
-    monkeypatch.setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "tok")
-
-    with respx.mock:
-        route = respx.get(f"{request_url}&audience=api://AzureADTokenExchange").mock(
-            return_value=httpx.Response(200, json={"value": "jwt-token"})
-        )
-        auth_module._fetch_github_oidc_jwt()
-
-    # Confirm the audience param was appended (URL-encoded or raw both acceptable)
-    sent_url = str(route.calls.last.request.url)
+    # Confirm both query params are present in the final URL
+    sent_url = str(sent_request.url)
+    assert "api-version=2.0" in sent_url
     assert (
         "audience=api%3A%2F%2FAzureADTokenExchange" in sent_url
         or "audience=api://AzureADTokenExchange" in sent_url
     )
 
 
-def test_fetch_github_oidc_jwt_raises_config_error_on_http_error(
+def test_fetch_github_oidc_jwt_sends_correct_audience(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """_fetch_github_oidc_jwt must raise ConfigError when the endpoint returns non-2xx."""
-    request_url = "https://pipelines.actions.githubusercontent.com/oidc/token"
+    """_fetch_github_oidc_jwt must append audience=api://AzureADTokenExchange."""
+    request_url = "https://pipelines.actions.githubusercontent.com/oidc/token?api-version=2.0"
     monkeypatch.setenv("ACTIONS_ID_TOKEN_REQUEST_URL", request_url)
     monkeypatch.setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "tok")
 
     with respx.mock:
-        respx.get(f"{request_url}&audience=api://AzureADTokenExchange").mock(
-            return_value=httpx.Response(403, text="Forbidden")
-        )
+        route = respx.get(
+            "https://pipelines.actions.githubusercontent.com/oidc/token",
+            params={"api-version": "2.0", "audience": "api://AzureADTokenExchange"},
+        ).mock(return_value=httpx.Response(200, json={"value": "jwt-token"}))
+        auth_module._fetch_github_oidc_jwt()
+
+    # Confirm both params are present — audience added via copy_add_param preserving api-version
+    sent_url = str(route.calls.last.request.url)
+    assert "audience=api%3A%2F%2FAzureADTokenExchange" in sent_url
+    assert "api-version=2.0" in sent_url
+
+
+def test_fetch_github_oidc_jwt_raises_config_error_on_http_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_fetch_github_oidc_jwt must raise ConfigError when the endpoint returns non-2xx."""
+    request_url = "https://pipelines.actions.githubusercontent.com/oidc/token?api-version=2.0"
+    monkeypatch.setenv("ACTIONS_ID_TOKEN_REQUEST_URL", request_url)
+    monkeypatch.setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "tok")
+
+    with respx.mock:
+        respx.get(
+            "https://pipelines.actions.githubusercontent.com/oidc/token",
+            params={"api-version": "2.0", "audience": "api://AzureADTokenExchange"},
+        ).mock(return_value=httpx.Response(403, text="Forbidden"))
         with pytest.raises(ConfigError, match="403"):
             auth_module._fetch_github_oidc_jwt()
 
@@ -494,23 +508,29 @@ def test_fetch_github_oidc_jwt_raises_config_error_when_env_missing(
 # ---------------------------------------------------------------------------
 
 
-def test_get_credential_default_returns_client_assertion_in_github_actions(
+def test_get_credential_default_returns_sync_adapter_wrapping_client_assertion_in_github_actions(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """DEFAULT mode must return ClientAssertionCredential when OIDC env vars are present."""
+    """DEFAULT mode returns SyncCredentialAdapter(SyncClientAssertionCredential) in GHA.
+
+    The sync credential is used (not the aio variant) so the blocking _fetch_github_oidc_jwt
+    runs in a worker thread via SyncCredentialAdapter, keeping the event loop free.
+    """
     monkeypatch.setenv("ACTIONS_ID_TOKEN_REQUEST_URL", "https://token.example.com/")
     monkeypatch.setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "runner-token")
     monkeypatch.setenv("AZURE_TENANT_ID", "my-tenant-id")
     monkeypatch.setenv("AZURE_CLIENT_ID", "my-client-id")
 
-    with patch("fabric_dw.auth.ClientAssertionCredential") as mock_cac:
-        mock_cac.return_value = MagicMock(spec=ClientAssertionCredential)
-        get_credential(CredentialMode.DEFAULT)
+    with patch("fabric_dw.auth.SyncClientAssertionCredential") as mock_cac:
+        mock_cac.return_value = MagicMock(spec=SyncClientAssertionCredential)
+        credential = get_credential(CredentialMode.DEFAULT)
         mock_cac.assert_called_once()
         _, kwargs = mock_cac.call_args
         assert kwargs["tenant_id"] == "my-tenant-id"
         assert kwargs["client_id"] == "my-client-id"
         assert kwargs["func"] is auth_module._fetch_github_oidc_jwt
+        # The result must be a SyncCredentialAdapter wrapping the sync credential
+        assert isinstance(credential, SyncCredentialAdapter)
 
 
 def test_get_credential_default_returns_default_azure_credential_outside_github_actions(

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -3,8 +3,11 @@
 import threading
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
+import respx
 from azure.core.credentials import AccessToken
+from azure.identity.aio import ClientAssertionCredential
 from azure.identity.aio import ClientSecretCredential as AsyncClientSecretCredential
 from azure.identity.aio import DefaultAzureCredential as AsyncDefaultAzureCredential
 
@@ -29,18 +32,30 @@ def test_sql_scope_constant() -> None:
     assert SQL_SCOPE == "https://database.windows.net/.default"
 
 
-def test_get_credential_default_returns_default_azure_credential() -> None:
+def test_get_credential_default_returns_default_azure_credential(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("ACTIONS_ID_TOKEN_REQUEST_URL", raising=False)
+    monkeypatch.delenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", raising=False)
     credential = get_credential(CredentialMode.DEFAULT)
     assert isinstance(credential, AsyncDefaultAzureCredential)
 
 
-def test_get_credential_default_is_default_argument() -> None:
+def test_get_credential_default_is_default_argument(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("ACTIONS_ID_TOKEN_REQUEST_URL", raising=False)
+    monkeypatch.delenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", raising=False)
     credential = get_credential()
     assert isinstance(credential, AsyncDefaultAzureCredential)
 
 
-def test_get_credential_default_includes_interactive_browser() -> None:
+def test_get_credential_default_includes_interactive_browser(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """DefaultAzureCredential must NOT exclude the interactive browser credential."""
+    monkeypatch.delenv("ACTIONS_ID_TOKEN_REQUEST_URL", raising=False)
+    monkeypatch.delenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", raising=False)
     with patch("fabric_dw.auth.DefaultAzureCredential") as mock_dac:
         get_credential(CredentialMode.DEFAULT)
         _, kwargs = mock_dac.call_args
@@ -234,6 +249,8 @@ def test_interactive_mode_no_tenant_id_when_not_set(monkeypatch: pytest.MonkeyPa
 
 def test_default_mode_passes_interactive_browser_client_id(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("FABRIC_INTERACTIVE_CLIENT_ID", raising=False)
+    monkeypatch.delenv("ACTIONS_ID_TOKEN_REQUEST_URL", raising=False)
+    monkeypatch.delenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", raising=False)
     with patch("fabric_dw.auth.DefaultAzureCredential") as mock_dac:
         get_credential(CredentialMode.DEFAULT)
         _, kwargs = mock_dac.call_args
@@ -245,6 +262,8 @@ def test_default_mode_respects_env_override_for_interactive(
 ) -> None:
     custom_id = "deadbeef-0000-0000-0000-000000000002"
     monkeypatch.setenv("FABRIC_INTERACTIVE_CLIENT_ID", custom_id)
+    monkeypatch.delenv("ACTIONS_ID_TOKEN_REQUEST_URL", raising=False)
+    monkeypatch.delenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", raising=False)
     with patch("fabric_dw.auth.DefaultAzureCredential") as mock_dac:
         get_credential(CredentialMode.DEFAULT)
         _, kwargs = mock_dac.call_args
@@ -254,6 +273,8 @@ def test_default_mode_respects_env_override_for_interactive(
 def test_default_mode_passes_interactive_browser_tenant_id(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("FABRIC_INTERACTIVE_CLIENT_ID", raising=False)
     monkeypatch.setenv("FABRIC_INTERACTIVE_TENANT_ID", "my-tenant-id")
+    monkeypatch.delenv("ACTIONS_ID_TOKEN_REQUEST_URL", raising=False)
+    monkeypatch.delenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", raising=False)
     with patch("fabric_dw.auth.DefaultAzureCredential") as mock_dac:
         get_credential(CredentialMode.DEFAULT)
         _, kwargs = mock_dac.call_args
@@ -265,6 +286,8 @@ def test_default_mode_no_interactive_browser_tenant_id_when_not_set(
 ) -> None:
     monkeypatch.delenv("FABRIC_INTERACTIVE_CLIENT_ID", raising=False)
     monkeypatch.delenv("FABRIC_INTERACTIVE_TENANT_ID", raising=False)
+    monkeypatch.delenv("ACTIONS_ID_TOKEN_REQUEST_URL", raising=False)
+    monkeypatch.delenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", raising=False)
     with patch("fabric_dw.auth.DefaultAzureCredential") as mock_dac:
         get_credential(CredentialMode.DEFAULT)
         _, kwargs = mock_dac.call_args
@@ -293,8 +316,10 @@ def test_sp_mode_does_not_use_interactive_client_id(monkeypatch: pytest.MonkeyPa
 # ---------------------------------------------------------------------------
 
 
-def test_registry_dispatches_default_mode() -> None:
+def test_registry_dispatches_default_mode(monkeypatch: pytest.MonkeyPatch) -> None:
     """Registry must dispatch to the default factory for CredentialMode.DEFAULT."""
+    monkeypatch.delenv("ACTIONS_ID_TOKEN_REQUEST_URL", raising=False)
+    monkeypatch.delenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", raising=False)
     mock_factory = MagicMock(return_value=MagicMock())
     original = auth_module._CREDENTIAL_REGISTRY[CredentialMode.DEFAULT]
     try:
@@ -356,3 +381,184 @@ def test_get_credential_unknown_mode_raises_config_error() -> None:
     """get_credential must raise ConfigError for a mode not in the registry."""
     with pytest.raises(ConfigError, match="Unknown credential mode"):
         get_credential("not-a-real-mode")  # ty: ignore[invalid-argument-type]
+
+
+# ---------------------------------------------------------------------------
+# GitHub Actions OIDC credential — _is_github_actions_oidc
+# ---------------------------------------------------------------------------
+
+
+def test_is_github_actions_oidc_true_when_both_vars_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ACTIONS_ID_TOKEN_REQUEST_URL", "https://token.example.com/")
+    monkeypatch.setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "secret-runner-token")
+    assert auth_module._is_github_actions_oidc() is True
+
+
+def test_is_github_actions_oidc_false_when_url_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ACTIONS_ID_TOKEN_REQUEST_URL", raising=False)
+    monkeypatch.setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "secret-runner-token")
+    assert auth_module._is_github_actions_oidc() is False
+
+
+def test_is_github_actions_oidc_false_when_token_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ACTIONS_ID_TOKEN_REQUEST_URL", "https://token.example.com/")
+    monkeypatch.delenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", raising=False)
+    assert auth_module._is_github_actions_oidc() is False
+
+
+def test_is_github_actions_oidc_false_when_both_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ACTIONS_ID_TOKEN_REQUEST_URL", raising=False)
+    monkeypatch.delenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", raising=False)
+    assert auth_module._is_github_actions_oidc() is False
+
+
+# ---------------------------------------------------------------------------
+# GitHub Actions OIDC credential — _fetch_github_oidc_jwt
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_github_oidc_jwt_returns_value_from_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_fetch_github_oidc_jwt must GET the OIDC endpoint and return the JWT."""
+    request_url = "https://pipelines.actions.githubusercontent.com/oidc/token"
+    runner_token = "gha-runner-token-abc"  # noqa: S105
+    expected_jwt = "eyJhbGciOiJSUzI1NiJ9.fake.jwt"
+
+    monkeypatch.setenv("ACTIONS_ID_TOKEN_REQUEST_URL", request_url)
+    monkeypatch.setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", runner_token)
+
+    with respx.mock:
+        route = respx.get(f"{request_url}&audience=api://AzureADTokenExchange").mock(
+            return_value=httpx.Response(200, json={"value": expected_jwt})
+        )
+        result = auth_module._fetch_github_oidc_jwt()
+
+    assert result == expected_jwt
+    assert route.called
+    sent_request = route.calls.last.request
+    assert sent_request.headers["authorization"] == f"Bearer {runner_token}"
+
+
+def test_fetch_github_oidc_jwt_sends_correct_audience(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_fetch_github_oidc_jwt must append audience=api://AzureADTokenExchange."""
+    request_url = "https://pipelines.actions.githubusercontent.com/oidc/token?base=1"
+    monkeypatch.setenv("ACTIONS_ID_TOKEN_REQUEST_URL", request_url)
+    monkeypatch.setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "tok")
+
+    with respx.mock:
+        route = respx.get(f"{request_url}&audience=api://AzureADTokenExchange").mock(
+            return_value=httpx.Response(200, json={"value": "jwt-token"})
+        )
+        auth_module._fetch_github_oidc_jwt()
+
+    # Confirm the audience param was appended (URL-encoded or raw both acceptable)
+    sent_url = str(route.calls.last.request.url)
+    assert (
+        "audience=api%3A%2F%2FAzureADTokenExchange" in sent_url
+        or "audience=api://AzureADTokenExchange" in sent_url
+    )
+
+
+def test_fetch_github_oidc_jwt_raises_config_error_on_http_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_fetch_github_oidc_jwt must raise ConfigError when the endpoint returns non-2xx."""
+    request_url = "https://pipelines.actions.githubusercontent.com/oidc/token"
+    monkeypatch.setenv("ACTIONS_ID_TOKEN_REQUEST_URL", request_url)
+    monkeypatch.setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "tok")
+
+    with respx.mock:
+        respx.get(f"{request_url}&audience=api://AzureADTokenExchange").mock(
+            return_value=httpx.Response(403, text="Forbidden")
+        )
+        with pytest.raises(ConfigError, match="403"):
+            auth_module._fetch_github_oidc_jwt()
+
+
+def test_fetch_github_oidc_jwt_raises_config_error_when_env_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_fetch_github_oidc_jwt must raise ConfigError when env vars are absent."""
+    monkeypatch.delenv("ACTIONS_ID_TOKEN_REQUEST_URL", raising=False)
+    monkeypatch.delenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", raising=False)
+
+    with pytest.raises(ConfigError, match="ACTIONS_ID_TOKEN_REQUEST_URL"):
+        auth_module._fetch_github_oidc_jwt()
+
+
+# ---------------------------------------------------------------------------
+# GitHub Actions OIDC credential — get_credential DEFAULT mode routing
+# ---------------------------------------------------------------------------
+
+
+def test_get_credential_default_returns_client_assertion_in_github_actions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """DEFAULT mode must return ClientAssertionCredential when OIDC env vars are present."""
+    monkeypatch.setenv("ACTIONS_ID_TOKEN_REQUEST_URL", "https://token.example.com/")
+    monkeypatch.setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "runner-token")
+    monkeypatch.setenv("AZURE_TENANT_ID", "my-tenant-id")
+    monkeypatch.setenv("AZURE_CLIENT_ID", "my-client-id")
+
+    with patch("fabric_dw.auth.ClientAssertionCredential") as mock_cac:
+        mock_cac.return_value = MagicMock(spec=ClientAssertionCredential)
+        get_credential(CredentialMode.DEFAULT)
+        mock_cac.assert_called_once()
+        _, kwargs = mock_cac.call_args
+        assert kwargs["tenant_id"] == "my-tenant-id"
+        assert kwargs["client_id"] == "my-client-id"
+        assert kwargs["func"] is auth_module._fetch_github_oidc_jwt
+
+
+def test_get_credential_default_returns_default_azure_credential_outside_github_actions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """DEFAULT mode must fall back to DefaultAzureCredential when OIDC env vars are absent."""
+    monkeypatch.delenv("ACTIONS_ID_TOKEN_REQUEST_URL", raising=False)
+    monkeypatch.delenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", raising=False)
+
+    with patch("fabric_dw.auth.DefaultAzureCredential") as mock_dac:
+        get_credential(CredentialMode.DEFAULT)
+        mock_dac.assert_called_once()
+
+
+def test_get_credential_default_raises_config_error_missing_tenant_id_in_github_actions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """DEFAULT mode must raise ConfigError if AZURE_TENANT_ID is missing in GitHub Actions."""
+    monkeypatch.setenv("ACTIONS_ID_TOKEN_REQUEST_URL", "https://token.example.com/")
+    monkeypatch.setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "runner-token")
+    monkeypatch.setenv("AZURE_CLIENT_ID", "my-client-id")
+    monkeypatch.delenv("AZURE_TENANT_ID", raising=False)
+
+    with pytest.raises(ConfigError, match="AZURE_TENANT_ID"):
+        get_credential(CredentialMode.DEFAULT)
+
+
+def test_get_credential_default_raises_config_error_missing_client_id_in_github_actions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """DEFAULT mode must raise ConfigError if AZURE_CLIENT_ID is missing in GitHub Actions."""
+    monkeypatch.setenv("ACTIONS_ID_TOKEN_REQUEST_URL", "https://token.example.com/")
+    monkeypatch.setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "runner-token")
+    monkeypatch.setenv("AZURE_TENANT_ID", "my-tenant-id")
+    monkeypatch.delenv("AZURE_CLIENT_ID", raising=False)
+
+    with pytest.raises(ConfigError, match="AZURE_CLIENT_ID"):
+        get_credential(CredentialMode.DEFAULT)
+
+
+def test_get_credential_default_raises_config_error_missing_both_in_github_actions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """DEFAULT mode must raise ConfigError if AZURE_TENANT_ID and AZURE_CLIENT_ID are missing."""
+    monkeypatch.setenv("ACTIONS_ID_TOKEN_REQUEST_URL", "https://token.example.com/")
+    monkeypatch.setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "runner-token")
+    monkeypatch.delenv("AZURE_TENANT_ID", raising=False)
+    monkeypatch.delenv("AZURE_CLIENT_ID", raising=False)
+
+    with pytest.raises(ConfigError):
+        get_credential(CredentialMode.DEFAULT)


### PR DESCRIPTION
## Problem

The 56-minute integration suite fails mid-run with ~26 cascading authentication errors:

```
AADSTS700024: Client assertion is not within its valid time range
```

`azure/login@v3` captures a GitHub OIDC JWT **once** at job start. That JWT is valid only ~5 minutes. When `azure-identity` needs to refresh an Azure access token later in the run, it re-presents the now-expired assertion to Entra ID and gets rejected.

## Solution

`azure.identity.aio.ClientAssertionCredential` accepts a `func: Callable[[], str]` callback that is invoked on **every** token acquisition. By fetching a fresh GitHub OIDC JWT inside that callback we guarantee the assertion is always within its validity window, regardless of how long the job runs.

Key implementation details:

- `_is_github_actions_oidc()` — detects GitHub OIDC by checking both `ACTIONS_ID_TOKEN_REQUEST_URL` and `ACTIONS_ID_TOKEN_REQUEST_TOKEN` are set.
- `_fetch_github_oidc_jwt()` — synchronous `httpx.get` to `{ACTIONS_ID_TOKEN_REQUEST_URL}&audience=api://AzureADTokenExchange` (same audience as `azure/login`). The `func` parameter is `Callable[[], str]` (sync) in azure-identity 1.25.3.
- `_make_default_credential()` — in `CredentialMode.DEFAULT`, branches to `ClientAssertionCredential` when OIDC env vars are present; otherwise falls back to `DefaultAzureCredential` unchanged.
- The workflow's three pytest steps gain `AZURE_CLIENT_ID` and `AZURE_TENANT_ID` env vars (from existing secrets). `azure/login` is kept for the `az` capacity resume/suspend steps.
- No long-lived secret is used — only the ephemeral OIDC exchange.

## azure-identity details

- Version: **1.25.3**
- `ClientAssertionCredential.func` is **sync** (`Callable[[], str]`)

## `just check` results

```
ruff check .          → All checks passed!
ruff format --check . → 173 files already formatted
ty check src tests    → All checks passed!
pytest tests/unit     → 2123 passed in 22.31s
coverage              → 97.02% (required: 80%)
```

## Test plan

- [ ] Confirm `just check` passes in CI
- [ ] Trigger integration suite (`workflow_dispatch` or add `integration` label to this PR) and verify no `AADSTS700024` errors appear mid-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)