### PR TITLE
fix(load): correct OneLake DFS upload protocol (+ diagnostic logging on 400)

### DIFF
--- a/src/fabric_dw/services/load.py
+++ b/src/fabric_dw/services/load.py
@@ -81,6 +81,23 @@ _UPLOAD_CHUNK_SIZE: int = 4 * 1024 * 1024
 #: Maximum local file size before staging upload is rejected (2 GiB).
 _MAX_STAGING_FILE_BYTES: int = 2 * 1024 * 1024 * 1024
 
+#: ADLS Gen2 / OneLake DFS API version sent on every request.
+#:
+#: The OneLake documentation (https://learn.microsoft.com/fabric/onelake/onelake-access-api)
+#: shows ``x-ms-version: 2021-06-08`` in the sample response, which is the earliest version
+#: confirmed to work with OneLake.  Sending a version header makes the server's behaviour
+#: deterministic and avoids the ``UnsupportedRestVersion`` 400 that can occur when the
+#: service falls back to a very old default.
+_DFS_API_VERSION = "2021-06-08"
+
+#: Maximum number of retries for the DFS create-file PUT on transient 400 / 503 responses.
+#: A newly-provisioned Lakehouse may briefly return 400 before its OneLake storage backend
+#: is fully ready, even after the Fabric LRO has completed.
+_DFS_CREATE_MAX_RETRIES: int = 3
+
+#: Base delay (seconds) between DFS create-file retries.
+_DFS_CREATE_RETRY_DELAY: float = 2.0
+
 # SQL Endpoint rejection message.
 _SQL_ENDPOINT_READONLY_MSG = "SQL Endpoints are read-only; COPY INTO not supported"
 
@@ -388,6 +405,35 @@ def infer_file_format(path: Path) -> FileFormat:
 # ---------------------------------------------------------------------------
 
 
+def _log_dfs_error(resp: httpx.Response, context: str) -> None:
+    """Log the DFS error code and body from a non-2xx response.
+
+    Extracts the ``x-ms-error-code`` response header and the JSON error body
+    (which contains the ADLS Gen2 error code and message) and logs them at
+    ERROR level.  The Authorization token is never read or logged — only the
+    response data is used.
+
+    Args:
+        resp: The non-2xx :class:`httpx.Response`.
+        context: A short label for the log message (e.g. ``"DFS create"``).
+    """
+    error_code = resp.headers.get("x-ms-error-code", "<none>")
+    request_id = resp.headers.get("x-ms-request-id", "<none>")
+    try:
+        body_text = resp.text
+    except Exception:
+        body_text = "<unreadable>"
+
+    _logger.error(
+        "%s failed: HTTP %s  x-ms-error-code=%s  x-ms-request-id=%s  body=%s",
+        context,
+        resp.status_code,
+        error_code,
+        request_id,
+        body_text,
+    )
+
+
 async def create_staging_lakehouse(
     http: FabricHttpClient,
     workspace_id: uuid.UUID,
@@ -489,9 +535,16 @@ async def onelake_upload_file(
     """Upload a local file to the OneLake DFS API using chunked create/append/flush.
 
     Uses the ADLS Gen2 DFS protocol:
-    - PUT ``?resource=file``      — creates the file (0 bytes).
-    - PATCH ``?action=append``    — appends data chunks.
-    - PATCH ``?action=flush``     — commits the file at final position.
+    - PUT  ``?resource=file``              — creates the file (0 bytes).
+    - PATCH ``?action=append&position=N`` — appends data chunks.
+    - PATCH ``?action=flush&position=N``  — commits the file at the final offset.
+
+    All requests include ``x-ms-version: 2021-06-08`` (the earliest version
+    confirmed to work with OneLake DFS) and ``Content-Length`` as required by
+    the ADLS Gen2 Path API.  Non-2xx responses log the ``x-ms-error-code``
+    header and the JSON error body *before* raising, so the next integration
+    run will surface the exact server-side error code without exposing auth
+    tokens.
 
     Args:
         credential: An async Azure credential for the storage scope.
@@ -503,38 +556,70 @@ async def onelake_upload_file(
         chunk_size: Bytes per append chunk (default 4 MiB).
 
     Raises:
-        httpx.HTTPStatusError: On non-2xx DFS responses.
+        httpx.HTTPStatusError: On non-2xx DFS responses (after logging the
+            error code and body).
     """
     # Fetch a storage-scoped token.
     token_obj = await credential.get_token(STORAGE_SCOPE)
     token = token_obj.token
-    headers = {"Authorization": f"Bearer {token}"}
 
-    dfs_base = f"{_ONELAKE_DFS_BASE}/{workspace_id}/{lakehouse_id}.Lakehouse/Files/{dest_path}"
+    # Base headers sent with every DFS request.
+    # x-ms-version: the ADLS Gen2 / OneLake DFS API version.  The OneLake
+    # documentation shows 2021-06-08 in response headers as the minimum
+    # supported version; omitting it can cause the service to fall back to an
+    # unexpectedly old default that may reject the request.
+    base_headers: dict[str, str] = {
+        "Authorization": f"Bearer {token}",
+        "x-ms-version": _DFS_API_VERSION,
+    }
+
+    dfs_url = f"{_ONELAKE_DFS_BASE}/{workspace_id}/{lakehouse_id}.Lakehouse/Files/{dest_path}"
 
     file_size = local_path.stat().st_size
     _logger.debug(
         "onelake_upload_file: %s -> %s (size=%d bytes, chunk=%d)",
         local_path,
-        dfs_base,
+        dfs_url,
         file_size,
         chunk_size,
     )
 
     async with httpx.AsyncClient(timeout=300.0) as client:
+        # ------------------------------------------------------------------
         # Step 1: create an empty file.
-        # The ADLS Gen2 DFS API requires Content-Length: 0 on the PUT create
-        # call — omitting it or sending a non-zero value results in a 400
-        # ContentLengthMustBeZero error from OneLake.
-        create_resp = await client.put(
-            dfs_base,
-            params={"resource": "file"},
-            headers={**headers, "Content-Length": "0"},
-            content=b"",
-        )
+        #
+        # The ADLS Gen2 DFS Path - Create API requires Content-Length: 0 on
+        # the PUT ?resource=file call.  Omitting it or sending a non-zero
+        # value results in a 400 ContentLengthMustBeZero error.
+        #
+        # A freshly provisioned Lakehouse can briefly return 400 before its
+        # OneLake storage backend is fully ready even though the Fabric LRO
+        # has already signalled completion.  We retry with a short backoff to
+        # tolerate this transient provisioning delay.
+        # ------------------------------------------------------------------
+        create_headers = {**base_headers, "Content-Length": "0"}
+        create_resp: httpx.Response | None = None
+        for attempt in range(_DFS_CREATE_MAX_RETRIES):
+            create_resp = await client.put(
+                dfs_url,
+                params={"resource": "file"},
+                headers=create_headers,
+                content=b"",
+            )
+            if create_resp.is_success:
+                break
+            attempt_label = f"attempt {attempt + 1}/{_DFS_CREATE_MAX_RETRIES}"
+            _log_dfs_error(create_resp, f"DFS create ({attempt_label})")
+            if attempt < _DFS_CREATE_MAX_RETRIES - 1:
+                await asyncio.sleep(_DFS_CREATE_RETRY_DELAY * (attempt + 1))
+        if create_resp is None:  # pragma: no cover — loop always sets this
+            msg = "DFS create: no response received"
+            raise RuntimeError(msg)
         create_resp.raise_for_status()
 
+        # ------------------------------------------------------------------
         # Step 2: append chunks.
+        # ------------------------------------------------------------------
         offset = 0
         with local_path.open("rb") as fh:
             while True:
@@ -542,26 +627,32 @@ async def onelake_upload_file(
                 if not chunk:
                     break
                 append_resp = await client.patch(
-                    dfs_base,
+                    dfs_url,
                     params={"action": "append", "position": offset},
                     content=chunk,
                     headers={
-                        **headers,
+                        **base_headers,
                         "Content-Type": "application/octet-stream",
                         "Content-Length": str(len(chunk)),
                     },
                 )
+                if not append_resp.is_success:
+                    _log_dfs_error(append_resp, f"DFS append (offset={offset})")
                 append_resp.raise_for_status()
                 offset += len(chunk)
 
+        # ------------------------------------------------------------------
         # Step 3: flush (commit).
-        # Content-Length must be 0 for the flush call (no request body).
+        # Content-Length must be 0 for flush (no request body).
+        # ------------------------------------------------------------------
         flush_resp = await client.patch(
-            dfs_base,
+            dfs_url,
             params={"action": "flush", "position": offset},
-            headers={**headers, "Content-Length": "0"},
+            headers={**base_headers, "Content-Length": "0"},
             content=b"",
         )
+        if not flush_resp.is_success:
+            _log_dfs_error(flush_resp, f"DFS flush (position={offset})")
         flush_resp.raise_for_status()
 
     _logger.debug("onelake_upload_file: upload complete, %d bytes written", offset)

--- a/src/fabric_dw/services/load.py
+++ b/src/fabric_dw/services/load.py
@@ -83,20 +83,32 @@ _MAX_STAGING_FILE_BYTES: int = 2 * 1024 * 1024 * 1024
 
 #: ADLS Gen2 / OneLake DFS API version sent on every request.
 #:
-#: The OneLake documentation (https://learn.microsoft.com/fabric/onelake/onelake-access-api)
-#: shows ``x-ms-version: 2021-06-08`` in the sample response, which is the earliest version
-#: confirmed to work with OneLake.  Sending a version header makes the server's behaviour
-#: deterministic and avoids the ``UnsupportedRestVersion`` 400 that can occur when the
-#: service falls back to a very old default.
+#: The OneLake / ADLS Gen2 DFS Path API documentation shows this value in sample responses.
+#: Sending an explicit version header pins the server to a known, supported protocol version
+#: and avoids the ``UnsupportedRestVersion`` 400 that can occur when the service falls back
+#: to a very old default.  This value was chosen because it appears in the OneLake
+#: documentation examples and is consistent with the ADLS Gen2 service version that supports
+#: the create/append/flush workflow used here.
 _DFS_API_VERSION = "2021-06-08"
 
-#: Maximum number of retries for the DFS create-file PUT on transient 400 / 503 responses.
+#: Maximum number of retries for the DFS create-file PUT on transient failures.
 #: A newly-provisioned Lakehouse may briefly return 400 before its OneLake storage backend
 #: is fully ready, even after the Fabric LRO has completed.
 _DFS_CREATE_MAX_RETRIES: int = 3
 
-#: Base delay (seconds) between DFS create-file retries.
+#: Base delay (seconds) between DFS create-file retries.  Each subsequent attempt waits
+#: an additional ``_DFS_CREATE_RETRY_DELAY`` seconds (i.e. 2 s, 4 s, 6 s …) — an
+#: arithmetic ramp, not a flat delay.
 _DFS_CREATE_RETRY_DELAY: float = 2.0
+
+#: HTTP status codes that are considered transient and safe to retry on the create PUT.
+#: Only these statuses trigger a retry; all others (including 401/403/404/409) surface
+#: immediately so the caller gets actionable feedback rather than silent retries.
+#: - 400: may indicate a provisioning-lag ``InvalidUri`` / ``UnsupportedRestVersion``.
+#: - 408: Request Timeout.
+#: - 429: Too Many Requests (throttling).
+#: - 5xx: server-side errors (502/503/504 are common transient gateway failures).
+_DFS_CREATE_RETRYABLE_STATUSES: frozenset[int] = frozenset({400, 408, 429, 500, 502, 503, 504})
 
 # SQL Endpoint rejection message.
 _SQL_ENDPOINT_READONLY_MSG = "SQL Endpoints are read-only; COPY INTO not supported"
@@ -421,7 +433,8 @@ def _log_dfs_error(resp: httpx.Response, context: str) -> None:
     request_id = resp.headers.get("x-ms-request-id", "<none>")
     try:
         body_text = resp.text
-    except Exception:
+    except Exception as exc:
+        _logger.warning("_log_dfs_error: could not read response body: %s", exc)
         body_text = "<unreadable>"
 
     _logger.error(
@@ -610,6 +623,11 @@ async def onelake_upload_file(
                 break
             attempt_label = f"attempt {attempt + 1}/{_DFS_CREATE_MAX_RETRIES}"
             _log_dfs_error(create_resp, f"DFS create ({attempt_label})")
+            # Only retry on transient statuses.  Hard failures (401/403/404) and
+            # 409 Conflict (file already exists from a prior partial attempt) must
+            # surface immediately so the caller gets actionable feedback.
+            if create_resp.status_code not in _DFS_CREATE_RETRYABLE_STATUSES:
+                break
             if attempt < _DFS_CREATE_MAX_RETRIES - 1:
                 await asyncio.sleep(_DFS_CREATE_RETRY_DELAY * (attempt + 1))
         if create_resp is None:  # pragma: no cover — loop always sets this

--- a/tests/unit/services/test_load.py
+++ b/tests/unit/services/test_load.py
@@ -17,6 +17,7 @@ from fabric_dw.models import CopyIntoResult, WarehouseKind
 from fabric_dw.services.load import (
     _DFS_API_VERSION,
     _DFS_CREATE_MAX_RETRIES,
+    _DFS_CREATE_RETRY_DELAY,
     _ONELAKE_DFS_BASE,
     CopyIntoCsvOptions,
     _build_copy_into_sql,
@@ -1244,37 +1245,37 @@ class TestOneLakeUploadFile:
                 f"x-ms-version={_DFS_API_VERSION!r}; got {version!r}"
             )
 
-    @respx.mock
-    async def test_token_not_in_x_ms_version_header(self, tmp_path: Path) -> None:
-        """The auth token must never appear in the x-ms-version header value."""
-        data_file = tmp_path / "data.parquet"
-        data_file.write_bytes(b"PAYLOAD")
+    def test_log_dfs_error_does_not_read_request_headers(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """_log_dfs_error must never read resp.request.headers (which contains Authorization).
 
-        captured: list[httpx.Request] = []
+        The token-leak guarantee is that _log_dfs_error only reads *response* data.
+        This test attaches a request with a secret token to the response and asserts
+        that the secret does not appear in any log record, proving that the function
+        does not forward request headers to the logger.
+        """
+        secret_token = "super-secret-bearer-XYZ"  # noqa: S105
 
-        def _capture(request: httpx.Request) -> httpx.Response:
-            captured.append(request)
-            action = request.url.params.get("action", "")
-            if request.method == "PUT":
-                return httpx.Response(201)
-            return httpx.Response(202 if action == "append" else 200)
-
-        respx.put(self._DFS_BASE).mock(side_effect=_capture)
-        respx.patch(self._DFS_BASE).mock(side_effect=_capture)
-
-        await onelake_upload_file(
-            self._make_credential(),
-            self._WS_ID,
-            self._LH_ID,
-            "data.parquet",
-            data_file,
+        # Build a response that has a fabricated request object carrying Authorization.
+        request = httpx.Request(
+            "PUT",
+            "https://onelake.dfs.fabric.microsoft.com/ws/lh/Files/f.parquet",
+            headers={"Authorization": f"Bearer {secret_token}"},
+        )
+        resp = httpx.Response(
+            400,
+            json={"error": {"code": "UnsupportedRestVersion", "message": "bad version"}},
+            headers={"x-ms-error-code": "UnsupportedRestVersion", "x-ms-request-id": "req-xyz"},
+            request=request,
         )
 
-        fake_token = "fake-bearer-token"  # noqa: S105 — matches _make_credential stub
-        for req in captured:
-            version_val = req.headers.get("x-ms-version", "")
-            assert fake_token not in version_val, (
-                f"Auth token must not appear in x-ms-version: {version_val!r}"
+        with caplog.at_level(logging.DEBUG, logger="fabric_dw"):
+            _log_dfs_error(resp, "DFS create")
+
+        for record in caplog.records:
+            assert secret_token not in record.getMessage(), (
+                f"Auth token leaked into log record: {record.getMessage()!r}"
             )
 
     # -----------------------------------------------------------------------
@@ -1415,7 +1416,7 @@ class TestOneLakeUploadFile:
         respx.put(self._DFS_BASE).mock(side_effect=_flaky_put)
         respx.patch(self._DFS_BASE).mock(return_value=httpx.Response(202))
 
-        with patch("fabric_dw.services.load.asyncio.sleep"):
+        with patch("fabric_dw.services.load.asyncio.sleep") as mock_sleep:
             await onelake_upload_file(
                 self._make_credential(),
                 self._WS_ID,
@@ -1425,6 +1426,11 @@ class TestOneLakeUploadFile:
             )
 
         assert call_count == 2, f"Expected 2 PUT attempts (1 fail + 1 success); got {call_count}"
+        # Verify that the backoff delay was applied: attempt 0 → sleep(_DFS_CREATE_RETRY_DELAY * 1)
+        sleep_calls = [c.args[0] for c in mock_sleep.call_args_list]
+        assert sleep_calls == [_DFS_CREATE_RETRY_DELAY * 1], (
+            f"Expected backoff delays {[_DFS_CREATE_RETRY_DELAY * 1]!r}; got {sleep_calls!r}"
+        )
 
     @respx.mock
     async def test_create_exhausts_retries_then_raises(self, tmp_path: Path) -> None:
@@ -1442,7 +1448,7 @@ class TestOneLakeUploadFile:
         respx.put(self._DFS_BASE).mock(side_effect=_always_400)
 
         with (
-            patch("fabric_dw.services.load.asyncio.sleep"),
+            patch("fabric_dw.services.load.asyncio.sleep") as mock_sleep,
             pytest.raises(httpx.HTTPStatusError),
         ):
             await onelake_upload_file(
@@ -1456,6 +1462,81 @@ class TestOneLakeUploadFile:
         assert call_count == _DFS_CREATE_MAX_RETRIES, (
             f"Expected exactly {_DFS_CREATE_MAX_RETRIES} PUT attempts; got {call_count}"
         )
+        # Verify the arithmetic backoff ramp: sleep is called between each retry pair
+        # (not after the final attempt), so for MAX_RETRIES=3: delays are 2 s, 4 s.
+        expected_delays = [
+            _DFS_CREATE_RETRY_DELAY * (i + 1) for i in range(_DFS_CREATE_MAX_RETRIES - 1)
+        ]
+        sleep_calls = [c.args[0] for c in mock_sleep.call_args_list]
+        assert sleep_calls == expected_delays, (
+            f"Expected backoff delays {expected_delays!r}; got {sleep_calls!r}"
+        )
+
+    @respx.mock
+    async def test_create_409_not_retried(self, tmp_path: Path) -> None:
+        """A 409 Conflict on the create PUT must NOT be retried.
+
+        409 means the file already exists (from a prior partial attempt).  Retrying
+        the same PUT would be incorrect; the error must surface immediately so the
+        caller can handle it (e.g. delete and re-try at a higher level).
+        """
+        data_file = tmp_path / "data.parquet"
+        data_file.write_bytes(b"PAYLOAD")
+
+        call_count = 0
+
+        def _always_409(_request: httpx.Request) -> httpx.Response:
+            nonlocal call_count
+            call_count += 1
+            return httpx.Response(409)
+
+        respx.put(self._DFS_BASE).mock(side_effect=_always_409)
+
+        with (
+            patch("fabric_dw.services.load.asyncio.sleep") as mock_sleep,
+            pytest.raises(httpx.HTTPStatusError),
+        ):
+            await onelake_upload_file(
+                self._make_credential(),
+                self._WS_ID,
+                self._LH_ID,
+                "data.parquet",
+                data_file,
+            )
+
+        assert call_count == 1, f"409 must not be retried; got {call_count} PUT attempts"
+        assert not mock_sleep.called, "No sleep should occur when 409 surfaces immediately"
+
+    @pytest.mark.parametrize("status", [401, 403, 404])
+    @respx.mock
+    async def test_create_hard_failure_not_retried(self, tmp_path: Path, status: int) -> None:
+        """Hard failure statuses (401/403/404) on the create PUT must NOT be retried."""
+        data_file = tmp_path / "data.parquet"
+        data_file.write_bytes(b"PAYLOAD")
+
+        call_count = 0
+
+        def _hard_fail(_request: httpx.Request) -> httpx.Response:
+            nonlocal call_count
+            call_count += 1
+            return httpx.Response(status)
+
+        respx.put(self._DFS_BASE).mock(side_effect=_hard_fail)
+
+        with (
+            patch("fabric_dw.services.load.asyncio.sleep") as mock_sleep,
+            pytest.raises(httpx.HTTPStatusError),
+        ):
+            await onelake_upload_file(
+                self._make_credential(),
+                self._WS_ID,
+                self._LH_ID,
+                "data.parquet",
+                data_file,
+            )
+
+        assert call_count == 1, f"HTTP {status} must not be retried; got {call_count} PUT attempts"
+        assert not mock_sleep.called, f"No sleep should occur on non-retryable HTTP {status}"
 
     @respx.mock
     async def test_flush_400_logs_error_body(

--- a/tests/unit/services/test_load.py
+++ b/tests/unit/services/test_load.py
@@ -15,10 +15,13 @@ from azure.core.credentials_async import AsyncTokenCredential
 from fabric_dw.exceptions import FabricError, ItemKindError
 from fabric_dw.models import CopyIntoResult, WarehouseKind
 from fabric_dw.services.load import (
+    _DFS_API_VERSION,
+    _DFS_CREATE_MAX_RETRIES,
     _ONELAKE_DFS_BASE,
     CopyIntoCsvOptions,
     _build_copy_into_sql,
     _json_to_parquet,
+    _log_dfs_error,
     _safe_dest_filename,
     _sq,
     _validate_https_url,
@@ -901,12 +904,24 @@ class TestOneLakeUploadFile:
     """Verify the ADLS Gen2 DFS create/append/flush request sequence.
 
     The OneLake DFS API requires:
-    - PUT  ?resource=file          Content-Length: 0  (create empty file)
-    - PATCH ?action=append&position=N  Content-Length: <chunk size>  (upload data)
-    - PATCH ?action=flush&position=N   Content-Length: 0  (commit)
+    - PUT  ?resource=file                    Content-Length: 0             (create empty file)
+    - PATCH ?action=append&position=N        Content-Length: <chunk size>  (upload data)
+    - PATCH ?action=flush&position=<total>   Content-Length: 0             (commit)
+
+    All requests must carry x-ms-version (the ADLS Gen2 API version) so the
+    server uses a deterministic, supported protocol version rather than falling
+    back to a very old default that may reject the call with 400
+    UnsupportedRestVersion.
 
     Missing or incorrect Content-Length on the PUT or flush PATCH results in a
     400 ContentLengthMustBeZero / MissingRequiredHeader from OneLake.
+
+    On any non-2xx response the code must log the x-ms-error-code header and
+    the response body (never the auth token) before raising HTTPStatusError.
+
+    The create PUT is retried up to _DFS_CREATE_MAX_RETRIES times on failure to
+    tolerate the transient provisioning lag that can occur immediately after a
+    new Lakehouse is created.
     """
 
     _WS_ID = uuid.UUID("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
@@ -1090,13 +1105,17 @@ class TestOneLakeUploadFile:
 
     @respx.mock
     async def test_create_non_2xx_raises(self, tmp_path: Path) -> None:
-        """A non-2xx response on the create PUT must raise HTTPStatusError."""
+        """A persistent non-2xx on the create PUT must raise HTTPStatusError after all retries."""
         data_file = tmp_path / "data.parquet"
         data_file.write_bytes(b"DATA")
 
+        # All retry attempts return 400 — must ultimately raise.
         respx.put(self._DFS_BASE).mock(return_value=httpx.Response(400))
 
-        with pytest.raises(httpx.HTTPStatusError):
+        with (
+            patch("fabric_dw.services.load.asyncio.sleep"),  # skip real sleep
+            pytest.raises(httpx.HTTPStatusError),
+        ):
             await onelake_upload_file(
                 self._make_credential(),
                 self._WS_ID,
@@ -1179,3 +1198,298 @@ class TestOneLakeUploadFile:
         assert append_positions == [0, 4, 8], (
             f"Expected append positions [0, 4, 8] for 3-chunk upload; got {append_positions}"
         )
+
+    # -----------------------------------------------------------------------
+    # x-ms-version header (protocol correctness — #402)
+    # -----------------------------------------------------------------------
+
+    @respx.mock
+    async def test_all_requests_carry_x_ms_version(self, tmp_path: Path) -> None:
+        """Every DFS request (create, append, flush) must include the x-ms-version header.
+
+        Sending a valid API version makes OneLake use a deterministic protocol
+        version instead of falling back to a very old default that can return
+        400 UnsupportedRestVersion.
+        """
+        data_file = tmp_path / "data.parquet"
+        data_file.write_bytes(b"HELLO")
+
+        all_requests: list[httpx.Request] = []
+
+        def _capture_put(request: httpx.Request) -> httpx.Response:
+            all_requests.append(request)
+            return httpx.Response(201)
+
+        def _capture_patch(request: httpx.Request) -> httpx.Response:
+            all_requests.append(request)
+            action = request.url.params.get("action", "")
+            return httpx.Response(202 if action == "append" else 200)
+
+        respx.put(self._DFS_BASE).mock(side_effect=_capture_put)
+        respx.patch(self._DFS_BASE).mock(side_effect=_capture_patch)
+
+        await onelake_upload_file(
+            self._make_credential(),
+            self._WS_ID,
+            self._LH_ID,
+            "data.parquet",
+            data_file,
+        )
+
+        assert all_requests, "Expected at least one DFS request"
+        for req in all_requests:
+            version = req.headers.get("x-ms-version")
+            assert version == _DFS_API_VERSION, (
+                f"Request {req.method} {req.url.params} must include "
+                f"x-ms-version={_DFS_API_VERSION!r}; got {version!r}"
+            )
+
+    @respx.mock
+    async def test_token_not_in_x_ms_version_header(self, tmp_path: Path) -> None:
+        """The auth token must never appear in the x-ms-version header value."""
+        data_file = tmp_path / "data.parquet"
+        data_file.write_bytes(b"PAYLOAD")
+
+        captured: list[httpx.Request] = []
+
+        def _capture(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            action = request.url.params.get("action", "")
+            if request.method == "PUT":
+                return httpx.Response(201)
+            return httpx.Response(202 if action == "append" else 200)
+
+        respx.put(self._DFS_BASE).mock(side_effect=_capture)
+        respx.patch(self._DFS_BASE).mock(side_effect=_capture)
+
+        await onelake_upload_file(
+            self._make_credential(),
+            self._WS_ID,
+            self._LH_ID,
+            "data.parquet",
+            data_file,
+        )
+
+        fake_token = "fake-bearer-token"  # noqa: S105 — matches _make_credential stub
+        for req in captured:
+            version_val = req.headers.get("x-ms-version", "")
+            assert fake_token not in version_val, (
+                f"Auth token must not appear in x-ms-version: {version_val!r}"
+            )
+
+    # -----------------------------------------------------------------------
+    # Diagnostic error logging on non-2xx responses (no secret leakage)
+    # -----------------------------------------------------------------------
+
+    def test_log_dfs_error_logs_error_code_and_body(self, caplog: pytest.LogCaptureFixture) -> None:
+        """_log_dfs_error must log x-ms-error-code and body at ERROR level."""
+        resp = httpx.Response(
+            400,
+            json={"error": {"code": "ContentLengthMustBeZero", "message": "CL must be 0"}},
+            headers={"x-ms-error-code": "ContentLengthMustBeZero", "x-ms-request-id": "req-123"},
+        )
+
+        with caplog.at_level(logging.ERROR, logger="fabric_dw"):
+            _log_dfs_error(resp, "DFS create")
+
+        log_text = "\n".join(r.getMessage() for r in caplog.records)
+        assert "400" in log_text, "Status code must appear in log"
+        assert "ContentLengthMustBeZero" in log_text, "Error code must appear in log"
+        assert "req-123" in log_text, "x-ms-request-id must appear in log"
+
+    def test_log_dfs_error_never_logs_token(self, caplog: pytest.LogCaptureFixture) -> None:
+        """_log_dfs_error must never log the Authorization header value."""
+        secret_token = "super-secret-bearer-token-xyz"  # noqa: S105
+        # The Authorization header is only on the *request*; _log_dfs_error only
+        # reads from the *response*.  This test verifies the logged text contains no token.
+        resp = httpx.Response(
+            400,
+            json={"error": {"code": "InvalidInput", "message": "bad"}},
+            headers={
+                "x-ms-error-code": "InvalidInput",
+                # Response headers will NOT include Authorization, but we verify
+                # that even if somehow a token appears it is not re-logged.
+                "x-custom-header": f"not-auth:{secret_token}",
+            },
+        )
+
+        with caplog.at_level(logging.ERROR, logger="fabric_dw"):
+            _log_dfs_error(resp, "DFS flush")
+
+        for record in caplog.records:
+            msg = record.getMessage()
+            # The token itself must not appear, but header value may appear in body
+            # if it were present; we verify the specific secret string is absent from
+            # the log line produced by _log_dfs_error (which only logs body + error code).
+            # We check the full formatted message.
+            assert secret_token not in record.getMessage(), f"Secret token leaked into log: {msg!r}"
+
+    @respx.mock
+    async def test_create_400_logs_error_body(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A 400 on the create PUT must log the x-ms-error-code and body before raising."""
+        data_file = tmp_path / "data.parquet"
+        data_file.write_bytes(b"DATA")
+
+        respx.put(self._DFS_BASE).mock(
+            return_value=httpx.Response(
+                400,
+                json={"error": {"code": "InvalidUri", "message": "bad path"}},
+                headers={"x-ms-error-code": "InvalidUri", "x-ms-request-id": "req-abc"},
+            )
+        )
+
+        with (
+            caplog.at_level(logging.ERROR, logger="fabric_dw"),
+            patch("fabric_dw.services.load.asyncio.sleep"),  # skip real sleep
+            pytest.raises(httpx.HTTPStatusError),
+        ):
+            await onelake_upload_file(
+                self._make_credential(),
+                self._WS_ID,
+                self._LH_ID,
+                "data.parquet",
+                data_file,
+            )
+
+        error_logs = [r for r in caplog.records if r.levelno >= logging.ERROR]
+        assert error_logs, "Expected at least one ERROR log on 400 create"
+        combined = "\n".join(r.getMessage() for r in error_logs)
+        assert "InvalidUri" in combined, f"Error code not in log: {combined!r}"
+
+    @respx.mock
+    async def test_create_400_auth_token_not_logged(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """On a 400 create response the auth token must never appear in the log."""
+        data_file = tmp_path / "data.parquet"
+        data_file.write_bytes(b"DATA")
+
+        respx.put(self._DFS_BASE).mock(
+            return_value=httpx.Response(
+                400,
+                json={"error": {"code": "SomeError", "message": "fail"}},
+                headers={"x-ms-error-code": "SomeError"},
+            )
+        )
+
+        fake_token = "fake-bearer-token"  # noqa: S105
+        with (
+            caplog.at_level(logging.DEBUG, logger="fabric_dw"),
+            patch("fabric_dw.services.load.asyncio.sleep"),
+            pytest.raises(httpx.HTTPStatusError),
+        ):
+            await onelake_upload_file(
+                self._make_credential(),
+                self._WS_ID,
+                self._LH_ID,
+                "data.parquet",
+                data_file,
+            )
+
+        for record in caplog.records:
+            assert fake_token not in record.getMessage(), (
+                f"Auth token leaked into log record: {record.getMessage()!r}"
+            )
+
+    # -----------------------------------------------------------------------
+    # Retry behaviour on create 400 (transient provisioning lag — #402)
+    # -----------------------------------------------------------------------
+
+    @respx.mock
+    async def test_create_retries_on_400_then_succeeds(self, tmp_path: Path) -> None:
+        """The create PUT is retried on 400 — success on the second attempt must proceed."""
+        data_file = tmp_path / "data.parquet"
+        data_file.write_bytes(b"PAYLOAD")
+
+        call_count = 0
+
+        def _flaky_put(_request: httpx.Request) -> httpx.Response:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return httpx.Response(400)  # first attempt fails
+            return httpx.Response(201)  # second attempt succeeds
+
+        respx.put(self._DFS_BASE).mock(side_effect=_flaky_put)
+        respx.patch(self._DFS_BASE).mock(return_value=httpx.Response(202))
+
+        with patch("fabric_dw.services.load.asyncio.sleep"):
+            await onelake_upload_file(
+                self._make_credential(),
+                self._WS_ID,
+                self._LH_ID,
+                "data.parquet",
+                data_file,
+            )
+
+        assert call_count == 2, f"Expected 2 PUT attempts (1 fail + 1 success); got {call_count}"
+
+    @respx.mock
+    async def test_create_exhausts_retries_then_raises(self, tmp_path: Path) -> None:
+        """After _DFS_CREATE_MAX_RETRIES failures the create PUT must raise HTTPStatusError."""
+        data_file = tmp_path / "data.parquet"
+        data_file.write_bytes(b"PAYLOAD")
+
+        call_count = 0
+
+        def _always_400(_request: httpx.Request) -> httpx.Response:
+            nonlocal call_count
+            call_count += 1
+            return httpx.Response(400)
+
+        respx.put(self._DFS_BASE).mock(side_effect=_always_400)
+
+        with (
+            patch("fabric_dw.services.load.asyncio.sleep"),
+            pytest.raises(httpx.HTTPStatusError),
+        ):
+            await onelake_upload_file(
+                self._make_credential(),
+                self._WS_ID,
+                self._LH_ID,
+                "data.parquet",
+                data_file,
+            )
+
+        assert call_count == _DFS_CREATE_MAX_RETRIES, (
+            f"Expected exactly {_DFS_CREATE_MAX_RETRIES} PUT attempts; got {call_count}"
+        )
+
+    @respx.mock
+    async def test_flush_400_logs_error_body(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A 400 on the flush PATCH must log the error code and body before raising."""
+        data_file = tmp_path / "data.parquet"
+        data_file.write_bytes(b"DATA")
+
+        def _on_patch(request: httpx.Request) -> httpx.Response:
+            if request.url.params.get("action") == "append":
+                return httpx.Response(202)
+            return httpx.Response(
+                400,
+                json={"error": {"code": "InvalidFlushPosition", "message": "bad position"}},
+                headers={"x-ms-error-code": "InvalidFlushPosition"},
+            )
+
+        respx.put(self._DFS_BASE).mock(return_value=httpx.Response(201))
+        respx.patch(self._DFS_BASE).mock(side_effect=_on_patch)
+
+        with (
+            caplog.at_level(logging.ERROR, logger="fabric_dw"),
+            pytest.raises(httpx.HTTPStatusError),
+        ):
+            await onelake_upload_file(
+                self._make_credential(),
+                self._WS_ID,
+                self._LH_ID,
+                "data.parquet",
+                data_file,
+            )
+
+        error_logs = [r for r in caplog.records if r.levelno >= logging.ERROR]
+        assert error_logs, "Expected at least one ERROR log on 400 flush"
+        combined = "\n".join(r.getMessage() for r in error_logs)
+        assert "InvalidFlushPosition" in combined, f"Error code not in log: {combined!r}"


### PR DESCRIPTION
## Summary

Refs #402 — diagnostics, hardening, and retry narrowing for the OneLake DFS 400.
Issue #402 stays **open** until integration logs confirm the root cause.

The OneLake DFS upload was returning `400 Bad Request` on `PUT ?resource=file` (the create step). The previous fix (#370) addressed `ContentLengthMustBeZero`, but a different 400 persisted. Because `httpx.raise_for_status()` does not include the response body in the error message, the exact `x-ms-error-code` was never logged — only the HTTP status — making diagnosis impossible without a code change.

### Root-cause analysis

Three protocol gaps were identified by cross-referencing the OneLake / ADLS Gen2 DFS Path API documentation:

1. **Missing `x-ms-version` header** — The ADLS Gen2 Path API documentation shows `x-ms-version: 2021-06-08` in sample responses. Without an explicit version header the service can default to a very old API version and return `400 UnsupportedRestVersion`. Sending the header pins behaviour to a known, supported protocol version.

2. **No diagnostic logging on non-2xx** — `raise_for_status()` produced only `Client error '400 Bad Request' for url '...'`; the `x-ms-error-code` header and JSON error body (which name the exact error) were never captured. This made every subsequent 400 blind.

3. **Transient provisioning lag** — A newly created Lakehouse may briefly return 400 before its OneLake storage backend is fully ready, even after the Fabric LRO reports completion. A retry with arithmetic backoff on the create PUT covers this race.

### Changes

**`src/fabric_dw/services/load.py`**
- Added `_DFS_API_VERSION = "2021-06-08"`, `_DFS_CREATE_MAX_RETRIES = 3`, `_DFS_CREATE_RETRY_DELAY = 2.0`, `_DFS_CREATE_RETRYABLE_STATUSES` constants.
- Added `_log_dfs_error(resp, context)` — logs `x-ms-error-code`, `x-ms-request-id`, and response body at ERROR level on any non-2xx DFS response. Reads only from the response object; never touches or logs the auth token. Logs a WARNING if the body cannot be read, instead of swallowing the exception silently.
- Updated `onelake_upload_file` to include `x-ms-version` in every DFS request, retry the create PUT with arithmetic backoff only on transient statuses (`_DFS_CREATE_RETRYABLE_STATUSES`), and call `_log_dfs_error()` before `raise_for_status()` on all three steps.
- Hard failures (401/403/404) and 409 Conflict surface immediately without retrying.

**`tests/unit/services/test_load.py`**
- `x-ms-version` present on all requests, `_log_dfs_error` logs error code/body, retry count matches `_DFS_CREATE_MAX_RETRIES`, flush 400 is also logged.
- Backoff delay values are now asserted (removing the multiplier would fail the tests).
- Replaced tautological `test_token_not_in_x_ms_version_header` with `test_log_dfs_error_does_not_read_request_headers` — attaches a request carrying a real secret token to the response and verifies no log record contains it.
- New: `test_create_409_not_retried`, `test_create_hard_failure_not_retried[401/403/404]`.

## Test plan

- [x] `just check` passes (ruff + ty + 3228 unit tests, 0 failures)
- [ ] Integration run (label `integration`) — the newly-logged `x-ms-error-code` will reveal the true root cause; #402 stays open until confirmed