### PR TITLE
fix(auth): inject self-refreshing OIDC access token into SQL connections

### DIFF
--- a/src/fabric_dw/auth.py
+++ b/src/fabric_dw/auth.py
@@ -3,6 +3,7 @@
 import asyncio
 import os
 import struct
+import threading
 from collections.abc import Callable
 from enum import StrEnum
 from types import TracebackType
@@ -202,6 +203,29 @@ def _fetch_github_oidc_jwt() -> str:
     return str(response.json()["value"])
 
 
+def _build_sync_oidc_credential() -> SyncClientAssertionCredential:
+    """Validate env-vars and construct a :class:`SyncClientAssertionCredential`.
+
+    Shared by :func:`_make_github_oidc_credential` (async wrapper path) and
+    :func:`_get_sql_oidc_credential` (sync SQL-injection path) to avoid duplicating
+    the env-var check and constructor call.
+
+    Raises:
+        ConfigError: If AZURE_TENANT_ID or AZURE_CLIENT_ID are missing.
+    """
+    missing = [name for name in ("AZURE_TENANT_ID", "AZURE_CLIENT_ID") if not os.environ.get(name)]
+    if missing:
+        raise ConfigError(
+            f"GitHub Actions OIDC credential requires {', '.join(missing)} "
+            f"to be set in the environment."
+        )
+    return SyncClientAssertionCredential(
+        tenant_id=os.environ["AZURE_TENANT_ID"],
+        client_id=os.environ["AZURE_CLIENT_ID"],
+        func=_fetch_github_oidc_jwt,
+    )
+
+
 def _make_github_oidc_credential() -> AsyncTokenCredential:
     """Build a self-refreshing ClientAssertionCredential backed by GitHub OIDC.
 
@@ -220,45 +244,27 @@ def _make_github_oidc_credential() -> AsyncTokenCredential:
     Raises:
         ConfigError: If AZURE_TENANT_ID or AZURE_CLIENT_ID are missing.
     """
-    missing = [name for name in ("AZURE_TENANT_ID", "AZURE_CLIENT_ID") if not os.environ.get(name)]
-    if missing:
-        raise ConfigError(
-            f"GitHub Actions OIDC credential requires {', '.join(missing)} "
-            f"to be set in the environment."
-        )
-
-    return SyncCredentialAdapter(
-        SyncClientAssertionCredential(
-            tenant_id=os.environ["AZURE_TENANT_ID"],
-            client_id=os.environ["AZURE_CLIENT_ID"],
-            func=_fetch_github_oidc_jwt,
-        )
-    )
+    return SyncCredentialAdapter(_build_sync_oidc_credential())
 
 
 # Module-level cached sync credential for SQL token injection under GitHub OIDC.
 # Caching allows azure-identity's in-memory token cache to work across connects,
 # so tokens are only re-acquired when they genuinely expire — NOT on every connect.
 _sql_oidc_credential: SyncClientAssertionCredential | None = None
+_sql_oidc_credential_lock = threading.Lock()
 
 
 def _get_sql_oidc_credential() -> SyncClientAssertionCredential:
-    """Return (creating once) the sync OIDC credential used for SQL token injection."""
+    """Return (creating once) the sync OIDC credential used for SQL token injection.
+
+    Uses double-checked locking so concurrent callers never race to initialise
+    the module-level singleton — mirroring the ``_pool_lock`` pattern in sql.py.
+    """
     global _sql_oidc_credential  # noqa: PLW0603
     if _sql_oidc_credential is None:
-        missing = [
-            name for name in ("AZURE_TENANT_ID", "AZURE_CLIENT_ID") if not os.environ.get(name)
-        ]
-        if missing:
-            raise ConfigError(
-                f"GitHub Actions OIDC credential requires {', '.join(missing)} "
-                f"to be set in the environment."
-            )
-        _sql_oidc_credential = SyncClientAssertionCredential(
-            tenant_id=os.environ["AZURE_TENANT_ID"],
-            client_id=os.environ["AZURE_CLIENT_ID"],
-            func=_fetch_github_oidc_jwt,
-        )
+        with _sql_oidc_credential_lock:
+            if _sql_oidc_credential is None:
+                _sql_oidc_credential = _build_sync_oidc_credential()
     return _sql_oidc_credential
 
 

--- a/src/fabric_dw/auth.py
+++ b/src/fabric_dw/auth.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import os
+import struct
 from collections.abc import Callable
 from enum import StrEnum
 from types import TracebackType
@@ -44,6 +45,7 @@ __all__ = [
     "CredentialMode",
     "SyncCredentialAdapter",
     "get_credential",
+    "get_sql_token_struct",
 ]
 
 
@@ -232,6 +234,74 @@ def _make_github_oidc_credential() -> AsyncTokenCredential:
             func=_fetch_github_oidc_jwt,
         )
     )
+
+
+# Module-level cached sync credential for SQL token injection under GitHub OIDC.
+# Caching allows azure-identity's in-memory token cache to work across connects,
+# so tokens are only re-acquired when they genuinely expire — NOT on every connect.
+_sql_oidc_credential: SyncClientAssertionCredential | None = None
+
+
+def _get_sql_oidc_credential() -> SyncClientAssertionCredential:
+    """Return (creating once) the sync OIDC credential used for SQL token injection."""
+    global _sql_oidc_credential  # noqa: PLW0603
+    if _sql_oidc_credential is None:
+        missing = [
+            name for name in ("AZURE_TENANT_ID", "AZURE_CLIENT_ID") if not os.environ.get(name)
+        ]
+        if missing:
+            raise ConfigError(
+                f"GitHub Actions OIDC credential requires {', '.join(missing)} "
+                f"to be set in the environment."
+            )
+        _sql_oidc_credential = SyncClientAssertionCredential(
+            tenant_id=os.environ["AZURE_TENANT_ID"],
+            client_id=os.environ["AZURE_CLIENT_ID"],
+            func=_fetch_github_oidc_jwt,
+        )
+    return _sql_oidc_credential
+
+
+def get_sql_token_struct(mode: CredentialMode = CredentialMode.DEFAULT) -> bytes | None:
+    """Return a packed ODBC SQL access-token struct for injection under GitHub OIDC.
+
+    When running under GitHub Actions OIDC (both ``ACTIONS_ID_TOKEN_REQUEST_URL``
+    and ``ACTIONS_ID_TOKEN_REQUEST_TOKEN`` are set), acquires a fresh SQL access
+    token from a module-level cached :class:`~azure.identity.ClientAssertionCredential`
+    backed by :func:`_fetch_github_oidc_jwt` and packs it in the format required
+    by the ``SQL_COPT_SS_ACCESS_TOKEN`` ODBC connection attribute (attribute 1256):
+    a 4-byte little-endian length prefix followed by the token encoded as UTF-16-LE.
+
+    When NOT under OIDC (local dev / interactive), returns ``None`` so the caller
+    falls back to the ``Authentication=`` connection-string key.
+
+    The ``mode`` parameter is accepted for API symmetry but is ignored on the OIDC
+    path — the CI service-principal identity is fixed by the GitHub Actions environment.
+
+    Args:
+        mode: Ignored on the OIDC path; kept for symmetry with other auth helpers.
+
+    Returns:
+        Packed token bytes when running under GitHub Actions OIDC, otherwise ``None``.
+
+    Raises:
+        ConfigError: If OIDC is detected but AZURE_TENANT_ID or AZURE_CLIENT_ID
+            are missing from the environment.
+    """
+    # Suppress unused-arg warning: mode is intentionally ignored on OIDC path.
+    _ = mode
+
+    if not _is_github_actions_oidc():
+        return None
+
+    credential = _get_sql_oidc_credential()
+    # Call get_token on every connect — the credential's own in-memory cache returns
+    # a cached access token when it is still valid; _fetch_github_oidc_jwt is only
+    # invoked when the assertion itself needs refreshing (every ~5 min in CI).
+    # We must NOT cache the resulting struct here — let the credential decide expiry.
+    token = credential.get_token(SQL_SCOPE).token
+    token_bytes = token.encode("UTF-16-LE")
+    return struct.pack(f"<I{len(token_bytes)}s", len(token_bytes), token_bytes)
 
 
 def _make_default_credential() -> AsyncTokenCredential:

--- a/src/fabric_dw/sql.py
+++ b/src/fabric_dw/sql.py
@@ -46,7 +46,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any, Literal, Protocol
 
-from fabric_dw.auth import CredentialMode
+from fabric_dw.auth import CredentialMode, get_sql_token_struct
 from fabric_dw.exceptions import AuthError, NotFoundError, PermissionDeniedError
 
 # ---------------------------------------------------------------------------
@@ -145,6 +145,12 @@ _TRANSIENT_FRAGMENTS = (
     # _wait_for_sql_readiness in tests/integration/conftest.py handles the warm-up
     # case correctly by inspecting the AuthError message directly.
 )
+
+# ODBC connection attribute number for injecting a pre-acquired SQL access token.
+# When set in attrs_before, the driver uses this token instead of its own
+# DefaultAzureCredential chain — critical for long-running CI jobs where the
+# mssql-python driver's own AzureCliCredential assertion expires after ~5 min.
+SQL_COPT_SS_ACCESS_TOKEN: int = 1256
 
 # Mapping from CredentialMode to the ActiveDirectory auth type suffix.
 _MODE_TO_AD_AUTH: dict[CredentialMode, str] = {
@@ -413,6 +419,7 @@ def build_connection_string(
     target: SqlTarget,
     *,
     mode: CredentialMode = CredentialMode.DEFAULT,
+    use_access_token: bool = False,
 ) -> str:
     """Augment the API-provided connection string with auth, encryption and database settings.
 
@@ -423,6 +430,10 @@ def build_connection_string(
         target: The :class:`SqlTarget` whose ``connection_string`` and ``database``
             are used as inputs.
         mode: The credential mode, used to select the ActiveDirectory auth variant.
+            Ignored when ``use_access_token`` is ``True``.
+        use_access_token: When ``True``, omit the ``Authentication=`` key from the
+            connection string.  The caller is responsible for injecting a pre-acquired
+            token via ``attrs_before={SQL_COPT_SS_ACCESS_TOKEN: token_struct}``.
 
     Returns:
         The augmented ODBC connection string, ready to pass to the driver.
@@ -433,8 +444,12 @@ def build_connection_string(
     raw = target.connection_string
     if not _has_key(raw, "Server"):
         raw = f"Server={raw}"
-    cs = _set_key(raw, "Authentication", _MODE_TO_AD_AUTH[mode])
-    cs = _set_key(cs, "Encrypt", "yes")
+    # Only set the Authentication key when we are NOT injecting a pre-acquired token.
+    # With a token in attrs_before, the Authentication key must be absent — the driver
+    # uses whichever identity source is provided first and having both causes conflicts.
+    if not use_access_token:
+        raw = _set_key(raw, "Authentication", _MODE_TO_AD_AUTH[mode])
+    cs = _set_key(raw, "Encrypt", "yes")
     cs = _set_key(cs, "TrustServerCertificate", "no")
     return _set_key(cs, "Database", target.database)
 
@@ -476,13 +491,22 @@ def open_connection(
         A :class:`_PooledConnection` wrapping a DB-API 2.0 connection from
         the ``mssql_python`` driver.
     """
-    cs = build_connection_string(target, mode=mode)
+    # Acquire a token struct when running under GitHub OIDC.  This bypasses the
+    # mssql-python driver's own DefaultAzureCredential chain (which uses AzureCliCredential
+    # whose GitHub OIDC assertion expires after ~5 min) in favour of our self-refreshing
+    # credential whose _fetch_github_oidc_jwt always obtains a fresh assertion.
+    # Token acquisition happens here — only for NEW physical connections — not on
+    # pool checkout (checked-out connections are already authenticated).
+    token_struct = get_sql_token_struct(mode)
+    use_token = token_struct is not None
+    cs = build_connection_string(target, mode=mode, use_access_token=use_token)
+    attrs: dict[int, bytes] | None = {SQL_COPT_SS_ACCESS_TOKEN: token_struct} if use_token else None
 
     # Autocommit connections bypass the pool entirely to avoid cross-contaminating
     # a pooled autocommit=False connection with autocommit=True semantics or vice
     # versa.  They are always opened fresh and physically closed after use.
     if autocommit:
-        raw_conn: Any = _get_mssql().connect(cs, autocommit=True)
+        raw_conn: Any = _get_mssql().connect(cs, autocommit=True, attrs_before=attrs)
         # Wrap in _PooledConnection with a sentinel key; _discard=True ensures
         # .close() physically closes the connection rather than pooling it.
         key = _make_pool_key(target, mode)
@@ -497,7 +521,7 @@ def open_connection(
         if cached is not None:
             return _PooledConnection(cached, key)
 
-    raw_conn = _get_mssql().connect(cs)
+    raw_conn = _get_mssql().connect(cs, attrs_before=attrs)
     return _PooledConnection(raw_conn, key)
 
 

--- a/src/fabric_dw/sql.py
+++ b/src/fabric_dw/sql.py
@@ -491,21 +491,21 @@ def open_connection(
         A :class:`_PooledConnection` wrapping a DB-API 2.0 connection from
         the ``mssql_python`` driver.
     """
-    # Acquire a token struct when running under GitHub OIDC.  This bypasses the
-    # mssql-python driver's own DefaultAzureCredential chain (which uses AzureCliCredential
-    # whose GitHub OIDC assertion expires after ~5 min) in favour of our self-refreshing
-    # credential whose _fetch_github_oidc_jwt always obtains a fresh assertion.
-    # Token acquisition happens here — only for NEW physical connections — not on
-    # pool checkout (checked-out connections are already authenticated).
-    token_struct = get_sql_token_struct(mode)
-    use_token = token_struct is not None
-    cs = build_connection_string(target, mode=mode, use_access_token=use_token)
-    attrs: dict[int, bytes] | None = {SQL_COPT_SS_ACCESS_TOKEN: token_struct} if use_token else None
-
     # Autocommit connections bypass the pool entirely to avoid cross-contaminating
     # a pooled autocommit=False connection with autocommit=True semantics or vice
     # versa.  They are always opened fresh and physically closed after use.
     if autocommit:
+        # Acquire a token struct when running under GitHub OIDC.  This bypasses the
+        # mssql-python driver's own DefaultAzureCredential chain (which uses
+        # AzureCliCredential whose GitHub OIDC assertion expires after ~5 min) in
+        # favour of our self-refreshing credential whose _fetch_github_oidc_jwt
+        # always obtains a fresh assertion.
+        token_struct = get_sql_token_struct(mode)
+        use_token = token_struct is not None
+        cs = build_connection_string(target, mode=mode, use_access_token=use_token)
+        attrs: dict[int, bytes] | None = (
+            {SQL_COPT_SS_ACCESS_TOKEN: token_struct} if use_token else None
+        )
         raw_conn: Any = _get_mssql().connect(cs, autocommit=True, attrs_before=attrs)
         # Wrap in _PooledConnection with a sentinel key; _discard=True ensures
         # .close() physically closes the connection rather than pooling it.
@@ -519,8 +519,19 @@ def open_connection(
     if _pool_enabled():
         cached = _pool_checkout(key)
         if cached is not None:
+            # Pool HIT — return the cached connection without acquiring a token.
+            # Checked-out connections are already authenticated; acquiring a token
+            # here would invoke credential.get_token() (holding azure-identity's
+            # token-cache lock) and then discard the result — pure waste.
             return _PooledConnection(cached, key)
 
+    # Pool MISS (or pooling disabled) — open a new physical connection.
+    # Only now do we acquire the OIDC token struct, so the credential is never
+    # consulted on pool-hit paths.
+    token_struct = get_sql_token_struct(mode)
+    use_token = token_struct is not None
+    cs = build_connection_string(target, mode=mode, use_access_token=use_token)
+    attrs = {SQL_COPT_SS_ACCESS_TOKEN: token_struct} if use_token else None
     raw_conn = _get_mssql().connect(cs, attrs_before=attrs)
     return _PooledConnection(raw_conn, key)
 

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -582,3 +582,168 @@ def test_get_credential_default_raises_config_error_missing_both_in_github_actio
 
     with pytest.raises(ConfigError):
         get_credential(CredentialMode.DEFAULT)
+
+
+# ---------------------------------------------------------------------------
+# get_sql_token_struct — SQL access-token injection for GitHub OIDC
+# ---------------------------------------------------------------------------
+
+
+def test_get_sql_token_struct_exported_in_all() -> None:
+    assert "get_sql_token_struct" in auth_module.__all__
+
+
+def test_get_sql_token_struct_returns_none_outside_github_actions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When not under OIDC, get_sql_token_struct must return None."""
+    monkeypatch.delenv("ACTIONS_ID_TOKEN_REQUEST_URL", raising=False)
+    monkeypatch.delenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", raising=False)
+    from fabric_dw.auth import get_sql_token_struct  # noqa: PLC0415
+
+    result = get_sql_token_struct()
+    assert result is None
+
+
+def test_get_sql_token_struct_mode_param_ignored_outside_oidc(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The mode parameter must not affect the None return outside OIDC."""
+    monkeypatch.delenv("ACTIONS_ID_TOKEN_REQUEST_URL", raising=False)
+    monkeypatch.delenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", raising=False)
+    from fabric_dw.auth import get_sql_token_struct  # noqa: PLC0415
+
+    result = get_sql_token_struct(CredentialMode.SERVICE_PRINCIPAL)
+    assert result is None
+
+
+def test_get_sql_token_struct_packs_token_correctly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """get_sql_token_struct must pack the token as 4-byte LE length + UTF-16-LE bytes."""
+    import struct  # noqa: PLC0415
+
+    monkeypatch.setenv("ACTIONS_ID_TOKEN_REQUEST_URL", "https://token.example.com/")
+    monkeypatch.setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "runner-token")
+    monkeypatch.setenv("AZURE_TENANT_ID", "my-tenant-id")
+    monkeypatch.setenv("AZURE_CLIENT_ID", "my-client-id")
+
+    # Reset cached credential so monkeypatched env vars take effect.
+    import fabric_dw.auth as _auth_module  # noqa: PLC0415
+
+    _auth_module._sql_oidc_credential = None
+
+    known_token = "eyJhbGciOiJSUzI1NiJ9.test-token"  # noqa: S105
+    mock_access_token = AccessToken(known_token, 9999999999)
+
+    with patch("fabric_dw.auth.SyncClientAssertionCredential") as mock_cred_class:
+        mock_cred_instance = MagicMock()
+        mock_cred_instance.get_token.return_value = mock_access_token
+        mock_cred_class.return_value = mock_cred_instance
+
+        result = _auth_module.get_sql_token_struct()
+
+    assert result is not None
+    token_bytes = known_token.encode("UTF-16-LE")
+    expected = struct.pack(f"<I{len(token_bytes)}s", len(token_bytes), token_bytes)
+    assert result == expected
+    # Verify correct scope was requested.
+    mock_cred_instance.get_token.assert_called_once_with(SQL_SCOPE)
+
+
+def test_get_sql_token_struct_struct_format_4_byte_le_length(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The packed struct must start with a 4-byte little-endian token length."""
+    import struct  # noqa: PLC0415
+
+    monkeypatch.setenv("ACTIONS_ID_TOKEN_REQUEST_URL", "https://token.example.com/")
+    monkeypatch.setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "runner-token")
+    monkeypatch.setenv("AZURE_TENANT_ID", "my-tenant-id")
+    monkeypatch.setenv("AZURE_CLIENT_ID", "my-client-id")
+
+    import fabric_dw.auth as _auth_module  # noqa: PLC0415
+
+    _auth_module._sql_oidc_credential = None
+
+    known_token = "test"  # noqa: S105
+    mock_access_token = AccessToken(known_token, 9999999999)
+
+    with patch("fabric_dw.auth.SyncClientAssertionCredential") as mock_cred_class:
+        mock_cred_instance = MagicMock()
+        mock_cred_instance.get_token.return_value = mock_access_token
+        mock_cred_class.return_value = mock_cred_instance
+
+        result = _auth_module.get_sql_token_struct()
+
+    assert result is not None
+    length_field = struct.unpack_from("<I", result, 0)[0]
+    token_bytes = known_token.encode("UTF-16-LE")
+    assert length_field == len(token_bytes)
+    assert result[4:] == token_bytes
+
+
+def test_get_sql_token_struct_raises_config_error_missing_tenant_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """get_sql_token_struct must raise ConfigError if AZURE_TENANT_ID is missing."""
+    monkeypatch.setenv("ACTIONS_ID_TOKEN_REQUEST_URL", "https://token.example.com/")
+    monkeypatch.setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "runner-token")
+    monkeypatch.setenv("AZURE_CLIENT_ID", "my-client-id")
+    monkeypatch.delenv("AZURE_TENANT_ID", raising=False)
+
+    import fabric_dw.auth as _auth_module  # noqa: PLC0415
+
+    _auth_module._sql_oidc_credential = None
+    from fabric_dw.auth import get_sql_token_struct  # noqa: PLC0415
+
+    with pytest.raises(ConfigError, match="AZURE_TENANT_ID"):
+        get_sql_token_struct()
+
+
+def test_get_sql_token_struct_raises_config_error_missing_client_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """get_sql_token_struct must raise ConfigError if AZURE_CLIENT_ID is missing."""
+    monkeypatch.setenv("ACTIONS_ID_TOKEN_REQUEST_URL", "https://token.example.com/")
+    monkeypatch.setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "runner-token")
+    monkeypatch.setenv("AZURE_TENANT_ID", "my-tenant-id")
+    monkeypatch.delenv("AZURE_CLIENT_ID", raising=False)
+
+    import fabric_dw.auth as _auth_module  # noqa: PLC0415
+    from fabric_dw.auth import get_sql_token_struct  # noqa: PLC0415
+
+    _auth_module._sql_oidc_credential = None
+
+    with pytest.raises(ConfigError, match="AZURE_CLIENT_ID"):
+        get_sql_token_struct()
+
+
+def test_get_sql_token_struct_caches_credential_across_calls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The sync credential must be created once and reused across multiple calls."""
+    monkeypatch.setenv("ACTIONS_ID_TOKEN_REQUEST_URL", "https://token.example.com/")
+    monkeypatch.setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "runner-token")
+    monkeypatch.setenv("AZURE_TENANT_ID", "my-tenant-id")
+    monkeypatch.setenv("AZURE_CLIENT_ID", "my-client-id")
+
+    import fabric_dw.auth as _auth_module  # noqa: PLC0415
+
+    _auth_module._sql_oidc_credential = None
+
+    known_token = "my-sql-token"  # noqa: S105
+    mock_access_token = AccessToken(known_token, 9999999999)
+
+    with patch("fabric_dw.auth.SyncClientAssertionCredential") as mock_cred_class:
+        mock_cred_instance = MagicMock()
+        mock_cred_instance.get_token.return_value = mock_access_token
+        mock_cred_class.return_value = mock_cred_instance
+
+        _auth_module.get_sql_token_struct()
+        _auth_module.get_sql_token_struct()
+
+    # Credential class must be instantiated only once across multiple calls.
+    mock_cred_class.assert_called_once()
+    # get_token must be called each time (fresh struct per call).
+    assert mock_cred_instance.get_token.call_count == 2

--- a/tests/unit/test_sql.py
+++ b/tests/unit/test_sql.py
@@ -1179,8 +1179,9 @@ class TestOpenConnectionOidcTokenInjection:
         open_connection(_make_target())
 
         call_kwargs = mock_mssql.connect.call_args.kwargs
-        # attrs_before must be None (falsy) — no token injected.
-        assert not call_kwargs.get("attrs_before")
+        # attrs_before must be explicitly None — not merely absent (falsy).
+        # The implementation always passes attrs_before=None on the non-OIDC path.
+        assert call_kwargs.get("attrs_before") is None
         # Connection string must contain Authentication=.
         called_cs: str = mock_mssql.connect.call_args.args[0]
         assert "Authentication=" in called_cs
@@ -1258,3 +1259,51 @@ class TestOpenConnectionOidcTokenInjection:
         from fabric_dw.sql import SQL_COPT_SS_ACCESS_TOKEN  # noqa: PLC0415
 
         assert SQL_COPT_SS_ACCESS_TOKEN == 1256
+
+    def test_oidc_pool_hit_does_not_call_connect(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Pool HIT under OIDC must NOT call connect and must NOT invoke get_sql_token_struct.
+
+        On the first call a new physical connection is opened (pool miss).
+        After .close() returns the connection to the pool, the second call must
+        return the cached connection without acquiring a token — verifying that
+        the token acquisition is gated behind the pool-miss path.
+        """
+        import struct  # noqa: PLC0415
+
+        mock_mssql, mock_conn, _ = _make_mock_mssql()
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        # Enable the pool for this test.
+        monkeypatch.setenv("FABRIC_SQL_POOL", "1")
+        reset_pool()
+
+        # Track how many times the token stub is invoked.
+        token_call_count = 0
+
+        token_bytes = b"fake-oidc-token"
+        fake_struct = struct.pack(f"<I{len(token_bytes)}s", len(token_bytes), token_bytes)
+
+        def _counting_token_stub(*_a: object, **_kw: object) -> bytes:
+            nonlocal token_call_count
+            token_call_count += 1
+            return fake_struct
+
+        monkeypatch.setattr(_sql_module, "get_sql_token_struct", _counting_token_stub)
+
+        from fabric_dw.sql import open_connection  # noqa: PLC0415
+
+        target = _make_target()
+
+        # First call: pool miss → opens a new physical connection, acquires token.
+        conn1 = open_connection(target)
+        assert mock_mssql.connect.call_count == 1
+        assert token_call_count == 1
+        conn1.close()  # return to pool
+
+        # Second call: pool HIT → must reuse cached connection, not call connect,
+        # and must NOT invoke get_sql_token_struct at all.
+        conn2 = open_connection(target)
+        assert mock_mssql.connect.call_count == 1, "connect must NOT be called on pool hit"
+        assert token_call_count == 1, "get_sql_token_struct must NOT be called on pool hit"
+        assert conn2._raw is mock_conn  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+        conn2.close()

--- a/tests/unit/test_sql.py
+++ b/tests/unit/test_sql.py
@@ -277,7 +277,7 @@ class TestOpenConnection:
 
         thread_ids: list[int] = []
 
-        def _capture_connect(_cs: str) -> MagicMock:
+        def _capture_connect(_cs: str, **_kwargs: object) -> MagicMock:
             thread_ids.append(threading.get_ident())
             return MagicMock()
 
@@ -1113,3 +1113,148 @@ class TestTransientRetry:
 
         # Must NOT retry — only one connect attempt.
         assert mock_mssql.connect.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# GitHub OIDC SQL token injection — build_connection_string + open_connection
+# ---------------------------------------------------------------------------
+
+
+class TestBuildConnectionStringAccessToken:
+    """Tests for build_connection_string(use_access_token=True)."""
+
+    def test_use_access_token_omits_authentication_key(self) -> None:
+        """When use_access_token=True, Authentication= must NOT appear in the cs."""
+        result = build_connection_string(_make_target(), use_access_token=True)
+        assert "Authentication=" not in result
+
+    def test_use_access_token_still_adds_encrypt_and_tls_keys(self) -> None:
+        """Encryption settings must be present even when injecting a token."""
+        result = build_connection_string(_make_target(), use_access_token=True)
+        assert "Encrypt=yes" in result
+        assert "TrustServerCertificate=no" in result
+
+    def test_use_access_token_still_adds_database(self) -> None:
+        """Database= must be present even when injecting a token."""
+        target = _make_target(database="mydb")
+        result = build_connection_string(target, use_access_token=True)
+        assert "Database=mydb" in result
+
+    def test_default_use_access_token_false_keeps_authentication(self) -> None:
+        """Default (use_access_token=False) must keep Authentication=."""
+        result = build_connection_string(_make_target())
+        assert "Authentication=ActiveDirectoryDefault" in result
+
+    def test_use_access_token_false_explicitly_keeps_authentication(self) -> None:
+        """Explicit use_access_token=False must keep Authentication=."""
+        result = build_connection_string(_make_target(), use_access_token=False)
+        assert "Authentication=ActiveDirectoryDefault" in result
+
+    def test_use_access_token_no_double_semicolons(self) -> None:
+        """Token-injection path must not produce double semicolons."""
+        result = build_connection_string(_make_target(), use_access_token=True)
+        assert ";;" not in result
+
+
+class TestOpenConnectionOidcTokenInjection:
+    """Tests for OIDC token injection in open_connection.
+
+    The mssql_python driver is never imported: _mssql is monkeypatched with a
+    MagicMock.  get_sql_token_struct is patched at the fabric_dw.sql module level
+    so that the mock controls the OIDC environment independently of env-vars.
+    """
+
+    def test_non_oidc_connect_called_without_attrs_before(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Outside OIDC, connect must be called WITHOUT attrs_before (or attrs_before=None)
+        and the connection string must contain Authentication=."""
+        mock_mssql, _, _ = _make_mock_mssql()
+        _patch_mssql(monkeypatch, mock_mssql)
+        # Simulate non-OIDC: get_sql_token_struct returns None.
+        monkeypatch.setattr(_sql_module, "get_sql_token_struct", lambda *_a, **_kw: None)
+
+        from fabric_dw.sql import open_connection  # noqa: PLC0415
+
+        open_connection(_make_target())
+
+        call_kwargs = mock_mssql.connect.call_args.kwargs
+        # attrs_before must be None (falsy) — no token injected.
+        assert not call_kwargs.get("attrs_before")
+        # Connection string must contain Authentication=.
+        called_cs: str = mock_mssql.connect.call_args.args[0]
+        assert "Authentication=" in called_cs
+
+    def test_oidc_connect_called_with_attrs_before_containing_key_1256(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Under OIDC, connect must receive attrs_before={1256: <bytes>}."""
+        import struct  # noqa: PLC0415
+
+        mock_mssql, _, _ = _make_mock_mssql()
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        # Build a known token struct the same way the real code does.
+        known_token = "eyJhbGciOiJSUzI1NiJ9.mock-sql-token"  # noqa: S105
+        token_bytes = known_token.encode("UTF-16-LE")
+        fake_struct = struct.pack(f"<I{len(token_bytes)}s", len(token_bytes), token_bytes)
+
+        monkeypatch.setattr(_sql_module, "get_sql_token_struct", lambda *_a, **_kw: fake_struct)
+
+        from fabric_dw.sql import SQL_COPT_SS_ACCESS_TOKEN, open_connection  # noqa: PLC0415
+
+        open_connection(_make_target())
+
+        call_kwargs = mock_mssql.connect.call_args.kwargs
+        attrs = call_kwargs.get("attrs_before")
+        assert attrs is not None
+        assert SQL_COPT_SS_ACCESS_TOKEN in attrs
+        assert attrs[SQL_COPT_SS_ACCESS_TOKEN] == fake_struct
+
+    def test_oidc_connect_called_without_authentication_in_cs(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Under OIDC, the connection string must NOT contain Authentication=."""
+        import struct  # noqa: PLC0415
+
+        mock_mssql, _, _ = _make_mock_mssql()
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        token_bytes = b"fake"
+        fake_struct = struct.pack(f"<I{len(token_bytes)}s", len(token_bytes), token_bytes)
+        monkeypatch.setattr(_sql_module, "get_sql_token_struct", lambda *_a, **_kw: fake_struct)
+
+        from fabric_dw.sql import open_connection  # noqa: PLC0415
+
+        open_connection(_make_target())
+
+        called_cs: str = mock_mssql.connect.call_args.args[0]
+        assert "Authentication=" not in called_cs
+
+    def test_oidc_autocommit_connect_called_with_attrs_before(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Under OIDC, autocommit=True connections must also receive attrs_before."""
+        import struct  # noqa: PLC0415
+
+        mock_mssql, _, _ = _make_mock_mssql()
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        token_bytes = b"tok"
+        fake_struct = struct.pack(f"<I{len(token_bytes)}s", len(token_bytes), token_bytes)
+        monkeypatch.setattr(_sql_module, "get_sql_token_struct", lambda *_a, **_kw: fake_struct)
+
+        from fabric_dw.sql import SQL_COPT_SS_ACCESS_TOKEN, open_connection  # noqa: PLC0415
+
+        open_connection(_make_target(), autocommit=True)
+
+        call_kwargs = mock_mssql.connect.call_args.kwargs
+        attrs = call_kwargs.get("attrs_before")
+        assert attrs is not None
+        assert SQL_COPT_SS_ACCESS_TOKEN in attrs
+
+    def test_sql_copt_ss_access_token_constant_is_1256(self) -> None:
+        """SQL_COPT_SS_ACCESS_TOKEN must equal 1256 (the ODBC attribute number)."""
+        from fabric_dw.sql import SQL_COPT_SS_ACCESS_TOKEN  # noqa: PLC0415
+
+        assert SQL_COPT_SS_ACCESS_TOKEN == 1256


### PR DESCRIPTION
## Root cause

CI integration tests failed after ~5 min with 18 errors:
- `Authentication token is missing in the federated authentication message`
- `AADSTS700024: Client assertion is not within its valid time range`

The mssql-python driver uses `Authentication=ActiveDirectoryDefault` in the ODBC connection string, which causes it to acquire its own Entra token via `DefaultAzureCredential → AzureCliCredential`. That credential consumes the GitHub OIDC federated assertion, which is only valid for ~5 minutes. Our self-refreshing `_make_github_oidc_credential` only fixed the REST/Fabric API path — the SQL path remained broken.

## Fix

- **`auth.py`**: Added `get_sql_token_struct(mode) -> bytes | None` (exported in `__all__`). Under GitHub Actions OIDC it acquires a fresh SQL access token from a module-level cached `SyncClientAssertionCredential` backed by `_fetch_github_oidc_jwt`, then packs it as `struct.pack("<I{n}s", len, utf16le_bytes)` — the format required by `SQL_COPT_SS_ACCESS_TOKEN` (ODBC attribute 1256). Returns `None` outside OIDC so local/interactive paths are unchanged.
- **`sql.py`**: Added `SQL_COPT_SS_ACCESS_TOKEN = 1256`. Extended `build_connection_string` with `use_access_token: bool = False` that omits `Authentication=` when `True`. In `open_connection`, calls `get_sql_token_struct(mode)` before every physical `connect()` call (both autocommit and non-pooled); if non-None, passes `attrs_before={SQL_COPT_SS_ACCESS_TOKEN: struct}` and builds cs with `use_access_token=True`. Pool checkout is unaffected — already-authenticated connections are not touched.

## Tests

- Fixed two pre-existing gaps in `test_sql.py` (missing `get_sql_token_struct` import in one test; `_capture_connect` signature now accepts `**kwargs` to handle `attrs_before`).
- Added `TestBuildConnectionStringAccessToken` — verifies `use_access_token=True` omits `Authentication=` while keeping encryption keys.
- Added `TestOpenConnectionOidcTokenInjection` — verifies: non-OIDC → no `attrs_before` + `Authentication=` present; OIDC → `attrs_before={1256: packed_struct}` + no `Authentication=`; same for `autocommit=True`; constant value 1256.
- `mssql_python` is never imported — driver is always mocked via `_mssql` monkeypatch.
- `just check` (ruff + ty + 2142 unit tests) fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)