### PR TITLE
refactor(cli): core — add global -w/--workspace option + resolve_workspace (no command changes yet)

### DIFF
--- a/src/fabric_dw/cli/_context.py
+++ b/src/fabric_dw/cli/_context.py
@@ -18,6 +18,7 @@ class CliContext:
     json_output: bool = False
     yes: bool = False
     auth: CredentialMode = field(default_factory=lambda: CredentialMode.DEFAULT)
+    workspace: str | None = None
     _config: UserConfig | None = field(default=None, repr=False, compare=False)
 
     @property

--- a/src/fabric_dw/cli/_main.py
+++ b/src/fabric_dw/cli/_main.py
@@ -358,6 +358,14 @@ def _patch_group_for_telemetry(group: click.Group) -> None:
     help="Authentication mode.",
 )
 @click.option(
+    "-w",
+    "--workspace",
+    "workspace",
+    metavar="NAME|GUID",
+    default=None,
+    help="Target workspace (name or GUID). Falls back to the configured default.",
+)
+@click.option(
     "--yes",
     "-y",
     "yes",
@@ -378,6 +386,7 @@ def cli(
     ctx: click.Context,
     json_output: bool,
     auth_mode: str,
+    workspace: str | None,
     yes: bool,
     verbose: bool,
 ) -> None:
@@ -388,6 +397,7 @@ def cli(
         json_output=json_output,
         yes=yes,
         auth=CredentialMode(auth_mode),
+        workspace=workspace,
     )
 
     maybe_print_first_run_notice()

--- a/src/fabric_dw/cli/commands/_utils.py
+++ b/src/fabric_dw/cli/commands/_utils.py
@@ -334,6 +334,19 @@ def get_ctx(click_ctx: click.Context) -> CliContext:
 # ---------------------------------------------------------------------------
 
 
+def _workspace_default(ctx: CliContext) -> str | None:
+    """Return the configured-default workspace, env var first then config file.
+
+    Shared by :func:`resolve_workspace_arg` and :func:`resolve_workspace`:
+    consults ``FABRIC_DW_DEFAULT_WORKSPACE`` then ``ctx.config.defaults.workspace``.
+    Returns *None* when neither is set.
+    """
+    env = os.environ.get("FABRIC_DW_DEFAULT_WORKSPACE")
+    if env:
+        return env
+    return ctx.config.defaults.workspace
+
+
 def resolve_workspace_arg(ctx: CliContext, value: str | None) -> str:
     """Resolve the workspace argument using the priority order.
 
@@ -344,14 +357,35 @@ def resolve_workspace_arg(ctx: CliContext, value: str | None) -> str:
     """
     if value is not None:
         return value
-    env = os.environ.get("FABRIC_DW_DEFAULT_WORKSPACE")
-    if env:
-        return env
-    cfg_val = ctx.config.defaults.workspace
-    if cfg_val is not None:
-        return cfg_val
+    default = _workspace_default(ctx)
+    if default is not None:
+        return default
     raise click.UsageError(
         "no workspace specified; pass one as an argument, or set a persistent default"
+        " with 'fabric-dw config set workspace <name|id>'"
+    )
+
+
+def resolve_workspace(ctx: CliContext) -> str:
+    """Resolve the target workspace for the global ``-w/--workspace`` option.
+
+    Precedence:
+
+    1. Explicit ``-w/--workspace`` (``ctx.workspace``) if not *None*.
+    2. ``FABRIC_DW_DEFAULT_WORKSPACE`` environment variable.
+    3. ``ctx.config.defaults.workspace`` from the config file.
+    4. None of the above → :class:`click.UsageError`.
+
+    Raises:
+        click.UsageError: If no workspace can be resolved from any source.
+    """
+    if ctx.workspace is not None:
+        return ctx.workspace
+    default = _workspace_default(ctx)
+    if default is not None:
+        return default
+    raise click.UsageError(
+        "no workspace specified; pass -w/--workspace <name|id>, or set a persistent default"
         " with 'fabric-dw config set workspace <name|id>'"
     )
 
@@ -403,3 +437,30 @@ def validate_workspace_or_all_workspaces(workspace: str | None, all_workspaces: 
         raise click.UsageError("WORKSPACE and --all-workspaces are mutually exclusive.")
     if not workspace and not all_workspaces:
         raise click.UsageError("Provide WORKSPACE or pass --all-workspaces / -A.")
+
+
+def validate_workspace_option_or_all_workspaces(
+    explicit_workspace: str | None, all_workspaces: bool
+) -> None:
+    """Enforce the ``-w/--workspace`` / ``-A/--all-workspaces`` contract.
+
+    Companion to :func:`validate_workspace_or_all_workspaces` for commands that
+    take the global ``-w`` option rather than a positional WORKSPACE.  An
+    **explicit** ``-w`` (``ctx.workspace is not None``) is mutually exclusive
+    with ``-A``; a configured *default* workspace must NOT conflict with ``-A``
+    (so ``-A`` always wins over a default and only the explicit flag clashes).
+
+    Unlike :func:`validate_workspace_or_all_workspaces`, this helper does NOT
+    require one of the two to be present: neither explicit ``-w`` nor ``-A`` is
+    valid because a configured default may still supply the workspace later.
+
+    Args:
+        explicit_workspace: ``ctx.workspace`` — the explicit ``-w`` value, or
+            *None* when ``-w`` was not passed.
+        all_workspaces: Whether ``--all-workspaces`` / ``-A`` was passed.
+
+    Raises:
+        click.UsageError: If both an explicit ``-w`` and ``-A`` are given.
+    """
+    if explicit_workspace is not None and all_workspaces:
+        raise click.UsageError("-w/--workspace and --all-workspaces / -A are mutually exclusive.")

--- a/tests/unit/cli/commands/test_utils.py
+++ b/tests/unit/cli/commands/test_utils.py
@@ -25,9 +25,12 @@ from fabric_dw.cli.commands._utils import (
     parse_iso_datetime,
     parse_qualified_name,
     resolve_item,
+    resolve_workspace,
     resolve_workspace_id,
+    validate_workspace_option_or_all_workspaces,
     validate_workspace_or_all_workspaces,
 )
+from fabric_dw.config import Defaults, UserConfig
 from fabric_dw.exceptions import ConfigError
 from fabric_dw.models import WarehouseKind
 from fabric_dw.resolver import Resolver
@@ -554,3 +557,73 @@ class TestResolveWarehouseArgErrorMessage:
         assert "config set warehouse" in output
         assert "default" in output
         assert "SQL Analytics Endpoint" in output
+
+
+# ---------------------------------------------------------------------------
+# resolve_workspace — precedence for the global -w/--workspace option
+# ---------------------------------------------------------------------------
+
+
+def _ctx_with(*, workspace: str | None = None, config_workspace: str | None = None) -> CliContext:
+    """Build a CliContext with an explicit -w value and/or a configured default."""
+    ctx = CliContext(workspace=workspace)
+    # Inject a pre-loaded config so .config does not touch disk.
+    ctx._config = UserConfig(defaults=Defaults(workspace=config_workspace))
+    return ctx
+
+
+class TestResolveWorkspace:
+    """resolve_workspace precedence: -w > env > config > UsageError."""
+
+    def test_explicit_workspace_wins(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("FABRIC_DW_DEFAULT_WORKSPACE", "env-ws")
+        ctx = _ctx_with(workspace="flag-ws", config_workspace="cfg-ws")
+        assert resolve_workspace(ctx) == "flag-ws"
+
+    def test_env_var_used_when_no_flag(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("FABRIC_DW_DEFAULT_WORKSPACE", "env-ws")
+        ctx = _ctx_with(workspace=None, config_workspace="cfg-ws")
+        assert resolve_workspace(ctx) == "env-ws"
+
+    def test_config_used_when_no_flag_or_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("FABRIC_DW_DEFAULT_WORKSPACE", raising=False)
+        ctx = _ctx_with(workspace=None, config_workspace="cfg-ws")
+        assert resolve_workspace(ctx) == "cfg-ws"
+
+    def test_missing_everywhere_raises_with_flag_first(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("FABRIC_DW_DEFAULT_WORKSPACE", raising=False)
+        ctx = _ctx_with(workspace=None, config_workspace=None)
+        with pytest.raises(click.UsageError) as excinfo:
+            resolve_workspace(ctx)
+        msg = str(excinfo.value)
+        assert "no workspace specified" in msg
+        assert "-w/--workspace" in msg
+        assert "config set workspace" in msg
+        # -w must be mentioned before the config-set fallback.
+        assert msg.index("-w/--workspace") < msg.index("config set workspace")
+
+
+# ---------------------------------------------------------------------------
+# validate_workspace_option_or_all_workspaces — -w vs -A mutual exclusion
+# ---------------------------------------------------------------------------
+
+
+class TestValidateWorkspaceOptionOrAllWorkspaces:
+    """The -w/--workspace vs -A/--all-workspaces mutual-exclusion guard."""
+
+    def test_explicit_workspace_only_passes(self) -> None:
+        validate_workspace_option_or_all_workspaces("my-ws", all_workspaces=False)
+
+    def test_all_workspaces_only_passes(self) -> None:
+        validate_workspace_option_or_all_workspaces(None, all_workspaces=True)
+
+    def test_neither_passes(self) -> None:
+        # A configured default may still supply the workspace later, so neither
+        # explicit -w nor -A is valid (unlike the positional WORKSPACE guard).
+        validate_workspace_option_or_all_workspaces(None, all_workspaces=False)
+
+    def test_both_raises_usage_error(self) -> None:
+        with pytest.raises(click.UsageError, match="mutually exclusive"):
+            validate_workspace_option_or_all_workspaces("my-ws", all_workspaces=True)

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -11,7 +11,9 @@ import pytest
 from click.testing import CliRunner
 
 import fabric_dw.cli as _cli_pkg
+import fabric_dw.cli._main as _main_mod
 import fabric_dw.telemetry as _tel
+from fabric_dw.cli._context import CliContext
 from fabric_dw.cli._main import cli
 
 
@@ -47,6 +49,47 @@ class TestCliHelp:
         runner = CliRunner()
         result = runner.invoke(cli, ["--help"])
         assert "--verbose" in result.output or "-v" in result.output
+
+    def test_global_workspace_option_is_listed(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--help"])
+        assert "--workspace" in result.output or "-w" in result.output
+
+
+class TestCliWorkspaceOption:
+    """The root -w / --workspace option populates CliContext.workspace."""
+
+    def _captured_workspace(self, args: list[str]) -> str | None:
+        """Invoke *args* and return the workspace stored on the built CliContext.
+
+        Spies on the ``CliContext`` constructor so the workspace passed by the
+        root ``cli`` callback can be inspected. ``cache --help`` runs the root
+        callback (which builds ctx.obj) without any network access.
+        """
+        captured: list[CliContext] = []
+        original = _main_mod.CliContext
+
+        def _spy(**kwargs: object) -> CliContext:
+            obj = original(**kwargs)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+            captured.append(obj)
+            return obj
+
+        with patch.object(_main_mod, "CliContext", _spy):
+            runner = CliRunner()
+            runner.invoke(cli, args)
+        assert captured, "root callback did not construct a CliContext"
+        return captured[-1].workspace
+
+    def test_workspace_long_option_sets_context(self) -> None:
+        args = ["--workspace", "Sales WS", "cache", "--help"]
+        assert self._captured_workspace(args) == "Sales WS"
+
+    def test_workspace_short_option_sets_context(self) -> None:
+        guid = "a1b2c3d4-0000-0000-0000-000000000000"
+        assert self._captured_workspace(["-w", guid, "cache", "--help"]) == guid
+
+    def test_workspace_defaults_to_none_when_absent(self) -> None:
+        assert self._captured_workspace(["cache", "--help"]) is None
 
 
 class TestCliUnknownCommand:


### PR DESCRIPTION
Closes #465

**PR 1 of the CLI-wide workspace-as-option refactor.** This is the CORE: it adds the shared infrastructure WITHOUT converting any command, so existing behaviour is unchanged.

## What this adds
- **`CliContext.workspace: str | None = None`** — new field alongside `json_output`, `yes`, `auth`.
- **Root `-w / --workspace` option** (metavar `NAME|GUID`, default `None`, help: "Target workspace (name or GUID). Falls back to the configured default."). Consumed in the root `cli(...)` callback exactly like `--auth` and stored on `CliContext`. Root-position only for now (it is **not** routed through the `_inject_global_options` post-subcommand meta mechanism).
- **`resolve_workspace(ctx) -> str`** — precedence: explicit `-w` (`ctx.workspace`) → `FABRIC_DW_DEFAULT_WORKSPACE` env → configured default → `click.UsageError`. The error mirrors the #423 wording but mentions `-w` first:
  > no workspace specified; pass -w/--workspace <name|id>, or set a persistent default with 'fabric-dw config set workspace <name|id>'

  Config-reading is shared with `resolve_workspace_arg` via a small internal `_workspace_default(ctx)` helper (no duplicated config parsing).
- **`validate_workspace_option_or_all_workspaces(explicit_workspace, all_workspaces)`** — new guard for the `-w` vs `-A/--all-workspaces` mutual exclusion. "Explicit" means `ctx.workspace is not None`, so a configured default does **not** conflict with `-A`. Raises `UsageError` only when both an explicit `-w` and `-A` are given.

## What this deliberately leaves untouched
- `resolve_workspace_arg(ctx, value)` — unchanged; the `workspaces` group's `get`/`set-collation` still use it.
- The existing `validate_workspace_or_all_workspaces(workspace, all_workspaces)` — unchanged; current list-command callers (`warehouses`, `sql_endpoints`) keep working. A new function was added rather than changing its signature, since the new "explicit" semantics differ from the positional-WORKSPACE semantics.
- No command module calls `resolve_workspace` yet, so no user-facing behaviour changed.

## Tests
- Root `-w`/`--workspace` populates `ctx.workspace` (long, short, and absent → `None`); option listed in `--help`.
- `resolve_workspace` precedence: `-w` > env > config > `UsageError` (asserts the helpful message mentions `-w/--workspace` before the config-set fallback).
- The new `-w` vs `-A` mutual-exclusion guard.

`just check` is clean; the full existing unit suite passes unchanged (3424 passed). Pure infra + unit tests, so **no `integration` label**.

## Documented fast-follow
A post-noun `-w` (parsed after the subcommand via the global-options meta mechanism, like `--json`/`-y`/`-v`) is intentionally out of scope here and is a documented fast-follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)