### PR TITLE
feat(cli): add 'fdw' short alias for the fabric-dw command

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ pip install fabric-dw
 uvx fabric-dw --help
 ```
 
+The `fdw` command is a short alias for `fabric-dw` — both invoke the same entry point.
+
 ## Quick Start
 
 ### CLI

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ pip install fabric-dw
 uvx fabric-dw --help
 ```
 
-The `fdw` command is a short alias for `fabric-dw` — both invoke the same entry point.
+After installation, the `fdw` command is a short alias for `fabric-dw` — both invoke the same entry point.
 
 ## Quick Start
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -39,6 +39,9 @@ fabric-dw --help
 
 You should see the top-level help output listing available commands.
 
+!!! tip "Short alias"
+    `fdw` is an equivalent short alias for `fabric-dw` — both commands invoke the same entry point.
+
 ---
 
 See also the [Authentication](authentication.md) page for the full credential chain and the [Troubleshooting](troubleshooting.md) page for common failure modes such as expired tokens and 403 permission errors.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ Issues = "https://github.com/sdebruyn/fabric-dw-mcp-cli/issues"
 [project.scripts]
 fabric-dw = "fabric_dw.cli:main"
 fabric-dw-mcp = "fabric_dw.mcp.server:run"
+fdw = "fabric_dw.cli:main"
 
 [dependency-groups]
 dev = [

--- a/tests/unit/test_entry_points.py
+++ b/tests/unit/test_entry_points.py
@@ -1,0 +1,40 @@
+"""Ensure the expected console-script entry points are declared in pyproject.toml.
+
+Parsing pyproject.toml directly avoids a package-install requirement and keeps the
+test fast and self-contained.  Any drift between pyproject.toml and this assertion
+file will be caught immediately by the unit suite.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+PYPROJECT = Path(__file__).parent.parent.parent / "pyproject.toml"
+
+_EXPECTED_SCRIPTS: dict[str, str] = {
+    "fabric-dw": "fabric_dw.cli:main",
+    "fdw": "fabric_dw.cli:main",
+    "fabric-dw-mcp": "fabric_dw.mcp.server:run",
+}
+
+
+def test_console_scripts_declared() -> None:
+    """All expected console scripts are present and target the correct entry point."""
+    data = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+    scripts: dict[str, str] = data["project"]["scripts"]
+    for name, target in _EXPECTED_SCRIPTS.items():
+        assert name in scripts, f"console script {name!r} not found in [project.scripts]"
+        assert scripts[name] == target, (
+            f"console script {name!r} targets {scripts[name]!r}, expected {target!r}"
+        )
+
+
+def test_fdw_and_fabric_dw_same_target() -> None:
+    """`fdw` and `fabric-dw` must point to the identical entry point."""
+    data = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+    scripts: dict[str, str] = data["project"]["scripts"]
+    assert scripts["fdw"] == scripts["fabric-dw"], (
+        f"'fdw' ({scripts['fdw']!r}) and 'fabric-dw' ({scripts['fabric-dw']!r}) "
+        "must share the same target"
+    )

--- a/tests/unit/test_entry_points.py
+++ b/tests/unit/test_entry_points.py
@@ -18,23 +18,23 @@ _EXPECTED_SCRIPTS: dict[str, str] = {
     "fabric-dw-mcp": "fabric_dw.mcp.server:run",
 }
 
+_SCRIPTS: dict[str, str] = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))["project"][
+    "scripts"
+]
+
 
 def test_console_scripts_declared() -> None:
     """All expected console scripts are present and target the correct entry point."""
-    data = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
-    scripts: dict[str, str] = data["project"]["scripts"]
     for name, target in _EXPECTED_SCRIPTS.items():
-        assert name in scripts, f"console script {name!r} not found in [project.scripts]"
-        assert scripts[name] == target, (
-            f"console script {name!r} targets {scripts[name]!r}, expected {target!r}"
+        assert name in _SCRIPTS, f"console script {name!r} not found in [project.scripts]"
+        assert _SCRIPTS[name] == target, (
+            f"console script {name!r} targets {_SCRIPTS[name]!r}, expected {target!r}"
         )
 
 
 def test_fdw_and_fabric_dw_same_target() -> None:
     """`fdw` and `fabric-dw` must point to the identical entry point."""
-    data = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
-    scripts: dict[str, str] = data["project"]["scripts"]
-    assert scripts["fdw"] == scripts["fabric-dw"], (
-        f"'fdw' ({scripts['fdw']!r}) and 'fabric-dw' ({scripts['fabric-dw']!r}) "
+    assert _SCRIPTS["fdw"] == _SCRIPTS["fabric-dw"], (
+        f"'fdw' ({_SCRIPTS['fdw']!r}) and 'fabric-dw' ({_SCRIPTS['fabric-dw']!r}) "
         "must share the same target"
     )


### PR DESCRIPTION
## Summary

- Adds `fdw = "fabric_dw.cli:main"` to `[project.scripts]` in `pyproject.toml`, making `fdw` an equivalent short alias for `fabric-dw`.
- Documents the alias in `docs/install.md` (tip admonition) and `README.md` (one sentence near the install section).
- Adds `tests/unit/test_entry_points.py` with two lightweight tests that parse `pyproject.toml` directly to assert both `fdw` and `fabric-dw` are declared and share the same entry point target.

Closes #446

## Test plan

- [ ] `uv sync` installs the `fdw` script; `uv run fdw --help` produces the same output as `uv run fabric-dw --help`.
- [ ] `just check` passes clean (ruff + ty + 3355 unit tests).
- [ ] New tests in `test_entry_points.py` pass and assert the `pyproject.toml` declaration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)