### PR TITLE
feat(tables): create empty DW tables from explicit spec, Parquet, or CSV

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1435,7 +1435,10 @@ fabric-dw tables read MyWorkspace SalesWH dbo.orders --count 5
 
 **Targets:** Data Warehouse only
 
-Create a new table via CTAS (`CREATE TABLE … AS SELECT`). The body must start with `SELECT` (leading block and line comments are allowed).
+Create a new table on a Fabric Data Warehouse. Two modes are available:
+
+- **CTAS** (`CREATE TABLE … AS SELECT`) — supply `--select` or `--from-file`. The body must start with `SELECT` (leading block/line comments are allowed).
+- **Empty DDL** (`CREATE TABLE … (col TYPE, …)`) — supply one or more of `--from-parquet`, `--from-csv`, `--from-schema`, or `--column`. No data is ever read or inserted; this scaffolds the table structure only.
 
 **Synopsis**
 
@@ -1443,20 +1446,81 @@ Create a new table via CTAS (`CREATE TABLE … AS SELECT`). The body must start 
 fabric-dw tables create [OPTIONS] [WORKSPACE] [WAREHOUSE]
 ```
 
+#### CTAS options
+
 | Option | Description |
 | --- | --- |
 | `--name SCHEMA.TABLE` | **Required.** Qualified table name. |
-| `--select TEXT` | Inline SELECT statement. |
+| `--select TEXT` | Inline SELECT statement for CTAS. |
 | `--from-file PATH` | Path to a `.sql` file containing the SELECT body (UTF-8/UTF-8-sig). |
 
-Exactly one of `--select` or `--from-file` must be provided.
+Exactly one of `--select` or `--from-file` must be provided for the CTAS path. Cannot be combined with empty-DDL options.
 
-**Example**
+#### Empty-DDL options
+
+| Option | Description |
+| --- | --- |
+| `--name SCHEMA.TABLE` | **Required.** Qualified table name. |
+| `--from-parquet PATH` | Derive schema from a Parquet file (reads footer only — no data loaded). |
+| `--from-csv PATH` | Derive schema from a CSV header + bounded sample (no data loaded). |
+| `--from-schema PATH` | JSON file with column specs: `[{"name": "…", "type": "…", "nullable": true}]`. |
+| `--column NAME:TYPE[:null\|notnull]` | Inline column definition (repeatable). Can be combined with `--from-schema`. |
+| `--all-varchar` | (CSV) Force all columns to `VARCHAR`; skip type inference. |
+| `--varchar-length N` | Default VARCHAR/VARBINARY length for string/binary columns (1–8000, default `8000`). |
+| `--delimiter CHAR` | (CSV) Field delimiter (default `,`). |
+| `--encoding ENC` | (CSV) File encoding (default `utf-8-sig`). |
+| `--sample-rows N` | (CSV) Rows to sample for type inference (1–100 000, default `1000`). |
+
+`--from-parquet`, `--from-csv`, and `--from-schema`/`--column` are mutually exclusive with each other and with the CTAS path. For the explicit-schema path at least one `--from-schema` or `--column` must be provided.
+
+**Arrow → T-SQL type mapping (Parquet / CSV inference)**
+
+| Arrow type | T-SQL type |
+| --- | --- |
+| `int8`, `int16`, `uint8` | `SMALLINT` |
+| `int32`, `uint16` | `INT` |
+| `int64`, `uint32`, `uint64` | `BIGINT` |
+| `float16`, `float32` | `REAL` |
+| `float64` | `FLOAT` |
+| `bool` | `BIT` |
+| `decimal128(p,s)` | `DECIMAL(p,s)` |
+| `date32`, `date64` | `DATE` |
+| `time*` | `TIME(7)` |
+| `timestamp*` | `DATETIME2(7)` |
+| `string`, `large_string` | `VARCHAR(n)` |
+| `binary`, `large_binary` | `VARBINARY(n)` |
+| nested / list / struct | **Error** — use `--all-varchar` or `--from-schema` to override |
+
+**Examples**
 
 ```shell
+# CTAS
 fabric-dw tables create MyWorkspace SalesWH \
   --name dbo.orders_2026 \
   --select "SELECT * FROM dbo.orders WHERE YEAR(sale_date) = 2026"
+
+# Empty table from Parquet schema
+fabric-dw tables create MyWorkspace SalesWH \
+  --name dbo.sales_empty \
+  --from-parquet ./exports/sales.parquet
+
+# Empty table from CSV header (type inference)
+fabric-dw tables create MyWorkspace SalesWH \
+  --name staging.raw_products \
+  --from-csv ./data/products.csv --varchar-length 500
+
+# Empty table with explicit inline columns
+fabric-dw tables create MyWorkspace SalesWH \
+  --name dbo.events \
+  --column "event_id:BIGINT:notnull" \
+  --column "event_type:VARCHAR(100)" \
+  --column "occurred_at:DATETIME2(7)"
+
+# Explicit schema from JSON file + extra columns
+fabric-dw tables create MyWorkspace SalesWH \
+  --name dbo.audit_log \
+  --from-schema ./schemas/audit_log.json \
+  --column "inserted_at:DATETIME2(7):notnull"
 ```
 
 ---

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -863,6 +863,43 @@ Create a new SQL table via CTAS (`CREATE TABLE … AS SELECT`).
 
 ---
 
+### create_empty_table
+
+**Targets:** Data Warehouse only
+
+Create an empty SQL table from an explicit column specification (DDL only — no data is ever read or inserted). This scaffolds the table structure so that data can be loaded separately.
+
+Server-side file access is unreliable in MCP deployments, so CSV/Parquet schema inference is not available via this tool. Use `fabric-dw tables create --from-parquet` or `--from-csv` (CLI) for file-based schema inference.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `item` (`str`) — warehouse name or GUID. SQL Analytics Endpoints are rejected.
+- `qualified_name` (`str`) — dot-separated table name, e.g. `dbo.sales`.
+- `columns` (`list[object]`) — non-empty list of column definitions, each an object with:
+  - `name` (`str`) — column identifier (must be a valid SQL identifier).
+  - `sql_type` (`str`) — Fabric-DW-supported T-SQL type, e.g. `"INT"`, `"VARCHAR(255)"`, `"DECIMAL(18,2)"`.
+  - `nullable` (`bool`, optional, default `true`) — whether the column allows `NULL`.
+
+**Returns:** `Table` — the newly-created table record.
+
+**Example call:**
+
+```json
+{
+  "workspace": "MyWorkspace",
+  "item": "SalesWarehouse",
+  "qualified_name": "dbo.events",
+  "columns": [
+    {"name": "event_id", "sql_type": "BIGINT", "nullable": false},
+    {"name": "event_type", "sql_type": "VARCHAR(100)", "nullable": true},
+    {"name": "occurred_at", "sql_type": "DATETIME2(7)", "nullable": false}
+  ]
+}
+```
+
+---
+
 ### delete_table
 
 **Targets:** Data Warehouse only

--- a/src/fabric_dw/cli/commands/tables.py
+++ b/src/fabric_dw/cli/commands/tables.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+import re
 from pathlib import Path
 
 import click
@@ -20,6 +22,7 @@ from fabric_dw.cli.commands._utils import (
     resolve_workspace_arg,
 )
 from fabric_dw.exceptions import FabricError
+from fabric_dw.models import ColumnSpec
 from fabric_dw.services import tables as _tables_svc
 from fabric_dw.sql_io import OutputFormat, columns_rows_to_arrow, write_arrow
 
@@ -105,33 +108,288 @@ async def read_cmd(
         raise click.ClickException(str(exc)) from exc
 
 
+_COLUMN_SPEC_RE = re.compile(
+    r"^(?P<name>[A-Za-z_][A-Za-z0-9_]{0,127})"
+    r":(?P<type>[^:]+)"
+    r"(?::(?P<nullability>null|notnull))?$",
+    re.IGNORECASE,
+)
+
+
+def _parse_column_spec(value: str) -> ColumnSpec:
+    """Parse a ``name:TYPE[:null|notnull]`` column spec string.
+
+    Args:
+        value: The raw spec string, e.g. ``"id:INT:notnull"`` or ``"name:VARCHAR(100)"``.
+
+    Returns:
+        A :class:`~fabric_dw.models.ColumnSpec` instance.
+
+    Raises:
+        click.UsageError: If *value* does not match the expected format.
+    """
+    m = _COLUMN_SPEC_RE.match(value.strip())
+    if not m:
+        raise click.UsageError(
+            f"Invalid --column spec {value!r}. "
+            "Expected format: name:TYPE or name:TYPE:null or name:TYPE:notnull. "
+            "Example: id:INT:notnull or description:VARCHAR(255)"
+        )
+    name = m.group("name")
+    sql_type = m.group("type").strip()
+    nullability = (m.group("nullability") or "null").lower()
+    nullable = nullability != "notnull"
+    return ColumnSpec(name=name, sql_type=sql_type, nullable=nullable)
+
+
+def _parse_schema_file(path: str) -> list[ColumnSpec]:
+    """Load a JSON column spec file as a list of :class:`~fabric_dw.models.ColumnSpec`.
+
+    The file must contain a JSON array of objects, each with ``name`` and ``type``
+    keys, and an optional ``nullable`` boolean.
+
+    Args:
+        path: Path to the JSON file.
+
+    Returns:
+        A list of :class:`~fabric_dw.models.ColumnSpec` instances.
+
+    Raises:
+        click.UsageError: If the file does not exist, is not valid JSON,
+            or does not match the expected schema.
+    """
+    p = Path(path)
+    if not p.is_file():
+        raise click.UsageError(f"Schema file not found: {path}")
+    try:
+        raw = json.loads(p.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise click.UsageError(f"Invalid JSON in --from-schema {path!r}: {exc}") from exc
+    if not isinstance(raw, list):
+        raise click.UsageError(
+            f"--from-schema {path!r} must be a JSON array of objects, got {type(raw).__name__}"
+        )
+    specs: list[ColumnSpec] = []
+    for i, item in enumerate(raw):
+        if not isinstance(item, dict):
+            raise click.UsageError(
+                f"--from-schema {path!r}: element {i} must be an object, got {type(item).__name__}"
+            )
+        name = item.get("name")
+        sql_type = item.get("type")
+        if not name or not sql_type:
+            raise click.UsageError(
+                f"--from-schema {path!r}: element {i} must have 'name' and 'type' keys"
+            )
+        nullable = bool(item.get("nullable", True))
+        specs.append(ColumnSpec(name=str(name), sql_type=str(sql_type), nullable=nullable))
+    if not specs:
+        raise click.UsageError(f"--from-schema {path!r}: schema file contains no columns")
+    return specs
+
+
 @tables_group.command("create")
 @click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.option("--name", "qualified_name", required=True, help="Qualified name: schema.table.")
+# CTAS path
 @click.option("--select", "select_body", default=None, help="Inline SELECT statement for CTAS.")
 @click.option("--from-file", default=None, help="Path to a .sql file containing the SELECT body.")
+# Empty-table DDL path — sources (mutually exclusive with each other and with CTAS)
+@click.option(
+    "--from-parquet",
+    "parquet_path",
+    default=None,
+    metavar="PATH",
+    help="Create an empty table whose schema is derived from a Parquet file (no data is loaded).",
+)
+@click.option(
+    "--from-csv",
+    "csv_path",
+    default=None,
+    metavar="PATH",
+    help="Create an empty table whose schema is derived from a CSV file header.",
+)
+@click.option(
+    "--from-schema",
+    "schema_file",
+    default=None,
+    metavar="PATH",
+    help=(
+        "Create an empty table from a JSON spec file (array of {name, type, nullable?} objects)."
+    ),
+)
+@click.option(
+    "--column",
+    "column_specs",
+    multiple=True,
+    metavar="NAME:TYPE[:null|notnull]",
+    help=(
+        "Add a column in NAME:TYPE[:null|notnull] format (repeatable). "
+        "Can be combined with --from-schema."
+    ),
+)
+# CSV-specific options
+@click.option(
+    "--all-varchar",
+    is_flag=True,
+    default=False,
+    help="(CSV) Force all columns to VARCHAR; skip type inference.",
+)
+@click.option(
+    "--varchar-length",
+    default=8000,
+    show_default=True,
+    type=click.IntRange(1, 8000),
+    help="Default VARCHAR/VARBINARY length for string/binary columns.",
+)
+@click.option(
+    "--delimiter",
+    default=",",
+    show_default=True,
+    help="(CSV) Field delimiter.",
+)
+@click.option(
+    "--encoding",
+    default="utf-8-sig",
+    show_default=True,
+    help="(CSV) File encoding.",
+)
+@click.option(
+    "--sample-rows",
+    default=1000,
+    show_default=True,
+    type=click.IntRange(1, 100_000),
+    help="(CSV) Maximum number of rows to sample for type inference.",
+)
 @click.pass_obj
 @coro
-async def create_cmd(
+async def create_cmd(  # noqa: PLR0912
     ctx: CliContext,
     workspace: str | None,
     item: str | None,
     qualified_name: str,
     select_body: str | None,
     from_file: str | None,
+    parquet_path: str | None,
+    csv_path: str | None,
+    schema_file: str | None,
+    column_specs: tuple[str, ...],
+    all_varchar: bool,
+    varchar_length: int,
+    delimiter: str,
+    encoding: str,
+    sample_rows: int,
 ) -> None:
-    """Create a new table via CTAS (CREATE TABLE AS SELECT) on ITEM in WORKSPACE."""
+    """Create a new table on ITEM in WORKSPACE.
+
+    \b
+    Two modes are available:
+      CTAS (CREATE TABLE AS SELECT) — supply --select or --from-file.
+      Empty DDL — supply one of --from-parquet, --from-csv, --from-schema,
+                  or --column (repeatable).  These can be combined:
+                  --from-schema adds base columns and --column appends extras.
+
+    \b
+    CSV options (only with --from-csv):
+      --all-varchar     Force all columns to VARCHAR, skipping type inference.
+      --varchar-length  Default VARCHAR length (1-8000, default 8000).
+      --delimiter       Field delimiter (default ',').
+      --encoding        File encoding (default 'utf-8-sig').
+      --sample-rows     Rows to sample for inference (default 1000).
+    """
     ws = resolve_workspace_arg(ctx, workspace)
     wh = resolve_warehouse_arg(ctx, item)
     schema, table_name = parse_qualified_name(qualified_name, kind="table")
-    body = load_sql_body(select_body, from_file)
+
+    # Determine which mode the user wants and validate mutual exclusivity.
+    has_ctas = bool(select_body or from_file)
+    has_parquet = parquet_path is not None
+    has_csv = csv_path is not None
+    has_explicit = schema_file is not None or bool(column_specs)
+
+    # Count distinct source groups.
+    source_count = sum([has_ctas, has_parquet, has_csv, has_explicit])
+
+    if source_count == 0:
+        raise click.UsageError(
+            "Specify a source: --select/--from-file (CTAS), --from-parquet, "
+            "--from-csv, --from-schema, or --column."
+        )
+
+    # CTAS cannot be combined with empty-DDL sources.
+    if has_ctas and (has_parquet or has_csv or has_explicit):
+        raise click.UsageError(
+            "--select/--from-file (CTAS) cannot be combined with "
+            "--from-parquet, --from-csv, --from-schema, or --column."
+        )
+
+    # Parquet, CSV, and explicit schema are mutually exclusive with each other.
+    if has_parquet and has_csv:
+        raise click.UsageError("--from-parquet and --from-csv are mutually exclusive.")
+    if has_parquet and schema_file:
+        raise click.UsageError("--from-parquet and --from-schema are mutually exclusive.")
+    if has_parquet and column_specs:
+        raise click.UsageError("--from-parquet and --column are mutually exclusive.")
+    if has_csv and schema_file:
+        raise click.UsageError("--from-csv and --from-schema are mutually exclusive.")
+    if has_csv and column_specs:
+        raise click.UsageError("--from-csv and --column are mutually exclusive.")
+
+    # --all-varchar only makes sense with --from-csv.
+    if all_varchar and not has_csv:
+        raise click.UsageError("--all-varchar requires --from-csv.")
+
     try:
         async with build_http_client(ctx) as http:
             target, entry = await build_sql_target(http, ws, wh)
-            t = await _tables_svc.create_table(
-                target, schema, table_name, body, kind=entry.kind, mode=ctx.auth
-            )
+
+            if has_ctas:
+                body = load_sql_body(select_body, from_file)
+                t = await _tables_svc.create_table(
+                    target, schema, table_name, body, kind=entry.kind, mode=ctx.auth
+                )
+
+            elif has_parquet:
+                t = await _tables_svc.create_table_from_parquet(
+                    target,
+                    schema,
+                    table_name,
+                    Path(parquet_path),  # type: ignore[arg-type]
+                    kind=entry.kind,
+                    mode=ctx.auth,
+                    varchar_length=varchar_length,
+                )
+
+            elif has_csv:
+                t = await _tables_svc.create_table_from_csv(
+                    target,
+                    schema,
+                    table_name,
+                    Path(csv_path),  # type: ignore[arg-type]
+                    kind=entry.kind,
+                    mode=ctx.auth,
+                    all_varchar=all_varchar,
+                    varchar_length=varchar_length,
+                    delimiter=delimiter,
+                    encoding=encoding,
+                    sample_rows=sample_rows,
+                )
+
+            else:
+                # Explicit schema via --from-schema and/or --column.
+                cols: list[ColumnSpec] = []
+                if schema_file:
+                    cols.extend(_parse_schema_file(schema_file))
+                cols.extend(_parse_column_spec(s) for s in column_specs)
+                if not cols:
+                    raise click.UsageError(
+                        "--from-schema or at least one --column is required for the DDL path."
+                    )
+                t = await _tables_svc.create_empty_table(
+                    target, schema, table_name, cols, kind=entry.kind, mode=ctx.auth
+                )
+
             render(t.model_dump(by_alias=True, mode="json"), json_output=ctx.json_output)
     except (ValueError, FabricError) as exc:
         raise click.ClickException(str(exc)) from exc

--- a/src/fabric_dw/mcp/tools/tables.py
+++ b/src/fabric_dw/mcp/tools/tables.py
@@ -23,9 +23,27 @@ from fabric_dw.mcp._helpers import (
     safe_rows,
     tool_err,
 )
+from fabric_dw.models import ColumnSpec
 from fabric_dw.services import tables as tables_svc
 
 __all__ = ["register"]
+
+
+def _parse_column_dict(i: int, col: object) -> ColumnSpec:
+    """Convert a raw dict from MCP input into a :class:`ColumnSpec`.
+
+    Raises :class:`TypeError` when *col* is not a ``dict``, and
+    :class:`ValueError` when required keys are missing.
+    """
+    if not isinstance(col, dict):
+        raise TypeError(f"columns[{i}] must be an object, got {type(col).__name__}")
+    name = col.get("name")
+    sql_type = col.get("sql_type")
+    if not name or not sql_type:
+        raise ValueError(f"columns[{i}] must have 'name' and 'sql_type' keys")
+    nullable = bool(col.get("nullable", True))
+    return ColumnSpec(name=str(name), sql_type=str(sql_type), nullable=nullable)
+
 
 _log = logging.getLogger(__name__)
 
@@ -186,6 +204,58 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         except (ValueError, FabricError) as exc:
             raise tool_err(exc) from exc
         return {"truncated": True}
+
+    @mutating_tool(mcp, "create_empty_table")
+    async def create_empty_table_tool(
+        workspace: str,
+        item: str,
+        qualified_name: str,
+        columns: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        """Create an empty table from an explicit column spec (DDL only, no data).
+
+        Builds ``CREATE TABLE [schema].[table] (col TYPE [NULL|NOT NULL], …)`` from
+        the supplied column definitions.  No data is read or inserted; this is a
+        pure DDL operation.
+
+        Server-side file access is unreliable in MCP deployments, so CSV/Parquet
+        inference is not available via this tool — use the ``fabric-dw tables create
+        --from-parquet`` or ``--from-csv`` CLI commands instead.
+
+        Only supported on Fabric Data Warehouses (not SQL Analytics Endpoints).
+
+        Args:
+            workspace: Workspace name or GUID.
+            item: Warehouse name or GUID.
+            qualified_name: Dot-separated qualified table name, e.g. ``dbo.sales``.
+            columns: List of column definitions, each a dict with:
+                ``name`` (str) — column identifier;
+                ``sql_type`` (str) — Fabric-DW T-SQL type, e.g. ``"INT"``, ``"VARCHAR(255)"``;
+                ``nullable`` (bool, optional, default true) — whether the column allows NULL.
+        """
+        schema, table_name = parse_qualified_name(qualified_name, kind="table")
+        assert_workspace_allowed(workspace)
+        ctx = get_context()
+        try:
+            col_specs = [_parse_column_dict(i, col) for i, col in enumerate(columns)]
+            ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
+            assert_workspace_allowed(workspace, str(ws_id))
+            _log.debug(
+                "create_empty_table ws=%s item=%s table=%s.%s cols=%d",
+                ws_id,
+                entry.id,
+                schema,
+                table_name,
+                len(col_specs),
+            )
+            target = make_sql_target(ws_id, entry, item)
+            result = await tables_svc.create_empty_table(
+                target, schema, table_name, col_specs, kind=entry.kind, mode=ctx.auth_mode
+            )
+        except (TypeError, ValueError, FabricError) as exc:
+            raise tool_err(exc) from exc
+        ctx.resolver.clear_negative_cache()
+        return result.model_dump(mode="json")
 
     @mutating_tool(mcp, "clone_table")
     async def clone_table(

--- a/src/fabric_dw/models.py
+++ b/src/fabric_dw/models.py
@@ -702,6 +702,27 @@ class ItemAccess(_FabricBase):
         return cls.model_validate(raw)
 
 
+class ColumnSpec(_FabricBase):
+    """Specification for a single column in a DDL CREATE TABLE statement.
+
+    Used by :func:`~fabric_dw.services.tables.create_empty_table` and the
+    ``create_empty_table`` MCP tool to describe each column independently of
+    any source file (Parquet or CSV inference is done before constructing these).
+
+    Attributes:
+        name: The column identifier.  Must pass
+            :func:`~fabric_dw.identifiers.validate_identifier`.
+        sql_type: A Fabric-DW-supported T-SQL type string, e.g. ``"INT"``,
+            ``"VARCHAR(255)"``, ``"DECIMAL(18,2)"``.
+        nullable: When ``True`` (default) the column gets a ``NULL`` constraint;
+            when ``False`` it gets ``NOT NULL``.
+    """
+
+    name: str
+    sql_type: str
+    nullable: bool = True
+
+
 class SqlResult(_FabricBase):
     """Result set returned by :func:`~fabric_dw.services.sql_exec.execute`.
 

--- a/src/fabric_dw/services/tables.py
+++ b/src/fabric_dw/services/tables.py
@@ -380,7 +380,8 @@ async def create_table_from_parquet(
         raise FileNotFoundError(msg)
 
     # Read schema only — pq.read_schema reads the footer without loading any row groups.
-    arrow_schema = pq.read_schema(str(parquet_path))
+    # Wrapped in asyncio.to_thread for consistency with other blocking I/O in this module.
+    arrow_schema = await asyncio.to_thread(pq.read_schema, str(parquet_path))
 
     columns: list[ColumnSpec] = []
     for field in arrow_schema:
@@ -473,32 +474,53 @@ async def create_table_from_csv(
             for col_name in header
         ]
     else:
-        # Read header + sample for inference via pyarrow.csv.
-        read_opts = pa_csv.ReadOptions(
-            encoding=encoding,
-            block_size=max(1, sample_rows) * 1024,  # approximate; pyarrow clips if needed
-        )
+        # Read header + a bounded sample for type inference via pyarrow.csv.
+        # Use open_csv() (streaming batches) so that only a prefix of the file
+        # is ever loaded into memory — read_csv() would buffer the entire file
+        # before slice() could discard excess rows.
+        import pyarrow as pa  # noqa: PLC0415
+
+        read_opts = pa_csv.ReadOptions(encoding=encoding)
         parse_opts = pa_csv.ParseOptions(delimiter=delimiter)
         # ConvertOptions: auto-convert types, treat empty fields as null
         convert_opts = pa_csv.ConvertOptions(null_values=["", "NULL", "null", "NA", "N/A"])
 
-        # pyarrow reads the whole file by default — we limit via block_size above
-        # but also wrap with a bounded read to avoid loading huge files.
+        def _read_csv_sample() -> pa.Table:
+            """Read at most *sample_rows* rows via the streaming CSV reader.
 
-        arrow_table = pa_csv.read_csv(
-            str(csv_path),
-            read_options=read_opts,
-            parse_options=parse_opts,
-            convert_options=convert_opts,
-        )
-
-        # Trim to sample_rows to bound the inference sample.
-        if arrow_table.num_rows > sample_rows:
-            arrow_table = arrow_table.slice(0, sample_rows)
-            _log.debug(
-                "create_table_from_csv: trimmed to %d sample rows for type inference",
-                sample_rows,
+            Uses :func:`pyarrow.csv.open_csv` (batch streaming) so that the
+            file is read lazily and iteration stops as soon as *sample_rows*
+            rows have been accumulated.  Only the prefix of the file is ever
+            loaded into memory, regardless of total file size.
+            """
+            reader = pa_csv.open_csv(
+                str(csv_path),
+                read_options=read_opts,
+                parse_options=parse_opts,
+                convert_options=convert_opts,
             )
+            # reader.schema is available before iteration and reflects inferred types.
+            inferred_schema = reader.schema
+            batches: list[pa.RecordBatch] = []
+            rows_seen = 0
+            for batch in reader:
+                remaining = sample_rows - rows_seen
+                chunk = batch.slice(0, remaining) if batch.num_rows > remaining else batch
+                batches.append(chunk)
+                rows_seen += chunk.num_rows
+                if rows_seen >= sample_rows:
+                    break
+            if not batches:
+                # Header-only CSV — return a zero-row table so schema is preserved.
+                return inferred_schema.empty_table()
+            return pa.Table.from_batches(batches)
+
+        arrow_table = await asyncio.to_thread(_read_csv_sample)
+        _log.debug(
+            "create_table_from_csv: read %d sample rows from %s for type inference",
+            arrow_table.num_rows,
+            csv_path.name,
+        )
 
         columns = []
         for i, name in enumerate(arrow_table.schema.names):

--- a/src/fabric_dw/services/tables.py
+++ b/src/fabric_dw/services/tables.py
@@ -2,14 +2,17 @@
 
 Public API
 ----------
-- :func:`validate_identifier` — re-exported from :mod:`fabric_dw.identifiers`.
-- :func:`list_tables`          — list all tables via TDS ``sys.tables JOIN sys.schemas``.
-- :func:`read_table`           — ``SELECT TOP (N) * FROM [schema].[table]``.
-- :func:`create_table`         — ``CREATE TABLE … AS <select_body>`` (CTAS).
-- :func:`clone_table`          — ``CREATE TABLE … AS CLONE OF …`` (zero-copy clone).
-- :func:`delete_table`         — ``DROP TABLE [schema].[table]``.
-- :func:`clear_table`          — ``TRUNCATE TABLE [schema].[table]``.
-- :func:`rename_table`         — ``EXEC sp_rename`` (Data-Warehouse-only).
+- :func:`validate_identifier`     — re-exported from :mod:`fabric_dw.identifiers`.
+- :func:`list_tables`             — list all tables via TDS ``sys.tables JOIN sys.schemas``.
+- :func:`read_table`              — ``SELECT TOP (N) * FROM [schema].[table]``.
+- :func:`create_table`            — ``CREATE TABLE … AS <select_body>`` (CTAS).
+- :func:`create_empty_table`      — ``CREATE TABLE … (col TYPE [NULL|NOT NULL], …)`` (DDL only).
+- :func:`create_table_from_parquet` — infer schema from Parquet file → :func:`create_empty_table`.
+- :func:`create_table_from_csv`   — infer schema from CSV file → :func:`create_empty_table`.
+- :func:`clone_table`             — ``CREATE TABLE … AS CLONE OF …`` (zero-copy clone).
+- :func:`delete_table`            — ``DROP TABLE [schema].[table]``.
+- :func:`clear_table`             — ``TRUNCATE TABLE [schema].[table]``.
+- :func:`rename_table`            — ``EXEC sp_rename`` (Data-Warehouse-only).
 
 List-source note
 ----------------
@@ -22,26 +25,34 @@ falls back to TDS via ``sys.tables JOIN sys.schemas``, mirroring the
 from __future__ import annotations
 
 import asyncio
+import logging
 from datetime import datetime, timedelta
+from pathlib import Path
 from typing import cast
 
 from fabric_dw.auth import CredentialMode
 from fabric_dw.exceptions import ItemKindError, NotFoundError
 from fabric_dw.identifiers import parse_qualified_name, quote_identifier, validate_identifier
-from fabric_dw.models import Table, WarehouseKind
+from fabric_dw.models import ColumnSpec, Table, WarehouseKind
 from fabric_dw.services._helpers import reject_non_select
 from fabric_dw.sql import SqlTarget, run_query
+from fabric_dw.types import arrow_type_to_tsql, validate_tsql_type
 
 __all__ = [
     "clear_table",
     "clone_table",
+    "create_empty_table",
     "create_table",
+    "create_table_from_csv",
+    "create_table_from_parquet",
     "delete_table",
     "list_tables",
     "read_table",
     "rename_table",
     "validate_identifier",
 ]
+
+_log = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Guard
@@ -258,6 +269,257 @@ async def create_table(
 
     await asyncio.to_thread(_run_ddl)
     return await _fetch_table(target, schema, table_name, mode=mode)
+
+
+async def create_empty_table(
+    target: SqlTarget,
+    schema: str,
+    table_name: str,
+    columns: list[ColumnSpec],
+    *,
+    kind: WarehouseKind = WarehouseKind.WAREHOUSE,
+    mode: CredentialMode = CredentialMode.DEFAULT,
+) -> Table:
+    """Create an empty table from an explicit column spec (DDL only, no data).
+
+    Builds ``CREATE TABLE [schema].[table] (col TYPE [NULL|NOT NULL], …)`` from
+    the validated :class:`~fabric_dw.models.ColumnSpec` list.  No data is ever
+    read or inserted; this is a pure DDL operation.
+
+    Args:
+        target: The warehouse to connect to.
+        schema: The schema name.  Must pass :func:`validate_identifier`.
+        table_name: The table name.  Must pass :func:`validate_identifier`.
+        columns: Non-empty list of :class:`~fabric_dw.models.ColumnSpec` instances
+            describing each column.
+        kind: The :class:`~fabric_dw.models.WarehouseKind` of the item.
+            SQL Endpoint items are rejected with :class:`~fabric_dw.exceptions.ItemKindError`.
+        mode: The credential mode for Entra authentication.
+
+    Returns:
+        A :class:`~fabric_dw.models.Table` reflecting the newly-created table
+        (fetched via ``sys.tables`` after DDL).
+
+    Raises:
+        ItemKindError: If *kind* is :attr:`~fabric_dw.models.WarehouseKind.SQL_ENDPOINT`.
+        ValueError: If *schema* or *table_name* fails identifier validation,
+            if *columns* is empty, if any column name fails identifier validation,
+            or if any column ``sql_type`` is not on the Fabric DW type allowlist.
+        PermissionDeniedError: If the driver reports a CREATE TABLE permission error.
+    """
+    _assert_not_sql_endpoint(kind)
+    validate_identifier(schema)
+    validate_identifier(table_name)
+
+    if not columns:
+        msg = "columns must not be empty; provide at least one ColumnSpec"
+        raise ValueError(msg)
+
+    col_defs: list[str] = []
+    for col in columns:
+        validate_identifier(col.name)
+        validated_type = validate_tsql_type(col.sql_type)
+        null_clause = "NULL" if col.nullable else "NOT NULL"
+        col_defs.append(f"    {quote_identifier(col.name)} {validated_type} {null_clause}")
+
+    col_block = ",\n".join(col_defs)
+    ddl = (
+        f"CREATE TABLE {quote_identifier(schema)}.{quote_identifier(table_name)} (\n{col_block}\n)"
+    )
+
+    def _run_ddl() -> None:
+        run_query(target, ddl, mode=mode, commit=True, fetch="none")
+
+    await asyncio.to_thread(_run_ddl)
+    return await _fetch_table(target, schema, table_name, mode=mode)
+
+
+async def create_table_from_parquet(
+    target: SqlTarget,
+    schema: str,
+    table_name: str,
+    parquet_path: Path,
+    *,
+    kind: WarehouseKind = WarehouseKind.WAREHOUSE,
+    mode: CredentialMode = CredentialMode.DEFAULT,
+    varchar_length: int = 8000,
+) -> Table:
+    """Create an empty table whose schema is derived from a Parquet file.
+
+    Reads **only the Parquet footer** (schema metadata) — no data rows are ever
+    read or inserted.  Arrow types are mapped to Fabric-DW-supported T-SQL types
+    via :func:`~fabric_dw.types.arrow_type_to_tsql`.  Nullability is taken from
+    the Arrow schema field.
+
+    Args:
+        target: The warehouse to connect to.
+        schema: The schema name.  Must pass :func:`validate_identifier`.
+        table_name: The table name.  Must pass :func:`validate_identifier`.
+        parquet_path: Path to the Parquet file.  Only the file footer (schema)
+            is accessed — no data rows are read.
+        kind: The :class:`~fabric_dw.models.WarehouseKind` of the item.
+            SQL Endpoint items are rejected with :class:`~fabric_dw.exceptions.ItemKindError`.
+        mode: The credential mode for Entra authentication.
+        varchar_length: Default VARCHAR/VARBINARY length for string and binary
+            columns.  Defaults to 8000 (Fabric DW non-MAX maximum).
+
+    Returns:
+        A :class:`~fabric_dw.models.Table` reflecting the newly-created table.
+
+    Raises:
+        ItemKindError: If *kind* is :attr:`~fabric_dw.models.WarehouseKind.SQL_ENDPOINT`.
+        ValueError: If any Parquet field maps to an unsupported T-SQL type,
+            or if any derived identifier fails validation.
+        FileNotFoundError: If *parquet_path* does not exist.
+    """
+    import pyarrow.parquet as pq  # noqa: PLC0415
+
+    _assert_not_sql_endpoint(kind)
+    if not parquet_path.exists():
+        msg = f"Parquet file not found: {parquet_path}"
+        raise FileNotFoundError(msg)
+
+    # Read schema only — pq.read_schema reads the footer without loading any row groups.
+    arrow_schema = pq.read_schema(str(parquet_path))
+
+    columns: list[ColumnSpec] = []
+    for field in arrow_schema:
+        sql_type = arrow_type_to_tsql(field.type, field.name, varchar_length=varchar_length)
+        nullable = field.nullable
+        columns.append(ColumnSpec(name=field.name, sql_type=sql_type, nullable=nullable))
+
+    _log.debug("create_table_from_parquet: %d columns from %s", len(columns), parquet_path.name)
+    return await create_empty_table(target, schema, table_name, columns, kind=kind, mode=mode)
+
+
+async def create_table_from_csv(
+    target: SqlTarget,
+    schema: str,
+    table_name: str,
+    csv_path: Path,
+    *,
+    kind: WarehouseKind = WarehouseKind.WAREHOUSE,
+    mode: CredentialMode = CredentialMode.DEFAULT,
+    infer_types: bool = True,
+    all_varchar: bool = False,
+    varchar_length: int = 8000,
+    sample_rows: int = 1000,
+    delimiter: str = ",",
+    encoding: str = "utf-8-sig",
+) -> Table:
+    """Create an empty table whose schema is derived from a CSV file header.
+
+    Reads the CSV **header row + a bounded sample** of rows for type inference.
+    No data is inserted into the warehouse.
+
+    When *all_varchar* is ``True``, every column becomes ``VARCHAR(*varchar_length*)``
+    regardless of observed values — useful as an escape hatch when inference
+    produces unexpected types.
+
+    When *infer_types* is ``True`` (the default), :mod:`pyarrow.csv` is used to
+    read up to *sample_rows* rows and infer types; the mapping to T-SQL types
+    follows :func:`~fabric_dw.types.arrow_type_to_tsql`.
+
+    Args:
+        target: The warehouse to connect to.
+        schema: The schema name.  Must pass :func:`validate_identifier`.
+        table_name: The table name.  Must pass :func:`validate_identifier`.
+        csv_path: Path to the CSV file.  Only the header + a bounded sample of
+            rows are read — this is schema inference, not data loading.
+        kind: The :class:`~fabric_dw.models.WarehouseKind` of the item.
+            SQL Endpoint items are rejected with :class:`~fabric_dw.exceptions.ItemKindError`.
+        mode: The credential mode for Entra authentication.
+        infer_types: When ``True`` (default), types are inferred from sampled rows.
+            When ``False``, every column becomes ``VARCHAR(*varchar_length*)``.
+        all_varchar: Force all columns to ``VARCHAR(*varchar_length*)``, overriding
+            inference.  Useful when inference produces unexpected results.
+        varchar_length: Length for VARCHAR columns (default 8000).
+        sample_rows: Maximum number of rows to read for type inference (default 1000).
+        delimiter: CSV field delimiter (default ``,``).
+        encoding: File encoding (default ``utf-8-sig`` to strip BOM if present).
+
+    Returns:
+        A :class:`~fabric_dw.models.Table` reflecting the newly-created table.
+
+    Raises:
+        ItemKindError: If *kind* is :attr:`~fabric_dw.models.WarehouseKind.SQL_ENDPOINT`.
+        ValueError: If any inferred type maps to an unsupported T-SQL type,
+            or if any column name fails identifier validation.
+        FileNotFoundError: If *csv_path* does not exist.
+    """
+    import pyarrow.csv as pa_csv  # noqa: PLC0415
+
+    _assert_not_sql_endpoint(kind)
+    if not csv_path.exists():
+        msg = f"CSV file not found: {csv_path}"
+        raise FileNotFoundError(msg)
+
+    use_varchar = all_varchar or not infer_types
+
+    if use_varchar:
+        # Read just the header row to get column names.
+        import csv  # noqa: PLC0415
+
+        with csv_path.open(encoding=encoding, newline="") as fh:
+            reader = csv.reader(fh, delimiter=delimiter)
+            try:
+                header = next(reader)
+            except StopIteration:
+                msg = f"CSV file is empty: {csv_path}"
+                raise ValueError(msg) from None
+
+        columns = [
+            ColumnSpec(name=col_name, sql_type=f"VARCHAR({varchar_length})", nullable=True)
+            for col_name in header
+        ]
+    else:
+        # Read header + sample for inference via pyarrow.csv.
+        read_opts = pa_csv.ReadOptions(
+            encoding=encoding,
+            block_size=max(1, sample_rows) * 1024,  # approximate; pyarrow clips if needed
+        )
+        parse_opts = pa_csv.ParseOptions(delimiter=delimiter)
+        # ConvertOptions: auto-convert types, treat empty fields as null
+        convert_opts = pa_csv.ConvertOptions(null_values=["", "NULL", "null", "NA", "N/A"])
+
+        # pyarrow reads the whole file by default — we limit via block_size above
+        # but also wrap with a bounded read to avoid loading huge files.
+
+        arrow_table = pa_csv.read_csv(
+            str(csv_path),
+            read_options=read_opts,
+            parse_options=parse_opts,
+            convert_options=convert_opts,
+        )
+
+        # Trim to sample_rows to bound the inference sample.
+        if arrow_table.num_rows > sample_rows:
+            arrow_table = arrow_table.slice(0, sample_rows)
+            _log.debug(
+                "create_table_from_csv: trimmed to %d sample rows for type inference",
+                sample_rows,
+            )
+
+        columns = []
+        for i, name in enumerate(arrow_table.schema.names):
+            field = arrow_table.schema.field(i)
+            try:
+                sql_type = arrow_type_to_tsql(field.type, name, varchar_length=varchar_length)
+            except ValueError:
+                # Fall back to VARCHAR for non-mappable inferred types.
+                _log.warning(
+                    "Column %r: inferred Arrow type %r has no T-SQL equivalent; "
+                    "falling back to VARCHAR(%d)",
+                    name,
+                    field.type,
+                    varchar_length,
+                )
+                sql_type = f"VARCHAR({varchar_length})"
+            # CSV columns are always nullable (empty cells).
+            columns.append(ColumnSpec(name=name, sql_type=sql_type, nullable=True))
+
+    _log.debug("create_table_from_csv: %d columns from %s", len(columns), csv_path.name)
+    return await create_empty_table(target, schema, table_name, columns, kind=kind, mode=mode)
 
 
 async def clone_table(

--- a/src/fabric_dw/types.py
+++ b/src/fabric_dw/types.py
@@ -93,8 +93,12 @@ def _arrow_primitive_to_tsql(  # noqa: PLR0911,PLR0912
         return "SMALLINT"
     if pa.types.is_int32(at) or pa.types.is_uint16(at):
         return "INT"
-    if pa.types.is_int64(at) or pa.types.is_uint32(at) or pa.types.is_uint64(at):
+    if pa.types.is_int64(at) or pa.types.is_uint32(at):
         return "BIGINT"
+    # uint64 can hold values up to 2^64-1, which overflows BIGINT (max 2^63-1).
+    # DECIMAL(20,0) safely covers the full uint64 range without silent truncation.
+    if pa.types.is_uint64(at):
+        return "DECIMAL(20,0)"
     # Floats
     if pa.types.is_float16(at) or pa.types.is_float32(at):
         return "REAL"
@@ -106,6 +110,12 @@ def _arrow_primitive_to_tsql(  # noqa: PLR0911,PLR0912
     # Decimal
     if pa.types.is_decimal(at):
         dec = at  # type: ignore[assignment]
+        if dec.precision > 38:  # noqa: PLR2004
+            msg = (
+                f"Decimal type has precision {dec.precision}, which exceeds the Fabric DW "
+                "maximum of 38. Use --all-varchar or reduce precision before export."
+            )
+            raise ValueError(msg)
         return f"DECIMAL({dec.precision},{dec.scale})"
     # Dates / times
     if pa.types.is_date(at):
@@ -113,6 +123,12 @@ def _arrow_primitive_to_tsql(  # noqa: PLR0911,PLR0912
     if pa.types.is_time(at):
         return "TIME(7)"
     if pa.types.is_timestamp(at):
+        # Preserve timezone offset when the Arrow type carries timezone info.
+        # DATETIMEOFFSET stores the UTC value plus the original UTC offset,
+        # while DATETIME2 silently drops the offset.
+        ts = at  # type: ignore[assignment]
+        if ts.tz is not None:
+            return "DATETIMEOFFSET(7)"
         return "DATETIME2(7)"
     if pa.types.is_duration(at):
         return "BIGINT"

--- a/src/fabric_dw/types.py
+++ b/src/fabric_dw/types.py
@@ -1,0 +1,184 @@
+"""Arrow/Parquet → Fabric DW T-SQL type mapping.
+
+Fabric Data Warehouse supports a subset of SQL Server T-SQL types.  This module
+provides a single authoritative function for converting a :class:`pyarrow.DataType`
+(as returned from a Parquet schema or CSV inference) to a supported T-SQL type
+string.
+
+References
+----------
+- Fabric DW data types:
+  https://learn.microsoft.com/en-us/fabric/data-warehouse/data-types
+- CREATE TABLE (Fabric DW):
+  https://learn.microsoft.com/en-us/sql/t-sql/statements/create-table-azure-sql-data-warehouse?view=fabric
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pyarrow as pa
+
+__all__ = ["arrow_type_to_tsql", "validate_tsql_type"]
+
+# ---------------------------------------------------------------------------
+# Allowlist: T-SQL base type keywords supported by Fabric DW.
+# ---------------------------------------------------------------------------
+
+_TSQL_ALLOWLIST_RE = re.compile(
+    r"""
+    ^
+    (?:
+        SMALLINT | TINYINT | INT | BIGINT
+        | FLOAT | REAL
+        | BIT
+        | DECIMAL | NUMERIC
+        | DATE | DATETIME2 | TIME | DATETIMEOFFSET
+        | VARCHAR | NVARCHAR | CHAR | NCHAR
+        | VARBINARY
+        | UNIQUEIDENTIFIER
+    )
+    (?:\s*\(\s*\d+\s*(?:,\s*\d+\s*)?\))?
+    $
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+# Default VARCHAR length used when an exact length is not available.
+_DEFAULT_VARCHAR_LEN = 8000
+
+
+def validate_tsql_type(sql_type: str) -> str:
+    """Validate that *sql_type* is an allowlisted Fabric-DW T-SQL type.
+
+    This prevents injection via a caller-supplied type string.  Only the type
+    token itself (name + optional numeric parameters) is accepted — no keywords
+    like ``NULL``, ``NOT NULL``, ``IDENTITY``, etc.
+
+    Args:
+        sql_type: A T-SQL type string, e.g. ``"INT"``, ``"VARCHAR(255)"``.
+
+    Returns:
+        *sql_type* unchanged if valid.
+
+    Raises:
+        ValueError: If *sql_type* does not match the allowlist.
+    """
+    cleaned = sql_type.strip()
+    if not _TSQL_ALLOWLIST_RE.match(cleaned):
+        msg = (
+            f"Unsupported or unsafe T-SQL type {sql_type!r}. "
+            "Must be a Fabric-DW-supported type such as INT, VARCHAR(n), DECIMAL(p,s), "
+            "DATETIME2, DATE, BIT, BIGINT, REAL, FLOAT, VARBINARY(n)."
+        )
+        raise ValueError(msg)
+    return cleaned
+
+
+def _arrow_primitive_to_tsql(  # noqa: PLR0911,PLR0912
+    at: pa.DataType,
+    varchar_length: int,
+) -> str | None:
+    """Map a primitive (non-nested) Arrow type to a T-SQL type string.
+
+    Returns ``None`` for types that are not directly mappable (nested, union, etc.)
+    so the caller can apply fall-through logic.
+    """
+    import pyarrow as pa  # noqa: PLC0415
+
+    # Integers — ordered from smallest to largest to minimise False branches.
+    if pa.types.is_int8(at) or pa.types.is_int16(at) or pa.types.is_uint8(at):
+        return "SMALLINT"
+    if pa.types.is_int32(at) or pa.types.is_uint16(at):
+        return "INT"
+    if pa.types.is_int64(at) or pa.types.is_uint32(at) or pa.types.is_uint64(at):
+        return "BIGINT"
+    # Floats
+    if pa.types.is_float16(at) or pa.types.is_float32(at):
+        return "REAL"
+    if pa.types.is_float64(at):
+        return "FLOAT"
+    # Boolean
+    if pa.types.is_boolean(at):
+        return "BIT"
+    # Decimal
+    if pa.types.is_decimal(at):
+        dec = at  # type: ignore[assignment]
+        return f"DECIMAL({dec.precision},{dec.scale})"
+    # Dates / times
+    if pa.types.is_date(at):
+        return "DATE"
+    if pa.types.is_time(at):
+        return "TIME(7)"
+    if pa.types.is_timestamp(at):
+        return "DATETIME2(7)"
+    if pa.types.is_duration(at):
+        return "BIGINT"
+    # Strings
+    if pa.types.is_string(at) or pa.types.is_large_string(at):
+        return f"VARCHAR({varchar_length})"
+    # UTF-8 view (Arrow 12+)
+    try:
+        if pa.types.is_string_view(at):  # type: ignore[attr-defined]
+            return f"VARCHAR({varchar_length})"
+    except AttributeError:  # pragma: no cover — older pyarrow
+        pass
+    # Binary
+    if pa.types.is_binary(at) or pa.types.is_large_binary(at):
+        return f"VARBINARY({varchar_length})"
+    # Null type — map to the smallest nullable type
+    if pa.types.is_null(at):
+        return "VARCHAR(1)"
+    return None
+
+
+def arrow_type_to_tsql(
+    arrow_type: pa.DataType,
+    field_name: str = "<unknown>",
+    *,
+    varchar_length: int = _DEFAULT_VARCHAR_LEN,
+) -> str:
+    """Convert a :class:`pyarrow.DataType` to a Fabric-DW-supported T-SQL type string.
+
+    The mapping covers all common Arrow/Parquet primitive types.  Nested,
+    list, struct, and map types are not supported (and not representable in
+    Fabric DW's CREATE TABLE syntax).
+
+    Args:
+        arrow_type: The Arrow data type from a Parquet field or CSV-inferred schema.
+        field_name: The column name — used only in error messages so the caller
+            can identify which column triggered the error.
+        varchar_length: Default length for ``VARCHAR``/``NVARCHAR`` / ``VARBINARY``
+            columns when the type carries no length information.  Defaults to 8000
+            (Fabric DW maximum for non-MAX varchar).
+
+    Returns:
+        A Fabric-DW-compatible T-SQL type string, e.g. ``"INT"``, ``"VARCHAR(8000)"``.
+
+    Raises:
+        ValueError: When the Arrow type has no supported T-SQL equivalent
+            (e.g. list, struct, map, union, or dictionary with an unsupported key).
+    """
+    import pyarrow as pa  # noqa: PLC0415
+
+    at = arrow_type
+
+    # Try primitive mapping first.
+    result = _arrow_primitive_to_tsql(at, varchar_length)
+    if result is not None:
+        return result
+
+    # Dictionary (categorical) — expand to value type.
+    if pa.types.is_dictionary(at):
+        dict_type = at  # type: ignore[assignment]
+        return arrow_type_to_tsql(dict_type.value_type, field_name, varchar_length=varchar_length)
+
+    # Everything else (list, struct, map, union, fixed_size_list, …) is unsupported.
+    msg = (
+        f"Column {field_name!r}: Arrow type {at!r} has no supported Fabric DW T-SQL equivalent. "
+        "Nested types (list, struct, map, union) are not representable as a scalar column. "
+        "Use --all-varchar to fall back to VARCHAR for all columns."
+    )
+    raise ValueError(msg)

--- a/tests/integration/test_services_create_empty_table.py
+++ b/tests/integration/test_services_create_empty_table.py
@@ -1,0 +1,246 @@
+"""Integration tests for create_empty_table, create_table_from_parquet, create_table_from_csv.
+
+Run with: pytest -m integration tests/integration/test_services_create_empty_table.py
+
+Fixture note: uses ``warehouse_schema`` from conftest, which creates a uniquely-named
+schema inside the session-shared warm warehouse and cascade-drops it on teardown.
+The endpoint guard test uses ``ephemeral_sql_endpoint`` (a separate, function-scoped
+fixture that creates and tears down an ephemeral lakehouse + SQL endpoint).
+"""
+
+from __future__ import annotations
+
+import contextlib
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from fabric_dw.exceptions import ItemKindError
+from fabric_dw.models import ColumnSpec, Table, WarehouseKind
+from fabric_dw.services import tables
+from fabric_dw.sql import SqlTarget, run_query
+
+pytestmark = pytest.mark.integration
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_columns(target: SqlTarget, schema: str, table_name: str) -> list[dict[str, object]]:
+    """Fetch column metadata from sys.columns for the given table."""
+    sql = """\
+SELECT c.name AS column_name, t.name AS type_name, c.is_nullable
+FROM sys.columns c
+JOIN sys.types t ON t.user_type_id = c.user_type_id
+JOIN sys.tables tbl ON tbl.object_id = c.object_id
+JOIN sys.schemas s ON s.schema_id = tbl.schema_id
+WHERE s.name = ? AND tbl.name = ?
+ORDER BY c.column_id;
+"""
+    cols, rows = run_query(target, sql, params=[schema, table_name])
+    return [dict(zip(cols, r, strict=True)) for r in rows]
+
+
+# ---------------------------------------------------------------------------
+# create_empty_table — explicit schema
+# ---------------------------------------------------------------------------
+
+
+async def test_create_empty_table_explicit_schema(
+    warehouse_schema: tuple[SqlTarget, str],
+) -> None:
+    """Creating a table from an explicit ColumnSpec list produces the correct columns."""
+    sql_target, schema = warehouse_schema
+    table_name = "pytest_empty_explicit"
+
+    columns = [
+        ColumnSpec(name="id", sql_type="INT", nullable=False),
+        ColumnSpec(name="label", sql_type="VARCHAR(200)", nullable=True),
+        ColumnSpec(name="score", sql_type="FLOAT", nullable=True),
+    ]
+
+    try:
+        result = await tables.create_empty_table(sql_target, schema, table_name, columns)
+        assert isinstance(result, Table)
+        assert result.schema_name == schema
+        assert result.name == table_name
+
+        # Verify schema via sys.columns
+        db_cols = _get_columns(sql_target, schema, table_name)
+        assert len(db_cols) == 3
+        col_names = [c["column_name"] for c in db_cols]
+        assert "id" in col_names
+        assert "label" in col_names
+        assert "score" in col_names
+
+        # Verify nullability: id should be NOT NULL
+        id_col = next(c for c in db_cols if c["column_name"] == "id")
+        assert not id_col["is_nullable"], "id column should be NOT NULL"
+
+        # Verify the table is empty (DDL-only, no data)
+        _, rows = run_query(sql_target, f"SELECT COUNT(*) FROM [{schema}].[{table_name}]")  # noqa: S608  # noqa: S608
+        assert rows[0][0] == 0
+
+    finally:
+        with contextlib.suppress(Exception):
+            await tables.delete_table(sql_target, schema, table_name)
+
+
+# ---------------------------------------------------------------------------
+# create_empty_table — endpoint guard
+# ---------------------------------------------------------------------------
+
+
+async def test_create_empty_table_rejects_sql_endpoint(
+    ephemeral_sql_endpoint: object,
+) -> None:
+    """create_empty_table raises ItemKindError for SQL Analytics Endpoints."""
+    from fabric_dw.models import Warehouse  # noqa: PLC0415
+
+    endpoint = ephemeral_sql_endpoint  # type: ignore[assignment]
+    assert isinstance(endpoint, Warehouse)
+    assert endpoint.connection_string
+
+    # Use the already-provisioned endpoint fixture.
+    target = SqlTarget(
+        workspace_id=str(endpoint.workspace_id),
+        database=endpoint.name,
+        connection_string=endpoint.connection_string,  # type: ignore[arg-type]
+    )
+    cols = [ColumnSpec(name="id", sql_type="INT", nullable=True)]
+    with pytest.raises(ItemKindError):
+        await tables.create_empty_table(
+            target, "dbo", "should_not_be_created", cols, kind=WarehouseKind.SQL_ENDPOINT
+        )
+
+
+# ---------------------------------------------------------------------------
+# create_table_from_parquet
+# ---------------------------------------------------------------------------
+
+
+async def test_create_table_from_parquet(
+    warehouse_schema: tuple[SqlTarget, str],
+    tmp_path: Path,
+) -> None:
+    """create_table_from_parquet reads schema from a Parquet file and creates an empty table."""
+    sql_target, schema = warehouse_schema
+    table_name = "pytest_empty_parquet"
+
+    # Write a tiny Parquet file with a typed schema — no data rows.
+    arrow_schema = pa.schema(
+        [
+            pa.field("record_id", pa.int64(), nullable=False),
+            pa.field("description", pa.string(), nullable=True),
+            pa.field("amount", pa.float64(), nullable=True),
+            pa.field("is_active", pa.bool_(), nullable=True),
+        ]
+    )
+    parquet_file = tmp_path / "sample.parquet"
+    pq.write_table(
+        pa.table(
+            {
+                "record_id": pa.array([], type=pa.int64()),
+                "description": pa.array([], type=pa.string()),
+                "amount": pa.array([], type=pa.float64()),
+                "is_active": pa.array([], type=pa.bool_()),
+            },
+            schema=arrow_schema,
+        ),
+        str(parquet_file),
+    )
+
+    try:
+        result = await tables.create_table_from_parquet(
+            sql_target, schema, table_name, parquet_file
+        )
+        assert isinstance(result, Table)
+        assert result.schema_name == schema
+        assert result.name == table_name
+
+        # Verify columns in the DB match the Parquet schema.
+        db_cols = _get_columns(sql_target, schema, table_name)
+        col_names = [c["column_name"] for c in db_cols]
+        assert "record_id" in col_names
+        assert "description" in col_names
+        assert "amount" in col_names
+        assert "is_active" in col_names
+
+        # Verify empty (no data loaded).
+        _, rows = run_query(sql_target, f"SELECT COUNT(*) FROM [{schema}].[{table_name}]")  # noqa: S608
+        assert rows[0][0] == 0
+
+    finally:
+        with contextlib.suppress(Exception):
+            await tables.delete_table(sql_target, schema, table_name)
+
+
+# ---------------------------------------------------------------------------
+# create_table_from_csv
+# ---------------------------------------------------------------------------
+
+
+async def test_create_table_from_csv(
+    warehouse_schema: tuple[SqlTarget, str],
+    tmp_path: Path,
+) -> None:
+    """create_table_from_csv reads header + sample from CSV and creates an empty table."""
+    sql_target, schema = warehouse_schema
+    table_name = "pytest_empty_csv"
+
+    csv_file = tmp_path / "sample.csv"
+    csv_file.write_text(
+        "product_id,product_name,unit_price,in_stock\n1,Widget,9.99,true\n2,Gadget,19.99,false\n"
+    )
+
+    try:
+        result = await tables.create_table_from_csv(sql_target, schema, table_name, csv_file)
+        assert isinstance(result, Table)
+        assert result.schema_name == schema
+        assert result.name == table_name
+
+        # Verify columns exist.
+        db_cols = _get_columns(sql_target, schema, table_name)
+        col_names = [c["column_name"] for c in db_cols]
+        assert "product_id" in col_names
+        assert "product_name" in col_names
+
+        # Verify empty (no data loaded).
+        _, rows = run_query(sql_target, f"SELECT COUNT(*) FROM [{schema}].[{table_name}]")  # noqa: S608
+        assert rows[0][0] == 0
+
+    finally:
+        with contextlib.suppress(Exception):
+            await tables.delete_table(sql_target, schema, table_name)
+
+
+async def test_create_table_from_csv_all_varchar(
+    warehouse_schema: tuple[SqlTarget, str],
+    tmp_path: Path,
+) -> None:
+    """create_table_from_csv with --all-varchar maps every column to VARCHAR."""
+    sql_target, schema = warehouse_schema
+    table_name = "pytest_empty_csv_varchar"
+
+    csv_file = tmp_path / "sample_vc.csv"
+    csv_file.write_text("qty,name\n1,foo\n2,bar\n")
+
+    try:
+        result = await tables.create_table_from_csv(
+            sql_target, schema, table_name, csv_file, all_varchar=True, varchar_length=255
+        )
+        assert isinstance(result, Table)
+
+        db_cols = _get_columns(sql_target, schema, table_name)
+        for col in db_cols:
+            assert str(col["type_name"]).lower() == "varchar", (
+                f"Expected VARCHAR for {col['column_name']!r}, got {col['type_name']!r}"
+            )
+
+    finally:
+        with contextlib.suppress(Exception):
+            await tables.delete_table(sql_target, schema, table_name)

--- a/tests/unit/cli/commands/test_tables.py
+++ b/tests/unit/cli/commands/test_tables.py
@@ -10,10 +10,15 @@ from pathlib import Path
 from unittest.mock import AsyncMock, patch
 from uuid import UUID
 
+import click
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
 from click.testing import CliRunner
 
 from fabric_dw.cache import ItemEntry
 from fabric_dw.cli._main import cli
+from fabric_dw.cli.commands.tables import _parse_column_spec, _parse_schema_file
 from fabric_dw.exceptions import ItemKindError, NotFoundError, PermissionDeniedError
 from fabric_dw.models import Table, WarehouseKind
 from fabric_dw.sql import SqlTarget
@@ -1307,4 +1312,292 @@ class TestTablesRename:
                 cli,
                 ["tables", "rename", WS_GUID, WH_GUID, "dbo.sales", "--new-name", "sales_v2"],
             )
+        assert result.exit_code != 0
+
+
+# ===========================================================================
+# tables create — empty DDL path
+# ===========================================================================
+
+
+class TestTablesCreateEmpty:
+    """Tests for the empty-DDL source flags on tables create."""
+
+    def test_column_flag_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        mock_create_empty = AsyncMock(return_value=_make_table())
+        with (
+            patch(
+                "fabric_dw.cli.commands.tables.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.tables.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.tables.create_empty_table",
+                new=mock_create_empty,
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--json",
+                    "tables",
+                    "create",
+                    WS_GUID,
+                    WH_GUID,
+                    "--name",
+                    "dbo.sales",
+                    "--column",
+                    "id:INT:notnull",
+                    "--column",
+                    "name:VARCHAR(100)",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        mock_create_empty.assert_awaited_once()
+        parsed = json.loads(result.output)
+        assert parsed["name"] == "sales"
+
+    def test_from_schema_file_exits_zero(
+        self, runner: CliRunner, cache_env: Path, tmp_path: Path
+    ) -> None:
+        _ = cache_env
+        schema_file = tmp_path / "schema.json"
+        schema_file.write_text(
+            '[{"name": "id", "type": "INT", "nullable": false}, '
+            '{"name": "label", "type": "VARCHAR(100)"}]'
+        )
+        mock_http = AsyncMock()
+        mock_create_empty = AsyncMock(return_value=_make_table())
+        with (
+            patch(
+                "fabric_dw.cli.commands.tables.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.tables.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.tables.create_empty_table",
+                new=mock_create_empty,
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--json",
+                    "tables",
+                    "create",
+                    WS_GUID,
+                    WH_GUID,
+                    "--name",
+                    "dbo.sales",
+                    "--from-schema",
+                    str(schema_file),
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        mock_create_empty.assert_awaited_once()
+
+    def test_from_parquet_exits_zero(
+        self, runner: CliRunner, cache_env: Path, tmp_path: Path
+    ) -> None:
+        _ = cache_env
+        parquet_file = tmp_path / "data.parquet"
+        schema = pa.schema([pa.field("id", pa.int32()), pa.field("name", pa.string())])
+        pq.write_table(
+            pa.table(
+                {"id": pa.array([], type=pa.int32()), "name": pa.array([], type=pa.string())},
+                schema=schema,
+            ),
+            str(parquet_file),
+        )
+        mock_http = AsyncMock()
+        mock_create_empty = AsyncMock(return_value=_make_table())
+        with (
+            patch(
+                "fabric_dw.cli.commands.tables.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.tables.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.tables.create_table_from_parquet",
+                new=mock_create_empty,
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--json",
+                    "tables",
+                    "create",
+                    WS_GUID,
+                    WH_GUID,
+                    "--name",
+                    "dbo.sales",
+                    "--from-parquet",
+                    str(parquet_file),
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        mock_create_empty.assert_awaited_once()
+
+    def test_from_csv_exits_zero(self, runner: CliRunner, cache_env: Path, tmp_path: Path) -> None:
+        _ = cache_env
+        csv_file = tmp_path / "data.csv"
+        csv_file.write_text("id,name\n1,Alice\n2,Bob\n")
+        mock_http = AsyncMock()
+        mock_create_empty = AsyncMock(return_value=_make_table())
+        with (
+            patch(
+                "fabric_dw.cli.commands.tables.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.tables.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.tables.create_table_from_csv",
+                new=mock_create_empty,
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--json",
+                    "tables",
+                    "create",
+                    WS_GUID,
+                    WH_GUID,
+                    "--name",
+                    "dbo.sales",
+                    "--from-csv",
+                    str(csv_file),
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        mock_create_empty.assert_awaited_once()
+
+    def test_no_source_fails(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        result = runner.invoke(
+            cli,
+            ["tables", "create", WS_GUID, WH_GUID, "--name", "dbo.sales"],
+        )
+        assert result.exit_code != 0
+
+    def test_ctas_and_parquet_mutually_exclusive(
+        self, runner: CliRunner, cache_env: Path, tmp_path: Path
+    ) -> None:
+        _ = cache_env
+        parquet_file = tmp_path / "data.parquet"
+        pq.write_table(pa.table({"id": pa.array([], type=pa.int32())}), str(parquet_file))
+        result = runner.invoke(
+            cli,
+            [
+                "tables",
+                "create",
+                WS_GUID,
+                WH_GUID,
+                "--name",
+                "dbo.sales",
+                "--select",
+                "SELECT 1",
+                "--from-parquet",
+                str(parquet_file),
+            ],
+        )
+        assert result.exit_code != 0
+
+    def test_parquet_and_csv_mutually_exclusive(
+        self, runner: CliRunner, cache_env: Path, tmp_path: Path
+    ) -> None:
+        _ = cache_env
+        parquet_file = tmp_path / "data.parquet"
+        csv_file = tmp_path / "data.csv"
+        pq.write_table(pa.table({"id": pa.array([], type=pa.int32())}), str(parquet_file))
+        csv_file.write_text("id\n1\n")
+        result = runner.invoke(
+            cli,
+            [
+                "tables",
+                "create",
+                WS_GUID,
+                WH_GUID,
+                "--name",
+                "dbo.sales",
+                "--from-parquet",
+                str(parquet_file),
+                "--from-csv",
+                str(csv_file),
+            ],
+        )
+        assert result.exit_code != 0
+
+    def test_parse_column_spec_null(self) -> None:
+        spec = _parse_column_spec("my_col:VARCHAR(100):null")
+        assert spec.name == "my_col"
+        assert spec.sql_type == "VARCHAR(100)"
+        assert spec.nullable is True
+
+    def test_parse_column_spec_notnull(self) -> None:
+        spec = _parse_column_spec("id:INT:notnull")
+        assert spec.name == "id"
+        assert spec.sql_type == "INT"
+        assert spec.nullable is False
+
+    def test_parse_column_spec_default_nullable(self) -> None:
+        spec = _parse_column_spec("label:BIGINT")
+        assert spec.nullable is True
+
+    def test_parse_column_spec_invalid_format(self) -> None:
+        with pytest.raises(click.UsageError):
+            _parse_column_spec("notype")
+
+    def test_parse_schema_file_valid(self, tmp_path: Path) -> None:
+        f = tmp_path / "s.json"
+        f.write_text(
+            '[{"name": "id", "type": "INT"},'
+            ' {"name": "lbl", "type": "VARCHAR(100)", "nullable": false}]'
+        )
+        specs = _parse_schema_file(str(f))
+        assert len(specs) == 2
+        assert specs[0].name == "id"
+        assert specs[1].nullable is False
+
+    def test_parse_schema_file_missing(self) -> None:
+        with pytest.raises(click.UsageError, match="not found"):
+            _parse_schema_file("/nonexistent/path.json")
+
+    def test_parse_schema_file_invalid_json(self, tmp_path: Path) -> None:
+        f = tmp_path / "bad.json"
+        f.write_text("not json")
+        with pytest.raises(click.UsageError, match="Invalid JSON"):
+            _parse_schema_file(str(f))
+
+    def test_all_varchar_requires_from_csv(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        result = runner.invoke(
+            cli,
+            [
+                "tables",
+                "create",
+                WS_GUID,
+                WH_GUID,
+                "--name",
+                "dbo.sales",
+                "--column",
+                "id:INT",
+                "--all-varchar",
+            ],
+        )
         assert result.exit_code != 0

--- a/tests/unit/mcp/test_contract.py
+++ b/tests/unit/mcp/test_contract.py
@@ -46,7 +46,7 @@ from tests.unit.mcp.conftest import WS_ID, WS_NAME, make_item_entry
 # Expected tool count (sync with test_server.EXPECTED_TOOL_NAMES)
 # ---------------------------------------------------------------------------
 
-_EXPECTED_TOOL_COUNT = 78  # +5 statistics tools, +1 generate_dbt_profile, +3 create-from-schema
+_EXPECTED_TOOL_COUNT = 79  # +5 statistics tools, +1 generate_dbt_profile, +3 create-from-schema
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/mcp/test_contract.py
+++ b/tests/unit/mcp/test_contract.py
@@ -46,7 +46,7 @@ from tests.unit.mcp.conftest import WS_ID, WS_NAME, make_item_entry
 # Expected tool count (sync with test_server.EXPECTED_TOOL_NAMES)
 # ---------------------------------------------------------------------------
 
-_EXPECTED_TOOL_COUNT = 78  # +5 statistics tools, +1 generate_dbt_profile
+_EXPECTED_TOOL_COUNT = 78  # +5 statistics tools, +1 generate_dbt_profile, +3 create-from-schema
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/mcp/test_server.py
+++ b/tests/unit/mcp/test_server.py
@@ -120,6 +120,7 @@ EXPECTED_TOOL_NAMES: frozenset[str] = frozenset(
         "list_tables",
         "read_table",
         "create_table",
+        "create_empty_table",
         "clone_table",
         "rename_table",
         "delete_table",

--- a/tests/unit/mcp/tools/test_tables.py
+++ b/tests/unit/mcp/tools/test_tables.py
@@ -481,3 +481,90 @@ async def test_clone_table_bad_at_timestamp_raises_tool_error(ctx_patch) -> None
         )
 
     assert "ISO-8601" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# create_empty_table — MCP tool
+# ---------------------------------------------------------------------------
+
+
+async def test_create_empty_table_happy_path(mock_ctx, ctx_patch) -> None:
+    """create_empty_table resolves workspace + item, builds target, calls service."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    table = _make_table()
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+    mock_create = AsyncMock(return_value=table)
+
+    with (
+        ctx_patch,
+        patch("fabric_dw.services.tables.create_empty_table", new=mock_create),
+        patch.dict(os.environ, {"FABRIC_MCP_WRITES": "true"}),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "create_empty_table",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_name": "dbo.sales",
+                "columns": [
+                    {"name": "id", "sql_type": "INT", "nullable": False},
+                    {"name": "label", "sql_type": "VARCHAR(100)"},
+                ],
+            },
+        )
+
+    mock_create.assert_called_once()
+    assert result["name"] == "sales"
+    assert result["schema_name"] == "dbo"
+
+
+async def test_create_empty_table_bad_column_raises_tool_error(mock_ctx, ctx_patch) -> None:
+    """create_empty_table raises ToolError when a column dict is missing required keys."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_WRITES": "true"}),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "create_empty_table",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_name": "dbo.sales",
+                "columns": [{"name": "id"}],  # missing sql_type
+            },
+        )
+
+
+async def test_create_empty_table_sql_endpoint_raises_tool_error(mock_ctx, ctx_patch) -> None:
+    """create_empty_table raises ToolError for SQL Analytics Endpoints."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+    from tests.unit.mcp.conftest import make_sql_endpoint_entry  # noqa: PLC0415
+
+    endpoint_entry = make_sql_endpoint_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=endpoint_entry)
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_WRITES": "true"}),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "create_empty_table",
+            {
+                "workspace": WS_NAME,
+                "item": "MySqlEndpoint",
+                "qualified_name": "dbo.sales",
+                "columns": [{"name": "id", "sql_type": "INT"}],
+            },
+        )

--- a/tests/unit/services/test_tables.py
+++ b/tests/unit/services/test_tables.py
@@ -1256,3 +1256,44 @@ class TestCreateTableFromCsv:
         target = _make_target()
         with pytest.raises(ValueError, match="empty"):
             await tables.create_table_from_csv(target, "dbo", "sales", csv_file, all_varchar=True)
+
+    async def test_csv_bounded_streaming_reads_only_prefix(self, tmp_path: Path) -> None:
+        """Only a bounded prefix of the CSV is read — large tail is never loaded.
+
+        We write a 10-row CSV and pass sample_rows=3.  The resulting table must
+        use the inferred schema (not all-varchar) and the DDL must reference the
+        correct column names, confirming inference ran on the sample only.
+        """
+        csv_file = tmp_path / "big.csv"
+        rows = ["id,value"] + [f"{i},{i * 10}" for i in range(10)]
+        csv_file.write_text("\n".join(rows) + "\n")
+
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_TABLE_ROW_1], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            result = await tables.create_table_from_csv(
+                target, "dbo", "sales", csv_file, sample_rows=3
+            )
+        assert isinstance(result, Table)
+        ddl_cursor = ddl_conn.cursor.return_value
+        sql: str = ddl_cursor.execute.call_args[0][0]
+        # Columns must appear in the DDL — confirms schema was inferred.
+        assert "[id]" in sql
+        assert "[value]" in sql
+
+    async def test_csv_header_only_produces_varchar_columns(self, tmp_path: Path) -> None:
+        """A header-only CSV (no data rows) results in NULL-typed columns mapped to VARCHAR."""
+        csv_file = tmp_path / "header_only.csv"
+        csv_file.write_text("col_a,col_b\n")
+
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_TABLE_ROW_1], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            result = await tables.create_table_from_csv(target, "dbo", "sales", csv_file)
+        assert isinstance(result, Table)
+        ddl_cursor = ddl_conn.cursor.return_value
+        sql: str = ddl_cursor.execute.call_args[0][0]
+        assert "[col_a]" in sql
+        assert "[col_b]" in sql

--- a/tests/unit/services/test_tables.py
+++ b/tests/unit/services/test_tables.py
@@ -4,12 +4,15 @@ from __future__ import annotations
 
 import time
 from datetime import UTC, datetime
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pyarrow as pa
+import pyarrow.parquet as pq
 import pytest
 
 from fabric_dw.exceptions import AuthError, ItemKindError, NotFoundError, PermissionDeniedError
-from fabric_dw.models import Table, WarehouseKind
+from fabric_dw.models import ColumnSpec, Table, WarehouseKind
 from fabric_dw.services import tables
 from fabric_dw.services.tables import validate_identifier
 from tests.unit.services._helpers import _make_conn, _make_conn_for_ddl, _make_target
@@ -1019,3 +1022,237 @@ class TestRenameTable:
                 target, "dbo.sales", "sales_v2", kind=WarehouseKind.WAREHOUSE
             )
         assert isinstance(result, Table)
+
+
+# ===========================================================================
+# create_empty_table
+# ===========================================================================
+
+
+class TestCreateEmptyTable:
+    _COLS = _LIST_COLS  # schema_name, name, created, modified
+
+    async def test_basic_ddl_executed_and_table_returned(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_TABLE_ROW_1], _LIST_COLS)
+        cols = [
+            ColumnSpec(name="id", sql_type="INT", nullable=False),
+            ColumnSpec(name="name", sql_type="VARCHAR(255)", nullable=True),
+        ]
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            result = await tables.create_empty_table(target, "dbo", "sales", cols)
+        assert isinstance(result, Table)
+        assert result.name == "sales"
+
+    async def test_ddl_contains_create_table(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_TABLE_ROW_1], _LIST_COLS)
+        cols = [ColumnSpec(name="id", sql_type="INT", nullable=False)]
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            await tables.create_empty_table(target, "dbo", "sales", cols)
+        ddl_cursor = ddl_conn.cursor.return_value
+        sql: str = ddl_cursor.execute.call_args[0][0]
+        assert "CREATE TABLE" in sql
+        assert "[dbo]" in sql
+        assert "[sales]" in sql
+
+    async def test_ddl_uses_not_null(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_TABLE_ROW_1], _LIST_COLS)
+        cols = [ColumnSpec(name="id", sql_type="INT", nullable=False)]
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            await tables.create_empty_table(target, "dbo", "sales", cols)
+        ddl_cursor = ddl_conn.cursor.return_value
+        sql: str = ddl_cursor.execute.call_args[0][0]
+        assert "NOT NULL" in sql
+
+    async def test_ddl_uses_null(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_TABLE_ROW_1], _LIST_COLS)
+        cols = [ColumnSpec(name="desc", sql_type="VARCHAR(100)", nullable=True)]
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            await tables.create_empty_table(target, "dbo", "sales", cols)
+        ddl_cursor = ddl_conn.cursor.return_value
+        sql: str = ddl_cursor.execute.call_args[0][0]
+        assert " NULL" in sql
+
+    async def test_rejects_empty_columns(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="empty"):
+            await tables.create_empty_table(target, "dbo", "sales", [])
+
+    async def test_rejects_sql_endpoint(self) -> None:
+        target = _make_target()
+        cols = [ColumnSpec(name="id", sql_type="INT", nullable=True)]
+        with pytest.raises(ItemKindError):
+            await tables.create_empty_table(
+                target, "dbo", "sales", cols, kind=WarehouseKind.SQL_ENDPOINT
+            )
+
+    async def test_rejects_invalid_schema(self) -> None:
+        target = _make_target()
+        cols = [ColumnSpec(name="id", sql_type="INT", nullable=True)]
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await tables.create_empty_table(target, "bad;schema", "sales", cols)
+
+    async def test_rejects_invalid_table_name(self) -> None:
+        target = _make_target()
+        cols = [ColumnSpec(name="id", sql_type="INT", nullable=True)]
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await tables.create_empty_table(target, "dbo", "bad--table", cols)
+
+    async def test_rejects_invalid_column_name(self) -> None:
+        target = _make_target()
+        cols = [ColumnSpec(name="bad]col", sql_type="INT", nullable=True)]
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await tables.create_empty_table(target, "dbo", "sales", cols)
+
+    async def test_rejects_unsupported_sql_type(self) -> None:
+        target = _make_target()
+        cols = [ColumnSpec(name="col", sql_type="TEXT", nullable=True)]
+        with pytest.raises(ValueError, match="Unsupported"):
+            await tables.create_empty_table(target, "dbo", "sales", cols)
+
+    async def test_rejects_injection_in_type(self) -> None:
+        target = _make_target()
+        cols = [ColumnSpec(name="col", sql_type="INT; DROP TABLE foo--", nullable=True)]
+        with pytest.raises(ValueError, match="Unsupported"):
+            await tables.create_empty_table(target, "dbo", "sales", cols)
+
+    async def test_rejects_injection_in_col_name(self) -> None:
+        target = _make_target()
+        cols = [ColumnSpec(name="col]; DROP TABLE foo--", sql_type="INT", nullable=True)]
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await tables.create_empty_table(target, "dbo", "sales", cols)
+
+    async def test_warehouse_kind_allowed(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_TABLE_ROW_1], _LIST_COLS)
+        cols = [ColumnSpec(name="id", sql_type="INT", nullable=True)]
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            result = await tables.create_empty_table(
+                target, "dbo", "sales", cols, kind=WarehouseKind.WAREHOUSE
+            )
+        assert isinstance(result, Table)
+
+
+# ===========================================================================
+# create_table_from_parquet
+# ===========================================================================
+
+
+class TestCreateTableFromParquet:
+    async def test_creates_table_from_parquet_schema(self, tmp_path: Path) -> None:
+        parquet_file = tmp_path / "data.parquet"
+        schema = pa.schema(
+            [
+                pa.field("id", pa.int32(), nullable=False),
+                pa.field("name", pa.string(), nullable=True),
+            ]
+        )
+        pq.write_table(
+            pa.table(
+                {"id": pa.array([], type=pa.int32()), "name": pa.array([], type=pa.string())},
+                schema=schema,
+            ),
+            str(parquet_file),
+        )
+
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_TABLE_ROW_1], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            result = await tables.create_table_from_parquet(target, "dbo", "sales", parquet_file)
+        assert isinstance(result, Table)
+
+    async def test_parquet_ddl_uses_bracket_quoted_names(self, tmp_path: Path) -> None:
+        parquet_file = tmp_path / "data.parquet"
+        schema = pa.schema([pa.field("id", pa.int32())])
+        pq.write_table(
+            pa.table({"id": pa.array([], type=pa.int32())}, schema=schema),
+            str(parquet_file),
+        )
+
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_TABLE_ROW_1], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            await tables.create_table_from_parquet(target, "dbo", "sales", parquet_file)
+        ddl_cursor = ddl_conn.cursor.return_value
+        sql: str = ddl_cursor.execute.call_args[0][0]
+        assert "[dbo]" in sql
+        assert "[sales]" in sql
+        assert "[id]" in sql
+
+    async def test_parquet_rejects_sql_endpoint(self, tmp_path: Path) -> None:
+        parquet_file = tmp_path / "data.parquet"
+        pq.write_table(pa.table({"id": pa.array([], type=pa.int32())}), str(parquet_file))
+        target = _make_target()
+        with pytest.raises(ItemKindError):
+            await tables.create_table_from_parquet(
+                target, "dbo", "sales", parquet_file, kind=WarehouseKind.SQL_ENDPOINT
+            )
+
+    async def test_parquet_raises_file_not_found(self, tmp_path: Path) -> None:
+        target = _make_target()
+        with pytest.raises(FileNotFoundError):
+            await tables.create_table_from_parquet(
+                target, "dbo", "sales", tmp_path / "nonexistent.parquet"
+            )
+
+
+# ===========================================================================
+# create_table_from_csv
+# ===========================================================================
+
+
+class TestCreateTableFromCsv:
+    async def test_creates_table_from_csv_header(self, tmp_path: Path) -> None:
+        csv_file = tmp_path / "data.csv"
+        csv_file.write_text("id,name\n1,Alice\n2,Bob\n")
+
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_TABLE_ROW_1], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            result = await tables.create_table_from_csv(target, "dbo", "sales", csv_file)
+        assert isinstance(result, Table)
+
+    async def test_all_varchar_uses_varchar(self, tmp_path: Path) -> None:
+        csv_file = tmp_path / "data.csv"
+        csv_file.write_text("count,label\n1,foo\n")
+
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_TABLE_ROW_1], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            await tables.create_table_from_csv(target, "dbo", "sales", csv_file, all_varchar=True)
+        ddl_cursor = ddl_conn.cursor.return_value
+        sql: str = ddl_cursor.execute.call_args[0][0]
+        assert "VARCHAR" in sql
+
+    async def test_csv_rejects_sql_endpoint(self, tmp_path: Path) -> None:
+        csv_file = tmp_path / "data.csv"
+        csv_file.write_text("id\n1\n")
+        target = _make_target()
+        with pytest.raises(ItemKindError):
+            await tables.create_table_from_csv(
+                target, "dbo", "sales", csv_file, kind=WarehouseKind.SQL_ENDPOINT
+            )
+
+    async def test_csv_raises_file_not_found(self, tmp_path: Path) -> None:
+        target = _make_target()
+        with pytest.raises(FileNotFoundError):
+            await tables.create_table_from_csv(target, "dbo", "sales", tmp_path / "nonexistent.csv")
+
+    async def test_csv_empty_file_raises(self, tmp_path: Path) -> None:
+        csv_file = tmp_path / "empty.csv"
+        csv_file.write_text("")
+        target = _make_target()
+        with pytest.raises(ValueError, match="empty"):
+            await tables.create_table_from_csv(target, "dbo", "sales", csv_file, all_varchar=True)

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -1,0 +1,198 @@
+"""Unit tests for fabric_dw.types — Arrow→T-SQL type mapping."""
+
+from __future__ import annotations
+
+import pyarrow as pa
+import pytest
+
+from fabric_dw.types import arrow_type_to_tsql, validate_tsql_type
+
+# ===========================================================================
+# validate_tsql_type
+# ===========================================================================
+
+
+class TestValidateTsqlType:
+    def test_simple_types_accepted(self) -> None:
+        for t in ["INT", "BIGINT", "SMALLINT", "TINYINT", "BIT", "FLOAT", "REAL", "DATE"]:
+            assert validate_tsql_type(t) == t
+
+    def test_case_insensitive(self) -> None:
+        assert validate_tsql_type("int") == "int"
+        assert validate_tsql_type("Varchar(255)") == "Varchar(255)"
+
+    def test_parameterised_types_accepted(self) -> None:
+        assert validate_tsql_type("VARCHAR(255)") == "VARCHAR(255)"
+        assert validate_tsql_type("DECIMAL(18,4)") == "DECIMAL(18,4)"
+        assert validate_tsql_type("VARBINARY(8000)") == "VARBINARY(8000)"
+        assert validate_tsql_type("DATETIME2(7)") == "DATETIME2(7)"
+        assert validate_tsql_type("TIME(7)") == "TIME(7)"
+        assert validate_tsql_type("NVARCHAR(100)") == "NVARCHAR(100)"
+
+    def test_injection_rejected(self) -> None:
+        with pytest.raises(ValueError, match="Unsupported or unsafe"):
+            validate_tsql_type("INT; DROP TABLE users--")
+
+    def test_text_rejected(self) -> None:
+        with pytest.raises(ValueError, match="Unsupported or unsafe"):
+            validate_tsql_type("TEXT")
+
+    def test_xml_rejected(self) -> None:
+        with pytest.raises(ValueError, match="Unsupported or unsafe"):
+            validate_tsql_type("XML")
+
+    def test_money_rejected(self) -> None:
+        with pytest.raises(ValueError, match="Unsupported or unsafe"):
+            validate_tsql_type("MONEY")
+
+    def test_image_rejected(self) -> None:
+        with pytest.raises(ValueError, match="Unsupported or unsafe"):
+            validate_tsql_type("IMAGE")
+
+    def test_empty_rejected(self) -> None:
+        with pytest.raises(ValueError, match="Unsupported or unsafe"):
+            validate_tsql_type("")
+
+    def test_whitespace_stripped(self) -> None:
+        assert validate_tsql_type("  INT  ") == "INT"
+
+
+# ===========================================================================
+# arrow_type_to_tsql — supported types
+# ===========================================================================
+
+
+class TestArrowTypeToTsqlSupported:
+    """Each supported Arrow type maps to the correct T-SQL type."""
+
+    # --- integers ---
+    def test_int8_to_smallint(self) -> None:
+        assert arrow_type_to_tsql(pa.int8()) == "SMALLINT"
+
+    def test_int16_to_smallint(self) -> None:
+        assert arrow_type_to_tsql(pa.int16()) == "SMALLINT"
+
+    def test_uint8_to_smallint(self) -> None:
+        assert arrow_type_to_tsql(pa.uint8()) == "SMALLINT"
+
+    def test_int32_to_int(self) -> None:
+        assert arrow_type_to_tsql(pa.int32()) == "INT"
+
+    def test_uint16_to_int(self) -> None:
+        assert arrow_type_to_tsql(pa.uint16()) == "INT"
+
+    def test_int64_to_bigint(self) -> None:
+        assert arrow_type_to_tsql(pa.int64()) == "BIGINT"
+
+    def test_uint32_to_bigint(self) -> None:
+        assert arrow_type_to_tsql(pa.uint32()) == "BIGINT"
+
+    def test_uint64_to_bigint(self) -> None:
+        assert arrow_type_to_tsql(pa.uint64()) == "BIGINT"
+
+    # --- floats ---
+    def test_float16_to_real(self) -> None:
+        assert arrow_type_to_tsql(pa.float16()) == "REAL"
+
+    def test_float32_to_real(self) -> None:
+        assert arrow_type_to_tsql(pa.float32()) == "REAL"
+
+    def test_float64_to_float(self) -> None:
+        assert arrow_type_to_tsql(pa.float64()) == "FLOAT"
+
+    # --- boolean ---
+    def test_bool_to_bit(self) -> None:
+        assert arrow_type_to_tsql(pa.bool_()) == "BIT"
+
+    # --- decimal ---
+    def test_decimal128_to_decimal(self) -> None:
+        assert arrow_type_to_tsql(pa.decimal128(18, 4)) == "DECIMAL(18,4)"
+
+    def test_decimal128_zero_scale(self) -> None:
+        assert arrow_type_to_tsql(pa.decimal128(10, 0)) == "DECIMAL(10,0)"
+
+    # --- date ---
+    def test_date32_to_date(self) -> None:
+        assert arrow_type_to_tsql(pa.date32()) == "DATE"
+
+    def test_date64_to_date(self) -> None:
+        assert arrow_type_to_tsql(pa.date64()) == "DATE"
+
+    # --- time ---
+    def test_time32_to_time(self) -> None:
+        assert arrow_type_to_tsql(pa.time32("s")) == "TIME(7)"
+
+    def test_time64_to_time(self) -> None:
+        assert arrow_type_to_tsql(pa.time64("us")) == "TIME(7)"
+
+    # --- timestamp ---
+    def test_timestamp_to_datetime2(self) -> None:
+        assert arrow_type_to_tsql(pa.timestamp("us")) == "DATETIME2(7)"
+
+    def test_timestamp_tz_to_datetime2(self) -> None:
+        assert arrow_type_to_tsql(pa.timestamp("us", tz="UTC")) == "DATETIME2(7)"
+
+    # --- duration ---
+    def test_duration_to_bigint(self) -> None:
+        assert arrow_type_to_tsql(pa.duration("s")) == "BIGINT"
+
+    # --- strings ---
+    def test_string_to_varchar_default(self) -> None:
+        assert arrow_type_to_tsql(pa.string()) == "VARCHAR(8000)"
+
+    def test_large_string_to_varchar_default(self) -> None:
+        assert arrow_type_to_tsql(pa.large_string()) == "VARCHAR(8000)"
+
+    def test_string_to_varchar_custom_length(self) -> None:
+        assert arrow_type_to_tsql(pa.string(), varchar_length=255) == "VARCHAR(255)"
+
+    # --- binary ---
+    def test_binary_to_varbinary(self) -> None:
+        assert arrow_type_to_tsql(pa.binary()) == "VARBINARY(8000)"
+
+    def test_large_binary_to_varbinary(self) -> None:
+        assert arrow_type_to_tsql(pa.large_binary()) == "VARBINARY(8000)"
+
+    # --- null ---
+    def test_null_to_varchar1(self) -> None:
+        assert arrow_type_to_tsql(pa.null()) == "VARCHAR(1)"
+
+    # --- dictionary (categorical) ---
+    def test_dict_string_values_to_varchar(self) -> None:
+        dict_type = pa.dictionary(pa.int8(), pa.string())
+        assert arrow_type_to_tsql(dict_type) == "VARCHAR(8000)"
+
+    def test_dict_int32_values_to_int(self) -> None:
+        dict_type = pa.dictionary(pa.int8(), pa.int32())
+        assert arrow_type_to_tsql(dict_type) == "INT"
+
+
+# ===========================================================================
+# arrow_type_to_tsql — unsupported types
+# ===========================================================================
+
+
+class TestArrowTypeToTsqlUnsupported:
+    """Unsupported Arrow types raise ValueError naming the column."""
+
+    def test_list_type_raises(self) -> None:
+        with pytest.raises(ValueError, match="col_a"):
+            arrow_type_to_tsql(pa.list_(pa.int32()), "col_a")
+
+    def test_struct_type_raises(self) -> None:
+        struct_type = pa.struct([pa.field("x", pa.int32())])
+        with pytest.raises(ValueError, match="col_b"):
+            arrow_type_to_tsql(struct_type, "col_b")
+
+    def test_map_type_raises(self) -> None:
+        map_type = pa.map_(pa.string(), pa.int32())
+        with pytest.raises(ValueError, match="col_c"):
+            arrow_type_to_tsql(map_type, "col_c")
+
+    def test_error_mentions_all_varchar_hint(self) -> None:
+        with pytest.raises(ValueError, match="all-varchar"):
+            arrow_type_to_tsql(pa.list_(pa.int32()), "bad_col")
+
+    def test_fixed_size_list_raises(self) -> None:
+        with pytest.raises(ValueError, match=r"(?i)nested"):
+            arrow_type_to_tsql(pa.list_(pa.float32(), 3), "vec")

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -87,8 +87,10 @@ class TestArrowTypeToTsqlSupported:
     def test_uint32_to_bigint(self) -> None:
         assert arrow_type_to_tsql(pa.uint32()) == "BIGINT"
 
-    def test_uint64_to_bigint(self) -> None:
-        assert arrow_type_to_tsql(pa.uint64()) == "BIGINT"
+    def test_uint64_to_decimal20(self) -> None:
+        # uint64 can hold values up to 2^64-1, overflowing BIGINT (max 2^63-1).
+        # DECIMAL(20,0) covers the full uint64 range without silent truncation.
+        assert arrow_type_to_tsql(pa.uint64()) == "DECIMAL(20,0)"
 
     # --- floats ---
     def test_float16_to_real(self) -> None:
@@ -129,8 +131,12 @@ class TestArrowTypeToTsqlSupported:
     def test_timestamp_to_datetime2(self) -> None:
         assert arrow_type_to_tsql(pa.timestamp("us")) == "DATETIME2(7)"
 
-    def test_timestamp_tz_to_datetime2(self) -> None:
-        assert arrow_type_to_tsql(pa.timestamp("us", tz="UTC")) == "DATETIME2(7)"
+    def test_timestamp_tz_to_datetimeoffset(self) -> None:
+        # tz-aware timestamps map to DATETIMEOFFSET to preserve the UTC offset.
+        assert arrow_type_to_tsql(pa.timestamp("us", tz="UTC")) == "DATETIMEOFFSET(7)"
+
+    def test_timestamp_tz_named_zone_to_datetimeoffset(self) -> None:
+        assert arrow_type_to_tsql(pa.timestamp("s", tz="Europe/Brussels")) == "DATETIMEOFFSET(7)"
 
     # --- duration ---
     def test_duration_to_bigint(self) -> None:
@@ -196,3 +202,16 @@ class TestArrowTypeToTsqlUnsupported:
     def test_fixed_size_list_raises(self) -> None:
         with pytest.raises(ValueError, match=r"(?i)nested"):
             arrow_type_to_tsql(pa.list_(pa.float32(), 3), "vec")
+
+    def test_decimal256_precision_39_raises(self) -> None:
+        # decimal256 allows up to precision 76, but Fabric DW caps at 38.
+        with pytest.raises(ValueError, match="precision 39"):
+            arrow_type_to_tsql(pa.decimal256(39, 10), "amount")
+
+    def test_decimal256_precision_76_raises(self) -> None:
+        with pytest.raises(ValueError, match="precision 76"):
+            arrow_type_to_tsql(pa.decimal256(76, 10), "amount")
+
+    def test_decimal_precision_38_accepted(self) -> None:
+        # Exactly 38 is the maximum — must succeed.
+        assert arrow_type_to_tsql(pa.decimal128(38, 10)) == "DECIMAL(38,10)"


### PR DESCRIPTION
## Summary

- Add `ColumnSpec` model and `src/fabric_dw/types.py` with an Arrow→T-SQL type allowlist mapping (`arrow_type_to_tsql`, `validate_tsql_type`) that prevents injection through user-supplied type strings
- Add three new service functions in `services/tables.py`: `create_empty_table` (explicit column specs), `create_table_from_parquet` (reads Parquet footer only — no data), and `create_table_from_csv` (samples header + infers types via Arrow CSV reader); all three reject SQL Analytics Endpoints
- Extend `fabric-dw tables create` CLI with mutually-exclusive DDL source flags (`--column`, `--from-schema`, `--from-parquet`, `--from-csv`, `--all-varchar`, `--varchar-length`, etc.)
- Add `create_empty_table` MCP tool (DDL only; Parquet/CSV inference is CLI-only due to server-side file access constraints)
- Unit tests: Arrow→T-SQL mapping (36 cases), validate_tsql_type (10 cases), service-layer DDL mocks (23 cases), CLI flag mutual-exclusivity (14 cases), MCP tool (3 cases)
- Integration tests (marked `integration`): use `warehouse_schema` fixture for schema-isolated round-trips; endpoint guard uses `ephemeral_sql_endpoint`

Closes #308

## Test plan

- [ ] `just check` passes (ruff lint + ty + unit tests at 97% coverage)
- [ ] Integration suite: `pytest -m integration tests/integration/test_services_create_empty_table.py` against a live Fabric workspace
- [ ] `fabric-dw tables create <ws> <wh> --name dbo.my_table --column id:INT:notnull --column name:VARCHAR(255)` creates the table
- [ ] `fabric-dw tables create <ws> <wh> --name dbo.from_parquet --from-parquet path/to/file.parquet` creates the table
- [ ] `fabric-dw tables create <ws> <wh> --name dbo.from_csv --from-csv path/to/file.csv` creates the table
- [ ] MCP `create_empty_table` tool with a columns list returns the new table object

🤖 Generated with [Claude Code](https://claude.com/claude-code)