### PR TITLE
feat(cli)!: make 'sql' the direct execute command (drop 'sql exec')

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ uvx fabric-dw workspaces list
 uvx fabric-dw warehouses list <workspace-name-or-id>
 
 # Execute a SQL query against a warehouse
-uvx fabric-dw sql exec <workspace-name-or-id> <warehouse-name-or-id> "SELECT TOP 10 * FROM dbo.my_table"
+uvx fabric-dw sql <workspace-name-or-id> <warehouse-name-or-id> -q "SELECT TOP 10 * FROM dbo.my_table"
 
 # List restore points for a warehouse
 uvx fabric-dw restore-points list <workspace-name-or-id> <warehouse-name-or-id>

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -483,7 +483,8 @@ fabric-dw --json sql-endpoints permissions MyWorkspace MyLakehouseEP
 
 Execute SQL against a Fabric Data Warehouse or SQL Analytics Endpoint.
 
-### sql exec
+> **Breaking change:** The former `sql exec` subcommand was promoted to `sql` itself.
+> Replace `fdw sql exec ...` with `fdw sql ...`.
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
 
@@ -494,7 +495,7 @@ Execute a SQL statement or file against a warehouse or SQL Analytics Endpoint. P
 **Synopsis**
 
 ```
-fabric-dw sql exec [OPTIONS] [WORKSPACE] [ITEM]
+fabric-dw sql [OPTIONS] [WORKSPACE] [ITEM]
 ```
 
 | Option | Description |
@@ -508,10 +509,10 @@ Output defaults to a Rich table (rows/columns). Pass `--json` on the root comman
 
 ```shell
 # Inline query, Rich table output (default)
-fabric-dw sql exec MyWorkspace SalesWH -q "SELECT TOP 5 * FROM dbo.Sales"
+fabric-dw sql MyWorkspace SalesWH -q "SELECT TOP 5 * FROM dbo.Sales"
 
 # File input, JSON output
-fabric-dw --json sql exec MyWorkspace SalesWH -f ./queries/report.sql
+fabric-dw --json sql MyWorkspace SalesWH -f ./queries/report.sql
 ```
 
 ```json

--- a/docs/integration-coverage.md
+++ b/docs/integration-coverage.md
@@ -159,7 +159,7 @@ during these tests.
 
 | Feature | Integration test | CLI | MCP |
 |---|---|---|---|
-| `sql exec` | [✅](https://github.com/sdebruyn/fabric-dw-mcp-cli/blob/main/tests/integration/test_services_sql_exec.py#L13) | ✅ | ✅ |
+| `sql` | [✅](https://github.com/sdebruyn/fabric-dw-mcp-cli/blob/main/tests/integration/test_services_sql_exec.py#L13) | ✅ | ✅ |
 
 ## What this does and doesn't cover
 
@@ -180,7 +180,7 @@ So a ✅ in "Integration test" gives confidence that the Fabric API contract is 
 
 The integration tests provision two ephemeral fixtures:
 
-- An **ephemeral Data Warehouse** (`ephemeral_warehouse` / `ephemeral_sql_target` in `conftest.py`) used by warehouse-focused tests (tables, views, schemas, stored procedures, audit, snapshots, restore points, queries, query insights, sql exec).
+- An **ephemeral Data Warehouse** (`ephemeral_warehouse` / `ephemeral_sql_target` in `conftest.py`) used by warehouse-focused tests (tables, views, schemas, stored procedures, audit, snapshots, restore points, queries, query insights, sql).
 - A **schema-enabled Lakehouse** with its paired **SQL Analytics Endpoint** (`ephemeral_lakehouse` / `ephemeral_sql_endpoint` in `conftest.py`) used by the SQL Analytics Endpoint tests. The Lakehouse is created with `enableSchemas=true`; Fabric auto-provisions the SQL endpoint alongside it. The fixture polls until provisioning reaches `Success` (up to 5 minutes) and skips rather than fails if it does not complete in time.
 
 The one remaining ❌ in the coverage table (`restore-points restore`) is not run in standard CI:

--- a/src/fabric_dw/cli/_main.py
+++ b/src/fabric_dw/cli/_main.py
@@ -23,7 +23,7 @@ from fabric_dw.cli.commands.queries import queries_group
 from fabric_dw.cli.commands.restore_points import restore_points_group
 from fabric_dw.cli.commands.schemas import schemas_group
 from fabric_dw.cli.commands.snapshots import snapshots_group
-from fabric_dw.cli.commands.sql import sql_group
+from fabric_dw.cli.commands.sql import sql_cmd
 from fabric_dw.cli.commands.sql_endpoints import sql_endpoints_group
 from fabric_dw.cli.commands.sql_pools import sql_pools_group
 from fabric_dw.cli.commands.statistics import statistics_group
@@ -435,7 +435,7 @@ cli.add_command(audit_group)
 cli.add_command(queries_group)
 cli.add_command(restore_points_group)
 cli.add_command(snapshots_group)
-cli.add_command(sql_group)
+cli.add_command(sql_cmd)
 cli.add_command(sql_pools_group)
 cli.add_command(schemas_group)
 cli.add_command(tables_group)

--- a/src/fabric_dw/cli/_main.py
+++ b/src/fabric_dw/cli/_main.py
@@ -269,11 +269,17 @@ def _build_command_name(root_ctx: click.Context) -> str | None:
     sorts segments by nesting depth (shallowest first), and joins them to form
     a path like ``warehouses.list`` or ``config.set.workspace``.
 
+    For direct leaf commands registered on the root group (e.g. ``fdw sql``),
+    no sub-group invoke wrapper writes a segment, so ``_segments`` is empty.
+    In that case ``root_ctx.invoked_subcommand`` holds the command name and we
+    return it directly (e.g. ``"sql"``).
+
     Returns ``None`` when no segments were accumulated (e.g. root ``--help``).
     """
     segments: list[tuple[int, str, str]] = root_ctx.meta.get(_CLI_SEGMENTS_KEY, [])
     if not segments:
-        return None
+        # Direct leaf command on the root group (e.g. ``fdw sql -q "SELECT 1"``).
+        return root_ctx.invoked_subcommand or None
 
     # Sort by depth (ascending) to get outermost → innermost order.
     segments_sorted = sorted(segments, key=lambda t: t[0])

--- a/src/fabric_dw/cli/commands/sql.py
+++ b/src/fabric_dw/cli/commands/sql.py
@@ -1,8 +1,12 @@
-"""SQL sub-commands for the fabric-dw CLI.
+"""SQL command for the fabric-dw CLI.
 
 Commands
 --------
-- ``sql exec <ws> <item>`` — execute an arbitrary SQL statement or file.
+- ``sql <ws> <item>`` — execute an arbitrary SQL statement or file.
+
+.. note::
+   **Breaking change (v0.x → v0.y):** The former ``sql exec`` sub-command was
+   promoted to ``sql`` itself.  Replace ``fdw sql exec ...`` with ``fdw sql ...``.
 """
 
 from __future__ import annotations
@@ -23,12 +27,7 @@ from fabric_dw.exceptions import FabricError
 from fabric_dw.services import sql_exec as _sql_exec_svc
 
 
-@click.group("sql")
-def sql_group() -> None:
-    """Execute SQL statements against Fabric warehouses and SQL Analytics Endpoints."""
-
-
-@sql_group.command("exec")
+@click.command("sql")
 @click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.option(
@@ -48,7 +47,7 @@ def sql_group() -> None:
 )
 @click.pass_obj
 @coro
-async def exec_cmd(
+async def sql_cmd(
     ctx: CliContext,
     workspace: str | None,
     item: str | None,

--- a/src/fabric_dw/services/functions.py
+++ b/src/fabric_dw/services/functions.py
@@ -426,7 +426,7 @@ async def create_function(
         schema: The schema name.  Must pass :func:`validate_identifier`.
         function_name: The function name.  Must pass :func:`validate_identifier`.
         body: The free-form function body (parameter list, RETURNS clause, and body).
-            Not validated — the caller owns the SQL (same trust model as ``sql exec``).
+            Not validated — the caller owns the SQL (same trust model as ``sql``).
         mode: The credential mode for Entra authentication.
 
     Returns:

--- a/src/fabric_dw/services/procedures.py
+++ b/src/fabric_dw/services/procedures.py
@@ -202,7 +202,7 @@ async def create_procedure(
         schema: The schema name.  Must pass :func:`validate_identifier`.
         procedure_name: The procedure name.  Must pass :func:`validate_identifier`.
         body: The free-form procedure body.  Not validated — the caller owns
-            the SQL (same trust model as ``sql exec``).
+            the SQL (same trust model as ``sql``).
         mode: The credential mode for Entra authentication.
 
     Returns:

--- a/tests/integration/test_cli_smoke.py
+++ b/tests/integration/test_cli_smoke.py
@@ -174,7 +174,7 @@ def _child_env(extra: dict[str, str] | None = None) -> dict[str, str]:
 async def _cli_smoke_sql_env(shared_warehouse: SharedWarehouseTarget) -> dict[str, str]:
     """Return env-var overrides pointing the CLI at the shared test warehouse.
 
-    The ``sql exec`` smoke command needs a workspace + warehouse to connect to.
+    The ``sql`` smoke command needs a workspace + warehouse to connect to.
     Rather than hard-coding names, we reuse the ``shared_warehouse`` session fixture
     and surface its coordinates as the ``FABRIC_DW_DEFAULT_*`` env vars the CLI
     already supports.
@@ -315,7 +315,7 @@ def test_workspaces_get_json_valid(
 def test_sql_exec_select1_clean_stderr(
     _cli_smoke_sql_env: dict[str, str],  # noqa: PT019 — value IS used in the body
 ) -> None:
-    """``sql exec -q 'SELECT 1'`` must exit 0 with a clean stderr.
+    """``sql -q 'SELECT 1'`` must exit 0 with a clean stderr.
 
     Exercises the sync SQL / TDS credential path (mssql-python lifecycle, separate
     from the async aiohttp credential) through interpreter teardown.  The workspace
@@ -328,12 +328,12 @@ def test_sql_exec_select1_clean_stderr(
     inside this test function itself.
     """
     child_env = _child_env(_cli_smoke_sql_env)
-    result = _run("sql", "exec", "-q", "SELECT 1 AS n", env=child_env)
+    result = _run("sql", "-q", "SELECT 1 AS n", env=child_env)
     assert result.returncode == 0, (
-        f"sql exec exited {result.returncode}; stderr:\n{result.stderr}\nstdout:\n{result.stdout}"
+        f"sql exited {result.returncode}; stderr:\n{result.stderr}\nstdout:\n{result.stdout}"
     )
-    assert result.stdout.strip(), "sql exec produced no output"
+    assert result.stdout.strip(), "sql produced no output"
     for forbidden in _STDERR_FORBIDDEN:
         assert forbidden not in result.stderr, (
-            f"'sql exec' stderr contains forbidden pattern {forbidden!r}:\n{result.stderr}"
+            f"'sql' stderr contains forbidden pattern {forbidden!r}:\n{result.stderr}"
         )

--- a/tests/unit/cli/commands/test_sql.py
+++ b/tests/unit/cli/commands/test_sql.py
@@ -1,4 +1,4 @@
-"""Tests for sql CLI sub-commands — TDD."""
+"""Tests for the sql CLI command — TDD."""
 
 from __future__ import annotations
 
@@ -60,10 +60,10 @@ def _make_empty_sql_result() -> SqlResult:
     return SqlResult(columns=[], rows=[], rowcount=3)
 
 
-class TestSqlExec:
-    """sql exec — happy paths."""
+class TestSql:
+    """sql — happy paths."""
 
-    def test_exec_query_flag_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
+    def test_query_flag_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
         mock_http = AsyncMock()
         with (
@@ -82,12 +82,12 @@ class TestSqlExec:
         ):
             result = runner.invoke(
                 cli,
-                ["sql", "exec", WS_GUID, WH_GUID, "-q", "SELECT 1"],
+                ["sql", WS_GUID, WH_GUID, "-q", "SELECT 1"],
             )
         assert result.exit_code == 0
 
-    def test_exec_outputs_table_by_default(self, runner: CliRunner, cache_env: Path) -> None:
-        """sql exec defaults to Rich table output (--json on root switches to JSON)."""
+    def test_outputs_table_by_default(self, runner: CliRunner, cache_env: Path) -> None:
+        """sql defaults to Rich table output (--json on root switches to JSON)."""
         _ = cache_env
         mock_http = AsyncMock()
         with (
@@ -106,15 +106,15 @@ class TestSqlExec:
         ):
             result = runner.invoke(
                 cli,
-                ["sql", "exec", WS_GUID, WH_GUID, "-q", "SELECT id, name FROM t"],
+                ["sql", WS_GUID, WH_GUID, "-q", "SELECT id, name FROM t"],
             )
         assert result.exit_code == 0
         # Default is table — output must NOT be parseable as JSON
         with pytest.raises(json.JSONDecodeError):
             json.loads(result.output)
 
-    def test_exec_outputs_json_with_json_flag(self, runner: CliRunner, cache_env: Path) -> None:
-        """Global --json flag triggers JSON output for sql exec."""
+    def test_outputs_json_with_json_flag(self, runner: CliRunner, cache_env: Path) -> None:
+        """Global --json flag triggers JSON output for sql."""
         _ = cache_env
         mock_http = AsyncMock()
         with (
@@ -133,7 +133,7 @@ class TestSqlExec:
         ):
             result = runner.invoke(
                 cli,
-                ["--json", "sql", "exec", WS_GUID, WH_GUID, "-q", "SELECT id, name FROM t"],
+                ["--json", "sql", WS_GUID, WH_GUID, "-q", "SELECT id, name FROM t"],
             )
         assert result.exit_code == 0
         parsed = json.loads(result.output)
@@ -141,9 +141,7 @@ class TestSqlExec:
         assert parsed["rows"] == [[1, "foo"], [2, "bar"]]
         assert parsed["rowcount"] == 2
 
-    def test_exec_file_flag_reads_file(
-        self, runner: CliRunner, cache_env: Path, tmp_path: Path
-    ) -> None:
+    def test_file_flag_reads_file(self, runner: CliRunner, cache_env: Path, tmp_path: Path) -> None:
         _ = cache_env
         sql_file = tmp_path / "query.sql"
         sql_file.write_text("SELECT 1 AS n")
@@ -170,12 +168,12 @@ class TestSqlExec:
         ):
             result = runner.invoke(
                 cli,
-                ["sql", "exec", WS_GUID, WH_GUID, "-f", str(sql_file)],
+                ["sql", WS_GUID, WH_GUID, "-f", str(sql_file)],
             )
         assert result.exit_code == 0
         assert captured_query[0] == "SELECT 1 AS n"
 
-    def test_exec_file_flag_strips_utf8_bom(
+    def test_file_flag_strips_utf8_bom(
         self, runner: CliRunner, cache_env: Path, tmp_path: Path
     ) -> None:
         """Files saved with UTF-8 BOM (e.g. from SSMS/ADS) must not pass the BOM to execute."""
@@ -206,15 +204,15 @@ class TestSqlExec:
         ):
             result = runner.invoke(
                 cli,
-                ["sql", "exec", WS_GUID, WH_GUID, "-f", str(sql_file)],
+                ["sql", WS_GUID, WH_GUID, "-f", str(sql_file)],
             )
         assert result.exit_code == 0
         assert captured_query[0][0] == "S", (
             f"BOM not stripped: first char is {captured_query[0][0]!r}"
         )
 
-    def test_exec_default_renders_table(self, runner: CliRunner, cache_env: Path) -> None:
-        """sql exec default output is a Rich table (no --table flag needed anymore)."""
+    def test_default_renders_table(self, runner: CliRunner, cache_env: Path) -> None:
+        """sql default output is a Rich table (no --table flag needed anymore)."""
         _ = cache_env
         mock_http = AsyncMock()
         with (
@@ -233,14 +231,14 @@ class TestSqlExec:
         ):
             result = runner.invoke(
                 cli,
-                ["sql", "exec", WS_GUID, WH_GUID, "-q", "SELECT id, name FROM t"],
+                ["sql", WS_GUID, WH_GUID, "-q", "SELECT id, name FROM t"],
             )
         assert result.exit_code == 0
         # Default is table; JSON flag not set so output must NOT be parseable as JSON
         with pytest.raises(json.JSONDecodeError):
             json.loads(result.output)
 
-    def test_exec_dml_no_rows_shows_rowcount(self, runner: CliRunner, cache_env: Path) -> None:
+    def test_dml_no_rows_shows_rowcount(self, runner: CliRunner, cache_env: Path) -> None:
         """DML with no result rows prints rowcount message."""
         _ = cache_env
         mock_http = AsyncMock()
@@ -262,7 +260,6 @@ class TestSqlExec:
                 cli,
                 [
                     "sql",
-                    "exec",
                     WS_GUID,
                     WH_GUID,
                     "-q",
@@ -273,15 +270,15 @@ class TestSqlExec:
         assert "rowcount" in result.output
 
 
-class TestSqlExecErrors:
-    """sql exec — error paths."""
+class TestSqlErrors:
+    """sql — error paths."""
 
-    def test_exec_no_query_or_file_is_error(self, runner: CliRunner, cache_env: Path) -> None:
+    def test_no_query_or_file_is_error(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
-        result = runner.invoke(cli, ["sql", "exec", WS_GUID, WH_GUID])
+        result = runner.invoke(cli, ["sql", WS_GUID, WH_GUID])
         assert result.exit_code != 0
 
-    def test_exec_both_query_and_file_is_error(
+    def test_both_query_and_file_is_error(
         self, runner: CliRunner, cache_env: Path, tmp_path: Path
     ) -> None:
         _ = cache_env
@@ -289,13 +286,11 @@ class TestSqlExecErrors:
         sql_file.write_text("SELECT 1")
         result = runner.invoke(
             cli,
-            ["sql", "exec", WS_GUID, WH_GUID, "-q", "SELECT 1", "-f", str(sql_file)],
+            ["sql", WS_GUID, WH_GUID, "-q", "SELECT 1", "-f", str(sql_file)],
         )
         assert result.exit_code != 0
 
-    def test_exec_permission_denied_returns_nonzero(
-        self, runner: CliRunner, cache_env: Path
-    ) -> None:
+    def test_permission_denied_returns_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
         mock_http = AsyncMock()
         with (
@@ -314,11 +309,11 @@ class TestSqlExecErrors:
         ):
             result = runner.invoke(
                 cli,
-                ["sql", "exec", WS_GUID, WH_GUID, "-q", "SELECT * FROM sensitive"],
+                ["sql", WS_GUID, WH_GUID, "-q", "SELECT * FROM sensitive"],
             )
         assert result.exit_code != 0
 
-    def test_exec_not_found_returns_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
+    def test_not_found_returns_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
         mock_http = AsyncMock()
         with (
@@ -333,13 +328,11 @@ class TestSqlExecErrors:
         ):
             result = runner.invoke(
                 cli,
-                ["sql", "exec", WS_GUID, WH_GUID, "-q", "SELECT 1"],
+                ["sql", WS_GUID, WH_GUID, "-q", "SELECT 1"],
             )
         assert result.exit_code != 0
 
-    def test_exec_no_connection_string_returns_nonzero(
-        self, runner: CliRunner, cache_env: Path
-    ) -> None:
+    def test_no_connection_string_returns_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
         mock_http = AsyncMock()
         # build_sql_target raises ClickException when connection_string is None;
@@ -360,6 +353,6 @@ class TestSqlExecErrors:
         ):
             result = runner.invoke(
                 cli,
-                ["sql", "exec", WS_GUID, WH_GUID, "-q", "SELECT 1"],
+                ["sql", WS_GUID, WH_GUID, "-q", "SELECT 1"],
             )
         assert result.exit_code != 0

--- a/tests/unit/test_telemetry_commands.py
+++ b/tests/unit/test_telemetry_commands.py
@@ -575,6 +575,36 @@ class TestCliCommandInvokedInstrumentation:
         ]
         assert len(command_invoked_calls) == 0
 
+    def test_sql_direct_emits_command_invoked(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Direct leaf ``sql`` command (no sub-group) emits exactly one command_invoked event."""
+        mock = self._run_cli(["sql", "--help"], monkeypatch)
+        command_invoked_calls = [c for c in mock.call_args_list if c[0][0] == "command_invoked"]
+        assert len(command_invoked_calls) == 1
+
+    def test_sql_direct_name_is_sql(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """command_invoked name for the direct ``sql`` command is ``"sql"``."""
+        mock = self._run_cli(["sql", "--help"], monkeypatch)
+        command_invoked_calls = [c for c in mock.call_args_list if c[0][0] == "command_invoked"]
+        assert command_invoked_calls, "No command_invoked event emitted"
+        attrs: dict = command_invoked_calls[0][0][1]
+        assert attrs["name"] == "sql"
+
+    def test_sql_direct_surface_is_cli(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """command_invoked surface for the direct ``sql`` command is ``"cli"``."""
+        mock = self._run_cli(["sql", "--help"], monkeypatch)
+        command_invoked_calls = [c for c in mock.call_args_list if c[0][0] == "command_invoked"]
+        assert command_invoked_calls
+        attrs: dict = command_invoked_calls[0][0][1]
+        assert attrs["surface"] == "cli"
+
+    def test_sql_direct_domain_is_sql(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """command_invoked domain for the direct ``sql`` command is ``"sql"``."""
+        mock = self._run_cli(["sql", "--help"], monkeypatch)
+        command_invoked_calls = [c for c in mock.call_args_list if c[0][0] == "command_invoked"]
+        assert command_invoked_calls
+        attrs: dict = command_invoked_calls[0][0][1]
+        assert attrs["domain"] == "sql"
+
 
 # ---------------------------------------------------------------------------
 # MCP instrumentation — command_invoked emitted per tool call


### PR DESCRIPTION
## Summary

- Converts `sql` from a group+`exec`-subcommand to a single `@click.command("sql")` carrying the same args and options
- Updates `_main.py` import (`sql_group` → `sql_cmd`) and `add_command` call
- Updates unit tests (class names, test names, all invocations `["sql", "exec", ...]` → `["sql", ...]`)
- Updates integration smoke test (`_run("sql", "exec", ...)` → `_run("sql", ...)`)
- Updates `docs/cli.md`, `docs/integration-coverage.md`, and `README.md`

## Breaking change

`fdw sql exec ...` → `fdw sql ...`

The `exec` word is dropped. The `sql` command now directly accepts the positional `[WORKSPACE] [ITEM]` arguments and `-q`/`-f` options. Scripts using `fdw sql exec` must be updated.

Click would interpret `exec` as the `WORKSPACE` positional argument if left as-is, so there is no backward-compatible alias path.

## Test plan

- [x] `just check` clean: ruff check, ruff format, ty check, 3361 unit tests passed
- [ ] Integration smoke test `test_sql_exec_select1_clean_stderr` validates the renamed command end-to-end (requires `integration` label gate)

Closes #453

🤖 Generated with [Claude Code](https://claude.com/claude-code)