### PR TITLE
test(integration): raise readiness/provision timeouts to 10 min (#347 head-start)

### DIFF
--- a/src/fabric_dw/services/sql_endpoints.py
+++ b/src/fabric_dw/services/sql_endpoints.py
@@ -16,7 +16,7 @@ _logger = logging.getLogger("fabric_dw.sql_endpoints")
 
 # Bounded polling for eventual-consistency fields (e.g. connection_string).
 _CONN_STRING_POLL_INTERVAL: float = 5.0
-_CONN_STRING_POLL_TIMEOUT: float = 120.0
+_CONN_STRING_POLL_TIMEOUT: float = 600.0  # 10 min — Fabric preview eventual-consistency window
 
 __all__ = [
     "get_endpoint",
@@ -122,7 +122,7 @@ async def get_endpoint_connection_string(
         workspace_id: The UUID of the workspace containing the endpoint.
         endpoint_id: The UUID of the SQL analytics endpoint.
         poll_interval: Seconds between polls (default 5.0).
-        timeout: Maximum wall-clock seconds to wait (default 120.0).
+        timeout: Maximum wall-clock seconds to wait (default 600.0, i.e. 10 min).
 
     Returns:
         The non-empty connection string.

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -20,13 +20,13 @@ from fabric_dw.sql import SqlTarget, is_transient_connection_error, run_query
 logger = logging.getLogger(__name__)
 
 # Maximum time to wait for a SQL analytics endpoint to provision on a new lakehouse.
-_SQL_ENDPOINT_PROVISION_TIMEOUT_S = 300
+_SQL_ENDPOINT_PROVISION_TIMEOUT_S = 600  # 10 min — Fabric preview provisioning can be slow
 # Polling interval between provisioning status checks.
 _SQL_ENDPOINT_POLL_INTERVAL_S = 5
 
 # Maximum time (seconds) to wait for a fresh warehouse/endpoint SQL database
 # to become connectable after creation.
-_SQL_READINESS_TIMEOUT_S = 240
+_SQL_READINESS_TIMEOUT_S = 600  # 10 min — warm-up window for Fabric preview SQL engine
 # Starting backoff delay (seconds) between readiness probe attempts.
 _SQL_READINESS_BACKOFF_INITIAL_S = 2.0
 # Maximum backoff delay cap (seconds).
@@ -35,7 +35,7 @@ _SQL_READINESS_BACKOFF_MAX_S = 5.0
 # Maximum time (seconds) to wait for a freshly-created snapshot to appear in
 # sys.databases on the parent warehouse's SQL connection and report a non-null
 # TIMESTAMP property (i.e. be ready for ALTER DATABASE … SET TIMESTAMP = …).
-_SNAP_SQL_READINESS_TIMEOUT_S = 300.0
+_SNAP_SQL_READINESS_TIMEOUT_S = 600.0  # 10 min — Fabric preview snapshot SQL-layer provisioning
 # Polling interval (seconds) between snapshot readiness probes.
 _SNAP_SQL_READINESS_POLL_S = 5.0
 
@@ -86,7 +86,7 @@ async def _wait_for_sql_readiness(
             # "database was not found" flavour (AuthError from map_driver_error).
             # We do NOT swallow all "login failed" messages — that is too broad
             # and would hide genuine permanent auth misconfiguration (wrong tenant,
-            # expired service principal, etc.) for the full 240 s timeout.
+            # expired service principal, etc.) for the full 600 s timeout.
             # "database was not found" uniquely identifies the provisioning-transient
             # variant of login-failed (error 18456), so it is the right signal here.
             is_warmup = "database was not found" in msg_lower


### PR DESCRIPTION
## Summary

Head-start toward #347: raises all readiness and provisioning wait windows that gate the currently-skipped SQL-endpoint and snapshot-roll integration tests to **600 s (10 min)**, giving Fabric preview-provisioning latency time to complete before the fixtures time out.

### Constants changed

| Constant | File | Old | New |
|---|---|---|---|
| `_SQL_ENDPOINT_PROVISION_TIMEOUT_S` | `tests/integration/conftest.py` | 300 | 600 |
| `_SQL_READINESS_TIMEOUT_S` | `tests/integration/conftest.py` | 240 | 600 |
| `_SNAP_SQL_READINESS_TIMEOUT_S` | `tests/integration/conftest.py` | 300.0 | 600.0 |
| `_CONN_STRING_POLL_TIMEOUT` | `src/fabric_dw/services/sql_endpoints.py` | 120.0 | 600.0 |

### What is NOT changed

- Skip-on-timeout fallback logic is **preserved** — a timeout still results in a skip, not a failure.
- Backoff intervals are unchanged.
- No tests are unskipped.

## Remaining work (stays open in #347, depends on #312)

Once #312 (parallelise/speed up the integration suite) lands, the remaining steps are:
1. Remove the `pytest.skip()` fallback in `_wait_for_snapshot_sql_readiness` and the `ephemeral_sql_endpoint` fixture so a genuine timeout **FAILS** rather than skips.
2. Confirm the 5 tests (`test_endpoint_appears_in_list`, `test_get_endpoint_by_id`, `test_get_endpoint_connection_string_populated`, `test_refresh_metadata_returns_table_sync_statuses`, `test_roll_timestamp_updates_snapshot`) run green in CI.

Refs #347

## Test plan

- [x] `uv run pytest tests/integration -m integration --collect-only` — 87 tests collected, 0 errors
- [x] `just check` — ruff, ty, and 2413 unit tests all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)