### PR TITLE
feat(load): auto-create target table on load (create-and-load)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1806,13 +1806,34 @@ Load data into a warehouse table via `COPY INTO` from either a local file or a r
 
 **Remote URL** (`--url`): `COPY INTO` is issued directly from the given URL. For OneLake or same-tenant URLs no credential is needed. For secured external URLs (Azure Blob Storage, ADLS Gen2) supply `--credential-type` and `--secret`/`--identity` as appropriate.
 
+**Auto-create (create-and-load)** — Pass `--create` to auto-create the target table from the source schema before loading (local files only; requires `pyarrow`). The schema is inferred from the source:
+
+- **Parquet**: exact types are read from the Parquet footer (no row data is read).
+- **CSV**: the header row and up to `--sample-rows` rows are read for type inference. Use `--all-varchar` to skip inference and force every column to `VARCHAR`.
+- **JSON**: the file is converted to Parquet internally (as required for staging); the schema is read from the resulting Parquet footer.
+
+Use `--if-exists` to control behaviour when the table already exists:
+
+| `--if-exists` value | Table exists | Table absent |
+| --- | --- | --- |
+| `fail` (default with `--create`) | Error — table already exists | Create + load |
+| `append` | Skip create, `COPY INTO` existing | Create + load |
+| `truncate` ⚠️ **DESTRUCTIVE** | `TRUNCATE` existing table, then load | Create + load |
+| `replace` ⚠️ **DESTRUCTIVE** | `DROP` + recreate from inferred schema, then load | Create + load |
+
+`truncate` and `replace` are permanently destructive and require confirmation (or `--yes` / `-y`).
+
+Use `--cleanup-on-failure` to drop the table if WE created it in this call and the subsequent `COPY INTO` fails. A pre-existing table is never dropped by this flag.
+
+> **Not atomic.** `CREATE TABLE` and `COPY INTO` are separate statements. A failure between them may leave an empty table. Use `--cleanup-on-failure` to auto-drop in that case.
+
 **Synopsis**
 
 ```
 fabric-dw tables load [OPTIONS] [WORKSPACE] [ITEM] QUALIFIED_NAME
 ```
 
-`QUALIFIED_NAME` is the dot-separated `schema.table_name` of the destination table, which must already exist.
+`QUALIFIED_NAME` is the dot-separated `schema.table_name` of the destination table.
 
 | Option | Default | Description |
 | --- | --- | --- |
@@ -1831,18 +1852,38 @@ fabric-dw tables load [OPTIONS] [WORKSPACE] [ITEM] QUALIFIED_NAME
 | `--keep-staging` | off | Keep the staging Lakehouse after load (for debugging). |
 | `--max-errors INT` | — | Maximum errors before aborting. |
 | `--rejected-row-location TEXT` | — | URL to write rejected rows to. |
+| `--create` | off | Auto-create the target table from the source schema (local files only). |
+| `--if-exists [fail\|append\|truncate\|replace]` | `fail` (with `--create`) | What to do when the target table already exists. `truncate` and `replace` are destructive and require confirmation. |
+| `--all-varchar` | off | (CSV, `--create`) Force all columns to `VARCHAR`; skip type inference. |
+| `--varchar-length INT` | `8000` | (`--create`) Default VARCHAR/VARBINARY length for inferred columns. |
+| `--sample-rows INT` | `1000` | (CSV, `--create`) Maximum rows to sample for type inference. |
+| `--cleanup-on-failure` | off | Drop the table if WE created it and the load fails. Never drops a pre-existing table. |
 
 **Examples**
 
 ```shell
-# Load a local CSV (header row present)
+# Load a local CSV into an existing table (header row present)
 fabric-dw tables load MyWorkspace SalesWH dbo.sales --file data.csv
 
-# Load a local Parquet file
+# Load a local Parquet file into an existing table
 fabric-dw tables load MyWorkspace SalesWH dbo.events --file events.parquet
 
 # Load a local JSON file (converts to Parquet internally; requires pyarrow)
 fabric-dw tables load MyWorkspace SalesWH dbo.products --file products.json
+
+# Auto-create the table from a Parquet schema, then load
+fabric-dw tables load MyWorkspace SalesWH dbo.sales --file data.parquet --create
+
+# Auto-create from CSV, force all columns to VARCHAR
+fabric-dw tables load MyWorkspace SalesWH dbo.raw --file raw.csv --create --all-varchar
+
+# Replace the existing table (drop + recreate schema + load), skip confirmation
+fabric-dw tables load MyWorkspace SalesWH dbo.sales --file data.parquet --create \
+    --if-exists replace -y
+
+# Auto-create; drop the table if the load fails (cleanup_on_failure)
+fabric-dw tables load MyWorkspace SalesWH dbo.sales --file data.parquet --create \
+    --cleanup-on-failure
 
 # Load from a remote OneLake URL (no credential needed)
 fabric-dw tables load MyWorkspace SalesWH dbo.orders \

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -981,6 +981,8 @@ Load data into a Data Warehouse table via `COPY INTO` from a remote URL. For One
 
 > **Secret safety.** The `secret` and `identity` parameters are accepted but are **never** logged or echoed in any server output.
 
+> **Table must exist.** This tool does not create the target table. Use [`import_table_from_url`](#import_table_from_url) for a load-only flow with `if_exists` control over an existing table, or the CLI `tables load --file --create` for auto-create from a local file with schema inference.
+
 **Parameters:**
 
 - `workspace` (`str`) — workspace name or GUID.
@@ -988,6 +990,50 @@ Load data into a Data Warehouse table via `COPY INTO` from a remote URL. For One
 - `qualified_name` (`str`) — dot-separated qualified table name, e.g. `dbo.sales`.
 - `url` (`str`) — source URL (OneLake DFS URL or external Azure Blob URL).
 - `file_type` (`"CSV" | "PARQUET"`) — file type to load.
+- `credential_type` (`"none" | "sas" | "managed-identity" | "service-principal" | "account-key"`, default `"none"`) — credential type for secured external URLs.
+- `secret` (`str | null`, optional) — credential secret (SAS token, client secret, or account key). Never logged.
+- `identity` (`str | null`, optional) — identity for `managed-identity` or `service-principal`.
+- `delimiter` (`str | null`, optional) — CSV column delimiter (e.g. `,`, `\t`).
+- `has_header` (`bool`, default `true`) — when `true`, the first CSV row is a header and is skipped.
+- `encoding` (`str | null`, optional) — CSV encoding (e.g. `UTF8`, `UTF8BOM`).
+- `field_quote` (`str | null`, optional) — CSV field-quote character.
+- `row_terminator` (`str | null`, optional) — CSV row terminator (e.g. `\n`, `\r\n`).
+- `max_errors` (`int | null`, optional) — maximum errors before aborting.
+- `rejected_row_location` (`str | null`, optional) — URL to write rejected rows to.
+
+**Returns:** `CopyIntoResult` — `{ "rows_loaded": int, "rows_rejected": int, "target": "schema.table" }`.
+
+---
+
+### import_table_from_url
+
+**Targets:** Data Warehouse only
+
+Load data from a remote URL into an existing Data Warehouse table with control over what happens when the table already has data. This tool extends [`load_table_from_url`](#load_table_from_url) with an `if_exists` policy.
+
+> **Schema inference not supported for remote URLs.** This tool does not auto-create the target table from the source schema (downloading the full file just for schema inference is not practical for remote sources). To auto-create a table from schema, use the CLI `tables load --file --create` with a local file. For `if_exists="replace"`, use the CLI instead.
+
+> **`truncate` and `replace` are destructive** and require `FABRIC_MCP_ALLOW_DESTRUCTIVE=1`.
+
+> **Secret safety.** The `secret` and `identity` parameters are accepted but are **never** logged or echoed in any server output.
+
+**`if_exists` policy:**
+
+| Value | Table exists | Table absent |
+| --- | --- | --- |
+| `"fail"` (default) | Error — table already exists | Load normally |
+| `"append"` | Load into existing table | Load normally |
+| `"truncate"` ⚠️ | `TRUNCATE` existing table, then load | Load normally |
+| `"replace"` ⚠️ | Not supported for remote URLs — use CLI | Load normally |
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `item` (`str`) — warehouse name or GUID. SQL Analytics Endpoints are rejected.
+- `qualified_name` (`str`) — dot-separated qualified table name, e.g. `dbo.sales`.
+- `url` (`str`) — source URL (OneLake DFS URL or external Azure Blob URL).
+- `file_type` (`"CSV" | "PARQUET"`) — file type to load. JSON is not supported for remote URLs.
+- `if_exists` (`"fail" | "append" | "truncate" | "replace"`, default `"fail"`) — what to do when the target table already exists.
 - `credential_type` (`"none" | "sas" | "managed-identity" | "service-principal" | "account-key"`, default `"none"`) — credential type for secured external URLs.
 - `secret` (`str | null`, optional) — credential secret (SAS token, client secret, or account key). Never logged.
 - `identity` (`str | null`, optional) — identity for `managed-identity` or `service-principal`.

--- a/src/fabric_dw/cli/commands/tables.py
+++ b/src/fabric_dw/cli/commands/tables.py
@@ -32,7 +32,9 @@ from fabric_dw.models import ColumnSpec, CopyIntoResult
 from fabric_dw.services import tables as _tables_svc
 from fabric_dw.services.load import (
     CopyIntoCsvOptions,
+    IfExistsPolicy,
     copy_into_from_url,
+    create_and_load,
     infer_file_format,
     load_local_file,
 )
@@ -652,9 +654,64 @@ def _resolve_url_file_type(fmt: str | None, url: str) -> str:
     default=None,
     help="URL for rejected-row output.",
 )
+# ── Create-and-load options ──────────────────────────────────────────────────
+@click.option(
+    "--create/--no-create",
+    "create",
+    default=False,
+    help=(
+        "Auto-create the target table from the source schema before loading. "
+        "Only supported for local files (--file). "
+        "Requires pyarrow."
+    ),
+)
+@click.option(
+    "--if-exists",
+    "if_exists",
+    type=click.Choice(["fail", "append", "truncate", "replace"], case_sensitive=False),
+    default=None,
+    help=(
+        "What to do when the target table already exists. "
+        "Default: 'fail' with --create; 'append' without --create. "
+        "'truncate' and 'replace' are destructive and require confirmation."
+    ),
+)
+@click.option(
+    "--all-varchar",
+    "all_varchar",
+    is_flag=True,
+    default=False,
+    help="(--create, CSV) Force all columns to VARCHAR; skip type inference.",
+)
+@click.option(
+    "--varchar-length",
+    "varchar_length",
+    default=8000,
+    show_default=True,
+    type=click.IntRange(1, 8000),
+    help="(--create) Default VARCHAR/VARBINARY length for inferred columns.",
+)
+@click.option(
+    "--sample-rows",
+    "sample_rows",
+    default=1000,
+    show_default=True,
+    type=click.IntRange(1, 100_000),
+    help="(--create, CSV) Maximum rows to sample for type inference.",
+)
+@click.option(
+    "--cleanup-on-failure",
+    "cleanup_on_failure",
+    is_flag=True,
+    default=False,
+    help=(
+        "Drop the table if WE created it and the subsequent load fails. "
+        "Never drops a pre-existing table."
+    ),
+)
 @click.pass_obj
 @coro
-async def load_cmd(
+async def load_cmd(  # noqa: PLR0912
     ctx: CliContext,
     workspace: str | None,
     item: str | None,
@@ -674,6 +731,12 @@ async def load_cmd(
     keep_staging: bool,
     max_errors: int | None,
     rejected_row_location: str | None,
+    create: bool,
+    if_exists: str | None,
+    all_varchar: bool,
+    varchar_length: int,
+    sample_rows: int,
+    cleanup_on_failure: bool,
 ) -> None:
     """Load data into QUALIFIED_NAME (schema.table) on ITEM in WORKSPACE via COPY INTO.
 
@@ -685,9 +748,21 @@ async def load_cmd(
     JSON files are converted to Parquet client-side before staging.
 
     \b
+    With --create, the target table is auto-created from the source schema
+    before loading (local files only, requires pyarrow).
+    Use --if-exists to control behaviour when the table already exists:
+      fail      Error if table exists (default with --create).
+      append    Load into existing table without modifying it.
+      truncate  TRUNCATE the existing table, then load.  [DESTRUCTIVE]
+      replace   DROP + recreate from inferred schema, then load.  [DESTRUCTIVE]
+
+    \b
     Examples:
       fabric-dw tables load myws mywarehouse dbo.sales --file data.csv
       fabric-dw tables load myws mywarehouse dbo.sales --url https://... --format parquet
+      fabric-dw tables load myws mywarehouse dbo.sales --file data.parquet --create
+      fabric-dw tables load myws mywarehouse dbo.sales \
+          --file data.csv --create --if-exists replace -y
     """
     ws = resolve_workspace_arg(ctx, workspace)
     wh = resolve_warehouse_arg(ctx, item)
@@ -697,6 +772,37 @@ async def load_cmd(
         raise click.UsageError("Provide either --file or --url, not both.")
     if not file_path and not url:
         raise click.UsageError("Provide --file (local path) or --url (remote URL).")
+
+    # --create is only supported for local files.
+    if create and url:
+        raise click.UsageError("--create is only supported for local files (--file).")
+
+    # --all-varchar / --sample-rows only make sense with --create.
+    if all_varchar and not create:
+        raise click.UsageError("--all-varchar requires --create.")
+    # sample_rows != default only matters with --create; silently ignore otherwise.
+    if sample_rows != 1000 and not create:  # noqa: PLR2004
+        pass  # silently ignore — it only takes effect with --create
+
+    # Resolve --if-exists default.
+    effective_if_exists: IfExistsPolicy
+    if if_exists is not None:
+        effective_if_exists = cast("IfExistsPolicy", if_exists)
+    elif create:
+        effective_if_exists = "fail"
+    else:
+        effective_if_exists = "append"
+
+    # Destructive confirmation for truncate / replace.
+    is_destructive = effective_if_exists in ("truncate", "replace")
+    if is_destructive:
+        action = "TRUNCATE" if effective_if_exists == "truncate" else "DROP+recreate"
+        if not confirm_destructive(
+            f"{action} table [{schema}].[{table_name}] before loading?",
+            yes=ctx.yes,
+        ):
+            click.echo("Aborted.")
+            return
 
     csv_kw = {
         "has_header": has_header,
@@ -718,22 +824,45 @@ async def load_cmd(
             )
 
             if file_path:
-                result = await _load_cmd_local(
-                    ctx,
-                    http,
-                    ws_id,
-                    sql_target,
-                    entry,
-                    schema,
-                    table_name,
-                    file_path,
-                    fmt,
-                    csv_kw,
-                    staging_lakehouse_name,
-                    keep_staging,
-                    max_errors,
-                    rejected_row_location,
-                )
+                if create:
+                    result = await _load_cmd_create_and_load(
+                        ctx,
+                        http,
+                        ws_id,
+                        sql_target,
+                        entry,
+                        schema,
+                        table_name,
+                        file_path,
+                        fmt,
+                        csv_kw,
+                        staging_lakehouse_name,
+                        keep_staging,
+                        max_errors,
+                        rejected_row_location,
+                        effective_if_exists,
+                        all_varchar,
+                        varchar_length,
+                        sample_rows,
+                        cleanup_on_failure,
+                    )
+                else:
+                    result = await _load_cmd_local(
+                        ctx,
+                        http,
+                        ws_id,
+                        sql_target,
+                        entry,
+                        schema,
+                        table_name,
+                        file_path,
+                        fmt,
+                        csv_kw,
+                        staging_lakehouse_name,
+                        keep_staging,
+                        max_errors,
+                        rejected_row_location,
+                    )
             else:
                 assert url is not None  # noqa: S101 — checked above
                 result = await _load_cmd_url(
@@ -821,6 +950,86 @@ async def _load_cmd_local(
         rejected_row_location=rejected_row_location,
         kind=entry.kind,
         mode=ctx.auth,
+    )
+
+
+async def _load_cmd_create_and_load(
+    ctx: CliContext,
+    http: FabricHttpClient,
+    ws_id: UUID,
+    sql_target: SqlTarget,
+    entry: ItemEntry,
+    schema: str,
+    table_name: str,
+    file_path: str,
+    fmt: str | None,
+    csv_kw: Mapping[str, object],
+    staging_lakehouse_name: str | None,
+    keep_staging: bool,
+    max_errors: int | None,
+    rejected_row_location: str | None,
+    if_exists: IfExistsPolicy,
+    all_varchar: bool,
+    varchar_length: int,
+    sample_rows: int,
+    cleanup_on_failure: bool,
+) -> CopyIntoResult:
+    """Dispatch the create-and-load sub-path (--create)."""
+    from fabric_dw import auth as _auth  # noqa: PLC0415
+    from fabric_dw.services.load import FileFormat  # noqa: PLC0415
+
+    local = Path(file_path)
+    if not local.exists():
+        raise click.UsageError(f"File not found: {file_path}")
+
+    try:
+        raw_format = fmt or infer_file_format(local)
+    except ValueError as exc:
+        raise click.UsageError(str(exc)) from exc
+
+    file_format: FileFormat = cast("FileFormat", raw_format)
+
+    # Build CSV load options (for the COPY INTO step).
+    csv_options = (
+        _make_csv_options(
+            has_header=bool(csv_kw.get("has_header", True)),
+            delimiter=cast("str | None", csv_kw.get("delimiter") or None),
+            encoding=cast("str | None", csv_kw.get("encoding") or None),
+            field_quote=cast("str | None", csv_kw.get("field_quote") or None),
+            row_terminator=cast("str | None", csv_kw.get("row_terminator") or None),
+        )
+        if file_format == "csv"
+        else None
+    )
+
+    # CSV delimiter for schema inference (from csv_kw or default).
+    infer_delimiter = cast("str", csv_kw.get("delimiter") or ",")
+    infer_encoding = cast("str", csv_kw.get("encoding") or "utf-8-sig")
+
+    credential = _auth.get_credential(ctx.auth)
+    return await create_and_load(
+        http,
+        credential,
+        ws_id,
+        sql_target,
+        schema,
+        table_name,
+        local,
+        if_exists=if_exists,
+        file_format=file_format,
+        staging_lakehouse_name=staging_lakehouse_name,
+        keep_staging=keep_staging,
+        csv_options=csv_options,
+        max_errors=max_errors,
+        rejected_row_location=rejected_row_location,
+        kind=entry.kind,
+        mode=ctx.auth,
+        cleanup_on_failure=cleanup_on_failure,
+        all_varchar=all_varchar,
+        varchar_length=varchar_length,
+        sample_rows=sample_rows,
+        csv_delimiter=infer_delimiter,
+        csv_encoding=infer_encoding,
     )
 
 

--- a/src/fabric_dw/cli/commands/tables.py
+++ b/src/fabric_dw/cli/commands/tables.py
@@ -793,6 +793,15 @@ async def load_cmd(  # noqa: PLR0912
     else:
         effective_if_exists = "append"
 
+    # truncate/replace are only meaningful on the --create path (local files).
+    # For --url there is no schema to infer, and for --file without --create the
+    # destructive policies are undefined.  Reject early with a clear message.
+    if effective_if_exists in ("truncate", "replace") and not create:
+        raise click.UsageError(
+            f"--if-exists {effective_if_exists} requires --create "
+            "(destructive policies only apply to the auto-create load path)."
+        )
+
     # Destructive confirmation for truncate / replace.
     is_destructive = effective_if_exists in ("truncate", "replace")
     if is_destructive:

--- a/src/fabric_dw/mcp/tools/load.py
+++ b/src/fabric_dw/mcp/tools/load.py
@@ -18,14 +18,18 @@ from fabric_dw.mcp._helpers import (
     resolve_item,
     tool_err,
 )
-from fabric_dw.services.load import CopyIntoCsvOptions, copy_into_from_url
+from fabric_dw.services.load import (
+    CopyIntoCsvOptions,
+    IfExistsPolicy,
+    copy_into_from_url,
+)
 
 __all__ = ["register"]
 
 _log = logging.getLogger(__name__)
 
 
-def register(mcp: FastMCP) -> None:
+def register(mcp: FastMCP) -> None:  # noqa: PLR0915
     """Register table-load tools against *mcp*."""
 
     @mutating_tool(mcp, "load_table_from_url")
@@ -177,6 +181,247 @@ def register(mcp: FastMCP) -> None:
                 # secret and identity are intentionally excluded from this log call
             )
             sql_target = make_sql_target(ws_id, entry, item)
+            result = await copy_into_from_url(
+                sql_target,
+                schema,
+                table_name,
+                url,
+                file_type=file_type,
+                credential_type=credential_type,  # type: ignore[arg-type]
+                secret=secret,
+                identity=identity,
+                csv_options=csv_options,
+                max_errors=max_errors,
+                rejected_row_location=rejected_row_location,
+                kind=entry.kind,
+                mode=ctx.auth_mode,
+            )
+        except (ValueError, FabricError) as exc:
+            raise tool_err(exc) from exc
+        return result.model_dump(mode="json")
+
+    @mutating_tool(mcp, "import_table_from_url")
+    async def import_table_from_url(  # noqa: PLR0913
+        workspace: str,
+        item: str,
+        qualified_name: str,
+        url: str,
+        file_type: Annotated[
+            Literal["CSV", "PARQUET"],
+            Field(
+                description=(
+                    "File type.  JSON is not supported for remote URLs;"
+                    " download and convert locally first."
+                ),
+            ),
+        ],
+        if_exists: Annotated[
+            IfExistsPolicy,
+            Field(
+                description=(
+                    "What to do when the target table already exists. "
+                    "'fail': error (default). "
+                    "'append': load into existing table. "
+                    "'truncate': TRUNCATE then load (destructive). "
+                    "'replace': DROP + recreate from inferred schema, then load (destructive)."
+                ),
+            ),
+        ] = "fail",
+        credential_type: Annotated[
+            Literal["none", "sas", "managed-identity", "service-principal", "account-key"],
+            Field(
+                description=(
+                    "Credential type for secured external URLs."
+                    " Use 'none' for OneLake or public URLs."
+                ),
+            ),
+        ] = "none",
+        secret: Annotated[
+            str | None,
+            Field(
+                description=(
+                    "Credential secret (SAS token, client secret, or account key)."
+                    " NEVER log or echo this value."
+                ),
+                default=None,
+            ),
+        ] = None,
+        identity: Annotated[
+            str | None,
+            Field(
+                description=(
+                    "Identity value for managed-identity or service-principal credential types."
+                ),
+                default=None,
+            ),
+        ] = None,
+        delimiter: Annotated[
+            str | None,
+            Field(description="CSV column delimiter (e.g. ',', '\\t').", default=None),
+        ] = None,
+        has_header: Annotated[  # noqa: FBT002
+            bool,
+            Field(
+                description="When True, the first CSV row is a header and is skipped.",
+                default=True,
+            ),
+        ] = True,
+        encoding: Annotated[
+            str | None,
+            Field(description="CSV file encoding (e.g. 'UTF8', 'UTF8BOM').", default=None),
+        ] = None,
+        field_quote: Annotated[
+            str | None,
+            Field(description="CSV field-quote character.", default=None),
+        ] = None,
+        row_terminator: Annotated[
+            str | None,
+            Field(
+                description="CSV row terminator (e.g. '\\n', '\\r\\n').",
+                default=None,
+            ),
+        ] = None,
+        max_errors: Annotated[
+            int | None,
+            Field(description="Maximum number of errors before aborting.", default=None),
+        ] = None,
+        rejected_row_location: Annotated[
+            str | None,
+            Field(description="URL to write rejected rows to.", default=None),
+        ] = None,
+    ) -> dict[str, Any]:
+        """Load data into a Data Warehouse table via ``COPY INTO`` from a remote URL.
+
+        Unlike ``load_table_from_url``, this tool does **not** require the target
+        table to exist — it loads data directly from the given URL.  The target
+        table must already exist and have a compatible schema; use the CLI
+        ``tables load --file --create`` for auto-create with schema inference
+        (local files only, as remote schema inference requires downloading).
+
+        When ``if_exists`` is ``"truncate"`` or ``"replace"`` the operation is
+        **destructive** and requires ``FABRIC_MCP_ALLOW_DESTRUCTIVE=1``.
+
+        Supported file types: ``CSV``, ``PARQUET``.  JSON remote URLs require
+        downloading and converting locally first; use the CLI ``tables load``
+        command for local files (including JSON).
+
+        For OneLake or same-tenant URLs, no credential is needed.  For secured
+        external URLs supply ``credential_type`` and the appropriate
+        ``secret``/``identity`` values.
+
+        CAUTION: ``truncate`` and ``replace`` are permanently destructive.
+        Confirm the source URL and target table before calling.
+
+        Note: ``secret`` / ``identity`` values are accepted but are NEVER logged
+        or included in any debug output.
+
+        Args:
+            workspace: Workspace name or GUID.
+            item: Warehouse name or GUID.  SQL Analytics Endpoints are rejected.
+            qualified_name: Dot-separated qualified table name, e.g. ``dbo.sales``.
+            url: Source URL (OneLake DFS URL or external Azure Blob URL).
+            file_type: ``CSV`` or ``PARQUET``.
+            if_exists: Policy for an existing target table.
+            credential_type: Credential type for the source URL.
+            secret: Credential secret (not logged).
+            identity: Identity for managed-identity or service-principal.
+            delimiter: CSV column delimiter.
+            has_header: Whether the CSV file has a header row.
+            encoding: CSV file encoding.
+            field_quote: CSV field-quote character.
+            row_terminator: CSV row terminator.
+            max_errors: Maximum errors before aborting.
+            rejected_row_location: URL for rejected-row output.
+        """
+        from fabric_dw.exceptions import ItemKindError  # noqa: PLC0415
+        from fabric_dw.models import WarehouseKind  # noqa: PLC0415
+
+        schema, table_name = parse_qualified_name(qualified_name, kind="table")
+        assert_workspace_allowed(workspace)
+        ctx = get_context()
+
+        # Destructive guard for truncate / replace.
+        if if_exists in ("truncate", "replace"):
+            from fabric_dw.mcp._guards import assert_destructive_allowed  # noqa: PLC0415
+
+            assert_destructive_allowed()
+
+        # SQL Endpoint guard: CREATE TABLE + COPY INTO are Warehouse-only.
+        # The file_type validation and credential handling mirror load_table_from_url.
+        if file_type not in ("CSV", "PARQUET"):
+            from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+            raise ToolError(f"Unsupported file_type {file_type!r}; must be CSV or PARQUET")
+
+        # Build CSV options.
+        csv_options: CopyIntoCsvOptions | None = None
+        if file_type == "CSV":
+            first_row = 2 if has_header else 1
+            csv_options = CopyIntoCsvOptions(
+                delimiter=delimiter,
+                first_row=first_row,
+                encoding=encoding,
+                field_quote=field_quote,
+                row_terminator=row_terminator,
+            )
+
+        try:
+            ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
+            assert_workspace_allowed(workspace, str(ws_id))
+
+            # SQL Endpoint: COPY INTO is Warehouse-only.
+            if entry.kind == WarehouseKind.SQL_ENDPOINT:
+                raise ItemKindError("SQL Endpoints are read-only; COPY INTO not supported")
+
+            _log.debug(
+                "import_table_from_url ws=%s item=%s table=%s.%s url=%s "
+                "file_type=%s if_exists=%s cred_type=%s",
+                ws_id,
+                entry.id,
+                schema,
+                table_name,
+                url,
+                file_type,
+                if_exists,
+                credential_type,
+            )
+            sql_target = make_sql_target(ws_id, entry, item)
+
+            # This tool loads from a URL (no create-from-schema for remote sources
+            # without downloading), so we delegate directly to copy_into_from_url
+            # after applying the if_exists policy via SQL.
+            from fabric_dw.services.load import (  # noqa: PLC0415
+                _assert_not_sql_endpoint,
+                _table_exists,
+                _truncate_table_sql,
+            )
+
+            # The SQL Endpoint guard was already checked above, but guard helpers
+            # accept the kind for a consistent pattern.
+            _assert_not_sql_endpoint(entry.kind)
+
+            from mcp.server.fastmcp.exceptions import ToolError as _ToolError  # noqa: PLC0415
+
+            exists = await _table_exists(sql_target, schema, table_name, mode=ctx.auth_mode)
+            if exists:
+                if if_exists == "fail":
+                    raise _ToolError(
+                        f"Table [{schema}].[{table_name}] already exists. "
+                        "Use if_exists='append', 'truncate', or 'replace'."
+                    )
+                if if_exists == "truncate":
+                    await _truncate_table_sql(sql_target, schema, table_name, mode=ctx.auth_mode)
+                elif if_exists == "replace":
+                    # For remote URLs we cannot infer schema without downloading;
+                    # the user should use the CLI for auto-create from local files.
+                    raise _ToolError(
+                        "if_exists='replace' for remote URLs requires a pre-existing schema. "
+                        "Use if_exists='truncate' to keep the current schema, or download "
+                        "the file locally and use the CLI 'tables load --file --create "
+                        "--if-exists replace' for full auto-create from schema."
+                    )
+                # "append": do nothing
+
             result = await copy_into_from_url(
                 sql_target,
                 schema,

--- a/src/fabric_dw/mcp/tools/load.py
+++ b/src/fabric_dw/mcp/tools/load.py
@@ -290,16 +290,22 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             Field(description="URL to write rejected rows to.", default=None),
         ] = None,
     ) -> dict[str, Any]:
-        """Load data into a Data Warehouse table via ``COPY INTO`` from a remote URL.
+        """Load data into an existing Data Warehouse table via ``COPY INTO`` from a remote URL.
 
-        Unlike ``load_table_from_url``, this tool does **not** require the target
-        table to exist — it loads data directly from the given URL.  The target
-        table must already exist and have a compatible schema; use the CLI
-        ``tables load --file --create`` for auto-create with schema inference
-        (local files only, as remote schema inference requires downloading).
+        The target table **must already exist** and have a compatible schema.
+        For auto-create with schema inference from local files, use the CLI
+        ``tables load --file --create`` command instead.
 
-        When ``if_exists`` is ``"truncate"`` or ``"replace"`` the operation is
-        **destructive** and requires ``FABRIC_MCP_ALLOW_DESTRUCTIVE=1``.
+        ``if_exists`` controls behaviour when the table already exists:
+
+        - ``"fail"`` (default): raise an error if the table already exists.
+        - ``"append"``: load rows into the existing table without modification.
+        - ``"truncate"``: TRUNCATE the existing table first, then load.
+          Requires ``FABRIC_MCP_ALLOW_DESTRUCTIVE=1``.  Raises an error if the
+          table does **not** exist.
+        - ``"replace"``: not supported for remote URLs (schema inference requires
+          downloading the file).  Use ``"truncate"`` to keep the current schema,
+          or download locally and use the CLI with ``--create --if-exists replace``.
 
         Supported file types: ``CSV``, ``PARQUET``.  JSON remote URLs require
         downloading and converting locally first; use the CLI ``tables load``
@@ -309,7 +315,7 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         external URLs supply ``credential_type`` and the appropriate
         ``secret``/``identity`` values.
 
-        CAUTION: ``truncate`` and ``replace`` are permanently destructive.
+        CAUTION: ``truncate`` is permanently destructive.
         Confirm the source URL and target table before calling.
 
         Note: ``secret`` / ``identity`` values are accepted but are NEVER logged
@@ -321,7 +327,7 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             qualified_name: Dot-separated qualified table name, e.g. ``dbo.sales``.
             url: Source URL (OneLake DFS URL or external Azure Blob URL).
             file_type: ``CSV`` or ``PARQUET``.
-            if_exists: Policy for an existing target table.
+            if_exists: Policy when the target table already exists.
             credential_type: Credential type for the source URL.
             secret: Credential secret (not logged).
             identity: Identity for managed-identity or service-principal.
@@ -340,14 +346,7 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         assert_workspace_allowed(workspace)
         ctx = get_context()
 
-        # Destructive guard for truncate / replace.
-        if if_exists in ("truncate", "replace"):
-            from fabric_dw.mcp._guards import assert_destructive_allowed  # noqa: PLC0415
-
-            assert_destructive_allowed()
-
-        # SQL Endpoint guard: CREATE TABLE + COPY INTO are Warehouse-only.
-        # The file_type validation and credential handling mirror load_table_from_url.
+        # SQL Endpoint guard: COPY INTO is Warehouse-only.
         if file_type not in ("CSV", "PARQUET"):
             from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
 
@@ -387,22 +386,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             )
             sql_target = make_sql_target(ws_id, entry, item)
 
-            # This tool loads from a URL (no create-from-schema for remote sources
-            # without downloading), so we delegate directly to copy_into_from_url
-            # after applying the if_exists policy via SQL.
-            from fabric_dw.services.load import (  # noqa: PLC0415
-                _assert_not_sql_endpoint,
-                _table_exists,
-                _truncate_table_sql,
+            from mcp.server.fastmcp.exceptions import (  # noqa: PLC0415
+                ToolError as _ToolError,
             )
 
-            # The SQL Endpoint guard was already checked above, but guard helpers
-            # accept the kind for a consistent pattern.
-            _assert_not_sql_endpoint(entry.kind)
+            from fabric_dw.services.load import table_exists, truncate_table  # noqa: PLC0415
 
-            from mcp.server.fastmcp.exceptions import ToolError as _ToolError  # noqa: PLC0415
-
-            exists = await _table_exists(sql_target, schema, table_name, mode=ctx.auth_mode)
+            exists = await table_exists(sql_target, schema, table_name, mode=ctx.auth_mode)
             if exists:
                 if if_exists == "fail":
                     raise _ToolError(
@@ -410,17 +400,43 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
                         "Use if_exists='append', 'truncate', or 'replace'."
                     )
                 if if_exists == "truncate":
-                    await _truncate_table_sql(sql_target, schema, table_name, mode=ctx.auth_mode)
+                    # Destructive guard: only fire when a TRUNCATE will actually execute.
+                    from fabric_dw.mcp._guards import assert_destructive_allowed  # noqa: PLC0415
+
+                    assert_destructive_allowed()
+                    await truncate_table(sql_target, schema, table_name, mode=ctx.auth_mode)
                 elif if_exists == "replace":
+                    # replace requires destructive flag even though it raises below —
+                    # the intent is destructive regardless of the error.
+                    from fabric_dw.mcp._guards import assert_destructive_allowed  # noqa: PLC0415
+
+                    assert_destructive_allowed()
                     # For remote URLs we cannot infer schema without downloading;
                     # the user should use the CLI for auto-create from local files.
                     raise _ToolError(
-                        "if_exists='replace' for remote URLs requires a pre-existing schema. "
-                        "Use if_exists='truncate' to keep the current schema, or download "
-                        "the file locally and use the CLI 'tables load --file --create "
-                        "--if-exists replace' for full auto-create from schema."
+                        "if_exists='replace' for remote URLs requires downloading the file "
+                        "to infer schema. Use if_exists='truncate' to keep the current schema, "
+                        "or download the file locally and use the CLI "
+                        "'tables load --file --create --if-exists replace'."
                     )
-                # "append": do nothing
+                # "append": do nothing — COPY INTO will add rows to the existing table.
+            else:
+                # Table does not exist.
+                if if_exists == "truncate":
+                    raise _ToolError(
+                        f"Table [{schema}].[{table_name}] does not exist; "
+                        "nothing to truncate. Create the table first or use "
+                        "if_exists='fail' / 'append'."
+                    )
+                if if_exists == "replace":
+                    raise _ToolError(
+                        f"Table [{schema}].[{table_name}] does not exist; "
+                        "if_exists='replace' for remote URLs requires downloading the file "
+                        "to infer schema. Use the CLI "
+                        "'tables load --file --create --if-exists replace' instead."
+                    )
+                # "fail" or "append" on absent table: proceed; COPY INTO will raise a
+                # clear SQL error if the table truly does not exist.
 
             result = await copy_into_from_url(
                 sql_target,

--- a/src/fabric_dw/services/load.py
+++ b/src/fabric_dw/services/load.py
@@ -49,13 +49,17 @@ from fabric_dw.sql import SqlTarget, run_query
 __all__ = [
     "CopyIntoCredentialType",
     "CopyIntoCsvOptions",
+    "IfExistsPolicy",
     "copy_into_from_url",
+    "create_and_load",
     "create_staging_lakehouse",
     "delete_lakehouse",
     "infer_file_format",
     "load_local_file",
     "onelake_upload_file",
 ]
+
+IfExistsPolicy = Literal["fail", "append", "truncate", "replace"]
 
 _logger = logging.getLogger(__name__)
 
@@ -872,3 +876,387 @@ async def load_local_file(  # noqa: PLR0912, PLR0915
                     converted_path,
                     exc,
                 )
+
+
+# ---------------------------------------------------------------------------
+# Table existence check
+# ---------------------------------------------------------------------------
+
+
+async def _table_exists(
+    target: SqlTarget,
+    schema: str,
+    table: str,
+    mode: object = None,
+) -> bool:
+    """Return True when ``[schema].[table]`` exists in ``sys.tables``."""
+    from fabric_dw.auth import CredentialMode  # noqa: PLC0415
+
+    _mode = mode if isinstance(mode, CredentialMode) else CredentialMode.DEFAULT
+
+    _sql = (
+        "SELECT 1 FROM sys.tables t "
+        "JOIN sys.schemas s ON s.schema_id = t.schema_id "
+        "WHERE s.name = ? AND t.name = ?;"
+    )
+
+    def _run() -> bool:
+        _cols, rows = run_query(target, _sql, params=[schema, table], mode=_mode)
+        return bool(rows)
+
+    return await asyncio.to_thread(_run)
+
+
+async def _drop_table_sql(
+    target: SqlTarget,
+    schema: str,
+    table: str,
+    mode: object = None,
+) -> None:
+    """Issue ``DROP TABLE [schema].[table]``."""
+    from fabric_dw.auth import CredentialMode  # noqa: PLC0415
+
+    _mode = mode if isinstance(mode, CredentialMode) else CredentialMode.DEFAULT
+    ddl = f"DROP TABLE {quote_identifier(schema)}.{quote_identifier(table)}"
+
+    def _run() -> None:
+        run_query(target, ddl, mode=_mode, commit=True, fetch="none")
+
+    await asyncio.to_thread(_run)
+
+
+async def _truncate_table_sql(
+    target: SqlTarget,
+    schema: str,
+    table: str,
+    mode: object = None,
+) -> None:
+    """Issue ``TRUNCATE TABLE [schema].[table]``."""
+    from fabric_dw.auth import CredentialMode  # noqa: PLC0415
+
+    _mode = mode if isinstance(mode, CredentialMode) else CredentialMode.DEFAULT
+    ddl = f"TRUNCATE TABLE {quote_identifier(schema)}.{quote_identifier(table)}"
+
+    def _run() -> None:
+        run_query(target, ddl, mode=_mode, commit=True, fetch="none")
+
+    await asyncio.to_thread(_run)
+
+
+# ---------------------------------------------------------------------------
+# Schema inference for local files (reuse #308 helpers)
+# ---------------------------------------------------------------------------
+
+
+async def _infer_columns_from_local(  # noqa: PLR0915
+    local_path: Path,
+    fmt: FileFormat,
+    *,
+    all_varchar: bool = False,
+    varchar_length: int = 8000,
+    sample_rows: int = 1000,
+    csv_delimiter: str = ",",
+    csv_encoding: str = "utf-8-sig",
+) -> list:
+    """Infer :class:`~fabric_dw.models.ColumnSpec` list from a local file.
+
+    Uses the #308 helpers from :mod:`fabric_dw.services.tables`:
+    - Parquet: ``pq.read_schema`` (footer only).
+    - CSV: ``pyarrow.csv.open_csv`` with bounded sampling.
+    - JSON: convert to Parquet via :func:`_json_to_parquet`, then read schema.
+
+    Returns a list of :class:`~fabric_dw.models.ColumnSpec`.
+    """
+    from fabric_dw.models import ColumnSpec  # noqa: PLC0415
+    from fabric_dw.types import arrow_type_to_tsql  # noqa: PLC0415
+
+    if fmt == "parquet":
+        import pyarrow.parquet as pq  # noqa: PLC0415
+
+        arrow_schema = await asyncio.to_thread(pq.read_schema, str(local_path))
+        columns: list[ColumnSpec] = []
+        for field in arrow_schema:
+            sql_type = arrow_type_to_tsql(field.type, field.name, varchar_length=varchar_length)
+            columns.append(ColumnSpec(name=field.name, sql_type=sql_type, nullable=field.nullable))
+        return columns
+
+    if fmt == "json":
+        # JSON → Parquet (same path used by load_local_file); schema comes for free.
+        converted: Path | None = None
+        try:
+            converted = await asyncio.to_thread(_json_to_parquet, local_path)
+            return await _infer_columns_from_local(
+                converted,
+                "parquet",
+                all_varchar=all_varchar,
+                varchar_length=varchar_length,
+            )
+        finally:
+            if converted is not None:
+                import contextlib as _cl  # noqa: PLC0415
+
+                with _cl.suppress(OSError):
+                    converted.unlink(missing_ok=True)
+
+    # CSV
+    import pyarrow as pa  # noqa: PLC0415
+    import pyarrow.csv as pa_csv  # noqa: PLC0415
+
+    if all_varchar:
+        import csv  # noqa: PLC0415
+
+        with local_path.open(encoding=csv_encoding, newline="") as fh:
+            reader = csv.reader(fh, delimiter=csv_delimiter)
+            try:
+                header = next(reader)
+            except StopIteration:
+                msg = f"CSV file is empty: {local_path}"
+                raise ValueError(msg) from None
+        from fabric_dw.models import ColumnSpec  # noqa: PLC0415
+
+        return [
+            ColumnSpec(name=col_name, sql_type=f"VARCHAR({varchar_length})", nullable=True)
+            for col_name in header
+        ]
+
+    read_opts = pa_csv.ReadOptions(encoding=csv_encoding)
+    parse_opts = pa_csv.ParseOptions(delimiter=csv_delimiter)
+    convert_opts = pa_csv.ConvertOptions(null_values=["", "NULL", "null", "NA", "N/A"])
+
+    def _read_csv_sample() -> pa.Table:
+        reader = pa_csv.open_csv(
+            str(local_path),
+            read_options=read_opts,
+            parse_options=parse_opts,
+            convert_options=convert_opts,
+        )
+        inferred_schema = reader.schema
+        batches: list[pa.RecordBatch] = []
+        rows_seen = 0
+        for batch in reader:
+            remaining = sample_rows - rows_seen
+            chunk = batch.slice(0, remaining) if batch.num_rows > remaining else batch
+            batches.append(chunk)
+            rows_seen += chunk.num_rows
+            if rows_seen >= sample_rows:
+                break
+        if not batches:
+            return inferred_schema.empty_table()
+        return pa.Table.from_batches(batches)
+
+    arrow_table = await asyncio.to_thread(_read_csv_sample)
+    columns_csv: list[ColumnSpec] = []  # type: ignore[type-arg]
+    for i, name in enumerate(arrow_table.schema.names):
+        field = arrow_table.schema.field(i)
+        try:
+            sql_type = arrow_type_to_tsql(field.type, name, varchar_length=varchar_length)
+        except ValueError:
+            _logger.warning(
+                "create_and_load CSV: column %r inferred type %r has no T-SQL mapping; "
+                "falling back to VARCHAR(%d)",
+                name,
+                field.type,
+                varchar_length,
+            )
+            sql_type = f"VARCHAR({varchar_length})"
+        columns_csv.append(ColumnSpec(name=name, sql_type=sql_type, nullable=True))
+    return columns_csv
+
+
+# ---------------------------------------------------------------------------
+# create_and_load — public API
+# ---------------------------------------------------------------------------
+
+
+async def create_and_load(
+    http: FabricHttpClient,
+    credential: AsyncTokenCredential,
+    workspace_id: uuid.UUID,
+    target: SqlTarget,
+    schema: str,
+    table: str,
+    local_path: Path,
+    *,
+    if_exists: IfExistsPolicy = "fail",
+    file_format: FileFormat | None = None,
+    staging_lakehouse_name: str | None = None,
+    keep_staging: bool = False,
+    csv_options: CopyIntoCsvOptions | None = None,
+    max_errors: int | None = None,
+    rejected_row_location: str | None = None,
+    kind: WarehouseKind = WarehouseKind.WAREHOUSE,
+    mode: object = None,
+    cleanup_on_failure: bool = False,
+    # Schema-inference options
+    all_varchar: bool = False,
+    varchar_length: int = 8000,
+    sample_rows: int = 1000,
+    csv_delimiter: str = ",",
+    csv_encoding: str = "utf-8-sig",
+) -> CopyIntoResult:
+    """Create the target table from the source schema and load data into it.
+
+    Combines schema inference (#308) with ``COPY INTO`` (#309) in a single call.
+
+    Flow
+    ----
+    1. Guard: SQL Analytics Endpoints are rejected (CREATE TABLE + COPY INTO are
+       Data Warehouse-only).
+    2. Infer columns from *local_path* (Parquet footer / CSV header+sample /
+       JSON→Parquet; reuses #308 helpers).
+    3. Check whether ``[schema].[table]`` already exists.
+    4. Apply the *if_exists* policy:
+
+       - ``"fail"`` — raise :class:`ValueError` when the table already exists.
+       - ``"append"`` — skip CREATE, load into the existing table.
+       - ``"truncate"`` — TRUNCATE the existing table, then load.
+       - ``"replace"`` — DROP + recreate from inferred schema, then load.
+
+    5. Create the table when needed (via #308 ``create_empty_table``).
+    6. Load via #309 ``load_local_file``.
+    7. If we created the table and *cleanup_on_failure* is ``True``, drop the
+       table on load failure — but **never** drop a pre-existing table.
+
+    Args:
+        http: Authenticated Fabric HTTP client.
+        credential: Azure credential for storage-scoped token (DFS upload).
+        workspace_id: Workspace in which to stage and load.
+        target: SQL connection target (warehouse connection string).
+        schema: Validated SQL schema name.
+        table: Validated SQL table name.
+        local_path: Path to the local file (CSV, Parquet, or JSON).
+        if_exists: Policy when the table already exists.  One of ``"fail"``,
+            ``"append"``, ``"truncate"``, or ``"replace"``.
+        file_format: Explicit format; inferred from extension when ``None``.
+        staging_lakehouse_name: Explicit staging Lakehouse name; auto-generated
+            when ``None``.
+        keep_staging: Keep the staging Lakehouse after loading (debugging).
+        csv_options: CSV loading options (used when file_format is ``"csv"``).
+        max_errors: Maximum errors before aborting the load.
+        rejected_row_location: URL for rejected-row output.
+        kind: Warehouse item kind.  SQL Analytics Endpoints are rejected.
+        mode: Credential mode for SQL authentication.
+        cleanup_on_failure: Drop the table if WE created it and the load fails.
+            Pre-existing tables are never dropped.
+        all_varchar: Force all CSV columns to ``VARCHAR(*varchar_length*)``.
+        varchar_length: Default VARCHAR/VARBINARY length for inferred columns.
+        sample_rows: Maximum rows to sample for CSV type inference.
+        csv_delimiter: CSV field delimiter (used for schema inference only).
+        csv_encoding: CSV encoding for schema inference.
+
+    Returns:
+        A :class:`~fabric_dw.models.CopyIntoResult`.
+
+    Raises:
+        ItemKindError: If *kind* is SQL_ENDPOINT.
+        ValueError: If the table exists and *if_exists* is ``"fail"``, or if
+            the file format is unrecognised or unsupported.
+        FileNotFoundError: If *local_path* does not exist.
+    """
+    _assert_not_sql_endpoint(kind)
+    validate_identifier(schema)
+    validate_identifier(table)
+
+    if not local_path.exists():
+        msg = f"Local file not found: {local_path}"
+        raise FileNotFoundError(msg)
+
+    fmt = file_format or infer_file_format(local_path)
+
+    # Step 1: infer schema from the source file.
+    _logger.debug("create_and_load: inferring schema from %s (format=%s)", local_path.name, fmt)
+    columns = await _infer_columns_from_local(
+        local_path,
+        fmt,
+        all_varchar=all_varchar,
+        varchar_length=varchar_length,
+        sample_rows=sample_rows,
+        csv_delimiter=csv_delimiter,
+        csv_encoding=csv_encoding,
+    )
+
+    # Step 2: check existence.
+    exists = await _table_exists(target, schema, table, mode=mode)
+
+    # Track whether WE created the table so cleanup_on_failure is scoped.
+    we_created = False
+
+    if exists:
+        if if_exists == "fail":
+            msg = (
+                f"Table [{schema}].[{table}] already exists. "
+                "Use --if-exists append/truncate/replace to handle existing tables."
+            )
+            raise ValueError(msg)
+        if if_exists == "truncate":
+            _logger.info("create_and_load: TRUNCATE TABLE [%s].[%s]", schema, table)
+            await _truncate_table_sql(target, schema, table, mode=mode)
+        elif if_exists == "replace":
+            _logger.info("create_and_load: DROP + recreate TABLE [%s].[%s]", schema, table)
+            await _drop_table_sql(target, schema, table, mode=mode)
+            await _create_table_from_columns(target, schema, table, columns, kind=kind, mode=mode)
+            we_created = True
+        # "append": do nothing — COPY INTO will add rows to the existing table.
+    else:
+        # Table does not exist — create it (for "fail", "replace", "append" with no table).
+        _logger.info("create_and_load: CREATE TABLE [%s].[%s]", schema, table)
+        await _create_table_from_columns(target, schema, table, columns, kind=kind, mode=mode)
+        we_created = True
+
+    # Step 3: load data.
+    try:
+        result = await load_local_file(
+            http,
+            credential,
+            workspace_id,
+            target,
+            schema,
+            table,
+            local_path,
+            file_format=fmt,
+            staging_lakehouse_name=staging_lakehouse_name,
+            keep_staging=keep_staging,
+            csv_options=csv_options,
+            max_errors=max_errors,
+            rejected_row_location=rejected_row_location,
+            kind=kind,
+            mode=mode,
+        )
+    except Exception:
+        if cleanup_on_failure and we_created:
+            _logger.info("create_and_load: cleanup_on_failure — dropping [%s].[%s]", schema, table)
+            try:
+                await _drop_table_sql(target, schema, table, mode=mode)
+            except Exception as drop_exc:
+                _logger.warning("create_and_load: cleanup_on_failure drop failed: %s", drop_exc)
+        raise
+
+    _logger.info(
+        "create_and_load: loaded %d rows into [%s].[%s] (rejected=%d)",
+        result.rows_loaded,
+        schema,
+        table,
+        result.rows_rejected,
+    )
+    return result
+
+
+async def _create_table_from_columns(
+    target: SqlTarget,
+    schema: str,
+    table: str,
+    columns: list,
+    *,
+    kind: WarehouseKind = WarehouseKind.WAREHOUSE,
+    mode: object = None,
+) -> None:
+    """Create an empty table from an inferred column list.
+
+    Thin wrapper delegating to
+    :func:`~fabric_dw.services.tables.create_empty_table`.
+    """
+    from fabric_dw.auth import CredentialMode  # noqa: PLC0415
+    from fabric_dw.services.tables import create_empty_table  # noqa: PLC0415
+
+    _mode = mode if isinstance(mode, CredentialMode) else CredentialMode.DEFAULT
+    await create_empty_table(target, schema, table, columns, kind=kind, mode=_mode)

--- a/src/fabric_dw/services/load.py
+++ b/src/fabric_dw/services/load.py
@@ -57,6 +57,8 @@ __all__ = [
     "infer_file_format",
     "load_local_file",
     "onelake_upload_file",
+    "table_exists",
+    "truncate_table",
 ]
 
 IfExistsPolicy = Literal["fail", "append", "truncate", "replace"]
@@ -883,6 +885,26 @@ async def load_local_file(  # noqa: PLR0912, PLR0915
 # ---------------------------------------------------------------------------
 
 
+async def table_exists(
+    target: SqlTarget,
+    schema: str,
+    table: str,
+    mode: object = None,
+) -> bool:
+    """Return ``True`` when ``[schema].[table]`` exists in ``sys.tables``."""
+    return await _table_exists(target, schema, table, mode=mode)
+
+
+async def truncate_table(
+    target: SqlTarget,
+    schema: str,
+    table: str,
+    mode: object = None,
+) -> None:
+    """Issue ``TRUNCATE TABLE [schema].[table]``."""
+    await _truncate_table_sql(target, schema, table, mode=mode)
+
+
 async def _table_exists(
     target: SqlTarget,
     schema: str,
@@ -948,7 +970,7 @@ async def _truncate_table_sql(
 # ---------------------------------------------------------------------------
 
 
-async def _infer_columns_from_local(  # noqa: PLR0915
+async def _infer_columns_from_local(
     local_path: Path,
     fmt: FileFormat,
     *,
@@ -960,37 +982,31 @@ async def _infer_columns_from_local(  # noqa: PLR0915
 ) -> list:
     """Infer :class:`~fabric_dw.models.ColumnSpec` list from a local file.
 
-    Uses the #308 helpers from :mod:`fabric_dw.services.tables`:
-    - Parquet: ``pq.read_schema`` (footer only).
-    - CSV: ``pyarrow.csv.open_csv`` with bounded sampling.
-    - JSON: convert to Parquet via :func:`_json_to_parquet`, then read schema.
+    Delegates to the public helpers in :mod:`fabric_dw.services.tables`:
+
+    - Parquet: :func:`~fabric_dw.services.tables.infer_columns_from_parquet`
+      (reads the Parquet footer only — no data rows).
+    - CSV: :func:`~fabric_dw.services.tables.infer_columns_from_csv`
+      (header + bounded sample via ``pyarrow.csv``).
+    - JSON: converts to Parquet via :func:`_json_to_parquet`, then delegates
+      to the Parquet path above.
 
     Returns a list of :class:`~fabric_dw.models.ColumnSpec`.
     """
-    from fabric_dw.models import ColumnSpec  # noqa: PLC0415
-    from fabric_dw.types import arrow_type_to_tsql  # noqa: PLC0415
+    from fabric_dw.services.tables import (  # noqa: PLC0415
+        infer_columns_from_csv,
+        infer_columns_from_parquet,
+    )
 
     if fmt == "parquet":
-        import pyarrow.parquet as pq  # noqa: PLC0415
-
-        arrow_schema = await asyncio.to_thread(pq.read_schema, str(local_path))
-        columns: list[ColumnSpec] = []
-        for field in arrow_schema:
-            sql_type = arrow_type_to_tsql(field.type, field.name, varchar_length=varchar_length)
-            columns.append(ColumnSpec(name=field.name, sql_type=sql_type, nullable=field.nullable))
-        return columns
+        return await infer_columns_from_parquet(local_path, varchar_length=varchar_length)
 
     if fmt == "json":
         # JSON → Parquet (same path used by load_local_file); schema comes for free.
         converted: Path | None = None
         try:
             converted = await asyncio.to_thread(_json_to_parquet, local_path)
-            return await _infer_columns_from_local(
-                converted,
-                "parquet",
-                all_varchar=all_varchar,
-                varchar_length=varchar_length,
-            )
+            return await infer_columns_from_parquet(converted, varchar_length=varchar_length)
         finally:
             if converted is not None:
                 import contextlib as _cl  # noqa: PLC0415
@@ -999,68 +1015,14 @@ async def _infer_columns_from_local(  # noqa: PLR0915
                     converted.unlink(missing_ok=True)
 
     # CSV
-    import pyarrow as pa  # noqa: PLC0415
-    import pyarrow.csv as pa_csv  # noqa: PLC0415
-
-    if all_varchar:
-        import csv  # noqa: PLC0415
-
-        with local_path.open(encoding=csv_encoding, newline="") as fh:
-            reader = csv.reader(fh, delimiter=csv_delimiter)
-            try:
-                header = next(reader)
-            except StopIteration:
-                msg = f"CSV file is empty: {local_path}"
-                raise ValueError(msg) from None
-        from fabric_dw.models import ColumnSpec  # noqa: PLC0415
-
-        return [
-            ColumnSpec(name=col_name, sql_type=f"VARCHAR({varchar_length})", nullable=True)
-            for col_name in header
-        ]
-
-    read_opts = pa_csv.ReadOptions(encoding=csv_encoding)
-    parse_opts = pa_csv.ParseOptions(delimiter=csv_delimiter)
-    convert_opts = pa_csv.ConvertOptions(null_values=["", "NULL", "null", "NA", "N/A"])
-
-    def _read_csv_sample() -> pa.Table:
-        reader = pa_csv.open_csv(
-            str(local_path),
-            read_options=read_opts,
-            parse_options=parse_opts,
-            convert_options=convert_opts,
-        )
-        inferred_schema = reader.schema
-        batches: list[pa.RecordBatch] = []
-        rows_seen = 0
-        for batch in reader:
-            remaining = sample_rows - rows_seen
-            chunk = batch.slice(0, remaining) if batch.num_rows > remaining else batch
-            batches.append(chunk)
-            rows_seen += chunk.num_rows
-            if rows_seen >= sample_rows:
-                break
-        if not batches:
-            return inferred_schema.empty_table()
-        return pa.Table.from_batches(batches)
-
-    arrow_table = await asyncio.to_thread(_read_csv_sample)
-    columns_csv: list[ColumnSpec] = []  # type: ignore[type-arg]
-    for i, name in enumerate(arrow_table.schema.names):
-        field = arrow_table.schema.field(i)
-        try:
-            sql_type = arrow_type_to_tsql(field.type, name, varchar_length=varchar_length)
-        except ValueError:
-            _logger.warning(
-                "create_and_load CSV: column %r inferred type %r has no T-SQL mapping; "
-                "falling back to VARCHAR(%d)",
-                name,
-                field.type,
-                varchar_length,
-            )
-            sql_type = f"VARCHAR({varchar_length})"
-        columns_csv.append(ColumnSpec(name=name, sql_type=sql_type, nullable=True))
-    return columns_csv
+    return await infer_columns_from_csv(
+        local_path,
+        all_varchar=all_varchar,
+        varchar_length=varchar_length,
+        sample_rows=sample_rows,
+        delimiter=csv_delimiter,
+        encoding=csv_encoding,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/fabric_dw/services/tables.py
+++ b/src/fabric_dw/services/tables.py
@@ -46,6 +46,8 @@ __all__ = [
     "create_table_from_csv",
     "create_table_from_parquet",
     "delete_table",
+    "infer_columns_from_csv",
+    "infer_columns_from_parquet",
     "list_tables",
     "read_table",
     "rename_table",
@@ -334,6 +336,49 @@ async def create_empty_table(
     return await _fetch_table(target, schema, table_name, mode=mode)
 
 
+async def infer_columns_from_parquet(
+    parquet_path: Path,
+    *,
+    varchar_length: int = 8000,
+) -> list[ColumnSpec]:
+    """Infer a :class:`~fabric_dw.models.ColumnSpec` list from a Parquet file footer.
+
+    Reads **only the Parquet footer** (schema metadata) — no data rows are ever
+    loaded.  Arrow types are mapped to Fabric-DW-supported T-SQL types via
+    :func:`~fabric_dw.types.arrow_type_to_tsql`.  Nullability is taken from the
+    Arrow schema field.
+
+    Args:
+        parquet_path: Path to the Parquet file.  Only the file footer is read.
+        varchar_length: Default VARCHAR/VARBINARY length for string and binary
+            columns.  Defaults to 8000 (Fabric DW non-MAX maximum).
+
+    Returns:
+        A list of :class:`~fabric_dw.models.ColumnSpec` instances (one per column).
+
+    Raises:
+        FileNotFoundError: If *parquet_path* does not exist.
+        ValueError: If any Parquet field maps to an unsupported T-SQL type.
+    """
+    import pyarrow.parquet as pq  # noqa: PLC0415
+
+    if not parquet_path.exists():
+        msg = f"Parquet file not found: {parquet_path}"
+        raise FileNotFoundError(msg)
+
+    # Read schema only — pq.read_schema reads the footer without loading any row groups.
+    arrow_schema = await asyncio.to_thread(pq.read_schema, str(parquet_path))
+
+    columns: list[ColumnSpec] = []
+    for field in arrow_schema:
+        sql_type = arrow_type_to_tsql(field.type, field.name, varchar_length=varchar_length)
+        nullable = field.nullable
+        columns.append(ColumnSpec(name=field.name, sql_type=sql_type, nullable=nullable))
+
+    _log.debug("infer_columns_from_parquet: %d columns from %s", len(columns), parquet_path.name)
+    return columns
+
+
 async def create_table_from_parquet(
     target: SqlTarget,
     schema: str,
@@ -372,25 +417,136 @@ async def create_table_from_parquet(
             or if any derived identifier fails validation.
         FileNotFoundError: If *parquet_path* does not exist.
     """
-    import pyarrow.parquet as pq  # noqa: PLC0415
-
     _assert_not_sql_endpoint(kind)
-    if not parquet_path.exists():
-        msg = f"Parquet file not found: {parquet_path}"
-        raise FileNotFoundError(msg)
-
-    # Read schema only — pq.read_schema reads the footer without loading any row groups.
-    # Wrapped in asyncio.to_thread for consistency with other blocking I/O in this module.
-    arrow_schema = await asyncio.to_thread(pq.read_schema, str(parquet_path))
-
-    columns: list[ColumnSpec] = []
-    for field in arrow_schema:
-        sql_type = arrow_type_to_tsql(field.type, field.name, varchar_length=varchar_length)
-        nullable = field.nullable
-        columns.append(ColumnSpec(name=field.name, sql_type=sql_type, nullable=nullable))
-
+    columns = await infer_columns_from_parquet(parquet_path, varchar_length=varchar_length)
     _log.debug("create_table_from_parquet: %d columns from %s", len(columns), parquet_path.name)
     return await create_empty_table(target, schema, table_name, columns, kind=kind, mode=mode)
+
+
+async def infer_columns_from_csv(
+    csv_path: Path,
+    *,
+    all_varchar: bool = False,
+    varchar_length: int = 8000,
+    sample_rows: int = 1000,
+    delimiter: str = ",",
+    encoding: str = "utf-8-sig",
+) -> list[ColumnSpec]:
+    """Infer a :class:`~fabric_dw.models.ColumnSpec` list from a CSV file.
+
+    Reads the CSV **header row + a bounded sample** of rows for type inference.
+    No data is inserted into the warehouse; this is a pure inference operation.
+
+    When *all_varchar* is ``True``, every column becomes
+    ``VARCHAR(*varchar_length*)`` regardless of observed values.
+
+    Args:
+        csv_path: Path to the CSV file.  Only the header + a bounded sample are read.
+        all_varchar: Force all columns to ``VARCHAR(*varchar_length*)``, overriding
+            inference.  Useful when inference produces unexpected results.
+        varchar_length: Length for VARCHAR columns (default 8000).
+        sample_rows: Maximum number of rows to read for type inference (default 1000).
+        delimiter: CSV field delimiter (default ``,``).
+        encoding: File encoding (default ``utf-8-sig`` to strip BOM if present).
+
+    Returns:
+        A list of :class:`~fabric_dw.models.ColumnSpec` instances (one per column).
+
+    Raises:
+        FileNotFoundError: If *csv_path* does not exist.
+        ValueError: If the CSV file is empty (no header row), or if any inferred
+            Arrow type cannot be mapped to a T-SQL type and fallback fails.
+    """
+    if not csv_path.exists():
+        msg = f"CSV file not found: {csv_path}"
+        raise FileNotFoundError(msg)
+
+    if all_varchar:
+        # Read just the header row to get column names.
+        import csv  # noqa: PLC0415
+
+        with csv_path.open(encoding=encoding, newline="") as fh:
+            reader = csv.reader(fh, delimiter=delimiter)
+            try:
+                header = next(reader)
+            except StopIteration:
+                msg = f"CSV file is empty: {csv_path}"
+                raise ValueError(msg) from None
+
+        return [
+            ColumnSpec(name=col_name, sql_type=f"VARCHAR({varchar_length})", nullable=True)
+            for col_name in header
+        ]
+
+    # Read header + a bounded sample for type inference via pyarrow.csv.
+    # Use open_csv() (streaming batches) so that only a prefix of the file
+    # is ever loaded into memory — read_csv() would buffer the entire file
+    # before slice() could discard excess rows.
+    import pyarrow as pa  # noqa: PLC0415
+    import pyarrow.csv as pa_csv  # noqa: PLC0415
+
+    read_opts = pa_csv.ReadOptions(encoding=encoding)
+    parse_opts = pa_csv.ParseOptions(delimiter=delimiter)
+    # ConvertOptions: auto-convert types, treat empty fields as null
+    convert_opts = pa_csv.ConvertOptions(null_values=["", "NULL", "null", "NA", "N/A"])
+
+    def _read_csv_sample() -> pa.Table:
+        """Read at most *sample_rows* rows via the streaming CSV reader.
+
+        Uses :func:`pyarrow.csv.open_csv` (batch streaming) so that the
+        file is read lazily and iteration stops as soon as *sample_rows*
+        rows have been accumulated.  Only the prefix of the file is ever
+        loaded into memory, regardless of total file size.
+        """
+        reader = pa_csv.open_csv(
+            str(csv_path),
+            read_options=read_opts,
+            parse_options=parse_opts,
+            convert_options=convert_opts,
+        )
+        # reader.schema is available before iteration and reflects inferred types.
+        inferred_schema = reader.schema
+        batches: list[pa.RecordBatch] = []
+        rows_seen = 0
+        for batch in reader:
+            remaining = sample_rows - rows_seen
+            chunk = batch.slice(0, remaining) if batch.num_rows > remaining else batch
+            batches.append(chunk)
+            rows_seen += chunk.num_rows
+            if rows_seen >= sample_rows:
+                break
+        if not batches:
+            # Header-only CSV — return a zero-row table so schema is preserved.
+            return inferred_schema.empty_table()
+        return pa.Table.from_batches(batches)
+
+    arrow_table = await asyncio.to_thread(_read_csv_sample)
+    _log.debug(
+        "infer_columns_from_csv: read %d sample rows from %s for type inference",
+        arrow_table.num_rows,
+        csv_path.name,
+    )
+
+    columns: list[ColumnSpec] = []
+    for i, name in enumerate(arrow_table.schema.names):
+        field = arrow_table.schema.field(i)
+        try:
+            sql_type = arrow_type_to_tsql(field.type, name, varchar_length=varchar_length)
+        except ValueError:
+            # Fall back to VARCHAR for non-mappable inferred types.
+            _log.warning(
+                "Column %r: inferred Arrow type %r has no T-SQL equivalent; "
+                "falling back to VARCHAR(%d)",
+                name,
+                field.type,
+                varchar_length,
+            )
+            sql_type = f"VARCHAR({varchar_length})"
+        # CSV columns are always nullable (empty cells).
+        columns.append(ColumnSpec(name=name, sql_type=sql_type, nullable=True))
+
+    _log.debug("infer_columns_from_csv: %d columns from %s", len(columns), csv_path.name)
+    return columns
 
 
 async def create_table_from_csv(
@@ -448,98 +604,15 @@ async def create_table_from_csv(
             or if any column name fails identifier validation.
         FileNotFoundError: If *csv_path* does not exist.
     """
-    import pyarrow.csv as pa_csv  # noqa: PLC0415
-
     _assert_not_sql_endpoint(kind)
-    if not csv_path.exists():
-        msg = f"CSV file not found: {csv_path}"
-        raise FileNotFoundError(msg)
-
-    use_varchar = all_varchar or not infer_types
-
-    if use_varchar:
-        # Read just the header row to get column names.
-        import csv  # noqa: PLC0415
-
-        with csv_path.open(encoding=encoding, newline="") as fh:
-            reader = csv.reader(fh, delimiter=delimiter)
-            try:
-                header = next(reader)
-            except StopIteration:
-                msg = f"CSV file is empty: {csv_path}"
-                raise ValueError(msg) from None
-
-        columns = [
-            ColumnSpec(name=col_name, sql_type=f"VARCHAR({varchar_length})", nullable=True)
-            for col_name in header
-        ]
-    else:
-        # Read header + a bounded sample for type inference via pyarrow.csv.
-        # Use open_csv() (streaming batches) so that only a prefix of the file
-        # is ever loaded into memory — read_csv() would buffer the entire file
-        # before slice() could discard excess rows.
-        import pyarrow as pa  # noqa: PLC0415
-
-        read_opts = pa_csv.ReadOptions(encoding=encoding)
-        parse_opts = pa_csv.ParseOptions(delimiter=delimiter)
-        # ConvertOptions: auto-convert types, treat empty fields as null
-        convert_opts = pa_csv.ConvertOptions(null_values=["", "NULL", "null", "NA", "N/A"])
-
-        def _read_csv_sample() -> pa.Table:
-            """Read at most *sample_rows* rows via the streaming CSV reader.
-
-            Uses :func:`pyarrow.csv.open_csv` (batch streaming) so that the
-            file is read lazily and iteration stops as soon as *sample_rows*
-            rows have been accumulated.  Only the prefix of the file is ever
-            loaded into memory, regardless of total file size.
-            """
-            reader = pa_csv.open_csv(
-                str(csv_path),
-                read_options=read_opts,
-                parse_options=parse_opts,
-                convert_options=convert_opts,
-            )
-            # reader.schema is available before iteration and reflects inferred types.
-            inferred_schema = reader.schema
-            batches: list[pa.RecordBatch] = []
-            rows_seen = 0
-            for batch in reader:
-                remaining = sample_rows - rows_seen
-                chunk = batch.slice(0, remaining) if batch.num_rows > remaining else batch
-                batches.append(chunk)
-                rows_seen += chunk.num_rows
-                if rows_seen >= sample_rows:
-                    break
-            if not batches:
-                # Header-only CSV — return a zero-row table so schema is preserved.
-                return inferred_schema.empty_table()
-            return pa.Table.from_batches(batches)
-
-        arrow_table = await asyncio.to_thread(_read_csv_sample)
-        _log.debug(
-            "create_table_from_csv: read %d sample rows from %s for type inference",
-            arrow_table.num_rows,
-            csv_path.name,
-        )
-
-        columns = []
-        for i, name in enumerate(arrow_table.schema.names):
-            field = arrow_table.schema.field(i)
-            try:
-                sql_type = arrow_type_to_tsql(field.type, name, varchar_length=varchar_length)
-            except ValueError:
-                # Fall back to VARCHAR for non-mappable inferred types.
-                _log.warning(
-                    "Column %r: inferred Arrow type %r has no T-SQL equivalent; "
-                    "falling back to VARCHAR(%d)",
-                    name,
-                    field.type,
-                    varchar_length,
-                )
-                sql_type = f"VARCHAR({varchar_length})"
-            # CSV columns are always nullable (empty cells).
-            columns.append(ColumnSpec(name=name, sql_type=sql_type, nullable=True))
-
+    columns = await infer_columns_from_csv(
+        csv_path,
+        all_varchar=all_varchar or not infer_types,
+        varchar_length=varchar_length,
+        sample_rows=sample_rows,
+        delimiter=delimiter,
+        encoding=encoding,
+    )
     _log.debug("create_table_from_csv: %d columns from %s", len(columns), csv_path.name)
     return await create_empty_table(target, schema, table_name, columns, kind=kind, mode=mode)
 

--- a/tests/integration/test_services_create_and_load.py
+++ b/tests/integration/test_services_create_and_load.py
@@ -1,0 +1,490 @@
+"""Integration tests for create_and_load — requires real Fabric credentials.
+
+Run with: pytest -m integration tests/integration/test_services_create_and_load.py
+
+These tests:
+- Auto-create + load from local Parquet, CSV, and JSON.
+- Auto-create + load from a remote OneLake URL.
+- Replace an existing table (DROP + recreate + load).
+- Append into an existing table.
+- Truncate an existing table, then load.
+- --cleanup-on-failure drops ONLY the table we created.
+- Staging Lakehouse is cleaned up by the service.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import uuid
+from pathlib import Path
+from typing import Any
+
+import pytest
+import pytest_asyncio
+
+from fabric_dw.auth import get_credential
+from fabric_dw.http_client import FabricHttpClient
+from fabric_dw.services import tables
+from fabric_dw.services.load import (
+    create_and_load,
+)
+from fabric_dw.sql import SqlTarget, run_query
+
+pytestmark = pytest.mark.integration
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def http_and_cred():
+    """Yield (FabricHttpClient, credential) sharing the same credential object."""
+    cred = get_credential()
+    async with FabricHttpClient(cred) as client:
+        yield client, cred
+
+
+def _count_rows(target: SqlTarget, schema: str, table_name: str) -> int:
+    from fabric_dw.identifiers import quote_identifier  # noqa: PLC0415
+
+    schema_q = quote_identifier(schema)
+    table_q = quote_identifier(table_name)
+    _cols, rows = run_query(target, f"SELECT COUNT(*) FROM {schema_q}.{table_q}")  # noqa: S608
+    return int(rows[0][0]) if rows else 0
+
+
+async def _drop_table_if_exists(target: SqlTarget, schema: str, table_name: str) -> None:
+    with contextlib.suppress(Exception):
+        await tables.delete_table(target, schema, table_name)
+
+
+# ---------------------------------------------------------------------------
+# Tests: auto-create + load from Parquet
+# ---------------------------------------------------------------------------
+
+
+async def test_create_and_load_local_parquet(
+    warehouse_schema: tuple[SqlTarget, str],
+    http_and_cred: tuple[FabricHttpClient, Any],
+    tmp_path: Path,
+) -> None:
+    """Auto-create + load from a local Parquet file (schema inferred from footer)."""
+    import asyncio  # noqa: PLC0415
+
+    pytest.importorskip("pyarrow")
+    import pyarrow as pa  # noqa: PLC0415
+    import pyarrow.parquet as pap  # noqa: PLC0415
+
+    sql_target, schema = warehouse_schema
+    http, cred = http_and_cred
+    table_name = "pytest_cal_parquet"
+
+    parquet_file = tmp_path / "data.parquet"
+    pa_table = pa.table({"id": [1, 2, 3], "value": [10, 20, 30]})
+    pap.write_table(pa_table, parquet_file)
+
+    try:
+        workspace_id = uuid.UUID(sql_target.workspace_id)
+        result = await create_and_load(
+            http,
+            cred,
+            workspace_id,
+            sql_target,
+            schema,
+            table_name,
+            parquet_file,
+            if_exists="fail",
+            file_format="parquet",
+        )
+        assert result.rows_loaded == 3
+        row_count = await asyncio.to_thread(_count_rows, sql_target, schema, table_name)
+        assert row_count == 3
+    finally:
+        await _drop_table_if_exists(sql_target, schema, table_name)
+
+
+# ---------------------------------------------------------------------------
+# Tests: auto-create + load from CSV
+# ---------------------------------------------------------------------------
+
+
+async def test_create_and_load_local_csv(
+    warehouse_schema: tuple[SqlTarget, str],
+    http_and_cred: tuple[FabricHttpClient, Any],
+    tmp_path: Path,
+) -> None:
+    """Auto-create + load from a local CSV file."""
+    import asyncio  # noqa: PLC0415
+
+    sql_target, schema = warehouse_schema
+    http, cred = http_and_cred
+    table_name = "pytest_cal_csv"
+
+    csv_file = tmp_path / "data.csv"
+    csv_file.write_text("id,name\n1,Alice\n2,Bob\n", encoding="utf-8")
+
+    try:
+        workspace_id = uuid.UUID(sql_target.workspace_id)
+        from fabric_dw.services.load import CopyIntoCsvOptions  # noqa: PLC0415
+
+        csv_options = CopyIntoCsvOptions(first_row=2)
+        result = await create_and_load(
+            http,
+            cred,
+            workspace_id,
+            sql_target,
+            schema,
+            table_name,
+            csv_file,
+            if_exists="fail",
+            file_format="csv",
+            csv_options=csv_options,
+        )
+        assert result.rows_loaded == 2
+        row_count = await asyncio.to_thread(_count_rows, sql_target, schema, table_name)
+        assert row_count == 2
+    finally:
+        await _drop_table_if_exists(sql_target, schema, table_name)
+
+
+# ---------------------------------------------------------------------------
+# Tests: auto-create + load from JSON
+# ---------------------------------------------------------------------------
+
+
+async def test_create_and_load_local_json(
+    warehouse_schema: tuple[SqlTarget, str],
+    http_and_cred: tuple[FabricHttpClient, Any],
+    tmp_path: Path,
+) -> None:
+    """Auto-create + load from a local JSON file (converted to Parquet internally)."""
+    import asyncio  # noqa: PLC0415
+
+    pytest.importorskip("pyarrow")
+
+    sql_target, schema = warehouse_schema
+    http, cred = http_and_cred
+    table_name = "pytest_cal_json"
+
+    json_file = tmp_path / "data.json"
+    json_file.write_text('{"id": 1, "name": "X"}\n{"id": 2, "name": "Y"}\n', encoding="utf-8")
+
+    try:
+        workspace_id = uuid.UUID(sql_target.workspace_id)
+        result = await create_and_load(
+            http,
+            cred,
+            workspace_id,
+            sql_target,
+            schema,
+            table_name,
+            json_file,
+            if_exists="fail",
+            file_format="json",
+        )
+        assert result.rows_loaded == 2
+        row_count = await asyncio.to_thread(_count_rows, sql_target, schema, table_name)
+        assert row_count == 2
+    finally:
+        await _drop_table_if_exists(sql_target, schema, table_name)
+
+
+# ---------------------------------------------------------------------------
+# Append policy
+# ---------------------------------------------------------------------------
+
+
+async def test_create_and_load_append(
+    warehouse_schema: tuple[SqlTarget, str],
+    http_and_cred: tuple[FabricHttpClient, Any],
+    tmp_path: Path,
+) -> None:
+    """if_exists=append: load into existing table, doubling the rows."""
+    import asyncio  # noqa: PLC0415
+
+    pytest.importorskip("pyarrow")
+    import pyarrow as pa  # noqa: PLC0415
+    import pyarrow.parquet as pap  # noqa: PLC0415
+
+    sql_target, schema = warehouse_schema
+    http, cred = http_and_cred
+    table_name = "pytest_cal_append"
+
+    parquet_file = tmp_path / "data.parquet"
+    pa_table = pa.table({"id": [1, 2]})
+    pap.write_table(pa_table, parquet_file)
+
+    try:
+        workspace_id = uuid.UUID(sql_target.workspace_id)
+        # First load (creates table).
+        await create_and_load(
+            http,
+            cred,
+            workspace_id,
+            sql_target,
+            schema,
+            table_name,
+            parquet_file,
+            if_exists="fail",
+            file_format="parquet",
+        )
+        # Second load (appends).
+        result = await create_and_load(
+            http,
+            cred,
+            workspace_id,
+            sql_target,
+            schema,
+            table_name,
+            parquet_file,
+            if_exists="append",
+            file_format="parquet",
+        )
+        assert result.rows_loaded == 2
+        row_count = await asyncio.to_thread(_count_rows, sql_target, schema, table_name)
+        assert row_count == 4
+    finally:
+        await _drop_table_if_exists(sql_target, schema, table_name)
+
+
+# ---------------------------------------------------------------------------
+# Truncate policy
+# ---------------------------------------------------------------------------
+
+
+async def test_create_and_load_truncate(
+    warehouse_schema: tuple[SqlTarget, str],
+    http_and_cred: tuple[FabricHttpClient, Any],
+    tmp_path: Path,
+) -> None:
+    """if_exists=truncate: truncate existing table then load — row count matches last load."""
+    import asyncio  # noqa: PLC0415
+
+    pytest.importorskip("pyarrow")
+    import pyarrow as pa  # noqa: PLC0415
+    import pyarrow.parquet as pap  # noqa: PLC0415
+
+    sql_target, schema = warehouse_schema
+    http, cred = http_and_cred
+    table_name = "pytest_cal_truncate"
+
+    parquet_file = tmp_path / "data.parquet"
+    pa_table = pa.table({"id": [1, 2, 3]})
+    pap.write_table(pa_table, parquet_file)
+
+    try:
+        workspace_id = uuid.UUID(sql_target.workspace_id)
+        # First load (creates and loads 3 rows).
+        await create_and_load(
+            http,
+            cred,
+            workspace_id,
+            sql_target,
+            schema,
+            table_name,
+            parquet_file,
+            if_exists="fail",
+            file_format="parquet",
+        )
+        # Second load (truncates, then loads 3 rows again).
+        result = await create_and_load(
+            http,
+            cred,
+            workspace_id,
+            sql_target,
+            schema,
+            table_name,
+            parquet_file,
+            if_exists="truncate",
+            file_format="parquet",
+        )
+        assert result.rows_loaded == 3
+        row_count = await asyncio.to_thread(_count_rows, sql_target, schema, table_name)
+        assert row_count == 3
+    finally:
+        await _drop_table_if_exists(sql_target, schema, table_name)
+
+
+# ---------------------------------------------------------------------------
+# Replace policy
+# ---------------------------------------------------------------------------
+
+
+async def test_create_and_load_replace(
+    warehouse_schema: tuple[SqlTarget, str],
+    http_and_cred: tuple[FabricHttpClient, Any],
+    tmp_path: Path,
+) -> None:
+    """if_exists=replace: DROP + recreate from schema, then load."""
+    import asyncio  # noqa: PLC0415
+
+    pytest.importorskip("pyarrow")
+    import pyarrow as pa  # noqa: PLC0415
+    import pyarrow.parquet as pap  # noqa: PLC0415
+
+    sql_target, schema = warehouse_schema
+    http, cred = http_and_cred
+    table_name = "pytest_cal_replace"
+
+    parquet_file = tmp_path / "data.parquet"
+    pa_table = pa.table({"id": [1, 2], "value": [10, 20]})
+    pap.write_table(pa_table, parquet_file)
+
+    try:
+        workspace_id = uuid.UUID(sql_target.workspace_id)
+        # First load.
+        await create_and_load(
+            http,
+            cred,
+            workspace_id,
+            sql_target,
+            schema,
+            table_name,
+            parquet_file,
+            if_exists="fail",
+            file_format="parquet",
+        )
+        # Replace load (drop + recreate + load).
+        result = await create_and_load(
+            http,
+            cred,
+            workspace_id,
+            sql_target,
+            schema,
+            table_name,
+            parquet_file,
+            if_exists="replace",
+            file_format="parquet",
+        )
+        assert result.rows_loaded == 2
+        row_count = await asyncio.to_thread(_count_rows, sql_target, schema, table_name)
+        assert row_count == 2
+    finally:
+        await _drop_table_if_exists(sql_target, schema, table_name)
+
+
+# ---------------------------------------------------------------------------
+# Tests: cleanup_on_failure drops only WE-created table
+# ---------------------------------------------------------------------------
+
+
+async def test_cleanup_on_failure_drops_created_table(
+    warehouse_schema: tuple[SqlTarget, str],
+    http_and_cred: tuple[FabricHttpClient, Any],
+    tmp_path: Path,
+) -> None:
+    """When cleanup_on_failure=True and the load fails, the table WE created is dropped."""
+
+    pytest.importorskip("pyarrow")
+    import pyarrow as pa  # noqa: PLC0415
+    import pyarrow.parquet as pap  # noqa: PLC0415
+
+    sql_target, schema = warehouse_schema
+    http, cred = http_and_cred
+    table_name = "pytest_cal_cleanup_created"
+
+    parquet_file = tmp_path / "data.parquet"
+    pa_table = pa.table({"id": [1]})
+    pap.write_table(pa_table, parquet_file)
+
+    workspace_id = uuid.UUID(sql_target.workspace_id)
+
+    # Patch load_local_file to simulate a COPY INTO failure.
+    from unittest.mock import AsyncMock, patch  # noqa: PLC0415
+
+    try:
+        with (
+            patch(
+                "fabric_dw.services.load.load_local_file",
+                new=AsyncMock(side_effect=RuntimeError("simulated COPY INTO failure")),
+            ),
+            pytest.raises(RuntimeError),
+        ):
+            await create_and_load(
+                http,
+                cred,
+                workspace_id,
+                sql_target,
+                schema,
+                table_name,
+                parquet_file,
+                if_exists="fail",
+                file_format="parquet",
+                cleanup_on_failure=True,
+            )
+
+        # Table should be gone.
+        existing_tables = await tables.list_tables(sql_target, schema=schema)
+        names = {t.name for t in existing_tables}
+        assert table_name not in names, (
+            f"Table {table_name!r} should have been cleaned up but still exists"
+        )
+    finally:
+        # Belt-and-suspenders.
+        await _drop_table_if_exists(sql_target, schema, table_name)
+
+
+async def test_cleanup_on_failure_does_not_drop_preexisting_table(
+    warehouse_schema: tuple[SqlTarget, str],
+    http_and_cred: tuple[FabricHttpClient, Any],
+    tmp_path: Path,
+) -> None:
+    """cleanup_on_failure=True with pre-existing table: load fails, table is NOT dropped."""
+    import asyncio  # noqa: PLC0415
+
+    pytest.importorskip("pyarrow")
+    import pyarrow as pa  # noqa: PLC0415
+    import pyarrow.parquet as pap  # noqa: PLC0415
+
+    sql_target, schema = warehouse_schema
+    http, cred = http_and_cred
+    table_name = "pytest_cal_cleanup_preexist"
+
+    parquet_file = tmp_path / "data.parquet"
+    pa_table = pa.table({"id": [1]})
+    pap.write_table(pa_table, parquet_file)
+
+    workspace_id = uuid.UUID(sql_target.workspace_id)
+
+    # Create the pre-existing table manually.
+    await asyncio.to_thread(
+        run_query,
+        sql_target,
+        f"CREATE TABLE [{schema}].[{table_name}] (id INT)",
+        commit=True,
+        fetch="none",
+    )
+
+    from unittest.mock import AsyncMock, patch  # noqa: PLC0415
+
+    try:
+        with (
+            patch(
+                "fabric_dw.services.load.load_local_file",
+                new=AsyncMock(side_effect=RuntimeError("simulated COPY INTO failure")),
+            ),
+            pytest.raises(RuntimeError),
+        ):
+            await create_and_load(
+                http,
+                cred,
+                workspace_id,
+                sql_target,
+                schema,
+                table_name,
+                parquet_file,
+                if_exists="append",  # table exists → we don't create → cleanup_on_failure noop
+                file_format="parquet",
+                cleanup_on_failure=True,
+            )
+
+        # Pre-existing table must still exist.
+        existing_tables = await tables.list_tables(sql_target, schema=schema)
+        names = {t.name for t in existing_tables}
+        assert table_name in names, (
+            f"Pre-existing table {table_name!r} should NOT have been dropped"
+        )
+    finally:
+        await _drop_table_if_exists(sql_target, schema, table_name)

--- a/tests/unit/cli/commands/test_tables.py
+++ b/tests/unit/cli/commands/test_tables.py
@@ -1786,3 +1786,72 @@ class TestLoadCreateAndLoad:
 
         assert result.exit_code == 0, result.output
         assert "2" in result.output
+
+    def test_if_exists_truncate_without_create_raises_usage_error(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """--if-exists truncate without --create raises UsageError."""
+        csv_file = tmp_path / "data.csv"
+        csv_file.write_text("id\n1\n", encoding="utf-8")
+
+        result = runner.invoke(
+            cli,
+            [
+                "tables",
+                "load",
+                "ws",
+                "wh",
+                "dbo.sales",
+                "--file",
+                str(csv_file),
+                "--if-exists",
+                "truncate",
+            ],
+            catch_exceptions=False,
+        )
+        assert result.exit_code != 0
+        assert "truncate" in result.output.lower() or "create" in result.output.lower()
+
+    def test_if_exists_replace_without_create_raises_usage_error(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """--if-exists replace without --create raises UsageError."""
+        csv_file = tmp_path / "data.csv"
+        csv_file.write_text("id\n1\n", encoding="utf-8")
+
+        result = runner.invoke(
+            cli,
+            [
+                "tables",
+                "load",
+                "ws",
+                "wh",
+                "dbo.sales",
+                "--file",
+                str(csv_file),
+                "--if-exists",
+                "replace",
+            ],
+            catch_exceptions=False,
+        )
+        assert result.exit_code != 0
+        assert "replace" in result.output.lower() or "create" in result.output.lower()
+
+    def test_if_exists_truncate_with_url_raises_usage_error(self, runner: CliRunner) -> None:
+        """--if-exists truncate with --url raises UsageError (no --create for URL path)."""
+        result = runner.invoke(
+            cli,
+            [
+                "tables",
+                "load",
+                "ws",
+                "wh",
+                "dbo.sales",
+                "--url",
+                "https://example.com/f.parquet",
+                "--if-exists",
+                "truncate",
+            ],
+            catch_exceptions=False,
+        )
+        assert result.exit_code != 0

--- a/tests/unit/cli/commands/test_tables.py
+++ b/tests/unit/cli/commands/test_tables.py
@@ -1601,3 +1601,188 @@ class TestTablesCreateEmpty:
             ],
         )
         assert result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# tables load --create (create-and-load)
+# ---------------------------------------------------------------------------
+
+
+class TestLoadCreateAndLoad:
+    """Tests for 'tables load --create' (auto-create + load)."""
+
+    def _invoke(self, runner: CliRunner, args: list[str]) -> object:
+        return runner.invoke(cli, ["tables", "load", *args], catch_exceptions=False)
+
+    def test_create_with_url_raises_usage_error(self, runner: CliRunner) -> None:
+        """--create is not supported with --url."""
+        result = runner.invoke(
+            cli,
+            [
+                "tables",
+                "load",
+                "ws",
+                "wh",
+                "dbo.sales",
+                "--url",
+                "https://example.com/f.parquet",
+                "--create",
+            ],
+            catch_exceptions=False,
+        )
+        assert result.exit_code != 0
+        assert "local files" in result.output.lower() or "file" in result.output.lower()
+
+    def test_all_varchar_without_create_raises_usage_error(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """--all-varchar requires --create."""
+        csv_file = tmp_path / "data.csv"
+        csv_file.write_text("id\n1\n", encoding="utf-8")
+
+        result = runner.invoke(
+            cli,
+            [
+                "tables",
+                "load",
+                "ws",
+                "wh",
+                "dbo.sales",
+                "--file",
+                str(csv_file),
+                "--all-varchar",
+            ],
+            catch_exceptions=False,
+        )
+        assert result.exit_code != 0
+
+    def test_create_and_load_happy_path(self, runner: CliRunner, tmp_path: Path) -> None:
+        """--create with a local Parquet file invokes create_and_load."""
+        from fabric_dw.http_client import FabricHttpClient  # noqa: PLC0415
+        from fabric_dw.models import CopyIntoResult  # noqa: PLC0415
+
+        parquet_file = tmp_path / "data.parquet"
+        parquet_file.write_bytes(b"PAR1")
+
+        mock_result = CopyIntoResult(rows_loaded=5, rows_rejected=0, target="dbo.sales")
+        mock_http = AsyncMock(spec=FabricHttpClient)
+        mock_entry = _make_item_entry()
+
+        _http_patch = "fabric_dw.cli.commands.tables.build_http_client"
+        with (
+            patch(_http_patch, new=_make_http_cm(mock_http)),
+            patch(
+                "fabric_dw.cli.commands.tables.resolve_item",
+                new=AsyncMock(return_value=(WS_UUID, mock_entry)),
+            ),
+            patch(
+                "fabric_dw.cli.commands.tables.create_and_load",
+                new=AsyncMock(return_value=mock_result),
+            ) as mock_cal,
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "tables",
+                    "load",
+                    "ws",
+                    "wh",
+                    "dbo.sales",
+                    "--file",
+                    str(parquet_file),
+                    "--create",
+                ],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0, result.output
+        assert "5" in result.output
+        mock_cal.assert_called_once()
+
+    def test_create_and_load_if_exists_replace_requires_confirmation(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """--if-exists replace requires destructive confirmation; 'n' aborts."""
+        parquet_file = tmp_path / "data.parquet"
+        parquet_file.write_bytes(b"PAR1")
+
+        from fabric_dw.http_client import FabricHttpClient  # noqa: PLC0415
+
+        mock_http = AsyncMock(spec=FabricHttpClient)
+        mock_entry = _make_item_entry()
+
+        _http_patch = "fabric_dw.cli.commands.tables.build_http_client"
+        with (
+            patch(_http_patch, new=_make_http_cm(mock_http)),
+            patch(
+                "fabric_dw.cli.commands.tables.resolve_item",
+                new=AsyncMock(return_value=(WS_UUID, mock_entry)),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "tables",
+                    "load",
+                    "ws",
+                    "wh",
+                    "dbo.sales",
+                    "--file",
+                    str(parquet_file),
+                    "--create",
+                    "--if-exists",
+                    "replace",
+                ],
+                input="n\n",
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0
+        assert "aborted" in result.output.lower()
+
+    def test_create_and_load_if_exists_replace_with_yes_flag(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """--if-exists replace with -y skips confirmation."""
+        from fabric_dw.http_client import FabricHttpClient  # noqa: PLC0415
+        from fabric_dw.models import CopyIntoResult  # noqa: PLC0415
+
+        parquet_file = tmp_path / "data.parquet"
+        parquet_file.write_bytes(b"PAR1")
+
+        mock_result = CopyIntoResult(rows_loaded=2, rows_rejected=0, target="dbo.sales")
+        mock_http = AsyncMock(spec=FabricHttpClient)
+        mock_entry = _make_item_entry()
+
+        _http_patch = "fabric_dw.cli.commands.tables.build_http_client"
+        with (
+            patch(_http_patch, new=_make_http_cm(mock_http)),
+            patch(
+                "fabric_dw.cli.commands.tables.resolve_item",
+                new=AsyncMock(return_value=(WS_UUID, mock_entry)),
+            ),
+            patch(
+                "fabric_dw.cli.commands.tables.create_and_load",
+                new=AsyncMock(return_value=mock_result),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "-y",
+                    "tables",
+                    "load",
+                    "ws",
+                    "wh",
+                    "dbo.sales",
+                    "--file",
+                    str(parquet_file),
+                    "--create",
+                    "--if-exists",
+                    "replace",
+                ],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0, result.output
+        assert "2" in result.output

--- a/tests/unit/mcp/test_contract.py
+++ b/tests/unit/mcp/test_contract.py
@@ -46,8 +46,9 @@ from tests.unit.mcp.conftest import WS_ID, WS_NAME, make_item_entry
 # Expected tool count (sync with test_server.EXPECTED_TOOL_NAMES)
 # ---------------------------------------------------------------------------
 
-# 77 baseline + 5 statistics + 1 dbt + 3 table-create + 6 functions + 1 load_table_from_url
-_EXPECTED_TOOL_COUNT = 86
+# 77 baseline + 5 statistics + 1 dbt + 3 table-create + 6 functions
+# + 1 load_table_from_url + 1 import_table_from_url
+_EXPECTED_TOOL_COUNT = 87
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/mcp/test_server.py
+++ b/tests/unit/mcp/test_server.py
@@ -134,6 +134,7 @@ EXPECTED_TOOL_NAMES: frozenset[str] = frozenset(
         "clear_table",
         # Load
         "load_table_from_url",
+        "import_table_from_url",
         # Restore Points
         "list_restore_points",
         "get_restore_point",

--- a/tests/unit/mcp/tools/test_load.py
+++ b/tests/unit/mcp/tools/test_load.py
@@ -85,7 +85,7 @@ async def test_import_table_from_url_rejects_sql_endpoint(
 async def test_import_table_from_url_truncate_blocked_without_destructive_flag(
     mock_ctx, ctx_patch, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """truncate is blocked when FABRIC_MCP_ALLOW_DESTRUCTIVE is unset."""
+    """truncate is blocked when FABRIC_MCP_ALLOW_DESTRUCTIVE is unset (table exists)."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
     monkeypatch.delenv("FABRIC_MCP_READONLY", raising=False)
@@ -94,7 +94,14 @@ async def test_import_table_from_url_truncate_blocked_without_destructive_flag(
     mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
     mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
 
-    with ctx_patch, pytest.raises(ToolError, match="destructive"):
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.load.table_exists",
+            new=AsyncMock(return_value=True),
+        ),
+        pytest.raises(ToolError, match="destructive"),
+    ):
         await mcp._tool_manager.call_tool(
             "import_table_from_url",
             {
@@ -123,7 +130,7 @@ async def test_import_table_from_url_replace_raises_tool_error(
     with (
         ctx_patch,
         patch(
-            "fabric_dw.services.load._table_exists",
+            "fabric_dw.services.load.table_exists",
             new=AsyncMock(return_value=True),
         ),
         pytest.raises(ToolError, match=r"replace.*remote"),
@@ -161,7 +168,7 @@ async def test_import_table_from_url_fail_when_table_exists(
     with (
         ctx_patch,
         patch(
-            "fabric_dw.services.load._table_exists",
+            "fabric_dw.services.load.table_exists",
             new=AsyncMock(return_value=True),
         ),
         pytest.raises(ToolError, match="already exists"),
@@ -198,7 +205,7 @@ async def test_import_table_from_url_append_table_not_exists_happy_path(
     with (
         ctx_patch,
         patch(
-            "fabric_dw.services.load._table_exists",
+            "fabric_dw.services.load.table_exists",
             new=AsyncMock(return_value=False),
         ),
         patch(
@@ -242,11 +249,11 @@ async def test_import_table_from_url_truncate_with_flag_succeeds(
     with (
         ctx_patch,
         patch(
-            "fabric_dw.services.load._table_exists",
+            "fabric_dw.services.load.table_exists",
             new=AsyncMock(return_value=True),
         ),
         patch(
-            "fabric_dw.services.load._truncate_table_sql",
+            "fabric_dw.services.load.truncate_table",
             new=AsyncMock(),
         ) as mock_truncate,
         patch(
@@ -295,5 +302,76 @@ async def test_import_table_from_url_rejects_json_file_type(
                 "qualified_name": "dbo.sales",
                 "url": "https://example.com/f.json",
                 "file_type": "JSON",
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# import_table_from_url — table absent with truncate/replace
+# ---------------------------------------------------------------------------
+
+
+async def test_import_table_from_url_truncate_absent_table_raises(
+    mock_ctx, ctx_patch, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """import_table_from_url with if_exists=truncate raises ToolError when table does not exist."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    monkeypatch.delenv("FABRIC_MCP_READONLY", raising=False)
+    monkeypatch.setenv("FABRIC_MCP_ALLOW_DESTRUCTIVE", "1")
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.load.table_exists",
+            new=AsyncMock(return_value=False),
+        ),
+        pytest.raises(ToolError, match="does not exist"),
+    ):
+        await mcp._tool_manager.call_tool(
+            "import_table_from_url",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_name": "dbo.sales",
+                "url": "https://example.com/f.parquet",
+                "file_type": "PARQUET",
+                "if_exists": "truncate",
+            },
+        )
+
+
+async def test_import_table_from_url_replace_absent_table_raises(
+    mock_ctx, ctx_patch, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """import_table_from_url with if_exists=replace raises ToolError when table does not exist."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    monkeypatch.delenv("FABRIC_MCP_READONLY", raising=False)
+    monkeypatch.setenv("FABRIC_MCP_ALLOW_DESTRUCTIVE", "1")
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.load.table_exists",
+            new=AsyncMock(return_value=False),
+        ),
+        pytest.raises(ToolError, match="does not exist"),
+    ):
+        await mcp._tool_manager.call_tool(
+            "import_table_from_url",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_name": "dbo.sales",
+                "url": "https://example.com/f.parquet",
+                "file_type": "PARQUET",
+                "if_exists": "replace",
             },
         )

--- a/tests/unit/mcp/tools/test_load.py
+++ b/tests/unit/mcp/tools/test_load.py
@@ -1,0 +1,299 @@
+"""Unit tests for fabric_dw.mcp.tools.load — import_table_from_url tool."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from mcp.server.fastmcp.exceptions import ToolError
+
+from fabric_dw.models import CopyIntoResult
+from tests.unit.mcp.conftest import (
+    WH_NAME,
+    WS_ID,
+    WS_NAME,
+    make_item_entry,
+    make_sql_endpoint_entry,
+)
+
+
+def _make_result() -> CopyIntoResult:
+    return CopyIntoResult(rows_loaded=3, rows_rejected=0, target="dbo.sales")
+
+
+# ---------------------------------------------------------------------------
+# import_table_from_url — write guard (READONLY mode)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("mock_ctx")
+async def test_import_table_from_url_blocked_in_readonly(
+    ctx_patch, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """import_table_from_url raises ToolError when FABRIC_MCP_READONLY=1."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    monkeypatch.setenv("FABRIC_MCP_READONLY", "1")
+
+    with ctx_patch, pytest.raises(ToolError, match="mutating tool"):
+        await mcp._tool_manager.call_tool(
+            "import_table_from_url",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_name": "dbo.sales",
+                "url": "https://onelake.dfs.fabric.microsoft.com/ws/lh/Files/f.parquet",
+                "file_type": "PARQUET",
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# import_table_from_url — SQL Endpoint rejection
+# ---------------------------------------------------------------------------
+
+
+async def test_import_table_from_url_rejects_sql_endpoint(
+    mock_ctx, ctx_patch, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """import_table_from_url raises ToolError for SQL Analytics Endpoint items."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    monkeypatch.delenv("FABRIC_MCP_READONLY", raising=False)
+    endpoint_entry = make_sql_endpoint_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=endpoint_entry)
+
+    with ctx_patch, pytest.raises(ToolError, match="read-only"):
+        await mcp._tool_manager.call_tool(
+            "import_table_from_url",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_name": "dbo.sales",
+                "url": "https://example.com/f.parquet",
+                "file_type": "PARQUET",
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# import_table_from_url — destructive guard for truncate/replace
+# ---------------------------------------------------------------------------
+
+
+async def test_import_table_from_url_truncate_blocked_without_destructive_flag(
+    mock_ctx, ctx_patch, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """truncate is blocked when FABRIC_MCP_ALLOW_DESTRUCTIVE is unset."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    monkeypatch.delenv("FABRIC_MCP_READONLY", raising=False)
+    monkeypatch.delenv("FABRIC_MCP_ALLOW_DESTRUCTIVE", raising=False)
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+
+    with ctx_patch, pytest.raises(ToolError, match="destructive"):
+        await mcp._tool_manager.call_tool(
+            "import_table_from_url",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_name": "dbo.sales",
+                "url": "https://example.com/f.parquet",
+                "file_type": "PARQUET",
+                "if_exists": "truncate",
+            },
+        )
+
+
+async def test_import_table_from_url_replace_raises_tool_error(
+    mock_ctx, ctx_patch, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """import_table_from_url: if_exists=replace raises ToolError (not supported for remote URLs)."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    monkeypatch.delenv("FABRIC_MCP_READONLY", raising=False)
+    monkeypatch.setenv("FABRIC_MCP_ALLOW_DESTRUCTIVE", "1")
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.load._table_exists",
+            new=AsyncMock(return_value=True),
+        ),
+        pytest.raises(ToolError, match=r"replace.*remote"),
+    ):
+        await mcp._tool_manager.call_tool(
+            "import_table_from_url",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_name": "dbo.sales",
+                "url": "https://example.com/f.parquet",
+                "file_type": "PARQUET",
+                "if_exists": "replace",
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# import_table_from_url — if_exists=fail + table exists
+# ---------------------------------------------------------------------------
+
+
+async def test_import_table_from_url_fail_when_table_exists(
+    mock_ctx, ctx_patch, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """import_table_from_url with if_exists=fail raises ToolError when table exists."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    monkeypatch.delenv("FABRIC_MCP_READONLY", raising=False)
+    monkeypatch.delenv("FABRIC_MCP_ALLOW_DESTRUCTIVE", raising=False)
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.load._table_exists",
+            new=AsyncMock(return_value=True),
+        ),
+        pytest.raises(ToolError, match="already exists"),
+    ):
+        await mcp._tool_manager.call_tool(
+            "import_table_from_url",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_name": "dbo.sales",
+                "url": "https://example.com/f.parquet",
+                "file_type": "PARQUET",
+                "if_exists": "fail",
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# import_table_from_url — happy path (append, table not exists)
+# ---------------------------------------------------------------------------
+
+
+async def test_import_table_from_url_append_table_not_exists_happy_path(
+    mock_ctx, ctx_patch, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """import_table_from_url with if_exists=append + no existing table succeeds."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    monkeypatch.delenv("FABRIC_MCP_READONLY", raising=False)
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.load._table_exists",
+            new=AsyncMock(return_value=False),
+        ),
+        patch(
+            "fabric_dw.mcp.tools.load.copy_into_from_url",
+            new=AsyncMock(return_value=_make_result()),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "import_table_from_url",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_name": "dbo.sales",
+                "url": "https://onelake.dfs.fabric.microsoft.com/ws/lh/Files/f.parquet",
+                "file_type": "PARQUET",
+                "if_exists": "append",
+            },
+        )
+
+    assert result["rows_loaded"] == 3
+    assert result["target"] == "dbo.sales"
+
+
+# ---------------------------------------------------------------------------
+# import_table_from_url — truncate + allowed
+# ---------------------------------------------------------------------------
+
+
+async def test_import_table_from_url_truncate_with_flag_succeeds(
+    mock_ctx, ctx_patch, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """import_table_from_url with if_exists=truncate + flag set → TRUNCATE + load."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    monkeypatch.delenv("FABRIC_MCP_READONLY", raising=False)
+    monkeypatch.setenv("FABRIC_MCP_ALLOW_DESTRUCTIVE", "1")
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.load._table_exists",
+            new=AsyncMock(return_value=True),
+        ),
+        patch(
+            "fabric_dw.services.load._truncate_table_sql",
+            new=AsyncMock(),
+        ) as mock_truncate,
+        patch(
+            "fabric_dw.mcp.tools.load.copy_into_from_url",
+            new=AsyncMock(return_value=_make_result()),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "import_table_from_url",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_name": "dbo.sales",
+                "url": "https://onelake.dfs.fabric.microsoft.com/ws/lh/Files/f.parquet",
+                "file_type": "PARQUET",
+                "if_exists": "truncate",
+            },
+        )
+
+    mock_truncate.assert_called_once()
+    assert result["rows_loaded"] == 3
+
+
+# ---------------------------------------------------------------------------
+# import_table_from_url — unsupported file_type
+# ---------------------------------------------------------------------------
+
+
+async def test_import_table_from_url_rejects_json_file_type(
+    mock_ctx, ctx_patch, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """import_table_from_url raises ToolError for JSON file_type (not supported for remote URLs)."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    monkeypatch.delenv("FABRIC_MCP_READONLY", raising=False)
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+
+    with ctx_patch, pytest.raises(ToolError):
+        await mcp._tool_manager.call_tool(
+            "import_table_from_url",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_name": "dbo.sales",
+                "url": "https://example.com/f.json",
+                "file_type": "JSON",
+            },
+        )

--- a/tests/unit/services/test_create_and_load.py
+++ b/tests/unit/services/test_create_and_load.py
@@ -466,6 +466,124 @@ async def test_cleanup_on_failure_replace_policy_two_drops(tmp_path: Path) -> No
     assert len(drop_calls) == 2
 
 
+async def test_cleanup_on_failure_truncate_preexisting_does_not_drop(tmp_path: Path) -> None:
+    """if_exists=truncate + pre-existing table + cleanup_on_failure=True + load fails.
+
+    TRUNCATE runs (data is lost, but schema is kept), then the load fails.
+    cleanup_on_failure must NOT drop the pre-existing table — we didn't create it.
+    """
+    import uuid  # noqa: PLC0415
+
+    from fabric_dw.models import ColumnSpec  # noqa: PLC0415
+    from fabric_dw.services.load import create_and_load  # noqa: PLC0415
+
+    parquet_file = tmp_path / "data.parquet"
+    parquet_file.write_bytes(b"PAR1")
+    ws_id = uuid.UUID(_WS_ID)
+    _columns = [ColumnSpec(name="id", sql_type="INT", nullable=False)]
+
+    with (
+        patch(
+            "fabric_dw.services.load._infer_columns_from_local",
+            new=AsyncMock(return_value=_columns),
+        ),
+        patch(
+            "fabric_dw.services.load._table_exists",
+            new=AsyncMock(return_value=True),  # pre-existing table
+        ),
+        patch(
+            "fabric_dw.services.load._truncate_table_sql",
+            new=AsyncMock(),
+        ) as mock_truncate,
+        patch(
+            "fabric_dw.services.load._drop_table_sql",
+            new=AsyncMock(),
+        ) as mock_drop,
+        patch(
+            "fabric_dw.services.load.load_local_file",
+            new=AsyncMock(side_effect=RuntimeError("load failed")),
+        ),
+        pytest.raises(RuntimeError, match="load failed"),
+    ):
+        await create_and_load(
+            AsyncMock(),
+            AsyncMock(),
+            ws_id,
+            MagicMock(),
+            _SCHEMA,
+            _TABLE,
+            parquet_file,
+            file_format="parquet",
+            if_exists="truncate",
+            cleanup_on_failure=True,
+        )
+
+    # TRUNCATE fired once (the truncate policy).
+    mock_truncate.assert_called_once()
+    # Pre-existing table must NEVER be dropped by cleanup_on_failure.
+    mock_drop.assert_not_called()
+
+
+async def test_cleanup_on_failure_replace_not_exists_drops_created_table(tmp_path: Path) -> None:
+    """if_exists=replace + table does NOT exist + cleanup_on_failure=True + load fails.
+
+    When the table is absent, replace falls through to the create path (we_created=True).
+    If the load then fails, cleanup_on_failure must drop exactly the table we created.
+    """
+    import uuid  # noqa: PLC0415
+
+    from fabric_dw.models import ColumnSpec  # noqa: PLC0415
+    from fabric_dw.services.load import create_and_load  # noqa: PLC0415
+
+    parquet_file = tmp_path / "data.parquet"
+    parquet_file.write_bytes(b"PAR1")
+    ws_id = uuid.UUID(_WS_ID)
+    _columns = [ColumnSpec(name="id", sql_type="INT", nullable=False)]
+    drop_calls: list[str] = []
+
+    async def _track_drop(*_args, **_kwargs) -> None:
+        drop_calls.append("drop")
+
+    with (
+        patch(
+            "fabric_dw.services.load._infer_columns_from_local",
+            new=AsyncMock(return_value=_columns),
+        ),
+        patch(
+            "fabric_dw.services.load._table_exists",
+            new=AsyncMock(return_value=False),  # table absent → create path
+        ),
+        patch(
+            "fabric_dw.services.load._create_table_from_columns",
+            new=AsyncMock(),
+        ),
+        patch(
+            "fabric_dw.services.load._drop_table_sql",
+            new=AsyncMock(side_effect=_track_drop),
+        ),
+        patch(
+            "fabric_dw.services.load.load_local_file",
+            new=AsyncMock(side_effect=RuntimeError("load failed")),
+        ),
+        pytest.raises(RuntimeError, match="load failed"),
+    ):
+        await create_and_load(
+            AsyncMock(),
+            AsyncMock(),
+            ws_id,
+            MagicMock(),
+            _SCHEMA,
+            _TABLE,
+            parquet_file,
+            file_format="parquet",
+            if_exists="replace",
+            cleanup_on_failure=True,
+        )
+
+    # Exactly one drop: the cleanup_on_failure drop of the table we created.
+    assert len(drop_calls) == 1
+
+
 # ---------------------------------------------------------------------------
 # File-not-found guard
 # ---------------------------------------------------------------------------

--- a/tests/unit/services/test_create_and_load.py
+++ b/tests/unit/services/test_create_and_load.py
@@ -1,0 +1,527 @@
+"""Unit tests for create_and_load in fabric_dw.services.load.
+
+Tests cover:
+- The full --if-exists decision matrix (fail/append/truncate/replace x table exists/not).
+- cleanup_on_failure drops ONLY a table we created (never a pre-existing one).
+- SQL Endpoint guard rejection.
+- Existence-check logic.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from fabric_dw.exceptions import ItemKindError
+from fabric_dw.models import CopyIntoResult, WarehouseKind
+from fabric_dw.services.load import IfExistsPolicy
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_WS_ID = "00000000-0000-0000-0000-000000000001"
+_SCHEMA = "dbo"
+_TABLE = "sales"
+
+
+def _make_result(rows: int = 5) -> CopyIntoResult:
+    return CopyIntoResult(rows_loaded=rows, rows_rejected=0, target=f"{_SCHEMA}.{_TABLE}")
+
+
+async def _call_create_and_load(
+    tmp_path: Path,
+    *,
+    if_exists: IfExistsPolicy = "fail",
+    table_exists: bool = False,
+    cleanup_on_failure: bool = False,
+    kind: WarehouseKind = WarehouseKind.WAREHOUSE,
+) -> tuple:
+    """Call create_and_load with heavy mocking; returns (result, mocks...)."""
+    import uuid  # noqa: PLC0415
+
+    from fabric_dw.models import ColumnSpec  # noqa: PLC0415
+    from fabric_dw.services.load import create_and_load  # noqa: PLC0415
+
+    parquet_file = tmp_path / "data.parquet"
+    parquet_file.write_bytes(b"PAR1")
+
+    mock_http = AsyncMock()
+    mock_cred = AsyncMock()
+    ws_id = uuid.UUID(_WS_ID)
+    mock_target = MagicMock()
+    _columns = [ColumnSpec(name="id", sql_type="INT", nullable=False)]
+
+    with (
+        patch(
+            "fabric_dw.services.load._infer_columns_from_local",
+            new=AsyncMock(return_value=_columns),
+        ),
+        patch(
+            "fabric_dw.services.load._table_exists",
+            new=AsyncMock(return_value=table_exists),
+        ),
+        patch(
+            "fabric_dw.services.load._drop_table_sql",
+            new=AsyncMock(),
+        ) as mock_drop,
+        patch(
+            "fabric_dw.services.load._truncate_table_sql",
+            new=AsyncMock(),
+        ) as mock_truncate,
+        patch(
+            "fabric_dw.services.load._create_table_from_columns",
+            new=AsyncMock(),
+        ) as mock_create,
+        patch(
+            "fabric_dw.services.load.load_local_file",
+            new=AsyncMock(return_value=_make_result()),
+        ) as mock_load,
+    ):
+        result = await create_and_load(
+            mock_http,
+            mock_cred,
+            ws_id,
+            mock_target,
+            _SCHEMA,
+            _TABLE,
+            parquet_file,
+            if_exists=if_exists,
+            file_format="parquet",
+            kind=kind,
+            cleanup_on_failure=cleanup_on_failure,
+        )
+
+    return result, mock_create, mock_truncate, mock_drop, mock_load
+
+
+# ---------------------------------------------------------------------------
+# SQL Endpoint guard
+# ---------------------------------------------------------------------------
+
+
+async def test_create_and_load_rejects_sql_endpoint(tmp_path: Path) -> None:
+    """SQL Analytics Endpoints must be rejected before any I/O."""
+    import uuid  # noqa: PLC0415
+
+    from fabric_dw.services.load import create_and_load  # noqa: PLC0415
+
+    parquet_file = tmp_path / "data.parquet"
+    parquet_file.write_bytes(b"PAR1")
+
+    with pytest.raises(ItemKindError):
+        await create_and_load(
+            AsyncMock(),
+            AsyncMock(),
+            uuid.UUID(_WS_ID),
+            MagicMock(),
+            _SCHEMA,
+            _TABLE,
+            parquet_file,
+            file_format="parquet",
+            kind=WarehouseKind.SQL_ENDPOINT,
+        )
+
+
+# ---------------------------------------------------------------------------
+# --if-exists x table exists/not matrix
+# ---------------------------------------------------------------------------
+
+
+async def test_if_exists_fail_table_not_exists_creates_and_loads(tmp_path: Path) -> None:
+    """if_exists=fail, table not present: CREATE + COPY INTO."""
+    result, mock_create, mock_truncate, mock_drop, mock_load = await _call_create_and_load(
+        tmp_path, if_exists="fail", table_exists=False
+    )
+
+    mock_create.assert_called_once()
+    mock_truncate.assert_not_called()
+    mock_drop.assert_not_called()
+    mock_load.assert_called_once()
+    assert result.rows_loaded == 5
+
+
+async def test_if_exists_fail_table_exists_raises(tmp_path: Path) -> None:
+    """if_exists=fail, table already present: ValueError."""
+    import uuid  # noqa: PLC0415
+
+    from fabric_dw.models import ColumnSpec  # noqa: PLC0415
+    from fabric_dw.services.load import create_and_load  # noqa: PLC0415
+
+    parquet_file = tmp_path / "data.parquet"
+    parquet_file.write_bytes(b"PAR1")
+    _columns = [ColumnSpec(name="id", sql_type="INT", nullable=False)]
+
+    with (
+        patch(
+            "fabric_dw.services.load._infer_columns_from_local",
+            new=AsyncMock(return_value=_columns),
+        ),
+        patch(
+            "fabric_dw.services.load._table_exists",
+            new=AsyncMock(return_value=True),
+        ),
+        pytest.raises(ValueError, match="already exists"),
+    ):
+        await create_and_load(
+            AsyncMock(),
+            AsyncMock(),
+            uuid.UUID(_WS_ID),
+            MagicMock(),
+            _SCHEMA,
+            _TABLE,
+            parquet_file,
+            file_format="parquet",
+            if_exists="fail",
+        )
+
+
+async def test_if_exists_append_table_not_exists_creates_and_loads(tmp_path: Path) -> None:
+    """if_exists=append, table absent: CREATE + COPY INTO."""
+    result, mock_create, mock_truncate, mock_drop, mock_load = await _call_create_and_load(
+        tmp_path, if_exists="append", table_exists=False
+    )
+
+    mock_create.assert_called_once()
+    mock_truncate.assert_not_called()
+    mock_drop.assert_not_called()
+    mock_load.assert_called_once()
+    assert result.rows_loaded == 5
+
+
+async def test_if_exists_append_table_exists_skips_create(tmp_path: Path) -> None:
+    """if_exists=append, table present: skip CREATE; COPY INTO only."""
+    result, mock_create, mock_truncate, mock_drop, mock_load = await _call_create_and_load(
+        tmp_path, if_exists="append", table_exists=True
+    )
+
+    mock_create.assert_not_called()
+    mock_truncate.assert_not_called()
+    mock_drop.assert_not_called()
+    mock_load.assert_called_once()
+    assert result.rows_loaded == 5
+
+
+async def test_if_exists_truncate_table_exists_truncates_then_loads(tmp_path: Path) -> None:
+    """if_exists=truncate, table present: TRUNCATE + COPY INTO (no create/drop)."""
+    result, mock_create, mock_truncate, mock_drop, mock_load = await _call_create_and_load(
+        tmp_path, if_exists="truncate", table_exists=True
+    )
+
+    mock_truncate.assert_called_once()
+    mock_create.assert_not_called()
+    mock_drop.assert_not_called()
+    mock_load.assert_called_once()
+    assert result.rows_loaded == 5
+
+
+async def test_if_exists_truncate_table_not_exists_creates_and_loads(tmp_path: Path) -> None:
+    """if_exists=truncate, table absent: CREATE + COPY INTO (no truncate)."""
+    _result, mock_create, mock_truncate, mock_drop, mock_load = await _call_create_and_load(
+        tmp_path, if_exists="truncate", table_exists=False
+    )
+
+    mock_create.assert_called_once()
+    mock_truncate.assert_not_called()
+    mock_drop.assert_not_called()
+    mock_load.assert_called_once()
+
+
+async def test_if_exists_replace_table_exists_drops_recreates_loads(tmp_path: Path) -> None:
+    """if_exists=replace, table present: DROP + CREATE + COPY INTO."""
+    result, mock_create, mock_truncate, mock_drop, mock_load = await _call_create_and_load(
+        tmp_path, if_exists="replace", table_exists=True
+    )
+
+    mock_drop.assert_called_once()
+    mock_create.assert_called_once()
+    mock_truncate.assert_not_called()
+    mock_load.assert_called_once()
+    assert result.rows_loaded == 5
+
+
+async def test_if_exists_replace_table_not_exists_creates_and_loads(tmp_path: Path) -> None:
+    """if_exists=replace, table absent: CREATE + COPY INTO (no drop)."""
+    _result, mock_create, mock_truncate, mock_drop, mock_load = await _call_create_and_load(
+        tmp_path, if_exists="replace", table_exists=False
+    )
+
+    mock_drop.assert_not_called()
+    mock_create.assert_called_once()
+    mock_truncate.assert_not_called()
+    mock_load.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# cleanup_on_failure
+# ---------------------------------------------------------------------------
+
+
+async def test_cleanup_on_failure_drops_created_table(tmp_path: Path) -> None:
+    """cleanup_on_failure=True, WE created the table, load fails: DROP is called."""
+    import uuid  # noqa: PLC0415
+
+    from fabric_dw.models import ColumnSpec  # noqa: PLC0415
+    from fabric_dw.services.load import create_and_load  # noqa: PLC0415
+
+    parquet_file = tmp_path / "data.parquet"
+    parquet_file.write_bytes(b"PAR1")
+    ws_id = uuid.UUID(_WS_ID)
+    _columns = [ColumnSpec(name="id", sql_type="INT", nullable=False)]
+
+    with (
+        patch(
+            "fabric_dw.services.load._infer_columns_from_local",
+            new=AsyncMock(return_value=_columns),
+        ),
+        patch(
+            "fabric_dw.services.load._table_exists",
+            new=AsyncMock(return_value=False),  # table absent -> we create it
+        ),
+        patch(
+            "fabric_dw.services.load._create_table_from_columns",
+            new=AsyncMock(),
+        ),
+        patch(
+            "fabric_dw.services.load._drop_table_sql",
+            new=AsyncMock(),
+        ) as mock_drop,
+        patch(
+            "fabric_dw.services.load.load_local_file",
+            new=AsyncMock(side_effect=RuntimeError("load failed")),
+        ),
+        pytest.raises(RuntimeError, match="load failed"),
+    ):
+        await create_and_load(
+            AsyncMock(),
+            AsyncMock(),
+            ws_id,
+            MagicMock(),
+            _SCHEMA,
+            _TABLE,
+            parquet_file,
+            file_format="parquet",
+            cleanup_on_failure=True,
+        )
+
+    mock_drop.assert_called_once()
+
+
+async def test_cleanup_on_failure_does_not_drop_preexisting_table(tmp_path: Path) -> None:
+    """cleanup_on_failure=True, table PRE-EXISTED, load fails: DROP is NOT called."""
+    import uuid  # noqa: PLC0415
+
+    from fabric_dw.models import ColumnSpec  # noqa: PLC0415
+    from fabric_dw.services.load import create_and_load  # noqa: PLC0415
+
+    parquet_file = tmp_path / "data.parquet"
+    parquet_file.write_bytes(b"PAR1")
+    ws_id = uuid.UUID(_WS_ID)
+    _columns = [ColumnSpec(name="id", sql_type="INT", nullable=False)]
+
+    with (
+        patch(
+            "fabric_dw.services.load._infer_columns_from_local",
+            new=AsyncMock(return_value=_columns),
+        ),
+        patch(
+            "fabric_dw.services.load._table_exists",
+            new=AsyncMock(return_value=True),  # table EXISTS -> we don't create it
+        ),
+        patch(
+            "fabric_dw.services.load._drop_table_sql",
+            new=AsyncMock(),
+        ) as mock_drop,
+        patch(
+            "fabric_dw.services.load.load_local_file",
+            new=AsyncMock(side_effect=RuntimeError("load failed")),
+        ),
+        pytest.raises(RuntimeError, match="load failed"),
+    ):
+        await create_and_load(
+            AsyncMock(),
+            AsyncMock(),
+            ws_id,
+            MagicMock(),
+            _SCHEMA,
+            _TABLE,
+            parquet_file,
+            file_format="parquet",
+            if_exists="append",
+            cleanup_on_failure=True,
+        )
+
+    # Pre-existing table must NEVER be dropped.
+    mock_drop.assert_not_called()
+
+
+async def test_cleanup_on_failure_false_does_not_drop_on_failure(tmp_path: Path) -> None:
+    """cleanup_on_failure=False (default), load fails: DROP is NOT called."""
+    import uuid  # noqa: PLC0415
+
+    from fabric_dw.models import ColumnSpec  # noqa: PLC0415
+    from fabric_dw.services.load import create_and_load  # noqa: PLC0415
+
+    parquet_file = tmp_path / "data.parquet"
+    parquet_file.write_bytes(b"PAR1")
+    ws_id = uuid.UUID(_WS_ID)
+    _columns = [ColumnSpec(name="id", sql_type="INT", nullable=False)]
+
+    with (
+        patch(
+            "fabric_dw.services.load._infer_columns_from_local",
+            new=AsyncMock(return_value=_columns),
+        ),
+        patch(
+            "fabric_dw.services.load._table_exists",
+            new=AsyncMock(return_value=False),
+        ),
+        patch(
+            "fabric_dw.services.load._create_table_from_columns",
+            new=AsyncMock(),
+        ),
+        patch(
+            "fabric_dw.services.load._drop_table_sql",
+            new=AsyncMock(),
+        ) as mock_drop,
+        patch(
+            "fabric_dw.services.load.load_local_file",
+            new=AsyncMock(side_effect=RuntimeError("load failed")),
+        ),
+        pytest.raises(RuntimeError, match="load failed"),
+    ):
+        await create_and_load(
+            AsyncMock(),
+            AsyncMock(),
+            ws_id,
+            MagicMock(),
+            _SCHEMA,
+            _TABLE,
+            parquet_file,
+            file_format="parquet",
+            cleanup_on_failure=False,
+        )
+
+    mock_drop.assert_not_called()
+
+
+async def test_cleanup_on_failure_replace_policy_two_drops(tmp_path: Path) -> None:
+    """if_exists=replace + cleanup_on_failure=True + load fails: two drop calls.
+
+    First drop is the 'replace' DROP; second is the cleanup_on_failure drop.
+    Both are expected because we recreated the table (we_created=True).
+    """
+    import uuid  # noqa: PLC0415
+
+    from fabric_dw.models import ColumnSpec  # noqa: PLC0415
+    from fabric_dw.services.load import create_and_load  # noqa: PLC0415
+
+    parquet_file = tmp_path / "data.parquet"
+    parquet_file.write_bytes(b"PAR1")
+    ws_id = uuid.UUID(_WS_ID)
+    _columns = [ColumnSpec(name="id", sql_type="INT", nullable=False)]
+    drop_calls: list[str] = []
+
+    async def _track_drop(*_args, **_kwargs) -> None:
+        drop_calls.append("drop")
+
+    with (
+        patch(
+            "fabric_dw.services.load._infer_columns_from_local",
+            new=AsyncMock(return_value=_columns),
+        ),
+        patch(
+            "fabric_dw.services.load._table_exists",
+            new=AsyncMock(return_value=True),  # pre-existing -> replace path
+        ),
+        patch(
+            "fabric_dw.services.load._create_table_from_columns",
+            new=AsyncMock(),
+        ),
+        patch(
+            "fabric_dw.services.load._drop_table_sql",
+            new=AsyncMock(side_effect=_track_drop),
+        ),
+        patch(
+            "fabric_dw.services.load.load_local_file",
+            new=AsyncMock(side_effect=RuntimeError("load failed")),
+        ),
+        pytest.raises(RuntimeError, match="load failed"),
+    ):
+        await create_and_load(
+            AsyncMock(),
+            AsyncMock(),
+            ws_id,
+            MagicMock(),
+            _SCHEMA,
+            _TABLE,
+            parquet_file,
+            file_format="parquet",
+            if_exists="replace",
+            cleanup_on_failure=True,
+        )
+
+    assert len(drop_calls) == 2
+
+
+# ---------------------------------------------------------------------------
+# File-not-found guard
+# ---------------------------------------------------------------------------
+
+
+async def test_create_and_load_file_not_found(tmp_path: Path) -> None:
+    """FileNotFoundError is raised when local_path does not exist."""
+    import uuid  # noqa: PLC0415
+
+    from fabric_dw.services.load import create_and_load  # noqa: PLC0415
+
+    missing = tmp_path / "nope.parquet"
+
+    with pytest.raises(FileNotFoundError):
+        await create_and_load(
+            AsyncMock(),
+            AsyncMock(),
+            uuid.UUID(_WS_ID),
+            MagicMock(),
+            _SCHEMA,
+            _TABLE,
+            missing,
+            file_format="parquet",
+        )
+
+
+# ---------------------------------------------------------------------------
+# _table_exists helper
+# ---------------------------------------------------------------------------
+
+
+async def test_table_exists_returns_true_when_row_found() -> None:
+    """_table_exists returns True when sys.tables contains the table."""
+    from fabric_dw.services.load import _table_exists  # noqa: PLC0415
+
+    mock_target = MagicMock()
+
+    def _fake_run_query(_target, _sql, **_kw) -> tuple:
+        return ["col1"], [(1,)]
+
+    with patch("fabric_dw.services.load.run_query", side_effect=_fake_run_query):
+        result = await _table_exists(mock_target, "dbo", "sales")
+
+    assert result is True
+
+
+async def test_table_exists_returns_false_when_no_rows() -> None:
+    """_table_exists returns False when sys.tables has no matching row."""
+    from fabric_dw.services.load import _table_exists  # noqa: PLC0415
+
+    mock_target = MagicMock()
+
+    def _fake_run_query(_target, _sql, **_kw) -> tuple:
+        return [], []
+
+    with patch("fabric_dw.services.load.run_query", side_effect=_fake_run_query):
+        result = await _table_exists(mock_target, "dbo", "sales")
+
+    assert result is False


### PR DESCRIPTION
## Summary

- Adds `create_and_load()` service function with full `IfExistsPolicy` matrix (fail / append / truncate / replace), schema inference from Parquet/CSV/JSON via pyarrow, and `cleanup_on_failure` scoped only to tables WE created.
- Extends `fabric-dw tables load` with `--create`, `--if-exists`, `--all-varchar`, `--varchar-length`, `--sample-rows`, and `--cleanup-on-failure` options, with destructive confirmation for truncate/replace.
- Adds new `import_table_from_url` MCP tool (tool count: 86 → 87) with write/destructive guards and SQL Endpoint rejection.
- Unit tests cover the full if-exists × table-exists matrix, cleanup_on_failure logic, SQL Endpoint guard, and MCP tool surface.
- Integration tests (marked) cover Parquet/CSV/JSON auto-create + load, all if-exists policies, and cleanup-on-failure.
- Updated `docs/cli.md` and `docs/mcp-tools.md`.

Closes #310

## Test plan

- [x] `just check` passes (lint + ty + 3095 unit tests)
- [ ] Integration tests: `pytest -m integration tests/integration/test_services_create_and_load.py` (requires Fabric credentials)