### PR TITLE
fix(cli): skip telemetry on --help/-h so subcommand help is instant

### DIFF
--- a/src/fabric_dw/cli/__init__.py
+++ b/src/fabric_dw/cli/__init__.py
@@ -2,9 +2,25 @@
 
 from __future__ import annotations
 
+import sys
+
 from fabric_dw.cli._main import cli
+from fabric_dw.telemetry import suppress_telemetry
+
+# Help-option names declared on the root group's context_settings.
+_HELP_FLAGS: frozenset[str] = frozenset({"-h", "--help"})
 
 
 def main() -> None:
     """Entrypoint registered in pyproject.toml [project.scripts]."""
+    # Suppress all telemetry for help invocations at any level.  Click's eager
+    # --help for the ROOT group short-circuits before the group callback runs, so
+    # it never pays any telemetry cost.  Subcommand help (e.g. ``fdw config -h``)
+    # DOES run the root callback (to dispatch toward the subcommand) and then
+    # exits, which would otherwise trigger a full telemetry init + network flush.
+    # Detecting the help flag here and calling suppress_telemetry() before cli()
+    # ensures every help invocation at any depth is a guaranteed no-op for
+    # telemetry, bringing subcommand help latency from ~2-4 s to <0.5 s.
+    if _HELP_FLAGS.intersection(sys.argv[1:]):
+        suppress_telemetry()
     cli()

--- a/src/fabric_dw/telemetry.py
+++ b/src/fabric_dw/telemetry.py
@@ -52,6 +52,7 @@ __all__ = [
     "record_mcp_server_started",
     "set_tenant_id",
     "shutdown_telemetry",
+    "suppress_telemetry",
     "telemetry_enabled",
 ]
 
@@ -97,6 +98,32 @@ def _is_ci() -> bool:
 
 
 # ---------------------------------------------------------------------------
+# Process-level suppression (used for --help/-h invocations)
+# ---------------------------------------------------------------------------
+
+_SUPPRESSED: bool = False
+
+
+def suppress_telemetry(value: bool = True) -> None:  # noqa: FBT001, FBT002
+    """Suppress (or un-suppress) telemetry for this process.
+
+    When *value* is ``True`` (the default), :func:`telemetry_enabled` returns
+    ``False`` for the remainder of the process lifetime, causing all telemetry
+    functions to become no-ops.  This is checked **before** any env-var or
+    config-file logic, so it is always authoritative.
+
+    Pass ``value=False`` to restore the normal enable/disable evaluation.
+    This is primarily useful in tests to reset state between test runs.
+
+    Args:
+        value: ``True`` to suppress telemetry (default), ``False`` to lift the
+            suppression and let normal env/config checks apply.
+    """
+    global _SUPPRESSED  # noqa: PLW0603
+    _SUPPRESSED = value
+
+
+# ---------------------------------------------------------------------------
 # Opt-out helpers
 # ---------------------------------------------------------------------------
 
@@ -134,12 +161,19 @@ def telemetry_enabled() -> bool:
 
     Telemetry is ON by default.  Any of the following disables it:
 
+    - :func:`suppress_telemetry` has been called (process-level suppression,
+      checked first — used by ``--help``/``-h`` invocations to skip all
+      telemetry init and network I/O)
     - ``FABRIC_TELEMETRY`` in ``{"0", "false", "no", "off"}``
     - ``FABRIC_DISABLE_TELEMETRY`` is truthy
     - ``DO_NOT_TRACK`` is truthy
     - A CI environment is detected (``CI``, ``GITHUB_ACTIONS``, etc.)
     - The config file has ``[telemetry] disabled = true``
     """
+    # Process-level suppression (e.g. --help/-h) — checked first, always wins.
+    if _SUPPRESSED:
+        return False
+
     # Explicit opt-out via FABRIC_TELEMETRY=<falsy>
     fabric_tel = os.environ.get("FABRIC_TELEMETRY", "").strip().lower()
     if fabric_tel in _FALSY_VALUES:

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -3,10 +3,15 @@
 from __future__ import annotations
 
 import logging
+import sys
+from collections.abc import Generator
 from unittest.mock import patch
 
+import pytest
 from click.testing import CliRunner
 
+import fabric_dw.cli as _cli_pkg
+import fabric_dw.telemetry as _tel
 from fabric_dw.cli._main import cli
 
 
@@ -83,3 +88,80 @@ class TestCliVerboseFlag:
             result = runner.invoke(cli, ["cache", "--help"])
             assert result.exit_code == 0
             mock_setup.assert_called_once_with(logging.INFO)
+
+
+class TestHelpTelemetrySuppression:
+    """Help invocations must suppress all telemetry (no SDK init, no network flush)."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_suppress_flag(self) -> Generator[None, None, None]:
+        """Reset the suppress_telemetry flag after every test to avoid state leakage."""
+        _tel.suppress_telemetry(value=False)
+        yield
+        _tel.suppress_telemetry(value=False)
+
+    @pytest.mark.parametrize("help_flag", ["-h", "--help"])
+    def test_main_suppresses_telemetry_when_help_flag_in_argv(
+        self, help_flag: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """main() must suppress telemetry when a help flag appears in sys.argv.
+
+        We verify by checking that _SUPPRESSED is True after main() detects
+        the help flag, without needing to let the real cli() execute.
+        """
+        monkeypatch.setattr(sys, "argv", ["fdw", "config", help_flag])
+
+        # Start unsuppressed.
+        _tel.suppress_telemetry(value=False)
+
+        # Patch cli() in the __init__ module so main() doesn't actually run Click.
+        with patch.object(_cli_pkg, "cli", autospec=False):
+            _cli_pkg.main()
+
+        # After main(), the suppress flag must be set.
+        assert _tel._SUPPRESSED is True, (  # type: ignore[attr-defined]
+            f"_SUPPRESSED must be True after main() when {help_flag!r} is in argv"
+        )
+
+    def test_main_does_not_suppress_telemetry_for_normal_command(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """main() must NOT suppress telemetry for a normal (non-help) invocation."""
+        monkeypatch.setattr(sys, "argv", ["fdw", "config", "get"])
+
+        _tel.suppress_telemetry(value=False)  # start unsuppressed
+
+        with patch.object(_cli_pkg, "cli", autospec=False):
+            _cli_pkg.main()
+
+        assert _tel._SUPPRESSED is False, (  # type: ignore[attr-defined]
+            "_SUPPRESSED must remain False when no help flag is present"
+        )
+
+    def test_get_tracer_not_called_on_subcommand_help(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When a subcommand is invoked with --help, _get_tracer must not be called."""
+        monkeypatch.setattr(sys, "argv", ["fdw", "config", "--help"])
+
+        # Suppress from the start (as main() would do).
+        _tel.suppress_telemetry()
+
+        tracer_calls: list[str] = []
+        with patch.object(_tel, "_get_tracer", side_effect=lambda: tracer_calls.append("called")):  # type: ignore[attr-defined]
+            runner = CliRunner()
+            result = runner.invoke(cli, ["config", "--help"])
+
+        assert result.exit_code == 0
+        assert tracer_calls == [], "_get_tracer must not be called when telemetry is suppressed"
+
+    def test_subcommand_help_exits_without_telemetry_enabled(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """After suppress_telemetry(), telemetry_enabled() must return False."""
+        monkeypatch.setattr(sys, "argv", ["fdw", "config", "-h"])
+        _tel.suppress_telemetry()
+
+        assert _tel.telemetry_enabled() is False, (
+            "telemetry_enabled() must return False when suppress_telemetry() has been called"
+        )

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -1883,3 +1883,201 @@ def test_statsbeat_env_not_overridden_when_already_set(
         "os.environ.setdefault must not override a pre-existing value — "
         "an explicit operator setting must be respected (#418)"
     )
+
+
+# ---------------------------------------------------------------------------
+# suppress_telemetry — process-level help-flag suppression
+# ---------------------------------------------------------------------------
+
+
+def test_suppress_telemetry_makes_telemetry_enabled_return_false(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """suppress_telemetry() must cause telemetry_enabled() to return False."""
+    # Start with telemetry ON (all opt-out signals absent).
+    for var in [
+        "FABRIC_TELEMETRY",
+        "FABRIC_DISABLE_TELEMETRY",
+        "DO_NOT_TRACK",
+        "CI",
+        "GITHUB_ACTIONS",
+        "JENKINS_URL",
+        "TRAVIS",
+        "CIRCLECI",
+        "GITLAB_CI",
+        "TF_BUILD",
+    ]:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    mod = _reload_telemetry()
+    assert mod.telemetry_enabled() is True, "Precondition: telemetry should be enabled"
+
+    mod.suppress_telemetry()
+    assert mod.telemetry_enabled() is False, (
+        "After suppress_telemetry(), telemetry_enabled() must return False"
+    )
+
+
+def test_suppress_telemetry_is_resettable(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """suppress_telemetry(False) must restore normal enable/disable evaluation."""
+    for var in [
+        "FABRIC_TELEMETRY",
+        "FABRIC_DISABLE_TELEMETRY",
+        "DO_NOT_TRACK",
+        "CI",
+        "GITHUB_ACTIONS",
+        "JENKINS_URL",
+        "TRAVIS",
+        "CIRCLECI",
+        "GITLAB_CI",
+        "TF_BUILD",
+    ]:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    mod = _reload_telemetry()
+    mod.suppress_telemetry(value=True)
+    assert mod.telemetry_enabled() is False, "After suppress_telemetry(True), should be False"
+
+    mod.suppress_telemetry(value=False)
+    assert mod.telemetry_enabled() is True, "After suppress_telemetry(False), should be True again"
+
+
+def test_suppress_telemetry_prevents_get_tracer_call(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """When suppressed, emit_event must not call _get_tracer (no SDK init)."""
+    for var in [
+        "FABRIC_TELEMETRY",
+        "FABRIC_DISABLE_TELEMETRY",
+        "DO_NOT_TRACK",
+        "CI",
+        "GITHUB_ACTIONS",
+        "JENKINS_URL",
+        "TRAVIS",
+        "CIRCLECI",
+        "GITLAB_CI",
+        "TF_BUILD",
+    ]:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    mod = _reload_telemetry()
+    mod.suppress_telemetry()
+
+    tracer_calls: list[str] = []
+    with patch.object(mod, "_get_tracer", side_effect=lambda: tracer_calls.append("called")):  # type: ignore[attr-defined]
+        mod.emit_event("test_event", {"foo": "bar"})
+
+    assert tracer_calls == [], "_get_tracer must not be called when telemetry is suppressed"
+
+
+def test_suppress_telemetry_prevents_configure_azure_monitor(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """When suppressed, _get_tracer must not call configure_azure_monitor."""
+    for var in [
+        "FABRIC_TELEMETRY",
+        "FABRIC_DISABLE_TELEMETRY",
+        "DO_NOT_TRACK",
+        "CI",
+        "GITHUB_ACTIONS",
+        "JENKINS_URL",
+        "TRAVIS",
+        "CIRCLECI",
+        "GITLAB_CI",
+        "TF_BUILD",
+    ]:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    mod = _reload_telemetry()
+    mod.suppress_telemetry()
+
+    configure_calls: list[str] = []
+
+    def fake_configure(**_kwargs: object) -> None:
+        configure_calls.append("called")
+
+    fake_tracer = object()
+
+    class _FakeTrace(types.ModuleType):
+        def get_tracer(self, *_args: object, **_kw: object) -> object:
+            return fake_tracer
+
+    fake_azure_mod: Any = types.ModuleType("azure.monitor.opentelemetry")
+    fake_azure_mod.configure_azure_monitor = fake_configure
+    fake_trace_mod = _FakeTrace("opentelemetry.trace")
+
+    monkeypatch.setitem(sys.modules, "azure.monitor.opentelemetry", fake_azure_mod)
+    monkeypatch.setitem(sys.modules, "opentelemetry.trace", fake_trace_mod)
+
+    # Trigger emit path — should be suppressed before _get_tracer is reached.
+    mod.record_app_started("cli")
+
+    assert configure_calls == [], (
+        "configure_azure_monitor must not be called when telemetry is suppressed"
+    )
+
+
+def test_suppress_telemetry_prevents_first_run_notice(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """maybe_print_first_run_notice must be a no-op when telemetry is suppressed."""
+    for var in [
+        "FABRIC_TELEMETRY",
+        "FABRIC_DISABLE_TELEMETRY",
+        "DO_NOT_TRACK",
+        "CI",
+        "GITHUB_ACTIONS",
+        "JENKINS_URL",
+        "TRAVIS",
+        "CIRCLECI",
+        "GITLAB_CI",
+        "TF_BUILD",
+    ]:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    mod = _reload_telemetry()
+    mod.suppress_telemetry()
+
+    mod.maybe_print_first_run_notice()
+
+    captured = capsys.readouterr()
+    assert captured.err == "", (
+        "maybe_print_first_run_notice must print nothing when telemetry is suppressed"
+    )
+
+
+def test_suppress_telemetry_shutdown_is_noop(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """shutdown_telemetry must be a no-op when suppressed (SDK was never initialised)."""
+    for var in [
+        "FABRIC_TELEMETRY",
+        "FABRIC_DISABLE_TELEMETRY",
+        "DO_NOT_TRACK",
+        "CI",
+        "GITHUB_ACTIONS",
+        "JENKINS_URL",
+        "TRAVIS",
+        "CIRCLECI",
+        "GITLAB_CI",
+        "TF_BUILD",
+    ]:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    mod = _reload_telemetry()
+    mod.suppress_telemetry()
+
+    # SDK must never have been initialised if suppressed from the start.
+    assert mod._sdk_initialised is False  # type: ignore[attr-defined]
+
+    # Must complete instantly (no network I/O) and not raise.
+    mod.shutdown_telemetry()
+
+    # SDK must remain un-initialised.
+    assert mod._sdk_initialised is False  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary

- **Root cause**: `fdw config -h` and any subcommand help took 2–4 s because Click runs the root group callback (to dispatch toward the subcommand) before the subcommand's eager `--help` exits. That callback called `record_app_started()` (enqueuing a telemetry span) and registered `_on_close`. Then `_InstrumentedGroup.invoke`'s `finally` block called `shutdown_telemetry()`, which flushed the span over the network (2–4 s). Top-level `fdw --help` was already fast because Click's eager `--help` short-circuits *before* the root callback runs.
- **Fix (3 parts)**:
  1. Added `_SUPPRESSED: bool = False` module flag and `suppress_telemetry(value: bool = True)` to `telemetry.py`. `telemetry_enabled()` now checks this flag first — when set, all telemetry functions (`emit_event`, `record_app_started`, `record_app_exited`, `maybe_print_first_run_notice`, `shutdown_telemetry`) are guaranteed no-ops with zero network I/O.
  2. In `cli/__init__.py` `main()`, detect `-h`/`--help` in `sys.argv[1:]` and call `suppress_telemetry()` before `cli()`. This covers help at any subcommand depth.
  3. `maybe_print_first_run_notice()` is already gated on `telemetry_enabled()`, so the first-run telemetry notice is also suppressed on help (no one-time marker file consumed, no stderr noise).

## Before / After

| Command | Before | After |
|---|---|---|
| `fdw config -h` | 2–4 s (network-dependent) | ~0.34 s |
| `fdw warehouses list --help` | 2–4 s | ~0.34 s |
| `fdw --help` | ~0.29 s (unchanged) | ~0.29 s |
| `fdw config get` (real command) | telemetry enabled | telemetry enabled (no regression) |

## Test plan

- [x] `suppress_telemetry()` makes `telemetry_enabled()` return `False`
- [x] `suppress_telemetry(value=False)` resets the flag (no test leakage)
- [x] `emit_event` / `_get_tracer` / `configure_azure_monitor` not called when suppressed
- [x] `maybe_print_first_run_notice` prints nothing when suppressed
- [x] `shutdown_telemetry` is a no-op (SDK never initialised) when suppressed
- [x] `main()` sets `_SUPPRESSED=True` when `-h` or `--help` in `sys.argv`
- [x] `main()` does NOT suppress for normal commands
- [x] `_get_tracer` not called when CLI help is invoked with suppression active
- [x] `just check` clean (lint + mypy + 3372 unit tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)