### PR TITLE
fix(query_insights): use Fabric column number_of_canceled_runs (single l)

### DIFF
--- a/src/fabric_dw/models.py
+++ b/src/fabric_dw/models.py
@@ -329,7 +329,7 @@ class FrequentlyRunQuery(_FabricBase):
     max_run_total_elapsed_time_ms: int
     number_of_successful_runs: int
     number_of_failed_runs: int
-    number_of_cancelled_runs: int
+    number_of_canceled_runs: int
     query_hash: str | None = None
 
 

--- a/src/fabric_dw/services/query_insights.py
+++ b/src/fabric_dw/services/query_insights.py
@@ -138,7 +138,7 @@ FREQUENTLY_RUN_QUERIES_COLUMNS: tuple[str, ...] = (
     "max_run_total_elapsed_time_ms",
     "number_of_successful_runs",
     "number_of_failed_runs",
-    "number_of_cancelled_runs",
+    "number_of_canceled_runs",
     "query_hash",
 )
 
@@ -360,7 +360,7 @@ SELECT TOP ({limit})
     max_run_total_elapsed_time_ms,
     number_of_successful_runs,
     number_of_failed_runs,
-    number_of_cancelled_runs,
+    number_of_canceled_runs,
     query_hash
 FROM queryinsights.frequently_run_queries{where}
 ORDER BY number_of_runs DESC;

--- a/tests/unit/cli/commands/test_query_insights.py
+++ b/tests/unit/cli/commands/test_query_insights.py
@@ -124,7 +124,7 @@ def _make_frequent_query_row() -> FrequentlyRunQuery:
             "max_run_total_elapsed_time_ms": 2000,
             "number_of_successful_runs": 40,
             "number_of_failed_runs": 1,
-            "number_of_cancelled_runs": 1,
+            "number_of_canceled_runs": 1,
         }
     )
 

--- a/tests/unit/mcp/tools/test_queries.py
+++ b/tests/unit/mcp/tools/test_queries.py
@@ -129,7 +129,7 @@ def _make_frequently_run_query() -> FrequentlyRunQuery:
             "max_run_total_elapsed_time_ms": 300,
             "number_of_successful_runs": 9,
             "number_of_failed_runs": 1,
-            "number_of_cancelled_runs": 0,
+            "number_of_canceled_runs": 0,
         }
     )
 

--- a/tests/unit/services/test_query_insights.py
+++ b/tests/unit/services/test_query_insights.py
@@ -372,6 +372,7 @@ async def test_list_frequent_queries_parses_fields() -> None:
     row = result[0]
     assert row.number_of_runs == 42
     assert row.avg_total_elapsed_time_ms == 1500
+    assert row.number_of_canceled_runs == 1
 
 
 async def test_list_frequent_queries_sql_references_view() -> None:

--- a/tests/unit/services/test_query_insights.py
+++ b/tests/unit/services/test_query_insights.py
@@ -342,7 +342,7 @@ _FREQ_ROW = (
     2000,  # max_run_total_elapsed_time_ms
     40,  # number_of_successful_runs
     1,  # number_of_failed_runs
-    1,  # number_of_cancelled_runs
+    1,  # number_of_canceled_runs
     "abc123",  # query_hash
 )
 


### PR DESCRIPTION
## Summary

- The `queryinsights.frequently_run_queries` Fabric view uses the American spelling `number_of_canceled_runs` (one 'l'), not the British `number_of_cancelled_runs`
- The two-'l' spelling caused `mssql_python.exceptions.ProgrammingError: Invalid column name 'number_of_cancelled_runs'` in integration tests
- Renamed in all four locations: the SQL SELECT clause, the `FREQUENTLY_RUN_QUERIES_COLUMNS` constant, the `FrequentlyRunQuery` Pydantic model field, and all three unit-test fixtures

## Test plan

- [x] `just check` passes (ruff, ruff format, ty, 2155 unit tests)
- [ ] Integration test `test_list_frequent_queries_returns_a_list` should pass against the real Fabric endpoint