### PR TITLE
feat(cli): warehouses list — hide workspace-id for single ws, add --warehouses-only

### DIFF
--- a/src/fabric_dw/cli/_render.py
+++ b/src/fabric_dw/cli/_render.py
@@ -83,6 +83,7 @@ def render(
     json_output: bool,
     console: Console | None = None,
     table_title: str | None = None,
+    drop_columns: Sequence[str] | None = None,
 ) -> None:
     """Print *data* to stdout using JSON or Rich formatting.
 
@@ -97,6 +98,11 @@ def render(
             default console (stdout) is used. Ignored when *json_output=True*.
         table_title: Optional title shown above the Rich Table.
             Ignored when *json_output=True* or when *data* is not a list.
+        drop_columns: Optional column names to omit from the **human-readable
+            table only**.  Useful for hiding redundant columns (e.g. a
+            workspace-id column when every row shares the same workspace).
+            Ignored when *json_output=True* (machine-readable output is never
+            pruned) and when *data* is not a list.
     """
     if json_output:
         click.echo(_json.dumps(data, indent=2, default=str))
@@ -105,7 +111,7 @@ def render(
     con = console if console is not None else _DEFAULT_CONSOLE
 
     if isinstance(data, list):
-        _render_table(data, console=con, title=table_title)
+        _render_table(data, console=con, title=table_title, drop_columns=drop_columns)
     elif isinstance(data, dict):
         _render_panel({str(k): v for k, v in data.items()}, console=con, title=table_title)
     else:
@@ -138,14 +144,29 @@ def _column_is_all_null(col: str, norm_rows: list[dict[str, object] | object]) -
     return True
 
 
-def _render_table(rows: Sequence[object], *, console: Console, title: str | None) -> None:
+def _render_table(
+    rows: Sequence[object],
+    *,
+    console: Console,
+    title: str | None,
+    drop_columns: Sequence[str] | None = None,
+) -> None:
     """Render a list of dicts as a Rich Table.
 
     Columns whose value is ``None`` in **every** row are omitted from the
     output — they only clutter list views (e.g. ``definition`` for
     ``procedures list``).  A column that is non-null in at least one row is
     kept, and any null cells in that column still render as ``[dim]NULL[/dim]``.
+
+    Args:
+        rows: The list of rows (dicts or scalars) to render.
+        console: The Rich console to print to.
+        title: Optional table title.
+        drop_columns: Optional column names to explicitly omit, in addition to
+            the automatic all-null pruning.  Used by callers to hide a column
+            that is redundant in a given context (e.g. a shared workspace id).
     """
+    dropped: frozenset[str] = frozenset(drop_columns or ())
     table = Table(title=title, show_header=True, header_style="bold")
 
     if not rows:
@@ -172,7 +193,7 @@ def _render_table(rows: Sequence[object], *, console: Console, title: str | None
     # Non-dict rows (scalars) are never counted as "having" any column value, so
     # a column is only kept if at least one dict-row provides a non-None value.
     all_null = {col for col in columns if _column_is_all_null(col, norm_rows)}
-    visible_columns = [col for col in columns if col not in all_null]
+    visible_columns = [col for col in columns if col not in all_null and col not in dropped]
 
     for col in visible_columns:
         if _is_guid_column(col, norm_rows):

--- a/src/fabric_dw/cli/_render.py
+++ b/src/fabric_dw/cli/_render.py
@@ -83,7 +83,7 @@ def render(
     json_output: bool,
     console: Console | None = None,
     table_title: str | None = None,
-    drop_columns: Sequence[str] | None = None,
+    drop_columns: tuple[str, ...] | list[str] | None = None,
 ) -> None:
     """Print *data* to stdout using JSON or Rich formatting.
 
@@ -99,7 +99,8 @@ def render(
         table_title: Optional title shown above the Rich Table.
             Ignored when *json_output=True* or when *data* is not a list.
         drop_columns: Optional column names to omit from the **human-readable
-            table only**.  Useful for hiding redundant columns (e.g. a
+            table only**.  Must be a ``tuple[str, ...]`` or ``list[str]`` (not
+            a bare ``str``).  Useful for hiding redundant columns (e.g. a
             workspace-id column when every row shares the same workspace).
             Ignored when *json_output=True* (machine-readable output is never
             pruned) and when *data* is not a list.
@@ -149,7 +150,7 @@ def _render_table(
     *,
     console: Console,
     title: str | None,
-    drop_columns: Sequence[str] | None = None,
+    drop_columns: tuple[str, ...] | list[str] | None = None,
 ) -> None:
     """Render a list of dicts as a Rich Table.
 

--- a/src/fabric_dw/cli/commands/warehouses.py
+++ b/src/fabric_dw/cli/commands/warehouses.py
@@ -41,13 +41,32 @@ def warehouses_group() -> None:
     default=False,
     help="Scan all visible workspaces and aggregate results.",
 )
+@click.option(
+    "--warehouses-only",
+    "warehouses_only",
+    is_flag=True,
+    default=False,
+    help="List only Warehouses; exclude SQL Analytics Endpoints (skips an API call).",
+)
 @click.pass_obj
 @coro
-async def list_cmd(ctx: CliContext, workspace: str | None, all_workspaces: bool) -> None:
+async def list_cmd(
+    ctx: CliContext,
+    workspace: str | None,
+    all_workspaces: bool,
+    warehouses_only: bool,
+) -> None:
     """List all warehouses in WORKSPACE (name or GUID).
+
+    Lists both Warehouses and SQL Analytics Endpoints by default; pass
+    --warehouses-only to exclude SQL Analytics Endpoints.
 
     Pass -A / --all-workspaces to scan every visible workspace instead.
     WORKSPACE and --all-workspaces are mutually exclusive; exactly one is required.
+
+    The human-readable table omits the redundant Workspace ID column when a
+    single workspace is targeted (every row shares it); -A keeps it because
+    rows then span workspaces.  --json output always includes workspace_id.
     """
     # Resolve the workspace default before the XOR validation so that a
     # configured default-workspace (env / config file) is honoured when no
@@ -57,18 +76,28 @@ async def list_cmd(ctx: CliContext, workspace: str | None, all_workspaces: bool)
     try:
         async with build_http_client(ctx) as http:
             if all_workspaces:
-                items = await _warehouses_svc.list_all_workspaces(http)
+                items = await _warehouses_svc.list_all_workspaces(
+                    http, warehouses_only=warehouses_only
+                )
             else:
                 # resolved_workspace is guaranteed non-None by validate_workspace_or_all_workspaces
                 if resolved_workspace is None:  # pragma: no cover — defensive
                     raise click.UsageError("Provide WORKSPACE or pass --all-workspaces / -A.")
                 resolver, _ = make_resolver(http)
                 ws_id = await resolver.workspace_id(resolved_workspace)
-                items = await _warehouses_svc.list_warehouses(http, ws_id)
+                items = await _warehouses_svc.list_warehouses(
+                    http, ws_id, warehouses_only=warehouses_only
+                )
+            # Single-workspace listings share one workspace per row, so the
+            # Workspace ID column is redundant noise in the human table — drop
+            # it (table only).  -A spans workspaces, so the column is kept.
+            # --json is never pruned (render ignores drop_columns for JSON).
+            drop_columns = None if all_workspaces else ("workspaceId",)
             render(
                 [w.model_dump(by_alias=True, mode="json") for w in items],
                 json_output=ctx.json_output,
                 table_title="Warehouses",
+                drop_columns=drop_columns,
             )
     except (ValueError, FabricError) as exc:
         raise click.ClickException(str(exc)) from exc

--- a/src/fabric_dw/services/sql_endpoints.py
+++ b/src/fabric_dw/services/sql_endpoints.py
@@ -42,6 +42,33 @@ async def list_endpoints(http: FabricHttpClient, workspace_id: UUID) -> list[War
     parsed as a :class:`~fabric_dw.models.Warehouse` with
     ``kind=SQL_ENDPOINT``.
 
+    Note (incomplete metadata vs. Warehouses):
+        Unlike Warehouses, SQL-endpoint list rows carry **no**
+        ``connection_string`` and **no** ``created_date``.  This is an API
+        limitation, not a bug here.  The Fabric ``SQLEndpoint`` resource schema
+        (used by both ``GET /sqlEndpoints`` and ``GET /sqlEndpoints/{id}``)
+        exposes only ``id``, ``displayName``, ``description``, ``type``,
+        ``workspaceId``, ``folderId``, ``sensitivityLabel``, ``tags`` and
+        ``defaultIdentity`` — neither ``createdDate`` nor ``connectionString``
+        is present (contrast Get Warehouse, which returns connection string +
+        created date + collation).  See
+        https://learn.microsoft.com/rest/api/fabric/sqlendpoint/items/list-sql-endpoints
+        and the type-specific-properties table at
+        https://learn.microsoft.com/rest/api/fabric/articles/onelakecatalog/overview#get-type-specific-item-properties
+        (SQLEndpoint is absent from it).
+
+        * ``connection_string`` — only resolvable per-endpoint, either via the
+          dedicated ``Items - Get Connection String`` API or via the parent
+          Lakehouse's ``properties.sqlEndpointProperties.connectionString``
+          (see :func:`_resolve_lakehouse_connection_string` / #347).  Both are
+          N+1; the list endpoint deliberately does NOT enrich it.
+        * ``created_date`` — not returned by the endpoint resource at all (list
+          or item), so it cannot be surfaced from a single list request.
+
+        Per the "one request → fix it, per-item request → leave it" rule, both
+        are left out of the list.  A future opt-in ``--enrich`` flag could fill
+        them per endpoint if the extra calls are acceptable.
+
     Args:
         http: An authenticated :class:`~fabric_dw.http_client.FabricHttpClient`.
         workspace_id: The UUID of the workspace to query.

--- a/src/fabric_dw/services/warehouses.py
+++ b/src/fabric_dw/services/warehouses.py
@@ -107,8 +107,10 @@ __all__ = [
 ]
 
 
-async def list_warehouses(http: FabricHttpClient, workspace_id: UUID) -> list[Warehouse]:
-    """Return all warehouses and SQL analytics endpoints in a workspace.
+async def list_warehouses(
+    http: FabricHttpClient, workspace_id: UUID, *, warehouses_only: bool = False
+) -> list[Warehouse]:
+    """Return warehouses (and, by default, SQL analytics endpoints) in a workspace.
 
     Combines results from ``GET /workspaces/{ws}/warehouses`` and
     ``GET /workspaces/{ws}/sqlEndpoints``, both followed through pagination.
@@ -117,6 +119,10 @@ async def list_warehouses(http: FabricHttpClient, workspace_id: UUID) -> list[Wa
     Args:
         http: An authenticated :class:`~fabric_dw.http_client.FabricHttpClient`.
         workspace_id: The UUID of the workspace to query.
+        warehouses_only: When ``True``, list only Warehouses
+            (kind=WAREHOUSE) and skip the ``GET /workspaces/{ws}/sqlEndpoints``
+            call entirely (saving an API request).  Defaults to ``False``,
+            which lists both Warehouses and SQL Analytics Endpoints.
 
     Returns:
         A list of :class:`~fabric_dw.models.Warehouse` instances with their
@@ -128,6 +134,8 @@ async def list_warehouses(http: FabricHttpClient, workspace_id: UUID) -> list[Wa
             HttpBase.FABRIC, f"/workspaces/{workspace_id}/warehouses"
         )
     ]
+    if warehouses_only:
+        return result
     result += [
         Warehouse.from_api(item, kind=WarehouseKind.SQL_ENDPOINT)
         async for item in http.iter_paginated(
@@ -137,7 +145,9 @@ async def list_warehouses(http: FabricHttpClient, workspace_id: UUID) -> list[Wa
     return result
 
 
-async def list_all_workspaces(http: FabricHttpClient) -> list[Warehouse]:
+async def list_all_workspaces(
+    http: FabricHttpClient, *, warehouses_only: bool = False
+) -> list[Warehouse]:
     """Scan every visible workspace and collect its warehouses.
 
     Iterates all workspaces returned by :func:`~fabric_dw.services.workspaces.list_all`
@@ -157,6 +167,9 @@ async def list_all_workspaces(http: FabricHttpClient) -> list[Warehouse]:
 
     Args:
         http: An authenticated :class:`~fabric_dw.http_client.FabricHttpClient`.
+        warehouses_only: When ``True``, list only Warehouses (kind=WAREHOUSE)
+            per workspace and skip the SQL-endpoints fetch entirely.  Defaults
+            to ``False`` (both Warehouses and SQL Analytics Endpoints).
 
     Returns:
         A flat list of :class:`~fabric_dw.models.Warehouse` instances from all
@@ -186,7 +199,7 @@ async def list_all_workspaces(http: FabricHttpClient) -> list[Warehouse]:
     )
     return await scan_all_workspaces(
         workspaces,
-        lambda ws: list_warehouses(http, ws.id),  # type: ignore[union-attr]  # mypy false-positive: Sequence[_HasNameIdAndCapacity] exposes id: UUID but mypy loses the concrete type through the Protocol abstraction
+        lambda ws: list_warehouses(http, ws.id, warehouses_only=warehouses_only),  # type: ignore[union-attr]  # mypy false-positive: Sequence[_HasNameIdAndCapacity] exposes id: UUID but mypy loses the concrete type through the Protocol abstraction
         logger=_logger,
         skip_errors=(PermissionDeniedError, NotFoundError),
         capacity_states=capacity_states,

--- a/tests/unit/cli/commands/test_warehouses.py
+++ b/tests/unit/cli/commands/test_warehouses.py
@@ -124,6 +124,195 @@ class TestWarehousesList:
         assert isinstance(parsed, list)
 
 
+class TestWarehousesListHideWorkspaceId:
+    """(a) Single-workspace table hides Workspace ID; -A keeps it; --json unchanged."""
+
+    @staticmethod
+    def _wh_item(name: str = "SalesWarehouse") -> dict[str, object]:
+        return {
+            "id": WH_GUID,
+            "displayName": name,
+            "type": "Warehouse",
+            "workspaceId": WS_GUID,
+            "properties": {"connectionString": "srv.datawarehouse.fabric.microsoft.com"},
+        }
+
+    def test_single_workspace_table_hides_workspace_id(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """Human table for a single workspace must NOT contain the workspace GUID."""
+        _ = cache_env
+        mock_http = AsyncMock()
+        mock_http.iter_paginated = MagicMock(
+            side_effect=lambda _base, path: (
+                _async_iter([self._wh_item()]) if "warehouses" in path else _async_iter([])
+            )
+        )
+        with (
+            patch(
+                "fabric_dw.cli.commands.warehouses.build_http_client",
+                new=_make_cm(mock_http, None),
+            ),
+            patch(
+                "fabric_dw.resolver.Resolver.workspace_id",
+                new=AsyncMock(return_value=WS_UUID),
+            ),
+        ):
+            result = runner.invoke(cli, ["warehouses", "list", WS_GUID])
+        assert result.exit_code == 0, result.output
+        # The warehouse id (GUID column, full width) is shown, but the
+        # redundant workspace GUID column is dropped.  Asserting on the GUIDs is
+        # robust to the narrow CliRunner terminal width (text columns truncate,
+        # GUID columns do not).  WS_GUID and WH_GUID are distinct values.
+        assert WH_GUID in result.output
+        assert WS_GUID not in result.output
+
+    def test_single_workspace_json_keeps_workspace_id(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """--json for a single workspace must STILL include workspace_id (machine-readable)."""
+        _ = cache_env
+        mock_http = AsyncMock()
+        mock_http.iter_paginated = MagicMock(
+            side_effect=lambda _base, path: (
+                _async_iter([self._wh_item()]) if "warehouses" in path else _async_iter([])
+            )
+        )
+        with (
+            patch(
+                "fabric_dw.cli.commands.warehouses.build_http_client",
+                new=_make_cm(mock_http, None),
+            ),
+            patch(
+                "fabric_dw.resolver.Resolver.workspace_id",
+                new=AsyncMock(return_value=WS_UUID),
+            ),
+        ):
+            result = runner.invoke(cli, ["--json", "warehouses", "list", WS_GUID])
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.output)
+        assert parsed[0]["workspaceId"] == WS_GUID
+
+    def test_all_workspaces_table_keeps_workspace_id(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """-A table must KEEP the Workspace ID column (rows span workspaces)."""
+        _ = cache_env
+        wh = Warehouse.model_validate(
+            {
+                "id": WH_GUID,
+                "displayName": "SalesWarehouse",
+                "workspaceId": WS_GUID,
+                "kind": WarehouseKind.WAREHOUSE,
+            }
+        )
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.warehouses.build_http_client",
+                new=_make_cm(mock_http, None),
+            ),
+            patch(
+                "fabric_dw.services.warehouses.list_all_workspaces",
+                new=AsyncMock(return_value=[wh]),
+            ),
+        ):
+            result = runner.invoke(cli, ["warehouses", "list", "-A"])
+        assert result.exit_code == 0, result.output
+        assert WS_GUID in result.output
+
+
+class TestWarehousesListWarehousesOnly:
+    """(b) --warehouses-only excludes SQL endpoints and skips the sqlEndpoints fetch."""
+
+    def test_warehouses_only_skips_sql_endpoints_fetch(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """With --warehouses-only the service must NOT page /sqlEndpoints."""
+        _ = cache_env
+        wh_item = {
+            "id": WH_GUID,
+            "displayName": "SalesWarehouse",
+            "type": "Warehouse",
+            "workspaceId": WS_GUID,
+        }
+        mock_http = AsyncMock()
+        mock_http.iter_paginated = MagicMock(
+            side_effect=lambda _base, path: (
+                _async_iter([wh_item]) if "warehouses" in path else _async_iter([])
+            )
+        )
+        with (
+            patch(
+                "fabric_dw.cli.commands.warehouses.build_http_client",
+                new=_make_cm(mock_http, None),
+            ),
+            patch(
+                "fabric_dw.resolver.Resolver.workspace_id",
+                new=AsyncMock(return_value=WS_UUID),
+            ),
+        ):
+            result = runner.invoke(
+                cli, ["--json", "warehouses", "list", WS_GUID, "--warehouses-only"]
+            )
+        assert result.exit_code == 0, result.output
+        # Only the /warehouses endpoint may be paged — never /sqlEndpoints.
+        called_paths = [c.args[1] for c in mock_http.iter_paginated.call_args_list if c.args]
+        assert any("warehouses" in p for p in called_paths)
+        assert all("sqlEndpoints" not in p for p in called_paths)
+        parsed = json.loads(result.output)
+        assert all(row["kind"] == WarehouseKind.WAREHOUSE for row in parsed)
+
+    def test_default_includes_sql_endpoints_fetch(self, runner: CliRunner, cache_env: Path) -> None:
+        """Without the flag, the default behaviour still pages /sqlEndpoints."""
+        _ = cache_env
+        mock_http = AsyncMock()
+        mock_http.iter_paginated = MagicMock(return_value=_async_iter([]))
+        with (
+            patch(
+                "fabric_dw.cli.commands.warehouses.build_http_client",
+                new=_make_cm(mock_http, None),
+            ),
+            patch(
+                "fabric_dw.resolver.Resolver.workspace_id",
+                new=AsyncMock(return_value=WS_UUID),
+            ),
+        ):
+            result = runner.invoke(cli, ["--json", "warehouses", "list", WS_GUID])
+        assert result.exit_code == 0, result.output
+        called_paths = [c.args[1] for c in mock_http.iter_paginated.call_args_list if c.args]
+        assert any("sqlEndpoints" in p for p in called_paths)
+
+    def test_warehouses_only_all_workspaces(self, runner: CliRunner, cache_env: Path) -> None:
+        """--warehouses-only is threaded through the -A path to the service layer."""
+        _ = cache_env
+        wh = Warehouse.model_validate(
+            {
+                "id": WH_GUID,
+                "displayName": "SalesWarehouse",
+                "workspaceId": WS_GUID,
+                "kind": WarehouseKind.WAREHOUSE,
+            }
+        )
+        mock_http = AsyncMock()
+        mock_list_all = AsyncMock(return_value=[wh])
+        with (
+            patch(
+                "fabric_dw.cli.commands.warehouses.build_http_client",
+                new=_make_cm(mock_http, None),
+            ),
+            patch(
+                "fabric_dw.services.warehouses.list_all_workspaces",
+                new=mock_list_all,
+            ),
+        ):
+            result = runner.invoke(cli, ["--json", "warehouses", "list", "-A", "--warehouses-only"])
+        assert result.exit_code == 0, result.output
+        # The service must have been called with warehouses_only=True.
+        assert mock_list_all.await_args is not None
+        assert mock_list_all.await_args.kwargs.get("warehouses_only") is True
+
+
 class TestWarehousesGet:
     """warehouses get — happy path and 404."""
 

--- a/tests/unit/cli/test_render.py
+++ b/tests/unit/cli/test_render.py
@@ -318,6 +318,60 @@ class TestOmitAllNullColumns:
         assert "definition" not in output
 
 
+class TestDropColumns:
+    """render(..., drop_columns=...) omits the named columns from the table only."""
+
+    def _render_to_string(
+        self,
+        data: object,
+        *,
+        drop_columns: tuple[str, ...] | None = None,
+    ) -> str:
+        sio = StringIO()
+        console = Console(file=sio, width=200, highlight=False, no_color=True)
+        render(data, json_output=False, console=console, drop_columns=drop_columns)
+        return sio.getvalue()
+
+    def test_dropped_column_absent_from_table(self) -> None:
+        data = [
+            {"id": "1", "name": "foo", "workspaceId": "ws-1"},
+            {"id": "2", "name": "bar", "workspaceId": "ws-1"},
+        ]
+        output = self._render_to_string(data, drop_columns=("workspaceId",))
+        assert "name" in output
+        assert "workspaceId" not in output
+        # The dropped column's values must also be absent.
+        assert "ws-1" not in output
+
+    def test_other_columns_preserved_when_one_dropped(self) -> None:
+        data = [{"id": "1", "name": "foo", "workspaceId": "ws-1"}]
+        output = self._render_to_string(data, drop_columns=("workspaceId",))
+        assert "id" in output
+        assert "name" in output
+        assert "foo" in output
+
+    def test_none_drop_columns_keeps_all(self) -> None:
+        data = [{"id": "1", "workspaceId": "ws-1"}]
+        output = self._render_to_string(data, drop_columns=None)
+        assert "workspaceId" in output
+        assert "ws-1" in output
+
+    def test_drop_columns_ignored_for_json(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """drop_columns must NOT affect JSON output (machine-readable, never pruned)."""
+        data = [{"id": "1", "workspaceId": "ws-1"}]
+        render(data, json_output=True, drop_columns=("workspaceId",))
+        captured = capsys.readouterr()
+        parsed = json.loads(captured.out)
+        assert parsed[0]["workspaceId"] == "ws-1"
+
+    def test_drop_unknown_column_is_noop(self) -> None:
+        """Dropping a column that does not exist leaves the table unchanged."""
+        data = [{"id": "1", "name": "foo"}]
+        output = self._render_to_string(data, drop_columns=("nonexistent",))
+        assert "id" in output
+        assert "name" in output
+
+
 class TestNonDictListRows:
     """_render_table handles list rows that are not dicts (lines 113, 135)."""
 

--- a/tests/unit/services/test_capacity_skip.py
+++ b/tests/unit/services/test_capacity_skip.py
@@ -111,7 +111,10 @@ async def test_proactive_skip_inactive_capacity_no_warehouses_call(
 
     fetch_call_ids: list[UUID] = []
 
-    async def _fetch_spy(_http: object, ws_id: UUID) -> list[Warehouse]:
+    async def _fetch_spy(
+        _http: object, ws_id: UUID, *, warehouses_only: bool = False
+    ) -> list[Warehouse]:
+        _ = warehouses_only
         fetch_call_ids.append(ws_id)
         return [wh_active] if ws_id == _WS_ACTIVE else []
 
@@ -191,7 +194,10 @@ async def test_proactive_skip_null_capacity_id(
 
     fetch_call_ids: list[UUID] = []
 
-    async def _fetch_spy(_http: object, ws_id: UUID) -> list[Warehouse]:
+    async def _fetch_spy(
+        _http: object, ws_id: UUID, *, warehouses_only: bool = False
+    ) -> list[Warehouse]:
+        _ = warehouses_only
         fetch_call_ids.append(ws_id)
         return [wh_active]
 
@@ -639,7 +645,10 @@ async def test_sql_endpoints_proactive_skip_inactive_capacity(
 
     fetch_call_ids: list[UUID] = []
 
-    async def _fetch_spy(_http: object, ws_id: UUID) -> list[Warehouse]:
+    async def _fetch_spy(
+        _http: object, ws_id: UUID, *, warehouses_only: bool = False
+    ) -> list[Warehouse]:
+        _ = warehouses_only
         fetch_call_ids.append(ws_id)
         return [ep_active]
 

--- a/tests/unit/services/test_warehouses.py
+++ b/tests/unit/services/test_warehouses.py
@@ -157,6 +157,29 @@ async def test_list_all_items_are_warehouse_instances() -> None:
     assert all(isinstance(item, Warehouse) for item in result)
 
 
+async def test_list_warehouses_only_skips_sql_endpoints_request() -> None:
+    """warehouses_only=True must NOT issue any /sqlEndpoints request."""
+    wh_payload = json.loads(WAREHOUSE_LIST_PAYLOAD)
+    wh_payload.pop("continuationUri", None)
+
+    with respx.mock(assert_all_called=False) as mock_router:
+        wh_route = mock_router.get(_WAREHOUSES_URL).mock(
+            return_value=httpx.Response(200, json=wh_payload)
+        )
+        ep_route = mock_router.get(_SQL_ENDPOINTS_URL).mock(
+            return_value=httpx.Response(200, json={"value": []})
+        )
+
+        client = await _make_client()
+        async with client:
+            result = await warehouses.list_warehouses(client, _WORKSPACE_ID, warehouses_only=True)
+
+    assert wh_route.called
+    assert not ep_route.called, "sqlEndpoints must not be requested when warehouses_only=True"
+    assert result
+    assert all(item.kind == WarehouseKind.WAREHOUSE for item in result)
+
+
 # ---------------------------------------------------------------------------
 # get
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #452

Improves `fdw warehouses list` (lists Warehouses + SQL Analytics Endpoints) with three changes.

## (a) Hide the Workspace ID column for a single workspace
When the command targets ONE workspace (default / `WORKSPACE` arg, i.e. not `-A/--all-workspaces`), the human-readable table now omits the `workspaceId` column — every row shares the same workspace, so it was redundant noise. `-A/--all-workspaces` keeps the column (rows span workspaces). `--json` output is unchanged: `workspaceId` is always emitted (machine-readable).

Implemented cleanly via a new `drop_columns` argument on `render` / `_render_table` in `cli/_render.py`. It only affects the Rich table; the JSON path never prunes columns.

## (b) `--warehouses-only` flag
New boolean flag on `warehouses list` that lists only Warehouses (kind=Warehouse) and excludes SQL Analytics Endpoints. Default behaviour (both kinds) is unchanged. When set, the `GET /workspaces/{ws}/sqlEndpoints` call is skipped entirely (saves an API request), threaded through `services/warehouses.py` `list_warehouses` and `list_all_workspaces` via a `warehouses_only` keyword.

## (c) Investigation — SQL-endpoint connection_string + created_date (no free fix)
SQL-endpoint rows show no `connection_string` and no `created_date`, while Warehouses do. Verified against the Fabric REST API spec via the Microsoft Learn docs:

- **List SQL Endpoints** (`GET /workspaces/{ws}/sqlEndpoints`) returns the `SQLEndpoint` object, whose entire schema is: `id`, `displayName`, `description`, `type`, `workspaceId`, `folderId`, `sensitivityLabel`, `tags`, `defaultIdentity`. **No `createdDate`, no `connectionString`.**
  Source: https://learn.microsoft.com/rest/api/fabric/sqlendpoint/items/list-sql-endpoints
- The per-item Get shares the same `SQLEndpoint` model, so per-item adds nothing. The OneLake-catalog "type-specific item properties" table lists Warehouse as returning "SQL connection string, created date, collation type" but **does not list SQLEndpoint at all** — confirming the SQL-endpoint Get returns no extra properties beyond generic item metadata.
  Source: https://learn.microsoft.com/rest/api/fabric/articles/onelakecatalog/overview#get-type-specific-item-properties
- `connection_string` is only resolvable per-endpoint, either via the dedicated `Items - Get Connection String` API or via the parent Lakehouse's `properties.sqlEndpointProperties.connectionString` (verified live in prior work, #347). Both are N+1.
- `created_date` is not returned by the SQL-endpoint resource at all (list or item), so it cannot be surfaced from a single list request.

**Decision (per the "one request → fix it; per-item request → leave it" rule):** there is **no free fix**. Both `connection_string` and `created_date` require per-endpoint calls (or are unavailable entirely), so both are left out of the default list and the limitation is documented in a code comment near `list_endpoints` in `services/sql_endpoints.py`. A future opt-in `--enrich` flag could fill them per endpoint (noted as a follow-up; not built here).

## Tests
- `cli/test_render.py`: `drop_columns` table-pruning + JSON-unaffected.
- `cli/commands/test_warehouses.py`: single-ws table hides workspace GUID, single-ws `--json` keeps `workspaceId`, `-A` keeps the column, `--warehouses-only` skips the sqlEndpoints fetch / passes through `-A`.
- `services/test_warehouses.py`: `list_warehouses(..., warehouses_only=True)` issues no `/sqlEndpoints` request.
- Updated existing `test_capacity_skip.py` spies to accept the new keyword.

`just check` clean (ruff + ty + 3373 unit tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)