### PR TITLE
refactor(cli): dedupe helpers, clean dead code (L02/L06-L12/L15-L16/L18-L19/L21-L22)

### DIFF
--- a/src/fabric_dw/cli/_context.py
+++ b/src/fabric_dw/cli/_context.py
@@ -18,7 +18,6 @@ class CliContext:
     json_output: bool = False
     yes: bool = False
     auth: CredentialMode = field(default_factory=lambda: CredentialMode.DEFAULT)
-    verbose: bool = False
     _config: UserConfig | None = field(default=None, repr=False, compare=False)
 
     @property

--- a/src/fabric_dw/cli/_main.py
+++ b/src/fabric_dw/cli/_main.py
@@ -74,7 +74,6 @@ def cli(
         json_output=json_output,
         yes=yes,
         auth=CredentialMode(auth_mode),
-        verbose=verbose,
     )
 
 

--- a/src/fabric_dw/cli/_render.py
+++ b/src/fabric_dw/cli/_render.py
@@ -49,7 +49,7 @@ def render(
         data: The data to render. Supported shapes:
             - ``list[dict]`` → Rich Table (or JSON array).
             - ``dict`` → Rich Panel (or JSON object).
-            - primitives → ``repr()`` string (or JSON scalar).
+            - other → ``str()`` conversion via ``click.echo`` (or JSON scalar).
         json_output: When *True*, emit indented JSON via ``click.echo``.
             When *False*, use Rich for human-friendly output.
         console: Optional Rich Console instance. When *None* the module-level
@@ -68,7 +68,7 @@ def render(
     elif isinstance(data, dict):
         _render_panel({str(k): v for k, v in data.items()}, console=con, title=table_title)
     else:
-        click.echo(repr(data))
+        click.echo(str(data))
 
 
 def _cell(value: object) -> str:
@@ -80,6 +80,21 @@ def _cell(value: object) -> str:
     if value is None:
         return "[dim]NULL[/dim]"
     return str(value)
+
+
+def _column_is_all_null(col: str, norm_rows: list[dict[str, object] | object]) -> bool:
+    """Return *True* when every dict-row in *norm_rows* has a ``None`` value for *col*.
+
+    Non-dict rows (scalars) are never considered to "have" a value for any
+    column, so they are skipped.  A column is kept as soon as one dict-row
+    provides a non-``None`` value.
+    """
+    for row in norm_rows:
+        if not isinstance(row, dict):
+            continue
+        if row.get(col) is not None:
+            return False
+    return True
 
 
 def _render_table(rows: Sequence[object], *, console: Console, title: str | None) -> None:
@@ -115,14 +130,7 @@ def _render_table(rows: Sequence[object], *, console: Console, title: str | None
     # Drop columns where every dict-row's value is None (or the key is absent).
     # Non-dict rows (scalars) are never counted as "having" any column value, so
     # a column is only kept if at least one dict-row provides a non-None value.
-    all_null: set[str] = {
-        col
-        for col in columns
-        if all(
-            (isinstance(r, dict) and r.get(col) is None) or not isinstance(r, dict)
-            for r in norm_rows
-        )
-    }
+    all_null = {col for col in columns if _column_is_all_null(col, norm_rows)}
     visible_columns = [col for col in columns if col not in all_null]
 
     for col in visible_columns:
@@ -170,7 +178,7 @@ def render_permissions_table(
         )
         return
 
-    con = console or Console()
+    con = console if console is not None else _DEFAULT_CONSOLE
     table = Table(title=title, show_header=True, header_style="bold")
     table.add_column("Display Name", no_wrap=True)
     table.add_column("UPN / App ID")
@@ -194,7 +202,7 @@ def render_refresh_table(
     statuses: list[TableSyncStatus], *, console: Console | None = None
 ) -> None:
     """Render a list of :class:`~fabric_dw.models.TableSyncStatus` as a Rich table."""
-    con = console or Console()
+    con = console if console is not None else _DEFAULT_CONSOLE
     table = Table(title="Metadata Refresh Results", show_header=True, header_style="bold")
     table.add_column("Table", no_wrap=True)
     table.add_column("Status")

--- a/src/fabric_dw/cli/commands/_utils.py
+++ b/src/fabric_dw/cli/commands/_utils.py
@@ -58,10 +58,6 @@ def coro(f: Callable[_P, Coroutine[None, None, _R]]) -> Callable[_P, _R]:
     return wrapper
 
 
-# Private alias kept for backward compatibility with existing imports.
-_coro = coro
-
-
 # ---------------------------------------------------------------------------
 # HTTP client context manager
 # ---------------------------------------------------------------------------
@@ -134,11 +130,6 @@ async def resolve_workspace_id(http: FabricHttpClient, workspace: str) -> UUID:
     return await resolver.workspace_id(workspace)
 
 
-# Private aliases kept for backward compatibility with existing imports.
-_resolve_item = resolve_item
-_resolve_item_with_cache = resolve_item_with_cache
-
-
 # ---------------------------------------------------------------------------
 # SqlTarget builder
 # ---------------------------------------------------------------------------
@@ -189,22 +180,34 @@ def parse_qualified_name(qualified_name: str, *, kind: str = "object") -> tuple[
         raise click.UsageError(f"Expected <schema>.{kind}, got {qualified_name!r}") from None
 
 
-def load_select_body(select: str | None, from_file: str | None) -> str:
-    """Return the SELECT body from the inline option or file option.
+def load_sql_body(
+    inline: str | None,
+    from_file: str | None,
+    *,
+    inline_opt: str = "--select",
+    file_opt: str = "--from-file",
+) -> str:
+    """Return the SQL body from the inline option or file option.
+
+    Args:
+        inline: The inline SQL text (e.g. from ``--select`` or ``--body``).
+        from_file: Path to a ``.sql`` file.
+        inline_opt: Name of the inline option used in error messages.
+        file_opt: Name of the file option used in error messages.
 
     Raises:
         click.UsageError: If neither or both are provided, or file is missing.
     """
-    if select and from_file:
-        raise click.UsageError("Provide either --select or --from-file, not both.")
+    if inline and from_file:
+        raise click.UsageError(f"Provide either {inline_opt} or {file_opt}, not both.")
     if from_file:
         path = Path(from_file)
         if not path.is_file():
             raise click.UsageError(f"File not found: {from_file}")
         return path.read_text(encoding="utf-8-sig").strip()
-    if select:
-        return select
-    raise click.UsageError("Provide --select or --from-file.")
+    if inline:
+        return inline
+    raise click.UsageError(f"Provide {inline_opt} or {file_opt}.")
 
 
 # ---------------------------------------------------------------------------
@@ -241,6 +244,46 @@ def parse_iso_datetime(value: str, param_name: str, *, assume_utc: bool = True) 
             "(2000-2100). Check the timestamp."
         )
     return dt
+
+
+def parse_iso_optional(value: str | None, param_name: str) -> datetime | None:
+    """Parse an optional ISO-8601 string; return *None* when *value* is *None*.
+
+    Convenience wrapper used by ``queries`` and ``sql-pools insights`` commands
+    for ``--since``/``--until`` options.
+
+    Raises:
+        click.UsageError: If *value* is set but is not a valid ISO-8601 string.
+    """
+    if value is None:
+        return None
+    return parse_iso_datetime(value, param_name, assume_utc=False)
+
+
+#: Shared Click option for ``--limit`` used by query-insights commands.
+LIMIT_OPTION = click.option(
+    "--limit",
+    default=100,
+    show_default=True,
+    type=click.IntRange(1, 10_000),
+    help="Maximum number of rows to return (1-10 000).",
+)
+
+#: Shared Click option for ``--since`` used by query-insights commands.
+SINCE_OPTION = click.option(
+    "--since",
+    default=None,
+    metavar="ISO8601",
+    help="Return rows with timestamp >= this value (ISO-8601).",
+)
+
+#: Shared Click option for ``--until`` used by query-insights commands.
+UNTIL_OPTION = click.option(
+    "--until",
+    default=None,
+    metavar="ISO8601",
+    help="Return rows with timestamp <= this value (ISO-8601).",
+)
 
 
 # ---------------------------------------------------------------------------

--- a/src/fabric_dw/cli/commands/audit.py
+++ b/src/fabric_dw/cli/commands/audit.py
@@ -2,23 +2,19 @@
 
 from __future__ import annotations
 
-import logging
-
 import click
 
 from fabric_dw.cli._context import CliContext
 from fabric_dw.cli._render import confirm, render
 from fabric_dw.cli.commands._utils import (
-    _coro,
-    _resolve_item,
     build_http_client,
+    coro,
+    resolve_item,
     resolve_warehouse_arg,
     resolve_workspace_arg,
 )
 from fabric_dw.exceptions import FabricError
 from fabric_dw.services import audit as _audit_svc
-
-_log = logging.getLogger(__name__)
 
 
 @click.group("audit")
@@ -30,14 +26,14 @@ def audit_group() -> None:
 @click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.pass_obj
-@_coro
+@coro
 async def get_cmd(ctx: CliContext, workspace: str | None, item: str | None) -> None:
     """Get the current audit settings for ITEM (warehouse) in WORKSPACE."""
     ws = resolve_workspace_arg(ctx, workspace)
     wh = resolve_warehouse_arg(ctx, item)
     try:
         async with build_http_client(ctx) as http:
-            ws_id, entry = await _resolve_item(http, ws, wh)
+            ws_id, entry = await resolve_item(http, ws, wh)
             obj = await _audit_svc.get_settings(http, ws_id, entry.id)
             render(obj.model_dump(by_alias=True, mode="json"), json_output=ctx.json_output)
     except (ValueError, FabricError) as exc:
@@ -63,7 +59,7 @@ async def get_cmd(ctx: CliContext, workspace: str | None, item: str | None) -> N
     "Mutually exclusive with --retention-days.",
 )
 @click.pass_obj
-@_coro
+@coro
 async def enable_cmd(
     ctx: CliContext,
     workspace: str | None,
@@ -91,7 +87,7 @@ async def enable_cmd(
     wh = resolve_warehouse_arg(ctx, item)
     try:
         async with build_http_client(ctx) as http:
-            ws_id, entry = await _resolve_item(http, ws, wh)
+            ws_id, entry = await resolve_item(http, ws, wh)
             obj = await _audit_svc.enable(http, ws_id, entry.id, retention_days=effective_days)
             render(obj.model_dump(by_alias=True, mode="json"), json_output=ctx.json_output)
     except (ValueError, FabricError) as exc:
@@ -102,14 +98,14 @@ async def enable_cmd(
 @click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.pass_obj
-@_coro
+@coro
 async def disable_cmd(ctx: CliContext, workspace: str | None, item: str | None) -> None:
     """Disable SQL auditing on ITEM (warehouse) in WORKSPACE."""
     ws = resolve_workspace_arg(ctx, workspace)
     wh = resolve_warehouse_arg(ctx, item)
     try:
         async with build_http_client(ctx) as http:
-            ws_id, entry = await _resolve_item(http, ws, wh)
+            ws_id, entry = await resolve_item(http, ws, wh)
             confirmed = confirm(
                 f"Disable auditing on warehouse {entry.display_name!r} ({entry.id})?",
                 yes=ctx.yes,
@@ -133,7 +129,7 @@ async def disable_cmd(ctx: CliContext, workspace: str | None, item: str | None) 
     help="Retention period in days (>= 1). Does not change the audit enabled/disabled state.",
 )
 @click.pass_obj
-@_coro
+@coro
 async def set_retention_cmd(
     ctx: CliContext,
     workspace: str | None,
@@ -149,7 +145,7 @@ async def set_retention_cmd(
     wh = resolve_warehouse_arg(ctx, item)
     try:
         async with build_http_client(ctx) as http:
-            ws_id, entry = await _resolve_item(http, ws, wh)
+            ws_id, entry = await resolve_item(http, ws, wh)
             obj = await _audit_svc.set_retention(http, ws_id, entry.id, days=days)
             render(obj.model_dump(by_alias=True, mode="json"), json_output=ctx.json_output)
     except (ValueError, FabricError) as exc:
@@ -168,7 +164,7 @@ async def set_retention_cmd(
     help="Audit action group name (repeat for multiple).",
 )
 @click.pass_obj
-@_coro
+@coro
 async def set_groups_cmd(
     ctx: CliContext, workspace: str | None, item: str | None, groups: tuple[str, ...]
 ) -> None:
@@ -181,7 +177,7 @@ async def set_groups_cmd(
     wh = resolve_warehouse_arg(ctx, item)
     try:
         async with build_http_client(ctx) as http:
-            ws_id, entry = await _resolve_item(http, ws, wh)
+            ws_id, entry = await resolve_item(http, ws, wh)
             obj = await _audit_svc.set_action_groups(http, ws_id, entry.id, list(groups))
             render(obj.model_dump(by_alias=True, mode="json"), json_output=ctx.json_output)
     except (ValueError, FabricError) as exc:
@@ -193,7 +189,7 @@ async def set_groups_cmd(
 @click.argument("item", required=False, default=None)
 @click.argument("group")
 @click.pass_obj
-@_coro
+@coro
 async def add_group_cmd(
     ctx: CliContext, workspace: str | None, item: str | None, group: str
 ) -> None:
@@ -206,7 +202,7 @@ async def add_group_cmd(
     wh = resolve_warehouse_arg(ctx, item)
     try:
         async with build_http_client(ctx) as http:
-            ws_id, entry = await _resolve_item(http, ws, wh)
+            ws_id, entry = await resolve_item(http, ws, wh)
             obj = await _audit_svc.add_action_group(http, ws_id, entry.id, group)
             render(obj.model_dump(by_alias=True, mode="json"), json_output=ctx.json_output)
     except (ValueError, FabricError) as exc:
@@ -218,7 +214,7 @@ async def add_group_cmd(
 @click.argument("item", required=False, default=None)
 @click.argument("group")
 @click.pass_obj
-@_coro
+@coro
 async def remove_group_cmd(
     ctx: CliContext, workspace: str | None, item: str | None, group: str
 ) -> None:
@@ -231,7 +227,7 @@ async def remove_group_cmd(
     wh = resolve_warehouse_arg(ctx, item)
     try:
         async with build_http_client(ctx) as http:
-            ws_id, entry = await _resolve_item(http, ws, wh)
+            ws_id, entry = await resolve_item(http, ws, wh)
             obj = await _audit_svc.remove_action_group(http, ws_id, entry.id, group)
             render(obj.model_dump(by_alias=True, mode="json"), json_output=ctx.json_output)
     except (ValueError, FabricError) as exc:

--- a/src/fabric_dw/cli/commands/completion.py
+++ b/src/fabric_dw/cli/commands/completion.py
@@ -103,6 +103,14 @@ def _append_idempotent(path: Path, script: str) -> None:
     Uses ``# >>> fabric-dw completion >>>`` / ``# <<< fabric-dw completion <<<``
     sentinel markers so the block is replaced rather than duplicated when the
     completion script changes (e.g. after a version upgrade).
+
+    **Lone-end-marker edge case:** if the rc-file contains ``_SENTINEL_END``
+    but *not* ``_SENTINEL_START`` (e.g. the file was manually edited and the
+    start marker was deleted), the ``_SENTINEL_START in existing`` guard is
+    ``False``, so the new block is appended normally.  The result is a file
+    with an orphaned end marker above the newly-written sentinel-wrapped block.
+    This is functionally safe — the next ``install`` run will find the new
+    ``_SENTINEL_START`` and replace the block correctly.
     """
     block = f"\n{_SENTINEL_START}\n{script.strip()}\n{_SENTINEL_END}\n"
     existing = path.read_text() if path.exists() else ""

--- a/src/fabric_dw/cli/commands/completion.py
+++ b/src/fabric_dw/cli/commands/completion.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import click
@@ -28,6 +29,12 @@ _SHELL_INSTALL_MAP: dict[str, tuple[str, str]] = {
     "zsh": (".zshrc", "append"),
     "fish": (".config/fish/completions/fabric-dw.fish", "write"),
 }
+
+# Stable sentinel markers used to bracket the managed completion block inside
+# rc-files (e.g. ~/.bashrc).  The block is replaced (not duplicated) on
+# re-install even when the completion script changes between versions.
+_SENTINEL_START = "# >>> fabric-dw completion >>>"
+_SENTINEL_END = "# <<< fabric-dw completion <<<"
 
 
 def _completion_script(shell: str) -> str:
@@ -84,7 +91,6 @@ def install(shell: str, print_only: bool) -> None:
 
     if mode == "append":
         _append_idempotent(target, script)
-        click.echo(f"Completion script appended to {target}. Reload with: source {target}")
     else:  # "write"
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_text(script)
@@ -92,11 +98,26 @@ def install(shell: str, print_only: bool) -> None:
 
 
 def _append_idempotent(path: Path, script: str) -> None:
-    """Append *script* to *path* only if the script is not already present."""
+    """Append *script* to *path*, replacing any previous fabric-dw block.
+
+    Uses ``# >>> fabric-dw completion >>>`` / ``# <<< fabric-dw completion <<<``
+    sentinel markers so the block is replaced rather than duplicated when the
+    completion script changes (e.g. after a version upgrade).
+    """
+    block = f"\n{_SENTINEL_START}\n{script.strip()}\n{_SENTINEL_END}\n"
     existing = path.read_text() if path.exists() else ""
-    marker = script.strip()
-    if marker and marker in existing:
-        click.echo(f"Completion script already present in {path}. Nothing to do.")
-        return
-    with path.open("a") as fh:
-        fh.write("\n" + script)
+
+    if _SENTINEL_START in existing:
+        # Replace the existing managed block in-place.
+        new_content = re.sub(
+            rf"{re.escape(_SENTINEL_START)}.*?{re.escape(_SENTINEL_END)}",
+            block.strip(),
+            existing,
+            flags=re.DOTALL,
+        )
+        path.write_text(new_content)
+        click.echo(f"Completion script updated in {path}. Reload with: source {path}")
+    else:
+        with path.open("a") as fh:
+            fh.write(block)
+        click.echo(f"Completion script appended to {path}. Reload with: source {path}")

--- a/src/fabric_dw/cli/commands/procedures.py
+++ b/src/fabric_dw/cli/commands/procedures.py
@@ -2,26 +2,22 @@
 
 from __future__ import annotations
 
-import logging
-
 import click
 
 from fabric_dw.cli._context import CliContext
 from fabric_dw.cli._render import confirm, render
 from fabric_dw.cli.commands._utils import (
-    _coro,
     build_http_client,
     build_sql_target,
     confirm_destructive,
-    load_select_body,
+    coro,
+    load_sql_body,
     parse_qualified_name,
     resolve_warehouse_arg,
     resolve_workspace_arg,
 )
 from fabric_dw.exceptions import FabricError
 from fabric_dw.services import procedures as _procs_svc
-
-_log = logging.getLogger(__name__)
 
 
 @click.group("procedures")
@@ -34,7 +30,7 @@ def procedures_group() -> None:
 @click.argument("item", required=False, default=None)
 @click.option("--schema", default=None, help="Filter by schema name.")
 @click.pass_obj
-@_coro
+@coro
 async def list_cmd(
     ctx: CliContext, workspace: str | None, item: str | None, schema: str | None
 ) -> None:
@@ -59,7 +55,7 @@ async def list_cmd(
 @click.argument("item", required=False, default=None)
 @click.argument("qualified_name")
 @click.pass_obj
-@_coro
+@coro
 async def get_cmd(
     ctx: CliContext,
     workspace: str | None,
@@ -88,7 +84,7 @@ async def get_cmd(
     "--from-file", default=None, help="Path to a .sql file containing the procedure body."
 )
 @click.pass_obj
-@_coro
+@coro
 async def create_cmd(
     ctx: CliContext,
     workspace: str | None,
@@ -101,7 +97,7 @@ async def create_cmd(
     ws = resolve_workspace_arg(ctx, workspace)
     wh = resolve_warehouse_arg(ctx, item)
     schema, proc_name = parse_qualified_name(qualified_name, kind="procedure")
-    proc_body = load_select_body(body, from_file)
+    proc_body = load_sql_body(body, from_file, inline_opt="--body")
     try:
         async with build_http_client(ctx) as http:
             target, _entry = await build_sql_target(http, ws, wh)
@@ -122,7 +118,7 @@ async def create_cmd(
     "--from-file", default=None, help="Path to a .sql file containing the procedure body."
 )
 @click.pass_obj
-@_coro
+@coro
 async def update_cmd(
     ctx: CliContext,
     workspace: str | None,
@@ -135,7 +131,7 @@ async def update_cmd(
     ws = resolve_workspace_arg(ctx, workspace)
     wh = resolve_warehouse_arg(ctx, item)
     schema, proc_name = parse_qualified_name(qualified_name, kind="procedure")
-    proc_body = load_select_body(body, from_file)
+    proc_body = load_sql_body(body, from_file, inline_opt="--body")
     try:
         async with build_http_client(ctx) as http:
             target, entry = await build_sql_target(http, ws, wh)
@@ -159,7 +155,7 @@ async def update_cmd(
 @click.argument("item", required=False, default=None)
 @click.argument("qualified_name")
 @click.pass_obj
-@_coro
+@coro
 async def drop_cmd(
     ctx: CliContext,
     workspace: str | None,

--- a/src/fabric_dw/cli/commands/queries.py
+++ b/src/fabric_dw/cli/commands/queries.py
@@ -2,55 +2,25 @@
 
 from __future__ import annotations
 
-import logging
-from datetime import datetime
-
 import click
 
 from fabric_dw.cli._context import CliContext
 from fabric_dw.cli._render import render
 from fabric_dw.cli.commands._utils import (
-    _coro,
+    LIMIT_OPTION,
+    SINCE_OPTION,
+    UNTIL_OPTION,
     build_http_client,
     build_sql_target,
     confirm_destructive,
-    parse_iso_datetime,
+    coro,
+    parse_iso_optional,
     resolve_warehouse_arg,
     resolve_workspace_arg,
 )
 from fabric_dw.exceptions import FabricError
 from fabric_dw.services import queries as _queries_svc
 from fabric_dw.services import query_insights as _qi_svc
-
-_log = logging.getLogger(__name__)
-
-
-def _parse_iso(value: str | None, param_name: str) -> datetime | None:
-    """Parse an optional ISO-8601 string; raise UsageError on bad input."""
-    if value is None:
-        return None
-    return parse_iso_datetime(value, param_name, assume_utc=False)
-
-
-_LIMIT_OPTION = click.option(
-    "--limit",
-    default=100,
-    show_default=True,
-    type=click.IntRange(1, 10_000),
-    help="Maximum number of rows to return (1-10 000).",
-)
-_SINCE_OPTION = click.option(
-    "--since",
-    default=None,
-    metavar="ISO8601",
-    help="Return rows with timestamp >= this value (ISO-8601).",
-)
-_UNTIL_OPTION = click.option(
-    "--until",
-    default=None,
-    metavar="ISO8601",
-    help="Return rows with timestamp <= this value (ISO-8601).",
-)
 
 
 @click.group("queries")
@@ -62,7 +32,7 @@ def queries_group() -> None:
 @click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.pass_obj
-@_coro
+@coro
 async def list_cmd(ctx: CliContext, workspace: str | None, item: str | None) -> None:
     """List currently running queries on ITEM (warehouse or endpoint) in WORKSPACE."""
     ws = resolve_workspace_arg(ctx, workspace)
@@ -84,7 +54,7 @@ async def list_cmd(ctx: CliContext, workspace: str | None, item: str | None) -> 
 @click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.pass_obj
-@_coro
+@coro
 async def list_connections_cmd(ctx: CliContext, workspace: str | None, item: str | None) -> None:
     """List active SQL connections on ITEM (warehouse or endpoint) in WORKSPACE."""
     ws = resolve_workspace_arg(ctx, workspace)
@@ -107,7 +77,7 @@ async def list_connections_cmd(ctx: CliContext, workspace: str | None, item: str
 @click.argument("item", required=False, default=None)
 @click.argument("session_id", type=int)
 @click.pass_obj
-@_coro
+@coro
 async def kill_cmd(
     ctx: CliContext, workspace: str | None, item: str | None, session_id: int
 ) -> None:
@@ -140,11 +110,11 @@ async def kill_cmd(
 @queries_group.command("request-history")
 @click.argument("workspace", required=False, default=None)
 @click.argument("warehouse", required=False, default=None)
-@_LIMIT_OPTION
-@_SINCE_OPTION
-@_UNTIL_OPTION
+@LIMIT_OPTION
+@SINCE_OPTION
+@UNTIL_OPTION
 @click.pass_obj
-@_coro
+@coro
 async def request_history_cmd(
     ctx: CliContext,
     workspace: str | None,
@@ -156,8 +126,8 @@ async def request_history_cmd(
     """List completed SQL requests from queryinsights.exec_requests_history."""
     ws = resolve_workspace_arg(ctx, workspace)
     wh = resolve_warehouse_arg(ctx, warehouse)
-    since_dt = _parse_iso(since, "--since")
-    until_dt = _parse_iso(until, "--until")
+    since_dt = parse_iso_optional(since, "--since")
+    until_dt = parse_iso_optional(until, "--until")
     try:
         async with build_http_client(ctx) as http:
             target, _ = await build_sql_target(http, ws, wh)
@@ -181,11 +151,11 @@ async def request_history_cmd(
 @queries_group.command("session-history")
 @click.argument("workspace", required=False, default=None)
 @click.argument("warehouse", required=False, default=None)
-@_LIMIT_OPTION
-@_SINCE_OPTION
-@_UNTIL_OPTION
+@LIMIT_OPTION
+@SINCE_OPTION
+@UNTIL_OPTION
 @click.pass_obj
-@_coro
+@coro
 async def session_history_cmd(
     ctx: CliContext,
     workspace: str | None,
@@ -197,8 +167,8 @@ async def session_history_cmd(
     """List completed sessions from queryinsights.exec_sessions_history."""
     ws = resolve_workspace_arg(ctx, workspace)
     wh = resolve_warehouse_arg(ctx, warehouse)
-    since_dt = _parse_iso(since, "--since")
-    until_dt = _parse_iso(until, "--until")
+    since_dt = parse_iso_optional(since, "--since")
+    until_dt = parse_iso_optional(until, "--until")
     try:
         async with build_http_client(ctx) as http:
             target, _ = await build_sql_target(http, ws, wh)
@@ -222,11 +192,11 @@ async def session_history_cmd(
 @queries_group.command("frequent")
 @click.argument("workspace", required=False, default=None)
 @click.argument("warehouse", required=False, default=None)
-@_LIMIT_OPTION
-@_SINCE_OPTION
-@_UNTIL_OPTION
+@LIMIT_OPTION
+@SINCE_OPTION
+@UNTIL_OPTION
 @click.pass_obj
-@_coro
+@coro
 async def frequent_cmd(
     ctx: CliContext,
     workspace: str | None,
@@ -238,8 +208,8 @@ async def frequent_cmd(
     """List frequently-run queries from queryinsights.frequently_run_queries."""
     ws = resolve_workspace_arg(ctx, workspace)
     wh = resolve_warehouse_arg(ctx, warehouse)
-    since_dt = _parse_iso(since, "--since")
-    until_dt = _parse_iso(until, "--until")
+    since_dt = parse_iso_optional(since, "--since")
+    until_dt = parse_iso_optional(until, "--until")
     try:
         async with build_http_client(ctx) as http:
             target, _ = await build_sql_target(http, ws, wh)
@@ -263,11 +233,11 @@ async def frequent_cmd(
 @queries_group.command("long-running")
 @click.argument("workspace", required=False, default=None)
 @click.argument("warehouse", required=False, default=None)
-@_LIMIT_OPTION
-@_SINCE_OPTION
-@_UNTIL_OPTION
+@LIMIT_OPTION
+@SINCE_OPTION
+@UNTIL_OPTION
 @click.pass_obj
-@_coro
+@coro
 async def long_running_cmd(
     ctx: CliContext,
     workspace: str | None,
@@ -279,8 +249,8 @@ async def long_running_cmd(
     """List long-running queries from queryinsights.long_running_queries."""
     ws = resolve_workspace_arg(ctx, workspace)
     wh = resolve_warehouse_arg(ctx, warehouse)
-    since_dt = _parse_iso(since, "--since")
-    until_dt = _parse_iso(until, "--until")
+    since_dt = parse_iso_optional(since, "--since")
+    until_dt = parse_iso_optional(until, "--until")
     try:
         async with build_http_client(ctx) as http:
             target, _ = await build_sql_target(http, ws, wh)

--- a/src/fabric_dw/cli/commands/restore_points.py
+++ b/src/fabric_dw/cli/commands/restore_points.py
@@ -2,24 +2,20 @@
 
 from __future__ import annotations
 
-import logging
-
 import click
 
 from fabric_dw.cli._context import CliContext
 from fabric_dw.cli._render import render
 from fabric_dw.cli.commands._utils import (
-    _coro,
     build_http_client,
     confirm_destructive,
+    coro,
     resolve_item,
     resolve_warehouse_arg,
     resolve_workspace_arg,
 )
 from fabric_dw.exceptions import FabricError
 from fabric_dw.services import restore as _restore_svc
-
-_log = logging.getLogger(__name__)
 
 
 @click.group("restore-points")
@@ -31,7 +27,7 @@ def restore_points_group() -> None:
 @click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.pass_obj
-@_coro
+@coro
 async def list_cmd(ctx: CliContext, workspace: str | None, item: str | None) -> None:
     """List all restore points for ITEM (warehouse) in WORKSPACE."""
     ws = resolve_workspace_arg(ctx, workspace)
@@ -55,7 +51,7 @@ async def list_cmd(ctx: CliContext, workspace: str | None, item: str | None) -> 
 @click.argument("item", required=False, default=None)
 @click.argument("restore_point_id")
 @click.pass_obj
-@_coro
+@coro
 async def get_cmd(
     ctx: CliContext,
     workspace: str | None,
@@ -81,7 +77,7 @@ async def get_cmd(
 @click.option("--name", default=None, help="Optional display name (max 128 chars).")
 @click.option("--description", default=None, help="Optional description (max 512 chars).")
 @click.pass_obj
-@_coro
+@coro
 async def create_cmd(
     ctx: CliContext,
     workspace: str | None,
@@ -111,7 +107,7 @@ async def create_cmd(
 @click.argument("new_name")
 @click.option("--description", default=None, help="Optional new description.")
 @click.pass_obj
-@_coro
+@coro
 async def rename_cmd(
     ctx: CliContext,
     workspace: str | None,
@@ -145,7 +141,7 @@ async def rename_cmd(
 @click.argument("item", required=False, default=None)
 @click.argument("restore_point_id")
 @click.pass_obj
-@_coro
+@coro
 async def delete_cmd(
     ctx: CliContext,
     workspace: str | None,
@@ -185,7 +181,7 @@ async def delete_cmd(
 @click.argument("item", required=False, default=None)
 @click.argument("restore_point_id")
 @click.pass_obj
-@_coro
+@coro
 async def restore_cmd(
     ctx: CliContext,
     workspace: str | None,

--- a/src/fabric_dw/cli/commands/schemas.py
+++ b/src/fabric_dw/cli/commands/schemas.py
@@ -2,24 +2,20 @@
 
 from __future__ import annotations
 
-import logging
-
 import click
 
 from fabric_dw.cli._context import CliContext
 from fabric_dw.cli._render import render
 from fabric_dw.cli.commands._utils import (
-    _coro,
     build_http_client,
     build_sql_target,
     confirm_destructive,
+    coro,
     resolve_warehouse_arg,
     resolve_workspace_arg,
 )
 from fabric_dw.exceptions import FabricError
 from fabric_dw.services import schemas as _schemas_svc
-
-_log = logging.getLogger(__name__)
 
 
 @click.group("schemas")
@@ -31,7 +27,7 @@ def schemas_group() -> None:
 @click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.pass_obj
-@_coro
+@coro
 async def list_cmd(ctx: CliContext, workspace: str | None, item: str | None) -> None:
     """List user-defined schemas on ITEM (warehouse) in WORKSPACE."""
     ws = resolve_workspace_arg(ctx, workspace)
@@ -54,7 +50,7 @@ async def list_cmd(ctx: CliContext, workspace: str | None, item: str | None) -> 
 @click.argument("item", required=False, default=None)
 @click.argument("name")
 @click.pass_obj
-@_coro
+@coro
 async def create_cmd(
     ctx: CliContext,
     workspace: str | None,
@@ -87,7 +83,7 @@ async def create_cmd(
     ),
 )
 @click.pass_obj
-@_coro
+@coro
 async def delete_cmd(
     ctx: CliContext,
     workspace: str | None,

--- a/src/fabric_dw/cli/commands/snapshots.py
+++ b/src/fabric_dw/cli/commands/snapshots.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from datetime import datetime
 
 import click
@@ -10,20 +9,18 @@ import click
 from fabric_dw.cli._context import CliContext
 from fabric_dw.cli._render import render
 from fabric_dw.cli.commands._utils import (
-    _coro,
-    _resolve_item,
-    _resolve_item_with_cache,
     build_http_client,
     build_sql_target,
     confirm_destructive,
+    coro,
     parse_iso_datetime,
+    resolve_item,
+    resolve_item_with_cache,
     resolve_warehouse_arg,
     resolve_workspace_arg,
 )
 from fabric_dw.exceptions import FabricError
 from fabric_dw.services import snapshots as _snapshots_svc
-
-_log = logging.getLogger(__name__)
 
 
 @click.group("snapshots")
@@ -35,14 +32,14 @@ def snapshots_group() -> None:
 @click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.pass_obj
-@_coro
+@coro
 async def list_cmd(ctx: CliContext, workspace: str | None, item: str | None) -> None:
     """List all snapshots for ITEM (warehouse) in WORKSPACE."""
     ws = resolve_workspace_arg(ctx, workspace)
     wh = resolve_warehouse_arg(ctx, item)
     try:
         async with build_http_client(ctx) as http:
-            ws_id, entry = await _resolve_item(http, ws, wh)
+            ws_id, entry = await resolve_item(http, ws, wh)
             items = await _snapshots_svc.list_snapshots(http, ws_id, entry.id)
             render(
                 [s.model_dump(by_alias=True, mode="json") for s in items],
@@ -64,7 +61,7 @@ async def list_cmd(ctx: CliContext, workspace: str | None, item: str | None) -> 
     help="Optional snapshot datetime (ISO 8601, UTC).",
 )
 @click.pass_obj
-@_coro
+@coro
 async def create_cmd(
     ctx: CliContext,
     workspace: str | None,
@@ -82,7 +79,7 @@ async def create_cmd(
 
     try:
         async with build_http_client(ctx) as http:
-            ws_id, entry = await _resolve_item(http, ws, wh)
+            ws_id, entry = await resolve_item(http, ws, wh)
             obj = await _snapshots_svc.create(
                 http,
                 ws_id,
@@ -102,7 +99,7 @@ async def create_cmd(
 @click.argument("new_name")
 @click.option("--description", default=None, help="Optional new description.")
 @click.pass_obj
-@_coro
+@coro
 async def rename_cmd(
     ctx: CliContext,
     workspace: str,
@@ -113,7 +110,7 @@ async def rename_cmd(
     """Rename SNAPSHOT in WORKSPACE to NEW_NAME (workspace and snapshot accept name or GUID)."""
     try:
         async with build_http_client(ctx) as http:
-            ws_id, entry, cache = await _resolve_item_with_cache(http, workspace, snapshot)
+            ws_id, entry, cache = await resolve_item_with_cache(http, workspace, snapshot)
             obj = await _snapshots_svc.rename(
                 http,
                 ws_id,
@@ -132,12 +129,12 @@ async def rename_cmd(
 @click.argument("workspace")
 @click.argument("snapshot")
 @click.pass_obj
-@_coro
+@coro
 async def delete_cmd(ctx: CliContext, workspace: str, snapshot: str) -> None:
     """Delete SNAPSHOT from WORKSPACE (both accept name or GUID)."""
     try:
         async with build_http_client(ctx) as http:
-            ws_id, entry, cache = await _resolve_item_with_cache(http, workspace, snapshot)
+            ws_id, entry, cache = await resolve_item_with_cache(http, workspace, snapshot)
             if not confirm_destructive(
                 f"Delete snapshot {entry.display_name!r} ({entry.id})?",
                 yes=ctx.yes,
@@ -173,7 +170,7 @@ async def delete_cmd(ctx: CliContext, workspace: str, snapshot: str) -> None:
     help="Target datetime (ISO 8601, UTC). Defaults to CURRENT_TIMESTAMP.",
 )
 @click.pass_obj
-@_coro
+@coro
 async def roll_cmd(
     ctx: CliContext,
     workspace: str | None,

--- a/src/fabric_dw/cli/commands/sql.py
+++ b/src/fabric_dw/cli/commands/sql.py
@@ -7,27 +7,20 @@ Commands
 
 from __future__ import annotations
 
-import logging
-from pathlib import Path
-from typing import TYPE_CHECKING
-
 import click
 
+from fabric_dw.cli._context import CliContext
 from fabric_dw.cli._render import render
 from fabric_dw.cli.commands._utils import (
-    _coro,
     build_http_client,
     build_sql_target,
+    coro,
+    load_sql_body,
     resolve_warehouse_arg,
     resolve_workspace_arg,
 )
 from fabric_dw.exceptions import FabricError
 from fabric_dw.services import sql_exec as _sql_exec_svc
-
-if TYPE_CHECKING:
-    from fabric_dw.cli._context import CliContext
-
-_log = logging.getLogger(__name__)
 
 
 @click.group("sql")
@@ -54,7 +47,7 @@ def sql_group() -> None:
     help="Path to a .sql file to execute.",
 )
 @click.pass_obj
-@_coro
+@coro
 async def exec_cmd(
     ctx: CliContext,
     workspace: str | None,
@@ -71,22 +64,14 @@ async def exec_cmd(
     Output defaults to a Rich table (rows/columns).  Pass --json on the root command
     for machine-readable JSON ({columns: [...], rows: [...], rowcount: N}).
     """
-    if query_text is not None and query_file is not None:
-        raise click.UsageError("Use -q/--query OR -f/--file, not both.")
-    if query_text is None and query_file is None:
-        raise click.UsageError("Provide a query via -q/--query or -f/--file.")
-
-    if query_file is not None:
-        query_text = Path(query_file).read_text(encoding="utf-8-sig")
-
-    assert query_text is not None  # noqa: S101 — satisfied by guards above
+    query = load_sql_body(query_text, query_file, inline_opt="-q/--query", file_opt="-f/--file")
 
     ws = resolve_workspace_arg(ctx, workspace)
     wh = resolve_warehouse_arg(ctx, item)
     try:
         async with build_http_client(ctx) as http:
             target, _entry = await build_sql_target(http, ws, wh)
-            result = await _sql_exec_svc.execute(target, query_text, mode=ctx.auth)
+            result = await _sql_exec_svc.execute(target, query, mode=ctx.auth)
 
             if ctx.json_output:
                 render(

--- a/src/fabric_dw/cli/commands/sql_endpoints.py
+++ b/src/fabric_dw/cli/commands/sql_endpoints.py
@@ -2,17 +2,15 @@
 
 from __future__ import annotations
 
-import logging
-
 import click
 
 from fabric_dw.cli._context import CliContext
 from fabric_dw.cli._render import render, render_permissions_table, render_refresh_table
 from fabric_dw.cli.commands._utils import (
-    _coro,
-    _resolve_item,
     build_http_client,
+    coro,
     make_resolver,
+    resolve_item,
     resolve_warehouse_arg,
     resolve_workspace_arg,
     validate_workspace_or_all_workspaces,
@@ -20,8 +18,6 @@ from fabric_dw.cli.commands._utils import (
 from fabric_dw.exceptions import FabricError
 from fabric_dw.services import permissions as _permissions_svc
 from fabric_dw.services import sql_endpoints as _sql_endpoints_svc
-
-_log = logging.getLogger(__name__)
 
 
 @click.group("sql-endpoints")
@@ -40,7 +36,7 @@ def sql_endpoints_group() -> None:
     help="Scan all visible workspaces and aggregate results.",
 )
 @click.pass_obj
-@_coro
+@coro
 async def list_cmd(ctx: CliContext, workspace: str | None, all_workspaces: bool) -> None:
     """List all SQL analytics endpoints in WORKSPACE (name or GUID).
 
@@ -57,7 +53,9 @@ async def list_cmd(ctx: CliContext, workspace: str | None, all_workspaces: bool)
             if all_workspaces:
                 items = await _sql_endpoints_svc.list_all_workspaces(http)
             else:
-                assert resolved_workspace is not None  # noqa: S101 - validated above
+                # resolved_workspace is guaranteed non-None by validate_workspace_or_all_workspaces
+                if resolved_workspace is None:  # pragma: no cover — defensive
+                    raise click.UsageError("Provide WORKSPACE or pass --all-workspaces / -A.")
                 resolver, _ = make_resolver(http)
                 ws_id = await resolver.workspace_id(resolved_workspace)
                 items = await _sql_endpoints_svc.list_endpoints(http, ws_id)
@@ -74,14 +72,14 @@ async def list_cmd(ctx: CliContext, workspace: str | None, all_workspaces: bool)
 @click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.pass_obj
-@_coro
+@coro
 async def get_cmd(ctx: CliContext, workspace: str | None, item: str | None) -> None:
     """Get details for ITEM (SQL analytics endpoint) in WORKSPACE (both accept name or GUID)."""
     ws = resolve_workspace_arg(ctx, workspace)
     ep = resolve_warehouse_arg(ctx, item)
     try:
         async with build_http_client(ctx) as http:
-            ws_id, entry = await _resolve_item(http, ws, ep)
+            ws_id, entry = await resolve_item(http, ws, ep)
             obj = await _sql_endpoints_svc.get_endpoint(http, ws_id, entry.id)
             render(obj.model_dump(by_alias=True, mode="json"), json_output=ctx.json_output)
     except FabricError as exc:
@@ -103,7 +101,7 @@ async def get_cmd(ctx: CliContext, workspace: str | None, item: str | None) -> N
     ),
 )
 @click.pass_obj
-@_coro
+@coro
 async def refresh_cmd(
     ctx: CliContext, workspace: str | None, item: str | None, recreate_tables: bool
 ) -> None:
@@ -119,7 +117,7 @@ async def refresh_cmd(
     ep = resolve_warehouse_arg(ctx, item)
     try:
         async with build_http_client(ctx) as http:
-            ws_id, entry = await _resolve_item(http, ws, ep)
+            ws_id, entry = await resolve_item(http, ws, ep)
             statuses = await _sql_endpoints_svc.refresh_metadata(
                 http, ws_id, entry.id, recreate_tables=recreate_tables
             )
@@ -138,7 +136,7 @@ async def refresh_cmd(
 @click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.pass_obj
-@_coro
+@coro
 async def permissions_cmd(ctx: CliContext, workspace: str | None, item: str | None) -> None:
     """List principals with access to ITEM (SQL endpoint) in WORKSPACE (both accept name or GUID).
 
@@ -149,7 +147,7 @@ async def permissions_cmd(ctx: CliContext, workspace: str | None, item: str | No
     ep = resolve_warehouse_arg(ctx, item)
     try:
         async with build_http_client(ctx) as http:
-            ws_id, entry = await _resolve_item(http, ws, ep)
+            ws_id, entry = await resolve_item(http, ws, ep)
             items = await _permissions_svc.list_item_access(http, ws_id, entry.id)
             render_permissions_table(
                 items,

--- a/src/fabric_dw/cli/commands/sql_pools.py
+++ b/src/fabric_dw/cli/commands/sql_pools.py
@@ -7,18 +7,18 @@
 
 from __future__ import annotations
 
-import logging
-from datetime import datetime
-
 import click
 
 from fabric_dw.cli._context import CliContext
 from fabric_dw.cli._render import confirm, render
 from fabric_dw.cli.commands._utils import (
-    _coro,
+    LIMIT_OPTION,
+    SINCE_OPTION,
+    UNTIL_OPTION,
     build_http_client,
     build_sql_target,
-    parse_iso_datetime,
+    coro,
+    parse_iso_optional,
     resolve_warehouse_arg,
     resolve_workspace_arg,
     resolve_workspace_id,
@@ -32,8 +32,6 @@ from fabric_dw.exceptions import (
 from fabric_dw.models import SqlPool, SqlPoolClassifier
 from fabric_dw.services import query_insights as _qi_svc
 from fabric_dw.services import sql_pools as _svc
-
-_log = logging.getLogger(__name__)
 
 
 def _permission_hint(exc: PermissionDeniedError) -> click.ClickException:
@@ -53,7 +51,7 @@ def sql_pools_group() -> None:
 @sql_pools_group.command("get")
 @click.argument("workspace", required=False, default=None)
 @click.pass_obj
-@_coro
+@coro
 async def get_cmd(ctx: CliContext, workspace: str | None) -> None:
     """Fetch the SQL Pools configuration for WORKSPACE."""
     ws = resolve_workspace_arg(ctx, workspace)
@@ -79,7 +77,7 @@ async def get_cmd(ctx: CliContext, workspace: str | None) -> None:
 @sql_pools_group.command("list")
 @click.argument("workspace", required=False, default=None)
 @click.pass_obj
-@_coro
+@coro
 async def list_cmd(ctx: CliContext, workspace: str | None) -> None:
     """List all SQL pools in WORKSPACE."""
     ws = resolve_workspace_arg(ctx, workspace)
@@ -104,7 +102,7 @@ async def list_cmd(ctx: CliContext, workspace: str | None) -> None:
 @click.argument("workspace", required=False, default=None)
 @click.option("--name", required=True, help="Name of the pool to show.")
 @click.pass_obj
-@_coro
+@coro
 async def show_cmd(ctx: CliContext, workspace: str | None, name: str) -> None:
     """Show details for a single SQL pool in WORKSPACE."""
     ws = resolve_workspace_arg(ctx, workspace)
@@ -164,7 +162,7 @@ async def show_cmd(ctx: CliContext, workspace: str | None, name: str) -> None:
     help="Classifier value(s). Repeat for multiple values.",
 )
 @click.pass_obj
-@_coro
+@coro
 async def create_cmd(
     ctx: CliContext,
     workspace: str | None,
@@ -249,7 +247,7 @@ async def create_cmd(
     help="New classifier value(s). Repeat for multiple values. Replaces all existing values.",
 )
 @click.pass_obj
-@_coro
+@coro
 async def update_cmd(
     ctx: CliContext,
     workspace: str | None,
@@ -299,7 +297,7 @@ async def update_cmd(
 @click.argument("workspace", required=False, default=None)
 @click.option("--name", required=True, help="Name of the pool to delete.")
 @click.pass_obj
-@_coro
+@coro
 async def delete_cmd(ctx: CliContext, workspace: str | None, name: str) -> None:
     """Remove an SQL pool from WORKSPACE."""
     ws = resolve_workspace_arg(ctx, workspace)
@@ -327,7 +325,7 @@ async def delete_cmd(ctx: CliContext, workspace: str | None, name: str) -> None:
 @sql_pools_group.command("enable")
 @click.argument("workspace", required=False, default=None)
 @click.pass_obj
-@_coro
+@coro
 async def enable_cmd(ctx: CliContext, workspace: str | None) -> None:
     """Enable custom SQL Pools for WORKSPACE (preserves pool configuration)."""
     ws = resolve_workspace_arg(ctx, workspace)
@@ -348,7 +346,7 @@ async def enable_cmd(ctx: CliContext, workspace: str | None) -> None:
 @sql_pools_group.command("disable")
 @click.argument("workspace", required=False, default=None)
 @click.pass_obj
-@_coro
+@coro
 async def disable_cmd(ctx: CliContext, workspace: str | None) -> None:
     """Disable custom SQL Pools for WORKSPACE (preserves pool configuration).
 
@@ -374,37 +372,14 @@ async def disable_cmd(ctx: CliContext, workspace: str | None) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _parse_iso(value: str | None, param_name: str) -> datetime | None:
-    """Parse an optional ISO-8601 string; raise UsageError on bad input."""
-    if value is None:
-        return None
-    return parse_iso_datetime(value, param_name, assume_utc=False)
-
-
 @sql_pools_group.command("insights")
 @click.argument("workspace", required=False, default=None)
 @click.argument("warehouse", required=False, default=None)
-@click.option(
-    "--limit",
-    default=100,
-    show_default=True,
-    type=click.IntRange(1, 10_000),
-    help="Maximum number of rows to return (1-10 000).",
-)
-@click.option(
-    "--since",
-    default=None,
-    metavar="ISO8601",
-    help="Return rows with timestamp >= this value (ISO-8601).",
-)
-@click.option(
-    "--until",
-    default=None,
-    metavar="ISO8601",
-    help="Return rows with timestamp <= this value (ISO-8601).",
-)
+@LIMIT_OPTION
+@SINCE_OPTION
+@UNTIL_OPTION
 @click.pass_obj
-@_coro
+@coro
 async def insights_cmd(
     ctx: CliContext,
     workspace: str | None,
@@ -416,8 +391,8 @@ async def insights_cmd(
     """List SQL pool insights from queryinsights.sql_pool_insights."""
     ws = resolve_workspace_arg(ctx, workspace)
     wh = resolve_warehouse_arg(ctx, warehouse)
-    since_dt = _parse_iso(since, "--since")
-    until_dt = _parse_iso(until, "--until")
+    since_dt = parse_iso_optional(since, "--since")
+    until_dt = parse_iso_optional(until, "--until")
     try:
         async with build_http_client(ctx) as http:
             target, _ = await build_sql_target(http, ws, wh)

--- a/src/fabric_dw/cli/commands/tables.py
+++ b/src/fabric_dw/cli/commands/tables.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from pathlib import Path
 
 import click
@@ -10,11 +9,11 @@ import click
 from fabric_dw.cli._context import CliContext
 from fabric_dw.cli._render import render
 from fabric_dw.cli.commands._utils import (
-    _coro,
     build_http_client,
     build_sql_target,
     confirm_destructive,
-    load_select_body,
+    coro,
+    load_sql_body,
     parse_iso_datetime,
     parse_qualified_name,
     resolve_warehouse_arg,
@@ -23,8 +22,6 @@ from fabric_dw.cli.commands._utils import (
 from fabric_dw.exceptions import FabricError
 from fabric_dw.services import tables as _tables_svc
 from fabric_dw.sql_io import OutputFormat, columns_rows_to_arrow, write_arrow
-
-_log = logging.getLogger(__name__)
 
 
 @click.group("tables")
@@ -37,7 +34,7 @@ def tables_group() -> None:
 @click.argument("item", required=False, default=None)
 @click.option("--schema", default=None, help="Filter by schema name.")
 @click.pass_obj
-@_coro
+@coro
 async def list_cmd(
     ctx: CliContext, workspace: str | None, item: str | None, schema: str | None
 ) -> None:
@@ -72,7 +69,7 @@ async def list_cmd(
 )
 @click.option("--output", default=None, help="Write to this file instead of stdout.")
 @click.pass_obj
-@_coro
+@coro
 async def read_cmd(
     ctx: CliContext,
     workspace: str | None,
@@ -115,7 +112,7 @@ async def read_cmd(
 @click.option("--select", "select_body", default=None, help="Inline SELECT statement for CTAS.")
 @click.option("--from-file", default=None, help="Path to a .sql file containing the SELECT body.")
 @click.pass_obj
-@_coro
+@coro
 async def create_cmd(
     ctx: CliContext,
     workspace: str | None,
@@ -128,7 +125,7 @@ async def create_cmd(
     ws = resolve_workspace_arg(ctx, workspace)
     wh = resolve_warehouse_arg(ctx, item)
     schema, table_name = parse_qualified_name(qualified_name, kind="table")
-    body = load_select_body(select_body, from_file)
+    body = load_sql_body(select_body, from_file)
     try:
         async with build_http_client(ctx) as http:
             target, entry = await build_sql_target(http, ws, wh)
@@ -145,7 +142,7 @@ async def create_cmd(
 @click.argument("item", required=False, default=None)
 @click.argument("qualified_name")
 @click.pass_obj
-@_coro
+@coro
 async def delete_cmd(
     ctx: CliContext,
     workspace: str | None,
@@ -184,7 +181,7 @@ async def delete_cmd(
 @click.argument("item", required=False, default=None)
 @click.argument("qualified_name")
 @click.pass_obj
-@_coro
+@coro
 async def clear_cmd(
     ctx: CliContext,
     workspace: str | None,
@@ -235,7 +232,7 @@ async def clear_cmd(
     ),
 )
 @click.pass_obj
-@_coro
+@coro
 async def clone_cmd(
     ctx: CliContext,
     workspace: str | None,
@@ -278,7 +275,7 @@ async def clone_cmd(
 @click.argument("qualified_name")
 @click.option("--new-name", required=True, help="New (unqualified) table name.")
 @click.pass_obj
-@_coro
+@coro
 async def rename_cmd(
     ctx: CliContext,
     workspace: str | None,

--- a/src/fabric_dw/cli/commands/views.py
+++ b/src/fabric_dw/cli/commands/views.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from pathlib import Path
 
 import click
@@ -10,11 +9,11 @@ import click
 from fabric_dw.cli._context import CliContext
 from fabric_dw.cli._render import confirm, render
 from fabric_dw.cli.commands._utils import (
-    _coro,
     build_http_client,
     build_sql_target,
     confirm_destructive,
-    load_select_body,
+    coro,
+    load_sql_body,
     parse_qualified_name,
     resolve_warehouse_arg,
     resolve_workspace_arg,
@@ -22,8 +21,6 @@ from fabric_dw.cli.commands._utils import (
 from fabric_dw.exceptions import FabricError
 from fabric_dw.services import views as _views_svc
 from fabric_dw.sql_io import OutputFormat, columns_rows_to_arrow, write_arrow
-
-_log = logging.getLogger(__name__)
 
 
 @click.group("views")
@@ -36,7 +33,7 @@ def views_group() -> None:
 @click.argument("item", required=False, default=None)
 @click.option("--schema", default=None, help="Filter by schema name.")
 @click.pass_obj
-@_coro
+@coro
 async def list_cmd(
     ctx: CliContext, workspace: str | None, item: str | None, schema: str | None
 ) -> None:
@@ -71,7 +68,7 @@ async def list_cmd(
 )
 @click.option("--output", default=None, help="Write to this file instead of stdout.")
 @click.pass_obj
-@_coro
+@coro
 async def read_cmd(
     ctx: CliContext,
     workspace: str | None,
@@ -112,7 +109,7 @@ async def read_cmd(
 @click.argument("item", required=False, default=None)
 @click.argument("qualified_name")
 @click.pass_obj
-@_coro
+@coro
 async def get_cmd(
     ctx: CliContext,
     workspace: str | None,
@@ -139,7 +136,7 @@ async def get_cmd(
 @click.option("--select", "select_body", default=None, help="Inline SELECT statement.")
 @click.option("--from-file", default=None, help="Path to a .sql file containing the SELECT body.")
 @click.pass_obj
-@_coro
+@coro
 async def create_cmd(
     ctx: CliContext,
     workspace: str | None,
@@ -152,7 +149,7 @@ async def create_cmd(
     ws = resolve_workspace_arg(ctx, workspace)
     wh = resolve_warehouse_arg(ctx, item)
     schema, view_name = parse_qualified_name(qualified_name, kind="view")
-    body = load_select_body(select_body, from_file)
+    body = load_sql_body(select_body, from_file)
     try:
         async with build_http_client(ctx) as http:
             target, _entry = await build_sql_target(http, ws, wh)
@@ -169,7 +166,7 @@ async def create_cmd(
 @click.option("--select", "select_body", default=None, help="Inline SELECT statement.")
 @click.option("--from-file", default=None, help="Path to a .sql file containing the SELECT body.")
 @click.pass_obj
-@_coro
+@coro
 async def update_cmd(
     ctx: CliContext,
     workspace: str | None,
@@ -182,7 +179,7 @@ async def update_cmd(
     ws = resolve_workspace_arg(ctx, workspace)
     wh = resolve_warehouse_arg(ctx, item)
     schema, view_name = parse_qualified_name(qualified_name, kind="view")
-    body = load_select_body(select_body, from_file)
+    body = load_sql_body(select_body, from_file)
     try:
         async with build_http_client(ctx) as http:
             target, entry = await build_sql_target(http, ws, wh)
@@ -204,7 +201,7 @@ async def update_cmd(
 @click.argument("item", required=False, default=None)
 @click.argument("qualified_name")
 @click.pass_obj
-@_coro
+@coro
 async def drop_cmd(
     ctx: CliContext,
     workspace: str | None,
@@ -239,7 +236,7 @@ async def drop_cmd(
 @click.argument("qualified_name")
 @click.option("--new-name", required=True, help="New bare (unqualified) view name.")
 @click.pass_obj
-@_coro
+@coro
 async def rename_cmd(
     ctx: CliContext,
     workspace: str | None,

--- a/src/fabric_dw/cli/commands/warehouses.py
+++ b/src/fabric_dw/cli/commands/warehouses.py
@@ -2,19 +2,17 @@
 
 from __future__ import annotations
 
-import logging
-
 import click
 
 from fabric_dw.cli._context import CliContext
 from fabric_dw.cli._render import render, render_permissions_table
 from fabric_dw.cli.commands._utils import (
-    _coro,
-    _resolve_item,
-    _resolve_item_with_cache,
     build_http_client,
     confirm_destructive,
+    coro,
     make_resolver,
+    resolve_item,
+    resolve_item_with_cache,
     resolve_warehouse_arg,
     resolve_workspace_arg,
     validate_workspace_or_all_workspaces,
@@ -24,8 +22,6 @@ from fabric_dw.models import WarehouseKind
 from fabric_dw.services import ownership as _ownership_svc
 from fabric_dw.services import permissions as _permissions_svc
 from fabric_dw.services import warehouses as _warehouses_svc
-
-_log = logging.getLogger(__name__)
 
 
 @click.group("warehouses")
@@ -46,7 +42,7 @@ def warehouses_group() -> None:
     help="Scan all visible workspaces and aggregate results.",
 )
 @click.pass_obj
-@_coro
+@coro
 async def list_cmd(ctx: CliContext, workspace: str | None, all_workspaces: bool) -> None:
     """List all warehouses in WORKSPACE (name or GUID).
 
@@ -63,7 +59,9 @@ async def list_cmd(ctx: CliContext, workspace: str | None, all_workspaces: bool)
             if all_workspaces:
                 items = await _warehouses_svc.list_all_workspaces(http)
             else:
-                assert resolved_workspace is not None  # noqa: S101 - validated above
+                # resolved_workspace is guaranteed non-None by validate_workspace_or_all_workspaces
+                if resolved_workspace is None:  # pragma: no cover — defensive
+                    raise click.UsageError("Provide WORKSPACE or pass --all-workspaces / -A.")
                 resolver, _ = make_resolver(http)
                 ws_id = await resolver.workspace_id(resolved_workspace)
                 items = await _warehouses_svc.list_warehouses(http, ws_id)
@@ -80,14 +78,14 @@ async def list_cmd(ctx: CliContext, workspace: str | None, all_workspaces: bool)
 @click.argument("workspace", required=False, default=None)
 @click.argument("warehouse", required=False, default=None)
 @click.pass_obj
-@_coro
+@coro
 async def get_cmd(ctx: CliContext, workspace: str | None, warehouse: str | None) -> None:
     """Get details for WAREHOUSE in WORKSPACE (both accept name or GUID)."""
     ws = resolve_workspace_arg(ctx, workspace)
     wh = resolve_warehouse_arg(ctx, warehouse)
     try:
         async with build_http_client(ctx) as http:
-            ws_id, entry = await _resolve_item(http, ws, wh)
+            ws_id, entry = await resolve_item(http, ws, wh)
             obj = await _warehouses_svc.get_warehouse(http, ws_id, entry.id)
             render(obj.model_dump(by_alias=True, mode="json"), json_output=ctx.json_output)
     except (ValueError, FabricError) as exc:
@@ -100,7 +98,7 @@ async def get_cmd(ctx: CliContext, workspace: str | None, warehouse: str | None)
 @click.option("--collation", default=None, help="Default collation for the warehouse.")
 @click.option("--description", default=None, help="Description for the warehouse.")
 @click.pass_obj
-@_coro
+@coro
 async def create_cmd(
     ctx: CliContext,
     workspace: str | None,
@@ -132,7 +130,7 @@ async def create_cmd(
 @click.argument("new_name")
 @click.option("--description", default=None, help="Optional new description.")
 @click.pass_obj
-@_coro
+@coro
 async def rename_cmd(
     ctx: CliContext,
     workspace: str | None,
@@ -145,7 +143,7 @@ async def rename_cmd(
     wh = resolve_warehouse_arg(ctx, warehouse)
     try:
         async with build_http_client(ctx) as http:
-            ws_id, entry, cache = await _resolve_item_with_cache(http, ws, wh)
+            ws_id, entry, cache = await resolve_item_with_cache(http, ws, wh)
             if not confirm_destructive(
                 f"Rename warehouse {entry.display_name!r} ({entry.id}) to {new_name!r}?",
                 yes=ctx.yes,
@@ -170,14 +168,14 @@ async def rename_cmd(
 @click.argument("workspace", required=False, default=None)
 @click.argument("warehouse", required=False, default=None)
 @click.pass_obj
-@_coro
+@coro
 async def delete_cmd(ctx: CliContext, workspace: str | None, warehouse: str | None) -> None:
     """Delete WAREHOUSE from WORKSPACE (both accept name or GUID)."""
     ws = resolve_workspace_arg(ctx, workspace)
     wh = resolve_warehouse_arg(ctx, warehouse)
     try:
         async with build_http_client(ctx) as http:
-            ws_id, entry, cache = await _resolve_item_with_cache(http, ws, wh)
+            ws_id, entry, cache = await resolve_item_with_cache(http, ws, wh)
             if not confirm_destructive(
                 f"Delete warehouse {entry.display_name!r} ({entry.id})?",
                 yes=ctx.yes,
@@ -206,7 +204,7 @@ async def delete_cmd(ctx: CliContext, workspace: str | None, warehouse: str | No
 @click.argument("workspace", required=False, default=None)
 @click.argument("warehouse", required=False, default=None)
 @click.pass_obj
-@_coro
+@coro
 async def takeover_cmd(ctx: CliContext, workspace: str | None, warehouse: str | None) -> None:
     """Take ownership of WAREHOUSE in WORKSPACE (both accept name or GUID).
 
@@ -216,7 +214,7 @@ async def takeover_cmd(ctx: CliContext, workspace: str | None, warehouse: str | 
     wh = resolve_warehouse_arg(ctx, warehouse)
     try:
         async with build_http_client(ctx) as http:
-            ws_id, entry = await _resolve_item(http, ws, wh)
+            ws_id, entry = await resolve_item(http, ws, wh)
     except (ValueError, FabricError) as exc:
         raise click.ClickException(str(exc)) from exc
     if entry.kind == WarehouseKind.SQL_ENDPOINT:
@@ -239,7 +237,7 @@ async def takeover_cmd(ctx: CliContext, workspace: str | None, warehouse: str | 
 @click.argument("workspace", required=False, default=None)
 @click.argument("warehouse", required=False, default=None)
 @click.pass_obj
-@_coro
+@coro
 async def permissions_cmd(ctx: CliContext, workspace: str | None, warehouse: str | None) -> None:
     """List principals with access to WAREHOUSE in WORKSPACE (both accept name or GUID).
 
@@ -250,7 +248,7 @@ async def permissions_cmd(ctx: CliContext, workspace: str | None, warehouse: str
     wh = resolve_warehouse_arg(ctx, warehouse)
     try:
         async with build_http_client(ctx) as http:
-            ws_id, entry = await _resolve_item(http, ws, wh)
+            ws_id, entry = await resolve_item(http, ws, wh)
             items = await _permissions_svc.list_item_access(http, ws_id, entry.id)
             render_permissions_table(
                 items, title="Warehouse Permissions", json_output=ctx.json_output

--- a/src/fabric_dw/cli/commands/workspaces.py
+++ b/src/fabric_dw/cli/commands/workspaces.py
@@ -2,23 +2,19 @@
 
 from __future__ import annotations
 
-import logging
-
 import click
 
 from fabric_dw.cli._context import CliContext
 from fabric_dw.cli._render import render
 from fabric_dw.cli.commands._utils import (
-    _coro,
     build_http_client,
     confirm_destructive,
+    coro,
     resolve_workspace_arg,
     resolve_workspace_id,
 )
 from fabric_dw.exceptions import FabricError
 from fabric_dw.services import workspaces as _workspaces_svc
-
-_log = logging.getLogger(__name__)
 
 
 @click.group("workspaces")
@@ -28,7 +24,7 @@ def workspaces_group() -> None:
 
 @workspaces_group.command("list")
 @click.pass_obj
-@_coro
+@coro
 async def list_cmd(ctx: CliContext) -> None:
     """List all workspaces the authenticated principal has access to."""
     try:
@@ -46,7 +42,7 @@ async def list_cmd(ctx: CliContext) -> None:
 @workspaces_group.command("get")
 @click.argument("workspace", required=False, default=None)
 @click.pass_obj
-@_coro
+@coro
 async def get_cmd(ctx: CliContext, workspace: str | None) -> None:
     """Get details for WORKSPACE (name or GUID)."""
     ws = resolve_workspace_arg(ctx, workspace)
@@ -63,7 +59,7 @@ async def get_cmd(ctx: CliContext, workspace: str | None) -> None:
 @click.argument("workspace", required=False, default=None)
 @click.argument("collation")
 @click.pass_obj
-@_coro
+@coro
 async def set_collation_cmd(ctx: CliContext, workspace: str | None, collation: str) -> None:
     """Set the default Data Warehouse COLLATION for WORKSPACE (name or GUID).
 

--- a/tests/unit/cli/commands/test_audit.py
+++ b/tests/unit/cli/commands/test_audit.py
@@ -67,7 +67,7 @@ class TestAuditGet:
                 new=_make_cm(mock_http, None),
             ),
             patch(
-                "fabric_dw.cli.commands.audit._resolve_item",
+                "fabric_dw.cli.commands.audit.resolve_item",
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
             ),
         ):
@@ -84,7 +84,7 @@ class TestAuditGet:
                 new=_make_cm(mock_http, None),
             ),
             patch(
-                "fabric_dw.cli.commands.audit._resolve_item",
+                "fabric_dw.cli.commands.audit.resolve_item",
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
             ),
         ):
@@ -102,7 +102,7 @@ class TestAuditGet:
                 new=_make_cm(mock_http, None),
             ),
             patch(
-                "fabric_dw.cli.commands.audit._resolve_item",
+                "fabric_dw.cli.commands.audit.resolve_item",
                 new=AsyncMock(side_effect=NotFoundError("not found")),
             ),
         ):
@@ -123,7 +123,7 @@ class TestAuditEnable:
                 new=_make_cm(mock_http, None),
             ),
             patch(
-                "fabric_dw.cli.commands.audit._resolve_item",
+                "fabric_dw.cli.commands.audit.resolve_item",
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
             ),
         ):
@@ -140,7 +140,7 @@ class TestAuditEnable:
                 new=_make_cm(mock_http, None),
             ),
             patch(
-                "fabric_dw.cli.commands.audit._resolve_item",
+                "fabric_dw.cli.commands.audit.resolve_item",
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
             ),
         ):
@@ -164,7 +164,7 @@ class TestAuditEnable:
                 new=_make_cm(mock_http, None),
             ),
             patch(
-                "fabric_dw.cli.commands.audit._resolve_item",
+                "fabric_dw.cli.commands.audit.resolve_item",
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
             ),
             patch(
@@ -222,7 +222,7 @@ class TestAuditDisable:
                 new=_make_cm(mock_http, None),
             ),
             patch(
-                "fabric_dw.cli.commands.audit._resolve_item",
+                "fabric_dw.cli.commands.audit.resolve_item",
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
             ),
         ):
@@ -239,7 +239,7 @@ class TestAuditDisable:
                 new=_make_cm(mock_http, None),
             ),
             patch(
-                "fabric_dw.cli.commands.audit._resolve_item",
+                "fabric_dw.cli.commands.audit.resolve_item",
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
             ),
         ):
@@ -261,7 +261,7 @@ class TestAuditSetRetention:
                 new=_make_cm(mock_http, None),
             ),
             patch(
-                "fabric_dw.cli.commands.audit._resolve_item",
+                "fabric_dw.cli.commands.audit.resolve_item",
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
             ),
         ):
@@ -280,7 +280,7 @@ class TestAuditSetRetention:
                 new=_make_cm(mock_http, None),
             ),
             patch(
-                "fabric_dw.cli.commands.audit._resolve_item",
+                "fabric_dw.cli.commands.audit.resolve_item",
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
             ),
         ):
@@ -302,7 +302,7 @@ class TestAuditSetRetention:
                 new=_make_cm(mock_http, None),
             ),
             patch(
-                "fabric_dw.cli.commands.audit._resolve_item",
+                "fabric_dw.cli.commands.audit.resolve_item",
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
             ),
             patch(
@@ -348,7 +348,7 @@ class TestAuditSetRetention:
                 new=_make_cm(mock_http, None),
             ),
             patch(
-                "fabric_dw.cli.commands.audit._resolve_item",
+                "fabric_dw.cli.commands.audit.resolve_item",
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
             ),
         ):
@@ -371,7 +371,7 @@ class TestAuditSetGroups:
                 new=_make_cm(mock_http, None),
             ),
             patch(
-                "fabric_dw.cli.commands.audit._resolve_item",
+                "fabric_dw.cli.commands.audit.resolve_item",
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
             ),
         ):
@@ -401,7 +401,7 @@ class TestAuditSetGroups:
                 new=_make_cm(mock_http, None),
             ),
             patch(
-                "fabric_dw.cli.commands.audit._resolve_item",
+                "fabric_dw.cli.commands.audit.resolve_item",
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
             ),
         ):
@@ -437,7 +437,7 @@ class TestAuditAddGroup:
                 new=_make_cm(mock_http, None),
             ),
             patch(
-                "fabric_dw.cli.commands.audit._resolve_item",
+                "fabric_dw.cli.commands.audit.resolve_item",
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
             ),
         ):
@@ -463,7 +463,7 @@ class TestAuditAddGroup:
                 new=_make_cm(mock_http, None),
             ),
             patch(
-                "fabric_dw.cli.commands.audit._resolve_item",
+                "fabric_dw.cli.commands.audit.resolve_item",
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
             ),
         ):
@@ -486,7 +486,7 @@ class TestAuditAddGroup:
                 new=_make_cm(mock_http, None),
             ),
             patch(
-                "fabric_dw.cli.commands.audit._resolve_item",
+                "fabric_dw.cli.commands.audit.resolve_item",
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
             ),
         ):
@@ -507,7 +507,7 @@ class TestAuditAddGroup:
                 new=_make_cm(mock_http, None),
             ),
             patch(
-                "fabric_dw.cli.commands.audit._resolve_item",
+                "fabric_dw.cli.commands.audit.resolve_item",
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
             ),
             patch(
@@ -534,7 +534,7 @@ class TestAuditRemoveGroup:
                 new=_make_cm(AsyncMock(), None),
             ),
             patch(
-                "fabric_dw.cli.commands.audit._resolve_item",
+                "fabric_dw.cli.commands.audit.resolve_item",
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
             ),
             patch(
@@ -563,7 +563,7 @@ class TestAuditRemoveGroup:
                 new=_make_cm(AsyncMock(), None),
             ),
             patch(
-                "fabric_dw.cli.commands.audit._resolve_item",
+                "fabric_dw.cli.commands.audit.resolve_item",
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
             ),
             patch(
@@ -590,7 +590,7 @@ class TestAuditRemoveGroup:
                 new=_make_cm(mock_http, None),
             ),
             patch(
-                "fabric_dw.cli.commands.audit._resolve_item",
+                "fabric_dw.cli.commands.audit.resolve_item",
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
             ),
         ):
@@ -611,7 +611,7 @@ class TestAuditRemoveGroup:
                 new=_make_cm(mock_http, None),
             ),
             patch(
-                "fabric_dw.cli.commands.audit._resolve_item",
+                "fabric_dw.cli.commands.audit.resolve_item",
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
             ),
             patch(
@@ -646,7 +646,7 @@ class TestAuditDefaultFallback:
                 new=_make_cm(mock_http, None),
             ),
             patch(
-                "fabric_dw.cli.commands.audit._resolve_item",
+                "fabric_dw.cli.commands.audit.resolve_item",
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
             ),
         ):

--- a/tests/unit/cli/commands/test_completion.py
+++ b/tests/unit/cli/commands/test_completion.py
@@ -9,7 +9,12 @@ import pytest
 from click.testing import CliRunner
 
 from fabric_dw.cli._main import cli
-from fabric_dw.cli.commands.completion import _append_idempotent, _completion_script
+from fabric_dw.cli.commands.completion import (
+    _SENTINEL_END,
+    _SENTINEL_START,
+    _append_idempotent,
+    _completion_script,
+)
 
 
 @pytest.fixture
@@ -89,22 +94,32 @@ class TestCompletionInstallAppendShells:
     def test_bash_install_idempotent_when_script_already_present(
         self, runner: CliRunner, tmp_path: Path
     ) -> None:
-        """Re-running install when the script is already in ~/.bashrc does nothing."""
+        """Re-running install when the sentinel block is in ~/.bashrc updates it in-place."""
         mock_script = "# bash completion script\n_FABRIC_DW_COMPLETE=bash_source fabric-dw\n"
         rc_file = tmp_path / ".bashrc"
-        rc_file.write_text("# existing rc\n" + mock_script)
+        # Pre-populate with the sentinel-wrapped block (simulates a previous install).
+        rc_file.write_text(
+            f"# existing rc\n{_SENTINEL_START}\n{mock_script.strip()}\n{_SENTINEL_END}\n"
+        )
+
+        new_script = "# updated bash completion\n_FABRIC_DW_COMPLETE=bash_source fabric-dw\n"
 
         with (
             patch("fabric_dw.cli.commands.completion.Path.home", return_value=tmp_path),
             patch(
                 "fabric_dw.cli.commands.completion._completion_script",
-                return_value=mock_script,
+                return_value=new_script,
             ),
         ):
             result = runner.invoke(cli, ["completion", "install", "bash"])
 
         assert result.exit_code == 0
-        assert "already present" in result.output.lower()
+        # "updated" is the message for in-place replacement.
+        assert "updated" in result.output.lower() or "Reload" in result.output
+        content = rc_file.read_text()
+        # Old script replaced; no duplicate sentinels.
+        assert content.count(_SENTINEL_START) == 1
+        assert new_script.strip() in content
 
 
 class TestCompletionInstallWriteShell:
@@ -161,14 +176,26 @@ class TestAppendIdempotent:
         assert "# existing" in content
         assert "# newscript" in content
 
-    def test_does_not_append_when_already_present(self, tmp_path: Path) -> None:
-        script = "# completion\n_COMPLETE=bash_source prog\n"
+    def test_wraps_script_in_sentinel_markers(self, tmp_path: Path) -> None:
         target = tmp_path / ".bashrc"
-        target.write_text("# existing\n" + script)
-        _append_idempotent(target, script)
+        _append_idempotent(target, "# script\n")
         content = target.read_text()
-        # Script should appear only once
-        assert content.count(script.strip()) == 1
+        assert _SENTINEL_START in content
+        assert _SENTINEL_END in content
+
+    def test_replaces_block_when_sentinel_already_present(self, tmp_path: Path) -> None:
+        """Re-install replaces the existing managed block instead of duplicating it."""
+        old_script = "# old completion\n"
+        new_script = "# new completion\n"
+        target = tmp_path / ".bashrc"
+        # Simulate a previous install by writing the sentinel-wrapped block.
+        target.write_text(f"# existing\n{_SENTINEL_START}\n{old_script.strip()}\n{_SENTINEL_END}\n")
+        _append_idempotent(target, new_script)
+        content = target.read_text()
+        # Exactly one block, containing the new script.
+        assert content.count(_SENTINEL_START) == 1
+        assert "# new completion" in content
+        assert "# old completion" not in content
 
 
 class TestCompletionScript:

--- a/tests/unit/cli/commands/test_snapshots.py
+++ b/tests/unit/cli/commands/test_snapshots.py
@@ -102,7 +102,7 @@ class TestSnapshotsList:
                 new=_make_http_cm(mock_http),
             ),
             patch(
-                "fabric_dw.cli.commands.snapshots._resolve_item",
+                "fabric_dw.cli.commands.snapshots.resolve_item",
                 new=AsyncMock(return_value=(WS_UUID, _make_wh_entry())),
             ),
         ):
@@ -119,7 +119,7 @@ class TestSnapshotsList:
                 new=_make_http_cm(mock_http),
             ),
             patch(
-                "fabric_dw.cli.commands.snapshots._resolve_item",
+                "fabric_dw.cli.commands.snapshots.resolve_item",
                 new=AsyncMock(return_value=(WS_UUID, _make_wh_entry())),
             ),
         ):
@@ -137,7 +137,7 @@ class TestSnapshotsList:
                 new=_make_http_cm(mock_http),
             ),
             patch(
-                "fabric_dw.cli.commands.snapshots._resolve_item",
+                "fabric_dw.cli.commands.snapshots.resolve_item",
                 new=AsyncMock(side_effect=NotFoundError("not found")),
             ),
         ):
@@ -171,7 +171,7 @@ class TestSnapshotsCreate:
                 new=_make_http_cm(mock_http),
             ),
             patch(
-                "fabric_dw.cli.commands.snapshots._resolve_item",
+                "fabric_dw.cli.commands.snapshots.resolve_item",
                 new=AsyncMock(return_value=(WS_UUID, _make_wh_entry())),
             ),
             patch("asyncio.sleep", new=AsyncMock()),
@@ -242,7 +242,7 @@ class TestSnapshotsRename:
                 new=_make_http_cm(mock_http),
             ),
             patch(
-                "fabric_dw.cli.commands.snapshots._resolve_item_with_cache",
+                "fabric_dw.cli.commands.snapshots.resolve_item_with_cache",
                 new=AsyncMock(return_value=(WS_UUID, _make_snap_entry(), _cache)),
             ),
         ):
@@ -267,7 +267,7 @@ class TestSnapshotsDelete:
                 new=_make_http_cm(mock_http),
             ),
             patch(
-                "fabric_dw.cli.commands.snapshots._resolve_item_with_cache",
+                "fabric_dw.cli.commands.snapshots.resolve_item_with_cache",
                 new=AsyncMock(return_value=(WS_UUID, _make_snap_entry(), _cache)),
             ),
         ):
@@ -285,7 +285,7 @@ class TestSnapshotsDelete:
                 new=_make_http_cm(mock_http),
             ),
             patch(
-                "fabric_dw.cli.commands.snapshots._resolve_item_with_cache",
+                "fabric_dw.cli.commands.snapshots.resolve_item_with_cache",
                 new=AsyncMock(return_value=(WS_UUID, _make_snap_entry(), _cache)),
             ),
         ):
@@ -445,7 +445,7 @@ class TestSnapshotsDefaultFallback:
                 new=_make_http_cm(mock_http),
             ),
             patch(
-                "fabric_dw.cli.commands.snapshots._resolve_item",
+                "fabric_dw.cli.commands.snapshots.resolve_item",
                 new=AsyncMock(return_value=(WS_UUID, _make_wh_entry())),
             ),
         ):

--- a/tests/unit/cli/commands/test_sql_endpoints.py
+++ b/tests/unit/cli/commands/test_sql_endpoints.py
@@ -227,7 +227,7 @@ class TestEndpointsGet:
                 new=_make_cm(mock_http, None),
             ),
             patch(
-                "fabric_dw.cli.commands.sql_endpoints._resolve_item",
+                "fabric_dw.cli.commands.sql_endpoints.resolve_item",
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
             ),
         ):
@@ -243,7 +243,7 @@ class TestEndpointsGet:
                 new=_make_cm(mock_http, None),
             ),
             patch(
-                "fabric_dw.cli.commands.sql_endpoints._resolve_item",
+                "fabric_dw.cli.commands.sql_endpoints.resolve_item",
                 new=AsyncMock(side_effect=NotFoundError("endpoint not found")),
             ),
         ):
@@ -288,7 +288,7 @@ class TestEndpointsRefresh:
                 new=_make_cm(mock_http, None),
             ),
             patch(
-                "fabric_dw.cli.commands.sql_endpoints._resolve_item",
+                "fabric_dw.cli.commands.sql_endpoints.resolve_item",
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
             ),
             patch(
@@ -310,7 +310,7 @@ class TestEndpointsRefresh:
                 new=_make_cm(mock_http, None),
             ),
             patch(
-                "fabric_dw.cli.commands.sql_endpoints._resolve_item",
+                "fabric_dw.cli.commands.sql_endpoints.resolve_item",
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
             ),
             patch(
@@ -339,7 +339,7 @@ class TestEndpointsRefresh:
                 new=_make_cm(mock_http, None),
             ),
             patch(
-                "fabric_dw.cli.commands.sql_endpoints._resolve_item",
+                "fabric_dw.cli.commands.sql_endpoints.resolve_item",
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
             ),
             patch(
@@ -369,7 +369,7 @@ class TestEndpointsRefresh:
                 new=_make_cm(mock_http, None),
             ),
             patch(
-                "fabric_dw.cli.commands.sql_endpoints._resolve_item",
+                "fabric_dw.cli.commands.sql_endpoints.resolve_item",
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
             ),
             patch(
@@ -400,7 +400,7 @@ class TestEndpointsRefresh:
                 new=_make_cm(mock_http, None),
             ),
             patch(
-                "fabric_dw.cli.commands.sql_endpoints._resolve_item",
+                "fabric_dw.cli.commands.sql_endpoints.resolve_item",
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
             ),
             patch(
@@ -423,7 +423,7 @@ class TestEndpointsRefresh:
                 new=_make_cm(mock_http, None),
             ),
             patch(
-                "fabric_dw.cli.commands.sql_endpoints._resolve_item",
+                "fabric_dw.cli.commands.sql_endpoints.resolve_item",
                 new=AsyncMock(side_effect=NotFoundError("endpoint not found")),
             ),
         ):

--- a/tests/unit/cli/commands/test_utils.py
+++ b/tests/unit/cli/commands/test_utils.py
@@ -19,7 +19,7 @@ from fabric_dw.cli.commands._utils import (
     build_sql_target,
     confirm_destructive,
     get_ctx,
-    load_select_body,
+    load_sql_body,
     make_resolver,
     parse_iso_datetime,
     parse_qualified_name,
@@ -321,42 +321,51 @@ class TestParseQualifiedName:
 
 
 # ---------------------------------------------------------------------------
-# load_select_body
+# load_sql_body
 # ---------------------------------------------------------------------------
 
 
-class TestLoadSelectBody:
-    """load_select_body returns the body text or raises UsageError."""
+class TestLoadSqlBody:
+    """load_sql_body returns the body text or raises UsageError."""
 
     def test_returns_inline_select(self) -> None:
-        body = load_select_body("SELECT 1", None)
+        body = load_sql_body("SELECT 1", None)
         assert body == "SELECT 1"
 
     def test_returns_file_contents(self, tmp_path: Path) -> None:
         f = tmp_path / "query.sql"
         f.write_text("SELECT 2", encoding="utf-8")
-        body = load_select_body(None, str(f))
+        body = load_sql_body(None, str(f))
         assert body == "SELECT 2"
 
     def test_file_bom_stripped(self, tmp_path: Path) -> None:
         f = tmp_path / "query.sql"
         f.write_bytes(b"\xef\xbb\xbfSELECT 3")  # UTF-8 BOM
-        body = load_select_body(None, str(f))
+        body = load_sql_body(None, str(f))
         assert body == "SELECT 3"
 
     def test_both_raises_usage_error(self, tmp_path: Path) -> None:
         f = tmp_path / "q.sql"
         f.write_text("x", encoding="utf-8")
         with pytest.raises(click.UsageError, match="not both"):
-            load_select_body("SELECT 1", str(f))
+            load_sql_body("SELECT 1", str(f))
 
     def test_neither_raises_usage_error(self) -> None:
         with pytest.raises(click.UsageError):
-            load_select_body(None, None)
+            load_sql_body(None, None)
 
     def test_missing_file_raises_usage_error(self) -> None:
         with pytest.raises(click.UsageError, match="not found"):
-            load_select_body(None, "/nonexistent/path/query.sql")
+            load_sql_body(None, "/nonexistent/path/query.sql")
+
+    def test_custom_option_names_in_error_messages(self, tmp_path: Path) -> None:
+        """Callers can pass custom option names into error messages."""
+        f = tmp_path / "q.sql"
+        f.write_text("x", encoding="utf-8")
+        with pytest.raises(click.UsageError, match="--body"):
+            load_sql_body("SELECT 1", str(f), inline_opt="--body")
+        with pytest.raises(click.UsageError, match="--body"):
+            load_sql_body(None, None, inline_opt="--body")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/cli/commands/test_warehouses.py
+++ b/tests/unit/cli/commands/test_warehouses.py
@@ -129,7 +129,7 @@ class TestWarehousesGet:
                 new=_make_cm(mock_http, None),
             ),
             patch(
-                "fabric_dw.cli.commands.warehouses._resolve_item",
+                "fabric_dw.cli.commands.warehouses.resolve_item",
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
             ),
         ):
@@ -145,7 +145,7 @@ class TestWarehousesGet:
                 new=_make_cm(mock_http, None),
             ),
             patch(
-                "fabric_dw.cli.commands.warehouses._resolve_item",
+                "fabric_dw.cli.commands.warehouses.resolve_item",
                 new=AsyncMock(side_effect=NotFoundError("not found")),
             ),
         ):
@@ -198,7 +198,7 @@ class TestWarehousesRename:
                 new=_make_cm(mock_http, None),
             ),
             patch(
-                "fabric_dw.cli.commands.warehouses._resolve_item_with_cache",
+                "fabric_dw.cli.commands.warehouses.resolve_item_with_cache",
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry(), _cache)),
             ),
         ):
@@ -219,7 +219,7 @@ class TestWarehousesRename:
                 new=_make_cm(mock_http, None),
             ),
             patch(
-                "fabric_dw.cli.commands.warehouses._resolve_item_with_cache",
+                "fabric_dw.cli.commands.warehouses.resolve_item_with_cache",
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry(), _cache)),
             ),
         ):
@@ -246,7 +246,7 @@ class TestWarehousesDelete:
                 new=_make_cm(mock_http, None),
             ),
             patch(
-                "fabric_dw.cli.commands.warehouses._resolve_item_with_cache",
+                "fabric_dw.cli.commands.warehouses.resolve_item_with_cache",
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry(), _cache)),
             ),
         ):
@@ -264,7 +264,7 @@ class TestWarehousesDelete:
                 new=_make_cm(mock_http, None),
             ),
             patch(
-                "fabric_dw.cli.commands.warehouses._resolve_item_with_cache",
+                "fabric_dw.cli.commands.warehouses.resolve_item_with_cache",
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry(), _cache)),
             ),
         ):
@@ -284,7 +284,7 @@ class TestWarehousesDelete:
                 new=_make_cm(mock_http, None),
             ),
             patch(
-                "fabric_dw.cli.commands.warehouses._resolve_item_with_cache",
+                "fabric_dw.cli.commands.warehouses.resolve_item_with_cache",
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry(), _cache)),
             ),
         ):
@@ -356,7 +356,7 @@ class TestWarehousesTakeover:
                 new=_make_cm(mock_http, None),
             ),
             patch(
-                "fabric_dw.cli.commands.warehouses._resolve_item",
+                "fabric_dw.cli.commands.warehouses.resolve_item",
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry(WarehouseKind.WAREHOUSE))),
             ),
         ):
@@ -372,7 +372,7 @@ class TestWarehousesTakeover:
                 new=_make_cm(mock_http, None),
             ),
             patch(
-                "fabric_dw.cli.commands.warehouses._resolve_item",
+                "fabric_dw.cli.commands.warehouses.resolve_item",
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry(WarehouseKind.SQL_ENDPOINT))),
             ),
         ):
@@ -503,7 +503,7 @@ class TestWarehousesRenameError:
                 new=_make_cm(mock_http, None),
             ),
             patch(
-                "fabric_dw.cli.commands.warehouses._resolve_item_with_cache",
+                "fabric_dw.cli.commands.warehouses.resolve_item_with_cache",
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry(), _cache)),
             ),
             patch(
@@ -531,7 +531,7 @@ class TestWarehousesDeleteError:
                 new=_make_cm(mock_http, None),
             ),
             patch(
-                "fabric_dw.cli.commands.warehouses._resolve_item_with_cache",
+                "fabric_dw.cli.commands.warehouses.resolve_item_with_cache",
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry(), _cache)),
             ),
             patch(
@@ -558,7 +558,7 @@ class TestWarehousesTakeoverErrors:
                 new=_make_cm(mock_http, None),
             ),
             patch(
-                "fabric_dw.cli.commands.warehouses._resolve_item",
+                "fabric_dw.cli.commands.warehouses.resolve_item",
                 new=AsyncMock(side_effect=FabricError("resolve error")),
             ),
         ):
@@ -575,7 +575,7 @@ class TestWarehousesTakeoverErrors:
                 new=_make_cm(mock_http, None),
             ),
             patch(
-                "fabric_dw.cli.commands.warehouses._resolve_item",
+                "fabric_dw.cli.commands.warehouses.resolve_item",
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry(WarehouseKind.WAREHOUSE))),
             ),
         ):
@@ -599,7 +599,7 @@ class TestWarehousesTakeoverErrors:
                 new=_make_cm(mock_http, None),
             ),
             patch(
-                "fabric_dw.cli.commands.warehouses._resolve_item",
+                "fabric_dw.cli.commands.warehouses.resolve_item",
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry(WarehouseKind.WAREHOUSE))),
             ),
             patch(
@@ -647,7 +647,7 @@ class TestWarehousesPermissions:
                 new=_make_cm(mock_http, None),
             ),
             patch(
-                "fabric_dw.cli.commands.warehouses._resolve_item",
+                "fabric_dw.cli.commands.warehouses.resolve_item",
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
             ),
             patch(
@@ -669,7 +669,7 @@ class TestWarehousesPermissions:
                 new=_make_cm(mock_http, None),
             ),
             patch(
-                "fabric_dw.cli.commands.warehouses._resolve_item",
+                "fabric_dw.cli.commands.warehouses.resolve_item",
                 new=AsyncMock(side_effect=FabricError("server error")),
             ),
         ):

--- a/tests/unit/cli/test_render.py
+++ b/tests/unit/cli/test_render.py
@@ -96,10 +96,19 @@ class TestRenderTable:
         assert "abc" in output
         assert "foo" in output
 
-    def test_primitive_renders_repr(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_primitive_renders_str(self, capsys: pytest.CaptureFixture[str]) -> None:
         render(42, json_output=False)
         captured = capsys.readouterr()
         assert "42" in captured.out
+
+    def test_string_primitive_renders_without_quotes(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """str() is used, not repr() — so string primitives have no surrounding quotes."""
+        render("hello", json_output=False)
+        captured = capsys.readouterr()
+        assert "hello" in captured.out
+        assert "'hello'" not in captured.out
 
     def test_empty_list_renders_without_error(self) -> None:
         output = self._render_to_string([])


### PR DESCRIPTION
## Summary

Code-review findings from `review/` addressed in `src/fabric_dw/cli/`:

| ID | Status | How addressed |
|----|--------|---------------|
| **L02** | Partial (structural) | ~50× boilerplate pattern retained — each command owns its try/except so complex multi-block commands (`takeover`, `restore`, `set-collation`) stay readable. Alias/naming cleanup (L09) is the structural improvement; full extraction blocked by the diverse command bodies. |
| **L06** | Fixed | `sql exec` now uses `load_sql_body` instead of hand-rolled mutual-exclusion + inline `Path.read_text` + `assert`. |
| **L07** | Fixed | `load_select_body` → `load_sql_body`; accepts `inline_opt`/`file_opt` kwargs so callers can supply accurate option names (`--body`, `-q/--query`). |
| **L09** | Fixed | `_coro`, `_resolve_item`, `_resolve_item_with_cache` aliases removed from `_utils.py`; all 13 command modules updated to the public names. Test patch targets updated accordingly. |
| **L10** | Fixed | `_parse_iso` merged into `_utils.parse_iso_optional`; shared `LIMIT_OPTION`/`SINCE_OPTION`/`UNTIL_OPTION` constants replace the inline option trio in `sql_pools.insights`. |
| **L11** | Fixed | `render_permissions_table` and `render_refresh_table` use `_DEFAULT_CONSOLE` as fallback instead of `Console()`, matching `render()`'s lifecycle policy. |
| **L12** | Fixed | `CliContext.verbose` dead field removed; `_main.py` no longer passes it to the constructor. |
| **L15** | Fixed | `sql.py` TYPE_CHECKING import converted to runtime import, consistent with every other command module. |
| **L16** | Fixed | `import logging` + `_log = logging.getLogger(__name__)` removed from 13 command files where they were never used. |
| **L18** | Fixed | All-null column filter refactored into `_column_is_all_null(col, norm_rows)` named helper with early-return loop. |
| **L19** | Fixed | `_append_idempotent` rewritten with stable sentinel markers (`# >>> fabric-dw completion >>>` / `# <<<`). Re-installs replace the block in-place rather than duplicating it. Tests updated. |
| **L21** | Fixed | `assert … is not None  # noqa: S101` replaced with proper `if … is None: raise click.UsageError` narrowing in `sql_endpoints.list` and `warehouses.list`. |
| **L22** | Fixed | `render()` primitive branch changed `repr(data)` → `str(data)` (removes Python-quoting); docstring updated. |

## Test plan

- [x] `just check` fully green: ruff lint, ruff format, ty strict, pytest (2242 passed)
- [x] All patch targets in tests updated for renamed imports (no `_resolve_item` / `_coro` / `_resolve_item_with_cache` references remain)
- [x] `_append_idempotent` tests updated to use sentinel-based assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)