### PR TITLE
fix(release): use cyclonedx-bom for SBOM and make it non-blocking for publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,16 +53,24 @@ jobs:
       - run: uv build
 
       - name: Generate CycloneDX SBOM
+        # Use `--from cyclonedx-bom` to invoke the real tool (not the unrelated `cyclonedx-py`
+        # package on PyPI, which does not accept --outfile and would fail with exit 2).
+        # Flags: --of JSON (output format), -o <file> (output file) — correct for cyclonedx-bom.
+        # continue-on-error: true so an SBOM failure can never block the PyPI publish.
+        continue-on-error: true
         run: |
-          uvx cyclonedx-py environment --output-format json --outfile dist/sbom.cdx.json
+          uvx --from 'cyclonedx-bom==7.3.0' cyclonedx-py environment --of JSON -o dist/sbom.cdx.json "$(uv python find)"
           python -c "import json,sys; d=json.load(open('dist/sbom.cdx.json')); print(f'SBOM: {len(d.get(\"components\",[]))} components')"
 
       - name: Upload SBOM artifact
+        # Only upload if the SBOM was actually generated (SBOM step may have been skipped/failed).
+        if: ${{ hashFiles('dist/sbom.cdx.json') != '' }}
+        continue-on-error: true
         uses: actions/upload-artifact@v7
         with:
           name: sbom-cyclonedx
           path: dist/sbom.cdx.json
-          if-no-files-found: error
+          if-no-files-found: warn
 
       - name: Attest build provenance
         uses: actions/attest-build-provenance@v4
@@ -103,5 +111,6 @@ jobs:
             dist/*.whl
             dist/*.tar.gz
             dist/sbom.cdx.json
+          fail_on_unmatched_files: false
           generate_release_notes: true
           name: ${{ github.ref_name }}


### PR DESCRIPTION
## Summary

Closes #380

## Root cause

The "Generate CycloneDX SBOM" step used `uvx cyclonedx-py`, which resolved the **unrelated** PyPI package `cyclonedx-py` — not the real SBOM tool `cyclonedx-bom` (which provides the `cyclonedx-py` executable). The wrong package's CLI does not accept `--outfile` (nor `--output-format`), so it exited with code 2. Because the step ran without `continue-on-error`, the entire rest of the job — attestation, SBOM upload, and the PyPI publish — was silently skipped.

## Changes

- **Fixed SBOM command**: `uvx --from 'cyclonedx-bom==7.3.0' cyclonedx-py environment --of JSON -o dist/sbom.cdx.json "$(uv python find)"`. Uses the correct package (`--from cyclonedx-bom`), correct flags (`--of JSON` / `-o` instead of `--output-format` / `--outfile`), and targets the uv-managed venv via `$(uv python find)`.
- **SBOM is non-blocking**: `continue-on-error: true` on the "Generate CycloneDX SBOM" step so any future SBOM failure cannot prevent publishing.
- **Upload step is defensive**: guarded with `if: ${{ hashFiles('dist/sbom.cdx.json') != '' }}` and `continue-on-error: true`; `if-no-files-found` changed from `error` to `warn`.
- **GitHub Release step**: `fail_on_unmatched_files: false` added so a missing `sbom.cdx.json` does not fail the release.
- **Critical path unaffected**: `uv build` → "Attest build provenance" → "Publish to PyPI (OIDC)" → (tag-only) "Create GitHub Release" all proceed regardless of SBOM outcome. No `integration` label added — this is a CI-only change with no code impact.

## Validation

- Local SBOM run: `uvx --from 'cyclonedx-bom==7.3.0' cyclonedx-py environment --of JSON -o /tmp/sbom_test.json "$(uv python find)"` produced a valid CycloneDX 1.6 JSON with 90 components.
- `python -c "import yaml; yaml.safe_load(open('.github/workflows/publish.yml'))"` — valid.
- `actionlint` — clean (no output).