### PR TITLE
fix(snapshots): retry roll_timestamp until the snapshot database is ready

### DIFF
--- a/src/fabric_dw/services/snapshots.py
+++ b/src/fabric_dw/services/snapshots.py
@@ -3,16 +3,18 @@
 from __future__ import annotations
 
 import asyncio
+import time as _time
 from datetime import UTC, datetime
 from uuid import UUID
 
 from fabric_dw.auth import CredentialMode
 from fabric_dw.cache import ItemEntry, LookupCache
+from fabric_dw.exceptions import FabricError
 from fabric_dw.http_client import FabricHttpClient, HttpBase
 from fabric_dw.models import WarehouseKind, WarehouseSnapshot, WarehouseSnapshotApiPayload, as_props
 from fabric_dw.services._helpers import compact
 from fabric_dw.services._lro import LRO_DETAIL_WAIT_S, LRO_MAX_DETAIL_RETRIES, resolve_lro_item_id
-from fabric_dw.sql import SqlTarget, run_statements
+from fabric_dw.sql import SqlTarget, is_snapshot_not_ready_error, run_statements
 
 __all__ = [
     "create",
@@ -21,6 +23,16 @@ __all__ = [
     "rename",
     "roll_timestamp",
 ]
+
+# ---------------------------------------------------------------------------
+# Readiness-retry configuration for roll_timestamp
+# ---------------------------------------------------------------------------
+
+# How long to wait between ALTER retries while the snapshot DB is provisioning.
+_SNAP_READY_POLL_INTERVAL_S: float = 4.0
+# Total time (seconds) to wait for the snapshot DB to become ready before
+# giving up and raising FabricError.
+_SNAP_READY_TIMEOUT_S: float = 90.0
 
 # Characters / sequences that could enable SQL injection in a bracket-quoted name.
 # This is a strict blocklist: snapshot names are NOT passed through
@@ -349,6 +361,17 @@ async def roll_timestamp(
     # Correct fix: open the connection with ODBC-level ``autocommit=True`` so
     # the driver never wraps any statement in an explicit transaction, then run
     # the ALTER as the sole statement on that connection.
+    #
+    # Additionally, a freshly-created snapshot database is subject to an
+    # eventual-consistency / provisioning lag at the SQL layer.  During this
+    # window the TDS endpoint rejects the ALTER with a message of the form:
+    #   "User does not have permission to alter database '<name>', the database
+    #    does not exist, or the database is not in a state that allows access
+    #    checks."
+    # This is NOT a real permission failure — it is a transient provisioning
+    # state.  We detect it via :func:`~fabric_dw.sql.is_snapshot_not_ready_error`
+    # and retry with a bounded back-off (``_SNAP_READY_POLL_INTERVAL_S`` sleep,
+    # ``_SNAP_READY_TIMEOUT_S`` total wall-clock budget).
     def _run() -> None:
         run_statements(
             parent_target,
@@ -357,4 +380,23 @@ async def roll_timestamp(
             autocommit=True,
         )
 
-    await asyncio.to_thread(_run)
+    deadline = _time.monotonic() + _SNAP_READY_TIMEOUT_S
+    while True:
+        try:
+            await asyncio.to_thread(_run)
+        except Exception as exc:
+            if not is_snapshot_not_ready_error(exc):
+                # Real error (permission denied, auth failure, SQL syntax …) — propagate.
+                raise
+            if _time.monotonic() >= deadline:
+                msg = (
+                    f"roll_timestamp: snapshot database {snapshot_name!r} did not become "
+                    f"ready within {_SNAP_READY_TIMEOUT_S:.0f}s.  The snapshot may still "
+                    "be provisioning at the SQL layer.  Retry the operation after a short "
+                    "wait or check the snapshot status in the Fabric portal."
+                )
+                raise FabricError(msg) from exc
+            # Provisioning lag — wait and retry.
+            await asyncio.sleep(_SNAP_READY_POLL_INTERVAL_S)
+        else:
+            return  # ALTER succeeded — we're done

--- a/src/fabric_dw/sql.py
+++ b/src/fabric_dw/sql.py
@@ -132,10 +132,7 @@ _NOT_FOUND_FRAGMENTS = (
 # maps them via the permission-denied fragment path), so we detect them by
 # matching the unique sub-phrase that distinguishes provisioning lag from a real
 # permission denial.
-_SNAPSHOT_NOT_READY_FRAGMENTS = (
-    "does not exist, or the database is not in a state that allows access checks",
-    "not in a state that allows access checks",
-)
+_SNAPSHOT_NOT_READY_FRAGMENTS = ("not in a state that allows access checks",)
 
 # Fragments that indicate a transient connection-level drop (TCP tear-down,
 # server-side restart, or fabric warm-up).  These are safe to retry because

--- a/src/fabric_dw/sql.py
+++ b/src/fabric_dw/sql.py
@@ -123,6 +123,20 @@ _NOT_FOUND_FRAGMENTS = (
     "base table or view not found",
 )
 
+# Fragments that indicate a freshly-created snapshot database has not yet
+# finished provisioning at the SQL layer ("eventual consistency" lag).  The
+# full error from the Fabric TDS endpoint reads:
+#   "User does not have permission to alter database '<name>', the database
+#    does not exist, or the database is not in a state that allows access checks."
+# All three clauses are surfaced as a single PermissionDeniedError (the driver
+# maps them via the permission-denied fragment path), so we detect them by
+# matching the unique sub-phrase that distinguishes provisioning lag from a real
+# permission denial.
+_SNAPSHOT_NOT_READY_FRAGMENTS = (
+    "does not exist, or the database is not in a state that allows access checks",
+    "not in a state that allows access checks",
+)
+
 # Fragments that indicate a transient connection-level drop (TCP tear-down,
 # server-side restart, or fabric warm-up).  These are safe to retry because
 # the statement has NOT been executed on the server yet (connection failed).
@@ -568,6 +582,34 @@ def is_transient_connection_error(exc: BaseException) -> bool:
     """
     msg = str(exc).lower()
     return any(fragment in msg for fragment in _TRANSIENT_FRAGMENTS)
+
+
+def is_snapshot_not_ready_error(exc: BaseException) -> bool:
+    """Return True when *exc* indicates a snapshot DB is still provisioning.
+
+    A freshly-created Fabric warehouse snapshot database is not immediately
+    accessible at the SQL layer.  During the provisioning window the TDS
+    endpoint returns a message of the form:
+
+        "User does not have permission to alter database '<name>', the database
+         does not exist, or the database is not in a state that allows access
+         checks."
+
+    This is surfaced as a :class:`~fabric_dw.exceptions.PermissionDeniedError`
+    by :func:`map_driver_error` because the message contains the
+    "permission was denied" / "permission" fragment.  However, retrying is
+    safe here — the statement was rejected *before* it could execute, and once
+    provisioning finishes the same ``ALTER DATABASE`` will succeed.
+
+    Args:
+        exc: The exception raised by the driver or by :func:`map_driver_error`.
+
+    Returns:
+        ``True`` when the message matches a known snapshot-not-ready fragment,
+        ``False`` for all other errors.
+    """
+    msg = str(exc).lower()
+    return any(fragment in msg for fragment in _SNAPSHOT_NOT_READY_FRAGMENTS)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/services/test_snapshots.py
+++ b/tests/unit/services/test_snapshots.py
@@ -14,7 +14,7 @@ import pytest
 import respx
 
 from fabric_dw.cache import ItemEntry, LookupCache
-from fabric_dw.exceptions import NotFoundError, PermissionDeniedError
+from fabric_dw.exceptions import FabricError, NotFoundError, PermissionDeniedError
 from fabric_dw.http_client import FabricHttpClient
 from fabric_dw.models import WarehouseKind, WarehouseSnapshot
 from fabric_dw.services import snapshots
@@ -714,6 +714,131 @@ async def test_roll_timestamp_closes_connection() -> None:
         await snapshots.roll_timestamp(target, "MySnapshot")
 
     conn.close.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# roll_timestamp — snapshot-not-ready retry
+# ---------------------------------------------------------------------------
+
+# The transient error message the Fabric TDS endpoint emits while a freshly
+# created snapshot DB is still provisioning at the SQL layer.
+_SNAP_NOT_READY_MSG = (
+    "User does not have permission to alter database 'my-snap', "
+    "the database does not exist, or the database is not in a state "
+    "that allows access checks."
+)
+
+
+async def test_roll_timestamp_retries_once_on_snapshot_not_ready() -> None:
+    """roll_timestamp retries once when run_statements raises the not-ready error, then succeeds."""
+    target = _make_sql_target()
+    transient_exc = PermissionDeniedError(_SNAP_NOT_READY_MSG)
+
+    call_count = 0
+
+    def _run_side_effect(*_args: object, **_kwargs: object) -> None:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise transient_exc
+
+    # Freeze monotonic time so the deadline is never hit.
+    fake_now = [0.0]
+
+    def _fake_monotonic() -> float:
+        return fake_now[0]
+
+    with (
+        patch("fabric_dw.services.snapshots.run_statements", side_effect=_run_side_effect),
+        patch("time.monotonic", side_effect=_fake_monotonic),
+    ):
+        await snapshots.roll_timestamp(target, "MySnapshot")
+
+    assert call_count == 2
+
+
+async def test_roll_timestamp_retries_twice_on_snapshot_not_ready() -> None:
+    """roll_timestamp retries up to N times, succeeding on the third attempt."""
+    target = _make_sql_target()
+    transient_exc = PermissionDeniedError(_SNAP_NOT_READY_MSG)
+
+    call_count = 0
+
+    def _run_side_effect(*_args: object, **_kwargs: object) -> None:
+        nonlocal call_count
+        call_count += 1
+        if call_count < 3:
+            raise transient_exc
+
+    fake_now = [0.0]
+
+    def _fake_monotonic() -> float:
+        return fake_now[0]
+
+    with (
+        patch("fabric_dw.services.snapshots.run_statements", side_effect=_run_side_effect),
+        patch("time.monotonic", side_effect=_fake_monotonic),
+    ):
+        await snapshots.roll_timestamp(target, "MySnapshot")
+
+    assert call_count == 3
+
+
+async def test_roll_timestamp_raises_fabric_error_on_timeout() -> None:
+    """roll_timestamp raises FabricError once the timeout budget is exhausted."""
+    target = _make_sql_target()
+    transient_exc = PermissionDeniedError(_SNAP_NOT_READY_MSG)
+
+    # Always raise the transient error.
+    def _run_always_fails(*_args: object, **_kwargs: object) -> None:
+        raise transient_exc
+
+    # Simulate time advancing past the deadline on the second monotonic() call
+    # (first call sets the deadline, second call is checked inside the loop).
+    # Return a large value for any additional calls (teardown etc.).
+    timeout = snapshots._SNAP_READY_TIMEOUT_S
+    call_counter = [0]
+
+    def _fake_monotonic() -> float:
+        call_counter[0] += 1
+        if call_counter[0] == 1:
+            return 0.0  # initial deadline computation
+        return timeout + 1.0  # past deadline on every subsequent check
+
+    with (
+        patch("fabric_dw.services.snapshots.run_statements", side_effect=_run_always_fails),
+        patch("time.monotonic", side_effect=_fake_monotonic),
+        pytest.raises(FabricError, match="did not become ready"),
+    ):
+        await snapshots.roll_timestamp(target, "MySnapshot")
+
+
+async def test_roll_timestamp_does_not_retry_real_permission_error() -> None:
+    """roll_timestamp propagates real PermissionDeniedError without retrying."""
+    target = _make_sql_target()
+    real_permission_exc = PermissionDeniedError("permission was denied on ALTER DATABASE")
+
+    call_count = 0
+
+    def _run_side_effect(*_args: object, **_kwargs: object) -> None:
+        nonlocal call_count
+        call_count += 1
+        raise real_permission_exc
+
+    fake_now = [0.0]
+
+    def _fake_monotonic() -> float:
+        return fake_now[0]
+
+    with (
+        patch("fabric_dw.services.snapshots.run_statements", side_effect=_run_side_effect),
+        patch("time.monotonic", side_effect=_fake_monotonic),
+        pytest.raises(PermissionDeniedError),
+    ):
+        await snapshots.roll_timestamp(target, "MySnapshot")
+
+    # Must NOT retry a real permission error.
+    assert call_count == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `is_snapshot_not_ready_error()` to `sql.py` that detects the specific transient error message emitted by the Fabric TDS endpoint while a freshly-created snapshot DB is still provisioning
- Wraps the `ALTER DATABASE … SET TIMESTAMP` in a bounded retry loop (4 s poll interval, 90 s total timeout) that retries only on this transient error and raises a clear `FabricError` on timeout
- Adds four unit tests: retry-once success, retry-twice success, timeout raises `FabricError`, and real permission errors are propagated immediately without retrying

## Test plan

- [x] `just check` fully green (lint + type + 2127 unit tests)
- [x] `test_roll_timestamp_retries_once_on_snapshot_not_ready` — succeeds on 2nd attempt
- [x] `test_roll_timestamp_retries_twice_on_snapshot_not_ready` — succeeds on 3rd attempt
- [x] `test_roll_timestamp_raises_fabric_error_on_timeout` — raises `FabricError` with "did not become ready" message after deadline
- [x] `test_roll_timestamp_does_not_retry_real_permission_error` — real `PermissionDeniedError` propagated on first raise, no retry
- [ ] Integration test `test_roll_timestamp_updates_snapshot` — requires live Fabric environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)