### PR TITLE
fix(cli): suggest setting a config default in missing workspace/warehouse errors

### DIFF
--- a/src/fabric_dw/cli/commands/_utils.py
+++ b/src/fabric_dw/cli/commands/_utils.py
@@ -351,7 +351,8 @@ def resolve_workspace_arg(ctx: CliContext, value: str | None) -> str:
     if cfg_val is not None:
         return cfg_val
     raise click.UsageError(
-        "no workspace specified; pass as argument or run 'fabric-dw config set workspace ...'"
+        "no workspace specified; pass one as an argument, or set a persistent default"
+        " with 'fabric-dw config set workspace <name|id>'"
     )
 
 
@@ -372,7 +373,9 @@ def resolve_warehouse_arg(ctx: CliContext, value: str | None) -> str:
     if cfg_val is not None:
         return cfg_val
     raise click.UsageError(
-        "no warehouse specified; pass as argument or run 'fabric-dw config set warehouse ...'"
+        "no warehouse specified; pass one as an argument, or set a persistent default"
+        " with 'fabric-dw config set warehouse <name|id>'"
+        " (accepts a warehouse or SQL Analytics Endpoint)"
     )
 
 

--- a/tests/unit/cli/commands/test_utils.py
+++ b/tests/unit/cli/commands/test_utils.py
@@ -10,6 +10,7 @@ from uuid import UUID
 import anyio
 import click
 import pytest
+from click.testing import CliRunner
 
 from fabric_dw.cache import ItemEntry, LookupCache
 from fabric_dw.cli._context import CliContext
@@ -507,3 +508,48 @@ class TestGetCtx:
         result = get_ctx(mock_ctx)
 
         assert result is sentinel
+
+
+# ---------------------------------------------------------------------------
+# resolve_workspace_arg / resolve_warehouse_arg — missing-default error messages
+# ---------------------------------------------------------------------------
+
+
+class TestResolveWorkspaceArgErrorMessage:
+    """resolve_workspace_arg raises UsageError with actionable guidance when no default is set."""
+
+    def test_missing_workspace_error_suggests_config_default(
+        self, runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Error message must mention the config-set command and the word 'default'."""
+        monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+        monkeypatch.delenv("FABRIC_DW_DEFAULT_WORKSPACE", raising=False)
+        # warehouses list requires WORKSPACE (or --all-workspaces); invoke with neither.
+        result = runner.invoke(cli, ["warehouses", "list"])
+        assert result.exit_code != 0
+        output = result.output
+        assert "no workspace specified" in output
+        assert "config set workspace" in output
+        assert "default" in output
+
+
+class TestResolveWarehouseArgErrorMessage:
+    """resolve_warehouse_arg raises UsageError with actionable guidance when no default is set."""
+
+    def test_missing_warehouse_error_suggests_config_default(
+        self, runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Error message must mention the config-set command, 'default', and SQL Analytics Endpoint."""  # noqa: E501
+        monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+        monkeypatch.delenv("FABRIC_DW_DEFAULT_WORKSPACE", raising=False)
+        monkeypatch.delenv("FABRIC_DW_DEFAULT_WAREHOUSE", raising=False)
+        # warehouses get requires WORKSPACE and WAREHOUSE; supply workspace but omit warehouse.
+        result = runner.invoke(cli, ["warehouses", "get", WS_GUID])
+        assert result.exit_code != 0
+        output = result.output
+        assert "no warehouse specified" in output
+        assert "config set warehouse" in output
+        assert "default" in output
+        assert "SQL Analytics Endpoint" in output

--- a/tests/unit/cli/commands/test_utils.py
+++ b/tests/unit/cli/commands/test_utils.py
@@ -525,6 +525,7 @@ class TestResolveWorkspaceArgErrorMessage:
         monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
         monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
         monkeypatch.delenv("FABRIC_DW_DEFAULT_WORKSPACE", raising=False)
+        monkeypatch.delenv("FABRIC_DW_DEFAULT_WAREHOUSE", raising=False)
         # warehouses list requires WORKSPACE (or --all-workspaces); invoke with neither.
         result = runner.invoke(cli, ["warehouses", "list"])
         assert result.exit_code != 0


### PR DESCRIPTION
## Summary

- Updates the `UsageError` messages in `resolve_workspace_arg` and `resolve_warehouse_arg` to make the guidance explicit and actionable: both messages now mention passing an argument *or* setting a persistent default via `fabric-dw config set`, include a `<name|id>` placeholder, and the warehouse message adds that a SQL Analytics Endpoint is accepted.
- Adds two focused unit tests in `test_utils.py` that assert the key substrings in each error message, with proper config isolation (`XDG_CONFIG_HOME` → tmp dir, `monkeypatch.delenv` for both env-var defaults).

## Test plan

- [ ] `just check` passes clean (ruff, ty, 3312 unit tests, coverage ≥ 80%)
- [ ] `test_missing_workspace_error_suggests_config_default` asserts `"no workspace specified"`, `"config set workspace"`, `"default"` in output
- [ ] `test_missing_warehouse_error_suggests_config_default` asserts `"no warehouse specified"`, `"config set warehouse"`, `"default"`, `"SQL Analytics Endpoint"` in output

Closes #422

🤖 Generated with [Claude Code](https://claude.com/claude-code)