### PR TITLE
fix(services): bind datetime in WHERE, faithful kill error mapping via run_query, dedupe where-builder

### DIFF
--- a/src/fabric_dw/services/queries.py
+++ b/src/fabric_dw/services/queries.py
@@ -10,11 +10,8 @@ Public API
 from __future__ import annotations
 
 import asyncio
-from contextlib import closing
 
-from fabric_dw import sql
 from fabric_dw.auth import CredentialMode
-from fabric_dw.exceptions import AuthError, PermissionDeniedError
 from fabric_dw.models import Connection, RunningQuery
 from fabric_dw.sql import SqlTarget, run_query
 
@@ -138,35 +135,23 @@ async def kill(
 
     Raises:
         ValueError: If *session_id* is not a positive integer (i.e. <= 0).
-        PermissionDeniedError: If the driver raises a permission or auth error
+        PermissionDeniedError: If the driver reports a permission error
             (KILL requires Monitor or Admin permission on Fabric DW).
+        AuthError: If the driver reports an authentication failure.
+        NotFoundError: If the driver reports a missing object (e.g. the
+            session no longer exists when the KILL is issued).
     """
     if session_id <= 0:
         msg = f"session_id must be a positive integer; got {session_id}"
         raise ValueError(msg)
 
-    # KILL requires a bare integer (no quotes, no parameter binding).
-    # We validate and cast to int to prevent injection before embedding.
+    # KILL requires a bare integer literal — the SQL syntax does not accept
+    # a parameter placeholder here.  We cast to int explicitly to prevent any
+    # accidental injection before embedding in the statement.
     safe_id = int(session_id)
     kill_sql = f"KILL {safe_id}"
 
     def _run() -> None:
-        with closing(sql.open_connection(target, mode=mode)) as conn:
-            cursor = conn.cursor()
-            try:
-                cursor.execute(kill_sql)
-                conn.commit()
-            except Exception as exc:
-                mapped = sql.map_driver_error(exc)
-                if mapped:
-                    msg = f"Permission denied when trying to KILL session {session_id}: {mapped}"
-                    raise PermissionDeniedError(
-                        msg,
-                        hint="KILL requires Monitor or Admin permission on Fabric DW.",
-                    ) from exc
-                if isinstance(exc, (PermissionDeniedError, AuthError)):
-                    msg = f"Permission denied when trying to KILL session {session_id}: {exc}"
-                    raise PermissionDeniedError(msg) from exc
-                raise
+        run_query(target, kill_sql, mode=mode, commit=True, fetch="none")
 
     await asyncio.to_thread(_run)

--- a/src/fabric_dw/services/query_insights.py
+++ b/src/fabric_dw/services/query_insights.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime
-from typing import Any
 
 from fabric_dw.auth import CredentialMode
 from fabric_dw.exceptions import PermissionDeniedError
@@ -175,24 +174,60 @@ def _build_where(
     since: datetime | None,
     until: datetime | None,
     column: str,
-) -> str:
-    """Return a WHERE clause fragment (without the WHERE keyword) or empty string."""
-    parts: list[str] = []
+) -> tuple[str, list[object]]:
+    """Return a ``(where_clause, params)`` pair for the given time window.
+
+    The ``where_clause`` is either an empty string (no filter) or a
+    ``\\nWHERE <fragment>`` string ready to splice into the SQL template.
+    The datetime values are returned as *params* for ``?``-style driver
+    binding — they are **never** interpolated into the SQL text.
+
+    Args:
+        since: Optional inclusive lower bound (``column >= ?``).
+        until: Optional inclusive upper bound (``column <= ?``).
+        column: The pre-validated column name to filter on.  Must be a
+            trusted constant — it is interpolated directly into the SQL
+            fragment (identifier, not a value).
+
+    Returns:
+        A ``(where_clause, params)`` tuple where ``params`` holds the
+        datetime values to be passed via ``run_query(params=...)``.
+    """
+    fragments: list[str] = []
+    params: list[object] = []
     if since is not None:
-        parts.append(f"{column} >= '{since.isoformat()}'")
+        fragments.append(f"{column} >= ?")
+        params.append(since)
     if until is not None:
-        parts.append(f"{column} <= '{until.isoformat()}'")
-    return " AND ".join(parts)
+        fragments.append(f"{column} <= ?")
+        params.append(until)
+    if not fragments:
+        return "", []
+    return "\nWHERE " + " AND ".join(fragments), params
 
 
 def _execute_sql(
     target: SqlTarget,
     sql_text: str,
     mode: CredentialMode,
-) -> list[dict[str, Any]]:
-    """Execute *sql_text* synchronously and return rows as list of dicts."""
+    params: list[object] | None = None,
+) -> list[dict[str, object]]:
+    """Execute *sql_text* synchronously and return rows as list of dicts.
+
+    Args:
+        target: The warehouse or SQL analytics endpoint to query.
+        sql_text: The SQL statement to execute.  Use ``?`` placeholders for
+            any values; pass the corresponding values via *params*.
+        mode: The credential mode for Entra authentication.
+        params: Optional bound parameters for ``?`` placeholders.
+
+    Raises:
+        PermissionDeniedError: If the driver reports a 403 / permission error.
+            Re-raised with a documentation hint pointing to the Fabric
+            Query Insights permissions page.
+    """
     try:
-        cols, rows = run_query(target, sql_text, mode=mode)
+        cols, rows = run_query(target, sql_text, params=params or None, mode=mode)
     except PermissionDeniedError as exc:
         raise PermissionDeniedError(str(exc), hint=_PERMISSION_DENIED_DOCS) from exc
     return [dict(zip(cols, r, strict=True)) for r in rows]
@@ -260,10 +295,9 @@ async def list_request_history(
         PermissionDeniedError: If the caller lacks Contributor or above permission.
     """
     clamped = _clamp_limit(limit)
-    where_fragment = _build_where(since=since, until=until, column="submit_time")
-    where_clause = f"\nWHERE {where_fragment}" if where_fragment else ""
+    where_clause, where_params = _build_where(since=since, until=until, column="submit_time")
     sql_text = _REQUEST_HISTORY_SQL_TEMPLATE.format(limit=clamped, where=where_clause)
-    rows = await asyncio.to_thread(_execute_sql, target, sql_text, mode)
+    rows = await asyncio.to_thread(_execute_sql, target, sql_text, mode, where_params)
     return [ExecRequestHistory.model_validate(r) for r in rows]
 
 
@@ -337,10 +371,9 @@ async def list_session_history(
         PermissionDeniedError: If the caller lacks Contributor or above permission.
     """
     clamped = _clamp_limit(limit)
-    where_fragment = _build_where(since=since, until=until, column="session_start_time")
-    where_clause = f"\nWHERE {where_fragment}" if where_fragment else ""
+    where_clause, where_params = _build_where(since=since, until=until, column="session_start_time")
     sql_text = _SESSION_HISTORY_SQL_TEMPLATE.format(limit=clamped, where=where_clause)
-    rows = await asyncio.to_thread(_execute_sql, target, sql_text, mode)
+    rows = await asyncio.to_thread(_execute_sql, target, sql_text, mode, where_params)
     return [ExecSessionHistory.model_validate(r) for r in rows]
 
 
@@ -392,10 +425,11 @@ async def list_frequent_queries(
         PermissionDeniedError: If the caller lacks Contributor or above permission.
     """
     clamped = _clamp_limit(limit)
-    where_fragment = _build_where(since=since, until=until, column="last_run_start_time")
-    where_clause = f"\nWHERE {where_fragment}" if where_fragment else ""
+    where_clause, where_params = _build_where(
+        since=since, until=until, column="last_run_start_time"
+    )
     sql_text = _FREQUENT_QUERIES_SQL_TEMPLATE.format(limit=clamped, where=where_clause)
-    rows = await asyncio.to_thread(_execute_sql, target, sql_text, mode)
+    rows = await asyncio.to_thread(_execute_sql, target, sql_text, mode, where_params)
     return [FrequentlyRunQuery.model_validate(r) for r in rows]
 
 
@@ -442,10 +476,11 @@ async def list_long_running_queries(
         PermissionDeniedError: If the caller lacks Contributor or above permission.
     """
     clamped = _clamp_limit(limit)
-    where_fragment = _build_where(since=since, until=until, column="last_run_start_time")
-    where_clause = f"\nWHERE {where_fragment}" if where_fragment else ""
+    where_clause, where_params = _build_where(
+        since=since, until=until, column="last_run_start_time"
+    )
     sql_text = _LONG_RUNNING_SQL_TEMPLATE.format(limit=clamped, where=where_clause)
-    rows = await asyncio.to_thread(_execute_sql, target, sql_text, mode)
+    rows = await asyncio.to_thread(_execute_sql, target, sql_text, mode, where_params)
     return [LongRunningQuery.model_validate(r) for r in rows]
 
 
@@ -491,8 +526,7 @@ async def list_sql_pool_insights(
         PermissionDeniedError: If the caller lacks Contributor or above permission.
     """
     clamped = _clamp_limit(limit)
-    where_fragment = _build_where(since=since, until=until, column="timestamp")
-    where_clause = f"\nWHERE {where_fragment}" if where_fragment else ""
+    where_clause, where_params = _build_where(since=since, until=until, column="timestamp")
     sql_text = _SQL_POOL_INSIGHTS_SQL_TEMPLATE.format(limit=clamped, where=where_clause)
-    rows = await asyncio.to_thread(_execute_sql, target, sql_text, mode)
+    rows = await asyncio.to_thread(_execute_sql, target, sql_text, mode, where_params)
     return [SqlPoolInsight.model_validate(r) for r in rows]

--- a/src/fabric_dw/services/query_insights.py
+++ b/src/fabric_dw/services/query_insights.py
@@ -227,7 +227,7 @@ def _execute_sql(
             Query Insights permissions page.
     """
     try:
-        cols, rows = run_query(target, sql_text, params=params or None, mode=mode)
+        cols, rows = run_query(target, sql_text, params=params, mode=mode)
     except PermissionDeniedError as exc:
         raise PermissionDeniedError(str(exc), hint=_PERMISSION_DENIED_DOCS) from exc
     return [dict(zip(cols, r, strict=True)) for r in rows]

--- a/src/fabric_dw/services/schemas.py
+++ b/src/fabric_dw/services/schemas.py
@@ -89,10 +89,11 @@ _SYSTEM_SCHEMAS: frozenset[str] = frozenset(
 )
 
 # Build the IN-clause using parameter binding (? placeholders).
-# The placeholders string is constructed from the frozenset length; the actual
-# values are passed as params so the driver handles quoting/escaping.
-_SYSTEM_SCHEMA_PLACEHOLDERS = ", ".join("?" for _ in _SYSTEM_SCHEMAS)
+# Both the placeholder string and the ordered param tuple are derived from the
+# same sorted sequence so that "len(placeholders) == len(params)" is a
+# structural guarantee, not an implicit invariant between two separate constants.
 _SYSTEM_SCHEMA_PARAMS: tuple[str, ...] = tuple(sorted(_SYSTEM_SCHEMAS))
+_SYSTEM_SCHEMA_PLACEHOLDERS = ", ".join("?" for _ in _SYSTEM_SCHEMA_PARAMS)
 
 _LIST_SCHEMAS_SQL = f"""\
 SELECT

--- a/tests/unit/services/test_queries.py
+++ b/tests/unit/services/test_queries.py
@@ -234,6 +234,7 @@ async def test_list_running_unrelated_error_propagates() -> None:
 
 
 async def test_kill_issues_kill_statement() -> None:
+    """KILL statement embeds the session_id as a bare integer literal."""
     target = _make_target()
     conn = MagicMock()
     cursor = MagicMock()

--- a/tests/unit/services/test_queries.py
+++ b/tests/unit/services/test_queries.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from fabric_dw.exceptions import AuthError, PermissionDeniedError
+from fabric_dw.exceptions import AuthError, NotFoundError, PermissionDeniedError
 from fabric_dw.models import Connection, RunningQuery
 from fabric_dw.services import queries
 
@@ -248,6 +248,7 @@ async def test_kill_issues_kill_statement() -> None:
 
 
 async def test_kill_commits_after_execute() -> None:
+    """run_query with commit=True issues commit via the shared execution path."""
     target = _make_target()
     conn = MagicMock()
     cursor = MagicMock()
@@ -260,6 +261,7 @@ async def test_kill_commits_after_execute() -> None:
 
 
 async def test_kill_closes_connection_after_success() -> None:
+    """run_query always closes the connection in its finally block."""
     target = _make_target()
     conn = MagicMock()
     cursor = MagicMock()
@@ -344,8 +346,8 @@ async def test_kill_maps_permission_denied_from_cursor() -> None:
         await queries.kill(target, 42)
 
 
-async def test_kill_maps_auth_error_to_permission_denied() -> None:
-    """kill should map AuthError → PermissionDeniedError."""
+async def test_kill_maps_auth_error_faithfully() -> None:
+    """kill should surface AuthError as AuthError, not as PermissionDeniedError."""
     target = _make_target()
     conn = MagicMock()
     cursor = MagicMock()
@@ -354,23 +356,43 @@ async def test_kill_maps_auth_error_to_permission_denied() -> None:
 
     with (
         patch("fabric_dw.sql.open_connection", return_value=conn),
-        pytest.raises(PermissionDeniedError),
+        pytest.raises(AuthError),
     ):
         await queries.kill(target, 42)
 
 
-async def test_kill_permission_denied_message_contains_session_id() -> None:
+async def test_kill_maps_not_found_faithfully() -> None:
+    """kill surfaces NotFoundError (e.g. session already gone) as NotFoundError."""
     target = _make_target()
     conn = MagicMock()
     cursor = MagicMock()
-    cursor.execute.side_effect = Exception("Authentication failed for user ''")
+    cursor.execute.side_effect = Exception("Invalid object name 'session'")
     conn.cursor.return_value = cursor
 
     with (
         patch("fabric_dw.sql.open_connection", return_value=conn),
-        pytest.raises(PermissionDeniedError, match="42"),
+        pytest.raises(NotFoundError),
     ):
         await queries.kill(target, 42)
+
+
+async def test_kill_uses_run_query_not_direct_connection() -> None:
+    """kill must go through run_query (shared path), not open_connection directly."""
+    target = _make_target()
+
+    with patch("fabric_dw.services.queries.run_query") as mock_run_query:
+        mock_run_query.return_value = ([], [])
+        await queries.kill(target, 99)
+
+    mock_run_query.assert_called_once()
+    call_kwargs = mock_run_query.call_args
+    # Verify the SQL contains KILL and the session id
+    sql_arg: str = call_kwargs.args[1]
+    assert "KILL" in sql_arg
+    assert "99" in sql_arg
+    # Verify commit=True and fetch="none" are set
+    assert call_kwargs.kwargs.get("commit") is True
+    assert call_kwargs.kwargs.get("fetch") == "none"
 
 
 # ---------------------------------------------------------------------------
@@ -663,3 +685,18 @@ async def test_kill_sql_session_id_is_integer_not_string() -> None:
     assert "'7'" not in call_sql
     assert '"7"' not in call_sql
     assert "7" in call_sql
+
+
+async def test_kill_sql_no_params_bound() -> None:
+    """KILL embeds the session id as a literal integer — no ? placeholders, no params."""
+    target = _make_target()
+    conn = MagicMock()
+    cursor = MagicMock()
+    conn.cursor.return_value = cursor
+
+    with patch("fabric_dw.sql.open_connection", return_value=conn):
+        await queries.kill(target, 55)
+
+    # cursor.execute must be called with exactly one positional arg (the SQL),
+    # not with a second params argument, because KILL does not support binding.
+    assert cursor.execute.call_args.args == ("KILL 55",)

--- a/tests/unit/services/test_query_insights.py
+++ b/tests/unit/services/test_query_insights.py
@@ -323,6 +323,9 @@ async def test_list_session_history_since_adds_where() -> None:
     cursor = conn.cursor.return_value
     call_sql: str = cursor.execute.call_args[0][0]
     assert "session_start_time" in call_sql
+    # datetime must be bound as a param, never interpolated into the SQL string
+    assert since.isoformat() not in call_sql
+    assert since in cursor.execute.call_args[0][1]
 
 
 # ---------------------------------------------------------------------------
@@ -417,6 +420,9 @@ async def test_list_frequent_queries_since_adds_where() -> None:
     cursor = conn.cursor.return_value
     call_sql: str = cursor.execute.call_args[0][0]
     assert "last_run_start_time" in call_sql
+    # datetime must be bound as a param, never interpolated into the SQL string
+    assert since.isoformat() not in call_sql
+    assert since in cursor.execute.call_args[0][1]
 
 
 # ---------------------------------------------------------------------------
@@ -505,6 +511,9 @@ async def test_list_long_running_since_adds_where() -> None:
     cursor = conn.cursor.return_value
     call_sql: str = cursor.execute.call_args[0][0]
     assert "last_run_start_time" in call_sql
+    # datetime must be bound as a param, never interpolated into the SQL string
+    assert since.isoformat() not in call_sql
+    assert since in cursor.execute.call_args[0][1]
 
 
 # ---------------------------------------------------------------------------
@@ -593,6 +602,9 @@ async def test_list_sql_pool_insights_since_adds_where() -> None:
     cursor = conn.cursor.return_value
     call_sql: str = cursor.execute.call_args[0][0]
     assert "timestamp" in call_sql
+    # datetime must be bound as a param, never interpolated into the SQL string
+    assert since.isoformat() not in call_sql
+    assert since in cursor.execute.call_args[0][1]
 
 
 async def test_list_sql_pool_insights_closes_connection() -> None:

--- a/tests/unit/services/test_query_insights.py
+++ b/tests/unit/services/test_query_insights.py
@@ -696,3 +696,109 @@ def test_long_running_queries_sql_excludes_last_run_session_id() -> None:
     """last_run_session_id must NOT appear — it crashes on live Fabric (#195)."""
     sql = query_insights._LONG_RUNNING_SQL_TEMPLATE.format(limit=100, where="")
     assert "last_run_session_id" not in sql
+
+
+# ---------------------------------------------------------------------------
+# V01: _build_where datetime binding — unit tests for the helper directly
+# ---------------------------------------------------------------------------
+
+
+def test_build_where_no_bounds_returns_empty_clause_and_no_params() -> None:
+    """No since/until → empty string and empty params."""
+    clause, params = query_insights._build_where(since=None, until=None, column="col")
+    assert clause == ""
+    assert params == []
+
+
+def test_build_where_since_only_returns_clause_and_one_param() -> None:
+    """since-only → WHERE clause with one ? placeholder and the datetime as param."""
+    since = datetime(2024, 1, 1, tzinfo=UTC)
+    clause, params = query_insights._build_where(since=since, until=None, column="ts")
+    assert "WHERE" in clause
+    assert "ts >= ?" in clause
+    assert params == [since]
+    # The datetime must NOT be interpolated as a string literal.
+    assert since.isoformat() not in clause
+
+
+def test_build_where_until_only_returns_clause_and_one_param() -> None:
+    """until-only → WHERE clause with one ? placeholder and the datetime as param."""
+    until = datetime(2024, 12, 31, tzinfo=UTC)
+    clause, params = query_insights._build_where(since=None, until=until, column="ts")
+    assert "WHERE" in clause
+    assert "ts <= ?" in clause
+    assert params == [until]
+    assert until.isoformat() not in clause
+
+
+def test_build_where_since_and_until_returns_two_params_in_order() -> None:
+    """since+until → WHERE with two ? placeholders; params in since, until order."""
+    since = datetime(2024, 1, 1, tzinfo=UTC)
+    until = datetime(2024, 12, 31, tzinfo=UTC)
+    clause, params = query_insights._build_where(since=since, until=until, column="ts")
+    assert "WHERE" in clause
+    assert "AND" in clause
+    assert params == [since, until]
+    assert since.isoformat() not in clause
+    assert until.isoformat() not in clause
+
+
+def test_build_where_clause_prefixed_with_newline_where() -> None:
+    """Non-empty clause starts with \\nWHERE so it splices cleanly into SQL."""
+    since = datetime(2024, 6, 1, tzinfo=UTC)
+    clause, _ = query_insights._build_where(since=since, until=None, column="ts")
+    assert clause.startswith("\nWHERE ")
+
+
+# ---------------------------------------------------------------------------
+# V01: end-to-end binding — datetime params passed to run_query, not in SQL
+# ---------------------------------------------------------------------------
+
+
+async def test_list_request_history_since_passed_as_param_not_interpolated() -> None:
+    """since datetime must be in the params tuple, never in the SQL string."""
+    target = _make_target()
+    conn = _make_conn([], _REQ_HIST_COLS)
+    since = datetime(2024, 3, 15, 9, 30, tzinfo=UTC)
+    with patch("fabric_dw.sql.open_connection", return_value=conn):
+        await query_insights.list_request_history(target, since=since)
+    cursor = conn.cursor.return_value
+    # SQL string must not contain the ISO-formatted datetime value
+    call_sql: str = cursor.execute.call_args[0][0]
+    assert since.isoformat() not in call_sql
+    # The datetime must appear as a bound parameter (second positional arg to execute)
+    call_params = cursor.execute.call_args[0][1]
+    assert since in call_params
+
+
+async def test_list_request_history_until_passed_as_param_not_interpolated() -> None:
+    """until datetime must be in the params tuple, never in the SQL string."""
+    target = _make_target()
+    conn = _make_conn([], _REQ_HIST_COLS)
+    until = datetime(2024, 9, 30, 23, 59, tzinfo=UTC)
+    with patch("fabric_dw.sql.open_connection", return_value=conn):
+        await query_insights.list_request_history(target, until=until)
+    cursor = conn.cursor.return_value
+    call_sql: str = cursor.execute.call_args[0][0]
+    assert until.isoformat() not in call_sql
+    call_params = cursor.execute.call_args[0][1]
+    assert until in call_params
+
+
+async def test_list_request_history_both_bounds_passed_as_params() -> None:
+    """Both since and until must be bound as params (two ? placeholders in SQL)."""
+    target = _make_target()
+    conn = _make_conn([], _REQ_HIST_COLS)
+    since = datetime(2024, 1, 1, tzinfo=UTC)
+    until = datetime(2024, 12, 31, tzinfo=UTC)
+    with patch("fabric_dw.sql.open_connection", return_value=conn):
+        await query_insights.list_request_history(target, since=since, until=until)
+    cursor = conn.cursor.return_value
+    call_sql: str = cursor.execute.call_args[0][0]
+    # Neither value interpolated
+    assert since.isoformat() not in call_sql
+    assert until.isoformat() not in call_sql
+    # Both present as params
+    call_params = cursor.execute.call_args[0][1]
+    assert since in call_params
+    assert until in call_params


### PR DESCRIPTION
## Summary

Addresses seven service-layer SQL-safety findings from the code review.

## Findings addressed

| ID | Severity | Status | How addressed |
|----|----------|--------|---------------|
| **V01** | HIGH | Fixed | `_build_where` now returns `(where_clause, params)` tuple; datetime values bound as `?` params via `run_query(params=...)` — never interpolated into the SQL string. |
| **V02** | HIGH | Fixed | `kill()` now uses `run_query` which calls `map_driver_error` faithfully and raises the mapped type as-is — `NotFoundError` stays `NotFoundError`, `AuthError` stays `AuthError`. Previous `if mapped: raise PermissionDeniedError(...)` blanket mis-mapping removed. |
| **V19** | Design | Fixed | `kill()` refactored to `run_query(target, kill_sql, mode=mode, commit=True, fetch="none")`, removing the manual `closing(open_connection(...))` + `try/except Exception` re-implementation. V02 is fixed as a consequence. |
| **V18** | Error-handling | Documented | `_execute_sql` intentionally only enriches `PermissionDeniedError` — it is the 403/Contributor gate described in the module docstring. Docstring tightened to say "403 driver error" explicitly, documenting why only that one. |
| **V22** | Typing | Fixed | `_execute_sql` return type tightened from `list[dict[str, Any]]` to `list[dict[str, object]]`; `Any` import removed. |
| **V06** | DRY | Fixed | `_build_where` now constructs the full `\nWHERE <fragment>` clause itself, eliminating the 5× duplicated `where_clause = f"\nWHERE {fragment}" if fragment else ""` call-site pattern. |
| **V20** | Clean-code | Fixed | `_SYSTEM_SCHEMA_PLACEHOLDERS` in `schemas.py` is now derived from `_SYSTEM_SCHEMA_PARAMS` (`", ".join("?" for _ in _SYSTEM_SCHEMA_PARAMS)`), making the placeholder count structurally guaranteed to equal the param count. |

## Tests added / updated

- `_build_where` direct unit tests: since-only, until-only, both, neither — asserting `?` placeholder in SQL, datetime in params, ISO string **not** in SQL.
- End-to-end binding tests for `list_request_history` (since, until, both bounds).
- `kill()` faithful error-mapping tests: `AuthError` → `AuthError`, `NotFoundError` → `NotFoundError`.
- `test_kill_uses_run_query_not_direct_connection`: verifies `run_query` is called with `commit=True, fetch="none"`.
- Removed `test_kill_maps_auth_error_to_permission_denied` which was pinning the buggy mapping (T09).

## Test plan

- [x] `just check` fully green (ruff, ty, pytest — 2206 passed)
- [x] No integration tests run (per instructions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)