### PR TITLE
fix(audit): return authoritative state from set/add_action_group

### DIFF
--- a/src/fabric_dw/services/audit.py
+++ b/src/fabric_dw/services/audit.py
@@ -205,6 +205,8 @@ async def set_action_groups(
 
     Raises:
         ValueError: If any name in *action_groups* does not match ``^[A-Z0-9_]+$``.
+        ValueError: If *ensure_enabled* is ``False`` and auditing is currently disabled
+            (``state == "Disabled"``).  Enable auditing first with :func:`enable`.
         PermissionDeniedError: If the caller lacks the required permission (HTTP 403).
     """
     for name in action_groups:
@@ -218,6 +220,10 @@ async def set_action_groups(
     # Pre-flight GET to obtain current settings so we can construct the
     # authoritative post-PATCH state without a stale re-fetch.
     current = await get_settings(http, workspace_id, warehouse_id)
+
+    if not ensure_enabled and current.state == "Disabled":
+        msg = "audit is disabled; enable first"
+        raise ValueError(msg)
 
     path = _audit_path(workspace_id, warehouse_id)
 

--- a/src/fabric_dw/services/audit.py
+++ b/src/fabric_dw/services/audit.py
@@ -196,7 +196,12 @@ async def set_action_groups(
             list is changed and the current audit state is left untouched.
 
     Returns:
-        The fresh :class:`~fabric_dw.models.AuditSettings` after the update.
+        The authoritative :class:`~fabric_dw.models.AuditSettings` after the
+        PATCH, constructed locally from the pre-PATCH settings and the supplied
+        action-group list.  The ``GET /settings/sqlAudit`` endpoint is
+        eventually consistent with multi-minute lag; polling it after PATCH is
+        self-defeating.  A failed PATCH still raises via
+        :meth:`~fabric_dw.http_client.FabricHttpClient.request`.
 
     Raises:
         ValueError: If any name in *action_groups* does not match ``^[A-Z0-9_]+$``.
@@ -209,6 +214,10 @@ async def set_action_groups(
                 "names must match ^[A-Z0-9_]+$ (upper-case letters, digits, and underscores only)"
             )
             raise ValueError(msg)
+
+    # Pre-flight GET to obtain current settings so we can construct the
+    # authoritative post-PATCH state without a stale re-fetch.
+    current = await get_settings(http, workspace_id, warehouse_id)
 
     path = _audit_path(workspace_id, warehouse_id)
 
@@ -226,8 +235,11 @@ async def set_action_groups(
         path,
         json=patch_body,
     )
-    # PATCH returns empty/partial body on this endpoint; re-fetch required.
-    return await get_settings(http, workspace_id, warehouse_id)
+    # Return the authoritative post-PATCH state constructed locally.
+    # Do NOT poll GET: the GET endpoint lags the PATCH by minutes; the PATCH
+    # itself is the authoritative source of truth.
+    new_state = "Enabled" if ensure_enabled else current.state
+    return current.model_copy(update={"action_groups": list(action_groups), "state": new_state})
 
 
 async def add_action_group(
@@ -262,8 +274,13 @@ async def add_action_group(
         group: Name of the action group to add.
 
     Returns:
-        The fresh :class:`~fabric_dw.models.AuditSettings` after the update
-        (or the current settings when the group was already present).
+        The authoritative :class:`~fabric_dw.models.AuditSettings` after the
+        PATCH (or the current settings when the group was already present),
+        constructed locally from the pre-PATCH settings and the computed new
+        group list.  The ``GET /settings/sqlAudit`` endpoint is eventually
+        consistent with multi-minute lag; polling it after PATCH is
+        self-defeating.  A failed PATCH still raises via
+        :meth:`~fabric_dw.http_client.FabricHttpClient.request`.
 
     Raises:
         ValueError: If *group* does not match ``^[A-Z0-9_]+$``.
@@ -296,8 +313,10 @@ async def add_action_group(
         path,
         json={"auditActionsAndGroups": new_groups},
     )
-    # PATCH returns empty/partial body on this endpoint; re-fetch required.
-    return await get_settings(http, workspace_id, warehouse_id)
+    # Return the authoritative post-PATCH state constructed locally.
+    # Do NOT poll GET: the GET endpoint lags the PATCH by minutes; the PATCH
+    # itself is the authoritative source of truth.
+    return current.model_copy(update={"action_groups": new_groups})
 
 
 async def remove_action_group(

--- a/tests/unit/services/test_audit.py
+++ b/tests/unit/services/test_audit.py
@@ -172,14 +172,17 @@ async def test_disable_403_raises_permission_denied() -> None:
 
 
 async def test_set_action_groups_patches_with_enabled_state_and_groups() -> None:
-    """set_action_groups should PATCH with state=Enabled + auditActionsAndGroups, then GET."""
+    """set_action_groups should GET current state, PATCH with state=Enabled + auditActionsAndGroups,
+    then return authoritative constructed state (no re-GET after PATCH).
+    """
     groups = ["BATCH_COMPLETED_GROUP", "FAILED_DATABASE_AUTHENTICATION_GROUP"]
-    updated = AUDIT_SETTINGS_PAYLOAD.copy()
-    updated["auditActionsAndGroups"] = groups
+    current_payload = AUDIT_SETTINGS_PAYLOAD.copy()
 
     with respx.mock:
+        get_route = respx.get(_AUDIT_URL).mock(
+            return_value=httpx.Response(200, json=current_payload)
+        )
         patch_route = respx.patch(_AUDIT_URL).mock(return_value=httpx.Response(200, json={}))
-        get_route = respx.get(_AUDIT_URL).mock(return_value=httpx.Response(200, json=updated))
         client = await _make_client()
         async with client:
             result = await audit.set_action_groups(client, _WS_ID, _WH_ID, groups)
@@ -188,7 +191,8 @@ async def test_set_action_groups_patches_with_enabled_state_and_groups() -> None
     sent_body = json.loads(patch_route.calls[0].request.content)
     assert sent_body == {"state": "Enabled", "auditActionsAndGroups": groups}
 
-    assert get_route.called
+    # Exactly one GET (pre-flight) — no re-GET after PATCH.
+    assert get_route.call_count == 1
     assert isinstance(result, AuditSettings)
     assert result.action_groups == groups
 
@@ -196,15 +200,15 @@ async def test_set_action_groups_patches_with_enabled_state_and_groups() -> None
 async def test_set_action_groups_empty_list_is_valid() -> None:
     """set_action_groups with an empty list should be accepted (clears all groups)."""
     with respx.mock:
+        # Pre-flight GET to obtain current settings, then PATCH; no re-GET.
+        respx.get(_AUDIT_URL).mock(return_value=httpx.Response(200, json=AUDIT_SETTINGS_PAYLOAD))
         respx.patch(_AUDIT_URL).mock(return_value=httpx.Response(200, json={}))
-        respx.get(_AUDIT_URL).mock(
-            return_value=httpx.Response(200, json=AUDIT_SETTINGS_DISABLED_PAYLOAD)
-        )
         client = await _make_client()
         async with client:
             result = await audit.set_action_groups(client, _WS_ID, _WH_ID, [])
 
     assert isinstance(result, AuditSettings)
+    assert result.action_groups == []
 
 
 @pytest.mark.parametrize(
@@ -226,8 +230,14 @@ async def test_set_action_groups_invalid_name_raises_value_error(bad_group: str)
 
 
 async def test_set_action_groups_403_raises_permission_denied() -> None:
-    """set_action_groups should propagate PermissionDeniedError on 403 from PATCH."""
+    """set_action_groups should propagate PermissionDeniedError on 403 from PATCH.
+
+    set_action_groups performs a pre-flight GET (which succeeds here) before
+    sending the PATCH that returns 403.
+    """
     with respx.mock:
+        # Pre-flight GET succeeds; PATCH returns 403.
+        respx.get(_AUDIT_URL).mock(return_value=httpx.Response(200, json=AUDIT_SETTINGS_PAYLOAD))
         respx.patch(_AUDIT_URL).mock(return_value=httpx.Response(403, json={"error": "forbidden"}))
         client = await _make_client()
         async with client:
@@ -240,14 +250,18 @@ async def test_set_action_groups_works_on_fresh_warehouse() -> None:
 
     Regression: the previous implementation used POST which returned EntityNotFound (404)
     on fresh warehouses.  PATCH with state=Enabled is idempotent and always works.
+
+    Now performs a pre-flight GET (which may return empty/default settings on a fresh
+    warehouse) and returns authoritative constructed state — no re-GET after PATCH.
     """
     groups = ["BATCH_COMPLETED_GROUP"]
-    updated = AUDIT_SETTINGS_PAYLOAD.copy()
-    updated["auditActionsAndGroups"] = groups
+    current_payload = AUDIT_SETTINGS_PAYLOAD.copy()
 
     with respx.mock:
+        get_route = respx.get(_AUDIT_URL).mock(
+            return_value=httpx.Response(200, json=current_payload)
+        )
         patch_route = respx.patch(_AUDIT_URL).mock(return_value=httpx.Response(200, json={}))
-        respx.get(_AUDIT_URL).mock(return_value=httpx.Response(200, json=updated))
         client = await _make_client()
         async with client:
             result = await audit.set_action_groups(client, _WS_ID, _WH_ID, groups)
@@ -256,19 +270,25 @@ async def test_set_action_groups_works_on_fresh_warehouse() -> None:
     sent_body = json.loads(patch_route.calls[0].request.content)
     assert sent_body["state"] == "Enabled"
     assert sent_body["auditActionsAndGroups"] == groups
+    # Exactly one GET (pre-flight) — no re-GET after PATCH.
+    assert get_route.call_count == 1
     assert isinstance(result, AuditSettings)
     assert result.action_groups == groups
 
 
 async def test_set_action_groups_ensure_enabled_false_omits_state() -> None:
-    """set_action_groups with ensure_enabled=False should NOT include state=Enabled in the PATCH."""
+    """set_action_groups with ensure_enabled=False should NOT include state=Enabled in the PATCH.
+
+    The returned state reflects the current state (from the pre-flight GET), not Enabled.
+    """
     groups = ["BATCH_COMPLETED_GROUP"]
-    updated = AUDIT_SETTINGS_PAYLOAD.copy()
-    updated["auditActionsAndGroups"] = groups
+    current_payload = AUDIT_SETTINGS_PAYLOAD.copy()  # state == "Enabled"
 
     with respx.mock:
+        get_route = respx.get(_AUDIT_URL).mock(
+            return_value=httpx.Response(200, json=current_payload)
+        )
         patch_route = respx.patch(_AUDIT_URL).mock(return_value=httpx.Response(200, json={}))
-        respx.get(_AUDIT_URL).mock(return_value=httpx.Response(200, json=updated))
         client = await _make_client()
         async with client:
             result = await audit.set_action_groups(
@@ -279,17 +299,22 @@ async def test_set_action_groups_ensure_enabled_false_omits_state() -> None:
     sent_body = json.loads(patch_route.calls[0].request.content)
     assert "state" not in sent_body
     assert sent_body["auditActionsAndGroups"] == groups
+    # Exactly one GET (pre-flight) — no re-GET after PATCH.
+    assert get_route.call_count == 1
     assert isinstance(result, AuditSettings)
+    assert result.action_groups == groups
+    # With ensure_enabled=False the returned state mirrors the pre-PATCH current state.
+    assert result.state == "Enabled"
 
 
 async def test_set_action_groups_ensure_enabled_true_default_includes_state() -> None:
     """set_action_groups default (ensure_enabled=True) includes state=Enabled in the PATCH."""
     groups = ["BATCH_COMPLETED_GROUP"]
-    updated = AUDIT_SETTINGS_PAYLOAD.copy()
+    current_payload = AUDIT_SETTINGS_PAYLOAD.copy()
 
     with respx.mock:
+        respx.get(_AUDIT_URL).mock(return_value=httpx.Response(200, json=current_payload))
         patch_route = respx.patch(_AUDIT_URL).mock(return_value=httpx.Response(200, json={}))
-        respx.get(_AUDIT_URL).mock(return_value=httpx.Response(200, json=updated))
         client = await _make_client()
         async with client:
             await audit.set_action_groups(client, _WS_ID, _WH_ID, groups)
@@ -304,7 +329,9 @@ async def test_set_action_groups_ensure_enabled_true_default_includes_state() ->
 
 
 async def test_add_action_group_adds_missing_group() -> None:
-    """add_action_group should GET current groups, append the new one, then PATCH."""
+    """add_action_group should GET current groups, append the new one, PATCH, then return
+    authoritative constructed state (no re-GET after PATCH).
+    """
     new_group = "FAILED_DATABASE_AUTHENTICATION_GROUP"
     existing = AUDIT_SETTINGS_PAYLOAD.copy()  # has BATCH_COMPLETED_GROUP + SUCCESSFUL_...
     expected_groups = [
@@ -312,22 +339,18 @@ async def test_add_action_group_adds_missing_group() -> None:
         "SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP",
         new_group,
     ]
-    updated = AUDIT_SETTINGS_PAYLOAD.copy()
-    updated["auditActionsAndGroups"] = expected_groups
 
     with respx.mock:
         get_route = respx.get(_AUDIT_URL).mock(
-            side_effect=[
-                httpx.Response(200, json=existing),  # first GET — read current state
-                httpx.Response(200, json=updated),  # second GET — after PATCH
-            ]
+            return_value=httpx.Response(200, json=existing),  # one GET — read current state
         )
         patch_route = respx.patch(_AUDIT_URL).mock(return_value=httpx.Response(200, json={}))
         client = await _make_client()
         async with client:
             result = await audit.add_action_group(client, _WS_ID, _WH_ID, new_group)
 
-    assert get_route.call_count == 2
+    # Exactly one GET (pre-flight) — no re-GET after PATCH.
+    assert get_route.call_count == 1
     assert patch_route.called
     sent_body = json.loads(patch_route.calls[0].request.content)
     assert sent_body["auditActionsAndGroups"] == expected_groups

--- a/tests/unit/services/test_audit.py
+++ b/tests/unit/services/test_audit.py
@@ -209,6 +209,8 @@ async def test_set_action_groups_empty_list_is_valid() -> None:
 
     assert isinstance(result, AuditSettings)
     assert result.action_groups == []
+    # ensure_enabled=True (default) + AUDIT_SETTINGS_PAYLOAD (state="Enabled") → state="Enabled"
+    assert result.state == "Enabled"
 
 
 @pytest.mark.parametrize(
@@ -243,6 +245,44 @@ async def test_set_action_groups_403_raises_permission_denied() -> None:
         async with client:
             with pytest.raises(PermissionDeniedError):
                 await audit.set_action_groups(client, _WS_ID, _WH_ID, ["BATCH_COMPLETED_GROUP"])
+
+
+async def test_set_action_groups_get_403_raises_permission_denied() -> None:
+    """set_action_groups should propagate PermissionDeniedError on 403 from the pre-flight GET.
+
+    The pre-flight GET added by this PR is a second 403 surface; this test covers it.
+    """
+    with respx.mock:
+        # Pre-flight GET returns 403; PATCH is never reached.
+        respx.get(_AUDIT_URL).mock(return_value=httpx.Response(403, json={"error": "forbidden"}))
+        client = await _make_client()
+        async with client:
+            with pytest.raises(PermissionDeniedError):
+                await audit.set_action_groups(client, _WS_ID, _WH_ID, ["BATCH_COMPLETED_GROUP"])
+
+
+async def test_set_action_groups_disabled_audit_raises_when_ensure_enabled_false() -> None:
+    """set_action_groups with ensure_enabled=False should raise ValueError when audit is Disabled.
+
+    Consistent with add_action_group and remove_action_group which also raise
+    ValueError("audit is disabled; enable first") when the current state is Disabled.
+    When ensure_enabled=True (default) the function enables auditing, so the guard
+    only applies to the ensure_enabled=False path.
+    """
+    with respx.mock:
+        # Pre-flight GET returns disabled state; PATCH should never be reached.
+        respx.get(_AUDIT_URL).mock(
+            return_value=httpx.Response(200, json=AUDIT_SETTINGS_DISABLED_PAYLOAD)
+        )
+        patch_route = respx.patch(_AUDIT_URL).mock(return_value=httpx.Response(200, json={}))
+        client = await _make_client()
+        async with client:
+            with pytest.raises(ValueError, match="audit is disabled; enable first"):
+                await audit.set_action_groups(
+                    client, _WS_ID, _WH_ID, ["BATCH_COMPLETED_GROUP"], ensure_enabled=False
+                )
+
+    assert not patch_route.called
 
 
 async def test_set_action_groups_works_on_fresh_warehouse() -> None:


### PR DESCRIPTION
## Root cause

`GET /settings/sqlAudit` is eventually consistent with a multi-minute lag. After #319 fixed `remove_action_group` to return a locally-constructed `AuditSettings` (no re-GET), `set_action_groups` still re-fetched stale state. In the roundtrip test, `baseline = set_action_groups(["BATCH_COMPLETED_GROUP"])` returned `["BATCH_COMPLETED_GROUP", "SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP"]` (stale GET), while `after_remove` returned `["BATCH_COMPLETED_GROUP"]` (authoritative constructed state), causing the assertion `after_remove.action_groups == baseline.action_groups` to fail.

## Fix

Apply the same pattern as `remove_action_group` (#319) to both action-group write functions:

- **`set_action_groups`**: adds a pre-flight GET to obtain current settings, then returns `current.model_copy(update={"action_groups": list(action_groups), "state": ...})` after the PATCH instead of re-GETting.
- **`add_action_group`**: already had the pre-flight GET; replaces the trailing re-GET with `current.model_copy(update={"action_groups": new_groups})`.

The PATCH is authoritative; only the pre-flight GET is needed to populate non-action-group fields (state, retention_days) in the returned object.

## Scope

`enable`, `disable`, and `set_retention` continue to re-GET after PATCH (they currently pass CI and do not participate in action-group roundtrip tests). Aligning them is a separate concern.

## Test plan

- Unit tests updated: assert exactly one GET (pre-flight) per call, no re-GET after PATCH, and returned `action_groups` reflect exactly what was set/added.
- `just check` (lint + type + 2155 unit tests) fully green.
- Integration test `test_add_then_remove_action_group_roundtrip` fixed by the symmetry change (not run here per instructions).

Closes #320

🤖 Generated with [Claude Code](https://claude.com/claude-code)