### PR TITLE
feat(cli): accept -h as a short alias for --help everywhere

### DIFF
--- a/src/fabric_dw/cli/_main.py
+++ b/src/fabric_dw/cli/_main.py
@@ -178,7 +178,11 @@ def _patch_group_for_telemetry(group: click.Group) -> None:
     group.invoke = _patched_invoke  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
 
 
-@click.group(invoke_without_command=False, cls=_InstrumentedGroup)
+@click.group(
+    invoke_without_command=False,
+    cls=_InstrumentedGroup,
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
 @click.option(
     "--json",
     "json_output",

--- a/tests/unit/test_cli_help_alias.py
+++ b/tests/unit/test_cli_help_alias.py
@@ -1,0 +1,59 @@
+"""Tests that -h is accepted as a short alias for --help at every CLI level.
+
+Covers: root group, a sub-group (warehouses), and a nested leaf command
+(warehouses list).  Propagation must work through the custom
+_InstrumentedGroup class and the telemetry patching applied to sub-groups.
+"""
+
+from __future__ import annotations
+
+import pytest
+from click.testing import CliRunner
+
+from fabric_dw.cli._main import cli
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def _invoke_help(runner: CliRunner, args: list[str]) -> None:
+    """Assert that *args* produces a successful help page."""
+    result = runner.invoke(cli, args)
+    assert result.exit_code == 0, (
+        f"Expected exit_code 0 for {args!r}, got {result.exit_code}.\nOutput:\n{result.output}"
+    )
+    assert "Usage:" in result.output, (
+        f"Expected 'Usage:' in output for {args!r}.\nOutput:\n{result.output}"
+    )
+
+
+def test_root_short_help(runner: CliRunner) -> None:
+    """-h on the root group shows help."""
+    _invoke_help(runner, ["-h"])
+
+
+def test_root_long_help(runner: CliRunner) -> None:
+    """--help on the root group still works."""
+    _invoke_help(runner, ["--help"])
+
+
+def test_subgroup_short_help(runner: CliRunner) -> None:
+    """-h on a sub-group shows help."""
+    _invoke_help(runner, ["warehouses", "-h"])
+
+
+def test_subgroup_long_help(runner: CliRunner) -> None:
+    """--help on a sub-group still works."""
+    _invoke_help(runner, ["warehouses", "--help"])
+
+
+def test_leaf_short_help(runner: CliRunner) -> None:
+    """-h on a nested leaf command shows help."""
+    _invoke_help(runner, ["warehouses", "list", "-h"])
+
+
+def test_leaf_long_help(runner: CliRunner) -> None:
+    """--help on a nested leaf command still works."""
+    _invoke_help(runner, ["warehouses", "list", "--help"])


### PR DESCRIPTION
## Summary

- Add `context_settings={"help_option_names": ["-h", "--help"]}` to the root `cli` group decorator in `src/fabric_dw/cli/_main.py`
- The single root-level setting propagates via Click's context inheritance to all sub-groups and leaf commands, including those going through `_InstrumentedGroup` and telemetry-patched sub-groups
- Add unit tests asserting that `-h` returns exit code 0 and a `Usage:` header on the root group, a sub-group (`warehouses`), and a nested leaf command (`warehouses list`); `--help` is verified to remain functional on all three levels

## Test plan

- [ ] `uv run fabric-dw -h` prints help
- [ ] `uv run fabric-dw warehouses -h` prints help
- [ ] `uv run fabric-dw warehouses list -h` prints help
- [ ] `uv run fabric-dw --help` still prints help
- [ ] `just check` passes (ruff + ty + 3136 unit tests)

Closes #386

🤖 Generated with [Claude Code](https://claude.com/claude-code)