### PR TITLE
test: disable telemetry globally in the test suite (stop polluting production App Insights)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,11 @@ automatically after the test by pytest's monkeypatch machinery.
 Without this autouse fixture, a test that asserts "the guard is absent so the
 operation is allowed" would silently become a false positive whenever a developer
 runs the suite from a shell that exports ``FABRIC_MCP_READONLY=1`` or similar.
+
+This conftest also disables anonymous telemetry for the whole test run
+(``_disable_telemetry_globally``) so that no test — in-process or subprocess —
+ever performs a real telemetry send to the production Application Insights
+resource.
 """
 
 from __future__ import annotations
@@ -21,6 +26,16 @@ _FABRIC_MCP_VARS = (
     "FABRIC_MCP_ALLOW_DESTRUCTIVE",
     "FABRIC_MCP_WORKSPACES",
     "FABRIC_MCP_ALLOW_REMOTE",
+)
+
+# Test modules that exercise telemetry behaviour directly and therefore manage
+# their own FABRIC_DISABLE_TELEMETRY / FABRIC_TELEMETRY env state.  They are
+# exempt from the global telemetry-disable fixture below.
+_TELEMETRY_SELF_MANAGED_MODULES = frozenset(
+    {
+        "test_telemetry.py",
+        "test_telemetry_commands.py",
+    }
 )
 
 
@@ -36,3 +51,39 @@ def _isolate_fabric_mcp_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """
     for var in _FABRIC_MCP_VARS:
         monkeypatch.delenv(var, raising=False)
+
+
+@pytest.fixture(autouse=True)
+def _disable_telemetry_globally(
+    request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Disable anonymous telemetry for the entire test run — no real network sends.
+
+    On a typical developer machine ``telemetry_enabled()`` returns ``True`` (not
+    CI, no opt-out env var, no config opt-out), so without this fixture every
+    in-process ``CliRunner`` test — and every integration smoke test that spawns
+    the real ``fdw`` binary as a subprocess — would emit **real** telemetry to the
+    **production** Application Insights resource, drowning genuine usage in test
+    noise (see issue tracking this).
+
+    Setting ``FABRIC_DISABLE_TELEMETRY=1`` via ``monkeypatch.setenv`` makes
+    :func:`fabric_dw.telemetry.telemetry_enabled` return ``False``, so
+    ``emit_event`` / provider init / flush all become no-ops:
+
+    - The truthy ``FABRIC_DISABLE_TELEMETRY`` check wins even over the forced
+      ``FABRIC_TELEMETRY=1`` that ``tests/integration/test_cli_smoke.py`` injects
+      into its child env, because it is evaluated first in ``telemetry_enabled``.
+    - ``monkeypatch`` mutates ``os.environ`` in place, so subprocess tests that do
+      ``os.environ.copy()`` inherit the disable; ``monkeypatch`` auto-restores it
+      after each test.
+
+    ``tests/unit/test_telemetry.py`` and ``tests/unit/test_telemetry_commands.py``
+    are exempt: they exercise telemetry behaviour directly and manage their own env
+    state (mirrors the ``_suppress_telemetry_notice`` exemption in
+    ``tests/unit/conftest.py``).  The check is by exact filename so unrelated
+    modules that merely contain ``telemetry`` in their name (e.g. the self-test for
+    this very fixture) are still covered.
+    """
+    if request.path is not None and request.path.name in _TELEMETRY_SELF_MANAGED_MODULES:
+        return
+    monkeypatch.setenv("FABRIC_DISABLE_TELEMETRY", "1")

--- a/tests/unit/test_global_telemetry_disable.py
+++ b/tests/unit/test_global_telemetry_disable.py
@@ -1,0 +1,27 @@
+"""Self-test for the global ``_disable_telemetry_globally`` autouse fixture.
+
+The fixture lives in ``tests/conftest.py`` (root) and disables anonymous
+telemetry for the entire test run so that no test — in-process or subprocess —
+ever performs a real send to the production Application Insights resource.
+
+These tests confirm the fixture is actually active for ordinary modules.  Only
+``test_telemetry.py`` and ``test_telemetry_commands.py`` are exempt (they manage
+their own telemetry env state); this module is *not* in that set, so it is
+subject to the global disable.
+"""
+
+from __future__ import annotations
+
+import os
+
+from fabric_dw.telemetry import telemetry_enabled
+
+
+def test_disable_telemetry_env_is_set_by_global_fixture() -> None:
+    """The global autouse fixture exports FABRIC_DISABLE_TELEMETRY=1."""
+    assert os.environ.get("FABRIC_DISABLE_TELEMETRY") == "1"
+
+
+def test_telemetry_is_disabled_inside_a_test() -> None:
+    """With the fixture active, telemetry_enabled() must be False."""
+    assert telemetry_enabled() is False


### PR DESCRIPTION
Closes #463

## Problem

Running the test suite on a developer machine sent **real telemetry to the production Application Insights resource**. A live query found ~976 `command_invoked` customEvents (plus `app_started`/`app_exited`) emitted within a 15-minute window — all from local `just check` runs, not real usage. This noise was drowning out genuine usage data.

Root cause: there was no global telemetry disable in the test environment.

- `telemetry_enabled()` returns `True` on a typical dev machine (not CI, no opt-out env var, no config opt-out).
- The only telemetry-related autouse fixture (`tests/unit/conftest.py::_suppress_telemetry_notice`) patched only the printed first-run notice (`maybe_print_first_run_notice`), **not** the emission path (`record_app_started` / `emit_command_invoked` / `emit_event`).
- So every in-process `CliRunner`/CLI test emitted real telemetry, and the integration smoke tests (`tests/integration/test_cli_smoke.py`) spawn the real `fdw` binary as a subprocess and, via `_child_env()`, deliberately unset CI markers and force `FABRIC_TELEMETRY=1` to exercise the init → flush → shutdown path — sending to the **production** connection string.

In CI this leak is incidentally suppressed because `CI=true` / `GITHUB_ACTIONS` disables telemetry, so the problem only manifested on **developer machines**.

## Fix

Add a global autouse fixture `_disable_telemetry_globally` in `tests/conftest.py` (root — applies to both unit and integration) that sets `FABRIC_DISABLE_TELEMETRY=1` via `monkeypatch.setenv` for the duration of every test. This makes `telemetry_enabled()` return `False`, so `emit_event` / provider init / flush all become no-ops → zero network sends.

- The truthy `FABRIC_DISABLE_TELEMETRY` check is evaluated first in `telemetry_enabled()`, so it wins even over the forced `FABRIC_TELEMETRY=1` that the smoke-test child env injects.
- `monkeypatch` mutates `os.environ` in place, so subprocess tests (`os.environ.copy()`) inherit the disable; `monkeypatch` auto-restores it after each test.

### test_telemetry exemption

`tests/unit/test_telemetry.py` and `tests/unit/test_telemetry_commands.py` are exempt — they exercise telemetry behaviour directly and manage their own `FABRIC_DISABLE_TELEMETRY` / `FABRIC_TELEMETRY` env state (mirroring the existing `_suppress_telemetry_notice` exemption). The exemption matches by **exact filename** (`_TELEMETRY_SELF_MANAGED_MODULES`) rather than the broad `"test_telemetry" in path` substring, so modules that merely contain `telemetry` in their name (e.g. the self-test for this fixture) are still covered by the disable. Both telemetry modules' "enabled" tests already mock the SDK (`_get_tracer`, `emit_event`, provider `force_flush`) and the envelope test uses `_convert_log_to_envelope` offline — none depend on a real network send.

### Self-test

Added `tests/unit/test_global_telemetry_disable.py` asserting that, with the fixture active, `FABRIC_DISABLE_TELEMETRY` is set and `telemetry_enabled()` is `False` inside a test.

## Verification

- `just check` clean: ruff check, ruff format, ty all pass; **3404 passed, 2 deselected** (exit 0).
- Tests that assert telemetry functions are *called* do so via mocks (they patch `emit_event` / `record_*`), so disabling real telemetry via the env does not break them — confirmed by the full suite.

## Scope note

This is test-infra only and unit-validated. It also changes integration conftest behaviour (the smoke tests no longer perform a real telemetry send), which is intentional and is the whole point — stopping dev-machine test runs from polluting the production App Insights resource. No `integration` label is applied.