### PR TITLE
test(cli): assert behavior/output not just exit code; respx wire validation

### DIFF
--- a/tests/unit/cli/commands/conftest.py
+++ b/tests/unit/cli/commands/conftest.py
@@ -1,0 +1,56 @@
+"""Shared pytest fixtures for CLI command unit tests."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from azure.core.credentials import AccessToken
+from click.testing import CliRunner
+
+from fabric_dw.http_client import FabricHttpClient
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def cache_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# respx / wire-validation helpers (used by test_warehouses_respx.py and any
+# future respx-based test modules in this directory)
+# ---------------------------------------------------------------------------
+
+
+def _fake_token() -> AccessToken:
+    return AccessToken(token="fake-bearer", expires_on=int(time.time()) + 3600)  # noqa: S106
+
+
+def _make_fake_credential() -> MagicMock:
+    """Return a mock AsyncTokenCredential that yields a long-lived fake token."""
+    cred = MagicMock()
+    cred.get_token = AsyncMock(return_value=_fake_token())
+    return cred
+
+
+@asynccontextmanager
+async def _real_http_client_cm(_ctx: object) -> AsyncIterator[FabricHttpClient]:
+    """Context manager that yields a *real* FabricHttpClient backed by a fake credential.
+
+    Use this as the replacement for ``build_http_client`` in respx-based tests.
+    The returned client is fully functional but its HTTP calls are intercepted by
+    whichever ``respx.mock`` context is active at call time.
+    """
+    cred = _make_fake_credential()
+    async with FabricHttpClient(credential=cred, rps=100) as client:
+        yield client

--- a/tests/unit/cli/commands/test_audit.py
+++ b/tests/unit/cli/commands/test_audit.py
@@ -25,17 +25,6 @@ WS_UUID = UUID(WS_GUID)
 WH_UUID = UUID(WH_GUID)
 
 
-@pytest.fixture
-def runner() -> CliRunner:
-    return CliRunner()
-
-
-@pytest.fixture
-def cache_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
-    return tmp_path
-
-
 def _make_cm(http: object, _sql: object = None) -> object:
     @asynccontextmanager
     async def _cm(_ctx: object) -> AsyncIterator[object]:

--- a/tests/unit/cli/commands/test_audit.py
+++ b/tests/unit/cli/commands/test_audit.py
@@ -44,6 +44,10 @@ def _make_cm(http: object, _sql: object = None) -> object:
     return _cm
 
 
+def _make_audit_settings() -> AuditSettings:
+    return AuditSettings.model_validate(json.loads(AUDIT_SETTINGS_PAYLOAD))
+
+
 def _make_item_entry() -> ItemEntry:
     return ItemEntry(
         id=WH_UUID,
@@ -71,8 +75,11 @@ class TestAuditGet:
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
             ),
         ):
-            result = runner.invoke(cli, ["audit", "get", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["--json", "audit", "get", WS_GUID, WH_GUID])
         assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["state"] == "Enabled"
+        assert parsed["retentionDays"] == 30
 
     def test_get_json_output(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
@@ -117,6 +124,7 @@ class TestAuditEnable:
         _ = cache_env
         mock_http = AsyncMock()
         mock_http.request = AsyncMock(return_value=_make_response(200, AUDIT_SETTINGS_PAYLOAD))
+        mock_enable = AsyncMock(return_value=_make_audit_settings())
         with (
             patch(
                 "fabric_dw.cli.commands.audit.build_http_client",
@@ -126,14 +134,19 @@ class TestAuditEnable:
                 "fabric_dw.cli.commands.audit.resolve_item",
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
             ),
+            patch("fabric_dw.cli.commands.audit._audit_svc.enable", new=mock_enable),
         ):
-            result = runner.invoke(cli, ["audit", "enable", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["--json", "audit", "enable", WS_GUID, WH_GUID])
         assert result.exit_code == 0
+        mock_enable.assert_awaited_once()
+        parsed = json.loads(result.output)
+        assert parsed["state"] == "Enabled"
 
     def test_enable_with_retention_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
         mock_http = AsyncMock()
         mock_http.request = AsyncMock(return_value=_make_response(200, AUDIT_SETTINGS_PAYLOAD))
+        mock_enable = AsyncMock(return_value=_make_audit_settings())
         with (
             patch(
                 "fabric_dw.cli.commands.audit.build_http_client",
@@ -143,11 +156,15 @@ class TestAuditEnable:
                 "fabric_dw.cli.commands.audit.resolve_item",
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
             ),
+            patch("fabric_dw.cli.commands.audit._audit_svc.enable", new=mock_enable),
         ):
             result = runner.invoke(
                 cli, ["audit", "enable", WS_GUID, WH_GUID, "--retention-days", "30"]
             )
         assert result.exit_code == 0
+        mock_enable.assert_awaited_once()
+        _, kwargs = mock_enable.call_args
+        assert kwargs.get("retention_days") == 30
 
     def test_enable_with_unlimited_flag_exits_zero(
         self, runner: CliRunner, cache_env: Path
@@ -216,6 +233,7 @@ class TestAuditDisable:
         _ = cache_env
         mock_http = AsyncMock()
         mock_http.request = AsyncMock(return_value=_make_response(200, AUDIT_SETTINGS_PAYLOAD))
+        mock_disable = AsyncMock(return_value=_make_audit_settings())
         with (
             patch(
                 "fabric_dw.cli.commands.audit.build_http_client",
@@ -225,9 +243,11 @@ class TestAuditDisable:
                 "fabric_dw.cli.commands.audit.resolve_item",
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
             ),
+            patch("fabric_dw.cli.commands.audit._audit_svc.disable", new=mock_disable),
         ):
             result = runner.invoke(cli, ["--yes", "audit", "disable", WS_GUID, WH_GUID])
         assert result.exit_code == 0
+        mock_disable.assert_awaited_once()
 
     def test_disable_declined_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
         """Declining disable is a clean no-op (exit 0, policy: decline != error)."""
@@ -255,6 +275,7 @@ class TestAuditSetRetention:
         _ = cache_env
         mock_http = AsyncMock()
         mock_http.request = AsyncMock(return_value=_make_response(200, AUDIT_SETTINGS_PAYLOAD))
+        mock_set_retention = AsyncMock(return_value=_make_audit_settings())
         with (
             patch(
                 "fabric_dw.cli.commands.audit.build_http_client",
@@ -264,11 +285,15 @@ class TestAuditSetRetention:
                 "fabric_dw.cli.commands.audit.resolve_item",
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
             ),
+            patch("fabric_dw.cli.commands.audit._audit_svc.set_retention", new=mock_set_retention),
         ):
             result = runner.invoke(
                 cli, ["audit", "set-retention", WS_GUID, WH_GUID, "--days", "90"]
             )
         assert result.exit_code == 0
+        mock_set_retention.assert_awaited_once()
+        _, kwargs = mock_set_retention.call_args
+        assert kwargs.get("days") == 90
 
     def test_set_retention_json_output(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
@@ -342,6 +367,7 @@ class TestAuditSetRetention:
         _ = cache_env
         mock_http = AsyncMock()
         mock_http.request = AsyncMock(return_value=_make_response(200, AUDIT_SETTINGS_PAYLOAD))
+        mock_set_retention = AsyncMock(return_value=_make_audit_settings())
         with (
             patch(
                 "fabric_dw.cli.commands.audit.build_http_client",
@@ -351,11 +377,14 @@ class TestAuditSetRetention:
                 "fabric_dw.cli.commands.audit.resolve_item",
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
             ),
+            patch("fabric_dw.cli.commands.audit._audit_svc.set_retention", new=mock_set_retention),
         ):
             result = runner.invoke(
                 cli, ["audit", "set-retention", WS_GUID, WH_GUID, "--days", "30"]
             )
         assert result.exit_code == 0
+        # No pre-check GET — service is called exactly once (the PATCH)
+        mock_set_retention.assert_awaited_once()
 
 
 class TestAuditSetGroups:
@@ -365,6 +394,7 @@ class TestAuditSetGroups:
         _ = cache_env
         mock_http = AsyncMock()
         mock_http.request = AsyncMock(return_value=_make_response(200, AUDIT_SETTINGS_PAYLOAD))
+        mock_set_groups = AsyncMock(return_value=_make_audit_settings())
         with (
             patch(
                 "fabric_dw.cli.commands.audit.build_http_client",
@@ -374,6 +404,7 @@ class TestAuditSetGroups:
                 "fabric_dw.cli.commands.audit.resolve_item",
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
             ),
+            patch("fabric_dw.cli.commands.audit._audit_svc.set_action_groups", new=mock_set_groups),
         ):
             result = runner.invoke(
                 cli,
@@ -389,6 +420,11 @@ class TestAuditSetGroups:
                 ],
             )
         assert result.exit_code == 0
+        mock_set_groups.assert_awaited_once()
+        # Verify both groups were forwarded to the service
+        groups_arg = mock_set_groups.call_args.args[3]
+        assert "BATCH_COMPLETED_GROUP" in groups_arg
+        assert "SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP" in groups_arg
 
     def test_set_groups_invalid_name_returns_nonzero(
         self, runner: CliRunner, cache_env: Path
@@ -431,6 +467,7 @@ class TestAuditAddGroup:
         _ = cache_env
         mock_http = AsyncMock()
         mock_http.request = AsyncMock(return_value=_make_response(200, AUDIT_SETTINGS_PAYLOAD))
+        mock_add_group = AsyncMock(return_value=_make_audit_settings())
         with (
             patch(
                 "fabric_dw.cli.commands.audit.build_http_client",
@@ -440,6 +477,7 @@ class TestAuditAddGroup:
                 "fabric_dw.cli.commands.audit.resolve_item",
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
             ),
+            patch("fabric_dw.cli.commands.audit._audit_svc.add_action_group", new=mock_add_group),
         ):
             result = runner.invoke(
                 cli,
@@ -452,6 +490,9 @@ class TestAuditAddGroup:
                 ],
             )
         assert result.exit_code == 0
+        mock_add_group.assert_awaited_once()
+        # Group name must have been forwarded
+        assert mock_add_group.call_args.args[3] == "BATCH_COMPLETED_GROUP"
 
     def test_add_group_json_output(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
@@ -640,6 +681,7 @@ class TestAuditDefaultFallback:
         runner.invoke(cli, ["config", "set", "warehouse", WH_GUID])
         mock_http = AsyncMock()
         mock_http.request = AsyncMock(return_value=_make_response(200, AUDIT_SETTINGS_PAYLOAD))
+        mock_resolve = AsyncMock(return_value=(WS_UUID, _make_item_entry()))
         with (
             patch(
                 "fabric_dw.cli.commands.audit.build_http_client",
@@ -647,11 +689,15 @@ class TestAuditDefaultFallback:
             ),
             patch(
                 "fabric_dw.cli.commands.audit.resolve_item",
-                new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
+                new=mock_resolve,
             ),
         ):
-            result = runner.invoke(cli, ["audit", "get"])
+            result = runner.invoke(cli, ["--json", "audit", "get"])
         assert result.exit_code == 0
+        # resolve_item was called — workspace/warehouse resolved from config defaults
+        mock_resolve.assert_awaited_once()
+        parsed = json.loads(result.output)
+        assert parsed["state"] == "Enabled"
 
     def test_get_missing_both_raises_usage_error(
         self, runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/cli/commands/test_completion.py
+++ b/tests/unit/cli/commands/test_completion.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
 from click.testing import CliRunner
 
 from fabric_dw.cli._main import cli
@@ -15,11 +14,6 @@ from fabric_dw.cli.commands.completion import (
     _append_idempotent,
     _completion_script,
 )
-
-
-@pytest.fixture
-def runner() -> CliRunner:
-    return CliRunner()
 
 
 class TestCompletionInstallPrintOnly:

--- a/tests/unit/cli/commands/test_config.py
+++ b/tests/unit/cli/commands/test_config.py
@@ -13,11 +13,6 @@ from fabric_dw.config import Defaults, UserConfig, default_path, load_config
 
 
 @pytest.fixture
-def runner() -> CliRunner:
-    return CliRunner()
-
-
-@pytest.fixture
 def config_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     """Point XDG_CONFIG_HOME to a temp dir so tests are isolated."""
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))

--- a/tests/unit/cli/commands/test_procedures.py
+++ b/tests/unit/cli/commands/test_procedures.py
@@ -10,7 +10,6 @@ from pathlib import Path
 from unittest.mock import AsyncMock, patch
 from uuid import UUID
 
-import pytest
 from click.testing import CliRunner
 
 from fabric_dw.cache import ItemEntry
@@ -25,17 +24,6 @@ WS_UUID = UUID(WS_GUID)
 WH_UUID = UUID(WH_GUID)
 
 _NOW = datetime(2024, 6, 1, 12, 0, 0, tzinfo=UTC)
-
-
-@pytest.fixture
-def runner() -> CliRunner:
-    return CliRunner()
-
-
-@pytest.fixture
-def cache_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
-    return tmp_path
 
 
 def _make_sql_target() -> SqlTarget:

--- a/tests/unit/cli/commands/test_queries.py
+++ b/tests/unit/cli/commands/test_queries.py
@@ -25,17 +25,6 @@ WS_UUID = UUID(WS_GUID)
 WH_UUID = UUID(WH_GUID)
 
 
-@pytest.fixture
-def runner() -> CliRunner:
-    return CliRunner()
-
-
-@pytest.fixture
-def cache_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
-    return tmp_path
-
-
 def _make_http_cm(http: object) -> object:
     """Build an asynccontextmanager that yields just the http client."""
 

--- a/tests/unit/cli/commands/test_query_insights.py
+++ b/tests/unit/cli/commands/test_query_insights.py
@@ -34,17 +34,6 @@ WH_UUID = UUID(WH_GUID)
 _NOW = datetime(2024, 6, 1, 12, 0, 0, tzinfo=UTC)
 
 
-@pytest.fixture
-def runner() -> CliRunner:
-    return CliRunner()
-
-
-@pytest.fixture
-def cache_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
-    return tmp_path
-
-
 def _make_sql_target() -> SqlTarget:
     return SqlTarget(
         workspace_id=WS_GUID,

--- a/tests/unit/cli/commands/test_restore_points.py
+++ b/tests/unit/cli/commands/test_restore_points.py
@@ -76,17 +76,6 @@ def _make_restore_point(
     )
 
 
-@pytest.fixture
-def runner() -> CliRunner:
-    return CliRunner()
-
-
-@pytest.fixture
-def cache_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
-    return tmp_path
-
-
 # ---------------------------------------------------------------------------
 # list
 # ---------------------------------------------------------------------------

--- a/tests/unit/cli/commands/test_restore_points.py
+++ b/tests/unit/cli/commands/test_restore_points.py
@@ -113,8 +113,11 @@ class TestRestorePointsList:
                 new=AsyncMock(return_value=[rp]),
             ),
         ):
-            result = runner.invoke(cli, ["restore-points", "list", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["--json", "restore-points", "list", WS_GUID, WH_GUID])
         assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert isinstance(parsed, list)
+        assert parsed[0]["id"] == RP_ID
 
     def test_list_json_output_is_list(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
@@ -157,8 +160,10 @@ class TestRestorePointsList:
                 new=AsyncMock(return_value=[]),
             ),
         ):
-            result = runner.invoke(cli, ["restore-points", "list", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["--json", "restore-points", "list", WS_GUID, WH_GUID])
         assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed == []
 
     def test_list_fabric_error_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
@@ -219,8 +224,13 @@ class TestRestorePointsGet:
                 new=AsyncMock(return_value=rp),
             ),
         ):
-            result = runner.invoke(cli, ["restore-points", "get", WS_GUID, WH_GUID, RP_ID])
+            result = runner.invoke(
+                cli, ["--json", "restore-points", "get", WS_GUID, WH_GUID, RP_ID]
+            )
         assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["id"] == RP_ID
+        assert parsed["displayName"] == "RestorePoint_20240315"
 
     def test_get_json_output_has_id(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
@@ -280,6 +290,7 @@ class TestRestorePointsCreate:
         _ = cache_env
         mock_http = AsyncMock()
         rp = _make_restore_point()
+        mock_create = AsyncMock(return_value=rp)
         with (
             patch(
                 "fabric_dw.cli.commands.restore_points.build_http_client",
@@ -291,11 +302,14 @@ class TestRestorePointsCreate:
             ),
             patch(
                 "fabric_dw.services.restore.create_point",
-                new=AsyncMock(return_value=rp),
+                new=mock_create,
             ),
         ):
-            result = runner.invoke(cli, ["restore-points", "create", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["--json", "restore-points", "create", WS_GUID, WH_GUID])
         assert result.exit_code == 0
+        mock_create.assert_awaited_once()
+        parsed = json.loads(result.output)
+        assert parsed["id"] == RP_ID
 
     def test_create_with_name_and_description(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
@@ -366,6 +380,7 @@ class TestRestorePointsRename:
         _ = cache_env
         mock_http = AsyncMock()
         rp = _make_restore_point(name="NewName")
+        mock_update = AsyncMock(return_value=rp)
         with (
             patch(
                 "fabric_dw.cli.commands.restore_points.build_http_client",
@@ -377,14 +392,17 @@ class TestRestorePointsRename:
             ),
             patch(
                 "fabric_dw.services.restore.update_point",
-                new=AsyncMock(return_value=rp),
+                new=mock_update,
             ),
         ):
             result = runner.invoke(
                 cli,
-                ["restore-points", "rename", WS_GUID, WH_GUID, RP_ID, "NewName"],
+                ["--json", "restore-points", "rename", WS_GUID, WH_GUID, RP_ID, "NewName"],
             )
         assert result.exit_code == 0
+        mock_update.assert_awaited_once()
+        parsed = json.loads(result.output)
+        assert parsed["displayName"] == "NewName"
 
     def test_rename_with_description(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
@@ -675,6 +693,7 @@ class TestRestorePointsDefaultFallback:
         runner.invoke(cli, ["config", "set", "workspace", WS_GUID])
         runner.invoke(cli, ["config", "set", "warehouse", WH_GUID])
         mock_http = AsyncMock()
+        mock_resolve = AsyncMock(return_value=(WS_UUID, _make_wh_entry()))
         with (
             patch(
                 "fabric_dw.cli.commands.restore_points.build_http_client",
@@ -682,15 +701,19 @@ class TestRestorePointsDefaultFallback:
             ),
             patch(
                 "fabric_dw.cli.commands.restore_points.resolve_item",
-                new=AsyncMock(return_value=(WS_UUID, _make_wh_entry())),
+                new=mock_resolve,
             ),
             patch(
                 "fabric_dw.services.restore.list_points",
                 new=AsyncMock(return_value=[]),
             ),
         ):
-            result = runner.invoke(cli, ["restore-points", "list"])
+            result = runner.invoke(cli, ["--json", "restore-points", "list"])
         assert result.exit_code == 0
+        # resolve_item was called (workspace/warehouse resolved from config defaults)
+        mock_resolve.assert_awaited_once()
+        parsed = json.loads(result.output)
+        assert parsed == []
 
     def test_list_missing_workspace_raises_error(
         self, runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/cli/commands/test_schemas.py
+++ b/tests/unit/cli/commands/test_schemas.py
@@ -10,7 +10,6 @@ from pathlib import Path
 from unittest.mock import AsyncMock, patch
 from uuid import UUID
 
-import pytest
 from click.testing import CliRunner
 
 from fabric_dw.cache import ItemEntry
@@ -25,17 +24,6 @@ WS_UUID = UUID(WS_GUID)
 WH_UUID = UUID(WH_GUID)
 
 _NOW = datetime(2024, 6, 1, 12, 0, 0, tzinfo=UTC)
-
-
-@pytest.fixture
-def runner() -> CliRunner:
-    return CliRunner()
-
-
-@pytest.fixture
-def cache_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
-    return tmp_path
 
 
 def _make_sql_target() -> SqlTarget:

--- a/tests/unit/cli/commands/test_schemas.py
+++ b/tests/unit/cli/commands/test_schemas.py
@@ -87,6 +87,7 @@ class TestSchemasList:
     def test_list_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
         mock_http = AsyncMock()
+        mock_list = AsyncMock(return_value=[_make_schema()])
         with (
             patch(
                 "fabric_dw.cli.commands.schemas.build_http_client",
@@ -98,11 +99,13 @@ class TestSchemasList:
             ),
             patch(
                 "fabric_dw.services.schemas.list_schemas",
-                new=AsyncMock(return_value=[_make_schema()]),
+                new=mock_list,
             ),
         ):
             result = runner.invoke(cli, ["schemas", "list", WS_GUID, WH_GUID])
         assert result.exit_code == 0
+        mock_list.assert_awaited_once()
+        assert "sales" in result.output
 
     def test_list_json_output(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
@@ -175,6 +178,7 @@ class TestSchemasCreate:
     def test_create_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
         mock_http = AsyncMock()
+        mock_create = AsyncMock(return_value=_make_schema())
         with (
             patch(
                 "fabric_dw.cli.commands.schemas.build_http_client",
@@ -186,11 +190,13 @@ class TestSchemasCreate:
             ),
             patch(
                 "fabric_dw.services.schemas.create_schema",
-                new=AsyncMock(return_value=_make_schema()),
+                new=mock_create,
             ),
         ):
             result = runner.invoke(cli, ["schemas", "create", WS_GUID, WH_GUID, "sales"])
         assert result.exit_code == 0
+        mock_create.assert_awaited_once()
+        assert "sales" in result.output
 
     def test_create_json_output_contains_name(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
@@ -218,6 +224,7 @@ class TestSchemasCreate:
         """CREATE SCHEMA is supported on SQL Analytics Endpoints (Fabric T-SQL reference)."""
         _ = cache_env
         mock_http = AsyncMock()
+        mock_create = AsyncMock(return_value=_make_schema())
         with (
             patch(
                 "fabric_dw.cli.commands.schemas.build_http_client",
@@ -229,11 +236,13 @@ class TestSchemasCreate:
             ),
             patch(
                 "fabric_dw.services.schemas.create_schema",
-                new=AsyncMock(return_value=_make_schema()),
+                new=mock_create,
             ),
         ):
             result = runner.invoke(cli, ["schemas", "create", WS_GUID, WH_GUID, "sales"])
         assert result.exit_code == 0
+        mock_create.assert_awaited_once()
+        assert "sales" in result.output
 
     def test_create_permission_error_returns_nonzero(
         self, runner: CliRunner, cache_env: Path
@@ -380,6 +389,7 @@ class TestSchemasDelete:
     def test_delete_cascade_warns_on_stderr(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
         mock_http = AsyncMock()
+        mock_delete = AsyncMock(return_value=None)
         with (
             patch(
                 "fabric_dw.cli.commands.schemas.build_http_client",
@@ -391,15 +401,17 @@ class TestSchemasDelete:
             ),
             patch(
                 "fabric_dw.services.schemas.delete_schema",
-                new=AsyncMock(return_value=None),
+                new=mock_delete,
             ),
         ):
             result = runner.invoke(
                 cli,
                 ["-y", "schemas", "delete", WS_GUID, WH_GUID, "sales", "--cascade"],
             )
-        # With --yes the prompt is skipped entirely; the command exits cleanly.
+        # With --yes the prompt is skipped entirely; the command exits cleanly and reports the drop.
         assert result.exit_code == 0
+        mock_delete.assert_awaited_once()
+        assert "dropped" in result.output
 
     def test_delete_permission_error_returns_nonzero(
         self, runner: CliRunner, cache_env: Path

--- a/tests/unit/cli/commands/test_snapshots.py
+++ b/tests/unit/cli/commands/test_snapshots.py
@@ -27,17 +27,6 @@ WH_UUID = UUID(WH_GUID)
 SNAP_UUID = UUID(SNAP_GUID)
 
 
-@pytest.fixture
-def runner() -> CliRunner:
-    return CliRunner()
-
-
-@pytest.fixture
-def cache_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
-    return tmp_path
-
-
 def _make_http_cm(http: object) -> object:
     """Build an asynccontextmanager that yields just the http client."""
 
@@ -256,9 +245,18 @@ class TestSnapshotsRename:
                 ["--json", "snapshots", "rename", WS_GUID, SNAP_GUID, "NewSnapshotName"],
             )
         assert result.exit_code == 0
+        # Verify that the PATCH request body contained the NEW display name, not the old one.
+        # This would fail if new_name were ignored (regression detection).
+        patch_call = next(
+            call
+            for call in mock_http.request.call_args_list
+            if call.args and call.args[0] == "PATCH"
+        )
+        patch_json = patch_call.kwargs.get("json", {})
+        assert patch_json.get("displayName") == "NewSnapshotName"
+        # Also verify the rendered output returned the snapshot id
         data = json.loads(result.output)
         assert data["id"] == SNAP_GUID
-        assert "displayName" in data
 
 
 class TestSnapshotsDelete:
@@ -282,7 +280,9 @@ class TestSnapshotsDelete:
             result = runner.invoke(cli, ["--yes", "snapshots", "delete", SNAP_GUID, WS_GUID])
         assert result.exit_code == 0
         mock_http.request.assert_awaited_once()
-        assert "deleted" in result.output or "SalesWarehouse_Snapshot_20240315" in result.output
+        # Assert only the real success signal — the snapshot name is always in the fixture
+        # so the second disjunct would never catch a regression.
+        assert "deleted" in result.output
 
     def test_delete_declined_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
         """Declining delete is a clean no-op (exit 0, policy: decline != error)."""
@@ -338,7 +338,9 @@ class TestSnapshotsRoll:
             )
         assert result.exit_code == 0
         mock_roll.assert_awaited_once()
-        assert "rolled" in result.output or "SalesWarehouse_Snapshot_20240315" in result.output
+        # Assert only the real success signal — the snapshot name is always in the fixture
+        # so the second disjunct would never catch a regression.
+        assert "rolled" in result.output
 
     def test_roll_with_at_flag_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
@@ -373,9 +375,11 @@ class TestSnapshotsRoll:
             )
         assert result.exit_code == 0
         mock_roll.assert_awaited_once()
-        # The --at datetime must have been parsed and forwarded to the service.
+        # The --at datetime must have been parsed to the exact UTC datetime and forwarded.
+        # This assert would fail if parse_iso_datetime were skipped or the wrong value passed.
         _args, _kwargs = mock_roll.call_args
-        assert _args[2] is not None  # new_dt positional arg
+        expected_dt = datetime(2024, 3, 15, 12, 0, 0, tzinfo=UTC)
+        assert _args[2] == expected_dt, f"Expected {expected_dt!r}, got {_args[2]!r}"
 
     def test_roll_declined_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
         """Declining roll is a clean no-op (exit 0, policy: decline != error)."""

--- a/tests/unit/cli/commands/test_snapshots.py
+++ b/tests/unit/cli/commands/test_snapshots.py
@@ -106,8 +106,10 @@ class TestSnapshotsList:
                 new=AsyncMock(return_value=(WS_UUID, _make_wh_entry())),
             ),
         ):
-            result = runner.invoke(cli, ["snapshots", "list", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["--json", "snapshots", "list", WS_GUID, WH_GUID])
         assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert isinstance(parsed, list)
 
     def test_list_json_output(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
@@ -178,9 +180,12 @@ class TestSnapshotsCreate:
         ):
             result = runner.invoke(
                 cli,
-                ["snapshots", "create", WS_GUID, WH_GUID, "MySnapshot"],
+                ["--json", "snapshots", "create", WS_GUID, WH_GUID, "MySnapshot"],
             )
         assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["id"] == SNAP_GUID
+        assert data["displayName"] == "SalesWarehouse_Snapshot_20240315"
 
 
 class TestSnapshotsCreateDatetime:
@@ -248,9 +253,12 @@ class TestSnapshotsRename:
         ):
             result = runner.invoke(
                 cli,
-                ["snapshots", "rename", SNAP_GUID, "NewSnapshotName", WS_GUID],
+                ["--json", "snapshots", "rename", WS_GUID, SNAP_GUID, "NewSnapshotName"],
             )
         assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["id"] == SNAP_GUID
+        assert "displayName" in data
 
 
 class TestSnapshotsDelete:
@@ -273,6 +281,8 @@ class TestSnapshotsDelete:
         ):
             result = runner.invoke(cli, ["--yes", "snapshots", "delete", SNAP_GUID, WS_GUID])
         assert result.exit_code == 0
+        mock_http.request.assert_awaited_once()
+        assert "deleted" in result.output or "SalesWarehouse_Snapshot_20240315" in result.output
 
     def test_delete_declined_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
         """Declining delete is a clean no-op (exit 0, policy: decline != error)."""
@@ -300,6 +310,7 @@ class TestSnapshotsRoll:
     def test_roll_with_yes_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
         mock_http = AsyncMock()
+        mock_roll = AsyncMock(return_value=None)
         with (
             patch(
                 "fabric_dw.cli.commands.snapshots.build_http_client",
@@ -311,7 +322,7 @@ class TestSnapshotsRoll:
             ),
             patch(
                 "fabric_dw.services.snapshots.roll_timestamp",
-                new=AsyncMock(return_value=None),
+                new=mock_roll,
             ),
         ):
             result = runner.invoke(
@@ -326,10 +337,13 @@ class TestSnapshotsRoll:
                 ],
             )
         assert result.exit_code == 0
+        mock_roll.assert_awaited_once()
+        assert "rolled" in result.output or "SalesWarehouse_Snapshot_20240315" in result.output
 
     def test_roll_with_at_flag_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
         mock_http = AsyncMock()
+        mock_roll = AsyncMock(return_value=None)
         with (
             patch(
                 "fabric_dw.cli.commands.snapshots.build_http_client",
@@ -341,7 +355,7 @@ class TestSnapshotsRoll:
             ),
             patch(
                 "fabric_dw.services.snapshots.roll_timestamp",
-                new=AsyncMock(return_value=None),
+                new=mock_roll,
             ),
         ):
             result = runner.invoke(
@@ -358,6 +372,10 @@ class TestSnapshotsRoll:
                 ],
             )
         assert result.exit_code == 0
+        mock_roll.assert_awaited_once()
+        # The --at datetime must have been parsed and forwarded to the service.
+        _args, _kwargs = mock_roll.call_args
+        assert _args[2] is not None  # new_dt positional arg
 
     def test_roll_declined_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
         """Declining roll is a clean no-op (exit 0, policy: decline != error)."""
@@ -439,6 +457,7 @@ class TestSnapshotsDefaultFallback:
         runner.invoke(cli, ["config", "set", "warehouse", WH_GUID])
         mock_http = AsyncMock()
         mock_http.iter_paginated = MagicMock(return_value=_async_iter([]))
+        mock_resolve = AsyncMock(return_value=(WS_UUID, _make_wh_entry()))
         with (
             patch(
                 "fabric_dw.cli.commands.snapshots.build_http_client",
@@ -446,11 +465,15 @@ class TestSnapshotsDefaultFallback:
             ),
             patch(
                 "fabric_dw.cli.commands.snapshots.resolve_item",
-                new=AsyncMock(return_value=(WS_UUID, _make_wh_entry())),
+                new=mock_resolve,
             ),
         ):
-            result = runner.invoke(cli, ["snapshots", "list"])
+            result = runner.invoke(cli, ["--json", "snapshots", "list"])
         assert result.exit_code == 0
+        # resolve_item must have been called (config defaults were picked up)
+        mock_resolve.assert_awaited_once()
+        parsed = json.loads(result.output)
+        assert isinstance(parsed, list)
 
     def test_list_missing_workspace_raises_usage_error(
         self, runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/cli/commands/test_snapshots.py
+++ b/tests/unit/cli/commands/test_snapshots.py
@@ -242,7 +242,7 @@ class TestSnapshotsRename:
         ):
             result = runner.invoke(
                 cli,
-                ["--json", "snapshots", "rename", SNAP_GUID, "NewSnapshotName"],
+                ["--json", "snapshots", "rename", SNAP_GUID, "NewSnapshotName", WS_GUID],
             )
         assert result.exit_code == 0
         # Verify that the PATCH request body contained the NEW display name, not the old one.

--- a/tests/unit/cli/commands/test_snapshots.py
+++ b/tests/unit/cli/commands/test_snapshots.py
@@ -242,7 +242,7 @@ class TestSnapshotsRename:
         ):
             result = runner.invoke(
                 cli,
-                ["--json", "snapshots", "rename", WS_GUID, SNAP_GUID, "NewSnapshotName"],
+                ["--json", "snapshots", "rename", SNAP_GUID, "NewSnapshotName"],
             )
         assert result.exit_code == 0
         # Verify that the PATCH request body contained the NEW display name, not the old one.

--- a/tests/unit/cli/commands/test_sql.py
+++ b/tests/unit/cli/commands/test_sql.py
@@ -26,17 +26,6 @@ WS_UUID = UUID(WS_GUID)
 WH_UUID = UUID(WH_GUID)
 
 
-@pytest.fixture
-def runner() -> CliRunner:
-    return CliRunner()
-
-
-@pytest.fixture
-def cache_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
-    return tmp_path
-
-
 def _make_sql_target() -> SqlTarget:
     return SqlTarget(
         workspace_id=WS_GUID,

--- a/tests/unit/cli/commands/test_sql_endpoints.py
+++ b/tests/unit/cli/commands/test_sql_endpoints.py
@@ -27,17 +27,6 @@ WS_UUID = UUID(WS_GUID)
 EP_UUID = UUID(EP_GUID)
 
 
-@pytest.fixture
-def runner() -> CliRunner:
-    return CliRunner()
-
-
-@pytest.fixture
-def cache_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
-    return tmp_path
-
-
 def _make_cm(http: object, _sql: object = None) -> object:
     @asynccontextmanager
     async def _cm(_ctx: object) -> AsyncIterator[object]:

--- a/tests/unit/cli/commands/test_sql_pools.py
+++ b/tests/unit/cli/commands/test_sql_pools.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 import json
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from datetime import datetime
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 from uuid import UUID
 
-import pytest
 from click.testing import CliRunner
 
 from fabric_dw.cli._main import cli
@@ -78,17 +78,6 @@ _CONFIG = SqlPoolsConfiguration.model_validate(POOLS_PAYLOAD)
 _CONFIG_DISABLED = SqlPoolsConfiguration.model_validate(POOLS_DISABLED_PAYLOAD)
 _CONFIG_EMPTY = SqlPoolsConfiguration.model_validate(POOLS_EMPTY_PAYLOAD)
 _CONFIG_MULTI = SqlPoolsConfiguration.model_validate(MULTI_POOL_PAYLOAD)
-
-
-@pytest.fixture
-def runner() -> CliRunner:
-    return CliRunner()
-
-
-@pytest.fixture
-def cache_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
-    return tmp_path
 
 
 def _make_http_cm(http: object) -> object:
@@ -1094,11 +1083,19 @@ class TestSqlPoolsInsights:
                 ],
             )
         assert result.exit_code == 0
-        # since/until must have been parsed and forwarded to the service
+        # since/until must have been parsed to the exact datetime values and forwarded.
+        # These asserts would fail if parse_iso_datetime were skipped or wrong values passed.
         mock_insights.assert_awaited_once()
         _, kwargs = mock_insights.call_args
-        assert kwargs.get("since") is not None
-        assert kwargs.get("until") is not None
+        # The CLI uses parse_iso_optional(assume_utc=False), so naive input stays naive.
+        expected_since = datetime(2024, 1, 1, 0, 0, 0)  # noqa: DTZ001 — testing naive CLI output
+        expected_until = datetime(2024, 12, 31, 23, 59, 59)  # noqa: DTZ001
+        assert kwargs.get("since") == expected_since, (
+            f"Expected since={expected_since!r}, got {kwargs.get('since')!r}"
+        )
+        assert kwargs.get("until") == expected_until, (
+            f"Expected until={expected_until!r}, got {kwargs.get('until')!r}"
+        )
 
     def test_insights_fabric_error_exits_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env

--- a/tests/unit/cli/commands/test_sql_pools.py
+++ b/tests/unit/cli/commands/test_sql_pools.py
@@ -116,8 +116,11 @@ class TestSqlPoolsGet:
                 new=AsyncMock(return_value=_CONFIG),
             ),
         ):
-            result = runner.invoke(cli, ["sql-pools", "get", WS_GUID])
+            result = runner.invoke(cli, ["--json", "sql-pools", "get", WS_GUID])
         assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["customSQLPoolsEnabled"] is True
+        assert len(data["customSQLPools"]) == 1
 
     def test_get_json_output(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
@@ -179,8 +182,13 @@ class TestSqlPoolsList:
                 new=AsyncMock(return_value=_CONFIG_MULTI),
             ),
         ):
-            result = runner.invoke(cli, ["sql-pools", "list", WS_GUID])
+            result = runner.invoke(cli, ["--json", "sql-pools", "list", WS_GUID])
         assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert isinstance(data, list)
+        pool_names = [p["name"] for p in data]
+        assert "ETL" in pool_names
+        assert "Reporting" in pool_names
 
     def test_list_json_shows_pool_array(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
@@ -225,8 +233,11 @@ class TestSqlPoolsShow:
                 new=AsyncMock(return_value=_CONFIG_MULTI),
             ),
         ):
-            result = runner.invoke(cli, ["sql-pools", "show", WS_GUID, "--name", "ETL"])
+            result = runner.invoke(cli, ["--json", "sql-pools", "show", WS_GUID, "--name", "ETL"])
         assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["name"] == "ETL"
+        assert data["maxResourcePercentage"] == 40
 
     def test_show_missing_pool_exits_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
@@ -600,6 +611,7 @@ class TestSqlPoolsDelete:
 class TestSqlPoolsEnable:
     def test_enable_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
+        mock_enable = AsyncMock(return_value=_CONFIG)
         with (
             patch(
                 "fabric_dw.cli.commands.sql_pools.build_http_client",
@@ -611,11 +623,14 @@ class TestSqlPoolsEnable:
             ),
             patch(
                 "fabric_dw.cli.commands.sql_pools._svc.enable",
-                new=AsyncMock(return_value=_CONFIG),
+                new=mock_enable,
             ),
         ):
-            result = runner.invoke(cli, ["sql-pools", "enable", WS_GUID])
+            result = runner.invoke(cli, ["--json", "sql-pools", "enable", WS_GUID])
         assert result.exit_code == 0
+        mock_enable.assert_awaited_once()
+        data = json.loads(result.output)
+        assert data["customSQLPoolsEnabled"] is True
 
     def test_enable_403_shows_permission_hint(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
@@ -641,6 +656,7 @@ class TestSqlPoolsEnable:
 class TestSqlPoolsDisable:
     def test_disable_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
+        mock_disable = AsyncMock(return_value=_CONFIG_DISABLED)
         with (
             patch(
                 "fabric_dw.cli.commands.sql_pools.build_http_client",
@@ -652,11 +668,14 @@ class TestSqlPoolsDisable:
             ),
             patch(
                 "fabric_dw.cli.commands.sql_pools._svc.disable",
-                new=AsyncMock(return_value=_CONFIG_DISABLED),
+                new=mock_disable,
             ),
         ):
-            result = runner.invoke(cli, ["sql-pools", "disable", WS_GUID])
+            result = runner.invoke(cli, ["--json", "sql-pools", "disable", WS_GUID])
         assert result.exit_code == 0
+        mock_disable.assert_awaited_once()
+        data = json.loads(result.output)
+        assert data["customSQLPoolsEnabled"] is False
 
 
 class TestSqlPoolsGetFabricError:
@@ -1021,6 +1040,7 @@ class TestSqlPoolsInsights:
 
     def test_insights_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
+        mock_insights = AsyncMock(return_value=[])
         with (
             patch(
                 "fabric_dw.cli.commands.sql_pools.build_http_client",
@@ -1032,15 +1052,19 @@ class TestSqlPoolsInsights:
             ),
             patch(
                 "fabric_dw.cli.commands.sql_pools._qi_svc.list_sql_pool_insights",
-                new=AsyncMock(return_value=[]),
+                new=mock_insights,
             ),
         ):
-            result = runner.invoke(cli, ["sql-pools", "insights", WS_GUID, WS_GUID])
+            result = runner.invoke(cli, ["--json", "sql-pools", "insights", WS_GUID, WS_GUID])
         assert result.exit_code == 0
+        mock_insights.assert_awaited_once()
+        data = json.loads(result.output)
+        assert isinstance(data, list)
 
     def test_insights_with_since_and_until(self, runner: CliRunner, cache_env: Path) -> None:
         """Passes --since and --until to exercise the _parse_iso line 410."""
         _ = cache_env
+        mock_insights = AsyncMock(return_value=[])
         with (
             patch(
                 "fabric_dw.cli.commands.sql_pools.build_http_client",
@@ -1052,12 +1076,13 @@ class TestSqlPoolsInsights:
             ),
             patch(
                 "fabric_dw.cli.commands.sql_pools._qi_svc.list_sql_pool_insights",
-                new=AsyncMock(return_value=[]),
+                new=mock_insights,
             ),
         ):
             result = runner.invoke(
                 cli,
                 [
+                    "--json",
                     "sql-pools",
                     "insights",
                     WS_GUID,
@@ -1069,6 +1094,11 @@ class TestSqlPoolsInsights:
                 ],
             )
         assert result.exit_code == 0
+        # since/until must have been parsed and forwarded to the service
+        mock_insights.assert_awaited_once()
+        _, kwargs = mock_insights.call_args
+        assert kwargs.get("since") is not None
+        assert kwargs.get("until") is not None
 
     def test_insights_fabric_error_exits_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env

--- a/tests/unit/cli/commands/test_tables.py
+++ b/tests/unit/cli/commands/test_tables.py
@@ -10,7 +10,6 @@ from pathlib import Path
 from unittest.mock import AsyncMock, patch
 from uuid import UUID
 
-import pytest
 from click.testing import CliRunner
 
 from fabric_dw.cache import ItemEntry
@@ -28,17 +27,6 @@ WS_UUID = UUID(WS_GUID)
 WH_UUID = UUID(WH_GUID)
 
 _NOW = datetime(2024, 6, 1, 12, 0, 0, tzinfo=UTC)
-
-
-@pytest.fixture
-def runner() -> CliRunner:
-    return CliRunner()
-
-
-@pytest.fixture
-def cache_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
-    return tmp_path
 
 
 def _make_sql_target() -> SqlTarget:

--- a/tests/unit/cli/commands/test_tables.py
+++ b/tests/unit/cli/commands/test_tables.py
@@ -110,8 +110,12 @@ class TestTablesList:
                 new=AsyncMock(return_value=[_make_table()]),
             ),
         ):
-            result = runner.invoke(cli, ["tables", "list", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["--json", "tables", "list", WS_GUID, WH_GUID])
         assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert isinstance(parsed, list)
+        assert parsed[0]["name"] == "sales"
+        assert parsed[0]["schema_name"] == "dbo"
 
     def test_list_json_output(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
@@ -134,6 +138,7 @@ class TestTablesList:
         assert result.exit_code == 0
         parsed = json.loads(result.output)
         assert isinstance(parsed, list)
+        assert parsed[0]["qualified_name"] == "dbo.sales"
 
     def test_list_with_schema_filter(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
@@ -196,6 +201,10 @@ class TestTablesRead:
         ):
             result = runner.invoke(cli, ["tables", "read", WS_GUID, WH_GUID, "dbo.sales"])
         assert result.exit_code == 0
+        # Default output is JSON; row data must appear
+        parsed = json.loads(result.output)
+        assert parsed[0]["id"] == 1
+        assert parsed[0]["name"] == "Alice"
 
     def test_read_json_output_to_stdout(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
@@ -267,6 +276,8 @@ class TestTablesRead:
             )
         assert result.exit_code == 0
         assert out_file.exists()
+        content = out_file.read_text()
+        assert "id" in content  # CSV header row present
 
     def test_read_explicit_format_beats_json_flag(
         self, runner: CliRunner, cache_env: Path, tmp_path: Path
@@ -348,6 +359,7 @@ class TestTablesCreate:
     def test_create_with_select_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
         mock_http = AsyncMock()
+        mock_create = AsyncMock(return_value=_make_table())
         with (
             patch(
                 "fabric_dw.cli.commands.tables.build_http_client",
@@ -359,12 +371,13 @@ class TestTablesCreate:
             ),
             patch(
                 "fabric_dw.services.tables.create_table",
-                new=AsyncMock(return_value=_make_table()),
+                new=mock_create,
             ),
         ):
             result = runner.invoke(
                 cli,
                 [
+                    "--json",
                     "tables",
                     "create",
                     WS_GUID,
@@ -376,12 +389,16 @@ class TestTablesCreate:
                 ],
             )
         assert result.exit_code == 0
+        mock_create.assert_awaited_once()
+        parsed = json.loads(result.output)
+        assert parsed["name"] == "sales"
 
     def test_create_with_file(self, runner: CliRunner, cache_env: Path, tmp_path: Path) -> None:
         _ = cache_env
         sql_file = tmp_path / "ctas.sql"
         sql_file.write_text("SELECT id FROM src.raw")
         mock_http = AsyncMock()
+        mock_create = AsyncMock(return_value=_make_table())
         with (
             patch(
                 "fabric_dw.cli.commands.tables.build_http_client",
@@ -393,12 +410,13 @@ class TestTablesCreate:
             ),
             patch(
                 "fabric_dw.services.tables.create_table",
-                new=AsyncMock(return_value=_make_table()),
+                new=mock_create,
             ),
         ):
             result = runner.invoke(
                 cli,
                 [
+                    "--json",
                     "tables",
                     "create",
                     WS_GUID,
@@ -410,6 +428,12 @@ class TestTablesCreate:
                 ],
             )
         assert result.exit_code == 0
+        # Verify SQL from file was passed to the service
+        mock_create.assert_awaited_once()
+        # 4th positional arg is the select_body
+        assert "SELECT id FROM src.raw" in mock_create.call_args.args[3]
+        parsed = json.loads(result.output)
+        assert parsed["name"] == "sales"
 
     def test_create_no_select_fails(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
@@ -480,6 +504,7 @@ class TestTablesCreate:
         """Warehouse items should not be blocked by the SQL Endpoint guard."""
         _ = cache_env
         mock_http = AsyncMock()
+        mock_create = AsyncMock(return_value=_make_table())
         with (
             patch(
                 "fabric_dw.cli.commands.tables.build_http_client",
@@ -491,12 +516,13 @@ class TestTablesCreate:
             ),
             patch(
                 "fabric_dw.services.tables.create_table",
-                new=AsyncMock(return_value=_make_table()),
+                new=mock_create,
             ),
         ):
             result = runner.invoke(
                 cli,
                 [
+                    "--json",
                     "tables",
                     "create",
                     WS_GUID,
@@ -508,6 +534,10 @@ class TestTablesCreate:
                 ],
             )
         assert result.exit_code == 0
+        # Must have actually called create (not short-circuited by DDL guard)
+        mock_create.assert_awaited_once()
+        parsed = json.loads(result.output)
+        assert parsed["qualified_name"] == "dbo.sales"
 
     def test_create_sql_endpoint_rejected(self, runner: CliRunner, cache_env: Path) -> None:
         """SQL Endpoint items must be rejected by the service-layer guard before issuing DDL."""
@@ -549,6 +579,7 @@ class TestTablesDelete:
     def test_delete_with_yes_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
         mock_http = AsyncMock()
+        mock_delete = AsyncMock(return_value=None)
         with (
             patch(
                 "fabric_dw.cli.commands.tables.build_http_client",
@@ -560,13 +591,14 @@ class TestTablesDelete:
             ),
             patch(
                 "fabric_dw.services.tables.delete_table",
-                new=AsyncMock(return_value=None),
+                new=mock_delete,
             ),
         ):
             result = runner.invoke(
                 cli, ["--yes", "tables", "delete", WS_GUID, WH_GUID, "dbo.sales"]
             )
         assert result.exit_code == 0
+        mock_delete.assert_awaited_once()
 
     def test_delete_declined_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
         """Declining delete is a clean no-op (exit 0, policy: decline != error)."""
@@ -625,6 +657,7 @@ class TestTablesDelete:
         """Warehouse items should not be blocked by the SQL Endpoint guard."""
         _ = cache_env
         mock_http = AsyncMock()
+        mock_delete = AsyncMock(return_value=None)
         with (
             patch(
                 "fabric_dw.cli.commands.tables.build_http_client",
@@ -636,13 +669,15 @@ class TestTablesDelete:
             ),
             patch(
                 "fabric_dw.services.tables.delete_table",
-                new=AsyncMock(return_value=None),
+                new=mock_delete,
             ),
         ):
             result = runner.invoke(
                 cli, ["--yes", "tables", "delete", WS_GUID, WH_GUID, "dbo.sales"]
             )
         assert result.exit_code == 0
+        # Must have proceeded to actual delete (DDL guard passed)
+        mock_delete.assert_awaited_once()
 
     def test_delete_sql_endpoint_rejected(self, runner: CliRunner, cache_env: Path) -> None:
         """SQL Endpoint items must be rejected by the service-layer guard before issuing DDL."""
@@ -674,6 +709,7 @@ class TestTablesClear:
     def test_clear_with_yes_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
         mock_http = AsyncMock()
+        mock_clear = AsyncMock(return_value=None)
         with (
             patch(
                 "fabric_dw.cli.commands.tables.build_http_client",
@@ -685,11 +721,12 @@ class TestTablesClear:
             ),
             patch(
                 "fabric_dw.services.tables.clear_table",
-                new=AsyncMock(return_value=None),
+                new=mock_clear,
             ),
         ):
             result = runner.invoke(cli, ["--yes", "tables", "clear", WS_GUID, WH_GUID, "dbo.sales"])
         assert result.exit_code == 0
+        mock_clear.assert_awaited_once()
 
     def test_clear_declined_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
         """Declining clear is a clean no-op (exit 0, policy: decline != error)."""
@@ -746,6 +783,7 @@ class TestTablesClear:
         """Warehouse items should not be blocked by the SQL Endpoint guard."""
         _ = cache_env
         mock_http = AsyncMock()
+        mock_clear = AsyncMock(return_value=None)
         with (
             patch(
                 "fabric_dw.cli.commands.tables.build_http_client",
@@ -757,11 +795,13 @@ class TestTablesClear:
             ),
             patch(
                 "fabric_dw.services.tables.clear_table",
-                new=AsyncMock(return_value=None),
+                new=mock_clear,
             ),
         ):
             result = runner.invoke(cli, ["--yes", "tables", "clear", WS_GUID, WH_GUID, "dbo.sales"])
         assert result.exit_code == 0
+        # Must have proceeded to actual clear (DDL guard passed)
+        mock_clear.assert_awaited_once()
 
     def test_clear_sql_endpoint_rejected(self, runner: CliRunner, cache_env: Path) -> None:
         """SQL Endpoint items must be rejected by the service-layer guard before issuing DDL."""
@@ -791,6 +831,13 @@ class TestTablesClone:
     def test_clone_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
         mock_http = AsyncMock()
+        clone_result = Table(
+            schema_name="dbo",
+            name="sales_clone",
+            qualified_name="dbo.sales_clone",
+            created=_NOW,
+            modified=_NOW,
+        )
         with (
             patch(
                 "fabric_dw.cli.commands.tables.build_http_client",
@@ -802,12 +849,13 @@ class TestTablesClone:
             ),
             patch(
                 "fabric_dw.services.tables.clone_table",
-                new=AsyncMock(return_value=_make_table()),
+                new=AsyncMock(return_value=clone_result),
             ),
         ):
             result = runner.invoke(
                 cli,
                 [
+                    "--json",
                     "tables",
                     "clone",
                     WS_GUID,
@@ -819,6 +867,8 @@ class TestTablesClone:
                 ],
             )
         assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["name"] == "sales_clone"
 
     def test_clone_json_output(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
@@ -1018,6 +1068,7 @@ class TestTablesClone:
         """Warehouse items should not be blocked by the SQL Endpoint guard."""
         _ = cache_env
         mock_http = AsyncMock()
+        mock_clone = AsyncMock(return_value=_make_table())
         with (
             patch(
                 "fabric_dw.cli.commands.tables.build_http_client",
@@ -1029,7 +1080,7 @@ class TestTablesClone:
             ),
             patch(
                 "fabric_dw.services.tables.clone_table",
-                new=AsyncMock(return_value=_make_table()),
+                new=mock_clone,
             ),
         ):
             result = runner.invoke(
@@ -1046,6 +1097,8 @@ class TestTablesClone:
                 ],
             )
         assert result.exit_code == 0
+        # DDL guard passed — clone must have been invoked
+        mock_clone.assert_awaited_once()
 
     def test_clone_permission_denied_returns_nonzero(
         self, runner: CliRunner, cache_env: Path
@@ -1093,6 +1146,7 @@ class TestTablesRename:
             created=_NOW,
             modified=_NOW,
         )
+        mock_rename = AsyncMock(return_value=renamed)
         with (
             patch(
                 "fabric_dw.cli.commands.tables.build_http_client",
@@ -1104,14 +1158,26 @@ class TestTablesRename:
             ),
             patch(
                 "fabric_dw.services.tables.rename_table",
-                new=AsyncMock(return_value=renamed),
+                new=mock_rename,
             ),
         ):
             result = runner.invoke(
                 cli,
-                ["tables", "rename", WS_GUID, WH_GUID, "dbo.sales", "--new-name", "sales_v2"],
+                [
+                    "--json",
+                    "tables",
+                    "rename",
+                    WS_GUID,
+                    WH_GUID,
+                    "dbo.sales",
+                    "--new-name",
+                    "sales_v2",
+                ],
             )
         assert result.exit_code == 0
+        mock_rename.assert_awaited_once()
+        parsed = json.loads(result.output)
+        assert parsed["name"] == "sales_v2"
 
     def test_rename_json_output(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env

--- a/tests/unit/cli/commands/test_views.py
+++ b/tests/unit/cli/commands/test_views.py
@@ -98,8 +98,12 @@ class TestViewsList:
                 new=AsyncMock(return_value=[_make_view()]),
             ),
         ):
-            result = runner.invoke(cli, ["views", "list", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["--json", "views", "list", WS_GUID, WH_GUID])
         assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert isinstance(parsed, list)
+        assert parsed[0]["name"] == "vw_sales"
+        assert parsed[0]["schema_name"] == "dbo"
 
     def test_list_json_output(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
@@ -184,6 +188,10 @@ class TestViewsRead:
         ):
             result = runner.invoke(cli, ["views", "read", WS_GUID, WH_GUID, "dbo.vw_sales"])
         assert result.exit_code == 0
+        # Default output is JSON
+        parsed = json.loads(result.output)
+        assert parsed[0]["id"] == 1
+        assert parsed[0]["name"] == "Alice"
 
     def test_read_json_output_to_stdout(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
@@ -255,6 +263,8 @@ class TestViewsRead:
             )
         assert result.exit_code == 0
         assert out_file.exists()
+        content = out_file.read_text()
+        assert "id" in content  # CSV header present
 
     def test_read_bad_qualified_name_exits_nonzero(
         self, runner: CliRunner, cache_env: Path
@@ -307,8 +317,14 @@ class TestViewsGet:
                 new=AsyncMock(return_value=_make_view(with_definition=True)),
             ),
         ):
-            result = runner.invoke(cli, ["views", "get", WS_GUID, WH_GUID, "dbo.vw_sales"])
+            result = runner.invoke(
+                cli,
+                ["--json", "views", "get", WS_GUID, WH_GUID, "dbo.vw_sales"],
+            )
         assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["name"] == "vw_sales"
+        assert "SELECT id FROM dbo.sales" in parsed.get("definition", "")
 
     def test_get_json_output(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
@@ -369,6 +385,7 @@ class TestViewsCreate:
     def test_create_with_select_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
         mock_http = AsyncMock()
+        mock_create = AsyncMock(return_value=_make_view(with_definition=True))
         with (
             patch(
                 "fabric_dw.cli.commands.views.build_http_client",
@@ -380,12 +397,13 @@ class TestViewsCreate:
             ),
             patch(
                 "fabric_dw.services.views.create_view",
-                new=AsyncMock(return_value=_make_view(with_definition=True)),
+                new=mock_create,
             ),
         ):
             result = runner.invoke(
                 cli,
                 [
+                    "--json",
                     "views",
                     "create",
                     WS_GUID,
@@ -397,12 +415,16 @@ class TestViewsCreate:
                 ],
             )
         assert result.exit_code == 0
+        mock_create.assert_awaited_once()
+        parsed = json.loads(result.output)
+        assert parsed["name"] == "vw_sales"
 
     def test_create_with_file(self, runner: CliRunner, cache_env: Path, tmp_path: Path) -> None:
         _ = cache_env
         sql_file = tmp_path / "view.sql"
         sql_file.write_text("SELECT id FROM dbo.sales")
         mock_http = AsyncMock()
+        mock_create = AsyncMock(return_value=_make_view(with_definition=True))
         with (
             patch(
                 "fabric_dw.cli.commands.views.build_http_client",
@@ -414,12 +436,13 @@ class TestViewsCreate:
             ),
             patch(
                 "fabric_dw.services.views.create_view",
-                new=AsyncMock(return_value=_make_view(with_definition=True)),
+                new=mock_create,
             ),
         ):
             result = runner.invoke(
                 cli,
                 [
+                    "--json",
                     "views",
                     "create",
                     WS_GUID,
@@ -431,6 +454,9 @@ class TestViewsCreate:
                 ],
             )
         assert result.exit_code == 0
+        mock_create.assert_awaited_once()
+        parsed = json.loads(result.output)
+        assert parsed["name"] == "vw_sales"
 
     def test_create_no_select_fails(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
@@ -550,6 +576,7 @@ class TestViewsUpdate:
     def test_update_with_yes_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
         mock_http = AsyncMock()
+        mock_update = AsyncMock(return_value=_make_view(with_definition=True))
         with (
             patch(
                 "fabric_dw.cli.commands.views.build_http_client",
@@ -561,13 +588,14 @@ class TestViewsUpdate:
             ),
             patch(
                 "fabric_dw.services.views.update_view",
-                new=AsyncMock(return_value=_make_view(with_definition=True)),
+                new=mock_update,
             ),
         ):
             result = runner.invoke(
                 cli,
                 [
                     "--yes",
+                    "--json",
                     "views",
                     "update",
                     WS_GUID,
@@ -578,6 +606,9 @@ class TestViewsUpdate:
                 ],
             )
         assert result.exit_code == 0
+        mock_update.assert_awaited_once()
+        parsed = json.loads(result.output)
+        assert parsed["name"] == "vw_sales"
 
     def test_update_declined_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
         """Declining update is a clean no-op (exit 0, policy: decline != error)."""
@@ -661,6 +692,7 @@ class TestViewsDrop:
     def test_drop_with_yes_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
         mock_http = AsyncMock()
+        mock_drop = AsyncMock(return_value=None)
         with (
             patch(
                 "fabric_dw.cli.commands.views.build_http_client",
@@ -672,13 +704,14 @@ class TestViewsDrop:
             ),
             patch(
                 "fabric_dw.services.views.drop_view",
-                new=AsyncMock(return_value=None),
+                new=mock_drop,
             ),
         ):
             result = runner.invoke(
                 cli, ["--yes", "views", "drop", WS_GUID, WH_GUID, "dbo.vw_sales"]
             )
         assert result.exit_code == 0
+        mock_drop.assert_awaited_once()
 
     def test_drop_declined_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
         """Declining drop is a clean no-op (exit 0, policy: decline != error)."""
@@ -753,6 +786,7 @@ class TestViewsRename:
     def test_rename_with_yes_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
         mock_http = AsyncMock()
+        mock_rename = AsyncMock(return_value=self._make_renamed_view())
         with (
             patch(
                 "fabric_dw.cli.commands.views.build_http_client",
@@ -764,13 +798,14 @@ class TestViewsRename:
             ),
             patch(
                 "fabric_dw.services.views.rename_view",
-                new=AsyncMock(return_value=self._make_renamed_view()),
+                new=mock_rename,
             ),
         ):
             result = runner.invoke(
                 cli,
                 [
                     "--yes",
+                    "--json",
                     "views",
                     "rename",
                     WS_GUID,
@@ -781,6 +816,9 @@ class TestViewsRename:
                 ],
             )
         assert result.exit_code == 0
+        mock_rename.assert_awaited_once()
+        parsed = json.loads(result.output)
+        assert parsed["name"] == "vw_revenue"
 
     def test_rename_json_output_contains_new_name(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env

--- a/tests/unit/cli/commands/test_views.py
+++ b/tests/unit/cli/commands/test_views.py
@@ -10,7 +10,6 @@ from pathlib import Path
 from unittest.mock import AsyncMock, patch
 from uuid import UUID
 
-import pytest
 from click.testing import CliRunner
 
 from fabric_dw.cache import ItemEntry
@@ -25,17 +24,6 @@ WS_UUID = UUID(WS_GUID)
 WH_UUID = UUID(WH_GUID)
 
 _NOW = datetime(2024, 6, 1, 12, 0, 0, tzinfo=UTC)
-
-
-@pytest.fixture
-def runner() -> CliRunner:
-    return CliRunner()
-
-
-@pytest.fixture
-def cache_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
-    return tmp_path
 
 
 def _make_sql_target() -> SqlTarget:

--- a/tests/unit/cli/commands/test_warehouses.py
+++ b/tests/unit/cli/commands/test_warehouses.py
@@ -16,7 +16,7 @@ from click.testing import CliRunner
 from fabric_dw.cache import ItemEntry, LookupCache
 from fabric_dw.cli._main import cli
 from fabric_dw.exceptions import FabricError, NotFoundError
-from fabric_dw.models import WarehouseKind
+from fabric_dw.models import Warehouse, WarehouseKind
 from tests.fixtures.api_payloads import (
     WAREHOUSE_CREATE_202_PAYLOAD,
     WAREHOUSE_GET_PAYLOAD,
@@ -46,6 +46,18 @@ def _make_cm(http: object, _sql: object = None) -> object:
         yield http
 
     return _cm
+
+
+def _make_warehouse(name: str = "SalesWarehouse") -> Warehouse:
+    return Warehouse.model_validate(
+        {
+            "id": WH_GUID,
+            "displayName": name,
+            "workspaceId": WS_GUID,
+            "kind": WarehouseKind.WAREHOUSE,
+            "connectionString": "wh.datawarehouse.fabric.microsoft.com",
+        }
+    )
 
 
 def _make_item_entry(kind: WarehouseKind = WarehouseKind.WAREHOUSE) -> ItemEntry:
@@ -83,6 +95,8 @@ class TestWarehousesList:
         ):
             result = runner.invoke(cli, ["warehouses", "list", WS_GUID])
         assert result.exit_code == 0
+        # Table renders without error — heading or empty-state text visible
+        assert result.output is not None
 
     def test_list_json_output(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
@@ -133,8 +147,11 @@ class TestWarehousesGet:
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
             ),
         ):
-            result = runner.invoke(cli, ["warehouses", "get", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["--json", "warehouses", "get", WS_GUID, WH_GUID])
         assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["displayName"] == "SalesWarehouse"
+        assert parsed["id"] == WH_GUID
 
     def test_get_not_found_returns_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
@@ -192,6 +209,7 @@ class TestWarehousesRename:
         mock_http = AsyncMock()
         mock_http.request = AsyncMock(return_value=_make_response(200, WAREHOUSE_GET_PAYLOAD))
         _cache = LookupCache(path=cache_env / "lookup.json")
+        mock_rename = AsyncMock(return_value=_make_warehouse("NewName"))
         with (
             patch(
                 "fabric_dw.cli.commands.warehouses.build_http_client",
@@ -201,12 +219,16 @@ class TestWarehousesRename:
                 "fabric_dw.cli.commands.warehouses.resolve_item_with_cache",
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry(), _cache)),
             ),
+            patch("fabric_dw.services.warehouses.rename", new=mock_rename),
         ):
             result = runner.invoke(
                 cli,
-                ["--yes", "warehouses", "rename", WS_GUID, WH_GUID, "NewName"],
+                ["--json", "--yes", "warehouses", "rename", WS_GUID, WH_GUID, "NewName"],
             )
         assert result.exit_code == 0
+        mock_rename.assert_awaited_once()
+        data = json.loads(result.output)
+        assert data["displayName"] == "NewName"
 
     def test_rename_declined_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
         """Declining rename is a clean no-op (exit 0, policy: decline != error)."""
@@ -240,6 +262,7 @@ class TestWarehousesDelete:
         mock_http = AsyncMock()
         mock_http.request = AsyncMock(return_value=_make_response(204, ""))
         _cache = LookupCache(path=cache_env / "lookup.json")
+        mock_delete = AsyncMock(return_value=None)
         with (
             patch(
                 "fabric_dw.cli.commands.warehouses.build_http_client",
@@ -249,9 +272,11 @@ class TestWarehousesDelete:
                 "fabric_dw.cli.commands.warehouses.resolve_item_with_cache",
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry(), _cache)),
             ),
+            patch("fabric_dw.services.warehouses.delete", new=mock_delete),
         ):
             result = runner.invoke(cli, ["--yes", "warehouses", "delete", WS_GUID, WH_GUID])
         assert result.exit_code == 0
+        mock_delete.assert_awaited_once()
 
     def test_delete_declined_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
         """Declining delete is a clean no-op (exit 0, policy: decline != error)."""
@@ -350,6 +375,7 @@ class TestWarehousesTakeover:
         _ = cache_env
         mock_http = AsyncMock()
         mock_http.request = AsyncMock(return_value=_make_response(200, "{}"))
+        mock_takeover = AsyncMock(return_value=None)
         with (
             patch(
                 "fabric_dw.cli.commands.warehouses.build_http_client",
@@ -359,9 +385,11 @@ class TestWarehousesTakeover:
                 "fabric_dw.cli.commands.warehouses.resolve_item",
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry(WarehouseKind.WAREHOUSE))),
             ),
+            patch("fabric_dw.services.ownership.takeover", new=mock_takeover),
         ):
             result = runner.invoke(cli, ["--yes", "warehouses", "takeover", WS_GUID, WH_GUID])
         assert result.exit_code == 0
+        mock_takeover.assert_awaited_once()
 
     def test_takeover_sql_endpoint_refused(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
@@ -408,8 +436,11 @@ class TestWarehousesDefaultFallback:
                 new=AsyncMock(return_value=WS_UUID),
             ),
         ):
-            result = runner.invoke(cli, ["warehouses", "list", WS_GUID])
+            result = runner.invoke(cli, ["--json", "warehouses", "list", WS_GUID])
         assert result.exit_code == 0
+        # Empty list renders as valid JSON array when no warehouses exist
+        parsed = json.loads(result.output)
+        assert isinstance(parsed, list)
 
     def test_list_uses_config_default_workspace(
         self, runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -422,6 +453,7 @@ class TestWarehousesDefaultFallback:
         assert setup.exit_code == 0
         mock_http = AsyncMock()
         mock_http.iter_paginated = MagicMock(return_value=_async_iter([]))
+        mock_ws_id = AsyncMock(return_value=WS_UUID)
         with (
             patch(
                 "fabric_dw.cli.commands.warehouses.build_http_client",
@@ -429,12 +461,16 @@ class TestWarehousesDefaultFallback:
             ),
             patch(
                 "fabric_dw.resolver.Resolver.workspace_id",
-                new=AsyncMock(return_value=WS_UUID),
+                new=mock_ws_id,
             ),
         ):
             # No WORKSPACE argument — must fall back to config default.
-            result = runner.invoke(cli, ["warehouses", "list"])
+            result = runner.invoke(cli, ["--json", "warehouses", "list"])
         assert result.exit_code == 0
+        # Resolver must have been called (workspace resolved from config default)
+        mock_ws_id.assert_awaited_once()
+        parsed = json.loads(result.output)
+        assert isinstance(parsed, list)
 
     def test_list_missing_workspace_raises_usage_error(
         self, runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -655,8 +691,12 @@ class TestWarehousesPermissions:
                 new=AsyncMock(return_value=[access]),
             ),
         ):
-            result = runner.invoke(cli, ["warehouses", "permissions", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["--json", "warehouses", "permissions", WS_GUID, WH_GUID])
         assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert isinstance(parsed, list)
+        # Alice's principal must appear in the rendered permissions list
+        assert any(p.get("principal", {}).get("displayName") == "Alice" for p in parsed)
 
     def test_permissions_fabric_error_exits_nonzero(
         self, runner: CliRunner, cache_env: Path

--- a/tests/unit/cli/commands/test_warehouses.py
+++ b/tests/unit/cli/commands/test_warehouses.py
@@ -29,17 +29,6 @@ WS_UUID = UUID(WS_GUID)
 WH_UUID = UUID(WH_GUID)
 
 
-@pytest.fixture
-def runner() -> CliRunner:
-    return CliRunner()
-
-
-@pytest.fixture
-def cache_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
-    return tmp_path
-
-
 def _make_cm(http: object, _sql: object = None) -> object:
     @asynccontextmanager
     async def _cm(_ctx: object) -> AsyncIterator[object]:
@@ -95,8 +84,13 @@ class TestWarehousesList:
         ):
             result = runner.invoke(cli, ["warehouses", "list", WS_GUID])
         assert result.exit_code == 0
-        # Table renders without error — heading or empty-state text visible
-        assert result.output is not None
+        # iter_paginated must have been called with a URL containing the resolved workspace UUID,
+        # proving workspace resolution happened and the list call reached the service layer.
+        # This assert would fail if workspace_id were wrong or the call were never made.
+        calls = mock_http.iter_paginated.call_args_list
+        assert len(calls) >= 1
+        called_path = calls[0].args[1] if calls[0].args else str(calls[0])
+        assert str(WS_UUID) in called_path
 
     def test_list_json_output(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env

--- a/tests/unit/cli/commands/test_warehouses_respx.py
+++ b/tests/unit/cli/commands/test_warehouses_respx.py
@@ -41,21 +41,16 @@ Each follows the same pattern established here.
 from __future__ import annotations
 
 import json
-import time
-from collections.abc import AsyncIterator
-from contextlib import asynccontextmanager
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import patch
 
 import httpx
-import pytest
 import respx
-from azure.core.credentials import AccessToken
 from click.testing import CliRunner
 
 from fabric_dw.cli._main import cli
-from fabric_dw.http_client import FabricHttpClient
 from tests.fixtures.api_payloads import WAREHOUSE_GET_PAYLOAD
+from tests.unit.cli.commands.conftest import _real_http_client_cm
 
 # ---------------------------------------------------------------------------
 # Constants matching fixtures
@@ -74,17 +69,6 @@ _WAREHOUSE_URL = f"{_BASE}/workspaces/{WS_GUID}/warehouses/{WH_GUID}"
 # ---------------------------------------------------------------------------
 
 
-def _fake_token() -> AccessToken:
-    return AccessToken(token="fake-bearer", expires_on=int(time.time()) + 3600)  # noqa: S106
-
-
-def _make_fake_credential() -> MagicMock:
-    """Return a mock AsyncTokenCredential that yields a long-lived fake token."""
-    cred = MagicMock()
-    cred.get_token = AsyncMock(return_value=_fake_token())
-    return cred
-
-
 # Generic items response needed by the Resolver GUID fast-path:
 # GET /workspaces/{ws}/items/{item} discovers the item type.
 _ITEMS_GENERIC_RESPONSE = {
@@ -97,33 +81,9 @@ _ITEMS_GENERIC_RESPONSE = {
 _WAREHOUSE_DETAIL = json.loads(WAREHOUSE_GET_PAYLOAD)
 
 
-@asynccontextmanager
-async def _real_http_client_cm(_ctx: object) -> AsyncIterator[FabricHttpClient]:
-    """Context manager that yields a *real* FabricHttpClient backed by a fake credential.
-
-    Use this as the replacement for ``build_http_client`` in respx-based tests.
-    The returned client is fully functional but its HTTP calls are intercepted by
-    whichever ``respx.mock`` context is active at call time.
-    """
-    cred = _make_fake_credential()
-    async with FabricHttpClient(credential=cred, rps=100) as client:
-        yield client
-
-
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
-
-
-@pytest.fixture
-def runner() -> CliRunner:
-    return CliRunner()
-
-
-@pytest.fixture
-def cache_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
-    return tmp_path
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/cli/commands/test_warehouses_respx.py
+++ b/tests/unit/cli/commands/test_warehouses_respx.py
@@ -1,0 +1,297 @@
+"""T15: respx-based CLI tests for warehouses — HTTP wire validation.
+
+These tests replace the ``FabricHttpClient`` AsyncMock with a *real* client
+backed by a fake credential, and use ``respx`` to intercept HTTP at the httpx
+layer.  This validates:
+
+* The exact URL constructed by each CLI command path
+* The HTTP method used
+* The JSON request body shape (for POST/PATCH)
+* The JSON response is parsed and rendered correctly
+
+Pattern
+-------
+1. Patch ``fabric_dw.cli.commands._utils._auth.get_credential`` to return a
+   fake ``AsyncTokenCredential`` (no real token exchange).
+2. Open the real ``FabricHttpClient`` inside a ``respx.mock`` context so all
+   ``httpx.AsyncClient`` requests are intercepted.
+3. Assert on ``respx.calls`` to verify URL, method, and body.
+
+Scope of this file
+------------------
+Covers the most important "read" and "write" warehouse commands:
+  * ``warehouses get`` (GET wire → validates URL and JSON parsing)
+  * ``warehouses delete`` (DELETE wire → validates URL and method)
+  * ``warehouses rename`` (PATCH wire → validates URL, method, and body shape)
+
+What remains to convert
+-----------------------
+All other CLI test modules still use ``AsyncMock(FabricHttpClient)`` at the
+Python-object layer.  They validate exit codes and rendered output but do NOT
+validate wire-level details.  Candidate modules for follow-up conversion:
+
+  * test_snapshots.py  — create (POST LRO), rename (PATCH), delete (DELETE)
+  * test_audit.py      — enable (PATCH), disable (PATCH), set-retention (PATCH)
+  * test_restore_points.py — create (POST), rename (PATCH)
+  * test_workspaces.py — list (GET with pagination), get (GET)
+
+Each follows the same pattern established here.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+import respx
+from azure.core.credentials import AccessToken
+from click.testing import CliRunner
+
+from fabric_dw.cli._main import cli
+from fabric_dw.http_client import FabricHttpClient
+from tests.fixtures.api_payloads import WAREHOUSE_GET_PAYLOAD
+
+# ---------------------------------------------------------------------------
+# Constants matching fixtures
+# ---------------------------------------------------------------------------
+
+WS_GUID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+WH_GUID = "d4e5f6a7-b8c9-0123-def0-123456789abc"
+
+_BASE = "https://api.fabric.microsoft.com/v1"
+_ITEMS_URL = f"{_BASE}/workspaces/{WS_GUID}/items/{WH_GUID}"
+_WAREHOUSE_URL = f"{_BASE}/workspaces/{WS_GUID}/warehouses/{WH_GUID}"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _fake_token() -> AccessToken:
+    return AccessToken(token="fake-bearer", expires_on=int(time.time()) + 3600)  # noqa: S106
+
+
+def _make_fake_credential() -> MagicMock:
+    """Return a mock AsyncTokenCredential that yields a long-lived fake token."""
+    cred = MagicMock()
+    cred.get_token = AsyncMock(return_value=_fake_token())
+    return cred
+
+
+# Generic items response needed by the Resolver GUID fast-path:
+# GET /workspaces/{ws}/items/{item} discovers the item type.
+_ITEMS_GENERIC_RESPONSE = {
+    "id": WH_GUID,
+    "displayName": "SalesWarehouse",
+    "type": "Warehouse",
+    "workspaceId": WS_GUID,
+}
+
+_WAREHOUSE_DETAIL = json.loads(WAREHOUSE_GET_PAYLOAD)
+
+
+@asynccontextmanager
+async def _real_http_client_cm(_ctx: object) -> AsyncIterator[FabricHttpClient]:
+    """Context manager that yields a *real* FabricHttpClient backed by a fake credential.
+
+    Use this as the replacement for ``build_http_client`` in respx-based tests.
+    The returned client is fully functional but its HTTP calls are intercepted by
+    whichever ``respx.mock`` context is active at call time.
+    """
+    cred = _make_fake_credential()
+    async with FabricHttpClient(credential=cred, rps=100) as client:
+        yield client
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def cache_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# T15: warehouses get — wire validation
+# ---------------------------------------------------------------------------
+
+
+class TestWarehousesGetRespx:
+    """Validate that ``warehouses get`` issues the correct GET requests.
+
+    Two GET calls are expected:
+    1. Resolver GUID fast-path: GET /v1/workspaces/{ws}/items/{wh}
+       (discovers item type → "Warehouse")
+    2. Resolver type-specific: GET /v1/workspaces/{ws}/warehouses/{wh}
+       (fetches full detail including connectionString)
+    3. get_warehouse service: GET /v1/workspaces/{ws}/warehouses/{wh}
+       (another detail fetch used to render the response)
+
+    Calls 2 and 3 hit the same URL; respx counts them both.
+    """
+
+    def test_get_issues_correct_url(self, runner: CliRunner, cache_env: Path) -> None:
+        """The CLI must GET the correct Fabric API URL for the warehouse."""
+        _ = cache_env
+        with respx.mock(assert_all_called=False) as mock_router:
+            # Resolver generic-items endpoint
+            items_route = mock_router.get(_ITEMS_URL).mock(
+                return_value=httpx.Response(200, json=_ITEMS_GENERIC_RESPONSE)
+            )
+            # Resolver type-specific + get_warehouse service endpoint (same URL, called 2x)
+            warehouse_route = mock_router.get(_WAREHOUSE_URL).mock(
+                return_value=httpx.Response(200, json=_WAREHOUSE_DETAIL)
+            )
+
+            with patch(
+                "fabric_dw.cli.commands.warehouses.build_http_client",
+                new=_real_http_client_cm,
+            ):
+                result = runner.invoke(cli, ["--json", "warehouses", "get", WS_GUID, WH_GUID])
+
+        assert result.exit_code == 0, result.output
+        # Verify the exact URLs were called (wire validation)
+        assert items_route.called, f"Expected GET {_ITEMS_URL} to be called"
+        assert warehouse_route.called, f"Expected GET {_WAREHOUSE_URL} to be called"
+        # Verify the parsed output matches the fixture
+        data = json.loads(result.output)
+        assert data["displayName"] == "SalesWarehouse"
+        assert data["id"] == WH_GUID
+
+    def test_get_uses_bearer_auth(self, runner: CliRunner, cache_env: Path) -> None:
+        """Every request must carry an Authorization: Bearer … header."""
+        _ = cache_env
+        seen_headers: list[dict[str, str]] = []
+
+        def _capture(request: httpx.Request) -> httpx.Response:
+            seen_headers.append(dict(request.headers))
+            if "items" in str(request.url):
+                return httpx.Response(200, json=_ITEMS_GENERIC_RESPONSE)
+            return httpx.Response(200, json=_WAREHOUSE_DETAIL)
+
+        with respx.mock(assert_all_called=False) as mock_router:
+            mock_router.get(url__regex=r".*/workspaces/.*").mock(side_effect=_capture)
+
+            with patch(
+                "fabric_dw.cli.commands.warehouses.build_http_client",
+                new=_real_http_client_cm,
+            ):
+                result = runner.invoke(cli, ["warehouses", "get", WS_GUID, WH_GUID])
+
+        assert result.exit_code == 0, result.output
+        # Every captured request must have an Authorization header
+        for headers in seen_headers:
+            auth_header = headers.get("authorization", "")
+            assert auth_header.startswith("Bearer "), f"Expected Bearer token, got: {auth_header!r}"
+
+
+# ---------------------------------------------------------------------------
+# T15: warehouses delete — wire validation
+# ---------------------------------------------------------------------------
+
+
+class TestWarehousesDeleteRespx:
+    """Validate that ``warehouses delete`` issues a DELETE request with the correct URL."""
+
+    def test_delete_issues_delete_method(self, runner: CliRunner, cache_env: Path) -> None:
+        """The CLI must DELETE the correct Fabric API URL for warehouses."""
+        _ = cache_env
+        # warehouses.delete uses DELETE /workspaces/{ws}/warehouses/{wh}
+        delete_url = _WAREHOUSE_URL
+
+        with respx.mock(assert_all_called=False) as mock_router:
+            # Resolver calls (GUID fast-path)
+            mock_router.get(_ITEMS_URL).mock(
+                return_value=httpx.Response(200, json=_ITEMS_GENERIC_RESPONSE)
+            )
+            mock_router.get(_WAREHOUSE_URL).mock(
+                return_value=httpx.Response(200, json=_WAREHOUSE_DETAIL)
+            )
+            # The actual delete
+            delete_route = mock_router.delete(delete_url).mock(return_value=httpx.Response(204))
+
+            with patch(
+                "fabric_dw.cli.commands.warehouses.build_http_client",
+                new=_real_http_client_cm,
+            ):
+                result = runner.invoke(
+                    cli,
+                    ["--yes", "warehouses", "delete", WS_GUID, WH_GUID],
+                )
+
+        assert result.exit_code == 0, result.output
+        # The DELETE must have been called on the correct warehouse URL
+        assert delete_route.called, f"Expected DELETE {delete_url} to be called"
+
+
+# ---------------------------------------------------------------------------
+# T15: warehouses rename — wire validation (PATCH body)
+# ---------------------------------------------------------------------------
+
+
+class TestWarehousesRenameRespx:
+    """Validate that ``warehouses rename`` issues a PATCH with the correct body."""
+
+    def test_rename_patch_body_contains_new_name(self, runner: CliRunner, cache_env: Path) -> None:
+        """PATCH body must include the new displayName."""
+        _ = cache_env
+        # warehouses.rename uses PATCH /workspaces/{ws}/warehouses/{wh}
+        patch_url = _WAREHOUSE_URL
+        captured_bodies: list[dict[str, object]] = []
+
+        def _capture_patch(request: httpx.Request) -> httpx.Response:
+            captured_bodies.append(json.loads(request.content))
+            return httpx.Response(200, json=_WAREHOUSE_DETAIL)
+
+        # Renamed warehouse response (displayName updated)
+        _renamed_wh = dict(_WAREHOUSE_DETAIL)
+        _renamed_wh["displayName"] = "RenamedWarehouse"
+
+        with respx.mock(assert_all_called=False) as mock_router:
+            # Resolver calls (same as other tests)
+            mock_router.get(_ITEMS_URL).mock(
+                return_value=httpx.Response(200, json=_ITEMS_GENERIC_RESPONSE)
+            )
+            mock_router.get(_WAREHOUSE_URL).mock(return_value=httpx.Response(200, json=_renamed_wh))
+            # PATCH intercept to capture body
+            mock_router.patch(patch_url).mock(side_effect=_capture_patch)
+
+            with patch(
+                "fabric_dw.cli.commands.warehouses.build_http_client",
+                new=_real_http_client_cm,
+            ):
+                result = runner.invoke(
+                    cli,
+                    [
+                        "--json",
+                        "--yes",
+                        "warehouses",
+                        "rename",
+                        WS_GUID,
+                        WH_GUID,
+                        "RenamedWarehouse",
+                    ],
+                )
+
+        assert result.exit_code == 0, result.output
+        # The PATCH must have been called with the new name in the body
+        assert len(captured_bodies) == 1, "Expected exactly one PATCH request"
+        body = captured_bodies[0]
+        assert body.get("displayName") == "RenamedWarehouse", (
+            f"PATCH body missing correct displayName: {body}"
+        )

--- a/tests/unit/cli/commands/test_workspaces.py
+++ b/tests/unit/cli/commands/test_workspaces.py
@@ -21,11 +21,6 @@ WS_UUID = UUID(WS_GUID)
 
 
 @pytest.fixture
-def runner() -> CliRunner:
-    return CliRunner()
-
-
-@pytest.fixture
 def cache_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     """Redirect XDG_CACHE_HOME to a temp dir so cache files are isolated."""
     monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))


### PR DESCRIPTION
## Summary

Addresses two CLI test-quality findings from the review:

**T14 (HIGH, test-smell)**: ~125 CLI tests asserted only `result.exit_code == 0`
with no output or side-effect validation.

**T15 (overmocking)**: CLI tests replaced `FabricHttpClient` with `AsyncMock`
instead of validating actual HTTP wire interactions.

## T14 — strengthened output/behavior assertions

Modules strengthened (all tests still pass, no tests weakened):

| Module | Changes |
|---|---|
| `test_warehouses.py` | 8 tests: `--json` + JSON field checks, `assert_awaited_once()`, PATCH body assertions |
| `test_tables.py` | 14 tests: JSON field checks, service call verification, arg forwarding |
| `test_views.py` | 9 tests: JSON field checks, `assert_awaited_once()` |
| `test_audit.py` | 9 tests: JSON field checks, kwarg forwarding (`retention_days`, groups) |
| `test_restore_points.py` | 6 tests: JSON field checks, `assert_awaited_once()` |
| `test_sql_pools.py` | 7 tests: JSON field checks, since/until forwarding |
| `test_schemas.py` | 4 tests: `assert_awaited_once()`, output content checks |
| `test_snapshots.py` | 7 tests: JSON field checks, roll service call verification |

## T15 — respx wire-validation pattern

New file: `tests/unit/cli/commands/test_warehouses_respx.py`

Establishes the pattern for CLI tests that use a **real** `FabricHttpClient`
(backed by a fake credential) inside `respx.mock`, intercepting at the
`httpx.AsyncClient` level. Covers:

- `warehouses get` — validates exact GET URLs, Bearer auth header
- `warehouses delete` — validates DELETE method on correct URL
- `warehouses rename` — validates PATCH method + request body shape

**What remains** (documented in the file docstring):
- `test_snapshots.py`: create (POST LRO), rename (PATCH), delete (DELETE)
- `test_audit.py`: enable/disable/set-retention (all PATCH)
- `test_restore_points.py`: create (POST), rename (PATCH)
- `test_workspaces.py`: list (GET with pagination), get (GET)

## Test plan

- [x] `just check` fully green (2351 tests, 0 failures, ruff + ty clean)
- [x] No existing tests weakened
- [x] All new assertions are deterministic and fast

🤖 Generated with [Claude Code](https://claude.com/claude-code)