### PR TITLE
fix(statistics): correct DBCC SHOW_STATISTICS table argument — use string literal, not bracket-quoted identifier

### DIFF
--- a/src/fabric_dw/services/statistics.py
+++ b/src/fabric_dw/services/statistics.py
@@ -12,10 +12,21 @@ Identifier safety
 -----------------
 All table, column, schema, and stat names are identifiers that CANNOT be bound
 as SQL parameters.  Every such name is validated via
-:func:`~fabric_dw.identifiers.validate_identifier` (allowlist regex + explicit
-forbidden-char guards) and then bracket-quoted via
-:func:`~fabric_dw.identifiers.quote_identifier` (which escapes ``]`` as ``]]``
-for defence-in-depth) before being embedded in SQL.
+:func:`~fabric_dw.identifiers.validate_identifier` (allowlist regex
+``^[A-Za-z_][A-Za-z0-9_]{0,127}$`` — single-quotes and brackets are outside
+this charset and therefore always rejected).
+
+**CREATE / UPDATE / DROP** statements then bracket-quote identifiers via
+:func:`~fabric_dw.identifiers.quote_identifier` (which additionally escapes
+``]`` as ``]]`` for defence-in-depth) before embedding them in SQL.
+
+**DBCC SHOW_STATISTICS** is different: Fabric DW does not accept bracket-quoted
+identifiers in the first (table) argument position — doing so causes
+``Incorrect syntax near '.'``.  The table argument is therefore embedded as a
+**single-quoted string literal** of the form ``'schema.table'``.  Because
+``validate_identifier`` has already accepted both parts, neither can contain a
+single-quote, so no ``'``→``''`` escaping is needed.  The stat-name (second
+argument) is still bracket-quoted in the normal way.
 
 The ``sample_percent`` argument is a numeric value; it is range-validated as an
 :class:`int` (1-100) and embedded as a literal integer — never an arbitrary

--- a/src/fabric_dw/services/statistics.py
+++ b/src/fabric_dw/services/statistics.py
@@ -106,11 +106,15 @@ WHERE ({schema_filter})
 ORDER BY s.name, t.name, st.name;
 """
 
-# DBCC SHOW_STATISTICS takes identifier tokens for table and stat_name.
-# Both are validated + bracket-quoted before embedding.
-_DBCC_STAT_HEADER_SQL = "DBCC SHOW_STATISTICS ({table_q}, {stat_q}) WITH STAT_HEADER;"
-_DBCC_DENSITY_SQL = "DBCC SHOW_STATISTICS ({table_q}, {stat_q}) WITH DENSITY_VECTOR;"
-_DBCC_HISTOGRAM_SQL = "DBCC SHOW_STATISTICS ({table_q}, {stat_q}) WITH HISTOGRAM;"
+# DBCC SHOW_STATISTICS on Fabric DW requires the table as a string literal
+# ('schema.table') — NOT as bracket-quoted identifier tokens ([schema].[table]).
+# Passing bracket-quoted identifiers causes "Incorrect syntax near '.'" because
+# the parser does not accept a two-part identifier in that argument position.
+# The stat name (second argument) is still bracket-quoted as an identifier token.
+# Both parts are validated via validate_identifier before embedding.
+_DBCC_STAT_HEADER_SQL = "DBCC SHOW_STATISTICS ('{table_s}', {stat_q}) WITH STAT_HEADER;"
+_DBCC_DENSITY_SQL = "DBCC SHOW_STATISTICS ('{table_s}', {stat_q}) WITH DENSITY_VECTOR;"
+_DBCC_HISTOGRAM_SQL = "DBCC SHOW_STATISTICS ('{table_s}', {stat_q}) WITH HISTOGRAM;"
 
 # CREATE STATISTICS: identifiers are bracket-quoted; FULLSCAN/SAMPLE are keywords.
 _CREATE_STAT_FULLSCAN_SQL = "CREATE STATISTICS {stat_q} ON {table_q} ({col_q}) WITH FULLSCAN;"
@@ -384,15 +388,20 @@ async def show_statistics(
     validate_identifier(table)
     validate_identifier(stat_name)
 
-    # DBCC SHOW_STATISTICS takes a two-part table ref and a stat name.
-    # Use [schema].[table] notation for the table argument — it must be
-    # bracket-quoted as a whole token (not as a string literal parameter).
-    table_q = f"{quote_identifier(schema)}.{quote_identifier(table)}"
+    # DBCC SHOW_STATISTICS on Fabric DW requires the table as a string literal
+    # ('schema.table'), NOT as bracket-quoted identifier tokens ([schema].[table]).
+    # Using bracket-quoted identifiers in the first DBCC argument causes
+    # "Incorrect syntax near '.'" on real Fabric (the parser does not accept a
+    # two-part identifier in that position).  The stat name (second arg) is still
+    # bracket-quoted as a regular identifier token.
+    # Both schema and table have already been validated via validate_identifier
+    # (allowlist [A-Za-z_][A-Za-z0-9_]*), so they cannot contain single-quotes.
+    table_s = f"{schema}.{table}"
     stat_q = quote_identifier(stat_name)
 
-    header_sql = _DBCC_STAT_HEADER_SQL.format(table_q=table_q, stat_q=stat_q)
-    density_sql = _DBCC_DENSITY_SQL.format(table_q=table_q, stat_q=stat_q)
-    histogram_sql = _DBCC_HISTOGRAM_SQL.format(table_q=table_q, stat_q=stat_q)
+    header_sql = _DBCC_STAT_HEADER_SQL.format(table_s=table_s, stat_q=stat_q)
+    density_sql = _DBCC_DENSITY_SQL.format(table_s=table_s, stat_q=stat_q)
+    histogram_sql = _DBCC_HISTOGRAM_SQL.format(table_s=table_s, stat_q=stat_q)
 
     def _run() -> StatisticDetails:
         if histogram_only:

--- a/tests/unit/services/test_statistics.py
+++ b/tests/unit/services/test_statistics.py
@@ -363,6 +363,23 @@ class TestShowStatistics:
                 "stat",
             )
 
+    async def test_single_quote_in_schema_rejected(self) -> None:
+        """Single-quote in schema must be rejected before it can reach the string literal.
+
+        DBCC SHOW_STATISTICS embeds the table as 'schema.table'. validate_identifier
+        must block any name containing a quote so that the literal is safe without
+        explicit escaping.
+        """
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await statistics.show_statistics(target, "dbo'.sales", "stat")
+
+    async def test_single_quote_in_table_rejected(self) -> None:
+        """Single-quote in table name must be rejected before it can reach the string literal."""
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await statistics.show_statistics(target, "dbo.sales'", "stat")
+
 
 # ===========================================================================
 # create_statistics
@@ -879,6 +896,7 @@ class TestExactSqlRoundtripRegression:
 
         Regression: passing [schema].[table] caused 'Incorrect syntax near .' on
         real Fabric DW.  The first argument must be 'schema.table' (string literal).
+        All three DBCC templates (STAT_HEADER, DENSITY_VECTOR, HISTOGRAM) are pinned.
         """
         target = _make_target()
         header_conn = _make_conn([_HEADER_ROW], _HEADER_COLS)
@@ -889,15 +907,38 @@ class TestExactSqlRoundtripRegression:
             side_effect=[header_conn, density_conn, hist_conn],
         ):
             await statistics.show_statistics(target, self._QUALIFIED, self._STAT)
-        call_sql: str = header_conn.cursor.return_value.execute.call_args[0][0]
-        expected = (
-            f"DBCC SHOW_STATISTICS ('{self._SCHEMA}.{self._TABLE}', [{self._STAT}])"
-            " WITH STAT_HEADER;"
+
+        table_literal = f"'{self._SCHEMA}.{self._TABLE}'"
+        stat_q = f"[{self._STAT}]"
+
+        # --- STAT_HEADER ---
+        header_sql: str = header_conn.cursor.return_value.execute.call_args[0][0]
+        expected_header = f"DBCC SHOW_STATISTICS ({table_literal}, {stat_q}) WITH STAT_HEADER;"
+        assert header_sql == expected_header, (
+            f"STAT_HEADER SQL mismatch.\nGot:      {header_sql!r}\nExpected: {expected_header!r}"
         )
-        assert call_sql == expected, f"Got: {call_sql!r}\nExpected: {expected!r}"
-        # Stray-dot regression guard: must not produce [schema].[table] in DBCC arg.
-        assert ".." not in call_sql
-        assert f"[{self._SCHEMA}].[{self._TABLE}]" not in call_sql
+        assert ".." not in header_sql
+        assert f"[{self._SCHEMA}].[{self._TABLE}]" not in header_sql
+
+        # --- DENSITY_VECTOR ---
+        density_sql: str = density_conn.cursor.return_value.execute.call_args[0][0]
+        expected_density = f"DBCC SHOW_STATISTICS ({table_literal}, {stat_q}) WITH DENSITY_VECTOR;"
+        assert density_sql == expected_density, (
+            f"DENSITY_VECTOR SQL mismatch.\n"
+            f"Got:      {density_sql!r}\nExpected: {expected_density!r}"
+        )
+        assert ".." not in density_sql
+        assert f"[{self._SCHEMA}].[{self._TABLE}]" not in density_sql
+
+        # --- HISTOGRAM ---
+        histogram_sql: str = hist_conn.cursor.return_value.execute.call_args[0][0]
+        expected_histogram = f"DBCC SHOW_STATISTICS ({table_literal}, {stat_q}) WITH HISTOGRAM;"
+        assert histogram_sql == expected_histogram, (
+            f"HISTOGRAM SQL mismatch.\n"
+            f"Got:      {histogram_sql!r}\nExpected: {expected_histogram!r}"
+        )
+        assert ".." not in histogram_sql
+        assert f"[{self._SCHEMA}].[{self._TABLE}]" not in histogram_sql
 
     async def test_create_statistics_exact_sql(self) -> None:
         """CREATE STATISTICS SQL must be bracket-quoted with no stray dots."""

--- a/tests/unit/services/test_statistics.py
+++ b/tests/unit/services/test_statistics.py
@@ -275,7 +275,13 @@ class TestShowStatistics:
             assert "DBCC" in call_sql
             assert "SHOW_STATISTICS" in call_sql
 
-    async def test_sql_bracket_quotes_table_identifier(self) -> None:
+    async def test_sql_uses_string_literal_for_table(self) -> None:
+        """show_statistics must pass the table as a string literal 'schema.table'.
+
+        Fabric DW DBCC SHOW_STATISTICS does not accept bracket-quoted identifiers
+        ([schema].[table]) in the first argument — that causes 'Incorrect syntax
+        near '.''.  The table must be a single-quoted string literal.
+        """
         target = _make_target()
         header_conn = _make_conn([_HEADER_ROW], _HEADER_COLS)
         density_conn = _make_conn([_DENSITY_ROW], _DENSITY_COLS)
@@ -286,8 +292,10 @@ class TestShowStatistics:
         ):
             await statistics.show_statistics(target, "dbo.sales", "stat_sales_id")
         call_sql: str = header_conn.cursor.return_value.execute.call_args[0][0]
-        assert "[dbo]" in call_sql
-        assert "[sales]" in call_sql
+        # Table must be a string literal, not bracket-quoted identifiers.
+        assert "'dbo.sales'" in call_sql
+        # Regression: must NOT have stray dot outside the string (the original bug).
+        assert "[dbo].[sales]" not in call_sql
 
     async def test_sql_bracket_quotes_stat_identifier(self) -> None:
         target = _make_target()
@@ -844,3 +852,95 @@ class TestBracketInjection:
         target = _make_target()
         with pytest.raises(ValueError, match="Invalid SQL identifier"):
             await statistics.drop_statistics(target, "dbo.sales", "my]stat")
+
+
+# ===========================================================================
+# Regression: issue-371 — exact SQL for roundtrip identifiers
+# ===========================================================================
+#
+# The integration test uses schema='pytest_d1e50944', table='pytest_stat_roundtrip',
+# stat='pytest_stat_on_id'.  These tests pin the exact SQL each operation
+# produces so that any future regression (stray '.', wrong quoting) is caught
+# without a Fabric round-trip.
+# ===========================================================================
+
+
+class TestExactSqlRoundtripRegression:
+    """Pin the exact SQL for the integration roundtrip identifiers (issue-371)."""
+
+    _SCHEMA = "pytest_d1e50944"
+    _TABLE = "pytest_stat_roundtrip"
+    _COL = "id"
+    _STAT = "pytest_stat_on_id"
+    _QUALIFIED = f"{_SCHEMA}.{_TABLE}"
+
+    async def test_show_statistics_exact_sql_no_stray_dot(self) -> None:
+        """DBCC SHOW_STATISTICS must use string literal for table, not [schema].[table].
+
+        Regression: passing [schema].[table] caused 'Incorrect syntax near .' on
+        real Fabric DW.  The first argument must be 'schema.table' (string literal).
+        """
+        target = _make_target()
+        header_conn = _make_conn([_HEADER_ROW], _HEADER_COLS)
+        density_conn = _make_conn([_DENSITY_ROW], _DENSITY_COLS)
+        hist_conn = _make_conn([_HISTOGRAM_ROW], _HISTOGRAM_COLS)
+        with patch(
+            "fabric_dw.sql.open_connection",
+            side_effect=[header_conn, density_conn, hist_conn],
+        ):
+            await statistics.show_statistics(target, self._QUALIFIED, self._STAT)
+        call_sql: str = header_conn.cursor.return_value.execute.call_args[0][0]
+        expected = (
+            f"DBCC SHOW_STATISTICS ('{self._SCHEMA}.{self._TABLE}', [{self._STAT}])"
+            " WITH STAT_HEADER;"
+        )
+        assert call_sql == expected, f"Got: {call_sql!r}\nExpected: {expected!r}"
+        # Stray-dot regression guard: must not produce [schema].[table] in DBCC arg.
+        assert ".." not in call_sql
+        assert f"[{self._SCHEMA}].[{self._TABLE}]" not in call_sql
+
+    async def test_create_statistics_exact_sql(self) -> None:
+        """CREATE STATISTICS SQL must be bracket-quoted with no stray dots."""
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_STAT_ROW_1], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            await statistics.create_statistics(
+                target,
+                self._QUALIFIED,
+                self._COL,
+                name=self._STAT,
+                fullscan=True,
+            )
+        call_sql: str = ddl_conn.cursor.return_value.execute.call_args[0][0]
+        expected = (
+            f"CREATE STATISTICS [{self._STAT}]"
+            f" ON [{self._SCHEMA}].[{self._TABLE}]"
+            f" ([{self._COL}]) WITH FULLSCAN;"
+        )
+        assert call_sql == expected, f"Got: {call_sql!r}\nExpected: {expected!r}"
+        assert ".." not in call_sql
+
+    async def test_update_statistics_exact_sql(self) -> None:
+        """UPDATE STATISTICS SQL must be bracket-quoted with no stray dots."""
+        target = _make_target()
+        conn = _make_conn_for_ddl()
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await statistics.update_statistics(target, self._QUALIFIED, self._STAT, fullscan=True)
+        call_sql: str = conn.cursor.return_value.execute.call_args[0][0]
+        expected = (
+            f"UPDATE STATISTICS [{self._SCHEMA}].[{self._TABLE}] ([{self._STAT}]) WITH FULLSCAN;"
+        )
+        assert call_sql == expected, f"Got: {call_sql!r}\nExpected: {expected!r}"
+        assert ".." not in call_sql
+
+    async def test_drop_statistics_exact_sql(self) -> None:
+        """DROP STATISTICS SQL must use three-part bracket-quoted name with no stray dots."""
+        target = _make_target()
+        conn = _make_conn_for_ddl()
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await statistics.drop_statistics(target, self._QUALIFIED, self._STAT)
+        call_sql: str = conn.cursor.return_value.execute.call_args[0][0]
+        expected = f"DROP STATISTICS [{self._SCHEMA}].[{self._TABLE}].[{self._STAT}];"
+        assert call_sql == expected, f"Got: {call_sql!r}\nExpected: {expected!r}"
+        assert ".." not in call_sql


### PR DESCRIPTION
## Summary

- **Root cause**: `DBCC SHOW_STATISTICS` on Fabric DW requires the table as a **string literal** (`'schema.table'`), not bracket-quoted identifiers (`[schema].[table]`). Passing `[schema].[table]` in the first argument causes `Incorrect syntax near '.'` because the Fabric DW parser does not accept a two-part identifier token in that position.
- **Fix**: Changed the three `_DBCC_*_SQL` templates in `show_statistics` to use `'{table_s}'` (string literal form) and updated `show_statistics` to build `table_s = f"{schema}.{table}"` (safe: both parts are already validated via `validate_identifier` which only allows `[A-Za-z_][A-Za-z0-9_]*` — no single-quotes possible).
- **Scope**: Only `show_statistics` / `DBCC SHOW_STATISTICS` is affected. `CREATE STATISTICS`, `UPDATE STATISTICS`, and `DROP STATISTICS` all use standard DDL syntax that correctly accepts bracket-quoted two-part names.

## Test plan

- [x] Updated `TestShowStatistics::test_sql_uses_string_literal_for_table` to assert `'schema.table'` string-literal form and that `[schema].[table]` is absent.
- [x] Added `TestExactSqlRoundtripRegression` class pinning the exact SQL for the integration roundtrip identifiers (`pytest_d1e50944.pytest_stat_roundtrip`, `pytest_stat_on_id`) for all four operations (show/create/update/drop), with `..`-free assertions.
- [x] `just check` clean — ruff, ty, 3035 unit tests pass.
- [ ] Integration run against real Fabric validates the end-to-end roundtrip.

Closes #371

🤖 Generated with [Claude Code](https://claude.com/claude-code)