### PR TITLE
docs(cli): mention MCP server in root --help description

### DIFF
--- a/src/fabric_dw/cli/_main.py
+++ b/src/fabric_dw/cli/_main.py
@@ -218,7 +218,7 @@ def cli(
     yes: bool,
     verbose: bool,
 ) -> None:
-    """Microsoft Fabric Data Warehouse CLI."""
+    """Microsoft Fabric Data Warehouse CLI & MCP Server."""
     setup_logging(logging.DEBUG if verbose else logging.INFO)
 
     ctx.obj = CliContext(


### PR DESCRIPTION
## Summary

- Updates the root CLI group docstring from `Microsoft Fabric Data Warehouse CLI.` to `Microsoft Fabric Data Warehouse CLI & MCP Server.`
- No test assertions referenced the old wording, so no test changes were required

## Test plan

- [x] `just check` green (ruff + ty + 3130 unit tests passing)
- [x] `fabric-dw --help` will show the updated wording

Closes #383