### PR TITLE
feat(telemetry): emit command_invoked usage events for CLI and MCP

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -28,7 +28,42 @@ Every telemetry event includes a shared envelope of anonymous fields:
 | `mcp_server_started` | When the MCP server boots | — |
 | `app_exited` | On process exit | `duration_ms`, `exit_status` (ok / user_error / api_error), `error_category` |
 
-> **Note:** Per-command usage tracking (`command_invoked`) is a planned follow-up (#367) and is **not** included in this release.
+### `command_invoked` — per-command usage
+
+One `command_invoked` event is emitted after every CLI command and every MCP tool call completes (success or failure).
+
+| Field | Description |
+|---|---|
+| `name` | Command name. CLI: `<group>.<subcommand>` (e.g. `warehouses.list`). MCP: tool name (e.g. `create_table`). Never SQL text or identifiers. |
+| `domain` | Rolled-up feature area (see table below). |
+| `surface` | `cli` or `mcp`. |
+| `status` | `success`, `user_error` (validation/usage problems), or `api_error` (HTTP/driver/unexpected). |
+| `duration_ms_bucket` | Bucketed wall-clock duration: `<100ms`, `<1s`, `<10s`, or `>10s`. |
+| `destructive_op` | `true` only for permanently-destructive MCP tools (delete, clear, restore in-place). Omitted otherwise. |
+
+#### Domain rollup
+
+| Domain | CLI group(s) | Representative MCP tools |
+|---|---|---|
+| `workspaces` | `workspaces` | `list_workspaces`, `get_workspace`, `set_workspace_collation` |
+| `warehouses` | `warehouses` | `list_warehouses`, `create_warehouse`, `delete_warehouse`, … |
+| `sql_endpoints` | `sql-endpoints` | `list_sql_endpoints`, `get_sql_endpoint`, … |
+| `sql` | `sql` | `execute_sql` |
+| `tables` | `tables` | `list_tables`, `create_table`, `delete_table`, … |
+| `views` | `views` | `list_views`, `create_view`, `drop_view`, … |
+| `procedures` | `procedures` | `list_procedures`, `create_procedure`, `drop_procedure`, … |
+| `functions` | `functions` | `list_functions`, `create_function`, `drop_function`, … |
+| `schemas` | `schemas` | `list_schemas`, `create_schema`, `delete_schema` |
+| `statistics` | `statistics` | `list_statistics`, `create_statistics`, `delete_statistics` |
+| `snapshots` | `snapshots` | `list_snapshots`, `create_snapshot`, `delete_snapshot`, … |
+| `restore_points` | `restore-points` | `list_restore_points`, `create_restore_point`, `restore_warehouse_in_place`, … |
+| `audit` | `audit` | `get_audit_settings`, `enable_audit`, `disable_audit`, … |
+| `queries` | `queries` | `list_running_queries`, `kill_session`, `list_request_history`, … |
+| `sql_pools` | `sql-pools` | `list_sql_pools`, `create_sql_pool`, `delete_sql_pool`, … |
+| `dbt` | `dbt` | `generate_dbt_profile` |
+| `cache` | `cache` | `clear_cache` |
+| `config` | `config` | — |
+| `completion` | `completion` | — |
 
 ### What is deliberately NOT collected
 

--- a/src/fabric_dw/cli/_main.py
+++ b/src/fabric_dw/cli/_main.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import sys
 import time
+from typing import Any
 
 import click
 
@@ -36,9 +37,132 @@ from fabric_dw.telemetry import (
     record_app_exited,
     record_app_started,
 )
+from fabric_dw.telemetry_commands import (
+    emit_command_invoked,
+    map_status,
+    now_ms,
+)
+
+_CLI_TELEMETRY_KEY = "fabric_dw_telemetry_command_name"
+_CLI_SEGMENTS_KEY = _CLI_TELEMETRY_KEY + "_segments"
 
 
-@click.group(invoke_without_command=False)
+class _InstrumentedGroup(click.Group):
+    """A :class:`click.Group` subclass that emits one ``command_invoked``
+    telemetry event per leaf command invocation.
+
+    The event is fired *after* the subcommand (or the nested group + leaf)
+    finishes so that the ``status`` and ``duration_ms`` are accurate.
+    The fully-qualified ``name`` attribute uses the format
+    ``<group>.<subcommand>`` (e.g. ``warehouses.list``).
+
+    All child groups added via :meth:`add_command` are transparently patched
+    to record ``<group>.<leaf>`` in the root context's :attr:`click.Context.meta`
+    dict.  The root group (``parent is None``) emits the ``command_invoked``
+    event once the full call stack has unwound.
+    """
+
+    def add_command(self, cmd: click.Command, name: str | None = None) -> None:
+        """Add *cmd* and patch its ``invoke`` to capture the command path."""
+        if isinstance(cmd, click.Group):
+            _patch_group_for_telemetry(cmd)
+        super().add_command(cmd, name)
+
+    def invoke(self, ctx: click.Context) -> object:
+        """Invoke the root group and emit ``command_invoked`` when done."""
+        start = now_ms()
+        exc_seen: BaseException | None = None
+        try:
+            return super().invoke(ctx)
+        except BaseException as exc:
+            exc_seen = exc
+            raise
+        finally:
+            command_name = _build_command_name(ctx)
+            if command_name:
+                duration = now_ms() - start
+                status = map_status(exc_seen)
+                emit_command_invoked(
+                    name=command_name,
+                    surface="cli",
+                    status=status,
+                    duration_ms=duration,
+                )
+
+
+def _build_command_name(root_ctx: click.Context) -> str | None:
+    """Build the fully-qualified command name from accumulated path segments.
+
+    Reads the ``_segments`` list written by patched sub-group invoke wrappers,
+    sorts segments by nesting depth (shallowest first), and joins them to form
+    a path like ``warehouses.list`` or ``config.set.workspace``.
+
+    Returns ``None`` when no segments were accumulated (e.g. root ``--help``).
+    """
+    segments: list[tuple[int, str, str]] = root_ctx.meta.get(_CLI_SEGMENTS_KEY, [])
+    if not segments:
+        return None
+
+    # Sort by depth (ascending) to get outermost → innermost order.
+    segments_sorted = sorted(segments, key=lambda t: t[0])
+
+    # Build path: take the group name from each segment, then append the
+    # subcommand name from the deepest segment.
+    parts: list[str] = []
+    for _depth, group_name, _sub in segments_sorted:
+        parts.append(group_name)
+    # Append the leaf subcommand name from the deepest segment.
+    if segments_sorted:
+        parts.append(segments_sorted[-1][2])
+
+    return ".".join(parts)
+
+
+def _patch_group_for_telemetry(group: click.Group) -> None:
+    """Monkey-patch *group*.invoke to record its portion of the command path.
+
+    The strategy is simple and correct for arbitrarily nested groups:
+
+    - Each patched group's ``finally`` block records its own name in the root
+      context's ``meta`` as a **list of (depth, name) segments**.
+    - After all groups have written their segments, the root
+      :class:`_InstrumentedGroup` reads the segments, sorts by depth, and
+      joins them to build the full path (e.g. ``config.set.workspace``).
+
+    Recursive patching ensures that sub-groups added before this function
+    is called (e.g. ``config.set``) are also patched.
+    """
+    # Recursively patch any sub-groups already registered.
+    for sub_cmd in group.commands.values():  # type: ignore[attr-defined]
+        if isinstance(sub_cmd, click.Group):
+            _patch_group_for_telemetry(sub_cmd)
+
+    original_invoke = group.invoke
+
+    def _patched_invoke(ctx: click.Context) -> Any:  # noqa: ANN401
+        try:
+            return original_invoke(ctx)
+        finally:
+            group_name = ctx.info_name or ""
+            sub_name = ctx.invoked_subcommand or ""
+            if group_name and sub_name:
+                # Calculate nesting depth: count ancestors up to (not including) root.
+                depth = 0
+                node = ctx
+                while node.parent is not None:
+                    depth += 1
+                    node = node.parent
+                root_ctx = node  # node is now the root context
+
+                # Accumulate segments: list of (depth, group_name, sub_name).
+                segs: list[tuple[int, str, str]] = root_ctx.meta.get(_CLI_SEGMENTS_KEY, [])
+                segs.append((depth, group_name, sub_name))
+                root_ctx.meta[_CLI_SEGMENTS_KEY] = segs
+
+    group.invoke = _patched_invoke  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
+
+
+@click.group(invoke_without_command=False, cls=_InstrumentedGroup)
 @click.option(
     "--json",
     "json_output",

--- a/src/fabric_dw/cli/_main.py
+++ b/src/fabric_dw/cli/_main.py
@@ -60,6 +60,16 @@ class _InstrumentedGroup(click.Group):
     to record ``<group>.<leaf>`` in the root context's :attr:`click.Context.meta`
     dict.  The root group (``parent is None``) emits the ``command_invoked``
     event once the full call stack has unwound.
+
+    Flush ordering
+    --------------
+    ``flush_telemetry()`` must run AFTER ``emit_command_invoked`` so that the
+    ``command_invoked`` span is enqueued before the exporter is flushed.
+    Click's ``call_on_close`` callbacks run INSIDE ``super().invoke()``, so they
+    complete before this ``finally`` block executes.  For this reason the
+    ``_on_close`` callback registered on the CLI group context does NOT call
+    ``flush_telemetry()`` — the flush is performed here, after emission, by the
+    root group only.
     """
 
     def add_command(self, cmd: click.Command, name: str | None = None) -> None:
@@ -69,7 +79,7 @@ class _InstrumentedGroup(click.Group):
         super().add_command(cmd, name)
 
     def invoke(self, ctx: click.Context) -> object:
-        """Invoke the root group and emit ``command_invoked`` when done."""
+        """Invoke the root group, emit ``command_invoked``, then flush telemetry."""
         start = now_ms()
         exc_seen: BaseException | None = None
         try:
@@ -88,6 +98,12 @@ class _InstrumentedGroup(click.Group):
                     status=status,
                     duration_ms=duration,
                 )
+            # Flush AFTER emission so command_invoked is included in the batch.
+            # app_started and app_exited are emitted before this point (via
+            # record_app_started in the group callback and record_app_exited in
+            # _on_close which runs inside super().invoke()), so all three events
+            # are enqueued before this bounded flush runs.
+            flush_telemetry()
 
 
 def _build_command_name(root_ctx: click.Context) -> str | None:
@@ -239,7 +255,11 @@ def cli(
             exit_status=exit_status,
             error_category=None,
         )
-        flush_telemetry()
+        # NOTE: flush_telemetry() is NOT called here.  It is called in
+        # _InstrumentedGroup.invoke() AFTER emit_command_invoked() so that
+        # the command_invoked span is enqueued before the flush runs.
+        # (call_on_close callbacks run inside super().invoke(), which returns
+        # before the finally block in _InstrumentedGroup.invoke() executes.)
 
     ctx.call_on_close(_on_close)
 

--- a/src/fabric_dw/mcp/_helpers.py
+++ b/src/fabric_dw/mcp/_helpers.py
@@ -19,6 +19,12 @@ This module provides utilities imported by every domain tool module:
   round-trip so tools avoid the double workspace-lookup pattern.
 - :func:`safe_rows` — apply ``json_safe`` to every cell in a row-set in one
   place, removing duplicated list-comprehensions.
+
+Telemetry
+---------
+Both :func:`mutating_tool` and the :class:`InstrumentedFastMCP` subclass
+wrap every registered tool with a timing + ``command_invoked`` telemetry
+call (fire-and-forget, never raises).
 """
 
 from __future__ import annotations
@@ -39,8 +45,14 @@ from fabric_dw.mcp import _guards
 from fabric_dw.resolver import Resolver
 from fabric_dw.sql import SqlTarget
 from fabric_dw.sql_io import json_safe as _json_safe
+from fabric_dw.telemetry_commands import (
+    emit_command_invoked,
+    map_status,
+    now_ms,
+)
 
 __all__ = [
+    "InstrumentedFastMCP",
     "fabric_err",
     "make_sql_target",
     "mutating_tool",
@@ -59,6 +71,51 @@ _log = logging.getLogger(__name__)
 # Note: CREATE/DROP SCHEMA, views, procedures, and functions are all supported
 # on SQL Analytics Endpoints — see T-SQL Applies-to reference for Fabric.
 # No DDL guard is needed for these operations; only table DML/DDL is blocked.
+
+
+def _wrap_mcp_tool_with_telemetry(
+    fn: Callable[_P, Coroutine[None, None, _R]],
+    name: str,
+    *,
+    destructive: bool = False,
+) -> Callable[_P, Coroutine[None, None, _R]]:
+    """Return *fn* wrapped with a fire-and-forget ``command_invoked`` telemetry call.
+
+    The wrapper records wall-clock duration and maps the outcome to a status
+    string before calling :func:`~fabric_dw.telemetry_commands.emit_command_invoked`.
+    Telemetry failures are swallowed inside ``emit_command_invoked``; they
+    never propagate to the caller.
+
+    Args:
+        fn: The async tool function to wrap.
+        name: The MCP tool name string (used as the ``name`` attribute).
+        destructive: When ``True``, the ``destructive_op`` attribute is set.
+
+    Returns:
+        A new coroutine function with the same signature that emits telemetry.
+    """
+
+    @wraps(fn)
+    async def telemetry_wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R:
+        start = now_ms()
+        exc_seen: BaseException | None = None
+        try:
+            return await fn(*args, **kwargs)
+        except BaseException as exc:
+            exc_seen = exc
+            raise
+        finally:
+            duration = now_ms() - start
+            status = map_status(exc_seen)
+            emit_command_invoked(
+                name=name,
+                surface="mcp",
+                status=status,
+                duration_ms=duration,
+                destructive=destructive,
+            )
+
+    return telemetry_wrapper
 
 
 def mutating_tool(
@@ -81,6 +138,9 @@ def mutating_tool(
     :func:`~fabric_dw.mcp._guards.assert_destructive_allowed` call is injected
     after the write guard, eliminating the second duplicate for permanently-destructive
     tools (drop, delete, clear, restore-in-place, etc.).
+
+    A fire-and-forget ``command_invoked`` telemetry event is emitted after the
+    wrapped function returns or raises, regardless of outcome.
 
     Usage::
 
@@ -109,17 +169,69 @@ def mutating_tool(
         fn: Callable[_P, Coroutine[None, None, _R]],
     ) -> Callable[_P, Coroutine[None, None, _R]]:
         @wraps(fn)
-        async def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R:
+        async def guard_wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R:
             _guards.assert_writes_allowed(name)
             if destructive:
                 _guards.assert_destructive_allowed()
             return await fn(*args, **kwargs)
 
+        # Add telemetry around the guard wrapper.
+        tel_wrapped = _wrap_mcp_tool_with_telemetry(guard_wrapper, name, destructive=destructive)
+
         # Register the wrapper (which includes the guard) under the given name.
-        registered: Callable[_P, Coroutine[None, None, _R]] = mcp.tool(name=name)(wrapper)
+        registered: Callable[_P, Coroutine[None, None, _R]] = mcp.tool(name=name)(tel_wrapped)
         return registered
 
     return decorator
+
+
+class InstrumentedFastMCP(FastMCP):
+    """A :class:`~mcp.server.fastmcp.FastMCP` subclass that wraps every
+    ``@mcp.tool(name=...)`` call with a fire-and-forget ``command_invoked``
+    telemetry event.
+
+    This class is used as the single choke-point for MCP telemetry
+    instrumentation for *read-only* tools (those registered with
+    ``@mcp.tool(name=...)``).  Mutating tools use :func:`mutating_tool`
+    which wraps telemetry explicitly.
+
+    No changes to any tool registration code are required: all existing
+    ``@mcp.tool(name=...)`` calls automatically gain instrumentation.
+    """
+
+    def tool(  # type: ignore[override]  # noqa: PLR0913
+        self,
+        name: str | None = None,
+        title: str | None = None,
+        description: str | None = None,
+        annotations: Any = None,  # noqa: ANN401
+        icons: Any = None,  # noqa: ANN401
+        meta: dict[str, Any] | None = None,
+        structured_output: bool | None = None,  # noqa: FBT001
+    ) -> Callable[[Any], Any]:
+        """Override :meth:`FastMCP.tool` to inject per-call telemetry."""
+        parent_decorator = super().tool(
+            name=name,
+            title=title,
+            description=description,
+            annotations=annotations,
+            icons=icons,
+            meta=meta,
+            structured_output=structured_output,
+        )
+
+        def instrumented_decorator(fn: Any) -> Any:  # noqa: ANN401
+            tool_name = name if name is not None else fn.__name__
+            # Wrap only coroutine functions; passthrough for sync (safety net).
+            import asyncio  # noqa: PLC0415
+
+            if asyncio.iscoroutinefunction(fn):
+                tel_fn = _wrap_mcp_tool_with_telemetry(fn, tool_name)
+            else:
+                tel_fn = fn
+            return parent_decorator(tel_fn)
+
+        return instrumented_decorator
 
 
 def fabric_err(exc: Exception) -> ToolError:

--- a/src/fabric_dw/mcp/_helpers.py
+++ b/src/fabric_dw/mcp/_helpers.py
@@ -29,6 +29,7 @@ call (fire-and-forget, never raises).
 
 from __future__ import annotations
 
+import inspect
 import logging
 from collections.abc import Callable, Coroutine
 from datetime import datetime
@@ -73,6 +74,9 @@ _log = logging.getLogger(__name__)
 # No DDL guard is needed for these operations; only table DML/DDL is blocked.
 
 
+_TELEMETRY_WRAPPED_ATTR = "__fabric_telemetry_wrapped__"
+
+
 def _wrap_mcp_tool_with_telemetry(
     fn: Callable[_P, Coroutine[None, None, _R]],
     name: str,
@@ -85,6 +89,10 @@ def _wrap_mcp_tool_with_telemetry(
     string before calling :func:`~fabric_dw.telemetry_commands.emit_command_invoked`.
     Telemetry failures are swallowed inside ``emit_command_invoked``; they
     never propagate to the caller.
+
+    The wrapper sets ``__fabric_telemetry_wrapped__ = True`` on the returned
+    callable so that :class:`InstrumentedFastMCP` can detect already-wrapped
+    functions and skip the second wrapping (preventing double-emission).
 
     Args:
         fn: The async tool function to wrap.
@@ -115,6 +123,8 @@ def _wrap_mcp_tool_with_telemetry(
                 destructive=destructive,
             )
 
+    # Mark as already instrumented so InstrumentedFastMCP.tool() skips re-wrapping.
+    setattr(telemetry_wrapper, _TELEMETRY_WRAPPED_ATTR, True)
     return telemetry_wrapper
 
 
@@ -222,10 +232,12 @@ class InstrumentedFastMCP(FastMCP):
 
         def instrumented_decorator(fn: Any) -> Any:  # noqa: ANN401
             tool_name = name if name is not None else fn.__name__
+            # Skip wrapping when the callable is already instrumented (e.g. from
+            # mutating_tool) to guarantee exactly ONE command_invoked event per call.
+            already_wrapped = getattr(fn, _TELEMETRY_WRAPPED_ATTR, False)
             # Wrap only coroutine functions; passthrough for sync (safety net).
-            import asyncio  # noqa: PLC0415
-
-            if asyncio.iscoroutinefunction(fn):
+            # Use inspect.iscoroutinefunction (asyncio variant is deprecated in 3.12+).
+            if not already_wrapped and inspect.iscoroutinefunction(fn):
                 tel_fn = _wrap_mcp_tool_with_telemetry(fn, tool_name)
             else:
                 tel_fn = fn

--- a/src/fabric_dw/mcp/server.py
+++ b/src/fabric_dw/mcp/server.py
@@ -58,11 +58,10 @@ import sys
 from collections.abc import Sequence
 from typing import Literal
 
-from mcp.server.fastmcp import FastMCP
-
 from fabric_dw.logging import setup_logging
 from fabric_dw.mcp._context import fabric_lifespan
 from fabric_dw.mcp._guards import env_flag as _guards_env_flag
+from fabric_dw.mcp._helpers import InstrumentedFastMCP
 from fabric_dw.mcp.tools import register_all
 from fabric_dw.telemetry import (
     maybe_print_first_run_notice,
@@ -73,10 +72,10 @@ from fabric_dw.telemetry import (
 __all__ = ["mcp", "run"]
 
 # ---------------------------------------------------------------------------
-# FastMCP server instance
+# FastMCP server instance (instrumented subclass emits command_invoked events)
 # ---------------------------------------------------------------------------
 
-mcp: FastMCP = FastMCP("fabric-dw", lifespan=fabric_lifespan)
+mcp: InstrumentedFastMCP = InstrumentedFastMCP("fabric-dw", lifespan=fabric_lifespan)
 
 # ---------------------------------------------------------------------------
 # Register all domain tools

--- a/src/fabric_dw/telemetry_commands.py
+++ b/src/fabric_dw/telemetry_commands.py
@@ -225,6 +225,27 @@ def resolve_domain(name: str) -> str:
     return "unknown"
 
 
+def _click_exit_code(exc: BaseException) -> int:
+    """Extract the exit code from a :class:`click.exceptions.Exit` instance.
+
+    Click stores the exit code in ``exit_code`` (the constructor attribute) or
+    ``code`` (the ``SystemExit`` base-class attribute).  The ``or``-chain
+    idiom ``getattr(exc, "exit_code", None) or getattr(exc, "code", 0)`` is
+    **incorrect** when the exit code is ``0`` (a falsy value): the chain would
+    fall through to ``code`` even though ``exit_code`` is explicitly ``0``.
+
+    This helper checks each attribute explicitly, using ``is None`` as the
+    sentinel, and defaults to ``0`` only when neither attribute is set.
+    """
+    v = getattr(exc, "exit_code", None)
+    if v is not None:
+        return int(v)
+    v = getattr(exc, "code", None)
+    if v is not None:
+        return int(v)
+    return 0
+
+
 def _is_click_user_error(exc: BaseException) -> bool:
     """Return True when *exc* is a Click user-facing error (usage/abort/non-zero exit)."""
     with contextlib.suppress(ImportError):
@@ -233,8 +254,7 @@ def _is_click_user_error(exc: BaseException) -> bool:
         if isinstance(exc, (click.exceptions.UsageError, click.exceptions.Abort)):
             return True
         if isinstance(exc, click.exceptions.Exit):
-            code = getattr(exc, "exit_code", None) or getattr(exc, "code", 0)
-            return code != 0
+            return _click_exit_code(exc) != 0
         if isinstance(exc, SystemExit):
             code = getattr(exc, "code", None)
             return not (code is None or code == 0)
@@ -247,8 +267,7 @@ def _is_click_exit_ok(exc: BaseException) -> bool:
         import click  # noqa: PLC0415
 
         if isinstance(exc, click.exceptions.Exit):
-            code = getattr(exc, "exit_code", None) or getattr(exc, "code", 0)
-            return code == 0
+            return _click_exit_code(exc) == 0
         if isinstance(exc, SystemExit):
             code = getattr(exc, "code", None)
             return code is None or code == 0

--- a/src/fabric_dw/telemetry_commands.py
+++ b/src/fabric_dw/telemetry_commands.py
@@ -1,0 +1,377 @@
+"""Per-command telemetry instrumentation for the fabric-dw CLI and MCP server.
+
+Emits one ``command_invoked`` event per CLI command invocation and per MCP
+tool call, with categorical/aggregate attributes only — never identifiers,
+SQL text, or flag values.
+
+Public API
+----------
+- :func:`resolve_domain` — map a CLI group name or MCP tool name to a domain.
+- :func:`map_status` — classify an exception (or ``None``) to a status string.
+- :func:`duration_bucket` — bucket a float duration in ms to a human label.
+- :func:`emit_command_invoked` — fire the ``command_invoked`` event (safe).
+- :data:`DOMAIN_MAP` — the authoritative name → domain lookup dict.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import time
+
+__all__ = [
+    "DOMAIN_MAP",
+    "duration_bucket",
+    "emit_command_invoked",
+    "map_status",
+    "resolve_domain",
+]
+
+_log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Domain map — maps CLI group names AND MCP tool-name prefixes/overrides
+# to domain strings.
+#
+# Rules:
+#   1. CLI commands: use the Click group name (e.g. "warehouses").
+#   2. MCP tools:    the tool name is the key (exact match), or the leading
+#      verb+noun prefix that maps to a domain (fallback: prefix before "_").
+# ---------------------------------------------------------------------------
+
+#: Mapping from CLI group name or MCP tool name to a domain string.
+#: Add entries here when new commands or tools are introduced.
+DOMAIN_MAP: dict[str, str] = {
+    # ── CLI group names ───────────────────────────────────────────────────────
+    "workspaces": "workspaces",
+    "warehouses": "warehouses",
+    "sql-endpoints": "sql_endpoints",
+    "sql_endpoints": "sql_endpoints",
+    "sql": "sql",
+    "tables": "tables",
+    "views": "views",
+    "procedures": "procedures",
+    "schemas": "schemas",
+    "statistics": "statistics",
+    "functions": "functions",
+    "snapshots": "snapshots",
+    "restore-points": "restore_points",
+    "restore_points": "restore_points",
+    "audit": "audit",
+    "queries": "queries",
+    "sql-pools": "sql_pools",
+    "sql_pools": "sql_pools",
+    "dbt": "dbt",
+    "cache": "cache",
+    "config": "config",
+    "completion": "completion",
+    # ── MCP tool names (explicit overrides / multi-domain tools) ─────────────
+    # Workspaces
+    "list_workspaces": "workspaces",
+    "get_workspace": "workspaces",
+    "set_workspace_collation": "workspaces",
+    # Warehouses
+    "list_warehouses": "warehouses",
+    "get_warehouse": "warehouses",
+    "create_warehouse": "warehouses",
+    "rename_warehouse": "warehouses",
+    "delete_warehouse": "warehouses",
+    "takeover_warehouse": "warehouses",
+    "get_warehouse_permissions": "warehouses",
+    # SQL Endpoints
+    "list_sql_endpoints": "sql_endpoints",
+    "get_sql_endpoint": "sql_endpoints",
+    "refresh_sql_endpoint_metadata": "sql_endpoints",
+    "get_sql_endpoint_permissions": "sql_endpoints",
+    # Audit
+    "get_audit_settings": "audit",
+    "enable_audit": "audit",
+    "disable_audit": "audit",
+    "set_audit_action_groups": "audit",
+    "add_audit_group": "audit",
+    "remove_audit_group": "audit",
+    "set_audit_retention": "audit",
+    # Queries / running sessions
+    "list_running_queries": "queries",
+    "kill_session": "queries",
+    "list_connections": "queries",
+    "list_request_history": "queries",
+    "list_session_history": "queries",
+    "list_frequent_queries": "queries",
+    "list_long_running_queries": "queries",
+    # SQL execution
+    "execute_sql": "sql",
+    # Snapshots
+    "list_snapshots": "snapshots",
+    "create_snapshot": "snapshots",
+    "rename_snapshot": "snapshots",
+    "delete_snapshot": "snapshots",
+    "roll_snapshot_timestamp": "snapshots",
+    # Restore points
+    "list_restore_points": "restore_points",
+    "get_restore_point": "restore_points",
+    "create_restore_point": "restore_points",
+    "update_restore_point": "restore_points",
+    "delete_restore_point": "restore_points",
+    "restore_warehouse_in_place": "restore_points",
+    # Schemas
+    "list_schemas": "schemas",
+    "create_schema": "schemas",
+    "delete_schema": "schemas",
+    # Tables
+    "list_tables": "tables",
+    "read_table": "tables",
+    "create_table": "tables",
+    "create_empty_table": "tables",
+    "clone_table": "tables",
+    "rename_table": "tables",
+    "delete_table": "tables",
+    "clear_table": "tables",
+    "load_table_from_url": "tables",
+    # Views
+    "list_views": "views",
+    "read_view": "views",
+    "get_view": "views",
+    "create_view": "views",
+    "update_view": "views",
+    "drop_view": "views",
+    "rename_view": "views",
+    # Stored procedures
+    "list_procedures": "procedures",
+    "get_procedure": "procedures",
+    "create_procedure": "procedures",
+    "update_procedure": "procedures",
+    "drop_procedure": "procedures",
+    # Functions
+    "list_functions": "functions",
+    "get_function": "functions",
+    "create_function": "functions",
+    "update_function": "functions",
+    "drop_function": "functions",
+    "rename_function": "functions",
+    # Statistics
+    "list_statistics": "statistics",
+    "show_statistics": "statistics",
+    "create_statistics": "statistics",
+    "update_statistics": "statistics",
+    "delete_statistics": "statistics",
+    # SQL Pools
+    "get_sql_pools_configuration": "sql_pools",
+    "list_sql_pools": "sql_pools",
+    "get_sql_pool": "sql_pools",
+    "create_sql_pool": "sql_pools",
+    "update_sql_pool": "sql_pools",
+    "delete_sql_pool": "sql_pools",
+    "enable_sql_pools": "sql_pools",
+    "disable_sql_pools": "sql_pools",
+    "list_sql_pool_insights": "sql_pools",
+    # DBT
+    "generate_dbt_profile": "dbt",
+    # Cache
+    "clear_cache": "cache",
+}
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_KNOWN_DOMAINS: frozenset[str] = frozenset(
+    {
+        "workspaces",
+        "warehouses",
+        "sql_endpoints",
+        "sql",
+        "tables",
+        "views",
+        "procedures",
+        "schemas",
+        "statistics",
+        "functions",
+        "snapshots",
+        "restore_points",
+        "audit",
+        "queries",
+        "sql_pools",
+        "dbt",
+        "cache",
+        "config",
+        "completion",
+    }
+)
+
+
+def resolve_domain(name: str) -> str:
+    """Return the domain for a CLI group name or MCP tool name.
+
+    Looks up *name* in :data:`DOMAIN_MAP` first.  Falls back to the string
+    before the first underscore for MCP tool names whose prefix maps to a
+    known domain.  Returns ``"unknown"`` when no mapping is found.
+
+    Args:
+        name: A CLI group name (e.g. ``"warehouses"``) or MCP tool name
+              (e.g. ``"create_warehouse"``).
+
+    Returns:
+        A domain string from the :data:`_KNOWN_DOMAINS` set, or ``"unknown"``.
+    """
+    domain = DOMAIN_MAP.get(name)
+    if domain is not None:
+        return domain
+    # Fallback: try the first segment before the first underscore.
+    prefix = name.split("_", maxsplit=1)[0] if "_" in name else name
+    fallback = DOMAIN_MAP.get(prefix)
+    if fallback is not None:
+        return fallback
+    return "unknown"
+
+
+def _is_click_user_error(exc: BaseException) -> bool:
+    """Return True when *exc* is a Click user-facing error (usage/abort/non-zero exit)."""
+    with contextlib.suppress(ImportError):
+        import click  # noqa: PLC0415
+
+        if isinstance(exc, (click.exceptions.UsageError, click.exceptions.Abort)):
+            return True
+        if isinstance(exc, click.exceptions.Exit):
+            code = getattr(exc, "exit_code", None) or getattr(exc, "code", 0)
+            return code != 0
+        if isinstance(exc, SystemExit):
+            code = getattr(exc, "code", None)
+            return not (code is None or code == 0)
+    return False
+
+
+def _is_click_exit_ok(exc: BaseException) -> bool:
+    """Return True when *exc* is a zero-code Click/System exit (success)."""
+    with contextlib.suppress(ImportError):
+        import click  # noqa: PLC0415
+
+        if isinstance(exc, click.exceptions.Exit):
+            code = getattr(exc, "exit_code", None) or getattr(exc, "code", 0)
+            return code == 0
+        if isinstance(exc, SystemExit):
+            code = getattr(exc, "code", None)
+            return code is None or code == 0
+    return False
+
+
+def map_status(exc: BaseException | None) -> str:
+    """Map an exception (or None for success) to a categorical status string.
+
+    Status categories:
+
+    - ``"success"``  -- no exception (normal return) or zero-exit Click/SystemExit.
+    - ``"user_error"`` -- validation / usage problems: Click usage errors,
+      Abort, ValueError, ConfigError, and NotFoundError
+      (which typically means the user referenced a non-existent resource).
+    - ``"api_error"`` -- FabricError / HTTP / driver / unexpected exceptions.
+
+    Args:
+        exc: The active exception, or ``None`` when the command succeeded.
+
+    Returns:
+        One of ``"success"``, ``"user_error"``, or ``"api_error"``.
+    """
+    if exc is None or _is_click_exit_ok(exc):
+        return "success"
+    if _is_click_user_error(exc):
+        return "user_error"
+
+    with contextlib.suppress(ImportError):
+        from fabric_dw.exceptions import ConfigError, FabricError, NotFoundError  # noqa: PLC0415
+
+        if isinstance(exc, (ValueError, ConfigError, NotFoundError)):
+            return "user_error"
+        if isinstance(exc, FabricError):
+            return "api_error"
+
+    with contextlib.suppress(ImportError):
+        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+        if isinstance(exc, ToolError):
+            return "user_error"
+
+    return "api_error"
+
+
+_MS_100 = 100.0
+_MS_1S = 1_000.0
+_MS_10S = 10_000.0
+
+
+def duration_bucket(duration_ms: float) -> str:
+    """Bucket *duration_ms* (milliseconds) to a human-readable label.
+
+    Buckets:
+
+    - ``"<100ms"`` -- under 100 ms
+    - ``"<1s"``    -- 100 ms to 1 s
+    - ``"<10s"``   -- 1 s to 10 s
+    - ``">10s"``   -- 10 s or more
+
+    Args:
+        duration_ms: Wall-clock duration in milliseconds.
+
+    Returns:
+        A bucket label string.
+    """
+    if duration_ms < _MS_100:
+        return "<100ms"
+    if duration_ms < _MS_1S:
+        return "<1s"
+    if duration_ms < _MS_10S:
+        return "<10s"
+    return ">10s"
+
+
+def emit_command_invoked(
+    *,
+    name: str,
+    surface: str,
+    status: str,
+    duration_ms: float,
+    destructive: bool = False,
+) -> None:
+    """Emit one ``command_invoked`` telemetry event.
+
+    Fire-and-forget: all exceptions are swallowed and nothing is raised.
+    When telemetry is disabled this is a guaranteed no-op (no work done).
+
+    Args:
+        name: The command name — for CLI: ``"<group>.<subcommand>"``,
+              for MCP: the tool name.
+        surface: ``"cli"`` or ``"mcp"``.
+        status: One of ``"success"``, ``"user_error"``, ``"api_error"``.
+        duration_ms: Wall-clock duration in milliseconds.
+        destructive: Whether this is a permanently-destructive operation.
+    """
+    try:
+        from fabric_dw.telemetry import emit_event, telemetry_enabled  # noqa: PLC0415
+
+        if not telemetry_enabled():
+            return
+
+        domain = resolve_domain(name.split(".", maxsplit=1)[0] if "." in name else name)
+        attrs: dict[str, object] = {
+            "name": name,
+            "domain": domain,
+            "surface": surface,
+            "status": status,
+            "duration_ms_bucket": duration_bucket(duration_ms),
+        }
+        if destructive:
+            attrs["destructive_op"] = True
+
+        emit_event("command_invoked", attrs)
+    except Exception:
+        _log.debug("Failed to emit command_invoked event for %r", name, exc_info=True)
+
+
+# ---------------------------------------------------------------------------
+# Monotonic timer helper (cheap, no imports beyond stdlib)
+# ---------------------------------------------------------------------------
+
+
+def now_ms() -> float:
+    """Return the current monotonic time in milliseconds."""
+    return time.monotonic() * 1_000

--- a/tests/unit/test_telemetry_commands.py
+++ b/tests/unit/test_telemetry_commands.py
@@ -764,3 +764,121 @@ class TestMcpCommandInvokedInstrumentation:
             result = asyncio.run(wrapped())
 
         assert result == "result"
+
+    def test_mutating_tool_via_instrumented_mcp_emits_exactly_one_event(self) -> None:
+        """A mutating tool registered via mutating_tool() emits EXACTLY ONE command_invoked.
+
+        This is the regression test for the double-emission bug: mutating_tool()
+        calls _wrap_mcp_tool_with_telemetry (layer 1) and then mcp.tool() which
+        triggers InstrumentedFastMCP.tool() (potential layer 2).  The fix marks
+        already-wrapped callables with __fabric_telemetry_wrapped__ so that
+        InstrumentedFastMCP.tool() skips the second wrapping.
+        """
+        import asyncio  # noqa: PLC0415
+
+        from fabric_dw.mcp._helpers import InstrumentedFastMCP, mutating_tool  # noqa: PLC0415
+
+        instrumented_mcp: InstrumentedFastMCP = InstrumentedFastMCP("test-server")
+
+        @mutating_tool(instrumented_mcp, "create_warehouse")
+        async def create_warehouse(name: str) -> dict:  # type: ignore[return]
+            return {"name": name}
+
+        with patch(_TELEMETRY_ENABLED, return_value=True), patch(_EMIT_EVENT) as mock_emit:
+            asyncio.run(
+                instrumented_mcp._tool_manager.call_tool("create_warehouse", {"name": "wh1"})
+            )
+
+        command_invoked_calls = [
+            c for c in mock_emit.call_args_list if c[0][0] == "command_invoked"
+        ]
+        assert len(command_invoked_calls) == 1, (
+            f"Expected exactly 1 command_invoked event, got {len(command_invoked_calls)}"
+        )
+
+    def test_read_only_tool_via_instrumented_mcp_emits_exactly_one_event(self) -> None:
+        """A read-only tool registered via @mcp.tool() emits EXACTLY ONE command_invoked."""
+        import asyncio  # noqa: PLC0415
+
+        from fabric_dw.mcp._helpers import InstrumentedFastMCP  # noqa: PLC0415
+
+        instrumented_mcp: InstrumentedFastMCP = InstrumentedFastMCP("test-server-ro")
+
+        @instrumented_mcp.tool(name="list_warehouses")
+        async def list_warehouses(workspace: str) -> list:  # type: ignore[return]
+            _ = workspace
+            return []
+
+        with patch(_TELEMETRY_ENABLED, return_value=True), patch(_EMIT_EVENT) as mock_emit:
+            asyncio.run(
+                instrumented_mcp._tool_manager.call_tool("list_warehouses", {"workspace": "ws1"})
+            )
+
+        command_invoked_calls = [
+            c for c in mock_emit.call_args_list if c[0][0] == "command_invoked"
+        ]
+        assert len(command_invoked_calls) == 1, (
+            f"Expected exactly 1 command_invoked event, got {len(command_invoked_calls)}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# CLI flush ordering — command_invoked must be enqueued before flush
+# ---------------------------------------------------------------------------
+
+
+class TestCliFlushOrdering:
+    """Verify that command_invoked is emitted before flush_telemetry runs.
+
+    Regression tests for the ordering bug where flush_telemetry() (called via
+    call_on_close) ran BEFORE emit_command_invoked (in the finally block of
+    _InstrumentedGroup.invoke), causing the command_invoked event to be lost.
+    """
+
+    def _run_cli_capture_order(self, args: list[str], monkeypatch: pytest.MonkeyPatch) -> list[str]:
+        """Run CLI and return the sequence of telemetry calls in invocation order."""
+        from fabric_dw.cli._main import cli  # noqa: PLC0415
+
+        monkeypatch.delenv("FABRIC_DISABLE_TELEMETRY", raising=False)
+        monkeypatch.delenv("CI", raising=False)
+        monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+        monkeypatch.delenv("JENKINS_URL", raising=False)
+        monkeypatch.delenv("TRAVIS", raising=False)
+        monkeypatch.delenv("CIRCLECI", raising=False)
+        monkeypatch.delenv("GITLAB_CI", raising=False)
+        monkeypatch.delenv("TF_BUILD", raising=False)
+
+        call_order: list[str] = []
+
+        def _track_emit(event_name: str, _attrs: dict) -> None:
+            call_order.append(f"emit:{event_name}")
+
+        def _track_flush(_timeout_ms: int = 2000) -> None:
+            call_order.append("flush")
+
+        runner = CliRunner()  # type: ignore[no-untyped-call]
+        with (
+            patch(_TELEMETRY_ENABLED, return_value=True),
+            patch(_EMIT_EVENT, side_effect=_track_emit),
+            patch("fabric_dw.cli._main.flush_telemetry", side_effect=_track_flush),
+        ):
+            runner.invoke(cli, args, catch_exceptions=True)
+
+        return call_order
+
+    def test_command_invoked_enqueued_before_flush(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """command_invoked must appear in the call order BEFORE the final flush."""
+        order = self._run_cli_capture_order(["cache", "clear"], monkeypatch)
+
+        assert "emit:command_invoked" in order, "command_invoked event was never emitted"
+        assert "flush" in order, "flush_telemetry was never called"
+
+        last_command_invoked_idx = max(
+            i for i, e in enumerate(order) if e == "emit:command_invoked"
+        )
+        last_flush_idx = max(i for i, e in enumerate(order) if e == "flush")
+
+        assert last_command_invoked_idx < last_flush_idx, (
+            f"command_invoked (index {last_command_invoked_idx}) must come before "
+            f"flush (index {last_flush_idx}); actual order: {order}"
+        )

--- a/tests/unit/test_telemetry_commands.py
+++ b/tests/unit/test_telemetry_commands.py
@@ -1,0 +1,766 @@
+"""Tests for fabric_dw.telemetry_commands — per-command usage instrumentation.
+
+Written TDD-first.  All tests run without a network and without real Azure
+Monitor SDK calls (every telemetry emission is mocked via monkeypatch).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from fabric_dw.telemetry_commands import (
+    _KNOWN_DOMAINS,
+    DOMAIN_MAP,
+    duration_bucket,
+    emit_command_invoked,
+    map_status,
+    now_ms,
+    resolve_domain,
+)
+
+# Telemetry patch targets (lazily imported inside emit_command_invoked).
+_TELEMETRY_ENABLED = "fabric_dw.telemetry.telemetry_enabled"
+_EMIT_EVENT = "fabric_dw.telemetry.emit_event"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def disable_telemetry(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Disable real telemetry by default (safe tests, no network)."""
+    monkeypatch.setenv("FABRIC_DISABLE_TELEMETRY", "1")
+
+
+# ---------------------------------------------------------------------------
+# resolve_domain
+# ---------------------------------------------------------------------------
+
+
+class TestResolveDomain:
+    def test_known_cli_group(self) -> None:
+        assert resolve_domain("warehouses") == "warehouses"
+
+    def test_known_cli_group_sql_endpoints(self) -> None:
+        assert resolve_domain("sql-endpoints") == "sql_endpoints"
+
+    def test_known_mcp_tool_exact(self) -> None:
+        assert resolve_domain("list_warehouses") == "warehouses"
+
+    def test_known_mcp_tool_create_warehouse(self) -> None:
+        assert resolve_domain("create_warehouse") == "warehouses"
+
+    def test_known_mcp_tool_execute_sql(self) -> None:
+        assert resolve_domain("execute_sql") == "sql"
+
+    def test_known_mcp_tool_generate_dbt_profile(self) -> None:
+        assert resolve_domain("generate_dbt_profile") == "dbt"
+
+    def test_unknown_returns_unknown(self) -> None:
+        assert resolve_domain("does_not_exist_abc") == "unknown"
+
+    def test_all_domain_map_values_are_known_domains(self) -> None:
+        """Every value in DOMAIN_MAP must be a known domain string."""
+        bad = {k: v for k, v in DOMAIN_MAP.items() if v not in _KNOWN_DOMAINS}
+        assert bad == {}, f"Unknown domain values in DOMAIN_MAP: {bad}"
+
+
+# ---------------------------------------------------------------------------
+# Domain coverage — exhaustive check
+# ---------------------------------------------------------------------------
+
+
+class TestDomainCoverage:
+    """Every registered MCP tool and every CLI command must resolve to a known domain."""
+
+    # Canonical MCP tool names taken from test_server.EXPECTED_TOOL_NAMES.
+    MCP_TOOL_NAMES: frozenset[str] = frozenset(
+        {
+            "list_workspaces",
+            "get_workspace",
+            "set_workspace_collation",
+            "list_warehouses",
+            "get_warehouse",
+            "create_warehouse",
+            "rename_warehouse",
+            "delete_warehouse",
+            "takeover_warehouse",
+            "get_warehouse_permissions",
+            "list_sql_endpoints",
+            "get_sql_endpoint",
+            "refresh_sql_endpoint_metadata",
+            "get_sql_endpoint_permissions",
+            "get_audit_settings",
+            "enable_audit",
+            "disable_audit",
+            "set_audit_action_groups",
+            "add_audit_group",
+            "remove_audit_group",
+            "set_audit_retention",
+            "list_running_queries",
+            "kill_session",
+            "list_connections",
+            "list_request_history",
+            "list_session_history",
+            "list_frequent_queries",
+            "list_long_running_queries",
+            "execute_sql",
+            "list_snapshots",
+            "create_snapshot",
+            "rename_snapshot",
+            "delete_snapshot",
+            "roll_snapshot_timestamp",
+            "list_restore_points",
+            "get_restore_point",
+            "create_restore_point",
+            "update_restore_point",
+            "delete_restore_point",
+            "restore_warehouse_in_place",
+            "list_schemas",
+            "create_schema",
+            "delete_schema",
+            "list_views",
+            "read_view",
+            "get_view",
+            "create_view",
+            "update_view",
+            "drop_view",
+            "rename_view",
+            "list_procedures",
+            "get_procedure",
+            "create_procedure",
+            "update_procedure",
+            "drop_procedure",
+            "list_functions",
+            "get_function",
+            "create_function",
+            "update_function",
+            "drop_function",
+            "rename_function",
+            "list_tables",
+            "read_table",
+            "create_table",
+            "create_empty_table",
+            "clone_table",
+            "rename_table",
+            "delete_table",
+            "clear_table",
+            "load_table_from_url",
+            "get_sql_pools_configuration",
+            "list_sql_pools",
+            "get_sql_pool",
+            "create_sql_pool",
+            "update_sql_pool",
+            "delete_sql_pool",
+            "enable_sql_pools",
+            "disable_sql_pools",
+            "list_sql_pool_insights",
+            "list_statistics",
+            "show_statistics",
+            "create_statistics",
+            "update_statistics",
+            "delete_statistics",
+            "generate_dbt_profile",
+            "clear_cache",
+        }
+    )
+
+    # Canonical CLI group names (top-level groups registered on the root cli).
+    CLI_GROUP_NAMES: frozenset[str] = frozenset(
+        {
+            "workspaces",
+            "warehouses",
+            "sql-endpoints",
+            "sql",
+            "tables",
+            "views",
+            "procedures",
+            "schemas",
+            "statistics",
+            "functions",
+            "snapshots",
+            "restore-points",
+            "audit",
+            "queries",
+            "sql-pools",
+            "dbt",
+            "cache",
+            "config",
+            "completion",
+        }
+    )
+
+    def test_all_mcp_tools_resolve_to_known_domain(self) -> None:
+        """Every MCP tool name must resolve to a domain that is NOT 'unknown'."""
+        unknown = {name for name in self.MCP_TOOL_NAMES if resolve_domain(name) == "unknown"}
+        assert unknown == set(), f"MCP tools with unknown domain: {sorted(unknown)}"
+
+    def test_all_cli_groups_resolve_to_known_domain(self) -> None:
+        """Every top-level CLI group name must resolve to a domain that is NOT 'unknown'."""
+        unknown = {name for name in self.CLI_GROUP_NAMES if resolve_domain(name) == "unknown"}
+        assert unknown == set(), f"CLI groups with unknown domain: {sorted(unknown)}"
+
+
+# ---------------------------------------------------------------------------
+# map_status
+# ---------------------------------------------------------------------------
+
+
+class TestMapStatus:
+    def test_none_is_success(self) -> None:
+        assert map_status(None) == "success"
+
+    def test_usage_error_is_user_error(self) -> None:
+        exc = click.exceptions.UsageError("bad input")
+        assert map_status(exc) == "user_error"
+
+    def test_abort_is_user_error(self) -> None:
+        exc = click.exceptions.Abort()
+        assert map_status(exc) == "user_error"
+
+    def test_system_exit_0_is_success(self) -> None:
+        exc = SystemExit(0)
+        assert map_status(exc) == "success"
+
+    def test_system_exit_1_is_user_error(self) -> None:
+        exc = SystemExit(1)
+        assert map_status(exc) == "user_error"
+
+    def test_click_exit_0_is_success(self) -> None:
+        exc = click.exceptions.Exit(0)
+        assert map_status(exc) == "success"
+
+    def test_click_exit_1_is_user_error(self) -> None:
+        exc = click.exceptions.Exit(1)
+        assert map_status(exc) == "user_error"
+
+    def test_value_error_is_user_error(self) -> None:
+
+        exc = ValueError("invalid argument")
+        assert map_status(exc) == "user_error"
+
+    def test_config_error_is_user_error(self) -> None:
+        from fabric_dw.exceptions import ConfigError  # noqa: PLC0415
+
+        exc = ConfigError("missing env var")
+        assert map_status(exc) == "user_error"
+
+    def test_not_found_error_is_user_error(self) -> None:
+        from fabric_dw.exceptions import NotFoundError  # noqa: PLC0415
+
+        exc = NotFoundError("resource not found")
+        assert map_status(exc) == "user_error"
+
+    def test_fabric_error_is_api_error(self) -> None:
+        from fabric_dw.exceptions import FabricError  # noqa: PLC0415
+
+        exc = FabricError("api error", status=500)
+        assert map_status(exc) == "api_error"
+
+    def test_tool_error_is_user_error(self) -> None:
+        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+        exc = ToolError("bad tool call")
+        assert map_status(exc) == "user_error"
+
+    def test_unexpected_exception_is_api_error(self) -> None:
+        exc = RuntimeError("unexpected")
+        assert map_status(exc) == "api_error"
+
+    def test_keyboard_interrupt_is_api_error(self) -> None:
+        exc = KeyboardInterrupt()
+        assert map_status(exc) == "api_error"
+
+
+# ---------------------------------------------------------------------------
+# duration_bucket
+# ---------------------------------------------------------------------------
+
+
+class TestDurationBucket:
+    def test_under_100ms(self) -> None:
+        assert duration_bucket(0.0) == "<100ms"
+        assert duration_bucket(50.0) == "<100ms"
+        assert duration_bucket(99.9) == "<100ms"
+
+    def test_exactly_100ms(self) -> None:
+        assert duration_bucket(100.0) == "<1s"
+
+    def test_500ms(self) -> None:
+        assert duration_bucket(500.0) == "<1s"
+
+    def test_999ms(self) -> None:
+        assert duration_bucket(999.9) == "<1s"
+
+    def test_exactly_1s(self) -> None:
+        assert duration_bucket(1_000.0) == "<10s"
+
+    def test_5s(self) -> None:
+        assert duration_bucket(5_000.0) == "<10s"
+
+    def test_exactly_10s(self) -> None:
+        assert duration_bucket(10_000.0) == ">10s"
+
+    def test_60s(self) -> None:
+        assert duration_bucket(60_000.0) == ">10s"
+
+
+# ---------------------------------------------------------------------------
+# now_ms
+# ---------------------------------------------------------------------------
+
+
+class TestNowMs:
+    def test_returns_float(self) -> None:
+        t = now_ms()
+        assert isinstance(t, float)
+
+    def test_is_monotonic(self) -> None:
+        t1 = now_ms()
+        t2 = now_ms()
+        assert t2 >= t1
+
+
+# ---------------------------------------------------------------------------
+# emit_command_invoked — disabled → nothing emitted
+# ---------------------------------------------------------------------------
+
+
+class TestEmitCommandInvokedDisabled:
+    def test_disabled_emits_nothing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When telemetry is disabled, emit_event must never be called."""
+        monkeypatch.setenv("FABRIC_DISABLE_TELEMETRY", "1")
+
+        with patch(_EMIT_EVENT) as mock_emit, patch(_TELEMETRY_ENABLED, return_value=False):
+            emit_command_invoked(
+                name="warehouses.list",
+                surface="cli",
+                status="success",
+                duration_ms=50.0,
+            )
+        mock_emit.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# emit_command_invoked — enabled path (spy on emit_event)
+# ---------------------------------------------------------------------------
+
+
+class TestEmitCommandInvokedEnabled:
+    @pytest.fixture(autouse=True)
+    def enable_telemetry(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("FABRIC_DISABLE_TELEMETRY", raising=False)
+        monkeypatch.delenv("FABRIC_TELEMETRY", raising=False)
+        monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+        monkeypatch.delenv("CI", raising=False)
+        monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+        monkeypatch.delenv("JENKINS_URL", raising=False)
+        monkeypatch.delenv("TRAVIS", raising=False)
+        monkeypatch.delenv("CIRCLECI", raising=False)
+        monkeypatch.delenv("GITLAB_CI", raising=False)
+        monkeypatch.delenv("TF_BUILD", raising=False)
+
+    def _run(self, **kwargs):  # type: ignore[no-untyped-def]
+        """Call emit_command_invoked with telemetry_enabled patched to True."""
+        with patch(_TELEMETRY_ENABLED, return_value=True), patch(_EMIT_EVENT) as mock_emit:
+            emit_command_invoked(**kwargs)
+        return mock_emit
+
+    def test_emits_one_event(self) -> None:
+        mock = self._run(
+            name="warehouses.list",
+            surface="cli",
+            status="success",
+            duration_ms=50.0,
+        )
+        mock.assert_called_once()
+
+    def test_event_name_is_command_invoked(self) -> None:
+        mock = self._run(
+            name="warehouses.list",
+            surface="cli",
+            status="success",
+            duration_ms=50.0,
+        )
+        args, _ = mock.call_args
+        assert args[0] == "command_invoked"
+
+    def test_attributes_contain_name(self) -> None:
+        mock = self._run(
+            name="warehouses.list",
+            surface="cli",
+            status="success",
+            duration_ms=50.0,
+        )
+        attrs: dict = mock.call_args[0][1]
+        assert attrs["name"] == "warehouses.list"
+
+    def test_attributes_contain_domain(self) -> None:
+        mock = self._run(
+            name="warehouses.list",
+            surface="cli",
+            status="success",
+            duration_ms=50.0,
+        )
+        attrs: dict = mock.call_args[0][1]
+        assert attrs["domain"] == "warehouses"
+
+    def test_attributes_contain_surface_cli(self) -> None:
+        mock = self._run(
+            name="warehouses.list",
+            surface="cli",
+            status="success",
+            duration_ms=50.0,
+        )
+        attrs: dict = mock.call_args[0][1]
+        assert attrs["surface"] == "cli"
+
+    def test_attributes_contain_surface_mcp(self) -> None:
+        mock = self._run(
+            name="list_warehouses",
+            surface="mcp",
+            status="success",
+            duration_ms=50.0,
+        )
+        attrs: dict = mock.call_args[0][1]
+        assert attrs["surface"] == "mcp"
+
+    def test_attributes_contain_status(self) -> None:
+        mock = self._run(
+            name="warehouses.list",
+            surface="cli",
+            status="success",
+            duration_ms=50.0,
+        )
+        attrs: dict = mock.call_args[0][1]
+        assert attrs["status"] == "success"
+
+    def test_attributes_contain_duration_bucket(self) -> None:
+        mock = self._run(
+            name="warehouses.list",
+            surface="cli",
+            status="success",
+            duration_ms=50.0,
+        )
+        attrs: dict = mock.call_args[0][1]
+        assert attrs["duration_ms_bucket"] == "<100ms"
+
+    def test_destructive_op_attribute_when_true(self) -> None:
+        mock = self._run(
+            name="delete_warehouse",
+            surface="mcp",
+            status="success",
+            duration_ms=200.0,
+            destructive=True,
+        )
+        attrs: dict = mock.call_args[0][1]
+        assert attrs.get("destructive_op") is True
+
+    def test_destructive_op_absent_when_false(self) -> None:
+        mock = self._run(
+            name="list_warehouses",
+            surface="mcp",
+            status="success",
+            duration_ms=50.0,
+            destructive=False,
+        )
+        attrs: dict = mock.call_args[0][1]
+        assert "destructive_op" not in attrs
+
+    def test_no_identifiers_in_attributes(self) -> None:
+        """The emitted attributes must not contain any identifier-like strings."""
+        mock = self._run(
+            name="warehouses.list",
+            surface="cli",
+            status="success",
+            duration_ms=50.0,
+        )
+        attrs: dict = mock.call_args[0][1]
+        # None of the values should look like workspace names, GUIDs, or SQL text.
+        for key, value in attrs.items():
+            if isinstance(value, str):
+                # Should only be from a fixed categorical set, never free-form user input.
+                assert len(value) < 200, f"Attribute {key!r} value too long: {value!r}"
+                # Must not contain SQL keywords that would indicate SQL leakage.
+                lower = value.lower()
+                assert "select " not in lower, f"SQL-like text in {key!r}: {value!r}"
+                assert "from " not in lower, f"SQL-like text in {key!r}: {value!r}"
+
+    def test_emit_failure_does_not_raise(self) -> None:
+        """If emit_event raises, emit_command_invoked must not propagate."""
+        with (
+            patch(_TELEMETRY_ENABLED, return_value=True),
+            patch(_EMIT_EVENT, side_effect=RuntimeError("network error")),
+        ):
+            # Must not raise.
+            emit_command_invoked(
+                name="warehouses.list",
+                surface="cli",
+                status="success",
+                duration_ms=50.0,
+            )
+
+
+# ---------------------------------------------------------------------------
+# CLI integration — command_invoked emitted per command
+# ---------------------------------------------------------------------------
+
+
+class TestCliCommandInvokedInstrumentation:
+    """Verify that the CLI emits exactly one command_invoked per leaf command."""
+
+    def _run_cli(self, args: list[str], monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+        """Run the CLI with *args* and return the emit_event mock."""
+        from fabric_dw.cli._main import cli  # noqa: PLC0415
+
+        # Enable telemetry for these tests.
+        monkeypatch.delenv("FABRIC_DISABLE_TELEMETRY", raising=False)
+        monkeypatch.delenv("CI", raising=False)
+        monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+        monkeypatch.delenv("JENKINS_URL", raising=False)
+        monkeypatch.delenv("TRAVIS", raising=False)
+        monkeypatch.delenv("CIRCLECI", raising=False)
+        monkeypatch.delenv("GITLAB_CI", raising=False)
+        monkeypatch.delenv("TF_BUILD", raising=False)
+
+        runner = CliRunner()
+        # Patch telemetry_enabled at the source (fabric_dw.telemetry) so both
+        # the per-command and lifecycle telemetry are controlled.
+        with patch(_TELEMETRY_ENABLED, return_value=True), patch(_EMIT_EVENT) as mock_emit:
+            runner.invoke(cli, args, catch_exceptions=True)
+        return mock_emit
+
+    def test_cache_clear_emits_command_invoked(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mock = self._run_cli(["cache", "clear"], monkeypatch)
+        command_invoked_calls = [c for c in mock.call_args_list if c[0][0] == "command_invoked"]
+        assert len(command_invoked_calls) == 1
+
+    def test_cache_clear_name_is_cache_clear(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mock = self._run_cli(["cache", "clear"], monkeypatch)
+        command_invoked_calls = [c for c in mock.call_args_list if c[0][0] == "command_invoked"]
+        assert command_invoked_calls, "No command_invoked event emitted"
+        attrs: dict = command_invoked_calls[0][0][1]
+        assert attrs["name"] == "cache.clear"
+
+    def test_cache_clear_surface_is_cli(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mock = self._run_cli(["cache", "clear"], monkeypatch)
+        command_invoked_calls = [c for c in mock.call_args_list if c[0][0] == "command_invoked"]
+        assert command_invoked_calls
+        attrs: dict = command_invoked_calls[0][0][1]
+        assert attrs["surface"] == "cli"
+
+    def test_cache_clear_domain_is_cache(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mock = self._run_cli(["cache", "clear"], monkeypatch)
+        command_invoked_calls = [c for c in mock.call_args_list if c[0][0] == "command_invoked"]
+        assert command_invoked_calls
+        attrs: dict = command_invoked_calls[0][0][1]
+        assert attrs["domain"] == "cache"
+
+    def test_disabled_emits_nothing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When telemetry is disabled, no command_invoked event is emitted."""
+        from fabric_dw.cli._main import cli  # noqa: PLC0415
+
+        monkeypatch.setenv("FABRIC_DISABLE_TELEMETRY", "1")
+        runner = CliRunner()
+        with patch(_EMIT_EVENT) as mock_emit, patch(_TELEMETRY_ENABLED, return_value=False):
+            runner.invoke(cli, ["cache", "clear"], catch_exceptions=True)
+        command_invoked_calls = [
+            c for c in mock_emit.call_args_list if c[0][0] == "command_invoked"
+        ]
+        assert len(command_invoked_calls) == 0
+
+
+# ---------------------------------------------------------------------------
+# MCP instrumentation — command_invoked emitted per tool call
+# ---------------------------------------------------------------------------
+
+
+class TestMcpCommandInvokedInstrumentation:
+    """Verify that MCP tool calls emit exactly one command_invoked event."""
+
+    @pytest.fixture(autouse=True)
+    def enable_telemetry(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("FABRIC_DISABLE_TELEMETRY", raising=False)
+        monkeypatch.delenv("CI", raising=False)
+        monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+        monkeypatch.delenv("JENKINS_URL", raising=False)
+        monkeypatch.delenv("TRAVIS", raising=False)
+        monkeypatch.delenv("CIRCLECI", raising=False)
+        monkeypatch.delenv("GITLAB_CI", raising=False)
+        monkeypatch.delenv("TF_BUILD", raising=False)
+
+    def _make_spy(self) -> MagicMock:
+        return MagicMock()
+
+    def test_wrap_emits_on_success(self) -> None:
+        """_wrap_mcp_tool_with_telemetry emits command_invoked on success."""
+        import asyncio  # noqa: PLC0415
+
+        from fabric_dw.mcp._helpers import _wrap_mcp_tool_with_telemetry  # noqa: PLC0415
+
+        async def _tool() -> str:
+            return "ok"
+
+        wrapped = _wrap_mcp_tool_with_telemetry(_tool, "list_warehouses")
+
+        with patch(_TELEMETRY_ENABLED, return_value=True), patch(_EMIT_EVENT) as mock_emit:
+            asyncio.run(wrapped())
+
+        command_invoked_calls = [
+            c for c in mock_emit.call_args_list if c[0][0] == "command_invoked"
+        ]
+        assert len(command_invoked_calls) == 1
+
+    def test_wrap_emits_on_exception(self) -> None:
+        """_wrap_mcp_tool_with_telemetry emits even when the tool raises."""
+        import asyncio  # noqa: PLC0415
+
+        from fabric_dw.mcp._helpers import _wrap_mcp_tool_with_telemetry  # noqa: PLC0415
+
+        async def _tool() -> str:
+            raise RuntimeError("oops")
+
+        wrapped = _wrap_mcp_tool_with_telemetry(_tool, "list_warehouses")
+
+        with (
+            patch(_TELEMETRY_ENABLED, return_value=True),
+            patch(_EMIT_EVENT) as mock_emit,
+            pytest.raises(RuntimeError),
+        ):
+            asyncio.run(wrapped())
+
+        command_invoked_calls = [
+            c for c in mock_emit.call_args_list if c[0][0] == "command_invoked"
+        ]
+        assert len(command_invoked_calls) == 1
+
+    def test_wrap_status_success(self) -> None:
+        import asyncio  # noqa: PLC0415
+
+        from fabric_dw.mcp._helpers import _wrap_mcp_tool_with_telemetry  # noqa: PLC0415
+
+        async def _tool() -> str:
+            return "ok"
+
+        wrapped = _wrap_mcp_tool_with_telemetry(_tool, "list_warehouses")
+
+        with patch(_TELEMETRY_ENABLED, return_value=True), patch(_EMIT_EVENT) as mock_emit:
+            asyncio.run(wrapped())
+
+        attrs: dict = mock_emit.call_args_list[-1][0][1]
+        assert attrs["status"] == "success"
+
+    def test_wrap_status_api_error_on_unexpected_exception(self) -> None:
+        import asyncio  # noqa: PLC0415
+
+        from fabric_dw.mcp._helpers import _wrap_mcp_tool_with_telemetry  # noqa: PLC0415
+
+        async def _tool() -> str:
+            raise RuntimeError("unexpected")
+
+        wrapped = _wrap_mcp_tool_with_telemetry(_tool, "list_warehouses")
+
+        with (
+            patch(_TELEMETRY_ENABLED, return_value=True),
+            patch(_EMIT_EVENT) as mock_emit,
+            pytest.raises(RuntimeError),
+        ):
+            asyncio.run(wrapped())
+
+        attrs: dict = mock_emit.call_args_list[-1][0][1]
+        assert attrs["status"] == "api_error"
+
+    def test_wrap_status_user_error_on_tool_error(self) -> None:
+        import asyncio  # noqa: PLC0415
+
+        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+        from fabric_dw.mcp._helpers import _wrap_mcp_tool_with_telemetry  # noqa: PLC0415
+
+        async def _tool() -> str:
+            raise ToolError("bad input")
+
+        wrapped = _wrap_mcp_tool_with_telemetry(_tool, "list_warehouses")
+
+        with (
+            patch(_TELEMETRY_ENABLED, return_value=True),
+            patch(_EMIT_EVENT) as mock_emit,
+            pytest.raises(ToolError),
+        ):
+            asyncio.run(wrapped())
+
+        attrs: dict = mock_emit.call_args_list[-1][0][1]
+        assert attrs["status"] == "user_error"
+
+    def test_wrap_name_attribute(self) -> None:
+        import asyncio  # noqa: PLC0415
+
+        from fabric_dw.mcp._helpers import _wrap_mcp_tool_with_telemetry  # noqa: PLC0415
+
+        async def _tool() -> str:
+            return "ok"
+
+        wrapped = _wrap_mcp_tool_with_telemetry(_tool, "list_warehouses")
+
+        with patch(_TELEMETRY_ENABLED, return_value=True), patch(_EMIT_EVENT) as mock_emit:
+            asyncio.run(wrapped())
+
+        attrs: dict = mock_emit.call_args_list[-1][0][1]
+        assert attrs["name"] == "list_warehouses"
+
+    def test_wrap_surface_is_mcp(self) -> None:
+        import asyncio  # noqa: PLC0415
+
+        from fabric_dw.mcp._helpers import _wrap_mcp_tool_with_telemetry  # noqa: PLC0415
+
+        async def _tool() -> str:
+            return "ok"
+
+        wrapped = _wrap_mcp_tool_with_telemetry(_tool, "list_warehouses")
+
+        with patch(_TELEMETRY_ENABLED, return_value=True), patch(_EMIT_EVENT) as mock_emit:
+            asyncio.run(wrapped())
+
+        attrs: dict = mock_emit.call_args_list[-1][0][1]
+        assert attrs["surface"] == "mcp"
+
+    def test_wrap_destructive_flag(self) -> None:
+        import asyncio  # noqa: PLC0415
+
+        from fabric_dw.mcp._helpers import _wrap_mcp_tool_with_telemetry  # noqa: PLC0415
+
+        async def _tool() -> str:
+            return "ok"
+
+        wrapped = _wrap_mcp_tool_with_telemetry(_tool, "delete_warehouse", destructive=True)
+
+        with patch(_TELEMETRY_ENABLED, return_value=True), patch(_EMIT_EVENT) as mock_emit:
+            asyncio.run(wrapped())
+
+        attrs: dict = mock_emit.call_args_list[-1][0][1]
+        assert attrs.get("destructive_op") is True
+
+    def test_emit_failure_does_not_break_tool(self) -> None:
+        """If telemetry emission fails, the tool result must still propagate."""
+        import asyncio  # noqa: PLC0415
+
+        from fabric_dw.mcp._helpers import _wrap_mcp_tool_with_telemetry  # noqa: PLC0415
+
+        async def _tool() -> str:
+            return "result"
+
+        wrapped = _wrap_mcp_tool_with_telemetry(_tool, "list_warehouses")
+
+        with (
+            patch(_TELEMETRY_ENABLED, return_value=True),
+            patch(_EMIT_EVENT, side_effect=RuntimeError("emit failed")),
+        ):
+            result = asyncio.run(wrapped())
+
+        assert result == "result"


### PR DESCRIPTION
## Summary

- Emits exactly one `command_invoked` telemetry event per CLI command and per MCP tool call with categorical-only attributes: `name`, `domain`, `surface`, `status`, `duration_ms_bucket`, and optional `destructive_op`.
- CLI instrumented via `_InstrumentedGroup` (a `click.Group` subclass) that monkey-patches sub-group `invoke()` methods to accumulate `(depth, group_name, subcommand)` segments in `click.Context.meta`; the root group reads and sorts these to build the full dotted path (e.g. `warehouses.list`, `config.set.workspace`).
- MCP instrumented via `InstrumentedFastMCP` (a `FastMCP` subclass) that overrides `tool()` to wrap every registered coroutine with a telemetry timer+emitter; mutating tools use `mutating_tool()` which wraps telemetry explicitly to avoid double-instrumentation.
- Fire-and-forget: all exceptions in `emit_command_invoked` are swallowed; no-op when `telemetry_enabled()` is False.

## Files changed

- `src/fabric_dw/telemetry_commands.py` — new module: `DOMAIN_MAP`, `resolve_domain`, `map_status`, `duration_bucket`, `emit_command_invoked`, `now_ms`
- `src/fabric_dw/cli/_main.py` — added `_InstrumentedGroup`, `_patch_group_for_telemetry`, `_build_command_name`
- `src/fabric_dw/mcp/_helpers.py` — added `_wrap_mcp_tool_with_telemetry`, `InstrumentedFastMCP`
- `src/fabric_dw/mcp/server.py` — switched to `InstrumentedFastMCP`
- `tests/unit/test_telemetry_commands.py` — 61 new TDD tests (domain coverage, status mapping, duration buckets, CLI/MCP integration, no-identifier guarantee, disabled no-op, emit-failure safety)
- `docs/telemetry.md` — documents `command_invoked` event and domain rollup table

## Test plan

- [ ] `just check` passes (ruff + ty + pytest ≥80% coverage)
- [ ] Verify `_EXPECTED_TOOL_COUNT` in `tests/unit/mcp/test_contract.py` is unchanged
- [ ] All 86 MCP tools and 19 CLI groups resolve to a known domain (exhaustive test in `TestDomainCoverage`)
- [ ] No real network calls in any new test

Closes #367