### PR TITLE
fix(sql): fetch result set before commit so COPY INTO works

### DIFF
--- a/src/fabric_dw/sql.py
+++ b/src/fabric_dw/sql.py
@@ -977,20 +977,33 @@ def run_query(  # noqa: PLR0913
             cur.execute(statement, params)
         else:
             cur.execute(statement)
-        if commit and not autocommit:
-            c.commit()
 
         if fetch == "none":
+            # No result set to read; commit now (if requested) and return.
+            if commit and not autocommit:
+                c.commit()
             return [], []
 
+        # Fetch the result set BEFORE committing.  Committing first invalidates
+        # the cursor's prepared statement on mssql-python, which causes
+        # "Associated statement is not prepared" on the subsequent fetchall/
+        # fetchone call.  COPY INTO is the primary path that sets both
+        # commit=True and fetch != "none".
         cols = [col[0] for col in (cur.description or [])]
 
         if fetch == "one":
             row = cur.fetchone()
-            return cols, ([row] if row is not None else [])
+            result: tuple[list[str], list[tuple[Any, ...]]] = (
+                cols,
+                ([row] if row is not None else []),
+            )
+        else:
+            rows: list[tuple[Any, ...]] = cur.fetchall()
+            result = cols, rows
 
-        rows: list[tuple[Any, ...]] = cur.fetchall()
-        return cols, rows
+        if commit and not autocommit:
+            c.commit()
+        return result
 
     conn, attempt, max_attempts, _ = _with_connect_retry(target, mode, autocommit)
     try:

--- a/tests/unit/test_sql.py
+++ b/tests/unit/test_sql.py
@@ -2026,3 +2026,145 @@ class TestAuthFailedConnectRetry:
         # Exactly one sleep before the retry.
         assert fake_time.sleep.call_count == 1  # ty: ignore[unresolved-attribute]
         assert fake_time.sleep.call_args.args[0] == 10.0  # ty: ignore[unresolved-attribute]
+
+
+# ---------------------------------------------------------------------------
+# D12 — fetch-before-commit ordering (COPY INTO fix)
+# ---------------------------------------------------------------------------
+
+
+class _CommitInvalidatingCursor:
+    """Fake cursor that mimics mssql-python's "Associated statement is not prepared" error.
+
+    After ``commit()`` is called on the owning connection, any access to
+    ``fetchall()``, ``fetchone()``, or ``description`` raises ``_ProgrammingError``
+    with that message — exactly what mssql-python does when a committed cursor is
+    subsequently read.
+    """
+
+    _PREPARED_ERROR = "Associated statement is not prepared"
+
+    def __init__(
+        self,
+        description: list[tuple[str, None]],
+        rows: list[tuple[object, ...]],
+        committed_flag: list[bool],
+    ) -> None:
+        self._description = description
+        self._rows = rows
+        self._committed = committed_flag
+
+    def execute(self, _sql: str, _params: object = None) -> None:
+        pass
+
+    @property
+    def description(self) -> list[tuple[str, None]]:
+        if self._committed[0]:
+            raise _ProgrammingError(self._PREPARED_ERROR)
+        return self._description
+
+    def fetchall(self) -> list[tuple[object, ...]]:
+        if self._committed[0]:
+            raise _ProgrammingError(self._PREPARED_ERROR)
+        return self._rows
+
+    def fetchone(self) -> tuple[object, ...] | None:
+        if self._committed[0]:
+            raise _ProgrammingError(self._PREPARED_ERROR)
+        return self._rows[0] if self._rows else None
+
+
+class _CommitInvalidatingConnection:
+    """Fake _Connection whose ``commit()`` invalidates the cursor."""
+
+    def __init__(
+        self,
+        description: list[tuple[str, None]],
+        rows: list[tuple[object, ...]],
+    ) -> None:
+        self._committed: list[bool] = [False]
+        self._cursor = _CommitInvalidatingCursor(description, rows, self._committed)
+
+    def cursor(self) -> _CommitInvalidatingCursor:
+        return self._cursor
+
+    def commit(self) -> None:
+        self._committed[0] = True
+
+    def close(self) -> None:
+        pass
+
+
+class _ProgrammingError(Exception):
+    """Minimal stand-in for mssql_python.exceptions.ProgrammingError."""
+
+
+class TestFetchBeforeCommitOrdering:
+    """D12: result set must be fetched BEFORE commit() is called.
+
+    These tests use a fake cursor/connection that raises once ``commit()`` has
+    been called, mirroring the mssql-python "Associated statement is not
+    prepared" behaviour that broke COPY INTO.
+    """
+
+    def _patch_with_invalidating_conn(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        description: list[tuple[str, None]],
+        rows: list[tuple[object, ...]],
+    ) -> _CommitInvalidatingConnection:
+        fake_conn = _CommitInvalidatingConnection(description, rows)
+        mock_mssql = MagicMock()
+        mock_mssql.connect.return_value = fake_conn
+        monkeypatch.setattr(_sql_module, "_mssql", mock_mssql)
+        return fake_conn
+
+    def test_fetch_all_commit_true_returns_rows(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """fetch='all' + commit=True must return rows even if commit invalidates cursor."""
+        description = [("rows_loaded", None), ("rows_rejected", None)]
+        rows: list[tuple[object, ...]] = [(1000, 0)]
+        self._patch_with_invalidating_conn(monkeypatch, description, rows)
+
+        cols, result_rows = run_query(
+            _make_target(),
+            "COPY INTO [dbo].[t] FROM '...' WITH (FILE_TYPE='PARQUET')",
+            commit=True,
+            fetch="all",
+        )
+
+        assert cols == ["rows_loaded", "rows_rejected"]
+        assert result_rows == [(1000, 0)]
+
+    def test_fetch_one_commit_true_returns_row(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """fetch='one' + commit=True must return the single row before the commit fires."""
+        description = [("rows_loaded", None), ("rows_rejected", None)]
+        rows: list[tuple[object, ...]] = [(500, 2)]
+        self._patch_with_invalidating_conn(monkeypatch, description, rows)
+
+        cols, result_rows = run_query(
+            _make_target(),
+            "COPY INTO [dbo].[t] FROM '...' WITH (FILE_TYPE='PARQUET')",
+            commit=True,
+            fetch="one",
+        )
+
+        assert cols == ["rows_loaded", "rows_rejected"]
+        assert result_rows == [(500, 2)]
+
+    def test_fetch_none_commit_true_still_commits(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """fetch='none' + commit=True (DDL/DML path) must still call commit()."""
+        description: list[tuple[str, None]] = []
+        rows: list[tuple[object, ...]] = []
+        fake_conn = self._patch_with_invalidating_conn(monkeypatch, description, rows)
+
+        cols, result_rows = run_query(
+            _make_target(),
+            "INSERT INTO [dbo].[t] VALUES (1)",
+            commit=True,
+            fetch="none",
+        )
+
+        assert cols == []
+        assert result_rows == []
+        # Verify commit was actually called.
+        assert fake_conn._committed[0] is True


### PR DESCRIPTION
Closes #437

## Problem
Integration load tests (`test_services_load`, `test_services_create_and_load`) fail with `mssql_python.exceptions.ProgrammingError: Associated statement is not prepared`, surfaced as `FabricError: COPY INTO [...] failed: ProgrammingError (details suppressed to protect credentials)`. Reproduces identically on mssql-python 1.8.0 and 1.9.0 — driver-version independent.

## Root cause
`sql._execute_once` committed BEFORE reading the result set (`cur.execute` → `c.commit()` → `cur.description`/`cur.fetchall()`). `COPY INTO` is the only `commit=True` path that ALSO returns a result set (`rows_loaded`, `rows_rejected`); committing first invalidated the cursor's prepared statement, so the fetch raised "Associated statement is not prepared". Pure DDL/DML uses `fetch="none"` (no result set) and was unaffected.

## Fix
Reorder `_execute_once` to fetch the result set BEFORE committing when `fetch != "none"`. Unit tests in `tests/unit/test_sql.py` (`TestFetchBeforeCommitOrdering`) prove fetch-before-commit for `fetch="all"`/`fetch="one"` and that `fetch="none"` still commits.