### PR TITLE
fix(telemetry): silence Azure exporter stderr tracebacks when endpoint unreachable

### DIFF
--- a/src/fabric_dw/telemetry.py
+++ b/src/fabric_dw/telemetry.py
@@ -338,6 +338,50 @@ def _get_connection_string() -> str:
     return os.environ.get("FABRIC_TELEMETRY_CONNECTION_STRING", _DEFAULT_CONNECTION_STRING)
 
 
+def _harden_azure_sdk_logging() -> None:
+    """Raise the level of noisy Azure SDK loggers to CRITICAL and detach them from root.
+
+    When the App Insights / Live Metrics endpoint is unreachable (offline user,
+    firewall, or CI with a bogus endpoint) the Azure SDK writes full Python
+    tracebacks and retry warnings to stderr via its own loggers.  This is
+    independent of ``disable_logging=True`` passed to configure_azure_monitor,
+    which only controls the OTel log exporter — not the SDK's own logger tree.
+
+    The two noise sources suppressed here (#411):
+
+    1. ``azure.monitor.opentelemetry.exporter``
+       Covers ``export/_base.py`` ("Retrying due to server request error") and
+       ``_quickpulse/_exporter.py`` (full traceback from ``_ping`` / ``is_subscribed``
+       when the LiveEndpoint is unreachable, even with ``enable_live_metrics=False``
+       as belt-and-suspenders). Also covers ``statsbeat/_manager.py``
+       ("Exporter is missing a valid region.").
+
+    2. ``azure.core.pipeline.policies``
+       The azure-core retry policy logs "Retrying due to server request error" at
+       WARNING level via ``azure.core.pipeline.policies._retry``.
+
+    We set CRITICAL (instead of logging.NOTSET) and propagate=False so that no
+    record at WARNING/ERROR/EXCEPTION from these trees ever reaches the root
+    handler (typically StreamHandler → stderr).  A NullHandler is attached so
+    that the "No handlers could be found" last-resort message is also suppressed.
+
+    This function is idempotent: calling it multiple times is safe.
+    """
+    for name in (
+        # A2: Azure Monitor exporter — covers retry warnings, statsbeat "missing a
+        # valid region", and quickpulse _ping tracebacks via a single parent logger.
+        "azure.monitor.opentelemetry.exporter",
+        # A3: azure-core pipeline retry policy — "Retrying due to server request error"
+        # at WARNING, emitted by azure.core.pipeline.policies._retry and siblings.
+        "azure.core.pipeline.policies",
+    ):
+        lgr = logging.getLogger(name)
+        lgr.setLevel(logging.CRITICAL)
+        lgr.propagate = False
+        if not any(isinstance(h, logging.NullHandler) for h in lgr.handlers):
+            lgr.addHandler(logging.NullHandler())
+
+
 def _get_tracer() -> object | None:
     """Lazily initialise the Azure Monitor OpenTelemetry tracer.
 
@@ -358,6 +402,10 @@ def _get_tracer() -> object | None:
     - ``shutdown_on_exit=False`` prevents the default 30-second atexit flush that
       can hang the CLI process (B2).  A bounded ``provider.shutdown()`` is
       performed by ``shutdown_telemetry()`` instead.
+    - ``enable_live_metrics=False`` is set explicitly so QuickPulse never pings
+      the LiveEndpoint, belt-and-suspenders against a future default change (A2).
+    - ``_harden_azure_sdk_logging()`` is called before ``configure_azure_monitor``
+      so the SDK's own logger tree is silenced before any network attempt (#411).
     """
     global _tracer, _sdk_initialised  # noqa: PLW0603
 
@@ -370,6 +418,9 @@ def _get_tracer() -> object | None:
         from azure.monitor.opentelemetry import configure_azure_monitor  # noqa: PLC0415
         from opentelemetry import trace  # noqa: PLC0415
 
+        # A2/A3: silence Azure SDK logger trees before any network attempt (#411).
+        _harden_azure_sdk_logging()
+
         configure_azure_monitor(
             connection_string=_get_connection_string(),
             logger_name="fabric_dw.telemetry",
@@ -379,6 +430,10 @@ def _get_tracer() -> object | None:
             # azure-monitor-opentelemetry 1.8+; its _get_processor_time callback
             # divides by zero on short-lived processes and logs a traceback (#399).
             enable_performance_counters=False,
+            # A2: belt-and-suspenders — QuickPulse must never ping the LiveEndpoint.
+            # Suppresses _quickpulse/_exporter.py::_ping tracebacks on connection
+            # refused even if the default changes in a future SDK version (#411).
+            enable_live_metrics=False,
             # B2: disable unbounded (30 s) atexit flush — we do our own bounded flush.
             shutdown_on_exit=False,
             # B1: disable all auto-HTTP / Azure SDK instrumentors (privacy).

--- a/src/fabric_dw/telemetry.py
+++ b/src/fabric_dw/telemetry.py
@@ -357,8 +357,12 @@ def _harden_azure_sdk_logging() -> None:
        ("Exporter is missing a valid region.").
 
     2. ``azure.core.pipeline.policies``
-       The azure-core retry policy logs "Retrying due to server request error" at
-       WARNING level via ``azure.core.pipeline.policies._retry``.
+       Belt-and-suspenders suppression.  At the pinned versions (azure-monitor-opentelemetry
+       1.8.8 / exporter 1.0.0b53) ``azure.core.pipeline.policies._retry`` defines ``_LOGGER``
+       but has **zero call sites** — the "Retrying due to server request error" message is
+       actually emitted by ``azure.monitor.opentelemetry.exporter.export._base`` (already
+       covered by entry 1).  This entry guards against future SDK versions adding log calls
+       to the azure-core pipeline tree.
 
     We set CRITICAL (instead of logging.NOTSET) and propagate=False so that no
     record at WARNING/ERROR/EXCEPTION from these trees ever reaches the root
@@ -371,8 +375,11 @@ def _harden_azure_sdk_logging() -> None:
         # A2: Azure Monitor exporter — covers retry warnings, statsbeat "missing a
         # valid region", and quickpulse _ping tracebacks via a single parent logger.
         "azure.monitor.opentelemetry.exporter",
-        # A3: azure-core pipeline retry policy — "Retrying due to server request error"
-        # at WARNING, emitted by azure.core.pipeline.policies._retry and siblings.
+        # A3: azure-core pipeline — belt-and-suspenders only at pinned versions
+        # (azure.core.pipeline.policies._retry defines _LOGGER but has zero call sites;
+        # the "Retrying due to server request error" message comes from
+        # azure.monitor.opentelemetry.exporter.export._base, already covered above).
+        # Kept here to guard against future SDK versions emitting from this tree.
         "azure.core.pipeline.policies",
     ):
         lgr = logging.getLogger(name)

--- a/tests/unit/test_shutdown_clean.py
+++ b/tests/unit/test_shutdown_clean.py
@@ -64,6 +64,10 @@ _FORBIDDEN_STDERR_SUBSTRINGS = [
     "Error getting processor time",
     "_get_processor_time",
     "_performance_counters",
+    # #411: Azure Monitor exporter / azure-core retry-policy noise when the
+    # endpoint is unreachable (offline / firewalled users).
+    "Retrying due to server request error",
+    "missing a valid region",
 ]
 
 # Invoke fabric-dw via ``python -c "from fabric_dw.cli import main; main()"``

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -11,6 +11,7 @@ import logging
 import sys
 import types
 import uuid
+from collections.abc import Generator
 from pathlib import Path
 from typing import Any
 from unittest.mock import patch
@@ -1667,13 +1668,39 @@ _HARDENED_LOGGER_NAMES = [
     # export/_base.py "Retrying due to server request error", and quickpulse
     # _ping tracebacks (#411).
     "azure.monitor.opentelemetry.exporter",
-    # azure-core pipeline retry policy: "Retrying due to server request error"
-    # at WARNING (#411).
+    # azure-core pipeline — belt-and-suspenders (#411).
     "azure.core.pipeline.policies",
 ]
 
 
-def test_harden_azure_sdk_logging_sets_level_to_critical() -> None:
+@pytest.fixture
+def restore_hardened_loggers() -> Generator[None, None, None]:
+    """Save and restore the global logging state for the loggers targeted by
+    _harden_azure_sdk_logging.
+
+    Note: _reload_telemetry() evicts the telemetry module from sys.modules but
+    does NOT reset the Python logging registry — Logger objects are singletons
+    keyed by name.  Without this fixture, the four _harden tests would leave
+    those loggers permanently at CRITICAL/propagate=False for the rest of the
+    test process.  Any future test that needs to observe log output from these
+    namespaces (e.g. a caplog test checking behaviour when hardening is NOT
+    applied) would silently pass even when it should fail.
+    """
+    saved: dict[str, tuple[int, bool, list[logging.Handler]]] = {}
+    for name in _HARDENED_LOGGER_NAMES:
+        lgr = logging.getLogger(name)
+        saved[name] = (lgr.level, lgr.propagate, list(lgr.handlers))
+    yield
+    for name, (level, propagate, handlers) in saved.items():
+        lgr = logging.getLogger(name)
+        lgr.setLevel(level)
+        lgr.propagate = propagate
+        lgr.handlers = list(handlers)
+
+
+def test_harden_azure_sdk_logging_sets_level_to_critical(
+    restore_hardened_loggers: None,  # noqa: ARG001
+) -> None:
     """_harden_azure_sdk_logging must raise each targeted logger to CRITICAL."""
     mod = _reload_telemetry()
     mod._harden_azure_sdk_logging()  # type: ignore[attr-defined]
@@ -1685,7 +1712,9 @@ def test_harden_azure_sdk_logging_sets_level_to_critical() -> None:
         )
 
 
-def test_harden_azure_sdk_logging_sets_propagate_false() -> None:
+def test_harden_azure_sdk_logging_sets_propagate_false(
+    restore_hardened_loggers: None,  # noqa: ARG001
+) -> None:
     """_harden_azure_sdk_logging must set propagate=False on each targeted logger."""
     mod = _reload_telemetry()
     mod._harden_azure_sdk_logging()  # type: ignore[attr-defined]
@@ -1697,7 +1726,9 @@ def test_harden_azure_sdk_logging_sets_propagate_false() -> None:
         )
 
 
-def test_harden_azure_sdk_logging_attaches_null_handler() -> None:
+def test_harden_azure_sdk_logging_attaches_null_handler(
+    restore_hardened_loggers: None,  # noqa: ARG001
+) -> None:
     """_harden_azure_sdk_logging must attach a NullHandler to each targeted logger."""
     mod = _reload_telemetry()
     mod._harden_azure_sdk_logging()  # type: ignore[attr-defined]
@@ -1709,7 +1740,9 @@ def test_harden_azure_sdk_logging_attaches_null_handler() -> None:
         )
 
 
-def test_harden_azure_sdk_logging_is_idempotent() -> None:
+def test_harden_azure_sdk_logging_is_idempotent(
+    restore_hardened_loggers: None,  # noqa: ARG001
+) -> None:
     """Calling _harden_azure_sdk_logging multiple times must not add duplicate handlers."""
     mod = _reload_telemetry()
     mod._harden_azure_sdk_logging()  # type: ignore[attr-defined]

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -7,6 +7,7 @@ no real network calls (every Azure Monitor SDK interaction is mocked).
 from __future__ import annotations
 
 import importlib
+import logging
 import sys
 import types
 import uuid
@@ -1654,3 +1655,69 @@ def test_shutdown_telemetry_never_raises_on_provider_exception(
 
     # Must not raise
     mod.shutdown_telemetry()  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# _harden_azure_sdk_logging — logging hardening for #411
+# ---------------------------------------------------------------------------
+
+# Logger names that must be silenced by _harden_azure_sdk_logging.
+_HARDENED_LOGGER_NAMES = [
+    # Azure Monitor exporter tree: covers statsbeat "missing a valid region",
+    # export/_base.py "Retrying due to server request error", and quickpulse
+    # _ping tracebacks (#411).
+    "azure.monitor.opentelemetry.exporter",
+    # azure-core pipeline retry policy: "Retrying due to server request error"
+    # at WARNING (#411).
+    "azure.core.pipeline.policies",
+]
+
+
+def test_harden_azure_sdk_logging_sets_level_to_critical() -> None:
+    """_harden_azure_sdk_logging must raise each targeted logger to CRITICAL."""
+    mod = _reload_telemetry()
+    mod._harden_azure_sdk_logging()  # type: ignore[attr-defined]
+
+    for name in _HARDENED_LOGGER_NAMES:
+        lgr = logging.getLogger(name)
+        assert lgr.level >= logging.CRITICAL, (
+            f"Logger {name!r} level {lgr.level} is below CRITICAL ({logging.CRITICAL})"
+        )
+
+
+def test_harden_azure_sdk_logging_sets_propagate_false() -> None:
+    """_harden_azure_sdk_logging must set propagate=False on each targeted logger."""
+    mod = _reload_telemetry()
+    mod._harden_azure_sdk_logging()  # type: ignore[attr-defined]
+
+    for name in _HARDENED_LOGGER_NAMES:
+        lgr = logging.getLogger(name)
+        assert lgr.propagate is False, (
+            f"Logger {name!r} propagate is not False — records can still reach root handler"
+        )
+
+
+def test_harden_azure_sdk_logging_attaches_null_handler() -> None:
+    """_harden_azure_sdk_logging must attach a NullHandler to each targeted logger."""
+    mod = _reload_telemetry()
+    mod._harden_azure_sdk_logging()  # type: ignore[attr-defined]
+
+    for name in _HARDENED_LOGGER_NAMES:
+        lgr = logging.getLogger(name)
+        assert any(isinstance(h, logging.NullHandler) for h in lgr.handlers), (
+            f"Logger {name!r} has no NullHandler — last-resort stderr message possible"
+        )
+
+
+def test_harden_azure_sdk_logging_is_idempotent() -> None:
+    """Calling _harden_azure_sdk_logging multiple times must not add duplicate handlers."""
+    mod = _reload_telemetry()
+    mod._harden_azure_sdk_logging()  # type: ignore[attr-defined]
+    mod._harden_azure_sdk_logging()  # type: ignore[attr-defined]
+
+    for name in _HARDENED_LOGGER_NAMES:
+        lgr = logging.getLogger(name)
+        null_count = sum(1 for h in lgr.handlers if isinstance(h, logging.NullHandler))
+        assert null_count == 1, (
+            f"Logger {name!r} has {null_count} NullHandlers after two calls — expected exactly 1"
+        )


### PR DESCRIPTION
## Summary

- Adds `_harden_azure_sdk_logging()` helper that sets `azure.monitor.opentelemetry.exporter` and `azure.core.pipeline.policies` to CRITICAL / `propagate=False` / `NullHandler` before `configure_azure_monitor` runs, so neither tree can write tracebacks or retry-warnings to stderr when the App Insights endpoint is unreachable.
- Passes `enable_live_metrics=False` explicitly to `configure_azure_monitor` as belt-and-suspenders against QuickPulse pinging the LiveEndpoint.
- Adds four focused unit tests for `_harden_azure_sdk_logging` (level, propagate, NullHandler, idempotency).
- Adds `"Retrying due to server request error"` and `"missing a valid region"` to `_FORBIDDEN_STDERR_SUBSTRINGS` in `test_shutdown_clean.py` to lock the fix in.

Closes #411

## Test plan

- [x] `uv run pytest tests/unit/test_shutdown_clean.py -m slow -v` — `test_cli_exits_without_shutdown_noise_on_auth_command` passes (was the failing CI gate).
- [x] `uv run pytest tests/unit/test_shutdown_clean.py -v` — both shutdown tests pass.
- [x] `uv run pytest tests/unit/test_telemetry.py -v` — all 101 telemetry tests pass (including 4 new `_harden_azure_sdk_logging` tests).
- [x] `just check` — ruff, ty, 3263 unit tests, ≥80% coverage all green.
- [x] `uv run pytest tests/unit -m slow -v` — all slow tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)