### PR TITLE
feat(cli): sql-endpoints list drops redundant columns; clarify cross-workspace default 404

### DIFF
--- a/src/fabric_dw/cli/commands/sql_endpoints.py
+++ b/src/fabric_dw/cli/commands/sql_endpoints.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import click
 
 from fabric_dw.cli._context import CliContext
@@ -15,9 +17,70 @@ from fabric_dw.cli.commands._utils import (
     resolve_workspace_arg,
     validate_workspace_or_all_workspaces,
 )
-from fabric_dw.exceptions import FabricError
+from fabric_dw.exceptions import FabricError, NotFoundError
 from fabric_dw.services import permissions as _permissions_svc
 from fabric_dw.services import sql_endpoints as _sql_endpoints_svc
+
+if TYPE_CHECKING:
+    from uuid import UUID
+
+    from fabric_dw.cache import ItemEntry
+    from fabric_dw.http_client import FabricHttpClient
+
+# Per-row keys that carry no information in the single-workspace human table:
+# every SQL endpoint row has kind == "SQLEndpoint", and (without -A) a single
+# workspace id.  They are stripped from the dicts handed to ``render`` for the
+# table path only — the ``--json`` path keeps the complete payload.
+_REDUNDANT_TABLE_KEYS = ("kind", "workspaceId")
+
+
+def _strip_table_keys(
+    rows: list[dict[str, object]], *, all_workspaces: bool
+) -> list[dict[str, object]]:
+    """Return *rows* with table-redundant keys removed (human/table path only).
+
+    Always drops ``kind`` (every row is a SQL endpoint).  Drops ``workspaceId``
+    too unless *all_workspaces* is set, in which case rows span workspaces and
+    the column carries real information.
+    """
+    drop = {"kind"} if all_workspaces else set(_REDUNDANT_TABLE_KEYS)
+    return [{k: v for k, v in row.items() if k not in drop} for row in rows]
+
+
+async def _resolve_endpoint_or_hint(
+    http: FabricHttpClient,
+    ws: str,
+    endpoint: str,
+    *,
+    endpoint_explicit: bool,
+) -> tuple[UUID, ItemEntry]:
+    """Resolve *endpoint* in workspace *ws*, turning a stale-default 404 into a clear error.
+
+    When the endpoint argument was NOT supplied explicitly it has been taken
+    from a configured default (env / config file).  A configured default that
+    belongs to a *different* workspace makes ``resolve_item`` issue
+    ``GET /workspaces/{ws}/items/{default}`` which 404s with a cryptic
+    ``EntityNotFound``.  Translate that into an actionable message instead.
+
+    Raises:
+        click.ClickException: When the (defaulted) endpoint is not found in *ws*.
+        NotFoundError: When the endpoint was passed explicitly but not found —
+            the caller's ``except FabricError`` surfaces the original message.
+    """
+    try:
+        return await resolve_item(http, ws, endpoint)
+    except NotFoundError:
+        if endpoint_explicit:
+            raise
+        raise click.ClickException(
+            f"SQL endpoint {endpoint!r} (the configured default) was not found in "
+            f"workspace {ws!r}. The default endpoint likely belongs to a different "
+            "workspace. Pass the endpoint explicitly as the second argument "
+            "('fabric-dw sql-endpoints <command> <workspace> <endpoint>'), or set a "
+            "default that belongs to this workspace with "
+            "'fabric-dw config set warehouse <name|id>' (accepts a warehouse or "
+            "SQL Analytics Endpoint)."
+        ) from None
 
 
 @click.group("sql-endpoints")
@@ -59,8 +122,13 @@ async def list_cmd(ctx: CliContext, workspace: str | None, all_workspaces: bool)
                 resolver, _ = make_resolver(http)
                 ws_id = await resolver.workspace_id(resolved_workspace)
                 items = await _sql_endpoints_svc.list_endpoints(http, ws_id)
+            rows = [ep.model_dump(by_alias=True, mode="json") for ep in items]
+            # The --json path stays COMPLETE; only the human/table path drops the
+            # always-redundant columns (kind, and workspaceId when single-workspace).
+            if not ctx.json_output:
+                rows = _strip_table_keys(rows, all_workspaces=all_workspaces)
             render(
-                [ep.model_dump(by_alias=True, mode="json") for ep in items],
+                rows,
                 json_output=ctx.json_output,
                 table_title="SQL Analytics Endpoints",
             )
@@ -76,10 +144,13 @@ async def list_cmd(ctx: CliContext, workspace: str | None, all_workspaces: bool)
 async def get_cmd(ctx: CliContext, workspace: str | None, item: str | None) -> None:
     """Get details for ITEM (SQL analytics endpoint) in WORKSPACE (both accept name or GUID)."""
     ws = resolve_workspace_arg(ctx, workspace)
+    endpoint_explicit = item is not None
     ep = resolve_warehouse_arg(ctx, item)
     try:
         async with build_http_client(ctx) as http:
-            ws_id, entry = await resolve_item(http, ws, ep)
+            ws_id, entry = await _resolve_endpoint_or_hint(
+                http, ws, ep, endpoint_explicit=endpoint_explicit
+            )
             obj = await _sql_endpoints_svc.get_endpoint(http, ws_id, entry.id)
             render(obj.model_dump(by_alias=True, mode="json"), json_output=ctx.json_output)
     except FabricError as exc:
@@ -114,10 +185,13 @@ async def refresh_cmd(
     command) to emit raw JSON instead.
     """
     ws = resolve_workspace_arg(ctx, workspace)
+    endpoint_explicit = item is not None
     ep = resolve_warehouse_arg(ctx, item)
     try:
         async with build_http_client(ctx) as http:
-            ws_id, entry = await resolve_item(http, ws, ep)
+            ws_id, entry = await _resolve_endpoint_or_hint(
+                http, ws, ep, endpoint_explicit=endpoint_explicit
+            )
             statuses = await _sql_endpoints_svc.refresh_metadata(
                 http, ws_id, entry.id, recreate_tables=recreate_tables
             )
@@ -144,10 +218,13 @@ async def permissions_cmd(ctx: CliContext, workspace: str | None, item: str | No
     See https://learn.microsoft.com/en-us/fabric/admin/microsoft-fabric-admin for details.
     """
     ws = resolve_workspace_arg(ctx, workspace)
+    endpoint_explicit = item is not None
     ep = resolve_warehouse_arg(ctx, item)
     try:
         async with build_http_client(ctx) as http:
-            ws_id, entry = await resolve_item(http, ws, ep)
+            ws_id, entry = await _resolve_endpoint_or_hint(
+                http, ws, ep, endpoint_explicit=endpoint_explicit
+            )
             items = await _permissions_svc.list_item_access(http, ws_id, entry.id)
             render_permissions_table(
                 items,

--- a/tests/unit/cli/commands/test_sql_endpoints.py
+++ b/tests/unit/cli/commands/test_sql_endpoints.py
@@ -131,6 +131,112 @@ class TestEndpointsList:
         assert isinstance(parsed, list)
 
 
+_LIST_EP_ITEM = {
+    "id": EP_GUID,
+    "displayName": "SalesLakehouse",
+    "description": "SQL endpoint",
+    "type": "SQLEndpoint",
+    "workspaceId": WS_GUID,
+    "properties": {
+        "sqlEndpointProperties": {
+            "connectionString": "lakehouse-sql-ep.datawarehouse.fabric.microsoft.com",
+            "id": "f6a7b8c9-d0e1-2345-f012-34567890abcd",
+            "provisioningStatus": "Success",
+        }
+    },
+}
+
+
+class TestEndpointsListColumns:
+    """endpoints list — redundant-column stripping in the human (table) path."""
+
+    def test_single_workspace_table_omits_kind_and_workspace_id(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """Single-workspace table must drop both the kind and workspaceId columns."""
+        _ = cache_env
+        mock_http = AsyncMock()
+        mock_http.iter_paginated = MagicMock(return_value=_async_iter([_LIST_EP_ITEM]))
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql_endpoints.build_http_client",
+                new=_make_cm(mock_http, None),
+            ),
+            patch(
+                "fabric_dw.resolver.Resolver.workspace_id",
+                new=AsyncMock(return_value=WS_UUID),
+            ),
+        ):
+            # Force a wide console so Rich does not truncate the header text.
+            result = runner.invoke(cli, ["sql-endpoints", "list", WS_GUID], env={"COLUMNS": "200"})
+        assert result.exit_code == 0
+        out = result.output
+        assert "kind" not in out
+        assert "workspaceId" not in out
+        # A genuinely useful column is still present.
+        assert "connectionString" in out
+        # The endpoint itself is shown.
+        assert "SalesLakehouse" in out
+
+    def test_all_workspaces_table_omits_kind_but_keeps_workspace_id(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """With -A the table keeps workspaceId (rows span workspaces) but still drops kind."""
+        _ = cache_env
+        from fabric_dw.models import Warehouse, WarehouseKind  # noqa: PLC0415
+
+        ep = Warehouse.model_validate(
+            {
+                "id": EP_GUID,
+                "displayName": "SalesLakehouse",
+                "workspaceId": WS_GUID,
+                "kind": WarehouseKind.SQL_ENDPOINT,
+                "connectionString": "lakehouse-sql-ep.datawarehouse.fabric.microsoft.com",
+            }
+        )
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql_endpoints.build_http_client",
+                new=_make_cm(mock_http, None),
+            ),
+            patch(
+                "fabric_dw.services.sql_endpoints.list_all_workspaces",
+                new=AsyncMock(return_value=[ep]),
+            ),
+        ):
+            result = runner.invoke(cli, ["sql-endpoints", "list", "-A"], env={"COLUMNS": "200"})
+        assert result.exit_code == 0
+        out = result.output
+        assert "kind" not in out
+        assert "workspaceId" in out
+
+    def test_json_output_includes_kind_and_workspace_id(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """--json must keep the COMPLETE payload (both kind and workspaceId)."""
+        _ = cache_env
+        mock_http = AsyncMock()
+        mock_http.iter_paginated = MagicMock(return_value=_async_iter([_LIST_EP_ITEM]))
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql_endpoints.build_http_client",
+                new=_make_cm(mock_http, None),
+            ),
+            patch(
+                "fabric_dw.resolver.Resolver.workspace_id",
+                new=AsyncMock(return_value=WS_UUID),
+            ),
+        ):
+            result = runner.invoke(cli, ["--json", "sql-endpoints", "list", WS_GUID])
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert isinstance(parsed, list)
+        assert len(parsed) == 1
+        assert parsed[0]["kind"] == WarehouseKind.SQL_ENDPOINT
+        assert parsed[0]["workspaceId"] == WS_GUID
+
+
 class TestEndpointsListAllWorkspaces:
     """endpoints list --all-workspaces / -A."""
 
@@ -418,6 +524,110 @@ class TestEndpointsRefresh:
         ):
             result = runner.invoke(cli, ["sql-endpoints", "refresh", WS_GUID, EP_GUID])
         assert result.exit_code != 0
+
+
+class TestEndpointsPermissions:
+    """endpoints permissions — happy path and the stale-default cross-workspace 404 UX."""
+
+    def test_permissions_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql_endpoints.build_http_client",
+                new=_make_cm(mock_http, None),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_endpoints.resolve_item",
+                new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.permissions.list_item_access",
+                new=AsyncMock(return_value=[]),
+            ),
+        ):
+            result = runner.invoke(cli, ["sql-endpoints", "permissions", WS_GUID, EP_GUID])
+        assert result.exit_code == 0
+
+
+# GUID of a default endpoint that belongs to a *different* workspace than the
+# one passed positionally — reproduces the stale cross-workspace default case.
+_STALE_DEFAULT_GUID = "54094bde-0000-0000-0000-000000000000"
+
+
+def _configure_default_warehouse(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Persist a default warehouse/endpoint and isolate config + cache dirs."""
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.delenv("FABRIC_DW_DEFAULT_WAREHOUSE", raising=False)
+    setup = runner.invoke(cli, ["config", "set", "warehouse", _STALE_DEFAULT_GUID])
+    assert setup.exit_code == 0
+
+
+class TestEndpointsStaleDefaultHint:
+    """A defaulted endpoint missing from the target workspace yields a friendly error."""
+
+    @pytest.mark.parametrize("command", ["permissions", "get", "refresh"])
+    def test_missing_default_endpoint_raises_clear_error(
+        self,
+        command: str,
+        runner: CliRunner,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """One positional arg + stale default → actionable message, not a raw 404."""
+        _configure_default_warehouse(runner, monkeypatch, tmp_path)
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql_endpoints.build_http_client",
+                new=_make_cm(mock_http, None),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_endpoints.resolve_item",
+                new=AsyncMock(
+                    side_effect=NotFoundError(
+                        f"HTTP 404 for .../workspaces/{WS_GUID}/items/"
+                        f"{_STALE_DEFAULT_GUID}: EntityNotFound"
+                    )
+                ),
+            ),
+        ):
+            # Only ONE positional arg — the endpoint comes from the stale default.
+            result = runner.invoke(cli, ["sql-endpoints", command, WS_GUID])
+        assert result.exit_code != 0
+        out = result.output
+        assert "configured default" in out
+        assert "different" in out
+        assert WS_GUID in out
+        assert _STALE_DEFAULT_GUID in out
+        assert "second argument" in out
+        # The cryptic raw 404 body must NOT leak through.
+        assert "EntityNotFound" not in out
+
+    def test_explicit_missing_endpoint_keeps_original_error(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """When the endpoint is passed explicitly, the original NotFound surfaces unchanged."""
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql_endpoints.build_http_client",
+                new=_make_cm(mock_http, None),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql_endpoints.resolve_item",
+                new=AsyncMock(side_effect=NotFoundError("endpoint not found")),
+            ),
+        ):
+            result = runner.invoke(cli, ["sql-endpoints", "permissions", WS_GUID, EP_GUID])
+        assert result.exit_code != 0
+        # The friendly stale-default wording must NOT appear for an explicit arg.
+        assert "configured default" not in result.output
+        assert "endpoint not found" in result.output
 
 
 class TestRenderRefreshTable:


### PR DESCRIPTION
## Summary

Two UX improvements in `src/fabric_dw/cli/commands/sql_endpoints.py`.

### 1. `sql-endpoints list` — drop redundant columns (human table only)

- ALWAYS drop the `kind` column (every row is `SQLEndpoint` — redundant).
- Drop the `workspaceId` column when NOT `-A/--all-workspaces` (single workspace → identical on every row); KEEP it under `-A` where rows span workspaces.
- `--json` output stays COMPLETE — it always includes `kind` and `workspaceId`. Only the human/table path strips keys.

Implementation is scoped to `list_cmd`: a small `_strip_table_keys` helper removes the keys from the per-row dicts before they reach `render(...)`. The shared `render()` signature in `cli/_render.py` is left unchanged (avoids conflicting with the parallel warehouses-list work).

### 2. Confusing `sql-endpoints permissions` 404

Repro: `fdw sql-endpoints permissions <workspace>` (one positional arg) →
`Error: HTTP 404 ... /workspaces/<ws>/items/<default> EntityNotFound`.

**Diagnosis:** with a single positional arg the endpoint argument is `None`, so `resolve_warehouse_arg` falls back to the configured DEFAULT warehouse/endpoint. When that stale default belongs to a *different* workspace, `resolve_item` → `_fetch_item_detail` issues `GET /workspaces/{ws}/items/{default}` which 404s with a cryptic `EntityNotFound`. This is **purely a stale-default cross-workspace UX issue** — not an API-path bug. The permissions admin path (`/admin/workspaces/{ws}/items/{id}/users` in `services/permissions.py`) is correct; the 404 originates earlier, in item resolution.

**Fix:** a local `_resolve_endpoint_or_hint` helper wraps `resolve_item`. When the endpoint was taken from a default (not passed explicitly) and resolution raises `NotFoundError`, it raises a clear `click.ClickException` explaining that the SQL endpoint was not found in the target workspace and that the configured default likely belongs to a different workspace — telling the user to pass the endpoint explicitly or fix the default (mirrors the #423 wording style). When the endpoint was passed explicitly, the original not-found error surfaces unchanged.

The same stale-default pattern affects `get` and `refresh` (identical resolve flow), so the helper is applied to all three commands.

## Test plan

- [x] `just check` clean (ruff lint + format, ty, full unit suite — 3380 passed)
- [x] list: single-ws table omits `kind` + `workspaceId`; `-A` table omits `kind` but keeps `workspaceId`; `--json` includes both.
- [x] stale-default hint: parametrised over `permissions`/`get`/`refresh` — friendly message, no raw `EntityNotFound`; explicit endpoint keeps the original error.

No smoke-test behaviour changed (`test_cli_smoke.py` untouched) — CLI rendering + error UX, fully unit-tested.

Closes #458

🤖 Generated with [Claude Code](https://claude.com/claude-code)