### PR TITLE
refactor(cli)!: warehouses & sql-endpoints take workspace via -w/--workspace (drop positional)

### DIFF
--- a/src/fabric_dw/cli/commands/sql_endpoints.py
+++ b/src/fabric_dw/cli/commands/sql_endpoints.py
@@ -19,8 +19,8 @@ from fabric_dw.cli.commands._utils import (
     make_resolver,
     resolve_item,
     resolve_warehouse_arg,
-    resolve_workspace_arg,
-    validate_workspace_or_all_workspaces,
+    resolve_workspace,
+    validate_workspace_option_or_all_workspaces,
 )
 from fabric_dw.exceptions import FabricError, NotFoundError
 from fabric_dw.services import permissions as _permissions_svc
@@ -80,8 +80,8 @@ async def _resolve_endpoint_or_hint(
         raise click.ClickException(
             f"SQL endpoint {endpoint!r} (the configured default) was not found in "
             f"workspace {ws!r}. The default endpoint likely belongs to a different "
-            "workspace. Pass the endpoint explicitly as the second argument "
-            "('fabric-dw sql-endpoints <command> <workspace> <endpoint>'), or set a "
+            "workspace. Pass the endpoint explicitly as the ENDPOINT argument "
+            "('fabric-dw -w <workspace> sql-endpoints <command> <endpoint>'), or set a "
             "default that belongs to this workspace with "
             "'fabric-dw config set warehouse <name|id>' (accepts a warehouse or "
             "SQL Analytics Endpoint)."
@@ -94,7 +94,6 @@ def sql_endpoints_group() -> None:
 
 
 @sql_endpoints_group.command("list")
-@click.argument("workspace", required=False, default=None)
 @click.option(
     "-A",
     "--all-workspaces",
@@ -105,27 +104,24 @@ def sql_endpoints_group() -> None:
 )
 @click.pass_obj
 @coro
-async def list_cmd(ctx: CliContext, workspace: str | None, all_workspaces: bool) -> None:
-    """List all SQL analytics endpoints in WORKSPACE (name or GUID).
+async def list_cmd(ctx: CliContext, all_workspaces: bool) -> None:
+    """List all SQL analytics endpoints in the target workspace.
+
+    The workspace comes from -w/--workspace (or the configured default).
 
     Pass -A / --all-workspaces to scan every visible workspace instead.
-    WORKSPACE and --all-workspaces are mutually exclusive; exactly one is required.
+    -w/--workspace and --all-workspaces are mutually exclusive.
     """
-    # Resolve the workspace default before the XOR validation so that a
-    # configured default-workspace (env / config file) is honoured when no
-    # positional arg is passed but --all-workspaces is also absent.
-    resolved_workspace = None if all_workspaces else resolve_workspace_arg(ctx, workspace)
-    validate_workspace_or_all_workspaces(resolved_workspace, all_workspaces)
+    # An explicit -w clashes with -A; a configured default does not (so -A
+    # always wins over a default and only the explicit flag is a conflict).
+    validate_workspace_option_or_all_workspaces(ctx.workspace, all_workspaces)
     try:
         async with build_http_client(ctx) as http:
             if all_workspaces:
                 items = await _sql_endpoints_svc.list_all_workspaces(http)
             else:
-                # resolved_workspace is guaranteed non-None by validate_workspace_or_all_workspaces
-                if resolved_workspace is None:  # pragma: no cover — defensive
-                    raise click.UsageError("Provide WORKSPACE or pass --all-workspaces / -A.")
                 resolver, _ = make_resolver(http)
-                ws_id = await resolver.workspace_id(resolved_workspace)
+                ws_id = await resolver.workspace_id(resolve_workspace(ctx))
                 items = await _sql_endpoints_svc.list_endpoints(http, ws_id)
             rows = [ep.model_dump(by_alias=True, mode="json") for ep in items]
             # The --json path stays COMPLETE; only the human/table path drops the
@@ -144,13 +140,12 @@ async def list_cmd(ctx: CliContext, workspace: str | None, all_workspaces: bool)
 
 
 @sql_endpoints_group.command("get")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.pass_obj
 @coro
-async def get_cmd(ctx: CliContext, workspace: str | None, item: str | None) -> None:
-    """Get details for ITEM (SQL analytics endpoint) in WORKSPACE (both accept name or GUID)."""
-    ws = resolve_workspace_arg(ctx, workspace)
+async def get_cmd(ctx: CliContext, item: str | None) -> None:
+    """Get details for ITEM (SQL analytics endpoint, name or GUID) in the target workspace."""
+    ws = resolve_workspace(ctx)
     endpoint_explicit = item is not None
     ep = resolve_warehouse_arg(ctx, item)
     try:
@@ -170,7 +165,6 @@ async def get_cmd(ctx: CliContext, workspace: str | None, item: str | None) -> N
 
 
 @sql_endpoints_group.command("refresh")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.option(
     "--recreate-tables",
@@ -185,10 +179,8 @@ async def get_cmd(ctx: CliContext, workspace: str | None, item: str | None) -> N
 )
 @click.pass_obj
 @coro
-async def refresh_cmd(
-    ctx: CliContext, workspace: str | None, item: str | None, recreate_tables: bool
-) -> None:
-    """Refresh metadata for ITEM (SQL endpoint) in WORKSPACE (both accept name or GUID).
+async def refresh_cmd(ctx: CliContext, item: str | None, recreate_tables: bool) -> None:
+    """Refresh metadata for ITEM (SQL endpoint, name or GUID) in the target workspace.
 
     Triggers a metadata sync from the underlying Lakehouse delta tables.
     This is a long-running operation (LRO) that is polled to completion.
@@ -196,7 +188,7 @@ async def refresh_cmd(
     By default, results are shown as a Rich table.  Pass --json (on the root
     command) to emit raw JSON instead.
     """
-    ws = resolve_workspace_arg(ctx, workspace)
+    ws = resolve_workspace(ctx)
     endpoint_explicit = item is not None
     ep = resolve_warehouse_arg(ctx, item)
     try:
@@ -219,17 +211,16 @@ async def refresh_cmd(
 
 
 @sql_endpoints_group.command("permissions")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.pass_obj
 @coro
-async def permissions_cmd(ctx: CliContext, workspace: str | None, item: str | None) -> None:
-    """List principals with access to ITEM (SQL endpoint) in WORKSPACE (both accept name or GUID).
+async def permissions_cmd(ctx: CliContext, item: str | None) -> None:
+    """List principals with access to ITEM (SQL endpoint, name or GUID) in the target workspace.
 
     Requires Fabric Administrator role.
     See https://learn.microsoft.com/en-us/fabric/admin/microsoft-fabric-admin for details.
     """
-    ws = resolve_workspace_arg(ctx, workspace)
+    ws = resolve_workspace(ctx)
     endpoint_explicit = item is not None
     ep = resolve_warehouse_arg(ctx, item)
     try:

--- a/src/fabric_dw/cli/commands/warehouses.py
+++ b/src/fabric_dw/cli/commands/warehouses.py
@@ -18,8 +18,8 @@ from fabric_dw.cli.commands._utils import (
     resolve_item,
     resolve_item_with_cache,
     resolve_warehouse_arg,
-    resolve_workspace_arg,
-    validate_workspace_or_all_workspaces,
+    resolve_workspace,
+    validate_workspace_option_or_all_workspaces,
 )
 from fabric_dw.exceptions import FabricError
 from fabric_dw.models import WarehouseKind
@@ -36,7 +36,6 @@ def warehouses_group() -> None:
 
 
 @warehouses_group.command("list")
-@click.argument("workspace", required=False, default=None)
 @click.option(
     "-A",
     "--all-workspaces",
@@ -56,27 +55,26 @@ def warehouses_group() -> None:
 @coro
 async def list_cmd(
     ctx: CliContext,
-    workspace: str | None,
     all_workspaces: bool,
     warehouses_only: bool,
 ) -> None:
-    """List all warehouses in WORKSPACE (name or GUID).
+    """List all warehouses in the target workspace.
+
+    The workspace comes from -w/--workspace (or the configured default).
 
     Lists both Warehouses and SQL Analytics Endpoints by default; pass
     --warehouses-only to exclude SQL Analytics Endpoints.
 
     Pass -A / --all-workspaces to scan every visible workspace instead.
-    WORKSPACE and --all-workspaces are mutually exclusive; exactly one is required.
+    -w/--workspace and --all-workspaces are mutually exclusive.
 
     The human-readable table omits the redundant Workspace ID column when a
     single workspace is targeted (every row shares it); -A keeps it because
     rows then span workspaces.  --json output always includes workspace_id.
     """
-    # Resolve the workspace default before the XOR validation so that a
-    # configured default-workspace (env / config file) is honoured when no
-    # positional arg is passed but --all-workspaces is also absent.
-    resolved_workspace = None if all_workspaces else resolve_workspace_arg(ctx, workspace)
-    validate_workspace_or_all_workspaces(resolved_workspace, all_workspaces)
+    # An explicit -w clashes with -A; a configured default does not (so -A
+    # always wins over a default and only the explicit flag is a conflict).
+    validate_workspace_option_or_all_workspaces(ctx.workspace, all_workspaces)
     try:
         async with build_http_client(ctx) as http:
             if all_workspaces:
@@ -84,11 +82,8 @@ async def list_cmd(
                     http, warehouses_only=warehouses_only
                 )
             else:
-                # resolved_workspace is guaranteed non-None by validate_workspace_or_all_workspaces
-                if resolved_workspace is None:  # pragma: no cover — defensive
-                    raise click.UsageError("Provide WORKSPACE or pass --all-workspaces / -A.")
                 resolver, _ = make_resolver(http)
-                ws_id = await resolver.workspace_id(resolved_workspace)
+                ws_id = await resolver.workspace_id(resolve_workspace(ctx))
                 items = await _warehouses_svc.list_warehouses(
                     http, ws_id, warehouses_only=warehouses_only
                 )
@@ -111,13 +106,12 @@ async def list_cmd(
 
 
 @warehouses_group.command("get")
-@click.argument("workspace", required=False, default=None)
 @click.argument("warehouse", required=False, default=None)
 @click.pass_obj
 @coro
-async def get_cmd(ctx: CliContext, workspace: str | None, warehouse: str | None) -> None:
-    """Get details for WAREHOUSE in WORKSPACE (both accept name or GUID)."""
-    ws = resolve_workspace_arg(ctx, workspace)
+async def get_cmd(ctx: CliContext, warehouse: str | None) -> None:
+    """Get details for WAREHOUSE (name or GUID) in the target workspace."""
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, warehouse)
     try:
         async with build_http_client(ctx) as http:
@@ -134,7 +128,6 @@ async def get_cmd(ctx: CliContext, workspace: str | None, warehouse: str | None)
 
 
 @warehouses_group.command("create")
-@click.argument("workspace", required=False, default=None)
 @click.argument("name")
 @click.option("--collation", default=None, help="Default collation for the warehouse.")
 @click.option("--description", default=None, help="Description for the warehouse.")
@@ -142,13 +135,12 @@ async def get_cmd(ctx: CliContext, workspace: str | None, warehouse: str | None)
 @coro
 async def create_cmd(
     ctx: CliContext,
-    workspace: str | None,
     name: str,
     collation: str | None,
     description: str | None,
 ) -> None:
-    """Create a new warehouse named NAME in WORKSPACE (name or GUID)."""
-    ws = resolve_workspace_arg(ctx, workspace)
+    """Create a new warehouse named NAME in the target workspace."""
+    ws = resolve_workspace(ctx)
     try:
         async with build_http_client(ctx) as http:
             resolver, _ = make_resolver(http)
@@ -169,7 +161,6 @@ async def create_cmd(
 
 
 @warehouses_group.command("rename")
-@click.argument("workspace", required=False, default=None)
 @click.argument("warehouse", required=False, default=None)
 @click.argument("new_name")
 @click.option("--description", default=None, help="Optional new description.")
@@ -177,13 +168,12 @@ async def create_cmd(
 @coro
 async def rename_cmd(
     ctx: CliContext,
-    workspace: str | None,
     warehouse: str | None,
     new_name: str,
     description: str | None,
 ) -> None:
-    """Rename WAREHOUSE in WORKSPACE to NEW_NAME (workspace and warehouse accept name or GUID)."""
-    ws = resolve_workspace_arg(ctx, workspace)
+    """Rename WAREHOUSE (name or GUID) to NEW_NAME in the target workspace."""
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, warehouse)
     try:
         async with build_http_client(ctx) as http:
@@ -212,13 +202,12 @@ async def rename_cmd(
 
 
 @warehouses_group.command("delete")
-@click.argument("workspace", required=False, default=None)
 @click.argument("warehouse", required=False, default=None)
 @click.pass_obj
 @coro
-async def delete_cmd(ctx: CliContext, workspace: str | None, warehouse: str | None) -> None:
-    """Delete WAREHOUSE from WORKSPACE (both accept name or GUID)."""
-    ws = resolve_workspace_arg(ctx, workspace)
+async def delete_cmd(ctx: CliContext, warehouse: str | None) -> None:
+    """Delete WAREHOUSE (name or GUID) from the target workspace."""
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, warehouse)
     try:
         async with build_http_client(ctx) as http:
@@ -248,16 +237,15 @@ async def delete_cmd(ctx: CliContext, workspace: str | None, warehouse: str | No
 
 
 @warehouses_group.command("takeover")
-@click.argument("workspace", required=False, default=None)
 @click.argument("warehouse", required=False, default=None)
 @click.pass_obj
 @coro
-async def takeover_cmd(ctx: CliContext, workspace: str | None, warehouse: str | None) -> None:
-    """Take ownership of WAREHOUSE in WORKSPACE (both accept name or GUID).
+async def takeover_cmd(ctx: CliContext, warehouse: str | None) -> None:
+    """Take ownership of WAREHOUSE (name or GUID) in the target workspace.
 
     Not supported for SQL Analytics Endpoints.
     """
-    ws = resolve_workspace_arg(ctx, workspace)
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, warehouse)
     try:
         async with build_http_client(ctx) as http:
@@ -277,17 +265,16 @@ async def takeover_cmd(ctx: CliContext, workspace: str | None, warehouse: str | 
 
 
 @warehouses_group.command("permissions")
-@click.argument("workspace", required=False, default=None)
 @click.argument("warehouse", required=False, default=None)
 @click.pass_obj
 @coro
-async def permissions_cmd(ctx: CliContext, workspace: str | None, warehouse: str | None) -> None:
-    """List principals with access to WAREHOUSE in WORKSPACE (both accept name or GUID).
+async def permissions_cmd(ctx: CliContext, warehouse: str | None) -> None:
+    """List principals with access to WAREHOUSE (name or GUID) in the target workspace.
 
     Requires Fabric Administrator role.
     See https://learn.microsoft.com/en-us/fabric/admin/microsoft-fabric-admin for details.
     """
-    ws = resolve_workspace_arg(ctx, workspace)
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, warehouse)
     try:
         async with build_http_client(ctx) as http:

--- a/tests/unit/cli/commands/test_sql_endpoints.py
+++ b/tests/unit/cli/commands/test_sql_endpoints.py
@@ -107,7 +107,7 @@ class TestEndpointsList:
                 new=AsyncMock(return_value=WS_UUID),
             ),
         ):
-            result = runner.invoke(cli, ["sql-endpoints", "list", WS_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "sql-endpoints", "list"])
         assert result.exit_code == 0
 
     def test_list_json_output(self, runner: CliRunner, cache_env: Path) -> None:
@@ -138,7 +138,7 @@ class TestEndpointsList:
                 new=AsyncMock(return_value=WS_UUID),
             ),
         ):
-            result = runner.invoke(cli, ["--json", "sql-endpoints", "list", WS_GUID])
+            result = runner.invoke(cli, ["--json", "-w", WS_GUID, "sql-endpoints", "list"])
         assert result.exit_code == 0
         parsed = json.loads(result.output)
         assert isinstance(parsed, list)
@@ -181,7 +181,9 @@ class TestEndpointsListColumns:
             ),
         ):
             # Force a wide console so Rich does not truncate the header text.
-            result = runner.invoke(cli, ["sql-endpoints", "list", WS_GUID], env={"COLUMNS": "200"})
+            result = runner.invoke(
+                cli, ["-w", WS_GUID, "sql-endpoints", "list"], env={"COLUMNS": "200"}
+            )
         assert result.exit_code == 0
         out = result.output
         assert "kind" not in out
@@ -241,7 +243,7 @@ class TestEndpointsListColumns:
                 new=AsyncMock(return_value=WS_UUID),
             ),
         ):
-            result = runner.invoke(cli, ["--json", "sql-endpoints", "list", WS_GUID])
+            result = runner.invoke(cli, ["--json", "-w", WS_GUID, "sql-endpoints", "list"])
         assert result.exit_code == 0
         parsed = json.loads(result.output)
         assert isinstance(parsed, list)
@@ -293,7 +295,7 @@ class TestEndpointsListAllWorkspaces:
             "fabric_dw.cli.commands.sql_endpoints.build_http_client",
             new=_make_cm(mock_http, None),
         ):
-            result = runner.invoke(cli, ["sql-endpoints", "list", WS_GUID, "-A"])
+            result = runner.invoke(cli, ["-w", WS_GUID, "sql-endpoints", "list", "-A"])
         assert result.exit_code != 0
 
     def test_list_uses_config_default_workspace(
@@ -339,7 +341,7 @@ class TestEndpointsGet:
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
             ),
         ):
-            result = runner.invoke(cli, ["sql-endpoints", "get", WS_GUID, EP_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "sql-endpoints", "get", EP_GUID])
         assert result.exit_code == 0
 
     def test_get_not_found_returns_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
@@ -355,7 +357,7 @@ class TestEndpointsGet:
                 new=AsyncMock(side_effect=NotFoundError("endpoint not found")),
             ),
         ):
-            result = runner.invoke(cli, ["sql-endpoints", "get", WS_GUID, EP_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "sql-endpoints", "get", EP_GUID])
         assert result.exit_code != 0
 
     def test_get_human_output_shows_default_collation(
@@ -375,7 +377,7 @@ class TestEndpointsGet:
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
             ),
         ):
-            result = runner.invoke(cli, ["sql-endpoints", "get", WS_GUID, EP_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "sql-endpoints", "get", EP_GUID])
         assert result.exit_code == 0, result.output
         assert FABRIC_DEFAULT_COLLATION in result.output
         assert "(default)" in result.output
@@ -397,7 +399,7 @@ class TestEndpointsGet:
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
             ),
         ):
-            result = runner.invoke(cli, ["--json", "sql-endpoints", "get", WS_GUID, EP_GUID])
+            result = runner.invoke(cli, ["--json", "-w", WS_GUID, "sql-endpoints", "get", EP_GUID])
         assert result.exit_code == 0, result.output
         parsed = json.loads(result.output)
         assert parsed["defaultCollation"] is None
@@ -421,7 +423,7 @@ class TestEndpointsGet:
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
             ),
         ):
-            result = runner.invoke(cli, ["sql-endpoints", "get", WS_GUID, EP_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "sql-endpoints", "get", EP_GUID])
         assert result.exit_code == 0, result.output
         assert "Latin1_General_100_CI_AS_KS_WS_SC_UTF8" in result.output
         assert "(default)" not in result.output
@@ -472,7 +474,7 @@ class TestEndpointsRefresh:
                 new=AsyncMock(return_value=_make_table_sync_statuses()),
             ),
         ):
-            result = runner.invoke(cli, ["sql-endpoints", "refresh", WS_GUID, EP_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "sql-endpoints", "refresh", EP_GUID])
         assert result.exit_code == 0
 
     def test_refresh_default_renders_rich_table(self, runner: CliRunner, cache_env: Path) -> None:
@@ -494,7 +496,7 @@ class TestEndpointsRefresh:
                 new=AsyncMock(return_value=_make_table_sync_statuses()),
             ),
         ):
-            result = runner.invoke(cli, ["sql-endpoints", "refresh", WS_GUID, EP_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "sql-endpoints", "refresh", EP_GUID])
         assert result.exit_code == 0
         # Rich table output must not be valid JSON
         try:
@@ -523,7 +525,9 @@ class TestEndpointsRefresh:
                 new=AsyncMock(return_value=_make_table_sync_statuses()),
             ),
         ):
-            result = runner.invoke(cli, ["--json", "sql-endpoints", "refresh", WS_GUID, EP_GUID])
+            result = runner.invoke(
+                cli, ["--json", "-w", WS_GUID, "sql-endpoints", "refresh", EP_GUID]
+            )
         assert result.exit_code == 0
         parsed = json.loads(result.output)
         assert isinstance(parsed, list)
@@ -555,7 +559,7 @@ class TestEndpointsRefresh:
         ):
             result = runner.invoke(
                 cli,
-                ["sql-endpoints", "refresh", "--recreate-tables", WS_GUID, EP_GUID],
+                ["-w", WS_GUID, "sql-endpoints", "refresh", "--recreate-tables", EP_GUID],
             )
         assert result.exit_code == 0
         mock_refresh.assert_called_once()
@@ -584,7 +588,7 @@ class TestEndpointsRefresh:
                 new=mock_refresh,
             ),
         ):
-            result = runner.invoke(cli, ["sql-endpoints", "refresh", WS_GUID, EP_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "sql-endpoints", "refresh", EP_GUID])
         assert result.exit_code == 0
         mock_refresh.assert_called_once()
         _, kwargs = mock_refresh.call_args
@@ -603,7 +607,7 @@ class TestEndpointsRefresh:
                 new=AsyncMock(side_effect=NotFoundError("endpoint not found")),
             ),
         ):
-            result = runner.invoke(cli, ["sql-endpoints", "refresh", WS_GUID, EP_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "sql-endpoints", "refresh", EP_GUID])
         assert result.exit_code != 0
 
 
@@ -627,7 +631,7 @@ class TestEndpointsPermissions:
                 new=AsyncMock(return_value=[]),
             ),
         ):
-            result = runner.invoke(cli, ["sql-endpoints", "permissions", WS_GUID, EP_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "sql-endpoints", "permissions", EP_GUID])
         assert result.exit_code == 0
 
 
@@ -658,7 +662,7 @@ class TestEndpointsStaleDefaultHint:
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """One positional arg + stale default → actionable message, not a raw 404."""
+        """No ENDPOINT positional + stale default → actionable message, not a raw 404."""
         _configure_default_warehouse(runner, monkeypatch, tmp_path)
         mock_http = AsyncMock()
         with (
@@ -676,15 +680,15 @@ class TestEndpointsStaleDefaultHint:
                 ),
             ),
         ):
-            # Only ONE positional arg — the endpoint comes from the stale default.
-            result = runner.invoke(cli, ["sql-endpoints", command, WS_GUID])
+            # No ENDPOINT positional — the endpoint comes from the stale default.
+            result = runner.invoke(cli, ["-w", WS_GUID, "sql-endpoints", command])
         assert result.exit_code != 0
         out = result.output
         assert "configured default" in out
         assert "different" in out
         assert WS_GUID in out
         assert _STALE_DEFAULT_GUID in out
-        assert "second argument" in out
+        assert "ENDPOINT argument" in out
         # The cryptic raw 404 body must NOT leak through.
         assert "EntityNotFound" not in out
 
@@ -704,7 +708,7 @@ class TestEndpointsStaleDefaultHint:
                 new=AsyncMock(side_effect=NotFoundError("endpoint not found")),
             ),
         ):
-            result = runner.invoke(cli, ["sql-endpoints", "permissions", WS_GUID, EP_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "sql-endpoints", "permissions", EP_GUID])
         assert result.exit_code != 0
         # The friendly stale-default wording must NOT appear for an explicit arg.
         assert "configured default" not in result.output

--- a/tests/unit/cli/commands/test_utils.py
+++ b/tests/unit/cli/commands/test_utils.py
@@ -549,8 +549,9 @@ class TestResolveWarehouseArgErrorMessage:
         monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
         monkeypatch.delenv("FABRIC_DW_DEFAULT_WORKSPACE", raising=False)
         monkeypatch.delenv("FABRIC_DW_DEFAULT_WAREHOUSE", raising=False)
-        # warehouses get requires WORKSPACE and WAREHOUSE; supply workspace but omit warehouse.
-        result = runner.invoke(cli, ["warehouses", "get", WS_GUID])
+        # warehouses get needs a workspace (-w) and a WAREHOUSE; supply the
+        # workspace via -w but omit the warehouse positional.
+        result = runner.invoke(cli, ["-w", WS_GUID, "warehouses", "get"])
         assert result.exit_code != 0
         output = result.output
         assert "no warehouse specified" in output

--- a/tests/unit/cli/commands/test_warehouses.py
+++ b/tests/unit/cli/commands/test_warehouses.py
@@ -82,7 +82,7 @@ class TestWarehousesList:
                 new=AsyncMock(return_value=WS_UUID),
             ),
         ):
-            result = runner.invoke(cli, ["warehouses", "list", WS_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "warehouses", "list"])
         assert result.exit_code == 0
         # iter_paginated must have been called with a URL containing the resolved workspace UUID,
         # proving workspace resolution happened and the list call reached the service layer.
@@ -118,7 +118,7 @@ class TestWarehousesList:
                 new=AsyncMock(return_value=WS_UUID),
             ),
         ):
-            result = runner.invoke(cli, ["--json", "warehouses", "list", WS_GUID])
+            result = runner.invoke(cli, ["--json", "-w", WS_GUID, "warehouses", "list"])
         assert result.exit_code == 0
         parsed = json.loads(result.output)
         assert isinstance(parsed, list)
@@ -158,7 +158,7 @@ class TestWarehousesListHideWorkspaceId:
                 new=AsyncMock(return_value=WS_UUID),
             ),
         ):
-            result = runner.invoke(cli, ["warehouses", "list", WS_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "warehouses", "list"])
         assert result.exit_code == 0, result.output
         # The warehouse id (GUID column, full width) is shown, but the
         # redundant workspace GUID column is dropped.  Asserting on the GUIDs is
@@ -188,7 +188,7 @@ class TestWarehousesListHideWorkspaceId:
                 new=AsyncMock(return_value=WS_UUID),
             ),
         ):
-            result = runner.invoke(cli, ["--json", "warehouses", "list", WS_GUID])
+            result = runner.invoke(cli, ["--json", "-w", WS_GUID, "warehouses", "list"])
         assert result.exit_code == 0, result.output
         parsed = json.loads(result.output)
         assert parsed[0]["workspaceId"] == WS_GUID
@@ -253,7 +253,7 @@ class TestWarehousesListWarehousesOnly:
             ),
         ):
             result = runner.invoke(
-                cli, ["--json", "warehouses", "list", WS_GUID, "--warehouses-only"]
+                cli, ["--json", "-w", WS_GUID, "warehouses", "list", "--warehouses-only"]
             )
         assert result.exit_code == 0, result.output
         # Only the /warehouses endpoint may be paged — never /sqlEndpoints.
@@ -278,7 +278,7 @@ class TestWarehousesListWarehousesOnly:
                 new=AsyncMock(return_value=WS_UUID),
             ),
         ):
-            result = runner.invoke(cli, ["--json", "warehouses", "list", WS_GUID])
+            result = runner.invoke(cli, ["--json", "-w", WS_GUID, "warehouses", "list"])
         assert result.exit_code == 0, result.output
         called_paths = [c.args[1] for c in mock_http.iter_paginated.call_args_list if c.args]
         assert any("sqlEndpoints" in p for p in called_paths)
@@ -330,7 +330,7 @@ class TestWarehousesGet:
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
             ),
         ):
-            result = runner.invoke(cli, ["--json", "warehouses", "get", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["--json", "-w", WS_GUID, "warehouses", "get", WH_GUID])
         assert result.exit_code == 0
         parsed = json.loads(result.output)
         assert parsed["displayName"] == "SalesWarehouse"
@@ -349,7 +349,7 @@ class TestWarehousesGet:
                 new=AsyncMock(side_effect=NotFoundError("not found")),
             ),
         ):
-            result = runner.invoke(cli, ["warehouses", "get", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "warehouses", "get", WH_GUID])
         assert result.exit_code != 0
 
 
@@ -397,7 +397,7 @@ class TestWarehousesGetCollationDefault:
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
             ),
         ):
-            args = ["warehouses", "get", WS_GUID, WH_GUID]
+            args = ["-w", WS_GUID, "warehouses", "get", WH_GUID]
             if json_flag:
                 args = ["--json", *args]
             result = runner.invoke(cli, args)
@@ -464,7 +464,7 @@ class TestWarehousesCreate:
                 new=AsyncMock(return_value=WS_UUID),
             ),
         ):
-            result = runner.invoke(cli, ["warehouses", "create", WS_GUID, "NewWarehouse"])
+            result = runner.invoke(cli, ["-w", WS_GUID, "warehouses", "create", "NewWarehouse"])
         assert result.exit_code == 0
 
 
@@ -490,7 +490,7 @@ class TestWarehousesRename:
         ):
             result = runner.invoke(
                 cli,
-                ["--json", "--yes", "warehouses", "rename", WS_GUID, WH_GUID, "NewName"],
+                ["--json", "--yes", "-w", WS_GUID, "warehouses", "rename", WH_GUID, "NewName"],
             )
         assert result.exit_code == 0
         mock_rename.assert_awaited_once()
@@ -514,7 +514,7 @@ class TestWarehousesRename:
         ):
             result = runner.invoke(
                 cli,
-                ["warehouses", "rename", WS_GUID, WH_GUID, "NewName"],
+                ["-w", WS_GUID, "warehouses", "rename", WH_GUID, "NewName"],
                 input="n\n",
             )
         assert result.exit_code == 0
@@ -541,7 +541,7 @@ class TestWarehousesDelete:
             ),
             patch("fabric_dw.services.warehouses.delete", new=mock_delete),
         ):
-            result = runner.invoke(cli, ["--yes", "warehouses", "delete", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["--yes", "-w", WS_GUID, "warehouses", "delete", WH_GUID])
         assert result.exit_code == 0
         mock_delete.assert_awaited_once()
 
@@ -560,7 +560,9 @@ class TestWarehousesDelete:
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry(), _cache)),
             ),
         ):
-            result = runner.invoke(cli, ["warehouses", "delete", WS_GUID, WH_GUID], input="n\n")
+            result = runner.invoke(
+                cli, ["-w", WS_GUID, "warehouses", "delete", WH_GUID], input="n\n"
+            )
         assert result.exit_code == 0
         assert "Aborted." in result.output
 
@@ -581,7 +583,7 @@ class TestWarehousesDelete:
             ),
         ):
             result = runner.invoke(
-                cli, ["--yes", "--json", "warehouses", "delete", WS_GUID, WH_GUID]
+                cli, ["--yes", "--json", "-w", WS_GUID, "warehouses", "delete", WH_GUID]
             )
         assert result.exit_code == 0
         parsed = json.loads(result.output)
@@ -631,7 +633,7 @@ class TestWarehousesListAllWorkspaces:
             "fabric_dw.cli.commands.warehouses.build_http_client",
             new=_make_cm(mock_http, None),
         ):
-            result = runner.invoke(cli, ["warehouses", "list", WS_GUID, "-A"])
+            result = runner.invoke(cli, ["-w", WS_GUID, "warehouses", "list", "-A"])
         assert result.exit_code != 0
 
 
@@ -654,7 +656,7 @@ class TestWarehousesTakeover:
             ),
             patch("fabric_dw.services.ownership.takeover", new=mock_takeover),
         ):
-            result = runner.invoke(cli, ["--yes", "warehouses", "takeover", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["--yes", "-w", WS_GUID, "warehouses", "takeover", WH_GUID])
         assert result.exit_code == 0
         mock_takeover.assert_awaited_once()
 
@@ -671,7 +673,7 @@ class TestWarehousesTakeover:
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry(WarehouseKind.SQL_ENDPOINT))),
             ),
         ):
-            result = runner.invoke(cli, ["--yes", "warehouses", "takeover", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["--yes", "-w", WS_GUID, "warehouses", "takeover", WH_GUID])
         assert result.exit_code != 0
         assert "SQL Analytics Endpoint" in result.output
 
@@ -703,7 +705,7 @@ class TestWarehousesDefaultFallback:
                 new=AsyncMock(return_value=WS_UUID),
             ),
         ):
-            result = runner.invoke(cli, ["--json", "warehouses", "list", WS_GUID])
+            result = runner.invoke(cli, ["--json", "-w", WS_GUID, "warehouses", "list"])
         assert result.exit_code == 0
         # Empty list renders as valid JSON array when no warehouses exist
         parsed = json.loads(result.output)
@@ -765,7 +767,7 @@ class TestWarehousesListFabricError:
                 new=AsyncMock(side_effect=FabricError("server error")),
             ),
         ):
-            result = runner.invoke(cli, ["warehouses", "list", WS_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "warehouses", "list"])
         assert result.exit_code != 0
 
 
@@ -789,7 +791,7 @@ class TestWarehousesCreateError:
                 new=AsyncMock(side_effect=FabricError("server error")),
             ),
         ):
-            result = runner.invoke(cli, ["warehouses", "create", WS_GUID, "NewWarehouse"])
+            result = runner.invoke(cli, ["-w", WS_GUID, "warehouses", "create", "NewWarehouse"])
         assert result.exit_code != 0
 
 
@@ -816,7 +818,7 @@ class TestWarehousesRenameError:
         ):
             result = runner.invoke(
                 cli,
-                ["--yes", "warehouses", "rename", WS_GUID, WH_GUID, "NewName"],
+                ["--yes", "-w", WS_GUID, "warehouses", "rename", WH_GUID, "NewName"],
             )
         assert result.exit_code != 0
 
@@ -842,7 +844,7 @@ class TestWarehousesDeleteError:
                 new=AsyncMock(side_effect=FabricError("server error")),
             ),
         ):
-            result = runner.invoke(cli, ["--yes", "warehouses", "delete", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["--yes", "-w", WS_GUID, "warehouses", "delete", WH_GUID])
         assert result.exit_code != 0
 
 
@@ -865,7 +867,7 @@ class TestWarehousesTakeoverErrors:
                 new=AsyncMock(side_effect=FabricError("resolve error")),
             ),
         ):
-            result = runner.invoke(cli, ["--yes", "warehouses", "takeover", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["--yes", "-w", WS_GUID, "warehouses", "takeover", WH_GUID])
         assert result.exit_code != 0
 
     def test_takeover_declined_prints_aborted(self, runner: CliRunner, cache_env: Path) -> None:
@@ -884,7 +886,7 @@ class TestWarehousesTakeoverErrors:
         ):
             result = runner.invoke(
                 cli,
-                ["warehouses", "takeover", WS_GUID, WH_GUID],
+                ["-w", WS_GUID, "warehouses", "takeover", WH_GUID],
                 input="n\n",
             )
         assert result.exit_code == 0
@@ -910,7 +912,7 @@ class TestWarehousesTakeoverErrors:
                 new=AsyncMock(side_effect=FabricError("takeover failed")),
             ),
         ):
-            result = runner.invoke(cli, ["--yes", "warehouses", "takeover", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["--yes", "-w", WS_GUID, "warehouses", "takeover", WH_GUID])
         assert result.exit_code != 0
 
 
@@ -958,7 +960,9 @@ class TestWarehousesPermissions:
                 new=AsyncMock(return_value=[access]),
             ),
         ):
-            result = runner.invoke(cli, ["--json", "warehouses", "permissions", WS_GUID, WH_GUID])
+            result = runner.invoke(
+                cli, ["--json", "-w", WS_GUID, "warehouses", "permissions", WH_GUID]
+            )
         assert result.exit_code == 0
         parsed = json.loads(result.output)
         assert isinstance(parsed, list)
@@ -980,7 +984,7 @@ class TestWarehousesPermissions:
                 new=AsyncMock(side_effect=FabricError("server error")),
             ),
         ):
-            result = runner.invoke(cli, ["warehouses", "permissions", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "warehouses", "permissions", WH_GUID])
         assert result.exit_code != 0
 
 
@@ -1042,7 +1046,7 @@ class TestTakeoverSingleHttpOpen:
                 new=AsyncMock(return_value=None),
             ),
         ):
-            result = runner.invoke(cli, ["--yes", "warehouses", "takeover", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["--yes", "-w", WS_GUID, "warehouses", "takeover", WH_GUID])
 
         assert result.exit_code == 0, result.output
         assert open_count == 1, f"build_http_client opened {open_count} times, expected 1"

--- a/tests/unit/cli/commands/test_warehouses.py
+++ b/tests/unit/cli/commands/test_warehouses.py
@@ -222,6 +222,49 @@ class TestWarehousesListHideWorkspaceId:
         assert WS_GUID in result.output
 
 
+class TestWarehousesListAllWithConfigDefault:
+    """-A must NOT clash with a configured-default workspace (only explicit -w conflicts)."""
+
+    def test_all_workspaces_with_config_default_exits_zero(
+        self,
+        runner: CliRunner,
+        cache_env: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Passing -A together with a configured default workspace must succeed.
+
+        The mutual-exclusion guard only fires when an explicit -w is supplied.
+        A workspace set via FABRIC_DW_DEFAULT_WORKSPACE (or config-file default)
+        is NOT the same as an explicit -w, so -A must win and the command must
+        exit 0.
+        """
+        _ = cache_env
+        # Simulate a configured default workspace via the environment variable.
+        monkeypatch.setenv("FABRIC_DW_DEFAULT_WORKSPACE", WS_GUID)
+        wh = Warehouse.model_validate(
+            {
+                "id": WH_GUID,
+                "displayName": "SalesWarehouse",
+                "workspaceId": WS_GUID,
+                "kind": WarehouseKind.WAREHOUSE,
+            }
+        )
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.warehouses.build_http_client",
+                new=_make_cm(mock_http, None),
+            ),
+            patch(
+                "fabric_dw.services.warehouses.list_all_workspaces",
+                new=AsyncMock(return_value=[wh]),
+            ),
+        ):
+            # No -w flag; the workspace default is set only via env var.
+            result = runner.invoke(cli, ["warehouses", "list", "-A"])
+        assert result.exit_code == 0, result.output
+
+
 class TestWarehousesListWarehousesOnly:
     """(b) --warehouses-only excludes SQL endpoints and skips the sqlEndpoints fetch."""
 

--- a/tests/unit/cli/commands/test_warehouses_respx.py
+++ b/tests/unit/cli/commands/test_warehouses_respx.py
@@ -122,7 +122,7 @@ class TestWarehousesGetRespx:
                 "fabric_dw.cli.commands.warehouses.build_http_client",
                 new=_real_http_client_cm,
             ):
-                result = runner.invoke(cli, ["--json", "warehouses", "get", WS_GUID, WH_GUID])
+                result = runner.invoke(cli, ["--json", "-w", WS_GUID, "warehouses", "get", WH_GUID])
 
         assert result.exit_code == 0, result.output
         # Verify the exact URLs were called (wire validation)
@@ -151,7 +151,7 @@ class TestWarehousesGetRespx:
                 "fabric_dw.cli.commands.warehouses.build_http_client",
                 new=_real_http_client_cm,
             ):
-                result = runner.invoke(cli, ["warehouses", "get", WS_GUID, WH_GUID])
+                result = runner.invoke(cli, ["-w", WS_GUID, "warehouses", "get", WH_GUID])
 
         assert result.exit_code == 0, result.output
         # Every captured request must have an Authorization header
@@ -191,7 +191,7 @@ class TestWarehousesDeleteRespx:
             ):
                 result = runner.invoke(
                     cli,
-                    ["--yes", "warehouses", "delete", WS_GUID, WH_GUID],
+                    ["--yes", "-w", WS_GUID, "warehouses", "delete", WH_GUID],
                 )
 
         assert result.exit_code == 0, result.output
@@ -240,9 +240,10 @@ class TestWarehousesRenameRespx:
                     [
                         "--json",
                         "--yes",
+                        "-w",
+                        WS_GUID,
                         "warehouses",
                         "rename",
-                        WS_GUID,
                         WH_GUID,
                         "RenamedWarehouse",
                     ],


### PR DESCRIPTION
## What

Convert the `warehouses` and `sql-endpoints` command clusters to the global `-w/--workspace` root option instead of a leading positional `WORKSPACE` argument.

Each command drops its `@click.argument("workspace", ...)` decorator and the `workspace` callback parameter, resolving the target workspace via the core `resolve_workspace(ctx)` helper (precedence: explicit `-w` -> `FABRIC_DW_DEFAULT_WORKSPACE` -> config default -> `UsageError`). The remaining positional (warehouse / item / endpoint) becomes the leading positional.

The two `list` commands now use the core `validate_workspace_option_or_all_workspaces` helper for the `-w`-vs-`-A` contract: an explicit `-w` (`ctx.workspace is not None`) clashes with `-A`, while a configured default does not (so `-A` always wins over a default). The existing list rendering behaviour (column-stripping / `drop_columns`) is preserved.

## Converted commands

- **warehouses**: `list`, `get`, `create`, `rename`, `delete`, `takeover`, `permissions`
- **sql-endpoints**: `list`, `get`, `refresh`, `permissions`

## Breaking change

The `warehouses` and `sql-endpoints` subcommands no longer accept `WORKSPACE` as a positional argument. Pass the workspace with the global `-w/--workspace` option (or rely on `FABRIC_DW_DEFAULT_WORKSPACE` / the configured default) instead:

```
# before
fabric-dw warehouses get <workspace> <warehouse>
# after
fabric-dw -w <workspace> warehouses get <warehouse>
```

## Notes

- Unit-validated; `just check` (ruff + ty + unit) is clean (3424 passed).
- One out-of-cluster test (`tests/unit/cli/commands/test_utils.py`) used `warehouses get` as a vehicle to exercise the `resolve_warehouse_arg` error message; its invocation was realigned to the new `-w` shape (no core/helper logic changed).
- Docs (`docs/cli.md`, `README`, changelog) are intentionally NOT touched here; a separate docs sweep will cover them.
- No `integration` label: the integration smoke test relies on env defaults and is unaffected by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)