### PR TITLE
fix(statistics): retry DBCC SHOW_STATISTICS on eventual-consistency miss

### DIFF
--- a/src/fabric_dw/services/statistics.py
+++ b/src/fabric_dw/services/statistics.py
@@ -472,16 +472,21 @@ async def show_statistics(
     # "Could not locate statistics" for a short window after CREATE STATISTICS
     # (the statistic is visible in sys.stats but not yet to DBCC).  Retry
     # until visible or until the timeout expires, then raise NotFoundError.
+    # NOTE: the effective timeout can exceed _DBCC_STAT_TIMEOUT by up to one
+    # TDS round-trip (the time asyncio.to_thread(_run_once) takes to return).
     deadline = time.monotonic() + _DBCC_STAT_TIMEOUT
     while True:
         try:
             return await asyncio.to_thread(_run_once)
-        except NotFoundError:
-            # NotFoundError from empty rows — not retriable (stat does not exist).
-            raise
         except Exception as exc:
+            # map_driver_error() inside run_query may promote the raw DBCC
+            # driver error to NotFoundError before it reaches us.  Check the
+            # message on ANY exception so that promoted NotFoundErrors are
+            # still retried.  The empty-rows NotFoundError has the message
+            # "Statistic [..] on [..] not found" (no "could not locate
+            # statistics"), so it correctly falls through to the re-raise below.
             if _DBCC_NOT_FOUND_MSG not in str(exc).lower():
-                # Unrelated driver error — propagate immediately.
+                # Not the transient DBCC error — propagate immediately.
                 raise
             remaining = deadline - time.monotonic()
             if remaining <= 0:

--- a/src/fabric_dw/services/statistics.py
+++ b/src/fabric_dw/services/statistics.py
@@ -45,6 +45,7 @@ reject SQL Analytics Endpoint items client-side with a clear
 from __future__ import annotations
 
 import asyncio
+import time
 from datetime import UTC, datetime
 from typing import cast
 
@@ -79,6 +80,17 @@ _SQL_ENDPOINT_READONLY_MSG = (
 
 _SAMPLE_PERCENT_MIN = 1
 _SAMPLE_PERCENT_MAX = 100
+
+# Bounded retry for Fabric DW eventual-consistency: DBCC SHOW_STATISTICS may
+# return "Could not locate statistics" for a short window after CREATE STATISTICS
+# even though sys.stats already reflects the new statistic.  Poll until the
+# statistic becomes visible to DBCC, up to _DBCC_STAT_TIMEOUT seconds total.
+_DBCC_STAT_POLL_INTERVAL: float = 3.0
+_DBCC_STAT_TIMEOUT: float = 60.0
+
+# Substring matched (case-insensitive) against the exception message to
+# distinguish Fabric's eventual-consistency transient error from other errors.
+_DBCC_NOT_FOUND_MSG = "could not locate statistics"
 
 
 def _assert_not_sql_endpoint(kind: WarehouseKind) -> None:
@@ -431,7 +443,8 @@ async def show_statistics(
     density_sql = _DBCC_DENSITY_SQL.format(table_s=table_s, stat_literal=stat_literal)
     histogram_sql = _DBCC_HISTOGRAM_SQL.format(table_s=table_s, stat_literal=stat_literal)
 
-    def _run() -> StatisticDetails:
+    def _run_once() -> StatisticDetails:
+        """Execute DBCC SHOW_STATISTICS queries once (no retry)."""
         if histogram_only:
             h_cols, h_rows = run_query(target, histogram_sql, mode=mode)
             return StatisticDetails(
@@ -455,7 +468,26 @@ async def show_statistics(
             histogram=[_row_to_histogram(h_cols, r) for r in h_rows],
         )
 
-    return await asyncio.to_thread(_run)
+    # Fabric DW eventual-consistency retry: DBCC SHOW_STATISTICS may raise
+    # "Could not locate statistics" for a short window after CREATE STATISTICS
+    # (the statistic is visible in sys.stats but not yet to DBCC).  Retry
+    # until visible or until the timeout expires, then raise NotFoundError.
+    deadline = time.monotonic() + _DBCC_STAT_TIMEOUT
+    while True:
+        try:
+            return await asyncio.to_thread(_run_once)
+        except NotFoundError:
+            # NotFoundError from empty rows — not retriable (stat does not exist).
+            raise
+        except Exception as exc:
+            if _DBCC_NOT_FOUND_MSG not in str(exc).lower():
+                # Unrelated driver error — propagate immediately.
+                raise
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                msg = f"Statistic [{stat_name}] on [{schema}].[{table}] not found"
+                raise NotFoundError(msg) from exc
+            await asyncio.sleep(min(_DBCC_STAT_POLL_INTERVAL, remaining))
 
 
 async def create_statistics(

--- a/tests/unit/services/test_statistics.py
+++ b/tests/unit/services/test_statistics.py
@@ -414,6 +414,137 @@ class TestShowStatistics:
         with pytest.raises(ValueError, match="Invalid SQL identifier"):
             await statistics.show_statistics(target, "dbo.sales", "stat'name")
 
+    # --- Eventual-consistency retry (Fabric DW: DBCC SHOW_STATISTICS transient error) ---
+
+    async def test_retries_on_could_not_locate_statistics_then_succeeds(self) -> None:
+        """show_statistics must retry when DBCC raises 'Could not locate statistics'.
+
+        Simulate 2 transient "Could not locate statistics" errors followed by a
+        successful DBCC result.  The function must retry and ultimately return a
+        populated StatisticDetails.
+        """
+        target = _make_target()
+        transient_exc = Exception("Could not locate statistics 'pytest_stat_on_id'.")
+        header_conn_ok = _make_conn([_HEADER_ROW], _HEADER_COLS)
+        density_conn_ok = _make_conn([_DENSITY_ROW], _DENSITY_COLS)
+        hist_conn_ok = _make_conn([_HISTOGRAM_ROW], _HISTOGRAM_COLS)
+
+        call_count = 0
+
+        def _open_connection_side_effect(*_args: object, **_kwargs: object) -> object:
+            nonlocal call_count
+            call_count += 1
+            # First two attempts: the header connection raises the transient error.
+            # We do this by returning a connection whose cursor.execute raises.
+            if call_count in (1, 2):
+                bad_conn = MagicMock()
+                bad_cursor = MagicMock()
+                bad_cursor.execute.side_effect = transient_exc
+                bad_conn.cursor.return_value = bad_cursor
+                return bad_conn
+            # 3rd, 4th, 5th calls: the three successful DBCC queries.
+            if call_count == 3:
+                return header_conn_ok
+            if call_count == 4:
+                return density_conn_ok
+            return hist_conn_ok
+
+        with (
+            patch("fabric_dw.sql.open_connection", side_effect=_open_connection_side_effect),
+            patch("asyncio.sleep"),  # suppress real sleep in tests
+        ):
+            result = await statistics.show_statistics(
+                target,
+                "dbo.sales",
+                "stat_sales_id",
+                # Use a generous timeout so the test never races against the wall clock.
+            )
+
+        assert isinstance(result, StatisticDetails)
+        assert result.stat_header is not None
+        assert result.stat_header.name == "stat_sales_id"
+
+    async def test_does_not_retry_on_unrelated_error(self) -> None:
+        """show_statistics must NOT retry on errors unrelated to eventual consistency."""
+        target = _make_target()
+        unrelated_exc = Exception("Some other database error")
+        bad_conn = MagicMock()
+        bad_cursor = MagicMock()
+        bad_cursor.execute.side_effect = unrelated_exc
+        bad_conn.cursor.return_value = bad_cursor
+
+        sleep_calls: list[float] = []
+
+        async def _fake_sleep(secs: float) -> None:
+            sleep_calls.append(secs)
+
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=bad_conn),
+            patch("asyncio.sleep", side_effect=_fake_sleep),
+            pytest.raises(Exception, match="Some other database error"),
+        ):
+            await statistics.show_statistics(target, "dbo.sales", "stat_sales_id")
+
+        # No sleep should have been called — we propagated immediately.
+        assert sleep_calls == []
+
+    async def test_raises_not_found_after_timeout(self) -> None:
+        """show_statistics must raise NotFoundError once the retry deadline is exhausted."""
+        target = _make_target()
+        transient_exc = Exception("Could not locate statistics 'stat'.")
+        bad_conn = MagicMock()
+        bad_cursor = MagicMock()
+        bad_cursor.execute.side_effect = transient_exc
+        bad_conn.cursor.return_value = bad_cursor
+
+        # Monkeypatch time.monotonic to advance past the deadline on the first retry.
+        _start = 1_000_000.0  # arbitrary fixed start
+        _call = 0
+
+        def _fake_monotonic() -> float:
+            nonlocal _call
+            _call += 1
+            # First call (deadline = start + timeout): return _start.
+            # Every subsequent call: return _start + timeout + 1 (past deadline).
+            if _call == 1:
+                return _start
+            return _start + statistics._DBCC_STAT_TIMEOUT + 1
+
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=bad_conn),
+            patch("asyncio.sleep"),
+            patch("fabric_dw.services.statistics.time") as mock_time,
+        ):
+            mock_time.monotonic.side_effect = _fake_monotonic
+            with pytest.raises(NotFoundError):
+                await statistics.show_statistics(target, "dbo.sales", "stat")
+
+    async def test_not_found_from_empty_rows_is_not_retried(self) -> None:
+        """Empty DBCC result (stat simply does not exist) must raise NotFoundError immediately.
+
+        This is distinct from the 'Could not locate statistics' driver error —
+        an empty result set means the stat definitively does not exist and must
+        not trigger the eventual-consistency retry loop.
+        """
+        target = _make_target()
+        # Cursor returns no rows for the header query (stat absent from DBCC output).
+        header_conn = _make_conn([], _HEADER_COLS)
+
+        sleep_calls: list[float] = []
+
+        async def _fake_sleep(secs: float) -> None:
+            sleep_calls.append(secs)
+
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=header_conn),
+            patch("asyncio.sleep", side_effect=_fake_sleep),
+            pytest.raises(NotFoundError),
+        ):
+            await statistics.show_statistics(target, "dbo.sales", "nonexistent_stat")
+
+        # No sleep — NotFoundError from empty rows is not retriable.
+        assert sleep_calls == []
+
 
 # ===========================================================================
 # create_statistics

--- a/tests/unit/services/test_statistics.py
+++ b/tests/unit/services/test_statistics.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -464,6 +464,91 @@ class TestShowStatistics:
         assert result.stat_header is not None
         assert result.stat_header.name == "stat_sales_id"
 
+    async def test_retries_histogram_only_on_could_not_locate_statistics(self) -> None:
+        """show_statistics must retry the histogram_only path on the transient DBCC error.
+
+        The retry loop wraps the entire _run_once, including the histogram_only
+        early-return branch.  Verify that a transient "Could not locate statistics"
+        error on the histogram query is retried and ultimately returns a result.
+        """
+        target = _make_target()
+        transient_exc = Exception("Could not locate statistics 'stat_sales_id'.")
+        hist_conn_ok = _make_conn([_HISTOGRAM_ROW], _HISTOGRAM_COLS)
+
+        call_count = 0
+
+        def _open_connection_side_effect(*_args: object, **_kwargs: object) -> object:
+            nonlocal call_count
+            call_count += 1
+            # First attempt: histogram query raises the transient error.
+            if call_count == 1:
+                bad_conn = MagicMock()
+                bad_cursor = MagicMock()
+                bad_cursor.execute.side_effect = transient_exc
+                bad_conn.cursor.return_value = bad_cursor
+                return bad_conn
+            # Second attempt: successful histogram query.
+            return hist_conn_ok
+
+        with (
+            patch("fabric_dw.sql.open_connection", side_effect=_open_connection_side_effect),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            result = await statistics.show_statistics(
+                target,
+                "dbo.sales",
+                "stat_sales_id",
+                histogram_only=True,
+            )
+
+        assert isinstance(result, StatisticDetails)
+        assert result.stat_header is None
+        assert result.density_vector == []
+        assert len(result.histogram) == 1
+
+    async def test_retries_promoted_not_found_error_on_could_not_locate_statistics(self) -> None:
+        """show_statistics must retry even when the driver error is promoted to NotFoundError.
+
+        map_driver_error() inside run_query can promote a raw driver exception to
+        NotFoundError before it reaches show_statistics.  The retry predicate checks
+        the message on ANY exception type, so a NotFoundError whose message contains
+        "could not locate statistics" must still be retried.
+        """
+        target = _make_target()
+        # Simulate map_driver_error promoting the transient DBCC error to NotFoundError.
+        promoted_exc = NotFoundError("Could not locate statistics 'stat_sales_id'.")
+        hist_conn_ok = _make_conn([_HISTOGRAM_ROW], _HISTOGRAM_COLS)
+        header_conn_ok = _make_conn([_HEADER_ROW], _HEADER_COLS)
+        density_conn_ok = _make_conn([_DENSITY_ROW], _DENSITY_COLS)
+
+        call_count = 0
+
+        def _open_connection_side_effect(*_args: object, **_kwargs: object) -> object:
+            nonlocal call_count
+            call_count += 1
+            # First call: raises promoted NotFoundError with the transient message.
+            if call_count == 1:
+                bad_conn = MagicMock()
+                bad_cursor = MagicMock()
+                bad_cursor.execute.side_effect = promoted_exc
+                bad_conn.cursor.return_value = bad_cursor
+                return bad_conn
+            # Subsequent calls: successful queries.
+            if call_count == 2:
+                return header_conn_ok
+            if call_count == 3:
+                return density_conn_ok
+            return hist_conn_ok
+
+        with (
+            patch("fabric_dw.sql.open_connection", side_effect=_open_connection_side_effect),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            result = await statistics.show_statistics(target, "dbo.sales", "stat_sales_id")
+
+        assert isinstance(result, StatisticDetails)
+        assert result.stat_header is not None
+
     async def test_does_not_retry_on_unrelated_error(self) -> None:
         """show_statistics must NOT retry on errors unrelated to eventual consistency."""
         target = _make_target()
@@ -512,12 +597,16 @@ class TestShowStatistics:
 
         with (
             patch("fabric_dw.sql.open_connection", return_value=bad_conn),
-            patch("asyncio.sleep"),
+            patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
             patch("fabric_dw.services.statistics.time") as mock_time,
         ):
             mock_time.monotonic.side_effect = _fake_monotonic
             with pytest.raises(NotFoundError):
                 await statistics.show_statistics(target, "dbo.sales", "stat")
+
+        # Deadline was already exhausted after the first attempt — sleep must not
+        # have been called (we raise NotFoundError, not sleep-and-retry).
+        mock_sleep.assert_not_called()
 
     async def test_not_found_from_empty_rows_is_not_retried(self) -> None:
         """Empty DBCC result (stat simply does not exist) must raise NotFoundError immediately.


### PR DESCRIPTION
## Summary
- Adds bounded retry logic inside `show_statistics` (`src/fabric_dw/services/statistics.py`) to handle Fabric DW eventual consistency: `DBCC SHOW_STATISTICS` transiently fails with "Could not locate statistics" for a short window after `CREATE STATISTICS` succeeds.
- Retries every ~3 s for up to ~60 s; raises the existing `NotFoundError` on timeout. All other errors propagate immediately; empty-rows `NotFoundError` is not retried.
- Adds unit tests covering retry-then-succeed, no-retry-on-unrelated-error, timeout, and empty-rows paths.

Closes #438

## Test plan
- [ ] Unit tests: `uv run pytest tests/unit/services/test_statistics.py -v`
- [ ] Integration suite: `test_services_statistics.py::test_create_list_show_update_drop_roundtrip` should pass end-to-end without the transient DBCC miss failure
- [ ] Verify no retry delay added on unrelated errors (fast-fail still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)