### PR TITLE
feat(cli): accept --json/-y/-v after the subcommand too

### DIFF
--- a/src/fabric_dw/cli/_main.py
+++ b/src/fabric_dw/cli/_main.py
@@ -53,6 +53,147 @@ _CLI_SEGMENTS_KEY = _CLI_TELEMETRY_KEY + "_segments"
 # Cap of 160 prevents absurdly long lines on ultra-wide monitors.
 _HELP_MAX_WIDTH = max(80, min(shutil.get_terminal_size(fallback=(120, 24)).columns, 160))
 
+# ---------------------------------------------------------------------------
+# Global-options injection
+# ---------------------------------------------------------------------------
+# These option definitions are injected into every leaf command and sub-group
+# so that --json, -y/--yes, and -v/--verbose work regardless of whether they
+# appear before or after the subcommand on the command line.
+#
+# --auth is intentionally excluded: it is consumed in the root group callback
+# before any subcommand runs, so positional placement there is load-bearing.
+#
+# Design note — expose_value=False for all commands (groups and leaves):
+#   All injected options use expose_value=False so Click parses the option but
+#   does NOT pass it as a keyword argument to any command callback.  Instead,
+#   an option callback (see _make_meta_callback) stores the value in ctx.meta
+#   when the flag is set.  Before the command body runs, _apply_meta_global_params
+#   reads ctx.meta and OR-merges the stored flags into ctx.obj (the shared
+#   CliContext).  This uniform approach avoids having to distinguish between
+#   group callbacks and leaf-command callbacks.
+# ---------------------------------------------------------------------------
+
+_META_KEY_JSON = "fabric_dw_global_json_output"
+_META_KEY_YES = "fabric_dw_global_yes"
+_META_KEY_VERBOSE = "fabric_dw_global_verbose"
+
+
+def _make_meta_callback(meta_key: str) -> Any:  # noqa: ANN401
+    """Return an option callback that stores the flag value in ``ctx.meta``."""
+
+    def _cb(ctx: click.Context, _param: click.Parameter, value: bool) -> bool:
+        if value:
+            ctx.meta[meta_key] = True
+        return value
+
+    return _cb
+
+
+def _inject_global_options(cmd: click.Command) -> None:
+    """Add the three global options to *cmd*, skipping any that already exist.
+
+    All injected options use ``expose_value=False`` so they are never passed
+    as keyword arguments to the command's own callback (which may not declare
+    them).  Instead, an option callback stores the value in ``ctx.meta`` so
+    the ``_wrapped_invoke`` can read it and fold it into the shared
+    :class:`CliContext` before the command body runs.
+    """
+    existing_names: set[str] = set()
+    existing_dests: set[str] = set()
+    for param in cmd.params:
+        if isinstance(param, click.Option):
+            existing_names.update(param.opts)
+        if param.name is not None:
+            existing_dests.add(param.name)
+
+    # Tuples of (opts, dest, meta_key, help_text).
+    _specs: list[tuple[list[str], str, str, str]] = [
+        (
+            ["--json", "json_output"],
+            "json_output",
+            _META_KEY_JSON,
+            "Emit machine-readable JSON instead of Rich tables.",
+        ),
+        (["--yes", "-y", "yes"], "yes", _META_KEY_YES, "Skip confirmation prompts."),
+        (["--verbose", "-v", "verbose"], "verbose", _META_KEY_VERBOSE, "Enable debug logging."),
+    ]
+
+    for opts, dest, meta_key, help_text in _specs:
+        # Skip if any declared option string already exists on this command.
+        if existing_names.intersection(opts):
+            continue
+        # Skip if the destination name already exists.
+        if dest in existing_dests:
+            continue
+
+        option = click.Option(
+            opts,
+            is_flag=True,
+            default=False,
+            expose_value=False,
+            callback=_make_meta_callback(meta_key),
+            help=help_text,
+        )
+        cmd.params.append(option)
+        existing_dests.add(dest)
+        # Update existing_names with the actual flag strings (e.g. "--json", "-y")
+        # as returned by the constructed option, not the raw opts list which may
+        # include the Click destination name (e.g. "json_output").
+        existing_names.update(option.opts)
+
+
+def _apply_meta_global_params(ctx: click.Context) -> None:
+    """Apply global flags stored in ``ctx.meta`` to the shared :class:`CliContext`.
+
+    The option callbacks (set up via :func:`_inject_global_options`) store flag
+    values in ``ctx.meta`` when the flag is set.  This function merges those
+    stored values into ``ctx.obj`` (the shared :class:`CliContext`) before the
+    command body runs.
+
+    Merge semantics (OR-merge — the most-permissive position wins):
+    - ``json_output`` → ``ctx.obj.json_output = True``
+    - ``yes``         → ``ctx.obj.yes = True``
+    - ``verbose``     → re-applies ``setup_logging(DEBUG)``
+    """
+    obj: CliContext | None = ctx.obj
+    if obj is None:
+        return
+    if ctx.meta.get(_META_KEY_JSON):
+        obj.json_output = True
+    if ctx.meta.get(_META_KEY_YES):
+        obj.yes = True
+    if ctx.meta.get(_META_KEY_VERBOSE):
+        setup_logging(logging.DEBUG)
+
+
+def _patch_command_for_global_options(cmd: click.Command) -> None:
+    """Inject global options and an invoke wrapper into *cmd* in-place.
+
+    Idempotent: the ``_global_opts_patched`` sentinel prevents double-patching.
+    All injected options use ``expose_value=False`` so neither group nor leaf
+    callbacks receive unexpected keyword arguments.
+
+    Recurses into sub-groups' already-registered commands so that nested
+    command trees are fully covered when a sub-group is added to the root.
+    """
+    if getattr(cmd, "_global_opts_patched", False):
+        return
+    cmd._global_opts_patched = True  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+
+    _inject_global_options(cmd)
+
+    original_invoke = cmd.invoke
+
+    def _wrapped_invoke(ctx: click.Context) -> Any:  # noqa: ANN401
+        _apply_meta_global_params(ctx)
+        return original_invoke(ctx)
+
+    cmd.invoke = _wrapped_invoke  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
+
+    if isinstance(cmd, click.Group):
+        for sub in cmd.commands.values():  # type: ignore[attr-defined]
+            _patch_command_for_global_options(sub)
+
 
 class _InstrumentedGroup(click.Group):
     """A :class:`click.Group` subclass that emits one ``command_invoked``
@@ -81,9 +222,10 @@ class _InstrumentedGroup(click.Group):
     """
 
     def add_command(self, cmd: click.Command, name: str | None = None) -> None:
-        """Add *cmd* and patch its ``invoke`` to capture the command path."""
+        """Add *cmd*, patch for telemetry, and inject global options."""
         if isinstance(cmd, click.Group):
             _patch_group_for_telemetry(cmd)
+        _patch_command_for_global_options(cmd)
         super().add_command(cmd, name)
 
     def invoke(self, ctx: click.Context) -> object:

--- a/tests/unit/test_global_options_anywhere.py
+++ b/tests/unit/test_global_options_anywhere.py
@@ -1,0 +1,272 @@
+"""Tests for global options (--json, -y/--yes, -v/--verbose) accepted after subcommand.
+
+Covers:
+- Before-position (existing behaviour, regression test)
+- After the leaf command (new behaviour)
+- After/with a sub-group
+- Help still renders global flags in command help
+- -h / --help still work
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from fabric_dw.cli._main import cli
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# --json: BEFORE (regression) and AFTER the leaf command
+# ---------------------------------------------------------------------------
+
+
+class TestJsonFlag:
+    """--json can appear before or after the subcommand."""
+
+    @pytest.fixture
+    def patched_list(self) -> object:
+        mock_ws = MagicMock()
+        mock_ws.model_dump.return_value = {"id": "ws-1", "displayName": "Test"}
+        with patch(
+            "fabric_dw.cli.commands.workspaces._workspaces_svc.list_all",
+            new=AsyncMock(return_value=[mock_ws]),
+        ) as p:
+            yield p
+
+    def test_json_before_subcommand(self, runner: CliRunner, patched_list: object) -> None:  # noqa: ARG002
+        """--json BEFORE subcommand still works (regression)."""
+        result = runner.invoke(cli, ["--json", "workspaces", "list"], catch_exceptions=False)
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.output)
+        assert isinstance(parsed, list)
+
+    def test_json_after_leaf_command(self, runner: CliRunner, patched_list: object) -> None:  # noqa: ARG002
+        """--json AFTER the leaf command produces JSON output."""
+        result = runner.invoke(cli, ["workspaces", "list", "--json"], catch_exceptions=False)
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.output)
+        assert isinstance(parsed, list)
+
+    def test_json_after_subgroup(self, runner: CliRunner, patched_list: object) -> None:  # noqa: ARG002
+        """--json between sub-group and leaf command also works."""
+        result = runner.invoke(cli, ["workspaces", "--json", "list"], catch_exceptions=False)
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.output)
+        assert isinstance(parsed, list)
+
+
+# ---------------------------------------------------------------------------
+# -y / --yes: BEFORE (regression) and AFTER the leaf command
+# ---------------------------------------------------------------------------
+
+
+class TestYesFlag:
+    """--yes / -y can appear before or after the subcommand."""
+
+    @pytest.fixture
+    def patched_set_collation(self) -> object:
+        with (
+            patch(
+                "fabric_dw.cli.commands.workspaces._workspaces_svc.set_collation",
+                new=AsyncMock(return_value=None),
+            ),
+            patch(
+                "fabric_dw.cli.commands.workspaces.resolve_workspace_id",
+                new=AsyncMock(return_value="ws-id-1"),
+            ),
+            patch(
+                "fabric_dw.cli.commands.workspaces.build_http_client",
+            ) as mock_ctx_mgr,
+        ):
+            mock_http = AsyncMock()
+            mock_ctx_mgr.return_value.__aenter__ = AsyncMock(return_value=mock_http)
+            mock_ctx_mgr.return_value.__aexit__ = AsyncMock(return_value=None)
+            yield
+
+    def test_yes_before_subcommand(
+        self,
+        runner: CliRunner,
+        patched_set_collation: object,  # noqa: ARG002
+    ) -> None:
+        """--yes BEFORE skips confirmation (regression)."""
+        result = runner.invoke(
+            cli,
+            ["-y", "workspaces", "set-collation", "my-ws", "Latin1_General_100_BIN2_UTF8"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, result.output
+        # Prompt was skipped; command succeeded without interaction
+        assert "Aborted" not in result.output
+
+    def test_yes_after_leaf_command(
+        self,
+        runner: CliRunner,
+        patched_set_collation: object,  # noqa: ARG002
+    ) -> None:
+        """--yes AFTER the leaf command skips confirmation."""
+        result = runner.invoke(
+            cli,
+            ["workspaces", "set-collation", "my-ws", "Latin1_General_100_BIN2_UTF8", "--yes"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, result.output
+        assert "Aborted" not in result.output
+
+    def test_yes_short_after_leaf_command(
+        self,
+        runner: CliRunner,
+        patched_set_collation: object,  # noqa: ARG002
+    ) -> None:
+        """-y AFTER the leaf command skips confirmation."""
+        result = runner.invoke(
+            cli,
+            ["workspaces", "set-collation", "my-ws", "Latin1_General_100_BIN2_UTF8", "-y"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, result.output
+        assert "Aborted" not in result.output
+
+
+# ---------------------------------------------------------------------------
+# -v / --verbose: BEFORE (regression) and AFTER the leaf command
+# ---------------------------------------------------------------------------
+
+
+class TestVerboseFlag:
+    """--verbose / -v can appear before or after the subcommand."""
+
+    @pytest.fixture
+    def patched_list(self) -> object:
+        mock_ws = MagicMock()
+        mock_ws.model_dump.return_value = {"id": "ws-1", "displayName": "Test"}
+        with patch(
+            "fabric_dw.cli.commands.workspaces._workspaces_svc.list_all",
+            new=AsyncMock(return_value=[mock_ws]),
+        ):
+            yield
+
+    def test_verbose_before_subcommand(
+        self,
+        runner: CliRunner,
+        patched_list: object,  # noqa: ARG002
+    ) -> None:
+        """--verbose BEFORE subcommand enables DEBUG logging (regression)."""
+        result = runner.invoke(cli, ["-v", "workspaces", "list"], catch_exceptions=False)
+        assert result.exit_code == 0, result.output
+        pkg_logger = logging.getLogger("fabric_dw")
+        assert pkg_logger.level == logging.DEBUG
+
+    def test_verbose_after_leaf_command(
+        self,
+        runner: CliRunner,
+        patched_list: object,  # noqa: ARG002
+    ) -> None:
+        """--verbose AFTER the leaf command enables DEBUG logging."""
+        result = runner.invoke(cli, ["workspaces", "list", "--verbose"], catch_exceptions=False)
+        assert result.exit_code == 0, result.output
+        pkg_logger = logging.getLogger("fabric_dw")
+        assert pkg_logger.level == logging.DEBUG
+
+    def test_verbose_short_after_leaf_command(
+        self,
+        runner: CliRunner,
+        patched_list: object,  # noqa: ARG002
+    ) -> None:
+        """-v AFTER the leaf command enables DEBUG logging."""
+        result = runner.invoke(cli, ["workspaces", "list", "-v"], catch_exceptions=False)
+        assert result.exit_code == 0, result.output
+        pkg_logger = logging.getLogger("fabric_dw")
+        assert pkg_logger.level == logging.DEBUG
+
+
+# ---------------------------------------------------------------------------
+# Help output: global flags appear in command help
+# ---------------------------------------------------------------------------
+
+
+class TestHelpOutput:
+    """Global flags are visible in command help and help still works."""
+
+    def test_help_still_works_on_leaf(self, runner: CliRunner) -> None:
+        """--help / -h still works on a leaf command after injection."""
+        result = runner.invoke(cli, ["workspaces", "list", "--help"])
+        assert result.exit_code == 0, result.output
+        assert "Usage:" in result.output
+
+    def test_short_help_still_works_on_leaf(self, runner: CliRunner) -> None:
+        """-h still works on a leaf command."""
+        result = runner.invoke(cli, ["workspaces", "list", "-h"])
+        assert result.exit_code == 0, result.output
+        assert "Usage:" in result.output
+
+    def test_json_flag_in_leaf_help(self, runner: CliRunner) -> None:
+        """--json appears in leaf command help."""
+        result = runner.invoke(cli, ["workspaces", "list", "--help"])
+        assert result.exit_code == 0, result.output
+        assert "--json" in result.output
+
+    def test_yes_flag_in_leaf_help(self, runner: CliRunner) -> None:
+        """-y / --yes appears in leaf command help."""
+        result = runner.invoke(cli, ["workspaces", "list", "--help"])
+        assert result.exit_code == 0, result.output
+        assert "--yes" in result.output
+
+    def test_verbose_flag_in_leaf_help(self, runner: CliRunner) -> None:
+        """-v / --verbose appears in leaf command help."""
+        result = runner.invoke(cli, ["workspaces", "list", "--help"])
+        assert result.exit_code == 0, result.output
+        assert "--verbose" in result.output
+
+    def test_help_on_subgroup_still_works(self, runner: CliRunner) -> None:
+        """--help still works on a sub-group."""
+        result = runner.invoke(cli, ["workspaces", "--help"])
+        assert result.exit_code == 0, result.output
+        assert "Usage:" in result.output
+
+    def test_root_help_still_works(self, runner: CliRunner) -> None:
+        """--help still works on the root command."""
+        result = runner.invoke(cli, ["--help"])
+        assert result.exit_code == 0, result.output
+        assert "Usage:" in result.output
+
+    def test_auth_not_in_leaf_help(self, runner: CliRunner) -> None:
+        """--auth is intentionally NOT injected into leaf commands."""
+        result = runner.invoke(cli, ["workspaces", "list", "--help"])
+        assert result.exit_code == 0, result.output
+        # --auth only appears at the root level; not injected into leaves
+        assert "--auth" not in result.output
+
+
+# ---------------------------------------------------------------------------
+# Idempotency: no collision / double-injection
+# ---------------------------------------------------------------------------
+
+
+class TestIdempotency:
+    """Global flags are injected only once even if both root and leaf set them."""
+
+    def test_json_both_positions(self, runner: CliRunner) -> None:
+        """--json before AND after the subcommand doesn't cause an error."""
+        mock_ws = MagicMock()
+        mock_ws.model_dump.return_value = {"id": "ws-1", "displayName": "Test"}
+        with patch(
+            "fabric_dw.cli.commands.workspaces._workspaces_svc.list_all",
+            new=AsyncMock(return_value=[mock_ws]),
+        ):
+            result = runner.invoke(
+                cli, ["--json", "workspaces", "list", "--json"], catch_exceptions=False
+            )
+        # Should not raise "Got multiple values for option" or similar
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.output)
+        assert isinstance(parsed, list)

--- a/tests/unit/test_global_options_anywhere.py
+++ b/tests/unit/test_global_options_anywhere.py
@@ -145,6 +145,19 @@ class TestYesFlag:
 class TestVerboseFlag:
     """--verbose / -v can appear before or after the subcommand."""
 
+    @pytest.fixture(autouse=True)
+    def _restore_log_level(self) -> object:
+        """Capture and restore the fabric_dw logger level after each test.
+
+        setup_logging(DEBUG) mutates the global logger for the process
+        lifetime.  This fixture ensures that verbose tests are hermetically
+        isolated regardless of execution order.
+        """
+        pkg_logger = logging.getLogger("fabric_dw")
+        original = pkg_logger.level
+        yield
+        pkg_logger.setLevel(original)
+
     @pytest.fixture
     def patched_list(self) -> object:
         mock_ws = MagicMock()


### PR DESCRIPTION
## Summary

- Adds `_patch_command_for_global_options` which injects `--json`, `-y/--yes`, and `-v/--verbose` into every leaf command and sub-group at registration time, so these flags work regardless of their position on the command line (e.g. `fabric-dw workspaces list --json` as well as `fabric-dw --json workspaces list`).
- Injection happens centrally in `_InstrumentedGroup.add_command` — zero per-command boilerplate.
- All injected options use `expose_value=False` with a meta-storing callback, so existing command callbacks receive no unexpected keyword arguments. The invoke wrapper reads from `ctx.meta` and folds values into the shared `CliContext` via OR-merge semantics.
- Collision detection skips injection for any command that already defines an option with the same name or dest. `--auth` is intentionally excluded (group-only, as per spec).

## Test plan

- [ ] `TestJsonFlag`: `--json` before subcommand (regression), after leaf command, after sub-group — all produce JSON output
- [ ] `TestYesFlag`: `-y`/`--yes` before subcommand (regression), after leaf command — confirmation skipped in all cases
- [ ] `TestVerboseFlag`: `-v`/`--verbose` before subcommand (regression), after leaf command — `fabric_dw` logger set to DEBUG in all cases
- [ ] `TestHelpOutput`: `--help`/`-h` still works at root, sub-group, and leaf level; `--json`, `--yes`, `--verbose` appear in leaf help; `--auth` does NOT appear in leaf help
- [ ] `TestIdempotency`: `--json` specified at both root and leaf positions does not cause an error
- [ ] `just check` green (ruff + ty + 3190 unit tests, 94.91% coverage)

Closes #395

🤖 Generated with [Claude Code](https://claude.com/claude-code)