### PR TITLE
fix(sql_endpoints): tolerate synchronous refresh-metadata + poll for connection string

### DIFF
--- a/src/fabric_dw/services/sql_endpoints.py
+++ b/src/fabric_dw/services/sql_endpoints.py
@@ -182,9 +182,17 @@ async def refresh_metadata(
     """Trigger a metadata refresh for a SQL analytics endpoint.
 
     Issues ``POST /workspaces/{ws}/sqlEndpoints/{id}/refreshMetadata`` with
-    an optional ``recreateTables`` body flag.  The API returns a 202 with a
-    ``Location`` header pointing at a long-running operation (LRO).  The
-    function polls the LRO to completion and parses the per-table results.
+    an optional ``recreateTables`` body flag.
+
+    The API supports two completion modes:
+
+    * **Synchronous** (200/204, no ``Location`` or ``Operation-Location``
+      response header): the per-table results are read directly from the
+      response body.
+    * **Asynchronous** (202 + ``Location`` / ``Operation-Location`` header):
+      the function polls the LRO to completion via
+      :meth:`~fabric_dw.http_client.FabricHttpClient.poll_operation` and then
+      parses the per-table results from the operation result.
 
     Args:
         http: An authenticated :class:`~fabric_dw.http_client.FabricHttpClient`.
@@ -199,7 +207,8 @@ async def refresh_metadata(
         table, describing the outcome of the refresh.
 
     Raises:
-        FabricServerError: If the LRO fails or times out.
+        FabricServerError: If the async LRO fails or times out (async path
+            only).
         NotFoundError: If the endpoint does not exist (404).
     """
     json_body: dict[str, Any] | None = {"recreateTables": True} if recreate_tables else None

--- a/src/fabric_dw/services/sql_endpoints.py
+++ b/src/fabric_dw/services/sql_endpoints.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Any
 from uuid import UUID
 
-from fabric_dw.exceptions import NotFoundError, PermissionDeniedError
+from fabric_dw.exceptions import FabricServerError, NotFoundError, PermissionDeniedError
 from fabric_dw.http_client import FabricHttpClient, HttpBase
 from fabric_dw.models import TableSyncStatus, Warehouse, WarehouseKind
 from fabric_dw.services._concurrency import bounded_gather
@@ -14,8 +15,13 @@ from fabric_dw.services.workspaces import list_all as _list_all_workspaces
 
 _log = logging.getLogger("fabric_dw.sql_endpoints")
 
+# Bounded polling for eventual-consistency fields (e.g. connection_string).
+_CONN_STRING_POLL_INTERVAL: float = 5.0
+_CONN_STRING_POLL_TIMEOUT: float = 120.0
+
 __all__ = [
     "get_endpoint",
+    "get_endpoint_connection_string",
     "list_all_workspaces",
     "list_endpoints",
     "refresh_metadata",
@@ -112,6 +118,60 @@ async def get_endpoint(http: FabricHttpClient, workspace_id: UUID, endpoint_id: 
     return Warehouse.from_api(resp.json(), kind=WarehouseKind.SQL_ENDPOINT)
 
 
+async def get_endpoint_connection_string(
+    http: FabricHttpClient,
+    workspace_id: UUID,
+    endpoint_id: UUID,
+    *,
+    poll_interval: float = _CONN_STRING_POLL_INTERVAL,
+    timeout: float = _CONN_STRING_POLL_TIMEOUT,
+) -> str:
+    """Return the connection string for a SQL analytics endpoint, polling until non-empty.
+
+    SQL analytics endpoints are provisioned with eventual consistency: the
+    ``connectionString`` field may be empty or absent immediately after
+    the endpoint is created.  This function polls
+    ``GET /workspaces/{ws}/sqlEndpoints/{id}`` until the connection string
+    is non-empty, up to *timeout* seconds.
+
+    Args:
+        http: An authenticated :class:`~fabric_dw.http_client.FabricHttpClient`.
+        workspace_id: The UUID of the workspace containing the endpoint.
+        endpoint_id: The UUID of the SQL analytics endpoint.
+        poll_interval: Seconds between polls (default 5.0).
+        timeout: Maximum wall-clock seconds to wait (default 120.0).
+
+    Returns:
+        The non-empty connection string.
+
+    Raises:
+        FabricServerError: If the connection string remains empty after *timeout* seconds.
+        NotFoundError: If the endpoint does not exist (404).
+    """
+    import time as _time  # noqa: PLC0415 — local import avoids module-level shadowing
+
+    deadline = _time.monotonic() + timeout
+    while True:
+        ep = await get_endpoint(http, workspace_id, endpoint_id)
+        if ep.connection_string:
+            return ep.connection_string
+
+        remaining = deadline - _time.monotonic()
+        if remaining <= 0:
+            raise FabricServerError(
+                f"connection_string for SQL endpoint {endpoint_id} "
+                f"remained empty after {timeout:.0f}s"
+            )
+
+        wait = min(poll_interval, remaining)
+        _log.debug(
+            "connection_string not yet populated for endpoint %s; retrying in %.1fs",
+            endpoint_id,
+            wait,
+        )
+        await asyncio.sleep(wait)
+
+
 async def refresh_metadata(
     http: FabricHttpClient,
     workspace_id: UUID,
@@ -150,8 +210,23 @@ async def refresh_metadata(
         f"/workspaces/{workspace_id}/sqlEndpoints/{endpoint_id}/refreshMetadata",
         json=json_body,
     )
-    location: str = resp.headers["Location"]
-    lro_body = await http.poll_operation(location)
-    raw_value: Any = lro_body.get("value", []) if isinstance(lro_body, dict) else []
+
+    # The API may complete synchronously (200/204 with results inline) or
+    # asynchronously (202 + Location / Operation-Location header).  Try the
+    # async path first; fall back to treating the response body as the result.
+    location: str | None = resp.headers.get("Location") or resp.headers.get("Operation-Location")
+
+    if location:
+        lro_body = await http.poll_operation(location)
+        raw_value: Any = lro_body.get("value", []) if isinstance(lro_body, dict) else []
+    else:
+        # Synchronous completion: parse the table sync statuses from the body directly.
+        _log.debug(
+            "refresh_metadata for endpoint %s completed synchronously (no LRO header)",
+            endpoint_id,
+        )
+        body: Any = resp.json() if resp.content else {}
+        raw_value = body.get("value", []) if isinstance(body, dict) else []
+
     raw_items: list[Any] = raw_value if isinstance(raw_value, list) else []
     return [TableSyncStatus.model_validate(item) for item in raw_items]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -305,6 +305,29 @@ async def ephemeral_sql_endpoint(
                     f"SQL endpoint provisioned but id is not a valid UUID "
                     f"for lakehouse {lh_id}: {ep_id_raw!r}"
                 )
+
+            # Even after provisioningStatus=Success, the connectionString on the
+            # SQL endpoint resource itself can be empty due to eventual consistency.
+            # Poll GET /sqlEndpoints/{id} until connection_string is non-empty so
+            # that tests fetching the endpoint directly get a populated value.
+            from fabric_dw.services.sql_endpoints import (  # noqa: PLC0415
+                get_endpoint_connection_string,
+            )
+
+            try:
+                ep_conn = await get_endpoint_connection_string(
+                    http,
+                    workspace_id,
+                    ep_uuid,
+                    poll_interval=_SQL_ENDPOINT_POLL_INTERVAL_S,
+                    timeout=max(1.0, deadline - time.monotonic()),
+                )
+            except Exception as exc:
+                pytest.skip(
+                    f"SQL endpoint {ep_uuid} connection_string did not populate "
+                    f"within timeout: {exc}"
+                )
+
             wh = Warehouse.model_validate(
                 {
                     "id": str(ep_uuid),

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -340,13 +340,12 @@ async def ephemeral_sql_endpoint(
             # Even after the Fabric API reports provisioningStatus=Success, the
             # SQL analytics endpoint may not yet accept TDS connections (the DB
             # engine needs an additional warm-up window).  Poll until reachable.
-            if ep_conn:
-                sql_target = SqlTarget(
-                    workspace_id=str(workspace_id),
-                    database=wh.name,
-                    connection_string=ep_conn,
-                )
-                await _wait_for_sql_readiness(sql_target)
+            sql_target = SqlTarget(
+                workspace_id=str(workspace_id),
+                database=wh.name,
+                connection_string=ep_conn,
+            )
+            await _wait_for_sql_readiness(sql_target)
             yield wh
             return
 

--- a/tests/unit/services/test_sql_endpoints.py
+++ b/tests/unit/services/test_sql_endpoints.py
@@ -481,3 +481,184 @@ async def test_list_all_workspaces_endpoints_skips_not_found(
     assert ids == {_EP_A, _EP_C}
     assert any(f"WS-{_EP_WS_B}" in r.message for r in caplog.records)
     assert any("skipped 1 of 3" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# refresh_metadata — synchronous (no LRO header) path
+# ---------------------------------------------------------------------------
+
+
+async def test_refresh_metadata_sync_no_location_header_returns_statuses() -> None:
+    """refresh_metadata with no Location/Operation-Location header must parse body inline.
+
+    This covers the synchronous completion path: the API responds with 200 and
+    table sync results directly in the body, no LRO header present.
+    Should NOT raise KeyError.
+    """
+    from fabric_dw.services.sql_endpoints import refresh_metadata  # noqa: PLC0415
+
+    with respx.mock:
+        respx.post(_REFRESH_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json={"value": _REFRESH_TABLE_RESULTS},
+                # Deliberately no Location or Operation-Location header
+            )
+        )
+
+        client = await _make_client()
+        async with client:
+            result = await refresh_metadata(client, _WORKSPACE_ID, _ENDPOINT_ID)
+
+    assert isinstance(result, list)
+    assert len(result) == 2
+    assert all(isinstance(s, TableSyncStatus) for s in result)
+    assert result[0].table_name == "Table1"
+    assert result[0].status == "Success"
+    assert result[1].table_name == "Table2"
+    assert result[1].status == "Failure"
+
+
+async def test_refresh_metadata_sync_empty_body_returns_empty_list() -> None:
+    """refresh_metadata with 204 (no content) and no LRO header must return empty list."""
+    from fabric_dw.services.sql_endpoints import refresh_metadata  # noqa: PLC0415
+
+    with respx.mock:
+        respx.post(_REFRESH_URL).mock(return_value=httpx.Response(204, content=b""))
+
+        client = await _make_client()
+        async with client:
+            result = await refresh_metadata(client, _WORKSPACE_ID, _ENDPOINT_ID)
+
+    assert result == []
+
+
+async def test_refresh_metadata_operation_location_header_still_works() -> None:
+    """refresh_metadata must also poll when the header is Operation-Location (not Location)."""
+    from fabric_dw.services.sql_endpoints import refresh_metadata  # noqa: PLC0415
+
+    with respx.mock:
+        respx.post(_REFRESH_URL).mock(
+            return_value=httpx.Response(
+                202,
+                json={},
+                headers={"Operation-Location": _OPERATION_URL},
+            )
+        )
+        respx.get(_OPERATION_URL).mock(
+            return_value=httpx.Response(200, json=_REFRESH_LRO_SUCCEEDED)
+        )
+
+        client = await _make_client()
+        async with client:
+            result = await refresh_metadata(client, _WORKSPACE_ID, _ENDPOINT_ID)
+
+    assert isinstance(result, list)
+    assert len(result) == 2
+    assert result[0].table_name == "Table1"
+
+
+# ---------------------------------------------------------------------------
+# get_endpoint_connection_string — polling behaviour
+# ---------------------------------------------------------------------------
+
+_ENDPOINT_GET_EMPTY_CONN_STRING: dict[str, Any] = {
+    "id": str(_ENDPOINT_ID),
+    "displayName": "SalesLakehouse",
+    "description": "SQL endpoint for sales lakehouse",
+    "type": "SQLEndpoint",
+    "workspaceId": str(_WORKSPACE_ID),
+    "properties": {
+        "sqlEndpointProperties": {
+            "connectionString": "",
+            "id": "f6a7b8c9-d0e1-2345-f012-34567890abcd",
+            "provisioningStatus": "Success",
+        }
+    },
+}
+
+
+async def test_get_endpoint_connection_string_polls_until_populated() -> None:
+    """get_endpoint_connection_string must poll until connection_string is non-empty."""
+    from fabric_dw.services.sql_endpoints import get_endpoint_connection_string  # noqa: PLC0415
+
+    call_count = 0
+
+    def side_effect(_request: httpx.Request) -> httpx.Response:
+        nonlocal call_count
+        call_count += 1
+        if call_count < 3:
+            # First two calls return empty connection_string
+            return httpx.Response(200, json=_ENDPOINT_GET_EMPTY_CONN_STRING)
+        # Third call returns populated connection_string
+        return httpx.Response(200, json=_ENDPOINT_GET_PAYLOAD)
+
+    with respx.mock(assert_all_called=False) as mock_router:
+        mock_router.get(_ENDPOINT_URL).mock(side_effect=side_effect)
+
+        client = await _make_client()
+        async with client:
+            with patch(
+                "fabric_dw.services.sql_endpoints.asyncio.sleep",
+                new=AsyncMock(),
+            ) as mock_sleep:
+                result = await get_endpoint_connection_string(
+                    client,
+                    _WORKSPACE_ID,
+                    _ENDPOINT_ID,
+                    poll_interval=5.0,
+                    timeout=120.0,
+                )
+
+    assert result == "lakehouse-sql-ep.datawarehouse.fabric.microsoft.com"
+    assert call_count == 3
+    # sleep must have been called between polls (twice: after call 1 and call 2)
+    assert mock_sleep.call_count == 2
+
+
+async def test_get_endpoint_connection_string_immediate_return_no_sleep() -> None:
+    """get_endpoint_connection_string must return immediately when already populated."""
+    from fabric_dw.services.sql_endpoints import get_endpoint_connection_string  # noqa: PLC0415
+
+    with respx.mock:
+        respx.get(_ENDPOINT_URL).mock(return_value=httpx.Response(200, json=_ENDPOINT_GET_PAYLOAD))
+
+        client = await _make_client()
+        async with client:
+            with patch(
+                "fabric_dw.services.sql_endpoints.asyncio.sleep",
+                new=AsyncMock(),
+            ) as mock_sleep:
+                result = await get_endpoint_connection_string(
+                    client,
+                    _WORKSPACE_ID,
+                    _ENDPOINT_ID,
+                )
+
+    assert result == "lakehouse-sql-ep.datawarehouse.fabric.microsoft.com"
+    mock_sleep.assert_not_called()
+
+
+async def test_get_endpoint_connection_string_timeout_raises_fabric_server_error() -> None:
+    """get_endpoint_connection_string must raise FabricServerError after timeout.
+
+    Passes timeout=0.0 so the deadline is already expired after the first GET
+    that returns an empty connection_string — no need to mock time.
+    """
+    from fabric_dw.services.sql_endpoints import get_endpoint_connection_string  # noqa: PLC0415
+
+    with respx.mock(assert_all_called=False) as mock_router:
+        mock_router.get(_ENDPOINT_URL).mock(
+            return_value=httpx.Response(200, json=_ENDPOINT_GET_EMPTY_CONN_STRING)
+        )
+
+        client = await _make_client()
+        async with client:
+            with pytest.raises(FabricServerError, match="connection_string"):
+                await get_endpoint_connection_string(
+                    client,
+                    _WORKSPACE_ID,
+                    _ENDPOINT_ID,
+                    poll_interval=0.0,
+                    timeout=0.0,
+                )


### PR DESCRIPTION
## Summary

- **`refresh_metadata`**: fixes `KeyError: 'Location'` by checking for `Location` *or* `Operation-Location` headers; if neither is present (synchronous completion), parses table sync statuses directly from the response body instead of raising.
- **`get_endpoint_connection_string`**: new helper that polls `GET /sqlEndpoints/{id}` until `connectionString` is non-empty, with configurable `poll_interval`/`timeout` and a clear `FabricServerError` on expiry. The integration `conftest` `ephemeral_sql_endpoint` fixture now calls this after provisioning to handle the eventual-consistency gap.

## Test plan

- [x] Unit: `test_refresh_metadata_sync_no_location_header_returns_statuses` — no header → body parsed, no KeyError
- [x] Unit: `test_refresh_metadata_sync_empty_body_returns_empty_list` — 204 no-content → empty list
- [x] Unit: `test_refresh_metadata_operation_location_header_still_works` — `Operation-Location` header → LRO polled
- [x] Unit: `test_get_endpoint_connection_string_polls_until_populated` — empty×2 then populated → returns value, sleep called twice
- [x] Unit: `test_get_endpoint_connection_string_immediate_return_no_sleep` — populated immediately → no sleep
- [x] Unit: `test_get_endpoint_connection_string_timeout_raises_fabric_server_error` — `timeout=0.0` → `FabricServerError`
- [x] Existing async LRO path (`Location` header) unchanged and still passes
- [x] `just check` (lint + ty + 2129 unit tests) fully green

🤖 Generated with [Claude Code](https://claude.com/claude-code)