### PR TITLE
fix(cli): skip paused/no-capacity workspaces in -A scans via capacity state

### DIFF
--- a/src/fabric_dw/exceptions.py
+++ b/src/fabric_dw/exceptions.py
@@ -87,32 +87,6 @@ class FabricServerError(FabricError):
         self.is_retriable = is_retriable
 
 
-class CapacityUnavailableError(FabricServerError):
-    """Raised when a workspace's capacity is paused or has no capacity.
-
-    This is a subclass of :class:`FabricServerError` with ``is_retriable=False``
-    to prevent the HTTP client from retrying the ~22s-hanging data-plane call.
-    It is used as a signal for proactive and defensive per-workspace skipping
-    in ``-A`` scans.
-    """
-
-    def __init__(
-        self,
-        message: str,
-        *,
-        status: int | None = None,
-        request_id: str | None = None,
-        body: dict[str, object] | None = None,
-    ) -> None:
-        super().__init__(
-            message,
-            status=status,
-            request_id=request_id,
-            body=body,
-            is_retriable=False,
-        )
-
-
 class BadRequestError(FabricError):
     """Raised on HTTP 400 - the request body or parameters were invalid.
 

--- a/src/fabric_dw/exceptions.py
+++ b/src/fabric_dw/exceptions.py
@@ -64,7 +64,53 @@ class RateLimitedError(FabricError):
 
 
 class FabricServerError(FabricError):
-    """Raised on persistent 5xx errors or a failed LRO operation."""
+    """Raised on persistent 5xx errors or a failed LRO operation.
+
+    Attributes:
+        is_retriable: Mirrors the ``isRetriable`` flag from the Fabric error
+            envelope when present.  ``True`` by default (safe for existing
+            callers).  When ``False``, the HTTP retry layer will NOT retry the
+            request, failing fast instead of waiting through back-off cycles.
+    """
+
+    def __init__(  # noqa: PLR0913
+        self,
+        message: str,
+        *,
+        status: int | None = None,
+        request_id: str | None = None,
+        body: dict[str, object] | None = None,
+        hint: str | None = None,
+        is_retriable: bool = True,
+    ) -> None:
+        super().__init__(message, status=status, request_id=request_id, body=body, hint=hint)
+        self.is_retriable = is_retriable
+
+
+class CapacityUnavailableError(FabricServerError):
+    """Raised when a workspace's capacity is paused or has no capacity.
+
+    This is a subclass of :class:`FabricServerError` with ``is_retriable=False``
+    to prevent the HTTP client from retrying the ~22s-hanging data-plane call.
+    It is used as a signal for proactive and defensive per-workspace skipping
+    in ``-A`` scans.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status: int | None = None,
+        request_id: str | None = None,
+        body: dict[str, object] | None = None,
+    ) -> None:
+        super().__init__(
+            message,
+            status=status,
+            request_id=request_id,
+            body=body,
+            is_retriable=False,
+        )
 
 
 class BadRequestError(FabricError):

--- a/src/fabric_dw/http_client.py
+++ b/src/fabric_dw/http_client.py
@@ -202,13 +202,17 @@ def _make_should_retry(method: str) -> Callable[[BaseException], bool]:
     def _should_retry(exc: BaseException) -> bool:
         """Retry on 5xx *or* on timeout for idempotent methods.
 
-        - Always retry :class:`~fabric_dw.exceptions.FabricServerError` (5xx).
+        - Retry :class:`~fabric_dw.exceptions.FabricServerError` (5xx) ONLY
+          when ``is_retriable`` is ``True`` (the default).  A Fabric error
+          envelope with ``"isRetriable": false`` (e.g. the ~22s
+          InternalServerError from a paused-capacity workspace) must NOT be
+          retried — fail fast, no 60-70s back-off waste.
         - Retry :class:`httpx.TimeoutException` ONLY for idempotent HTTP
           methods (GET, HEAD, OPTIONS).  POST/PATCH/DELETE are not retried
           on timeout — the server may have already committed the request.
         """
         if isinstance(exc, FabricServerError):
-            return True
+            return exc.is_retriable
         if isinstance(exc, httpx.TimeoutException):
             return upper in _IDEMPOTENT_METHODS
         return False
@@ -576,11 +580,22 @@ class FabricHttpClient:
             )
 
         if status >= http.HTTPStatus.INTERNAL_SERVER_ERROR:
+            # Parse the isRetriable flag from the Fabric error envelope.
+            # Fabric sets isRetriable=false for errors like the ~22s
+            # InternalServerError from paused-capacity workspaces.  When
+            # false, the retry predicate in _make_should_retry will skip
+            # back-off entirely, failing fast rather than wasting 60-70s.
+            is_retriable = True
+            if body is not None:
+                raw_retriable = body.get("isRetriable")
+                if raw_retriable is False:
+                    is_retriable = False
             raise FabricServerError(
                 f"Server error {status} for {url}: {resp.text}",
                 status=status,
                 request_id=request_id,
                 body=body,
+                is_retriable=is_retriable,
             )
 
     # ------------------------------------------------------------------

--- a/src/fabric_dw/services/_helpers.py
+++ b/src/fabric_dw/services/_helpers.py
@@ -23,6 +23,17 @@ class _HasNameAndId(Protocol):
     def id(self) -> UUID: ...
 
 
+class _HasNameIdAndCapacity(_HasNameAndId, Protocol):
+    """Structural protocol for workspace objects that also carry a capacity ID.
+
+    The ``capacity_id`` attribute is ``None`` when the workspace is not
+    attached to a capacity (e.g. a Trial or personal workspace).
+    """
+
+    @property
+    def capacity_id(self) -> UUID | None: ...
+
+
 def compact(mapping: Mapping[str, object]) -> dict[str, object]:
     """Return a copy of *mapping* with all ``None``-valued entries removed.
 
@@ -40,12 +51,59 @@ def compact(mapping: Mapping[str, object]) -> dict[str, object]:
     return {k: v for k, v in mapping.items() if v is not None}
 
 
+def _is_capacity_active(
+    ws: _HasNameAndId,
+    capacity_states: dict[str, str] | None,
+) -> bool:
+    """Return ``True`` when *ws* should be included in a scan.
+
+    Returns ``False`` (skip the workspace) when:
+
+    * *capacity_states* is not ``None`` (proactive filtering is available) AND
+    * the workspace has no ``capacity_id`` attribute, or ``capacity_id`` is
+      ``None`` or empty, OR the mapped capacity state is not ``"Active"``.
+
+    When *capacity_states* is ``None`` (the caller lacks ``Capacity.Read.All``
+    permission and the proactive filter fell back), this function always
+    returns ``True`` so every workspace is attempted and the defensive
+    per-workspace error handling takes over.
+
+    Args:
+        ws: Workspace object.  Must implement :class:`_HasNameAndId`; optionally
+            also implements :class:`_HasNameIdAndCapacity`.
+        capacity_states: Lower-cased ``{capacity_id: state}`` map as returned
+            by :func:`~fabric_dw.services.capacities.get_capacity_states`, or
+            ``None`` when proactive filtering is unavailable.
+
+    Returns:
+        ``True`` if the workspace should be scanned, ``False`` if it should be
+        silently skipped.
+    """
+    if capacity_states is None:
+        # Proactive filtering unavailable — let the defensive path handle it.
+        return True
+
+    cap_id: UUID | None = getattr(ws, "capacity_id", None)
+    if cap_id is None:
+        return False
+
+    state = capacity_states.get(str(cap_id).lower())
+    if state is None:
+        # Capacity not found in map — treat as unavailable (conservative).
+        return False
+
+    from fabric_dw.services.capacities import ACTIVE_STATE  # noqa: PLC0415
+
+    return state == ACTIVE_STATE
+
+
 async def scan_all_workspaces(
     workspaces: Sequence[_HasNameAndId],
     fetch: Callable[[_HasNameAndId], Coroutine[object, object, list[_T]]],
     *,
     logger: logging.Logger,
     skip_errors: tuple[type[BaseException], ...],
+    capacity_states: dict[str, str] | None = None,
 ) -> list[_T]:
     """Fan-out *fetch* over every workspace with bounded concurrency.
 
@@ -53,39 +111,95 @@ async def scan_all_workspaces(
     per-workspace ``warning`` log entry.  Any other exception (including other
     :class:`BaseException` subclasses) propagates immediately.
 
+    Proactive capacity filtering
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    When *capacity_states* is provided (a ``{capacity_id_lower: state}`` dict
+    from ``GET /v1/capacities``), workspaces whose capacity is not ``"Active"``
+    (or whose ``capacity_id`` is ``None``) are skipped **before** the fan-out,
+    avoiding the ~22s hang that paused-capacity data-plane calls incur.  The
+    skip is logged at ``DEBUG`` level only (silent to the user).
+
+    Defensive fallback
+    ~~~~~~~~~~~~~~~~~~
+    When *capacity_states* is ``None`` (the caller lacks the capacity-read
+    permission), all workspaces are attempted.  A
+    :class:`~fabric_dw.exceptions.CapacityUnavailableError` (non-retriable
+    ``FabricServerError`` with ``is_retriable=False``) on a per-workspace call
+    is treated as a silent skip (``DEBUG`` log), not a fatal error.
+
     Args:
         workspaces: Sequence of workspace objects.  Each element must have a
             ``name`` attribute used in log messages.
         fetch: Async callable that receives a workspace object and returns a
             ``list[T]`` of items for that workspace.
         logger: Logger for per-workspace and summary warnings.
-        skip_errors: Exception types to skip (log + continue).
+        skip_errors: Exception types to skip with a WARNING log (e.g.
+            PermissionDeniedError, NotFoundError).
+        capacity_states: Optional ``{capacity_id_lower: state}`` map for
+            proactive capacity filtering.  Pass ``None`` to disable proactive
+            filtering and rely on the defensive fallback only.
 
     Returns:
         A flat list of all items collected from accessible workspaces.
     """
     # Import here to avoid circular imports at module level.
+    from fabric_dw.exceptions import FabricServerError  # noqa: PLC0415
     from fabric_dw.services._concurrency import bounded_gather  # noqa: PLC0415
+
+    # Proactive capacity filter: skip paused/no-capacity workspaces before
+    # issuing any data-plane call.  Only active when capacity_states is known.
+    capacity_skipped = 0
+    active_workspaces: list[_HasNameAndId] = []
+    for ws in workspaces:
+        if _is_capacity_active(ws, capacity_states):
+            active_workspaces.append(ws)
+        else:
+            logger.debug(
+                "skipping workspace %s: capacity is not Active (proactive capacity filter)",
+                ws.name,
+            )
+            capacity_skipped += 1
+
+    if capacity_skipped:
+        logger.debug(
+            "proactively skipped %d workspace(s) with inactive/missing capacity",
+            capacity_skipped,
+        )
 
     total = len(workspaces)
     raw = await bounded_gather(
-        [lambda ws=ws: fetch(ws) for ws in workspaces],  # type: ignore[misc]
+        [lambda ws=ws: fetch(ws) for ws in active_workspaces],  # type: ignore[misc]
         return_exceptions=True,
     )
 
     out: list[_T] = []
-    skipped = 0
-    for ws, result in zip(workspaces, raw, strict=True):
+    access_skipped = 0
+    capacity_defensive_skipped = 0
+    for ws, result in zip(active_workspaces, raw, strict=True):
         if isinstance(result, skip_errors):
             logger.warning("skipping workspace %s: %s", ws.name, result)
-            skipped += 1
+            access_skipped += 1
+        elif isinstance(result, FabricServerError) and not result.is_retriable:
+            # Non-retriable 5xx: most likely a paused capacity (defensive path
+            # when proactive capacity filter was unavailable).  Skip silently.
+            logger.debug(
+                "skipping workspace %s: non-retriable server error (capacity likely unavailable)",
+                ws.name,
+            )
+            capacity_defensive_skipped += 1
         elif isinstance(result, BaseException):
             raise result
         else:
             out.extend(result)  # type: ignore[arg-type]
 
-    if skipped:
-        logger.warning("skipped %d of %d workspaces due to access errors", skipped, total)
+    if access_skipped:
+        logger.warning("skipped %d of %d workspaces due to access errors", access_skipped, total)
+    if capacity_defensive_skipped:
+        logger.debug(
+            "defensively skipped %d workspace(s) with non-retriable server errors "
+            "(capacity likely unavailable)",
+            capacity_defensive_skipped,
+        )
 
     return out
 

--- a/src/fabric_dw/services/_helpers.py
+++ b/src/fabric_dw/services/_helpers.py
@@ -8,6 +8,8 @@ from collections.abc import Callable, Coroutine, Mapping, Sequence
 from typing import Protocol, TypeVar
 from uuid import UUID
 
+from fabric_dw.services.capacities import ACTIVE_STATE
+
 __all__ = ["compact", "reject_non_select", "scan_all_workspaces"]
 
 _T = TypeVar("_T")
@@ -52,7 +54,7 @@ def compact(mapping: Mapping[str, object]) -> dict[str, object]:
 
 
 def _is_capacity_active(
-    ws: _HasNameAndId,
+    ws: _HasNameIdAndCapacity,
     capacity_states: dict[str, str] | None,
 ) -> bool:
     """Return ``True`` when *ws* should be included in a scan.
@@ -69,8 +71,8 @@ def _is_capacity_active(
     per-workspace error handling takes over.
 
     Args:
-        ws: Workspace object.  Must implement :class:`_HasNameAndId`; optionally
-            also implements :class:`_HasNameIdAndCapacity`.
+        ws: Workspace object — must implement :class:`_HasNameIdAndCapacity`
+            (i.e. exposes ``name``, ``id``, and ``capacity_id``).
         capacity_states: Lower-cased ``{capacity_id: state}`` map as returned
             by :func:`~fabric_dw.services.capacities.get_capacity_states`, or
             ``None`` when proactive filtering is unavailable.
@@ -83,23 +85,22 @@ def _is_capacity_active(
         # Proactive filtering unavailable — let the defensive path handle it.
         return True
 
-    cap_id: UUID | None = getattr(ws, "capacity_id", None)
+    cap_id: UUID | None = ws.capacity_id
     if cap_id is None:
         return False
 
     state = capacity_states.get(str(cap_id).lower())
     if state is None:
-        # Capacity not found in map — treat as unavailable (conservative).
+        # Capacity ID present but absent from the capacity map — treat as
+        # unavailable (conservative skip).
         return False
-
-    from fabric_dw.services.capacities import ACTIVE_STATE  # noqa: PLC0415
 
     return state == ACTIVE_STATE
 
 
 async def scan_all_workspaces(
-    workspaces: Sequence[_HasNameAndId],
-    fetch: Callable[[_HasNameAndId], Coroutine[object, object, list[_T]]],
+    workspaces: Sequence[_HasNameIdAndCapacity],
+    fetch: Callable[[_HasNameIdAndCapacity], Coroutine[object, object, list[_T]]],
     *,
     logger: logging.Logger,
     skip_errors: tuple[type[BaseException], ...],
@@ -122,14 +123,27 @@ async def scan_all_workspaces(
     Defensive fallback
     ~~~~~~~~~~~~~~~~~~
     When *capacity_states* is ``None`` (the caller lacks the capacity-read
-    permission), all workspaces are attempted.  A
-    :class:`~fabric_dw.exceptions.CapacityUnavailableError` (non-retriable
-    ``FabricServerError`` with ``is_retriable=False``) on a per-workspace call
-    is treated as a silent skip (``DEBUG`` log), not a fatal error.
+    permission), all workspaces are attempted.  A non-retriable
+    :class:`~fabric_dw.exceptions.FabricServerError` (``is_retriable=False``)
+    on a per-workspace call is treated as a silent skip (``DEBUG`` log), not a
+    fatal error.
+
+    Result-classification precedence
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    For each per-workspace result the checks are applied in this order:
+
+    1. ``FabricServerError`` with ``is_retriable=False`` → silent ``DEBUG``
+       skip (defensive capacity path).  Checked first so that a
+       ``FabricServerError`` subclass that also happens to appear in
+       *skip_errors* still gets the quieter treatment.
+    2. ``isinstance(result, skip_errors)`` → ``WARNING``-level skip (access
+       errors: 403, 404, …).
+    3. Any other ``BaseException`` → propagate (unexpected error).
+    4. Otherwise → aggregate into the output list.
 
     Args:
-        workspaces: Sequence of workspace objects.  Each element must have a
-            ``name`` attribute used in log messages.
+        workspaces: Sequence of workspace objects.  Each element must implement
+            :class:`_HasNameIdAndCapacity` (``name``, ``id``, ``capacity_id``).
         fetch: Async callable that receives a workspace object and returns a
             ``list[T]`` of items for that workspace.
         logger: Logger for per-workspace and summary warnings.
@@ -149,7 +163,7 @@ async def scan_all_workspaces(
     # Proactive capacity filter: skip paused/no-capacity workspaces before
     # issuing any data-plane call.  Only active when capacity_states is known.
     capacity_skipped = 0
-    active_workspaces: list[_HasNameAndId] = []
+    active_workspaces: list[_HasNameIdAndCapacity] = []
     for ws in workspaces:
         if _is_capacity_active(ws, capacity_states):
             active_workspaces.append(ws)
@@ -166,7 +180,10 @@ async def scan_all_workspaces(
             capacity_skipped,
         )
 
-    total = len(workspaces)
+    # The denominator for the access-error summary is the number of workspaces
+    # that actually entered the fan-out (after the proactive capacity filter),
+    # not the total across all workspaces.
+    fan_out_total = len(active_workspaces)
     raw = await bounded_gather(
         [lambda ws=ws: fetch(ws) for ws in active_workspaces],  # type: ignore[misc]
         return_exceptions=True,
@@ -176,10 +193,10 @@ async def scan_all_workspaces(
     access_skipped = 0
     capacity_defensive_skipped = 0
     for ws, result in zip(active_workspaces, raw, strict=True):
-        if isinstance(result, skip_errors):
-            logger.warning("skipping workspace %s: %s", ws.name, result)
-            access_skipped += 1
-        elif isinstance(result, FabricServerError) and not result.is_retriable:
+        # Precedence matters — check non-retriable FabricServerError FIRST so
+        # that a FabricServerError subclass that also satisfies skip_errors
+        # still gets the silent DEBUG treatment (defensive capacity path).
+        if isinstance(result, FabricServerError) and not result.is_retriable:
             # Non-retriable 5xx: most likely a paused capacity (defensive path
             # when proactive capacity filter was unavailable).  Skip silently.
             logger.debug(
@@ -187,13 +204,20 @@ async def scan_all_workspaces(
                 ws.name,
             )
             capacity_defensive_skipped += 1
+        elif isinstance(result, skip_errors):
+            logger.warning("skipping workspace %s: %s", ws.name, result)
+            access_skipped += 1
         elif isinstance(result, BaseException):
             raise result
         else:
             out.extend(result)  # type: ignore[arg-type]
 
     if access_skipped:
-        logger.warning("skipped %d of %d workspaces due to access errors", access_skipped, total)
+        logger.warning(
+            "skipped %d of %d workspaces due to access errors",
+            access_skipped,
+            fan_out_total,
+        )
     if capacity_defensive_skipped:
         logger.debug(
             "defensively skipped %d workspace(s) with non-retriable server errors "

--- a/src/fabric_dw/services/capacities.py
+++ b/src/fabric_dw/services/capacities.py
@@ -1,0 +1,60 @@
+"""Service helpers for Microsoft Fabric capacity state.
+
+Provides a lightweight helper that fetches ``GET /v1/capacities`` and builds a
+``capacityId -> state`` mapping used by ``-A`` workspace scans to skip
+workspaces whose capacity is paused or suspended **before** issuing the
+data-plane call that would otherwise hang for ~22s and return a generic 500.
+
+Only the minimal fields (``id``, ``displayName``, ``sku``, ``state``) are
+modelled; extra API fields are silently ignored.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fabric_dw.exceptions import PermissionDeniedError
+from fabric_dw.http_client import FabricHttpClient, HttpBase
+
+__all__ = ["get_capacity_states"]
+
+_logger = logging.getLogger("fabric_dw.capacities")
+
+# The state value that indicates an active, healthy capacity.
+ACTIVE_STATE: str = "Active"
+
+
+async def get_capacity_states(http: FabricHttpClient) -> dict[str, str] | None:
+    """Return a mapping of lower-cased capacity ID to state string.
+
+    Fetches ``GET /v1/capacities`` and builds a ``{capacity_id_lower: state}``
+    dict.  Capacity IDs are lower-cased so callers can normalise workspace
+    ``capacityId`` values (which may be returned in any case) before lookup.
+
+    Returns ``None`` when the caller lacks the ``Capacity.Read.All`` permission
+    (HTTP 403) — in that case, the proactive filtering cannot run and the
+    caller should fall back to the defensive per-workspace error handling.
+
+    Args:
+        http: An authenticated :class:`~fabric_dw.http_client.FabricHttpClient`.
+
+    Returns:
+        A ``dict[str, str]`` mapping lower-cased capacity UUIDs to their
+        ``state`` strings (e.g. ``"Active"`` or ``"Inactive"``), or ``None``
+        if the caller is not permitted to read capacities.
+    """
+    try:
+        result: dict[str, str] = {}
+        async for item in http.iter_paginated(HttpBase.FABRIC, "/capacities"):
+            raw_id = item.get("id")
+            state = item.get("state")
+            if isinstance(raw_id, str) and isinstance(state, str):
+                result[raw_id.lower()] = state
+    except PermissionDeniedError:
+        _logger.debug(
+            "GET /v1/capacities returned 403 — proactive capacity filtering unavailable; "
+            "falling back to defensive per-workspace error handling"
+        )
+        return None
+    _logger.debug("fetched capacity states for %d capacities", len(result))
+    return result

--- a/src/fabric_dw/services/sql_endpoints.py
+++ b/src/fabric_dw/services/sql_endpoints.py
@@ -10,6 +10,7 @@ from fabric_dw.exceptions import FabricServerError, NotFoundError, PermissionDen
 from fabric_dw.http_client import FabricHttpClient, HttpBase
 from fabric_dw.models import TableSyncStatus, Warehouse, WarehouseKind
 from fabric_dw.services._helpers import scan_all_workspaces
+from fabric_dw.services.capacities import get_capacity_states
 from fabric_dw.services.workspaces import list_all as _list_all_workspaces
 
 _logger = logging.getLogger("fabric_dw.sql_endpoints")
@@ -55,24 +56,36 @@ async def list_all_workspaces(http: FabricHttpClient) -> list[Warehouse]:
 
     Iterates all workspaces returned by :func:`~fabric_dw.services.workspaces.list_all`
     and aggregates their SQL analytics endpoints using bounded concurrency (up to
-    8 workspaces in parallel).  Workspaces that raise
-    :class:`~fabric_dw.exceptions.PermissionDeniedError` or
-    :class:`~fabric_dw.exceptions.NotFoundError` are skipped with a per-workspace
-    warning; a summary warning is logged after the scan.
+    8 workspaces in parallel).
+
+    Workspaces whose capacity is not ``"Active"`` are skipped **before** the
+    data-plane call (proactive filter via ``GET /v1/capacities``), avoiding the
+    ~22s hang that paused-capacity workspaces incur.  If the caller lacks the
+    capacity-read permission, the proactive filter is unavailable and the
+    defensive fallback applies: a non-retriable 5xx per workspace is silently
+    skipped at ``DEBUG`` level.
+
+    Workspaces that raise :class:`~fabric_dw.exceptions.PermissionDeniedError`
+    or :class:`~fabric_dw.exceptions.NotFoundError` are skipped with a
+    per-workspace ``WARNING`` log; a summary ``WARNING`` is logged after the scan.
 
     Args:
         http: An authenticated :class:`~fabric_dw.http_client.FabricHttpClient`.
 
     Returns:
         A flat list of :class:`~fabric_dw.models.Warehouse` instances (with
-        ``kind == SQL_ENDPOINT``) from all accessible workspaces.
+        ``kind == SQL_ENDPOINT``) from all accessible, active-capacity workspaces.
     """
-    workspaces = await _list_all_workspaces(http)
+    workspaces, capacity_states = await asyncio.gather(
+        _list_all_workspaces(http),
+        get_capacity_states(http),
+    )
     return await scan_all_workspaces(
         workspaces,
         lambda ws: list_endpoints(http, ws.id),  # type: ignore[union-attr]  # mypy false-positive: Sequence[_HasNameAndId] exposes id: UUID but mypy loses the concrete type through the Protocol abstraction
         logger=_logger,
         skip_errors=(PermissionDeniedError, NotFoundError),
+        capacity_states=capacity_states,
     )
 
 

--- a/src/fabric_dw/services/sql_endpoints.py
+++ b/src/fabric_dw/services/sql_endpoints.py
@@ -85,7 +85,7 @@ async def list_all_workspaces(http: FabricHttpClient) -> list[Warehouse]:
     async def _get_capacity_states_safe() -> dict[str, str] | None:
         try:
             return await get_capacity_states(http)
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             _logger.debug(
                 "GET /v1/capacities failed (%s) — proactive capacity filtering unavailable; "
                 "falling back to defensive per-workspace error handling",

--- a/src/fabric_dw/services/sql_endpoints.py
+++ b/src/fabric_dw/services/sql_endpoints.py
@@ -76,6 +76,7 @@ async def list_all_workspaces(http: FabricHttpClient) -> list[Warehouse]:
         A flat list of :class:`~fabric_dw.models.Warehouse` instances (with
         ``kind == SQL_ENDPOINT``) from all accessible, active-capacity workspaces.
     """
+
     # Fetch workspaces and capacity states concurrently.  Capacity-state
     # fetching is best-effort: if GET /v1/capacities fails for any reason
     # other than 403 (which get_capacity_states already handles internally),

--- a/src/fabric_dw/services/sql_endpoints.py
+++ b/src/fabric_dw/services/sql_endpoints.py
@@ -76,13 +76,30 @@ async def list_all_workspaces(http: FabricHttpClient) -> list[Warehouse]:
         A flat list of :class:`~fabric_dw.models.Warehouse` instances (with
         ``kind == SQL_ENDPOINT``) from all accessible, active-capacity workspaces.
     """
+    # Fetch workspaces and capacity states concurrently.  Capacity-state
+    # fetching is best-effort: if GET /v1/capacities fails for any reason
+    # other than 403 (which get_capacity_states already handles internally),
+    # degrade to capacity_states=None and continue the scan via the defensive
+    # per-workspace fallback.  The workspace listing must never abort just
+    # because the capacity endpoint is unavailable.
+    async def _get_capacity_states_safe() -> dict[str, str] | None:
+        try:
+            return await get_capacity_states(http)
+        except Exception as exc:  # noqa: BLE001
+            _logger.debug(
+                "GET /v1/capacities failed (%s) — proactive capacity filtering unavailable; "
+                "falling back to defensive per-workspace error handling",
+                exc,
+            )
+            return None
+
     workspaces, capacity_states = await asyncio.gather(
         _list_all_workspaces(http),
-        get_capacity_states(http),
+        _get_capacity_states_safe(),
     )
     return await scan_all_workspaces(
         workspaces,
-        lambda ws: list_endpoints(http, ws.id),  # type: ignore[union-attr]  # mypy false-positive: Sequence[_HasNameAndId] exposes id: UUID but mypy loses the concrete type through the Protocol abstraction
+        lambda ws: list_endpoints(http, ws.id),  # type: ignore[union-attr]  # mypy false-positive: Sequence[_HasNameIdAndCapacity] exposes id: UUID but mypy loses the concrete type through the Protocol abstraction
         logger=_logger,
         skip_errors=(PermissionDeniedError, NotFoundError),
         capacity_states=capacity_states,

--- a/src/fabric_dw/services/warehouses.py
+++ b/src/fabric_dw/services/warehouses.py
@@ -160,13 +160,30 @@ async def list_all_workspaces(http: FabricHttpClient) -> list[Warehouse]:
         A flat list of :class:`~fabric_dw.models.Warehouse` instances from all
         accessible, active-capacity workspaces.
     """
+    # Fetch workspaces and capacity states concurrently.  Capacity-state
+    # fetching is best-effort: if GET /v1/capacities fails for any reason
+    # other than 403 (which get_capacity_states already handles internally),
+    # degrade to capacity_states=None and continue the scan via the defensive
+    # per-workspace fallback.  The workspace listing must never abort just
+    # because the capacity endpoint is unavailable.
+    async def _get_capacity_states_safe() -> dict[str, str] | None:
+        try:
+            return await get_capacity_states(http)
+        except Exception as exc:  # noqa: BLE001
+            _logger.debug(
+                "GET /v1/capacities failed (%s) — proactive capacity filtering unavailable; "
+                "falling back to defensive per-workspace error handling",
+                exc,
+            )
+            return None
+
     workspaces, capacity_states = await asyncio.gather(
         _list_all_workspaces(http),
-        get_capacity_states(http),
+        _get_capacity_states_safe(),
     )
     return await scan_all_workspaces(
         workspaces,
-        lambda ws: list_warehouses(http, ws.id),  # type: ignore[union-attr]  # mypy false-positive: Sequence[_HasNameAndId] exposes id: UUID but mypy loses the concrete type through the Protocol abstraction
+        lambda ws: list_warehouses(http, ws.id),  # type: ignore[union-attr]  # mypy false-positive: Sequence[_HasNameIdAndCapacity] exposes id: UUID but mypy loses the concrete type through the Protocol abstraction
         logger=_logger,
         skip_errors=(PermissionDeniedError, NotFoundError),
         capacity_states=capacity_states,

--- a/src/fabric_dw/services/warehouses.py
+++ b/src/fabric_dw/services/warehouses.py
@@ -160,6 +160,7 @@ async def list_all_workspaces(http: FabricHttpClient) -> list[Warehouse]:
         A flat list of :class:`~fabric_dw.models.Warehouse` instances from all
         accessible, active-capacity workspaces.
     """
+
     # Fetch workspaces and capacity states concurrently.  Capacity-state
     # fetching is best-effort: if GET /v1/capacities fails for any reason
     # other than 403 (which get_capacity_states already handles internally),

--- a/src/fabric_dw/services/warehouses.py
+++ b/src/fabric_dw/services/warehouses.py
@@ -12,6 +12,7 @@ from fabric_dw.exceptions import FabricServerError, NotFoundError, PermissionDen
 from fabric_dw.http_client import FabricHttpClient, HttpBase
 from fabric_dw.models import Warehouse, WarehouseKind
 from fabric_dw.services._helpers import compact, scan_all_workspaces
+from fabric_dw.services.capacities import get_capacity_states
 from fabric_dw.services.workspaces import SUPPORTED_COLLATIONS
 from fabric_dw.services.workspaces import list_all as _list_all_workspaces
 
@@ -139,24 +140,36 @@ async def list_all_workspaces(http: FabricHttpClient) -> list[Warehouse]:
 
     Iterates all workspaces returned by :func:`~fabric_dw.services.workspaces.list_all`
     and aggregates their warehouses using bounded concurrency (up to 8 workspaces
-    in parallel).  Workspaces that raise
-    :class:`~fabric_dw.exceptions.PermissionDeniedError` or
-    :class:`~fabric_dw.exceptions.NotFoundError` are skipped with a per-workspace
-    warning; a summary warning is logged after the scan.
+    in parallel).
+
+    Workspaces whose capacity is not ``"Active"`` are skipped **before** the
+    data-plane call (proactive filter via ``GET /v1/capacities``), avoiding the
+    ~22s hang that paused-capacity workspaces incur.  If the caller lacks the
+    capacity-read permission, the proactive filter is unavailable and the
+    defensive fallback applies: a non-retriable 5xx per workspace is silently
+    skipped at ``DEBUG`` level.
+
+    Workspaces that raise :class:`~fabric_dw.exceptions.PermissionDeniedError`
+    or :class:`~fabric_dw.exceptions.NotFoundError` are skipped with a
+    per-workspace ``WARNING`` log; a summary ``WARNING`` is logged after the scan.
 
     Args:
         http: An authenticated :class:`~fabric_dw.http_client.FabricHttpClient`.
 
     Returns:
         A flat list of :class:`~fabric_dw.models.Warehouse` instances from all
-        accessible workspaces.
+        accessible, active-capacity workspaces.
     """
-    workspaces = await _list_all_workspaces(http)
+    workspaces, capacity_states = await asyncio.gather(
+        _list_all_workspaces(http),
+        get_capacity_states(http),
+    )
     return await scan_all_workspaces(
         workspaces,
         lambda ws: list_warehouses(http, ws.id),  # type: ignore[union-attr]  # mypy false-positive: Sequence[_HasNameAndId] exposes id: UUID but mypy loses the concrete type through the Protocol abstraction
         logger=_logger,
         skip_errors=(PermissionDeniedError, NotFoundError),
+        capacity_states=capacity_states,
     )
 
 

--- a/src/fabric_dw/services/warehouses.py
+++ b/src/fabric_dw/services/warehouses.py
@@ -169,7 +169,7 @@ async def list_all_workspaces(http: FabricHttpClient) -> list[Warehouse]:
     async def _get_capacity_states_safe() -> dict[str, str] | None:
         try:
             return await get_capacity_states(http)
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             _logger.debug(
                 "GET /v1/capacities failed (%s) — proactive capacity filtering unavailable; "
                 "falling back to defensive per-workspace error handling",

--- a/tests/unit/services/test_capacity_skip.py
+++ b/tests/unit/services/test_capacity_skip.py
@@ -540,12 +540,14 @@ def test_fabric_server_error_explicit_non_retriable() -> None:
     assert err.is_retriable is False
 
 
-def test_capacity_unavailable_error_is_non_retriable() -> None:
-    """CapacityUnavailableError must always have is_retriable=False."""
-    from fabric_dw.exceptions import CapacityUnavailableError  # noqa: PLC0415
+def test_capacity_unavailable_error_removed() -> None:
+    """CapacityUnavailableError has been removed — the is_retriable-flag routing is the
+    real mechanism.  Importing it must raise AttributeError (not ImportError).
+    """
+    import fabric_dw.exceptions as exc_mod  # noqa: PLC0415
 
-    err = CapacityUnavailableError("paused", status=500)
-    assert err.is_retriable is False
+    with pytest.raises(AttributeError):
+        _ = exc_mod.CapacityUnavailableError  # type: ignore[attr-defined]
 
 
 # ---------------------------------------------------------------------------
@@ -661,3 +663,105 @@ async def test_sql_endpoints_proactive_skip_inactive_capacity(
     assert len(result) == 1
     assert _WS_INACTIVE not in fetch_call_ids
     assert _WS_ACTIVE in fetch_call_ids
+
+
+# ---------------------------------------------------------------------------
+# (l) _make_should_retry: missing isRetriable key defaults to retry=True
+# ---------------------------------------------------------------------------
+
+
+async def test_make_should_retry_no_is_retriable_key_defaults_to_retry() -> None:
+    """When the Fabric error envelope has NO isRetriable key, the HTTP client
+    must default is_retriable=True (safe default — keep retrying as usual).
+    The server error should be retried up to 3 attempts.
+    """
+    call_count = 0
+
+    def _side_effect(_request: httpx.Request) -> httpx.Response:
+        nonlocal call_count
+        call_count += 1
+        # No "isRetriable" key at all in the error body.
+        return httpx.Response(
+            500,
+            json={"errorCode": "InternalServerError", "message": "transient failure"},
+        )
+
+    with respx.mock(assert_all_called=False) as mock_router:
+        mock_router.get(f"{_WAREHOUSES_ACTIVE_URL}").mock(side_effect=_side_effect)
+
+        client = await _make_client()
+        async with client:
+            with pytest.raises(FabricServerError) as exc_info:
+                await client.request(
+                    "GET",
+                    HttpBase.FABRIC,
+                    f"/workspaces/{_WS_ACTIVE}/warehouses",
+                )
+
+    # Absent isRetriable → defaults to True → 3 retry attempts.
+    assert call_count == 3, f"Expected 3 attempts (default retry); got {call_count}"
+    assert exc_info.value.is_retriable is True
+
+
+# ---------------------------------------------------------------------------
+# (m) _is_capacity_active: capacity_id present but absent from the map → skip
+# ---------------------------------------------------------------------------
+
+
+def test_is_capacity_active_unknown_capacity_id_returns_false() -> None:
+    """A workspace whose capacity_id is set but absent from the capacity map
+    must be conservatively skipped (return False).
+    """
+    from fabric_dw.services._helpers import _is_capacity_active  # noqa: PLC0415
+
+    unknown_cap = UUID("dddddddd-cafe-0000-0000-000000000099")
+    ws = _make_workspace(_WS_ACTIVE, unknown_cap)
+
+    # The capacity map only knows about _CAP_ACTIVE and _CAP_INACTIVE.
+    states = _make_capacity_states()
+    assert str(unknown_cap).lower() not in states
+
+    result = _is_capacity_active(ws, states)
+    assert result is False, "Expected False (conservative skip) when capacity_id is not in the map"
+
+
+# ---------------------------------------------------------------------------
+# (n) Retriable FabricServerError that exhausts retries must propagate
+# ---------------------------------------------------------------------------
+
+
+async def test_retriable_server_error_exhausting_retries_propagates() -> None:
+    """A FabricServerError(is_retriable=True) that exhausts all retries must
+    propagate out of scan_all_workspaces — it must NOT be swallowed by the
+    non-retriable defensive skip guard.
+    """
+    from fabric_dw.services.warehouses import list_all_workspaces  # noqa: PLC0415
+
+    ws_a = _make_workspace(_WS_ACTIVE, _CAP_ACTIVE)
+
+    retriable_err = FabricServerError(
+        "Server error 500: transient failure",
+        status=500,
+        is_retriable=True,  # explicitly retriable — not a paused-capacity error
+    )
+
+    with (
+        patch(
+            "fabric_dw.services.warehouses._list_all_workspaces",
+            new=AsyncMock(return_value=[ws_a]),
+        ),
+        patch(
+            "fabric_dw.services.warehouses.get_capacity_states",
+            new=AsyncMock(return_value=None),  # defensive path
+        ),
+        patch(
+            "fabric_dw.services.warehouses.list_warehouses",
+            new=AsyncMock(side_effect=retriable_err),
+        ),
+        pytest.raises(FabricServerError) as exc_info,
+    ):
+        await list_all_workspaces(AsyncMock())
+
+    assert exc_info.value.is_retriable is True, (
+        "Retriable FabricServerError must propagate, not be silently swallowed"
+    )

--- a/tests/unit/services/test_capacity_skip.py
+++ b/tests/unit/services/test_capacity_skip.py
@@ -1,0 +1,663 @@
+"""TDD tests for issue #401: silently skip paused/no-capacity workspaces in -A scans.
+
+Covers:
+- Proactive capacity-state filter via GET /v1/capacities.
+- Inactive-capacity workspace is skipped without issuing the warehouses/endpoints call.
+- Active-capacity workspace is still aggregated.
+- GET /v1/capacities 403 falls back gracefully (no crash, defensive path).
+- Defensive: workspace returning 500 isRetriable:false is skipped silently (not fatal).
+- HTTP client does NOT retry a non-retriable 5xx (FabricServerError.is_retriable=False).
+- Genuine 403/404 still skip as before (WARNING level).
+- An unexpected error still surfaces (propagates).
+- Null capacityId workspace is proactively skipped.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from unittest.mock import AsyncMock, patch
+from uuid import UUID
+
+import httpx
+import pytest
+import respx
+
+from fabric_dw.exceptions import (
+    FabricServerError,
+    PermissionDeniedError,
+)
+from fabric_dw.http_client import HttpBase
+from fabric_dw.models import Warehouse, WarehouseKind, Workspace
+from tests.unit.services._helpers import _make_client
+
+# ---------------------------------------------------------------------------
+# Shared IDs
+# ---------------------------------------------------------------------------
+
+_CAP_ACTIVE = UUID("aaaaaaaa-cafe-0000-0000-000000000001")
+_CAP_INACTIVE = UUID("bbbbbbbb-cafe-0000-0000-000000000002")
+
+_WS_ACTIVE = UUID("aaaaaaaa-0000-0000-0000-000000000001")
+_WS_INACTIVE = UUID("bbbbbbbb-0000-0000-0000-000000000002")
+_WS_NO_CAP = UUID("cccccccc-0000-0000-0000-000000000003")
+
+_WH_ACTIVE = UUID("aaaaaaaa-1111-0000-0000-000000000001")
+
+_BASE = "https://api.fabric.microsoft.com/v1"
+_CAPACITIES_URL = f"{_BASE}/capacities"
+_WORKSPACES_URL = f"{_BASE}/workspaces"
+_WAREHOUSES_ACTIVE_URL = f"{_BASE}/workspaces/{_WS_ACTIVE}/warehouses"
+_WAREHOUSES_INACTIVE_URL = f"{_BASE}/workspaces/{_WS_INACTIVE}/warehouses"
+_SQL_ACTIVE_URL = f"{_BASE}/workspaces/{_WS_ACTIVE}/sqlEndpoints"
+_SQL_INACTIVE_URL = f"{_BASE}/workspaces/{_WS_INACTIVE}/sqlEndpoints"
+
+# ---------------------------------------------------------------------------
+# Model factories
+# ---------------------------------------------------------------------------
+
+
+def _make_workspace(ws_id: UUID, cap_id: UUID | None = None) -> Workspace:
+    return Workspace.model_validate(
+        {
+            "id": str(ws_id),
+            "displayName": f"WS-{ws_id}",
+            "description": None,
+            "capacityId": str(cap_id) if cap_id else None,
+        }
+    )
+
+
+def _make_wh(ws_id: UUID, wh_id: UUID) -> Warehouse:
+    return Warehouse.model_validate(
+        {
+            "id": str(wh_id),
+            "displayName": "WH",
+            "workspaceId": str(ws_id),
+            "kind": WarehouseKind.WAREHOUSE,
+            "connectionString": "wh.fabric.microsoft.com",
+        }
+    )
+
+
+def _make_capacity_states(
+    *,
+    active: UUID = _CAP_ACTIVE,
+    inactive: UUID = _CAP_INACTIVE,
+) -> dict[str, str]:
+    """Return a minimal capacity-states dict (as returned by get_capacity_states)."""
+    return {
+        str(active).lower(): "Active",
+        str(inactive).lower(): "Inactive",
+    }
+
+
+# ---------------------------------------------------------------------------
+# (a) Proactive skip: inactive-capacity workspace does NOT trigger warehouses call
+# ---------------------------------------------------------------------------
+
+
+async def test_proactive_skip_inactive_capacity_no_warehouses_call(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A workspace whose capacity is Inactive must be skipped WITHOUT issuing the
+    warehouses call (assert no request made for it).
+    """
+    from fabric_dw.services.warehouses import list_all_workspaces  # noqa: PLC0415
+
+    ws_active = _make_workspace(_WS_ACTIVE, _CAP_ACTIVE)
+    ws_inactive = _make_workspace(_WS_INACTIVE, _CAP_INACTIVE)
+    wh_active = _make_wh(_WS_ACTIVE, _WH_ACTIVE)
+
+    fetch_call_ids: list[UUID] = []
+
+    async def _fetch_spy(_http: object, ws_id: UUID) -> list[Warehouse]:
+        fetch_call_ids.append(ws_id)
+        return [wh_active] if ws_id == _WS_ACTIVE else []
+
+    with (
+        caplog.at_level(logging.DEBUG, logger="fabric_dw.warehouses"),
+        patch(
+            "fabric_dw.services.warehouses._list_all_workspaces",
+            new=AsyncMock(return_value=[ws_active, ws_inactive]),
+        ),
+        patch(
+            "fabric_dw.services.warehouses.get_capacity_states",
+            new=AsyncMock(return_value=_make_capacity_states()),
+        ),
+        patch(
+            "fabric_dw.services.warehouses.list_warehouses",
+            new=AsyncMock(side_effect=_fetch_spy),
+        ),
+    ):
+        result = await list_all_workspaces(AsyncMock())
+
+    # Only the active workspace's warehouse should be returned.
+    assert len(result) == 1
+    assert result[0].id == _WH_ACTIVE
+    # The inactive workspace's fetch must never have been called.
+    assert _WS_ACTIVE in fetch_call_ids
+    assert _WS_INACTIVE not in fetch_call_ids
+
+
+# ---------------------------------------------------------------------------
+# (b) Active-capacity workspace is still aggregated
+# ---------------------------------------------------------------------------
+
+
+async def test_active_capacity_workspace_is_aggregated() -> None:
+    """A workspace with an Active capacity must be included in the result."""
+    from fabric_dw.services.warehouses import list_all_workspaces  # noqa: PLC0415
+
+    ws_active = _make_workspace(_WS_ACTIVE, _CAP_ACTIVE)
+    wh_active = _make_wh(_WS_ACTIVE, _WH_ACTIVE)
+
+    with (
+        patch(
+            "fabric_dw.services.warehouses._list_all_workspaces",
+            new=AsyncMock(return_value=[ws_active]),
+        ),
+        patch(
+            "fabric_dw.services.warehouses.get_capacity_states",
+            new=AsyncMock(return_value=_make_capacity_states()),
+        ),
+        patch(
+            "fabric_dw.services.warehouses.list_warehouses",
+            new=AsyncMock(return_value=[wh_active]),
+        ),
+    ):
+        result = await list_all_workspaces(AsyncMock())
+
+    assert len(result) == 1
+    assert result[0].id == _WH_ACTIVE
+
+
+# ---------------------------------------------------------------------------
+# (c) Null capacityId: workspace with no capacity is proactively skipped
+# ---------------------------------------------------------------------------
+
+
+async def test_proactive_skip_null_capacity_id(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A workspace with capacityId=None must be proactively skipped when
+    capacity_states is available.
+    """
+    from fabric_dw.services.warehouses import list_all_workspaces  # noqa: PLC0415
+
+    ws_no_cap = _make_workspace(_WS_NO_CAP, None)  # no capacity attached
+    ws_active = _make_workspace(_WS_ACTIVE, _CAP_ACTIVE)
+    wh_active = _make_wh(_WS_ACTIVE, _WH_ACTIVE)
+
+    fetch_call_ids: list[UUID] = []
+
+    async def _fetch_spy(_http: object, ws_id: UUID) -> list[Warehouse]:
+        fetch_call_ids.append(ws_id)
+        return [wh_active]
+
+    with (
+        caplog.at_level(logging.DEBUG, logger="fabric_dw._helpers"),
+        patch(
+            "fabric_dw.services.warehouses._list_all_workspaces",
+            new=AsyncMock(return_value=[ws_no_cap, ws_active]),
+        ),
+        patch(
+            "fabric_dw.services.warehouses.get_capacity_states",
+            new=AsyncMock(return_value=_make_capacity_states()),
+        ),
+        patch(
+            "fabric_dw.services.warehouses.list_warehouses",
+            new=AsyncMock(side_effect=_fetch_spy),
+        ),
+    ):
+        result = await list_all_workspaces(AsyncMock())
+
+    # Only ws_active should be in the result.
+    assert len(result) == 1
+    assert result[0].id == _WH_ACTIVE
+    # The no-capacity workspace must not have been fetched.
+    assert _WS_NO_CAP not in fetch_call_ids
+    assert _WS_ACTIVE in fetch_call_ids
+
+
+# ---------------------------------------------------------------------------
+# (d) GET /v1/capacities 403 → graceful fallback (no crash)
+# ---------------------------------------------------------------------------
+
+
+async def test_capacities_403_falls_back_gracefully() -> None:
+    """When GET /v1/capacities returns 403, get_capacity_states returns None and
+    list_all_workspaces falls back to the defensive path without crashing.
+    """
+    from fabric_dw.services.warehouses import list_all_workspaces  # noqa: PLC0415
+
+    ws_active = _make_workspace(_WS_ACTIVE, _CAP_ACTIVE)
+    wh_active = _make_wh(_WS_ACTIVE, _WH_ACTIVE)
+
+    with (
+        patch(
+            "fabric_dw.services.warehouses._list_all_workspaces",
+            new=AsyncMock(return_value=[ws_active]),
+        ),
+        patch(
+            "fabric_dw.services.warehouses.get_capacity_states",
+            new=AsyncMock(return_value=None),  # 403 fallback → None
+        ),
+        patch(
+            "fabric_dw.services.warehouses.list_warehouses",
+            new=AsyncMock(return_value=[wh_active]),
+        ),
+    ):
+        result = await list_all_workspaces(AsyncMock())
+
+    # Should still return the warehouse when fallback applies.
+    assert len(result) == 1
+    assert result[0].id == _WH_ACTIVE
+
+
+# ---------------------------------------------------------------------------
+# (d2) get_capacity_states itself: 403 returns None without raising
+# ---------------------------------------------------------------------------
+
+
+async def test_get_capacity_states_403_returns_none(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """get_capacity_states must return None (not raise) when the API returns 403."""
+    from fabric_dw.services.capacities import get_capacity_states  # noqa: PLC0415
+
+    with (
+        caplog.at_level(logging.DEBUG, logger="fabric_dw.capacities"),
+        respx.mock,
+    ):
+        respx.get(_CAPACITIES_URL).mock(
+            return_value=httpx.Response(403, json={"error": "forbidden"})
+        )
+
+        client = await _make_client()
+        async with client:
+            result = await get_capacity_states(client)
+
+    assert result is None
+    assert any(
+        "403" in r.message or "proactive capacity filtering unavailable" in r.message
+        for r in caplog.records
+    )
+
+
+# ---------------------------------------------------------------------------
+# (d3) get_capacity_states: happy path returns correct mapping
+# ---------------------------------------------------------------------------
+
+
+async def test_get_capacity_states_returns_lowercase_id_map() -> None:
+    """get_capacity_states must return a dict of {lower-cased-capacity-id: state}."""
+    from fabric_dw.services.capacities import get_capacity_states  # noqa: PLC0415
+
+    cap_payload: dict[str, Any] = {
+        "value": [
+            {
+                "id": str(_CAP_ACTIVE).upper(),
+                "displayName": "CI-Cap",
+                "sku": "F2",
+                "state": "Active",
+            },
+            {
+                "id": str(_CAP_INACTIVE),
+                "displayName": "Paused-Cap",
+                "sku": "F4",
+                "state": "Inactive",
+            },
+        ]
+    }
+
+    with respx.mock:
+        respx.get(_CAPACITIES_URL).mock(return_value=httpx.Response(200, json=cap_payload))
+
+        client = await _make_client()
+        async with client:
+            result = await get_capacity_states(client)
+
+    assert result is not None
+    assert result[str(_CAP_ACTIVE).lower()] == "Active"
+    assert result[str(_CAP_INACTIVE).lower()] == "Inactive"
+
+
+# ---------------------------------------------------------------------------
+# (e) Defensive: non-retriable 500 is skipped silently (not fatal)
+# ---------------------------------------------------------------------------
+
+
+async def test_defensive_non_retriable_500_skipped_silently(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """When capacity_states is None (fallback mode), a workspace returning a
+    non-retriable FabricServerError must be skipped at DEBUG level, not raised.
+    """
+    from fabric_dw.services.warehouses import list_all_workspaces  # noqa: PLC0415
+
+    ws_a = _make_workspace(_WS_ACTIVE, _CAP_ACTIVE)
+    ws_b = _make_workspace(_WS_INACTIVE, _CAP_INACTIVE)
+    wh_a = _make_wh(_WS_ACTIVE, _WH_ACTIVE)
+
+    # ws_b returns a non-retriable 500 (paused-capacity signature).
+    non_retriable_err = FabricServerError(
+        "Server error 500 ...: An error occured",
+        status=500,
+        body={
+            "errorCode": "InternalServerError",
+            "message": "An error occured",
+            "isRetriable": False,
+        },
+        is_retriable=False,
+    )
+
+    with (
+        caplog.at_level(logging.DEBUG, logger="fabric_dw.warehouses"),
+        patch(
+            "fabric_dw.services.warehouses._list_all_workspaces",
+            new=AsyncMock(return_value=[ws_a, ws_b]),
+        ),
+        patch(
+            "fabric_dw.services.warehouses.get_capacity_states",
+            new=AsyncMock(return_value=None),  # defensive path (no capacity filter)
+        ),
+        patch(
+            "fabric_dw.services.warehouses.list_warehouses",
+            new=AsyncMock(side_effect=[[wh_a], non_retriable_err]),
+        ),
+    ):
+        result = await list_all_workspaces(AsyncMock())
+
+    # ws_a's warehouse is returned; ws_b is silently skipped.
+    assert len(result) == 1
+    assert result[0].id == _WH_ACTIVE
+    # The skip must be logged at DEBUG, not WARNING.
+    debug_records = [r for r in caplog.records if r.levelno == logging.DEBUG]
+    assert any("non-retriable" in r.message for r in debug_records)
+    # No WARNING should mention the capacity skip.
+    warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert not any("non-retriable" in r.message for r in warning_records)
+
+
+# ---------------------------------------------------------------------------
+# (f) HTTP client does NOT retry a non-retriable 5xx
+# ---------------------------------------------------------------------------
+
+
+async def test_http_client_does_not_retry_non_retriable_500() -> None:
+    """FabricHttpClient must NOT retry a 5xx response when isRetriable is false.
+
+    The non-retriable error should propagate immediately (1 attempt, not 3).
+    """
+    call_count = 0
+
+    def side_effect(_request: httpx.Request) -> httpx.Response:
+        nonlocal call_count
+        call_count += 1
+        return httpx.Response(
+            500,
+            json={
+                "errorCode": "InternalServerError",
+                "message": "An error occured",
+                "isRetriable": False,
+            },
+        )
+
+    with respx.mock(assert_all_called=False) as mock_router:
+        mock_router.get(f"{_WAREHOUSES_ACTIVE_URL}").mock(side_effect=side_effect)
+
+        client = await _make_client()
+        async with client:
+            with pytest.raises(FabricServerError) as exc_info:
+                await client.request(
+                    "GET",
+                    HttpBase.FABRIC,
+                    f"/workspaces/{_WS_ACTIVE}/warehouses",
+                )
+
+    # Must fail fast (1 attempt), not retry 3x (which would take ~60-70s in prod).
+    assert call_count == 1, f"Expected 1 attempt; got {call_count}"
+    assert exc_info.value.is_retriable is False
+
+
+async def test_http_client_retries_retriable_500() -> None:
+    """FabricHttpClient must still retry a 5xx when isRetriable is true (or absent)."""
+    call_count = 0
+
+    def side_effect(_request: httpx.Request) -> httpx.Response:
+        nonlocal call_count
+        call_count += 1
+        return httpx.Response(
+            500,
+            json={
+                "errorCode": "ServiceUnavailable",
+                "message": "Service temporarily unavailable",
+                "isRetriable": True,
+            },
+        )
+
+    with respx.mock(assert_all_called=False) as mock_router:
+        mock_router.get(f"{_WAREHOUSES_ACTIVE_URL}").mock(side_effect=side_effect)
+
+        client = await _make_client()
+        async with client:
+            with pytest.raises(FabricServerError) as exc_info:
+                await client.request(
+                    "GET",
+                    HttpBase.FABRIC,
+                    f"/workspaces/{_WS_ACTIVE}/warehouses",
+                )
+
+    # Must retry up to 3 attempts.
+    assert call_count == 3, f"Expected 3 attempts; got {call_count}"
+    assert exc_info.value.is_retriable is True
+
+
+# ---------------------------------------------------------------------------
+# (g) Genuine 403/404 still skip as before (WARNING level)
+# ---------------------------------------------------------------------------
+
+
+async def test_genuine_403_still_warns(caplog: pytest.LogCaptureFixture) -> None:
+    """A genuine PermissionDeniedError must still be skipped at WARNING level."""
+    from fabric_dw.services.warehouses import list_all_workspaces  # noqa: PLC0415
+
+    ws_a = _make_workspace(_WS_ACTIVE, _CAP_ACTIVE)
+    ws_b = _make_workspace(_WS_INACTIVE, _CAP_INACTIVE)
+    wh_a = _make_wh(_WS_ACTIVE, _WH_ACTIVE)
+
+    with (
+        caplog.at_level(logging.WARNING, logger="fabric_dw.warehouses"),
+        patch(
+            "fabric_dw.services.warehouses._list_all_workspaces",
+            new=AsyncMock(return_value=[ws_a, ws_b]),
+        ),
+        patch(
+            "fabric_dw.services.warehouses.get_capacity_states",
+            new=AsyncMock(return_value=None),  # fallback mode
+        ),
+        patch(
+            "fabric_dw.services.warehouses.list_warehouses",
+            new=AsyncMock(side_effect=[[wh_a], PermissionDeniedError("forbidden")]),
+        ),
+    ):
+        result = await list_all_workspaces(AsyncMock())
+
+    assert len(result) == 1
+    assert result[0].id == _WH_ACTIVE
+    # The 403 skip must log at WARNING.
+    warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("skipping workspace" in r.message for r in warning_records)
+
+
+# ---------------------------------------------------------------------------
+# (h) An unexpected error still surfaces (propagates)
+# ---------------------------------------------------------------------------
+
+
+async def test_unexpected_error_propagates() -> None:
+    """An unexpected exception (not skip_errors, not non-retriable 5xx) must propagate."""
+    from fabric_dw.services.warehouses import list_all_workspaces  # noqa: PLC0415
+
+    ws_a = _make_workspace(_WS_ACTIVE, _CAP_ACTIVE)
+
+    class _UnexpectedError(Exception):
+        pass
+
+    with (
+        patch(
+            "fabric_dw.services.warehouses._list_all_workspaces",
+            new=AsyncMock(return_value=[ws_a]),
+        ),
+        patch(
+            "fabric_dw.services.warehouses.get_capacity_states",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "fabric_dw.services.warehouses.list_warehouses",
+            new=AsyncMock(side_effect=_UnexpectedError("surprise")),
+        ),
+        pytest.raises(_UnexpectedError, match="surprise"),
+    ):
+        await list_all_workspaces(AsyncMock())
+
+
+# ---------------------------------------------------------------------------
+# (i) FabricServerError.is_retriable attribute
+# ---------------------------------------------------------------------------
+
+
+def test_fabric_server_error_default_is_retriable() -> None:
+    """FabricServerError.is_retriable must default to True."""
+    err = FabricServerError("oops", status=500)
+    assert err.is_retriable is True
+
+
+def test_fabric_server_error_explicit_non_retriable() -> None:
+    """FabricServerError(is_retriable=False) must set the flag."""
+    err = FabricServerError("oops", status=500, is_retriable=False)
+    assert err.is_retriable is False
+
+
+def test_capacity_unavailable_error_is_non_retriable() -> None:
+    """CapacityUnavailableError must always have is_retriable=False."""
+    from fabric_dw.exceptions import CapacityUnavailableError  # noqa: PLC0415
+
+    err = CapacityUnavailableError("paused", status=500)
+    assert err.is_retriable is False
+
+
+# ---------------------------------------------------------------------------
+# (j) http_client parses isRetriable from the Fabric error envelope
+# ---------------------------------------------------------------------------
+
+
+async def test_http_client_parses_is_retriable_false_from_body() -> None:
+    """_map_status must parse isRetriable:false from the 5xx JSON body and set
+    FabricServerError.is_retriable=False.
+    """
+    with respx.mock:
+        respx.get(f"{_WAREHOUSES_ACTIVE_URL}").mock(
+            return_value=httpx.Response(
+                500,
+                json={
+                    "requestId": "abc",
+                    "errorCode": "InternalServerError",
+                    "message": "An error occured",
+                    "isRetriable": False,
+                },
+            )
+        )
+        client = await _make_client()
+        async with client:
+            with pytest.raises(FabricServerError) as exc_info:
+                await client.request(
+                    "GET",
+                    HttpBase.FABRIC,
+                    f"/workspaces/{_WS_ACTIVE}/warehouses",
+                )
+
+    assert exc_info.value.is_retriable is False
+    assert exc_info.value.status == 500
+
+
+async def test_http_client_parses_is_retriable_true_from_body() -> None:
+    """_map_status must parse isRetriable:true from the body and set is_retriable=True."""
+    call_count = 0
+
+    def _side_effect(_request: httpx.Request) -> httpx.Response:
+        nonlocal call_count
+        call_count += 1
+        return httpx.Response(
+            500,
+            json={"errorCode": "ServiceUnavailable", "isRetriable": True},
+        )
+
+    with respx.mock(assert_all_called=False) as mock_router:
+        mock_router.get(f"{_WAREHOUSES_ACTIVE_URL}").mock(side_effect=_side_effect)
+
+        client = await _make_client()
+        async with client:
+            with pytest.raises(FabricServerError) as exc_info:
+                await client.request(
+                    "GET",
+                    HttpBase.FABRIC,
+                    f"/workspaces/{_WS_ACTIVE}/warehouses",
+                )
+
+    # isRetriable:true -> 3 attempts before giving up.
+    assert call_count == 3
+    assert exc_info.value.is_retriable is True
+
+
+# ---------------------------------------------------------------------------
+# (k) Proactive filter applied to sql-endpoints list_all_workspaces too
+# ---------------------------------------------------------------------------
+
+
+async def test_sql_endpoints_proactive_skip_inactive_capacity(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """sql_endpoints.list_all_workspaces must also skip inactive-capacity workspaces."""
+    from fabric_dw.services.sql_endpoints import list_all_workspaces as ep_list_all  # noqa: PLC0415
+
+    ws_active = _make_workspace(_WS_ACTIVE, _CAP_ACTIVE)
+    ws_inactive = _make_workspace(_WS_INACTIVE, _CAP_INACTIVE)
+
+    ep_active = Warehouse.model_validate(
+        {
+            "id": str(UUID("aaaaaaaa-2222-0000-0000-000000000001")),
+            "displayName": "EP",
+            "workspaceId": str(_WS_ACTIVE),
+            "kind": WarehouseKind.SQL_ENDPOINT,
+            "connectionString": "ep.fabric.microsoft.com",
+        }
+    )
+
+    fetch_call_ids: list[UUID] = []
+
+    async def _fetch_spy(_http: object, ws_id: UUID) -> list[Warehouse]:
+        fetch_call_ids.append(ws_id)
+        return [ep_active]
+
+    with (
+        caplog.at_level(logging.DEBUG, logger="fabric_dw.sql_endpoints"),
+        patch(
+            "fabric_dw.services.sql_endpoints._list_all_workspaces",
+            new=AsyncMock(return_value=[ws_active, ws_inactive]),
+        ),
+        patch(
+            "fabric_dw.services.sql_endpoints.get_capacity_states",
+            new=AsyncMock(return_value=_make_capacity_states()),
+        ),
+        patch(
+            "fabric_dw.services.sql_endpoints.list_endpoints",
+            new=AsyncMock(side_effect=_fetch_spy),
+        ),
+    ):
+        result = await ep_list_all(AsyncMock())
+
+    assert len(result) == 1
+    assert _WS_INACTIVE not in fetch_call_ids
+    assert _WS_ACTIVE in fetch_call_ids

--- a/tests/unit/services/test_sql_endpoints.py
+++ b/tests/unit/services/test_sql_endpoints.py
@@ -390,6 +390,10 @@ async def test_list_all_workspaces_endpoints_aggregates_across_workspaces() -> N
             new=AsyncMock(return_value=[ws_a, ws_b, ws_c]),
         ),
         patch(
+            "fabric_dw.services.sql_endpoints.get_capacity_states",
+            new=AsyncMock(return_value=None),  # proactive filter unavailable → no skip
+        ),
+        patch(
             "fabric_dw.services.sql_endpoints.list_endpoints",
             new=AsyncMock(
                 side_effect=[
@@ -424,6 +428,10 @@ async def test_list_all_workspaces_endpoints_skips_permission_denied(
         patch(
             "fabric_dw.services.sql_endpoints._list_all_workspaces",
             new=AsyncMock(return_value=[ws_a, ws_b, ws_c]),
+        ),
+        patch(
+            "fabric_dw.services.sql_endpoints.get_capacity_states",
+            new=AsyncMock(return_value=None),  # proactive filter unavailable → no proactive skip
         ),
         patch(
             "fabric_dw.services.sql_endpoints.list_endpoints",
@@ -462,6 +470,10 @@ async def test_list_all_workspaces_endpoints_skips_not_found(
         patch(
             "fabric_dw.services.sql_endpoints._list_all_workspaces",
             new=AsyncMock(return_value=[ws_a, ws_b, ws_c]),
+        ),
+        patch(
+            "fabric_dw.services.sql_endpoints.get_capacity_states",
+            new=AsyncMock(return_value=None),  # proactive filter unavailable → no proactive skip
         ),
         patch(
             "fabric_dw.services.sql_endpoints.list_endpoints",

--- a/tests/unit/services/test_warehouses.py
+++ b/tests/unit/services/test_warehouses.py
@@ -664,6 +664,10 @@ async def test_list_all_workspaces_aggregates_across_workspaces() -> None:
             new=AsyncMock(return_value=[ws_a, ws_b, ws_c]),
         ),
         patch(
+            "fabric_dw.services.warehouses.get_capacity_states",
+            new=AsyncMock(return_value=None),  # proactive filter unavailable → no skip
+        ),
+        patch(
             "fabric_dw.services.warehouses.list_warehouses",
             new=AsyncMock(
                 side_effect=[
@@ -698,6 +702,10 @@ async def test_list_all_workspaces_skips_permission_denied(
         patch(
             "fabric_dw.services.warehouses._list_all_workspaces",
             new=AsyncMock(return_value=[ws_a, ws_b, ws_c]),
+        ),
+        patch(
+            "fabric_dw.services.warehouses.get_capacity_states",
+            new=AsyncMock(return_value=None),  # proactive filter unavailable → no proactive skip
         ),
         patch(
             "fabric_dw.services.warehouses.list_warehouses",
@@ -736,6 +744,10 @@ async def test_list_all_workspaces_skips_not_found(caplog: pytest.LogCaptureFixt
         patch(
             "fabric_dw.services.warehouses._list_all_workspaces",
             new=AsyncMock(return_value=[ws_a, ws_b, ws_c]),
+        ),
+        patch(
+            "fabric_dw.services.warehouses.get_capacity_states",
+            new=AsyncMock(return_value=None),  # proactive filter unavailable → no proactive skip
         ),
         patch(
             "fabric_dw.services.warehouses.list_warehouses",


### PR DESCRIPTION
## Summary

- **Proactive capacity filter**: fetch `GET /v1/capacities` once before the fan-out and skip workspaces whose capacity `state != "Active"` (or whose `capacityId` is null) before issuing the data-plane call that hangs ~22s on paused capacities.
- **Graceful 403 fallback**: if the caller lacks `Capacity.Read.All` (`GET /v1/capacities` → 403), `get_capacity_states` returns `None` and the defensive path takes over.
- **`isRetriable` support**: `FabricServerError` now carries an `is_retriable` flag (parsed from the Fabric error envelope's `isRetriable` field). The HTTP retry predicate skips back-off for non-retriable 5xx (fail fast, no 60-70s waste). `scan_all_workspaces` treats non-retriable `FabricServerError` as a silent `DEBUG`-level skip rather than a fatal error.
- Applied to both `warehouses list -A` and `sql-endpoints list -A`.
- Genuine `403`/`404` per-workspace errors continue to skip at `WARNING` level.

## New files

- `src/fabric_dw/services/capacities.py` — `get_capacity_states()` helper
- `tests/unit/services/test_capacity_skip.py` — 17 new TDD unit tests

## Test plan

- [ ] `just check` passes (ruff + ty + 3232 unit tests, coverage 95%)
- [ ] Proactive skip: inactive-capacity workspace produces no warehouses/endpoints call (asserted via spy)
- [ ] Active-capacity workspace still aggregated
- [ ] `GET /v1/capacities` 403 → graceful fallback, no crash
- [ ] Defensive: non-retriable 500 skipped at DEBUG (not fatal, not WARNING)
- [ ] HTTP client: 1 attempt (not 3) for `isRetriable:false` 5xx
- [ ] HTTP client: 3 attempts retained for `isRetriable:true` 5xx
- [ ] Genuine 403/404 still skip at WARNING
- [ ] Unexpected errors still propagate

Closes #401

🤖 Generated with [Claude Code](https://claude.com/claude-code)