### PR TITLE
refactor(cli)!: procedures, functions, statistics, schemas take workspace via -w

### DIFF
--- a/src/fabric_dw/cli/commands/functions.py
+++ b/src/fabric_dw/cli/commands/functions.py
@@ -18,7 +18,7 @@ from fabric_dw.cli.commands._utils import (
     load_sql_body,
     parse_qualified_name,
     resolve_warehouse_arg,
-    resolve_workspace_arg,
+    resolve_workspace,
 )
 from fabric_dw.exceptions import FabricError
 from fabric_dw.services import functions as _fns_svc
@@ -35,7 +35,6 @@ def functions_group() -> None:
 
 
 @functions_group.command("list")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.option("--schema", default=None, help="Filter by schema name.")
 @click.option(
@@ -49,13 +48,12 @@ def functions_group() -> None:
 @coro
 async def list_cmd(
     ctx: CliContext,
-    workspace: str | None,
     item: str | None,
     schema: str | None,
     kind: str,
 ) -> None:
-    """List T-SQL user-defined functions on ITEM (warehouse or SQL endpoint) in WORKSPACE."""
-    ws = resolve_workspace_arg(ctx, workspace)
+    """List T-SQL user-defined functions on ITEM (warehouse or SQL endpoint)."""
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     try:
         async with build_http_client(ctx) as http:
@@ -76,19 +74,17 @@ async def list_cmd(
 
 
 @functions_group.command("get")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.argument("qualified_name")
 @click.pass_obj
 @coro
 async def get_cmd(
     ctx: CliContext,
-    workspace: str | None,
     item: str | None,
     qualified_name: str,
 ) -> None:
-    """Fetch the full definition of QUALIFIED_NAME (schema.fn) on ITEM in WORKSPACE."""
-    ws = resolve_workspace_arg(ctx, workspace)
+    """Fetch the full definition of QUALIFIED_NAME (schema.fn) on ITEM."""
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     schema, fn_name = parse_qualified_name(qualified_name, kind="function")
     try:
@@ -101,7 +97,6 @@ async def get_cmd(
 
 
 @functions_group.command("create")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.option("--name", "qualified_name", required=True, help="Qualified name: schema.fn.")
 @click.option("--body", "body", default=None, help="Inline function body.")
@@ -110,13 +105,12 @@ async def get_cmd(
 @coro
 async def create_cmd(
     ctx: CliContext,
-    workspace: str | None,
     item: str | None,
     qualified_name: str,
     body: str | None,
     from_file: str | None,
 ) -> None:
-    """Create a new T-SQL user-defined function QUALIFIED_NAME on ITEM in WORKSPACE.
+    """Create a new T-SQL user-defined function QUALIFIED_NAME on ITEM.
 
     The body should include the parameter list, RETURNS clause, and function body
     (everything after CREATE FUNCTION [schema].[name]).
@@ -124,7 +118,7 @@ async def create_cmd(
     Scalar UDFs and inline TVFs are preview features as of mid-2026.
     Function DDL is supported on both Data Warehouses and SQL Analytics Endpoints.
     """
-    ws = resolve_workspace_arg(ctx, workspace)
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     schema, fn_name = parse_qualified_name(qualified_name, kind="function")
     fn_body = load_sql_body(body, from_file, inline_opt="--body")
@@ -138,7 +132,6 @@ async def create_cmd(
 
 
 @functions_group.command("update")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.argument("qualified_name")
 @click.option("--body", "body", default=None, help="Inline function body.")
@@ -147,18 +140,17 @@ async def create_cmd(
 @coro
 async def update_cmd(
     ctx: CliContext,
-    workspace: str | None,
     item: str | None,
     qualified_name: str,
     body: str | None,
     from_file: str | None,
 ) -> None:
-    """Redefine QUALIFIED_NAME (schema.fn) on ITEM in WORKSPACE via CREATE OR ALTER FUNCTION.
+    """Redefine QUALIFIED_NAME (schema.fn) on ITEM via CREATE OR ALTER FUNCTION.
 
     Note: ALTER FUNCTION cannot change the function kind (e.g. scalar to inline TVF).
     You will be asked to confirm unless --yes is passed.
     """
-    ws = resolve_workspace_arg(ctx, workspace)
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     schema, fn_name = parse_qualified_name(qualified_name, kind="function")
     fn_body = load_sql_body(body, from_file, inline_opt="--body")
@@ -179,7 +171,6 @@ async def update_cmd(
 
 
 @functions_group.command("drop")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.argument("qualified_name")
 @click.option(
@@ -192,16 +183,15 @@ async def update_cmd(
 @coro
 async def drop_cmd(
     ctx: CliContext,
-    workspace: str | None,
     item: str | None,
     qualified_name: str,
     if_exists: bool,
 ) -> None:
-    """Drop QUALIFIED_NAME (schema.fn) from ITEM in WORKSPACE.
+    """Drop QUALIFIED_NAME (schema.fn) from ITEM.
 
     You will be asked to confirm unless --yes is passed.
     """
-    ws = resolve_workspace_arg(ctx, workspace)
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     schema, fn_name = parse_qualified_name(qualified_name, kind="function")
     try:
@@ -225,7 +215,6 @@ async def drop_cmd(
 
 
 @functions_group.command("rename")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.argument("qualified_name")
 @click.option("--new-name", required=True, help="New bare (unqualified) function name.")
@@ -233,18 +222,17 @@ async def drop_cmd(
 @coro
 async def rename_cmd(
     ctx: CliContext,
-    workspace: str | None,
     item: str | None,
     qualified_name: str,
     new_name: str,
 ) -> None:
-    """Rename QUALIFIED_NAME (schema.fn) on ITEM in WORKSPACE to --new-name.
+    """Rename QUALIFIED_NAME (schema.fn) on ITEM to --new-name.
 
     Uses EXEC sp_rename. The new name must be a bare (unqualified) identifier;
     sp_rename cannot move a function to a different schema.
     You will be asked to confirm unless --yes is passed.
     """
-    ws = resolve_workspace_arg(ctx, workspace)
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     schema, fn_name = parse_qualified_name(qualified_name, kind="function")
     try:

--- a/src/fabric_dw/cli/commands/procedures.py
+++ b/src/fabric_dw/cli/commands/procedures.py
@@ -14,7 +14,7 @@ from fabric_dw.cli.commands._utils import (
     load_sql_body,
     parse_qualified_name,
     resolve_warehouse_arg,
-    resolve_workspace_arg,
+    resolve_workspace,
 )
 from fabric_dw.exceptions import FabricError
 from fabric_dw.services import procedures as _procs_svc
@@ -26,16 +26,13 @@ def procedures_group() -> None:
 
 
 @procedures_group.command("list")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.option("--schema", default=None, help="Filter by schema name.")
 @click.pass_obj
 @coro
-async def list_cmd(
-    ctx: CliContext, workspace: str | None, item: str | None, schema: str | None
-) -> None:
-    """List stored procedures on ITEM (warehouse or SQL endpoint) in WORKSPACE."""
-    ws = resolve_workspace_arg(ctx, workspace)
+async def list_cmd(ctx: CliContext, item: str | None, schema: str | None) -> None:
+    """List stored procedures on ITEM (warehouse or SQL endpoint)."""
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     try:
         async with build_http_client(ctx) as http:
@@ -51,19 +48,17 @@ async def list_cmd(
 
 
 @procedures_group.command("get")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.argument("qualified_name")
 @click.pass_obj
 @coro
 async def get_cmd(
     ctx: CliContext,
-    workspace: str | None,
     item: str | None,
     qualified_name: str,
 ) -> None:
-    """Fetch the full definition of QUALIFIED_NAME (schema.proc) on ITEM in WORKSPACE."""
-    ws = resolve_workspace_arg(ctx, workspace)
+    """Fetch the full definition of QUALIFIED_NAME (schema.proc) on ITEM."""
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     schema, proc_name = parse_qualified_name(qualified_name, kind="procedure")
     try:
@@ -76,7 +71,6 @@ async def get_cmd(
 
 
 @procedures_group.command("create")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.option("--name", "qualified_name", required=True, help="Qualified name: schema.proc.")
 @click.option("--body", "body", default=None, help="Inline procedure body.")
@@ -87,14 +81,13 @@ async def get_cmd(
 @coro
 async def create_cmd(
     ctx: CliContext,
-    workspace: str | None,
     item: str | None,
     qualified_name: str,
     body: str | None,
     from_file: str | None,
 ) -> None:
-    """Create a new stored procedure QUALIFIED_NAME on ITEM in WORKSPACE."""
-    ws = resolve_workspace_arg(ctx, workspace)
+    """Create a new stored procedure QUALIFIED_NAME on ITEM."""
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     schema, proc_name = parse_qualified_name(qualified_name, kind="procedure")
     proc_body = load_sql_body(body, from_file, inline_opt="--body")
@@ -110,7 +103,6 @@ async def create_cmd(
 
 
 @procedures_group.command("update")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.argument("qualified_name")
 @click.option("--body", "body", default=None, help="Inline procedure body.")
@@ -121,14 +113,13 @@ async def create_cmd(
 @coro
 async def update_cmd(
     ctx: CliContext,
-    workspace: str | None,
     item: str | None,
     qualified_name: str,
     body: str | None,
     from_file: str | None,
 ) -> None:
-    """Redefine QUALIFIED_NAME (schema.proc) on ITEM in WORKSPACE via CREATE OR ALTER PROCEDURE."""
-    ws = resolve_workspace_arg(ctx, workspace)
+    """Redefine QUALIFIED_NAME (schema.proc) on ITEM via CREATE OR ALTER PROCEDURE."""
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     schema, proc_name = parse_qualified_name(qualified_name, kind="procedure")
     proc_body = load_sql_body(body, from_file, inline_opt="--body")
@@ -151,19 +142,17 @@ async def update_cmd(
 
 
 @procedures_group.command("drop")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.argument("qualified_name")
 @click.pass_obj
 @coro
 async def drop_cmd(
     ctx: CliContext,
-    workspace: str | None,
     item: str | None,
     qualified_name: str,
 ) -> None:
-    """Drop QUALIFIED_NAME (schema.proc) from ITEM in WORKSPACE."""
-    ws = resolve_workspace_arg(ctx, workspace)
+    """Drop QUALIFIED_NAME (schema.proc) from ITEM."""
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     schema, proc_name = parse_qualified_name(qualified_name, kind="procedure")
     try:

--- a/src/fabric_dw/cli/commands/schemas.py
+++ b/src/fabric_dw/cli/commands/schemas.py
@@ -12,7 +12,7 @@ from fabric_dw.cli.commands._utils import (
     confirm_destructive,
     coro,
     resolve_warehouse_arg,
-    resolve_workspace_arg,
+    resolve_workspace,
 )
 from fabric_dw.exceptions import FabricError
 from fabric_dw.services import schemas as _schemas_svc
@@ -24,13 +24,12 @@ def schemas_group() -> None:
 
 
 @schemas_group.command("list")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.pass_obj
 @coro
-async def list_cmd(ctx: CliContext, workspace: str | None, item: str | None) -> None:
-    """List user-defined schemas on ITEM (warehouse) in WORKSPACE."""
-    ws = resolve_workspace_arg(ctx, workspace)
+async def list_cmd(ctx: CliContext, item: str | None) -> None:
+    """List user-defined schemas on ITEM (warehouse)."""
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     try:
         async with build_http_client(ctx) as http:
@@ -46,19 +45,17 @@ async def list_cmd(ctx: CliContext, workspace: str | None, item: str | None) -> 
 
 
 @schemas_group.command("create")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.argument("name")
 @click.pass_obj
 @coro
 async def create_cmd(
     ctx: CliContext,
-    workspace: str | None,
     item: str | None,
     name: str,
 ) -> None:
-    """Create a new SQL schema NAME on ITEM in WORKSPACE."""
-    ws = resolve_workspace_arg(ctx, workspace)
+    """Create a new SQL schema NAME on ITEM."""
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     try:
         async with build_http_client(ctx) as http:
@@ -70,7 +67,6 @@ async def create_cmd(
 
 
 @schemas_group.command("delete")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.argument("name")
 @click.option(
@@ -86,17 +82,16 @@ async def create_cmd(
 @coro
 async def delete_cmd(
     ctx: CliContext,
-    workspace: str | None,
     item: str | None,
     name: str,
     cascade: bool,
 ) -> None:
-    """Drop schema NAME from ITEM in WORKSPACE.
+    """Drop schema NAME from ITEM.
 
     Pass --cascade to also drop all tables and views inside the schema first.
     This is a destructive, irreversible operation.
     """
-    ws = resolve_workspace_arg(ctx, workspace)
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     try:
         async with build_http_client(ctx) as http:

--- a/src/fabric_dw/cli/commands/statistics.py
+++ b/src/fabric_dw/cli/commands/statistics.py
@@ -13,7 +13,7 @@ from fabric_dw.cli.commands._utils import (
     coro,
     parse_qualified_name,
     resolve_warehouse_arg,
-    resolve_workspace_arg,
+    resolve_workspace,
 )
 from fabric_dw.exceptions import FabricError
 from fabric_dw.services import statistics as _stats_svc
@@ -30,7 +30,6 @@ def statistics_group() -> None:
 
 
 @statistics_group.command("list")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.option("--schema", default=None, help="Filter by schema name.")
 @click.option("--table", default=None, help="Filter by table name (unqualified).")
@@ -50,15 +49,14 @@ def statistics_group() -> None:
 @coro
 async def list_cmd(
     ctx: CliContext,
-    workspace: str | None,
     item: str | None,
     schema: str | None,
     table: str | None,
     user_only: bool,
     auto_only: bool,
 ) -> None:
-    """List statistics on ITEM (warehouse or SQL endpoint) in WORKSPACE."""
-    ws = resolve_workspace_arg(ctx, workspace)
+    """List statistics on ITEM (warehouse or SQL endpoint)."""
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     try:
         async with build_http_client(ctx) as http:
@@ -81,7 +79,6 @@ async def list_cmd(
 
 
 @statistics_group.command("show")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.argument("qualified_table")
 @click.argument("stat_name")
@@ -96,18 +93,17 @@ async def list_cmd(
 @coro
 async def show_cmd(
     ctx: CliContext,
-    workspace: str | None,
     item: str | None,
     qualified_table: str,
     stat_name: str,
     histogram_only: bool,
 ) -> None:
-    """Show details of STAT_NAME on QUALIFIED_TABLE (schema.table) in WORKSPACE.
+    """Show details of STAT_NAME on QUALIFIED_TABLE (schema.table).
 
     Uses DBCC SHOW_STATISTICS with STAT_HEADER, DENSITY_VECTOR, and HISTOGRAM
     variants. Pass --histogram to show only the histogram steps.
     """
-    ws = resolve_workspace_arg(ctx, workspace)
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     parse_qualified_name(qualified_table, kind="table")
     try:
@@ -126,7 +122,6 @@ async def show_cmd(
 
 
 @statistics_group.command("create")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.option(
     "--table",
@@ -161,7 +156,6 @@ async def show_cmd(
 @coro
 async def create_cmd(
     ctx: CliContext,
-    workspace: str | None,
     item: str | None,
     qualified_table: str,
     column: str,
@@ -169,12 +163,12 @@ async def create_cmd(
     fullscan: bool,
     sample_percent: int | None,
 ) -> None:
-    """Create a statistic on --table (schema.table) on ITEM in WORKSPACE.
+    """Create a statistic on --table (schema.table) on ITEM.
 
     Only Data Warehouses support DDL; SQL Analytics Endpoints are read-only.
     Only single-column statistics are supported (Fabric limitation).
     """
-    ws = resolve_workspace_arg(ctx, workspace)
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     parse_qualified_name(qualified_table, kind="table")
     if stat_name is None:
@@ -198,7 +192,6 @@ async def create_cmd(
 
 
 @statistics_group.command("update")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.argument("qualified_table")
 @click.argument("stat_name")
@@ -220,18 +213,17 @@ async def create_cmd(
 @coro
 async def update_cmd(
     ctx: CliContext,
-    workspace: str | None,
     item: str | None,
     qualified_table: str,
     stat_name: str,
     fullscan: bool,
     sample_percent: int | None,
 ) -> None:
-    """Update STAT_NAME on QUALIFIED_TABLE (schema.table) on ITEM in WORKSPACE.
+    """Update STAT_NAME on QUALIFIED_TABLE (schema.table) on ITEM.
 
     Only Data Warehouses support DDL; SQL Analytics Endpoints are read-only.
     """
-    ws = resolve_workspace_arg(ctx, workspace)
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     parse_qualified_name(qualified_table, kind="table")
     try:
@@ -258,7 +250,6 @@ async def update_cmd(
 
 
 @statistics_group.command("delete")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.argument("qualified_table")
 @click.argument("stat_name")
@@ -266,16 +257,15 @@ async def update_cmd(
 @coro
 async def delete_cmd(
     ctx: CliContext,
-    workspace: str | None,
     item: str | None,
     qualified_table: str,
     stat_name: str,
 ) -> None:
-    """Drop STAT_NAME on QUALIFIED_TABLE (schema.table) from ITEM in WORKSPACE.
+    """Drop STAT_NAME on QUALIFIED_TABLE (schema.table) from ITEM.
 
     Only Data Warehouses support DDL; SQL Analytics Endpoints are read-only.
     """
-    ws = resolve_workspace_arg(ctx, workspace)
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     parse_qualified_name(qualified_table, kind="table")
     try:

--- a/src/fabric_dw/cli/commands/statistics.py
+++ b/src/fabric_dw/cli/commands/statistics.py
@@ -219,7 +219,7 @@ async def update_cmd(
     fullscan: bool,
     sample_percent: int | None,
 ) -> None:
-    """Update STAT_NAME on QUALIFIED_TABLE (schema.table) on ITEM.
+    """Update STAT_NAME on QUALIFIED_TABLE (schema.table) for ITEM.
 
     Only Data Warehouses support DDL; SQL Analytics Endpoints are read-only.
     """

--- a/tests/unit/cli/commands/test_functions.py
+++ b/tests/unit/cli/commands/test_functions.py
@@ -91,7 +91,7 @@ class TestFunctionsList:
                 new=AsyncMock(return_value=[_make_fn()]),
             ),
         ):
-            result = runner.invoke(cli, ["functions", "list", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "functions", "list", WH_GUID])
         assert result.exit_code == 0
 
     def test_list_json_output(self, runner: CliRunner, cache_env: Path) -> None:
@@ -111,7 +111,7 @@ class TestFunctionsList:
                 new=AsyncMock(return_value=[_make_fn()]),
             ),
         ):
-            result = runner.invoke(cli, ["--json", "functions", "list", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["--json", "-w", WS_GUID, "functions", "list", WH_GUID])
         assert result.exit_code == 0
         parsed = json.loads(result.output)
         assert isinstance(parsed, list)
@@ -131,7 +131,9 @@ class TestFunctionsList:
             ),
             patch("fabric_dw.services.functions.list_functions", new=mock_list),
         ):
-            result = runner.invoke(cli, ["functions", "list", WS_GUID, WH_GUID, "--schema", "dbo"])
+            result = runner.invoke(
+                cli, ["-w", WS_GUID, "functions", "list", WH_GUID, "--schema", "dbo"]
+            )
         assert result.exit_code == 0
         mock_list.assert_awaited_once()
 
@@ -150,7 +152,9 @@ class TestFunctionsList:
             ),
             patch("fabric_dw.services.functions.list_functions", new=mock_list),
         ):
-            result = runner.invoke(cli, ["functions", "list", WS_GUID, WH_GUID, "--kind", "scalar"])
+            result = runner.invoke(
+                cli, ["-w", WS_GUID, "functions", "list", WH_GUID, "--kind", "scalar"]
+            )
         assert result.exit_code == 0
         _, kwargs = mock_list.call_args
         assert kwargs.get("kind") == "scalar"
@@ -168,7 +172,7 @@ class TestFunctionsList:
                 new=AsyncMock(side_effect=NotFoundError("not found")),
             ),
         ):
-            result = runner.invoke(cli, ["functions", "list", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "functions", "list", WH_GUID])
         assert result.exit_code != 0
 
     def test_list_works_on_sql_endpoint(self, runner: CliRunner, cache_env: Path) -> None:
@@ -194,7 +198,7 @@ class TestFunctionsList:
                 new=AsyncMock(return_value=[]),
             ),
         ):
-            result = runner.invoke(cli, ["functions", "list", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "functions", "list", WH_GUID])
         assert result.exit_code == 0
 
 
@@ -221,7 +225,9 @@ class TestFunctionsGet:
                 new=AsyncMock(return_value=_make_fn(with_definition=True)),
             ),
         ):
-            result = runner.invoke(cli, ["functions", "get", WS_GUID, WH_GUID, "dbo.fn_clean"])
+            result = runner.invoke(
+                cli, ["-w", WS_GUID, "functions", "get", WH_GUID, "dbo.fn_clean"]
+            )
         assert result.exit_code == 0
 
     def test_get_json_output(self, runner: CliRunner, cache_env: Path) -> None:
@@ -242,7 +248,7 @@ class TestFunctionsGet:
             ),
         ):
             result = runner.invoke(
-                cli, ["--json", "functions", "get", WS_GUID, WH_GUID, "dbo.fn_clean"]
+                cli, ["--json", "-w", WS_GUID, "functions", "get", WH_GUID, "dbo.fn_clean"]
             )
         assert result.exit_code == 0
         parsed = json.loads(result.output)
@@ -251,7 +257,7 @@ class TestFunctionsGet:
 
     def test_get_missing_dot_returns_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
-        result = runner.invoke(cli, ["functions", "get", WS_GUID, WH_GUID, "nodot"])
+        result = runner.invoke(cli, ["-w", WS_GUID, "functions", "get", WH_GUID, "nodot"])
         assert result.exit_code != 0
 
 
@@ -279,9 +285,10 @@ class TestFunctionsCreate:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "functions",
                     "create",
-                    WS_GUID,
                     WH_GUID,
                     "--name",
                     "dbo.fn_clean",
@@ -314,9 +321,10 @@ class TestFunctionsCreate:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "functions",
                     "create",
-                    WS_GUID,
                     WH_GUID,
                     "--name",
                     "dbo.fn_clean",
@@ -331,7 +339,7 @@ class TestFunctionsCreate:
         _ = cache_env
         result = runner.invoke(
             cli,
-            ["functions", "create", WS_GUID, WH_GUID, "--name", "dbo.fn_clean"],
+            ["-w", WS_GUID, "functions", "create", WH_GUID, "--name", "dbo.fn_clean"],
         )
         assert result.exit_code != 0
 
@@ -356,9 +364,10 @@ class TestFunctionsCreate:
                 cli,
                 [
                     "--json",
+                    "-w",
+                    WS_GUID,
                     "functions",
                     "create",
-                    WS_GUID,
                     WH_GUID,
                     "--name",
                     "dbo.fn_clean",
@@ -396,9 +405,10 @@ class TestFunctionsCreate:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "functions",
                     "create",
-                    WS_GUID,
                     WH_GUID,
                     "--name",
                     "dbo.fn_clean",
@@ -434,9 +444,10 @@ class TestFunctionsUpdate:
                 cli,
                 [
                     "--yes",
+                    "-w",
+                    WS_GUID,
                     "functions",
                     "update",
-                    WS_GUID,
                     WH_GUID,
                     "dbo.fn_clean",
                     "--body",
@@ -464,9 +475,10 @@ class TestFunctionsUpdate:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "functions",
                     "update",
-                    WS_GUID,
                     WH_GUID,
                     "dbo.fn_clean",
                     "--body",
@@ -498,9 +510,10 @@ class TestFunctionsUpdate:
                 cli,
                 [
                     "--yes",
+                    "-w",
+                    WS_GUID,
                     "functions",
                     "update",
-                    WS_GUID,
                     WH_GUID,
                     "dbo.fn_clean",
                     "--body",
@@ -532,7 +545,7 @@ class TestFunctionsDrop:
             patch("fabric_dw.services.functions.drop_function", new=mock_drop),
         ):
             result = runner.invoke(
-                cli, ["--yes", "functions", "drop", WS_GUID, WH_GUID, "dbo.fn_clean"]
+                cli, ["--yes", "-w", WS_GUID, "functions", "drop", WH_GUID, "dbo.fn_clean"]
             )
         assert result.exit_code == 0
         mock_drop.assert_awaited_once()
@@ -556,7 +569,7 @@ class TestFunctionsDrop:
         ):
             result = runner.invoke(
                 cli,
-                ["--json", "--yes", "functions", "drop", WS_GUID, WH_GUID, "dbo.fn_clean"],
+                ["--json", "--yes", "-w", WS_GUID, "functions", "drop", WH_GUID, "dbo.fn_clean"],
             )
         assert result.exit_code == 0
         parsed = json.loads(result.output)
@@ -578,7 +591,7 @@ class TestFunctionsDrop:
         ):
             result = runner.invoke(
                 cli,
-                ["functions", "drop", WS_GUID, WH_GUID, "dbo.fn_clean"],
+                ["-w", WS_GUID, "functions", "drop", WH_GUID, "dbo.fn_clean"],
                 input="n\n",
             )
         assert result.exit_code == 0
@@ -603,9 +616,10 @@ class TestFunctionsDrop:
                 cli,
                 [
                     "--yes",
+                    "-w",
+                    WS_GUID,
                     "functions",
                     "drop",
-                    WS_GUID,
                     WH_GUID,
                     "dbo.fn_clean",
                     "--if-exists",
@@ -641,9 +655,10 @@ class TestFunctionsRename:
                 cli,
                 [
                     "--yes",
+                    "-w",
+                    WS_GUID,
                     "functions",
                     "rename",
-                    WS_GUID,
                     WH_GUID,
                     "dbo.fn_clean",
                     "--new-name",
@@ -672,9 +687,10 @@ class TestFunctionsRename:
                 cli,
                 [
                     "--yes",
+                    "-w",
+                    WS_GUID,
                     "functions",
                     "rename",
-                    WS_GUID,
                     WH_GUID,
                     "dbo.fn_clean",
                     "--new-name",
@@ -703,9 +719,10 @@ class TestFunctionsRename:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "functions",
                     "rename",
-                    WS_GUID,
                     WH_GUID,
                     "dbo.fn_clean",
                     "--new-name",
@@ -720,7 +737,7 @@ class TestFunctionsRename:
         _ = cache_env
         result = runner.invoke(
             cli,
-            ["--yes", "functions", "rename", WS_GUID, WH_GUID, "dbo.fn_clean"],
+            ["--yes", "-w", WS_GUID, "functions", "rename", WH_GUID, "dbo.fn_clean"],
         )
         assert result.exit_code != 0
 
@@ -746,9 +763,10 @@ class TestFunctionsRename:
                 [
                     "--json",
                     "--yes",
+                    "-w",
+                    WS_GUID,
                     "functions",
                     "rename",
-                    WS_GUID,
                     WH_GUID,
                     "dbo.fn_clean",
                     "--new-name",

--- a/tests/unit/cli/commands/test_procedures.py
+++ b/tests/unit/cli/commands/test_procedures.py
@@ -86,7 +86,7 @@ class TestProceduresList:
                 new=AsyncMock(return_value=[_make_proc()]),
             ),
         ):
-            result = runner.invoke(cli, ["procedures", "list", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "procedures", "list", WH_GUID])
         assert result.exit_code == 0
 
     def test_list_json_output(self, runner: CliRunner, cache_env: Path) -> None:
@@ -106,7 +106,7 @@ class TestProceduresList:
                 new=AsyncMock(return_value=[_make_proc()]),
             ),
         ):
-            result = runner.invoke(cli, ["--json", "procedures", "list", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["--json", "-w", WS_GUID, "procedures", "list", WH_GUID])
         assert result.exit_code == 0
         parsed = json.loads(result.output)
         assert isinstance(parsed, list)
@@ -126,7 +126,9 @@ class TestProceduresList:
             ),
             patch("fabric_dw.services.procedures.list_procedures", new=mock_list),
         ):
-            result = runner.invoke(cli, ["procedures", "list", WS_GUID, WH_GUID, "--schema", "dbo"])
+            result = runner.invoke(
+                cli, ["-w", WS_GUID, "procedures", "list", WH_GUID, "--schema", "dbo"]
+            )
         assert result.exit_code == 0
         mock_list.assert_awaited_once()
 
@@ -143,7 +145,7 @@ class TestProceduresList:
                 new=AsyncMock(side_effect=NotFoundError("not found")),
             ),
         ):
-            result = runner.invoke(cli, ["procedures", "list", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "procedures", "list", WH_GUID])
         assert result.exit_code != 0
 
     def test_list_works_on_sql_endpoint(self, runner: CliRunner, cache_env: Path) -> None:
@@ -169,7 +171,7 @@ class TestProceduresList:
                 new=AsyncMock(return_value=[]),
             ),
         ):
-            result = runner.invoke(cli, ["procedures", "list", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "procedures", "list", WH_GUID])
         assert result.exit_code == 0
 
 
@@ -196,7 +198,9 @@ class TestProceduresGet:
                 new=AsyncMock(return_value=_make_proc(with_definition=True)),
             ),
         ):
-            result = runner.invoke(cli, ["procedures", "get", WS_GUID, WH_GUID, "dbo.usp_load"])
+            result = runner.invoke(
+                cli, ["-w", WS_GUID, "procedures", "get", WH_GUID, "dbo.usp_load"]
+            )
         assert result.exit_code == 0
 
     def test_get_json_output(self, runner: CliRunner, cache_env: Path) -> None:
@@ -217,7 +221,7 @@ class TestProceduresGet:
             ),
         ):
             result = runner.invoke(
-                cli, ["--json", "procedures", "get", WS_GUID, WH_GUID, "dbo.usp_load"]
+                cli, ["--json", "-w", WS_GUID, "procedures", "get", WH_GUID, "dbo.usp_load"]
             )
         assert result.exit_code == 0
         parsed = json.loads(result.output)
@@ -225,7 +229,7 @@ class TestProceduresGet:
 
     def test_get_bad_qualified_name_exits_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
-        result = runner.invoke(cli, ["procedures", "get", WS_GUID, WH_GUID, "no_dot_here"])
+        result = runner.invoke(cli, ["-w", WS_GUID, "procedures", "get", WH_GUID, "no_dot_here"])
         assert result.exit_code != 0
 
     def test_get_not_found_returns_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
@@ -245,7 +249,9 @@ class TestProceduresGet:
                 new=AsyncMock(side_effect=NotFoundError("not found")),
             ),
         ):
-            result = runner.invoke(cli, ["procedures", "get", WS_GUID, WH_GUID, "dbo.usp_missing"])
+            result = runner.invoke(
+                cli, ["-w", WS_GUID, "procedures", "get", WH_GUID, "dbo.usp_missing"]
+            )
         assert result.exit_code != 0
 
 
@@ -275,9 +281,10 @@ class TestProceduresCreate:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "procedures",
                     "create",
-                    WS_GUID,
                     WH_GUID,
                     "--name",
                     "dbo.usp_load",
@@ -309,9 +316,10 @@ class TestProceduresCreate:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "procedures",
                     "create",
-                    WS_GUID,
                     WH_GUID,
                     "--name",
                     "dbo.usp_load",
@@ -325,7 +333,7 @@ class TestProceduresCreate:
         _ = cache_env
         result = runner.invoke(
             cli,
-            ["procedures", "create", WS_GUID, WH_GUID, "--name", "dbo.usp_load"],
+            ["-w", WS_GUID, "procedures", "create", WH_GUID, "--name", "dbo.usp_load"],
         )
         assert result.exit_code != 0
 
@@ -338,9 +346,10 @@ class TestProceduresCreate:
         result = runner.invoke(
             cli,
             [
+                "-w",
+                WS_GUID,
                 "procedures",
                 "create",
-                WS_GUID,
                 WH_GUID,
                 "--name",
                 "dbo.usp_load",
@@ -386,9 +395,10 @@ class TestProceduresCreate:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "procedures",
                     "create",
-                    WS_GUID,
                     WH_GUID,
                     "--name",
                     "dbo.usp_load",
@@ -421,9 +431,10 @@ class TestProceduresCreate:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "procedures",
                     "create",
-                    WS_GUID,
                     WH_GUID,
                     "--name",
                     "dbo.usp_load",
@@ -461,9 +472,10 @@ class TestProceduresUpdate:
                 cli,
                 [
                     "--yes",
+                    "-w",
+                    WS_GUID,
                     "procedures",
                     "update",
-                    WS_GUID,
                     WH_GUID,
                     "dbo.usp_load",
                     "--body",
@@ -489,9 +501,10 @@ class TestProceduresUpdate:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "procedures",
                     "update",
-                    WS_GUID,
                     WH_GUID,
                     "dbo.usp_load",
                     "--body",
@@ -536,9 +549,10 @@ class TestProceduresUpdate:
                 cli,
                 [
                     "--yes",
+                    "-w",
+                    WS_GUID,
                     "procedures",
                     "update",
-                    WS_GUID,
                     WH_GUID,
                     "dbo.usp_load",
                     "--from-file",
@@ -573,7 +587,7 @@ class TestProceduresDrop:
             ),
         ):
             result = runner.invoke(
-                cli, ["--yes", "procedures", "drop", WS_GUID, WH_GUID, "dbo.usp_load"]
+                cli, ["--yes", "-w", WS_GUID, "procedures", "drop", WH_GUID, "dbo.usp_load"]
             )
         assert result.exit_code == 0
 
@@ -593,7 +607,7 @@ class TestProceduresDrop:
         ):
             result = runner.invoke(
                 cli,
-                ["procedures", "drop", WS_GUID, WH_GUID, "dbo.usp_load"],
+                ["-w", WS_GUID, "procedures", "drop", WH_GUID, "dbo.usp_load"],
                 input="n\n",
             )
         assert result.exit_code == 0
@@ -603,7 +617,7 @@ class TestProceduresDrop:
         self, runner: CliRunner, cache_env: Path
     ) -> None:
         _ = cache_env
-        result = runner.invoke(cli, ["procedures", "drop", WS_GUID, WH_GUID, "no_dot"])
+        result = runner.invoke(cli, ["-w", WS_GUID, "procedures", "drop", WH_GUID, "no_dot"])
         assert result.exit_code != 0
 
     def test_drop_permission_denied_returns_nonzero(
@@ -626,6 +640,6 @@ class TestProceduresDrop:
             ),
         ):
             result = runner.invoke(
-                cli, ["--yes", "procedures", "drop", WS_GUID, WH_GUID, "dbo.usp_load"]
+                cli, ["--yes", "-w", WS_GUID, "procedures", "drop", WH_GUID, "dbo.usp_load"]
             )
         assert result.exit_code != 0

--- a/tests/unit/cli/commands/test_schemas.py
+++ b/tests/unit/cli/commands/test_schemas.py
@@ -90,7 +90,7 @@ class TestSchemasList:
                 new=mock_list,
             ),
         ):
-            result = runner.invoke(cli, ["schemas", "list", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "schemas", "list", WH_GUID])
         assert result.exit_code == 0
         mock_list.assert_awaited_once()
         assert "sales" in result.output
@@ -112,7 +112,7 @@ class TestSchemasList:
                 new=AsyncMock(return_value=[_make_schema()]),
             ),
         ):
-            result = runner.invoke(cli, ["--json", "schemas", "list", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["--json", "-w", WS_GUID, "schemas", "list", WH_GUID])
         assert result.exit_code == 0
         parsed = json.loads(result.output)
         assert isinstance(parsed, list)
@@ -131,7 +131,7 @@ class TestSchemasList:
                 new=AsyncMock(side_effect=NotFoundError("not found")),
             ),
         ):
-            result = runner.invoke(cli, ["schemas", "list", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "schemas", "list", WH_GUID])
         assert result.exit_code != 0
 
     def test_list_permission_error_returns_nonzero(
@@ -153,7 +153,7 @@ class TestSchemasList:
                 new=AsyncMock(side_effect=PermissionDeniedError("access denied")),
             ),
         ):
-            result = runner.invoke(cli, ["schemas", "list", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "schemas", "list", WH_GUID])
         assert result.exit_code != 0
 
 
@@ -181,7 +181,7 @@ class TestSchemasCreate:
                 new=mock_create,
             ),
         ):
-            result = runner.invoke(cli, ["schemas", "create", WS_GUID, WH_GUID, "sales"])
+            result = runner.invoke(cli, ["-w", WS_GUID, "schemas", "create", WH_GUID, "sales"])
         assert result.exit_code == 0
         mock_create.assert_awaited_once()
         assert "sales" in result.output
@@ -203,7 +203,9 @@ class TestSchemasCreate:
                 new=AsyncMock(return_value=_make_schema()),
             ),
         ):
-            result = runner.invoke(cli, ["--json", "schemas", "create", WS_GUID, WH_GUID, "sales"])
+            result = runner.invoke(
+                cli, ["--json", "-w", WS_GUID, "schemas", "create", WH_GUID, "sales"]
+            )
         assert result.exit_code == 0
         parsed = json.loads(result.output)
         assert parsed["name"] == "sales"
@@ -227,7 +229,7 @@ class TestSchemasCreate:
                 new=mock_create,
             ),
         ):
-            result = runner.invoke(cli, ["schemas", "create", WS_GUID, WH_GUID, "sales"])
+            result = runner.invoke(cli, ["-w", WS_GUID, "schemas", "create", WH_GUID, "sales"])
         assert result.exit_code == 0
         mock_create.assert_awaited_once()
         assert "sales" in result.output
@@ -251,7 +253,7 @@ class TestSchemasCreate:
                 new=AsyncMock(side_effect=PermissionDeniedError("access denied")),
             ),
         ):
-            result = runner.invoke(cli, ["schemas", "create", WS_GUID, WH_GUID, "sales"])
+            result = runner.invoke(cli, ["-w", WS_GUID, "schemas", "create", WH_GUID, "sales"])
         assert result.exit_code != 0
 
 
@@ -278,7 +280,9 @@ class TestSchemasDelete:
                 new=AsyncMock(return_value=None),
             ),
         ):
-            result = runner.invoke(cli, ["-y", "schemas", "delete", WS_GUID, WH_GUID, "sales"])
+            result = runner.invoke(
+                cli, ["-y", "-w", WS_GUID, "schemas", "delete", WH_GUID, "sales"]
+            )
         assert result.exit_code == 0
         assert "dropped" in result.output
 
@@ -301,7 +305,7 @@ class TestSchemasDelete:
             ),
         ):
             result = runner.invoke(
-                cli, ["schemas", "delete", WS_GUID, WH_GUID, "sales"], input="n\n"
+                cli, ["-w", WS_GUID, "schemas", "delete", WH_GUID, "sales"], input="n\n"
             )
         assert result.exit_code == 0
         assert "Aborted." in result.output
@@ -323,7 +327,7 @@ class TestSchemasDelete:
         ):
             result = runner.invoke(
                 cli,
-                ["-y", "schemas", "delete", WS_GUID, WH_GUID, "sales", "--cascade"],
+                ["-y", "-w", WS_GUID, "schemas", "delete", WH_GUID, "sales", "--cascade"],
             )
         assert result.exit_code == 0
         _, kwargs = mock_delete.call_args
@@ -346,7 +350,7 @@ class TestSchemasDelete:
         ):
             result = runner.invoke(
                 cli,
-                ["-y", "schemas", "delete", WS_GUID, WH_GUID, "sales"],
+                ["-y", "-w", WS_GUID, "schemas", "delete", WH_GUID, "sales"],
             )
         assert result.exit_code == 0
         _, kwargs = mock_delete.call_args
@@ -370,7 +374,9 @@ class TestSchemasDelete:
                 new=AsyncMock(return_value=None),
             ),
         ):
-            result = runner.invoke(cli, ["-y", "schemas", "delete", WS_GUID, WH_GUID, "sales"])
+            result = runner.invoke(
+                cli, ["-y", "-w", WS_GUID, "schemas", "delete", WH_GUID, "sales"]
+            )
         assert result.exit_code == 0
         assert "dropped" in result.output
 
@@ -394,7 +400,7 @@ class TestSchemasDelete:
         ):
             result = runner.invoke(
                 cli,
-                ["-y", "schemas", "delete", WS_GUID, WH_GUID, "sales", "--cascade"],
+                ["-y", "-w", WS_GUID, "schemas", "delete", WH_GUID, "sales", "--cascade"],
             )
         # With --yes the prompt is skipped entirely; the command exits cleanly and reports the drop.
         assert result.exit_code == 0
@@ -420,7 +426,9 @@ class TestSchemasDelete:
                 new=AsyncMock(side_effect=PermissionDeniedError("access denied")),
             ),
         ):
-            result = runner.invoke(cli, ["-y", "schemas", "delete", WS_GUID, WH_GUID, "sales"])
+            result = runner.invoke(
+                cli, ["-y", "-w", WS_GUID, "schemas", "delete", WH_GUID, "sales"]
+            )
         assert result.exit_code != 0
 
     def test_delete_cascade_sql_endpoint_succeeds(self, runner: CliRunner, cache_env: Path) -> None:
@@ -443,7 +451,7 @@ class TestSchemasDelete:
         ):
             result = runner.invoke(
                 cli,
-                ["-y", "schemas", "delete", WS_GUID, WH_GUID, "sales", "--cascade"],
+                ["-y", "-w", WS_GUID, "schemas", "delete", WH_GUID, "sales", "--cascade"],
             )
         assert result.exit_code == 0
         assert "dropped" in result.output
@@ -468,7 +476,9 @@ class TestSchemasDelete:
                 new=AsyncMock(return_value=None),
             ),
         ):
-            result = runner.invoke(cli, ["-y", "schemas", "delete", WS_GUID, WH_GUID, "sales"])
+            result = runner.invoke(
+                cli, ["-y", "-w", WS_GUID, "schemas", "delete", WH_GUID, "sales"]
+            )
         assert result.exit_code == 0
         assert "dropped" in result.output
 
@@ -488,7 +498,7 @@ class TestSchemasDelete:
             ),
             patch("fabric_dw.services.schemas.delete_schema", new=mock_delete),
         ):
-            runner.invoke(cli, ["-y", "schemas", "delete", WS_GUID, WH_GUID, "sales"])
+            runner.invoke(cli, ["-y", "-w", WS_GUID, "schemas", "delete", WH_GUID, "sales"])
         _, kwargs = mock_delete.call_args
         assert kwargs.get("kind") == WarehouseKind.WAREHOUSE
 
@@ -514,6 +524,6 @@ class TestSchemasDelete:
             ),
             patch("fabric_dw.services.schemas.delete_schema", new=mock_delete),
         ):
-            runner.invoke(cli, ["-y", "schemas", "delete", WS_GUID, WH_GUID, "sales"])
+            runner.invoke(cli, ["-y", "-w", WS_GUID, "schemas", "delete", WH_GUID, "sales"])
         _, kwargs = mock_delete.call_args
         assert kwargs.get("kind") == WarehouseKind.SQL_ENDPOINT

--- a/tests/unit/cli/commands/test_statistics.py
+++ b/tests/unit/cli/commands/test_statistics.py
@@ -111,7 +111,7 @@ class TestStatisticsList:
                 new=AsyncMock(return_value=[_make_statistic()]),
             ),
         ):
-            result = runner.invoke(cli, ["statistics", "list", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "statistics", "list", WH_GUID])
         assert result.exit_code == 0
 
     def test_list_json_output(self, runner: CliRunner) -> None:
@@ -130,7 +130,7 @@ class TestStatisticsList:
                 new=AsyncMock(return_value=[_make_statistic()]),
             ),
         ):
-            result = runner.invoke(cli, ["--json", "statistics", "list", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["--json", "-w", WS_GUID, "statistics", "list", WH_GUID])
         assert result.exit_code == 0
         parsed = json.loads(result.output)
         assert isinstance(parsed, list)
@@ -151,7 +151,7 @@ class TestStatisticsList:
         ):
             result = runner.invoke(
                 cli,
-                ["statistics", "list", WS_GUID, WH_GUID, "--schema", "dbo"],
+                ["-w", WS_GUID, "statistics", "list", WH_GUID, "--schema", "dbo"],
             )
         assert result.exit_code == 0
         mock_list.assert_awaited_once()
@@ -172,7 +172,7 @@ class TestStatisticsList:
         ):
             result = runner.invoke(
                 cli,
-                ["statistics", "list", WS_GUID, WH_GUID, "--user-only"],
+                ["-w", WS_GUID, "statistics", "list", WH_GUID, "--user-only"],
             )
         assert result.exit_code == 0
         _, kwargs = mock_list.call_args
@@ -190,7 +190,7 @@ class TestStatisticsList:
                 new=AsyncMock(side_effect=NotFoundError("not found")),
             ),
         ):
-            result = runner.invoke(cli, ["statistics", "list", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "statistics", "list", WH_GUID])
         assert result.exit_code != 0
 
 
@@ -218,7 +218,7 @@ class TestStatisticsShow:
         ):
             result = runner.invoke(
                 cli,
-                ["statistics", "show", WS_GUID, WH_GUID, "dbo.sales", "stat_sales_id"],
+                ["-w", WS_GUID, "statistics", "show", WH_GUID, "dbo.sales", "stat_sales_id"],
             )
         assert result.exit_code == 0
 
@@ -239,9 +239,10 @@ class TestStatisticsShow:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "statistics",
                     "show",
-                    WS_GUID,
                     WH_GUID,
                     "dbo.sales",
                     "stat_sales_id",
@@ -255,7 +256,7 @@ class TestStatisticsShow:
     def test_show_bad_qualified_table_returns_nonzero(self, runner: CliRunner) -> None:
         result = runner.invoke(
             cli,
-            ["statistics", "show", WS_GUID, WH_GUID, "nodot", "stat"],
+            ["-w", WS_GUID, "statistics", "show", WH_GUID, "nodot", "stat"],
         )
         assert result.exit_code != 0
 
@@ -285,9 +286,10 @@ class TestStatisticsCreate:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "statistics",
                     "create",
-                    WS_GUID,
                     WH_GUID,
                     "--table",
                     "dbo.sales",
@@ -314,9 +316,10 @@ class TestStatisticsCreate:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "statistics",
                     "create",
-                    WS_GUID,
                     WH_GUID,
                     "--table",
                     "dbo.sales",
@@ -343,9 +346,10 @@ class TestStatisticsCreate:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "statistics",
                     "create",
-                    WS_GUID,
                     WH_GUID,
                     "--table",
                     "dbo.sales",
@@ -380,9 +384,10 @@ class TestStatisticsCreate:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "statistics",
                     "create",
-                    WS_GUID,
                     SE_GUID,
                     "--table",
                     "dbo.sales",
@@ -420,9 +425,10 @@ class TestStatisticsUpdate:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "statistics",
                     "update",
-                    WS_GUID,
                     WH_GUID,
                     "dbo.sales",
                     "stat_sales_id",
@@ -450,9 +456,10 @@ class TestStatisticsUpdate:
                 cli,
                 [
                     "--json",
+                    "-w",
+                    WS_GUID,
                     "statistics",
                     "update",
-                    WS_GUID,
                     WH_GUID,
                     "dbo.sales",
                     "stat_sales_id",
@@ -480,7 +487,7 @@ class TestStatisticsUpdate:
         ):
             result = runner.invoke(
                 cli,
-                ["statistics", "update", WS_GUID, SE_GUID, "dbo.sales", "s"],
+                ["-w", WS_GUID, "statistics", "update", SE_GUID, "dbo.sales", "s"],
             )
         assert result.exit_code != 0
 
@@ -511,9 +518,10 @@ class TestStatisticsDelete:
                 cli,
                 [
                     "--yes",
+                    "-w",
+                    WS_GUID,
                     "statistics",
                     "delete",
-                    WS_GUID,
                     WH_GUID,
                     "dbo.sales",
                     "stat_sales_id",
@@ -542,9 +550,10 @@ class TestStatisticsDelete:
                 [
                     "--json",
                     "--yes",
+                    "-w",
+                    WS_GUID,
                     "statistics",
                     "delete",
-                    WS_GUID,
                     WH_GUID,
                     "dbo.sales",
                     "stat_sales_id",
@@ -568,7 +577,7 @@ class TestStatisticsDelete:
         ):
             result = runner.invoke(
                 cli,
-                ["statistics", "delete", WS_GUID, WH_GUID, "dbo.sales", "s"],
+                ["-w", WS_GUID, "statistics", "delete", WH_GUID, "dbo.sales", "s"],
                 input="n\n",
             )
         assert result.exit_code == 0
@@ -592,6 +601,6 @@ class TestStatisticsDelete:
         ):
             result = runner.invoke(
                 cli,
-                ["--yes", "statistics", "delete", WS_GUID, SE_GUID, "dbo.sales", "s"],
+                ["--yes", "-w", WS_GUID, "statistics", "delete", SE_GUID, "dbo.sales", "s"],
             )
         assert result.exit_code != 0


### PR DESCRIPTION
## Summary

Part of the CLI-wide refactor to resolve the target workspace from the global `-w/--workspace` option instead of a per-command positional `WORKSPACE` argument.

This converts the **procedures**, **functions**, **statistics**, and **schemas** command clusters to use `resolve_workspace(ctx)` (precedence: explicit `-w` → `FABRIC_DW_DEFAULT_WORKSPACE` env → config default → helpful `UsageError`). The leading positional `WORKSPACE` is removed from every command; the remaining positionals (`item`, `qualified_name`, `qualified_table`, `stat_name`, `name`, …) keep their existing order. Docstrings drop the `WORKSPACE` reference.

## Converted commands

- `procedures`: `list`, `get`, `create`, `update`, `drop`
- `functions`: `list`, `get`, `create`, `update`, `drop`, `rename`
- `statistics`: `list`, `show`, `create`, `update`, `delete`
- `schemas`: `list`, `create`, `delete`

## Tests

Unit tests updated so positional-workspace invocations now pass the workspace with the root-level `-w` flag before the command group, e.g. `["statistics", "show", WS, ITEM, ...]` → `["-w", WS, "statistics", "show", ITEM, ...]`.

`just check` is clean (ruff lint + format, ty type check, full unit suite — 3424 passed).

## Breaking change

The `procedures`, `functions`, `statistics`, and `schemas` subcommands no longer accept a positional `WORKSPACE`. Pass the workspace with the global `-w/--workspace` option, or set a persistent default via `fabric-dw config set workspace <name|id>` / `FABRIC_DW_DEFAULT_WORKSPACE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)