### PR TITLE
refactor(cli)!: sql, sql-pools, audit take workspace via -w/--workspace

### DIFF
--- a/src/fabric_dw/cli/commands/audit.py
+++ b/src/fabric_dw/cli/commands/audit.py
@@ -11,7 +11,7 @@ from fabric_dw.cli.commands._utils import (
     coro,
     resolve_item,
     resolve_warehouse_arg,
-    resolve_workspace_arg,
+    resolve_workspace,
 )
 from fabric_dw.exceptions import FabricError
 from fabric_dw.services import audit as _audit_svc
@@ -23,13 +23,12 @@ def audit_group() -> None:
 
 
 @audit_group.command("get")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.pass_obj
 @coro
-async def get_cmd(ctx: CliContext, workspace: str | None, item: str | None) -> None:
-    """Get the current audit settings for ITEM (warehouse) in WORKSPACE."""
-    ws = resolve_workspace_arg(ctx, workspace)
+async def get_cmd(ctx: CliContext, item: str | None) -> None:
+    """Get the current audit settings for ITEM (warehouse)."""
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     try:
         async with build_http_client(ctx) as http:
@@ -41,7 +40,6 @@ async def get_cmd(ctx: CliContext, workspace: str | None, item: str | None) -> N
 
 
 @audit_group.command("enable")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.option(
     "--retention-days",
@@ -62,12 +60,11 @@ async def get_cmd(ctx: CliContext, workspace: str | None, item: str | None) -> N
 @coro
 async def enable_cmd(
     ctx: CliContext,
-    workspace: str | None,
     item: str | None,
     retention_days: int | None,
     unlimited: bool,
 ) -> None:
-    """Enable SQL auditing on ITEM (warehouse) in WORKSPACE.
+    """Enable SQL auditing on ITEM (warehouse).
 
     Omitting both --retention-days and --unlimited defaults to unlimited retention.
     """
@@ -83,7 +80,7 @@ async def enable_cmd(
     else:
         # No flag supplied — default to unlimited retention.
         effective_days = 0
-    ws = resolve_workspace_arg(ctx, workspace)
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     try:
         async with build_http_client(ctx) as http:
@@ -95,13 +92,12 @@ async def enable_cmd(
 
 
 @audit_group.command("disable")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.pass_obj
 @coro
-async def disable_cmd(ctx: CliContext, workspace: str | None, item: str | None) -> None:
-    """Disable SQL auditing on ITEM (warehouse) in WORKSPACE."""
-    ws = resolve_workspace_arg(ctx, workspace)
+async def disable_cmd(ctx: CliContext, item: str | None) -> None:
+    """Disable SQL auditing on ITEM (warehouse)."""
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     try:
         async with build_http_client(ctx) as http:
@@ -120,7 +116,6 @@ async def disable_cmd(ctx: CliContext, workspace: str | None, item: str | None) 
 
 
 @audit_group.command("set-retention")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.option(
     "--days",
@@ -132,16 +127,15 @@ async def disable_cmd(ctx: CliContext, workspace: str | None, item: str | None) 
 @coro
 async def set_retention_cmd(
     ctx: CliContext,
-    workspace: str | None,
     item: str | None,
     days: int,
 ) -> None:
-    """Update the audit log retention period for ITEM (warehouse) in WORKSPACE.
+    """Update the audit log retention period for ITEM (warehouse).
 
     Audit must already be enabled; if disabled, enable it first with
     ``audit enable``.  This command does NOT change the audit state.
     """
-    ws = resolve_workspace_arg(ctx, workspace)
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     try:
         async with build_http_client(ctx) as http:
@@ -153,7 +147,6 @@ async def set_retention_cmd(
 
 
 @audit_group.command("set-groups")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.option(
     "-g",
@@ -165,15 +158,13 @@ async def set_retention_cmd(
 )
 @click.pass_obj
 @coro
-async def set_groups_cmd(
-    ctx: CliContext, workspace: str | None, item: str | None, groups: tuple[str, ...]
-) -> None:
-    """Set audit action groups for ITEM (warehouse) in WORKSPACE.
+async def set_groups_cmd(ctx: CliContext, item: str | None, groups: tuple[str, ...]) -> None:
+    """Set audit action groups for ITEM (warehouse).
 
     Pass --group for each action group name, e.g.
     --group BATCH_COMPLETED_GROUP --group SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP.
     """
-    ws = resolve_workspace_arg(ctx, workspace)
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     try:
         async with build_http_client(ctx) as http:
@@ -185,20 +176,17 @@ async def set_groups_cmd(
 
 
 @audit_group.command("add-group")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.argument("group")
 @click.pass_obj
 @coro
-async def add_group_cmd(
-    ctx: CliContext, workspace: str | None, item: str | None, group: str
-) -> None:
-    """Add GROUP to the audit action groups for ITEM (warehouse) in WORKSPACE.
+async def add_group_cmd(ctx: CliContext, item: str | None, group: str) -> None:
+    """Add GROUP to the audit action groups for ITEM (warehouse).
 
     Idempotent — if GROUP is already present the command succeeds without
     modifying the configuration.  Auditing must already be enabled.
     """
-    ws = resolve_workspace_arg(ctx, workspace)
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     try:
         async with build_http_client(ctx) as http:
@@ -210,20 +198,17 @@ async def add_group_cmd(
 
 
 @audit_group.command("remove-group")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.argument("group")
 @click.pass_obj
 @coro
-async def remove_group_cmd(
-    ctx: CliContext, workspace: str | None, item: str | None, group: str
-) -> None:
-    """Remove GROUP from the audit action groups for ITEM (warehouse) in WORKSPACE.
+async def remove_group_cmd(ctx: CliContext, item: str | None, group: str) -> None:
+    """Remove GROUP from the audit action groups for ITEM (warehouse).
 
     Idempotent — if GROUP is not present the command succeeds without
     modifying the configuration.  Auditing must already be enabled.
     """
-    ws = resolve_workspace_arg(ctx, workspace)
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     try:
         async with build_http_client(ctx) as http:

--- a/src/fabric_dw/cli/commands/sql.py
+++ b/src/fabric_dw/cli/commands/sql.py
@@ -2,7 +2,7 @@
 
 Commands
 --------
-- ``sql <ws> <item>`` — execute an arbitrary SQL statement or file.
+- ``sql <item>`` — execute an arbitrary SQL statement or file.
 
 .. note::
    **Breaking change (v0.x → v0.y):** The former ``sql exec`` sub-command was
@@ -21,14 +21,13 @@ from fabric_dw.cli.commands._utils import (
     coro,
     load_sql_body,
     resolve_warehouse_arg,
-    resolve_workspace_arg,
+    resolve_workspace,
 )
 from fabric_dw.exceptions import FabricError
 from fabric_dw.services import sql_exec as _sql_exec_svc
 
 
 @click.command("sql")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.option(
     "-q",
@@ -49,12 +48,11 @@ from fabric_dw.services import sql_exec as _sql_exec_svc
 @coro
 async def sql_cmd(
     ctx: CliContext,
-    workspace: str | None,
     item: str | None,
     query_text: str | None,
     query_file: str | None,
 ) -> None:
-    """Execute a SQL statement against ITEM (warehouse or SQL endpoint) in WORKSPACE.
+    """Execute a SQL statement against ITEM (warehouse or SQL endpoint).
 
     Provide the query via -q/--query or -f/--file (not both).
     Multi-statement batches are supported; only the last result set is returned.
@@ -65,7 +63,7 @@ async def sql_cmd(
     """
     query = load_sql_body(query_text, query_file, inline_opt="-q/--query", file_opt="-f/--file")
 
-    ws = resolve_workspace_arg(ctx, workspace)
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     try:
         async with build_http_client(ctx) as http:

--- a/src/fabric_dw/cli/commands/sql_pools.py
+++ b/src/fabric_dw/cli/commands/sql_pools.py
@@ -20,7 +20,7 @@ from fabric_dw.cli.commands._utils import (
     coro,
     parse_iso_optional,
     resolve_warehouse_arg,
-    resolve_workspace_arg,
+    resolve_workspace,
     resolve_workspace_id,
 )
 from fabric_dw.exceptions import (
@@ -91,12 +91,11 @@ def sql_pools_group() -> None:
 
 
 @sql_pools_group.command("get")
-@click.argument("workspace", required=False, default=None)
 @click.pass_obj
 @coro
-async def get_cmd(ctx: CliContext, workspace: str | None) -> None:
-    """Fetch the SQL Pools configuration for WORKSPACE."""
-    ws = resolve_workspace_arg(ctx, workspace)
+async def get_cmd(ctx: CliContext) -> None:
+    """Fetch the SQL Pools configuration for the workspace."""
+    ws = resolve_workspace(ctx)
     try:
         async with build_http_client(ctx) as http:
             ws_id = await resolve_workspace_id(http, ws)
@@ -117,18 +116,17 @@ async def get_cmd(ctx: CliContext, workspace: str | None) -> None:
 
 
 @sql_pools_group.command("list")
-@click.argument("workspace", required=False, default=None)
 @click.pass_obj
 @coro
-async def list_cmd(ctx: CliContext, workspace: str | None) -> None:
-    """List all SQL pools in WORKSPACE.
+async def list_cmd(ctx: CliContext) -> None:
+    """List all SQL pools in the workspace.
 
     When no custom SQL pools are defined, Fabric Data Warehouse uses the default
     (autonomous) workload management: compute is split 50/50 into a ``SELECT``
     pool and a ``NON-SELECT`` pool.  This command reports those default pools
     instead of showing an empty list.
     """
-    ws = resolve_workspace_arg(ctx, workspace)
+    ws = resolve_workspace(ctx)
     try:
         async with build_http_client(ctx) as http:
             ws_id = await resolve_workspace_id(http, ws)
@@ -165,13 +163,12 @@ async def list_cmd(ctx: CliContext, workspace: str | None) -> None:
 
 
 @sql_pools_group.command("show")
-@click.argument("workspace", required=False, default=None)
 @click.option("--name", required=True, help="Name of the pool to show.")
 @click.pass_obj
 @coro
-async def show_cmd(ctx: CliContext, workspace: str | None, name: str) -> None:
-    """Show details for a single SQL pool in WORKSPACE."""
-    ws = resolve_workspace_arg(ctx, workspace)
+async def show_cmd(ctx: CliContext, name: str) -> None:
+    """Show details for a single SQL pool in the workspace."""
+    ws = resolve_workspace(ctx)
     try:
         async with build_http_client(ctx) as http:
             ws_id = await resolve_workspace_id(http, ws)
@@ -192,7 +189,6 @@ async def show_cmd(ctx: CliContext, workspace: str | None, name: str) -> None:
 
 
 @sql_pools_group.command("create")
-@click.argument("workspace", required=False, default=None)
 @click.option("--name", required=True, help="Pool name.")
 @click.option(
     "--max-percent",
@@ -231,7 +227,6 @@ async def show_cmd(ctx: CliContext, workspace: str | None, name: str) -> None:
 @coro
 async def create_cmd(
     ctx: CliContext,
-    workspace: str | None,
     name: str,
     max_percent: int,
     is_default: bool,
@@ -239,8 +234,8 @@ async def create_cmd(
     classifier_type: str | None,
     classifier_values: tuple[str, ...],
 ) -> None:
-    """Add a new SQL pool to WORKSPACE."""
-    ws = resolve_workspace_arg(ctx, workspace)
+    """Add a new SQL pool to the workspace."""
+    ws = resolve_workspace(ctx)
 
     classifier: SqlPoolClassifier | None = None
     if classifier_type is not None:
@@ -279,7 +274,6 @@ async def create_cmd(
 
 
 @sql_pools_group.command("update")
-@click.argument("workspace", required=False, default=None)
 @click.option("--name", required=True, help="Name of the pool to update.")
 @click.option(
     "--max-percent",
@@ -316,7 +310,6 @@ async def create_cmd(
 @coro
 async def update_cmd(
     ctx: CliContext,
-    workspace: str | None,
     name: str,
     max_percent: int | None,
     is_default: bool | None,
@@ -324,11 +317,11 @@ async def update_cmd(
     classifier_type: str | None,
     classifier_values: tuple[str, ...],
 ) -> None:
-    """Update an existing SQL pool in WORKSPACE.
+    """Update an existing SQL pool in the workspace.
 
     Only the flags you provide are changed; all other fields are preserved.
     """
-    ws = resolve_workspace_arg(ctx, workspace)
+    ws = resolve_workspace(ctx)
     cv: list[str] | None = list(classifier_values) if classifier_values else None
     try:
         async with build_http_client(ctx) as http:
@@ -360,13 +353,12 @@ async def update_cmd(
 
 
 @sql_pools_group.command("delete")
-@click.argument("workspace", required=False, default=None)
 @click.option("--name", required=True, help="Name of the pool to delete.")
 @click.pass_obj
 @coro
-async def delete_cmd(ctx: CliContext, workspace: str | None, name: str) -> None:
-    """Remove an SQL pool from WORKSPACE."""
-    ws = resolve_workspace_arg(ctx, workspace)
+async def delete_cmd(ctx: CliContext, name: str) -> None:
+    """Remove an SQL pool from the workspace."""
+    ws = resolve_workspace(ctx)
     if not confirm(f"Delete pool {name!r}?", yes=ctx.yes):
         click.echo("Aborted.")
         return
@@ -389,12 +381,11 @@ async def delete_cmd(ctx: CliContext, workspace: str | None, name: str) -> None:
 
 
 @sql_pools_group.command("enable")
-@click.argument("workspace", required=False, default=None)
 @click.pass_obj
 @coro
-async def enable_cmd(ctx: CliContext, workspace: str | None) -> None:
-    """Enable custom SQL Pools for WORKSPACE (preserves pool configuration)."""
-    ws = resolve_workspace_arg(ctx, workspace)
+async def enable_cmd(ctx: CliContext) -> None:
+    """Enable custom SQL Pools for the workspace (preserves pool configuration)."""
+    ws = resolve_workspace(ctx)
     try:
         async with build_http_client(ctx) as http:
             ws_id = await resolve_workspace_id(http, ws)
@@ -410,15 +401,14 @@ async def enable_cmd(ctx: CliContext, workspace: str | None) -> None:
 
 
 @sql_pools_group.command("disable")
-@click.argument("workspace", required=False, default=None)
 @click.pass_obj
 @coro
-async def disable_cmd(ctx: CliContext, workspace: str | None) -> None:
-    """Disable custom SQL Pools for WORKSPACE (preserves pool configuration).
+async def disable_cmd(ctx: CliContext) -> None:
+    """Disable custom SQL Pools for the workspace (preserves pool configuration).
 
     Re-enabling with 'sql-pools enable' restores the previously saved configuration.
     """
-    ws = resolve_workspace_arg(ctx, workspace)
+    ws = resolve_workspace(ctx)
     try:
         async with build_http_client(ctx) as http:
             ws_id = await resolve_workspace_id(http, ws)
@@ -439,7 +429,6 @@ async def disable_cmd(ctx: CliContext, workspace: str | None) -> None:
 
 
 @sql_pools_group.command("insights")
-@click.argument("workspace", required=False, default=None)
 @click.argument("warehouse", required=False, default=None)
 @LIMIT_OPTION
 @SINCE_OPTION
@@ -448,14 +437,13 @@ async def disable_cmd(ctx: CliContext, workspace: str | None) -> None:
 @coro
 async def insights_cmd(
     ctx: CliContext,
-    workspace: str | None,
     warehouse: str | None,
     limit: int,
     since: str | None,
     until: str | None,
 ) -> None:
     """List SQL pool insights from queryinsights.sql_pool_insights."""
-    ws = resolve_workspace_arg(ctx, workspace)
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, warehouse)
     since_dt = parse_iso_optional(since, "--since")
     until_dt = parse_iso_optional(until, "--until")

--- a/tests/unit/cli/commands/test_audit.py
+++ b/tests/unit/cli/commands/test_audit.py
@@ -64,7 +64,7 @@ class TestAuditGet:
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
             ),
         ):
-            result = runner.invoke(cli, ["--json", "audit", "get", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "--json", "audit", "get", WH_GUID])
         assert result.exit_code == 0
         parsed = json.loads(result.output)
         assert parsed["state"] == "Enabled"
@@ -84,7 +84,7 @@ class TestAuditGet:
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
             ),
         ):
-            result = runner.invoke(cli, ["--json", "audit", "get", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "--json", "audit", "get", WH_GUID])
         assert result.exit_code == 0
         parsed = json.loads(result.output)
         assert isinstance(parsed, dict)
@@ -102,7 +102,7 @@ class TestAuditGet:
                 new=AsyncMock(side_effect=NotFoundError("not found")),
             ),
         ):
-            result = runner.invoke(cli, ["audit", "get", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "audit", "get", WH_GUID])
         assert result.exit_code != 0
 
 
@@ -125,7 +125,7 @@ class TestAuditEnable:
             ),
             patch("fabric_dw.cli.commands.audit._audit_svc.enable", new=mock_enable),
         ):
-            result = runner.invoke(cli, ["--json", "audit", "enable", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "--json", "audit", "enable", WH_GUID])
         assert result.exit_code == 0
         mock_enable.assert_awaited_once()
         parsed = json.loads(result.output)
@@ -148,7 +148,7 @@ class TestAuditEnable:
             patch("fabric_dw.cli.commands.audit._audit_svc.enable", new=mock_enable),
         ):
             result = runner.invoke(
-                cli, ["audit", "enable", WS_GUID, WH_GUID, "--retention-days", "30"]
+                cli, ["-w", WS_GUID, "audit", "enable", WH_GUID, "--retention-days", "30"]
             )
         assert result.exit_code == 0
         mock_enable.assert_awaited_once()
@@ -178,7 +178,7 @@ class TestAuditEnable:
                 new=mock_enable,
             ),
         ):
-            result = runner.invoke(cli, ["audit", "enable", WS_GUID, WH_GUID, "--unlimited"])
+            result = runner.invoke(cli, ["-w", WS_GUID, "audit", "enable", WH_GUID, "--unlimited"])
         assert result.exit_code == 0
         mock_enable.assert_awaited_once()
         _, kwargs = mock_enable.call_args
@@ -191,7 +191,7 @@ class TestAuditEnable:
         _ = cache_env
         result = runner.invoke(
             cli,
-            ["audit", "enable", WS_GUID, WH_GUID, "--retention-days", "30", "--unlimited"],
+            ["-w", WS_GUID, "audit", "enable", WH_GUID, "--retention-days", "30", "--unlimited"],
         )
         assert result.exit_code != 0
 
@@ -200,7 +200,9 @@ class TestAuditEnable:
     ) -> None:
         """--retention-days 0 must be rejected with a usage error (click.IntRange >= 1)."""
         _ = cache_env
-        result = runner.invoke(cli, ["audit", "enable", WS_GUID, WH_GUID, "--retention-days", "0"])
+        result = runner.invoke(
+            cli, ["-w", WS_GUID, "audit", "enable", WH_GUID, "--retention-days", "0"]
+        )
         assert result.exit_code != 0
         # click.IntRange validation message; the hint to use --unlimited is in the --help text.
         assert "x>=1" in result.output or ">=1" in result.output or "range" in result.output
@@ -210,7 +212,9 @@ class TestAuditEnable:
     ) -> None:
         """Negative --retention-days must be rejected with a usage error."""
         _ = cache_env
-        result = runner.invoke(cli, ["audit", "enable", WS_GUID, WH_GUID, "--retention-days", "-1"])
+        result = runner.invoke(
+            cli, ["-w", WS_GUID, "audit", "enable", WH_GUID, "--retention-days", "-1"]
+        )
         assert result.exit_code != 0
         assert "range" in result.output
 
@@ -234,7 +238,7 @@ class TestAuditDisable:
             ),
             patch("fabric_dw.cli.commands.audit._audit_svc.disable", new=mock_disable),
         ):
-            result = runner.invoke(cli, ["--yes", "audit", "disable", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "--yes", "audit", "disable", WH_GUID])
         assert result.exit_code == 0
         mock_disable.assert_awaited_once()
 
@@ -252,7 +256,7 @@ class TestAuditDisable:
                 new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
             ),
         ):
-            result = runner.invoke(cli, ["audit", "disable", WS_GUID, WH_GUID], input="n\n")
+            result = runner.invoke(cli, ["-w", WS_GUID, "audit", "disable", WH_GUID], input="n\n")
         assert result.exit_code == 0
         assert "Aborted." in result.output
 
@@ -277,7 +281,7 @@ class TestAuditSetRetention:
             patch("fabric_dw.cli.commands.audit._audit_svc.set_retention", new=mock_set_retention),
         ):
             result = runner.invoke(
-                cli, ["audit", "set-retention", WS_GUID, WH_GUID, "--days", "90"]
+                cli, ["-w", WS_GUID, "audit", "set-retention", WH_GUID, "--days", "90"]
             )
         assert result.exit_code == 0
         mock_set_retention.assert_awaited_once()
@@ -299,7 +303,7 @@ class TestAuditSetRetention:
             ),
         ):
             result = runner.invoke(
-                cli, ["--json", "audit", "set-retention", WS_GUID, WH_GUID, "--days", "30"]
+                cli, ["-w", WS_GUID, "--json", "audit", "set-retention", WH_GUID, "--days", "30"]
             )
         assert result.exit_code == 0
         parsed = json.loads(result.output)
@@ -325,14 +329,16 @@ class TestAuditSetRetention:
             ),
         ):
             result = runner.invoke(
-                cli, ["audit", "set-retention", WS_GUID, WH_GUID, "--days", "9999"]
+                cli, ["-w", WS_GUID, "audit", "set-retention", WH_GUID, "--days", "9999"]
             )
         assert result.exit_code != 0
 
     def test_set_retention_zero_is_rejected(self, runner: CliRunner, cache_env: Path) -> None:
         """--days 0 must be rejected client-side (L24: >= 1 validation)."""
         _ = cache_env
-        result = runner.invoke(cli, ["audit", "set-retention", WS_GUID, WH_GUID, "--days", "0"])
+        result = runner.invoke(
+            cli, ["-w", WS_GUID, "audit", "set-retention", WH_GUID, "--days", "0"]
+        )
         assert result.exit_code != 0
         # click.IntRange validation message should appear.
         assert "range" in result.output
@@ -340,7 +346,9 @@ class TestAuditSetRetention:
     def test_set_retention_negative_is_rejected(self, runner: CliRunner, cache_env: Path) -> None:
         """--days -1 must be rejected client-side (L24: >= 1 validation)."""
         _ = cache_env
-        result = runner.invoke(cli, ["audit", "set-retention", WS_GUID, WH_GUID, "--days", "-1"])
+        result = runner.invoke(
+            cli, ["-w", WS_GUID, "audit", "set-retention", WH_GUID, "--days", "-1"]
+        )
         assert result.exit_code != 0
         assert "range" in result.output
 
@@ -369,7 +377,7 @@ class TestAuditSetRetention:
             patch("fabric_dw.cli.commands.audit._audit_svc.set_retention", new=mock_set_retention),
         ):
             result = runner.invoke(
-                cli, ["audit", "set-retention", WS_GUID, WH_GUID, "--days", "30"]
+                cli, ["-w", WS_GUID, "audit", "set-retention", WH_GUID, "--days", "30"]
             )
         assert result.exit_code == 0
         # No pre-check GET — service is called exactly once (the PATCH)
@@ -398,9 +406,10 @@ class TestAuditSetGroups:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "audit",
                     "set-groups",
-                    WS_GUID,
                     WH_GUID,
                     "--group",
                     "BATCH_COMPLETED_GROUP",
@@ -433,9 +442,10 @@ class TestAuditSetGroups:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "audit",
                     "set-groups",
-                    WS_GUID,
                     WH_GUID,
                     "--group",
                     "invalid-lowercase-group",
@@ -471,9 +481,10 @@ class TestAuditAddGroup:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "audit",
                     "add-group",
-                    WS_GUID,
                     WH_GUID,
                     "BATCH_COMPLETED_GROUP",
                 ],
@@ -499,7 +510,7 @@ class TestAuditAddGroup:
         ):
             result = runner.invoke(
                 cli,
-                ["--json", "audit", "add-group", WS_GUID, WH_GUID, "BATCH_COMPLETED_GROUP"],
+                ["-w", WS_GUID, "--json", "audit", "add-group", WH_GUID, "BATCH_COMPLETED_GROUP"],
             )
         assert result.exit_code == 0
         parsed = json.loads(result.output)
@@ -522,7 +533,7 @@ class TestAuditAddGroup:
         ):
             result = runner.invoke(
                 cli,
-                ["audit", "add-group", WS_GUID, WH_GUID, "invalid-lowercase"],
+                ["-w", WS_GUID, "audit", "add-group", WH_GUID, "invalid-lowercase"],
             )
         assert result.exit_code != 0
 
@@ -547,7 +558,7 @@ class TestAuditAddGroup:
         ):
             result = runner.invoke(
                 cli,
-                ["audit", "add-group", WS_GUID, WH_GUID, "BATCH_COMPLETED_GROUP"],
+                ["-w", WS_GUID, "audit", "add-group", WH_GUID, "BATCH_COMPLETED_GROUP"],
             )
         assert result.exit_code != 0
 
@@ -575,9 +586,10 @@ class TestAuditRemoveGroup:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "audit",
                     "remove-group",
-                    WS_GUID,
                     WH_GUID,
                     "BATCH_COMPLETED_GROUP",
                 ],
@@ -603,7 +615,15 @@ class TestAuditRemoveGroup:
         ):
             result = runner.invoke(
                 cli,
-                ["--json", "audit", "remove-group", WS_GUID, WH_GUID, "BATCH_COMPLETED_GROUP"],
+                [
+                    "-w",
+                    WS_GUID,
+                    "--json",
+                    "audit",
+                    "remove-group",
+                    WH_GUID,
+                    "BATCH_COMPLETED_GROUP",
+                ],
             )
         assert result.exit_code == 0
         parsed = json.loads(result.output)
@@ -626,7 +646,7 @@ class TestAuditRemoveGroup:
         ):
             result = runner.invoke(
                 cli,
-                ["audit", "remove-group", WS_GUID, WH_GUID, "invalid-lowercase"],
+                ["-w", WS_GUID, "audit", "remove-group", WH_GUID, "invalid-lowercase"],
             )
         assert result.exit_code != 0
 
@@ -651,7 +671,7 @@ class TestAuditRemoveGroup:
         ):
             result = runner.invoke(
                 cli,
-                ["audit", "remove-group", WS_GUID, WH_GUID, "BATCH_COMPLETED_GROUP"],
+                ["-w", WS_GUID, "audit", "remove-group", WH_GUID, "BATCH_COMPLETED_GROUP"],
             )
         assert result.exit_code != 0
 

--- a/tests/unit/cli/commands/test_audit_respx.py
+++ b/tests/unit/cli/commands/test_audit_respx.py
@@ -107,7 +107,7 @@ class TestAuditEnableRespx:
             ):
                 result = runner.invoke(
                     cli,
-                    ["--json", "audit", "enable", WS_GUID, WH_GUID],
+                    ["-w", WS_GUID, "--json", "audit", "enable", WH_GUID],
                 )
 
         assert result.exit_code == 0, result.output
@@ -147,10 +147,11 @@ class TestAuditEnableRespx:
                 result = runner.invoke(
                     cli,
                     [
+                        "-w",
+                        WS_GUID,
                         "--json",
                         "audit",
                         "enable",
-                        WS_GUID,
                         WH_GUID,
                         "--retention-days",
                         "30",
@@ -196,7 +197,7 @@ class TestAuditDisableRespx:
             ):
                 result = runner.invoke(
                     cli,
-                    ["--yes", "--json", "audit", "disable", WS_GUID, WH_GUID],
+                    ["-w", WS_GUID, "--yes", "--json", "audit", "disable", WH_GUID],
                 )
 
         assert result.exit_code == 0, result.output
@@ -223,7 +224,7 @@ class TestAuditDisableRespx:
             ):
                 result = runner.invoke(
                     cli,
-                    ["--yes", "audit", "disable", WS_GUID, WH_GUID],
+                    ["-w", WS_GUID, "--yes", "audit", "disable", WH_GUID],
                 )
 
         assert result.exit_code == 0, result.output
@@ -265,7 +266,7 @@ class TestAuditSetRetentionRespx:
             ):
                 result = runner.invoke(
                     cli,
-                    ["--json", "audit", "set-retention", WS_GUID, WH_GUID, "--days", "90"],
+                    ["-w", WS_GUID, "--json", "audit", "set-retention", WH_GUID, "--days", "90"],
                 )
 
         assert result.exit_code == 0, result.output
@@ -292,7 +293,7 @@ class TestAuditSetRetentionRespx:
             ):
                 result = runner.invoke(
                     cli,
-                    ["audit", "set-retention", WS_GUID, WH_GUID, "--days", "7"],
+                    ["-w", WS_GUID, "audit", "set-retention", WH_GUID, "--days", "7"],
                 )
 
         assert result.exit_code == 0, result.output
@@ -335,7 +336,7 @@ class TestAuditAddGroupRespx:
             ):
                 result = runner.invoke(
                     cli,
-                    ["--json", "audit", "add-group", WS_GUID, WH_GUID, new_group],
+                    ["-w", WS_GUID, "--json", "audit", "add-group", WH_GUID, new_group],
                 )
 
         assert result.exit_code == 0, result.output
@@ -367,7 +368,7 @@ class TestAuditAddGroupRespx:
             ):
                 result = runner.invoke(
                     cli,
-                    ["audit", "add-group", WS_GUID, WH_GUID, new_group],
+                    ["-w", WS_GUID, "audit", "add-group", WH_GUID, new_group],
                 )
 
         assert result.exit_code == 0, result.output
@@ -410,7 +411,7 @@ class TestAuditRemoveGroupRespx:
             ):
                 result = runner.invoke(
                     cli,
-                    ["--json", "audit", "remove-group", WS_GUID, WH_GUID, group_to_remove],
+                    ["-w", WS_GUID, "--json", "audit", "remove-group", WH_GUID, group_to_remove],
                 )
 
         assert result.exit_code == 0, result.output
@@ -443,7 +444,7 @@ class TestAuditRemoveGroupRespx:
             ):
                 result = runner.invoke(
                     cli,
-                    ["audit", "remove-group", WS_GUID, WH_GUID, group_to_remove],
+                    ["-w", WS_GUID, "audit", "remove-group", WH_GUID, group_to_remove],
                 )
 
         assert result.exit_code == 0, result.output

--- a/tests/unit/cli/commands/test_query_insights.py
+++ b/tests/unit/cli/commands/test_query_insights.py
@@ -438,7 +438,7 @@ class TestPoolInsights:
                 new=AsyncMock(return_value=[_make_pool_insight_row()]),
             ),
         ):
-            result = runner.invoke(cli, ["sql-pools", "insights", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "sql-pools", "insights", WH_GUID])
         assert result.exit_code == 0
 
     def test_json_output(self, runner: CliRunner, cache_env: Path) -> None:
@@ -460,7 +460,7 @@ class TestPoolInsights:
         ):
             result = runner.invoke(
                 cli,
-                ["--json", "sql-pools", "insights", WS_GUID, WH_GUID],
+                ["-w", WS_GUID, "--json", "sql-pools", "insights", WH_GUID],
             )
         assert result.exit_code == 0
         parsed = json.loads(result.output)

--- a/tests/unit/cli/commands/test_sql.py
+++ b/tests/unit/cli/commands/test_sql.py
@@ -82,7 +82,7 @@ class TestSql:
         ):
             result = runner.invoke(
                 cli,
-                ["sql", WS_GUID, WH_GUID, "-q", "SELECT 1"],
+                ["-w", WS_GUID, "sql", WH_GUID, "-q", "SELECT 1"],
             )
         assert result.exit_code == 0
 
@@ -106,7 +106,7 @@ class TestSql:
         ):
             result = runner.invoke(
                 cli,
-                ["sql", WS_GUID, WH_GUID, "-q", "SELECT id, name FROM t"],
+                ["-w", WS_GUID, "sql", WH_GUID, "-q", "SELECT id, name FROM t"],
             )
         assert result.exit_code == 0
         # Default is table — output must NOT be parseable as JSON
@@ -133,7 +133,7 @@ class TestSql:
         ):
             result = runner.invoke(
                 cli,
-                ["--json", "sql", WS_GUID, WH_GUID, "-q", "SELECT id, name FROM t"],
+                ["-w", WS_GUID, "--json", "sql", WH_GUID, "-q", "SELECT id, name FROM t"],
             )
         assert result.exit_code == 0
         parsed = json.loads(result.output)
@@ -168,7 +168,7 @@ class TestSql:
         ):
             result = runner.invoke(
                 cli,
-                ["sql", WS_GUID, WH_GUID, "-f", str(sql_file)],
+                ["-w", WS_GUID, "sql", WH_GUID, "-f", str(sql_file)],
             )
         assert result.exit_code == 0
         assert captured_query[0] == "SELECT 1 AS n"
@@ -204,7 +204,7 @@ class TestSql:
         ):
             result = runner.invoke(
                 cli,
-                ["sql", WS_GUID, WH_GUID, "-f", str(sql_file)],
+                ["-w", WS_GUID, "sql", WH_GUID, "-f", str(sql_file)],
             )
         assert result.exit_code == 0
         assert captured_query[0][0] == "S", (
@@ -231,7 +231,7 @@ class TestSql:
         ):
             result = runner.invoke(
                 cli,
-                ["sql", WS_GUID, WH_GUID, "-q", "SELECT id, name FROM t"],
+                ["-w", WS_GUID, "sql", WH_GUID, "-q", "SELECT id, name FROM t"],
             )
         assert result.exit_code == 0
         # Default is table; JSON flag not set so output must NOT be parseable as JSON
@@ -259,8 +259,9 @@ class TestSql:
             result = runner.invoke(
                 cli,
                 [
-                    "sql",
+                    "-w",
                     WS_GUID,
+                    "sql",
                     WH_GUID,
                     "-q",
                     "INSERT INTO t VALUES (1)",
@@ -275,7 +276,7 @@ class TestSqlErrors:
 
     def test_no_query_or_file_is_error(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
-        result = runner.invoke(cli, ["sql", WS_GUID, WH_GUID])
+        result = runner.invoke(cli, ["-w", WS_GUID, "sql", WH_GUID])
         assert result.exit_code != 0
 
     def test_both_query_and_file_is_error(
@@ -286,7 +287,7 @@ class TestSqlErrors:
         sql_file.write_text("SELECT 1")
         result = runner.invoke(
             cli,
-            ["sql", WS_GUID, WH_GUID, "-q", "SELECT 1", "-f", str(sql_file)],
+            ["-w", WS_GUID, "sql", WH_GUID, "-q", "SELECT 1", "-f", str(sql_file)],
         )
         assert result.exit_code != 0
 
@@ -309,7 +310,7 @@ class TestSqlErrors:
         ):
             result = runner.invoke(
                 cli,
-                ["sql", WS_GUID, WH_GUID, "-q", "SELECT * FROM sensitive"],
+                ["-w", WS_GUID, "sql", WH_GUID, "-q", "SELECT * FROM sensitive"],
             )
         assert result.exit_code != 0
 
@@ -328,7 +329,7 @@ class TestSqlErrors:
         ):
             result = runner.invoke(
                 cli,
-                ["sql", WS_GUID, WH_GUID, "-q", "SELECT 1"],
+                ["-w", WS_GUID, "sql", WH_GUID, "-q", "SELECT 1"],
             )
         assert result.exit_code != 0
 
@@ -353,6 +354,6 @@ class TestSqlErrors:
         ):
             result = runner.invoke(
                 cli,
-                ["sql", WS_GUID, WH_GUID, "-q", "SELECT 1"],
+                ["-w", WS_GUID, "sql", WH_GUID, "-q", "SELECT 1"],
             )
         assert result.exit_code != 0

--- a/tests/unit/cli/commands/test_sql_pools.py
+++ b/tests/unit/cli/commands/test_sql_pools.py
@@ -105,7 +105,7 @@ class TestSqlPoolsGet:
                 new=AsyncMock(return_value=_CONFIG),
             ),
         ):
-            result = runner.invoke(cli, ["--json", "sql-pools", "get", WS_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "--json", "sql-pools", "get"])
         assert result.exit_code == 0
         data = json.loads(result.output)
         assert data["customSQLPoolsEnabled"] is True
@@ -127,7 +127,7 @@ class TestSqlPoolsGet:
                 new=AsyncMock(return_value=_CONFIG),
             ),
         ):
-            result = runner.invoke(cli, ["--json", "sql-pools", "get", WS_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "--json", "sql-pools", "get"])
         assert result.exit_code == 0
         data = json.loads(result.output)
         assert data["customSQLPoolsEnabled"] is True
@@ -149,7 +149,7 @@ class TestSqlPoolsGet:
                 new=AsyncMock(side_effect=PermissionDeniedError("403")),
             ),
         ):
-            result = runner.invoke(cli, ["sql-pools", "get", WS_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "sql-pools", "get"])
         assert result.exit_code != 0
         assert "admin" in result.output.lower()
 
@@ -171,7 +171,7 @@ class TestSqlPoolsList:
                 new=AsyncMock(return_value=_CONFIG_MULTI),
             ),
         ):
-            result = runner.invoke(cli, ["--json", "sql-pools", "list", WS_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "--json", "sql-pools", "list"])
         assert result.exit_code == 0
         data = json.loads(result.output)
         assert isinstance(data, list)
@@ -195,7 +195,7 @@ class TestSqlPoolsList:
                 new=AsyncMock(return_value=_CONFIG_MULTI),
             ),
         ):
-            result = runner.invoke(cli, ["--json", "sql-pools", "list", WS_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "--json", "sql-pools", "list"])
         assert result.exit_code == 0
         data = json.loads(result.output)
         assert isinstance(data, list)
@@ -223,7 +223,7 @@ class TestSqlPoolsList:
                 new=AsyncMock(return_value=_CONFIG_EMPTY),
             ),
         ):
-            result = runner.invoke(cli, ["sql-pools", "list", WS_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "sql-pools", "list"])
         assert result.exit_code == 0
         out = result.output
         assert "No custom SQL pools" in out
@@ -254,7 +254,7 @@ class TestSqlPoolsList:
                 new=AsyncMock(return_value=disabled_empty),
             ),
         ):
-            result = runner.invoke(cli, ["sql-pools", "list", WS_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "sql-pools", "list"])
         assert result.exit_code == 0
         assert "NON-SELECT" in result.output
 
@@ -277,7 +277,7 @@ class TestSqlPoolsList:
                 new=AsyncMock(return_value=_CONFIG_EMPTY),
             ),
         ):
-            result = runner.invoke(cli, ["--json", "sql-pools", "list", WS_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "--json", "sql-pools", "list"])
         assert result.exit_code == 0
         data = json.loads(result.output)
         assert isinstance(data, dict)
@@ -309,7 +309,9 @@ class TestSqlPoolsShow:
                 new=AsyncMock(return_value=_CONFIG_MULTI),
             ),
         ):
-            result = runner.invoke(cli, ["--json", "sql-pools", "show", WS_GUID, "--name", "ETL"])
+            result = runner.invoke(
+                cli, ["-w", WS_GUID, "--json", "sql-pools", "show", "--name", "ETL"]
+            )
         assert result.exit_code == 0
         data = json.loads(result.output)
         assert data["name"] == "ETL"
@@ -331,7 +333,9 @@ class TestSqlPoolsShow:
                 new=AsyncMock(return_value=_CONFIG_MULTI),
             ),
         ):
-            result = runner.invoke(cli, ["sql-pools", "show", WS_GUID, "--name", "DoesNotExist"])
+            result = runner.invoke(
+                cli, ["-w", WS_GUID, "sql-pools", "show", "--name", "DoesNotExist"]
+            )
         assert result.exit_code != 0
 
 
@@ -356,9 +360,10 @@ class TestSqlPoolsCreate:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "sql-pools",
                     "create",
-                    WS_GUID,
                     "--name",
                     "NewPool",
                     "--max-percent",
@@ -394,9 +399,10 @@ class TestSqlPoolsCreate:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "sql-pools",
                     "create",
-                    WS_GUID,
                     "--name",
                     "NewPool",
                     "--max-percent",
@@ -434,9 +440,10 @@ class TestSqlPoolsCreate:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "sql-pools",
                     "create",
-                    WS_GUID,
                     "--name",
                     "Default",
                     "--max-percent",
@@ -466,9 +473,10 @@ class TestSqlPoolsCreate:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "sql-pools",
                     "create",
-                    WS_GUID,
                     "--name",
                     "Defaults",
                     "--max-percent",
@@ -503,9 +511,10 @@ class TestSqlPoolsUpdate:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "sql-pools",
                     "update",
-                    WS_GUID,
                     "--name",
                     "Default",
                     "--max-percent",
@@ -534,9 +543,10 @@ class TestSqlPoolsUpdate:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "sql-pools",
                     "update",
-                    WS_GUID,
                     "--name",
                     "NoPool",
                     "--max-percent",
@@ -567,9 +577,10 @@ class TestSqlPoolsUpdate:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "sql-pools",
                     "update",
-                    WS_GUID,
                     "--name",
                     "Default",
                     "--no-optimize-for-reads",
@@ -600,9 +611,10 @@ class TestSqlPoolsUpdate:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "sql-pools",
                     "update",
-                    WS_GUID,
                     "--name",
                     "Default",
                     "--no-default",
@@ -633,7 +645,7 @@ class TestSqlPoolsDelete:
         ):
             result = runner.invoke(
                 cli,
-                ["-y", "sql-pools", "delete", WS_GUID, "--name", "Default"],
+                ["-w", WS_GUID, "-y", "sql-pools", "delete", "--name", "Default"],
             )
         assert result.exit_code == 0
         mock_delete.assert_awaited_once()
@@ -656,7 +668,7 @@ class TestSqlPoolsDelete:
         ):
             result = runner.invoke(
                 cli,
-                ["-y", "sql-pools", "delete", WS_GUID, "--name", "NoPool"],
+                ["-w", WS_GUID, "-y", "sql-pools", "delete", "--name", "NoPool"],
             )
         assert result.exit_code != 0
 
@@ -678,7 +690,7 @@ class TestSqlPoolsDelete:
         ):
             result = runner.invoke(
                 cli,
-                ["-y", "sql-pools", "delete", WS_GUID, "--name", "Default"],
+                ["-w", WS_GUID, "-y", "sql-pools", "delete", "--name", "Default"],
             )
         assert result.exit_code != 0
         assert "admin" in result.output.lower()
@@ -702,7 +714,7 @@ class TestSqlPoolsEnable:
                 new=mock_enable,
             ),
         ):
-            result = runner.invoke(cli, ["--json", "sql-pools", "enable", WS_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "--json", "sql-pools", "enable"])
         assert result.exit_code == 0
         mock_enable.assert_awaited_once()
         data = json.loads(result.output)
@@ -724,7 +736,7 @@ class TestSqlPoolsEnable:
                 new=AsyncMock(side_effect=PermissionDeniedError("403")),
             ),
         ):
-            result = runner.invoke(cli, ["sql-pools", "enable", WS_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "sql-pools", "enable"])
         assert result.exit_code != 0
         assert "admin" in result.output.lower()
 
@@ -747,7 +759,7 @@ class TestSqlPoolsDisable:
                 new=mock_disable,
             ),
         ):
-            result = runner.invoke(cli, ["--json", "sql-pools", "disable", WS_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "--json", "sql-pools", "disable"])
         assert result.exit_code == 0
         mock_disable.assert_awaited_once()
         data = json.loads(result.output)
@@ -773,7 +785,7 @@ class TestSqlPoolsGetFabricError:
                 new=AsyncMock(side_effect=FabricError("server error")),
             ),
         ):
-            result = runner.invoke(cli, ["sql-pools", "get", WS_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "sql-pools", "get"])
         assert result.exit_code != 0
         assert "server error" in result.output
 
@@ -797,7 +809,7 @@ class TestSqlPoolsListErrors:
                 new=AsyncMock(side_effect=PermissionDeniedError("403")),
             ),
         ):
-            result = runner.invoke(cli, ["sql-pools", "list", WS_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "sql-pools", "list"])
         assert result.exit_code != 0
         assert "admin" in result.output.lower()
 
@@ -817,7 +829,7 @@ class TestSqlPoolsListErrors:
                 new=AsyncMock(side_effect=FabricError("server error")),
             ),
         ):
-            result = runner.invoke(cli, ["sql-pools", "list", WS_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "sql-pools", "list"])
         assert result.exit_code != 0
 
 
@@ -840,7 +852,7 @@ class TestSqlPoolsShowErrors:
                 new=AsyncMock(side_effect=PermissionDeniedError("403")),
             ),
         ):
-            result = runner.invoke(cli, ["sql-pools", "show", WS_GUID, "--name", "Default"])
+            result = runner.invoke(cli, ["-w", WS_GUID, "sql-pools", "show", "--name", "Default"])
         assert result.exit_code != 0
         assert "admin" in result.output.lower()
 
@@ -860,7 +872,7 @@ class TestSqlPoolsShowErrors:
                 new=AsyncMock(side_effect=FabricError("server error")),
             ),
         ):
-            result = runner.invoke(cli, ["sql-pools", "show", WS_GUID, "--name", "Default"])
+            result = runner.invoke(cli, ["-w", WS_GUID, "sql-pools", "show", "--name", "Default"])
         assert result.exit_code != 0
 
 
@@ -884,7 +896,8 @@ class TestSqlPoolsCreateErrors:
             ),
         ):
             result = runner.invoke(
-                cli, ["sql-pools", "create", WS_GUID, "--name", "NewPool", "--max-percent", "50"]
+                cli,
+                ["-w", WS_GUID, "sql-pools", "create", "--name", "NewPool", "--max-percent", "50"],
             )
         assert result.exit_code != 0
         assert "admin" in result.output.lower()
@@ -906,7 +919,8 @@ class TestSqlPoolsCreateErrors:
             ),
         ):
             result = runner.invoke(
-                cli, ["sql-pools", "create", WS_GUID, "--name", "NewPool", "--max-percent", "50"]
+                cli,
+                ["-w", WS_GUID, "sql-pools", "create", "--name", "NewPool", "--max-percent", "50"],
             )
         assert result.exit_code != 0
 
@@ -928,7 +942,8 @@ class TestSqlPoolsCreateErrors:
             ),
         ):
             result = runner.invoke(
-                cli, ["sql-pools", "create", WS_GUID, "--name", "NewPool", "--max-percent", "50"]
+                cli,
+                ["-w", WS_GUID, "sql-pools", "create", "--name", "NewPool", "--max-percent", "50"],
             )
         assert result.exit_code != 0
         assert "Invalid pool configuration" in result.output
@@ -955,7 +970,7 @@ class TestSqlPoolsUpdateErrors:
         ):
             result = runner.invoke(
                 cli,
-                ["sql-pools", "update", WS_GUID, "--name", "Default", "--max-percent", "50"],
+                ["-w", WS_GUID, "sql-pools", "update", "--name", "Default", "--max-percent", "50"],
             )
         assert result.exit_code != 0
         assert "admin" in result.output.lower()
@@ -978,7 +993,7 @@ class TestSqlPoolsUpdateErrors:
         ):
             result = runner.invoke(
                 cli,
-                ["sql-pools", "update", WS_GUID, "--name", "Default", "--max-percent", "50"],
+                ["-w", WS_GUID, "sql-pools", "update", "--name", "Default", "--max-percent", "50"],
             )
         assert result.exit_code != 0
 
@@ -1001,7 +1016,7 @@ class TestSqlPoolsUpdateErrors:
         ):
             result = runner.invoke(
                 cli,
-                ["sql-pools", "update", WS_GUID, "--name", "Default", "--max-percent", "50"],
+                ["-w", WS_GUID, "sql-pools", "update", "--name", "Default", "--max-percent", "50"],
             )
         assert result.exit_code != 0
         assert "Invalid pool configuration" in result.output
@@ -1013,7 +1028,7 @@ class TestSqlPoolsDeleteAbort:
     def test_delete_declined_prints_aborted(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
         result = runner.invoke(
-            cli, ["sql-pools", "delete", WS_GUID, "--name", "Default"], input="n\n"
+            cli, ["-w", WS_GUID, "sql-pools", "delete", "--name", "Default"], input="n\n"
         )
         assert result.exit_code == 0
         assert "Aborted." in result.output
@@ -1034,7 +1049,9 @@ class TestSqlPoolsDeleteAbort:
                 new=AsyncMock(side_effect=FabricError("server error")),
             ),
         ):
-            result = runner.invoke(cli, ["-y", "sql-pools", "delete", WS_GUID, "--name", "Default"])
+            result = runner.invoke(
+                cli, ["-w", WS_GUID, "-y", "sql-pools", "delete", "--name", "Default"]
+            )
         assert result.exit_code != 0
 
 
@@ -1057,7 +1074,7 @@ class TestSqlPoolsEnableFabricError:
                 new=AsyncMock(side_effect=FabricError("server error")),
             ),
         ):
-            result = runner.invoke(cli, ["sql-pools", "enable", WS_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "sql-pools", "enable"])
         assert result.exit_code != 0
 
 
@@ -1080,7 +1097,7 @@ class TestSqlPoolsDisableErrors:
                 new=AsyncMock(side_effect=PermissionDeniedError("403")),
             ),
         ):
-            result = runner.invoke(cli, ["sql-pools", "disable", WS_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "sql-pools", "disable"])
         assert result.exit_code != 0
         assert "admin" in result.output.lower()
 
@@ -1100,7 +1117,7 @@ class TestSqlPoolsDisableErrors:
                 new=AsyncMock(side_effect=FabricError("server error")),
             ),
         ):
-            result = runner.invoke(cli, ["sql-pools", "disable", WS_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "sql-pools", "disable"])
         assert result.exit_code != 0
 
 
@@ -1131,7 +1148,7 @@ class TestSqlPoolsInsights:
                 new=mock_insights,
             ),
         ):
-            result = runner.invoke(cli, ["--json", "sql-pools", "insights", WS_GUID, WS_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "--json", "sql-pools", "insights", WS_GUID])
         assert result.exit_code == 0
         mock_insights.assert_awaited_once()
         data = json.loads(result.output)
@@ -1158,10 +1175,11 @@ class TestSqlPoolsInsights:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "--json",
                     "sql-pools",
                     "insights",
-                    WS_GUID,
                     WS_GUID,
                     "--since",
                     "2024-01-01T00:00:00",
@@ -1196,5 +1214,5 @@ class TestSqlPoolsInsights:
                 new=AsyncMock(side_effect=FabricError("server error")),
             ),
         ):
-            result = runner.invoke(cli, ["sql-pools", "insights", WS_GUID, WS_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "sql-pools", "insights", WS_GUID])
         assert result.exit_code != 0


### PR DESCRIPTION
## Summary

Part of the CLI-wide refactor that moves the target workspace from a positional `WORKSPACE` argument to the global `-w/--workspace` root option.

This PR converts the **sql**, **sql-pools**, and **audit** command clusters. Each command now resolves its workspace via `resolve_workspace(ctx)` (from `_utils`), with precedence:

1. explicit `-w/--workspace`
2. `FABRIC_DW_DEFAULT_WORKSPACE` env var
3. config default
4. otherwise a helpful `UsageError`

The positional `WORKSPACE` argument is removed; where a command also took an item/warehouse positional, that becomes the leading argument. Docstrings are updated to drop `WORKSPACE`.

## Converted commands

- `sql`
- `sql-pools`: `get`, `list`, `show`, `create`, `update`, `delete`, `enable`, `disable`, `insights`
- `audit`: `get`, `enable`, `disable`, `set-retention`, `set-groups`, `add-group`, `remove-group`

## Breaking change

`WORKSPACE` is no longer a positional argument for the `sql`, `sql-pools`, and `audit` commands. Pass the workspace with `-w/--workspace` **before** the command, e.g.:

```
fabric-dw -w <workspace> sql <item> -q "SELECT 1"
fabric-dw -w <workspace> sql-pools get
fabric-dw -w <workspace> audit get <warehouse>
```

or rely on `FABRIC_DW_DEFAULT_WORKSPACE` / the configured default.

## Validation

`just check` (lint + ruff format check + ty type check + unit tests) is clean: 3424 passed.

Tests updated: positional-workspace invocations now pass `-w <ws>` before the group/command name across `test_sql.py`, `test_sql_pools.py`, `test_audit.py`, `test_audit_respx.py`, and the `TestPoolInsights` cases in `test_query_insights.py` (which exercise `sql-pools insights`). Docs are intentionally untouched (handled by the separate docs sweep PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)