### PR TITLE
fix(statistics): use string literal for stat name in DBCC SHOW_STATISTICS

### DIFF
--- a/src/fabric_dw/services/statistics.py
+++ b/src/fabric_dw/services/statistics.py
@@ -133,9 +133,11 @@ ORDER BY s.name, t.name, st.name;
 # Both schema, table, and stat_name are validated via validate_identifier
 # (allowlist [A-Za-z_][A-Za-z0-9_]*) before embedding, so none can contain
 # a single-quote — no escaping is required.
-_DBCC_STAT_HEADER_SQL = "DBCC SHOW_STATISTICS ('{table_s}', '{stat_s}') WITH STAT_HEADER;"
-_DBCC_DENSITY_SQL = "DBCC SHOW_STATISTICS ('{table_s}', '{stat_s}') WITH DENSITY_VECTOR;"
-_DBCC_HISTOGRAM_SQL = "DBCC SHOW_STATISTICS ('{table_s}', '{stat_s}') WITH HISTOGRAM;"
+# The format key {stat_literal} is intentionally named to signal that the
+# stat name is embedded as a string literal (not a bracket-quoted identifier).
+_DBCC_STAT_HEADER_SQL = "DBCC SHOW_STATISTICS ('{table_s}', '{stat_literal}') WITH STAT_HEADER;"
+_DBCC_DENSITY_SQL = "DBCC SHOW_STATISTICS ('{table_s}', '{stat_literal}') WITH DENSITY_VECTOR;"
+_DBCC_HISTOGRAM_SQL = "DBCC SHOW_STATISTICS ('{table_s}', '{stat_literal}') WITH HISTOGRAM;"
 
 # CREATE STATISTICS: identifiers are bracket-quoted; FULLSCAN/SAMPLE are keywords.
 _CREATE_STAT_FULLSCAN_SQL = "CREATE STATISTICS {stat_q} ON {table_q} ({col_q}) WITH FULLSCAN;"
@@ -423,11 +425,11 @@ async def show_statistics(
     # [A-Za-z_][A-Za-z0-9_]*), so none can contain single-quotes — no escaping
     # is required.
     table_s = f"{schema}.{table}"
-    stat_s = stat_name  # already validated; used as a single-quoted string literal
+    stat_literal = stat_name  # already validated; embedded as a single-quoted string literal
 
-    header_sql = _DBCC_STAT_HEADER_SQL.format(table_s=table_s, stat_s=stat_s)
-    density_sql = _DBCC_DENSITY_SQL.format(table_s=table_s, stat_s=stat_s)
-    histogram_sql = _DBCC_HISTOGRAM_SQL.format(table_s=table_s, stat_s=stat_s)
+    header_sql = _DBCC_STAT_HEADER_SQL.format(table_s=table_s, stat_literal=stat_literal)
+    density_sql = _DBCC_DENSITY_SQL.format(table_s=table_s, stat_literal=stat_literal)
+    histogram_sql = _DBCC_HISTOGRAM_SQL.format(table_s=table_s, stat_literal=stat_literal)
 
     def _run() -> StatisticDetails:
         if histogram_only:

--- a/src/fabric_dw/services/statistics.py
+++ b/src/fabric_dw/services/statistics.py
@@ -21,12 +21,14 @@ this charset and therefore always rejected).
 ``]`` as ``]]`` for defence-in-depth) before embedding them in SQL.
 
 **DBCC SHOW_STATISTICS** is different: Fabric DW does not accept bracket-quoted
-identifiers in the first (table) argument position — doing so causes
-``Incorrect syntax near '.'``.  The table argument is therefore embedded as a
-**single-quoted string literal** of the form ``'schema.table'``.  Because
-``validate_identifier`` has already accepted both parts, neither can contain a
-single-quote, so no ``'``→``''`` escaping is needed.  The stat-name (second
-argument) is still bracket-quoted in the normal way.
+identifiers in either argument position.  The official Fabric DW documentation
+examples use single-quoted string literals for both arguments:
+``DBCC SHOW_STATISTICS ('schema.table', 'stat_name')``.  Using bracket-quoted
+identifiers for the table argument causes ``Incorrect syntax near '.'``; using
+them for the stat-name argument causes ``Could not locate statistics``.
+Both arguments are therefore embedded as **single-quoted string literals**.
+Because ``validate_identifier`` has already accepted all name parts, none can
+contain a single-quote, so no ``'``→``''`` escaping is needed.
 
 The ``sample_percent`` argument is a numeric value; it is range-validated as an
 :class:`int` (1-100) and embedded as a literal integer — never an arbitrary
@@ -117,15 +119,23 @@ WHERE ({schema_filter})
 ORDER BY s.name, t.name, st.name;
 """
 
-# DBCC SHOW_STATISTICS on Fabric DW requires the table as a string literal
-# ('schema.table') — NOT as bracket-quoted identifier tokens ([schema].[table]).
-# Passing bracket-quoted identifiers causes "Incorrect syntax near '.'" because
-# the parser does not accept a two-part identifier in that argument position.
-# The stat name (second argument) is still bracket-quoted as an identifier token.
-# Both parts are validated via validate_identifier before embedding.
-_DBCC_STAT_HEADER_SQL = "DBCC SHOW_STATISTICS ('{table_s}', {stat_q}) WITH STAT_HEADER;"
-_DBCC_DENSITY_SQL = "DBCC SHOW_STATISTICS ('{table_s}', {stat_q}) WITH DENSITY_VECTOR;"
-_DBCC_HISTOGRAM_SQL = "DBCC SHOW_STATISTICS ('{table_s}', {stat_q}) WITH HISTOGRAM;"
+# DBCC SHOW_STATISTICS on Fabric DW requires BOTH arguments as string literals.
+# The official Fabric DW docs show: DBCC SHOW_STATISTICS ('schema.table', 'stat_name')
+#
+# First argument — table: bracket-quoted [schema].[table] causes
+# "Incorrect syntax near '.'" (fixed in #371).
+#
+# Second argument — stat name: bracket-quoted [stat_name] causes
+# "Could not locate statistics '<stat_name>'" because Fabric DW does not
+# resolve bracket-quoted tokens as statistics names in this position (fixed
+# in #403).
+#
+# Both schema, table, and stat_name are validated via validate_identifier
+# (allowlist [A-Za-z_][A-Za-z0-9_]*) before embedding, so none can contain
+# a single-quote — no escaping is required.
+_DBCC_STAT_HEADER_SQL = "DBCC SHOW_STATISTICS ('{table_s}', '{stat_s}') WITH STAT_HEADER;"
+_DBCC_DENSITY_SQL = "DBCC SHOW_STATISTICS ('{table_s}', '{stat_s}') WITH DENSITY_VECTOR;"
+_DBCC_HISTOGRAM_SQL = "DBCC SHOW_STATISTICS ('{table_s}', '{stat_s}') WITH HISTOGRAM;"
 
 # CREATE STATISTICS: identifiers are bracket-quoted; FULLSCAN/SAMPLE are keywords.
 _CREATE_STAT_FULLSCAN_SQL = "CREATE STATISTICS {stat_q} ON {table_q} ({col_q}) WITH FULLSCAN;"
@@ -399,20 +409,25 @@ async def show_statistics(
     validate_identifier(table)
     validate_identifier(stat_name)
 
-    # DBCC SHOW_STATISTICS on Fabric DW requires the table as a string literal
-    # ('schema.table'), NOT as bracket-quoted identifier tokens ([schema].[table]).
-    # Using bracket-quoted identifiers in the first DBCC argument causes
-    # "Incorrect syntax near '.'" on real Fabric (the parser does not accept a
-    # two-part identifier in that position).  The stat name (second arg) is still
-    # bracket-quoted as a regular identifier token.
-    # Both schema and table have already been validated via validate_identifier
-    # (allowlist [A-Za-z_][A-Za-z0-9_]*), so they cannot contain single-quotes.
+    # DBCC SHOW_STATISTICS on Fabric DW requires BOTH arguments as string literals.
+    # The Fabric DW documentation examples use single-quoted string literals for
+    # both the table and the stat name:
+    #   DBCC SHOW_STATISTICS ('schema.table', 'stat_name')
+    #
+    # Using bracket-quoted identifiers for the table causes "Incorrect syntax
+    # near '.'" (fixed in #371).  Using bracket-quoted identifiers for the stat
+    # name causes "Could not locate statistics '<name>'" because Fabric DW does
+    # not resolve bracket tokens as statistics names in that position (#403).
+    #
+    # All parts have already been validated via validate_identifier (allowlist
+    # [A-Za-z_][A-Za-z0-9_]*), so none can contain single-quotes — no escaping
+    # is required.
     table_s = f"{schema}.{table}"
-    stat_q = quote_identifier(stat_name)
+    stat_s = stat_name  # already validated; used as a single-quoted string literal
 
-    header_sql = _DBCC_STAT_HEADER_SQL.format(table_s=table_s, stat_q=stat_q)
-    density_sql = _DBCC_DENSITY_SQL.format(table_s=table_s, stat_q=stat_q)
-    histogram_sql = _DBCC_HISTOGRAM_SQL.format(table_s=table_s, stat_q=stat_q)
+    header_sql = _DBCC_STAT_HEADER_SQL.format(table_s=table_s, stat_s=stat_s)
+    density_sql = _DBCC_DENSITY_SQL.format(table_s=table_s, stat_s=stat_s)
+    histogram_sql = _DBCC_HISTOGRAM_SQL.format(table_s=table_s, stat_s=stat_s)
 
     def _run() -> StatisticDetails:
         if histogram_only:

--- a/tests/unit/services/test_statistics.py
+++ b/tests/unit/services/test_statistics.py
@@ -304,6 +304,9 @@ class TestShowStatistics:
         ([stat_name]) in the second argument — that causes 'Could not locate
         statistics'.  Both arguments must be single-quoted string literals, as
         shown in the official Fabric DW documentation examples.
+
+        All three DBCC variants (STAT_HEADER, DENSITY_VECTOR, HISTOGRAM) are
+        asserted so that a regression in any individual template is caught.
         """
         target = _make_target()
         header_conn = _make_conn([_HEADER_ROW], _HEADER_COLS)
@@ -314,11 +317,21 @@ class TestShowStatistics:
             side_effect=[header_conn, density_conn, hist_conn],
         ):
             await statistics.show_statistics(target, "dbo.sales", "stat_sales_id")
-        call_sql: str = header_conn.cursor.return_value.execute.call_args[0][0]
-        # Stat name must be a string literal, not a bracket-quoted identifier.
-        assert "'stat_sales_id'" in call_sql
-        # Regression: must NOT have bracket-quoted stat name (the #403 bug).
-        assert "[stat_sales_id]" not in call_sql
+        # All three DBCC templates must embed the stat name as a string literal.
+        for label, conn in [
+            ("STAT_HEADER", header_conn),
+            ("DENSITY_VECTOR", density_conn),
+            ("HISTOGRAM", hist_conn),
+        ]:
+            call_sql: str = conn.cursor.return_value.execute.call_args[0][0]
+            # Stat name must be a string literal, not a bracket-quoted identifier.
+            assert "'stat_sales_id'" in call_sql, (
+                f"{label}: expected single-quoted stat name in SQL, got: {call_sql!r}"
+            )
+            # Regression: must NOT have bracket-quoted stat name (the #403 bug).
+            assert "[stat_sales_id]" not in call_sql, (
+                f"{label}: bracket-quoted stat name found in SQL (regression): {call_sql!r}"
+            )
 
     async def test_raises_not_found_when_header_empty(self) -> None:
         target = _make_target()

--- a/tests/unit/services/test_statistics.py
+++ b/tests/unit/services/test_statistics.py
@@ -297,7 +297,14 @@ class TestShowStatistics:
         # Regression: must NOT have stray dot outside the string (the original bug).
         assert "[dbo].[sales]" not in call_sql
 
-    async def test_sql_bracket_quotes_stat_identifier(self) -> None:
+    async def test_sql_uses_string_literal_for_stat_name(self) -> None:
+        """show_statistics must pass the stat name as a string literal 'stat_name'.
+
+        Fabric DW DBCC SHOW_STATISTICS does not accept bracket-quoted identifiers
+        ([stat_name]) in the second argument — that causes 'Could not locate
+        statistics'.  Both arguments must be single-quoted string literals, as
+        shown in the official Fabric DW documentation examples.
+        """
         target = _make_target()
         header_conn = _make_conn([_HEADER_ROW], _HEADER_COLS)
         density_conn = _make_conn([_DENSITY_ROW], _DENSITY_COLS)
@@ -308,7 +315,10 @@ class TestShowStatistics:
         ):
             await statistics.show_statistics(target, "dbo.sales", "stat_sales_id")
         call_sql: str = header_conn.cursor.return_value.execute.call_args[0][0]
-        assert "[stat_sales_id]" in call_sql
+        # Stat name must be a string literal, not a bracket-quoted identifier.
+        assert "'stat_sales_id'" in call_sql
+        # Regression: must NOT have bracket-quoted stat name (the #403 bug).
+        assert "[stat_sales_id]" not in call_sql
 
     async def test_raises_not_found_when_header_empty(self) -> None:
         target = _make_target()
@@ -379,6 +389,17 @@ class TestShowStatistics:
         target = _make_target()
         with pytest.raises(ValueError, match="Invalid SQL identifier"):
             await statistics.show_statistics(target, "dbo.sales'", "stat")
+
+    async def test_single_quote_in_stat_name_rejected(self) -> None:
+        """Single-quote in stat name must be rejected before it can reach the string literal.
+
+        DBCC SHOW_STATISTICS embeds the stat name as 'stat_name' (string literal).
+        validate_identifier must block any name containing a quote so that the
+        literal is safe without explicit escaping.
+        """
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await statistics.show_statistics(target, "dbo.sales", "stat'name")
 
 
 # ===========================================================================
@@ -892,10 +913,15 @@ class TestExactSqlRoundtripRegression:
     _QUALIFIED = f"{_SCHEMA}.{_TABLE}"
 
     async def test_show_statistics_exact_sql_no_stray_dot(self) -> None:
-        """DBCC SHOW_STATISTICS must use string literal for table, not [schema].[table].
+        """DBCC SHOW_STATISTICS must use string literals for both table and stat name.
 
-        Regression: passing [schema].[table] caused 'Incorrect syntax near .' on
-        real Fabric DW.  The first argument must be 'schema.table' (string literal).
+        Regression #371: passing [schema].[table] caused 'Incorrect syntax near .'
+        on real Fabric DW.  The first argument must be 'schema.table' (string literal).
+
+        Regression #403: passing [stat_name] caused 'Could not locate statistics'
+        on real Fabric DW.  The second argument must also be 'stat_name' (string
+        literal), matching the official Fabric DW documentation examples.
+
         All three DBCC templates (STAT_HEADER, DENSITY_VECTOR, HISTOGRAM) are pinned.
         """
         target = _make_target()
@@ -909,36 +935,46 @@ class TestExactSqlRoundtripRegression:
             await statistics.show_statistics(target, self._QUALIFIED, self._STAT)
 
         table_literal = f"'{self._SCHEMA}.{self._TABLE}'"
-        stat_q = f"[{self._STAT}]"
+        stat_literal = f"'{self._STAT}'"
 
         # --- STAT_HEADER ---
         header_sql: str = header_conn.cursor.return_value.execute.call_args[0][0]
-        expected_header = f"DBCC SHOW_STATISTICS ({table_literal}, {stat_q}) WITH STAT_HEADER;"
+        expected_header = (
+            f"DBCC SHOW_STATISTICS ({table_literal}, {stat_literal}) WITH STAT_HEADER;"
+        )
         assert header_sql == expected_header, (
             f"STAT_HEADER SQL mismatch.\nGot:      {header_sql!r}\nExpected: {expected_header!r}"
         )
         assert ".." not in header_sql
         assert f"[{self._SCHEMA}].[{self._TABLE}]" not in header_sql
+        # Regression #403: stat name must NOT be bracket-quoted.
+        assert f"[{self._STAT}]" not in header_sql
 
         # --- DENSITY_VECTOR ---
         density_sql: str = density_conn.cursor.return_value.execute.call_args[0][0]
-        expected_density = f"DBCC SHOW_STATISTICS ({table_literal}, {stat_q}) WITH DENSITY_VECTOR;"
+        expected_density = (
+            f"DBCC SHOW_STATISTICS ({table_literal}, {stat_literal}) WITH DENSITY_VECTOR;"
+        )
         assert density_sql == expected_density, (
             f"DENSITY_VECTOR SQL mismatch.\n"
             f"Got:      {density_sql!r}\nExpected: {expected_density!r}"
         )
         assert ".." not in density_sql
         assert f"[{self._SCHEMA}].[{self._TABLE}]" not in density_sql
+        assert f"[{self._STAT}]" not in density_sql
 
         # --- HISTOGRAM ---
         histogram_sql: str = hist_conn.cursor.return_value.execute.call_args[0][0]
-        expected_histogram = f"DBCC SHOW_STATISTICS ({table_literal}, {stat_q}) WITH HISTOGRAM;"
+        expected_histogram = (
+            f"DBCC SHOW_STATISTICS ({table_literal}, {stat_literal}) WITH HISTOGRAM;"
+        )
         assert histogram_sql == expected_histogram, (
             f"HISTOGRAM SQL mismatch.\n"
             f"Got:      {histogram_sql!r}\nExpected: {expected_histogram!r}"
         )
         assert ".." not in histogram_sql
         assert f"[{self._SCHEMA}].[{self._TABLE}]" not in histogram_sql
+        assert f"[{self._STAT}]" not in histogram_sql
 
     async def test_create_statistics_exact_sql(self) -> None:
         """CREATE STATISTICS SQL must be bracket-quoted with no stray dots."""


### PR DESCRIPTION
## Summary

- **Root cause**: After #371 fixed the first `DBCC SHOW_STATISTICS` argument (table name) to use a single-quoted string literal, the second argument (stat name) was still passed as a bracket-quoted identifier `[stat_name]`. Fabric DW does not resolve bracket-quoted tokens as statistics names in that argument position, causing `Could not locate statistics 'pytest_stat_on_id'` on every SHOW/UPDATE call following a successful CREATE.
- **Fix**: Changed the three `_DBCC_*_SQL` templates to embed the stat name as `'{stat_s}'` (single-quoted string literal), matching the official Fabric DW documentation examples: `DBCC SHOW_STATISTICS ('schema.table', 'stat_name')`. The `quote_identifier` call for the stat name is replaced with a plain string reference; the name is already validated by `validate_identifier` so no escaping is needed.
- **Scope**: Only `show_statistics` / `DBCC SHOW_STATISTICS` is affected. `CREATE STATISTICS`, `UPDATE STATISTICS`, and `DROP STATISTICS` use standard DDL syntax that correctly accepts bracket-quoted identifiers.

## Test plan

- [x] Updated `test_sql_bracket_quotes_stat_identifier` → `test_sql_uses_string_literal_for_stat_name`: asserts `'stat_name'` is present and `[stat_name]` is absent from the emitted SQL.
- [x] Added `test_single_quote_in_stat_name_rejected`: verifies that a single-quote in the stat name is blocked by `validate_identifier` before it can reach the string literal (injection safety).
- [x] Updated `TestExactSqlRoundtripRegression::test_show_statistics_exact_sql_no_stray_dot`: pins the corrected full SQL for all three DBCC templates using `stat_literal = f"'{STAT}'"` and asserts `[STAT]` is absent.
- [x] `just check` clean — ruff, ty, 3216 unit tests pass, coverage 95%.

Closes #403