### PR TITLE
fix(sql): longer login/query timeouts and retry warm-up login failures (2x10s)

### DIFF
--- a/src/fabric_dw/sql.py
+++ b/src/fabric_dw/sql.py
@@ -58,6 +58,8 @@ __all__ = [
     "POOL_MAX_IDLE",
     "POOL_MAX_IDLE_SECS",
     "SQL_COPT_SS_ACCESS_TOKEN",
+    "SQL_LOGIN_TIMEOUT_S",
+    "SQL_QUERY_TIMEOUT_S",
     "SQL_TRANSIENT_MAX_RETRIES",
     "SqlTarget",
     "build_connection_string",
@@ -77,11 +79,28 @@ __all__ = [
 
 # Maximum number of retry attempts for transient TDS connection drops.
 # Set to 0 to disable retries entirely.  Unit tests can monkeypatch this.
-SQL_TRANSIENT_MAX_RETRIES: int = 3
+SQL_TRANSIENT_MAX_RETRIES: int = 2
 
-# Backoff delays (seconds) between retry attempts.  Index 0 = delay before
+# Fixed delays (seconds) between retry attempts.  Index 0 = delay before
 # attempt 2, index 1 = delay before attempt 3, etc.  Extend if needed.
-_TRANSIENT_RETRY_DELAYS: tuple[float, ...] = (1.0, 2.0, 4.0)
+# A flat 10s gap is used so that a warming-up warehouse (which typically
+# takes several seconds to become ready after the first auth failure) has
+# enough time to finish provisioning before the next attempt.
+_TRANSIENT_RETRY_DELAYS: tuple[float, ...] = (10.0, 10.0)
+
+# ---------------------------------------------------------------------------
+# Timeout configuration
+# ---------------------------------------------------------------------------
+
+# Login / connection timeout (seconds) injected into the ODBC connection
+# string via "Connection Timeout=<value>".  The driver default is ~15s which
+# is too short for a freshly-warming Fabric warehouse.
+SQL_LOGIN_TIMEOUT_S: int = 60
+
+# Query / command timeout (seconds) injected into the ODBC connection string
+# via "Command Timeout=<value>".  A generous value prevents long-running
+# administrative queries from being cancelled prematurely.
+SQL_QUERY_TIMEOUT_S: int = 300
 
 # ---------------------------------------------------------------------------
 # Lazy driver import — @functools.cache avoids the module-level global and the
@@ -554,6 +573,10 @@ def build_connection_string(
         raw = _set_key(raw, "Authentication", _MODE_TO_AD_AUTH[mode])
     cs = _set_key(raw, "Encrypt", "yes")
     cs = _set_key(cs, "TrustServerCertificate", "no")
+    # Set an explicit login timeout (generous, to cover warehouse warm-up) and a
+    # command/query timeout so long-running admin queries are not cut off early.
+    cs = _set_key(cs, "Connection Timeout", str(SQL_LOGIN_TIMEOUT_S))
+    cs = _set_key(cs, "Command Timeout", str(SQL_QUERY_TIMEOUT_S))
     return _set_key(cs, "Database", target.database)
 
 
@@ -765,6 +788,37 @@ def is_auth_failed_message(msg: str) -> bool:
 # ---------------------------------------------------------------------------
 
 
+def _is_connect_retryable(exc: BaseException) -> bool:
+    """Return True when *exc* is retryable on the connect/login path.
+
+    In addition to the standard transient TDS transport errors, authentication
+    failures (error 18456 / SQLSTATE 28000) are also treated as retryable here
+    because a freshly-created or warming-up Fabric warehouse may reject the
+    login with "authentication failed" / "could not login" until the TDS
+    endpoint finishes provisioning — even when the credentials are correct.
+
+    **Trade-off**: a genuinely-wrong credential will now be retried 2x (~20s)
+    before the AuthError is surfaced to the caller.  This is intentional and
+    accepted because the warm-up case is far more common in production usage.
+
+    Scope: this helper is ONLY used by :func:`_with_connect_retry`.  It is NOT
+    used in the execute-phase retry logic — auth errors there are still mapped
+    to :class:`~fabric_dw.exceptions.AuthError` and raised immediately.
+    """
+    if is_transient_connection_error(exc):
+        return True
+    # Also retry auth-failed errors on the connect/login path.
+    # Use the same constants as map_driver_error() for consistency.
+    ddbc_error = getattr(exc, "ddbc_error", None)
+    if ddbc_error:
+        for match in _NATIVE_ERROR_RE.finditer(str(ddbc_error)):
+            raw_num = match.group(1) or match.group(2)
+            if raw_num and int(raw_num) in _AUTH_FAILED_ERROR_NUMBERS:
+                return True
+    msg = str(exc).lower()
+    return any(fragment in msg for fragment in _AUTH_FAILED_FRAGMENTS)
+
+
 def _with_connect_retry(
     target: SqlTarget,
     mode: CredentialMode,
@@ -784,6 +838,13 @@ def _with_connect_retry(
     server already received and applied the statement — retrying such errors
     for non-idempotent DML would risk duplicate execution.
 
+    Auth-failed retries
+    -------------------
+    Authentication failures (error 18456) are retried here because a
+    warming-up Fabric warehouse may reject the login until provisioning
+    completes — even with correct credentials.  See :func:`_is_connect_retryable`
+    for the trade-off note.
+
     Args:
         target: The :class:`SqlTarget` to connect to.
         mode: The credential mode for Entra authentication.
@@ -798,8 +859,8 @@ def _with_connect_retry(
           (``None`` on first-attempt success).
 
     Raises:
-        Any non-transient exception from ``open_connection`` immediately.
-        The last transient exception if all attempts are exhausted.
+        Any non-retryable exception from ``open_connection`` immediately.
+        The last retryable exception if all attempts are exhausted.
     """
     max_attempts = 1 + max(0, SQL_TRANSIENT_MAX_RETRIES)
     last_exc: BaseException | None = None
@@ -813,14 +874,14 @@ def _with_connect_retry(
         try:
             conn = open_connection(target, mode=mode, autocommit=autocommit)
         except Exception as exc:
-            if is_transient_connection_error(exc) and attempt < max_attempts - 1:
+            if _is_connect_retryable(exc) and attempt < max_attempts - 1:
                 last_exc = exc
                 continue
             raise
         else:
             return conn, attempt, max_attempts, last_exc
 
-    # Exhausted all attempts — re-raise the last transient error.
+    # Exhausted all attempts — re-raise the last retryable error.
     assert last_exc is not None  # noqa: S101  # guaranteed: loop ran ≥1 time
     raise last_exc  # pragma: no cover
 

--- a/tests/unit/test_sql.py
+++ b/tests/unit/test_sql.py
@@ -1823,6 +1823,22 @@ class TestAuthFailedConnectRetry:
         assert rows == [(1,)]
         assert mock_mssql.connect.call_count == 2
 
+    def test_could_not_login_fragment_also_retried(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """'could not login' fragment (without ddbc_error) is retried via _AUTH_FAILED_FRAGMENTS."""
+        mock_mssql, good_conn, good_cursor = _make_mock_mssql()
+        good_cursor.description = [("n",)]
+        good_cursor.fetchall.return_value = [(1,)]
+
+        # Some Fabric TDS error paths surface "could not login" without a native error number.
+        frag_exc = Exception("could not login because the authentication failed")
+        mock_mssql.connect.side_effect = [frag_exc, good_conn]
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        _cols, rows = run_query(_make_target(), "SELECT 1")
+
+        assert rows == [(1,)]
+        assert mock_mssql.connect.call_count == 2
+
     def test_transient_connect_still_retried_with_10s_delay(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -1891,3 +1907,27 @@ class TestAuthFailedConnectRetry:
 
         # Only the initial connect attempt — no execute-phase retry for DML.
         assert mock_mssql.connect.call_count == 1
+
+    def test_run_statements_retries_auth_failed_connect(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """run_statements retries 18456 / auth-failed on the connect phase.
+
+        Mirrors the run_query case: a warming-up Fabric warehouse may reject the
+        login with error 18456 until provisioning completes.  _with_connect_retry
+        is shared by both run_query and run_statements, so both must retry.
+        """
+        mock_mssql, good_conn, _ = _make_mock_mssql()
+
+        auth_exc = self._make_auth_exc()
+        # First connect raises 18456; second succeeds.
+        mock_mssql.connect.side_effect = [auth_exc, good_conn]
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        run_statements(_make_target(), ["SELECT 1"])
+
+        assert mock_mssql.connect.call_count == 2
+        fake_time = _sql_module.time  # type: ignore[attr-defined]
+        # Exactly one sleep before the retry.
+        assert fake_time.sleep.call_count == 1  # ty: ignore[unresolved-attribute]
+        assert fake_time.sleep.call_args.args[0] == 10.0  # ty: ignore[unresolved-attribute]

--- a/tests/unit/test_sql.py
+++ b/tests/unit/test_sql.py
@@ -1679,3 +1679,215 @@ class TestD23PoolRollbackOnReturn:
         # rollback called on pool return; underlying NOT physically closed.
         mock_conn.rollback.assert_called_once()
         mock_conn.close.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Issue #405 — longer timeouts + auth-failed retry on connect path
+# ---------------------------------------------------------------------------
+
+
+class TestConnectionStringTimeouts:
+    """build_connection_string must embed explicit login and command timeouts."""
+
+    def test_login_timeout_in_connection_string(self) -> None:
+        """Connection string must contain Connection Timeout=<SQL_LOGIN_TIMEOUT_S>."""
+        import fabric_dw.sql as sql_mod  # noqa: PLC0415
+
+        result = build_connection_string(_make_target())
+        assert f"Connection Timeout={sql_mod.SQL_LOGIN_TIMEOUT_S}" in result
+
+    def test_query_timeout_in_connection_string(self) -> None:
+        """Connection string must contain Command Timeout=<SQL_QUERY_TIMEOUT_S>."""
+        import fabric_dw.sql as sql_mod  # noqa: PLC0415
+
+        result = build_connection_string(_make_target())
+        assert f"Command Timeout={sql_mod.SQL_QUERY_TIMEOUT_S}" in result
+
+    def test_login_timeout_constant_value(self) -> None:
+        """SQL_LOGIN_TIMEOUT_S must be 60 (generous vs ~15s driver default)."""
+        import fabric_dw.sql as sql_mod  # noqa: PLC0415
+
+        assert sql_mod.SQL_LOGIN_TIMEOUT_S == 60
+
+    def test_query_timeout_constant_value(self) -> None:
+        """SQL_QUERY_TIMEOUT_S must be 300 (generous for long-running admin queries)."""
+        import fabric_dw.sql as sql_mod  # noqa: PLC0415
+
+        assert sql_mod.SQL_QUERY_TIMEOUT_S == 300
+
+    def test_timeout_keys_not_duplicated_on_idempotent_call(self) -> None:
+        """Calling build_connection_string twice on the same augmented string must not
+        duplicate the timeout keys."""
+        target = _make_target()
+        first = build_connection_string(target)
+        target2 = SqlTarget(
+            workspace_id=target.workspace_id,
+            database=target.database,
+            connection_string=first,
+        )
+        second = build_connection_string(target2)
+        assert first == second
+        assert second.count("Connection Timeout=") == 1
+        assert second.count("Command Timeout=") == 1
+
+    def test_no_double_semicolons_with_timeouts(self) -> None:
+        """Adding timeouts must not introduce double semicolons."""
+        result = build_connection_string(_make_target())
+        assert ";;" not in result
+
+
+class TestAuthFailedConnectRetry:
+    """_with_connect_retry must retry auth-failed / 18456 errors on the connect path."""
+
+    @pytest.fixture(autouse=True)
+    def _disable_sleep(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Patch time.sleep to a no-op and capture calls."""
+        monkeypatch.setattr(_sql_module, "time", _make_fake_time_module())
+
+    # ------------------------------------------------------------------ #
+    # Helper: fake driver exception with ddbc_error containing 18456      #
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _make_auth_exc() -> Exception:
+        """Return a simulated 18456 auth exception with a ``ddbc_error`` attribute."""
+
+        class _AuthDriverError(Exception):
+            ddbc_error: str = "[SQL Server]Login failed. Error: 18456"
+
+            def __str__(self) -> str:
+                return (
+                    "Login failed for user '<token-identified principal>'. "
+                    "Could not login because the authentication failed."
+                )
+
+        return _AuthDriverError()
+
+    def test_auth_failed_connect_retried_twice_then_succeeds(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An 18456 error on attempts 1 and 2 is retried; attempt 3 succeeds.
+
+        time.sleep must be called twice (once before each retry) with the
+        configured 10s delay.
+        """
+        mock_mssql, good_conn, good_cursor = _make_mock_mssql()
+        good_cursor.description = [("n",)]
+        good_cursor.fetchall.return_value = [(1,)]
+
+        auth_exc = self._make_auth_exc()
+        # Fail twice, succeed on the third attempt.
+        mock_mssql.connect.side_effect = [auth_exc, auth_exc, good_conn]
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        _cols, rows = run_query(_make_target(), "SELECT 1")
+
+        assert rows == [(1,)]
+        assert mock_mssql.connect.call_count == 3
+
+        # time.sleep must have been called twice (before attempt 2 and 3).
+        fake_time = _sql_module.time  # type: ignore[attr-defined]
+        assert fake_time.sleep.call_count == 2  # ty: ignore[unresolved-attribute]
+        # Each delay must be 10s (the fixed retry interval).
+        for call in fake_time.sleep.call_args_list:  # ty: ignore[unresolved-attribute]
+            assert call.args[0] == 10.0
+
+    def test_auth_failed_connect_persistent_raises_after_retries(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When all 3 attempts raise 18456 the exception is propagated after 2 retries."""
+        mock_mssql, _, _ = _make_mock_mssql()
+        auth_exc = self._make_auth_exc()
+        mock_mssql.connect.side_effect = auth_exc
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        with pytest.raises(Exception, match="authentication failed"):
+            run_query(_make_target(), "SELECT 1")
+
+        # 3 total attempts (1 initial + 2 retries).
+        assert mock_mssql.connect.call_count == 3
+
+    def test_auth_failed_fragment_only_also_retried(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Auth-failed detected via message fragment only (no ddbc_error) is also retried."""
+        mock_mssql, good_conn, good_cursor = _make_mock_mssql()
+        good_cursor.description = [("n",)]
+        good_cursor.fetchall.return_value = [(1,)]
+
+        # Plain Exception has no ddbc_error; detection falls through to fragment path.
+        frag_exc = Exception("authentication failed for user ''")
+        mock_mssql.connect.side_effect = [frag_exc, good_conn]
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        _cols, rows = run_query(_make_target(), "SELECT 1")
+
+        assert rows == [(1,)]
+        assert mock_mssql.connect.call_count == 2
+
+    def test_transient_connect_still_retried_with_10s_delay(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Standard transient connect errors still use the 10s delay after the policy change."""
+        mock_mssql, good_conn, good_cursor = _make_mock_mssql()
+        good_cursor.description = [("n",)]
+        good_cursor.fetchall.return_value = [(1,)]
+
+        transient_exc = Exception("TCP Provider: connection failed")
+        mock_mssql.connect.side_effect = [transient_exc, good_conn]
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        _cols, rows = run_query(_make_target(), "SELECT 1")
+
+        assert rows == [(1,)]
+        fake_time = _sql_module.time  # type: ignore[attr-defined]
+        assert fake_time.sleep.call_count == 1  # ty: ignore[unresolved-attribute]
+        assert fake_time.sleep.call_args.args[0] == 10.0  # ty: ignore[unresolved-attribute]
+
+    def test_auth_failed_on_execute_phase_not_retried(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Auth-failed raised during EXECUTE (not connect) must NOT be retried.
+
+        The execute-phase retry only covers transient transport errors for
+        read-only queries; mapped AuthError is raised immediately.
+        """
+        mock_mssql, _, mock_cursor = _make_mock_mssql()
+
+        class _AuthDriverError(Exception):
+            ddbc_error: str = "[SQL Server]Login failed. Error: 18456"
+
+            def __str__(self) -> str:
+                return "Login failed: authentication failed"
+
+        mock_cursor.execute.side_effect = _AuthDriverError()
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        with pytest.raises(AuthError):
+            run_query(_make_target(), "SELECT 1")
+
+        # map_driver_error converts the 18456 to AuthError and raises immediately.
+        assert mock_mssql.connect.call_count == 1
+
+    def test_retry_policy_constants(self) -> None:
+        """SQL_TRANSIENT_MAX_RETRIES=2 and delays are both 10s (flat, not exponential)."""
+        assert _sql_module.SQL_TRANSIENT_MAX_RETRIES == 2
+        assert _sql_module._TRANSIENT_RETRY_DELAYS == (10.0, 10.0)
+
+    def test_dml_not_retried_execute_phase_unchanged(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """fetch='none' DML must still NOT be retried after execute raises transient (D10).
+
+        This test re-validates the idempotency boundary is unaffected by the
+        auth-failed-on-connect change.
+        """
+        mock_mssql, _, _ = _make_mock_mssql()
+        bad_cursor = MagicMock()
+        bad_cursor.execute.side_effect = Exception("communication link failure")
+        bad_conn = MagicMock()
+        bad_conn.cursor.return_value = bad_cursor
+        mock_mssql.connect.return_value = bad_conn
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        with pytest.raises(Exception, match="communication link failure"):
+            run_query(_make_target(), "INSERT INTO t VALUES (1)", fetch="none")
+
+        # Only the initial connect attempt — no execute-phase retry for DML.
+        assert mock_mssql.connect.call_count == 1


### PR DESCRIPTION
## Summary

- **Longer timeouts**: `Connection Timeout=60` (login) and `Command Timeout=300` (query) are now injected into the ODBC connection string via `build_connection_string`, replacing the ~15s driver default. Exposed as module constants `SQL_LOGIN_TIMEOUT_S` and `SQL_QUERY_TIMEOUT_S`.
- **Retry policy 2x10s**: `SQL_TRANSIENT_MAX_RETRIES` changed from 3 to 2, `_TRANSIENT_RETRY_DELAYS` changed from `(1.0, 2.0, 4.0)` to `(10.0, 10.0)` — 3 total attempts with a flat 10s gap (20s window) before surfacing an error.
- **Auth-failed retried on connect**: New `_is_connect_retryable` helper extends `_with_connect_retry` to also retry error 18456 / "authentication failed" on the connect/login path so a warming-up warehouse that rejects the login transiently gets the full 2x10s retry window. Trade-off documented: a genuinely-wrong credential now retries 2x (~20s) before raising — accepted and intended.
- Execute-phase D10 idempotency boundary is unchanged: DML (`fetch="none"`) is never retried after `cursor.execute` starts.

## Test plan

- [x] `build_connection_string` includes `Connection Timeout=60` and `Command Timeout=300`
- [x] Timeout keys are not duplicated on idempotent second call
- [x] `_with_connect_retry` retries an 18456 error 2x with 10s gaps (mocked `time.sleep`) then succeeds on attempt 3
- [x] Persistent auth-failed (18456) raises after 3 attempts total
- [x] Fragment-only auth-failed (no `ddbc_error`) is also retried on the connect path
- [x] Standard transient connect errors still use the 10s delay
- [x] Auth-failed on the **execute** phase is still mapped to `AuthError` and raised immediately (not retried)
- [x] DML `fetch="none"` execute-phase transient error is NOT retried (D10 boundary unchanged)
- [x] `just check` green (ruff + ty + 3228 unit tests, 95% coverage)

Complements #404 (test readiness probe for the same warm-up auth transient).

Closes #405

🤖 Generated with [Claude Code](https://claude.com/claude-code)