### PR TITLE
feat(telemetry): capture tenant_id from access-token tid claim

### DIFF
--- a/src/fabric_dw/auth.py
+++ b/src/fabric_dw/auth.py
@@ -365,6 +365,16 @@ def get_sql_token_struct(mode: CredentialMode = CredentialMode.DEFAULT) -> bytes
     # invoked when the assertion itself needs refreshing (every ~5 min in CI).
     # We must NOT cache the resulting struct here — let the credential decide expiry.
     token = credential.get_token(SQL_SCOPE).token
+
+    # Populate telemetry tenant_id from the SQL token's tid claim.  This covers
+    # the GitHub OIDC path where the HTTP client also acquires a token, but the
+    # SQL path runs synchronously before the async HTTP client initialises.
+    # cache_tenant_id_from_token is a no-op when telemetry is disabled or the
+    # override is already set; it never raises.
+    from fabric_dw import telemetry as _telemetry  # noqa: PLC0415
+
+    _telemetry.cache_tenant_id_from_token(token)
+
     token_bytes = token.encode("UTF-16-LE")
     return struct.pack(f"<I{len(token_bytes)}s", len(token_bytes), token_bytes)
 

--- a/src/fabric_dw/http_client.py
+++ b/src/fabric_dw/http_client.py
@@ -54,7 +54,7 @@ from azure.core.credentials import AccessToken
 from azure.core.credentials_async import AsyncTokenCredential
 from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
 
-from fabric_dw import auth
+from fabric_dw import auth, telemetry
 from fabric_dw.exceptions import (
     AuthError,
     BadRequestError,
@@ -308,6 +308,10 @@ class FabricHttpClient:
             if token is None or token.expires_on - time.time() < self._token_refresh_buffer:
                 token = await self._credential.get_token(scope)
                 self._tokens[scope] = token
+                # Decode the tid claim from the new token and cache it in the
+                # telemetry layer (no-op when telemetry is disabled or tid is
+                # already known).  Never raises — fail-safe wrapper.
+                telemetry.cache_tenant_id_from_token(token.token)
         return token.token
 
     # ------------------------------------------------------------------

--- a/src/fabric_dw/telemetry.py
+++ b/src/fabric_dw/telemetry.py
@@ -555,9 +555,10 @@ def decode_tid_from_token(token: str) -> str | None:
             return None
 
         payload_b64 = parts[1]
-        # base64url requires padding to a multiple of 4.
-        padding = (4 - len(payload_b64) % 4) % 4
-        payload_bytes = base64.b64decode(payload_b64 + "=" * padding, validate=False)
+        # JWT payloads use base64url encoding ('-' → 62, '_' → 63).
+        # urlsafe_b64decode handles both standard and URL-safe alphabets.
+        # Padding is added to satisfy the 4-byte block requirement.
+        payload_bytes = base64.urlsafe_b64decode(payload_b64 + "=" * (-len(payload_b64) % 4))
         claims = json.loads(payload_bytes)
         tid = claims.get("tid")
         return str(tid) if isinstance(tid, str) and tid else None
@@ -582,10 +583,13 @@ def cache_tenant_id_from_token(token: str) -> None:
         token: The raw JWT access-token string returned by
             ``credential.get_token(...).token``.
     """
-    if not telemetry_enabled():
-        return
-    if _tenant_id_override is not None:
-        return
-    tid = decode_tid_from_token(token)
-    if tid is not None:
-        set_tenant_id(tid)
+    try:
+        if _tenant_id_override is not None:
+            return
+        if not telemetry_enabled():
+            return
+        tid = decode_tid_from_token(token)
+        if tid is not None:
+            set_tenant_id(tid)
+    except Exception:  # noqa: S110
+        pass  # telemetry must never break the auth path

--- a/src/fabric_dw/telemetry.py
+++ b/src/fabric_dw/telemetry.py
@@ -38,6 +38,8 @@ import uuid
 from pathlib import Path
 
 __all__ = [
+    "cache_tenant_id_from_token",
+    "decode_tid_from_token",
     "emit_event",
     "flush_telemetry",
     "maybe_print_first_run_notice",
@@ -517,13 +519,73 @@ def maybe_print_first_run_notice() -> None:
 def set_tenant_id(tenant_id: str) -> None:
     """Store the tenant ID so the envelope reads it at runtime.
 
-    Follow-up #366 decodes the ``tid`` claim from the access token and calls
-    this function to propagate the value into every subsequent event envelope.
-    Until #366 lands the envelope falls back to the ``AZURE_TENANT_ID`` and
-    ``FABRIC_INTERACTIVE_TENANT_ID`` environment variables.
+    The ``tid`` claim decoded from an access token by :func:`decode_tid_from_token`
+    is propagated here so every subsequent event envelope carries the tenant.
+    Env-var fallback (``AZURE_TENANT_ID`` / ``FABRIC_INTERACTIVE_TENANT_ID``) is
+    used by :func:`_build_envelope` when this override has not been set.
 
     Args:
         tenant_id: The tenant UUID string extracted from the access token.
     """
     global _tenant_id_override  # noqa: PLW0603
     _tenant_id_override = tenant_id
+
+
+def decode_tid_from_token(token: str) -> str | None:
+    """Decode the ``tid`` claim from a JWT access token without verification.
+
+    Only the payload segment (the middle of three base64url-encoded parts) is
+    decoded — no signature verification, no network call, no new dependency.
+
+    The function is entirely fail-safe: any malformed, missing, or garbage
+    token returns ``None`` and never raises.
+
+    Args:
+        token: A JWT string in the form ``header.payload.signature``.
+
+    Returns:
+        The ``tid`` claim value as a string, or ``None`` if it cannot be read.
+    """
+    import base64  # noqa: PLC0415 (stdlib, always available)
+    import json  # noqa: PLC0415
+
+    try:
+        parts = token.split(".")
+        if len(parts) != 3:  # noqa: PLR2004
+            return None
+
+        payload_b64 = parts[1]
+        # base64url requires padding to a multiple of 4.
+        padding = (4 - len(payload_b64) % 4) % 4
+        payload_bytes = base64.b64decode(payload_b64 + "=" * padding, validate=False)
+        claims = json.loads(payload_bytes)
+        tid = claims.get("tid")
+        return str(tid) if isinstance(tid, str) and tid else None
+    except Exception:
+        return None
+
+
+def cache_tenant_id_from_token(token: str) -> None:
+    """Decode ``tid`` from *token* and cache it via :func:`set_tenant_id`.
+
+    A no-op when:
+    - Telemetry is disabled (avoids any decode work on opt-out paths).
+    - The tenant ID override is already set (idempotent — avoids redundant work
+      on subsequent token refreshes within the same session).
+    - The ``tid`` claim cannot be decoded from *token*.
+
+    Call this once after acquiring any access token.  Thread-safe for
+    concurrent callers on the asyncio event loop (the assignment to
+    ``_tenant_id_override`` is atomic on CPython).
+
+    Args:
+        token: The raw JWT access-token string returned by
+            ``credential.get_token(...).token``.
+    """
+    if not telemetry_enabled():
+        return
+    if _tenant_id_override is not None:
+        return
+    tid = decode_tid_from_token(token)
+    if tid is not None:
+        set_tenant_id(tid)

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -1136,3 +1136,291 @@ def test_first_run_notice_marker_written_after_print(
     assert captured.err != "", "Notice must be printed to stderr"
     # Marker file must exist after a successful print (written *after* print = A3).
     assert marker_file.exists(), "Marker file must exist after notice is printed"
+
+
+# ---------------------------------------------------------------------------
+# #366: decode_tid_from_token — JWT payload tid claim extraction
+# ---------------------------------------------------------------------------
+
+
+def _make_jwt(payload_dict: dict[str, object]) -> str:
+    """Construct a minimal JWT-shaped string with the given payload dict.
+
+    The header and signature are fake — only the payload segment is real.
+    """
+    import base64  # noqa: PLC0415
+    import json  # noqa: PLC0415
+
+    header = base64.urlsafe_b64encode(b'{"alg":"RS256","typ":"JWT"}').rstrip(b"=").decode()
+    payload_bytes = json.dumps(payload_dict).encode()
+    payload = base64.urlsafe_b64encode(payload_bytes).rstrip(b"=").decode()
+    signature = "fakesig"
+    return f"{header}.{payload}.{signature}"
+
+
+def test_decode_tid_returns_tid_from_valid_jwt() -> None:
+    """decode_tid_from_token returns the tid claim from a well-formed JWT payload."""
+    import importlib  # noqa: PLC0415
+
+    mod = importlib.import_module("fabric_dw.telemetry")
+    tenant = "aaaabbbb-1234-5678-abcd-000011112222"
+    token = _make_jwt(
+        {"tid": tenant, "oid": "some-oid", "iss": "https://login.microsoftonline.com/"}
+    )
+    result = mod.decode_tid_from_token(token)  # type: ignore[attr-defined]
+    assert result == tenant
+
+
+def test_decode_tid_returns_none_when_tid_missing() -> None:
+    """decode_tid_from_token returns None when the JWT payload has no tid claim."""
+    import importlib  # noqa: PLC0415
+
+    mod = importlib.import_module("fabric_dw.telemetry")
+    token = _make_jwt({"oid": "some-oid", "iss": "https://login.microsoftonline.com/"})
+    result = mod.decode_tid_from_token(token)  # type: ignore[attr-defined]
+    assert result is None
+
+
+def test_decode_tid_returns_none_for_malformed_token() -> None:
+    """decode_tid_from_token returns None (no exception) for garbage input."""
+    import importlib  # noqa: PLC0415
+
+    mod = importlib.import_module("fabric_dw.telemetry")
+    for bad_token in [
+        "",
+        "notajwt",
+        "only.two",
+        "too.many.parts.here.five",
+        "header.!!invalid_base64!!.sig",
+        "a.eyJub3RqExon.c",  # valid base64 but JSON parse fails (example)
+    ]:
+        result = mod.decode_tid_from_token(bad_token)  # type: ignore[attr-defined]
+        assert result is None, f"Expected None for {bad_token!r}, got {result!r}"
+
+
+def test_decode_tid_handles_missing_padding() -> None:
+    """decode_tid_from_token correctly handles base64url payloads with stripped padding."""
+    import base64  # noqa: PLC0415
+    import importlib  # noqa: PLC0415
+    import json  # noqa: PLC0415
+
+    mod = importlib.import_module("fabric_dw.telemetry")
+    tenant = "ccccdddd-1234-5678-efgh-000011112222"
+    # Build a payload whose base64url length mod 4 != 0 (i.e. needs padding)
+    payload_bytes = json.dumps({"tid": tenant}).encode()
+    payload_b64 = base64.urlsafe_b64encode(payload_bytes).rstrip(b"=").decode()
+    # Confirm there is actually missing padding in this fixture
+    assert len(payload_b64) % 4 != 0, "Fixture must have unpadded base64"
+    token = f"header.{payload_b64}.sig"
+    result = mod.decode_tid_from_token(token)  # type: ignore[attr-defined]
+    assert result == tenant
+
+
+def test_decode_tid_returns_none_for_non_string_tid() -> None:
+    """decode_tid_from_token returns None when tid is not a string (e.g. an int)."""
+    import importlib  # noqa: PLC0415
+
+    mod = importlib.import_module("fabric_dw.telemetry")
+    token = _make_jwt({"tid": 12345})
+    result = mod.decode_tid_from_token(token)  # type: ignore[attr-defined]
+    assert result is None
+
+
+def test_decode_tid_returns_none_for_empty_string_tid() -> None:
+    """decode_tid_from_token returns None when tid is an empty string."""
+    import importlib  # noqa: PLC0415
+
+    mod = importlib.import_module("fabric_dw.telemetry")
+    token = _make_jwt({"tid": ""})
+    result = mod.decode_tid_from_token(token)  # type: ignore[attr-defined]
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# #366: cache_tenant_id_from_token — integration with telemetry_enabled guard
+# ---------------------------------------------------------------------------
+
+
+def test_cache_tenant_id_sets_override_when_enabled(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """cache_tenant_id_from_token sets _tenant_id_override when telemetry is on."""
+    for var in [
+        "FABRIC_TELEMETRY",
+        "FABRIC_DISABLE_TELEMETRY",
+        "DO_NOT_TRACK",
+        "CI",
+        "GITHUB_ACTIONS",
+        "JENKINS_URL",
+        "TRAVIS",
+        "CIRCLECI",
+        "GITLAB_CI",
+        "TF_BUILD",
+    ]:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    mod = _reload_telemetry()
+    tenant = "aaaabbbb-0000-1111-2222-333344445555"
+    token = _make_jwt({"tid": tenant})
+
+    mod.cache_tenant_id_from_token(token)  # type: ignore[attr-defined]
+    assert mod._tenant_id_override == tenant  # type: ignore[attr-defined]
+
+
+def test_cache_tenant_id_does_not_decode_when_telemetry_disabled(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """cache_tenant_id_from_token is a no-op (no decode) when telemetry is disabled."""
+    monkeypatch.setenv("FABRIC_DISABLE_TELEMETRY", "1")
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    mod = _reload_telemetry()
+    tenant = "aaaabbbb-0000-1111-2222-333344445555"
+    token = _make_jwt({"tid": tenant})
+
+    # Track whether decode_tid_from_token is called
+    decode_calls: list[str] = []
+    original_decode = mod.decode_tid_from_token  # type: ignore[attr-defined]
+
+    def spy_decode(t: str) -> str | None:
+        decode_calls.append(t)
+        return original_decode(t)
+
+    with patch.object(mod, "decode_tid_from_token", side_effect=spy_decode):  # type: ignore[attr-defined]
+        mod.cache_tenant_id_from_token(token)  # type: ignore[attr-defined]
+
+    assert decode_calls == [], "decode_tid_from_token must not be called when telemetry is disabled"
+    assert mod._tenant_id_override is None  # type: ignore[attr-defined]
+
+
+def test_cache_tenant_id_is_idempotent_skips_decode_when_override_set(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """cache_tenant_id_from_token skips decode when _tenant_id_override is already set."""
+    for var in [
+        "FABRIC_TELEMETRY",
+        "FABRIC_DISABLE_TELEMETRY",
+        "DO_NOT_TRACK",
+        "CI",
+        "GITHUB_ACTIONS",
+        "JENKINS_URL",
+        "TRAVIS",
+        "CIRCLECI",
+        "GITLAB_CI",
+        "TF_BUILD",
+    ]:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    mod = _reload_telemetry()
+    existing_tenant = "existing-tenant-id"
+    mod._tenant_id_override = existing_tenant  # type: ignore[attr-defined]
+
+    decode_calls: list[str] = []
+    original_decode = mod.decode_tid_from_token  # type: ignore[attr-defined]
+
+    def spy_decode(t: str) -> str | None:
+        decode_calls.append(t)
+        return original_decode(t)
+
+    new_token = _make_jwt({"tid": "new-tenant-should-not-override"})
+    with patch.object(mod, "decode_tid_from_token", side_effect=spy_decode):  # type: ignore[attr-defined]
+        mod.cache_tenant_id_from_token(new_token)  # type: ignore[attr-defined]
+
+    assert decode_calls == [], "decode must be skipped when override is already set"
+    assert mod._tenant_id_override == existing_tenant  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# #366: env-var fallback precedence in _build_envelope
+# ---------------------------------------------------------------------------
+
+
+def test_envelope_uses_token_tid_over_env_var(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The decoded tid from a token takes precedence over AZURE_TENANT_ID env var.
+
+    This tests that _tenant_id_override (set via cache_tenant_id_from_token)
+    wins over the env-var fallback in _build_envelope.
+    """
+    for var in [
+        "FABRIC_TELEMETRY",
+        "FABRIC_DISABLE_TELEMETRY",
+        "DO_NOT_TRACK",
+        "CI",
+        "GITHUB_ACTIONS",
+        "JENKINS_URL",
+        "TRAVIS",
+        "CIRCLECI",
+        "GITLAB_CI",
+        "TF_BUILD",
+    ]:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setenv("AZURE_TENANT_ID", "env-var-tenant-id")
+
+    mod = _reload_telemetry()
+    tid_value = "token-tenant-id-from-tid-claim"
+    mod._tenant_id_override = tid_value  # type: ignore[attr-defined]
+
+    envelope = mod._build_envelope("cli")  # type: ignore[attr-defined]
+    assert envelope.get("tenant_id") == tid_value
+
+
+def test_envelope_falls_back_to_azure_tenant_id_env_when_no_override(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """_build_envelope falls back to AZURE_TENANT_ID when no token override is set."""
+    for var in [
+        "FABRIC_TELEMETRY",
+        "FABRIC_DISABLE_TELEMETRY",
+        "DO_NOT_TRACK",
+        "CI",
+        "GITHUB_ACTIONS",
+        "JENKINS_URL",
+        "TRAVIS",
+        "CIRCLECI",
+        "GITLAB_CI",
+        "TF_BUILD",
+        "FABRIC_INTERACTIVE_TENANT_ID",
+    ]:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setenv("AZURE_TENANT_ID", "fallback-env-tenant")
+
+    mod = _reload_telemetry()
+    # Ensure no override is set
+    mod._tenant_id_override = None  # type: ignore[attr-defined]
+
+    envelope = mod._build_envelope("cli")  # type: ignore[attr-defined]
+    assert envelope.get("tenant_id") == "fallback-env-tenant"
+
+
+def test_envelope_omits_tenant_id_when_no_source(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """_build_envelope omits tenant_id when neither override nor env vars are set."""
+    for var in [
+        "FABRIC_TELEMETRY",
+        "FABRIC_DISABLE_TELEMETRY",
+        "DO_NOT_TRACK",
+        "CI",
+        "GITHUB_ACTIONS",
+        "JENKINS_URL",
+        "TRAVIS",
+        "CIRCLECI",
+        "GITLAB_CI",
+        "TF_BUILD",
+        "AZURE_TENANT_ID",
+        "FABRIC_INTERACTIVE_TENANT_ID",
+    ]:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    mod = _reload_telemetry()
+    mod._tenant_id_override = None  # type: ignore[attr-defined]
+
+    envelope = mod._build_envelope("cli")  # type: ignore[attr-defined]
+    assert "tenant_id" not in envelope

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -1198,6 +1198,49 @@ def test_decode_tid_returns_none_for_malformed_token() -> None:
         assert result is None, f"Expected None for {bad_token!r}, got {result!r}"
 
 
+def test_decode_tid_handles_urlsafe_chars_in_payload() -> None:
+    """decode_tid_from_token correctly handles payloads with '-' in the base64url encoding.
+
+    This is a regression test for the b64decode vs urlsafe_b64decode bug.  The
+    standard base64 alphabet uses '+' and '/' where base64url uses '-' and '_'.
+    ``base64.b64decode`` with ``validate=False`` silently discards '-' and '_'
+    characters before the padding check, producing an incorrect result or an
+    ``Incorrect padding`` error — both of which cause the function to return
+    ``None`` instead of the tid.
+
+    The tid value ``"~~~"`` (three tildes) is chosen because JSON.encode of
+    ``{"tid": "~~~"}`` produces a byte sequence whose base64url encoding
+    contains '-' (specifically the group encoding the tilde bytes maps to
+    value 62 → '-' in base64url).
+
+    This test FAILS with ``base64.b64decode`` and PASSES with
+    ``base64.urlsafe_b64decode``.
+    """
+    import base64  # noqa: PLC0415
+    import importlib  # noqa: PLC0415
+    import json  # noqa: PLC0415
+
+    mod = importlib.import_module("fabric_dw.telemetry")
+
+    # '~~~' is chosen because json.dumps({'tid': '~~~'}) produces bytes whose
+    # base64url encoding contains '-', guaranteed by the tilde (0x7E) character.
+    tid_value = "~~~"
+    payload_bytes = json.dumps({"tid": tid_value}).encode()
+    b64url = base64.urlsafe_b64encode(payload_bytes).rstrip(b"=").decode()
+
+    # Sanity-check: the fixture must exercise the URL-safe character path.
+    assert any(c in "-_" for c in b64url), (
+        f"Fixture must contain '-' or '_' to exercise the bug; got: {b64url!r}"
+    )
+
+    token = f"fake_header.{b64url}.fake_sig"
+    result = mod.decode_tid_from_token(token)  # type: ignore[attr-defined]
+    assert result == tid_value, (
+        f"Expected {tid_value!r} but got {result!r}. "
+        "This indicates b64decode is being used instead of urlsafe_b64decode."
+    )
+
+
 def test_decode_tid_handles_missing_padding() -> None:
     """decode_tid_from_token correctly handles base64url payloads with stripped padding."""
     import base64  # noqa: PLC0415


### PR DESCRIPTION
## Summary

- Adds `decode_tid_from_token(token)` in `telemetry.py`: base64url-decodes the JWT payload segment, JSON-parses it, and returns the `tid` claim — no signature verification, no network call, no new dependency, fully fail-safe.
- Adds `cache_tenant_id_from_token(token)` in `telemetry.py`: guards on `telemetry_enabled()` and idempotency before calling `decode_tid_from_token` and `set_tenant_id`, so no decode work is done when telemetry is disabled.
- Calls `cache_tenant_id_from_token` in `FabricHttpClient._get_token()` (HTTP path) immediately after a new token is acquired.
- Calls `cache_tenant_id_from_token` in `auth.get_sql_token_struct()` (SQL/GitHub-OIDC path) after the SQL token is obtained.
- Env-var fallback (`AZURE_TENANT_ID` / `FABRIC_INTERACTIVE_TENANT_ID`) in `_build_envelope` is preserved; `_tenant_id_override` (set from the decoded claim) wins when present.

## Test plan

- [ ] `decode_tid_from_token` returns the `tid` from a crafted JWT (header.payload.sig)
- [ ] Returns `None` when `tid` is absent from payload
- [ ] Returns `None` for empty string `tid`
- [ ] Returns `None` for non-string `tid` (e.g. integer)
- [ ] Returns `None` for malformed tokens (empty string, wrong segment count, garbage base64, invalid JSON) — no exception raised
- [ ] Correctly re-pads base64url payloads whose length is not a multiple of 4
- [ ] `cache_tenant_id_from_token` does NOT call `decode_tid_from_token` when telemetry is disabled (monkeypatched spy)
- [ ] `cache_tenant_id_from_token` skips decode when `_tenant_id_override` is already set (idempotent)
- [ ] `cache_tenant_id_from_token` sets `_tenant_id_override` when telemetry is enabled and override is unset
- [ ] `_build_envelope` uses `_tenant_id_override` over `AZURE_TENANT_ID` env var
- [ ] `_build_envelope` falls back to `AZURE_TENANT_ID` when no override is set
- [ ] `_build_envelope` omits `tenant_id` entirely when no source is available
- [ ] `just check` (ruff + ty + 3043 unit tests) passes cleanly

Closes #366