### PR TITLE
feat(services/statistics): first-class user-defined statistics management

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1995,6 +1995,91 @@ fabric-dw sql-pools insights MyWorkspace SalesWH
 
 ---
 
+## fabric-dw statistics
+
+Manage user-defined statistics on Fabric Data Warehouses and read their details on SQL Analytics Endpoints.
+
+> **Note:** Only **single-column, histogram-based** statistics can be created or updated (Fabric limitation). Multi-column statistics are not supported.
+> DDL operations (`create`, `update`, `delete`) require a **Data Warehouse** — they are rejected client-side on SQL Analytics Endpoints. `list` and `show` work on both item kinds.
+
+### statistics list
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+List statistics on an item.
+
+```
+fabric-dw statistics list [WORKSPACE] [ITEM] [OPTIONS]
+```
+
+| Option | Description | Default |
+| --- | --- | --- |
+| `--schema NAME` | Filter by schema name. | (all schemas) |
+| `--table NAME` | Filter by table name (unqualified). | (all tables) |
+| `--user-only` | Only show user-created statistics. | off |
+| `--auto-only` | Only show auto-created statistics. | off |
+
+### statistics show
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Show details of a named statistic using `DBCC SHOW_STATISTICS`. Returns the stat header, density vector, and histogram steps.
+
+```
+fabric-dw statistics show [WORKSPACE] [ITEM] QUALIFIED_TABLE STAT_NAME [OPTIONS]
+```
+
+`QUALIFIED_TABLE` must be a dot-separated qualified name, e.g. `dbo.sales`.
+
+| Option | Description | Default |
+| --- | --- | --- |
+| `--histogram` | Show only the histogram steps (skip header and density vector). | off |
+
+### statistics create
+
+**Targets:** Data Warehouse only
+
+Create a new single-column statistic.
+
+```
+fabric-dw statistics create [WORKSPACE] [ITEM] --table schema.table --column COL --name NAME [OPTIONS]
+```
+
+| Option | Description | Default |
+| --- | --- | --- |
+| `--table schema.table` | Qualified table name (required). | — |
+| `--column COL` | Column name to build the statistic on (required). Single column only. | — |
+| `--name NAME` | Statistic name (required). | — |
+| `--fullscan` | Use `WITH FULLSCAN` (default). Mutually exclusive with `--sample-percent`. | on |
+| `--sample-percent N` | Sample `N`% of the table (1–100). Overrides `--fullscan`. | — |
+
+### statistics update
+
+**Targets:** Data Warehouse only
+
+Update an existing statistic via `UPDATE STATISTICS`.
+
+```
+fabric-dw statistics update [WORKSPACE] [ITEM] QUALIFIED_TABLE STAT_NAME [OPTIONS]
+```
+
+| Option | Description | Default |
+| --- | --- | --- |
+| `--fullscan` | Use `WITH FULLSCAN` (default). | on |
+| `--sample-percent N` | Sample `N`% of the table (1–100). Overrides `--fullscan`. | — |
+
+### statistics delete
+
+**Targets:** Data Warehouse only
+
+Drop a statistic via `DROP STATISTICS`. Prompts for confirmation unless `--yes` is passed.
+
+```
+fabric-dw statistics delete [WORKSPACE] [ITEM] QUALIFIED_TABLE STAT_NAME
+```
+
+---
+
 ## fabric-dw cache
 
 Manage the local name-to-UUID lookup cache. `fabric-dw` caches workspace and item name-to-GUID mappings to avoid repeated API round-trips. Use these commands if you rename items outside the CLI or need to force a fresh lookup.

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -1229,6 +1229,126 @@ Return SQL pool insight events from `queryinsights.sql_pool_insights`.
 
 ---
 
+## Statistics
+
+Manage user-defined statistics on Fabric Data Warehouses and inspect them on SQL Analytics Endpoints.
+
+> **Note:** Only **single-column, histogram-based** statistics can be created or updated (Fabric limitation). Multi-column statistics are not supported.
+> Write tools (`create_statistics`, `update_statistics`, `delete_statistics`) are rejected on SQL Analytics Endpoints. Read tools (`list_statistics`, `show_statistics`) work on both item kinds.
+
+### list_statistics
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+**Guards:** `assert_workspace_allowed`
+
+List statistics on a warehouse or SQL Analytics Endpoint.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `workspace` | `str` | Workspace name or GUID. |
+| `item` | `str` | Warehouse or SQL endpoint name or GUID. |
+| `schema` | `str \| None` | Filter by schema name. |
+| `table` | `str \| None` | Filter by table name (unqualified). |
+| `user_only` | `bool` | Only return user-created statistics. |
+| `auto_only` | `bool` | Only return auto-created statistics. |
+
+**Returns:** `list[dict]` — array of `Statistic` objects.
+
+---
+
+### show_statistics
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+**Guards:** `assert_workspace_allowed`
+
+Show details of a statistic using `DBCC SHOW_STATISTICS`. Returns the stat header, density vector, and histogram steps.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `workspace` | `str` | Workspace name or GUID. |
+| `item` | `str` | Warehouse or SQL endpoint name or GUID. |
+| `qualified_table` | `str` | Qualified table name, e.g. `dbo.sales`. |
+| `stat_name` | `str` | Name of the statistic to show. |
+| `histogram_only` | `bool` | When `true`, return only the histogram steps. |
+
+**Returns:** `StatisticDetails` — `{ stat_header, density_vector, histogram }`.
+
+---
+
+### create_statistics
+
+**Targets:** Data Warehouse only
+
+**Guards:** `assert_writes_allowed`, `assert_workspace_allowed`
+
+Create a single-column statistic on a table. Only single-column statistics are supported (Fabric limitation). SQL Analytics Endpoints are rejected.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `workspace` | `str` | Workspace name or GUID. |
+| `item` | `str` | Warehouse name or GUID. |
+| `qualified_table` | `str` | Qualified table name, e.g. `dbo.sales`. |
+| `column` | `str` | Column name. |
+| `stat_name` | `str` | Name for the new statistic. |
+| `fullscan` | `bool` | Use `WITH FULLSCAN` (default `true`). |
+| `sample_percent` | `int \| None` | Sample percentage (1–100). Overrides `fullscan`. |
+
+**Returns:** `Statistic` — the newly-created statistic.
+
+---
+
+### update_statistics
+
+**Targets:** Data Warehouse only
+
+**Guards:** `assert_writes_allowed`, `assert_workspace_allowed`
+
+Update an existing statistic via `UPDATE STATISTICS`. SQL Analytics Endpoints are rejected.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `workspace` | `str` | Workspace name or GUID. |
+| `item` | `str` | Warehouse name or GUID. |
+| `qualified_table` | `str` | Qualified table name, e.g. `dbo.sales`. |
+| `stat_name` | `str` | Name of the statistic to update. |
+| `fullscan` | `bool` | Use `WITH FULLSCAN` (default `true`). |
+| `sample_percent` | `int \| None` | Sample percentage (1–100). Overrides `fullscan`. |
+
+**Returns:** `{ "updated": true }` — confirmation.
+
+---
+
+### delete_statistics
+
+**Targets:** Data Warehouse only
+
+**Guards:** `assert_writes_allowed`, `assert_destructive_allowed`, `assert_workspace_allowed`
+
+Drop a statistic via `DROP STATISTICS`. **Destructive and irreversible.** Requires `FABRIC_MCP_ALLOW_DESTRUCTIVE=1`. SQL Analytics Endpoints are rejected.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `workspace` | `str` | Workspace name or GUID. |
+| `item` | `str` | Warehouse name or GUID. |
+| `qualified_table` | `str` | Qualified table name, e.g. `dbo.sales`. |
+| `stat_name` | `str` | Name of the statistic to drop. |
+
+**Returns:** `{ "dropped": true }` — confirmation.
+
+---
+
 ## Cache
 
 ### clear_cache

--- a/src/fabric_dw/cli/_main.py
+++ b/src/fabric_dw/cli/_main.py
@@ -20,6 +20,7 @@ from fabric_dw.cli.commands.snapshots import snapshots_group
 from fabric_dw.cli.commands.sql import sql_group
 from fabric_dw.cli.commands.sql_endpoints import sql_endpoints_group
 from fabric_dw.cli.commands.sql_pools import sql_pools_group
+from fabric_dw.cli.commands.statistics import statistics_group
 from fabric_dw.cli.commands.tables import tables_group
 from fabric_dw.cli.commands.views import views_group
 from fabric_dw.cli.commands.warehouses import warehouses_group
@@ -93,3 +94,4 @@ cli.add_command(schemas_group)
 cli.add_command(tables_group)
 cli.add_command(views_group)
 cli.add_command(procedures_group)
+cli.add_command(statistics_group)

--- a/src/fabric_dw/cli/commands/statistics.py
+++ b/src/fabric_dw/cli/commands/statistics.py
@@ -1,0 +1,306 @@
+"""Statistics sub-commands for the fabric-dw CLI."""
+
+from __future__ import annotations
+
+import click
+
+from fabric_dw.cli._context import CliContext
+from fabric_dw.cli._render import render
+from fabric_dw.cli.commands._utils import (
+    build_http_client,
+    build_sql_target,
+    confirm_destructive,
+    coro,
+    parse_qualified_name,
+    resolve_warehouse_arg,
+    resolve_workspace_arg,
+)
+from fabric_dw.exceptions import FabricError
+from fabric_dw.services import statistics as _stats_svc
+
+
+@click.group("statistics")
+def statistics_group() -> None:
+    """Manage user-defined statistics on Fabric Data Warehouses and SQL Analytics Endpoints.
+
+    Only single-column statistics are supported (Fabric limitation).
+    DDL operations (create/update/delete) require a Data Warehouse;
+    list and show work on both Data Warehouses and SQL Analytics Endpoints.
+    """
+
+
+@statistics_group.command("list")
+@click.argument("workspace", required=False, default=None)
+@click.argument("item", required=False, default=None)
+@click.option("--schema", default=None, help="Filter by schema name.")
+@click.option("--table", default=None, help="Filter by table name (unqualified).")
+@click.option(
+    "--user-only",
+    is_flag=True,
+    default=False,
+    help="Only show user-created statistics.",
+)
+@click.option(
+    "--auto-only",
+    is_flag=True,
+    default=False,
+    help="Only show auto-created statistics.",
+)
+@click.pass_obj
+@coro
+async def list_cmd(
+    ctx: CliContext,
+    workspace: str | None,
+    item: str | None,
+    schema: str | None,
+    table: str | None,
+    user_only: bool,
+    auto_only: bool,
+) -> None:
+    """List statistics on ITEM (warehouse or SQL endpoint) in WORKSPACE."""
+    ws = resolve_workspace_arg(ctx, workspace)
+    wh = resolve_warehouse_arg(ctx, item)
+    try:
+        async with build_http_client(ctx) as http:
+            target, _entry = await build_sql_target(http, ws, wh)
+            items = await _stats_svc.list_statistics(
+                target,
+                schema=schema,
+                table=table,
+                user_only=user_only,
+                auto_only=auto_only,
+                mode=ctx.auth,
+            )
+            render(
+                [s.model_dump(by_alias=True, mode="json") for s in items],
+                json_output=ctx.json_output,
+                table_title="Statistics",
+            )
+    except (ValueError, FabricError) as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@statistics_group.command("show")
+@click.argument("workspace", required=False, default=None)
+@click.argument("item", required=False, default=None)
+@click.argument("qualified_table")
+@click.argument("stat_name")
+@click.option(
+    "--histogram",
+    "histogram_only",
+    is_flag=True,
+    default=False,
+    help="Show only the histogram steps (skip header and density vector).",
+)
+@click.pass_obj
+@coro
+async def show_cmd(
+    ctx: CliContext,
+    workspace: str | None,
+    item: str | None,
+    qualified_table: str,
+    stat_name: str,
+    histogram_only: bool,
+) -> None:
+    """Show details of STAT_NAME on QUALIFIED_TABLE (schema.table) in WORKSPACE.
+
+    Uses DBCC SHOW_STATISTICS with STAT_HEADER, DENSITY_VECTOR, and HISTOGRAM
+    variants. Pass --histogram to show only the histogram steps.
+    """
+    ws = resolve_workspace_arg(ctx, workspace)
+    wh = resolve_warehouse_arg(ctx, item)
+    parse_qualified_name(qualified_table, kind="table")
+    try:
+        async with build_http_client(ctx) as http:
+            target, _entry = await build_sql_target(http, ws, wh)
+            details = await _stats_svc.show_statistics(
+                target,
+                qualified_table,
+                stat_name,
+                histogram_only=histogram_only,
+                mode=ctx.auth,
+            )
+            render(details.model_dump(by_alias=True, mode="json"), json_output=ctx.json_output)
+    except (ValueError, FabricError) as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@statistics_group.command("create")
+@click.argument("workspace", required=False, default=None)
+@click.argument("item", required=False, default=None)
+@click.option(
+    "--table",
+    "qualified_table",
+    required=True,
+    help="Qualified table name: schema.table.",
+)
+@click.option(
+    "--column",
+    required=True,
+    help=(
+        "Column name to create the statistic on. "
+        "Only single-column statistics are supported (Fabric limitation)."
+    ),
+)
+@click.option("--name", "stat_name", default=None, help="Statistic name.")
+@click.option(
+    "--fullscan",
+    "fullscan",
+    is_flag=True,
+    default=True,
+    help="Use FULLSCAN sampling (default). Mutually exclusive with --sample-percent.",
+)
+@click.option(
+    "--sample-percent",
+    "sample_percent",
+    type=click.IntRange(1, 100),
+    default=None,
+    help=("Sample a percentage of the table (1-100). When set, overrides --fullscan."),
+)
+@click.pass_obj
+@coro
+async def create_cmd(
+    ctx: CliContext,
+    workspace: str | None,
+    item: str | None,
+    qualified_table: str,
+    column: str,
+    stat_name: str | None,
+    fullscan: bool,
+    sample_percent: int | None,
+) -> None:
+    """Create a statistic on --table (schema.table) on ITEM in WORKSPACE.
+
+    Only Data Warehouses support DDL; SQL Analytics Endpoints are read-only.
+    Only single-column statistics are supported (Fabric limitation).
+    """
+    ws = resolve_workspace_arg(ctx, workspace)
+    wh = resolve_warehouse_arg(ctx, item)
+    parse_qualified_name(qualified_table, kind="table")
+    if stat_name is None:
+        raise click.UsageError("--name is required: Fabric requires an explicit statistic name.")
+    try:
+        async with build_http_client(ctx) as http:
+            target, entry = await build_sql_target(http, ws, wh)
+            stat = await _stats_svc.create_statistics(
+                target,
+                qualified_table,
+                column,
+                name=stat_name,
+                fullscan=fullscan,
+                sample_percent=sample_percent,
+                kind=entry.kind,
+                mode=ctx.auth,
+            )
+            render(stat.model_dump(by_alias=True, mode="json"), json_output=ctx.json_output)
+    except (ValueError, FabricError) as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@statistics_group.command("update")
+@click.argument("workspace", required=False, default=None)
+@click.argument("item", required=False, default=None)
+@click.argument("qualified_table")
+@click.argument("stat_name")
+@click.option(
+    "--fullscan",
+    "fullscan",
+    is_flag=True,
+    default=True,
+    help="Use FULLSCAN sampling (default). Mutually exclusive with --sample-percent.",
+)
+@click.option(
+    "--sample-percent",
+    "sample_percent",
+    type=click.IntRange(1, 100),
+    default=None,
+    help="Sample a percentage of the table (1-100). When set, overrides --fullscan.",
+)
+@click.pass_obj
+@coro
+async def update_cmd(
+    ctx: CliContext,
+    workspace: str | None,
+    item: str | None,
+    qualified_table: str,
+    stat_name: str,
+    fullscan: bool,
+    sample_percent: int | None,
+) -> None:
+    """Update STAT_NAME on QUALIFIED_TABLE (schema.table) on ITEM in WORKSPACE.
+
+    Only Data Warehouses support DDL; SQL Analytics Endpoints are read-only.
+    """
+    ws = resolve_workspace_arg(ctx, workspace)
+    wh = resolve_warehouse_arg(ctx, item)
+    parse_qualified_name(qualified_table, kind="table")
+    try:
+        async with build_http_client(ctx) as http:
+            target, entry = await build_sql_target(http, ws, wh)
+            await _stats_svc.update_statistics(
+                target,
+                qualified_table,
+                stat_name,
+                fullscan=fullscan,
+                sample_percent=sample_percent,
+                kind=entry.kind,
+                mode=ctx.auth,
+            )
+            if ctx.json_output:
+                render(
+                    {"status": "updated", "stat_name": stat_name, "table": qualified_table},
+                    json_output=True,
+                )
+            else:
+                click.echo(f"Statistics [{stat_name}] on {qualified_table} updated.")
+    except (ValueError, FabricError) as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@statistics_group.command("delete")
+@click.argument("workspace", required=False, default=None)
+@click.argument("item", required=False, default=None)
+@click.argument("qualified_table")
+@click.argument("stat_name")
+@click.pass_obj
+@coro
+async def delete_cmd(
+    ctx: CliContext,
+    workspace: str | None,
+    item: str | None,
+    qualified_table: str,
+    stat_name: str,
+) -> None:
+    """Drop STAT_NAME on QUALIFIED_TABLE (schema.table) from ITEM in WORKSPACE.
+
+    Only Data Warehouses support DDL; SQL Analytics Endpoints are read-only.
+    """
+    ws = resolve_workspace_arg(ctx, workspace)
+    wh = resolve_warehouse_arg(ctx, item)
+    parse_qualified_name(qualified_table, kind="table")
+    try:
+        async with build_http_client(ctx) as http:
+            target, entry = await build_sql_target(http, ws, wh)
+            if not confirm_destructive(
+                f"Drop statistic [{stat_name}] on {qualified_table} "
+                f"from {entry.display_name!r} ({entry.id})?",
+                yes=ctx.yes,
+            ):
+                click.echo("Aborted.")
+                return
+            await _stats_svc.drop_statistics(
+                target,
+                qualified_table,
+                stat_name,
+                kind=entry.kind,
+                mode=ctx.auth,
+            )
+            if ctx.json_output:
+                render(
+                    {"status": "dropped", "stat_name": stat_name, "table": qualified_table},
+                    json_output=True,
+                )
+            else:
+                click.echo(f"Statistics [{stat_name}] on {qualified_table} dropped.")
+    except (ValueError, FabricError) as exc:
+        raise click.ClickException(str(exc)) from exc

--- a/src/fabric_dw/mcp/tools/__init__.py
+++ b/src/fabric_dw/mcp/tools/__init__.py
@@ -19,6 +19,7 @@ Domains
 - :mod:`.schemas` — SQL schema listing and DDL
 - :mod:`.tables` — SQL table listing, reading, DDL
 - :mod:`.sql_pools` — SQL Pools beta API, pool insights DMV
+- :mod:`.statistics` — DW statistics listing, inspection, and DDL
 - :mod:`.cache` — cache management (clear_cache)
 """
 
@@ -37,6 +38,7 @@ from fabric_dw.mcp.tools import (
     sql_endpoints,
     sql_exec,
     sql_pools,
+    statistics,
     tables,
     views,
     warehouses,
@@ -58,6 +60,7 @@ _DOMAINS = [
     procedures,
     schemas,
     tables,
+    statistics,
     sql_pools,
     cache,
 ]

--- a/src/fabric_dw/mcp/tools/statistics.py
+++ b/src/fabric_dw/mcp/tools/statistics.py
@@ -1,0 +1,276 @@
+"""MCP tools for SQL statistics operations."""
+
+from __future__ import annotations
+
+import logging
+from typing import Annotated, Any
+
+from mcp.server.fastmcp import FastMCP
+from pydantic import Field
+
+from fabric_dw.exceptions import FabricError
+from fabric_dw.mcp._context import get_context
+from fabric_dw.mcp._guards import (
+    assert_workspace_allowed,
+)
+from fabric_dw.mcp._helpers import (
+    make_sql_target,
+    mutating_tool,
+    parse_qualified_name,
+    resolve_item,
+    tool_err,
+)
+from fabric_dw.services import statistics as statistics_svc
+
+__all__ = ["register"]
+
+_log = logging.getLogger(__name__)
+
+
+def register(mcp: FastMCP) -> None:  # noqa: PLR0915
+    """Register statistics tools against *mcp*."""
+
+    @mcp.tool(name="list_statistics")
+    async def list_statistics(  # noqa: PLR0913
+        workspace: str,
+        item: str,
+        schema: str | None = None,
+        table: str | None = None,
+        *,
+        user_only: bool = False,
+        auto_only: bool = False,
+    ) -> list[dict[str, Any]]:
+        """List statistics on a warehouse or SQL Analytics Endpoint.
+
+        Both Data Warehouses and SQL Analytics Endpoints are supported.
+
+        Args:
+            workspace: Workspace name or GUID.
+            item: Warehouse or SQL endpoint name or GUID.
+            schema: When provided, only statistics on tables in this schema are returned.
+            table: When provided, only statistics on this table (unqualified name) are returned.
+            user_only: When True, only user-created statistics are returned.
+            auto_only: When True, only auto-created statistics are returned.
+        """
+        assert_workspace_allowed(workspace)
+        ctx = get_context()
+        try:
+            ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
+            assert_workspace_allowed(workspace, str(ws_id))
+            _log.debug(
+                "list_statistics ws=%s item=%s schema=%r table=%r user_only=%s auto_only=%s",
+                ws_id,
+                entry.id,
+                schema,
+                table,
+                user_only,
+                auto_only,
+            )
+            target = make_sql_target(ws_id, entry, item)
+            result = await statistics_svc.list_statistics(
+                target,
+                schema=schema,
+                table=table,
+                user_only=user_only,
+                auto_only=auto_only,
+                mode=ctx.auth_mode,
+            )
+        except (ValueError, FabricError) as exc:
+            raise tool_err(exc) from exc
+        return [s.model_dump(mode="json") for s in result]
+
+    @mcp.tool(name="show_statistics")
+    async def show_statistics(
+        workspace: str,
+        item: str,
+        qualified_table: str,
+        stat_name: str,
+        *,
+        histogram_only: bool = False,
+    ) -> dict[str, Any]:
+        """Show details of a statistic using DBCC SHOW_STATISTICS.
+
+        Returns the stat header, density vector, and histogram steps.
+        Both Data Warehouses and SQL Analytics Endpoints are supported.
+
+        Args:
+            workspace: Workspace name or GUID.
+            item: Warehouse or SQL endpoint name or GUID.
+            qualified_table: Qualified table name, e.g. ``dbo.sales``.
+            stat_name: The name of the statistic to show.
+            histogram_only: When True, return only the histogram steps.
+        """
+        parse_qualified_name(qualified_table, kind="table")
+        assert_workspace_allowed(workspace)
+        ctx = get_context()
+        try:
+            ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
+            assert_workspace_allowed(workspace, str(ws_id))
+            _log.debug(
+                "show_statistics ws=%s item=%s table=%r stat=%r",
+                ws_id,
+                entry.id,
+                qualified_table,
+                stat_name,
+            )
+            target = make_sql_target(ws_id, entry, item)
+            result = await statistics_svc.show_statistics(
+                target,
+                qualified_table,
+                stat_name,
+                histogram_only=histogram_only,
+                mode=ctx.auth_mode,
+            )
+        except (ValueError, FabricError) as exc:
+            raise tool_err(exc) from exc
+        return result.model_dump(mode="json")
+
+    @mutating_tool(mcp, "create_statistics")
+    async def create_statistics(  # noqa: PLR0913
+        workspace: str,
+        item: str,
+        qualified_table: str,
+        column: str,
+        stat_name: str,
+        *,
+        fullscan: bool = True,
+        sample_percent: Annotated[int, Field(ge=1, le=100)] | None = None,
+    ) -> dict[str, Any]:
+        """Create a single-column statistic on a table.
+
+        Only supported on Data Warehouses (SQL Analytics Endpoints are read-only).
+        Only single-column statistics are supported (Fabric limitation).
+
+        Args:
+            workspace: Workspace name or GUID.
+            item: Warehouse name or GUID. SQL Analytics Endpoints are rejected.
+            qualified_table: Qualified table name, e.g. ``dbo.sales``.
+            column: Column name to build the statistic on.
+            stat_name: Name for the new statistic.
+            fullscan: When True (default), use WITH FULLSCAN.
+                Ignored when sample_percent is provided.
+            sample_percent: Sample percentage (1-100). When provided, overrides fullscan
+                and uses WITH SAMPLE n PERCENT.
+        """
+        parse_qualified_name(qualified_table, kind="table")
+        assert_workspace_allowed(workspace)
+        ctx = get_context()
+        try:
+            ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
+            assert_workspace_allowed(workspace, str(ws_id))
+            _log.debug(
+                "create_statistics ws=%s item=%s table=%r col=%r name=%r",
+                ws_id,
+                entry.id,
+                qualified_table,
+                column,
+                stat_name,
+            )
+            target = make_sql_target(ws_id, entry, item)
+            result = await statistics_svc.create_statistics(
+                target,
+                qualified_table,
+                column,
+                name=stat_name,
+                fullscan=fullscan,
+                sample_percent=sample_percent,
+                kind=entry.kind,
+                mode=ctx.auth_mode,
+            )
+        except (ValueError, FabricError) as exc:
+            raise tool_err(exc) from exc
+        return result.model_dump(mode="json")
+
+    @mutating_tool(mcp, "update_statistics")
+    async def update_statistics(  # noqa: PLR0913
+        workspace: str,
+        item: str,
+        qualified_table: str,
+        stat_name: str,
+        *,
+        fullscan: bool = True,
+        sample_percent: Annotated[int, Field(ge=1, le=100)] | None = None,
+    ) -> dict[str, Any]:
+        """Update an existing statistic via UPDATE STATISTICS.
+
+        Only supported on Data Warehouses (SQL Analytics Endpoints are read-only).
+
+        Args:
+            workspace: Workspace name or GUID.
+            item: Warehouse name or GUID. SQL Analytics Endpoints are rejected.
+            qualified_table: Qualified table name, e.g. ``dbo.sales``.
+            stat_name: Name of the statistic to update.
+            fullscan: When True (default), use WITH FULLSCAN.
+                Ignored when sample_percent is provided.
+            sample_percent: Sample percentage (1-100). When provided, overrides fullscan
+                and uses WITH SAMPLE n PERCENT.
+        """
+        parse_qualified_name(qualified_table, kind="table")
+        assert_workspace_allowed(workspace)
+        ctx = get_context()
+        try:
+            ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
+            assert_workspace_allowed(workspace, str(ws_id))
+            _log.debug(
+                "update_statistics ws=%s item=%s table=%r stat=%r",
+                ws_id,
+                entry.id,
+                qualified_table,
+                stat_name,
+            )
+            target = make_sql_target(ws_id, entry, item)
+            await statistics_svc.update_statistics(
+                target,
+                qualified_table,
+                stat_name,
+                fullscan=fullscan,
+                sample_percent=sample_percent,
+                kind=entry.kind,
+                mode=ctx.auth_mode,
+            )
+        except (ValueError, FabricError) as exc:
+            raise tool_err(exc) from exc
+        return {"updated": True}
+
+    @mutating_tool(mcp, "delete_statistics", destructive=True)
+    async def delete_statistics(
+        workspace: str,
+        item: str,
+        qualified_table: str,
+        stat_name: str,
+    ) -> dict[str, Any]:
+        """Drop a statistic via DROP STATISTICS.
+
+        CAUTION: This is a destructive, irreversible operation.
+        Only supported on Data Warehouses (SQL Analytics Endpoints are read-only).
+
+        Args:
+            workspace: Workspace name or GUID.
+            item: Warehouse name or GUID. SQL Analytics Endpoints are rejected.
+            qualified_table: Qualified table name, e.g. ``dbo.sales``.
+            stat_name: Name of the statistic to drop.
+        """
+        parse_qualified_name(qualified_table, kind="table")
+        assert_workspace_allowed(workspace)
+        ctx = get_context()
+        try:
+            ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
+            assert_workspace_allowed(workspace, str(ws_id))
+            _log.debug(
+                "delete_statistics ws=%s item=%s table=%r stat=%r",
+                ws_id,
+                entry.id,
+                qualified_table,
+                stat_name,
+            )
+            target = make_sql_target(ws_id, entry, item)
+            await statistics_svc.drop_statistics(
+                target,
+                qualified_table,
+                stat_name,
+                kind=entry.kind,
+                mode=ctx.auth_mode,
+            )
+        except (ValueError, FabricError) as exc:
+            raise tool_err(exc) from exc
+        return {"dropped": True}

--- a/src/fabric_dw/models.py
+++ b/src/fabric_dw/models.py
@@ -450,6 +450,67 @@ class Table(_FabricBase):
 
 
 # ---------------------------------------------------------------------------
+# Statistics
+# ---------------------------------------------------------------------------
+
+
+class Statistic(_FabricBase):
+    """A user-defined or auto-created statistic on a Fabric Data Warehouse table.
+
+    Sourced from ``sys.stats JOIN sys.stats_columns JOIN STATS_DATE``.
+    """
+
+    name: str
+    qualified_table: str  # schema.table
+    column: str
+    auto_created: bool
+    user_created: bool
+    last_updated: datetime | None
+    generation_method: str | None
+
+
+class StatisticHeaderRow(_FabricBase):
+    """The STAT_HEADER result from ``DBCC SHOW_STATISTICS … WITH STAT_HEADER``."""
+
+    name: str
+    updated: datetime | None
+    rows: int | None
+    rows_sampled: int | None
+    steps: int | None
+    density: float | None
+    average_key_length: float | None
+    string_index: str | None
+    filter_expression: str | None
+    unfiltered_rows: int | None
+
+
+class StatisticDensityRow(_FabricBase):
+    """One density-vector row from ``DBCC SHOW_STATISTICS … WITH DENSITY_VECTOR``."""
+
+    all_density: float | None
+    average_length: float | None
+    columns: str | None
+
+
+class StatisticHistogramStep(_FabricBase):
+    """One histogram step from ``DBCC SHOW_STATISTICS … WITH HISTOGRAM``."""
+
+    range_hi_key: str | None  # serialised as string; actual type depends on the column
+    range_rows: float | None
+    eq_rows: float | None
+    distinct_range_rows: float | None
+    avg_range_rows: float | None
+
+
+class StatisticDetails(_FabricBase):
+    """Full details from ``DBCC SHOW_STATISTICS``, composed of three result sets."""
+
+    stat_header: StatisticHeaderRow | None
+    density_vector: list[StatisticDensityRow]
+    histogram: list[StatisticHistogramStep]
+
+
+# ---------------------------------------------------------------------------
 # SQL Pools (beta)
 # ---------------------------------------------------------------------------
 

--- a/src/fabric_dw/services/statistics.py
+++ b/src/fabric_dw/services/statistics.py
@@ -1,0 +1,645 @@
+"""CRUD operations for user-defined statistics on Fabric Data Warehouses.
+
+Public API
+----------
+- :func:`list_statistics`   — list statistics via sys.stats (both DW and SQL Endpoint).
+- :func:`show_statistics`   — ``DBCC SHOW_STATISTICS`` (both DW and SQL Endpoint).
+- :func:`create_statistics` — ``CREATE STATISTICS … ON <table>(<column>)`` (DW only).
+- :func:`update_statistics` — ``UPDATE STATISTICS <table> (<stat>)`` (DW only).
+- :func:`drop_statistics`   — ``DROP STATISTICS <table>.<stat>`` (DW only).
+
+Identifier safety
+-----------------
+All table, column, schema, and stat names are identifiers that CANNOT be bound
+as SQL parameters.  Every such name is validated via
+:func:`~fabric_dw.identifiers.validate_identifier` (allowlist regex + explicit
+forbidden-char guards) and then bracket-quoted via
+:func:`~fabric_dw.identifiers.quote_identifier` (which escapes ``]`` as ``]]``
+for defence-in-depth) before being embedded in SQL.
+
+The ``sample_percent`` argument is a numeric value; it is range-validated as an
+:class:`int` (1-100) and embedded as a literal integer — never an arbitrary
+user string.
+
+SQL Endpoint guard
+------------------
+:func:`create_statistics`, :func:`update_statistics`, and :func:`drop_statistics`
+reject SQL Analytics Endpoint items client-side with a clear
+:class:`~fabric_dw.exceptions.ItemKindError` before any network I/O.
+:func:`list_statistics` and :func:`show_statistics` work on both item kinds.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from typing import cast
+
+from fabric_dw.auth import CredentialMode
+from fabric_dw.exceptions import ItemKindError, NotFoundError
+from fabric_dw.identifiers import parse_qualified_name, quote_identifier, validate_identifier
+from fabric_dw.models import (
+    Statistic,
+    StatisticDensityRow,
+    StatisticDetails,
+    StatisticHeaderRow,
+    StatisticHistogramStep,
+    WarehouseKind,
+)
+from fabric_dw.sql import SqlTarget, run_query
+
+__all__ = [
+    "create_statistics",
+    "drop_statistics",
+    "list_statistics",
+    "show_statistics",
+    "update_statistics",
+]
+
+# ---------------------------------------------------------------------------
+# SQL Endpoint guard
+# ---------------------------------------------------------------------------
+
+_SQL_ENDPOINT_READONLY_MSG = (
+    "SQL Analytics Endpoints are read-only; CREATE/UPDATE/DROP STATISTICS not supported"
+)
+
+_SAMPLE_PERCENT_MIN = 1
+_SAMPLE_PERCENT_MAX = 100
+
+
+def _assert_not_sql_endpoint(kind: WarehouseKind) -> None:
+    """Raise :class:`~fabric_dw.exceptions.ItemKindError` for SQL Endpoint items.
+
+    Args:
+        kind: The :class:`~fabric_dw.models.WarehouseKind` of the resolved item.
+
+    Raises:
+        ItemKindError: If *kind* is :attr:`~fabric_dw.models.WarehouseKind.SQL_ENDPOINT`.
+    """
+    if kind == WarehouseKind.SQL_ENDPOINT:
+        raise ItemKindError(_SQL_ENDPOINT_READONLY_MSG)
+
+
+# ---------------------------------------------------------------------------
+# SQL templates
+# ---------------------------------------------------------------------------
+
+_LIST_STATISTICS_SQL = """\
+SELECT
+    st.name AS stat_name,
+    s.name AS schema_name,
+    t.name AS table_name,
+    c.name AS column_name,
+    st.auto_created,
+    st.user_created,
+    STATS_DATE(st.object_id, st.stats_id) AS last_updated,
+    st.filter_definition AS generation_method
+FROM sys.stats st
+JOIN sys.stats_columns sc ON sc.object_id = st.object_id AND sc.stats_id = st.stats_id
+JOIN sys.columns c ON c.object_id = sc.object_id AND c.column_id = sc.column_id
+JOIN sys.tables t ON t.object_id = st.object_id
+JOIN sys.schemas s ON s.schema_id = t.schema_id
+WHERE ({schema_filter})
+  AND ({table_filter})
+  AND ({kind_filter})
+ORDER BY s.name, t.name, st.name;
+"""
+
+# DBCC SHOW_STATISTICS takes identifier tokens for table and stat_name.
+# Both are validated + bracket-quoted before embedding.
+_DBCC_STAT_HEADER_SQL = "DBCC SHOW_STATISTICS ({table_q}, {stat_q}) WITH STAT_HEADER;"
+_DBCC_DENSITY_SQL = "DBCC SHOW_STATISTICS ({table_q}, {stat_q}) WITH DENSITY_VECTOR;"
+_DBCC_HISTOGRAM_SQL = "DBCC SHOW_STATISTICS ({table_q}, {stat_q}) WITH HISTOGRAM;"
+
+# CREATE STATISTICS: identifiers are bracket-quoted; FULLSCAN/SAMPLE are keywords.
+_CREATE_STAT_FULLSCAN_SQL = "CREATE STATISTICS {stat_q} ON {table_q} ({col_q}) WITH FULLSCAN;"
+_CREATE_STAT_SAMPLE_SQL = (
+    "CREATE STATISTICS {stat_q} ON {table_q} ({col_q}) WITH SAMPLE {pct} PERCENT;"
+)
+_CREATE_STAT_DEFAULT_SQL = "CREATE STATISTICS {stat_q} ON {table_q} ({col_q});"
+
+# UPDATE STATISTICS: identifiers are bracket-quoted.
+_UPDATE_STAT_FULLSCAN_SQL = "UPDATE STATISTICS {table_q} ({stat_q}) WITH FULLSCAN;"
+_UPDATE_STAT_SAMPLE_SQL = "UPDATE STATISTICS {table_q} ({stat_q}) WITH SAMPLE {pct} PERCENT;"
+_UPDATE_STAT_DEFAULT_SQL = "UPDATE STATISTICS {table_q} ({stat_q});"
+
+# DROP STATISTICS: table.stat notation (both bracket-quoted).
+_DROP_STAT_SQL = "DROP STATISTICS {table_q}.{stat_q};"
+
+# Fetch a single statistic after create (to return a Statistic model).
+_FETCH_STAT_SQL = """\
+SELECT
+    st.name AS stat_name,
+    s.name AS schema_name,
+    t.name AS table_name,
+    c.name AS column_name,
+    st.auto_created,
+    st.user_created,
+    STATS_DATE(st.object_id, st.stats_id) AS last_updated,
+    st.filter_definition AS generation_method
+FROM sys.stats st
+JOIN sys.stats_columns sc ON sc.object_id = st.object_id AND sc.stats_id = st.stats_id
+JOIN sys.columns c ON c.object_id = sc.object_id AND c.column_id = sc.column_id
+JOIN sys.tables t ON t.object_id = st.object_id
+JOIN sys.schemas s ON s.schema_id = t.schema_id
+WHERE s.name = ? AND t.name = ? AND st.name = ?;
+"""
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _normalize_ts(ts: object) -> datetime | None:
+    """Normalize a ``STATS_DATE`` value to UTC-aware datetime or None."""
+    if ts is None:
+        return None
+    if isinstance(ts, datetime):
+        return ts.replace(tzinfo=UTC) if ts.tzinfo is None else ts.astimezone(UTC)
+    return None
+
+
+def _row_to_statistic(cols: list[str], row: tuple[object, ...]) -> Statistic:
+    """Build a :class:`Statistic` from a column-name list and a result row."""
+    data = dict(zip(cols, row, strict=True))
+    schema_name = str(data["schema_name"])
+    table_name = str(data["table_name"])
+    return Statistic(
+        name=str(data["stat_name"]),
+        qualified_table=f"{schema_name}.{table_name}",
+        column=str(data["column_name"]),
+        auto_created=bool(data["auto_created"]),
+        user_created=bool(data["user_created"]),
+        last_updated=_normalize_ts(data.get("last_updated")),
+        generation_method=(
+            str(data["generation_method"]) if data.get("generation_method") is not None else None
+        ),
+    )
+
+
+def _row_to_header(cols: list[str], row: tuple[object, ...]) -> StatisticHeaderRow:
+    """Build a :class:`StatisticHeaderRow` from STAT_HEADER output."""
+    data = dict(zip(cols, row, strict=True))
+    updated_raw = data.get("Updated") or data.get("updated")
+    return StatisticHeaderRow(
+        name=str(data.get("Name") or data.get("name") or ""),
+        updated=_normalize_ts(updated_raw),
+        rows=cast("int | None", data.get("Rows") or data.get("rows")),
+        rows_sampled=cast("int | None", data.get("Rows Sampled") or data.get("rows_sampled")),
+        steps=cast("int | None", data.get("Steps") or data.get("steps")),
+        density=cast("float | None", data.get("Density") or data.get("density")),
+        average_key_length=cast(
+            "float | None",
+            data.get("Average Key Length") or data.get("average_key_length"),
+        ),
+        string_index=cast(
+            "str | None",
+            data.get("String Index") or data.get("string_index"),
+        ),
+        filter_expression=cast(
+            "str | None",
+            data.get("Filter Expression") or data.get("filter_expression"),
+        ),
+        unfiltered_rows=cast(
+            "int | None",
+            data.get("Unfiltered Rows") or data.get("unfiltered_rows"),
+        ),
+    )
+
+
+def _row_to_density(cols: list[str], row: tuple[object, ...]) -> StatisticDensityRow:
+    """Build a :class:`StatisticDensityRow` from DENSITY_VECTOR output."""
+    data = dict(zip(cols, row, strict=True))
+    return StatisticDensityRow(
+        all_density=cast(
+            "float | None",
+            data.get("All density") or data.get("all_density"),
+        ),
+        average_length=cast(
+            "float | None",
+            data.get("Average Length") or data.get("average_length"),
+        ),
+        columns=cast("str | None", data.get("Columns") or data.get("columns")),
+    )
+
+
+def _row_to_histogram(cols: list[str], row: tuple[object, ...]) -> StatisticHistogramStep:
+    """Build a :class:`StatisticHistogramStep` from HISTOGRAM output."""
+    data = dict(zip(cols, row, strict=True))
+    range_hi = data.get("RANGE_HI_KEY") or data.get("range_hi_key")
+    return StatisticHistogramStep(
+        range_hi_key=str(range_hi) if range_hi is not None else None,
+        range_rows=cast("float | None", data.get("RANGE_ROWS") or data.get("range_rows")),
+        eq_rows=cast("float | None", data.get("EQ_ROWS") or data.get("eq_rows")),
+        distinct_range_rows=cast(
+            "float | None",
+            data.get("DISTINCT_RANGE_ROWS") or data.get("distinct_range_rows"),
+        ),
+        avg_range_rows=cast(
+            "float | None",
+            data.get("AVG_RANGE_ROWS") or data.get("avg_range_rows"),
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+async def list_statistics(
+    target: SqlTarget,
+    *,
+    schema: str | None = None,
+    table: str | None = None,
+    user_only: bool = False,
+    auto_only: bool = False,
+    mode: CredentialMode = CredentialMode.DEFAULT,
+) -> list[Statistic]:
+    """List statistics on *target*, optionally filtered by schema, table, or kind.
+
+    Works on both Data Warehouses and SQL Analytics Endpoints.
+
+    Args:
+        target: The warehouse or SQL Analytics Endpoint to query.
+        schema: When provided, only statistics on tables in this schema are
+            returned.  Must pass :func:`~fabric_dw.identifiers.validate_identifier`.
+        table: When provided, only statistics on this table name are returned.
+            Must pass :func:`~fabric_dw.identifiers.validate_identifier`.
+        user_only: When ``True``, only user-created statistics are returned.
+            Mutually exclusive with *auto_only*.
+        auto_only: When ``True``, only auto-created statistics are returned.
+            Mutually exclusive with *user_only*.
+        mode: The credential mode for Entra authentication.
+
+    Returns:
+        A (possibly empty) list of :class:`~fabric_dw.models.Statistic` instances.
+
+    Raises:
+        ValueError: If *schema* or *table* fail identifier validation, or if
+            both *user_only* and *auto_only* are ``True``.
+        PermissionDeniedError: If the driver reports a permission error.
+        AuthError: If the driver reports an authentication failure.
+    """
+    if user_only and auto_only:
+        msg = "user_only and auto_only are mutually exclusive"
+        raise ValueError(msg)
+
+    filter_params: list[object] = []
+
+    if schema is not None:
+        validate_identifier(schema)
+        schema_filter = "s.name = ?"
+        filter_params.append(schema)
+    else:
+        schema_filter = "1=1"
+
+    if table is not None:
+        validate_identifier(table)
+        table_filter = "t.name = ?"
+        filter_params.append(table)
+    else:
+        table_filter = "1=1"
+
+    if user_only:
+        kind_filter = "st.user_created = 1"
+    elif auto_only:
+        kind_filter = "st.auto_created = 1"
+    else:
+        kind_filter = "1=1"
+
+    list_sql = _LIST_STATISTICS_SQL.format(
+        schema_filter=schema_filter,
+        table_filter=table_filter,
+        kind_filter=kind_filter,
+    )
+
+    def _run() -> list[Statistic]:
+        cols, rows = run_query(
+            target,
+            list_sql,
+            params=filter_params or None,
+            mode=mode,
+        )
+        return [_row_to_statistic(cols, r) for r in rows]
+
+    return await asyncio.to_thread(_run)
+
+
+async def show_statistics(
+    target: SqlTarget,
+    qualified_table: str,
+    stat_name: str,
+    *,
+    histogram_only: bool = False,
+    mode: CredentialMode = CredentialMode.DEFAULT,
+) -> StatisticDetails:
+    """Return details from ``DBCC SHOW_STATISTICS`` for a named statistic.
+
+    Uses the ``WITH STAT_HEADER``, ``WITH DENSITY_VECTOR``, and ``WITH HISTOGRAM``
+    variants (three separate queries) to get clean, typed single result sets.
+
+    Works on both Data Warehouses and SQL Analytics Endpoints.
+
+    Args:
+        target: The warehouse or SQL Analytics Endpoint to query.
+        qualified_table: Qualified table name of the form ``schema.table``.
+            Both parts must pass :func:`~fabric_dw.identifiers.validate_identifier`.
+        stat_name: The name of the statistic to show.
+            Must pass :func:`~fabric_dw.identifiers.validate_identifier`.
+        histogram_only: When ``True``, skip the stat header and density vector
+            queries and return only the histogram steps.
+        mode: The credential mode for Entra authentication.
+
+    Returns:
+        A :class:`~fabric_dw.models.StatisticDetails` instance.
+
+    Raises:
+        ValueError: If any identifier fails validation.
+        NotFoundError: If no rows are returned for the stat header query.
+        PermissionDeniedError: If the driver reports a permission error.
+    """
+    schema, table = parse_qualified_name(qualified_table)
+    validate_identifier(schema)
+    validate_identifier(table)
+    validate_identifier(stat_name)
+
+    # DBCC SHOW_STATISTICS takes a two-part table ref and a stat name.
+    # Use [schema].[table] notation for the table argument — it must be
+    # bracket-quoted as a whole token (not as a string literal parameter).
+    table_q = f"{quote_identifier(schema)}.{quote_identifier(table)}"
+    stat_q = quote_identifier(stat_name)
+
+    header_sql = _DBCC_STAT_HEADER_SQL.format(table_q=table_q, stat_q=stat_q)
+    density_sql = _DBCC_DENSITY_SQL.format(table_q=table_q, stat_q=stat_q)
+    histogram_sql = _DBCC_HISTOGRAM_SQL.format(table_q=table_q, stat_q=stat_q)
+
+    def _run() -> StatisticDetails:
+        if histogram_only:
+            h_cols, h_rows = run_query(target, histogram_sql, mode=mode)
+            return StatisticDetails(
+                stat_header=None,
+                density_vector=[],
+                histogram=[_row_to_histogram(h_cols, r) for r in h_rows],
+            )
+
+        sh_cols, sh_rows = run_query(target, header_sql, mode=mode)
+        if not sh_rows:
+            msg = f"Statistic [{stat_name}] on [{schema}].[{table}] not found"
+            raise NotFoundError(msg)
+        header = _row_to_header(sh_cols, sh_rows[0])
+
+        dv_cols, dv_rows = run_query(target, density_sql, mode=mode)
+        h_cols, h_rows = run_query(target, histogram_sql, mode=mode)
+
+        return StatisticDetails(
+            stat_header=header,
+            density_vector=[_row_to_density(dv_cols, r) for r in dv_rows],
+            histogram=[_row_to_histogram(h_cols, r) for r in h_rows],
+        )
+
+    return await asyncio.to_thread(_run)
+
+
+async def create_statistics(
+    target: SqlTarget,
+    qualified_table: str,
+    column: str,
+    *,
+    name: str | None = None,
+    fullscan: bool = True,
+    sample_percent: int | None = None,
+    kind: WarehouseKind = WarehouseKind.WAREHOUSE,
+    mode: CredentialMode = CredentialMode.DEFAULT,
+) -> Statistic:
+    """Create a new single-column statistic on *qualified_table*.
+
+    Only single-column statistics are supported (Fabric limitation).
+
+    Args:
+        target: The warehouse to connect to.
+        qualified_table: Qualified table name of the form ``schema.table``.
+            Both parts must pass :func:`~fabric_dw.identifiers.validate_identifier`.
+        column: Column name to build the statistic on.
+            Must pass :func:`~fabric_dw.identifiers.validate_identifier`.
+        name: Optional statistic name.  When omitted the SQL engine assigns
+            a default name.  Must pass
+            :func:`~fabric_dw.identifiers.validate_identifier` when provided.
+        fullscan: When ``True`` (default), uses ``WITH FULLSCAN``.
+            Ignored when *sample_percent* is provided.
+        sample_percent: Sample percentage (1-100).  When provided, overrides
+            *fullscan* and uses ``WITH SAMPLE n PERCENT``.
+        kind: The :class:`~fabric_dw.models.WarehouseKind` of the item.
+            SQL Endpoint items are rejected with
+            :class:`~fabric_dw.exceptions.ItemKindError`.
+        mode: The credential mode for Entra authentication.
+
+    Returns:
+        A :class:`~fabric_dw.models.Statistic` reflecting the newly-created
+        statistic (fetched via ``sys.stats`` after DDL).
+
+    Raises:
+        ItemKindError: If *kind* is
+            :attr:`~fabric_dw.models.WarehouseKind.SQL_ENDPOINT`.
+        ValueError: If any identifier fails validation or *sample_percent* is
+            outside the range 1-100.
+        PermissionDeniedError: If the driver reports a permission error.
+    """
+    _assert_not_sql_endpoint(kind)
+
+    schema, table = parse_qualified_name(qualified_table)
+    validate_identifier(schema)
+    validate_identifier(table)
+    validate_identifier(column)
+    if name is not None:
+        validate_identifier(name)
+
+    if sample_percent is not None:
+        pct = int(sample_percent)
+        if not _SAMPLE_PERCENT_MIN <= pct <= _SAMPLE_PERCENT_MAX:
+            msg = f"sample_percent must be between 1 and 100, got {pct}"
+            raise ValueError(msg)
+
+    table_q = f"{quote_identifier(schema)}.{quote_identifier(table)}"
+    col_q = quote_identifier(column)
+
+    stat_q = quote_identifier(name) if name is not None else None
+
+    if stat_q is not None:
+        if sample_percent is not None:
+            ddl = _CREATE_STAT_SAMPLE_SQL.format(
+                stat_q=stat_q, table_q=table_q, col_q=col_q, pct=int(sample_percent)
+            )
+        elif fullscan:
+            ddl = _CREATE_STAT_FULLSCAN_SQL.format(stat_q=stat_q, table_q=table_q, col_q=col_q)
+        else:
+            ddl = _CREATE_STAT_DEFAULT_SQL.format(stat_q=stat_q, table_q=table_q, col_q=col_q)
+    else:
+        # Name is omitted — use a generated name placeholder; engine picks one.
+        # We cannot omit the name in CREATE STATISTICS — always require a name.
+        msg = "stat name is required: Fabric requires an explicit statistic name"
+        raise ValueError(msg)
+
+    def _run_ddl() -> None:
+        run_query(target, ddl, mode=mode, commit=True, fetch="none")
+
+    await asyncio.to_thread(_run_ddl)
+    assert name is not None  # raised ValueError above when name is None
+    return await _fetch_statistic(target, schema, table, name, mode=mode)
+
+
+async def update_statistics(
+    target: SqlTarget,
+    qualified_table: str,
+    stat_name: str,
+    *,
+    fullscan: bool = True,
+    sample_percent: int | None = None,
+    kind: WarehouseKind = WarehouseKind.WAREHOUSE,
+    mode: CredentialMode = CredentialMode.DEFAULT,
+) -> None:
+    """Update an existing statistic via ``UPDATE STATISTICS``.
+
+    Args:
+        target: The warehouse to connect to.
+        qualified_table: Qualified table name of the form ``schema.table``.
+            Both parts must pass :func:`~fabric_dw.identifiers.validate_identifier`.
+        stat_name: The name of the statistic to update.
+            Must pass :func:`~fabric_dw.identifiers.validate_identifier`.
+        fullscan: When ``True`` (default), uses ``WITH FULLSCAN``.
+            Ignored when *sample_percent* is provided.
+        sample_percent: Sample percentage (1-100).  When provided, overrides
+            *fullscan* and uses ``WITH SAMPLE n PERCENT``.
+        kind: The :class:`~fabric_dw.models.WarehouseKind` of the item.
+            SQL Endpoint items are rejected with
+            :class:`~fabric_dw.exceptions.ItemKindError`.
+        mode: The credential mode for Entra authentication.
+
+    Raises:
+        ItemKindError: If *kind* is
+            :attr:`~fabric_dw.models.WarehouseKind.SQL_ENDPOINT`.
+        ValueError: If any identifier fails validation or *sample_percent* is
+            outside the range 1-100.
+        PermissionDeniedError: If the driver reports a permission error.
+    """
+    _assert_not_sql_endpoint(kind)
+
+    schema, table = parse_qualified_name(qualified_table)
+    validate_identifier(schema)
+    validate_identifier(table)
+    validate_identifier(stat_name)
+
+    if sample_percent is not None:
+        pct = int(sample_percent)
+        if not _SAMPLE_PERCENT_MIN <= pct <= _SAMPLE_PERCENT_MAX:
+            msg = f"sample_percent must be between 1 and 100, got {pct}"
+            raise ValueError(msg)
+
+    table_q = f"{quote_identifier(schema)}.{quote_identifier(table)}"
+    stat_q = quote_identifier(stat_name)
+
+    if sample_percent is not None:
+        ddl = _UPDATE_STAT_SAMPLE_SQL.format(
+            table_q=table_q, stat_q=stat_q, pct=int(sample_percent)
+        )
+    elif fullscan:
+        ddl = _UPDATE_STAT_FULLSCAN_SQL.format(table_q=table_q, stat_q=stat_q)
+    else:
+        ddl = _UPDATE_STAT_DEFAULT_SQL.format(table_q=table_q, stat_q=stat_q)
+
+    def _run() -> None:
+        run_query(target, ddl, mode=mode, commit=True, fetch="none")
+
+    await asyncio.to_thread(_run)
+
+
+async def drop_statistics(
+    target: SqlTarget,
+    qualified_table: str,
+    stat_name: str,
+    *,
+    kind: WarehouseKind = WarehouseKind.WAREHOUSE,
+    mode: CredentialMode = CredentialMode.DEFAULT,
+) -> None:
+    """Drop a statistic via ``DROP STATISTICS <table>.<stat>``.
+
+    Args:
+        target: The warehouse to connect to.
+        qualified_table: Qualified table name of the form ``schema.table``.
+            Both parts must pass :func:`~fabric_dw.identifiers.validate_identifier`.
+        stat_name: The name of the statistic to drop.
+            Must pass :func:`~fabric_dw.identifiers.validate_identifier`.
+        kind: The :class:`~fabric_dw.models.WarehouseKind` of the item.
+            SQL Endpoint items are rejected with
+            :class:`~fabric_dw.exceptions.ItemKindError`.
+        mode: The credential mode for Entra authentication.
+
+    Raises:
+        ItemKindError: If *kind* is
+            :attr:`~fabric_dw.models.WarehouseKind.SQL_ENDPOINT`.
+        ValueError: If any identifier fails validation.
+        PermissionDeniedError: If the driver reports a permission error.
+    """
+    _assert_not_sql_endpoint(kind)
+
+    schema, table = parse_qualified_name(qualified_table)
+    validate_identifier(schema)
+    validate_identifier(table)
+    validate_identifier(stat_name)
+
+    # DROP STATISTICS uses schema.table.stat notation (dot-separated identifiers).
+    # We bracket-quote each of the three parts.
+    table_q = f"{quote_identifier(schema)}.{quote_identifier(table)}"
+    stat_q = quote_identifier(stat_name)
+    ddl = _DROP_STAT_SQL.format(table_q=table_q, stat_q=stat_q)
+
+    def _run() -> None:
+        run_query(target, ddl, mode=mode, commit=True, fetch="none")
+
+    await asyncio.to_thread(_run)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+async def _fetch_statistic(
+    target: SqlTarget,
+    schema: str,
+    table: str,
+    stat_name: str,
+    *,
+    mode: CredentialMode = CredentialMode.DEFAULT,
+) -> Statistic:
+    """Fetch a single statistic from sys.stats after DDL.
+
+    Args:
+        target: The warehouse to query.
+        schema: Schema name (already validated).
+        table: Table name (already validated).
+        stat_name: Statistic name (already validated).
+        mode: The credential mode for Entra authentication.
+
+    Returns:
+        A :class:`~fabric_dw.models.Statistic` instance.
+
+    Raises:
+        NotFoundError: If the statistic is not found after creation.
+    """
+
+    def _run() -> Statistic:
+        cols, rows = run_query(
+            target,
+            _FETCH_STAT_SQL,
+            params=[schema, table, stat_name],
+            mode=mode,
+        )
+        if not rows:
+            msg = f"Statistic [{stat_name}] on [{schema}].[{table}] not found after creation"
+            raise NotFoundError(msg)
+        return _row_to_statistic(cols, rows[0])
+
+    return await asyncio.to_thread(_run)

--- a/src/fabric_dw/services/statistics.py
+++ b/src/fabric_dw/services/statistics.py
@@ -117,7 +117,6 @@ _CREATE_STAT_FULLSCAN_SQL = "CREATE STATISTICS {stat_q} ON {table_q} ({col_q}) W
 _CREATE_STAT_SAMPLE_SQL = (
     "CREATE STATISTICS {stat_q} ON {table_q} ({col_q}) WITH SAMPLE {pct} PERCENT;"
 )
-_CREATE_STAT_DEFAULT_SQL = "CREATE STATISTICS {stat_q} ON {table_q} ({col_q});"
 
 # UPDATE STATISTICS: identifiers are bracket-quoted.
 _UPDATE_STAT_FULLSCAN_SQL = "UPDATE STATISTICS {table_q} ({stat_q}) WITH FULLSCAN;"
@@ -161,6 +160,30 @@ def _normalize_ts(ts: object) -> datetime | None:
     return None
 
 
+def _coalesce(data: dict[str, object], *keys: str) -> object:
+    """Return the value of the first key in *data* whose value is not ``None``.
+
+    This is used to handle DBCC output where column names may arrive in
+    mixed-case (e.g. ``"Rows"``) or lower-case (e.g. ``"rows"`` in test
+    fixtures) form.  Unlike ``data.get(k1) or data.get(k2)``, this helper
+    correctly returns ``0`` / ``0.0`` instead of falling through to the next
+    key when the DB value is zero-valued (falsy but present).
+
+    Args:
+        data: The row dict to look up keys in.
+        *keys: Keys to try in order; the value of the first non-``None`` hit is
+            returned.
+
+    Returns:
+        The first non-``None`` value found, or ``None`` if all keys are absent
+        or map to ``None``.
+    """
+    for k in keys:
+        if (v := data.get(k)) is not None:
+            return v
+    return None
+
+
 def _row_to_statistic(cols: list[str], row: tuple[object, ...]) -> Statistic:
     """Build a :class:`Statistic` from a column-name list and a result row."""
     data = dict(zip(cols, row, strict=True))
@@ -180,67 +203,62 @@ def _row_to_statistic(cols: list[str], row: tuple[object, ...]) -> Statistic:
 
 
 def _row_to_header(cols: list[str], row: tuple[object, ...]) -> StatisticHeaderRow:
-    """Build a :class:`StatisticHeaderRow` from STAT_HEADER output."""
-    data = dict(zip(cols, row, strict=True))
-    updated_raw = data.get("Updated") or data.get("updated")
+    """Build a :class:`StatisticHeaderRow` from STAT_HEADER output.
+
+    Column names are normalised to lower-case with spaces collapsed to
+    underscores so that mixed-case DBCC output and lower-case test fixtures
+    are handled by a single lookup key.
+    """
+    # Normalise: lower-case, spaces → underscores.  E.g. "Rows Sampled" → "rows_sampled".
+    data: dict[str, object] = {
+        k.lower().replace(" ", "_"): v for k, v in zip(cols, row, strict=True)
+    }
     return StatisticHeaderRow(
-        name=str(data.get("Name") or data.get("name") or ""),
-        updated=_normalize_ts(updated_raw),
-        rows=cast("int | None", data.get("Rows") or data.get("rows")),
-        rows_sampled=cast("int | None", data.get("Rows Sampled") or data.get("rows_sampled")),
-        steps=cast("int | None", data.get("Steps") or data.get("steps")),
-        density=cast("float | None", data.get("Density") or data.get("density")),
-        average_key_length=cast(
-            "float | None",
-            data.get("Average Key Length") or data.get("average_key_length"),
-        ),
-        string_index=cast(
-            "str | None",
-            data.get("String Index") or data.get("string_index"),
-        ),
-        filter_expression=cast(
-            "str | None",
-            data.get("Filter Expression") or data.get("filter_expression"),
-        ),
-        unfiltered_rows=cast(
-            "int | None",
-            data.get("Unfiltered Rows") or data.get("unfiltered_rows"),
-        ),
+        name=str(data.get("name") or ""),
+        updated=_normalize_ts(data.get("updated")),
+        rows=cast("int | None", _coalesce(data, "rows")),
+        rows_sampled=cast("int | None", _coalesce(data, "rows_sampled")),
+        steps=cast("int | None", _coalesce(data, "steps")),
+        density=cast("float | None", _coalesce(data, "density")),
+        average_key_length=cast("float | None", _coalesce(data, "average_key_length")),
+        string_index=cast("str | None", _coalesce(data, "string_index")),
+        filter_expression=cast("str | None", _coalesce(data, "filter_expression")),
+        unfiltered_rows=cast("int | None", _coalesce(data, "unfiltered_rows")),
     )
 
 
 def _row_to_density(cols: list[str], row: tuple[object, ...]) -> StatisticDensityRow:
-    """Build a :class:`StatisticDensityRow` from DENSITY_VECTOR output."""
-    data = dict(zip(cols, row, strict=True))
+    """Build a :class:`StatisticDensityRow` from DENSITY_VECTOR output.
+
+    Column names are normalised to lower-case with spaces collapsed to
+    underscores so that mixed-case DBCC output and lower-case test fixtures
+    are handled by a single lookup key.
+    """
+    data: dict[str, object] = {
+        k.lower().replace(" ", "_"): v for k, v in zip(cols, row, strict=True)
+    }
     return StatisticDensityRow(
-        all_density=cast(
-            "float | None",
-            data.get("All density") or data.get("all_density"),
-        ),
-        average_length=cast(
-            "float | None",
-            data.get("Average Length") or data.get("average_length"),
-        ),
-        columns=cast("str | None", data.get("Columns") or data.get("columns")),
+        all_density=cast("float | None", _coalesce(data, "all_density")),
+        average_length=cast("float | None", _coalesce(data, "average_length")),
+        columns=cast("str | None", _coalesce(data, "columns")),
     )
 
 
 def _row_to_histogram(cols: list[str], row: tuple[object, ...]) -> StatisticHistogramStep:
-    """Build a :class:`StatisticHistogramStep` from HISTOGRAM output."""
-    data = dict(zip(cols, row, strict=True))
-    range_hi = data.get("RANGE_HI_KEY") or data.get("range_hi_key")
+    """Build a :class:`StatisticHistogramStep` from HISTOGRAM output.
+
+    Column names are normalised to lower-case so that mixed-case DBCC output
+    (``RANGE_HI_KEY``) and lower-case test fixtures (``range_hi_key``) are
+    handled by a single lookup key.
+    """
+    data: dict[str, object] = {k.lower(): v for k, v in zip(cols, row, strict=True)}
+    range_hi = _coalesce(data, "range_hi_key")
     return StatisticHistogramStep(
         range_hi_key=str(range_hi) if range_hi is not None else None,
-        range_rows=cast("float | None", data.get("RANGE_ROWS") or data.get("range_rows")),
-        eq_rows=cast("float | None", data.get("EQ_ROWS") or data.get("eq_rows")),
-        distinct_range_rows=cast(
-            "float | None",
-            data.get("DISTINCT_RANGE_ROWS") or data.get("distinct_range_rows"),
-        ),
-        avg_range_rows=cast(
-            "float | None",
-            data.get("AVG_RANGE_ROWS") or data.get("avg_range_rows"),
-        ),
+        range_rows=cast("float | None", _coalesce(data, "range_rows")),
+        eq_rows=cast("float | None", _coalesce(data, "eq_rows")),
+        distinct_range_rows=cast("float | None", _coalesce(data, "distinct_range_rows")),
+        avg_range_rows=cast("float | None", _coalesce(data, "avg_range_rows")),
     )
 
 
@@ -424,9 +442,9 @@ async def create_statistics(
             Both parts must pass :func:`~fabric_dw.identifiers.validate_identifier`.
         column: Column name to build the statistic on.
             Must pass :func:`~fabric_dw.identifiers.validate_identifier`.
-        name: Optional statistic name.  When omitted the SQL engine assigns
-            a default name.  Must pass
-            :func:`~fabric_dw.identifiers.validate_identifier` when provided.
+        name: Statistic name.  Fabric requires an explicit statistic name;
+            omitting this argument raises :class:`ValueError`.  Must pass
+            :func:`~fabric_dw.identifiers.validate_identifier`.
         fullscan: When ``True`` (default), uses ``WITH FULLSCAN``.
             Ignored when *sample_percent* is provided.
         sample_percent: Sample percentage (1-100).  When provided, overrides
@@ -449,12 +467,15 @@ async def create_statistics(
     """
     _assert_not_sql_endpoint(kind)
 
+    if name is None:
+        msg = "stat name is required: Fabric requires an explicit statistic name"
+        raise ValueError(msg)
+
     schema, table = parse_qualified_name(qualified_table)
     validate_identifier(schema)
     validate_identifier(table)
     validate_identifier(column)
-    if name is not None:
-        validate_identifier(name)
+    validate_identifier(name)
 
     if sample_percent is not None:
         pct = int(sample_percent)
@@ -464,29 +485,22 @@ async def create_statistics(
 
     table_q = f"{quote_identifier(schema)}.{quote_identifier(table)}"
     col_q = quote_identifier(column)
+    stat_q = quote_identifier(name)
 
-    stat_q = quote_identifier(name) if name is not None else None
-
-    if stat_q is not None:
-        if sample_percent is not None:
-            ddl = _CREATE_STAT_SAMPLE_SQL.format(
-                stat_q=stat_q, table_q=table_q, col_q=col_q, pct=int(sample_percent)
-            )
-        elif fullscan:
-            ddl = _CREATE_STAT_FULLSCAN_SQL.format(stat_q=stat_q, table_q=table_q, col_q=col_q)
-        else:
-            ddl = _CREATE_STAT_DEFAULT_SQL.format(stat_q=stat_q, table_q=table_q, col_q=col_q)
+    if sample_percent is not None:
+        ddl = _CREATE_STAT_SAMPLE_SQL.format(
+            stat_q=stat_q, table_q=table_q, col_q=col_q, pct=int(sample_percent)
+        )
+    elif fullscan:
+        ddl = _CREATE_STAT_FULLSCAN_SQL.format(stat_q=stat_q, table_q=table_q, col_q=col_q)
     else:
-        # Name is omitted — use a generated name placeholder; engine picks one.
-        # We cannot omit the name in CREATE STATISTICS — always require a name.
-        msg = "stat name is required: Fabric requires an explicit statistic name"
-        raise ValueError(msg)
+        # No scan option specified — let the engine use its default sampling.
+        ddl = f"CREATE STATISTICS {stat_q} ON {table_q} ({col_q});"
 
     def _run_ddl() -> None:
         run_query(target, ddl, mode=mode, commit=True, fetch="none")
 
     await asyncio.to_thread(_run_ddl)
-    assert name is not None  # raised ValueError above when name is None
     return await _fetch_statistic(target, schema, table, name, mode=mode)
 
 

--- a/tests/integration/test_services_statistics.py
+++ b/tests/integration/test_services_statistics.py
@@ -1,0 +1,174 @@
+"""Integration tests for services.statistics — requires real Fabric credentials.
+
+Run with: pytest -m integration tests/integration/test_services_statistics.py
+
+Fixture note: uses ``ephemeral_sql_target`` (warehouse) from conftest for
+write operations, and ``ephemeral_sql_endpoint`` (SQL Analytics Endpoint, a
+``Warehouse`` object) for read-only / endpoint-guard tests.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from uuid import UUID
+
+import pytest
+
+from fabric_dw.exceptions import FabricError, ItemKindError, NotFoundError
+from fabric_dw.models import Statistic, StatisticDetails, Warehouse, WarehouseKind
+from fabric_dw.services import statistics, tables
+from fabric_dw.sql import SqlTarget
+
+pytestmark = pytest.mark.integration
+
+
+def _endpoint_to_target(endpoint: Warehouse, workspace_id: UUID) -> SqlTarget:
+    """Build a SqlTarget from an ephemeral SQL Analytics Endpoint Warehouse."""
+    assert endpoint.connection_string, "SQL endpoint has no connection string"
+    return SqlTarget(
+        workspace_id=str(workspace_id),
+        database=endpoint.name,
+        connection_string=endpoint.connection_string,
+    )
+
+
+# ---------------------------------------------------------------------------
+# list / read-only operations on a SQL Analytics Endpoint
+# ---------------------------------------------------------------------------
+
+
+async def test_list_statistics_on_sql_endpoint(
+    ephemeral_sql_endpoint: Warehouse,
+    workspace_id: UUID,
+) -> None:
+    """list_statistics works on SQL Analytics Endpoints (read-only is allowed)."""
+    target = _endpoint_to_target(ephemeral_sql_endpoint, workspace_id)
+    result = await statistics.list_statistics(target)
+    assert isinstance(result, list)
+
+
+# ---------------------------------------------------------------------------
+# SQL Endpoint guard rejection (client-side, no network SQL required)
+# ---------------------------------------------------------------------------
+
+
+async def test_create_statistics_endpoint_guard_rejected(
+    ephemeral_sql_target: SqlTarget,
+) -> None:
+    """create_statistics raises ItemKindError on SQL Analytics Endpoints (client-side guard)."""
+    with pytest.raises(ItemKindError, match="read-only"):
+        await statistics.create_statistics(
+            ephemeral_sql_target,
+            "dbo.nonexistent_table",
+            "id",
+            name="should_never_be_created",
+            kind=WarehouseKind.SQL_ENDPOINT,
+        )
+
+
+async def test_update_statistics_endpoint_guard_rejected(
+    ephemeral_sql_target: SqlTarget,
+) -> None:
+    """update_statistics raises ItemKindError on SQL Analytics Endpoints (client-side guard)."""
+    with pytest.raises(ItemKindError, match="read-only"):
+        await statistics.update_statistics(
+            ephemeral_sql_target,
+            "dbo.nonexistent_table",
+            "should_not_update",
+            kind=WarehouseKind.SQL_ENDPOINT,
+        )
+
+
+async def test_drop_statistics_endpoint_guard_rejected(
+    ephemeral_sql_target: SqlTarget,
+) -> None:
+    """drop_statistics raises ItemKindError on SQL Analytics Endpoints (client-side guard)."""
+    with pytest.raises(ItemKindError, match="read-only"):
+        await statistics.drop_statistics(
+            ephemeral_sql_target,
+            "dbo.nonexistent_table",
+            "should_not_drop",
+            kind=WarehouseKind.SQL_ENDPOINT,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Full create → list → show → update → drop round-trip on ephemeral warehouse
+# ---------------------------------------------------------------------------
+
+
+async def test_create_list_show_update_drop_roundtrip(
+    ephemeral_sql_target: SqlTarget,
+) -> None:
+    """Full lifecycle: create a table, build a statistic, inspect it, then drop all."""
+    schema = "dbo"
+    table_name = "pytest_stat_roundtrip"
+    stat_name = "pytest_stat_on_id"
+    select_body = "SELECT 1 AS id, 'hello' AS name"
+
+    try:
+        # Create the table
+        await tables.create_table(ephemeral_sql_target, schema, table_name, select_body)
+
+        qualified_table = f"{schema}.{table_name}"
+
+        # Create the statistic (fullscan)
+        created = await statistics.create_statistics(
+            ephemeral_sql_target,
+            qualified_table,
+            "id",
+            name=stat_name,
+            fullscan=True,
+        )
+        assert isinstance(created, Statistic)
+        assert created.name == stat_name
+        assert created.qualified_table == qualified_table
+        assert created.column == "id"
+        assert created.user_created is True
+        assert created.auto_created is False
+
+        # list_statistics — stat must be visible
+        all_stats = await statistics.list_statistics(ephemeral_sql_target)
+        stat_names = {s.name for s in all_stats}
+        assert stat_name in stat_names
+
+        # list_statistics filtered by schema and table
+        filtered = await statistics.list_statistics(
+            ephemeral_sql_target, schema=schema, table=table_name, user_only=True
+        )
+        assert any(s.name == stat_name for s in filtered)
+
+        # show_statistics — stat header must be populated
+        details = await statistics.show_statistics(ephemeral_sql_target, qualified_table, stat_name)
+        assert isinstance(details, StatisticDetails)
+        assert details.stat_header is not None
+        assert details.stat_header.name == stat_name
+
+        # show_statistics with histogram_only
+        hist_details = await statistics.show_statistics(
+            ephemeral_sql_target, qualified_table, stat_name, histogram_only=True
+        )
+        assert isinstance(hist_details, StatisticDetails)
+        assert hist_details.stat_header is None  # skipped
+
+        # update_statistics
+        await statistics.update_statistics(
+            ephemeral_sql_target, qualified_table, stat_name, fullscan=True
+        )
+
+        # After update, show still works
+        updated_details = await statistics.show_statistics(
+            ephemeral_sql_target, qualified_table, stat_name
+        )
+        assert updated_details.stat_header is not None
+
+        # drop_statistics
+        await statistics.drop_statistics(ephemeral_sql_target, qualified_table, stat_name)
+
+        # After drop, show should raise NotFoundError or similar
+        with pytest.raises((NotFoundError, FabricError, Exception)):
+            await statistics.show_statistics(ephemeral_sql_target, qualified_table, stat_name)
+
+    finally:
+        with contextlib.suppress(Exception):
+            await tables.delete_table(ephemeral_sql_target, schema, table_name)

--- a/tests/unit/cli/commands/test_statistics.py
+++ b/tests/unit/cli/commands/test_statistics.py
@@ -1,0 +1,597 @@
+"""Unit tests for the statistics CLI sub-commands."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+from uuid import UUID
+
+import pytest
+from click.testing import CliRunner
+
+from fabric_dw.cache import ItemEntry
+from fabric_dw.cli._main import cli
+from fabric_dw.exceptions import ItemKindError, NotFoundError
+from fabric_dw.models import Statistic, StatisticDetails, WarehouseKind
+from fabric_dw.sql import SqlTarget
+
+WS_GUID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+WH_GUID = "d4e5f6a7-b8c9-0123-def0-123456789abc"
+SE_GUID = "bbbbbbbb-cccc-dddd-eeee-ffffffffffff"
+WS_UUID = UUID(WS_GUID)
+WH_UUID = UUID(WH_GUID)
+SE_UUID = UUID(SE_GUID)
+
+_NOW = datetime(2024, 6, 1, 12, 0, 0, tzinfo=UTC)
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def _make_sql_target() -> SqlTarget:
+    return SqlTarget(
+        workspace_id=WS_GUID,
+        database="SalesWarehouse",
+        connection_string="wh.datawarehouse.fabric.microsoft.com",
+    )
+
+
+def _make_http_cm(http: object) -> object:
+    @asynccontextmanager
+    async def _cm(_ctx: object) -> AsyncIterator[object]:
+        yield http
+
+    return _cm
+
+
+def _make_item_entry() -> ItemEntry:
+    return ItemEntry(
+        id=WH_UUID,
+        kind=WarehouseKind.WAREHOUSE,
+        connection_string="wh.datawarehouse.fabric.microsoft.com",
+        fetched_at=datetime.now(tz=UTC),
+        display_name="SalesWarehouse",
+    )
+
+
+def _make_sql_endpoint_entry() -> ItemEntry:
+    return ItemEntry(
+        id=SE_UUID,
+        kind=WarehouseKind.SQL_ENDPOINT,
+        connection_string="se.datawarehouse.fabric.microsoft.com",
+        fetched_at=datetime.now(tz=UTC),
+        display_name="SalesLakehouse",
+    )
+
+
+def _make_statistic() -> Statistic:
+    return Statistic(
+        name="stat_sales_id",
+        qualified_table="dbo.sales",
+        column="id",
+        auto_created=False,
+        user_created=True,
+        last_updated=_NOW,
+        generation_method=None,
+    )
+
+
+def _make_statistic_details() -> StatisticDetails:
+    return StatisticDetails(
+        stat_header=None,
+        density_vector=[],
+        histogram=[],
+    )
+
+
+# ===========================================================================
+# statistics list
+# ===========================================================================
+
+
+class TestStatisticsList:
+    def test_list_exits_zero(self, runner: CliRunner) -> None:
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.statistics.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.statistics.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.statistics.list_statistics",
+                new=AsyncMock(return_value=[_make_statistic()]),
+            ),
+        ):
+            result = runner.invoke(cli, ["statistics", "list", WS_GUID, WH_GUID])
+        assert result.exit_code == 0
+
+    def test_list_json_output(self, runner: CliRunner) -> None:
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.statistics.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.statistics.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.statistics.list_statistics",
+                new=AsyncMock(return_value=[_make_statistic()]),
+            ),
+        ):
+            result = runner.invoke(cli, ["--json", "statistics", "list", WS_GUID, WH_GUID])
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert isinstance(parsed, list)
+
+    def test_list_with_schema_filter(self, runner: CliRunner) -> None:
+        mock_http = AsyncMock()
+        mock_list = AsyncMock(return_value=[_make_statistic()])
+        with (
+            patch(
+                "fabric_dw.cli.commands.statistics.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.statistics.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch("fabric_dw.services.statistics.list_statistics", new=mock_list),
+        ):
+            result = runner.invoke(
+                cli,
+                ["statistics", "list", WS_GUID, WH_GUID, "--schema", "dbo"],
+            )
+        assert result.exit_code == 0
+        mock_list.assert_awaited_once()
+
+    def test_list_user_only_flag(self, runner: CliRunner) -> None:
+        mock_http = AsyncMock()
+        mock_list = AsyncMock(return_value=[_make_statistic()])
+        with (
+            patch(
+                "fabric_dw.cli.commands.statistics.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.statistics.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch("fabric_dw.services.statistics.list_statistics", new=mock_list),
+        ):
+            result = runner.invoke(
+                cli,
+                ["statistics", "list", WS_GUID, WH_GUID, "--user-only"],
+            )
+        assert result.exit_code == 0
+        _, kwargs = mock_list.call_args
+        assert kwargs.get("user_only") is True
+
+    def test_list_error_returns_nonzero(self, runner: CliRunner) -> None:
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.statistics.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.statistics.build_sql_target",
+                new=AsyncMock(side_effect=NotFoundError("not found")),
+            ),
+        ):
+            result = runner.invoke(cli, ["statistics", "list", WS_GUID, WH_GUID])
+        assert result.exit_code != 0
+
+
+# ===========================================================================
+# statistics show
+# ===========================================================================
+
+
+class TestStatisticsShow:
+    def test_show_exits_zero(self, runner: CliRunner) -> None:
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.statistics.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.statistics.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.statistics.show_statistics",
+                new=AsyncMock(return_value=_make_statistic_details()),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                ["statistics", "show", WS_GUID, WH_GUID, "dbo.sales", "stat_sales_id"],
+            )
+        assert result.exit_code == 0
+
+    def test_show_histogram_flag(self, runner: CliRunner) -> None:
+        mock_http = AsyncMock()
+        mock_show = AsyncMock(return_value=_make_statistic_details())
+        with (
+            patch(
+                "fabric_dw.cli.commands.statistics.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.statistics.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch("fabric_dw.services.statistics.show_statistics", new=mock_show),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "statistics",
+                    "show",
+                    WS_GUID,
+                    WH_GUID,
+                    "dbo.sales",
+                    "stat_sales_id",
+                    "--histogram",
+                ],
+            )
+        assert result.exit_code == 0
+        _, kwargs = mock_show.call_args
+        assert kwargs.get("histogram_only") is True
+
+    def test_show_bad_qualified_table_returns_nonzero(self, runner: CliRunner) -> None:
+        result = runner.invoke(
+            cli,
+            ["statistics", "show", WS_GUID, WH_GUID, "nodot", "stat"],
+        )
+        assert result.exit_code != 0
+
+
+# ===========================================================================
+# statistics create
+# ===========================================================================
+
+
+class TestStatisticsCreate:
+    def test_create_exits_zero(self, runner: CliRunner) -> None:
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.statistics.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.statistics.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.statistics.create_statistics",
+                new=AsyncMock(return_value=_make_statistic()),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "statistics",
+                    "create",
+                    WS_GUID,
+                    WH_GUID,
+                    "--table",
+                    "dbo.sales",
+                    "--column",
+                    "id",
+                    "--name",
+                    "stat_sales_id",
+                ],
+            )
+        assert result.exit_code == 0
+
+    def test_create_without_name_raises_usage_error(self, runner: CliRunner) -> None:
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.statistics.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.statistics.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "statistics",
+                    "create",
+                    WS_GUID,
+                    WH_GUID,
+                    "--table",
+                    "dbo.sales",
+                    "--column",
+                    "id",
+                ],
+            )
+        assert result.exit_code != 0
+
+    def test_create_with_sample_percent(self, runner: CliRunner) -> None:
+        mock_http = AsyncMock()
+        mock_create = AsyncMock(return_value=_make_statistic())
+        with (
+            patch(
+                "fabric_dw.cli.commands.statistics.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.statistics.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch("fabric_dw.services.statistics.create_statistics", new=mock_create),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "statistics",
+                    "create",
+                    WS_GUID,
+                    WH_GUID,
+                    "--table",
+                    "dbo.sales",
+                    "--column",
+                    "id",
+                    "--name",
+                    "s",
+                    "--sample-percent",
+                    "50",
+                ],
+            )
+        assert result.exit_code == 0
+        _, kwargs = mock_create.call_args
+        assert kwargs.get("sample_percent") == 50
+
+    def test_create_sql_endpoint_rejected(self, runner: CliRunner) -> None:
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.statistics.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.statistics.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_sql_endpoint_entry())),
+            ),
+            patch(
+                "fabric_dw.services.statistics.create_statistics",
+                new=AsyncMock(side_effect=ItemKindError("read-only")),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "statistics",
+                    "create",
+                    WS_GUID,
+                    SE_GUID,
+                    "--table",
+                    "dbo.sales",
+                    "--column",
+                    "id",
+                    "--name",
+                    "s",
+                ],
+            )
+        assert result.exit_code != 0
+
+
+# ===========================================================================
+# statistics update
+# ===========================================================================
+
+
+class TestStatisticsUpdate:
+    def test_update_exits_zero(self, runner: CliRunner) -> None:
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.statistics.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.statistics.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.statistics.update_statistics",
+                new=AsyncMock(return_value=None),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "statistics",
+                    "update",
+                    WS_GUID,
+                    WH_GUID,
+                    "dbo.sales",
+                    "stat_sales_id",
+                ],
+            )
+        assert result.exit_code == 0
+
+    def test_update_json_output(self, runner: CliRunner) -> None:
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.statistics.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.statistics.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.statistics.update_statistics",
+                new=AsyncMock(return_value=None),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--json",
+                    "statistics",
+                    "update",
+                    WS_GUID,
+                    WH_GUID,
+                    "dbo.sales",
+                    "stat_sales_id",
+                ],
+            )
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["status"] == "updated"
+
+    def test_update_sql_endpoint_rejected(self, runner: CliRunner) -> None:
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.statistics.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.statistics.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_sql_endpoint_entry())),
+            ),
+            patch(
+                "fabric_dw.services.statistics.update_statistics",
+                new=AsyncMock(side_effect=ItemKindError("read-only")),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                ["statistics", "update", WS_GUID, SE_GUID, "dbo.sales", "s"],
+            )
+        assert result.exit_code != 0
+
+
+# ===========================================================================
+# statistics delete
+# ===========================================================================
+
+
+class TestStatisticsDelete:
+    def test_delete_with_yes_flag_exits_zero(self, runner: CliRunner) -> None:
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.statistics.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.statistics.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.statistics.drop_statistics",
+                new=AsyncMock(return_value=None),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--yes",
+                    "statistics",
+                    "delete",
+                    WS_GUID,
+                    WH_GUID,
+                    "dbo.sales",
+                    "stat_sales_id",
+                ],
+            )
+        assert result.exit_code == 0
+
+    def test_delete_json_output(self, runner: CliRunner) -> None:
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.statistics.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.statistics.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.statistics.drop_statistics",
+                new=AsyncMock(return_value=None),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--json",
+                    "--yes",
+                    "statistics",
+                    "delete",
+                    WS_GUID,
+                    WH_GUID,
+                    "dbo.sales",
+                    "stat_sales_id",
+                ],
+            )
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["status"] == "dropped"
+
+    def test_delete_aborted_without_yes(self, runner: CliRunner) -> None:
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.statistics.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.statistics.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                ["statistics", "delete", WS_GUID, WH_GUID, "dbo.sales", "s"],
+                input="n\n",
+            )
+        assert result.exit_code == 0
+        assert "Aborted" in result.output
+
+    def test_delete_sql_endpoint_rejected(self, runner: CliRunner) -> None:
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.statistics.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.statistics.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_sql_endpoint_entry())),
+            ),
+            patch(
+                "fabric_dw.services.statistics.drop_statistics",
+                new=AsyncMock(side_effect=ItemKindError("read-only")),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                ["--yes", "statistics", "delete", WS_GUID, SE_GUID, "dbo.sales", "s"],
+            )
+        assert result.exit_code != 0

--- a/tests/unit/mcp/test_contract.py
+++ b/tests/unit/mcp/test_contract.py
@@ -46,7 +46,7 @@ from tests.unit.mcp.conftest import WS_ID, WS_NAME, make_item_entry
 # Expected tool count (sync with test_server.EXPECTED_TOOL_NAMES)
 # ---------------------------------------------------------------------------
 
-_EXPECTED_TOOL_COUNT = 72  # as documented in server.py docstring
+_EXPECTED_TOOL_COUNT = 77  # updated: +5 statistics tools (list, show, create, update, delete)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/mcp/test_server.py
+++ b/tests/unit/mcp/test_server.py
@@ -142,6 +142,12 @@ EXPECTED_TOOL_NAMES: frozenset[str] = frozenset(
         "disable_sql_pools",
         # Connections
         "list_connections",
+        # Statistics
+        "list_statistics",
+        "show_statistics",
+        "create_statistics",
+        "update_statistics",
+        "delete_statistics",
     }
 )
 

--- a/tests/unit/mcp/tools/test_statistics.py
+++ b/tests/unit/mcp/tools/test_statistics.py
@@ -1,0 +1,486 @@
+"""Unit tests for fabric_dw.mcp.tools.statistics."""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from mcp.server.fastmcp.exceptions import ToolError
+
+from fabric_dw.exceptions import ItemKindError, NotFoundError
+from fabric_dw.models import Statistic, StatisticDetails
+from tests.unit.mcp.conftest import (
+    WH_NAME,
+    WS_NAME,
+    make_item_entry,
+    make_sql_endpoint_entry,
+)
+
+_NOW = datetime(2024, 6, 1, 12, 0, 0, tzinfo=UTC)
+
+
+def _make_statistic() -> Statistic:
+    return Statistic(
+        name="stat_sales_id",
+        qualified_table="dbo.sales",
+        column="id",
+        auto_created=False,
+        user_created=True,
+        last_updated=_NOW,
+        generation_method=None,
+    )
+
+
+def _make_details() -> StatisticDetails:
+    return StatisticDetails(
+        stat_header=None,
+        density_vector=[],
+        histogram=[],
+    )
+
+
+# ---------------------------------------------------------------------------
+# list_statistics — happy path + error funnel
+# ---------------------------------------------------------------------------
+
+
+async def test_list_statistics_happy_path(mock_ctx, ctx_patch) -> None:
+    """list_statistics resolves workspace + item and returns list of dicts."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    stat = _make_statistic()
+    item = make_item_entry()
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.statistics.list_statistics",
+            new=AsyncMock(return_value=[stat]),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "list_statistics",
+            {"workspace": WS_NAME, "item": WH_NAME},
+        )
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0]["name"] == "stat_sales_id"
+
+
+async def test_list_statistics_with_filters(mock_ctx, ctx_patch) -> None:
+    """list_statistics passes schema/table/user_only filters to service."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    stat = _make_statistic()
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+    mock_list = AsyncMock(return_value=[stat])
+
+    with (
+        ctx_patch,
+        patch("fabric_dw.services.statistics.list_statistics", new=mock_list),
+    ):
+        await mcp._tool_manager.call_tool(
+            "list_statistics",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "schema": "dbo",
+                "table": "sales",
+                "user_only": True,
+            },
+        )
+
+    _, kwargs = mock_list.call_args
+    assert kwargs.get("schema") == "dbo"
+    assert kwargs.get("table") == "sales"
+    assert kwargs.get("user_only") is True
+
+
+async def test_list_statistics_fabric_error_becomes_tool_error(mock_ctx, ctx_patch) -> None:
+    """list_statistics wraps FabricError into ToolError."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.statistics.list_statistics",
+            new=AsyncMock(side_effect=NotFoundError("warehouse not found")),
+        ),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "list_statistics",
+            {"workspace": WS_NAME, "item": WH_NAME},
+        )
+
+
+async def test_list_statistics_workspace_allowlist_blocks(ctx_patch) -> None:
+    """list_statistics raises ToolError when workspace is not in allowlist."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_WORKSPACES": "other-workspace"}),
+        pytest.raises(ToolError, match="allowlist"),
+    ):
+        await mcp._tool_manager.call_tool(
+            "list_statistics",
+            {"workspace": WS_NAME, "item": WH_NAME},
+        )
+
+
+# ---------------------------------------------------------------------------
+# show_statistics — happy path + error funnel
+# ---------------------------------------------------------------------------
+
+
+async def test_show_statistics_happy_path(mock_ctx, ctx_patch) -> None:
+    """show_statistics resolves item and returns StatisticDetails dict."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    details = _make_details()
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.statistics.show_statistics",
+            new=AsyncMock(return_value=details),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "show_statistics",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_table": "dbo.sales",
+                "stat_name": "stat_sales_id",
+            },
+        )
+
+    assert isinstance(result, dict)
+    assert "histogram" in result
+
+
+async def test_show_statistics_histogram_only(mock_ctx, ctx_patch) -> None:
+    """show_statistics passes histogram_only=True to service."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+    mock_show = AsyncMock(return_value=_make_details())
+
+    with (
+        ctx_patch,
+        patch("fabric_dw.services.statistics.show_statistics", new=mock_show),
+    ):
+        await mcp._tool_manager.call_tool(
+            "show_statistics",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_table": "dbo.sales",
+                "stat_name": "stat_sales_id",
+                "histogram_only": True,
+            },
+        )
+
+    _, kwargs = mock_show.call_args
+    assert kwargs.get("histogram_only") is True
+
+
+async def test_show_statistics_bad_qualified_table_raises_tool_error(ctx_patch) -> None:
+    """show_statistics raises ToolError for a non-qualified table name."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "show_statistics",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_table": "nodot",
+                "stat_name": "stat",
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# create_statistics — guard checks and happy path
+# ---------------------------------------------------------------------------
+
+
+async def test_create_statistics_happy_path(mock_ctx, ctx_patch) -> None:
+    """create_statistics calls service and returns Statistic dict."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    stat = _make_statistic()
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.statistics.create_statistics",
+            new=AsyncMock(return_value=stat),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "create_statistics",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_table": "dbo.sales",
+                "column": "id",
+                "stat_name": "stat_sales_id",
+            },
+        )
+
+    assert result["name"] == "stat_sales_id"
+
+
+async def test_create_statistics_readonly_blocked(ctx_patch) -> None:
+    """create_statistics is blocked by FABRIC_MCP_READONLY."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_READONLY": "1"}),
+        pytest.raises(ToolError, match="read-only"),
+    ):
+        await mcp._tool_manager.call_tool(
+            "create_statistics",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_table": "dbo.sales",
+                "column": "id",
+                "stat_name": "s",
+            },
+        )
+
+
+async def test_create_statistics_sql_endpoint_rejected(mock_ctx, ctx_patch) -> None:
+    """create_statistics rejects SQL Endpoint items via the service-layer guard."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.item = AsyncMock(return_value=make_sql_endpoint_entry())
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.statistics.create_statistics",
+            new=AsyncMock(side_effect=ItemKindError("read-only")),
+        ),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "create_statistics",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_table": "dbo.sales",
+                "column": "id",
+                "stat_name": "s",
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# update_statistics — guard checks and happy path
+# ---------------------------------------------------------------------------
+
+
+async def test_update_statistics_happy_path(mock_ctx, ctx_patch) -> None:
+    """update_statistics calls service and returns {"updated": True}."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.statistics.update_statistics",
+            new=AsyncMock(return_value=None),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "update_statistics",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_table": "dbo.sales",
+                "stat_name": "s",
+            },
+        )
+
+    assert result == {"updated": True}
+
+
+async def test_update_statistics_readonly_blocked(ctx_patch) -> None:
+    """update_statistics is blocked by FABRIC_MCP_READONLY."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_READONLY": "1"}),
+        pytest.raises(ToolError, match="read-only"),
+    ):
+        await mcp._tool_manager.call_tool(
+            "update_statistics",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_table": "dbo.sales",
+                "stat_name": "s",
+            },
+        )
+
+
+async def test_update_statistics_sql_endpoint_rejected(mock_ctx, ctx_patch) -> None:
+    """update_statistics rejects SQL Endpoint items via the service-layer guard."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.item = AsyncMock(return_value=make_sql_endpoint_entry())
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.statistics.update_statistics",
+            new=AsyncMock(side_effect=ItemKindError("read-only")),
+        ),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "update_statistics",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_table": "dbo.sales",
+                "stat_name": "s",
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# delete_statistics — destructive guard + happy path + endpoint guard
+# ---------------------------------------------------------------------------
+
+
+async def test_delete_statistics_happy_path(mock_ctx, ctx_patch) -> None:
+    """delete_statistics calls service and returns {"dropped": True}."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_ALLOW_DESTRUCTIVE": "1"}),
+        patch(
+            "fabric_dw.services.statistics.drop_statistics",
+            new=AsyncMock(return_value=None),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "delete_statistics",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_table": "dbo.sales",
+                "stat_name": "s",
+            },
+        )
+
+    assert result == {"dropped": True}
+
+
+async def test_delete_statistics_destructive_guard_blocks(ctx_patch) -> None:
+    """delete_statistics is blocked without FABRIC_MCP_ALLOW_DESTRUCTIVE."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {}, clear=True),  # ensure ALLOW_DESTRUCTIVE is absent
+        pytest.raises(ToolError, match="destructive"),
+    ):
+        await mcp._tool_manager.call_tool(
+            "delete_statistics",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_table": "dbo.sales",
+                "stat_name": "s",
+            },
+        )
+
+
+async def test_delete_statistics_readonly_blocked(ctx_patch) -> None:
+    """delete_statistics is blocked by FABRIC_MCP_READONLY (write guard fires first)."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_READONLY": "1"}),
+        pytest.raises(ToolError, match="read-only"),
+    ):
+        await mcp._tool_manager.call_tool(
+            "delete_statistics",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_table": "dbo.sales",
+                "stat_name": "s",
+            },
+        )
+
+
+async def test_delete_statistics_sql_endpoint_rejected(mock_ctx, ctx_patch) -> None:
+    """delete_statistics rejects SQL Endpoint items via the service-layer guard."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.item = AsyncMock(return_value=make_sql_endpoint_entry())
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_ALLOW_DESTRUCTIVE": "1"}),
+        patch(
+            "fabric_dw.services.statistics.drop_statistics",
+            new=AsyncMock(side_effect=ItemKindError("read-only")),
+        ),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "delete_statistics",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_table": "dbo.sales",
+                "stat_name": "s",
+            },
+        )
+
+
+async def test_delete_statistics_bad_qualified_table_raises_tool_error(ctx_patch) -> None:
+    """delete_statistics raises ToolError for a non-qualified table name."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_ALLOW_DESTRUCTIVE": "1"}),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "delete_statistics",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_table": "nodot",
+                "stat_name": "s",
+            },
+        )

--- a/tests/unit/services/test_statistics.py
+++ b/tests/unit/services/test_statistics.py
@@ -719,3 +719,128 @@ class TestSqlEndpointGuard:
                 kind=WarehouseKind.WAREHOUSE,
             )
         assert isinstance(result, Statistic)
+
+
+# ===========================================================================
+# Row-parser zero-value correctness
+# ===========================================================================
+
+
+class TestRowParserZeroValues:
+    """Verify that zero int/float DB values are not corrupted to None by the parsers."""
+
+    async def test_header_zero_rows_preserved(self) -> None:
+        """Rows=0 must survive as 0, not fall through to None."""
+        target = _make_target()
+        zero_row: tuple[object, ...] = (
+            "stat_empty",  # Name
+            _NOW,  # Updated
+            0,  # Rows        ← zero int
+            0,  # Rows Sampled← zero int
+            0,  # Steps       ← zero int
+            0.0,  # Density    ← zero float
+            0.0,  # Average Key Length ← zero float
+            "NO",  # String Index
+            None,  # Filter Expression
+            0,  # Unfiltered Rows ← zero int
+        )
+        header_conn = _make_conn([zero_row], _HEADER_COLS)
+        density_conn = _make_conn([], _DENSITY_COLS)
+        hist_conn = _make_conn([], _HISTOGRAM_COLS)
+        with patch(
+            "fabric_dw.sql.open_connection",
+            side_effect=[header_conn, density_conn, hist_conn],
+        ):
+            result = await statistics.show_statistics(target, "dbo.sales", "stat_empty")
+        hdr = result.stat_header
+        assert hdr is not None
+        assert hdr.rows == 0, f"Expected 0, got {hdr.rows!r}"
+        assert hdr.rows_sampled == 0, f"Expected 0, got {hdr.rows_sampled!r}"
+        assert hdr.steps == 0, f"Expected 0, got {hdr.steps!r}"
+        assert hdr.density == 0.0, f"Expected 0.0, got {hdr.density!r}"
+        assert hdr.average_key_length == 0.0, f"Expected 0.0, got {hdr.average_key_length!r}"
+        assert hdr.unfiltered_rows == 0, f"Expected 0, got {hdr.unfiltered_rows!r}"
+
+    async def test_density_zero_values_preserved(self) -> None:
+        """all_density=0.0 and average_length=0.0 must survive as 0.0, not None."""
+        target = _make_target()
+        zero_density_row: tuple[object, ...] = (0.0, 0.0, "id")  # all_density, avg_length, cols
+        header_conn = _make_conn([_HEADER_ROW], _HEADER_COLS)
+        density_conn = _make_conn([zero_density_row], _DENSITY_COLS)
+        hist_conn = _make_conn([], _HISTOGRAM_COLS)
+        with patch(
+            "fabric_dw.sql.open_connection",
+            side_effect=[header_conn, density_conn, hist_conn],
+        ):
+            result = await statistics.show_statistics(target, "dbo.sales", "stat_sales_id")
+        assert len(result.density_vector) == 1
+        dv = result.density_vector[0]
+        assert dv.all_density == 0.0, f"Expected 0.0, got {dv.all_density!r}"
+        assert dv.average_length == 0.0, f"Expected 0.0, got {dv.average_length!r}"
+
+    async def test_histogram_zero_float_values_preserved(self) -> None:
+        """RANGE_ROWS=0.0 and EQ_ROWS=0.0 must survive as 0.0, not None."""
+        target = _make_target()
+        zero_hist_row: tuple[object, ...] = (
+            "100",  # RANGE_HI_KEY
+            0.0,  # RANGE_ROWS       ← zero float
+            0.0,  # EQ_ROWS          ← zero float
+            0.0,  # DISTINCT_RANGE_ROWS ← zero float
+            0.0,  # AVG_RANGE_ROWS   ← zero float
+        )
+        hist_conn = _make_conn([zero_hist_row], _HISTOGRAM_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=hist_conn):
+            result = await statistics.show_statistics(
+                target, "dbo.sales", "stat_sales_id", histogram_only=True
+            )
+        assert len(result.histogram) == 1
+        step = result.histogram[0]
+        assert step.range_rows == 0.0, f"Expected 0.0, got {step.range_rows!r}"
+        assert step.eq_rows == 0.0, f"Expected 0.0, got {step.eq_rows!r}"
+        assert step.distinct_range_rows == 0.0, f"Expected 0.0, got {step.distinct_range_rows!r}"
+        assert step.avg_range_rows == 0.0, f"Expected 0.0, got {step.avg_range_rows!r}"
+
+
+# ===========================================================================
+# Injection safety — embedded ] in a single identifier segment
+# ===========================================================================
+
+
+class TestBracketInjection:
+    """Test that a bare ] inside a single identifier segment is rejected by validate_identifier."""
+
+    async def test_bracket_in_stat_name_rejected(self) -> None:
+        """show_statistics: stat_name containing ] must raise ValueError."""
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await statistics.show_statistics(target, "dbo.sales", "my]stat")
+
+    async def test_bracket_in_schema_rejected(self) -> None:
+        """show_statistics: schema part containing ] must raise ValueError."""
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await statistics.show_statistics(target, "my]schema.sales", "stat")
+
+    async def test_bracket_in_table_rejected(self) -> None:
+        """show_statistics: table part containing ] must raise ValueError."""
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await statistics.show_statistics(target, "dbo.my]table", "stat")
+
+    async def test_bracket_in_create_stat_name_rejected(self) -> None:
+        """create_statistics: stat name containing ] must raise ValueError."""
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await statistics.create_statistics(target, "dbo.sales", "id", name="my]stat")
+
+    async def test_bracket_in_update_stat_name_rejected(self) -> None:
+        """update_statistics: stat name containing ] must raise ValueError."""
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await statistics.update_statistics(target, "dbo.sales", "my]stat")
+
+    async def test_bracket_in_drop_stat_name_rejected(self) -> None:
+        """drop_statistics: stat name containing ] must raise ValueError."""
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await statistics.drop_statistics(target, "dbo.sales", "my]stat")

--- a/tests/unit/services/test_statistics.py
+++ b/tests/unit/services/test_statistics.py
@@ -1,0 +1,721 @@
+"""Unit tests for services.statistics — SQL construction and injection safety."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fabric_dw.exceptions import ItemKindError, NotFoundError, PermissionDeniedError
+from fabric_dw.models import Statistic, StatisticDetails, WarehouseKind
+from fabric_dw.services import statistics
+from tests.unit.services._helpers import _make_conn, _make_conn_for_ddl, _make_target
+
+# ---------------------------------------------------------------------------
+# Fixture data
+# ---------------------------------------------------------------------------
+
+_NOW = datetime(2024, 6, 1, 12, 0, 0, tzinfo=UTC)
+
+_LIST_COLS = [
+    "stat_name",
+    "schema_name",
+    "table_name",
+    "column_name",
+    "auto_created",
+    "user_created",
+    "last_updated",
+    "generation_method",
+]
+_STAT_ROW_1: tuple[object, ...] = (
+    "stat_sales_id",
+    "dbo",
+    "sales",
+    "id",
+    False,
+    True,
+    _NOW,
+    None,
+)
+_STAT_ROW_2: tuple[object, ...] = (
+    "_WA_Sys_id",
+    "dbo",
+    "orders",
+    "id",
+    True,
+    False,
+    _NOW,
+    None,
+)
+
+_HEADER_COLS = [
+    "Name",
+    "Updated",
+    "Rows",
+    "Rows Sampled",
+    "Steps",
+    "Density",
+    "Average Key Length",
+    "String Index",
+    "Filter Expression",
+    "Unfiltered Rows",
+]
+_HEADER_ROW: tuple[object, ...] = (
+    "stat_sales_id",
+    _NOW,
+    1000,
+    500,
+    10,
+    0.001,
+    4.0,
+    "NO",
+    None,
+    None,
+)
+
+_DENSITY_COLS = ["All density", "Average Length", "Columns"]
+_DENSITY_ROW: tuple[object, ...] = (0.001, 4.0, "id")
+
+_HISTOGRAM_COLS = [
+    "RANGE_HI_KEY",
+    "RANGE_ROWS",
+    "EQ_ROWS",
+    "DISTINCT_RANGE_ROWS",
+    "AVG_RANGE_ROWS",
+]
+_HISTOGRAM_ROW: tuple[object, ...] = ("100", 50.0, 10.0, 5.0, 2.0)
+
+
+# ===========================================================================
+# list_statistics
+# ===========================================================================
+
+
+class TestListStatistics:
+    async def test_returns_empty_when_no_rows(self) -> None:
+        target = _make_target()
+        conn = _make_conn([], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            result = await statistics.list_statistics(target)
+        assert result == []
+
+    async def test_returns_statistic_instances(self) -> None:
+        target = _make_target()
+        conn = _make_conn([_STAT_ROW_1], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            result = await statistics.list_statistics(target)
+        assert len(result) == 1
+        assert isinstance(result[0], Statistic)
+
+    async def test_parses_fields_correctly(self) -> None:
+        target = _make_target()
+        conn = _make_conn([_STAT_ROW_1], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            result = await statistics.list_statistics(target)
+        s = result[0]
+        assert s.name == "stat_sales_id"
+        assert s.qualified_table == "dbo.sales"
+        assert s.column == "id"
+        assert s.auto_created is False
+        assert s.user_created is True
+
+    async def test_returns_all_rows(self) -> None:
+        target = _make_target()
+        conn = _make_conn([_STAT_ROW_1, _STAT_ROW_2], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            result = await statistics.list_statistics(target)
+        assert len(result) == 2
+
+    async def test_sql_references_sys_stats(self) -> None:
+        target = _make_target()
+        conn = _make_conn([], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await statistics.list_statistics(target)
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert "sys.stats" in call_sql
+
+    async def test_schema_filter_uses_parameter(self) -> None:
+        target = _make_target()
+        conn = _make_conn([_STAT_ROW_1], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await statistics.list_statistics(target, schema="dbo")
+        cursor = conn.cursor.return_value
+        call_args = cursor.execute.call_args
+        call_sql: str = call_args[0][0]
+        assert "s.name = ?" in call_sql
+        params = call_args[0][1] if len(call_args[0]) > 1 else (call_args[1] or {}).get("params")
+        assert params is not None
+        assert "dbo" in list(params)
+
+    async def test_table_filter_uses_parameter(self) -> None:
+        target = _make_target()
+        conn = _make_conn([_STAT_ROW_1], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await statistics.list_statistics(target, table="sales")
+        cursor = conn.cursor.return_value
+        call_args = cursor.execute.call_args
+        call_sql: str = call_args[0][0]
+        assert "t.name = ?" in call_sql
+        params = call_args[0][1] if len(call_args[0]) > 1 else (call_args[1] or {}).get("params")
+        assert params is not None
+        assert "sales" in list(params)
+
+    async def test_user_only_filter(self) -> None:
+        target = _make_target()
+        conn = _make_conn([_STAT_ROW_1], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await statistics.list_statistics(target, user_only=True)
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert "user_created = 1" in call_sql
+
+    async def test_auto_only_filter(self) -> None:
+        target = _make_target()
+        conn = _make_conn([_STAT_ROW_2], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await statistics.list_statistics(target, auto_only=True)
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert "auto_created = 1" in call_sql
+
+    async def test_user_only_and_auto_only_raises(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            await statistics.list_statistics(target, user_only=True, auto_only=True)
+
+    async def test_schema_identifier_validated(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await statistics.list_statistics(target, schema="bad]schema")
+
+    async def test_table_identifier_validated(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await statistics.list_statistics(target, table="bad--table")
+
+    async def test_maps_permission_denied(self) -> None:
+        target = _make_target()
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.execute.side_effect = Exception("permission was denied on object sys.stats")
+        conn.cursor.return_value = cursor
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(PermissionDeniedError),
+        ):
+            await statistics.list_statistics(target)
+
+    async def test_last_updated_normalized_to_utc(self) -> None:
+        target = _make_target()
+        # Strip tzinfo to test UTC normalization — intentionally naive.
+        naive_dt = datetime(2024, 6, 1, 12, 0, 0, tzinfo=UTC).replace(tzinfo=None)
+        row: tuple[object, ...] = (
+            "stat_sales_id",
+            "dbo",
+            "sales",
+            "id",
+            False,
+            True,
+            naive_dt,
+            None,
+        )
+        conn = _make_conn([row], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            result = await statistics.list_statistics(target)
+        assert result[0].last_updated is not None
+        assert result[0].last_updated.tzinfo is not None
+
+
+# ===========================================================================
+# show_statistics
+# ===========================================================================
+
+
+class TestShowStatistics:
+    async def test_returns_statistic_details(self) -> None:
+        target = _make_target()
+        header_conn = _make_conn([_HEADER_ROW], _HEADER_COLS)
+        density_conn = _make_conn([_DENSITY_ROW], _DENSITY_COLS)
+        hist_conn = _make_conn([_HISTOGRAM_ROW], _HISTOGRAM_COLS)
+        with patch(
+            "fabric_dw.sql.open_connection",
+            side_effect=[header_conn, density_conn, hist_conn],
+        ):
+            result = await statistics.show_statistics(target, "dbo.sales", "stat_sales_id")
+        assert isinstance(result, StatisticDetails)
+        assert result.stat_header is not None
+        assert result.stat_header.name == "stat_sales_id"
+
+    async def test_histogram_only_skips_header_and_density(self) -> None:
+        target = _make_target()
+        hist_conn = _make_conn([_HISTOGRAM_ROW], _HISTOGRAM_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=hist_conn):
+            result = await statistics.show_statistics(
+                target, "dbo.sales", "stat_sales_id", histogram_only=True
+            )
+        assert result.stat_header is None
+        assert result.density_vector == []
+        assert len(result.histogram) == 1
+
+    async def test_sql_contains_dbcc_show_statistics(self) -> None:
+        target = _make_target()
+        header_conn = _make_conn([_HEADER_ROW], _HEADER_COLS)
+        density_conn = _make_conn([_DENSITY_ROW], _DENSITY_COLS)
+        hist_conn = _make_conn([_HISTOGRAM_ROW], _HISTOGRAM_COLS)
+        with patch(
+            "fabric_dw.sql.open_connection",
+            side_effect=[header_conn, density_conn, hist_conn],
+        ):
+            await statistics.show_statistics(target, "dbo.sales", "stat_sales_id")
+        # All three connections should receive DBCC queries
+        for conn in [header_conn, density_conn, hist_conn]:
+            call_sql: str = conn.cursor.return_value.execute.call_args[0][0].upper()
+            assert "DBCC" in call_sql
+            assert "SHOW_STATISTICS" in call_sql
+
+    async def test_sql_bracket_quotes_table_identifier(self) -> None:
+        target = _make_target()
+        header_conn = _make_conn([_HEADER_ROW], _HEADER_COLS)
+        density_conn = _make_conn([_DENSITY_ROW], _DENSITY_COLS)
+        hist_conn = _make_conn([_HISTOGRAM_ROW], _HISTOGRAM_COLS)
+        with patch(
+            "fabric_dw.sql.open_connection",
+            side_effect=[header_conn, density_conn, hist_conn],
+        ):
+            await statistics.show_statistics(target, "dbo.sales", "stat_sales_id")
+        call_sql: str = header_conn.cursor.return_value.execute.call_args[0][0]
+        assert "[dbo]" in call_sql
+        assert "[sales]" in call_sql
+
+    async def test_sql_bracket_quotes_stat_identifier(self) -> None:
+        target = _make_target()
+        header_conn = _make_conn([_HEADER_ROW], _HEADER_COLS)
+        density_conn = _make_conn([_DENSITY_ROW], _DENSITY_COLS)
+        hist_conn = _make_conn([_HISTOGRAM_ROW], _HISTOGRAM_COLS)
+        with patch(
+            "fabric_dw.sql.open_connection",
+            side_effect=[header_conn, density_conn, hist_conn],
+        ):
+            await statistics.show_statistics(target, "dbo.sales", "stat_sales_id")
+        call_sql: str = header_conn.cursor.return_value.execute.call_args[0][0]
+        assert "[stat_sales_id]" in call_sql
+
+    async def test_raises_not_found_when_header_empty(self) -> None:
+        target = _make_target()
+        header_conn = _make_conn([], _HEADER_COLS)
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=header_conn),
+            pytest.raises(NotFoundError),
+        ):
+            await statistics.show_statistics(target, "dbo.sales", "nonexistent_stat")
+
+    async def test_validates_schema_identifier(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await statistics.show_statistics(target, "bad]schema.sales", "stat")
+
+    async def test_validates_table_identifier(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await statistics.show_statistics(target, "dbo.sales--bad", "stat")
+
+    async def test_validates_stat_name_identifier(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await statistics.show_statistics(target, "dbo.sales", "stat; DROP TABLE--")
+
+    # --- Injection safety ---
+
+    async def test_injection_via_table_name_rejected(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await statistics.show_statistics(
+                target,
+                "dbo.sales]; DROP TABLE users--",
+                "stat",
+            )
+
+    async def test_injection_via_stat_name_rejected(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await statistics.show_statistics(
+                target,
+                "dbo.sales",
+                "s]; DROP TABLE users--",
+            )
+
+    async def test_injection_via_schema_rejected(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await statistics.show_statistics(
+                target,
+                "x]; DROP DATABASE master--.sales",
+                "stat",
+            )
+
+
+# ===========================================================================
+# create_statistics
+# ===========================================================================
+
+
+class TestCreateStatistics:
+    async def test_emits_create_statistics(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_STAT_ROW_1], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            await statistics.create_statistics(target, "dbo.sales", "id", name="my_stat")
+        cursor = ddl_conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0].upper()
+        assert "CREATE STATISTICS" in call_sql
+
+    async def test_bracket_quotes_table_identifier(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_STAT_ROW_1], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            await statistics.create_statistics(target, "dbo.sales", "id", name="my_stat")
+        cursor = ddl_conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert "[dbo].[sales]" in call_sql
+
+    async def test_bracket_quotes_column_identifier(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_STAT_ROW_1], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            await statistics.create_statistics(target, "dbo.sales", "id", name="my_stat")
+        cursor = ddl_conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert "[id]" in call_sql
+
+    async def test_bracket_quotes_stat_name(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_STAT_ROW_1], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            await statistics.create_statistics(target, "dbo.sales", "id", name="my_stat")
+        cursor = ddl_conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert "[my_stat]" in call_sql
+
+    async def test_fullscan_sql(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_STAT_ROW_1], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            await statistics.create_statistics(target, "dbo.sales", "id", name="s", fullscan=True)
+        cursor = ddl_conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0].upper()
+        assert "FULLSCAN" in call_sql
+
+    async def test_sample_percent_sql(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_STAT_ROW_1], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            await statistics.create_statistics(
+                target, "dbo.sales", "id", name="s", sample_percent=50
+            )
+        cursor = ddl_conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0].upper()
+        assert "SAMPLE" in call_sql
+        assert "50" in call_sql
+        assert "PERCENT" in call_sql
+
+    async def test_sample_percent_out_of_range_raises(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="sample_percent"):
+            await statistics.create_statistics(
+                target, "dbo.sales", "id", name="s", sample_percent=0
+            )
+
+    async def test_sample_percent_101_raises(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="sample_percent"):
+            await statistics.create_statistics(
+                target, "dbo.sales", "id", name="s", sample_percent=101
+            )
+
+    async def test_name_required_raises(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="name"):
+            await statistics.create_statistics(target, "dbo.sales", "id", name=None)
+
+    async def test_returns_statistic_object(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_STAT_ROW_1], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            result = await statistics.create_statistics(
+                target, "dbo.sales", "id", name="stat_sales_id"
+            )
+        assert isinstance(result, Statistic)
+
+    async def test_commits_after_execute(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_STAT_ROW_1], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            await statistics.create_statistics(target, "dbo.sales", "id", name="s")
+        ddl_conn.commit.assert_called_once()
+
+    # --- Injection safety ---
+
+    async def test_injection_via_table_schema_rejected(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await statistics.create_statistics(
+                target,
+                "dbo]; DROP TABLE users--.sales",
+                "id",
+                name="s",
+            )
+
+    async def test_injection_via_table_name_rejected(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await statistics.create_statistics(
+                target,
+                "dbo.sales]; DROP TABLE users--",
+                "id",
+                name="s",
+            )
+
+    async def test_injection_via_column_rejected(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await statistics.create_statistics(
+                target,
+                "dbo.sales",
+                "id]; DROP TABLE users--",
+                name="s",
+            )
+
+    async def test_injection_via_stat_name_rejected(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await statistics.create_statistics(
+                target,
+                "dbo.sales",
+                "id",
+                name="s]; DROP TABLE users--",
+            )
+
+
+# ===========================================================================
+# update_statistics
+# ===========================================================================
+
+
+class TestUpdateStatistics:
+    async def test_emits_update_statistics(self) -> None:
+        target = _make_target()
+        conn = _make_conn_for_ddl()
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await statistics.update_statistics(target, "dbo.sales", "my_stat")
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0].upper()
+        assert "UPDATE STATISTICS" in call_sql
+
+    async def test_bracket_quotes_identifiers(self) -> None:
+        target = _make_target()
+        conn = _make_conn_for_ddl()
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await statistics.update_statistics(target, "dbo.sales", "my_stat")
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert "[dbo].[sales]" in call_sql
+        assert "[my_stat]" in call_sql
+
+    async def test_fullscan_sql(self) -> None:
+        target = _make_target()
+        conn = _make_conn_for_ddl()
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await statistics.update_statistics(target, "dbo.sales", "s", fullscan=True)
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0].upper()
+        assert "FULLSCAN" in call_sql
+
+    async def test_sample_percent_sql(self) -> None:
+        target = _make_target()
+        conn = _make_conn_for_ddl()
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await statistics.update_statistics(target, "dbo.sales", "s", sample_percent=25)
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0].upper()
+        assert "SAMPLE" in call_sql
+        assert "25" in call_sql
+
+    async def test_sample_percent_range_validated(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="sample_percent"):
+            await statistics.update_statistics(target, "dbo.sales", "s", sample_percent=0)
+
+    async def test_commits_after_execute(self) -> None:
+        target = _make_target()
+        conn = _make_conn_for_ddl()
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await statistics.update_statistics(target, "dbo.sales", "s")
+        conn.commit.assert_called_once()
+
+    async def test_validates_stat_name_identifier(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await statistics.update_statistics(target, "dbo.sales", "s--bad")
+
+    # --- Injection safety ---
+
+    async def test_injection_via_stat_name_rejected(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await statistics.update_statistics(target, "dbo.sales", "s]; DROP TABLE users--")
+
+    async def test_injection_via_table_schema_rejected(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await statistics.update_statistics(target, "bad]schema.sales", "s")
+
+
+# ===========================================================================
+# drop_statistics
+# ===========================================================================
+
+
+class TestDropStatistics:
+    async def test_emits_drop_statistics(self) -> None:
+        target = _make_target()
+        conn = _make_conn_for_ddl()
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await statistics.drop_statistics(target, "dbo.sales", "my_stat")
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0].upper()
+        assert "DROP STATISTICS" in call_sql
+
+    async def test_bracket_quotes_identifiers(self) -> None:
+        target = _make_target()
+        conn = _make_conn_for_ddl()
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await statistics.drop_statistics(target, "dbo.sales", "my_stat")
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert "[dbo].[sales]" in call_sql
+        assert "[my_stat]" in call_sql
+
+    async def test_commits_after_execute(self) -> None:
+        target = _make_target()
+        conn = _make_conn_for_ddl()
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await statistics.drop_statistics(target, "dbo.sales", "my_stat")
+        conn.commit.assert_called_once()
+
+    async def test_validates_stat_name_identifier(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await statistics.drop_statistics(target, "dbo.sales", "bad;stat")
+
+    async def test_maps_permission_denied(self) -> None:
+        target = _make_target()
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.execute.side_effect = Exception("permission was denied to drop statistics")
+        conn.cursor.return_value = cursor
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(PermissionDeniedError),
+        ):
+            await statistics.drop_statistics(target, "dbo.sales", "my_stat")
+
+    # --- Injection safety ---
+
+    async def test_injection_via_stat_name_rejected(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await statistics.drop_statistics(target, "dbo.sales", "s]; DROP TABLE users--")
+
+    async def test_injection_via_table_name_rejected(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await statistics.drop_statistics(target, "dbo.sales]; DROP TABLE x--", "s")
+
+    async def test_injection_via_schema_rejected(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await statistics.drop_statistics(target, "x]; DROP DATABASE master--.sales", "s")
+
+
+# ===========================================================================
+# SQL Endpoint guard — service layer
+# ===========================================================================
+
+
+class TestSqlEndpointGuard:
+    """Verify that create/update/drop reject SQL Endpoint items before any I/O."""
+
+    async def test_create_statistics_rejects_sql_endpoint(self) -> None:
+        target = _make_target()
+        with pytest.raises(ItemKindError, match="read-only"):
+            await statistics.create_statistics(
+                target,
+                "dbo.sales",
+                "id",
+                name="s",
+                kind=WarehouseKind.SQL_ENDPOINT,
+            )
+
+    async def test_update_statistics_rejects_sql_endpoint(self) -> None:
+        target = _make_target()
+        with pytest.raises(ItemKindError, match="read-only"):
+            await statistics.update_statistics(
+                target,
+                "dbo.sales",
+                "s",
+                kind=WarehouseKind.SQL_ENDPOINT,
+            )
+
+    async def test_drop_statistics_rejects_sql_endpoint(self) -> None:
+        target = _make_target()
+        with pytest.raises(ItemKindError, match="read-only"):
+            await statistics.drop_statistics(
+                target,
+                "dbo.sales",
+                "s",
+                kind=WarehouseKind.SQL_ENDPOINT,
+            )
+
+    async def test_list_statistics_allows_sql_endpoint(self) -> None:
+        """list_statistics must NOT be guarded — SQL endpoints are read-only OK."""
+        target = _make_target()
+        conn = _make_conn([], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            result = await statistics.list_statistics(target)
+        assert isinstance(result, list)
+
+    async def test_guard_fires_before_identifier_validation(self) -> None:
+        """ItemKindError must fire even when identifiers are invalid."""
+        target = _make_target()
+        with pytest.raises(ItemKindError):
+            await statistics.create_statistics(
+                target,
+                "bad]schema.sales",
+                "id",
+                name="s",
+                kind=WarehouseKind.SQL_ENDPOINT,
+            )
+
+    async def test_warehouse_kind_allowed(self) -> None:
+        target = _make_target()
+        conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_STAT_ROW_1], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[conn, fetch_conn]):
+            result = await statistics.create_statistics(
+                target,
+                "dbo.sales",
+                "id",
+                name="stat_sales_id",
+                kind=WarehouseKind.WAREHOUSE,
+            )
+        assert isinstance(result, Statistic)


### PR DESCRIPTION
## Summary

Closes #307.

- **Service layer** (`src/fabric_dw/services/statistics.py`): `list_statistics`, `show_statistics`, `create_statistics`, `update_statistics`, `drop_statistics` — all identifiers validated via `validate_identifier` then bracket-quoted via `quote_identifier`; `sample_percent` range-validated as `int`; `DBCC SHOW_STATISTICS` uses three separate `WITH STAT_HEADER / DENSITY_VECTOR / HISTOGRAM` queries for clean single result sets.
- **Models** (`src/fabric_dw/models.py`): `Statistic`, `StatisticDetails`, `StatisticHeaderRow`, `StatisticDensityRow`, `StatisticHistogramStep`.
- **CLI group** (`fabric-dw statistics`): `list`, `show`, `create`, `update`, `delete` subcommands.
- **MCP tools**: `list_statistics`, `show_statistics`, `create_statistics`, `update_statistics`, `delete_statistics` (delete is destructive-guarded).
- **SQL Analytics Endpoint guard**: DDL operations (create/update/drop) are rejected client-side with `ItemKindError` before any network I/O.
- **Unit tests**: 100+ new tests across service, CLI, and MCP layers; injection-safety tests for all identifier inputs.
- **Integration tests**: full round-trip (create table → create stat → list → show → update → drop) on ephemeral warehouse; endpoint-guard tests client-side.
- **Docs**: `docs/cli.md` and `docs/mcp-tools.md` updated with all new commands/tools.

## Test plan

- [x] `uv run ruff check .` — no errors
- [x] `uv run ruff format --check .` — no reformats needed
- [x] `uv run ty check src tests` — no errors
- [x] `uv run pytest tests/unit -q` — 2510 passed
- [x] Coverage 97% (statistics service 95%, CLI 98%, MCP tools 98%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)