### PR TITLE
test(integration): per-worker shared warm warehouse with schema-per-test isolation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,6 +150,7 @@ markers = [
 ]
 addopts = "-ra --strict-markers -m 'not integration and not slow'"
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
 filterwarnings = [
     "error::RuntimeWarning",
     "error::DeprecationWarning",

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -313,15 +313,16 @@ async def shared_warehouse(
     name = f"pytest-{worker}-{uid}-wh"
 
     wh = await warehouses.create(_session_http, _session_workspace_id, name)
-    assert wh.connection_string, f"Warehouse {wh.id} returned no connection_string"
-
-    sql_target = SqlTarget(
-        workspace_id=str(_session_workspace_id),
-        database=wh.name,
-        connection_string=wh.connection_string,
-    )
 
     try:
+        assert wh.connection_string, f"Warehouse {wh.id} returned no connection_string"
+
+        sql_target = SqlTarget(
+            workspace_id=str(_session_workspace_id),
+            database=wh.name,
+            connection_string=wh.connection_string,
+        )
+
         # Wait for the SQL engine to accept connections before doing anything else.
         await _wait_for_sql_readiness(sql_target)
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -5,6 +5,7 @@ import os
 import time
 import uuid
 from collections.abc import AsyncIterator
+from typing import NamedTuple
 from uuid import UUID
 
 import pytest
@@ -14,7 +15,7 @@ from fabric_dw.auth import get_credential
 from fabric_dw.exceptions import NotFoundError
 from fabric_dw.http_client import FabricHttpClient, HttpBase
 from fabric_dw.models import Warehouse, WarehouseKind, WarehouseSnapshot
-from fabric_dw.services import snapshots, warehouses
+from fabric_dw.services import schemas, snapshots, warehouses
 from fabric_dw.sql import SqlTarget, is_transient_connection_error, run_query
 
 logger = logging.getLogger(__name__)
@@ -38,6 +39,25 @@ _SQL_READINESS_BACKOFF_MAX_S = 5.0
 _SNAP_SQL_READINESS_TIMEOUT_S = 300.0
 # Polling interval (seconds) between snapshot readiness probes.
 _SNAP_SQL_READINESS_POLL_S = 5.0
+
+# Name of the read-only seed schema pre-populated in the shared warehouse.
+# Tests that only READ data (list / get / query) may use this schema directly.
+# Tests that mutate state MUST use the ``warehouse_schema`` fixture instead.
+SEED_SCHEMA_NAME = "sample"
+
+
+class SharedWarehouseTarget(NamedTuple):
+    """Container yielded by ``shared_warehouse``.
+
+    Attributes:
+        warehouse: The live :class:`~fabric_dw.models.Warehouse` item.
+        sql_target: A :class:`~fabric_dw.sql.SqlTarget` pointing at it.
+        workspace_id: The workspace UUID.
+    """
+
+    warehouse: Warehouse
+    sql_target: SqlTarget
+    workspace_id: UUID
 
 
 async def _wait_for_sql_readiness(
@@ -216,6 +236,180 @@ async def _wait_for_snapshot_sql_readiness(
             )
 
         await asyncio.sleep(_SNAP_SQL_READINESS_POLL_S)
+
+
+# ---------------------------------------------------------------------------
+# Session-scoped helpers (shared by both shared_warehouse and legacy fixtures)
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture(loop_scope="session", scope="session")
+async def _session_workspace_id() -> UUID:
+    """Resolve FABRIC_TEST_WORKSPACE_ID once per session.
+
+    Session-scoped variant of ``workspace_id`` used exclusively by
+    ``shared_warehouse``.  The function-scoped ``workspace_id`` fixture (below)
+    remains unchanged so that tests that request it directly continue to work.
+    """
+    raw = os.environ.get("FABRIC_TEST_WORKSPACE_ID")
+    if not raw:
+        pytest.skip("set FABRIC_TEST_WORKSPACE_ID to run integration tests")
+    return UUID(raw)
+
+
+@pytest_asyncio.fixture(loop_scope="session", scope="session")
+async def _session_http() -> AsyncIterator[FabricHttpClient]:
+    """Long-lived HTTP client shared across all tests in the session.
+
+    Session-scoped variant of ``http`` used exclusively by ``shared_warehouse``.
+    The function-scoped ``http`` fixture remains unchanged so that tests that
+    request it directly continue to work.
+    """
+    cred = get_credential()
+    async with FabricHttpClient(cred) as client:
+        yield client
+
+
+# ---------------------------------------------------------------------------
+# Shared warm warehouse (session-scoped, one per xdist worker)
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture(loop_scope="session", scope="session")
+async def shared_warehouse(
+    _session_http: FabricHttpClient,
+    _session_workspace_id: UUID,
+) -> AsyncIterator[SharedWarehouseTarget]:
+    """Create ONE warm warehouse per session (per xdist worker) and reuse it.
+
+    Naming convention
+    -----------------
+    The warehouse name embeds ``PYTEST_XDIST_WORKER`` (defaulting to
+    ``"master"`` when xdist is not active) and a random UUID fragment so that
+    parallel workers each get their own warehouse without cross-process
+    coordination.
+
+    Seed schema
+    -----------
+    After the warehouse warms up, a read-only ``sample`` schema is created with
+    a couple of small tables so that pure-read tests can query real rows without
+    creating their own objects.  The schema name is exposed as
+    ``conftest.SEED_SCHEMA_NAME``.
+
+    **Tests MUST NOT mutate the seed schema.**  Mutating tests must use the
+    ``warehouse_schema`` fixture instead, which creates a uniquely-named schema
+    per test and cascade-drops it on teardown.
+
+    xdist compatibility
+    -------------------
+    Each xdist worker runs its own session, so this session-scoped fixture
+    runs once per worker — not once globally.  No cross-process locking is
+    required.  The ``loop_scope="session"`` argument aligns the asyncio event
+    loop lifetime with the session scope, which pytest-asyncio >= 0.23 /
+    1.x requires for session-scoped async fixtures.
+    """
+    worker = os.environ.get("PYTEST_XDIST_WORKER", "master")
+    uid = uuid.uuid4().hex[:8]
+    name = f"pytest-{worker}-{uid}-wh"
+
+    wh = await warehouses.create(_session_http, _session_workspace_id, name)
+    assert wh.connection_string, f"Warehouse {wh.id} returned no connection_string"
+
+    sql_target = SqlTarget(
+        workspace_id=str(_session_workspace_id),
+        database=wh.name,
+        connection_string=wh.connection_string,
+    )
+
+    try:
+        # Wait for the SQL engine to accept connections before doing anything else.
+        await _wait_for_sql_readiness(sql_target)
+
+        # Populate the read-only seed schema with a handful of small tables so
+        # pure-read tests have real data to work with without creating objects.
+        await schemas.create_schema(sql_target, SEED_SCHEMA_NAME)
+        await _seed_sample_data(sql_target)
+
+        logger.info(
+            "shared_warehouse %r ready for worker %r (workspace %s)",
+            wh.name,
+            worker,
+            _session_workspace_id,
+        )
+
+        yield SharedWarehouseTarget(
+            warehouse=wh,
+            sql_target=sql_target,
+            workspace_id=_session_workspace_id,
+        )
+    finally:
+        with contextlib.suppress(Exception):
+            await warehouses.delete(_session_http, _session_workspace_id, wh.id)
+
+
+async def _seed_sample_data(target: SqlTarget) -> None:
+    """Create two small read-only tables in the ``sample`` schema.
+
+    ``sample.colors``  — a tiny reference table with an id and name column.
+    ``sample.numbers`` — a numeric table with id and value columns.
+
+    These are intentionally small (a few rows each) so that read-only tests get
+    predictable, deterministic data without heavy setup cost.
+    """
+    from fabric_dw.services import tables  # noqa: PLC0415 — local import avoids circular dep
+
+    await tables.create_table(
+        target,
+        SEED_SCHEMA_NAME,
+        "colors",
+        "SELECT 1 AS id, 'red' AS name UNION ALL SELECT 2, 'green' UNION ALL SELECT 3, 'blue'",
+    )
+    await tables.create_table(
+        target,
+        SEED_SCHEMA_NAME,
+        "numbers",
+        "SELECT 1 AS id, 10 AS value UNION ALL SELECT 2, 20 UNION ALL SELECT 3, 30",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-test schema isolation fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def warehouse_schema(
+    shared_warehouse: SharedWarehouseTarget,
+) -> AsyncIterator[tuple[SqlTarget, str]]:
+    """Create a uniquely-named schema in the shared warehouse and cascade-drop it on teardown.
+
+    Yields ``(sql_target, schema_name)`` so the test can qualify every object
+    it creates under ``schema_name`` and remain fully isolated from every other
+    concurrently running test.
+
+    Design notes
+    ------------
+    - Each test gets a collision-resistant schema name (``pytest_<8-hex-chars>``).
+    - Teardown calls ``schemas.delete_schema(..., cascade=True)`` so the test
+      does not need to clean up individual objects — the cascade drop handles it.
+    - If setup fails (e.g. schema creation raises) the finally block is still
+      executed, but ``contextlib.suppress`` guards against delete failures on a
+      schema that was never fully created.
+    """
+    schema_name = f"pytest_{uuid.uuid4().hex[:8]}"
+    sql_target = shared_warehouse.sql_target
+
+    await schemas.create_schema(sql_target, schema_name)
+    try:
+        yield sql_target, schema_name
+    finally:
+        with contextlib.suppress(Exception):
+            await schemas.delete_schema(sql_target, schema_name, cascade=True)
+
+
+# ---------------------------------------------------------------------------
+# Legacy function-scoped fixtures (kept for tests that need a dedicated item)
+# ---------------------------------------------------------------------------
 
 
 @pytest_asyncio.fixture

--- a/tests/integration/test_services_procedures.py
+++ b/tests/integration/test_services_procedures.py
@@ -2,15 +2,15 @@
 
 Run with: pytest -m integration tests/integration/test_services_procedures.py
 
-Fixture note: uses ``ephemeral_sql_target`` from conftest.  The target points at
-a freshly-created warehouse for each test session; all procedures created here are
-cleaned up inside each test via try/finally.
+Fixture note: uses ``warehouse_schema`` from conftest, which creates a uniquely-named
+schema inside the session-shared warm warehouse and cascade-drops it on teardown.
+All procedures created here are created inside that schema; the schema cascade drop
+handles cleanup, with additional try/finally guards for mid-test failures.
 
 Note on scope: stored procedures are supported on **both** Fabric Data Warehouses
-and SQL Analytics Endpoints.  The ``ephemeral_sql_target`` fixture points at a
-warehouse; a separate ``ephemeral_sql_target``-equivalent for an endpoint is not
-set up here because endpoint tests require a Lakehouse, which is out of scope.
-The service itself has no endpoint guard.
+and SQL Analytics Endpoints.  The ``warehouse_schema`` fixture points at a warehouse;
+a separate endpoint variant is not set up here because endpoint tests require a
+Lakehouse, which is out of scope.  The service itself has no endpoint guard.
 """
 
 from __future__ import annotations
@@ -27,22 +27,25 @@ from fabric_dw.sql import SqlTarget
 pytestmark = pytest.mark.integration
 
 
-async def test_list_procedures_returns_list(ephemeral_sql_target: SqlTarget) -> None:
-    """list_procedures on a fresh warehouse must return an empty (or non-empty) list."""
-    result = await procedures.list_procedures(ephemeral_sql_target)
+async def test_list_procedures_returns_list(
+    warehouse_schema: tuple[SqlTarget, str],
+) -> None:
+    """list_procedures on the shared warehouse must return a list."""
+    sql_target, _schema = warehouse_schema
+    result = await procedures.list_procedures(sql_target)
     assert isinstance(result, list)
 
 
 async def test_create_procedure_returns_procedure_object(
-    ephemeral_sql_target: SqlTarget,
+    warehouse_schema: tuple[SqlTarget, str],
 ) -> None:
     """create_procedure must return a StoredProcedure with the correct schema/name."""
-    schema = "dbo"
+    sql_target, schema = warehouse_schema
     proc_name = "pytest_procs_create"
     body = "BEGIN SELECT 1 AS id, 'hello' AS greeting END"
 
     try:
-        created = await procedures.create_procedure(ephemeral_sql_target, schema, proc_name, body)
+        created = await procedures.create_procedure(sql_target, schema, proc_name, body)
         assert isinstance(created, StoredProcedure)
         assert created.schema_name == schema
         assert created.name == proc_name
@@ -51,49 +54,49 @@ async def test_create_procedure_returns_procedure_object(
         assert "SELECT" in created.definition.upper()
     finally:
         with contextlib.suppress(Exception):
-            await procedures.drop_procedure(ephemeral_sql_target, schema, proc_name)
+            await procedures.drop_procedure(sql_target, schema, proc_name)
 
 
 async def test_list_procedures_includes_created_procedure(
-    ephemeral_sql_target: SqlTarget,
+    warehouse_schema: tuple[SqlTarget, str],
 ) -> None:
     """A newly created procedure must appear in list_procedures results."""
-    schema = "dbo"
+    sql_target, schema = warehouse_schema
     proc_name = "pytest_procs_list"
     body = "BEGIN SELECT 42 AS answer END"
 
     try:
-        await procedures.create_procedure(ephemeral_sql_target, schema, proc_name, body)
+        await procedures.create_procedure(sql_target, schema, proc_name, body)
 
-        all_procs = await procedures.list_procedures(ephemeral_sql_target)
+        all_procs = await procedures.list_procedures(sql_target)
         names = {p.name for p in all_procs}
         assert proc_name in names
 
         # Also verify schema filter narrows correctly
-        dbo_procs = await procedures.list_procedures(ephemeral_sql_target, schema=schema)
-        dbo_names = {p.name for p in dbo_procs}
-        assert proc_name in dbo_names
+        schema_procs = await procedures.list_procedures(sql_target, schema=schema)
+        schema_names = {p.name for p in schema_procs}
+        assert proc_name in schema_names
 
         # A schema that doesn't exist should return empty
-        other_procs = await procedures.list_procedures(
-            ephemeral_sql_target, schema="nonexistent_schema_x"
-        )
+        other_procs = await procedures.list_procedures(sql_target, schema="nonexistent_schema_x")
         assert other_procs == []
     finally:
         with contextlib.suppress(Exception):
-            await procedures.drop_procedure(ephemeral_sql_target, schema, proc_name)
+            await procedures.drop_procedure(sql_target, schema, proc_name)
 
 
-async def test_get_procedure_returns_definition(ephemeral_sql_target: SqlTarget) -> None:
+async def test_get_procedure_returns_definition(
+    warehouse_schema: tuple[SqlTarget, str],
+) -> None:
     """get_procedure must return the StoredProcedure with its definition populated."""
-    schema = "dbo"
+    sql_target, schema = warehouse_schema
     proc_name = "pytest_procs_get"
     body = "BEGIN SELECT 99 AS magic_number END"
 
     try:
-        await procedures.create_procedure(ephemeral_sql_target, schema, proc_name, body)
+        await procedures.create_procedure(sql_target, schema, proc_name, body)
 
-        fetched = await procedures.get_procedure(ephemeral_sql_target, schema, proc_name)
+        fetched = await procedures.get_procedure(sql_target, schema, proc_name)
         assert isinstance(fetched, StoredProcedure)
         assert fetched.schema_name == schema
         assert fetched.name == proc_name
@@ -101,93 +104,94 @@ async def test_get_procedure_returns_definition(ephemeral_sql_target: SqlTarget)
         assert "magic_number" in fetched.definition.lower()
     finally:
         with contextlib.suppress(Exception):
-            await procedures.drop_procedure(ephemeral_sql_target, schema, proc_name)
+            await procedures.drop_procedure(sql_target, schema, proc_name)
 
 
 async def test_get_procedure_raises_not_found_for_missing_procedure(
-    ephemeral_sql_target: SqlTarget,
+    warehouse_schema: tuple[SqlTarget, str],
 ) -> None:
     """get_procedure must raise NotFoundError when the procedure does not exist."""
+    sql_target, schema = warehouse_schema
     with pytest.raises(NotFoundError):
-        await procedures.get_procedure(ephemeral_sql_target, "dbo", "pytest_procs_does_not_exist")
+        await procedures.get_procedure(sql_target, schema, "pytest_procs_does_not_exist")
 
 
-async def test_update_procedure_changes_definition(ephemeral_sql_target: SqlTarget) -> None:
+async def test_update_procedure_changes_definition(
+    warehouse_schema: tuple[SqlTarget, str],
+) -> None:
     """update_procedure must redefine the procedure and return the updated definition."""
-    schema = "dbo"
+    sql_target, schema = warehouse_schema
     proc_name = "pytest_procs_update"
     original_body = "BEGIN SELECT 1 AS version END"
     updated_body = "BEGIN SELECT 2 AS version, 'updated' AS status END"
 
     try:
-        await procedures.create_procedure(ephemeral_sql_target, schema, proc_name, original_body)
+        await procedures.create_procedure(sql_target, schema, proc_name, original_body)
 
-        updated = await procedures.update_procedure(
-            ephemeral_sql_target, schema, proc_name, updated_body
-        )
+        updated = await procedures.update_procedure(sql_target, schema, proc_name, updated_body)
         assert isinstance(updated, StoredProcedure)
         assert updated.definition is not None
         assert "status" in updated.definition.lower()
     finally:
         with contextlib.suppress(Exception):
-            await procedures.drop_procedure(ephemeral_sql_target, schema, proc_name)
+            await procedures.drop_procedure(sql_target, schema, proc_name)
 
 
-async def test_drop_procedure_removes_procedure(ephemeral_sql_target: SqlTarget) -> None:
+async def test_drop_procedure_removes_procedure(
+    warehouse_schema: tuple[SqlTarget, str],
+) -> None:
     """drop_procedure must remove the procedure so it no longer appears in list_procedures."""
-    schema = "dbo"
+    sql_target, schema = warehouse_schema
     proc_name = "pytest_procs_drop"
     body = "BEGIN SELECT 0 AS placeholder END"
 
-    await procedures.create_procedure(ephemeral_sql_target, schema, proc_name, body)
+    await procedures.create_procedure(sql_target, schema, proc_name, body)
 
     # Confirm it exists before dropping
-    before = await procedures.list_procedures(ephemeral_sql_target)
+    before = await procedures.list_procedures(sql_target)
     assert any(p.name == proc_name for p in before)
 
-    await procedures.drop_procedure(ephemeral_sql_target, schema, proc_name)
+    await procedures.drop_procedure(sql_target, schema, proc_name)
 
     # Must not appear in listing after drop
-    after = await procedures.list_procedures(ephemeral_sql_target)
+    after = await procedures.list_procedures(sql_target)
     assert not any(p.name == proc_name for p in after)
 
     # get_procedure must raise NotFoundError
     with pytest.raises(NotFoundError):
-        await procedures.get_procedure(ephemeral_sql_target, schema, proc_name)
+        await procedures.get_procedure(sql_target, schema, proc_name)
 
 
-async def test_create_procedure_full_roundtrip(ephemeral_sql_target: SqlTarget) -> None:
+async def test_create_procedure_full_roundtrip(
+    warehouse_schema: tuple[SqlTarget, str],
+) -> None:
     """End-to-end: create -> list -> get (definition contains body) -> update (definition
     changes) -> drop.
     """
-    schema = "dbo"
+    sql_target, schema = warehouse_schema
     proc_name = "pytest_procs_roundtrip"
     v1_body = "BEGIN SELECT 1 AS n END"
     v2_body = "BEGIN SELECT 2 AS n, 'v2' AS label END"
 
     try:
         # --- create ---
-        created = await procedures.create_procedure(
-            ephemeral_sql_target, schema, proc_name, v1_body
-        )
+        created = await procedures.create_procedure(sql_target, schema, proc_name, v1_body)
         assert created.name == proc_name
 
         # --- list ---
-        all_procs = await procedures.list_procedures(ephemeral_sql_target)
+        all_procs = await procedures.list_procedures(sql_target)
         assert any(p.name == proc_name for p in all_procs)
 
         # --- get (definition contains body) ---
-        fetched = await procedures.get_procedure(ephemeral_sql_target, schema, proc_name)
+        fetched = await procedures.get_procedure(sql_target, schema, proc_name)
         assert fetched.definition is not None
         assert "SELECT" in fetched.definition.upper()
 
         # --- update (definition changes) ---
-        updated = await procedures.update_procedure(
-            ephemeral_sql_target, schema, proc_name, v2_body
-        )
+        updated = await procedures.update_procedure(sql_target, schema, proc_name, v2_body)
         assert updated.definition is not None
         assert "label" in updated.definition.lower()
 
     finally:
         with contextlib.suppress(Exception):
-            await procedures.drop_procedure(ephemeral_sql_target, schema, proc_name)
+            await procedures.drop_procedure(sql_target, schema, proc_name)

--- a/tests/integration/test_services_procedures.py
+++ b/tests/integration/test_services_procedures.py
@@ -69,8 +69,7 @@ async def test_list_procedures_includes_created_procedure(
         await procedures.create_procedure(sql_target, schema, proc_name, body)
 
         all_procs = await procedures.list_procedures(sql_target)
-        names = {p.name for p in all_procs}
-        assert proc_name in names
+        assert any(p.name == proc_name and p.schema_name == schema for p in all_procs)
 
         # Also verify schema filter narrows correctly
         schema_procs = await procedures.list_procedures(sql_target, schema=schema)
@@ -149,13 +148,13 @@ async def test_drop_procedure_removes_procedure(
 
     # Confirm it exists before dropping
     before = await procedures.list_procedures(sql_target)
-    assert any(p.name == proc_name for p in before)
+    assert any(p.name == proc_name and p.schema_name == schema for p in before)
 
     await procedures.drop_procedure(sql_target, schema, proc_name)
 
     # Must not appear in listing after drop
     after = await procedures.list_procedures(sql_target)
-    assert not any(p.name == proc_name for p in after)
+    assert not any(p.name == proc_name and p.schema_name == schema for p in after)
 
     # get_procedure must raise NotFoundError
     with pytest.raises(NotFoundError):
@@ -180,7 +179,7 @@ async def test_create_procedure_full_roundtrip(
 
         # --- list ---
         all_procs = await procedures.list_procedures(sql_target)
-        assert any(p.name == proc_name for p in all_procs)
+        assert any(p.name == proc_name and p.schema_name == schema for p in all_procs)
 
         # --- get (definition contains body) ---
         fetched = await procedures.get_procedure(sql_target, schema, proc_name)

--- a/tests/integration/test_services_queries.py
+++ b/tests/integration/test_services_queries.py
@@ -1,26 +1,44 @@
+"""Integration tests for services.queries — requires real Fabric credentials.
+
+Fixture note: uses ``shared_warehouse`` from conftest.  These tests only read
+DMV data (running queries, connections) and send a SQL probe — no schema
+mutations — so they are safe to run against the shared warm warehouse without
+per-test schema isolation.
+"""
+
+from __future__ import annotations
+
 import pytest
 
 from fabric_dw.models import Connection
 from fabric_dw.services import queries
 from fabric_dw.sql import SqlTarget
 
+from .conftest import SharedWarehouseTarget
+
 pytestmark = pytest.mark.integration
 
 
-async def test_list_running_returns_a_list(ephemeral_sql_target: SqlTarget) -> None:
-    running = await queries.list_running(ephemeral_sql_target)
+async def test_list_running_returns_a_list(
+    shared_warehouse: SharedWarehouseTarget,
+) -> None:
+    sql_target: SqlTarget = shared_warehouse.sql_target
+    running = await queries.list_running(sql_target)
     assert isinstance(running, list)
 
 
-async def test_kill_invalid_session_id_raises(ephemeral_sql_target: SqlTarget) -> None:
+async def test_kill_invalid_session_id_raises(
+    shared_warehouse: SharedWarehouseTarget,
+) -> None:
+    sql_target: SqlTarget = shared_warehouse.sql_target
     with pytest.raises(ValueError, match="session_id must be a positive integer"):
-        await queries.kill(ephemeral_sql_target, 0)
+        await queries.kill(sql_target, 0)
     with pytest.raises(ValueError, match="session_id must be a positive integer"):
-        await queries.kill(ephemeral_sql_target, -1)
+        await queries.kill(sql_target, -1)
 
 
 async def test_list_connections_returns_connection_models(
-    ephemeral_sql_target: SqlTarget,
+    shared_warehouse: SharedWarehouseTarget,
 ) -> None:
     """list_connections returns a non-empty list of Connection instances.
 
@@ -28,7 +46,8 @@ async def test_list_connections_returns_connection_models(
     session), so the result list must be non-empty and every element must be
     a fully-validated Connection model with the expected scalar fields.
     """
-    connections = await queries.list_connections(ephemeral_sql_target)
+    sql_target: SqlTarget = shared_warehouse.sql_target
+    connections = await queries.list_connections(sql_target)
 
     assert isinstance(connections, list)
     assert len(connections) >= 1, "expected at least the current session in dm_exec_connections"

--- a/tests/integration/test_services_query_insights.py
+++ b/tests/integration/test_services_query_insights.py
@@ -1,4 +1,15 @@
-"""Integration tests for services.query_insights — hits real Fabric APIs."""
+"""Integration tests for services.query_insights — hits real Fabric APIs.
+
+Fixture note: uses ``shared_warehouse`` from conftest.  Query-insights views
+accumulate history over the lifetime of the shared warehouse, but all assertions
+here only check shape (isinstance list) and upper-bound limits (len <= 1 for
+limit=1 tests).  These assertions are deliberately robust to an accumulating
+query history and thus safe to run against the shared warm warehouse.
+
+If a future test needs to assert specific row counts or particular query text,
+it should use ``warehouse_schema`` (or a dedicated warehouse) to get a clean
+slate.
+"""
 
 from __future__ import annotations
 
@@ -6,6 +17,8 @@ import pytest
 
 from fabric_dw.services import query_insights
 from fabric_dw.sql import SqlTarget
+
+from .conftest import SharedWarehouseTarget
 
 pytestmark = pytest.mark.integration
 
@@ -32,10 +45,11 @@ def _is_queryinsights_unavailable(exc: BaseException) -> bool:
 
 
 async def test_list_request_history_returns_a_list(
-    ephemeral_sql_target: SqlTarget,
+    shared_warehouse: SharedWarehouseTarget,
 ) -> None:
+    sql_target: SqlTarget = shared_warehouse.sql_target
     try:
-        result = await query_insights.list_request_history(ephemeral_sql_target)
+        result = await query_insights.list_request_history(sql_target)
     except Exception as exc:
         if _is_queryinsights_unavailable(exc):
             pytest.skip(_SKIP_REASON)
@@ -44,10 +58,11 @@ async def test_list_request_history_returns_a_list(
 
 
 async def test_list_session_history_returns_a_list(
-    ephemeral_sql_target: SqlTarget,
+    shared_warehouse: SharedWarehouseTarget,
 ) -> None:
+    sql_target: SqlTarget = shared_warehouse.sql_target
     try:
-        result = await query_insights.list_session_history(ephemeral_sql_target)
+        result = await query_insights.list_session_history(sql_target)
     except Exception as exc:
         if _is_queryinsights_unavailable(exc):
             pytest.skip(_SKIP_REASON)
@@ -56,10 +71,11 @@ async def test_list_session_history_returns_a_list(
 
 
 async def test_list_frequent_queries_returns_a_list(
-    ephemeral_sql_target: SqlTarget,
+    shared_warehouse: SharedWarehouseTarget,
 ) -> None:
+    sql_target: SqlTarget = shared_warehouse.sql_target
     try:
-        result = await query_insights.list_frequent_queries(ephemeral_sql_target)
+        result = await query_insights.list_frequent_queries(sql_target)
     except Exception as exc:
         if _is_queryinsights_unavailable(exc):
             pytest.skip(_SKIP_REASON)
@@ -68,10 +84,11 @@ async def test_list_frequent_queries_returns_a_list(
 
 
 async def test_list_long_running_queries_returns_a_list(
-    ephemeral_sql_target: SqlTarget,
+    shared_warehouse: SharedWarehouseTarget,
 ) -> None:
+    sql_target: SqlTarget = shared_warehouse.sql_target
     try:
-        result = await query_insights.list_long_running_queries(ephemeral_sql_target)
+        result = await query_insights.list_long_running_queries(sql_target)
     except Exception as exc:
         if _is_queryinsights_unavailable(exc):
             pytest.skip(_SKIP_REASON)
@@ -80,10 +97,11 @@ async def test_list_long_running_queries_returns_a_list(
 
 
 async def test_list_sql_pool_insights_returns_a_list(
-    ephemeral_sql_target: SqlTarget,
+    shared_warehouse: SharedWarehouseTarget,
 ) -> None:
+    sql_target: SqlTarget = shared_warehouse.sql_target
     try:
-        result = await query_insights.list_sql_pool_insights(ephemeral_sql_target)
+        result = await query_insights.list_sql_pool_insights(sql_target)
     except Exception as exc:
         if _is_queryinsights_unavailable(exc):
             pytest.skip(_SKIP_REASON)
@@ -92,10 +110,11 @@ async def test_list_sql_pool_insights_returns_a_list(
 
 
 async def test_list_request_history_respects_limit(
-    ephemeral_sql_target: SqlTarget,
+    shared_warehouse: SharedWarehouseTarget,
 ) -> None:
+    sql_target: SqlTarget = shared_warehouse.sql_target
     try:
-        result = await query_insights.list_request_history(ephemeral_sql_target, limit=1)
+        result = await query_insights.list_request_history(sql_target, limit=1)
     except Exception as exc:
         if _is_queryinsights_unavailable(exc):
             pytest.skip(_SKIP_REASON)
@@ -104,10 +123,11 @@ async def test_list_request_history_respects_limit(
 
 
 async def test_list_frequent_queries_respects_limit(
-    ephemeral_sql_target: SqlTarget,
+    shared_warehouse: SharedWarehouseTarget,
 ) -> None:
+    sql_target: SqlTarget = shared_warehouse.sql_target
     try:
-        result = await query_insights.list_frequent_queries(ephemeral_sql_target, limit=1)
+        result = await query_insights.list_frequent_queries(sql_target, limit=1)
     except Exception as exc:
         if _is_queryinsights_unavailable(exc):
             pytest.skip(_SKIP_REASON)

--- a/tests/integration/test_services_schemas.py
+++ b/tests/integration/test_services_schemas.py
@@ -2,9 +2,18 @@
 
 Run with: pytest -m integration tests/integration/test_services_schemas.py
 
-Fixture note: uses ``ephemeral_sql_target`` from conftest.  The target points at
-a freshly-created warehouse for each test session; all schemas created here are
-cleaned up in the respective test's ``finally`` block.
+Fixture note: uses ``shared_warehouse`` (for read-only / listing tests) and
+``warehouse_schema`` (for tests that create or delete schemas) from conftest.
+``warehouse_schema`` itself creates a uniquely-named schema in the shared warm
+warehouse and cascade-drops it on teardown, so all nested schemas created by
+the tests below are cleaned up by that outer cascade or by the test's own
+try/finally block.
+
+Design: The schema-CRUD tests below create *additional* schemas inside the
+shared warehouse (not inside ``warehouse_schema``'s isolation schema, because
+schemas cannot be nested on Fabric).  Each test is responsible for deleting
+its own schema in a finally block.  The shared warehouse teardown at session
+end provides a backstop.
 """
 
 from __future__ import annotations
@@ -32,21 +41,27 @@ def _unique_schema_name() -> str:
 
 
 # ---------------------------------------------------------------------------
-# Tests
+# Read-only tests (use the shared warehouse SQL target directly)
 # ---------------------------------------------------------------------------
 
 
-async def test_list_schemas_returns_list(ephemeral_sql_target: SqlTarget) -> None:
+async def test_list_schemas_returns_list(
+    warehouse_schema: tuple[SqlTarget, str],
+) -> None:
     """list_schemas returns a list (dbo is always present on a fresh warehouse)."""
-    result = await schemas.list_schemas(ephemeral_sql_target)
+    sql_target, _schema = warehouse_schema
+    result = await schemas.list_schemas(sql_target)
     assert isinstance(result, list)
     # dbo is user-writable and must appear on every fresh Fabric DW.
     schema_names = {s.name for s in result}
     assert "dbo" in schema_names
 
 
-async def test_list_schemas_excludes_system_schemas(ephemeral_sql_target: SqlTarget) -> None:
+async def test_list_schemas_excludes_system_schemas(
+    warehouse_schema: tuple[SqlTarget, str],
+) -> None:
     """System schemas must not appear in list_schemas output."""
+    sql_target, _schema = warehouse_schema
     system_schemas = {
         "sys",
         "INFORMATION_SCHEMA",
@@ -61,48 +76,62 @@ async def test_list_schemas_excludes_system_schemas(ephemeral_sql_target: SqlTar
         "db_denydatareader",
         "db_denydatawriter",
     }
-    result = await schemas.list_schemas(ephemeral_sql_target)
+    result = await schemas.list_schemas(sql_target)
     schema_names = {s.name for s in result}
     overlap = schema_names & system_schemas
     assert not overlap, f"System schemas leaked into list_schemas output: {overlap}"
 
 
-async def test_create_schema_returns_schema_model(ephemeral_sql_target: SqlTarget) -> None:
+# ---------------------------------------------------------------------------
+# Mutating tests — each creates its own uniquely-named schema on the shared
+# warehouse and cleans it up in a finally block.
+# ---------------------------------------------------------------------------
+
+
+async def test_create_schema_returns_schema_model(
+    warehouse_schema: tuple[SqlTarget, str],
+) -> None:
     """create_schema returns a Schema with the correct name."""
+    sql_target, _parent_schema = warehouse_schema
     name = _unique_schema_name()
     try:
-        created = await schemas.create_schema(ephemeral_sql_target, name)
+        created = await schemas.create_schema(sql_target, name)
         assert isinstance(created, Schema)
         assert created.name == name
         assert created.principal_id is not None
     finally:
         with contextlib.suppress(Exception):
-            await schemas.delete_schema(ephemeral_sql_target, name)
+            await schemas.delete_schema(sql_target, name)
 
 
-async def test_create_list_delete_roundtrip(ephemeral_sql_target: SqlTarget) -> None:
+async def test_create_list_delete_roundtrip(
+    warehouse_schema: tuple[SqlTarget, str],
+) -> None:
     """Create a schema, verify it appears in list_schemas, then delete it."""
+    sql_target, _parent_schema = warehouse_schema
     name = _unique_schema_name()
     try:
-        await schemas.create_schema(ephemeral_sql_target, name)
+        await schemas.create_schema(sql_target, name)
 
-        listed = await schemas.list_schemas(ephemeral_sql_target)
+        listed = await schemas.list_schemas(sql_target)
         listed_names = {s.name for s in listed}
         assert name in listed_names, f"Newly-created schema {name!r} missing from list_schemas"
 
-        await schemas.delete_schema(ephemeral_sql_target, name)
+        await schemas.delete_schema(sql_target, name)
 
-        after_delete = await schemas.list_schemas(ephemeral_sql_target)
+        after_delete = await schemas.list_schemas(sql_target)
         after_delete_names = {s.name for s in after_delete}
         assert name not in after_delete_names, f"Schema {name!r} still present after delete_schema"
     finally:
         # Guard: ensure the schema is gone even if the test assertion failed
         # before the explicit delete above.
         with contextlib.suppress(Exception):
-            await schemas.delete_schema(ephemeral_sql_target, name)
+            await schemas.delete_schema(sql_target, name)
 
 
-async def test_delete_schema_cascade_drops_table(ephemeral_sql_target: SqlTarget) -> None:
+async def test_delete_schema_cascade_drops_table(
+    warehouse_schema: tuple[SqlTarget, str],
+) -> None:
     """delete_schema(cascade=True) drops contained tables before dropping the schema.
 
     Steps:
@@ -111,24 +140,25 @@ async def test_delete_schema_cascade_drops_table(ephemeral_sql_target: SqlTarget
     3. Call delete_schema(cascade=True) — must succeed without a "schema not empty" error.
     4. Verify the schema is gone from list_schemas.
     """
+    sql_target, _parent_schema = warehouse_schema
     schema_name = _unique_schema_name()
     table_name = "pytest_cascade_tbl"
 
     try:
-        await schemas.create_schema(ephemeral_sql_target, schema_name)
+        await schemas.create_schema(sql_target, schema_name)
 
         # Create a table inside the new schema so the schema is non-empty.
         await tables.create_table(
-            ephemeral_sql_target,
+            sql_target,
             schema_name,
             table_name,
             "SELECT 1 AS id",
         )
 
         # cascade=True must drop the table then the schema without raising.
-        await schemas.delete_schema(ephemeral_sql_target, schema_name, cascade=True)
+        await schemas.delete_schema(sql_target, schema_name, cascade=True)
 
-        after_delete = await schemas.list_schemas(ephemeral_sql_target)
+        after_delete = await schemas.list_schemas(sql_target)
         after_names = {s.name for s in after_delete}
         assert schema_name not in after_names, (
             f"Schema {schema_name!r} still present after cascade delete"
@@ -136,21 +166,24 @@ async def test_delete_schema_cascade_drops_table(ephemeral_sql_target: SqlTarget
     finally:
         # Belt-and-suspenders cleanup: suppress errors if already cleaned up.
         with contextlib.suppress(Exception):
-            await tables.delete_table(ephemeral_sql_target, schema_name, table_name)
+            await tables.delete_table(sql_target, schema_name, table_name)
         with contextlib.suppress(Exception):
-            await schemas.delete_schema(ephemeral_sql_target, schema_name)
+            await schemas.delete_schema(sql_target, schema_name)
 
 
-async def test_delete_plain_schema_no_cascade(ephemeral_sql_target: SqlTarget) -> None:
+async def test_delete_plain_schema_no_cascade(
+    warehouse_schema: tuple[SqlTarget, str],
+) -> None:
     """delete_schema without cascade succeeds on an empty schema."""
+    sql_target, _parent_schema = warehouse_schema
     name = _unique_schema_name()
     try:
-        await schemas.create_schema(ephemeral_sql_target, name)
+        await schemas.create_schema(sql_target, name)
         # Plain delete (no cascade) on an empty schema must succeed.
-        await schemas.delete_schema(ephemeral_sql_target, name)
+        await schemas.delete_schema(sql_target, name)
 
-        after = await schemas.list_schemas(ephemeral_sql_target)
+        after = await schemas.list_schemas(sql_target)
         assert name not in {s.name for s in after}
     finally:
         with contextlib.suppress(Exception):
-            await schemas.delete_schema(ephemeral_sql_target, name)
+            await schemas.delete_schema(sql_target, name)

--- a/tests/integration/test_services_sql_exec.py
+++ b/tests/integration/test_services_sql_exec.py
@@ -1,4 +1,8 @@
-"""Integration tests for services.sql_exec — requires a live Fabric warehouse."""
+"""Integration tests for services.sql_exec — requires a live Fabric warehouse.
+
+Fixture note: uses ``shared_warehouse`` from conftest.  The SELECT 1 probe is
+read-only and safe to run on the shared warm warehouse without any schema isolation.
+"""
 
 from __future__ import annotations
 
@@ -7,11 +11,16 @@ import pytest
 from fabric_dw.services import sql_exec
 from fabric_dw.sql import SqlTarget
 
+from .conftest import SharedWarehouseTarget
+
 pytestmark = pytest.mark.integration
 
 
-async def test_select_1_returns_expected_result(ephemeral_sql_target: SqlTarget) -> None:
+async def test_select_1_returns_expected_result(
+    shared_warehouse: SharedWarehouseTarget,
+) -> None:
     """SELECT 1 AS hello must return columns=['hello'] and rows=[[1]]."""
-    result = await sql_exec.execute(ephemeral_sql_target, "SELECT 1 AS hello")
+    sql_target: SqlTarget = shared_warehouse.sql_target
+    result = await sql_exec.execute(sql_target, "SELECT 1 AS hello")
     assert result.columns == ["hello"]
     assert result.rows == [[1]]

--- a/tests/integration/test_services_tables.py
+++ b/tests/integration/test_services_tables.py
@@ -2,9 +2,9 @@
 
 Run with: pytest -m integration tests/integration/test_services_tables.py
 
-Fixture note: uses ``ephemeral_sql_target`` from conftest.  The target points at
-a freshly-created warehouse for each test session; all tables created here are
-cleaned up in the roundtrip test itself.
+Fixture note: uses ``warehouse_schema`` from conftest, which creates a uniquely-named
+schema inside the session-shared warm warehouse and cascade-drops it on teardown.
+All tables are created inside that schema so tests are fully isolated from one another.
 """
 
 from __future__ import annotations
@@ -39,84 +39,87 @@ def _is_clone_at_unavailable(exc: BaseException) -> bool:
     return any(all(frag in msg for frag in frags) for frags in _CLONE_AT_SKIP_FRAGMENTS)
 
 
-async def test_list_tables_returns_list(ephemeral_sql_target: SqlTarget) -> None:
-    result = await tables.list_tables(ephemeral_sql_target)
+async def test_list_tables_returns_list(
+    warehouse_schema: tuple[SqlTarget, str],
+) -> None:
+    sql_target, _schema = warehouse_schema
+    result = await tables.list_tables(sql_target)
     assert isinstance(result, list)
 
 
-async def test_create_read_clear_delete_roundtrip(ephemeral_sql_target: SqlTarget) -> None:
-    schema = "dbo"
+async def test_create_read_clear_delete_roundtrip(
+    warehouse_schema: tuple[SqlTarget, str],
+) -> None:
+    sql_target, schema = warehouse_schema
     table_name = "pytest_tables_roundtrip"
     select_body = "SELECT 1 AS id, 'hello' AS greeting"
 
     try:
-        created = await tables.create_table(ephemeral_sql_target, schema, table_name, select_body)
+        created = await tables.create_table(sql_target, schema, table_name, select_body)
         assert isinstance(created, Table)
         assert created.schema_name == schema
         assert created.name == table_name
 
-        cols, rows = await tables.read_table(ephemeral_sql_target, schema, table_name, count=5)
+        cols, rows = await tables.read_table(sql_target, schema, table_name, count=5)
         assert "id" in cols or len(cols) > 0
         assert isinstance(rows, list)
 
-        all_tables = await tables.list_tables(ephemeral_sql_target)
+        all_tables = await tables.list_tables(sql_target)
         names = {t.name for t in all_tables}
         assert table_name in names
 
-        await tables.clear_table(ephemeral_sql_target, schema, table_name)
-        _, rows_after_clear = await tables.read_table(
-            ephemeral_sql_target, schema, table_name, count=5
-        )
+        await tables.clear_table(sql_target, schema, table_name)
+        _, rows_after_clear = await tables.read_table(sql_target, schema, table_name, count=5)
         assert rows_after_clear == []
 
     finally:
         with contextlib.suppress(Exception):
-            await tables.delete_table(ephemeral_sql_target, schema, table_name)
+            await tables.delete_table(sql_target, schema, table_name)
 
     with pytest.raises((NotFoundError, Exception)):
-        await tables.read_table(ephemeral_sql_target, schema, table_name)
+        await tables.read_table(sql_target, schema, table_name)
 
 
-async def test_clone_table_creates_identical_rows(ephemeral_sql_target: SqlTarget) -> None:
+async def test_clone_table_creates_identical_rows(
+    warehouse_schema: tuple[SqlTarget, str],
+) -> None:
     """clone_table (plain, no AT) creates a clone with the same rows as the source."""
-    schema = "dbo"
+    sql_target, schema = warehouse_schema
     source_name = "pytest_clone_source"
     clone_name = "pytest_clone_copy"
     select_body = "SELECT 1 AS id, 'hello' AS greeting"
 
     try:
         # Create the source table.
-        await tables.create_table(ephemeral_sql_target, schema, source_name, select_body)
+        await tables.create_table(sql_target, schema, source_name, select_body)
 
         # Clone it without a point-in-time.
         cloned = await tables.clone_table(
-            ephemeral_sql_target, f"{schema}.{source_name}", f"{schema}.{clone_name}"
+            sql_target, f"{schema}.{source_name}", f"{schema}.{clone_name}"
         )
         assert isinstance(cloned, Table)
         assert cloned.schema_name == schema
         assert cloned.name == clone_name
 
         # Verify the clone is visible and contains the same data.
-        all_tables = await tables.list_tables(ephemeral_sql_target, schema=schema)
+        all_tables = await tables.list_tables(sql_target, schema=schema)
         names = {t.name for t in all_tables}
         assert clone_name in names
 
-        src_cols, src_rows = await tables.read_table(
-            ephemeral_sql_target, schema, source_name, count=100
-        )
-        cln_cols, cln_rows = await tables.read_table(
-            ephemeral_sql_target, schema, clone_name, count=100
-        )
+        src_cols, src_rows = await tables.read_table(sql_target, schema, source_name, count=100)
+        cln_cols, cln_rows = await tables.read_table(sql_target, schema, clone_name, count=100)
         assert src_cols == cln_cols
         assert cln_rows == src_rows
     finally:
         with contextlib.suppress(Exception):
-            await tables.delete_table(ephemeral_sql_target, schema, source_name)
+            await tables.delete_table(sql_target, schema, source_name)
         with contextlib.suppress(Exception):
-            await tables.delete_table(ephemeral_sql_target, schema, clone_name)
+            await tables.delete_table(sql_target, schema, clone_name)
 
 
-async def test_clone_table_at_point_in_time(ephemeral_sql_target: SqlTarget) -> None:
+async def test_clone_table_at_point_in_time(
+    warehouse_schema: tuple[SqlTarget, str],
+) -> None:
     """clone_table with AT timestamp clones the table at the specified point in time.
 
     The AT timestamp must be >= the object creation time and <= the clone
@@ -131,7 +134,7 @@ async def test_clone_table_at_point_in_time(ephemeral_sql_target: SqlTarget) -> 
     have been committed *before* the AT time), the test is skipped rather than
     failed, as this is an expected engine limitation for freshly-created tables.
     """
-    schema = "dbo"
+    sql_target, schema = warehouse_schema
     source_name = "pytest_clone_at_source"
     clone_name = "pytest_clone_at_copy"
     select_body = "SELECT 42 AS value"
@@ -139,7 +142,7 @@ async def test_clone_table_at_point_in_time(ephemeral_sql_target: SqlTarget) -> 
     try:
         # Create the source table first so the server-side timestamp is taken
         # AFTER the DDL commit — guaranteeing AT >= object creation time.
-        await tables.create_table(ephemeral_sql_target, schema, source_name, select_body)
+        await tables.create_table(sql_target, schema, source_name, select_body)
 
         # Capture a server-side timestamp via SYSUTCDATETIME() executed on the
         # same Fabric warehouse.  This is always >= the DDL commit time (same
@@ -148,7 +151,7 @@ async def test_clone_table_at_point_in_time(ephemeral_sql_target: SqlTarget) -> 
         # where the client clock trails the server, making the AT appear to be
         # *before* the object was created from the server's perspective.
         def _get_server_ts() -> datetime:
-            _, rows = run_query(ephemeral_sql_target, "SELECT SYSUTCDATETIME() AS ts")
+            _, rows = run_query(sql_target, "SELECT SYSUTCDATETIME() AS ts")
             raw = rows[0][0]
             # mssql_python returns datetime objects; ensure timezone-aware UTC.
             if isinstance(raw, datetime):
@@ -172,7 +175,7 @@ async def test_clone_table_at_point_in_time(ephemeral_sql_target: SqlTarget) -> 
 
         try:
             cloned = await tables.clone_table(
-                ephemeral_sql_target,
+                sql_target,
                 f"{schema}.{source_name}",
                 f"{schema}.{clone_name}",
                 at=at_dt,
@@ -194,36 +197,38 @@ async def test_clone_table_at_point_in_time(ephemeral_sql_target: SqlTarget) -> 
         assert cloned.name == clone_name
     finally:
         with contextlib.suppress(Exception):
-            await tables.delete_table(ephemeral_sql_target, schema, source_name)
+            await tables.delete_table(sql_target, schema, source_name)
         with contextlib.suppress(Exception):
-            await tables.delete_table(ephemeral_sql_target, schema, clone_name)
+            await tables.delete_table(sql_target, schema, clone_name)
 
 
-async def test_rename_table_roundtrip(ephemeral_sql_target: SqlTarget) -> None:
+async def test_rename_table_roundtrip(
+    warehouse_schema: tuple[SqlTarget, str],
+) -> None:
     """Create a table, rename it, assert the old name is gone and the new name exists."""
-    schema = "dbo"
+    sql_target, schema = warehouse_schema
     old_name = "pytest_tables_rename_src"
     new_name = "pytest_tables_rename_dst"
     select_body = "SELECT 42 AS answer"
 
     try:
-        created = await tables.create_table(ephemeral_sql_target, schema, old_name, select_body)
+        created = await tables.create_table(sql_target, schema, old_name, select_body)
         assert isinstance(created, Table)
         assert created.name == old_name
 
-        renamed = await tables.rename_table(ephemeral_sql_target, f"{schema}.{old_name}", new_name)
+        renamed = await tables.rename_table(sql_target, f"{schema}.{old_name}", new_name)
         assert isinstance(renamed, Table)
         assert renamed.name == new_name
         assert renamed.schema_name == schema
         assert renamed.qualified_name == f"{schema}.{new_name}"
 
-        all_tables = await tables.list_tables(ephemeral_sql_target)
+        all_tables = await tables.list_tables(sql_target)
         names = {t.name for t in all_tables}
         assert new_name in names, f"New table {new_name!r} not found after rename"
         assert old_name not in names, f"Old table {old_name!r} still present after rename"
 
     finally:
         with contextlib.suppress(Exception):
-            await tables.delete_table(ephemeral_sql_target, schema, old_name)
+            await tables.delete_table(sql_target, schema, old_name)
         with contextlib.suppress(Exception):
-            await tables.delete_table(ephemeral_sql_target, schema, new_name)
+            await tables.delete_table(sql_target, schema, new_name)

--- a/tests/integration/test_services_views.py
+++ b/tests/integration/test_services_views.py
@@ -2,9 +2,10 @@
 
 Run with: pytest -m integration tests/integration/test_services_views.py
 
-Fixture note: uses ``ephemeral_sql_target`` from conftest.  The target points at
-a freshly-created warehouse for each test session; all views created here are
-cleaned up inside each test via try/finally.
+Fixture note: uses ``warehouse_schema`` from conftest, which creates a uniquely-named
+schema inside the session-shared warm warehouse and cascade-drops it on teardown.
+All views created here are created inside that schema and cleaned up by the schema
+cascade drop, with additional try/finally guards for mid-test failures.
 """
 
 from __future__ import annotations
@@ -21,20 +22,25 @@ from fabric_dw.sql import SqlTarget
 pytestmark = pytest.mark.integration
 
 
-async def test_list_views_returns_list(ephemeral_sql_target: SqlTarget) -> None:
-    """list_views on a fresh warehouse must return an empty (or non-empty) list."""
-    result = await views.list_views(ephemeral_sql_target)
+async def test_list_views_returns_list(
+    warehouse_schema: tuple[SqlTarget, str],
+) -> None:
+    """list_views on the shared warehouse must return a list (may be non-empty)."""
+    sql_target, _schema = warehouse_schema
+    result = await views.list_views(sql_target)
     assert isinstance(result, list)
 
 
-async def test_create_view_returns_view_object(ephemeral_sql_target: SqlTarget) -> None:
+async def test_create_view_returns_view_object(
+    warehouse_schema: tuple[SqlTarget, str],
+) -> None:
     """create_view must return a View with the correct schema/name."""
-    schema = "dbo"
+    sql_target, schema = warehouse_schema
     view_name = "pytest_views_create"
     select_body = "SELECT 1 AS id, 'hello' AS greeting"
 
     try:
-        created = await views.create_view(ephemeral_sql_target, schema, view_name, select_body)
+        created = await views.create_view(sql_target, schema, view_name, select_body)
         assert isinstance(created, View)
         assert created.schema_name == schema
         assert created.name == view_name
@@ -43,45 +49,49 @@ async def test_create_view_returns_view_object(ephemeral_sql_target: SqlTarget) 
         assert "SELECT" in created.definition.upper()
     finally:
         with contextlib.suppress(Exception):
-            await views.drop_view(ephemeral_sql_target, schema, view_name)
+            await views.drop_view(sql_target, schema, view_name)
 
 
-async def test_list_views_includes_created_view(ephemeral_sql_target: SqlTarget) -> None:
+async def test_list_views_includes_created_view(
+    warehouse_schema: tuple[SqlTarget, str],
+) -> None:
     """A newly created view must appear in list_views results."""
-    schema = "dbo"
+    sql_target, schema = warehouse_schema
     view_name = "pytest_views_list"
     select_body = "SELECT 42 AS answer"
 
     try:
-        await views.create_view(ephemeral_sql_target, schema, view_name, select_body)
+        await views.create_view(sql_target, schema, view_name, select_body)
 
-        all_views = await views.list_views(ephemeral_sql_target)
+        all_views = await views.list_views(sql_target)
         names = {v.name for v in all_views}
         assert view_name in names
 
         # Also verify schema filter narrows correctly
-        dbo_views = await views.list_views(ephemeral_sql_target, schema=schema)
+        dbo_views = await views.list_views(sql_target, schema=schema)
         dbo_names = {v.name for v in dbo_views}
         assert view_name in dbo_names
 
         # A schema that doesn't exist should return empty
-        other_views = await views.list_views(ephemeral_sql_target, schema="nonexistent_schema_x")
+        other_views = await views.list_views(sql_target, schema="nonexistent_schema_x")
         assert other_views == []
     finally:
         with contextlib.suppress(Exception):
-            await views.drop_view(ephemeral_sql_target, schema, view_name)
+            await views.drop_view(sql_target, schema, view_name)
 
 
-async def test_get_view_returns_definition(ephemeral_sql_target: SqlTarget) -> None:
+async def test_get_view_returns_definition(
+    warehouse_schema: tuple[SqlTarget, str],
+) -> None:
     """get_view must return the View with its definition populated."""
-    schema = "dbo"
+    sql_target, schema = warehouse_schema
     view_name = "pytest_views_get"
     select_body = "SELECT 99 AS magic_number"
 
     try:
-        await views.create_view(ephemeral_sql_target, schema, view_name, select_body)
+        await views.create_view(sql_target, schema, view_name, select_body)
 
-        fetched = await views.get_view(ephemeral_sql_target, schema, view_name)
+        fetched = await views.get_view(sql_target, schema, view_name)
         assert isinstance(fetched, View)
         assert fetched.schema_name == schema
         assert fetched.name == view_name
@@ -89,27 +99,30 @@ async def test_get_view_returns_definition(ephemeral_sql_target: SqlTarget) -> N
         assert "magic_number" in fetched.definition.lower()
     finally:
         with contextlib.suppress(Exception):
-            await views.drop_view(ephemeral_sql_target, schema, view_name)
+            await views.drop_view(sql_target, schema, view_name)
 
 
 async def test_get_view_raises_not_found_for_missing_view(
-    ephemeral_sql_target: SqlTarget,
+    warehouse_schema: tuple[SqlTarget, str],
 ) -> None:
     """get_view must raise NotFoundError when the view does not exist."""
+    sql_target, schema = warehouse_schema
     with pytest.raises(NotFoundError):
-        await views.get_view(ephemeral_sql_target, "dbo", "pytest_views_does_not_exist")
+        await views.get_view(sql_target, schema, "pytest_views_does_not_exist")
 
 
-async def test_read_view_returns_columns_and_rows(ephemeral_sql_target: SqlTarget) -> None:
+async def test_read_view_returns_columns_and_rows(
+    warehouse_schema: tuple[SqlTarget, str],
+) -> None:
     """read_view must return (columns, rows) where columns contains expected names."""
-    schema = "dbo"
+    sql_target, schema = warehouse_schema
     view_name = "pytest_views_read"
     select_body = "SELECT 7 AS lucky_number, 'world' AS message"
 
     try:
-        await views.create_view(ephemeral_sql_target, schema, view_name, select_body)
+        await views.create_view(sql_target, schema, view_name, select_body)
 
-        cols, rows = await views.read_view(ephemeral_sql_target, schema, view_name, count=5)
+        cols, rows = await views.read_view(sql_target, schema, view_name, count=5)
         assert isinstance(cols, list)
         assert len(cols) > 0
         assert "lucky_number" in cols
@@ -122,108 +135,117 @@ async def test_read_view_returns_columns_and_rows(ephemeral_sql_target: SqlTarge
         assert row_dict["message"] == "world"
     finally:
         with contextlib.suppress(Exception):
-            await views.drop_view(ephemeral_sql_target, schema, view_name)
+            await views.drop_view(sql_target, schema, view_name)
 
 
 async def test_read_view_raises_not_found_for_missing_view(
-    ephemeral_sql_target: SqlTarget,
+    warehouse_schema: tuple[SqlTarget, str],
 ) -> None:
     """read_view must raise NotFoundError when the view does not exist."""
+    sql_target, schema = warehouse_schema
     with pytest.raises(NotFoundError):
-        await views.read_view(ephemeral_sql_target, "dbo", "pytest_views_read_missing")
+        await views.read_view(sql_target, schema, "pytest_views_read_missing")
 
 
-async def test_update_view_changes_definition(ephemeral_sql_target: SqlTarget) -> None:
+async def test_update_view_changes_definition(
+    warehouse_schema: tuple[SqlTarget, str],
+) -> None:
     """update_view must redefine the view and return the updated definition."""
-    schema = "dbo"
+    sql_target, schema = warehouse_schema
     view_name = "pytest_views_update"
     original_body = "SELECT 1 AS version"
     updated_body = "SELECT 2 AS version, 'updated' AS status"
 
     try:
-        await views.create_view(ephemeral_sql_target, schema, view_name, original_body)
+        await views.create_view(sql_target, schema, view_name, original_body)
 
-        updated = await views.update_view(ephemeral_sql_target, schema, view_name, updated_body)
+        updated = await views.update_view(sql_target, schema, view_name, updated_body)
         assert isinstance(updated, View)
         assert updated.definition is not None
         assert "status" in updated.definition.lower()
 
         # Reading should reflect the new SELECT
-        cols, rows = await views.read_view(ephemeral_sql_target, schema, view_name, count=1)
+        cols, rows = await views.read_view(sql_target, schema, view_name, count=1)
         assert "status" in cols
         row_dict = dict(zip(cols, rows[0], strict=True))
         assert row_dict["version"] == 2
     finally:
         with contextlib.suppress(Exception):
-            await views.drop_view(ephemeral_sql_target, schema, view_name)
+            await views.drop_view(sql_target, schema, view_name)
 
 
-async def test_drop_view_removes_view(ephemeral_sql_target: SqlTarget) -> None:
+async def test_drop_view_removes_view(
+    warehouse_schema: tuple[SqlTarget, str],
+) -> None:
     """drop_view must remove the view so it no longer appears in list_views."""
-    schema = "dbo"
+    sql_target, schema = warehouse_schema
     view_name = "pytest_views_drop"
     select_body = "SELECT 0 AS placeholder"
 
-    await views.create_view(ephemeral_sql_target, schema, view_name, select_body)
+    await views.create_view(sql_target, schema, view_name, select_body)
 
     # Confirm it exists before dropping
-    before = await views.list_views(ephemeral_sql_target)
+    before = await views.list_views(sql_target)
     assert any(v.name == view_name for v in before)
 
-    await views.drop_view(ephemeral_sql_target, schema, view_name)
+    await views.drop_view(sql_target, schema, view_name)
 
     # Must not appear in listing after drop
-    after = await views.list_views(ephemeral_sql_target)
+    after = await views.list_views(sql_target)
     assert not any(v.name == view_name for v in after)
 
     # get_view must raise NotFoundError
     with pytest.raises(NotFoundError):
-        await views.get_view(ephemeral_sql_target, schema, view_name)
+        await views.get_view(sql_target, schema, view_name)
 
 
-async def test_create_view_full_roundtrip(ephemeral_sql_target: SqlTarget) -> None:
+async def test_create_view_full_roundtrip(
+    warehouse_schema: tuple[SqlTarget, str],
+) -> None:
     """End-to-end: create → list → get → read → update → read → drop."""
-    schema = "dbo"
+    sql_target, schema = warehouse_schema
     view_name = "pytest_views_roundtrip"
     v1_body = "SELECT 1 AS n"
     v2_body = "SELECT 2 AS n, 'v2' AS label"
 
     try:
         # --- create ---
-        created = await views.create_view(ephemeral_sql_target, schema, view_name, v1_body)
+        created = await views.create_view(sql_target, schema, view_name, v1_body)
         assert created.name == view_name
 
         # --- list ---
-        all_views = await views.list_views(ephemeral_sql_target)
+        all_views = await views.list_views(sql_target)
         assert any(v.name == view_name for v in all_views)
 
         # --- get ---
-        fetched = await views.get_view(ephemeral_sql_target, schema, view_name)
+        fetched = await views.get_view(sql_target, schema, view_name)
         assert fetched.definition is not None
 
         # --- read ---
-        cols, rows = await views.read_view(ephemeral_sql_target, schema, view_name, count=10)
+        cols, rows = await views.read_view(sql_target, schema, view_name, count=10)
         assert "n" in cols
         assert rows[0][cols.index("n")] == 1
 
         # --- update ---
-        updated = await views.update_view(ephemeral_sql_target, schema, view_name, v2_body)
+        updated = await views.update_view(sql_target, schema, view_name, v2_body)
         assert updated.definition is not None
         assert "label" in updated.definition.lower()
 
         # --- read again ---
-        cols2, rows2 = await views.read_view(ephemeral_sql_target, schema, view_name, count=10)
+        cols2, rows2 = await views.read_view(sql_target, schema, view_name, count=10)
         assert "label" in cols2
         assert rows2[0][cols2.index("n")] == 2
 
     finally:
         with contextlib.suppress(Exception):
-            await views.drop_view(ephemeral_sql_target, schema, view_name)
+            await views.drop_view(sql_target, schema, view_name)
 
 
-async def test_rename_view_creates_new_and_removes_old(ephemeral_sql_target: SqlTarget) -> None:
+async def test_rename_view_creates_new_and_removes_old(
+    warehouse_schema: tuple[SqlTarget, str],
+) -> None:
     """rename_view must make the old name disappear and the new name appear."""
-    schema = "dbo"
+    sql_target, schema = warehouse_schema
     old_name = "pytest_views_rename_old"
     new_name = "pytest_views_rename_new"
     qualified = f"{schema}.{old_name}"
@@ -231,21 +253,21 @@ async def test_rename_view_creates_new_and_removes_old(ephemeral_sql_target: Sql
 
     try:
         # Create with old name
-        await views.create_view(ephemeral_sql_target, schema, old_name, select_body)
+        await views.create_view(sql_target, schema, old_name, select_body)
 
         # Confirm old name exists
-        before = await views.list_views(ephemeral_sql_target)
+        before = await views.list_views(sql_target)
         assert any(v.name == old_name for v in before)
 
         # Rename
-        renamed = await views.rename_view(ephemeral_sql_target, qualified, new_name)
+        renamed = await views.rename_view(sql_target, qualified, new_name)
         assert isinstance(renamed, View)
         assert renamed.name == new_name
         assert renamed.schema_name == schema
         assert renamed.qualified_name == f"{schema}.{new_name}"
 
         # Old name must be gone
-        after = await views.list_views(ephemeral_sql_target)
+        after = await views.list_views(sql_target)
         assert not any(v.name == old_name for v in after)
 
         # New name must exist
@@ -253,14 +275,14 @@ async def test_rename_view_creates_new_and_removes_old(ephemeral_sql_target: Sql
 
         # get_view on old name must raise NotFoundError
         with pytest.raises(NotFoundError):
-            await views.get_view(ephemeral_sql_target, schema, old_name)
+            await views.get_view(sql_target, schema, old_name)
 
         # get_view on new name must succeed
-        fetched = await views.get_view(ephemeral_sql_target, schema, new_name)
+        fetched = await views.get_view(sql_target, schema, new_name)
         assert fetched.name == new_name
 
     finally:
         with contextlib.suppress(Exception):
-            await views.drop_view(ephemeral_sql_target, schema, old_name)
+            await views.drop_view(sql_target, schema, old_name)
         with contextlib.suppress(Exception):
-            await views.drop_view(ephemeral_sql_target, schema, new_name)
+            await views.drop_view(sql_target, schema, new_name)


### PR DESCRIPTION
## Summary

This PR implements **lever #2** from the speed-up plan agreed in #312: replacing per-test fresh-warehouse create + warm-up with a single session-scoped warm warehouse reused across all shareable tests, with per-test schema isolation for DDL mutations.

**Lever #1 (pytest-xdist -n)** follows in a second PR. The fixture plumbing in this PR is already xdist-ready.

## Fixture design

### `shared_warehouse` (session-scoped)

- Names the warehouse with `PYTEST_XDIST_WORKER` + random UUID so each xdist worker gets its own instance without any cross-process coordination.
- Calls `warehouses.create` → `_wait_for_sql_readiness` **once** per session, then yields a `SharedWarehouseTarget(warehouse, sql_target, workspace_id)` NamedTuple.
- Seeds a read-only `sample` schema with two small tables (`colors`, `numbers`) for pure-read tests.
- Deletes the warehouse in session teardown.

### `_session_http` / `_session_workspace_id` (session-scoped)

Session-scoped variants of the existing function-scoped helpers. Decorated with `@pytest_asyncio.fixture(loop_scope="session", scope="session")` as required by pytest-asyncio 1.x to share a single event loop for the full session. The original function-scoped `http`/`workspace_id` fixtures are kept intact.

### `warehouse_schema` (function-scoped)

- Creates a uniquely-named schema (`pytest_<8-hex>`) inside the shared warehouse and cascade-drops it on teardown via `schemas.delete_schema(..., cascade=True)` (from #228).
- Yields `(sql_target, schema_name)`. Mutating tests create all their objects under this schema.
- Full cleanup on every exit path including mid-test failures.

## Tests converted (7 modules)

| Module | Fixture before | Fixture after | Notes |
|---|---|---|---|
| `test_services_tables` | `ephemeral_sql_target` | `warehouse_schema` | Schema-scoped DDL |
| `test_services_views` | `ephemeral_sql_target` | `warehouse_schema` | Schema-scoped DDL |
| `test_services_procedures` | `ephemeral_sql_target` | `warehouse_schema` | Schema-scoped DDL |
| `test_services_schemas` | `ephemeral_sql_target` | `warehouse_schema` + own cleanup | Schemas can't be nested; each test creates and self-cleans its own schema |
| `test_services_queries` | `ephemeral_sql_target` | `shared_warehouse` | DMV reads only; no isolation needed |
| `test_services_query_insights` | `ephemeral_sql_target` | `shared_warehouse` | Assertions are shape-only (isinstance list, len ≤ limit) — robust to accumulated query history |
| `test_services_sql_exec` | `ephemeral_sql_target` | `shared_warehouse` | SELECT 1 probe; no isolation needed |

## Tests kept on dedicated fixtures

| Module | Reason |
|---|---|
| `test_services_snapshots` | Needs a fresh warehouse item for snapshot parent |
| `test_services_restore` | Needs a fresh warehouse for restore/restore-point operations |
| `test_services_ownership` | Takeover semantics require dedicated item ownership |
| `test_services_audit` | Mutates warehouse-global audit settings (enable/disable/retention); cannot be schema-isolated |
| `test_services_workspaces` | Workspace-level collation mutation |

## Verification

- `uv run pytest tests/integration -m integration --collect-only` — **87 tests collected, 0 errors**
- `just check` (lint + ty + unit tests) — **fully green**

## What comes next

PR 2 (closes #312) will add `pytest-xdist -n auto` (or a bounded count) to the integration workflow. No changes to this PR are needed for that — the `PYTEST_XDIST_WORKER`-aware naming and `loop_scope="session"` are already in place.

Refs #312