### PR TITLE
refactor(cli)!: tables, views take workspace via -w

### DIFF
--- a/src/fabric_dw/cli/commands/tables.py
+++ b/src/fabric_dw/cli/commands/tables.py
@@ -25,7 +25,7 @@ from fabric_dw.cli.commands._utils import (
     parse_qualified_name,
     resolve_item,
     resolve_warehouse_arg,
-    resolve_workspace_arg,
+    resolve_workspace,
 )
 from fabric_dw.exceptions import FabricError
 from fabric_dw.http_client import FabricHttpClient
@@ -49,16 +49,13 @@ def tables_group() -> None:
 
 
 @tables_group.command("list")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.option("--schema", default=None, help="Filter by schema name.")
 @click.pass_obj
 @coro
-async def list_cmd(
-    ctx: CliContext, workspace: str | None, item: str | None, schema: str | None
-) -> None:
-    """List tables on ITEM (warehouse or SQL endpoint) in WORKSPACE."""
-    ws = resolve_workspace_arg(ctx, workspace)
+async def list_cmd(ctx: CliContext, item: str | None, schema: str | None) -> None:
+    """List tables on ITEM (warehouse or SQL endpoint)."""
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     try:
         async with build_http_client(ctx) as http:
@@ -74,7 +71,6 @@ async def list_cmd(
 
 
 @tables_group.command("read")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.argument("qualified_name")
 @click.option("--count", default=10, show_default=True, help="Max rows to return.")
@@ -91,15 +87,14 @@ async def list_cmd(
 @coro
 async def read_cmd(
     ctx: CliContext,
-    workspace: str | None,
     item: str | None,
     qualified_name: str,
     count: int,
     fmt: str,
     output: str | None,
 ) -> None:
-    """Read up to COUNT rows from QUALIFIED_NAME (schema.table) on ITEM in WORKSPACE."""
-    ws = resolve_workspace_arg(ctx, workspace)
+    """Read up to COUNT rows from QUALIFIED_NAME (schema.table) on ITEM."""
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     schema, table_name = parse_qualified_name(qualified_name, kind="table")
     output_path = Path(output) if output else None
@@ -205,7 +200,6 @@ def _parse_schema_file(path: str) -> list[ColumnSpec]:
 
 
 @tables_group.command("create")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.option("--name", "qualified_name", required=True, help="Qualified name: schema.table.")
 # CTAS path
@@ -282,7 +276,6 @@ def _parse_schema_file(path: str) -> list[ColumnSpec]:
 @coro
 async def create_cmd(  # noqa: PLR0912
     ctx: CliContext,
-    workspace: str | None,
     item: str | None,
     qualified_name: str,
     select_body: str | None,
@@ -297,7 +290,7 @@ async def create_cmd(  # noqa: PLR0912
     encoding: str,
     sample_rows: int,
 ) -> None:
-    """Create a new table on ITEM in WORKSPACE.
+    """Create a new table on ITEM.
 
     \b
     Two modes are available:
@@ -314,7 +307,7 @@ async def create_cmd(  # noqa: PLR0912
       --encoding        File encoding (default 'utf-8-sig').
       --sample-rows     Rows to sample for inference (default 1000).
     """
-    ws = resolve_workspace_arg(ctx, workspace)
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     schema, table_name = parse_qualified_name(qualified_name, kind="table")
 
@@ -412,19 +405,17 @@ async def create_cmd(  # noqa: PLR0912
 
 
 @tables_group.command("delete")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.argument("qualified_name")
 @click.pass_obj
 @coro
 async def delete_cmd(
     ctx: CliContext,
-    workspace: str | None,
     item: str | None,
     qualified_name: str,
 ) -> None:
-    """Drop QUALIFIED_NAME (schema.table) from ITEM in WORKSPACE."""
-    ws = resolve_workspace_arg(ctx, workspace)
+    """Drop QUALIFIED_NAME (schema.table) from ITEM."""
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     schema, table_name = parse_qualified_name(qualified_name, kind="table")
     try:
@@ -451,19 +442,17 @@ async def delete_cmd(
 
 
 @tables_group.command("clear")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.argument("qualified_name")
 @click.pass_obj
 @coro
 async def clear_cmd(
     ctx: CliContext,
-    workspace: str | None,
     item: str | None,
     qualified_name: str,
 ) -> None:
-    """Truncate QUALIFIED_NAME (schema.table) on ITEM in WORKSPACE."""
-    ws = resolve_workspace_arg(ctx, workspace)
+    """Truncate QUALIFIED_NAME (schema.table) on ITEM."""
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     schema, table_name = parse_qualified_name(qualified_name, kind="table")
     try:
@@ -490,7 +479,6 @@ async def clear_cmd(
 
 
 @tables_group.command("clone")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.option("--source", required=True, help="Qualified source table: schema.table.")
 @click.option(
@@ -509,19 +497,18 @@ async def clear_cmd(
 @coro
 async def clone_cmd(
     ctx: CliContext,
-    workspace: str | None,
     item: str | None,
     source: str,
     new_table: str,
     at_str: str | None,
 ) -> None:
-    """Clone SOURCE table as a zero-copy clone named NAME on ITEM in WORKSPACE.
+    """Clone SOURCE table as a zero-copy clone named NAME on ITEM.
 
     Creates a new table using ``CREATE TABLE … AS CLONE OF …``.  The optional
     ``--at`` timestamp must be within the warehouse data-retention window (UTC).
     Only supported on Fabric Data Warehouses (not SQL Analytics Endpoints).
     """
-    ws = resolve_workspace_arg(ctx, workspace)
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     # Validate both qualified names eagerly so bad input is reported before any I/O.
     parse_qualified_name(source, kind="table")
@@ -590,7 +577,6 @@ def _resolve_url_file_type(fmt: str | None, url: str) -> str:
 
 
 @tables_group.command("load")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.argument("qualified_name")
 @click.option("--file", "file_path", default=None, help="Path to a local file to load.")
@@ -714,7 +700,6 @@ def _resolve_url_file_type(fmt: str | None, url: str) -> str:
 @coro
 async def load_cmd(  # noqa: PLR0912
     ctx: CliContext,
-    workspace: str | None,
     item: str | None,
     qualified_name: str,
     file_path: str | None,
@@ -739,7 +724,7 @@ async def load_cmd(  # noqa: PLR0912
     sample_rows: int,
     cleanup_on_failure: bool,
 ) -> None:
-    """Load data into QUALIFIED_NAME (schema.table) on ITEM in WORKSPACE via COPY INTO.
+    """Load data into QUALIFIED_NAME (schema.table) on ITEM via COPY INTO.
 
     Exactly one of --file (local path) or --url (remote URL) must be provided.
 
@@ -759,13 +744,13 @@ async def load_cmd(  # noqa: PLR0912
 
     \b
     Examples:
-      fabric-dw tables load myws mywarehouse dbo.sales --file data.csv
-      fabric-dw tables load myws mywarehouse dbo.sales --url https://... --format parquet
-      fabric-dw tables load myws mywarehouse dbo.sales --file data.parquet --create
-      fabric-dw tables load myws mywarehouse dbo.sales \
+      fabric-dw -w myws tables load mywarehouse dbo.sales --file data.csv
+      fabric-dw -w myws tables load mywarehouse dbo.sales --url https://... --format parquet
+      fabric-dw -w myws tables load mywarehouse dbo.sales --file data.parquet --create
+      fabric-dw -w myws tables load mywarehouse dbo.sales \
           --file data.csv --create --if-exists replace -y
     """
-    ws = resolve_workspace_arg(ctx, workspace)
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     schema, table_name = parse_qualified_name(qualified_name, kind="table")
 
@@ -1106,7 +1091,6 @@ async def _load_cmd_url(
 
 
 @tables_group.command("rename")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.argument("qualified_name")
 @click.option("--new-name", required=True, help="New (unqualified) table name.")
@@ -1114,18 +1098,17 @@ async def _load_cmd_url(
 @coro
 async def rename_cmd(
     ctx: CliContext,
-    workspace: str | None,
     item: str | None,
     qualified_name: str,
     new_name: str,
 ) -> None:
-    """Rename QUALIFIED_NAME (schema.table) on ITEM in WORKSPACE to --new-name.
+    """Rename QUALIFIED_NAME (schema.table) on ITEM to --new-name.
 
     ITEM must be a Data Warehouse; SQL Analytics Endpoints are read-only.
     The new name must be unqualified (bare table name) — sp_rename cannot
     move a table to a different schema.
     """
-    ws = resolve_workspace_arg(ctx, workspace)
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     parse_qualified_name(qualified_name, kind="table")
     try:

--- a/src/fabric_dw/cli/commands/views.py
+++ b/src/fabric_dw/cli/commands/views.py
@@ -16,7 +16,7 @@ from fabric_dw.cli.commands._utils import (
     load_sql_body,
     parse_qualified_name,
     resolve_warehouse_arg,
-    resolve_workspace_arg,
+    resolve_workspace,
 )
 from fabric_dw.exceptions import FabricError
 from fabric_dw.services import views as _views_svc
@@ -29,16 +29,13 @@ def views_group() -> None:
 
 
 @views_group.command("list")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.option("--schema", default=None, help="Filter by schema name.")
 @click.pass_obj
 @coro
-async def list_cmd(
-    ctx: CliContext, workspace: str | None, item: str | None, schema: str | None
-) -> None:
-    """List views on ITEM (warehouse or SQL endpoint) in WORKSPACE."""
-    ws = resolve_workspace_arg(ctx, workspace)
+async def list_cmd(ctx: CliContext, item: str | None, schema: str | None) -> None:
+    """List views on ITEM (warehouse or SQL endpoint)."""
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     try:
         async with build_http_client(ctx) as http:
@@ -54,7 +51,6 @@ async def list_cmd(
 
 
 @views_group.command("read")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.argument("qualified_name")
 @click.option("--count", default=10, show_default=True, help="Max rows to return.")
@@ -71,15 +67,14 @@ async def list_cmd(
 @coro
 async def read_cmd(
     ctx: CliContext,
-    workspace: str | None,
     item: str | None,
     qualified_name: str,
     count: int,
     fmt: str,
     output: str | None,
 ) -> None:
-    """Read up to COUNT rows from QUALIFIED_NAME (schema.view) on ITEM in WORKSPACE."""
-    ws = resolve_workspace_arg(ctx, workspace)
+    """Read up to COUNT rows from QUALIFIED_NAME (schema.view) on ITEM."""
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     schema, view_name = parse_qualified_name(qualified_name, kind="view")
     output_path = Path(output) if output else None
@@ -105,19 +100,17 @@ async def read_cmd(
 
 
 @views_group.command("get")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.argument("qualified_name")
 @click.pass_obj
 @coro
 async def get_cmd(
     ctx: CliContext,
-    workspace: str | None,
     item: str | None,
     qualified_name: str,
 ) -> None:
-    """Fetch the full definition of QUALIFIED_NAME (schema.view) on ITEM in WORKSPACE."""
-    ws = resolve_workspace_arg(ctx, workspace)
+    """Fetch the full definition of QUALIFIED_NAME (schema.view) on ITEM."""
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     schema, view_name = parse_qualified_name(qualified_name, kind="view")
     try:
@@ -130,7 +123,6 @@ async def get_cmd(
 
 
 @views_group.command("create")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.option("--name", "qualified_name", required=True, help="Qualified name: schema.view.")
 @click.option("--select", "select_body", default=None, help="Inline SELECT statement.")
@@ -139,14 +131,13 @@ async def get_cmd(
 @coro
 async def create_cmd(
     ctx: CliContext,
-    workspace: str | None,
     item: str | None,
     qualified_name: str,
     select_body: str | None,
     from_file: str | None,
 ) -> None:
-    """Create a new view QUALIFIED_NAME on ITEM in WORKSPACE."""
-    ws = resolve_workspace_arg(ctx, workspace)
+    """Create a new view QUALIFIED_NAME on ITEM."""
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     schema, view_name = parse_qualified_name(qualified_name, kind="view")
     body = load_sql_body(select_body, from_file)
@@ -160,7 +151,6 @@ async def create_cmd(
 
 
 @views_group.command("update")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.argument("qualified_name")
 @click.option("--select", "select_body", default=None, help="Inline SELECT statement.")
@@ -169,14 +159,13 @@ async def create_cmd(
 @coro
 async def update_cmd(
     ctx: CliContext,
-    workspace: str | None,
     item: str | None,
     qualified_name: str,
     select_body: str | None,
     from_file: str | None,
 ) -> None:
-    """Redefine QUALIFIED_NAME (schema.view) on ITEM in WORKSPACE via CREATE OR ALTER VIEW."""
-    ws = resolve_workspace_arg(ctx, workspace)
+    """Redefine QUALIFIED_NAME (schema.view) on ITEM via CREATE OR ALTER VIEW."""
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     schema, view_name = parse_qualified_name(qualified_name, kind="view")
     body = load_sql_body(select_body, from_file)
@@ -197,19 +186,17 @@ async def update_cmd(
 
 
 @views_group.command("drop")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.argument("qualified_name")
 @click.pass_obj
 @coro
 async def drop_cmd(
     ctx: CliContext,
-    workspace: str | None,
     item: str | None,
     qualified_name: str,
 ) -> None:
-    """Drop QUALIFIED_NAME (schema.view) from ITEM in WORKSPACE."""
-    ws = resolve_workspace_arg(ctx, workspace)
+    """Drop QUALIFIED_NAME (schema.view) from ITEM."""
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     schema, view_name = parse_qualified_name(qualified_name, kind="view")
     try:
@@ -231,7 +218,6 @@ async def drop_cmd(
 
 
 @views_group.command("rename")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.argument("qualified_name")
 @click.option("--new-name", required=True, help="New bare (unqualified) view name.")
@@ -239,13 +225,12 @@ async def drop_cmd(
 @coro
 async def rename_cmd(
     ctx: CliContext,
-    workspace: str | None,
     item: str | None,
     qualified_name: str,
     new_name: str,
 ) -> None:
-    """Rename QUALIFIED_NAME (schema.view) on ITEM in WORKSPACE to --new-name."""
-    ws = resolve_workspace_arg(ctx, workspace)
+    """Rename QUALIFIED_NAME (schema.view) on ITEM to --new-name."""
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     schema, view_name = parse_qualified_name(qualified_name, kind="view")
     try:

--- a/tests/unit/cli/commands/test_tables.py
+++ b/tests/unit/cli/commands/test_tables.py
@@ -1636,9 +1636,6 @@ class TestTablesCreateEmpty:
 class TestLoadCreateAndLoad:
     """Tests for 'tables load --create' (auto-create + load)."""
 
-    def _invoke(self, runner: CliRunner, args: list[str]) -> object:
-        return runner.invoke(cli, ["tables", "load", *args], catch_exceptions=False)
-
     def test_create_with_url_raises_usage_error(self, runner: CliRunner) -> None:
         """--create is not supported with --url."""
         result = runner.invoke(

--- a/tests/unit/cli/commands/test_tables.py
+++ b/tests/unit/cli/commands/test_tables.py
@@ -105,7 +105,7 @@ class TestTablesList:
                 new=AsyncMock(return_value=[_make_table()]),
             ),
         ):
-            result = runner.invoke(cli, ["--json", "tables", "list", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "--json", "tables", "list", WH_GUID])
         assert result.exit_code == 0
         parsed = json.loads(result.output)
         assert isinstance(parsed, list)
@@ -129,7 +129,7 @@ class TestTablesList:
                 new=AsyncMock(return_value=[_make_table()]),
             ),
         ):
-            result = runner.invoke(cli, ["--json", "tables", "list", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "--json", "tables", "list", WH_GUID])
         assert result.exit_code == 0
         parsed = json.loads(result.output)
         assert isinstance(parsed, list)
@@ -150,7 +150,9 @@ class TestTablesList:
             ),
             patch("fabric_dw.services.tables.list_tables", new=mock_list),
         ):
-            result = runner.invoke(cli, ["tables", "list", WS_GUID, WH_GUID, "--schema", "dbo"])
+            result = runner.invoke(
+                cli, ["-w", WS_GUID, "tables", "list", WH_GUID, "--schema", "dbo"]
+            )
         assert result.exit_code == 0
         mock_list.assert_awaited_once()
 
@@ -167,7 +169,7 @@ class TestTablesList:
                 new=AsyncMock(side_effect=NotFoundError("not found")),
             ),
         ):
-            result = runner.invoke(cli, ["tables", "list", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "tables", "list", WH_GUID])
         assert result.exit_code != 0
 
 
@@ -194,7 +196,7 @@ class TestTablesRead:
                 new=AsyncMock(return_value=(["id", "name"], [(1, "Alice")])),
             ),
         ):
-            result = runner.invoke(cli, ["tables", "read", WS_GUID, WH_GUID, "dbo.sales"])
+            result = runner.invoke(cli, ["-w", WS_GUID, "tables", "read", WH_GUID, "dbo.sales"])
         assert result.exit_code == 0
         # Default output is JSON; row data must appear
         parsed = json.loads(result.output)
@@ -218,7 +220,7 @@ class TestTablesRead:
                 new=AsyncMock(return_value=(["id"], [(42,)])),
             ),
         ):
-            result = runner.invoke(cli, ["tables", "read", WS_GUID, WH_GUID, "dbo.sales"])
+            result = runner.invoke(cli, ["-w", WS_GUID, "tables", "read", WH_GUID, "dbo.sales"])
         assert result.exit_code == 0
         parsed = json.loads(result.output)
         assert parsed[0]["id"] == 42
@@ -226,14 +228,14 @@ class TestTablesRead:
     def test_read_csv_requires_output(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
         result = runner.invoke(
-            cli, ["tables", "read", WS_GUID, WH_GUID, "dbo.sales", "--format", "csv"]
+            cli, ["-w", WS_GUID, "tables", "read", WH_GUID, "dbo.sales", "--format", "csv"]
         )
         assert result.exit_code != 0
 
     def test_read_parquet_requires_output(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
         result = runner.invoke(
-            cli, ["tables", "read", WS_GUID, WH_GUID, "dbo.sales", "--format", "parquet"]
+            cli, ["-w", WS_GUID, "tables", "read", WH_GUID, "dbo.sales", "--format", "parquet"]
         )
         assert result.exit_code != 0
 
@@ -258,9 +260,10 @@ class TestTablesRead:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "tables",
                     "read",
-                    WS_GUID,
                     WH_GUID,
                     "dbo.sales",
                     "--format",
@@ -298,10 +301,11 @@ class TestTablesRead:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "--json",
                     "tables",
                     "read",
-                    WS_GUID,
                     WH_GUID,
                     "dbo.sales",
                     "--format",
@@ -321,7 +325,7 @@ class TestTablesRead:
         self, runner: CliRunner, cache_env: Path
     ) -> None:
         _ = cache_env
-        result = runner.invoke(cli, ["tables", "read", WS_GUID, WH_GUID, "nodot"])
+        result = runner.invoke(cli, ["-w", WS_GUID, "tables", "read", WH_GUID, "nodot"])
         assert result.exit_code != 0
 
     def test_read_not_found_returns_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
@@ -341,7 +345,7 @@ class TestTablesRead:
                 new=AsyncMock(side_effect=NotFoundError("table not found")),
             ),
         ):
-            result = runner.invoke(cli, ["tables", "read", WS_GUID, WH_GUID, "dbo.missing"])
+            result = runner.invoke(cli, ["-w", WS_GUID, "tables", "read", WH_GUID, "dbo.missing"])
         assert result.exit_code != 0
 
 
@@ -372,10 +376,11 @@ class TestTablesCreate:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "--json",
                     "tables",
                     "create",
-                    WS_GUID,
                     WH_GUID,
                     "--name",
                     "dbo.sales",
@@ -411,10 +416,11 @@ class TestTablesCreate:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "--json",
                     "tables",
                     "create",
-                    WS_GUID,
                     WH_GUID,
                     "--name",
                     "dbo.sales",
@@ -434,7 +440,7 @@ class TestTablesCreate:
         _ = cache_env
         result = runner.invoke(
             cli,
-            ["tables", "create", WS_GUID, WH_GUID, "--name", "dbo.sales"],
+            ["-w", WS_GUID, "tables", "create", WH_GUID, "--name", "dbo.sales"],
         )
         assert result.exit_code != 0
 
@@ -447,9 +453,10 @@ class TestTablesCreate:
         result = runner.invoke(
             cli,
             [
+                "-w",
+                WS_GUID,
                 "tables",
                 "create",
-                WS_GUID,
                 WH_GUID,
                 "--name",
                 "dbo.sales",
@@ -483,9 +490,10 @@ class TestTablesCreate:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "tables",
                     "create",
-                    WS_GUID,
                     WH_GUID,
                     "--name",
                     "dbo.sales",
@@ -517,10 +525,11 @@ class TestTablesCreate:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "--json",
                     "tables",
                     "create",
-                    WS_GUID,
                     WH_GUID,
                     "--name",
                     "dbo.sales",
@@ -551,9 +560,10 @@ class TestTablesCreate:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "tables",
                     "create",
-                    WS_GUID,
                     SE_GUID,
                     "--name",
                     "dbo.sales",
@@ -590,7 +600,7 @@ class TestTablesDelete:
             ),
         ):
             result = runner.invoke(
-                cli, ["--yes", "tables", "delete", WS_GUID, WH_GUID, "dbo.sales"]
+                cli, ["-w", WS_GUID, "--yes", "tables", "delete", WH_GUID, "dbo.sales"]
             )
         assert result.exit_code == 0
         mock_delete.assert_awaited_once()
@@ -611,7 +621,7 @@ class TestTablesDelete:
         ):
             result = runner.invoke(
                 cli,
-                ["tables", "delete", WS_GUID, WH_GUID, "dbo.sales"],
+                ["-w", WS_GUID, "tables", "delete", WH_GUID, "dbo.sales"],
                 input="n\n",
             )
         assert result.exit_code == 0
@@ -621,7 +631,7 @@ class TestTablesDelete:
         self, runner: CliRunner, cache_env: Path
     ) -> None:
         _ = cache_env
-        result = runner.invoke(cli, ["tables", "delete", WS_GUID, WH_GUID, "nodot"])
+        result = runner.invoke(cli, ["-w", WS_GUID, "tables", "delete", WH_GUID, "nodot"])
         assert result.exit_code != 0
 
     def test_delete_permission_denied_returns_nonzero(
@@ -644,7 +654,7 @@ class TestTablesDelete:
             ),
         ):
             result = runner.invoke(
-                cli, ["--yes", "tables", "delete", WS_GUID, WH_GUID, "dbo.sales"]
+                cli, ["-w", WS_GUID, "--yes", "tables", "delete", WH_GUID, "dbo.sales"]
             )
         assert result.exit_code != 0
 
@@ -668,7 +678,7 @@ class TestTablesDelete:
             ),
         ):
             result = runner.invoke(
-                cli, ["--yes", "tables", "delete", WS_GUID, WH_GUID, "dbo.sales"]
+                cli, ["-w", WS_GUID, "--yes", "tables", "delete", WH_GUID, "dbo.sales"]
             )
         assert result.exit_code == 0
         # Must have proceeded to actual delete (DDL guard passed)
@@ -689,7 +699,7 @@ class TestTablesDelete:
             ),
         ):
             result = runner.invoke(
-                cli, ["--yes", "tables", "delete", WS_GUID, SE_GUID, "dbo.sales"]
+                cli, ["-w", WS_GUID, "--yes", "tables", "delete", SE_GUID, "dbo.sales"]
             )
         assert result.exit_code != 0
         assert "read-only" in result.output
@@ -719,7 +729,9 @@ class TestTablesClear:
                 new=mock_clear,
             ),
         ):
-            result = runner.invoke(cli, ["--yes", "tables", "clear", WS_GUID, WH_GUID, "dbo.sales"])
+            result = runner.invoke(
+                cli, ["-w", WS_GUID, "--yes", "tables", "clear", WH_GUID, "dbo.sales"]
+            )
         assert result.exit_code == 0
         mock_clear.assert_awaited_once()
 
@@ -739,7 +751,7 @@ class TestTablesClear:
         ):
             result = runner.invoke(
                 cli,
-                ["tables", "clear", WS_GUID, WH_GUID, "dbo.sales"],
+                ["-w", WS_GUID, "tables", "clear", WH_GUID, "dbo.sales"],
                 input="n\n",
             )
         assert result.exit_code == 0
@@ -749,7 +761,7 @@ class TestTablesClear:
         self, runner: CliRunner, cache_env: Path
     ) -> None:
         _ = cache_env
-        result = runner.invoke(cli, ["tables", "clear", WS_GUID, WH_GUID, "nodot"])
+        result = runner.invoke(cli, ["-w", WS_GUID, "tables", "clear", WH_GUID, "nodot"])
         assert result.exit_code != 0
 
     def test_clear_permission_denied_returns_nonzero(
@@ -771,7 +783,9 @@ class TestTablesClear:
                 new=AsyncMock(side_effect=PermissionDeniedError("no permission")),
             ),
         ):
-            result = runner.invoke(cli, ["--yes", "tables", "clear", WS_GUID, WH_GUID, "dbo.sales"])
+            result = runner.invoke(
+                cli, ["-w", WS_GUID, "--yes", "tables", "clear", WH_GUID, "dbo.sales"]
+            )
         assert result.exit_code != 0
 
     def test_clear_warehouse_item_allowed(self, runner: CliRunner, cache_env: Path) -> None:
@@ -793,7 +807,9 @@ class TestTablesClear:
                 new=mock_clear,
             ),
         ):
-            result = runner.invoke(cli, ["--yes", "tables", "clear", WS_GUID, WH_GUID, "dbo.sales"])
+            result = runner.invoke(
+                cli, ["-w", WS_GUID, "--yes", "tables", "clear", WH_GUID, "dbo.sales"]
+            )
         assert result.exit_code == 0
         # Must have proceeded to actual clear (DDL guard passed)
         mock_clear.assert_awaited_once()
@@ -812,7 +828,9 @@ class TestTablesClear:
                 new=AsyncMock(return_value=(_make_sql_target(), _make_sql_endpoint_entry())),
             ),
         ):
-            result = runner.invoke(cli, ["--yes", "tables", "clear", WS_GUID, SE_GUID, "dbo.sales"])
+            result = runner.invoke(
+                cli, ["-w", WS_GUID, "--yes", "tables", "clear", SE_GUID, "dbo.sales"]
+            )
         assert result.exit_code != 0
         assert "read-only" in result.output
 
@@ -850,10 +868,11 @@ class TestTablesClone:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "--json",
                     "tables",
                     "clone",
-                    WS_GUID,
                     WH_GUID,
                     "--source",
                     "dbo.source_tbl",
@@ -893,10 +912,11 @@ class TestTablesClone:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "--json",
                     "tables",
                     "clone",
-                    WS_GUID,
                     WH_GUID,
                     "--source",
                     "dbo.source_tbl",
@@ -926,9 +946,10 @@ class TestTablesClone:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "tables",
                     "clone",
-                    WS_GUID,
                     WH_GUID,
                     "--source",
                     "dbo.source_tbl",
@@ -947,9 +968,10 @@ class TestTablesClone:
         result = runner.invoke(
             cli,
             [
+                "-w",
+                WS_GUID,
                 "tables",
                 "clone",
-                WS_GUID,
                 WH_GUID,
                 "--source",
                 "dbo.source_tbl",
@@ -965,14 +987,7 @@ class TestTablesClone:
         _ = cache_env
         result = runner.invoke(
             cli,
-            [
-                "tables",
-                "clone",
-                WS_GUID,
-                WH_GUID,
-                "--name",
-                "dbo.sales_clone",
-            ],
+            ["-w", WS_GUID, "tables", "clone", WH_GUID, "--name", "dbo.sales_clone"],
         )
         assert result.exit_code != 0
 
@@ -980,14 +995,7 @@ class TestTablesClone:
         _ = cache_env
         result = runner.invoke(
             cli,
-            [
-                "tables",
-                "clone",
-                WS_GUID,
-                WH_GUID,
-                "--source",
-                "dbo.source_tbl",
-            ],
+            ["-w", WS_GUID, "tables", "clone", WH_GUID, "--source", "dbo.source_tbl"],
         )
         assert result.exit_code != 0
 
@@ -998,9 +1006,10 @@ class TestTablesClone:
         result = runner.invoke(
             cli,
             [
+                "-w",
+                WS_GUID,
                 "tables",
                 "clone",
-                WS_GUID,
                 WH_GUID,
                 "--source",
                 "nodot",
@@ -1017,9 +1026,10 @@ class TestTablesClone:
         result = runner.invoke(
             cli,
             [
+                "-w",
+                WS_GUID,
                 "tables",
                 "clone",
-                WS_GUID,
                 WH_GUID,
                 "--source",
                 "dbo.source_tbl",
@@ -1046,9 +1056,10 @@ class TestTablesClone:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "tables",
                     "clone",
-                    WS_GUID,
                     SE_GUID,
                     "--source",
                     "dbo.source_tbl",
@@ -1081,9 +1092,10 @@ class TestTablesClone:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "tables",
                     "clone",
-                    WS_GUID,
                     WH_GUID,
                     "--source",
                     "dbo.source_tbl",
@@ -1117,9 +1129,10 @@ class TestTablesClone:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "tables",
                     "clone",
-                    WS_GUID,
                     WH_GUID,
                     "--source",
                     "dbo.source_tbl",
@@ -1159,10 +1172,11 @@ class TestTablesRename:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "--json",
                     "tables",
                     "rename",
-                    WS_GUID,
                     WH_GUID,
                     "dbo.sales",
                     "--new-name",
@@ -1201,10 +1215,11 @@ class TestTablesRename:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "--json",
                     "tables",
                     "rename",
-                    WS_GUID,
                     WH_GUID,
                     "dbo.sales",
                     "--new-name",
@@ -1217,7 +1232,7 @@ class TestTablesRename:
 
     def test_rename_missing_new_name_fails(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
-        result = runner.invoke(cli, ["tables", "rename", WS_GUID, WH_GUID, "dbo.sales"])
+        result = runner.invoke(cli, ["-w", WS_GUID, "tables", "rename", WH_GUID, "dbo.sales"])
         assert result.exit_code != 0
 
     def test_rename_undotted_qualified_name_fails_before_io(
@@ -1227,7 +1242,7 @@ class TestTablesRename:
         _ = cache_env
         result = runner.invoke(
             cli,
-            ["tables", "rename", WS_GUID, WH_GUID, "nodot", "--new-name", "sales_v2"],
+            ["-w", WS_GUID, "tables", "rename", WH_GUID, "nodot", "--new-name", "sales_v2"],
         )
         assert result.exit_code != 0
         assert "table" in result.output.lower() or "Usage" in result.output
@@ -1255,9 +1270,10 @@ class TestTablesRename:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "tables",
                     "rename",
-                    WS_GUID,
                     WH_GUID,
                     "dbo.sales",
                     "--new-name",
@@ -1286,7 +1302,7 @@ class TestTablesRename:
         ):
             result = runner.invoke(
                 cli,
-                ["tables", "rename", WS_GUID, SE_GUID, "dbo.sales", "--new-name", "sales_v2"],
+                ["-w", WS_GUID, "tables", "rename", SE_GUID, "dbo.sales", "--new-name", "sales_v2"],
             )
         assert result.exit_code != 0
         assert "read-only" in result.output
@@ -1312,7 +1328,7 @@ class TestTablesRename:
         ):
             result = runner.invoke(
                 cli,
-                ["tables", "rename", WS_GUID, WH_GUID, "dbo.sales", "--new-name", "sales_v2"],
+                ["-w", WS_GUID, "tables", "rename", WH_GUID, "dbo.sales", "--new-name", "sales_v2"],
             )
         assert result.exit_code != 0
 
@@ -1346,10 +1362,11 @@ class TestTablesCreateEmpty:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "--json",
                     "tables",
                     "create",
-                    WS_GUID,
                     WH_GUID,
                     "--name",
                     "dbo.sales",
@@ -1392,10 +1409,11 @@ class TestTablesCreateEmpty:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "--json",
                     "tables",
                     "create",
-                    WS_GUID,
                     WH_GUID,
                     "--name",
                     "dbo.sales",
@@ -1438,10 +1456,11 @@ class TestTablesCreateEmpty:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "--json",
                     "tables",
                     "create",
-                    WS_GUID,
                     WH_GUID,
                     "--name",
                     "dbo.sales",
@@ -1475,10 +1494,11 @@ class TestTablesCreateEmpty:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "--json",
                     "tables",
                     "create",
-                    WS_GUID,
                     WH_GUID,
                     "--name",
                     "dbo.sales",
@@ -1493,7 +1513,7 @@ class TestTablesCreateEmpty:
         _ = cache_env
         result = runner.invoke(
             cli,
-            ["tables", "create", WS_GUID, WH_GUID, "--name", "dbo.sales"],
+            ["-w", WS_GUID, "tables", "create", WH_GUID, "--name", "dbo.sales"],
         )
         assert result.exit_code != 0
 
@@ -1506,9 +1526,10 @@ class TestTablesCreateEmpty:
         result = runner.invoke(
             cli,
             [
+                "-w",
+                WS_GUID,
                 "tables",
                 "create",
-                WS_GUID,
                 WH_GUID,
                 "--name",
                 "dbo.sales",
@@ -1531,9 +1552,10 @@ class TestTablesCreateEmpty:
         result = runner.invoke(
             cli,
             [
+                "-w",
+                WS_GUID,
                 "tables",
                 "create",
-                WS_GUID,
                 WH_GUID,
                 "--name",
                 "dbo.sales",
@@ -1591,9 +1613,10 @@ class TestTablesCreateEmpty:
         result = runner.invoke(
             cli,
             [
+                "-w",
+                WS_GUID,
                 "tables",
                 "create",
-                WS_GUID,
                 WH_GUID,
                 "--name",
                 "dbo.sales",
@@ -1621,9 +1644,10 @@ class TestLoadCreateAndLoad:
         result = runner.invoke(
             cli,
             [
+                "-w",
+                "ws",
                 "tables",
                 "load",
-                "ws",
                 "wh",
                 "dbo.sales",
                 "--url",
@@ -1645,9 +1669,10 @@ class TestLoadCreateAndLoad:
         result = runner.invoke(
             cli,
             [
+                "-w",
+                "ws",
                 "tables",
                 "load",
-                "ws",
                 "wh",
                 "dbo.sales",
                 "--file",
@@ -1685,9 +1710,10 @@ class TestLoadCreateAndLoad:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    "ws",
                     "tables",
                     "load",
-                    "ws",
                     "wh",
                     "dbo.sales",
                     "--file",
@@ -1724,9 +1750,10 @@ class TestLoadCreateAndLoad:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    "ws",
                     "tables",
                     "load",
-                    "ws",
                     "wh",
                     "dbo.sales",
                     "--file",
@@ -1771,10 +1798,11 @@ class TestLoadCreateAndLoad:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    "ws",
                     "-y",
                     "tables",
                     "load",
-                    "ws",
                     "wh",
                     "dbo.sales",
                     "--file",
@@ -1799,9 +1827,10 @@ class TestLoadCreateAndLoad:
         result = runner.invoke(
             cli,
             [
+                "-w",
+                "ws",
                 "tables",
                 "load",
-                "ws",
                 "wh",
                 "dbo.sales",
                 "--file",
@@ -1824,9 +1853,10 @@ class TestLoadCreateAndLoad:
         result = runner.invoke(
             cli,
             [
+                "-w",
+                "ws",
                 "tables",
                 "load",
-                "ws",
                 "wh",
                 "dbo.sales",
                 "--file",
@@ -1844,9 +1874,10 @@ class TestLoadCreateAndLoad:
         result = runner.invoke(
             cli,
             [
+                "-w",
+                "ws",
                 "tables",
                 "load",
-                "ws",
                 "wh",
                 "dbo.sales",
                 "--url",

--- a/tests/unit/cli/commands/test_views.py
+++ b/tests/unit/cli/commands/test_views.py
@@ -86,7 +86,7 @@ class TestViewsList:
                 new=AsyncMock(return_value=[_make_view()]),
             ),
         ):
-            result = runner.invoke(cli, ["--json", "views", "list", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "--json", "views", "list", WH_GUID])
         assert result.exit_code == 0
         parsed = json.loads(result.output)
         assert isinstance(parsed, list)
@@ -110,7 +110,7 @@ class TestViewsList:
                 new=AsyncMock(return_value=[_make_view()]),
             ),
         ):
-            result = runner.invoke(cli, ["--json", "views", "list", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "--json", "views", "list", WH_GUID])
         assert result.exit_code == 0
         parsed = json.loads(result.output)
         assert isinstance(parsed, list)
@@ -130,7 +130,9 @@ class TestViewsList:
             ),
             patch("fabric_dw.services.views.list_views", new=mock_list),
         ):
-            result = runner.invoke(cli, ["views", "list", WS_GUID, WH_GUID, "--schema", "dbo"])
+            result = runner.invoke(
+                cli, ["-w", WS_GUID, "views", "list", WH_GUID, "--schema", "dbo"]
+            )
         assert result.exit_code == 0
         mock_list.assert_awaited_once()
 
@@ -147,7 +149,7 @@ class TestViewsList:
                 new=AsyncMock(side_effect=NotFoundError("not found")),
             ),
         ):
-            result = runner.invoke(cli, ["views", "list", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "views", "list", WH_GUID])
         assert result.exit_code != 0
 
 
@@ -174,7 +176,7 @@ class TestViewsRead:
                 new=AsyncMock(return_value=(["id", "name"], [(1, "Alice")])),
             ),
         ):
-            result = runner.invoke(cli, ["views", "read", WS_GUID, WH_GUID, "dbo.vw_sales"])
+            result = runner.invoke(cli, ["-w", WS_GUID, "views", "read", WH_GUID, "dbo.vw_sales"])
         assert result.exit_code == 0
         # Default output is JSON
         parsed = json.loads(result.output)
@@ -198,7 +200,7 @@ class TestViewsRead:
                 new=AsyncMock(return_value=(["id"], [(42,)])),
             ),
         ):
-            result = runner.invoke(cli, ["views", "read", WS_GUID, WH_GUID, "dbo.vw_sales"])
+            result = runner.invoke(cli, ["-w", WS_GUID, "views", "read", WH_GUID, "dbo.vw_sales"])
         assert result.exit_code == 0
         parsed = json.loads(result.output)
         assert parsed[0]["id"] == 42
@@ -206,14 +208,14 @@ class TestViewsRead:
     def test_read_csv_requires_output(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
         result = runner.invoke(
-            cli, ["views", "read", WS_GUID, WH_GUID, "dbo.vw_sales", "--format", "csv"]
+            cli, ["-w", WS_GUID, "views", "read", WH_GUID, "dbo.vw_sales", "--format", "csv"]
         )
         assert result.exit_code != 0
 
     def test_read_parquet_requires_output(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
         result = runner.invoke(
-            cli, ["views", "read", WS_GUID, WH_GUID, "dbo.vw_sales", "--format", "parquet"]
+            cli, ["-w", WS_GUID, "views", "read", WH_GUID, "dbo.vw_sales", "--format", "parquet"]
         )
         assert result.exit_code != 0
 
@@ -238,9 +240,10 @@ class TestViewsRead:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "views",
                     "read",
-                    WS_GUID,
                     WH_GUID,
                     "dbo.vw_sales",
                     "--format",
@@ -258,7 +261,7 @@ class TestViewsRead:
         self, runner: CliRunner, cache_env: Path
     ) -> None:
         _ = cache_env
-        result = runner.invoke(cli, ["views", "read", WS_GUID, WH_GUID, "nodot"])
+        result = runner.invoke(cli, ["-w", WS_GUID, "views", "read", WH_GUID, "nodot"])
         assert result.exit_code != 0
 
     def test_read_not_found_returns_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
@@ -278,7 +281,7 @@ class TestViewsRead:
                 new=AsyncMock(side_effect=NotFoundError("view not found")),
             ),
         ):
-            result = runner.invoke(cli, ["views", "read", WS_GUID, WH_GUID, "dbo.vw_missing"])
+            result = runner.invoke(cli, ["-w", WS_GUID, "views", "read", WH_GUID, "dbo.vw_missing"])
         assert result.exit_code != 0
 
 
@@ -307,7 +310,7 @@ class TestViewsGet:
         ):
             result = runner.invoke(
                 cli,
-                ["--json", "views", "get", WS_GUID, WH_GUID, "dbo.vw_sales"],
+                ["-w", WS_GUID, "--json", "views", "get", WH_GUID, "dbo.vw_sales"],
             )
         assert result.exit_code == 0
         parsed = json.loads(result.output)
@@ -332,7 +335,7 @@ class TestViewsGet:
             ),
         ):
             result = runner.invoke(
-                cli, ["--json", "views", "get", WS_GUID, WH_GUID, "dbo.vw_sales"]
+                cli, ["-w", WS_GUID, "--json", "views", "get", WH_GUID, "dbo.vw_sales"]
             )
         assert result.exit_code == 0
         parsed = json.loads(result.output)
@@ -340,7 +343,7 @@ class TestViewsGet:
 
     def test_get_bad_qualified_name_exits_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
-        result = runner.invoke(cli, ["views", "get", WS_GUID, WH_GUID, "no_dot_here"])
+        result = runner.invoke(cli, ["-w", WS_GUID, "views", "get", WH_GUID, "no_dot_here"])
         assert result.exit_code != 0
 
     def test_get_not_found_returns_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
@@ -360,7 +363,7 @@ class TestViewsGet:
                 new=AsyncMock(side_effect=NotFoundError("not found")),
             ),
         ):
-            result = runner.invoke(cli, ["views", "get", WS_GUID, WH_GUID, "dbo.vw_missing"])
+            result = runner.invoke(cli, ["-w", WS_GUID, "views", "get", WH_GUID, "dbo.vw_missing"])
         assert result.exit_code != 0
 
 
@@ -391,10 +394,11 @@ class TestViewsCreate:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "--json",
                     "views",
                     "create",
-                    WS_GUID,
                     WH_GUID,
                     "--name",
                     "dbo.vw_sales",
@@ -430,10 +434,11 @@ class TestViewsCreate:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "--json",
                     "views",
                     "create",
-                    WS_GUID,
                     WH_GUID,
                     "--name",
                     "dbo.vw_sales",
@@ -450,7 +455,7 @@ class TestViewsCreate:
         _ = cache_env
         result = runner.invoke(
             cli,
-            ["views", "create", WS_GUID, WH_GUID, "--name", "dbo.vw_sales"],
+            ["-w", WS_GUID, "views", "create", WH_GUID, "--name", "dbo.vw_sales"],
         )
         assert result.exit_code != 0
 
@@ -463,9 +468,10 @@ class TestViewsCreate:
         result = runner.invoke(
             cli,
             [
+                "-w",
+                WS_GUID,
                 "views",
                 "create",
-                WS_GUID,
                 WH_GUID,
                 "--name",
                 "dbo.vw_sales",
@@ -507,9 +513,10 @@ class TestViewsCreate:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "views",
                     "create",
-                    WS_GUID,
                     WH_GUID,
                     "--name",
                     "dbo.vw_sales",
@@ -542,9 +549,10 @@ class TestViewsCreate:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "views",
                     "create",
-                    WS_GUID,
                     WH_GUID,
                     "--name",
                     "dbo.vw_sales",
@@ -582,11 +590,12 @@ class TestViewsUpdate:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "--yes",
                     "--json",
                     "views",
                     "update",
-                    WS_GUID,
                     WH_GUID,
                     "dbo.vw_sales",
                     "--select",
@@ -614,15 +623,7 @@ class TestViewsUpdate:
         ):
             result = runner.invoke(
                 cli,
-                [
-                    "views",
-                    "update",
-                    WS_GUID,
-                    WH_GUID,
-                    "dbo.vw_sales",
-                    "--select",
-                    "SELECT 1",
-                ],
+                ["-w", WS_GUID, "views", "update", WH_GUID, "dbo.vw_sales", "--select", "SELECT 1"],
                 input="n\n",
             )
         assert result.exit_code == 0
@@ -657,10 +658,11 @@ class TestViewsUpdate:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "--yes",
                     "views",
                     "update",
-                    WS_GUID,
                     WH_GUID,
                     "dbo.vw_sales",
                     "--from-file",
@@ -696,7 +698,7 @@ class TestViewsDrop:
             ),
         ):
             result = runner.invoke(
-                cli, ["--yes", "views", "drop", WS_GUID, WH_GUID, "dbo.vw_sales"]
+                cli, ["-w", WS_GUID, "--yes", "views", "drop", WH_GUID, "dbo.vw_sales"]
             )
         assert result.exit_code == 0
         mock_drop.assert_awaited_once()
@@ -717,7 +719,7 @@ class TestViewsDrop:
         ):
             result = runner.invoke(
                 cli,
-                ["views", "drop", WS_GUID, WH_GUID, "dbo.vw_sales"],
+                ["-w", WS_GUID, "views", "drop", WH_GUID, "dbo.vw_sales"],
                 input="n\n",
             )
         assert result.exit_code == 0
@@ -727,7 +729,7 @@ class TestViewsDrop:
         self, runner: CliRunner, cache_env: Path
     ) -> None:
         _ = cache_env
-        result = runner.invoke(cli, ["views", "drop", WS_GUID, WH_GUID, "no_dot"])
+        result = runner.invoke(cli, ["-w", WS_GUID, "views", "drop", WH_GUID, "no_dot"])
         assert result.exit_code != 0
 
     def test_drop_permission_denied_returns_nonzero(
@@ -750,7 +752,7 @@ class TestViewsDrop:
             ),
         ):
             result = runner.invoke(
-                cli, ["--yes", "views", "drop", WS_GUID, WH_GUID, "dbo.vw_sales"]
+                cli, ["-w", WS_GUID, "--yes", "views", "drop", WH_GUID, "dbo.vw_sales"]
             )
         assert result.exit_code != 0
 
@@ -792,11 +794,12 @@ class TestViewsRename:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "--yes",
                     "--json",
                     "views",
                     "rename",
-                    WS_GUID,
                     WH_GUID,
                     "dbo.vw_sales",
                     "--new-name",
@@ -828,11 +831,12 @@ class TestViewsRename:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "--yes",
                     "--json",
                     "views",
                     "rename",
-                    WS_GUID,
                     WH_GUID,
                     "dbo.vw_sales",
                     "--new-name",
@@ -860,9 +864,10 @@ class TestViewsRename:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "views",
                     "rename",
-                    WS_GUID,
                     WH_GUID,
                     "dbo.vw_sales",
                     "--new-name",
@@ -879,7 +884,7 @@ class TestViewsRename:
         _ = cache_env
         result = runner.invoke(
             cli,
-            ["views", "rename", WS_GUID, WH_GUID, "nodot", "--new-name", "vw_revenue"],
+            ["-w", WS_GUID, "views", "rename", WH_GUID, "nodot", "--new-name", "vw_revenue"],
         )
         assert result.exit_code != 0
 
@@ -889,7 +894,7 @@ class TestViewsRename:
         _ = cache_env
         result = runner.invoke(
             cli,
-            ["views", "rename", WS_GUID, WH_GUID, "dbo.vw_sales"],
+            ["-w", WS_GUID, "views", "rename", WH_GUID, "dbo.vw_sales"],
         )
         assert result.exit_code != 0
 
@@ -913,10 +918,11 @@ class TestViewsRename:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "--yes",
                     "views",
                     "rename",
-                    WS_GUID,
                     WH_GUID,
                     "dbo.vw_sales",
                     "--new-name",


### PR DESCRIPTION
## Summary

Converts the `tables` and `views` command clusters to the new global `-w/--workspace` option introduced in the core refactor (#466). Each command now resolves the target workspace via `resolve_workspace(ctx)` (precedence: explicit `-w` -> `FABRIC_DW_DEFAULT_WORKSPACE` env -> config default -> helpful `UsageError`) instead of accepting a positional `WORKSPACE` argument.

For every command:
- the positional `workspace` argument decorator and callback parameter are removed;
- the remaining positionals (`ITEM`, `QUALIFIED_NAME`, ...) shift left in their existing order;
- `resolve_workspace_arg(ctx, workspace)` is replaced with `resolve_workspace(ctx)` (unused import dropped);
- docstrings drop the `WORKSPACE` reference, and the `tables load` examples now use the `-w` root form.

Unit tests are updated so the workspace is passed via `-w <ws>` **before** the command group.

These modules have no `-A/--all-workspaces` option, so no mutual-exclusion handling is involved.

## Converted commands

- **tables**: `list`, `read`, `create`, `delete`, `clear`, `clone`, `load`, `rename`
- **views**: `list`, `read`, `get`, `create`, `update`, `drop`, `rename`

## Breaking change

The `tables` and `views` subcommands no longer accept a positional `WORKSPACE`. Pass `-w/--workspace <name|id>` (or set a default via `FABRIC_DW_DEFAULT_WORKSPACE` or `fabric-dw config set workspace`).

Before:
```
fabric-dw tables read myws mywarehouse dbo.sales
```
After:
```
fabric-dw -w myws tables read mywarehouse dbo.sales
```

## Validation

`just check` passes (ruff lint + format, ty type-check, full unit suite: 3424 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)