### PR TITLE
fix(functions): rename via DROP + CREATE on Fabric DW

### DIFF
--- a/src/fabric_dw/services/functions.py
+++ b/src/fabric_dw/services/functions.py
@@ -23,6 +23,7 @@ appear in catalog listings on migrated warehouses.
 from __future__ import annotations
 
 import asyncio
+import re
 from datetime import datetime
 from typing import Literal, cast
 
@@ -185,18 +186,21 @@ def _extract_function_body(schema: str, name: str, definition: str) -> str:
     Handles both bracket-quoted (``[schema].[name]``) and unquoted
     (``schema.name``) forms, as well as single-part names without a schema.
 
+    Uses ``re.search`` for ``CREATE FUNCTION`` to skip any leading comment
+    blocks that contain the word ``FUNCTION`` before the actual DDL keyword.
+
     Raises:
-        NotFoundError: If the ``FUNCTION`` keyword cannot be located in the
-            definition string (indicates a corrupted or unexpected definition).
+        NotFoundError: If the ``CREATE FUNCTION`` keyword pair cannot be located
+            in the definition string (indicates a corrupted or unexpected
+            definition).
     """
-    upper_def = definition.upper()
-    fn_kw_pos = upper_def.find("FUNCTION")
-    if fn_kw_pos == -1:
-        msg = f"Cannot parse definition for [{schema}].[{name}]: 'FUNCTION' keyword not found"
+    m = re.search(r"\bCREATE\s+FUNCTION\b", definition, re.IGNORECASE)
+    if m is None:
+        msg = f"Cannot parse definition for [{schema}].[{name}]: 'CREATE FUNCTION' not found"
         raise NotFoundError(msg)
 
     # Advance past "FUNCTION" and trailing whitespace.
-    pos = fn_kw_pos + len("FUNCTION")
+    pos = m.end()
     while pos < len(definition) and definition[pos] in (" ", "\t", "\n", "\r"):
         pos += 1
 
@@ -235,9 +239,9 @@ def _skip_name_token(definition: str, pos: int) -> int:
             end += 1
         return end
 
-    # Unquoted token — stop at whitespace, '(', or '.'.
+    # Unquoted token — stop at whitespace (including \r for CRLF), '(', or '.'.
     end = pos
-    while end < len(definition) and definition[end] not in (" ", "\t", "\n", "(", "."):
+    while end < len(definition) and definition[end] not in (" ", "\t", "\n", "\r", "(", "."):
         end += 1
     return end
 
@@ -553,8 +557,16 @@ async def rename_function(
     2. Create a new function with the same schema, body, and the new name.
     3. Drop the old function.
 
-    If step 2 or 3 fails the old function is still intact and the error propagates
-    to the caller — there is no silent partial state.
+    Partial-state behaviour:
+
+    - If step 2 fails (e.g. the new name already exists), the old function is
+      untouched and the error propagates cleanly — no state change occurs.
+    - If step 3 fails after step 2 has succeeded, **both** the old and the new
+      function exist simultaneously and an exception is raised.  The caller must
+      clean up the duplicate by manually dropping the old name.
+
+    The ordering (create-before-drop) is intentional: a failure must never
+    silently destroy the user's function.
 
     The new name must be unqualified (no dot) because the function stays in the
     same schema.
@@ -602,14 +614,11 @@ async def rename_function(
     # it under the new name.
     body = _extract_function_body(schema, old_name, existing.definition)
 
-    # Step 2: create under the new name.
-    await create_function(target, schema, new_name, body, mode=mode)
+    # Step 2: create under the new name.  create_function() already calls
+    # get_function() internally and returns the FunctionDetails — reuse it.
+    new_details = await create_function(target, schema, new_name, body, mode=mode)
 
     # Step 3: drop the old name.
     await drop_function(target, schema, old_name, mode=mode)
 
-    try:
-        return await get_function(target, schema, new_name, mode=mode)
-    except NotFoundError:
-        msg = f"Function [{schema}].[{new_name}] not found after rename"
-        raise NotFoundError(msg) from None
+    return new_details

--- a/src/fabric_dw/services/functions.py
+++ b/src/fabric_dw/services/functions.py
@@ -8,7 +8,7 @@ Public API
 - :func:`create_function`     — issue CREATE FUNCTION [<schema>].[<name>] AS <body>.
 - :func:`update_function`     — issue CREATE OR ALTER FUNCTION [<schema>].[<name>] AS <body>.
 - :func:`drop_function`       — issue DROP FUNCTION [IF EXISTS].
-- :func:`rename_function`     — rename a function via EXEC sp_rename.
+- :func:`rename_function`     — rename via DROP + CREATE (Fabric DW rejects sp_rename for UDFs).
 
 Note: User-defined functions are supported on **both** Fabric Data Warehouses and
 SQL Analytics Endpoints — no endpoint guard is applied here.  The CREATE FUNCTION,
@@ -97,10 +97,14 @@ WHERE s.name = ? AND o.name = ?
 ORDER BY p.parameter_id;
 """
 
-# sp_rename takes string arguments (not identifiers) → bind as ? parameters.
-# @objname = qualified old name ('schema.old_fn'), @newname = bare new name.
-# sp_rename cannot move across schemas, so @newname must be unqualified.
-_SP_RENAME_SQL = "EXEC sp_rename ?, ?, 'OBJECT'"
+# Fabric DW does not support sp_rename for user-defined functions.
+# Microsoft docs explicitly state: "drop the object and re-create it with the
+# new name" for functions, triggers, views, and stored procedures.
+# See https://learn.microsoft.com/sql/relational-databases/system-stored-procedures/sp-rename-transact-sql#remarks
+#
+# rename_function therefore fetches the current definition and re-creates the
+# function under the new name before dropping the old one.  No sp_rename SQL
+# constant is needed for functions.
 
 # ---------------------------------------------------------------------------
 # Internal helpers
@@ -169,6 +173,73 @@ def _row_to_function_details(
         created=cast(datetime, data["created"]),
         modified=cast(datetime, data["modified"]),
     )
+
+
+def _extract_function_body(schema: str, name: str, definition: str) -> str:
+    """Extract the parameter/RETURNS/body portion from a stored ``sys.sql_modules`` definition.
+
+    ``sys.sql_modules`` stores the full original ``CREATE FUNCTION`` statement.
+    For rename-via-recreate we need only the part after the qualified object
+    name so we can prepend a new ``CREATE FUNCTION [schema].[new_name]``.
+
+    Handles both bracket-quoted (``[schema].[name]``) and unquoted
+    (``schema.name``) forms, as well as single-part names without a schema.
+
+    Raises:
+        NotFoundError: If the ``FUNCTION`` keyword cannot be located in the
+            definition string (indicates a corrupted or unexpected definition).
+    """
+    upper_def = definition.upper()
+    fn_kw_pos = upper_def.find("FUNCTION")
+    if fn_kw_pos == -1:
+        msg = f"Cannot parse definition for [{schema}].[{name}]: 'FUNCTION' keyword not found"
+        raise NotFoundError(msg)
+
+    # Advance past "FUNCTION" and trailing whitespace.
+    pos = fn_kw_pos + len("FUNCTION")
+    while pos < len(definition) and definition[pos] in (" ", "\t", "\n", "\r"):
+        pos += 1
+
+    # Skip up to two name-tokens (schema + name) separated by a dot.
+    for _ in range(2):
+        if pos >= len(definition):
+            break
+        pos = _skip_name_token(definition, pos)
+        if pos < len(definition) and definition[pos] == ".":
+            pos += 1  # consume the dot between schema and name
+        else:
+            break  # single-part name or end of string
+
+    return definition[pos:]
+
+
+def _skip_name_token(definition: str, pos: int) -> int:
+    """Advance *pos* past one bracket-quoted or plain identifier token.
+
+    Returns the updated position (pointing to the first character after the
+    token).
+    """
+    if pos >= len(definition):
+        return pos
+
+    if definition[pos] == "[":
+        # Bracket-quoted token — find closing bracket, respecting escaped ']]'.
+        end = pos + 1
+        while end < len(definition):
+            if definition[end] == "]":
+                if end + 1 < len(definition) and definition[end + 1] == "]":
+                    end += 2  # escaped bracket
+                    continue
+                end += 1
+                break
+            end += 1
+        return end
+
+    # Unquoted token — stop at whitespace, '(', or '.'.
+    end = pos
+    while end < len(definition) and definition[end] not in (" ", "\t", "\n", "(", "."):
+        end += 1
+    return end
 
 
 def _as_int(value: object) -> int:
@@ -464,15 +535,29 @@ async def rename_function(
     *,
     mode: CredentialMode = CredentialMode.DEFAULT,
 ) -> FunctionDetails:
-    """Rename a user-defined function via ``EXEC sp_rename @objname, @newname, 'OBJECT'``.
+    """Rename a user-defined function via DROP + CREATE under the new name.
 
     Works on both Data Warehouses and SQL Analytics Endpoints — no DW-only guard
     is applied.
 
-    ``sp_rename`` takes names as STRING ARGUMENTS (not SQL identifiers), so both
-    the old qualified name and the new bare name are bound as ``?`` parameters.
-    The new name must be unqualified (no dot) because ``sp_rename`` cannot move
-    a function across schemas.
+    **Why not ``sp_rename``?**
+    Fabric Warehouse rejects ``sp_rename`` for user-defined functions with
+    "An invalid parameter or option was specified for procedure 'sys.sp_rename'".
+    The Microsoft T-SQL reference explicitly states that ``sp_rename`` must not be
+    used to rename functions; the recommended approach is to drop and re-create the
+    object.  See https://learn.microsoft.com/sql/relational-databases/system-stored-procedures/sp-rename-transact-sql#remarks
+
+    The implementation:
+
+    1. Fetch the existing function details (definition from ``sys.sql_modules``).
+    2. Create a new function with the same schema, body, and the new name.
+    3. Drop the old function.
+
+    If step 2 or 3 fails the old function is still intact and the error propagates
+    to the caller — there is no silent partial state.
+
+    The new name must be unqualified (no dot) because the function stays in the
+    same schema.
 
     Args:
         target: The warehouse or SQL Analytics Endpoint to connect to.
@@ -483,13 +568,14 @@ async def rename_function(
         mode: The credential mode for Entra authentication.
 
     Returns:
-        The renamed :class:`~fabric_dw.models.FunctionDetails` (fetched after rename
-        using the original schema and the new name).
+        The newly-created :class:`~fabric_dw.models.FunctionDetails` under the
+        new name (fetched after the DDL sequence completes).
 
     Raises:
         ValueError: If *qualified* cannot be parsed, if either identifier part
             fails validation, or if *new_name* is schema-qualified (contains a dot).
-        NotFoundError: If the renamed function cannot be found after the rename.
+        NotFoundError: If the source function does not exist, or if the newly
+            created function cannot be found after the DDL sequence.
         PermissionDeniedError: If the driver reports a permission error.
     """
     schema, old_name = parse_qualified_name(qualified)
@@ -499,25 +585,29 @@ async def rename_function(
     if "." in new_name:
         msg = (
             f"New name {new_name!r} must not be schema-qualified; "
-            "sp_rename cannot move a function to a different schema"
+            "rename cannot move a function to a different schema"
         )
         raise ValueError(msg)
     validate_identifier(new_name)
 
-    # @objname = 'schema.oldfn', @newname = 'newfn' — bound as ? params.
-    old_qualified = f"{schema}.{old_name}"
+    # Step 1: fetch the existing definition so we can re-create it.
+    existing = await get_function(target, schema, old_name, mode=mode)
 
-    def _run() -> None:
-        run_query(
-            target,
-            _SP_RENAME_SQL,
-            params=[old_qualified, new_name],
-            mode=mode,
-            commit=True,
-            fetch="none",
-        )
+    if existing.definition is None:
+        msg = f"Function [{schema}].[{old_name}] has no definition in sys.sql_modules"
+        raise NotFoundError(msg)
 
-    await asyncio.to_thread(_run)
+    # sys.sql_modules stores the full original CREATE FUNCTION statement.
+    # Strip the preamble (CREATE FUNCTION [schema].[name]) so we can re-issue
+    # it under the new name.
+    body = _extract_function_body(schema, old_name, existing.definition)
+
+    # Step 2: create under the new name.
+    await create_function(target, schema, new_name, body, mode=mode)
+
+    # Step 3: drop the old name.
+    await drop_function(target, schema, old_name, mode=mode)
+
     try:
         return await get_function(target, schema, new_name, mode=mode)
     except NotFoundError:

--- a/tests/unit/services/test_functions.py
+++ b/tests/unit/services/test_functions.py
@@ -659,47 +659,251 @@ class TestDropFunction:
 # rename_function
 # ===========================================================================
 
+# Definition as stored in sys.sql_modules — starts with the full CREATE preamble.
+_RENAME_DEF_BRACKET = (
+    "CREATE FUNCTION [dbo].[fn_clean]"
+    "(@input NVARCHAR(100)) RETURNS NVARCHAR(100) AS BEGIN RETURN LTRIM(RTRIM(@input)) END"
+)
+_RENAME_DEF_UNQUOTED = (
+    "CREATE FUNCTION dbo.fn_clean"
+    "(@input NVARCHAR(100)) RETURNS NVARCHAR(100) AS BEGIN RETURN LTRIM(RTRIM(@input)) END"
+)
+
+_GET_ROW_FN_WITH_DEF = (
+    "dbo",
+    "fn_clean",
+    "FN",
+    "SQL_SCALAR_FUNCTION",
+    _NOW,
+    _LATER,
+    _RENAME_DEF_BRACKET,
+    1,
+)
+_GET_ROW_FN_UNQUOTED = (
+    "dbo",
+    "fn_clean",
+    "FN",
+    "SQL_SCALAR_FUNCTION",
+    _NOW,
+    _LATER,
+    _RENAME_DEF_UNQUOTED,
+    1,
+)
+
 
 class TestRenameFunction:
-    async def test_emits_sp_rename_ddl(self) -> None:
-        target = _make_target()
-        ddl_conn = _make_conn_for_ddl()
-        conn_fn = _make_conn([_GET_ROW_FN], _GET_COLS)
-        conn_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
+    """rename_function uses DROP + CREATE (not sp_rename) because Fabric DW rejects
+    sp_rename for user-defined functions.  The Microsoft T-SQL reference explicitly
+    recommends dropping and re-creating functions instead."""
 
-        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, conn_fn, conn_params]):
+    # ------------------------------------------------------------------
+    # Happy-path: sequence of calls
+    # ------------------------------------------------------------------
+
+    async def test_issues_create_function_ddl(self) -> None:
+        """The rename must emit a CREATE FUNCTION DDL for the new name."""
+        target = _make_target()
+        # Connections consumed in order:
+        # 1) get_function (old) → metadata fetch
+        # 2) get_function (old) → params fetch
+        # 3) create_function DDL
+        # 4) get_function (new) → metadata fetch (inside create_function)
+        # 5) get_function (new) → params fetch (inside create_function)
+        # 6) drop_function DDL
+        # 7) get_function (new) → final fetch metadata
+        # 8) get_function (new) → final fetch params
+        conn_get_old_fn = _make_conn([_GET_ROW_FN_WITH_DEF], _GET_COLS)
+        conn_get_old_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
+        conn_create_ddl = _make_conn_for_ddl()
+        conn_get_new_fn = _make_conn([_GET_ROW_FN], _GET_COLS)
+        conn_get_new_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
+        conn_drop_ddl = _make_conn_for_ddl()
+        conn_final_fn = _make_conn([_GET_ROW_FN], _GET_COLS)
+        conn_final_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
+
+        with patch(
+            "fabric_dw.sql.open_connection",
+            side_effect=[
+                conn_get_old_fn,
+                conn_get_old_params,
+                conn_create_ddl,
+                conn_get_new_fn,
+                conn_get_new_params,
+                conn_drop_ddl,
+                conn_final_fn,
+                conn_final_params,
+            ],
+        ):
             await functions.rename_function(target, "dbo.fn_clean", "fn_sanitize")
 
-        cursor = ddl_conn.cursor.return_value
-        call_sql: str = cursor.execute.call_args[0][0].upper()
-        assert "SP_RENAME" in call_sql
+        create_cursor = conn_create_ddl.cursor.return_value
+        create_sql: str = create_cursor.execute.call_args[0][0].upper()
+        assert "CREATE FUNCTION" in create_sql
+        assert "[FN_SANITIZE]" in create_sql or "FN_SANITIZE" in create_sql
 
-    async def test_passes_old_and_new_name_as_params(self) -> None:
+    async def test_issues_drop_function_ddl(self) -> None:
+        """The rename must emit a DROP FUNCTION DDL for the old name."""
         target = _make_target()
-        ddl_conn = _make_conn_for_ddl()
-        conn_fn = _make_conn([_GET_ROW_FN], _GET_COLS)
-        conn_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
+        conn_get_old_fn = _make_conn([_GET_ROW_FN_WITH_DEF], _GET_COLS)
+        conn_get_old_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
+        conn_create_ddl = _make_conn_for_ddl()
+        conn_get_new_fn = _make_conn([_GET_ROW_FN], _GET_COLS)
+        conn_get_new_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
+        conn_drop_ddl = _make_conn_for_ddl()
+        conn_final_fn = _make_conn([_GET_ROW_FN], _GET_COLS)
+        conn_final_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
 
-        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, conn_fn, conn_params]):
+        with patch(
+            "fabric_dw.sql.open_connection",
+            side_effect=[
+                conn_get_old_fn,
+                conn_get_old_params,
+                conn_create_ddl,
+                conn_get_new_fn,
+                conn_get_new_params,
+                conn_drop_ddl,
+                conn_final_fn,
+                conn_final_params,
+            ],
+        ):
             await functions.rename_function(target, "dbo.fn_clean", "fn_sanitize")
 
-        cursor = ddl_conn.cursor.return_value
-        call_args = cursor.execute.call_args
-        params = list(call_args[0][1]) if len(call_args[0]) > 1 else []
-        assert "dbo.fn_clean" in params
-        assert "fn_sanitize" in params
+        drop_cursor = conn_drop_ddl.cursor.return_value
+        drop_sql: str = drop_cursor.execute.call_args[0][0].upper()
+        assert "DROP FUNCTION" in drop_sql
+        assert "[FN_CLEAN]" in drop_sql or "FN_CLEAN" in drop_sql
 
     async def test_returns_function_details_with_new_name(self) -> None:
+        """rename_function must return FunctionDetails (fetched after DDL)."""
         target = _make_target()
-        ddl_conn = _make_conn_for_ddl()
-        # get_function is called with new name — mock it returning fn_clean details
-        conn_fn = _make_conn([_GET_ROW_FN], _GET_COLS)
-        conn_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
+        conn_get_old_fn = _make_conn([_GET_ROW_FN_WITH_DEF], _GET_COLS)
+        conn_get_old_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
+        conn_create_ddl = _make_conn_for_ddl()
+        conn_get_new_fn = _make_conn([_GET_ROW_FN], _GET_COLS)
+        conn_get_new_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
+        conn_drop_ddl = _make_conn_for_ddl()
+        conn_final_fn = _make_conn([_GET_ROW_FN], _GET_COLS)
+        conn_final_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
 
-        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, conn_fn, conn_params]):
+        with patch(
+            "fabric_dw.sql.open_connection",
+            side_effect=[
+                conn_get_old_fn,
+                conn_get_old_params,
+                conn_create_ddl,
+                conn_get_new_fn,
+                conn_get_new_params,
+                conn_drop_ddl,
+                conn_final_fn,
+                conn_final_params,
+            ],
+        ):
             result = await functions.rename_function(target, "dbo.fn_clean", "fn_sanitize")
 
         assert isinstance(result, FunctionDetails)
+
+    async def test_does_not_emit_sp_rename(self) -> None:
+        """Fabric DW rejects sp_rename for UDFs — must NOT appear in any DDL."""
+        target = _make_target()
+        conn_get_old_fn = _make_conn([_GET_ROW_FN_WITH_DEF], _GET_COLS)
+        conn_get_old_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
+        conn_create_ddl = _make_conn_for_ddl()
+        conn_get_new_fn = _make_conn([_GET_ROW_FN], _GET_COLS)
+        conn_get_new_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
+        conn_drop_ddl = _make_conn_for_ddl()
+        conn_final_fn = _make_conn([_GET_ROW_FN], _GET_COLS)
+        conn_final_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
+
+        all_conns = [
+            conn_get_old_fn,
+            conn_get_old_params,
+            conn_create_ddl,
+            conn_get_new_fn,
+            conn_get_new_params,
+            conn_drop_ddl,
+            conn_final_fn,
+            conn_final_params,
+        ]
+
+        with patch("fabric_dw.sql.open_connection", side_effect=all_conns):
+            await functions.rename_function(target, "dbo.fn_clean", "fn_sanitize")
+
+        for conn in all_conns:
+            cursor = conn.cursor.return_value
+            if cursor.execute.called:
+                sql: str = cursor.execute.call_args[0][0].upper()
+                assert "SP_RENAME" not in sql, f"sp_rename must not be used; got: {sql!r}"
+
+    async def test_strips_create_preamble_bracket_quoted(self) -> None:
+        """Body extraction must work when sys.sql_modules returns bracket-quoted names."""
+        target = _make_target()
+        conn_get_old_fn = _make_conn([_GET_ROW_FN_WITH_DEF], _GET_COLS)
+        conn_get_old_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
+        conn_create_ddl = _make_conn_for_ddl()
+        conn_get_new_fn = _make_conn([_GET_ROW_FN], _GET_COLS)
+        conn_get_new_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
+        conn_drop_ddl = _make_conn_for_ddl()
+        conn_final_fn = _make_conn([_GET_ROW_FN], _GET_COLS)
+        conn_final_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
+
+        with patch(
+            "fabric_dw.sql.open_connection",
+            side_effect=[
+                conn_get_old_fn,
+                conn_get_old_params,
+                conn_create_ddl,
+                conn_get_new_fn,
+                conn_get_new_params,
+                conn_drop_ddl,
+                conn_final_fn,
+                conn_final_params,
+            ],
+        ):
+            await functions.rename_function(target, "dbo.fn_clean", "fn_sanitize")
+
+        create_cursor = conn_create_ddl.cursor.return_value
+        create_sql: str = create_cursor.execute.call_args[0][0]
+        # Body content must be passed through correctly
+        assert "LTRIM" in create_sql.upper() or "ltrim" in create_sql.lower()
+        # The old name must not appear as the function name in the CREATE statement.
+        after_fn_kw = create_sql.split("CREATE FUNCTION", 1)[-1]
+        before_params = after_fn_kw.split("(", maxsplit=1)[0]
+        assert "fn_clean" not in before_params.lower()
+
+    async def test_strips_create_preamble_unquoted(self) -> None:
+        """Body extraction must also handle unquoted names in sys.sql_modules."""
+        target = _make_target()
+        conn_get_old_fn = _make_conn([_GET_ROW_FN_UNQUOTED], _GET_COLS)
+        conn_get_old_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
+        conn_create_ddl = _make_conn_for_ddl()
+        conn_get_new_fn = _make_conn([_GET_ROW_FN], _GET_COLS)
+        conn_get_new_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
+        conn_drop_ddl = _make_conn_for_ddl()
+        conn_final_fn = _make_conn([_GET_ROW_FN], _GET_COLS)
+        conn_final_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
+
+        with patch(
+            "fabric_dw.sql.open_connection",
+            side_effect=[
+                conn_get_old_fn,
+                conn_get_old_params,
+                conn_create_ddl,
+                conn_get_new_fn,
+                conn_get_new_params,
+                conn_drop_ddl,
+                conn_final_fn,
+                conn_final_params,
+            ],
+        ):
+            await functions.rename_function(target, "dbo.fn_clean", "fn_sanitize")
+
+        create_cursor = conn_create_ddl.cursor.return_value
+        create_sql: str = create_cursor.execute.call_args[0][0]
+        assert "LTRIM" in create_sql.upper() or "ltrim" in create_sql.lower()
+
+    # ------------------------------------------------------------------
+    # Validation / error-path
+    # ------------------------------------------------------------------
 
     async def test_rejects_schema_qualified_new_name(self) -> None:
         target = _make_target()
@@ -726,27 +930,58 @@ class TestRenameFunction:
         with pytest.raises(ValueError, match="Invalid SQL identifier"):
             await functions.rename_function(target, "dbo.fn_clean", "fn_ok] WHERE 1=1--")
 
-    async def test_raises_not_found_when_post_rename_get_fails(self) -> None:
+    async def test_raises_not_found_when_source_function_missing(self) -> None:
+        """get_function for the old name raises NotFoundError when it does not exist."""
         target = _make_target()
-        ddl_conn = _make_conn_for_ddl()
         empty_conn = _make_conn([], _GET_COLS)
 
         with (
-            patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, empty_conn]),
-            pytest.raises(NotFoundError, match="not found after rename"),
+            patch("fabric_dw.sql.open_connection", return_value=empty_conn),
+            pytest.raises(NotFoundError),
         ):
             await functions.rename_function(target, "dbo.fn_clean", "fn_sanitize")
 
-    async def test_commits_after_execute(self) -> None:
+    async def test_raises_not_found_when_definition_is_none(self) -> None:
+        """If definition is NULL in sys.sql_modules, rename must raise NotFoundError."""
         target = _make_target()
-        ddl_conn = _make_conn_for_ddl()
-        conn_fn = _make_conn([_GET_ROW_FN], _GET_COLS)
+        row_no_def = ("dbo", "fn_clean", "FN", "SQL_SCALAR_FUNCTION", _NOW, _LATER, None, 1)
+        conn_fn = _make_conn([row_no_def], _GET_COLS)
         conn_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
 
-        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, conn_fn, conn_params]):
+        with (
+            patch("fabric_dw.sql.open_connection", side_effect=[conn_fn, conn_params]),
+            pytest.raises(NotFoundError),
+        ):
             await functions.rename_function(target, "dbo.fn_clean", "fn_sanitize")
 
-        ddl_conn.commit.assert_called_once()
+    async def test_raises_not_found_when_post_rename_get_fails(self) -> None:
+        """Final get_function fails → NotFoundError with 'not found after rename'."""
+        target = _make_target()
+        conn_get_old_fn = _make_conn([_GET_ROW_FN_WITH_DEF], _GET_COLS)
+        conn_get_old_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
+        conn_create_ddl = _make_conn_for_ddl()
+        conn_get_new_fn = _make_conn([_GET_ROW_FN], _GET_COLS)
+        conn_get_new_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
+        conn_drop_ddl = _make_conn_for_ddl()
+        # Final get_function returns empty → NotFoundError
+        conn_final_empty = _make_conn([], _GET_COLS)
+
+        with (
+            patch(
+                "fabric_dw.sql.open_connection",
+                side_effect=[
+                    conn_get_old_fn,
+                    conn_get_old_params,
+                    conn_create_ddl,
+                    conn_get_new_fn,
+                    conn_get_new_params,
+                    conn_drop_ddl,
+                    conn_final_empty,
+                ],
+            ),
+            pytest.raises(NotFoundError, match="not found after rename"),
+        ):
+            await functions.rename_function(target, "dbo.fn_clean", "fn_sanitize")
 
 
 # ===========================================================================

--- a/tests/unit/services/test_functions.py
+++ b/tests/unit/services/test_functions.py
@@ -696,6 +696,34 @@ class TestRenameFunction:
     sp_rename for user-defined functions.  The Microsoft T-SQL reference explicitly
     recommends dropping and re-creating functions instead."""
 
+    # Connections consumed by rename_function in the happy path (6 total):
+    # 1) get_function (old) → metadata fetch
+    # 2) get_function (old) → params fetch
+    # 3) create_function DDL
+    # 4) get_function (new) → metadata fetch (inside create_function)
+    # 5) get_function (new) → params fetch (inside create_function)
+    # 6) drop_function DDL
+    #
+    # Note: create_function() already calls get_function() internally and returns
+    # FunctionDetails — rename_function reuses that result without an extra round-trip.
+
+    def _make_rename_conns(
+        self,
+        *,
+        old_row: tuple[object, ...] | None = None,
+    ) -> list[MagicMock]:
+        """Return the standard 6-connection list for a successful rename."""
+        if old_row is None:
+            old_row = _GET_ROW_FN_WITH_DEF
+        return [
+            _make_conn([old_row], _GET_COLS),  # 1: get old fn metadata
+            _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS),  # 2: get old fn params
+            _make_conn_for_ddl(),  # 3: create DDL
+            _make_conn([_GET_ROW_FN], _GET_COLS),  # 4: get new fn (in create_function)
+            _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS),  # 5: get new fn params
+            _make_conn_for_ddl(),  # 6: drop DDL
+        ]
+
     # ------------------------------------------------------------------
     # Happy-path: sequence of calls
     # ------------------------------------------------------------------
@@ -703,37 +731,10 @@ class TestRenameFunction:
     async def test_issues_create_function_ddl(self) -> None:
         """The rename must emit a CREATE FUNCTION DDL for the new name."""
         target = _make_target()
-        # Connections consumed in order:
-        # 1) get_function (old) → metadata fetch
-        # 2) get_function (old) → params fetch
-        # 3) create_function DDL
-        # 4) get_function (new) → metadata fetch (inside create_function)
-        # 5) get_function (new) → params fetch (inside create_function)
-        # 6) drop_function DDL
-        # 7) get_function (new) → final fetch metadata
-        # 8) get_function (new) → final fetch params
-        conn_get_old_fn = _make_conn([_GET_ROW_FN_WITH_DEF], _GET_COLS)
-        conn_get_old_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
-        conn_create_ddl = _make_conn_for_ddl()
-        conn_get_new_fn = _make_conn([_GET_ROW_FN], _GET_COLS)
-        conn_get_new_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
-        conn_drop_ddl = _make_conn_for_ddl()
-        conn_final_fn = _make_conn([_GET_ROW_FN], _GET_COLS)
-        conn_final_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
+        conns = self._make_rename_conns()
+        conn_create_ddl = conns[2]
 
-        with patch(
-            "fabric_dw.sql.open_connection",
-            side_effect=[
-                conn_get_old_fn,
-                conn_get_old_params,
-                conn_create_ddl,
-                conn_get_new_fn,
-                conn_get_new_params,
-                conn_drop_ddl,
-                conn_final_fn,
-                conn_final_params,
-            ],
-        ):
+        with patch("fabric_dw.sql.open_connection", side_effect=conns):
             await functions.rename_function(target, "dbo.fn_clean", "fn_sanitize")
 
         create_cursor = conn_create_ddl.cursor.return_value
@@ -744,28 +745,10 @@ class TestRenameFunction:
     async def test_issues_drop_function_ddl(self) -> None:
         """The rename must emit a DROP FUNCTION DDL for the old name."""
         target = _make_target()
-        conn_get_old_fn = _make_conn([_GET_ROW_FN_WITH_DEF], _GET_COLS)
-        conn_get_old_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
-        conn_create_ddl = _make_conn_for_ddl()
-        conn_get_new_fn = _make_conn([_GET_ROW_FN], _GET_COLS)
-        conn_get_new_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
-        conn_drop_ddl = _make_conn_for_ddl()
-        conn_final_fn = _make_conn([_GET_ROW_FN], _GET_COLS)
-        conn_final_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
+        conns = self._make_rename_conns()
+        conn_drop_ddl = conns[5]
 
-        with patch(
-            "fabric_dw.sql.open_connection",
-            side_effect=[
-                conn_get_old_fn,
-                conn_get_old_params,
-                conn_create_ddl,
-                conn_get_new_fn,
-                conn_get_new_params,
-                conn_drop_ddl,
-                conn_final_fn,
-                conn_final_params,
-            ],
-        ):
+        with patch("fabric_dw.sql.open_connection", side_effect=conns):
             await functions.rename_function(target, "dbo.fn_clean", "fn_sanitize")
 
         drop_cursor = conn_drop_ddl.cursor.return_value
@@ -774,30 +757,11 @@ class TestRenameFunction:
         assert "[FN_CLEAN]" in drop_sql or "FN_CLEAN" in drop_sql
 
     async def test_returns_function_details_with_new_name(self) -> None:
-        """rename_function must return FunctionDetails (fetched after DDL)."""
+        """rename_function must return FunctionDetails (result from create_function)."""
         target = _make_target()
-        conn_get_old_fn = _make_conn([_GET_ROW_FN_WITH_DEF], _GET_COLS)
-        conn_get_old_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
-        conn_create_ddl = _make_conn_for_ddl()
-        conn_get_new_fn = _make_conn([_GET_ROW_FN], _GET_COLS)
-        conn_get_new_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
-        conn_drop_ddl = _make_conn_for_ddl()
-        conn_final_fn = _make_conn([_GET_ROW_FN], _GET_COLS)
-        conn_final_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
+        conns = self._make_rename_conns()
 
-        with patch(
-            "fabric_dw.sql.open_connection",
-            side_effect=[
-                conn_get_old_fn,
-                conn_get_old_params,
-                conn_create_ddl,
-                conn_get_new_fn,
-                conn_get_new_params,
-                conn_drop_ddl,
-                conn_final_fn,
-                conn_final_params,
-            ],
-        ):
+        with patch("fabric_dw.sql.open_connection", side_effect=conns):
             result = await functions.rename_function(target, "dbo.fn_clean", "fn_sanitize")
 
         assert isinstance(result, FunctionDetails)
@@ -805,30 +769,12 @@ class TestRenameFunction:
     async def test_does_not_emit_sp_rename(self) -> None:
         """Fabric DW rejects sp_rename for UDFs — must NOT appear in any DDL."""
         target = _make_target()
-        conn_get_old_fn = _make_conn([_GET_ROW_FN_WITH_DEF], _GET_COLS)
-        conn_get_old_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
-        conn_create_ddl = _make_conn_for_ddl()
-        conn_get_new_fn = _make_conn([_GET_ROW_FN], _GET_COLS)
-        conn_get_new_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
-        conn_drop_ddl = _make_conn_for_ddl()
-        conn_final_fn = _make_conn([_GET_ROW_FN], _GET_COLS)
-        conn_final_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
+        conns = self._make_rename_conns()
 
-        all_conns = [
-            conn_get_old_fn,
-            conn_get_old_params,
-            conn_create_ddl,
-            conn_get_new_fn,
-            conn_get_new_params,
-            conn_drop_ddl,
-            conn_final_fn,
-            conn_final_params,
-        ]
-
-        with patch("fabric_dw.sql.open_connection", side_effect=all_conns):
+        with patch("fabric_dw.sql.open_connection", side_effect=conns):
             await functions.rename_function(target, "dbo.fn_clean", "fn_sanitize")
 
-        for conn in all_conns:
+        for conn in conns:
             cursor = conn.cursor.return_value
             if cursor.execute.called:
                 sql: str = cursor.execute.call_args[0][0].upper()
@@ -837,28 +783,10 @@ class TestRenameFunction:
     async def test_strips_create_preamble_bracket_quoted(self) -> None:
         """Body extraction must work when sys.sql_modules returns bracket-quoted names."""
         target = _make_target()
-        conn_get_old_fn = _make_conn([_GET_ROW_FN_WITH_DEF], _GET_COLS)
-        conn_get_old_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
-        conn_create_ddl = _make_conn_for_ddl()
-        conn_get_new_fn = _make_conn([_GET_ROW_FN], _GET_COLS)
-        conn_get_new_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
-        conn_drop_ddl = _make_conn_for_ddl()
-        conn_final_fn = _make_conn([_GET_ROW_FN], _GET_COLS)
-        conn_final_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
+        conns = self._make_rename_conns()
+        conn_create_ddl = conns[2]
 
-        with patch(
-            "fabric_dw.sql.open_connection",
-            side_effect=[
-                conn_get_old_fn,
-                conn_get_old_params,
-                conn_create_ddl,
-                conn_get_new_fn,
-                conn_get_new_params,
-                conn_drop_ddl,
-                conn_final_fn,
-                conn_final_params,
-            ],
-        ):
+        with patch("fabric_dw.sql.open_connection", side_effect=conns):
             await functions.rename_function(target, "dbo.fn_clean", "fn_sanitize")
 
         create_cursor = conn_create_ddl.cursor.return_value
@@ -873,33 +801,86 @@ class TestRenameFunction:
     async def test_strips_create_preamble_unquoted(self) -> None:
         """Body extraction must also handle unquoted names in sys.sql_modules."""
         target = _make_target()
-        conn_get_old_fn = _make_conn([_GET_ROW_FN_UNQUOTED], _GET_COLS)
-        conn_get_old_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
-        conn_create_ddl = _make_conn_for_ddl()
-        conn_get_new_fn = _make_conn([_GET_ROW_FN], _GET_COLS)
-        conn_get_new_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
-        conn_drop_ddl = _make_conn_for_ddl()
-        conn_final_fn = _make_conn([_GET_ROW_FN], _GET_COLS)
-        conn_final_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
+        conns = self._make_rename_conns(old_row=_GET_ROW_FN_UNQUOTED)
+        conn_create_ddl = conns[2]
 
-        with patch(
-            "fabric_dw.sql.open_connection",
-            side_effect=[
-                conn_get_old_fn,
-                conn_get_old_params,
-                conn_create_ddl,
-                conn_get_new_fn,
-                conn_get_new_params,
-                conn_drop_ddl,
-                conn_final_fn,
-                conn_final_params,
-            ],
-        ):
+        with patch("fabric_dw.sql.open_connection", side_effect=conns):
             await functions.rename_function(target, "dbo.fn_clean", "fn_sanitize")
 
         create_cursor = conn_create_ddl.cursor.return_value
         create_sql: str = create_cursor.execute.call_args[0][0]
         assert "LTRIM" in create_sql.upper() or "ltrim" in create_sql.lower()
+
+    async def test_strips_create_preamble_with_leading_comment(self) -> None:
+        """Body extraction must skip leading comment blocks containing 'FUNCTION'.
+
+        sys.sql_modules may store definitions that begin with a comment whose
+        text contains the word FUNCTION.  The old find('FUNCTION') approach
+        latched on that first occurrence; re.search(r'\\bCREATE\\s+FUNCTION\\b')
+        skips it and finds the actual DDL keyword.
+        """
+        # Definition whose very first token is a comment containing "FUNCTION"
+        definition_with_comment = (
+            "-- This FUNCTION cleans strings\n"
+            "CREATE FUNCTION [dbo].[fn_clean]"
+            "(@input NVARCHAR(100)) RETURNS NVARCHAR(100) AS BEGIN RETURN LTRIM(RTRIM(@input)) END"
+        )
+        row_with_comment = (
+            "dbo",
+            "fn_clean",
+            "FN",
+            "SQL_SCALAR_FUNCTION",
+            _NOW,
+            _LATER,
+            definition_with_comment,
+            1,
+        )
+        target = _make_target()
+        conns = self._make_rename_conns(old_row=row_with_comment)
+        conn_create_ddl = conns[2]
+
+        with patch("fabric_dw.sql.open_connection", side_effect=conns):
+            await functions.rename_function(target, "dbo.fn_clean", "fn_sanitize")
+
+        create_cursor = conn_create_ddl.cursor.return_value
+        create_sql: str = create_cursor.execute.call_args[0][0]
+        # The body (parameter list etc.) must appear in the new CREATE statement
+        assert "LTRIM" in create_sql.upper() or "ltrim" in create_sql.lower()
+        # The generated DDL must reference the new name, not the old
+        after_fn_kw = create_sql.split("CREATE FUNCTION", 1)[-1]
+        before_params = after_fn_kw.split("(", maxsplit=1)[0]
+        assert "fn_clean" not in before_params.lower()
+        assert "fn_sanitize" in before_params.lower()
+
+    async def test_create_fails_leaves_old_function_intact(self) -> None:
+        """If create_function raises (e.g. new name already exists), the old function
+        is never dropped.  The exception propagates and drop_function is not called.
+        """
+        target = _make_target()
+        # get_function (old) succeeds — returns the existing function with a definition
+        conn_get_old_fn = _make_conn([_GET_ROW_FN_WITH_DEF], _GET_COLS)
+        conn_get_old_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
+        # create_function DDL fails (new name already exists)
+        conn_create_fail = MagicMock()
+        cursor_fail = MagicMock()
+        cursor_fail.execute.side_effect = Exception(
+            "There is already an object named 'fn_sanitize' in the database."
+        )
+        conn_create_fail.cursor.return_value = cursor_fail
+
+        drop_conn = _make_conn_for_ddl()  # must NOT be consumed
+
+        with (
+            patch(
+                "fabric_dw.sql.open_connection",
+                side_effect=[conn_get_old_fn, conn_get_old_params, conn_create_fail],
+            ),
+            pytest.raises(Exception, match="already an object named"),
+        ):
+            await functions.rename_function(target, "dbo.fn_clean", "fn_sanitize")
+
+        # drop_function DDL connection must never have been opened
+        drop_conn.cursor.return_value.execute.assert_not_called()
 
     # ------------------------------------------------------------------
     # Validation / error-path
@@ -951,35 +932,6 @@ class TestRenameFunction:
         with (
             patch("fabric_dw.sql.open_connection", side_effect=[conn_fn, conn_params]),
             pytest.raises(NotFoundError),
-        ):
-            await functions.rename_function(target, "dbo.fn_clean", "fn_sanitize")
-
-    async def test_raises_not_found_when_post_rename_get_fails(self) -> None:
-        """Final get_function fails → NotFoundError with 'not found after rename'."""
-        target = _make_target()
-        conn_get_old_fn = _make_conn([_GET_ROW_FN_WITH_DEF], _GET_COLS)
-        conn_get_old_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
-        conn_create_ddl = _make_conn_for_ddl()
-        conn_get_new_fn = _make_conn([_GET_ROW_FN], _GET_COLS)
-        conn_get_new_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
-        conn_drop_ddl = _make_conn_for_ddl()
-        # Final get_function returns empty → NotFoundError
-        conn_final_empty = _make_conn([], _GET_COLS)
-
-        with (
-            patch(
-                "fabric_dw.sql.open_connection",
-                side_effect=[
-                    conn_get_old_fn,
-                    conn_get_old_params,
-                    conn_create_ddl,
-                    conn_get_new_fn,
-                    conn_get_new_params,
-                    conn_drop_ddl,
-                    conn_final_empty,
-                ],
-            ),
-            pytest.raises(NotFoundError, match="not found after rename"),
         ):
             await functions.rename_function(target, "dbo.fn_clean", "fn_sanitize")
 


### PR DESCRIPTION
## Summary

- Fabric Warehouse rejects `sp_rename` for user-defined functions with *"An invalid parameter or option was specified for procedure 'sys.sp_rename'"* — the Microsoft T-SQL reference explicitly recommends dropping and re-creating functions instead of using `sp_rename` for this object type.
- `rename_function` is rewritten to fetch the existing definition from `sys.sql_modules`, strip the `CREATE FUNCTION [schema].[old_name]` preamble via a new `_extract_function_body` helper, create the function under the new name, then drop the old one.
- Unit tests updated: old `SP_RENAME` assertions removed; new assertions pin the CREATE + DROP sequence and explicitly verify `sp_rename` is never emitted. Two body-extraction tests cover bracket-quoted and unquoted definition forms.

## Why not sp_rename with named params?

The Fabric-specific syntax `sp_rename @objname = ?, @newname = ?, @objtype = 'OBJECT'` is valid for **tables**, but the Microsoft docs include this explicit caution in the Remarks section (applies to all versions):

> *Renaming a stored procedure, function, view, or trigger won't change the name of the corresponding object either in the definition column of the `sys.sql_modules` catalog view ... Therefore, we recommend that `sp_rename` not be used to rename these object types. Instead, drop and re-create the object with its new name.*

Integration run 27563609430 confirmed that Fabric DW enforces this restriction for functions at runtime. DROP + CREATE is the approach that actually works.

## Secondary note

`test_rename_function_roundtrip` errored at setup with `Could not login because the authentication failed` ~32 min into the integration run. This is consistent with a transient SQL token expiry during a long run, not a code bug. No auth code changes are made.

## Test plan

- [x] `just check` passes (ruff + ty + 3035 unit tests)
- [ ] Integration run validates `test_create_function_full_roundtrip` and `test_rename_function_roundtrip` against real Fabric DW

Closes #372

🤖 Generated with [Claude Code](https://claude.com/claude-code)