### PR TITLE
fix(http_client): per-scope token cache, robust redaction/retry bounds, concurrency + typing

### DIFF
--- a/src/fabric_dw/auth.py
+++ b/src/fabric_dw/auth.py
@@ -117,10 +117,17 @@ class SyncCredentialAdapter:
 
     Remove the ``InteractiveBrowserCredential`` usage of this adapter and switch to
     ``azure.identity.aio.InteractiveBrowserCredential`` once that ships in a stable release.
+
+    Thread-safety: ``_get_token_lock`` serialises concurrent ``get_token`` calls so that
+    multiple :class:`~fabric_dw.http_client.FabricHttpClient` instances sharing the same
+    credential do not race to mutate the underlying MSAL token cache concurrently.
     """
 
     def __init__(self, inner: _CloseableTokenCredential) -> None:
         self._inner = inner
+        # Per-credential async lock: serialises concurrent get_token calls across
+        # all FabricHttpClient instances that share this credential object.
+        self._get_token_lock: asyncio.Lock = asyncio.Lock()
 
     async def get_token(
         self,
@@ -130,14 +137,15 @@ class SyncCredentialAdapter:
         enable_cae: bool = False,
         **kwargs: object,
     ) -> AccessToken:
-        return await asyncio.to_thread(
-            self._inner.get_token,
-            *scopes,
-            claims=claims,
-            tenant_id=tenant_id,
-            enable_cae=enable_cae,
-            **kwargs,
-        )
+        async with self._get_token_lock:
+            return await asyncio.to_thread(
+                self._inner.get_token,
+                *scopes,
+                claims=claims,
+                tenant_id=tenant_id,
+                enable_cae=enable_cae,
+                **kwargs,
+            )
 
     async def close(self) -> None:
         await asyncio.to_thread(self._inner.close)

--- a/src/fabric_dw/http_client.py
+++ b/src/fabric_dw/http_client.py
@@ -14,9 +14,9 @@ Retry arithmetic
 Tenacity wraps ``_request_with_retry`` and retries on ``FabricServerError``
 (5xx) up to 3 attempts with exponential back-off.  Inside each attempt,
 ``_do_request`` executes a 429-loop of up to ``max_429_retries`` iterations.
-Worst-case total attempts = 3 tenacity attempts x 5 429-retries = 15 sends.
-In practice the 429-loop resets its counter on any non-429 response, so the
-two mechanisms are largely independent.
+Both mechanisms share a common wall-clock deadline (``_combined_deadline_s``
+seconds from the first attempt, default 120 s) so the combined worst-case
+latency is bounded even if the server returns large Retry-After values.
 
 Timeout retry safety
 ~~~~~~~~~~~~~~~~~~~~
@@ -25,18 +25,25 @@ is retried ONLY for idempotent HTTP methods (GET, HEAD, OPTIONS).  POST, PATCH,
 and DELETE are NOT retried on timeout because the server may have received and
 committed the request — re-sending a POST would duplicate the resource or cause
 a 409 Conflict.  LRO status polling (GET) is covered by the safe retry path.
+
+Credential ownership
+~~~~~~~~~~~~~~~~~~~~
+``FabricHttpClient`` does **not** close the credential passed to its constructor.
+The credential may be shared across multiple client instances or with other code,
+so its lifecycle is the caller's responsibility.  If you create a credential
+solely for one client, close it after the ``async with`` block completes.
 """
 
 from __future__ import annotations
 
 import asyncio
-import contextvars
 import datetime
 import http
+import json
 import logging
 import random
 import time as _time
-from collections.abc import AsyncIterator, Mapping
+from collections.abc import AsyncIterator, Callable, Mapping
 from email.utils import parsedate_to_datetime
 from enum import StrEnum
 from typing import Any
@@ -64,7 +71,6 @@ _logger = logging.getLogger("fabric_dw.http")
 __all__ = [
     "FabricHttpClient",
     "HttpBase",
-    "_parse_retry_after",
 ]
 
 # Module-level defaults (used as constructor defaults)
@@ -74,15 +80,16 @@ _MAX_429_RETRIES: int = 5
 _DEFAULT_POLL_INTERVAL: float = 2.0
 _TOKEN_REFRESH_BUFFER: float = 300.0  # seconds before expiry to refresh
 
+# Maximum wall-clock seconds for the combined 5xx-tenacity + 429-loop budget.
+# When this deadline is reached, whichever retry loop is active at that point
+# aborts and re-raises; this prevents unbounded waits when a server advertises
+# very large Retry-After values across multiple tenacity attempts.
+_DEFAULT_COMBINED_DEADLINE_S: float = 120.0
+
 # HTTP methods that are safe to retry on timeout: repeating them cannot duplicate
 # server-side state.  POST/PATCH/DELETE are excluded — a timed-out POST may have
 # committed server-side; re-sending it would create a duplicate resource or 409.
 _IDEMPOTENT_METHODS: frozenset[str] = frozenset({"GET", "HEAD", "OPTIONS"})
-
-# ContextVar that _request_with_retry sets before each call so the tenacity
-# retry predicate can inspect the HTTP method without changing the function
-# signature (tenacity only passes the exception to retry predicates).
-_current_method: contextvars.ContextVar[str] = contextvars.ContextVar("_current_method", default="")
 
 # Status code → exception class mapping (4xx errors only; 5xx handled separately)
 _STATUS_TO_EXC: dict[int, type[FabricError]] = {
@@ -105,6 +112,9 @@ def _parse_retry_after(value: str) -> float:
     Handles both the integer-seconds form and the HTTP-date form
     (RFC 7231 section 7.1.3).
 
+    Always returns a non-negative float; never raises — malformed values
+    fall back to 0.0.
+
     Args:
         value: The raw Retry-After header value.
 
@@ -118,27 +128,59 @@ def _parse_retry_after(value: str) -> float:
         pass
 
     # Try HTTP-date form, e.g. "Wed, 21 Oct 2026 07:28:00 GMT"
-    retry_dt = parsedate_to_datetime(value)
-    now = datetime.datetime.now(tz=datetime.UTC)
-    delta = (retry_dt - now).total_seconds()
-    return max(0.0, delta)
+    try:
+        retry_dt = parsedate_to_datetime(value)
+        now = datetime.datetime.now(tz=datetime.UTC)
+        delta = (retry_dt - now).total_seconds()
+        return max(0.0, delta)
+    except (TypeError, ValueError):
+        return 0.0
 
 
-def _should_retry(exc: BaseException) -> bool:
-    """Tenacity retry predicate: retry on 5xx *or* timeouts for idempotent methods.
+def _parse_json_body(resp: httpx.Response) -> dict[str, object] | None:
+    """Parse the response JSON as a dict, returning ``None`` on failure.
 
-    Returns ``True`` when tenacity should attempt another send:
-    - Always retry :class:`~fabric_dw.exceptions.FabricServerError` (5xx responses).
-    - Retry :class:`httpx.TimeoutException` ONLY when the current request method
-      is in :data:`_IDEMPOTENT_METHODS` (GET, HEAD, OPTIONS).  Non-idempotent
-      methods (POST, PATCH, DELETE) are NOT retried because the server may have
-      already committed the request.
+    Narrows the broad exception to ``(ValueError, json.JSONDecodeError)``
+    (httpx uses ``json.JSONDecodeError`` for invalid JSON) and silently
+    returns ``None`` for any other content type or malformed body.
     """
-    if isinstance(exc, FabricServerError):
-        return True
-    if isinstance(exc, httpx.TimeoutException):
-        return _current_method.get("") in _IDEMPOTENT_METHODS
-    return False
+    try:
+        parsed = resp.json()
+        if isinstance(parsed, dict):
+            return parsed  # type: ignore[return-value]
+    except (ValueError, json.JSONDecodeError):
+        pass
+    return None
+
+
+def _make_should_retry(method: str) -> Callable[[BaseException], bool]:
+    """Return a tenacity retry predicate bound to *method*.
+
+    Using a closure instead of a module-global ContextVar avoids shared
+    mutable state across concurrent coroutines and makes the method binding
+    explicit and testable.
+
+    Returns:
+        A predicate ``(exc: BaseException) -> bool`` that tenacity passes
+        to ``retry_if_exception``.
+    """
+    upper = method.upper()
+
+    def _should_retry(exc: BaseException) -> bool:
+        """Retry on 5xx *or* on timeout for idempotent methods.
+
+        - Always retry :class:`~fabric_dw.exceptions.FabricServerError` (5xx).
+        - Retry :class:`httpx.TimeoutException` ONLY for idempotent HTTP
+          methods (GET, HEAD, OPTIONS).  POST/PATCH/DELETE are not retried
+          on timeout — the server may have already committed the request.
+        """
+        if isinstance(exc, FabricServerError):
+            return True
+        if isinstance(exc, httpx.TimeoutException):
+            return upper in _IDEMPOTENT_METHODS
+        return False
+
+    return _should_retry
 
 
 class FabricHttpClient:
@@ -149,23 +191,32 @@ class FabricHttpClient:
         async with FabricHttpClient(credential) as client:
             resp = await client.request("GET", HttpBase.FABRIC, "/workspaces")
 
+    Credential ownership
+    ~~~~~~~~~~~~~~~~~~~~
+    This client does **not** close the credential.  The credential may be
+    shared with other clients or code, so its lifecycle is the caller's
+    responsibility.
+
     Retry arithmetic
     ~~~~~~~~~~~~~~~~
     Tenacity wraps ``_request_with_retry`` and retries on ``FabricServerError``
     (5xx) up to 3 attempts.  Inside each tenacity attempt, ``_do_request`` runs
-    a 429-loop of up to ``max_429_retries`` iterations.  Worst-case total sends
-    = 3 x ``max_429_retries`` (default 15).  The 429 counter resets on any
-    non-429 response, so both mechanisms are largely independent in practice.
+    a 429-loop of up to ``max_429_retries`` iterations.  Both mechanisms share a
+    common wall-clock deadline (``combined_deadline_s`` seconds from the first
+    send, default 120 s) so the total latency is bounded even when the server
+    advertises large ``Retry-After`` values.
 
     Args:
-        credential:          Azure credential used to fetch bearer tokens.
-        rps:                 Maximum requests per second (default 2).
-        timeout:             HTTP request timeout in seconds (default 60.0).
-        max_429_retries:     Maximum consecutive 429 responses before raising
-                             ``RateLimitedError`` (default 5).
-        poll_interval:       Default LRO polling interval in seconds (default 2.0).
-        token_refresh_buffer: Seconds before token expiry at which a refresh is
-                             triggered (default 300.0).
+        credential:             Azure credential used to fetch bearer tokens.
+        rps:                    Maximum requests per second (default 2).
+        timeout:                HTTP request timeout in seconds (default 60.0).
+        max_429_retries:        Maximum consecutive 429 responses before raising
+                                ``RateLimitedError`` (default 5).
+        poll_interval:          Default LRO polling interval in seconds (default 2.0).
+        token_refresh_buffer:   Seconds before token expiry at which a refresh is
+                                triggered (default 300.0).
+        combined_deadline_s:    Maximum wall-clock seconds for the combined
+                                5xx-retry + 429-loop budget (default 120.0).
     """
 
     def __init__(  # noqa: PLR0913
@@ -177,18 +228,26 @@ class FabricHttpClient:
         max_429_retries: int = _MAX_429_RETRIES,
         poll_interval: float = _DEFAULT_POLL_INTERVAL,
         token_refresh_buffer: float = _TOKEN_REFRESH_BUFFER,
+        combined_deadline_s: float = _DEFAULT_COMBINED_DEADLINE_S,
     ) -> None:
         self._credential = credential
         self._limiter = AsyncLimiter(max_rate=rps, time_period=1)
         self._http: httpx.AsyncClient | None = None
-        self._token: AccessToken | None = None
+        # Per-scope token cache: dict[scope, AccessToken]
+        self._tokens: dict[str, AccessToken] = {}
         self._token_lock = asyncio.Lock()
         self._timeout = timeout
         self._max_429_retries = max_429_retries
         self._poll_interval = poll_interval
         self._token_refresh_buffer = token_refresh_buffer
+        self._combined_deadline_s = combined_deadline_s
         # Monotonic deadline: sleep until this time before each send.
         # 0.0 means "no pause needed".
+        # Safety: this field is read and written by concurrent coroutines on
+        # the single-threaded asyncio event loop.  The read-modify-write
+        # ``self._pause_until = max(self._pause_until, deadline)`` in
+        # ``_do_request`` is not interrupted by an ``await``, so it is
+        # effectively atomic on CPython's event loop; no lock is needed.
         self._pause_until: float = 0.0
 
     async def __aenter__(self) -> FabricHttpClient:
@@ -204,20 +263,24 @@ class FabricHttpClient:
     # Token management
     # ------------------------------------------------------------------
 
-    async def _get_token(self) -> str:
-        """Return a valid bearer token, refreshing if close to expiry.
+    async def _get_token(self, scope: str = auth.FABRIC_SCOPE) -> str:
+        """Return a valid bearer token for *scope*, refreshing if close to expiry.
 
         A lock ensures that under concurrent calls only one refresh is
         performed even if multiple coroutines see the token as expired at
-        the same time.
+        the same time.  Tokens are cached per-scope so that different scopes
+        (e.g. ``FABRIC_SCOPE``, ``SQL_SCOPE``) do not share a single cache entry.
+
+        Args:
+            scope: The OAuth2 scope to request a token for.
+                   Defaults to :data:`~fabric_dw.auth.FABRIC_SCOPE`.
         """
         async with self._token_lock:
-            if (
-                self._token is None
-                or self._token.expires_on - _time.time() < self._token_refresh_buffer
-            ):
-                self._token = await self._credential.get_token(auth.FABRIC_SCOPE)
-        return self._token.token
+            token = self._tokens.get(scope)
+            if token is None or token.expires_on - _time.time() < self._token_refresh_buffer:
+                token = await self._credential.get_token(scope)
+                self._tokens[scope] = token
+        return token.token
 
     # ------------------------------------------------------------------
     # Core request
@@ -248,18 +311,16 @@ class FabricHttpClient:
             AuthError: On 401.
             PermissionDeniedError: On 403.
             NotFoundError: On 404.
-            RateLimitedError: After exactly ``max_429_retries`` consecutive 429 responses.
+            RateLimitedError: After exactly ``max_429_retries`` consecutive 429 responses
+                              or when the combined retry deadline is exceeded.
             FabricServerError: On persistent 5xx errors.
         """
         url = f"{base}{path}"
-        return await self._request_with_retry(method, url, json=json, params=params)
+        combined_deadline = _time.monotonic() + self._combined_deadline_s
+        return await self._request_with_retry(
+            method, url, json=json, params=params, combined_deadline=combined_deadline
+        )
 
-    @retry(
-        retry=retry_if_exception(_should_retry),
-        stop=stop_after_attempt(3),
-        wait=wait_exponential(multiplier=0.1, min=0.1, max=2),
-        reraise=True,
-    )
     async def _request_with_retry(
         self,
         method: str,
@@ -267,15 +328,28 @@ class FabricHttpClient:
         *,
         json: object = None,
         params: Mapping[str, Any] | None = None,
+        combined_deadline: float | None = None,
     ) -> httpx.Response:
-        """Inner request method wrapped with tenacity 5xx and idempotent-timeout retry.
+        """Inner request with tenacity 5xx and idempotent-timeout retry.
 
-        Sets :data:`_current_method` so that :func:`_should_retry` can inspect the
-        HTTP method when deciding whether a :class:`httpx.TimeoutException` is safe
-        to retry.
+        The tenacity decorator is built per-call so the method is bound
+        directly in the retry predicate closure, avoiding a fragile module-
+        global ContextVar.
         """
-        _current_method.set(method.upper())
-        return await self._do_request(method, url, json=json, params=params)
+        should_retry = _make_should_retry(method)
+
+        @retry(
+            retry=retry_if_exception(should_retry),
+            stop=stop_after_attempt(3),
+            wait=wait_exponential(multiplier=0.1, min=0.1, max=2),
+            reraise=True,
+        )
+        async def _attempt() -> httpx.Response:
+            return await self._do_request(
+                method, url, json=json, params=params, combined_deadline=combined_deadline
+            )
+
+        return await _attempt()
 
     async def _do_request(
         self,
@@ -284,6 +358,7 @@ class FabricHttpClient:
         *,
         json: object = None,
         params: Mapping[str, Any] | None = None,
+        combined_deadline: float | None = None,
     ) -> httpx.Response:
         """Execute a request with rate limiting and 429 handling.
 
@@ -294,7 +369,8 @@ class FabricHttpClient:
 
         On 429: updates the shared monotonic deadline and retries up to
         ``_max_429_retries`` consecutive times before raising
-        ``RateLimitedError``.
+        ``RateLimitedError``.  Respects *combined_deadline* to bound the
+        total wall-clock wait shared with the tenacity 5xx-retry layer.
         """
         if self._http is None:
             msg = "Client must be used as an async context manager"
@@ -303,6 +379,13 @@ class FabricHttpClient:
         consecutive_429 = 0
 
         while True:
+            # Shared deadline check: abort if the combined retry budget is spent.
+            if combined_deadline is not None and _time.monotonic() >= combined_deadline:
+                raise RateLimitedError(
+                    f"Combined retry deadline exceeded for {url}",
+                    status=429,
+                )
+
             resp = await self._send_once(method, url, json=json, params=params)
 
             if resp.status_code == http.HTTPStatus.TOO_MANY_REQUESTS:
@@ -315,9 +398,8 @@ class FabricHttpClient:
                     )
 
                 retry_after_raw = resp.headers.get("Retry-After", "1")
-                try:
-                    wait_s = _parse_retry_after(retry_after_raw)
-                except ValueError:
+                wait_s = _parse_retry_after(retry_after_raw)
+                if wait_s == 0.0 and retry_after_raw.strip() not in ("0", "0.0"):
                     _logger.warning(
                         "Malformed Retry-After header %r; falling back to 1.0s",
                         retry_after_raw,
@@ -325,6 +407,9 @@ class FabricHttpClient:
                     wait_s = 1.0
 
                 # Aggregate concurrent 429s: keep the latest (furthest) deadline.
+                # This read-modify-write is safe on the single-threaded asyncio
+                # event loop because there is no ``await`` between the read and
+                # the write — the assignment is effectively atomic.
                 deadline = _time.monotonic() + wait_s
                 self._pause_until = max(self._pause_until, deadline)
                 continue
@@ -399,21 +484,15 @@ class FabricHttpClient:
         Uses ``_STATUS_TO_EXC`` for known 4xx codes (401, 403, 404); raises
         ``BadRequestError`` for any other 4xx (including 400) so that Fabric
         error details are never silently discarded; raises ``FabricServerError``
-        for any 5xx response.  JSON body is parsed best-effort (parse errors
-        are silently swallowed).  The ``x-ms-request-id`` header is captured
-        for all raised exceptions.
+        for any 5xx response.  JSON body is parsed best-effort (only
+        ``ValueError``/``json.JSONDecodeError`` are suppressed).  The
+        ``x-ms-request-id`` header is captured for all raised exceptions.
         """
         status = resp.status_code
         request_id = resp.headers.get("x-ms-request-id")
 
-        # Best-effort JSON body parse
-        body: dict[str, object] | None = None
-        try:
-            parsed = resp.json()
-            if isinstance(parsed, dict):
-                body = parsed
-        except Exception:  # noqa: S110
-            pass
+        # Best-effort JSON body parse — narrowed to JSON-specific errors only
+        body = _parse_json_body(resp)
 
         exc_class = _STATUS_TO_EXC.get(status)
         if exc_class is not None:
@@ -474,7 +553,11 @@ class FabricHttpClient:
             # continuationUri is always a full URL; use _request_with_retry directly
             resp = await self._request_with_retry("GET", url, params=params if first else None)
             first = False
-            data: dict[str, object] = resp.json()
+            raw = resp.json()
+            if not isinstance(raw, dict):
+                # Non-dict page body (e.g. an array or null): no items, no continuation.
+                break
+            data: dict[str, object] = raw
             raw_items = data.get(key, [])
             if isinstance(raw_items, list):
                 for item in raw_items:
@@ -500,15 +583,22 @@ class FabricHttpClient:
                 or parsed from the ``Location`` header path).
 
         Returns:
-            The result body, e.g. ``{"id": "...", "type": "WarehouseSnapshot", ...}``.
+            The result body as a ``dict``, e.g.
+            ``{"id": "...", "type": "WarehouseSnapshot", ...}``.
+            Raises ``FabricServerError`` if the response body is not a JSON object.
 
         Raises:
             NotFoundError: If the result is not available (404).
-            FabricServerError: On 5xx errors.
+            FabricServerError: On 5xx errors or a non-dict response body.
         """
         result_url = f"{HttpBase.FABRIC}/operations/{operation_id}/result"
         resp = await self._request_with_retry("GET", result_url)
-        return resp.json()  # type: ignore[no-any-return]
+        body = _parse_json_body(resp)
+        if body is None:
+            raise FabricServerError(
+                f"LRO result for {operation_id} returned a non-dict body: {resp.text!r}"
+            )
+        return body
 
     async def poll_operation(
         self,
@@ -536,7 +626,7 @@ class FabricHttpClient:
                 raise FabricServerError(f"LRO timed out after {timeout_s}s for {location}")
 
             resp = await self._request_with_retry("GET", location)
-            body: dict[str, object] = resp.json()
+            body = _parse_json_body(resp) or {}
             status = body.get("status", "")
 
             if status == "Succeeded":
@@ -544,10 +634,14 @@ class FabricHttpClient:
             if status == "Failed":
                 raise FabricServerError(f"LRO failed for {location}: {body.get('error', body)}")
 
-            # Not finished yet - honour Retry-After or fall back to default, with jitter
+            # Not finished yet - honour Retry-After or fall back to default, with jitter.
+            # _parse_retry_after always returns a float (never raises).
             retry_after_raw = resp.headers.get("Retry-After")
             base_wait = (
                 _parse_retry_after(retry_after_raw) if retry_after_raw else self._poll_interval
             )
+            # If parse returned 0 but a header was present, fall back to poll interval.
+            if base_wait == 0.0 and retry_after_raw is not None:
+                base_wait = self._poll_interval
             wait_s = base_wait + random.uniform(0, base_wait * 0.25)  # noqa: S311
             await asyncio.sleep(wait_s)

--- a/src/fabric_dw/http_client.py
+++ b/src/fabric_dw/http_client.py
@@ -123,7 +123,7 @@ def _parse_retry_after(value: str) -> float:
     """
     value = value.strip()
     try:
-        return float(value)
+        return max(0.0, float(value))
     except ValueError:
         pass
 
@@ -135,6 +135,34 @@ def _parse_retry_after(value: str) -> float:
         return max(0.0, delta)
     except (TypeError, ValueError):
         return 0.0
+
+
+def _is_malformed_retry_after(value: str) -> bool:
+    """Return True when *value* is neither a valid numeric seconds string nor an HTTP date.
+
+    Used by ``_do_request`` to distinguish a legitimately-zero Retry-After (e.g.
+    ``"0.00"``, ``"0.000"``) from a completely unrecognisable value that fell
+    through ``_parse_retry_after`` as ``0.0``.
+
+    Args:
+        value: The raw Retry-After header value (not yet stripped).
+
+    Returns:
+        ``True`` only when the value cannot be parsed as a number or an HTTP date.
+    """
+    stripped = value.strip()
+    try:
+        float(stripped)
+    except ValueError:
+        pass
+    else:
+        return False  # valid number (including "0.00", "0.000", negative, etc.)
+    try:
+        parsedate_to_datetime(stripped)
+    except (TypeError, ValueError):
+        return True  # truly malformed
+    else:
+        return False  # valid HTTP date (even a past one mapping to 0.0)
 
 
 def _parse_json_body(resp: httpx.Response) -> dict[str, object] | None:
@@ -399,7 +427,13 @@ class FabricHttpClient:
 
                 retry_after_raw = resp.headers.get("Retry-After", "1")
                 wait_s = _parse_retry_after(retry_after_raw)
-                if wait_s == 0.0 and retry_after_raw.strip() not in ("0", "0.0"):
+                # Warn and override only when the header was truly unrecognizable.
+                # _parse_retry_after returns 0.0 both for a legitimate "0 seconds"
+                # value AND for a completely unparseable string.  Distinguish them
+                # by re-checking: if the raw value is a parseable number (any form
+                # of zero like "0.00") or a valid HTTP date (even a past one that
+                # maps to 0.0), treat it as intentional.  Only warn otherwise.
+                if wait_s == 0.0 and _is_malformed_retry_after(retry_after_raw):
                     _logger.warning(
                         "Malformed Retry-After header %r; falling back to 1.0s",
                         retry_after_raw,
@@ -548,10 +582,15 @@ class FabricHttpClient:
         """
         url: str | None = f"{base}{path}"
         first = True
+        # Apply the same combined wall-clock deadline used by request() so that
+        # 429 loops inside paginated fetches are time-bounded (C27).
+        combined_deadline = _time.monotonic() + self._combined_deadline_s
 
         while url is not None:
             # continuationUri is always a full URL; use _request_with_retry directly
-            resp = await self._request_with_retry("GET", url, params=params if first else None)
+            resp = await self._request_with_retry(
+                "GET", url, params=params if first else None, combined_deadline=combined_deadline
+            )
             first = False
             raw = resp.json()
             if not isinstance(raw, dict):
@@ -592,7 +631,10 @@ class FabricHttpClient:
             FabricServerError: On 5xx errors or a non-dict response body.
         """
         result_url = f"{HttpBase.FABRIC}/operations/{operation_id}/result"
-        resp = await self._request_with_retry("GET", result_url)
+        combined_deadline = _time.monotonic() + self._combined_deadline_s
+        resp = await self._request_with_retry(
+            "GET", result_url, combined_deadline=combined_deadline
+        )
         body = _parse_json_body(resp)
         if body is None:
             raise FabricServerError(
@@ -620,12 +662,27 @@ class FabricHttpClient:
                 timeout is exceeded.
         """
         deadline = _time.monotonic() + timeout_s
+        # Apply the combined wall-clock deadline so that 429 loops inside
+        # each poll request are time-bounded (C27).  For poll_operation the
+        # natural combined deadline is per-request: reset it each iteration so
+        # that a fresh ``_combined_deadline_s`` budget is granted per poll GET,
+        # while the LRO ``deadline`` bounds the overall polling duration.
+        #
+        # Note: combined_deadline is intentionally re-computed each iteration
+        # inside the loop (see below) so that each poll attempt gets its own
+        # fresh 429-retry budget rather than sharing a single budget across
+        # potentially hundreds of polls.
 
         while True:
             if _time.monotonic() >= deadline:
                 raise FabricServerError(f"LRO timed out after {timeout_s}s for {location}")
 
-            resp = await self._request_with_retry("GET", location)
+            # Fresh combined_deadline per poll GET so the 429-retry window is
+            # scoped to each individual HTTP request, not the entire LRO wait.
+            poll_combined_deadline = _time.monotonic() + self._combined_deadline_s
+            resp = await self._request_with_retry(
+                "GET", location, combined_deadline=poll_combined_deadline
+            )
             body = _parse_json_body(resp) or {}
             status = body.get("status", "")
 

--- a/src/fabric_dw/logging.py
+++ b/src/fabric_dw/logging.py
@@ -103,6 +103,9 @@ _SENSITIVE_HEADERS: frozenset[str] = frozenset(
     }
 )
 
+# Headers for which the scheme word (e.g. "Bearer") is preserved in redacted output.
+_SCHEME_PRESERVING_HEADERS: frozenset[str] = frozenset({"authorization", "proxy-authorization"})
+
 
 def redact_auth_header(headers: dict[str, str]) -> dict[str, str]:
     """Return a copy of *headers* with auth-bearing values replaced by ``***``.
@@ -122,12 +125,12 @@ def redact_auth_header(headers: dict[str, str]) -> dict[str, str]:
     """
     result: dict[str, str] = {}
     for key, value in headers.items():
-        if key.lower() in _SENSITIVE_HEADERS:
+        lower_key = key.lower()
+        if lower_key in _SENSITIVE_HEADERS:
             # Preserve the scheme word (e.g. "Bearer") for token-bearing headers
             # so the token type is still visible in debug logs.
             parts = value.split(" ", 1)
-            scheme_headers = {"authorization", "proxy-authorization"}
-            if len(parts) == 2 and key.lower() in scheme_headers:  # noqa: PLR2004
+            if len(parts) == 2 and lower_key in _SCHEME_PRESERVING_HEADERS:  # noqa: PLR2004
                 result[key] = f"{parts[0]} ***"
             else:
                 result[key] = "***"

--- a/src/fabric_dw/logging.py
+++ b/src/fabric_dw/logging.py
@@ -94,22 +94,43 @@ def setup_logging(level: int = logging.INFO) -> None:
     root.addHandler(handler)
 
 
-def redact_auth_header(headers: dict[str, str]) -> dict[str, str]:
-    """Return a copy of *headers* with the Bearer token replaced by ``***``.
+_SENSITIVE_HEADERS: frozenset[str] = frozenset(
+    {
+        "authorization",
+        "x-ms-authorization-auxiliary",
+        "proxy-authorization",
+        "cookie",
+    }
+)
 
-    Only the ``Authorization`` header is affected; the value is replaced with
-    ``Bearer ***`` when the original starts with ``Bearer `` (case-sensitive).
-    All other headers are copied as-is.
+
+def redact_auth_header(headers: dict[str, str]) -> dict[str, str]:
+    """Return a copy of *headers* with auth-bearing values replaced by ``***``.
+
+    Sensitive headers (``Authorization``, ``Proxy-Authorization``,
+    ``X-Ms-Authorization-Auxiliary``, ``Cookie``) are detected
+    case-insensitively.  For ``Authorization``/``Proxy-Authorization``,
+    the scheme word (e.g. ``Bearer``) is preserved so the token type is still
+    visible in logs: ``Bearer ***``.  Other sensitive headers are replaced
+    wholesale with ``***``.
 
     Args:
         headers: The original headers dict.  It is **not** mutated.
 
     Returns:
-        A new dict with the same keys; ``Authorization: Bearer <token>``
-        becomes ``Authorization: Bearer ***``.
+        A new dict with the same keys; sensitive credential values are redacted.
     """
-    result = dict(headers)
-    auth = result.get("Authorization", "")
-    if auth.startswith("Bearer "):
-        result["Authorization"] = "Bearer ***"
+    result: dict[str, str] = {}
+    for key, value in headers.items():
+        if key.lower() in _SENSITIVE_HEADERS:
+            # Preserve the scheme word (e.g. "Bearer") for token-bearing headers
+            # so the token type is still visible in debug logs.
+            parts = value.split(" ", 1)
+            scheme_headers = {"authorization", "proxy-authorization"}
+            if len(parts) == 2 and key.lower() in scheme_headers:  # noqa: PLR2004
+                result[key] = f"{parts[0]} ***"
+            else:
+                result[key] = "***"
+        else:
+            result[key] = value
     return result

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -1,5 +1,6 @@
 """Tests for fabric_dw.auth — written before implementation (TDD)."""
 
+import asyncio
 import threading
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -717,6 +718,58 @@ def test_get_sql_token_struct_raises_config_error_missing_client_id(
 
     with pytest.raises(ConfigError, match="AZURE_CLIENT_ID"):
         get_sql_token_struct()
+
+
+# ---------------------------------------------------------------------------
+# C01: cross-client SyncCredentialAdapter lock serialises concurrent get_token
+# ---------------------------------------------------------------------------
+
+
+async def test_sync_adapter_lock_serializes_concurrent_get_token_calls() -> None:
+    """Two concurrent adapter.get_token calls must not execute inner.get_token concurrently.
+
+    The per-adapter ``_get_token_lock`` must ensure that even when two separate
+    FabricHttpClient instances share the same SyncCredentialAdapter, their
+    concurrent token fetches are serialised and the underlying MSAL cache is
+    never mutated from two threads simultaneously.
+
+    We verify this by checking that the ``start`` events for the two concurrent
+    calls are never interleaved: the pattern must be start/end/start/end, NOT
+    start/start/end/end.
+    """
+    events: list[str] = []
+
+    async def slow_get_token(*_args: object, **_kwargs: object) -> AccessToken:
+        # Record that we have started; then yield control to allow another coroutine
+        # to run; then record that we have ended.
+        events.append("start")
+        # A small asyncio.sleep yields to the event loop.  If the adapter lock does
+        # NOT serialise, a second coroutine can enter here concurrently, appending
+        # a second "start" before any "end" is recorded.
+        await asyncio.sleep(0)
+        events.append("end")
+        return AccessToken("tok", 9999999999)
+
+    inner = MagicMock()
+    # Patch asyncio.to_thread so the "thread offload" runs as a coroutine in the
+    # same event loop — this makes the concurrency behaviour visible without
+    # spawning real threads.
+    adapter = SyncCredentialAdapter(inner)
+
+    with patch(
+        "fabric_dw.auth.asyncio.to_thread",
+        side_effect=slow_get_token,
+    ):
+        # Fire two concurrent get_token calls through the same adapter.
+        await asyncio.gather(
+            adapter.get_token(FABRIC_SCOPE),
+            adapter.get_token(FABRIC_SCOPE),
+        )
+
+    # With serialisation the events must be: start, end, start, end
+    assert events == ["start", "end", "start", "end"], (
+        f"Concurrent access detected — events were not serialised: {events}"
+    )
 
 
 def test_get_sql_token_struct_caches_credential_across_calls(

--- a/tests/unit/test_http_client.py
+++ b/tests/unit/test_http_client.py
@@ -16,6 +16,7 @@ from azure.core.credentials import AccessToken
 from azure.core.credentials_async import AsyncTokenCredential
 from freezegun import freeze_time
 
+from fabric_dw.auth import FABRIC_SCOPE, SQL_SCOPE
 from fabric_dw.exceptions import (
     AuthError,
     BadRequestError,
@@ -1356,3 +1357,148 @@ async def test_post_5xx_is_retried() -> None:
                 await client.request("POST", HttpBase.FABRIC, "/items", json={"x": 1})
 
     assert call_count == 3, f"POST 5xx must be retried 3 times (tenacity budget); got {call_count}"
+
+
+# ---------------------------------------------------------------------------
+# C04: poll_operation malformed Retry-After must not crash
+# ---------------------------------------------------------------------------
+
+
+async def test_poll_operation_malformed_retry_after_uses_fallback() -> None:
+    """poll_operation must survive a malformed Retry-After header (C04).
+
+    A garbage value must not propagate as an exception — _parse_retry_after
+    always returns a float (0.0 on failure), and poll_operation falls back to
+    poll_interval when it gets 0.0 from a non-null header.
+    """
+    poll_count = 0
+    sleep_durations: list[float] = []
+    original_sleep = asyncio.sleep
+
+    async def mock_sleep(seconds: float) -> None:
+        sleep_durations.append(seconds)
+        await original_sleep(0)
+
+    def side_effect(_request: httpx.Request) -> httpx.Response:
+        nonlocal poll_count
+        poll_count += 1
+        if poll_count == 1:
+            return httpx.Response(
+                202,
+                headers={"Retry-After": "not-a-date-or-number"},
+                json={"status": "Running"},
+            )
+        return httpx.Response(200, json={"status": "Succeeded"})
+
+    with respx.mock:
+        respx.get("https://api.fabric.microsoft.com/v1/operations/op-c04").mock(
+            side_effect=side_effect
+        )
+
+        client = FabricHttpClient(credential=_make_credential(), rps=10, poll_interval=0.5)
+        async with client:
+            with unittest.mock.patch("asyncio.sleep", side_effect=mock_sleep):
+                result = await client.poll_operation(
+                    "https://api.fabric.microsoft.com/v1/operations/op-c04"
+                )
+
+    assert result["status"] == "Succeeded"
+    # Must have slept once (falling back to poll_interval on malformed header)
+    assert len(sleep_durations) >= 1, f"Expected at least 1 sleep; got {sleep_durations}"
+    # The sleep duration should be around poll_interval (0.5 s), not 0.
+    assert all(d > 0 for d in sleep_durations), (
+        f"All sleeps must be positive (fallback to poll_interval); got {sleep_durations}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# C06: per-scope token cache
+# ---------------------------------------------------------------------------
+
+
+async def test_get_token_caches_per_scope() -> None:
+    """_get_token must maintain separate cache entries per scope (C06).
+
+    Fetching a token for FABRIC_SCOPE and then for SQL_SCOPE must produce
+    two separate get_token calls (one per scope), not reuse the FABRIC_SCOPE
+    token for the SQL request.
+    """
+    scopes_requested: list[str] = []
+
+    async def tracking_get_token(scope: str, *_: object, **__: object) -> AccessToken:
+        scopes_requested.append(scope)
+        return AccessToken(token=f"token-for-{scope}", expires_on=int(time.time()) + 3600)
+
+    cred = MagicMock(spec=AsyncTokenCredential)
+    cred.get_token = AsyncMock(side_effect=tracking_get_token)
+
+    client = FabricHttpClient(credential=cred, rps=10)
+    async with client:
+        tok_fabric = await client._get_token(FABRIC_SCOPE)  # type: ignore[attr-defined]
+        tok_sql = await client._get_token(SQL_SCOPE)  # type: ignore[attr-defined]
+        # Second call for each scope should be from cache (token not expired)
+        tok_fabric2 = await client._get_token(FABRIC_SCOPE)  # type: ignore[attr-defined]
+
+    assert tok_fabric == f"token-for-{FABRIC_SCOPE}"
+    assert tok_sql == f"token-for-{SQL_SCOPE}"
+    # Cache hit: third call must NOT trigger another credential fetch
+    assert tok_fabric2 == tok_fabric
+    assert scopes_requested.count(FABRIC_SCOPE) == 1, (
+        f"Expected 1 fetch for FABRIC_SCOPE; got {scopes_requested.count(FABRIC_SCOPE)}"
+    )
+    assert scopes_requested.count(SQL_SCOPE) == 1, (
+        f"Expected 1 fetch for SQL_SCOPE; got {scopes_requested.count(SQL_SCOPE)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# C16: iter_paginated non-dict page body is handled gracefully
+# ---------------------------------------------------------------------------
+
+
+async def test_iter_paginated_non_dict_page_does_not_crash() -> None:
+    """iter_paginated must not crash when a page body is not a dict (C16).
+
+    A list or null JSON body should produce zero items and stop pagination
+    cleanly, not crash with AttributeError on .get().
+    """
+    with respx.mock:
+        respx.get("https://api.fabric.microsoft.com/v1/items").mock(
+            return_value=httpx.Response(200, json=[{"id": "x"}, {"id": "y"}])
+        )
+
+        client = await _get_client()
+        async with client:
+            items = [item async for item in client.iter_paginated(HttpBase.FABRIC, "/items")]
+
+    # Non-dict body → no items yielded, no exception raised
+    assert items == [], f"Expected empty list for non-dict page; got {items}"
+
+
+# ---------------------------------------------------------------------------
+# C27: combined retry deadline bounds overall wait
+# ---------------------------------------------------------------------------
+
+
+async def test_combined_deadline_aborts_429_loop() -> None:
+    """A combined_deadline_s that has already elapsed must abort the 429-loop (C27).
+
+    Sets combined_deadline_s=0 so the deadline is immediately in the past.
+    The first iteration of _do_request must detect this and raise RateLimitedError
+    rather than entering the 429 retry loop at all.
+    """
+    with respx.mock:
+        # The route is registered but should never be hit because the deadline
+        # is already past before any request is made.
+        respx.get("https://api.fabric.microsoft.com/v1/items").mock(
+            return_value=httpx.Response(200, json={})
+        )
+
+        client = FabricHttpClient(
+            credential=_make_credential(),
+            rps=10,
+            combined_deadline_s=0,  # deadline already expired
+        )
+        async with client:
+            with pytest.raises(RateLimitedError, match="deadline"):
+                await client.request("GET", HttpBase.FABRIC, "/items")

--- a/tests/unit/test_http_client.py
+++ b/tests/unit/test_http_client.py
@@ -1502,3 +1502,98 @@ async def test_combined_deadline_aborts_429_loop() -> None:
         async with client:
             with pytest.raises(RateLimitedError, match="deadline"):
                 await client.request("GET", HttpBase.FABRIC, "/items")
+
+
+# ---------------------------------------------------------------------------
+# _parse_retry_after: negative value clamped to 0.0
+# ---------------------------------------------------------------------------
+
+
+def test_parse_retry_after_negative_clamped_to_zero() -> None:
+    """_parse_retry_after must clamp negative values to 0.0 (docstring guarantee).
+
+    'Retry-After: -1' is not a valid RFC 7231 value, but _parse_retry_after
+    promises always a non-negative float.  Before the fix, float('-1') = -1.0
+    was returned directly.
+    """
+    result = _parse_retry_after("-1")
+    assert result == 0.0, f"Expected 0.0 for negative Retry-After; got {result}"
+    result2 = _parse_retry_after("-100.5")
+    assert result2 == 0.0, f"Expected 0.0 for -100.5 Retry-After; got {result2}"
+
+
+# ---------------------------------------------------------------------------
+# Retry-After: 0.00 must NOT trigger spurious malformed-header warning
+# ---------------------------------------------------------------------------
+
+
+async def test_429_retry_after_zero_decimal_no_spurious_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Retry-After: 0.00 is a valid zero-second wait and must not emit a WARNING.
+
+    The old string-allowlist check ('0', '0.0') did not cover '0.00', '0.000', etc.,
+    causing a spurious 'Malformed Retry-After' warning and a 1.0s override even
+    though the server explicitly said to wait 0 seconds.
+    """
+    call_count = 0
+
+    def side_effect(_request: httpx.Request) -> httpx.Response:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return httpx.Response(429, headers={"Retry-After": "0.00"}, json={})
+        return httpx.Response(200, json={"ok": True})
+
+    with respx.mock:
+        respx.get("https://api.fabric.microsoft.com/v1/items").mock(side_effect=side_effect)
+
+        client = FabricHttpClient(credential=_make_credential(), rps=10)
+        async with client:
+            with caplog.at_level(logging.WARNING, logger="fabric_dw.http"):
+                resp = await client.request("GET", HttpBase.FABRIC, "/items")
+
+    assert resp.status_code == 200
+    assert call_count == 2
+    # Must not have emitted a 'Malformed' warning for '0.00'
+    malformed_warnings = [
+        r
+        for r in caplog.records
+        if r.levelno == logging.WARNING and "malformed" in r.getMessage().lower()
+    ]
+    assert malformed_warnings == [], (
+        f"Spurious malformed-header warning for Retry-After: 0.00 — got: "
+        f"{[r.getMessage() for r in malformed_warnings]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# C27: combined deadline applies to iter_paginated 429 loop
+# ---------------------------------------------------------------------------
+
+
+async def test_combined_deadline_aborts_paginated_429_loop() -> None:
+    """A combined_deadline_s=0 must abort the 429-loop inside iter_paginated (C27).
+
+    iter_paginated calls _request_with_retry directly.  Before the fix it passed
+    combined_deadline=None, making the 429 loop time-unbounded for pagination.
+    With the fix, iter_paginated sets its own combined_deadline from
+    _combined_deadline_s so the guard fires on the first iteration.
+    """
+    with respx.mock(assert_all_called=False) as mock_router:
+        # The route returns a 429 first; with combined_deadline_s=0 the deadline
+        # guard should fire before any request is made.
+        mock_router.get(url__regex=r"https://api\.fabric\.microsoft\.com/v1/items.*").mock(
+            return_value=httpx.Response(429, headers={"Retry-After": "10"}, json={})
+        )
+
+        client = FabricHttpClient(
+            credential=_make_credential(),
+            rps=10,
+            combined_deadline_s=0,  # deadline already expired
+        )
+        async with client:
+            with pytest.raises(RateLimitedError, match="deadline"):
+                # Exhaust the async generator — the first _request_with_retry call
+                # must raise RateLimitedError before returning any items.
+                _ = [item async for item in client.iter_paginated(HttpBase.FABRIC, "/items")]

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -67,11 +67,36 @@ class TestRedactAuthHeader:
         redact_auth_header(headers)
         assert headers == original
 
-    def test_non_bearer_authorization_header_preserved(self) -> None:
+    def test_non_bearer_authorization_scheme_redacted_with_scheme_preserved(self) -> None:
+        """Any Authorization scheme value is redacted; the scheme word is preserved."""
         headers = {"Authorization": "Basic dXNlcjpwYXNz"}
         result = redact_auth_header(headers)
-        # Non-bearer tokens are left as-is (only Bearer is a concern for this codebase)
-        assert result["Authorization"] == "Basic dXNlcjpwYXNz"
+        # C10: all Authorization values are redacted (not only Bearer); scheme preserved.
+        assert result["Authorization"] == "Basic ***"
+
+    def test_case_insensitive_authorization_redacted(self) -> None:
+        """redact_auth_header must handle Authorization regardless of key casing."""
+        headers = {"authorization": "bearer mytoken"}
+        result = redact_auth_header(headers)
+        assert result["authorization"] == "bearer ***"
+
+    def test_proxy_authorization_redacted(self) -> None:
+        """Proxy-Authorization is also a sensitive auth-bearing header."""
+        headers = {"Proxy-Authorization": "Bearer proxytoken"}
+        result = redact_auth_header(headers)
+        assert result["Proxy-Authorization"] == "Bearer ***"
+
+    def test_cookie_header_redacted(self) -> None:
+        """Cookie header is sensitive and must be replaced wholesale."""
+        headers = {"Cookie": "session=abc123; user=foo"}
+        result = redact_auth_header(headers)
+        assert result["Cookie"] == "***"
+
+    def test_x_ms_authorization_auxiliary_redacted(self) -> None:
+        """x-ms-authorization-auxiliary is an Azure auth header and must be redacted."""
+        headers = {"X-Ms-Authorization-Auxiliary": "Bearer auxtoken"}
+        result = redact_auth_header(headers)
+        assert result["X-Ms-Authorization-Auxiliary"] == "***"
 
 
 class TestJsonFormatterExtraFields:


### PR DESCRIPTION
## Summary

Addresses 13 code-review findings in `src/fabric_dw/http_client.py` (and related `auth.py` / `logging.py`).

| ID | How addressed |
|----|--------------|
| **C01** | Added `_get_token_lock: asyncio.Lock` per-credential inside `SyncCredentialAdapter` so concurrent `get_token` calls from multiple `FabricHttpClient` instances sharing the same credential are serialised at the credential level, not just within one client. |
| **C02** | Documented that `FabricHttpClient` does **not** own the credential lifecycle; credential may be shared across clients. Added docstring to module and class. |
| **C03** | Wrapped `parsedate_to_datetime` in `try/except (TypeError, ValueError)` with fallback to `0.0`. `_parse_retry_after` now always returns a non-negative float and never raises. |
| **C04** | Centralised fix in `_parse_retry_after` (C03 above) — `poll_operation` now benefits automatically because the helper can no longer raise. |
| **C06** | Token cache changed from `self._token: AccessToken | None` to `self._tokens: dict[str, AccessToken]`. `_get_token(scope)` is now parameterised; FABRIC_SCOPE and SQL_SCOPE tokens are cached independently. |
| **C10** | `redact_auth_header` in `logging.py` is now case-insensitive and covers `Authorization`, `Proxy-Authorization`, `X-Ms-Authorization-Auxiliary`, and `Cookie`. Scheme word (e.g. `Bearer`) is preserved for token-bearing headers. |
| **C13** | Removed module-global `ContextVar` (`_current_method`). Replaced with `_make_should_retry(method)` returning a closure that captures `method` at call time; passed to tenacity `retry_if_exception` inside `_request_with_retry`. |
| **C14** | The `_pause_until` read-modify-write has no `await` between read and write, making it effectively atomic on CPython's single-threaded event loop. Added an explanatory comment documenting this assumption. |
| **C15** | Introduced `_parse_json_body(resp)` helper that narrows to `(ValueError, json.JSONDecodeError)` and returns `dict | None`. All three JSON-parse call sites (`_map_status`, `get_operation_result`, `poll_operation`) now use it. |
| **C16** | `iter_paginated` guards `resp.json()` result with `isinstance(raw, dict)`; non-dict pages break cleanly with no items. |
| **C17** | `get_operation_result` and `poll_operation` now use `_parse_json_body` — `type: ignore` removed; non-dict bodies raise `FabricServerError`. |
| **C25** | `_parse_retry_after` removed from `__all__`. Still accessible by name for tests. |
| **C27** | Added `combined_deadline_s` parameter (default 120 s) threaded through `_request_with_retry` → `_do_request`. The deadline is checked at the top of the 429 loop, bounding the combined tenacity-5xx + 429-retry wall-clock wait. |

## New / updated tests

- `test_poll_operation_malformed_retry_after_uses_fallback` — C04
- `test_get_token_caches_per_scope` — C06
- `test_non_bearer_authorization_scheme_redacted_with_scheme_preserved`, `test_case_insensitive_authorization_redacted`, `test_proxy_authorization_redacted`, `test_cookie_header_redacted`, `test_x_ms_authorization_auxiliary_redacted` — C10
- `test_iter_paginated_non_dict_page_does_not_crash` — C16
- `test_combined_deadline_aborts_429_loop` — C27

## Test plan

- [x] `just check` fully green (2203 passed, 1 deselected, 2 pre-existing warnings)
- [x] All existing timing / 429 / LRO / pagination tests still pass
- [x] `_FakeClock`-based deterministic tests preserved and passing
- [ ] No integration tests run (per instructions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)