### PR TITLE
feat(functions): manage T-SQL user-defined functions via CLI and MCP

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1359,6 +1359,176 @@ fabric-dw --yes procedures drop MyWorkspace SalesWH dbo.usp_archive_orders
 
 ---
 
+## fabric-dw functions
+
+Manage T-SQL user-defined functions on Microsoft Fabric Data Warehouses and SQL Analytics Endpoints.
+
+> **Preview:** Scalar UDFs (`FN`) and inline TVFs (`IF`) are preview features as of mid-2026. Function DDL is supported on both Data Warehouses and SQL Analytics Endpoints — no endpoint guard is applied.
+
+### functions list
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+List T-SQL user-defined functions on a warehouse or SQL Analytics Endpoint. Pass `--schema` to filter by schema, or `--kind` to filter by function kind.
+
+**Synopsis**
+
+```
+fabric-dw functions list [OPTIONS] [WORKSPACE] [ITEM]
+```
+
+| Option | Description |
+| --- | --- |
+| `--schema TEXT` | Only list functions in this schema. |
+| `--kind [scalar\|inline-tvf\|all]` | Filter by function kind: `scalar` (FN), `inline-tvf` (IF), or `all` (default). |
+
+**Example**
+
+```shell
+fabric-dw functions list MyWorkspace SalesWH --schema dbo --kind scalar
+```
+
+```
+ schema_name  name           kind    is_inlineable  created               modified
+ ------------ -------------- ------- -------------- --------------------- ---------------------
+ dbo          fn_clean_input  scalar  True           2026-06-01T08:00:00Z  2026-06-10T12:00:00Z
+```
+
+---
+
+### functions get
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Get the full definition of a single T-SQL user-defined function, including its parameter list.
+
+**Synopsis**
+
+```
+fabric-dw functions get [WORKSPACE] [ITEM] QUALIFIED_NAME
+```
+
+`QUALIFIED_NAME` must be a dot-separated `schema.fn_name` string, e.g. `dbo.fn_clean_input`.
+
+**Example**
+
+```shell
+fabric-dw functions get MyWorkspace SalesWH dbo.fn_clean_input
+```
+
+---
+
+### functions create
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Create a new T-SQL user-defined function. Scalar UDFs and inline TVFs are preview features.
+
+**Synopsis**
+
+```
+fabric-dw functions create [OPTIONS] [WORKSPACE] [ITEM]
+```
+
+| Option | Description |
+| --- | --- |
+| `--name SCHEMA.FN` | **Required.** Qualified function name (e.g. `dbo.fn_clean_input`). |
+| `--body TEXT` | Inline function body (parameter list, RETURNS clause, and implementation). |
+| `--from-file PATH` | Path to a `.sql` file containing the function body. |
+
+Exactly one of `--body` or `--from-file` must be provided.
+
+**Example**
+
+```shell
+fabric-dw functions create MyWorkspace SalesWH \
+  --name dbo.fn_clean_input \
+  --body "(@input NVARCHAR(100)) RETURNS NVARCHAR(100) AS BEGIN RETURN LTRIM(RTRIM(@input)) END"
+```
+
+---
+
+### functions update
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Redefine an existing T-SQL user-defined function via `CREATE OR ALTER FUNCTION`.
+
+> **Note:** `ALTER FUNCTION` cannot change the function kind (e.g. scalar to inline TVF). The body must be compatible with the original function's kind.
+
+**Synopsis**
+
+```
+fabric-dw functions update [OPTIONS] [WORKSPACE] [ITEM] QUALIFIED_NAME
+```
+
+`QUALIFIED_NAME` is the dot-separated `schema.fn_name` to update.
+
+| Option | Description |
+| --- | --- |
+| `--body TEXT` | Inline function body. |
+| `--from-file PATH` | Path to a `.sql` file containing the function body. |
+
+Exactly one of `--body` or `--from-file` must be provided. You will be asked to confirm unless `--yes` is passed.
+
+**Example**
+
+```shell
+fabric-dw functions update MyWorkspace SalesWH dbo.fn_clean_input \
+  --from-file ./fns/fn_clean_input_v2.sql
+```
+
+---
+
+### functions drop
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Drop a T-SQL user-defined function. You will be asked to confirm unless `--yes` is passed.
+
+**Synopsis**
+
+```
+fabric-dw functions drop [OPTIONS] [WORKSPACE] [ITEM] QUALIFIED_NAME
+```
+
+| Option | Description |
+| --- | --- |
+| `--if-exists` | No-op when the function does not exist (`DROP FUNCTION IF EXISTS`). |
+
+**Example**
+
+```shell
+fabric-dw --yes functions drop MyWorkspace SalesWH dbo.fn_clean_input
+```
+
+---
+
+### functions rename
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Rename a T-SQL user-defined function via `EXEC sp_rename`. The new name must be a bare (unqualified) identifier — `sp_rename` cannot move a function to a different schema. You will be asked to confirm unless `--yes` is passed.
+
+**Synopsis**
+
+```
+fabric-dw functions rename [OPTIONS] [WORKSPACE] [ITEM] QUALIFIED_NAME
+```
+
+| Option | Description |
+| --- | --- |
+| `--new-name TEXT` | **Required.** New bare (unqualified) function name. |
+
+**Example**
+
+```shell
+fabric-dw --yes functions rename MyWorkspace SalesWH dbo.fn_clean_input \
+  --new-name fn_sanitize_input
+```
+
+---
+
 ## fabric-dw tables
 
 Manage SQL tables on Microsoft Fabric Data Warehouses and SQL Analytics Endpoints.

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -1059,6 +1059,117 @@ Drop a stored procedure.
 
 ---
 
+## Functions
+
+> **Preview:** Scalar UDFs (`FN`) and inline TVFs (`IF`) are preview features on Fabric DW as of mid-2026. Function DDL is supported on both Data Warehouses and SQL Analytics Endpoints — no endpoint guard applies.
+
+### list_functions
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+List T-SQL user-defined functions on a warehouse or SQL Analytics Endpoint, optionally filtered by schema or kind.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `item` (`str`) — warehouse or SQL Analytics Endpoint name or GUID.
+- `schema` (`str | null`, optional) — when provided, only functions in this schema are returned.
+- `kind` (`str`, optional) — filter by function kind: `"scalar"` (FN only), `"inline-tvf"` (IF only), or `"all"` (FN + IF + TF, the default).
+
+**Returns:** `list[Function]` — array of function objects, each with `schema_name`, `name`, `qualified_name`, `kind`, `is_inlineable`, `created`, and `modified`.
+
+---
+
+### get_function
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Fetch the full definition of a single T-SQL user-defined function, including its parameter list.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `item` (`str`) — warehouse or SQL Analytics Endpoint name or GUID.
+- `qualified_name` (`str`) — dot-separated qualified function name, e.g. `dbo.fn_clean_input`.
+
+**Returns:** `FunctionDetails` — single function object with `definition` (from `sys.sql_modules`) and `parameters` (from `sys.parameters`).
+
+---
+
+### create_function
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Create a new T-SQL user-defined function. Scalar UDFs and inline TVFs are preview features.
+
+> **CAUTION:** `body` is executed verbatim as DDL. Ensure the body matches the user's intent before calling this tool.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `item` (`str`) — warehouse or SQL Analytics Endpoint name or GUID.
+- `qualified_name` (`str`) — dot-separated qualified function name, e.g. `dbo.fn_clean_input`.
+- `body` (`str`) — the function body (parameter list, RETURNS clause, and implementation).
+
+**Returns:** `FunctionDetails` — the newly-created function object.
+
+---
+
+### update_function
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Redefine a T-SQL user-defined function via `CREATE OR ALTER FUNCTION`.
+
+> **Note:** `ALTER FUNCTION` cannot change the function kind (e.g. scalar to inline TVF). The body must be compatible with the original function's kind.
+
+> **CAUTION:** `body` is executed verbatim as DDL. Ensure the body matches the user's intent before calling this tool.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `item` (`str`) — warehouse or SQL Analytics Endpoint name or GUID.
+- `qualified_name` (`str`) — dot-separated qualified function name, e.g. `dbo.fn_clean_input`.
+- `body` (`str`) — the new function body (parameter list, RETURNS clause, and implementation).
+
+**Returns:** `FunctionDetails` — the updated function object.
+
+---
+
+### drop_function
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Drop a T-SQL user-defined function.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `item` (`str`) — warehouse or SQL Analytics Endpoint name or GUID.
+- `qualified_name` (`str`) — dot-separated qualified function name, e.g. `dbo.fn_clean_input`.
+- `if_exists` (`bool`, optional) — when `true`, emits `DROP FUNCTION IF EXISTS` (no-op when function does not exist). Defaults to `false`.
+
+**Returns:** `{ "dropped": true }` — confirmation.
+
+---
+
+### rename_function
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Rename a T-SQL user-defined function via `sp_rename`. The new name must be a bare (unqualified) identifier — `sp_rename` cannot move a function across schemas.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `item` (`str`) — warehouse or SQL Analytics Endpoint name or GUID.
+- `qualified_name` (`str`) — current dot-separated qualified function name, e.g. `dbo.fn_clean_input`.
+- `new_name` (`str`) — new bare function name (no schema prefix), e.g. `fn_sanitize_input`.
+
+**Returns:** `FunctionDetails` — the renamed function record.
+
+---
+
 ## Schemas
 
 > **List-source note** — no public REST API exists for enumerating warehouse schemas. `list_schemas` uses TDS `sys.schemas`, filtering out `sys`, `INFORMATION_SCHEMA`, `guest`, and `db_*` fixed-role schemas. `dbo` is always included because it is user-writable.

--- a/src/fabric_dw/cli/_main.py
+++ b/src/fabric_dw/cli/_main.py
@@ -13,6 +13,7 @@ from fabric_dw.cli.commands.cache import cache_group
 from fabric_dw.cli.commands.completion import completion_group
 from fabric_dw.cli.commands.config import config_group
 from fabric_dw.cli.commands.dbt import dbt_group
+from fabric_dw.cli.commands.functions import functions_group
 from fabric_dw.cli.commands.procedures import procedures_group
 from fabric_dw.cli.commands.queries import queries_group
 from fabric_dw.cli.commands.restore_points import restore_points_group
@@ -97,3 +98,4 @@ cli.add_command(tables_group)
 cli.add_command(views_group)
 cli.add_command(procedures_group)
 cli.add_command(statistics_group)
+cli.add_command(functions_group)

--- a/src/fabric_dw/cli/commands/functions.py
+++ b/src/fabric_dw/cli/commands/functions.py
@@ -22,6 +22,7 @@ from fabric_dw.cli.commands._utils import (
 )
 from fabric_dw.exceptions import FabricError
 from fabric_dw.services import functions as _fns_svc
+from fabric_dw.services.functions import validate_kind
 
 
 @click.group("functions")
@@ -62,7 +63,7 @@ async def list_cmd(
             items = await _fns_svc.list_functions(
                 target,
                 schema=schema,
-                kind=kind,  # ty: ignore[invalid-argument-type]
+                kind=validate_kind(kind),
                 mode=ctx.auth,  # type: ignore[arg-type]
             )
             render(

--- a/src/fabric_dw/cli/commands/functions.py
+++ b/src/fabric_dw/cli/commands/functions.py
@@ -64,7 +64,7 @@ async def list_cmd(
                 target,
                 schema=schema,
                 kind=validate_kind(kind),
-                mode=ctx.auth,  # type: ignore[arg-type]
+                mode=ctx.auth,
             )
             render(
                 [f.model_dump(by_alias=True, mode="json") for f in items],

--- a/src/fabric_dw/cli/commands/functions.py
+++ b/src/fabric_dw/cli/commands/functions.py
@@ -1,0 +1,263 @@
+"""Functions sub-commands for the fabric-dw CLI.
+
+Note: Scalar UDFs and inline TVFs are preview features on Microsoft Fabric DW as of mid-2026.
+Function DDL is supported on both Data Warehouses and SQL Analytics Endpoints.
+"""
+
+from __future__ import annotations
+
+import click
+
+from fabric_dw.cli._context import CliContext
+from fabric_dw.cli._render import confirm, render
+from fabric_dw.cli.commands._utils import (
+    build_http_client,
+    build_sql_target,
+    confirm_destructive,
+    coro,
+    load_sql_body,
+    parse_qualified_name,
+    resolve_warehouse_arg,
+    resolve_workspace_arg,
+)
+from fabric_dw.exceptions import FabricError
+from fabric_dw.services import functions as _fns_svc
+
+
+@click.group("functions")
+def functions_group() -> None:
+    """Manage T-SQL user-defined functions on Fabric warehouses and SQL Analytics Endpoints.
+
+    Scalar UDFs (FN) and inline TVFs (IF) are preview features as of mid-2026.
+    Function DDL is supported on both Data Warehouses and SQL Analytics Endpoints.
+    """
+
+
+@functions_group.command("list")
+@click.argument("workspace", required=False, default=None)
+@click.argument("item", required=False, default=None)
+@click.option("--schema", default=None, help="Filter by schema name.")
+@click.option(
+    "--kind",
+    type=click.Choice(["scalar", "inline-tvf", "all"], case_sensitive=False),
+    default="all",
+    show_default=True,
+    help="Filter by function kind: scalar (FN), inline-tvf (IF), or all.",
+)
+@click.pass_obj
+@coro
+async def list_cmd(
+    ctx: CliContext,
+    workspace: str | None,
+    item: str | None,
+    schema: str | None,
+    kind: str,
+) -> None:
+    """List T-SQL user-defined functions on ITEM (warehouse or SQL endpoint) in WORKSPACE."""
+    ws = resolve_workspace_arg(ctx, workspace)
+    wh = resolve_warehouse_arg(ctx, item)
+    try:
+        async with build_http_client(ctx) as http:
+            target, _entry = await build_sql_target(http, ws, wh)
+            items = await _fns_svc.list_functions(
+                target,
+                schema=schema,
+                kind=kind,  # ty: ignore[invalid-argument-type]
+                mode=ctx.auth,  # type: ignore[arg-type]
+            )
+            render(
+                [f.model_dump(by_alias=True, mode="json") for f in items],
+                json_output=ctx.json_output,
+                table_title="Functions",
+            )
+    except (ValueError, FabricError) as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@functions_group.command("get")
+@click.argument("workspace", required=False, default=None)
+@click.argument("item", required=False, default=None)
+@click.argument("qualified_name")
+@click.pass_obj
+@coro
+async def get_cmd(
+    ctx: CliContext,
+    workspace: str | None,
+    item: str | None,
+    qualified_name: str,
+) -> None:
+    """Fetch the full definition of QUALIFIED_NAME (schema.fn) on ITEM in WORKSPACE."""
+    ws = resolve_workspace_arg(ctx, workspace)
+    wh = resolve_warehouse_arg(ctx, item)
+    schema, fn_name = parse_qualified_name(qualified_name, kind="function")
+    try:
+        async with build_http_client(ctx) as http:
+            target, _entry = await build_sql_target(http, ws, wh)
+            f = await _fns_svc.get_function(target, schema, fn_name, mode=ctx.auth)
+            render(f.model_dump(by_alias=True, mode="json"), json_output=ctx.json_output)
+    except (ValueError, FabricError) as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@functions_group.command("create")
+@click.argument("workspace", required=False, default=None)
+@click.argument("item", required=False, default=None)
+@click.option("--name", "qualified_name", required=True, help="Qualified name: schema.fn.")
+@click.option("--body", "body", default=None, help="Inline function body.")
+@click.option("--from-file", default=None, help="Path to a .sql file containing the function body.")
+@click.pass_obj
+@coro
+async def create_cmd(
+    ctx: CliContext,
+    workspace: str | None,
+    item: str | None,
+    qualified_name: str,
+    body: str | None,
+    from_file: str | None,
+) -> None:
+    """Create a new T-SQL user-defined function QUALIFIED_NAME on ITEM in WORKSPACE.
+
+    The body should include the parameter list, RETURNS clause, and function body
+    (everything after CREATE FUNCTION [schema].[name]).
+
+    Scalar UDFs and inline TVFs are preview features as of mid-2026.
+    Function DDL is supported on both Data Warehouses and SQL Analytics Endpoints.
+    """
+    ws = resolve_workspace_arg(ctx, workspace)
+    wh = resolve_warehouse_arg(ctx, item)
+    schema, fn_name = parse_qualified_name(qualified_name, kind="function")
+    fn_body = load_sql_body(body, from_file, inline_opt="--body")
+    try:
+        async with build_http_client(ctx) as http:
+            target, _entry = await build_sql_target(http, ws, wh)
+            f = await _fns_svc.create_function(target, schema, fn_name, fn_body, mode=ctx.auth)
+            render(f.model_dump(by_alias=True, mode="json"), json_output=ctx.json_output)
+    except (ValueError, FabricError) as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@functions_group.command("update")
+@click.argument("workspace", required=False, default=None)
+@click.argument("item", required=False, default=None)
+@click.argument("qualified_name")
+@click.option("--body", "body", default=None, help="Inline function body.")
+@click.option("--from-file", default=None, help="Path to a .sql file containing the function body.")
+@click.pass_obj
+@coro
+async def update_cmd(
+    ctx: CliContext,
+    workspace: str | None,
+    item: str | None,
+    qualified_name: str,
+    body: str | None,
+    from_file: str | None,
+) -> None:
+    """Redefine QUALIFIED_NAME (schema.fn) on ITEM in WORKSPACE via CREATE OR ALTER FUNCTION.
+
+    Note: ALTER FUNCTION cannot change the function kind (e.g. scalar to inline TVF).
+    You will be asked to confirm unless --yes is passed.
+    """
+    ws = resolve_workspace_arg(ctx, workspace)
+    wh = resolve_warehouse_arg(ctx, item)
+    schema, fn_name = parse_qualified_name(qualified_name, kind="function")
+    fn_body = load_sql_body(body, from_file, inline_opt="--body")
+    try:
+        async with build_http_client(ctx) as http:
+            target, entry = await build_sql_target(http, ws, wh)
+            confirmed = confirm(
+                f"Redefine function [{schema}].[{fn_name}] on {entry.display_name!r}?",
+                yes=ctx.yes,
+            )
+            if not confirmed:
+                click.echo("Aborted.")
+                return
+            f = await _fns_svc.update_function(target, schema, fn_name, fn_body, mode=ctx.auth)
+            render(f.model_dump(by_alias=True, mode="json"), json_output=ctx.json_output)
+    except (ValueError, FabricError) as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@functions_group.command("drop")
+@click.argument("workspace", required=False, default=None)
+@click.argument("item", required=False, default=None)
+@click.argument("qualified_name")
+@click.option(
+    "--if-exists",
+    is_flag=True,
+    default=False,
+    help="No-op when the function does not exist (DROP FUNCTION IF EXISTS).",
+)
+@click.pass_obj
+@coro
+async def drop_cmd(
+    ctx: CliContext,
+    workspace: str | None,
+    item: str | None,
+    qualified_name: str,
+    if_exists: bool,
+) -> None:
+    """Drop QUALIFIED_NAME (schema.fn) from ITEM in WORKSPACE.
+
+    You will be asked to confirm unless --yes is passed.
+    """
+    ws = resolve_workspace_arg(ctx, workspace)
+    wh = resolve_warehouse_arg(ctx, item)
+    schema, fn_name = parse_qualified_name(qualified_name, kind="function")
+    try:
+        async with build_http_client(ctx) as http:
+            target, entry = await build_sql_target(http, ws, wh)
+            if not confirm_destructive(
+                f"Drop function [{schema}].[{fn_name}] from {entry.display_name!r} ({entry.id})?",
+                yes=ctx.yes,
+            ):
+                click.echo("Aborted.")
+                return
+            await _fns_svc.drop_function(
+                target, schema, fn_name, if_exists=if_exists, mode=ctx.auth
+            )
+            if ctx.json_output:
+                render({"status": "dropped", "name": f"[{schema}].[{fn_name}]"}, json_output=True)
+            else:
+                click.echo(f"Function [{schema}].[{fn_name}] dropped.")
+    except (ValueError, FabricError) as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@functions_group.command("rename")
+@click.argument("workspace", required=False, default=None)
+@click.argument("item", required=False, default=None)
+@click.argument("qualified_name")
+@click.option("--new-name", required=True, help="New bare (unqualified) function name.")
+@click.pass_obj
+@coro
+async def rename_cmd(
+    ctx: CliContext,
+    workspace: str | None,
+    item: str | None,
+    qualified_name: str,
+    new_name: str,
+) -> None:
+    """Rename QUALIFIED_NAME (schema.fn) on ITEM in WORKSPACE to --new-name.
+
+    Uses EXEC sp_rename. The new name must be a bare (unqualified) identifier;
+    sp_rename cannot move a function to a different schema.
+    You will be asked to confirm unless --yes is passed.
+    """
+    ws = resolve_workspace_arg(ctx, workspace)
+    wh = resolve_warehouse_arg(ctx, item)
+    schema, fn_name = parse_qualified_name(qualified_name, kind="function")
+    try:
+        async with build_http_client(ctx) as http:
+            target, entry = await build_sql_target(http, ws, wh)
+            confirmed = confirm(
+                f"Rename function [{schema}].[{fn_name}] on"
+                f" {entry.display_name!r} to {new_name!r}?",
+                yes=ctx.yes,
+            )
+            if not confirmed:
+                click.echo("Aborted.")
+                return
+            f = await _fns_svc.rename_function(target, qualified_name, new_name, mode=ctx.auth)
+            render(f.model_dump(by_alias=True, mode="json"), json_output=ctx.json_output)
+    except (ValueError, FabricError) as exc:
+        raise click.ClickException(str(exc)) from exc

--- a/src/fabric_dw/mcp/tools/__init__.py
+++ b/src/fabric_dw/mcp/tools/__init__.py
@@ -16,6 +16,7 @@ Domains
 - :mod:`.restore` — restore points CRUD, in-place restore
 - :mod:`.views` — SQL view listing, reading, CRUD
 - :mod:`.procedures` — stored procedure listing and CRUD
+- :mod:`.functions` — T-SQL user-defined function listing and CRUD
 - :mod:`.schemas` — SQL schema listing and DDL
 - :mod:`.tables` — SQL table listing, reading, DDL
 - :mod:`.sql_pools` — SQL Pools beta API, pool insights DMV
@@ -32,6 +33,7 @@ from fabric_dw.mcp.tools import (
     audit,
     cache,
     dbt,
+    functions,
     procedures,
     queries,
     restore,
@@ -60,6 +62,7 @@ _DOMAINS = [
     restore,
     views,
     procedures,
+    functions,
     schemas,
     tables,
     statistics,

--- a/src/fabric_dw/mcp/tools/functions.py
+++ b/src/fabric_dw/mcp/tools/functions.py
@@ -72,7 +72,7 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
                 target,
                 schema=schema,
                 kind=validate_kind(kind),
-                mode=ctx.auth_mode,  # type: ignore[arg-type]
+                mode=ctx.auth_mode,
             )
         except (ValueError, FabricError) as exc:
             raise tool_err(exc) from exc

--- a/src/fabric_dw/mcp/tools/functions.py
+++ b/src/fabric_dw/mcp/tools/functions.py
@@ -25,6 +25,7 @@ from fabric_dw.mcp._helpers import (
     tool_err,
 )
 from fabric_dw.services import functions as functions_svc
+from fabric_dw.services.functions import validate_kind
 
 __all__ = ["register"]
 
@@ -70,7 +71,7 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             result = await functions_svc.list_functions(
                 target,
                 schema=schema,
-                kind=kind,  # ty: ignore[invalid-argument-type]
+                kind=validate_kind(kind),
                 mode=ctx.auth_mode,  # type: ignore[arg-type]
             )
         except (ValueError, FabricError) as exc:

--- a/src/fabric_dw/mcp/tools/functions.py
+++ b/src/fabric_dw/mcp/tools/functions.py
@@ -1,0 +1,252 @@
+"""MCP tools for T-SQL user-defined function operations.
+
+Preview note: Scalar UDFs and inline TVFs are preview features on Microsoft Fabric DW
+as of mid-2026.  Function DDL is supported on both Data Warehouses and SQL Analytics
+Endpoints (no endpoint guard applies).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+from fabric_dw.exceptions import FabricError
+from fabric_dw.mcp._context import get_context
+from fabric_dw.mcp._guards import (
+    assert_workspace_allowed,
+)
+from fabric_dw.mcp._helpers import (
+    make_sql_target,
+    mutating_tool,
+    parse_qualified_name,
+    resolve_item,
+    tool_err,
+)
+from fabric_dw.services import functions as functions_svc
+
+__all__ = ["register"]
+
+_log = logging.getLogger(__name__)
+
+
+def register(mcp: FastMCP) -> None:  # noqa: PLR0915
+    """Register T-SQL user-defined function tools against *mcp*."""
+
+    @mcp.tool(name="list_functions")
+    async def list_functions(
+        workspace: str,
+        item: str,
+        schema: str | None = None,
+        kind: str = "all",
+    ) -> list[dict[str, Any]]:
+        """List T-SQL user-defined functions on a warehouse or SQL Analytics Endpoint.
+
+        Scalar UDFs (FN) and inline TVFs (IF) are preview features on Fabric DW as of
+        mid-2026.  Function DDL is supported on both Data Warehouses and SQL Analytics
+        Endpoints.
+
+        Args:
+            workspace: Workspace name or GUID.
+            item: Warehouse or SQL Analytics Endpoint name or GUID.
+            schema: When provided, only functions in this schema are returned.
+            kind: Filter by function kind — ``"scalar"`` (FN only),
+                ``"inline-tvf"`` (IF only), or ``"all"`` (FN + IF + TF, the default).
+        """
+        assert_workspace_allowed(workspace)
+        ctx = get_context()
+        try:
+            ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
+            assert_workspace_allowed(workspace, str(ws_id))
+            _log.debug(
+                "list_functions ws=%s item=%s schema=%r kind=%r",
+                ws_id,
+                entry.id,
+                schema,
+                kind,
+            )
+            target = make_sql_target(ws_id, entry, item)
+            result = await functions_svc.list_functions(
+                target,
+                schema=schema,
+                kind=kind,  # ty: ignore[invalid-argument-type]
+                mode=ctx.auth_mode,  # type: ignore[arg-type]
+            )
+        except (ValueError, FabricError) as exc:
+            raise tool_err(exc) from exc
+        return [f.model_dump(mode="json") for f in result]
+
+    @mcp.tool(name="get_function")
+    async def get_function(workspace: str, item: str, qualified_name: str) -> dict[str, Any]:
+        """Fetch the full definition of a T-SQL user-defined function (schema.fn).
+
+        Returns the function definition (from ``sys.sql_modules``) and its parameter list
+        (from ``sys.parameters``).  Scalar UDFs and inline TVFs are supported on both
+        Data Warehouses and SQL Analytics Endpoints.
+
+        Args:
+            workspace: Workspace name or GUID.
+            item: Warehouse or SQL Analytics Endpoint name or GUID.
+            qualified_name: Dot-separated qualified function name, e.g. ``dbo.fn_clean_input``.
+        """
+        schema, fn_name = parse_qualified_name(qualified_name, kind="function")
+        assert_workspace_allowed(workspace)
+        ctx = get_context()
+        try:
+            ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
+            assert_workspace_allowed(workspace, str(ws_id))
+            _log.debug("get_function ws=%s item=%s fn=%s.%s", ws_id, entry.id, schema, fn_name)
+            target = make_sql_target(ws_id, entry, item)
+            result = await functions_svc.get_function(target, schema, fn_name, mode=ctx.auth_mode)
+        except (ValueError, FabricError) as exc:
+            raise tool_err(exc) from exc
+        return result.model_dump(mode="json")
+
+    @mutating_tool(mcp, "create_function")
+    async def create_function(
+        workspace: str, item: str, qualified_name: str, body: str
+    ) -> dict[str, Any]:
+        """Create a new T-SQL user-defined function.
+
+        Scalar UDFs and inline TVFs are preview features on Fabric DW as of mid-2026.
+        Function DDL is supported on both Data Warehouses and SQL Analytics Endpoints.
+
+        CAUTION: ``body`` is executed verbatim as DDL. Ensure the body matches the
+        user's intent before calling this tool.
+
+        The body should include the parameter list, RETURNS clause, and function body
+        (everything that follows ``CREATE FUNCTION [schema].[name]``).
+
+        Args:
+            workspace: Workspace name or GUID.
+            item: Warehouse or SQL Analytics Endpoint name or GUID.
+            qualified_name: Dot-separated qualified function name, e.g. ``dbo.fn_clean_input``.
+            body: The function body (parameter list, RETURNS clause, and implementation).
+        """
+        schema, fn_name = parse_qualified_name(qualified_name, kind="function")
+        assert_workspace_allowed(workspace)
+        ctx = get_context()
+        try:
+            ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
+            assert_workspace_allowed(workspace, str(ws_id))
+            _log.debug("create_function ws=%s item=%s fn=%s.%s", ws_id, entry.id, schema, fn_name)
+            target = make_sql_target(ws_id, entry, item)
+            result = await functions_svc.create_function(
+                target, schema, fn_name, body, mode=ctx.auth_mode
+            )
+        except (ValueError, FabricError) as exc:
+            raise tool_err(exc) from exc
+        ctx.resolver.clear_negative_cache()
+        return result.model_dump(mode="json")
+
+    @mutating_tool(mcp, "update_function")
+    async def update_function(
+        workspace: str, item: str, qualified_name: str, body: str
+    ) -> dict[str, Any]:
+        """Redefine a T-SQL user-defined function via CREATE OR ALTER FUNCTION.
+
+        Note: ALTER FUNCTION cannot change the function kind (e.g. scalar to inline TVF).
+        The body must be compatible with the original function's kind.
+
+        Scalar UDFs and inline TVFs are preview features on Fabric DW as of mid-2026.
+        Function DDL is supported on both Data Warehouses and SQL Analytics Endpoints.
+
+        CAUTION: ``body`` is executed verbatim as DDL. Ensure the body matches the
+        user's intent before calling this tool.
+
+        Args:
+            workspace: Workspace name or GUID.
+            item: Warehouse or SQL Analytics Endpoint name or GUID.
+            qualified_name: Dot-separated qualified function name, e.g. ``dbo.fn_clean_input``.
+            body: The new function body (parameter list, RETURNS clause, and implementation).
+        """
+        schema, fn_name = parse_qualified_name(qualified_name, kind="function")
+        assert_workspace_allowed(workspace)
+        ctx = get_context()
+        try:
+            ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
+            assert_workspace_allowed(workspace, str(ws_id))
+            _log.debug("update_function ws=%s item=%s fn=%s.%s", ws_id, entry.id, schema, fn_name)
+            target = make_sql_target(ws_id, entry, item)
+            result = await functions_svc.update_function(
+                target, schema, fn_name, body, mode=ctx.auth_mode
+            )
+        except (ValueError, FabricError) as exc:
+            raise tool_err(exc) from exc
+        ctx.resolver.clear_negative_cache()
+        return result.model_dump(mode="json")
+
+    @mutating_tool(mcp, "drop_function", destructive=True)
+    async def drop_function(
+        workspace: str,
+        item: str,
+        qualified_name: str,
+        if_exists: bool = False,  # noqa: FBT001, FBT002
+    ) -> dict[str, Any]:
+        """Drop a T-SQL user-defined function.
+
+        Function DDL is supported on both Data Warehouses and SQL Analytics Endpoints.
+
+        Args:
+            workspace: Workspace name or GUID.
+            item: Warehouse or SQL Analytics Endpoint name or GUID.
+            qualified_name: Dot-separated qualified function name, e.g. ``dbo.fn_clean_input``.
+            if_exists: When ``true``, emits DROP FUNCTION IF EXISTS (no-op when function
+                does not exist). Defaults to ``false``.
+        """
+        schema, fn_name = parse_qualified_name(qualified_name, kind="function")
+        assert_workspace_allowed(workspace)
+        ctx = get_context()
+        try:
+            ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
+            assert_workspace_allowed(workspace, str(ws_id))
+            _log.debug("drop_function ws=%s item=%s fn=%s.%s", ws_id, entry.id, schema, fn_name)
+            target = make_sql_target(ws_id, entry, item)
+            await functions_svc.drop_function(
+                target, schema, fn_name, if_exists=if_exists, mode=ctx.auth_mode
+            )
+        except (ValueError, FabricError) as exc:
+            raise tool_err(exc) from exc
+        return {"dropped": True}
+
+    @mutating_tool(mcp, "rename_function")
+    async def rename_function(
+        workspace: str, item: str, qualified_name: str, new_name: str
+    ) -> dict[str, Any]:
+        """Rename a T-SQL user-defined function via sp_rename.
+
+        Works on both Data Warehouses and SQL Analytics Endpoints.
+
+        The new name must be a bare (unqualified) identifier — ``sp_rename``
+        cannot move a function across schemas.
+
+        Args:
+            workspace: Workspace name or GUID.
+            item: Warehouse or SQL Analytics Endpoint name or GUID.
+            qualified_name: Current dot-separated qualified function name,
+                e.g. ``dbo.fn_clean_input``.
+            new_name: New bare function name (no schema prefix), e.g. ``fn_sanitize_input``.
+        """
+        assert_workspace_allowed(workspace)
+        ctx = get_context()
+        schema, old_fn_name = parse_qualified_name(qualified_name, kind="function")
+        try:
+            ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
+            assert_workspace_allowed(workspace, str(ws_id))
+            _log.debug(
+                "rename_function ws=%s item=%s fn=%s.%s -> %s",
+                ws_id,
+                entry.id,
+                schema,
+                old_fn_name,
+                new_name,
+            )
+            target = make_sql_target(ws_id, entry, item)
+            result = await functions_svc.rename_function(
+                target, qualified_name, new_name, mode=ctx.auth_mode
+            )
+        except (ValueError, FabricError) as exc:
+            raise tool_err(exc) from exc
+        ctx.resolver.clear_negative_cache()
+        return result.model_dump(mode="json")

--- a/src/fabric_dw/models.py
+++ b/src/fabric_dw/models.py
@@ -432,6 +432,57 @@ class StoredProcedure(_FabricBase):
     modified: datetime
 
 
+class FunctionKind(StrEnum):
+    """Discriminates T-SQL user-defined function kinds.
+
+    ``SCALAR`` and ``INLINE_TVF`` are supported on both Fabric Data Warehouses and
+    SQL Analytics Endpoints (preview as of mid-2026).  ``MSTVF`` (multi-statement
+    TVFs) is not supported for creation on Fabric but may appear in catalog listings
+    on migrated warehouses.
+    """
+
+    SCALAR = "scalar"  # sys.objects.type = 'FN'
+    INLINE_TVF = "inline-tvf"  # sys.objects.type = 'IF'
+    MSTVF = "mstvf"  # sys.objects.type = 'TF' (not creatable, listed only)
+
+
+class FunctionParameter(_FabricBase):
+    """A parameter (or return value) of a T-SQL user-defined function.
+
+    ``parameter_id = 0`` is the return value pseudo-parameter; ``parameter_id > 0``
+    are regular input parameters.
+    """
+
+    parameter_id: int
+    name: str
+    data_type: str
+    max_length: int
+    is_output: bool
+
+
+class Function(_FabricBase):
+    """Summary row for a T-SQL user-defined function (list operations)."""
+
+    schema_name: str
+    name: str
+    qualified_name: str
+    kind: FunctionKind
+    is_inlineable: bool | None = None
+    created: datetime
+    modified: datetime
+
+
+class FunctionDetails(Function):
+    """Full details for a T-SQL user-defined function (get operations).
+
+    Extends :class:`Function` with ``definition`` (from ``sys.sql_modules``) and
+    ``parameters`` (from ``sys.parameters``).
+    """
+
+    definition: str | None = None
+    parameters: list[FunctionParameter] = Field(default_factory=list)
+
+
 class Schema(_FabricBase):
     """A SQL schema on a Fabric Data Warehouse."""
 

--- a/src/fabric_dw/services/functions.py
+++ b/src/fabric_dw/services/functions.py
@@ -254,8 +254,6 @@ async def list_functions(
     """
     if schema is not None:
         validate_identifier(schema)
-
-    if schema is not None:
         schema_filter = "s.name = ?"
         schema_params: list[object] = [schema]
     else:

--- a/src/fabric_dw/services/functions.py
+++ b/src/fabric_dw/services/functions.py
@@ -32,7 +32,11 @@ from fabric_dw.identifiers import parse_qualified_name, quote_identifier, valida
 from fabric_dw.models import Function, FunctionDetails, FunctionKind, FunctionParameter
 from fabric_dw.sql import SqlTarget, run_query
 
+# Valid values for the ``kind`` parameter of :func:`list_functions`.
+VALID_KINDS: frozenset[str] = frozenset({"scalar", "inline-tvf", "all"})
+
 __all__ = [
+    "VALID_KINDS",
     "create_function",
     "drop_function",
     "get_function",
@@ -40,6 +44,7 @@ __all__ = [
     "rename_function",
     "update_function",
     "validate_identifier",
+    "validate_kind",
 ]
 
 # ---------------------------------------------------------------------------
@@ -166,16 +171,29 @@ def _row_to_function_details(
     )
 
 
+def _as_int(value: object) -> int:
+    """Coerce a DB-driver value (int, Decimal, or str) to a Python ``int``.
+
+    The TDS driver returns numeric columns as ``int`` or ``Decimal`` depending
+    on the column type and driver version.  Both satisfy ``int(x)`` at runtime;
+    this helper makes the conversion explicit so the type-checker sees a
+    narrowed ``int`` result rather than an opaque ``object``.
+    """
+    if isinstance(value, int):
+        return value
+    return int(str(value))
+
+
 def _row_to_param(cols: list[str], row: tuple[object, ...]) -> FunctionParameter:
     """Build a :class:`FunctionParameter` from a column-name list and a result row tuple."""
     data = dict(zip(cols, row, strict=True))
     raw_is_output = data.get("is_output")
     is_output = bool(raw_is_output) if raw_is_output is not None else False
     return FunctionParameter(
-        parameter_id=int(data["parameter_id"]),  # ty: ignore[invalid-argument-type]
+        parameter_id=_as_int(data["parameter_id"]),
         name=str(data["name"]),
         data_type=str(data["data_type"]),
-        max_length=int(data["max_length"]),  # ty: ignore[invalid-argument-type]
+        max_length=_as_int(data["max_length"]),
         is_output=is_output,
     )
 
@@ -183,6 +201,25 @@ def _row_to_param(cols: list[str], row: tuple[object, ...]) -> FunctionParameter
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
+
+
+def validate_kind(kind: str) -> Literal["scalar", "inline-tvf", "all"]:
+    """Validate *kind* and return it narrowed to the expected Literal type.
+
+    Args:
+        kind: The raw kind string from a CLI or MCP caller.
+
+    Returns:
+        The same string narrowed to ``Literal["scalar", "inline-tvf", "all"]``.
+
+    Raises:
+        ValueError: If *kind* is not one of the recognised values.
+    """
+    if kind not in VALID_KINDS:
+        msg = f"Invalid kind {kind!r}. Must be one of: {', '.join(sorted(VALID_KINDS))}"
+        raise ValueError(msg)
+    # The membership check above narrows the type — cast is safe.
+    return cast(Literal["scalar", "inline-tvf", "all"], kind)
 
 
 async def list_functions(
@@ -203,14 +240,15 @@ async def list_functions(
         schema: When provided, only functions in this schema are returned.
             Must pass :func:`validate_identifier`.
         kind: Filter by function kind — ``"scalar"`` (FN), ``"inline-tvf"`` (IF),
-            or ``"all"`` (FN + IF + TF).  Defaults to ``"all"``.
+            or ``"all"`` (FN + IF + TF).  Defaults to ``"all"``.  Validated by
+            :func:`validate_kind`.
         mode: The credential mode for Entra authentication.
 
     Returns:
         A (possibly empty) list of :class:`~fabric_dw.models.Function` instances.
 
     Raises:
-        ValueError: If *schema* fails identifier validation.
+        ValueError: If *schema* fails identifier validation or *kind* is invalid.
         PermissionDeniedError: If the driver reports a permission error.
         AuthError: If the driver reports an authentication failure.
     """

--- a/src/fabric_dw/services/functions.py
+++ b/src/fabric_dw/services/functions.py
@@ -1,0 +1,489 @@
+"""CRUD operations for T-SQL user-defined functions on Fabric Data Warehouses and SQL Endpoints.
+
+Public API
+----------
+- :func:`validate_identifier` — re-exported from :mod:`fabric_dw.identifiers`.
+- :func:`list_functions`      — list all user-defined functions (filtered by schema/kind).
+- :func:`get_function`        — fetch a single function with its definition and parameters.
+- :func:`create_function`     — issue CREATE FUNCTION [<schema>].[<name>] AS <body>.
+- :func:`update_function`     — issue CREATE OR ALTER FUNCTION [<schema>].[<name>] AS <body>.
+- :func:`drop_function`       — issue DROP FUNCTION [IF EXISTS].
+- :func:`rename_function`     — rename a function via EXEC sp_rename.
+
+Note: User-defined functions are supported on **both** Fabric Data Warehouses and
+SQL Analytics Endpoints — no endpoint guard is applied here.  The CREATE FUNCTION,
+ALTER FUNCTION, and DROP FUNCTION "Applies to" lists include both
+"SQL analytics endpoint in Microsoft Fabric" and "Warehouse in Microsoft Fabric".
+
+Preview note: Scalar UDFs (FN) and inline TVFs (IF) are preview features as of
+mid-2026.  Multi-statement TVFs (TF) are not supported for creation but may
+appear in catalog listings on migrated warehouses.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from typing import Literal, cast
+
+from fabric_dw.auth import CredentialMode
+from fabric_dw.exceptions import NotFoundError
+from fabric_dw.identifiers import parse_qualified_name, quote_identifier, validate_identifier
+from fabric_dw.models import Function, FunctionDetails, FunctionKind, FunctionParameter
+from fabric_dw.sql import SqlTarget, run_query
+
+__all__ = [
+    "create_function",
+    "drop_function",
+    "get_function",
+    "list_functions",
+    "rename_function",
+    "update_function",
+    "validate_identifier",
+]
+
+# ---------------------------------------------------------------------------
+# SQL templates
+# ---------------------------------------------------------------------------
+
+_LIST_FUNCTIONS_SQL = """\
+SELECT
+    s.name  AS schema_name,
+    o.name,
+    o.type,
+    o.type_desc,
+    o.create_date AS created,
+    o.modify_date AS modified,
+    m.is_inlineable
+FROM sys.objects o
+JOIN sys.schemas s ON s.schema_id = o.schema_id
+JOIN sys.sql_modules m ON m.object_id = o.object_id
+WHERE ({schema_filter}) AND ({kind_filter})
+ORDER BY s.name, o.name;
+"""
+
+_GET_FUNCTION_SQL = """\
+SELECT
+    s.name  AS schema_name,
+    o.name,
+    o.type,
+    o.type_desc,
+    o.create_date AS created,
+    o.modify_date AS modified,
+    m.definition,
+    m.is_inlineable
+FROM sys.objects o
+JOIN sys.schemas s ON s.schema_id = o.schema_id
+JOIN sys.sql_modules m ON m.object_id = o.object_id
+WHERE s.name = ? AND o.name = ? AND o.type IN ('FN', 'IF', 'TF');
+"""
+
+_GET_PARAMS_SQL = """\
+SELECT
+    p.parameter_id,
+    p.name,
+    TYPE_NAME(p.user_type_id) AS data_type,
+    p.max_length,
+    p.is_output
+FROM sys.parameters p
+JOIN sys.objects o ON o.object_id = p.object_id
+JOIN sys.schemas s ON s.schema_id = o.schema_id
+WHERE s.name = ? AND o.name = ?
+ORDER BY p.parameter_id;
+"""
+
+# sp_rename takes string arguments (not identifiers) → bind as ? parameters.
+# @objname = qualified old name ('schema.old_fn'), @newname = bare new name.
+# sp_rename cannot move across schemas, so @newname must be unqualified.
+_SP_RENAME_SQL = "EXEC sp_rename ?, ?, 'OBJECT'"
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+_KIND_MAP: dict[str, FunctionKind] = {
+    "FN": FunctionKind.SCALAR,
+    "IF": FunctionKind.INLINE_TVF,
+    "TF": FunctionKind.MSTVF,
+}
+
+
+def _type_to_kind_filter(kind: Literal["scalar", "inline-tvf", "all"]) -> tuple[str, list[object]]:
+    """Return a (sql_fragment, params) pair for the kind filter clause."""
+    if kind == "scalar":
+        return "o.type = ?", ["FN"]
+    if kind == "inline-tvf":
+        return "o.type = ?", ["IF"]
+    # "all" — include FN, IF, and TF
+    return "o.type IN ('FN', 'IF', 'TF')", []
+
+
+def _row_to_function(cols: list[str], row: tuple[object, ...]) -> Function:
+    """Build a :class:`Function` from a column-name list and a result row tuple."""
+    data = dict(zip(cols, row, strict=True))
+    schema_name = str(data["schema_name"])
+    name = str(data["name"])
+    type_code = str(data["type"]).strip()
+    kind = _KIND_MAP.get(type_code, FunctionKind.SCALAR)
+    raw_inlineable = data.get("is_inlineable")
+    is_inlineable: bool | None = bool(raw_inlineable) if raw_inlineable is not None else None
+    return Function(
+        schema_name=schema_name,
+        name=name,
+        qualified_name=f"{schema_name}.{name}",
+        kind=kind,
+        is_inlineable=is_inlineable,
+        created=cast(datetime, data["created"]),
+        modified=cast(datetime, data["modified"]),
+    )
+
+
+def _row_to_function_details(
+    cols: list[str],
+    row: tuple[object, ...],
+    parameters: list[FunctionParameter],
+) -> FunctionDetails:
+    """Build a :class:`FunctionDetails` from a column-name list, row tuple, and parameter list."""
+    data = dict(zip(cols, row, strict=True))
+    schema_name = str(data["schema_name"])
+    name = str(data["name"])
+    type_code = str(data["type"]).strip()
+    kind = _KIND_MAP.get(type_code, FunctionKind.SCALAR)
+    raw_def = data.get("definition")
+    definition = cast("str | None", raw_def)
+    raw_inlineable = data.get("is_inlineable")
+    is_inlineable: bool | None = bool(raw_inlineable) if raw_inlineable is not None else None
+    return FunctionDetails(
+        schema_name=schema_name,
+        name=name,
+        qualified_name=f"{schema_name}.{name}",
+        kind=kind,
+        is_inlineable=is_inlineable,
+        definition=definition,
+        parameters=parameters,
+        created=cast(datetime, data["created"]),
+        modified=cast(datetime, data["modified"]),
+    )
+
+
+def _row_to_param(cols: list[str], row: tuple[object, ...]) -> FunctionParameter:
+    """Build a :class:`FunctionParameter` from a column-name list and a result row tuple."""
+    data = dict(zip(cols, row, strict=True))
+    raw_is_output = data.get("is_output")
+    is_output = bool(raw_is_output) if raw_is_output is not None else False
+    return FunctionParameter(
+        parameter_id=int(data["parameter_id"]),  # ty: ignore[invalid-argument-type]
+        name=str(data["name"]),
+        data_type=str(data["data_type"]),
+        max_length=int(data["max_length"]),  # ty: ignore[invalid-argument-type]
+        is_output=is_output,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+async def list_functions(
+    target: SqlTarget,
+    *,
+    schema: str | None = None,
+    kind: Literal["scalar", "inline-tvf", "all"] = "all",
+    mode: CredentialMode = CredentialMode.DEFAULT,
+) -> list[Function]:
+    """Return all user-defined functions on *target*, optionally filtered by *schema* and *kind*.
+
+    Supported on both Fabric Data Warehouses and SQL Analytics Endpoints.
+
+    Preview note: Scalar UDFs and inline TVFs are preview features on Fabric DW as of mid-2026.
+
+    Args:
+        target: The warehouse or SQL Analytics Endpoint to query.
+        schema: When provided, only functions in this schema are returned.
+            Must pass :func:`validate_identifier`.
+        kind: Filter by function kind — ``"scalar"`` (FN), ``"inline-tvf"`` (IF),
+            or ``"all"`` (FN + IF + TF).  Defaults to ``"all"``.
+        mode: The credential mode for Entra authentication.
+
+    Returns:
+        A (possibly empty) list of :class:`~fabric_dw.models.Function` instances.
+
+    Raises:
+        ValueError: If *schema* fails identifier validation.
+        PermissionDeniedError: If the driver reports a permission error.
+        AuthError: If the driver reports an authentication failure.
+    """
+    if schema is not None:
+        validate_identifier(schema)
+
+    if schema is not None:
+        schema_filter = "s.name = ?"
+        schema_params: list[object] = [schema]
+    else:
+        schema_filter = "1=1"
+        schema_params = []
+
+    kind_filter_sql, kind_params = _type_to_kind_filter(kind)
+    all_params = schema_params + kind_params
+
+    list_sql = _LIST_FUNCTIONS_SQL.format(schema_filter=schema_filter, kind_filter=kind_filter_sql)
+
+    def _run() -> list[Function]:
+        cols, rows = run_query(
+            target,
+            list_sql,
+            params=all_params or None,
+            mode=mode,
+        )
+        return [_row_to_function(cols, r) for r in rows]
+
+    return await asyncio.to_thread(_run)
+
+
+async def get_function(
+    target: SqlTarget,
+    schema: str,
+    function_name: str,
+    *,
+    mode: CredentialMode = CredentialMode.DEFAULT,
+) -> FunctionDetails:
+    """Fetch a single user-defined function with its definition and parameters.
+
+    Supported on both Fabric Data Warehouses and SQL Analytics Endpoints.
+
+    Args:
+        target: The warehouse or SQL Analytics Endpoint to query.
+        schema: The schema name.  Must pass :func:`validate_identifier`.
+        function_name: The function name.  Must pass :func:`validate_identifier`.
+        mode: The credential mode for Entra authentication.
+
+    Returns:
+        A :class:`~fabric_dw.models.FunctionDetails` with ``definition`` and
+        ``parameters`` populated.
+
+    Raises:
+        ValueError: If *schema* or *function_name* fails identifier validation.
+        NotFoundError: If no function with that schema/name exists.
+        PermissionDeniedError: If the driver reports a permission error.
+    """
+    validate_identifier(schema)
+    validate_identifier(function_name)
+
+    def _run() -> FunctionDetails:
+        # Fetch function metadata
+        cols, rows = run_query(
+            target,
+            _GET_FUNCTION_SQL,
+            params=[schema, function_name],
+            mode=mode,
+        )
+        if not rows:
+            msg = f"Function [{schema}].[{function_name}] not found"
+            raise NotFoundError(msg)
+
+        # Fetch parameters
+        param_cols, param_rows = run_query(
+            target,
+            _GET_PARAMS_SQL,
+            params=[schema, function_name],
+            mode=mode,
+        )
+        params = [_row_to_param(param_cols, pr) for pr in param_rows]
+
+        return _row_to_function_details(cols, rows[0], params)
+
+    return await asyncio.to_thread(_run)
+
+
+async def create_function(
+    target: SqlTarget,
+    schema: str,
+    function_name: str,
+    body: str,
+    *,
+    mode: CredentialMode = CredentialMode.DEFAULT,
+) -> FunctionDetails:
+    """Create a new user-defined function via ``CREATE FUNCTION [<schema>].[<name>] AS <body>``.
+
+    Supported on both Fabric Data Warehouses and SQL Analytics Endpoints.
+
+    Preview note: Scalar UDFs and inline TVFs are preview features on Fabric DW as of mid-2026.
+
+    Args:
+        target: The warehouse or SQL Analytics Endpoint to connect to.
+        schema: The schema name.  Must pass :func:`validate_identifier`.
+        function_name: The function name.  Must pass :func:`validate_identifier`.
+        body: The free-form function body (parameter list, RETURNS clause, and body).
+            Not validated — the caller owns the SQL (same trust model as ``sql exec``).
+        mode: The credential mode for Entra authentication.
+
+    Returns:
+        The newly-created :class:`~fabric_dw.models.FunctionDetails` (fetched after DDL).
+
+    Raises:
+        ValueError: If *schema* or *function_name* fails identifier validation.
+        PermissionDeniedError: If the driver reports a CREATE FUNCTION permission error.
+    """
+    validate_identifier(schema)
+    validate_identifier(function_name)
+
+    ddl = f"CREATE FUNCTION {quote_identifier(schema)}.{quote_identifier(function_name)} {body}"
+
+    def _run() -> None:
+        run_query(target, ddl, mode=mode, commit=True, fetch="none")
+
+    await asyncio.to_thread(_run)
+    return await get_function(target, schema, function_name, mode=mode)
+
+
+async def update_function(
+    target: SqlTarget,
+    schema: str,
+    function_name: str,
+    body: str,
+    *,
+    mode: CredentialMode = CredentialMode.DEFAULT,
+) -> FunctionDetails:
+    """Redefine a user-defined function via ``CREATE OR ALTER FUNCTION … <body>``.
+
+    Supported on both Fabric Data Warehouses and SQL Analytics Endpoints.
+
+    Note: ``ALTER FUNCTION`` cannot change the function kind (e.g. scalar to inline TVF).
+    The body must be compatible with the original function's kind.
+
+    Args:
+        target: The warehouse or SQL Analytics Endpoint to connect to.
+        schema: The schema name.  Must pass :func:`validate_identifier`.
+        function_name: The function name.  Must pass :func:`validate_identifier`.
+        body: The free-form function body.  Caller-owned.
+        mode: The credential mode for Entra authentication.
+
+    Returns:
+        The updated :class:`~fabric_dw.models.FunctionDetails` (fetched after DDL).
+
+    Raises:
+        ValueError: If *schema* or *function_name* fails identifier validation.
+        PermissionDeniedError: If the driver reports an ALTER FUNCTION permission error.
+    """
+    validate_identifier(schema)
+    validate_identifier(function_name)
+
+    ddl = (
+        f"CREATE OR ALTER FUNCTION"
+        f" {quote_identifier(schema)}.{quote_identifier(function_name)}"
+        f" {body}"
+    )
+
+    def _run() -> None:
+        run_query(target, ddl, mode=mode, commit=True, fetch="none")
+
+    await asyncio.to_thread(_run)
+    return await get_function(target, schema, function_name, mode=mode)
+
+
+async def drop_function(
+    target: SqlTarget,
+    schema: str,
+    function_name: str,
+    *,
+    if_exists: bool = False,
+    mode: CredentialMode = CredentialMode.DEFAULT,
+) -> None:
+    """Drop a user-defined function via ``DROP FUNCTION [IF EXISTS] [<schema>].[<name>]``.
+
+    Supported on both Fabric Data Warehouses and SQL Analytics Endpoints.
+
+    Args:
+        target: The warehouse or SQL Analytics Endpoint to connect to.
+        schema: The schema name.  Must pass :func:`validate_identifier`.
+        function_name: The function name.  Must pass :func:`validate_identifier`.
+        if_exists: When ``True``, emits ``DROP FUNCTION IF EXISTS`` so the statement
+            is a no-op when the function does not exist.
+        mode: The credential mode for Entra authentication.
+
+    Raises:
+        ValueError: If *schema* or *function_name* fails identifier validation.
+        PermissionDeniedError: If the driver reports a DROP FUNCTION permission error.
+    """
+    validate_identifier(schema)
+    validate_identifier(function_name)
+
+    if_exists_clause = "IF EXISTS " if if_exists else ""
+    ddl = (
+        f"DROP FUNCTION {if_exists_clause}"
+        f"{quote_identifier(schema)}.{quote_identifier(function_name)}"
+    )
+
+    def _run() -> None:
+        run_query(target, ddl, mode=mode, commit=True, fetch="none")
+
+    await asyncio.to_thread(_run)
+
+
+async def rename_function(
+    target: SqlTarget,
+    qualified: str,
+    new_name: str,
+    *,
+    mode: CredentialMode = CredentialMode.DEFAULT,
+) -> FunctionDetails:
+    """Rename a user-defined function via ``EXEC sp_rename @objname, @newname, 'OBJECT'``.
+
+    Works on both Data Warehouses and SQL Analytics Endpoints — no DW-only guard
+    is applied.
+
+    ``sp_rename`` takes names as STRING ARGUMENTS (not SQL identifiers), so both
+    the old qualified name and the new bare name are bound as ``?`` parameters.
+    The new name must be unqualified (no dot) because ``sp_rename`` cannot move
+    a function across schemas.
+
+    Args:
+        target: The warehouse or SQL Analytics Endpoint to connect to.
+        qualified: Current qualified name of the function, e.g. ``dbo.fn_clean``.
+            Parsed via :func:`~fabric_dw.identifiers.parse_qualified_name`.
+        new_name: New bare (unqualified) function name.  Must pass
+            :func:`validate_identifier` and must not contain a dot.
+        mode: The credential mode for Entra authentication.
+
+    Returns:
+        The renamed :class:`~fabric_dw.models.FunctionDetails` (fetched after rename
+        using the original schema and the new name).
+
+    Raises:
+        ValueError: If *qualified* cannot be parsed, if either identifier part
+            fails validation, or if *new_name* is schema-qualified (contains a dot).
+        NotFoundError: If the renamed function cannot be found after the rename.
+        PermissionDeniedError: If the driver reports a permission error.
+    """
+    schema, old_name = parse_qualified_name(qualified)
+    validate_identifier(schema)
+    validate_identifier(old_name)
+
+    if "." in new_name:
+        msg = (
+            f"New name {new_name!r} must not be schema-qualified; "
+            "sp_rename cannot move a function to a different schema"
+        )
+        raise ValueError(msg)
+    validate_identifier(new_name)
+
+    # @objname = 'schema.oldfn', @newname = 'newfn' — bound as ? params.
+    old_qualified = f"{schema}.{old_name}"
+
+    def _run() -> None:
+        run_query(
+            target,
+            _SP_RENAME_SQL,
+            params=[old_qualified, new_name],
+            mode=mode,
+            commit=True,
+            fetch="none",
+        )
+
+    await asyncio.to_thread(_run)
+    try:
+        return await get_function(target, schema, new_name, mode=mode)
+    except NotFoundError:
+        msg = f"Function [{schema}].[{new_name}] not found after rename"
+        raise NotFoundError(msg) from None

--- a/tests/integration/test_services_functions.py
+++ b/tests/integration/test_services_functions.py
@@ -1,0 +1,306 @@
+"""Integration tests for services.functions — requires real Fabric credentials.
+
+Run with: pytest -m integration tests/integration/test_services_functions.py
+
+Fixture note: uses ``ephemeral_sql_target`` from conftest.  The target points at
+a freshly-created warehouse for each test session; all functions created here are
+cleaned up inside each test via try/finally.
+
+Note on scope:
+- Scalar UDFs and inline TVFs are **preview** features on Fabric DW as of mid-2026.
+- Function DDL is supported on **both** Fabric Data Warehouses and SQL Analytics
+  Endpoints per the Microsoft Fabric T-SQL reference.  No endpoint guard applies.
+- Non-inlineable scalar UDFs (e.g. using GETDATE()) cannot be used inside
+  SELECT ... FROM <user_table> but can still be created and called standalone.
+"""
+
+from __future__ import annotations
+
+import contextlib
+
+import pytest
+
+from fabric_dw.exceptions import NotFoundError
+from fabric_dw.models import FunctionDetails, FunctionKind
+from fabric_dw.services import functions
+from fabric_dw.sql import SqlTarget
+
+pytestmark = pytest.mark.integration
+
+# ---------------------------------------------------------------------------
+# Sample function bodies (scalar UDFs)
+# ---------------------------------------------------------------------------
+
+_SCALAR_INLINEABLE_BODY = """\
+(@input NVARCHAR(100))
+RETURNS NVARCHAR(100)
+AS
+BEGIN
+    RETURN LTRIM(RTRIM(@input))
+END
+"""
+
+_SCALAR_UPDATED_BODY = """\
+(@input NVARCHAR(100))
+RETURNS NVARCHAR(100)
+AS
+BEGIN
+    RETURN LOWER(LTRIM(RTRIM(@input)))
+END
+"""
+
+_INLINE_TVF_BODY = """\
+(@min_val INT)
+RETURNS TABLE
+AS
+RETURN (SELECT 1 AS id WHERE 1 >= @min_val)
+"""
+
+
+async def test_list_functions_returns_list(ephemeral_sql_target: SqlTarget) -> None:
+    """list_functions on a fresh warehouse must return a (possibly empty) list."""
+    result = await functions.list_functions(ephemeral_sql_target)
+    assert isinstance(result, list)
+
+
+async def test_create_scalar_function_returns_function_details(
+    ephemeral_sql_target: SqlTarget,
+) -> None:
+    """create_function must return FunctionDetails with correct schema/name/kind."""
+    schema = "dbo"
+    fn_name = "pytest_fns_create_scalar"
+
+    try:
+        created = await functions.create_function(
+            ephemeral_sql_target, schema, fn_name, _SCALAR_INLINEABLE_BODY
+        )
+        assert isinstance(created, FunctionDetails)
+        assert created.schema_name == schema
+        assert created.name == fn_name
+        assert created.qualified_name == f"{schema}.{fn_name}"
+        assert created.kind == FunctionKind.SCALAR
+        assert created.definition is not None
+        assert "LTRIM" in created.definition.upper() or "ltrim" in created.definition.lower()
+    finally:
+        with contextlib.suppress(Exception):
+            await functions.drop_function(ephemeral_sql_target, schema, fn_name)
+
+
+async def test_list_functions_includes_created_function(
+    ephemeral_sql_target: SqlTarget,
+) -> None:
+    """A newly created function must appear in list_functions results."""
+    schema = "dbo"
+    fn_name = "pytest_fns_list"
+
+    try:
+        await functions.create_function(
+            ephemeral_sql_target, schema, fn_name, _SCALAR_INLINEABLE_BODY
+        )
+
+        all_fns = await functions.list_functions(ephemeral_sql_target)
+        names = {f.name for f in all_fns}
+        assert fn_name in names
+
+        # Schema filter
+        dbo_fns = await functions.list_functions(ephemeral_sql_target, schema=schema)
+        dbo_names = {f.name for f in dbo_fns}
+        assert fn_name in dbo_names
+
+        # Non-existent schema returns empty
+        other_fns = await functions.list_functions(
+            ephemeral_sql_target, schema="nonexistent_schema_x"
+        )
+        assert other_fns == []
+    finally:
+        with contextlib.suppress(Exception):
+            await functions.drop_function(ephemeral_sql_target, schema, fn_name)
+
+
+async def test_list_functions_kind_filter_scalar(
+    ephemeral_sql_target: SqlTarget,
+) -> None:
+    """list_functions with kind='scalar' must only return FN functions."""
+    schema = "dbo"
+    fn_name = "pytest_fns_kind_scalar"
+
+    try:
+        await functions.create_function(
+            ephemeral_sql_target, schema, fn_name, _SCALAR_INLINEABLE_BODY
+        )
+
+        scalar_fns = await functions.list_functions(ephemeral_sql_target, kind="scalar")
+        for f in scalar_fns:
+            assert f.kind == FunctionKind.SCALAR
+    finally:
+        with contextlib.suppress(Exception):
+            await functions.drop_function(ephemeral_sql_target, schema, fn_name)
+
+
+async def test_get_function_returns_definition(ephemeral_sql_target: SqlTarget) -> None:
+    """get_function must return FunctionDetails with definition and parameters populated."""
+    schema = "dbo"
+    fn_name = "pytest_fns_get"
+
+    try:
+        await functions.create_function(
+            ephemeral_sql_target, schema, fn_name, _SCALAR_INLINEABLE_BODY
+        )
+
+        fetched = await functions.get_function(ephemeral_sql_target, schema, fn_name)
+        assert isinstance(fetched, FunctionDetails)
+        assert fetched.schema_name == schema
+        assert fetched.name == fn_name
+        assert fetched.definition is not None
+        assert "ltrim" in fetched.definition.lower() or "LTRIM" in fetched.definition
+        # Parameters should include the return value (parameter_id=0) and @input (id=1)
+        assert len(fetched.parameters) >= 1
+    finally:
+        with contextlib.suppress(Exception):
+            await functions.drop_function(ephemeral_sql_target, schema, fn_name)
+
+
+async def test_get_function_raises_not_found_for_missing_function(
+    ephemeral_sql_target: SqlTarget,
+) -> None:
+    """get_function must raise NotFoundError when the function does not exist."""
+    with pytest.raises(NotFoundError):
+        await functions.get_function(ephemeral_sql_target, "dbo", "pytest_fns_does_not_exist_xyz")
+
+
+async def test_update_function_changes_definition(ephemeral_sql_target: SqlTarget) -> None:
+    """update_function must redefine the function and return the updated definition."""
+    schema = "dbo"
+    fn_name = "pytest_fns_update"
+
+    try:
+        await functions.create_function(
+            ephemeral_sql_target, schema, fn_name, _SCALAR_INLINEABLE_BODY
+        )
+
+        updated = await functions.update_function(
+            ephemeral_sql_target, schema, fn_name, _SCALAR_UPDATED_BODY
+        )
+        assert isinstance(updated, FunctionDetails)
+        assert updated.definition is not None
+        assert "lower" in updated.definition.lower() or "LOWER" in updated.definition
+    finally:
+        with contextlib.suppress(Exception):
+            await functions.drop_function(ephemeral_sql_target, schema, fn_name)
+
+
+async def test_drop_function_removes_function(ephemeral_sql_target: SqlTarget) -> None:
+    """drop_function must remove the function so it no longer appears in list_functions."""
+    schema = "dbo"
+    fn_name = "pytest_fns_drop"
+
+    await functions.create_function(ephemeral_sql_target, schema, fn_name, _SCALAR_INLINEABLE_BODY)
+
+    # Confirm it exists before dropping
+    before = await functions.list_functions(ephemeral_sql_target)
+    assert any(f.name == fn_name for f in before)
+
+    await functions.drop_function(ephemeral_sql_target, schema, fn_name)
+
+    # Must not appear in listing after drop
+    after = await functions.list_functions(ephemeral_sql_target)
+    assert not any(f.name == fn_name for f in after)
+
+    # get_function must raise NotFoundError
+    with pytest.raises(NotFoundError):
+        await functions.get_function(ephemeral_sql_target, schema, fn_name)
+
+
+async def test_rename_function_roundtrip(ephemeral_sql_target: SqlTarget) -> None:
+    """rename_function must rename the function and return updated details."""
+    schema = "dbo"
+    fn_name = "pytest_fns_rename_src"
+    new_name = "pytest_fns_rename_dst"
+
+    try:
+        await functions.create_function(
+            ephemeral_sql_target, schema, fn_name, _SCALAR_INLINEABLE_BODY
+        )
+
+        renamed = await functions.rename_function(
+            ephemeral_sql_target, f"{schema}.{fn_name}", new_name
+        )
+        assert isinstance(renamed, FunctionDetails)
+        assert renamed.name == new_name
+        assert renamed.schema_name == schema
+
+        # Old name must be gone
+        after = await functions.list_functions(ephemeral_sql_target)
+        assert not any(f.name == fn_name for f in after)
+        assert any(f.name == new_name for f in after)
+    finally:
+        with contextlib.suppress(Exception):
+            await functions.drop_function(ephemeral_sql_target, schema, fn_name)
+        with contextlib.suppress(Exception):
+            await functions.drop_function(ephemeral_sql_target, schema, new_name)
+
+
+async def test_create_function_full_roundtrip(ephemeral_sql_target: SqlTarget) -> None:
+    """End-to-end: create -> list -> get -> update -> rename -> drop."""
+    schema = "dbo"
+    fn_name = "pytest_fns_roundtrip"
+    renamed = "pytest_fns_roundtrip_v2"
+
+    try:
+        # --- create ---
+        created = await functions.create_function(
+            ephemeral_sql_target, schema, fn_name, _SCALAR_INLINEABLE_BODY
+        )
+        assert created.name == fn_name
+        assert created.kind == FunctionKind.SCALAR
+
+        # --- list ---
+        all_fns = await functions.list_functions(ephemeral_sql_target)
+        assert any(f.name == fn_name for f in all_fns)
+
+        # --- get (definition contains body) ---
+        fetched = await functions.get_function(ephemeral_sql_target, schema, fn_name)
+        assert fetched.definition is not None
+        assert "LTRIM" in fetched.definition.upper() or "ltrim" in fetched.definition.lower()
+
+        # --- update (definition changes) ---
+        updated = await functions.update_function(
+            ephemeral_sql_target, schema, fn_name, _SCALAR_UPDATED_BODY
+        )
+        assert updated.definition is not None
+        assert "lower" in updated.definition.lower() or "LOWER" in updated.definition
+
+        # --- rename ---
+        rn = await functions.rename_function(ephemeral_sql_target, f"{schema}.{fn_name}", renamed)
+        assert rn.name == renamed
+
+        # --- drop renamed ---
+        await functions.drop_function(ephemeral_sql_target, schema, renamed)
+        after = await functions.list_functions(ephemeral_sql_target)
+        assert not any(f.name == renamed for f in after)
+
+    finally:
+        with contextlib.suppress(Exception):
+            await functions.drop_function(ephemeral_sql_target, schema, fn_name)
+        with contextlib.suppress(Exception):
+            await functions.drop_function(ephemeral_sql_target, schema, renamed)
+
+
+async def test_list_functions_on_sql_analytics_endpoint(
+    ephemeral_sql_endpoint,
+    workspace_id,
+) -> None:
+    """list_functions on a SQL analytics endpoint must succeed (read OK, no guard)."""
+    from fabric_dw.models import Warehouse  # noqa: PLC0415
+    from fabric_dw.sql import SqlTarget  # noqa: PLC0415
+
+    ep: Warehouse = ephemeral_sql_endpoint
+    if ep.connection_string is None:
+        pytest.skip("SQL analytics endpoint has no connection string")
+    target = SqlTarget(
+        workspace_id=str(workspace_id),
+        database=ep.name,
+        connection_string=ep.connection_string,
+    )
+    result = await functions.list_functions(target)
+    assert isinstance(result, list)

--- a/tests/integration/test_services_functions.py
+++ b/tests/integration/test_services_functions.py
@@ -288,6 +288,35 @@ async def test_create_function_full_roundtrip(
             await functions.drop_function(sql_target, schema, renamed)
 
 
+async def test_create_inline_tvf_and_list_by_kind(
+    warehouse_schema: tuple[SqlTarget, str],
+) -> None:
+    """create_function with an inline TVF body must return kind=inline_tvf
+    and list_functions with kind='inline_tvf' must include it."""
+    sql_target, schema = warehouse_schema
+    fn_name = "pytest_fns_inline_tvf"
+
+    try:
+        created = await functions.create_function(sql_target, schema, fn_name, _INLINE_TVF_BODY)
+        assert isinstance(created, FunctionDetails)
+        assert created.schema_name == schema
+        assert created.name == fn_name
+        assert created.kind == FunctionKind.INLINE_TVF
+
+        # Kind filter must include the TVF
+        tvf_fns = await functions.list_functions(sql_target, schema=schema, kind="inline-tvf")
+        assert any(f.name == fn_name for f in tvf_fns)
+        for f in tvf_fns:
+            assert f.kind == FunctionKind.INLINE_TVF
+
+        # Scalar filter must exclude it
+        scalar_fns = await functions.list_functions(sql_target, schema=schema, kind="scalar")
+        assert not any(f.name == fn_name for f in scalar_fns)
+    finally:
+        with contextlib.suppress(Exception):
+            await functions.drop_function(sql_target, schema, fn_name)
+
+
 # ---------------------------------------------------------------------------
 # SQL Analytics Endpoint — list is allowed (no endpoint guard on functions)
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_services_functions.py
+++ b/tests/integration/test_services_functions.py
@@ -2,9 +2,14 @@
 
 Run with: pytest -m integration tests/integration/test_services_functions.py
 
-Fixture note: uses ``ephemeral_sql_target`` from conftest.  The target points at
-a freshly-created warehouse for each test session; all functions created here are
-cleaned up inside each test via try/finally.
+Fixture note: uses ``warehouse_schema`` from conftest, which creates a uniquely-named
+schema inside the session-shared warm warehouse and cascade-drops it on teardown.
+All functions created here are created inside that schema; the schema cascade drop
+handles cleanup, with additional try/finally guards for mid-test failures.
+
+The SQL Analytics Endpoint read test uses ``ephemeral_sql_endpoint`` (SQL Analytics
+Endpoint, a ``Warehouse`` object typed as ``WarehouseKind.SQL_ENDPOINT``) because
+the shared warehouse fixture does not cover endpoint-only behaviour.
 
 Note on scope:
 - Scalar UDFs and inline TVFs are **preview** features on Fabric DW as of mid-2026.
@@ -17,11 +22,12 @@ Note on scope:
 from __future__ import annotations
 
 import contextlib
+from uuid import UUID
 
 import pytest
 
 from fabric_dw.exceptions import NotFoundError
-from fabric_dw.models import FunctionDetails, FunctionKind
+from fabric_dw.models import FunctionDetails, FunctionKind, Warehouse
 from fabric_dw.services import functions
 from fabric_dw.sql import SqlTarget
 
@@ -57,22 +63,25 @@ RETURN (SELECT 1 AS id WHERE 1 >= @min_val)
 """
 
 
-async def test_list_functions_returns_list(ephemeral_sql_target: SqlTarget) -> None:
-    """list_functions on a fresh warehouse must return a (possibly empty) list."""
-    result = await functions.list_functions(ephemeral_sql_target)
+async def test_list_functions_returns_list(
+    warehouse_schema: tuple[SqlTarget, str],
+) -> None:
+    """list_functions on the shared warehouse must return a (possibly empty) list."""
+    sql_target, _schema = warehouse_schema
+    result = await functions.list_functions(sql_target)
     assert isinstance(result, list)
 
 
 async def test_create_scalar_function_returns_function_details(
-    ephemeral_sql_target: SqlTarget,
+    warehouse_schema: tuple[SqlTarget, str],
 ) -> None:
     """create_function must return FunctionDetails with correct schema/name/kind."""
-    schema = "dbo"
+    sql_target, schema = warehouse_schema
     fn_name = "pytest_fns_create_scalar"
 
     try:
         created = await functions.create_function(
-            ephemeral_sql_target, schema, fn_name, _SCALAR_INLINEABLE_BODY
+            sql_target, schema, fn_name, _SCALAR_INLINEABLE_BODY
         )
         assert isinstance(created, FunctionDetails)
         assert created.schema_name == schema
@@ -83,71 +92,65 @@ async def test_create_scalar_function_returns_function_details(
         assert "LTRIM" in created.definition.upper() or "ltrim" in created.definition.lower()
     finally:
         with contextlib.suppress(Exception):
-            await functions.drop_function(ephemeral_sql_target, schema, fn_name)
+            await functions.drop_function(sql_target, schema, fn_name)
 
 
 async def test_list_functions_includes_created_function(
-    ephemeral_sql_target: SqlTarget,
+    warehouse_schema: tuple[SqlTarget, str],
 ) -> None:
     """A newly created function must appear in list_functions results."""
-    schema = "dbo"
+    sql_target, schema = warehouse_schema
     fn_name = "pytest_fns_list"
 
     try:
-        await functions.create_function(
-            ephemeral_sql_target, schema, fn_name, _SCALAR_INLINEABLE_BODY
-        )
+        await functions.create_function(sql_target, schema, fn_name, _SCALAR_INLINEABLE_BODY)
 
-        all_fns = await functions.list_functions(ephemeral_sql_target)
-        names = {f.name for f in all_fns}
+        all_fns = await functions.list_functions(sql_target)
+        names = {f.name for f in all_fns if f.schema_name == schema}
         assert fn_name in names
 
-        # Schema filter
-        dbo_fns = await functions.list_functions(ephemeral_sql_target, schema=schema)
+        # Schema filter must narrow to only this schema
+        dbo_fns = await functions.list_functions(sql_target, schema=schema)
         dbo_names = {f.name for f in dbo_fns}
         assert fn_name in dbo_names
 
         # Non-existent schema returns empty
-        other_fns = await functions.list_functions(
-            ephemeral_sql_target, schema="nonexistent_schema_x"
-        )
+        other_fns = await functions.list_functions(sql_target, schema="nonexistent_schema_x")
         assert other_fns == []
     finally:
         with contextlib.suppress(Exception):
-            await functions.drop_function(ephemeral_sql_target, schema, fn_name)
+            await functions.drop_function(sql_target, schema, fn_name)
 
 
 async def test_list_functions_kind_filter_scalar(
-    ephemeral_sql_target: SqlTarget,
+    warehouse_schema: tuple[SqlTarget, str],
 ) -> None:
     """list_functions with kind='scalar' must only return FN functions."""
-    schema = "dbo"
+    sql_target, schema = warehouse_schema
     fn_name = "pytest_fns_kind_scalar"
 
     try:
-        await functions.create_function(
-            ephemeral_sql_target, schema, fn_name, _SCALAR_INLINEABLE_BODY
-        )
+        await functions.create_function(sql_target, schema, fn_name, _SCALAR_INLINEABLE_BODY)
 
-        scalar_fns = await functions.list_functions(ephemeral_sql_target, kind="scalar")
+        scalar_fns = await functions.list_functions(sql_target, kind="scalar")
         for f in scalar_fns:
             assert f.kind == FunctionKind.SCALAR
     finally:
         with contextlib.suppress(Exception):
-            await functions.drop_function(ephemeral_sql_target, schema, fn_name)
+            await functions.drop_function(sql_target, schema, fn_name)
 
 
-async def test_get_function_returns_definition(ephemeral_sql_target: SqlTarget) -> None:
+async def test_get_function_returns_definition(
+    warehouse_schema: tuple[SqlTarget, str],
+) -> None:
     """get_function must return FunctionDetails with definition and parameters populated."""
-    schema = "dbo"
+    sql_target, schema = warehouse_schema
     fn_name = "pytest_fns_get"
 
     try:
-        await functions.create_function(
-            ephemeral_sql_target, schema, fn_name, _SCALAR_INLINEABLE_BODY
-        )
+        await functions.create_function(sql_target, schema, fn_name, _SCALAR_INLINEABLE_BODY)
 
-        fetched = await functions.get_function(ephemeral_sql_target, schema, fn_name)
+        fetched = await functions.get_function(sql_target, schema, fn_name)
         assert isinstance(fetched, FunctionDetails)
         assert fetched.schema_name == schema
         assert fetched.name == fn_name
@@ -157,150 +160,150 @@ async def test_get_function_returns_definition(ephemeral_sql_target: SqlTarget) 
         assert len(fetched.parameters) >= 1
     finally:
         with contextlib.suppress(Exception):
-            await functions.drop_function(ephemeral_sql_target, schema, fn_name)
+            await functions.drop_function(sql_target, schema, fn_name)
 
 
 async def test_get_function_raises_not_found_for_missing_function(
-    ephemeral_sql_target: SqlTarget,
+    warehouse_schema: tuple[SqlTarget, str],
 ) -> None:
     """get_function must raise NotFoundError when the function does not exist."""
+    sql_target, schema = warehouse_schema
     with pytest.raises(NotFoundError):
-        await functions.get_function(ephemeral_sql_target, "dbo", "pytest_fns_does_not_exist_xyz")
+        await functions.get_function(sql_target, schema, "pytest_fns_does_not_exist_xyz")
 
 
-async def test_update_function_changes_definition(ephemeral_sql_target: SqlTarget) -> None:
+async def test_update_function_changes_definition(
+    warehouse_schema: tuple[SqlTarget, str],
+) -> None:
     """update_function must redefine the function and return the updated definition."""
-    schema = "dbo"
+    sql_target, schema = warehouse_schema
     fn_name = "pytest_fns_update"
 
     try:
-        await functions.create_function(
-            ephemeral_sql_target, schema, fn_name, _SCALAR_INLINEABLE_BODY
-        )
+        await functions.create_function(sql_target, schema, fn_name, _SCALAR_INLINEABLE_BODY)
 
-        updated = await functions.update_function(
-            ephemeral_sql_target, schema, fn_name, _SCALAR_UPDATED_BODY
-        )
+        updated = await functions.update_function(sql_target, schema, fn_name, _SCALAR_UPDATED_BODY)
         assert isinstance(updated, FunctionDetails)
         assert updated.definition is not None
         assert "lower" in updated.definition.lower() or "LOWER" in updated.definition
     finally:
         with contextlib.suppress(Exception):
-            await functions.drop_function(ephemeral_sql_target, schema, fn_name)
+            await functions.drop_function(sql_target, schema, fn_name)
 
 
-async def test_drop_function_removes_function(ephemeral_sql_target: SqlTarget) -> None:
+async def test_drop_function_removes_function(
+    warehouse_schema: tuple[SqlTarget, str],
+) -> None:
     """drop_function must remove the function so it no longer appears in list_functions."""
-    schema = "dbo"
+    sql_target, schema = warehouse_schema
     fn_name = "pytest_fns_drop"
 
-    await functions.create_function(ephemeral_sql_target, schema, fn_name, _SCALAR_INLINEABLE_BODY)
+    await functions.create_function(sql_target, schema, fn_name, _SCALAR_INLINEABLE_BODY)
 
     # Confirm it exists before dropping
-    before = await functions.list_functions(ephemeral_sql_target)
+    before = await functions.list_functions(sql_target, schema=schema)
     assert any(f.name == fn_name for f in before)
 
-    await functions.drop_function(ephemeral_sql_target, schema, fn_name)
+    await functions.drop_function(sql_target, schema, fn_name)
 
     # Must not appear in listing after drop
-    after = await functions.list_functions(ephemeral_sql_target)
+    after = await functions.list_functions(sql_target, schema=schema)
     assert not any(f.name == fn_name for f in after)
 
     # get_function must raise NotFoundError
     with pytest.raises(NotFoundError):
-        await functions.get_function(ephemeral_sql_target, schema, fn_name)
+        await functions.get_function(sql_target, schema, fn_name)
 
 
-async def test_rename_function_roundtrip(ephemeral_sql_target: SqlTarget) -> None:
+async def test_rename_function_roundtrip(
+    warehouse_schema: tuple[SqlTarget, str],
+) -> None:
     """rename_function must rename the function and return updated details."""
-    schema = "dbo"
+    sql_target, schema = warehouse_schema
     fn_name = "pytest_fns_rename_src"
     new_name = "pytest_fns_rename_dst"
 
     try:
-        await functions.create_function(
-            ephemeral_sql_target, schema, fn_name, _SCALAR_INLINEABLE_BODY
-        )
+        await functions.create_function(sql_target, schema, fn_name, _SCALAR_INLINEABLE_BODY)
 
-        renamed = await functions.rename_function(
-            ephemeral_sql_target, f"{schema}.{fn_name}", new_name
-        )
+        renamed = await functions.rename_function(sql_target, f"{schema}.{fn_name}", new_name)
         assert isinstance(renamed, FunctionDetails)
         assert renamed.name == new_name
         assert renamed.schema_name == schema
 
-        # Old name must be gone
-        after = await functions.list_functions(ephemeral_sql_target)
+        # Old name must be gone, new name must appear
+        after = await functions.list_functions(sql_target, schema=schema)
         assert not any(f.name == fn_name for f in after)
         assert any(f.name == new_name for f in after)
     finally:
         with contextlib.suppress(Exception):
-            await functions.drop_function(ephemeral_sql_target, schema, fn_name)
+            await functions.drop_function(sql_target, schema, fn_name)
         with contextlib.suppress(Exception):
-            await functions.drop_function(ephemeral_sql_target, schema, new_name)
+            await functions.drop_function(sql_target, schema, new_name)
 
 
-async def test_create_function_full_roundtrip(ephemeral_sql_target: SqlTarget) -> None:
+async def test_create_function_full_roundtrip(
+    warehouse_schema: tuple[SqlTarget, str],
+) -> None:
     """End-to-end: create -> list -> get -> update -> rename -> drop."""
-    schema = "dbo"
+    sql_target, schema = warehouse_schema
     fn_name = "pytest_fns_roundtrip"
     renamed = "pytest_fns_roundtrip_v2"
 
     try:
         # --- create ---
         created = await functions.create_function(
-            ephemeral_sql_target, schema, fn_name, _SCALAR_INLINEABLE_BODY
+            sql_target, schema, fn_name, _SCALAR_INLINEABLE_BODY
         )
         assert created.name == fn_name
         assert created.kind == FunctionKind.SCALAR
 
-        # --- list ---
-        all_fns = await functions.list_functions(ephemeral_sql_target)
+        # --- list (schema-filtered to avoid cross-test noise) ---
+        all_fns = await functions.list_functions(sql_target, schema=schema)
         assert any(f.name == fn_name for f in all_fns)
 
         # --- get (definition contains body) ---
-        fetched = await functions.get_function(ephemeral_sql_target, schema, fn_name)
+        fetched = await functions.get_function(sql_target, schema, fn_name)
         assert fetched.definition is not None
         assert "LTRIM" in fetched.definition.upper() or "ltrim" in fetched.definition.lower()
 
         # --- update (definition changes) ---
-        updated = await functions.update_function(
-            ephemeral_sql_target, schema, fn_name, _SCALAR_UPDATED_BODY
-        )
+        updated = await functions.update_function(sql_target, schema, fn_name, _SCALAR_UPDATED_BODY)
         assert updated.definition is not None
         assert "lower" in updated.definition.lower() or "LOWER" in updated.definition
 
         # --- rename ---
-        rn = await functions.rename_function(ephemeral_sql_target, f"{schema}.{fn_name}", renamed)
+        rn = await functions.rename_function(sql_target, f"{schema}.{fn_name}", renamed)
         assert rn.name == renamed
 
         # --- drop renamed ---
-        await functions.drop_function(ephemeral_sql_target, schema, renamed)
-        after = await functions.list_functions(ephemeral_sql_target)
+        await functions.drop_function(sql_target, schema, renamed)
+        after = await functions.list_functions(sql_target, schema=schema)
         assert not any(f.name == renamed for f in after)
 
     finally:
         with contextlib.suppress(Exception):
-            await functions.drop_function(ephemeral_sql_target, schema, fn_name)
+            await functions.drop_function(sql_target, schema, fn_name)
         with contextlib.suppress(Exception):
-            await functions.drop_function(ephemeral_sql_target, schema, renamed)
+            await functions.drop_function(sql_target, schema, renamed)
+
+
+# ---------------------------------------------------------------------------
+# SQL Analytics Endpoint — list is allowed (no endpoint guard on functions)
+# ---------------------------------------------------------------------------
 
 
 async def test_list_functions_on_sql_analytics_endpoint(
-    ephemeral_sql_endpoint,
-    workspace_id,
+    ephemeral_sql_endpoint: Warehouse,
+    workspace_id: UUID,
 ) -> None:
     """list_functions on a SQL analytics endpoint must succeed (read OK, no guard)."""
-    from fabric_dw.models import Warehouse  # noqa: PLC0415
-    from fabric_dw.sql import SqlTarget  # noqa: PLC0415
-
-    ep: Warehouse = ephemeral_sql_endpoint
-    if ep.connection_string is None:
+    if ephemeral_sql_endpoint.connection_string is None:
         pytest.skip("SQL analytics endpoint has no connection string")
     target = SqlTarget(
         workspace_id=str(workspace_id),
-        database=ep.name,
-        connection_string=ep.connection_string,
+        database=ephemeral_sql_endpoint.name,
+        connection_string=ephemeral_sql_endpoint.connection_string,
     )
     result = await functions.list_functions(target)
     assert isinstance(result, list)

--- a/tests/unit/cli/commands/test_functions.py
+++ b/tests/unit/cli/commands/test_functions.py
@@ -1,0 +1,760 @@
+"""Tests for functions CLI sub-commands."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+from uuid import UUID
+
+from click.testing import CliRunner
+
+from fabric_dw.cache import ItemEntry
+from fabric_dw.cli._main import cli
+from fabric_dw.exceptions import NotFoundError, PermissionDeniedError
+from fabric_dw.models import FunctionDetails, FunctionKind, WarehouseKind
+from fabric_dw.sql import SqlTarget
+
+WS_GUID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+WH_GUID = "d4e5f6a7-b8c9-0123-def0-123456789abc"
+WS_UUID = UUID(WS_GUID)
+WH_UUID = UUID(WH_GUID)
+
+_NOW = datetime(2024, 6, 1, 12, 0, 0, tzinfo=UTC)
+
+
+def _make_sql_target() -> SqlTarget:
+    return SqlTarget(
+        workspace_id=WS_GUID,
+        database="SalesWarehouse",
+        connection_string="wh.datawarehouse.fabric.microsoft.com",
+    )
+
+
+def _make_http_cm(http: object) -> object:
+    @asynccontextmanager
+    async def _cm(_ctx: object) -> AsyncIterator[object]:
+        yield http
+
+    return _cm
+
+
+def _make_item_entry(*, kind: WarehouseKind = WarehouseKind.WAREHOUSE) -> ItemEntry:
+    return ItemEntry(
+        id=WH_UUID,
+        kind=kind,
+        connection_string="wh.datawarehouse.fabric.microsoft.com",
+        fetched_at=datetime.now(tz=UTC),
+        display_name="SalesWarehouse",
+    )
+
+
+def _make_fn(*, with_definition: bool = False) -> FunctionDetails:
+    return FunctionDetails(
+        schema_name="dbo",
+        name="fn_clean",
+        qualified_name="dbo.fn_clean",
+        kind=FunctionKind.SCALAR,
+        is_inlineable=True,
+        definition="(@x NVARCHAR(100)) RETURNS NVARCHAR(100) AS BEGIN RETURN @x END"
+        if with_definition
+        else None,
+        parameters=[],
+        created=_NOW,
+        modified=_NOW,
+    )
+
+
+# ===========================================================================
+# functions list
+# ===========================================================================
+
+
+class TestFunctionsList:
+    def test_list_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.functions.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.functions.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.functions.list_functions",
+                new=AsyncMock(return_value=[_make_fn()]),
+            ),
+        ):
+            result = runner.invoke(cli, ["functions", "list", WS_GUID, WH_GUID])
+        assert result.exit_code == 0
+
+    def test_list_json_output(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.functions.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.functions.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.functions.list_functions",
+                new=AsyncMock(return_value=[_make_fn()]),
+            ),
+        ):
+            result = runner.invoke(cli, ["--json", "functions", "list", WS_GUID, WH_GUID])
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert isinstance(parsed, list)
+
+    def test_list_with_schema_filter(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        mock_list = AsyncMock(return_value=[_make_fn()])
+        with (
+            patch(
+                "fabric_dw.cli.commands.functions.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.functions.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch("fabric_dw.services.functions.list_functions", new=mock_list),
+        ):
+            result = runner.invoke(cli, ["functions", "list", WS_GUID, WH_GUID, "--schema", "dbo"])
+        assert result.exit_code == 0
+        mock_list.assert_awaited_once()
+
+    def test_list_with_kind_scalar(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        mock_list = AsyncMock(return_value=[_make_fn()])
+        with (
+            patch(
+                "fabric_dw.cli.commands.functions.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.functions.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch("fabric_dw.services.functions.list_functions", new=mock_list),
+        ):
+            result = runner.invoke(cli, ["functions", "list", WS_GUID, WH_GUID, "--kind", "scalar"])
+        assert result.exit_code == 0
+        _, kwargs = mock_list.call_args
+        assert kwargs.get("kind") == "scalar"
+
+    def test_list_not_found_returns_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.functions.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.functions.build_sql_target",
+                new=AsyncMock(side_effect=NotFoundError("not found")),
+            ),
+        ):
+            result = runner.invoke(cli, ["functions", "list", WS_GUID, WH_GUID])
+        assert result.exit_code != 0
+
+    def test_list_works_on_sql_endpoint(self, runner: CliRunner, cache_env: Path) -> None:
+        """list on a SQL Analytics Endpoint must succeed — no DW-only guard."""
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.functions.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.functions.build_sql_target",
+                new=AsyncMock(
+                    return_value=(
+                        _make_sql_target(),
+                        _make_item_entry(kind=WarehouseKind.SQL_ENDPOINT),
+                    )
+                ),
+            ),
+            patch(
+                "fabric_dw.services.functions.list_functions",
+                new=AsyncMock(return_value=[]),
+            ),
+        ):
+            result = runner.invoke(cli, ["functions", "list", WS_GUID, WH_GUID])
+        assert result.exit_code == 0
+
+
+# ===========================================================================
+# functions get
+# ===========================================================================
+
+
+class TestFunctionsGet:
+    def test_get_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.functions.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.functions.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.functions.get_function",
+                new=AsyncMock(return_value=_make_fn(with_definition=True)),
+            ),
+        ):
+            result = runner.invoke(cli, ["functions", "get", WS_GUID, WH_GUID, "dbo.fn_clean"])
+        assert result.exit_code == 0
+
+    def test_get_json_output(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.functions.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.functions.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.functions.get_function",
+                new=AsyncMock(return_value=_make_fn(with_definition=True)),
+            ),
+        ):
+            result = runner.invoke(
+                cli, ["--json", "functions", "get", WS_GUID, WH_GUID, "dbo.fn_clean"]
+            )
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["name"] == "fn_clean"
+        assert parsed["kind"] == "scalar"
+
+    def test_get_missing_dot_returns_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        result = runner.invoke(cli, ["functions", "get", WS_GUID, WH_GUID, "nodot"])
+        assert result.exit_code != 0
+
+
+# ===========================================================================
+# functions create
+# ===========================================================================
+
+
+class TestFunctionsCreate:
+    def test_create_with_inline_body(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        mock_create = AsyncMock(return_value=_make_fn(with_definition=True))
+        with (
+            patch(
+                "fabric_dw.cli.commands.functions.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.functions.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch("fabric_dw.services.functions.create_function", new=mock_create),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "functions",
+                    "create",
+                    WS_GUID,
+                    WH_GUID,
+                    "--name",
+                    "dbo.fn_clean",
+                    "--body",
+                    "(@x NVARCHAR(100)) RETURNS NVARCHAR(100) AS BEGIN RETURN @x END",
+                ],
+            )
+        assert result.exit_code == 0
+        mock_create.assert_awaited_once()
+
+    def test_create_with_from_file(
+        self, runner: CliRunner, cache_env: Path, tmp_path: Path
+    ) -> None:
+        _ = cache_env
+        sql_file = tmp_path / "fn.sql"
+        sql_file.write_text("(@x INT) RETURNS INT AS BEGIN RETURN @x * 2 END")
+        mock_http = AsyncMock()
+        mock_create = AsyncMock(return_value=_make_fn(with_definition=True))
+        with (
+            patch(
+                "fabric_dw.cli.commands.functions.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.functions.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch("fabric_dw.services.functions.create_function", new=mock_create),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "functions",
+                    "create",
+                    WS_GUID,
+                    WH_GUID,
+                    "--name",
+                    "dbo.fn_clean",
+                    "--from-file",
+                    str(sql_file),
+                ],
+            )
+        assert result.exit_code == 0
+        mock_create.assert_awaited_once()
+
+    def test_create_without_body_or_file_fails(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        result = runner.invoke(
+            cli,
+            ["functions", "create", WS_GUID, WH_GUID, "--name", "dbo.fn_clean"],
+        )
+        assert result.exit_code != 0
+
+    def test_create_json_output(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.functions.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.functions.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.functions.create_function",
+                new=AsyncMock(return_value=_make_fn(with_definition=True)),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--json",
+                    "functions",
+                    "create",
+                    WS_GUID,
+                    WH_GUID,
+                    "--name",
+                    "dbo.fn_clean",
+                    "--body",
+                    "(@x INT) RETURNS INT AS BEGIN RETURN @x END",
+                ],
+            )
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["name"] == "fn_clean"
+
+    def test_create_works_on_sql_endpoint(self, runner: CliRunner, cache_env: Path) -> None:
+        """create on a SQL Analytics Endpoint must succeed — no endpoint guard."""
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.functions.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.functions.build_sql_target",
+                new=AsyncMock(
+                    return_value=(
+                        _make_sql_target(),
+                        _make_item_entry(kind=WarehouseKind.SQL_ENDPOINT),
+                    )
+                ),
+            ),
+            patch(
+                "fabric_dw.services.functions.create_function",
+                new=AsyncMock(return_value=_make_fn(with_definition=True)),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "functions",
+                    "create",
+                    WS_GUID,
+                    WH_GUID,
+                    "--name",
+                    "dbo.fn_clean",
+                    "--body",
+                    "...",
+                ],
+            )
+        assert result.exit_code == 0
+
+
+# ===========================================================================
+# functions update
+# ===========================================================================
+
+
+class TestFunctionsUpdate:
+    def test_update_with_yes_flag(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        mock_update = AsyncMock(return_value=_make_fn(with_definition=True))
+        with (
+            patch(
+                "fabric_dw.cli.commands.functions.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.functions.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch("fabric_dw.services.functions.update_function", new=mock_update),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--yes",
+                    "functions",
+                    "update",
+                    WS_GUID,
+                    WH_GUID,
+                    "dbo.fn_clean",
+                    "--body",
+                    "(@x INT) RETURNS INT AS BEGIN RETURN @x * 2 END",
+                ],
+            )
+        assert result.exit_code == 0
+        mock_update.assert_awaited_once()
+
+    def test_update_aborted_without_yes(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.functions.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.functions.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch("fabric_dw.services.functions.update_function", new=AsyncMock()),
+        ):
+            # Decline the prompt
+            result = runner.invoke(
+                cli,
+                [
+                    "functions",
+                    "update",
+                    WS_GUID,
+                    WH_GUID,
+                    "dbo.fn_clean",
+                    "--body",
+                    "...",
+                ],
+                input="n\n",
+            )
+        assert result.exit_code == 0
+        assert "Aborted" in result.output
+
+    def test_update_permission_denied(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.functions.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.functions.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.functions.update_function",
+                new=AsyncMock(side_effect=PermissionDeniedError("permission denied")),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--yes",
+                    "functions",
+                    "update",
+                    WS_GUID,
+                    WH_GUID,
+                    "dbo.fn_clean",
+                    "--body",
+                    "...",
+                ],
+            )
+        assert result.exit_code != 0
+
+
+# ===========================================================================
+# functions drop
+# ===========================================================================
+
+
+class TestFunctionsDrop:
+    def test_drop_with_yes_flag(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        mock_drop = AsyncMock(return_value=None)
+        with (
+            patch(
+                "fabric_dw.cli.commands.functions.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.functions.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch("fabric_dw.services.functions.drop_function", new=mock_drop),
+        ):
+            result = runner.invoke(
+                cli, ["--yes", "functions", "drop", WS_GUID, WH_GUID, "dbo.fn_clean"]
+            )
+        assert result.exit_code == 0
+        mock_drop.assert_awaited_once()
+
+    def test_drop_json_output(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.functions.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.functions.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.functions.drop_function",
+                new=AsyncMock(return_value=None),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                ["--json", "--yes", "functions", "drop", WS_GUID, WH_GUID, "dbo.fn_clean"],
+            )
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["status"] == "dropped"
+
+    def test_drop_aborted_without_yes(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.functions.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.functions.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch("fabric_dw.services.functions.drop_function", new=AsyncMock()),
+        ):
+            result = runner.invoke(
+                cli,
+                ["functions", "drop", WS_GUID, WH_GUID, "dbo.fn_clean"],
+                input="n\n",
+            )
+        assert result.exit_code == 0
+        assert "Aborted" in result.output
+
+    def test_drop_with_if_exists(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        mock_drop = AsyncMock(return_value=None)
+        with (
+            patch(
+                "fabric_dw.cli.commands.functions.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.functions.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch("fabric_dw.services.functions.drop_function", new=mock_drop),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--yes",
+                    "functions",
+                    "drop",
+                    WS_GUID,
+                    WH_GUID,
+                    "dbo.fn_clean",
+                    "--if-exists",
+                ],
+            )
+        assert result.exit_code == 0
+        _, kwargs = mock_drop.call_args
+        assert kwargs.get("if_exists") is True
+
+
+# ===========================================================================
+# functions rename
+# ===========================================================================
+
+
+class TestFunctionsRename:
+    def test_rename_with_yes_flag(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        mock_rename = AsyncMock(return_value=_make_fn())
+        with (
+            patch(
+                "fabric_dw.cli.commands.functions.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.functions.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch("fabric_dw.services.functions.rename_function", new=mock_rename),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--yes",
+                    "functions",
+                    "rename",
+                    WS_GUID,
+                    WH_GUID,
+                    "dbo.fn_clean",
+                    "--new-name",
+                    "fn_sanitize",
+                ],
+            )
+        assert result.exit_code == 0
+        mock_rename.assert_awaited_once()
+
+    def test_rename_passes_qualified_and_new_name(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        mock_rename = AsyncMock(return_value=_make_fn())
+        with (
+            patch(
+                "fabric_dw.cli.commands.functions.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.functions.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch("fabric_dw.services.functions.rename_function", new=mock_rename),
+        ):
+            runner.invoke(
+                cli,
+                [
+                    "--yes",
+                    "functions",
+                    "rename",
+                    WS_GUID,
+                    WH_GUID,
+                    "dbo.fn_clean",
+                    "--new-name",
+                    "fn_sanitize",
+                ],
+            )
+        args, _kwargs = mock_rename.call_args
+        # qualified_name is positional arg 1, new_name is positional arg 2
+        assert args[1] == "dbo.fn_clean"
+        assert args[2] == "fn_sanitize"
+
+    def test_rename_aborted_without_yes(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.functions.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.functions.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch("fabric_dw.services.functions.rename_function", new=AsyncMock()),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "functions",
+                    "rename",
+                    WS_GUID,
+                    WH_GUID,
+                    "dbo.fn_clean",
+                    "--new-name",
+                    "fn_sanitize",
+                ],
+                input="n\n",
+            )
+        assert result.exit_code == 0
+        assert "Aborted" in result.output
+
+    def test_rename_missing_new_name_fails(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        result = runner.invoke(
+            cli,
+            ["--yes", "functions", "rename", WS_GUID, WH_GUID, "dbo.fn_clean"],
+        )
+        assert result.exit_code != 0
+
+    def test_rename_json_output(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.functions.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.functions.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.functions.rename_function",
+                new=AsyncMock(return_value=_make_fn()),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--json",
+                    "--yes",
+                    "functions",
+                    "rename",
+                    WS_GUID,
+                    WH_GUID,
+                    "dbo.fn_clean",
+                    "--new-name",
+                    "fn_sanitize",
+                ],
+            )
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["name"] == "fn_clean"

--- a/tests/unit/mcp/test_contract.py
+++ b/tests/unit/mcp/test_contract.py
@@ -46,7 +46,7 @@ from tests.unit.mcp.conftest import WS_ID, WS_NAME, make_item_entry
 # Expected tool count (sync with test_server.EXPECTED_TOOL_NAMES)
 # ---------------------------------------------------------------------------
 
-_EXPECTED_TOOL_COUNT = 85  # 77 baseline + 5 statistics + 1 generate_dbt_profile + 3 create-from-schema + 6 functions
+_EXPECTED_TOOL_COUNT = 85  # 77 baseline + 5 statistics + 1 dbt + 3 table-create + 6 functions
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/mcp/test_contract.py
+++ b/tests/unit/mcp/test_contract.py
@@ -46,7 +46,7 @@ from tests.unit.mcp.conftest import WS_ID, WS_NAME, make_item_entry
 # Expected tool count (sync with test_server.EXPECTED_TOOL_NAMES)
 # ---------------------------------------------------------------------------
 
-_EXPECTED_TOOL_COUNT = 79  # +5 statistics tools, +1 generate_dbt_profile, +3 create-from-schema
+_EXPECTED_TOOL_COUNT = 85  # 77 baseline + 5 statistics + 1 generate_dbt_profile + 3 create-from-schema + 6 functions
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/mcp/test_server.py
+++ b/tests/unit/mcp/test_server.py
@@ -116,6 +116,13 @@ EXPECTED_TOOL_NAMES: frozenset[str] = frozenset(
         "create_procedure",
         "update_procedure",
         "drop_procedure",
+        # Functions
+        "list_functions",
+        "get_function",
+        "create_function",
+        "update_function",
+        "drop_function",
+        "rename_function",
         # Tables
         "list_tables",
         "read_table",

--- a/tests/unit/mcp/tools/test_functions.py
+++ b/tests/unit/mcp/tools/test_functions.py
@@ -503,3 +503,69 @@ async def test_rename_function_invalid_qualified_name_raises(ctx_patch) -> None:
                 "new_name": "fn_new",
             },
         )
+
+
+# ---------------------------------------------------------------------------
+# list_functions — invalid kind rejected before reaching service
+# ---------------------------------------------------------------------------
+
+
+async def test_list_functions_invalid_kind_raises_tool_error(mock_ctx, ctx_patch) -> None:
+    """list_functions raises a ToolError when kind is not a valid value.
+
+    The validation happens inside the tool (via validate_kind) before the
+    service is called — so no mock of list_functions is needed.
+    """
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+
+    with (
+        ctx_patch,
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "list_functions",
+            {"workspace": WS_NAME, "item": WH_NAME, "kind": "multistatement-tvf"},
+        )
+
+
+@pytest.mark.parametrize("bad_kind", ["", "SCALAR", "Scalar", "fn", "tvf", "unknown"])
+async def test_list_functions_various_invalid_kinds_raise(
+    bad_kind: str, mock_ctx, ctx_patch
+) -> None:
+    """list_functions rejects all non-canonical kind values."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+
+    with (
+        ctx_patch,
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "list_functions",
+            {"workspace": WS_NAME, "item": WH_NAME, "kind": bad_kind},
+        )
+
+
+@pytest.mark.parametrize("valid_kind", ["scalar", "inline-tvf", "all"])
+async def test_list_functions_valid_kinds_accepted(valid_kind: str, mock_ctx, ctx_patch) -> None:
+    """list_functions accepts all three valid kind values without error."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+
+    with (
+        ctx_patch,
+        patch("fabric_dw.services.functions.list_functions", new=AsyncMock(return_value=[])),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "list_functions",
+            {"workspace": WS_NAME, "item": WH_NAME, "kind": valid_kind},
+        )
+
+    assert result == []

--- a/tests/unit/mcp/tools/test_functions.py
+++ b/tests/unit/mcp/tools/test_functions.py
@@ -1,0 +1,505 @@
+"""Unit tests for the MCP functions tool wrappers.
+
+Target: src/fabric_dw/mcp/tools/functions.py
+Goal:   ≥90% branch coverage.
+
+Strategy
+--------
+- All calls routed via ``mcp._tool_manager.call_tool`` (same path FastMCP uses
+  at runtime) so the ``@mcp.tool`` decorator, Pydantic validation, and guards
+  are all exercised.
+- ``ServerContext`` injected by patching ``fabric_dw.mcp._context._SERVER_CTX``
+  with the shared ``mock_ctx`` fixture (defined in conftest).
+- Service layer and SQL layer are fully mocked — no real network or SQL.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from mcp.server.fastmcp.exceptions import ToolError
+
+from fabric_dw.exceptions import FabricError, NotFoundError
+from fabric_dw.models import FunctionDetails, FunctionKind
+from tests.unit.mcp.conftest import (
+    WH_NAME,
+    WS_ID,
+    WS_NAME,
+    make_item_entry,
+    make_sql_endpoint_entry,
+)
+
+# ---------------------------------------------------------------------------
+# Module-level import of the mcp server (registers all tools)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _import_server() -> None:
+    from fabric_dw.mcp.server import mcp  # noqa: F401, PLC0415
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_fn_details(*, schema: str = "dbo", name: str = "fn_clean") -> FunctionDetails:
+    now = datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC)
+    return FunctionDetails(
+        schema_name=schema,
+        name=name,
+        qualified_name=f"{schema}.{name}",
+        kind=FunctionKind.SCALAR,
+        is_inlineable=True,
+        definition="(@x NVARCHAR(100)) RETURNS NVARCHAR(100) AS BEGIN RETURN @x END",
+        parameters=[],
+        created=now,
+        modified=now,
+    )
+
+
+# ---------------------------------------------------------------------------
+# list_functions — happy path
+# ---------------------------------------------------------------------------
+
+
+async def test_list_functions_happy_path(mock_ctx, ctx_patch) -> None:
+    """list_functions resolves workspace + item, returns list of function dicts."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    fn = _make_fn_details()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+
+    with (
+        ctx_patch,
+        patch("fabric_dw.services.functions.list_functions", new=AsyncMock(return_value=[fn])),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "list_functions",
+            {"workspace": WS_NAME, "item": WH_NAME},
+        )
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0]["name"] == "fn_clean"
+    assert result[0]["schema_name"] == "dbo"
+    assert result[0]["qualified_name"] == "dbo.fn_clean"
+    assert result[0]["kind"] == "scalar"
+
+
+async def test_list_functions_with_schema_filter(mock_ctx, ctx_patch) -> None:
+    """list_functions passes schema parameter to the service layer."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    fn = _make_fn_details(schema="sales")
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+    mock_svc = AsyncMock(return_value=[fn])
+
+    with (
+        ctx_patch,
+        patch("fabric_dw.services.functions.list_functions", new=mock_svc),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "list_functions",
+            {"workspace": WS_NAME, "item": WH_NAME, "schema": "sales"},
+        )
+
+    assert isinstance(result, list)
+    _, kwargs = mock_svc.call_args
+    assert kwargs.get("schema") == "sales"
+
+
+async def test_list_functions_empty_result(mock_ctx, ctx_patch) -> None:
+    """list_functions returns an empty list when no functions exist."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+
+    with (
+        ctx_patch,
+        patch("fabric_dw.services.functions.list_functions", new=AsyncMock(return_value=[])),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "list_functions",
+            {"workspace": WS_NAME, "item": WH_NAME},
+        )
+
+    assert result == []
+
+
+async def test_list_functions_on_sql_endpoint(mock_ctx, ctx_patch) -> None:
+    """list_functions must work on SQL Analytics Endpoints — no endpoint guard."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_sql_endpoint_entry())
+
+    with (
+        ctx_patch,
+        patch("fabric_dw.services.functions.list_functions", new=AsyncMock(return_value=[])),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "list_functions",
+            {"workspace": WS_NAME, "item": WH_NAME},
+        )
+
+    assert result == []
+
+
+async def test_list_functions_fabric_error_raises(mock_ctx, ctx_patch) -> None:
+    """list_functions propagates FabricError as an MCP tool error."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.functions.list_functions",
+            new=AsyncMock(side_effect=FabricError("service error")),
+        ),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "list_functions",
+            {"workspace": WS_NAME, "item": WH_NAME},
+        )
+
+
+# ---------------------------------------------------------------------------
+# get_function — happy path
+# ---------------------------------------------------------------------------
+
+
+async def test_get_function_happy_path(mock_ctx, ctx_patch) -> None:
+    """get_function returns a function dict with definition and parameters."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    fn = _make_fn_details()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+
+    with (
+        ctx_patch,
+        patch("fabric_dw.services.functions.get_function", new=AsyncMock(return_value=fn)),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "get_function",
+            {"workspace": WS_NAME, "item": WH_NAME, "qualified_name": "dbo.fn_clean"},
+        )
+
+    assert isinstance(result, dict)
+    assert result["name"] == "fn_clean"
+    assert result["schema_name"] == "dbo"
+    assert result["kind"] == "scalar"
+    assert result["is_inlineable"] is True
+
+
+async def test_get_function_not_found_raises(mock_ctx, ctx_patch) -> None:
+    """get_function raises a tool error when the function does not exist."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.functions.get_function",
+            new=AsyncMock(side_effect=NotFoundError("not found")),
+        ),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "get_function",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_name": "dbo.nonexistent",
+            },
+        )
+
+
+async def test_get_function_invalid_qualified_name_raises(ctx_patch) -> None:
+    """get_function raises when qualified_name has no dot."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "get_function",
+            {"workspace": WS_NAME, "item": WH_NAME, "qualified_name": "nodot"},
+        )
+
+
+# ---------------------------------------------------------------------------
+# create_function — mutating tool
+# ---------------------------------------------------------------------------
+
+
+async def test_create_function_happy_path(mock_ctx, ctx_patch) -> None:
+    """create_function creates a function and returns its details dict."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    fn = _make_fn_details()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+
+    with (
+        ctx_patch,
+        patch("fabric_dw.services.functions.create_function", new=AsyncMock(return_value=fn)),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "create_function",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_name": "dbo.fn_clean",
+                "body": "(@x NVARCHAR(100)) RETURNS NVARCHAR(100) AS BEGIN RETURN @x END",
+            },
+        )
+
+    assert isinstance(result, dict)
+    assert result["name"] == "fn_clean"
+
+
+async def test_create_function_on_sql_endpoint_succeeds(mock_ctx, ctx_patch) -> None:
+    """create_function on a SQL Analytics Endpoint must succeed — no endpoint guard."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    fn = _make_fn_details()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_sql_endpoint_entry())
+
+    with (
+        ctx_patch,
+        patch("fabric_dw.services.functions.create_function", new=AsyncMock(return_value=fn)),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "create_function",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_name": "dbo.fn_clean",
+                "body": "(@x INT) RETURNS INT AS BEGIN RETURN @x END",
+            },
+        )
+
+    assert isinstance(result, dict)
+
+
+async def test_create_function_clears_negative_cache(mock_ctx, ctx_patch) -> None:
+    """create_function calls clear_negative_cache after creation."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    fn = _make_fn_details()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+
+    with (
+        ctx_patch,
+        patch("fabric_dw.services.functions.create_function", new=AsyncMock(return_value=fn)),
+    ):
+        await mcp._tool_manager.call_tool(
+            "create_function",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_name": "dbo.fn_clean",
+                "body": "...",
+            },
+        )
+
+    mock_ctx.resolver.clear_negative_cache.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# update_function — mutating tool
+# ---------------------------------------------------------------------------
+
+
+async def test_update_function_happy_path(mock_ctx, ctx_patch) -> None:
+    """update_function returns updated function details dict."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    fn = _make_fn_details()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+
+    with (
+        ctx_patch,
+        patch("fabric_dw.services.functions.update_function", new=AsyncMock(return_value=fn)),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "update_function",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_name": "dbo.fn_clean",
+                "body": "(@x NVARCHAR(100)) RETURNS NVARCHAR(100) AS BEGIN RETURN UPPER(@x) END",
+            },
+        )
+
+    assert isinstance(result, dict)
+    assert result["name"] == "fn_clean"
+
+
+# ---------------------------------------------------------------------------
+# drop_function — destructive mutating tool
+# ---------------------------------------------------------------------------
+
+
+async def test_drop_function_happy_path(mock_ctx, ctx_patch) -> None:
+    """drop_function returns {\"dropped\": True}.
+
+    Requires FABRIC_MCP_ALLOW_DESTRUCTIVE=1 because drop_function is a destructive operation.
+    """
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_ALLOW_DESTRUCTIVE": "1"}),
+        patch("fabric_dw.services.functions.drop_function", new=AsyncMock(return_value=None)),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "drop_function",
+            {"workspace": WS_NAME, "item": WH_NAME, "qualified_name": "dbo.fn_clean"},
+        )
+
+    assert result == {"dropped": True}
+
+
+async def test_drop_function_not_found_raises(mock_ctx, ctx_patch) -> None:
+    """drop_function propagates NotFoundError."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_ALLOW_DESTRUCTIVE": "1"}),
+        patch(
+            "fabric_dw.services.functions.drop_function",
+            new=AsyncMock(side_effect=NotFoundError("not found")),
+        ),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "drop_function",
+            {"workspace": WS_NAME, "item": WH_NAME, "qualified_name": "dbo.nonexistent"},
+        )
+
+
+# ---------------------------------------------------------------------------
+# rename_function — mutating tool
+# ---------------------------------------------------------------------------
+
+
+async def test_rename_function_happy_path(mock_ctx, ctx_patch) -> None:
+    """rename_function returns updated function details dict with the new name."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    fn = _make_fn_details(name="fn_sanitize")
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+
+    with (
+        ctx_patch,
+        patch("fabric_dw.services.functions.rename_function", new=AsyncMock(return_value=fn)),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "rename_function",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_name": "dbo.fn_clean",
+                "new_name": "fn_sanitize",
+            },
+        )
+
+    assert isinstance(result, dict)
+    assert result["name"] == "fn_sanitize"
+
+
+async def test_rename_function_not_found_raises(mock_ctx, ctx_patch) -> None:
+    """rename_function raises a tool error when the function does not exist."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.functions.rename_function",
+            new=AsyncMock(side_effect=NotFoundError("not found after rename")),
+        ),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "rename_function",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_name": "dbo.fn_nonexistent",
+                "new_name": "fn_whatever",
+            },
+        )
+
+
+async def test_rename_function_clears_negative_cache(mock_ctx, ctx_patch) -> None:
+    """rename_function calls clear_negative_cache after rename."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    fn = _make_fn_details(name="fn_sanitize")
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+
+    with (
+        ctx_patch,
+        patch("fabric_dw.services.functions.rename_function", new=AsyncMock(return_value=fn)),
+    ):
+        await mcp._tool_manager.call_tool(
+            "rename_function",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_name": "dbo.fn_clean",
+                "new_name": "fn_sanitize",
+            },
+        )
+
+    mock_ctx.resolver.clear_negative_cache.assert_called_once()
+
+
+async def test_rename_function_invalid_qualified_name_raises(ctx_patch) -> None:
+    """rename_function raises when qualified_name has no dot."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "rename_function",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_name": "nodot",
+                "new_name": "fn_new",
+            },
+        )

--- a/tests/unit/services/test_functions.py
+++ b/tests/unit/services/test_functions.py
@@ -10,7 +10,7 @@ import pytest
 from fabric_dw.exceptions import AuthError, NotFoundError, PermissionDeniedError
 from fabric_dw.models import Function, FunctionDetails, FunctionKind, FunctionParameter
 from fabric_dw.services import functions
-from fabric_dw.services.functions import validate_identifier
+from fabric_dw.services.functions import validate_identifier, validate_kind
 from tests.unit.services._helpers import _make_conn, _make_conn_for_ddl, _make_target
 
 # ---------------------------------------------------------------------------
@@ -747,3 +747,35 @@ class TestRenameFunction:
             await functions.rename_function(target, "dbo.fn_clean", "fn_sanitize")
 
         ddl_conn.commit.assert_called_once()
+
+
+# ===========================================================================
+# validate_kind
+# ===========================================================================
+
+
+class TestValidateKind:
+    @pytest.mark.parametrize("kind", ["scalar", "inline-tvf", "all"])
+    def test_valid_kinds_returned_unchanged(self, kind: str) -> None:
+        assert validate_kind(kind) == kind
+
+    @pytest.mark.parametrize(
+        "bad_kind",
+        ["", "SCALAR", "Scalar", "fn", "tvf", "all-types", "multistatement-tvf", "unknown"],
+    )
+    def test_invalid_kind_raises_value_error(self, bad_kind: str) -> None:
+        with pytest.raises(ValueError, match="Invalid kind"):
+            validate_kind(bad_kind)
+
+    def test_error_message_lists_valid_choices(self) -> None:
+        with pytest.raises(ValueError, match="scalar"):
+            validate_kind("nope")
+
+    @pytest.mark.parametrize("kind", ["scalar", "inline-tvf", "all"])
+    async def test_list_functions_accepts_valid_kind(self, kind: str) -> None:
+        """list_functions does not raise for any of the three valid kinds."""
+        target = _make_target()
+        conn = _make_conn([], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            result = await functions.list_functions(target, kind=validate_kind(kind))
+        assert isinstance(result, list)

--- a/tests/unit/services/test_functions.py
+++ b/tests/unit/services/test_functions.py
@@ -1,0 +1,749 @@
+"""Tests for services.functions — DMV-mock tests + identifier-validator tests (TDD)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fabric_dw.exceptions import AuthError, NotFoundError, PermissionDeniedError
+from fabric_dw.models import Function, FunctionDetails, FunctionKind, FunctionParameter
+from fabric_dw.services import functions
+from fabric_dw.services.functions import validate_identifier
+from tests.unit.services._helpers import _make_conn, _make_conn_for_ddl, _make_target
+
+# ---------------------------------------------------------------------------
+# Fixture data
+# ---------------------------------------------------------------------------
+
+_NOW = datetime(2024, 6, 1, 12, 0, 0, tzinfo=UTC)
+_LATER = datetime(2024, 6, 2, 8, 30, 0, tzinfo=UTC)
+
+_LIST_COLS = ["schema_name", "name", "type", "type_desc", "created", "modified", "is_inlineable"]
+_GET_COLS = [
+    "schema_name",
+    "name",
+    "type",
+    "type_desc",
+    "created",
+    "modified",
+    "definition",
+    "is_inlineable",
+]
+_PARAM_COLS = ["parameter_id", "name", "data_type", "max_length", "is_output"]
+
+# FN = scalar, IF = inline TVF, TF = mstvf
+_FN_ROW_1 = ("dbo", "fn_clean", "FN", "SQL_SCALAR_FUNCTION", _NOW, _LATER, 1)
+_FN_ROW_2 = ("finance", "fn_calc_tax", "FN", "SQL_SCALAR_FUNCTION", _NOW, _NOW, 0)
+_IF_ROW = ("dbo", "fn_get_orders", "IF", "SQL_INLINE_TABLE_VALUED_FUNCTION", _NOW, _LATER, 1)
+_TF_ROW = ("dbo", "fn_complex", "TF", "SQL_TABLE_VALUED_FUNCTION", _NOW, _NOW, None)
+
+_GET_ROW_FN = (
+    "dbo",
+    "fn_clean",
+    "FN",
+    "SQL_SCALAR_FUNCTION",
+    _NOW,
+    _LATER,
+    "(@input NVARCHAR(100)) RETURNS NVARCHAR(100) AS BEGIN RETURN LTRIM(RTRIM(@input)) END",
+    1,
+)
+_GET_ROW_IF = (
+    "dbo",
+    "fn_get_orders",
+    "IF",
+    "SQL_INLINE_TABLE_VALUED_FUNCTION",
+    _NOW,
+    _LATER,
+    "(@cust_id INT) RETURNS TABLE AS RETURN (SELECT * FROM dbo.orders WHERE customer_id = @cust_id)",  # noqa: E501
+    1,
+)
+
+_PARAM_RETURN = (0, "", "nvarchar", 200, False)
+_PARAM_INPUT = (1, "@input", "nvarchar", 200, False)
+
+
+# ===========================================================================
+# identifier validator re-export
+# ===========================================================================
+
+
+class TestValidateIdentifier:
+    def test_simple_valid_identifier(self) -> None:
+        assert validate_identifier("fn_clean") == "fn_clean"
+
+    def test_rejects_semicolon(self) -> None:
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            validate_identifier("fn;injection")
+
+    def test_rejects_bracket(self) -> None:
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            validate_identifier("fn]name")
+
+    def test_rejects_dash_dash(self) -> None:
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            validate_identifier("fn--injection")
+
+    def test_rejects_injection_in_schema(self) -> None:
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            validate_identifier("x]; DROP TABLE users--")
+
+    def test_rejects_injection_in_name(self) -> None:
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            validate_identifier("fn_ok] WITH EXECUTE AS OWNER--")
+
+
+# ===========================================================================
+# _row_to_function — kind parsing
+# ===========================================================================
+
+
+class TestRowToFunction:
+    def test_fn_mapped_to_scalar(self) -> None:
+        result = functions._row_to_function(_LIST_COLS, _FN_ROW_1)
+        assert result.kind == FunctionKind.SCALAR
+
+    def test_if_mapped_to_inline_tvf(self) -> None:
+        result = functions._row_to_function(_LIST_COLS, _IF_ROW)
+        assert result.kind == FunctionKind.INLINE_TVF
+
+    def test_tf_mapped_to_mstvf(self) -> None:
+        result = functions._row_to_function(_LIST_COLS, _TF_ROW)
+        assert result.kind == FunctionKind.MSTVF
+
+    def test_is_inlineable_true(self) -> None:
+        result = functions._row_to_function(_LIST_COLS, _FN_ROW_1)
+        assert result.is_inlineable is True
+
+    def test_is_inlineable_false(self) -> None:
+        result = functions._row_to_function(_LIST_COLS, _FN_ROW_2)
+        assert result.is_inlineable is False
+
+    def test_is_inlineable_none_for_tf(self) -> None:
+        result = functions._row_to_function(_LIST_COLS, _TF_ROW)
+        assert result.is_inlineable is None
+
+    def test_qualified_name_built(self) -> None:
+        result = functions._row_to_function(_LIST_COLS, _FN_ROW_1)
+        assert result.qualified_name == "dbo.fn_clean"
+
+    def test_dates_set(self) -> None:
+        result = functions._row_to_function(_LIST_COLS, _FN_ROW_1)
+        assert result.created == _NOW
+        assert result.modified == _LATER
+
+
+# ===========================================================================
+# list_functions
+# ===========================================================================
+
+
+class TestListFunctions:
+    async def test_returns_empty_when_no_rows(self) -> None:
+        target = _make_target()
+        conn = _make_conn([], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            result = await functions.list_functions(target)
+        assert result == []
+
+    async def test_returns_function_instances(self) -> None:
+        target = _make_target()
+        conn = _make_conn([_FN_ROW_1], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            result = await functions.list_functions(target)
+        assert len(result) == 1
+        assert isinstance(result[0], Function)
+
+    async def test_parses_fields_correctly(self) -> None:
+        target = _make_target()
+        conn = _make_conn([_FN_ROW_1], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            result = await functions.list_functions(target)
+        f = result[0]
+        assert f.schema_name == "dbo"
+        assert f.name == "fn_clean"
+        assert f.qualified_name == "dbo.fn_clean"
+        assert f.kind == FunctionKind.SCALAR
+        assert f.is_inlineable is True
+        assert f.created == _NOW
+        assert f.modified == _LATER
+
+    async def test_returns_all_rows(self) -> None:
+        target = _make_target()
+        conn = _make_conn([_FN_ROW_1, _FN_ROW_2, _IF_ROW], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            result = await functions.list_functions(target)
+        assert len(result) == 3
+
+    async def test_sql_references_sys_objects(self) -> None:
+        target = _make_target()
+        conn = _make_conn([], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await functions.list_functions(target)
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert "sys.objects" in call_sql
+
+    async def test_sql_references_sys_sql_modules(self) -> None:
+        target = _make_target()
+        conn = _make_conn([], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await functions.list_functions(target)
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert "sys.sql_modules" in call_sql
+
+    async def test_filters_by_schema_when_provided(self) -> None:
+        target = _make_target()
+        conn = _make_conn([_FN_ROW_1], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await functions.list_functions(target, schema="dbo")
+        cursor = conn.cursor.return_value
+        call_args = cursor.execute.call_args
+        call_sql: str = call_args[0][0]
+        assert "s.name = ?" in call_sql
+        params = call_args[0][1] if len(call_args[0]) > 1 else []
+        assert "dbo" in list(params)
+
+    async def test_schema_filter_validates_identifier(self) -> None:
+        target = _make_target()
+        conn = _make_conn([], _LIST_COLS)
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(ValueError, match="Invalid SQL identifier"),
+        ):
+            await functions.list_functions(target, schema="bad]schema")
+
+    async def test_kind_scalar_filters_fn(self) -> None:
+        target = _make_target()
+        conn = _make_conn([], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await functions.list_functions(target, kind="scalar")
+        cursor = conn.cursor.return_value
+        call_args = cursor.execute.call_args
+        call_sql: str = call_args[0][0]
+        assert "o.type = ?" in call_sql
+        params = list(call_args[0][1]) if len(call_args[0]) > 1 else []
+        assert "FN" in params
+
+    async def test_kind_inline_tvf_filters_if(self) -> None:
+        target = _make_target()
+        conn = _make_conn([], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await functions.list_functions(target, kind="inline-tvf")
+        cursor = conn.cursor.return_value
+        call_args = cursor.execute.call_args
+        call_sql: str = call_args[0][0]
+        assert "o.type = ?" in call_sql
+        params = list(call_args[0][1]) if len(call_args[0]) > 1 else []
+        assert "IF" in params
+
+    async def test_kind_all_includes_fn_if_tf(self) -> None:
+        target = _make_target()
+        conn = _make_conn([], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await functions.list_functions(target, kind="all")
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert "IN ('FN', 'IF', 'TF')" in call_sql
+
+    async def test_no_endpoint_guard_raises(self) -> None:
+        """list_functions must NOT raise for SQL Analytics Endpoint targets."""
+        from fabric_dw.sql import SqlTarget  # noqa: PLC0415
+
+        endpoint_target = SqlTarget(
+            workspace_id="a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            database="MyLakehouse",
+            connection_string="ep.datawarehouse.fabric.microsoft.com",
+        )
+        conn = _make_conn([], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            result = await functions.list_functions(endpoint_target)
+        assert isinstance(result, list)
+
+    async def test_closes_connection_after_success(self) -> None:
+        target = _make_target()
+        conn = _make_conn([_FN_ROW_1], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await functions.list_functions(target)
+        conn.close.assert_called_once()
+
+    async def test_maps_permission_denied(self) -> None:
+        target = _make_target()
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.execute.side_effect = Exception("permission was denied on object sys.objects")
+        conn.cursor.return_value = cursor
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(PermissionDeniedError),
+        ):
+            await functions.list_functions(target)
+
+    async def test_maps_auth_error(self) -> None:
+        target = _make_target()
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.execute.side_effect = Exception("Authentication failed for user ''")
+        conn.cursor.return_value = cursor
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(AuthError),
+        ):
+            await functions.list_functions(target)
+
+
+# ===========================================================================
+# get_function
+# ===========================================================================
+
+
+class TestGetFunction:
+    async def test_returns_function_details_with_definition(self) -> None:
+        target = _make_target()
+        conn_fn = _make_conn([_GET_ROW_FN], _GET_COLS)
+        conn_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[conn_fn, conn_params]):
+            result = await functions.get_function(target, "dbo", "fn_clean")
+        assert isinstance(result, FunctionDetails)
+        assert result.definition is not None
+        assert "LTRIM" in result.definition
+
+    async def test_parses_all_fields(self) -> None:
+        target = _make_target()
+        conn_fn = _make_conn([_GET_ROW_FN], _GET_COLS)
+        conn_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[conn_fn, conn_params]):
+            result = await functions.get_function(target, "dbo", "fn_clean")
+        assert result.schema_name == "dbo"
+        assert result.name == "fn_clean"
+        assert result.qualified_name == "dbo.fn_clean"
+        assert result.kind == FunctionKind.SCALAR
+        assert result.is_inlineable is True
+        assert result.created == _NOW
+        assert result.modified == _LATER
+
+    async def test_parses_parameters(self) -> None:
+        target = _make_target()
+        conn_fn = _make_conn([_GET_ROW_FN], _GET_COLS)
+        conn_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[conn_fn, conn_params]):
+            result = await functions.get_function(target, "dbo", "fn_clean")
+        assert len(result.parameters) == 2
+        assert isinstance(result.parameters[0], FunctionParameter)
+        assert result.parameters[0].parameter_id == 0  # return value
+        assert result.parameters[1].parameter_id == 1
+        assert result.parameters[1].name == "@input"
+
+    async def test_raises_not_found_when_no_rows(self) -> None:
+        target = _make_target()
+        conn = _make_conn([], _GET_COLS)
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(NotFoundError),
+        ):
+            await functions.get_function(target, "dbo", "nonexistent")
+
+    async def test_validates_schema_identifier(self) -> None:
+        target = _make_target()
+        conn = _make_conn([], _GET_COLS)
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(ValueError, match="Invalid SQL identifier"),
+        ):
+            await functions.get_function(target, "bad;schema", "fn_clean")
+
+    async def test_validates_function_name_identifier(self) -> None:
+        target = _make_target()
+        conn = _make_conn([], _GET_COLS)
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(ValueError, match="Invalid SQL identifier"),
+        ):
+            await functions.get_function(target, "dbo", "fn--injection")
+
+    async def test_sql_references_sys_sql_modules(self) -> None:
+        target = _make_target()
+        conn_fn = _make_conn([_GET_ROW_FN], _GET_COLS)
+        conn_params = _make_conn([], _PARAM_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[conn_fn, conn_params]):
+            await functions.get_function(target, "dbo", "fn_clean")
+        cursor = conn_fn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert "sys.sql_modules" in call_sql
+
+    async def test_if_function_kind(self) -> None:
+        target = _make_target()
+        conn_fn = _make_conn([_GET_ROW_IF], _GET_COLS)
+        conn_params = _make_conn([], _PARAM_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[conn_fn, conn_params]):
+            result = await functions.get_function(target, "dbo", "fn_get_orders")
+        assert result.kind == FunctionKind.INLINE_TVF
+
+    async def test_maps_permission_denied(self) -> None:
+        target = _make_target()
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.execute.side_effect = Exception("permission was denied on sys.sql_modules")
+        conn.cursor.return_value = cursor
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(PermissionDeniedError),
+        ):
+            await functions.get_function(target, "dbo", "fn_clean")
+
+
+# ===========================================================================
+# create_function
+# ===========================================================================
+
+
+class TestCreateFunction:
+    async def test_emits_create_function_ddl(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        conn_fn = _make_conn([_GET_ROW_FN], _GET_COLS)
+        conn_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
+
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, conn_fn, conn_params]):
+            await functions.create_function(
+                target,
+                "dbo",
+                "fn_clean",
+                "(@x NVARCHAR(100)) RETURNS NVARCHAR(100) AS BEGIN RETURN @x END",
+            )
+
+        cursor = ddl_conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert "CREATE FUNCTION" in call_sql.upper()
+        assert "[dbo]" in call_sql
+        assert "[fn_clean]" in call_sql
+
+    async def test_includes_body(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        conn_fn = _make_conn([_GET_ROW_FN], _GET_COLS)
+        conn_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
+        body = "(@x NVARCHAR(100)) RETURNS NVARCHAR(100) AS BEGIN RETURN @x END"
+
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, conn_fn, conn_params]):
+            await functions.create_function(target, "dbo", "fn_clean", body)
+
+        cursor = ddl_conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert body in call_sql
+
+    async def test_returns_function_details(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        conn_fn = _make_conn([_GET_ROW_FN], _GET_COLS)
+        conn_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
+
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, conn_fn, conn_params]):
+            result = await functions.create_function(
+                target,
+                "dbo",
+                "fn_clean",
+                "(@x NVARCHAR(100)) RETURNS NVARCHAR(100) AS BEGIN RETURN @x END",
+            )
+
+        assert isinstance(result, FunctionDetails)
+        assert result.schema_name == "dbo"
+        assert result.name == "fn_clean"
+
+    async def test_validates_schema_identifier(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await functions.create_function(target, "bad]schema", "fn_clean", "...")
+
+    async def test_validates_function_name_identifier(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await functions.create_function(target, "dbo", "fn;drop", "...")
+
+    async def test_rejects_injection_via_schema(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await functions.create_function(target, "x]; DROP TABLE users--", "fn_ok", "...")
+
+    async def test_rejects_injection_via_name(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await functions.create_function(target, "dbo", "fn_ok] WITH EXECUTE AS OWNER--", "...")
+
+    async def test_commits_after_execute(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        conn_fn = _make_conn([_GET_ROW_FN], _GET_COLS)
+        conn_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
+
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, conn_fn, conn_params]):
+            await functions.create_function(target, "dbo", "fn_clean", "...")
+
+        ddl_conn.commit.assert_called_once()
+
+    async def test_maps_permission_denied(self) -> None:
+        target = _make_target()
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.execute.side_effect = Exception("permission was denied on database")
+        conn.cursor.return_value = cursor
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(PermissionDeniedError),
+        ):
+            await functions.create_function(target, "dbo", "fn_clean", "...")
+
+
+# ===========================================================================
+# update_function
+# ===========================================================================
+
+
+class TestUpdateFunction:
+    async def test_emits_create_or_alter_function_ddl(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        conn_fn = _make_conn([_GET_ROW_FN], _GET_COLS)
+        conn_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
+
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, conn_fn, conn_params]):
+            await functions.update_function(target, "dbo", "fn_clean", "...")
+
+        cursor = ddl_conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0].upper()
+        assert "CREATE OR ALTER FUNCTION" in call_sql
+
+    async def test_uses_brackets_for_schema_and_name(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        conn_fn = _make_conn([_GET_ROW_FN], _GET_COLS)
+        conn_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
+
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, conn_fn, conn_params]):
+            await functions.update_function(target, "dbo", "fn_clean", "...")
+
+        cursor = ddl_conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert "[dbo]" in call_sql
+        assert "[fn_clean]" in call_sql
+
+    async def test_returns_function_details(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        conn_fn = _make_conn([_GET_ROW_FN], _GET_COLS)
+        conn_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
+
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, conn_fn, conn_params]):
+            result = await functions.update_function(target, "dbo", "fn_clean", "...")
+
+        assert isinstance(result, FunctionDetails)
+
+    async def test_validates_schema_identifier(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await functions.update_function(target, "bad--schema", "fn_clean", "...")
+
+    async def test_validates_function_name_identifier(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await functions.update_function(target, "dbo", "fn;injection", "...")
+
+    async def test_commits_after_execute(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        conn_fn = _make_conn([_GET_ROW_FN], _GET_COLS)
+        conn_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
+
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, conn_fn, conn_params]):
+            await functions.update_function(target, "dbo", "fn_clean", "...")
+
+        ddl_conn.commit.assert_called_once()
+
+
+# ===========================================================================
+# drop_function
+# ===========================================================================
+
+
+class TestDropFunction:
+    async def test_emits_drop_function_ddl(self) -> None:
+        target = _make_target()
+        conn = _make_conn_for_ddl()
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await functions.drop_function(target, "dbo", "fn_clean")
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0].upper()
+        assert "DROP FUNCTION" in call_sql
+
+    async def test_uses_brackets_for_schema_and_name(self) -> None:
+        target = _make_target()
+        conn = _make_conn_for_ddl()
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await functions.drop_function(target, "dbo", "fn_clean")
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert "[dbo]" in call_sql
+        assert "[fn_clean]" in call_sql
+
+    async def test_if_exists_adds_if_exists_clause(self) -> None:
+        target = _make_target()
+        conn = _make_conn_for_ddl()
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await functions.drop_function(target, "dbo", "fn_clean", if_exists=True)
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0].upper()
+        assert "DROP FUNCTION IF EXISTS" in call_sql
+
+    async def test_commits_after_execute(self) -> None:
+        target = _make_target()
+        conn = _make_conn_for_ddl()
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await functions.drop_function(target, "dbo", "fn_clean")
+        conn.commit.assert_called_once()
+
+    async def test_closes_connection_after_success(self) -> None:
+        target = _make_target()
+        conn = _make_conn_for_ddl()
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await functions.drop_function(target, "dbo", "fn_clean")
+        conn.close.assert_called_once()
+
+    async def test_validates_schema_identifier(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await functions.drop_function(target, "bad]schema", "fn_clean")
+
+    async def test_validates_function_name_identifier(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await functions.drop_function(target, "dbo", "fn--bad")
+
+    async def test_rejects_injection_in_schema(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await functions.drop_function(target, "x]; DROP TABLE users--", "fn_ok")
+
+    async def test_rejects_injection_in_name(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await functions.drop_function(target, "dbo", "fn_ok] WHERE 1=1--")
+
+    async def test_maps_permission_denied(self) -> None:
+        target = _make_target()
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.execute.side_effect = Exception("permission was denied to drop function")
+        conn.cursor.return_value = cursor
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(PermissionDeniedError),
+        ):
+            await functions.drop_function(target, "dbo", "fn_clean")
+
+    async def test_unrelated_error_propagates(self) -> None:
+        target = _make_target()
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.execute.side_effect = RuntimeError("connection reset")
+        conn.cursor.return_value = cursor
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(RuntimeError, match="connection reset"),
+        ):
+            await functions.drop_function(target, "dbo", "fn_clean")
+
+
+# ===========================================================================
+# rename_function
+# ===========================================================================
+
+
+class TestRenameFunction:
+    async def test_emits_sp_rename_ddl(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        conn_fn = _make_conn([_GET_ROW_FN], _GET_COLS)
+        conn_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
+
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, conn_fn, conn_params]):
+            await functions.rename_function(target, "dbo.fn_clean", "fn_sanitize")
+
+        cursor = ddl_conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0].upper()
+        assert "SP_RENAME" in call_sql
+
+    async def test_passes_old_and_new_name_as_params(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        conn_fn = _make_conn([_GET_ROW_FN], _GET_COLS)
+        conn_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
+
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, conn_fn, conn_params]):
+            await functions.rename_function(target, "dbo.fn_clean", "fn_sanitize")
+
+        cursor = ddl_conn.cursor.return_value
+        call_args = cursor.execute.call_args
+        params = list(call_args[0][1]) if len(call_args[0]) > 1 else []
+        assert "dbo.fn_clean" in params
+        assert "fn_sanitize" in params
+
+    async def test_returns_function_details_with_new_name(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        # get_function is called with new name — mock it returning fn_clean details
+        conn_fn = _make_conn([_GET_ROW_FN], _GET_COLS)
+        conn_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
+
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, conn_fn, conn_params]):
+            result = await functions.rename_function(target, "dbo.fn_clean", "fn_sanitize")
+
+        assert isinstance(result, FunctionDetails)
+
+    async def test_rejects_schema_qualified_new_name(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="must not be schema-qualified"):
+            await functions.rename_function(target, "dbo.fn_clean", "other.fn_sanitize")
+
+    async def test_validates_schema_in_qualified_name(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await functions.rename_function(target, "bad;schema.fn_clean", "fn_sanitize")
+
+    async def test_validates_old_function_name(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await functions.rename_function(target, "dbo.fn--bad", "fn_sanitize")
+
+    async def test_validates_new_name_identifier(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await functions.rename_function(target, "dbo.fn_clean", "fn_bad]name")
+
+    async def test_rejects_injection_in_new_name(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await functions.rename_function(target, "dbo.fn_clean", "fn_ok] WHERE 1=1--")
+
+    async def test_raises_not_found_when_post_rename_get_fails(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        empty_conn = _make_conn([], _GET_COLS)
+
+        with (
+            patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, empty_conn]),
+            pytest.raises(NotFoundError, match="not found after rename"),
+        ):
+            await functions.rename_function(target, "dbo.fn_clean", "fn_sanitize")
+
+    async def test_commits_after_execute(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        conn_fn = _make_conn([_GET_ROW_FN], _GET_COLS)
+        conn_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
+
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, conn_fn, conn_params]):
+            await functions.rename_function(target, "dbo.fn_clean", "fn_sanitize")
+
+        ddl_conn.commit.assert_called_once()


### PR DESCRIPTION
## Summary

- Adds a `functions` surface for managing T-SQL scalar UDFs (`FN`) and inline TVFs (`IF`) on Fabric Data Warehouses and SQL Analytics Endpoints, mirroring the existing `procedures` surface.
- Implements all six operations: `list`, `get`, `create`, `update`, `drop`, and `rename` (via `sp_rename`).
- **No SQL Analytics Endpoint guard** — function DDL is supported on both item types (`CREATE/ALTER/DROP FUNCTION` applies to both in the Fabric docs), unlike `tables`/`statistics`.
- `rename` uses `EXEC sp_rename ?, ?, 'OBJECT'` with bound `?` parameters (not SQL identifiers), matching the sp_rename string-argument contract.
- Identifier safety: schema/function names pass through `validate_identifier` + `quote_identifier`; the function body is caller-owned free-form SQL (same trust model as `procedures`).
- Preview note: scalar UDFs and inline TVFs are preview features on Microsoft Fabric DW as of mid-2026.

## New files

- `src/fabric_dw/services/functions.py` — service layer (6 public functions, dual-query `get_function`, `_row_to_function`/`_row_to_param` helpers, `sp_rename` rename)
- `src/fabric_dw/cli/commands/functions.py` — CLI `functions` group with `list`/`get`/`create`/`update`/`drop`/`rename` sub-commands
- `src/fabric_dw/mcp/tools/functions.py` — 6 MCP tools (`list_functions`, `get_function`, `create_function`, `update_function`, `drop_function`, `rename_function`)
- `tests/unit/services/test_functions.py` (74 tests), `tests/unit/cli/commands/test_functions.py` (26 tests), `tests/unit/mcp/tools/test_functions.py` (18 tests), `tests/integration/test_services_functions.py`

## Modified files

- `src/fabric_dw/models.py` — adds `FunctionKind`, `FunctionParameter`, `Function`, `FunctionDetails`
- `src/fabric_dw/cli/_main.py` — registers `functions_group`
- `src/fabric_dw/mcp/tools/__init__.py` — registers `functions` domain (MCP tool count 72 → 78)
- `tests/unit/mcp/test_contract.py` — updates `_EXPECTED_TOOL_COUNT` 72 → 78
- `tests/unit/mcp/test_server.py` — adds 6 tool names to `EXPECTED_TOOL_NAMES`
- `docs/cli.md` — adds `## fabric-dw functions` section
- `docs/mcp-tools.md` — adds `## Functions` section

## Test plan

- [ ] `just check` passes fully (ruff lint + format, ty type check, 2531 unit tests, 97% coverage)
- [ ] Integration suite: `just integration` with real Fabric credentials — round-trip create→list→get→update→rename→drop for both Warehouse and SQL Analytics Endpoint
- [ ] Verify `--kind scalar` filter returns only FN-type objects
- [ ] Verify `DROP FUNCTION IF EXISTS` behaviour with `--if-exists` flag
- [ ] Verify `rename` rejects qualified new names (dot in `--new-name`)

Closes #356

🤖 Generated with [Claude Code](https://claude.com/claude-code)