### PR TITLE
fix(snapshots): raise roll_timestamp readiness timeout to 240s

### DIFF
--- a/src/fabric_dw/services/snapshots.py
+++ b/src/fabric_dw/services/snapshots.py
@@ -32,7 +32,7 @@ __all__ = [
 _SNAP_READY_POLL_INTERVAL_S: float = 4.0
 # Total time (seconds) to wait for the snapshot DB to become ready before
 # giving up and raising FabricError.
-_SNAP_READY_TIMEOUT_S: float = 90.0
+_SNAP_READY_TIMEOUT_S: float = 240.0
 
 # Characters / sequences that could enable SQL injection in a bracket-quoted name.
 # This is a strict blocklist: snapshot names are NOT passed through


### PR DESCRIPTION
## Summary

- Bumps `_SNAP_READY_TIMEOUT_S` from `90.0` to `240.0` in `src/fabric_dw/services/snapshots.py`
- Aligns snapshot SQL-layer readiness timeout with the warehouse SQL-readiness timeout (`_SQL_READINESS_TIMEOUT_S = 240s` in `tests/integration/conftest.py`) — both databases provision on the same SQL layer
- Fixes `test_roll_timestamp_updates_snapshot` failing with the "did not become ready within 90s" error in CI integration tests

## Test plan

- [x] `just check` passes (2156 unit tests, ruff, ty — all green)
- [x] The timeout-raises unit test reads `snapshots._SNAP_READY_TIMEOUT_S` dynamically, so it continues to trigger deterministically with the new value
- [ ] Integration test `test_roll_timestamp_updates_snapshot` should now pass (not run locally per task instructions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)