### PR TITLE
feat(cli): sql-pools list shows default workload pools when none are defined

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -2138,6 +2138,15 @@ fabric-dw sql-pools get MyWorkspace
 
 List all SQL pools in a workspace.
 
+When no custom SQL pools are defined, Fabric Data Warehouse uses the default
+(autonomous) workload management instead: the SQL analytics endpoint compute is
+split evenly (50/50) into two isolated pools, `SELECT` (read/analytics queries)
+and `NON-SELECT` (DML/DDL/ETL/ingestion statements). In that case this command
+reports the default pools rather than printing an empty list. The default split
+is documented in
+[Workload management](https://learn.microsoft.com/fabric/data-warehouse/workload-management#compute-pool-isolation)
+and [Custom SQL pools](https://learn.microsoft.com/fabric/data-warehouse/custom-sql-pools).
+
 **Synopsis**
 
 ```
@@ -2148,6 +2157,23 @@ fabric-dw sql-pools list [WORKSPACE]
 
 ```shell
 fabric-dw sql-pools list MyWorkspace
+```
+
+**Output**
+
+When custom pools exist, `--json` returns the array of custom pool objects (as
+before). When none are defined, `--json` returns an object that stays honest
+about there being no custom pools:
+
+```json
+{
+  "customSQLPools": [],
+  "default_workload_active": true,
+  "default_pools": [
+    {"name": "SELECT", "maxResourcePercentage": 50, "isDefault": true, "description": "Handles SELECT (read/analytics) queries."},
+    {"name": "NON-SELECT", "maxResourcePercentage": 50, "isDefault": true, "description": "Handles non-SELECT (DML/DDL/ETL/ingestion) statements."}
+  ]
+}
 ```
 
 ---

--- a/src/fabric_dw/cli/commands/sql_pools.py
+++ b/src/fabric_dw/cli/commands/sql_pools.py
@@ -29,13 +29,55 @@ from fabric_dw.exceptions import (
     NotFoundError,
     PermissionDeniedError,
 )
-from fabric_dw.models import SqlPool, SqlPoolClassifier
+from fabric_dw.models import (
+    DEFAULT_NON_SELECT_POOL_NAME,
+    DEFAULT_POOL_MAX_RESOURCE_PERCENTAGE,
+    DEFAULT_SELECT_POOL_NAME,
+    SqlPool,
+    SqlPoolClassifier,
+)
 from fabric_dw.services import query_insights as _qi_svc
 from fabric_dw.services import sql_pools as _svc
 
 
 def _permission_hint(exc: PermissionDeniedError) -> click.ClickException:
     return click.ClickException(f"{exc}  (Hint: the caller must have the workspace admin role.)")
+
+
+def _default_pool_rows() -> list[dict[str, object]]:
+    """Return descriptor rows for the default (autonomous) workload-management pools.
+
+    Used when a workspace has no custom SQL pools.  See the module-level
+    constants in :mod:`fabric_dw.models` for the documented values and the
+    Microsoft Learn source URLs.
+    """
+    return [
+        {
+            "name": DEFAULT_SELECT_POOL_NAME,
+            "maxResourcePercentage": DEFAULT_POOL_MAX_RESOURCE_PERCENTAGE,
+            "isDefault": True,
+            "description": "Handles SELECT (read/analytics) queries.",
+        },
+        {
+            "name": DEFAULT_NON_SELECT_POOL_NAME,
+            "maxResourcePercentage": DEFAULT_POOL_MAX_RESOURCE_PERCENTAGE,
+            "isDefault": True,
+            "description": "Handles non-SELECT (DML/DDL/ETL/ingestion) statements.",
+        },
+    ]
+
+
+def _print_default_workload_note() -> None:
+    """Print the human-readable note shown when no custom SQL pools exist."""
+    click.echo(
+        "No custom SQL pools are defined for this workspace. "
+        "Fabric Data Warehouse is using the default (autonomous) workload "
+        "management, which splits compute 50/50 into two isolated pools:"
+    )
+    for row in _default_pool_rows():
+        click.echo(
+            f"  - {row['name']} ({row['maxResourcePercentage']}%) (default) - {row['description']}"
+        )
 
 
 @click.group("sql-pools")
@@ -79,18 +121,42 @@ async def get_cmd(ctx: CliContext, workspace: str | None) -> None:
 @click.pass_obj
 @coro
 async def list_cmd(ctx: CliContext, workspace: str | None) -> None:
-    """List all SQL pools in WORKSPACE."""
+    """List all SQL pools in WORKSPACE.
+
+    When no custom SQL pools are defined, Fabric Data Warehouse uses the default
+    (autonomous) workload management: compute is split 50/50 into a ``SELECT``
+    pool and a ``NON-SELECT`` pool.  This command reports those default pools
+    instead of showing an empty list.
+    """
     ws = resolve_workspace_arg(ctx, workspace)
     try:
         async with build_http_client(ctx) as http:
             ws_id = await resolve_workspace_id(http, ws)
             config = await _svc.get_configuration(http, ws_id)
-            pools = [p.model_dump(by_alias=True, mode="json") for p in config.custom_sql_pools]
-            render(pools, json_output=ctx.json_output)
     except PermissionDeniedError as exc:
         raise _permission_hint(exc) from exc
     except FabricError as exc:
         raise click.ClickException(str(exc)) from exc
+
+    pools = [p.model_dump(by_alias=True, mode="json") for p in config.custom_sql_pools]
+    # No custom pools => the default (autonomous) workload management is active.
+    if not pools:
+        if ctx.json_output:
+            # Stay honest: do not fabricate custom pools. Report the real (empty)
+            # custom_sql_pools alongside explicit default-workload indicators.
+            render(
+                {
+                    "customSQLPools": pools,
+                    "default_workload_active": True,
+                    "default_pools": _default_pool_rows(),
+                },
+                json_output=True,
+            )
+        else:
+            _print_default_workload_note()
+        return
+
+    render(pools, json_output=ctx.json_output)
 
 
 # ---------------------------------------------------------------------------

--- a/src/fabric_dw/models.py
+++ b/src/fabric_dw/models.py
@@ -569,6 +569,24 @@ class StatisticDetails(_FabricBase):
 CLASSIFIER_TYPE_APPLICATION_NAME = "Application Name"
 CLASSIFIER_TYPE_APPLICATION_NAME_REGEX = "Application Name Regex"
 
+#: Default (autonomous) workload-management pools.
+#:
+#: When a workspace has **no** custom SQL pools (``customSQLPoolsEnabled`` is
+#: false, or ``customSQLPools`` is empty), Fabric Data Warehouse falls back to
+#: *autonomous workload management*: the SQL analytics endpoint compute is split
+#: evenly (50/50) into two isolated resource pools — ``SELECT`` (read/analytics
+#: queries) and ``NON-SELECT`` (DML/DDL/ETL/ingestion statements). These pools
+#: are managed by Fabric, not created by the user, and the split is fixed.
+#:
+#: Sources (verified via Microsoft Learn):
+#:  - https://learn.microsoft.com/fabric/data-warehouse/workload-management#compute-pool-isolation
+#:  - https://learn.microsoft.com/fabric/data-warehouse/custom-sql-pools
+#:  - https://learn.microsoft.com/sql/relational-databases/system-views/queryinsights-sql-pool-insights-transact-sql?view=fabric
+DEFAULT_SELECT_POOL_NAME = "SELECT"
+DEFAULT_NON_SELECT_POOL_NAME = "NON-SELECT"
+#: Each default pool is allocated 50% of the SQL analytics endpoint compute.
+DEFAULT_POOL_MAX_RESOURCE_PERCENTAGE = 50
+
 
 class SqlPoolClassifier(_FabricBase):
     """A classifier element that routes sessions to a SQL pool.

--- a/tests/unit/cli/commands/test_sql_pools.py
+++ b/tests/unit/cli/commands/test_sql_pools.py
@@ -204,6 +204,93 @@ class TestSqlPoolsList:
         assert "ETL" in names
         assert "Reporting" in names
 
+    def test_list_empty_human_shows_default_pools_note(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """No custom pools => human output explains the default SELECT/NON-SELECT pools."""
+        _ = cache_env
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql_pools.build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools.resolve_workspace_id",
+                new=AsyncMock(return_value=WS_UUID),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._svc.get_configuration",
+                new=AsyncMock(return_value=_CONFIG_EMPTY),
+            ),
+        ):
+            result = runner.invoke(cli, ["sql-pools", "list", WS_GUID])
+        assert result.exit_code == 0
+        out = result.output
+        assert "No custom SQL pools" in out
+        assert "default" in out.lower()
+        assert "SELECT" in out
+        assert "NON-SELECT" in out
+        assert "50%" in out
+
+    def test_list_empty_disabled_shows_default_pools_note(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """customSQLPoolsEnabled=False with no pools also shows the default note."""
+        _ = cache_env
+        disabled_empty = SqlPoolsConfiguration.model_validate(
+            {"customSQLPoolsEnabled": False, "customSQLPools": []}
+        )
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql_pools.build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools.resolve_workspace_id",
+                new=AsyncMock(return_value=WS_UUID),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._svc.get_configuration",
+                new=AsyncMock(return_value=disabled_empty),
+            ),
+        ):
+            result = runner.invoke(cli, ["sql-pools", "list", WS_GUID])
+        assert result.exit_code == 0
+        assert "NON-SELECT" in result.output
+
+    def test_list_empty_json_default_workload_shape(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """No custom pools => JSON is honest: empty customSQLPools + default indicators."""
+        _ = cache_env
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql_pools.build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools.resolve_workspace_id",
+                new=AsyncMock(return_value=WS_UUID),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_pools._svc.get_configuration",
+                new=AsyncMock(return_value=_CONFIG_EMPTY),
+            ),
+        ):
+            result = runner.invoke(cli, ["--json", "sql-pools", "list", WS_GUID])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert isinstance(data, dict)
+        # Honest: no fabricated custom pools.
+        assert data["customSQLPools"] == []
+        assert data["default_workload_active"] is True
+        default_pools = data["default_pools"]
+        assert isinstance(default_pools, list)
+        names = [p["name"] for p in default_pools]
+        assert names == ["SELECT", "NON-SELECT"]
+        assert all(p["maxResourcePercentage"] == 50 for p in default_pools)
+        assert all(p["isDefault"] is True for p in default_pools)
+
 
 class TestSqlPoolsShow:
     def test_show_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:


### PR DESCRIPTION
Closes #454

## Summary

`fdw sql-pools list` previously rendered an empty table when a workspace had no custom SQL pools. That is misleading: Fabric Data Warehouse always has workload management active. When no custom SQL pools are configured, the workspace runs under the **default (autonomous) workload management**, and this command now reports that instead of showing nothing.

## Verified default behaviour (Microsoft Learn)

The default behaviour and the 50/50 split were confirmed against official Microsoft Learn docs:

> This compute is split evenly (50/50) into two isolated resource pools for user queries to utilize: **SELECT Pool** (handles all `SELECT` queries) and **Non-SELECT Pool** (handles all non-`SELECT` queries, such as ETL or ingestion). [...] The `SELECT` and non-`SELECT` pool isolation is the default autonomous workload management applied to every workspace.

Sources:
- [Workload management — compute pool isolation](https://learn.microsoft.com/fabric/data-warehouse/workload-management#compute-pool-isolation) (50/50 split, SELECT / Non-SELECT, applied by default to every workspace)
- [Custom SQL pools](https://learn.microsoft.com/fabric/data-warehouse/custom-sql-pools) ("By default, the isolation boundaries are ingestion (non-`SELECT` statement types) and query processing (`SELECT` statements)"; if `customSQLPoolsEnabled` is not true, autonomous workload management is used)
- [queryinsights.sql_pool_insights (Transact-SQL)](https://learn.microsoft.com/sql/relational-databases/system-views/queryinsights-sql-pool-insights-transact-sql?view=fabric) ("Two pools are present by default: `SELECT` ... `NON SELECT` ...")

The user-stated 50%/50% split is accurate and matches the docs verbatim. No uncertainty.

## What changed

- **`models.py`**: added named constants `DEFAULT_SELECT_POOL_NAME` (`"SELECT"`), `DEFAULT_NON_SELECT_POOL_NAME` (`"NON-SELECT"`), `DEFAULT_POOL_MAX_RESOURCE_PERCENTAGE` (`50`), documented with the MS Learn source URLs so they are easy to update if Fabric changes them.
- **`sql_pools.py` `list_cmd`**: detects the no-custom-pools case (empty `custom_sql_pools`, regardless of the enabled flag) and branches output.

### Empty case — human (non-`--json`)

```
No custom SQL pools are defined for this workspace. Fabric Data Warehouse is using the default (autonomous) workload management, which splits compute 50/50 into two isolated pools:
  - SELECT (50%) (default) - Handles SELECT (read/analytics) queries.
  - NON-SELECT (50%) (default) - Handles non-SELECT (DML/DDL/ETL/ingestion) statements.
```

### Empty case — `--json` (honest, machine-stable)

Does not fabricate custom pools. Returns the real (empty) `customSQLPools` plus explicit indicators:

```json
{
  "customSQLPools": [],
  "default_workload_active": true,
  "default_pools": [
    {"name": "SELECT", "maxResourcePercentage": 50, "isDefault": true, "description": "Handles SELECT (read/analytics) queries."},
    {"name": "NON-SELECT", "maxResourcePercentage": 50, "isDefault": true, "description": "Handles non-SELECT (DML/DDL/ETL/ingestion) statements."}
  ]
}
```

### Non-empty case — unchanged

With custom pools present, both human (Rich table) and `--json` (array of pool objects) output are exactly as before. Backward compatible.

## Tests

Added unit tests covering: empty pools -> human output contains the default-pools note (SELECT / NON-SELECT / 50%); `customSQLPoolsEnabled=false` with no pools also shows the note; empty `--json` shape asserted (empty `customSQLPools`, `default_workload_active`, `default_pools` with the documented names/percentages); existing non-empty tests unchanged.

`just check` is clean (ruff + ty + 3375 unit tests pass).

Docs: updated `docs/cli.md` for the `sql-pools list` command (default-pool behaviour + JSON shape).

🤖 Generated with [Claude Code](https://claude.com/claude-code)