### PR TITLE
fix(ci): re-auth az before Suspend Fabric capacity to fix AADSTS700024 on long runs

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -291,6 +291,14 @@ jobs:
           anyio.run(main)
           "
 
+      - name: Re-authenticate for capacity suspend
+        if: always()
+        uses: azure/login@v3
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+
       - name: Suspend Fabric capacity
         if: always()
         run: |


### PR DESCRIPTION
## Root cause

On integration runs that last ~1.5 hours, the GitHub OIDC JWT captured by the initial `azure/login` step (at job start) expires ~5 minutes after it was issued. By the time the **Suspend Fabric capacity** post-step executes (~95 min later), `az` still holds the original expired client assertion and fails with:

```
AADSTS700024: Client assertion is not within its valid time range
```

This caused two problems:
1. The job went red even when all tests passed (cleanup failure, not test failure).
2. The Fabric capacity could be left running, incurring ongoing cost.

## Changes

1. **New `Re-authenticate for capacity suspend` step** inserted immediately before `Suspend Fabric capacity`. It re-runs `azure/login@v3` with the same credentials (`AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`) as the initial login, giving `az` a fresh OIDC token valid for the suspend operation.

2. **`if: always()`** on the re-auth step so it runs even when earlier steps (tests, wipe) have failed — ensuring the capacity is always suspended regardless of test outcome.

The `Suspend Fabric capacity` step already carried `if: always()`, so no change was needed there.

## Post-test steps audit

The **`Post-test full workspace wipe`** step (immediately before suspend) uses `FABRIC_AUTH: default` and calls the Python `FabricHttpClient` with `get_credential()` / `ClientAssertionCredential` — it does **not** invoke `az` directly. The self-refreshing credential handles token renewal internally, so no re-auth or `if: always()` change is needed for that step (it already had `if: always()`).

No other post-test steps use `az` directly.

## Validation

`actionlint` was run on the modified file. It reported only pre-existing `SC2034` shellcheck warnings (unused loop variable `i` in `for i in {1..30}` constructs that existed before this change). No new errors or YAML parse issues were introduced.

Closes #348