### PR TITLE
fix(load): use pure-GUID OneLake DFS path (FriendlyNameSupportDisabled)

### DIFF
--- a/src/fabric_dw/services/load.py
+++ b/src/fabric_dw/services/load.py
@@ -595,7 +595,12 @@ async def onelake_upload_file(
         "x-ms-version": _DFS_API_VERSION,
     }
 
-    dfs_url = f"{_ONELAKE_DFS_BASE}/{workspace_id}/{lakehouse_id}.Lakehouse/Files/{dest_path}"
+    # Pure-GUID OneLake DFS path: workspace GUID + item GUID, NO `.Lakehouse`
+    # type suffix.  The friendly-name form (`<guid>.Lakehouse`) is rejected with
+    # 400 FriendlyNameSupportDisabled on tenants where that feature is disabled.
+    # The pure-GUID form works regardless of whether friendly-name support is
+    # enabled, so it is unconditionally safer.
+    dfs_url = f"{_ONELAKE_DFS_BASE}/{workspace_id}/{lakehouse_id}/Files/{dest_path}"
 
     file_size = local_path.stat().st_size
     _logger.debug(
@@ -949,9 +954,11 @@ async def load_local_file(  # noqa: PLR0912, PLR0915
 
             # Step 5: COPY INTO from the OneLake URL.
             # Same-tenant OneLake → caller's Entra identity; no CREDENTIAL needed.
+            # Pure-GUID path (no .Lakehouse suffix) — required for tenants with
+            # FriendlyNameSupportDisabled; works universally regardless of tenant config.
             onelake_url = (
                 f"https://onelake.dfs.fabric.microsoft.com"
-                f"/{workspace_id}/{lakehouse_id}.Lakehouse/Files/{dest_filename}"
+                f"/{workspace_id}/{lakehouse_id}/Files/{dest_filename}"
             )
             result = await copy_into_from_url(
                 target,

--- a/src/fabric_dw/services/load.py
+++ b/src/fabric_dw/services/load.py
@@ -954,8 +954,10 @@ async def load_local_file(  # noqa: PLR0912, PLR0915
 
             # Step 5: COPY INTO from the OneLake URL.
             # Same-tenant OneLake → caller's Entra identity; no CREDENTIAL needed.
-            # Pure-GUID path (no .Lakehouse suffix) — required for tenants with
-            # FriendlyNameSupportDisabled; works universally regardless of tenant config.
+            # Pure-GUID path (no .Lakehouse suffix): the canonical OneLake form,
+            # consistent with the DFS upload path above and Microsoft's documented
+            # OPENROWSET/COPY INTO source form.  Works on all tenants regardless of
+            # whether the friendly-name feature is enabled.
             onelake_url = (
                 f"https://onelake.dfs.fabric.microsoft.com"
                 f"/{workspace_id}/{lakehouse_id}/Files/{dest_filename}"

--- a/tests/unit/services/test_load.py
+++ b/tests/unit/services/test_load.py
@@ -62,7 +62,7 @@ class TestBuildCopyIntoSql:
         sql = _build_copy_into_sql(
             "dbo",
             "sales",
-            "https://onelake.dfs.fabric.microsoft.com/ws/lh.Lakehouse/Files/f.parquet",
+            "https://onelake.dfs.fabric.microsoft.com/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/ffffffff-0000-1111-2222-333333333333/Files/f.parquet",
             "PARQUET",
         )
         assert "COPY INTO [dbo].[sales]" in sql
@@ -549,6 +549,60 @@ class TestLoadLocalFile:
         # The call to copy_into_from_url should use PARQUET file_type.
         _, kwargs = mock_copy.call_args
         assert kwargs.get("file_type") == "PARQUET" or mock_copy.call_args[0][4] == "PARQUET"
+
+    async def test_copy_into_url_is_pure_guid_no_lakehouse_suffix(self, tmp_path: Path) -> None:
+        """The onelake_url passed to copy_into_from_url must be pure-GUID with no .Lakehouse suffix.
+
+        load_local_file builds the COPY INTO source URL from the staging Lakehouse IDs.
+        This test asserts that the URL argument (positional arg index 3) does not
+        contain '.Lakehouse' and starts with the expected pure-GUID prefix, matching
+        the DFS upload path and Microsoft's documented OPENROWSET/COPY INTO source form.
+        """
+        csv_file = tmp_path / "data.csv"
+        csv_file.write_text("id,name\n1,Alice\n", encoding="utf-8")
+
+        from fabric_dw.sql import SqlTarget  # noqa: PLC0415
+
+        target = SqlTarget(
+            workspace_id="ws-id", database="db", connection_string="server=x;database=y"
+        )
+        ws_id = uuid.UUID("a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+        lh_id = "c0ffeeee-dead-beef-cafe-123456789abc"
+
+        mock_http = AsyncMock()
+        mock_credential = AsyncMock()
+
+        with (
+            patch("fabric_dw.services.load.create_staging_lakehouse", return_value=lh_id),
+            patch("fabric_dw.services.load.onelake_upload_file", return_value=None),
+            patch(
+                "fabric_dw.services.load.copy_into_from_url",
+                return_value=CopyIntoResult(rows_loaded=1, rows_rejected=0, target="dbo.t"),
+            ) as mock_copy,
+            patch("fabric_dw.services.load.delete_lakehouse"),
+        ):
+            await load_local_file(
+                mock_http,
+                mock_credential,
+                ws_id,
+                target,
+                "dbo",
+                "t",
+                csv_file,
+                file_format="csv",
+            )
+
+        mock_copy.assert_called_once()
+        # The URL is the 4th positional argument (index 3): target, schema, table, url
+        call_args = mock_copy.call_args
+        url_arg: str = call_args[0][3]
+        expected_prefix = f"https://onelake.dfs.fabric.microsoft.com/{ws_id}/{lh_id}/Files/"
+        assert ".Lakehouse" not in url_arg, (
+            f"COPY INTO URL must NOT contain '.Lakehouse' suffix; got: {url_arg!r}"
+        )
+        assert url_arg.startswith(expected_prefix), (
+            f"COPY INTO URL must start with pure-GUID prefix {expected_prefix!r}; got: {url_arg!r}"
+        )
 
     async def test_file_not_found_raises(self, tmp_path: Path) -> None:
         from fabric_dw.sql import SqlTarget  # noqa: PLC0415

--- a/tests/unit/services/test_load.py
+++ b/tests/unit/services/test_load.py
@@ -927,7 +927,9 @@ class TestOneLakeUploadFile:
 
     _WS_ID = uuid.UUID("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
     _LH_ID = "ffffffff-0000-1111-2222-333333333333"
-    _DFS_BASE = f"{_ONELAKE_DFS_BASE}/{_WS_ID}/{_LH_ID}.Lakehouse/Files/data.parquet"
+    # Pure-GUID DFS path — NO .Lakehouse suffix.  The friendly-name form is
+    # rejected with 400 FriendlyNameSupportDisabled on some tenants (#402).
+    _DFS_BASE = f"{_ONELAKE_DFS_BASE}/{_WS_ID}/{_LH_ID}/Files/data.parquet"
 
     def _make_credential(self) -> AsyncTokenCredential:
         """Return a minimal async credential stub that returns a fake token."""
@@ -938,6 +940,55 @@ class TestOneLakeUploadFile:
         cred = AsyncMock(spec=AsyncTokenCredential)
         cred.get_token.return_value = token
         return cred  # type: ignore[return-value]
+
+    # -----------------------------------------------------------------------
+    # Pure-GUID DFS path — no .Lakehouse suffix (#402)
+    # -----------------------------------------------------------------------
+
+    @respx.mock
+    async def test_dfs_url_is_pure_guid_no_type_suffix(self, tmp_path: Path) -> None:
+        """All DFS requests must use the pure-GUID path without a .Lakehouse type suffix.
+
+        Tenants with FriendlyNameSupportDisabled reject paths of the form
+        ``{workspace}/{item}.Lakehouse/Files/…`` with 400.  The correct form is
+        ``{workspace_guid}/{item_guid}/Files/…`` which works on all tenants.
+        """
+        data_file = tmp_path / "data.parquet"
+        data_file.write_bytes(b"PARQUET")
+
+        all_urls: list[str] = []
+
+        def _capture_put(request: httpx.Request) -> httpx.Response:
+            all_urls.append(str(request.url))
+            return httpx.Response(201)
+
+        def _capture_patch(request: httpx.Request) -> httpx.Response:
+            all_urls.append(str(request.url))
+            action = request.url.params.get("action", "")
+            return httpx.Response(202 if action == "append" else 200)
+
+        expected_path_prefix = f"{_ONELAKE_DFS_BASE}/{self._WS_ID}/{self._LH_ID}/Files/"
+        # Register routes for the pure-GUID URL (no .Lakehouse suffix).
+        respx.put(self._DFS_BASE).mock(side_effect=_capture_put)
+        respx.patch(self._DFS_BASE).mock(side_effect=_capture_patch)
+
+        await onelake_upload_file(
+            self._make_credential(),
+            self._WS_ID,
+            self._LH_ID,
+            "data.parquet",
+            data_file,
+        )
+
+        assert all_urls, "Expected at least one DFS request"
+        for url in all_urls:
+            assert ".Lakehouse" not in url, (
+                f"DFS URL must NOT contain '.Lakehouse' type suffix (FriendlyNameSupportDisabled); "
+                f"got: {url!r}"
+            )
+            assert url.startswith(expected_path_prefix), (
+                f"DFS URL must use pure-GUID form '{expected_path_prefix}…'; got: {url!r}"
+            )
 
     @respx.mock
     async def test_create_has_content_length_zero(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Removes the `.Lakehouse` type suffix from the OneLake DFS path in `onelake_upload_file` and from the COPY INTO OneLake URL in `load_local_file`.
- The friendly-name form (`{item_guid}.Lakehouse`) is rejected with `400 FriendlyNameSupportDisabled` on tenants where that feature is disabled (confirmed via the `_log_dfs_error` logging added in #410).
- The pure-GUID form (`{workspace_guid}/{item_guid}/Files/…`) is unconditionally correct and works on all tenants.
- Updates `TestOneLakeUploadFile._DFS_BASE` to match the corrected path and adds `test_dfs_url_is_pure_guid_no_type_suffix` to assert that no DFS request URL contains `.Lakehouse`.

Retains the `_log_dfs_error` diagnostic helper, `x-ms-version` header, and create-PUT retry logic from #410.

## Test plan

- [x] `just check` passes (ruff, ty, 3309 unit tests, 0 failures)
- [ ] Integration suite (`integration` label) passes against a real Fabric workspace to confirm `test_load_local_{csv,json,parquet}` and `test_create_and_load_{append,csv,json,parquet,replace,truncate}` no longer return 400

Closes #402

🤖 Generated with [Claude Code](https://claude.com/claude-code)