### PR TITLE
ci(release): publish dev pre-releases to PyPI on every main push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,11 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
+  # contents: write is required by softprops/action-gh-release (the "Create GitHub Release"
+  # step).  GitHub Actions does not support per-step permission overrides, so the only clean
+  # way to scope this down would be to split the job.  The release step is already guarded by
+  # `if: github.ref_type == 'tag' || ...`, so on main-branch pushes the write access is
+  # unused but unavoidable without a job split that would add complexity for minimal gain.
   contents: write
   id-token: write
   attestations: write
@@ -71,13 +76,18 @@ jobs:
         # so a re-run would try to upload an already-existing version.  PyPI returns HTTP 400
         # with "File already exists" in that case.  We treat that specific error as success
         # (idempotent re-run) while still propagating any other failure.
+        #
+        # GHA runs every `run:` block as `bash --noprofile --norc -eo pipefail {0}`, so `-e`
+        # is already active.  We must disable it around the pipeline so that a non-zero exit
+        # from `uv publish` does not abort the shell before we can inspect the output.
         run: |
-          set -o pipefail
+          set +e
           uv publish --trusted-publishing always 2>&1 | tee /tmp/uv_publish_output.txt
           exit_code=${PIPESTATUS[0]}
+          set -eo pipefail
           if [ "$exit_code" -ne 0 ]; then
-            if grep -qi "file already exists\|already been registered\|already exists" /tmp/uv_publish_output.txt; then
-              echo "Version already published to PyPI — treating as success (idempotent re-run)."
+            if grep -qiE 'already been registered|file[^ ]* already exist' /tmp/uv_publish_output.txt; then
+              echo "Version already on PyPI — treating as success (idempotent re-run)."
             else
               echo "Publish failed for an unexpected reason:" >&2
               cat /tmp/uv_publish_output.txt >&2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,13 @@
 name: Publish
 
+# Publish triggers:
+#   - push to main  → publishes a .devN pre-release to PyPI (continuous dev build;
+#                     no GitHub Release is created)
+#   - v* tag push   → publishes the clean release to PyPI AND creates a GitHub Release
+#   - workflow_dispatch (tag input) → same as tag push (manual release)
 on:
   push:
+    branches: [main]
     tags: ["v[0-9]*"]
   workflow_dispatch:
     inputs:
@@ -23,6 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: pypi
     steps:
+      # inputs.tag is only set for workflow_dispatch; on branch/tag pushes github.ref is used.
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
@@ -60,7 +67,23 @@ jobs:
             dist/*.tar.gz
 
       - name: Publish to PyPI (OIDC)
-        run: uv publish --trusted-publishing always
+        # hatch-vcs derives a unique .devN version per commit (distance since last v* tag),
+        # so a re-run would try to upload an already-existing version.  PyPI returns HTTP 400
+        # with "File already exists" in that case.  We treat that specific error as success
+        # (idempotent re-run) while still propagating any other failure.
+        run: |
+          set -o pipefail
+          uv publish --trusted-publishing always 2>&1 | tee /tmp/uv_publish_output.txt
+          exit_code=${PIPESTATUS[0]}
+          if [ "$exit_code" -ne 0 ]; then
+            if grep -qi "file already exists\|already been registered\|already exists" /tmp/uv_publish_output.txt; then
+              echo "Version already published to PyPI — treating as success (idempotent re-run)."
+            else
+              echo "Publish failed for an unexpected reason:" >&2
+              cat /tmp/uv_publish_output.txt >&2
+              exit "$exit_code"
+            fi
+          fi
 
       - name: Create GitHub Release (tag only)
         if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
Closes #378

## Summary

- Re-adds `push.branches: [main]` to the `on:` trigger in `.github/workflows/publish.yml`, so the workflow fires on both branch pushes and `v*` tag pushes.
- On a `main` push, `hatch-vcs` automatically produces a unique `.devN` version (commit distance since the last `v*` tag) — no manual version-stamping needed. The checkout `ref: ${{ inputs.tag || github.ref }}` resolves to `github.ref` (the branch ref) on a push, so the correct dev version is derived.
- The "Create GitHub Release" step retains its existing `if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'` guard — a `main` push publishes to PyPI only; no GitHub Release is created.
- SBOM generation, build-provenance attestation, and the `publish-${{ github.ref }}` concurrency guard from #235 are preserved and apply equally to dev builds.

## Idempotency (re-run safety)

`uv publish` is wrapped in a shell block that captures both stdout and stderr. If the command exits non-zero and the output contains the PyPI "File already exists" / "already been registered" message (HTTP 400), the step exits 0 — treating it as a benign duplicate. Any other non-zero exit propagates as a real failure.

## GitHub environment note

The publish job uses `environment: pypi`. If that environment is configured with a manual-approval protection rule in GitHub repository settings, pushes to `main` will pause waiting for a reviewer before publishing — making dev publishing semi-automatic rather than fully automatic. To make it truly automatic for `main`, the maintainer should either remove the approval requirement from the `pypi` environment or create a separate `pypi-dev` environment without it. This is a repository settings change and is outside the scope of this PR.

## No `integration` label

This PR touches only CI orchestration (`.github/workflows/`), not `src/` or `tests/`, so the ~95-minute integration suite is not needed and the `integration` label is intentionally omitted.

## Validation

- YAML parses without errors: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/publish.yml'))"` → OK
- `actionlint` passes with zero warnings or errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)