### PR TITLE
perf(ci): run integration suite in parallel with pytest-xdist

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -192,6 +192,8 @@ jobs:
           FABRIC_TEST_IS_TENANT_ADMIN: "true"
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          XDIST_WORKERS_INPUT: ${{ inputs.xdist_workers }}
+          PYTEST_K_INPUT: ${{ inputs.pytest_k }}
         run: |
           # Worker-count rationale
           # ----------------------
@@ -207,22 +209,28 @@ jobs:
           #
           # The xdist_workers workflow_dispatch input lets you tune this without
           # code changes.  For push events (no input), WORKERS defaults to 4.
-          WORKERS="${{ inputs.xdist_workers }}"
-          WORKERS="${WORKERS:-4}"
+          WORKERS="${XDIST_WORKERS_INPUT:-4}"
+
+          # Validate that WORKERS is a positive integer; reject 0, negatives, and
+          # non-numeric values before they reach pytest (which aborts with a
+          # cryptic error on -n 0 or -n -1).
+          [[ "${WORKERS}" =~ ^[1-9][0-9]*$ ]] || {
+            echo "ERROR: xdist_workers must be a positive integer, got: ${WORKERS}" >&2
+            exit 1
+          }
 
           # Default dist mode is "load" (xdist default): work-stealing scheduler
           # that keeps all workers busy.  This is the right choice here because
           # test durations vary widely (snapshot/restore tests are 10x slower than
           # query/schema tests).  "loadscope" would bin by module, which could
           # serialise the slow tests onto one worker and starve the rest.
-          CMD="uv run pytest tests/integration -m integration -v -n ${WORKERS}"
 
-          if [ -n "${{ inputs.pytest_k }}" ]; then
-            echo "Running subset: -k '${{ inputs.pytest_k }}' with ${WORKERS} worker(s)"
-            ${CMD} -k "${{ inputs.pytest_k }}"
+          if [ -n "${PYTEST_K_INPUT}" ]; then
+            echo "Running subset: -k '${PYTEST_K_INPUT}' with ${WORKERS} worker(s)"
+            uv run pytest tests/integration -m integration -v -n "${WORKERS}" -k "${PYTEST_K_INPUT}"
           else
             echo "Running full integration suite with ${WORKERS} worker(s)"
-            ${CMD}
+            uv run pytest tests/integration -m integration -v -n "${WORKERS}"
           fi
 
       - name: Post-test full workspace wipe

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,6 +11,10 @@ on:
         description: "Optional pytest -k expression to run a subset (empty = full suite)"
         required: false
         default: ""
+      xdist_workers:
+        description: "Number of parallel pytest-xdist workers (1 = serial, default 4)"
+        required: false
+        default: "4"
 
 permissions:
   id-token: write
@@ -189,11 +193,36 @@ jobs:
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
         run: |
+          # Worker-count rationale
+          # ----------------------
+          # Each xdist worker provisions its own warm warehouse (session-scoped
+          # shared_warehouse fixture, named pytest-<worker>-<uid>-wh).  Fabric
+          # capacity (CU) budget, the per-workspace item limit, and the HTTP 429
+          # rate-limit all constrain how many parallel warehouses are safe.
+          # 4 workers is a conservative default that fits within a single F4/F8
+          # capacity unit budget and leaves headroom for ephemeral items created
+          # by snapshot/restore/lakehouse tests.  Raise to 6 if the target
+          # capacity is F16+ and the workspace item limit is not an issue.
+          # Reduce to 1 (serial) to debug flaky tests without parallelism noise.
+          #
+          # The xdist_workers workflow_dispatch input lets you tune this without
+          # code changes.  For push events (no input), WORKERS defaults to 4.
+          WORKERS="${{ inputs.xdist_workers }}"
+          WORKERS="${WORKERS:-4}"
+
+          # Default dist mode is "load" (xdist default): work-stealing scheduler
+          # that keeps all workers busy.  This is the right choice here because
+          # test durations vary widely (snapshot/restore tests are 10x slower than
+          # query/schema tests).  "loadscope" would bin by module, which could
+          # serialise the slow tests onto one worker and starve the rest.
+          CMD="uv run pytest tests/integration -m integration -v -n ${WORKERS}"
+
           if [ -n "${{ inputs.pytest_k }}" ]; then
-            echo "Running subset: -k '${{ inputs.pytest_k }}'"
-            uv run pytest tests/integration -m integration -v -k "${{ inputs.pytest_k }}"
+            echo "Running subset: -k '${{ inputs.pytest_k }}' with ${WORKERS} worker(s)"
+            ${CMD} -k "${{ inputs.pytest_k }}"
           else
-            uv run pytest tests/integration -m integration -v
+            echo "Running full integration suite with ${WORKERS} worker(s)"
+            ${CMD}
           fi
 
       - name: Post-test full workspace wipe

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ fabric-dw-mcp = "fabric_dw.mcp.server:run"
 dev = [
     "pytest>=9.0",
     "pytest-asyncio>=1.4",
+    "pytest-xdist>=3.5",
     "anyio[trio]",
     "respx>=0.23",
     "freezegun>=1.5",

--- a/uv.lock
+++ b/uv.lock
@@ -591,6 +591,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "fabric-dw"
 source = { editable = "." }
 dependencies = [
@@ -618,6 +627,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-randomly" },
+    { name = "pytest-xdist" },
     { name = "respx" },
     { name = "ruff" },
     { name = "ty" },
@@ -652,6 +662,7 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=1.4" },
     { name = "pytest-cov" },
     { name = "pytest-randomly" },
+    { name = "pytest-xdist", specifier = ">=3.5" },
     { name = "respx", specifier = ">=0.23" },
     { name = "ruff", specifier = ">=0.15,<0.16" },
     { name = "ty", specifier = "==0.0.49" },
@@ -1659,6 +1670,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/27/b3/36192dacc0f470ac2cc516f73e01739c9a48a8224f76beada4f85e1c8a89/pytest_randomly-4.1.0.tar.gz", hash = "sha256:47f1d9746c3bc3efabd53ae1ebfb8bb385cf3d4df4b505b6d58d9c97a3dfe70f", size = 14302, upload-time = "2026-04-20T13:01:51.831Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/db/2df9a1fca597a273f957a559c20c2d95d629928384507b2afa43ba6909d1/pytest_randomly-4.1.0-py3-none-any.whl", hash = "sha256:f55e89e53367b090c0c053697d7f9d77595543d0e0516c93978b50c0f6b252f9", size = 8353, upload-time = "2026-04-20T13:01:50.382Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds `pytest-xdist>=3.5` as a dev dependency (installed: 3.8.0 + execnet 2.1.2); lockfile updated via `uv sync`.
- Enables `-n ${WORKERS}` in the `Run integration tests` step of `.github/workflows/integration.yml`, defaulting to **4 parallel workers**.
- Adds a `xdist_workers` `workflow_dispatch` input (default `"4"`) so the concurrency can be tuned without code changes. The existing `pytest_k` subset input continues to work alongside `-n` — both flags compose correctly.

## How parallelism works

Each xdist worker gets its own session-scoped warm warehouse (named `pytest-<gw0|gw1|…>-<uid>-wh`) via the `shared_warehouse` fixture already merged in #358.  Workers are independent; no cross-process locking is needed.

**Distribution mode:** xdist default `load` (work-stealing).  Tests are handed to whichever worker is free, which correctly handles the wide duration spread between fast schema/query tests and slow snapshot/restore tests.  `loadscope` (bin-by-module) would pin the slow modules onto a single worker, defeating the purpose.

**Why 4 workers (not more):**

> Each worker provisions its own Fabric warehouse.  The concurrency is bounded by three independent constraints: Fabric capacity (CU) budget — an F4/F8 capacity unit supports ~4 concurrent warehouse operations; the per-workspace item count limit; and HTTP 429 back-pressure from the Fabric REST API.  4 workers fits within a single F4/F8 budget with headroom for the ephemeral items created by snapshot/restore/lakehouse tests.  Raise to 6 for F16+ capacity or reduce to 1 to debug flakiness without parallelism noise — no code changes required, just set `xdist_workers` in the workflow dispatch.

## Verification

```
uv run pytest tests/integration -m integration --collect-only        # 92 tests, 0 errors
uv run pytest tests/integration -m integration --collect-only -n 2  # 92 tests, xdist loads cleanly
just check                                                           # ruff, ty, 2558 unit tests — all green
```

Closes #312