### PR TITLE
ci(codeql): add advanced CodeQL workflow (python + actions)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,12 +25,12 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           build-mode: none
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,36 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '27 3 * * 1'
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [actions, python]
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/codeql.yml` — a standard advanced CodeQL workflow that replaces Default setup.
- Runs on `push` to `main`, `pull_request` to `main`, and weekly on a schedule (`cron: '27 3 * * 1'`).
- Matrix over `actions` and `python` languages with `build-mode: none` (pure-Python project, no compiled build).
- Uses `actions/checkout@v6` and `github/codeql-action/{init,analyze}@v3` consistent with repo conventions.
- `category: "/language:${{ matrix.language }}"` matches the categories already recorded on `main`, so both sides of a PR diff align — this eliminates the "2 configurations not found" warning on Dependabot PRs (e.g. #426).

## MERGE STEP

**Before or at merge**, disable Default setup so advanced CodeQL takes over without a coverage gap:

```sh
gh api -X PATCH repos/sdebruyn/fabric-dw-mcp-cli/code-scanning/default-setup -f state=not-configured
```

Then merge this PR so `codeql.yml` lands on `main`. After the first run completes, verify that both `/language:python` and `/language:actions` analyses appear in the Security tab. If anything fails, re-enable Default setup to restore coverage.

> **Note:** While Default setup is still active, GitHub may skip or mark this PR's own CodeQL run with a "default setup enabled" notice. This is expected and is **not a failure**. CodeQL is not a required branch-protection check, so it will not block this PR from being merged.

## Test plan

- [x] `actionlint` passes with no errors on `.github/workflows/codeql.yml`
- [x] YAML parses cleanly (`yaml.safe_load`)
- [x] `just check` is green (3314 unit tests pass, no regressions)
- [ ] After merge + default-setup disabled: advanced CodeQL runs on `main` and produces both `/language:python` and `/language:actions` analyses
- [ ] A subsequent Dependabot PR no longer shows "configurations not found"

Closes #429

🤖 Generated with [Claude Code](https://claude.com/claude-code)