### PR TITLE
chore(ci): pin actions/deps, fix docker/docs/devcontainer review findings

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,6 @@
       "extensions": [
         "charliermarsh.ruff",
         "ms-python.python",
-        "ms-python.mypy-type-checker",
         "tamasfe.even-better-toml",
         "GitHub.copilot",
         "GitHub.copilot-chat"

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,23 +1,27 @@
 name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
+autolabeler:
+  - label: 'type:feature'
+    title:
+      - '/^feat(\(.+\))?!?:/i'
+  - label: 'type:fix'
+    title:
+      - '/^fix(\(.+\))?!?:/i'
+  - label: 'area:docs'
+    title:
+      - '/^docs(\(.+\))?!?:/i'
+  - label: 'area:ci'
+    title:
+      - '/^(ci|chore)(\(.+\))?!?:/i'
 categories:
   - title: 'Features'
     labels: ['type:feature']
-    commitish:
-      - "feat"
   - title: 'Fixes'
     labels: ['type:fix', 'bug']
-    commitish:
-      - "fix"
   - title: 'Documentation'
     labels: ['area:docs', 'area:docs-site']
-    commitish:
-      - "docs"
   - title: 'CI / Tooling'
     labels: ['area:ci', 'area:bootstrap']
-    commitish:
-      - "ci"
-      - "chore"
   - title: 'Other'
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 change-title-escapes: '\<*_&'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,13 +19,13 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
-      - uses: astral-sh/setup-uv@v8.2.0
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: true
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.11"
       - run: uv sync --frozen
@@ -36,13 +36,13 @@ jobs:
     name: Type check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
-      - uses: astral-sh/setup-uv@v8.2.0
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: true
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.11"
       - run: uv sync --frozen
@@ -59,31 +59,31 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
-      - uses: astral-sh/setup-uv@v8.2.0
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: true
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ${{ matrix.python-version }}
       - run: uv sync --frozen
       - run: uv run pytest tests/unit --cov --cov-branch --cov-report=xml --cov-report=term --junitxml=junit.xml -o junit_family=legacy
       - name: Enforce coverage threshold
         run: uv run coverage report --fail-under=80
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage-${{ matrix.python-version }}
           path: coverage.xml
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@04b047e8bb82a0c002c8312c1c880fbc6a999d45 # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: python-${{ matrix.python-version }}
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: python-${{ matrix.python-version }}
@@ -98,7 +98,7 @@ jobs:
           matrix.python-version == '3.13' &&
           (github.event_name != 'pull_request' ||
            github.event.pull_request.head.repo.full_name == github.repository)
-        uses: actions/upload-code-coverage@v1
+        uses: actions/upload-code-coverage@abb5995db9e0199b0e2bb9dbd136fce4cb1ec4d3 # v1
         continue-on-error: true
         with:
           file: coverage.xml

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,15 +19,15 @@ jobs:
   build-and-push:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
 
-      - uses: astral-sh/setup-uv@v8.2.0
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: true
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.13"
 
@@ -44,11 +44,11 @@ jobs:
             echo "tags=ghcr.io/sdebruyn/fabric-dw:${VERSION},ghcr.io/sdebruyn/fabric-dw:main" >> "${GITHUB_OUTPUT}"
           fi
 
-      - uses: docker/setup-qemu-action@v4
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
         id: buildx
 
-      - uses: docker/login-action@v4
+      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -56,7 +56,7 @@ jobs:
 
       - name: Build & push
         id: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -70,7 +70,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Attest image provenance
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@b3e506e8c389afc651c5bacf2b8f2a1ea0557215 # v4
         with:
           subject-name: ghcr.io/sdebruyn/fabric-dw
           subject-digest: ${{ steps.build.outputs.digest }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -27,11 +27,11 @@ jobs:
     environment: integration
     timeout-minutes: 150
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
 
-      - uses: azure/login@v3
+      - uses: azure/login@2dd0bbf4064d5a1812889dc200bb8eed2597f82a # v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -77,11 +77,11 @@ jobs:
           echo "Capacity did not reach Active state within 5 minutes" >&2
           exit 1
 
-      - uses: astral-sh/setup-uv@v8.2.0
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: true
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.13"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,16 +23,16 @@ jobs:
     runs-on: ubuntu-latest
     environment: pypi
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
           ref: ${{ inputs.tag || github.ref }}
 
-      - uses: astral-sh/setup-uv@v8.2.0
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: true
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.13"
 
@@ -46,14 +46,14 @@ jobs:
           python -c "import json,sys; d=json.load(open('dist/sbom.cdx.json')); print(f'SBOM: {len(d.get(\"components\",[]))} components')"
 
       - name: Upload SBOM artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: sbom-cyclonedx
           path: dist/sbom.cdx.json
           if-no-files-found: error
 
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@b3e506e8c389afc651c5bacf2b8f2a1ea0557215 # v4
         with:
           subject-path: |
             dist/*.whl
@@ -64,7 +64,7 @@ jobs:
 
       - name: Create GitHub Release (tag only)
         if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
         with:
           files: |
             dist/*.whl

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -11,7 +11,7 @@ concurrency:
 
 permissions:
   contents: write
-  pull-requests: read
+  pull-requests: write
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -16,6 +16,6 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v7
+      - uses: release-drafter/release-drafter@e1247478eabc9f6d9cf5ec2b3547469b0e1d2767 # v7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -14,9 +14,9 @@ jobs:
   gitleaks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@v3
+      - uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -16,38 +16,37 @@ jobs:
   bandit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
-      - uses: astral-sh/setup-uv@v8.2.0
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with: { enable-cache: true }
-      - name: Run bandit (SARIF)
-        run: uvx --quiet 'bandit[sarif]' -r src/ -ll -f sarif -o bandit.sarif
-        continue-on-error: true
+      - name: Run bandit (SARIF + gate)
+        # Single scan: exit code gates the job; SARIF is uploaded for the Security tab.
+        # bandit exits non-zero on findings >= -ll, which blocks the PR.
+        run: uvx --quiet 'bandit[sarif]==1.9.4' -r src/ -ll -f sarif -o bandit.sarif
       - name: Upload SARIF to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@411bbbe57033eedfc1a82d68c01345aa96c737d7 # v4
         if: always()
         with:
           sarif_file: bandit.sarif
-      - name: Run bandit (gate, human-readable)
-        run: uvx --quiet 'bandit[sarif]' -r src/ -ll
   dependency-review:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
-      - uses: actions/dependency-review-action@v5
+      - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: high
   pip-audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
-      - uses: astral-sh/setup-uv@v8.2.0
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with: { enable-cache: true }
       - run: uv sync --frozen
-      - run: uvx --quiet pip-audit --strict
+      - run: uvx --quiet 'pip-audit==2.10.1' --strict

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,9 @@ RUN uv build --wheel && \
     uv sync --frozen --no-dev --no-install-project && \
     uv pip install --no-deps dist/*.whl
 
-# Runtime stage — copy the pre-built venv from the build stage (all deps already pinned by lock)
-FROM ghcr.io/astral-sh/uv:python${PYTHON_VERSION}-trixie-slim AS runtime
+# Runtime stage — copy the pre-built venv from the build stage (all deps already pinned by lock).
+# Use plain python slim (no uv binary in production image) — Python path matches the build stage.
+FROM python:${PYTHON_VERSION}-slim AS runtime
 
 ARG VERSION
 # OCI image labels

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,14 @@ ENV SETUPTOOLS_SCM_PRETEND_VERSION_FOR_FABRIC_DW=${VERSION}
 
 COPY pyproject.toml uv.lock README.md LICENSE ./
 COPY src/ src/
-RUN uv build --wheel
+# Build the wheel, then install all runtime deps from the frozen lock into a venv.
+# uv sync --frozen reads uv.lock and installs exactly the locked versions (no fresh resolution).
+RUN uv build --wheel && \
+    uv sync --frozen --no-dev --no-install-project && \
+    uv pip install --no-deps dist/*.whl
 
-# Runtime stage stays minimal — slim Python, pip-install the wheel
-FROM python:${PYTHON_VERSION}-slim AS runtime
+# Runtime stage — copy the pre-built venv from the build stage (all deps already pinned by lock)
+FROM ghcr.io/astral-sh/uv:python${PYTHON_VERSION}-trixie-slim AS runtime
 
 ARG VERSION
 # OCI image labels
@@ -31,13 +35,19 @@ LABEL org.opencontainers.image.title="fabric-dw" \
       org.opencontainers.image.version="${VERSION}" \
       org.opencontainers.image.licenses="MIT"
 
-# Install system dependencies using BuildKit cache mount for faster rebuilds
+# Install system dependencies using BuildKit cache mount for faster rebuilds.
+# ca-certificates: required for TLS connections to Fabric REST APIs and Azure AD.
+# mssql-python (the SQL driver) bundles its own native driver (no separate ODBC
+# manager needed), so no unixodbc/libodbc system packages are required on top of
+# the glibc/OpenSSL already present in the Debian trixie-slim base image.
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     apt-get update && apt-get install -y --no-install-recommends ca-certificates
 
-COPY --from=build /app/dist/*.whl /tmp/
-RUN pip install --no-cache-dir /tmp/*.whl && rm /tmp/*.whl
+# Copy the virtualenv (with all locked deps + the wheel) from the build stage.
+# No pip/uv resolution happens here — all versions are already pinned by uv.lock.
+COPY --from=build /app/.venv /app/.venv
+ENV PATH="/app/.venv/bin:$PATH"
 
 ENV FABRIC_AUTH=default PYTHONUNBUFFERED=1
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The Docker image's default `ENTRYPOINT` is the **MCP server** (`fabric-dw-mcp`).
 docker pull ghcr.io/sdebruyn/fabric-dw:latest
 
 # Run the MCP server (default entrypoint — connect via stdio from your MCP client):
-docker run --rm \
+docker run --rm -i \
   -e AZURE_CLIENT_ID=… \
   -e AZURE_TENANT_ID=… \
   -e AZURE_CLIENT_SECRET=… \

--- a/README.md
+++ b/README.md
@@ -71,9 +71,22 @@ The MCP server exposes all CLI operations (workspaces, warehouses, SQL endpoints
 
 ## Run in Docker
 
+The Docker image's default `ENTRYPOINT` is the **MCP server** (`fabric-dw-mcp`). Use it as-is with your MCP client, or override the entrypoint to run the CLI instead.
+
 ```bash
 docker pull ghcr.io/sdebruyn/fabric-dw:latest
+
+# Run the MCP server (default entrypoint — connect via stdio from your MCP client):
 docker run --rm \
+  -e AZURE_CLIENT_ID=… \
+  -e AZURE_TENANT_ID=… \
+  -e AZURE_CLIENT_SECRET=… \
+  -e FABRIC_AUTH=sp \
+  ghcr.io/sdebruyn/fabric-dw
+
+# Run the CLI instead (override the entrypoint):
+docker run --rm \
+  --entrypoint fabric-dw \
   -e AZURE_CLIENT_ID=… \
   -e AZURE_TENANT_ID=… \
   -e AZURE_CLIENT_SECRET=… \

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ title: Home
 
 > Python CLI + MCP server for Microsoft Fabric Data Warehouse administration.
 
-`fabric-dw` is an open-source Python project that lets you administer Microsoft Fabric Data Warehouses and SQL Analytics Endpoints from the command line or from an AI assistant. It authenticates via the Azure CLI (`az login`) so no additional credentials need to be managed.
+`fabric-dw` is an open-source Python project that lets you administer Microsoft Fabric Data Warehouses and SQL Analytics Endpoints from the command line or from an AI assistant. It authenticates via the Azure credential chain — Azure CLI, Managed Identity, service principal, environment variables, and more — so it works in both local and automated environments without additional setup. See [Authentication](authentication.md) for the full chain.
 
 Both the CLI and the MCP server surfaces are built from a single Python package and share the same authentication, connection, and business logic layers. This means fixes and new features land in both interfaces simultaneously, and you only need to install one package regardless of how you plan to use it.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -25,10 +25,9 @@ See [Authentication](authentication.md) for the full credential chain, all suppo
 
 ```bash
 pip install fabric-dw
+# or run without installing:
+uvx fabric-dw --help
 ```
-
-!!! note
-    The package is not yet published to PyPI. Installation instructions will be updated on the first release. In the meantime, you can install directly from the repository source.
 
 ## Verify
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -309,6 +309,27 @@ env_vars = ["FABRIC_AUTH", "AZURE_TENANT_ID", "AZURE_CLIENT_ID", "AZURE_CLIENT_S
 
 Codex picks up config changes on the next invocation; no explicit reload is needed.
 
+## Security environment variables
+
+The MCP server reads the following environment variables to restrict what it may do. Pass them via your client's `env` block or your shell environment:
+
+| Variable | Default | Description |
+|---|---|---|
+| `FABRIC_MCP_READONLY` | unset | Set to `1` to restrict `execute_sql` to SELECT/WITH and block all mutating tools. |
+| `FABRIC_MCP_ALLOW_DESTRUCTIVE` | unset | Set to `1` to enable permanently-destructive tools (`delete_*`, `clear_table`, `restore_warehouse_in_place`). Disabled by default. |
+| `FABRIC_MCP_WORKSPACES` | unset | Comma-separated workspace names or GUIDs the server may touch. Unset = all workspaces allowed. |
+| `FABRIC_MCP_ALLOW_REMOTE` | unset | Set to `1` to allow the HTTP transport (`--transport http`) to bind on a non-loopback address. Always front with an authenticating reverse proxy that handles TLS. |
+
+### HTTP transport
+
+The MCP server can be started in HTTP mode for remote clients:
+
+```bash
+fabric-dw-mcp --transport http [--host 127.0.0.1] [--port 8000]
+```
+
+Binding to non-loopback addresses requires `FABRIC_MCP_ALLOW_REMOTE=1`. The HTTP transport has **no built-in authentication or TLS** — always front it with an authenticating reverse proxy.
+
 ## Verifying
 
 After configuring your client, restart it and ask the assistant to list its available tools. You should see entries like `list_workspaces`, `get_warehouse`, `kill_session`, `clear_cache`, and 23 others (27 tools total).

--- a/justfile
+++ b/justfile
@@ -19,9 +19,11 @@ test:
 
 cov:
     uv run pytest tests/unit --cov --cov-report=term
+    uv run coverage report --fail-under=80
 
 cov-html:
     uv run pytest tests/unit --cov --cov-report=html
+    uv run coverage report --fail-under=80
 
 integration:
     uv run pytest tests/integration -q -m integration
@@ -30,7 +32,7 @@ build:
     uv build
 
 audit:
-    uvx 'bandit[sarif]' -r src/ -ll
-    uvx pip-audit --strict
+    uvx 'bandit[sarif]==1.9.4' -r src/ -ll
+    uvx 'pip-audit==2.10.1' --strict
 
 check: lint type test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,8 +138,8 @@ ignore = [
 docstring-code-format = true
 
 [tool.ty]
-# ty 0.0.44 is in alpha; no meaningful strictness settings are stable yet.
-# Pinned to 0.0.44 in [dependency-groups].dev and the justfile `type` recipe.
+# ty 0.0.49 is in alpha; no meaningful strictness settings are stable yet.
+# Pinned to 0.0.49 in [dependency-groups].dev and the justfile `type` recipe.
 # Re-evaluate configuration options when ty reaches a stable 0.1+ release.
 # Run with: uv run ty check src tests
 


### PR DESCRIPTION
## Summary

Addresses the Packaging/CI/Docs code-review batch (P01–P13). Each finding is listed below with its resolution or skip reason.

| ID | Severity | Resolution |
|---|---|---|
| P01 | low | Updated `[tool.ty]` comments to reference 0.0.49 (matches the pinned dep). |
| P02 | HIGH | Dockerfile runtime stage switched from `pip install <wheel>` to `uv sync --frozen --no-dev` + `uv pip install --no-deps <wheel>` in the build stage; the pre-built `.venv` is copied to runtime — all dep versions come from `uv.lock`. |
| P03 | medium | Removed `ms-python.mypy-type-checker` from devcontainer extensions; project uses `ty`. |
| P04 | medium | README "Run in Docker" section updated to explain the default ENTRYPOINT is the MCP server and shows `--entrypoint fabric-dw` for CLI usage. |
| P05 | medium | Added `autolabeler` block to `.github/release-drafter.yml` with title-regex rules for `feat/fix/docs/ci/chore` prefixes; removed the misleading `commitish:` fields. |
| P06 | medium | Removed the stale "not yet published to PyPI" note from `docs/install.md`; README install instructions are now the canonical reference. |
| P07 | low | Pinned `bandit[sarif]==1.9.4` and `pip-audit==2.10.1` in both `security.yml` and `justfile`. |
| P08 | medium | Pinned **all** third-party actions in all 6 workflow files to full commit SHAs with trailing `# vX.Y.Z` comments. Covers: `actions/checkout`, `astral-sh/setup-uv`, `actions/setup-python`, `actions/upload-artifact`, `actions/upload-code-coverage`, `codecov/codecov-action`, `codecov/test-results-action`, `actions/attest-build-provenance`, `actions/dependency-review-action`, `docker/build-push-action`, `docker/login-action`, `docker/setup-buildx-action`, `docker/setup-qemu-action`, `github/codeql-action/upload-sarif`, `gitleaks/gitleaks-action`, `release-drafter/release-drafter`, `softprops/action-gh-release`, `azure/login`. |
| P09 | low | Added `uv run coverage report --fail-under=80` to both `cov` and `cov-html` justfile recipes so the threshold is enforced locally. |
| P10 | medium | Added "Security environment variables" section to `docs/mcp.md` documenting `FABRIC_MCP_READONLY`, `FABRIC_MCP_ALLOW_DESTRUCTIVE`, `FABRIC_MCP_WORKSPACES`, `FABRIC_MCP_ALLOW_REMOTE` and the HTTP transport. |
| P11 | low | `docs/index.md` landing page now references "the Azure credential chain" with examples (Azure CLI, Managed Identity, service principal) instead of implying `az login` is the only option. |
| P12 | low | Added a comment in the Dockerfile explaining that `mssql-python` bundles its own native driver (no separate `unixodbc` packages required on the Debian trixie-slim base). No application code changed; smoke-test tracking deferred to a follow-up issue. |
| P13 | low | Removed duplicate `bandit` scan: the SARIF-format run now also serves as the gate (no `continue-on-error`), so a single invocation uploads to the Security tab and fails the job on findings. |

## Test plan

- [x] `just check` passes (lint + type + unit tests)
- [x] All GitHub Actions pinned to immutable commit SHAs
- [x] Dockerfile now installs from `uv.lock`-frozen venv instead of bare pip
- [x] No application source code was changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)