### PR TITLE
refactor(cli)!: queries, restore-points, snapshots, dbt take workspace via -w

### DIFF
--- a/src/fabric_dw/cli/commands/dbt.py
+++ b/src/fabric_dw/cli/commands/dbt.py
@@ -2,7 +2,7 @@
 
 Commands
 --------
-- ``dbt init <ws> <item> <folder>`` — scaffold a new dbt-fabric project.
+- ``dbt init <item> <folder>`` — scaffold a new dbt-fabric project.
 """
 
 from __future__ import annotations
@@ -19,7 +19,7 @@ from fabric_dw.cli.commands._utils import (
     build_sql_target,
     coro,
     resolve_warehouse_arg,
-    resolve_workspace_arg,
+    resolve_workspace,
 )
 from fabric_dw.exceptions import FabricError
 from fabric_dw.services.dbt_scaffold import (
@@ -38,7 +38,6 @@ def dbt_group() -> None:
 
 
 @dbt_group.command("init")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.argument("folder", required=True)
 @click.option(
@@ -119,7 +118,6 @@ def dbt_group() -> None:
 @coro
 async def init_cmd(
     ctx: CliContext,
-    workspace: str | None,
     item: str | None,
     folder: str,
     project_name: str | None,
@@ -132,7 +130,7 @@ async def init_cmd(
     with_sources: bool,
     force: bool,
 ) -> None:
-    """Scaffold a new dbt-fabric project in FOLDER linked to ITEM in WORKSPACE.
+    """Scaffold a new dbt-fabric project in FOLDER linked to ITEM.
 
     Writes dbt_project.yml, profiles.yml (or merges into ~/.dbt/profiles.yml),
     requirements.txt, .gitignore, standard dbt folders, a sample model, and
@@ -140,7 +138,7 @@ async def init_cmd(
 
     If git is on PATH and FOLDER has no .git directory, ``git init`` is run.
     """
-    ws = resolve_workspace_arg(ctx, workspace)
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
 
     target_folder = Path(folder)

--- a/src/fabric_dw/cli/commands/queries.py
+++ b/src/fabric_dw/cli/commands/queries.py
@@ -16,7 +16,7 @@ from fabric_dw.cli.commands._utils import (
     coro,
     parse_iso_optional,
     resolve_warehouse_arg,
-    resolve_workspace_arg,
+    resolve_workspace,
 )
 from fabric_dw.exceptions import FabricError
 from fabric_dw.services import queries as _queries_svc
@@ -29,13 +29,12 @@ def queries_group() -> None:
 
 
 @queries_group.command("list")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.pass_obj
 @coro
-async def list_cmd(ctx: CliContext, workspace: str | None, item: str | None) -> None:
-    """List currently running queries on ITEM (warehouse or endpoint) in WORKSPACE."""
-    ws = resolve_workspace_arg(ctx, workspace)
+async def list_cmd(ctx: CliContext, item: str | None) -> None:
+    """List currently running queries on ITEM (warehouse or endpoint)."""
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     try:
         async with build_http_client(ctx) as http:
@@ -51,13 +50,12 @@ async def list_cmd(ctx: CliContext, workspace: str | None, item: str | None) -> 
 
 
 @queries_group.command("list-connections")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.pass_obj
 @coro
-async def list_connections_cmd(ctx: CliContext, workspace: str | None, item: str | None) -> None:
-    """List active SQL connections on ITEM (warehouse or endpoint) in WORKSPACE."""
-    ws = resolve_workspace_arg(ctx, workspace)
+async def list_connections_cmd(ctx: CliContext, item: str | None) -> None:
+    """List active SQL connections on ITEM (warehouse or endpoint)."""
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     try:
         async with build_http_client(ctx) as http:
@@ -73,16 +71,13 @@ async def list_connections_cmd(ctx: CliContext, workspace: str | None, item: str
 
 
 @queries_group.command("kill")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.argument("session_id", type=int)
 @click.pass_obj
 @coro
-async def kill_cmd(
-    ctx: CliContext, workspace: str | None, item: str | None, session_id: int
-) -> None:
-    """Kill the session SESSION_ID on ITEM (warehouse or endpoint) in WORKSPACE."""
-    ws = resolve_workspace_arg(ctx, workspace)
+async def kill_cmd(ctx: CliContext, item: str | None, session_id: int) -> None:
+    """Kill the session SESSION_ID on ITEM (warehouse or endpoint)."""
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     try:
         async with build_http_client(ctx) as http:
@@ -108,7 +103,6 @@ async def kill_cmd(
 
 
 @queries_group.command("request-history")
-@click.argument("workspace", required=False, default=None)
 @click.argument("warehouse", required=False, default=None)
 @LIMIT_OPTION
 @SINCE_OPTION
@@ -117,14 +111,13 @@ async def kill_cmd(
 @coro
 async def request_history_cmd(
     ctx: CliContext,
-    workspace: str | None,
     warehouse: str | None,
     limit: int,
     since: str | None,
     until: str | None,
 ) -> None:
     """List completed SQL requests from queryinsights.exec_requests_history."""
-    ws = resolve_workspace_arg(ctx, workspace)
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, warehouse)
     since_dt = parse_iso_optional(since, "--since")
     until_dt = parse_iso_optional(until, "--until")
@@ -149,7 +142,6 @@ async def request_history_cmd(
 
 
 @queries_group.command("session-history")
-@click.argument("workspace", required=False, default=None)
 @click.argument("warehouse", required=False, default=None)
 @LIMIT_OPTION
 @SINCE_OPTION
@@ -158,14 +150,13 @@ async def request_history_cmd(
 @coro
 async def session_history_cmd(
     ctx: CliContext,
-    workspace: str | None,
     warehouse: str | None,
     limit: int,
     since: str | None,
     until: str | None,
 ) -> None:
     """List completed sessions from queryinsights.exec_sessions_history."""
-    ws = resolve_workspace_arg(ctx, workspace)
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, warehouse)
     since_dt = parse_iso_optional(since, "--since")
     until_dt = parse_iso_optional(until, "--until")
@@ -190,7 +181,6 @@ async def session_history_cmd(
 
 
 @queries_group.command("frequent")
-@click.argument("workspace", required=False, default=None)
 @click.argument("warehouse", required=False, default=None)
 @LIMIT_OPTION
 @SINCE_OPTION
@@ -199,14 +189,13 @@ async def session_history_cmd(
 @coro
 async def frequent_cmd(
     ctx: CliContext,
-    workspace: str | None,
     warehouse: str | None,
     limit: int,
     since: str | None,
     until: str | None,
 ) -> None:
     """List frequently-run queries from queryinsights.frequently_run_queries."""
-    ws = resolve_workspace_arg(ctx, workspace)
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, warehouse)
     since_dt = parse_iso_optional(since, "--since")
     until_dt = parse_iso_optional(until, "--until")
@@ -231,7 +220,6 @@ async def frequent_cmd(
 
 
 @queries_group.command("long-running")
-@click.argument("workspace", required=False, default=None)
 @click.argument("warehouse", required=False, default=None)
 @LIMIT_OPTION
 @SINCE_OPTION
@@ -240,14 +228,13 @@ async def frequent_cmd(
 @coro
 async def long_running_cmd(
     ctx: CliContext,
-    workspace: str | None,
     warehouse: str | None,
     limit: int,
     since: str | None,
     until: str | None,
 ) -> None:
     """List long-running queries from queryinsights.long_running_queries."""
-    ws = resolve_workspace_arg(ctx, workspace)
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, warehouse)
     since_dt = parse_iso_optional(since, "--since")
     until_dt = parse_iso_optional(until, "--until")

--- a/src/fabric_dw/cli/commands/restore_points.py
+++ b/src/fabric_dw/cli/commands/restore_points.py
@@ -12,7 +12,7 @@ from fabric_dw.cli.commands._utils import (
     coro,
     resolve_item,
     resolve_warehouse_arg,
-    resolve_workspace_arg,
+    resolve_workspace,
 )
 from fabric_dw.exceptions import FabricError
 from fabric_dw.services import restore as _restore_svc
@@ -24,13 +24,12 @@ def restore_points_group() -> None:
 
 
 @restore_points_group.command("list")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.pass_obj
 @coro
-async def list_cmd(ctx: CliContext, workspace: str | None, item: str | None) -> None:
-    """List all restore points for ITEM (warehouse) in WORKSPACE."""
-    ws = resolve_workspace_arg(ctx, workspace)
+async def list_cmd(ctx: CliContext, item: str | None) -> None:
+    """List all restore points for ITEM (warehouse)."""
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     try:
         async with build_http_client(ctx) as http:
@@ -47,19 +46,17 @@ async def list_cmd(ctx: CliContext, workspace: str | None, item: str | None) -> 
 
 
 @restore_points_group.command("get")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.argument("restore_point_id")
 @click.pass_obj
 @coro
 async def get_cmd(
     ctx: CliContext,
-    workspace: str | None,
     item: str | None,
     restore_point_id: str,
 ) -> None:
-    """Get a restore point by RESTORE_POINT_ID for ITEM (warehouse) in WORKSPACE."""
-    ws = resolve_workspace_arg(ctx, workspace)
+    """Get a restore point by RESTORE_POINT_ID for ITEM (warehouse)."""
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     try:
         async with build_http_client(ctx) as http:
@@ -72,7 +69,6 @@ async def get_cmd(
 
 
 @restore_points_group.command("create")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.option("--name", default=None, help="Optional display name (max 128 chars).")
 @click.option("--description", default=None, help="Optional description (max 512 chars).")
@@ -80,13 +76,12 @@ async def get_cmd(
 @coro
 async def create_cmd(
     ctx: CliContext,
-    workspace: str | None,
     item: str | None,
     name: str | None,
     description: str | None,
 ) -> None:
-    """Create a restore point for ITEM (warehouse) in WORKSPACE at the current timestamp."""
-    ws = resolve_workspace_arg(ctx, workspace)
+    """Create a restore point for ITEM (warehouse) at the current timestamp."""
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     try:
         async with build_http_client(ctx) as http:
@@ -101,7 +96,6 @@ async def create_cmd(
 
 
 @restore_points_group.command("rename")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.argument("restore_point_id")
 @click.argument("new_name")
@@ -110,14 +104,13 @@ async def create_cmd(
 @coro
 async def rename_cmd(
     ctx: CliContext,
-    workspace: str | None,
     item: str | None,
     restore_point_id: str,
     new_name: str,
     description: str | None,
 ) -> None:
-    """Rename RESTORE_POINT_ID to NEW_NAME on ITEM (warehouse) in WORKSPACE."""
-    ws = resolve_workspace_arg(ctx, workspace)
+    """Rename RESTORE_POINT_ID to NEW_NAME on ITEM (warehouse)."""
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     try:
         async with build_http_client(ctx) as http:
@@ -137,24 +130,22 @@ async def rename_cmd(
 
 
 @restore_points_group.command("delete")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.argument("restore_point_id")
 @click.pass_obj
 @coro
 async def delete_cmd(
     ctx: CliContext,
-    workspace: str | None,
     item: str | None,
     restore_point_id: str,
 ) -> None:
-    """Delete RESTORE_POINT_ID on ITEM (warehouse) in WORKSPACE.
+    """Delete RESTORE_POINT_ID on ITEM (warehouse).
 
     Only user-defined restore points can be deleted; system-created points
     are automatically managed by the service.
     You will be asked to confirm unless --yes is passed.
     """
-    ws = resolve_workspace_arg(ctx, workspace)
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     try:
         async with build_http_client(ctx) as http:
@@ -177,25 +168,23 @@ async def delete_cmd(
 
 
 @restore_points_group.command("restore")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.argument("restore_point_id")
 @click.pass_obj
 @coro
 async def restore_cmd(
     ctx: CliContext,
-    workspace: str | None,
     item: str | None,
     restore_point_id: str,
 ) -> None:
-    """Restore ITEM (warehouse) in-place to RESTORE_POINT_ID in WORKSPACE.
+    """Restore ITEM (warehouse) in-place to RESTORE_POINT_ID.
 
     WARNING: This is a destructive operation. The warehouse will be
     unavailable for approximately 10 minutes while the restore completes.
     In interactive mode you must type the warehouse name to confirm.
     Pass --yes to skip the prompt for automation.
     """
-    ws = resolve_workspace_arg(ctx, workspace)
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     try:
         async with build_http_client(ctx) as http:

--- a/src/fabric_dw/cli/commands/snapshots.py
+++ b/src/fabric_dw/cli/commands/snapshots.py
@@ -17,7 +17,7 @@ from fabric_dw.cli.commands._utils import (
     resolve_item,
     resolve_item_with_cache,
     resolve_warehouse_arg,
-    resolve_workspace_arg,
+    resolve_workspace,
 )
 from fabric_dw.exceptions import FabricError
 from fabric_dw.services import snapshots as _snapshots_svc
@@ -29,13 +29,12 @@ def snapshots_group() -> None:
 
 
 @snapshots_group.command("list")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.pass_obj
 @coro
-async def list_cmd(ctx: CliContext, workspace: str | None, item: str | None) -> None:
-    """List all snapshots for ITEM (warehouse) in WORKSPACE."""
-    ws = resolve_workspace_arg(ctx, workspace)
+async def list_cmd(ctx: CliContext, item: str | None) -> None:
+    """List all snapshots for ITEM (warehouse)."""
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     try:
         async with build_http_client(ctx) as http:
@@ -51,7 +50,6 @@ async def list_cmd(ctx: CliContext, workspace: str | None, item: str | None) -> 
 
 
 @snapshots_group.command("create")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.argument("name")
 @click.option("--description", default=None, help="Optional description.")
@@ -64,14 +62,13 @@ async def list_cmd(ctx: CliContext, workspace: str | None, item: str | None) -> 
 @coro
 async def create_cmd(
     ctx: CliContext,
-    workspace: str | None,
     item: str | None,
     name: str,
     description: str | None,
     snapshot_dt: str | None,
 ) -> None:
-    """Create a new snapshot named NAME for ITEM (warehouse) in WORKSPACE."""
-    ws = resolve_workspace_arg(ctx, workspace)
+    """Create a new snapshot named NAME for ITEM (warehouse)."""
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     parsed_dt: datetime | None = None
     if snapshot_dt is not None:
@@ -96,7 +93,6 @@ async def create_cmd(
 @snapshots_group.command("rename")
 @click.argument("snapshot")
 @click.argument("new_name")
-@click.argument("workspace", required=False, default=None)
 @click.option("--description", default=None, help="Optional new description.")
 @click.pass_obj
 @coro
@@ -104,20 +100,15 @@ async def rename_cmd(
     ctx: CliContext,
     snapshot: str,
     new_name: str,
-    workspace: str | None,
     description: str | None,
 ) -> None:
-    """Rename SNAPSHOT to NEW_NAME in WORKSPACE (workspace and snapshot accept name or GUID).
+    """Rename SNAPSHOT to NEW_NAME (snapshot accepts name or GUID).
 
-    Argument order note (L08): WORKSPACE appears after SNAPSHOT and NEW_NAME here
-    and in the ``delete`` sub-command because these operations target a snapshot
-    GUID directly, making the snapshot the primary positional argument.  The
-    ``list``, ``create``, and ``roll`` sub-commands lead with WORKSPACE because
-    they need to scope the operation to a warehouse first.  The asymmetry is
-    intentional; WORKSPACE is optional in all cases and falls back to the
-    ``FABRIC_WORKSPACE`` environment variable.
+    The target workspace is taken from the global ``-w/--workspace`` option,
+    the ``FABRIC_DW_DEFAULT_WORKSPACE`` environment variable, or the configured
+    default.
     """
-    ws = resolve_workspace_arg(ctx, workspace)
+    ws = resolve_workspace(ctx)
     try:
         async with build_http_client(ctx) as http:
             ws_id, entry, cache = await resolve_item_with_cache(http, ws, snapshot)
@@ -137,16 +128,16 @@ async def rename_cmd(
 
 @snapshots_group.command("delete")
 @click.argument("snapshot")
-@click.argument("workspace", required=False, default=None)
 @click.pass_obj
 @coro
-async def delete_cmd(ctx: CliContext, snapshot: str, workspace: str | None) -> None:
-    """Delete SNAPSHOT from WORKSPACE (both accept name or GUID).
+async def delete_cmd(ctx: CliContext, snapshot: str) -> None:
+    """Delete SNAPSHOT (accepts name or GUID).
 
-    Argument order note (L08): see ``rename`` — WORKSPACE is intentionally last
-    because this operation targets a snapshot GUID directly.
+    The target workspace is taken from the global ``-w/--workspace`` option,
+    the ``FABRIC_DW_DEFAULT_WORKSPACE`` environment variable, or the configured
+    default.
     """
-    ws = resolve_workspace_arg(ctx, workspace)
+    ws = resolve_workspace(ctx)
     try:
         async with build_http_client(ctx) as http:
             ws_id, entry, cache = await resolve_item_with_cache(http, ws, snapshot)
@@ -175,7 +166,6 @@ async def delete_cmd(ctx: CliContext, snapshot: str, workspace: str | None) -> N
 
 
 @snapshots_group.command("roll")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.argument("snapshot_name")
 @click.option(
@@ -188,17 +178,16 @@ async def delete_cmd(ctx: CliContext, snapshot: str, workspace: str | None) -> N
 @coro
 async def roll_cmd(
     ctx: CliContext,
-    workspace: str | None,
     item: str | None,
     snapshot_name: str,
     new_dt: str | None,
 ) -> None:
-    """Roll SNAPSHOT_NAME on ITEM (warehouse) in WORKSPACE to a new timestamp.
+    """Roll SNAPSHOT_NAME on ITEM (warehouse) to a new timestamp.
 
-    WORKSPACE and ITEM accept name or GUID.
+    ITEM accepts name or GUID.
     SNAPSHOT_NAME must be the display name of the snapshot database.
     """
-    ws = resolve_workspace_arg(ctx, workspace)
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     parsed_dt: datetime | None = None
     if new_dt is not None:

--- a/tests/unit/cli/commands/test_dbt.py
+++ b/tests/unit/cli/commands/test_dbt.py
@@ -70,7 +70,7 @@ def _invoke_init(runner: CliRunner, tmp_path: Path, extra_args: list[str] | None
         ) as mock_scaffold,
     ):
         mock_scaffold.return_value = [tmp_path / "myproject" / "dbt_project.yml"]
-        args = ["dbt", "init", WS_GUID, WH_GUID, folder]
+        args = ["-w", WS_GUID, "dbt", "init", WH_GUID, folder]
         if extra_args:
             args.extend(extra_args)
         return runner.invoke(cli, args)
@@ -110,7 +110,7 @@ class TestDbtInitCommand:
             patch("fabric_dw.services.dbt_scaffold.scaffold") as mock_scaffold,
         ):
             mock_scaffold.return_value = []
-            result = runner.invoke(cli, ["dbt", "init", WS_GUID, WH_GUID, folder])
+            result = runner.invoke(cli, ["-w", WS_GUID, "dbt", "init", WH_GUID, folder])
         assert result.exit_code == 0
 
     def test_explicit_project_name_accepted(
@@ -201,7 +201,7 @@ class TestDbtInitWithSources:
             mock_scaffold.return_value = []
             result = runner.invoke(
                 cli,
-                ["dbt", "init", WS_GUID, WH_GUID, folder, "--with-sources"],
+                ["-w", WS_GUID, "dbt", "init", WH_GUID, folder, "--with-sources"],
             )
         assert result.exit_code == 0
         mock_schemas.assert_called_once()
@@ -232,7 +232,7 @@ class TestDbtInitErrors:
         ):
             result = runner.invoke(
                 cli,
-                ["dbt", "init", WS_GUID, WH_GUID, str(folder)],
+                ["-w", WS_GUID, "dbt", "init", WH_GUID, str(folder)],
             )
         assert result.exit_code != 0
 
@@ -252,5 +252,5 @@ class TestDbtInitErrors:
                 new=AsyncMock(side_effect=NotFoundError("Workspace not found")),
             ),
         ):
-            result = runner.invoke(cli, ["dbt", "init", WS_GUID, WH_GUID, folder])
+            result = runner.invoke(cli, ["-w", WS_GUID, "dbt", "init", WH_GUID, folder])
         assert result.exit_code != 0

--- a/tests/unit/cli/commands/test_queries.py
+++ b/tests/unit/cli/commands/test_queries.py
@@ -88,7 +88,7 @@ class TestQueriesList:
                 new=AsyncMock(return_value=[_make_running_query()]),
             ),
         ):
-            result = runner.invoke(cli, ["queries", "list", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "queries", "list", WH_GUID])
         assert result.exit_code == 0
 
     def test_list_json_output(self, runner: CliRunner, cache_env: Path) -> None:
@@ -108,7 +108,7 @@ class TestQueriesList:
                 new=AsyncMock(return_value=[_make_running_query()]),
             ),
         ):
-            result = runner.invoke(cli, ["--json", "queries", "list", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["--json", "-w", WS_GUID, "queries", "list", WH_GUID])
         assert result.exit_code == 0
         parsed = json.loads(result.output)
         assert isinstance(parsed, list)
@@ -126,7 +126,7 @@ class TestQueriesList:
                 new=AsyncMock(side_effect=NotFoundError("not found")),
             ),
         ):
-            result = runner.invoke(cli, ["queries", "list", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "queries", "list", WH_GUID])
         assert result.exit_code != 0
 
 
@@ -150,7 +150,7 @@ class TestQueriesKill:
                 new=AsyncMock(return_value=None),
             ),
         ):
-            result = runner.invoke(cli, ["--yes", "queries", "kill", WS_GUID, WH_GUID, "42"])
+            result = runner.invoke(cli, ["--yes", "-w", WS_GUID, "queries", "kill", WH_GUID, "42"])
         assert result.exit_code == 0
 
     def test_kill_declined_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
@@ -167,7 +167,9 @@ class TestQueriesKill:
                 new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
             ),
         ):
-            result = runner.invoke(cli, ["queries", "kill", WS_GUID, WH_GUID, "42"], input="n\n")
+            result = runner.invoke(
+                cli, ["-w", WS_GUID, "queries", "kill", WH_GUID, "42"], input="n\n"
+            )
         assert result.exit_code == 0
         assert "Aborted." in result.output
 
@@ -190,7 +192,7 @@ class TestQueriesKill:
                 new=AsyncMock(side_effect=PermissionDeniedError("no permission")),
             ),
         ):
-            result = runner.invoke(cli, ["--yes", "queries", "kill", WS_GUID, WH_GUID, "42"])
+            result = runner.invoke(cli, ["--yes", "-w", WS_GUID, "queries", "kill", WH_GUID, "42"])
         assert result.exit_code != 0
 
 
@@ -260,7 +262,7 @@ class TestQueriesListConnections:
                 new=AsyncMock(return_value=[]),
             ),
         ):
-            result = runner.invoke(cli, ["queries", "list-connections", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "queries", "list-connections", WH_GUID])
         assert result.exit_code == 0
 
     def test_list_connections_fabric_error_exits_nonzero(
@@ -278,7 +280,7 @@ class TestQueriesListConnections:
                 new=AsyncMock(side_effect=FabricError("server error")),
             ),
         ):
-            result = runner.invoke(cli, ["queries", "list-connections", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "queries", "list-connections", WH_GUID])
         assert result.exit_code != 0
 
 
@@ -302,7 +304,7 @@ class TestQueriesRequestHistory:
                 new=AsyncMock(return_value=[]),
             ),
         ):
-            result = runner.invoke(cli, ["queries", "request-history", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "queries", "request-history", WH_GUID])
         assert result.exit_code == 0
 
 
@@ -326,7 +328,7 @@ class TestQueriesSessionHistory:
                 new=AsyncMock(return_value=[]),
             ),
         ):
-            result = runner.invoke(cli, ["queries", "session-history", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "queries", "session-history", WH_GUID])
         assert result.exit_code == 0
 
     def test_session_history_fabric_error_exits_nonzero(
@@ -344,7 +346,7 @@ class TestQueriesSessionHistory:
                 new=AsyncMock(side_effect=FabricError("server error")),
             ),
         ):
-            result = runner.invoke(cli, ["queries", "session-history", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "queries", "session-history", WH_GUID])
         assert result.exit_code != 0
 
 
@@ -368,7 +370,7 @@ class TestQueriesFrequent:
                 new=AsyncMock(return_value=[]),
             ),
         ):
-            result = runner.invoke(cli, ["queries", "frequent", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "queries", "frequent", WH_GUID])
         assert result.exit_code == 0
 
     def test_frequent_fabric_error_exits_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
@@ -384,7 +386,7 @@ class TestQueriesFrequent:
                 new=AsyncMock(side_effect=FabricError("server error")),
             ),
         ):
-            result = runner.invoke(cli, ["queries", "frequent", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "queries", "frequent", WH_GUID])
         assert result.exit_code != 0
 
 
@@ -408,7 +410,7 @@ class TestQueriesLongRunning:
                 new=AsyncMock(return_value=[]),
             ),
         ):
-            result = runner.invoke(cli, ["queries", "long-running", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "queries", "long-running", WH_GUID])
         assert result.exit_code == 0
 
     def test_long_running_fabric_error_exits_nonzero(
@@ -426,5 +428,5 @@ class TestQueriesLongRunning:
                 new=AsyncMock(side_effect=FabricError("server error")),
             ),
         ):
-            result = runner.invoke(cli, ["queries", "long-running", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "queries", "long-running", WH_GUID])
         assert result.exit_code != 0

--- a/tests/unit/cli/commands/test_query_insights.py
+++ b/tests/unit/cli/commands/test_query_insights.py
@@ -164,7 +164,7 @@ class TestRequestHistory:
                 new=AsyncMock(return_value=[_make_request_history_row()]),
             ),
         ):
-            result = runner.invoke(cli, ["queries", "request-history", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "queries", "request-history", WH_GUID])
         assert result.exit_code == 0
 
     def test_json_output(self, runner: CliRunner, cache_env: Path) -> None:
@@ -186,7 +186,7 @@ class TestRequestHistory:
         ):
             result = runner.invoke(
                 cli,
-                ["--json", "queries", "request-history", WS_GUID, WH_GUID],
+                ["--json", "-w", WS_GUID, "queries", "request-history", WH_GUID],
             )
         assert result.exit_code == 0
         parsed = json.loads(result.output)
@@ -205,7 +205,7 @@ class TestRequestHistory:
                 new=AsyncMock(side_effect=NotFoundError("not found")),
             ),
         ):
-            result = runner.invoke(cli, ["queries", "request-history", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "queries", "request-history", WH_GUID])
         assert result.exit_code != 0
 
     def test_permission_denied_returns_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
@@ -225,7 +225,7 @@ class TestRequestHistory:
                 new=AsyncMock(side_effect=PermissionDeniedError("no permission")),
             ),
         ):
-            result = runner.invoke(cli, ["queries", "request-history", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "queries", "request-history", WH_GUID])
         assert result.exit_code != 0
 
     def test_invalid_since_returns_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
@@ -233,9 +233,10 @@ class TestRequestHistory:
         result = runner.invoke(
             cli,
             [
+                "-w",
+                WS_GUID,
                 "queries",
                 "request-history",
-                WS_GUID,
                 WH_GUID,
                 "--since",
                 "not-a-date",
@@ -248,9 +249,10 @@ class TestRequestHistory:
         result = runner.invoke(
             cli,
             [
+                "-w",
+                WS_GUID,
                 "queries",
                 "request-history",
-                WS_GUID,
                 WH_GUID,
                 "--until",
                 "not-a-date",
@@ -282,7 +284,7 @@ class TestSessionHistory:
                 new=AsyncMock(return_value=[_make_session_history_row()]),
             ),
         ):
-            result = runner.invoke(cli, ["queries", "session-history", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "queries", "session-history", WH_GUID])
         assert result.exit_code == 0
 
     def test_json_output(self, runner: CliRunner, cache_env: Path) -> None:
@@ -304,7 +306,7 @@ class TestSessionHistory:
         ):
             result = runner.invoke(
                 cli,
-                ["--json", "queries", "session-history", WS_GUID, WH_GUID],
+                ["--json", "-w", WS_GUID, "queries", "session-history", WH_GUID],
             )
         assert result.exit_code == 0
         parsed = json.loads(result.output)
@@ -334,7 +336,7 @@ class TestFrequent:
                 new=AsyncMock(return_value=[_make_frequent_query_row()]),
             ),
         ):
-            result = runner.invoke(cli, ["queries", "frequent", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "queries", "frequent", WH_GUID])
         assert result.exit_code == 0
 
     def test_json_output(self, runner: CliRunner, cache_env: Path) -> None:
@@ -356,7 +358,7 @@ class TestFrequent:
         ):
             result = runner.invoke(
                 cli,
-                ["--json", "queries", "frequent", WS_GUID, WH_GUID],
+                ["--json", "-w", WS_GUID, "queries", "frequent", WH_GUID],
             )
         assert result.exit_code == 0
         parsed = json.loads(result.output)
@@ -386,7 +388,7 @@ class TestLongRunning:
                 new=AsyncMock(return_value=[_make_long_running_row()]),
             ),
         ):
-            result = runner.invoke(cli, ["queries", "long-running", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "queries", "long-running", WH_GUID])
         assert result.exit_code == 0
 
     def test_json_output(self, runner: CliRunner, cache_env: Path) -> None:
@@ -408,7 +410,7 @@ class TestLongRunning:
         ):
             result = runner.invoke(
                 cli,
-                ["--json", "queries", "long-running", WS_GUID, WH_GUID],
+                ["--json", "-w", WS_GUID, "queries", "long-running", WH_GUID],
             )
         assert result.exit_code == 0
         parsed = json.loads(result.output)

--- a/tests/unit/cli/commands/test_restore_points.py
+++ b/tests/unit/cli/commands/test_restore_points.py
@@ -102,7 +102,9 @@ class TestRestorePointsList:
                 new=AsyncMock(return_value=[rp]),
             ),
         ):
-            result = runner.invoke(cli, ["--json", "restore-points", "list", WS_GUID, WH_GUID])
+            result = runner.invoke(
+                cli, ["--json", "-w", WS_GUID, "restore-points", "list", WH_GUID]
+            )
         assert result.exit_code == 0
         parsed = json.loads(result.output)
         assert isinstance(parsed, list)
@@ -126,7 +128,9 @@ class TestRestorePointsList:
                 new=AsyncMock(return_value=[rp]),
             ),
         ):
-            result = runner.invoke(cli, ["--json", "restore-points", "list", WS_GUID, WH_GUID])
+            result = runner.invoke(
+                cli, ["--json", "-w", WS_GUID, "restore-points", "list", WH_GUID]
+            )
         assert result.exit_code == 0
         parsed = json.loads(result.output)
         assert isinstance(parsed, list)
@@ -149,7 +153,9 @@ class TestRestorePointsList:
                 new=AsyncMock(return_value=[]),
             ),
         ):
-            result = runner.invoke(cli, ["--json", "restore-points", "list", WS_GUID, WH_GUID])
+            result = runner.invoke(
+                cli, ["--json", "-w", WS_GUID, "restore-points", "list", WH_GUID]
+            )
         assert result.exit_code == 0
         parsed = json.loads(result.output)
         assert parsed == []
@@ -167,7 +173,7 @@ class TestRestorePointsList:
                 new=AsyncMock(side_effect=NotFoundError("warehouse not found")),
             ),
         ):
-            result = runner.invoke(cli, ["restore-points", "list", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "restore-points", "list", WH_GUID])
         assert result.exit_code != 0
 
     def test_list_permission_denied_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
@@ -183,7 +189,7 @@ class TestRestorePointsList:
                 new=AsyncMock(side_effect=PermissionDeniedError("forbidden")),
             ),
         ):
-            result = runner.invoke(cli, ["restore-points", "list", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "restore-points", "list", WH_GUID])
         assert result.exit_code != 0
 
 
@@ -214,7 +220,7 @@ class TestRestorePointsGet:
             ),
         ):
             result = runner.invoke(
-                cli, ["--json", "restore-points", "get", WS_GUID, WH_GUID, RP_ID]
+                cli, ["--json", "-w", WS_GUID, "restore-points", "get", WH_GUID, RP_ID]
             )
         assert result.exit_code == 0
         parsed = json.loads(result.output)
@@ -240,7 +246,7 @@ class TestRestorePointsGet:
             ),
         ):
             result = runner.invoke(
-                cli, ["--json", "restore-points", "get", WS_GUID, WH_GUID, RP_ID]
+                cli, ["--json", "-w", WS_GUID, "restore-points", "get", WH_GUID, RP_ID]
             )
         assert result.exit_code == 0
         parsed = json.loads(result.output)
@@ -263,7 +269,7 @@ class TestRestorePointsGet:
                 new=AsyncMock(side_effect=NotFoundError("restore point not found")),
             ),
         ):
-            result = runner.invoke(cli, ["restore-points", "get", WS_GUID, WH_GUID, RP_ID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "restore-points", "get", WH_GUID, RP_ID])
         assert result.exit_code != 0
 
 
@@ -294,7 +300,9 @@ class TestRestorePointsCreate:
                 new=mock_create,
             ),
         ):
-            result = runner.invoke(cli, ["--json", "restore-points", "create", WS_GUID, WH_GUID])
+            result = runner.invoke(
+                cli, ["--json", "-w", WS_GUID, "restore-points", "create", WH_GUID]
+            )
         assert result.exit_code == 0
         mock_create.assert_awaited_once()
         parsed = json.loads(result.output)
@@ -319,9 +327,10 @@ class TestRestorePointsCreate:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "restore-points",
                     "create",
-                    WS_GUID,
                     WH_GUID,
                     "--name",
                     "MyRestorePoint",
@@ -353,7 +362,7 @@ class TestRestorePointsCreate:
                 new=AsyncMock(side_effect=FabricError("create failed", status=500)),
             ),
         ):
-            result = runner.invoke(cli, ["restore-points", "create", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "restore-points", "create", WH_GUID])
         assert result.exit_code != 0
 
 
@@ -386,7 +395,7 @@ class TestRestorePointsRename:
         ):
             result = runner.invoke(
                 cli,
-                ["--json", "restore-points", "rename", WS_GUID, WH_GUID, RP_ID, "NewName"],
+                ["--json", "-w", WS_GUID, "restore-points", "rename", WH_GUID, RP_ID, "NewName"],
             )
         assert result.exit_code == 0
         mock_update.assert_awaited_once()
@@ -412,9 +421,10 @@ class TestRestorePointsRename:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "restore-points",
                     "rename",
-                    WS_GUID,
                     WH_GUID,
                     RP_ID,
                     "NewName",
@@ -445,7 +455,7 @@ class TestRestorePointsRename:
         ):
             result = runner.invoke(
                 cli,
-                ["restore-points", "rename", WS_GUID, WH_GUID, RP_ID, "NewName"],
+                ["-w", WS_GUID, "restore-points", "rename", WH_GUID, RP_ID, "NewName"],
             )
         assert result.exit_code != 0
 
@@ -476,7 +486,7 @@ class TestRestorePointsDelete:
             ),
         ):
             result = runner.invoke(
-                cli, ["--yes", "restore-points", "delete", WS_GUID, WH_GUID, RP_ID]
+                cli, ["--yes", "-w", WS_GUID, "restore-points", "delete", WH_GUID, RP_ID]
             )
         assert result.exit_code == 0
         assert "deleted" in result.output.lower()
@@ -499,7 +509,7 @@ class TestRestorePointsDelete:
         ):
             result = runner.invoke(
                 cli,
-                ["restore-points", "delete", WS_GUID, WH_GUID, RP_ID],
+                ["-w", WS_GUID, "restore-points", "delete", WH_GUID, RP_ID],
                 input="n\n",
             )
         assert result.exit_code == 0
@@ -524,7 +534,7 @@ class TestRestorePointsDelete:
         ):
             result = runner.invoke(
                 cli,
-                ["restore-points", "delete", WS_GUID, WH_GUID, RP_ID],
+                ["-w", WS_GUID, "restore-points", "delete", WH_GUID, RP_ID],
                 input="y\n",
             )
         assert result.exit_code == 0
@@ -548,7 +558,7 @@ class TestRestorePointsDelete:
             ),
         ):
             result = runner.invoke(
-                cli, ["--yes", "restore-points", "delete", WS_GUID, WH_GUID, RP_ID]
+                cli, ["--yes", "-w", WS_GUID, "restore-points", "delete", WH_GUID, RP_ID]
             )
         assert result.exit_code != 0
 
@@ -579,7 +589,7 @@ class TestRestorePointsRestore:
             ),
         ):
             result = runner.invoke(
-                cli, ["--yes", "restore-points", "restore", WS_GUID, WH_GUID, RP_ID]
+                cli, ["--yes", "-w", WS_GUID, "restore-points", "restore", WH_GUID, RP_ID]
             )
         assert result.exit_code == 0
         assert "restored" in result.output.lower()
@@ -605,7 +615,7 @@ class TestRestorePointsRestore:
             # The prompt asks for the warehouse name: "SalesWarehouse"
             result = runner.invoke(
                 cli,
-                ["restore-points", "restore", WS_GUID, "SalesWarehouse", RP_ID],
+                ["-w", WS_GUID, "restore-points", "restore", "SalesWarehouse", RP_ID],
                 input="SalesWarehouse\n",
             )
         assert result.exit_code == 0
@@ -633,7 +643,7 @@ class TestRestorePointsRestore:
         ):
             result = runner.invoke(
                 cli,
-                ["restore-points", "restore", WS_GUID, "SalesWarehouse", RP_ID],
+                ["-w", WS_GUID, "restore-points", "restore", "SalesWarehouse", RP_ID],
                 input="WrongName\n",
             )
         assert result.exit_code == 0
@@ -658,7 +668,7 @@ class TestRestorePointsRestore:
             ),
         ):
             result = runner.invoke(
-                cli, ["--yes", "restore-points", "restore", WS_GUID, WH_GUID, RP_ID]
+                cli, ["--yes", "-w", WS_GUID, "restore-points", "restore", WH_GUID, RP_ID]
             )
         assert result.exit_code != 0
 

--- a/tests/unit/cli/commands/test_restore_points_respx.py
+++ b/tests/unit/cli/commands/test_restore_points_respx.py
@@ -137,9 +137,10 @@ class TestRestorePointsCreateRespx:
                     cli,
                     [
                         "--json",
+                        "-w",
+                        WS_GUID,
                         "restore-points",
                         "create",
-                        WS_GUID,
                         WH_GUID,
                         "--name",
                         "RestorePoint_20240315",
@@ -175,9 +176,10 @@ class TestRestorePointsCreateRespx:
                     cli,
                     [
                         "--json",
+                        "-w",
+                        WS_GUID,
                         "restore-points",
                         "create",
-                        WS_GUID,
                         WH_GUID,
                         "--name",
                         "RestorePoint_20240315",
@@ -210,7 +212,7 @@ class TestRestorePointsCreateRespx:
             ):
                 result = runner.invoke(
                     cli,
-                    ["--json", "restore-points", "create", WS_GUID, WH_GUID],
+                    ["--json", "-w", WS_GUID, "restore-points", "create", WH_GUID],
                 )
 
         assert result.exit_code == 0, result.output
@@ -248,7 +250,7 @@ class TestRestorePointsCreateRespx:
             ):
                 result = runner.invoke(
                     cli,
-                    ["--json", "restore-points", "create", WS_GUID, WH_GUID],
+                    ["--json", "-w", WS_GUID, "restore-points", "create", WH_GUID],
                 )
 
         assert result.exit_code == 0, result.output
@@ -293,9 +295,10 @@ class TestRestorePointsRenameRespx:
                     cli,
                     [
                         "--json",
+                        "-w",
+                        WS_GUID,
                         "restore-points",
                         "rename",
-                        WS_GUID,
                         WH_GUID,
                         RP_ID,
                         "RenamedRestorePoint",
@@ -331,9 +334,10 @@ class TestRestorePointsRenameRespx:
                     cli,
                     [
                         "--json",
+                        "-w",
+                        WS_GUID,
                         "restore-points",
                         "rename",
-                        WS_GUID,
                         WH_GUID,
                         RP_ID,
                         "RenamedRestorePoint",
@@ -365,9 +369,10 @@ class TestRestorePointsRenameRespx:
                     cli,
                     [
                         "--json",
+                        "-w",
+                        WS_GUID,
                         "restore-points",
                         "rename",
-                        WS_GUID,
                         WH_GUID,
                         RP_ID,
                         "RenamedRestorePoint",

--- a/tests/unit/cli/commands/test_snapshots.py
+++ b/tests/unit/cli/commands/test_snapshots.py
@@ -95,7 +95,7 @@ class TestSnapshotsList:
                 new=AsyncMock(return_value=(WS_UUID, _make_wh_entry())),
             ),
         ):
-            result = runner.invoke(cli, ["--json", "snapshots", "list", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["--json", "-w", WS_GUID, "snapshots", "list", WH_GUID])
         assert result.exit_code == 0
         parsed = json.loads(result.output)
         assert isinstance(parsed, list)
@@ -114,7 +114,7 @@ class TestSnapshotsList:
                 new=AsyncMock(return_value=(WS_UUID, _make_wh_entry())),
             ),
         ):
-            result = runner.invoke(cli, ["--json", "snapshots", "list", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["--json", "-w", WS_GUID, "snapshots", "list", WH_GUID])
         assert result.exit_code == 0
         parsed = json.loads(result.output)
         assert isinstance(parsed, list)
@@ -132,7 +132,7 @@ class TestSnapshotsList:
                 new=AsyncMock(side_effect=NotFoundError("not found")),
             ),
         ):
-            result = runner.invoke(cli, ["snapshots", "list", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "snapshots", "list", WH_GUID])
         assert result.exit_code != 0
 
 
@@ -169,7 +169,7 @@ class TestSnapshotsCreate:
         ):
             result = runner.invoke(
                 cli,
-                ["--json", "snapshots", "create", WS_GUID, WH_GUID, "MySnapshot"],
+                ["--json", "-w", WS_GUID, "snapshots", "create", WH_GUID, "MySnapshot"],
             )
         assert result.exit_code == 0
         data = json.loads(result.output)
@@ -186,9 +186,10 @@ class TestSnapshotsCreateDatetime:
         result = runner.invoke(
             cli,
             [
+                "-w",
+                WS_GUID,
                 "snapshots",
                 "create",
-                WS_GUID,
                 WH_GUID,
                 "MySnapshot",
                 "--snapshot-dt",
@@ -207,9 +208,10 @@ class TestSnapshotsCreateDatetime:
         result = runner.invoke(
             cli,
             [
+                "-w",
+                WS_GUID,
                 "snapshots",
                 "create",
-                WS_GUID,
                 WH_GUID,
                 "MySnapshot",
                 "--snapshot-dt",
@@ -242,7 +244,7 @@ class TestSnapshotsRename:
         ):
             result = runner.invoke(
                 cli,
-                ["--json", "snapshots", "rename", SNAP_GUID, "NewSnapshotName", WS_GUID],
+                ["--json", "-w", WS_GUID, "snapshots", "rename", SNAP_GUID, "NewSnapshotName"],
             )
         assert result.exit_code == 0
         # Verify that the PATCH request body contained the NEW display name, not the old one.
@@ -277,7 +279,7 @@ class TestSnapshotsDelete:
                 new=AsyncMock(return_value=(WS_UUID, _make_snap_entry(), _cache)),
             ),
         ):
-            result = runner.invoke(cli, ["--yes", "snapshots", "delete", SNAP_GUID, WS_GUID])
+            result = runner.invoke(cli, ["--yes", "-w", WS_GUID, "snapshots", "delete", SNAP_GUID])
         assert result.exit_code == 0
         mock_http.request.assert_awaited_once()
         # Assert only the real success signal — the snapshot name is always in the fixture
@@ -299,7 +301,9 @@ class TestSnapshotsDelete:
                 new=AsyncMock(return_value=(WS_UUID, _make_snap_entry(), _cache)),
             ),
         ):
-            result = runner.invoke(cli, ["snapshots", "delete", SNAP_GUID, WS_GUID], input="n\n")
+            result = runner.invoke(
+                cli, ["-w", WS_GUID, "snapshots", "delete", SNAP_GUID], input="n\n"
+            )
         assert result.exit_code == 0
         assert "Aborted." in result.output
 
@@ -329,9 +333,10 @@ class TestSnapshotsRoll:
                 cli,
                 [
                     "--yes",
+                    "-w",
+                    WS_GUID,
                     "snapshots",
                     "roll",
-                    WS_GUID,
                     WH_GUID,
                     "SalesWarehouse_Snapshot_20240315",
                 ],
@@ -364,9 +369,10 @@ class TestSnapshotsRoll:
                 cli,
                 [
                     "--yes",
+                    "-w",
+                    WS_GUID,
                     "snapshots",
                     "roll",
-                    WS_GUID,
                     WH_GUID,
                     "SalesWarehouse_Snapshot_20240315",
                     "--at",
@@ -398,9 +404,10 @@ class TestSnapshotsRoll:
             result = runner.invoke(
                 cli,
                 [
+                    "-w",
+                    WS_GUID,
                     "snapshots",
                     "roll",
-                    WS_GUID,
                     WH_GUID,
                     "SalesWarehouse_Snapshot_20240315",
                 ],
@@ -432,9 +439,10 @@ class TestSnapshotsRoll:
                 cli,
                 [
                     "--yes",
+                    "-w",
+                    WS_GUID,
                     "snapshots",
                     "roll",
-                    WS_GUID,
                     WH_GUID,
                     "SalesWarehouse_Snapshot_20240315",
                 ],

--- a/tests/unit/cli/commands/test_snapshots.py
+++ b/tests/unit/cli/commands/test_snapshots.py
@@ -550,7 +550,7 @@ class TestSnapshotsRenameDefaultWorkspace:
                 new=AsyncMock(return_value=(WS_UUID, _make_snap_entry(), _cache)),
             ),
         ):
-            # Omit workspace positional arg — should fall back to env var
+            # No -w given — should fall back to FABRIC_DW_DEFAULT_WORKSPACE
             result = runner.invoke(
                 cli,
                 ["snapshots", "rename", SNAP_GUID, "NewSnapshotName"],
@@ -579,7 +579,7 @@ class TestSnapshotsDeleteDefaultWorkspace:
                 new=AsyncMock(return_value=(WS_UUID, _make_snap_entry(), _cache)),
             ),
         ):
-            # Omit workspace positional arg — should fall back to env var
+            # No -w given — should fall back to FABRIC_DW_DEFAULT_WORKSPACE
             result = runner.invoke(
                 cli,
                 ["--yes", "snapshots", "delete", SNAP_GUID],

--- a/tests/unit/cli/commands/test_snapshots_respx.py
+++ b/tests/unit/cli/commands/test_snapshots_respx.py
@@ -191,7 +191,7 @@ class TestSnapshotsListRespx:
             ):
                 result = runner.invoke(
                     cli,
-                    ["--json", "snapshots", "list", WS_GUID, WH_GUID],
+                    ["--json", "-w", WS_GUID, "snapshots", "list", WH_GUID],
                 )
 
         assert result.exit_code == 0, result.output
@@ -235,7 +235,7 @@ class TestSnapshotsListRespx:
             ):
                 result = runner.invoke(
                     cli,
-                    ["--json", "snapshots", "list", WS_GUID, WH_GUID],
+                    ["--json", "-w", WS_GUID, "snapshots", "list", WH_GUID],
                 )
 
         assert result.exit_code == 0, result.output
@@ -318,9 +318,10 @@ class TestSnapshotsCreateRespx:
                     cli,
                     [
                         "--json",
+                        "-w",
+                        WS_GUID,
                         "snapshots",
                         "create",
-                        WS_GUID,
                         WH_GUID,
                         "SalesWarehouse_Snapshot_20240315",
                     ],
@@ -374,9 +375,10 @@ class TestSnapshotsCreateRespx:
                     cli,
                     [
                         "--json",
+                        "-w",
+                        WS_GUID,
                         "snapshots",
                         "create",
-                        WS_GUID,
                         WH_GUID,
                         "SalesWarehouse_Snapshot_20240315",
                     ],
@@ -421,9 +423,10 @@ class TestSnapshotsCreateRespx:
                     cli,
                     [
                         "--json",
+                        "-w",
+                        WS_GUID,
                         "snapshots",
                         "create",
-                        WS_GUID,
                         WH_GUID,
                         "SalesWarehouse_Snapshot_20240315",
                     ],
@@ -479,11 +482,12 @@ class TestSnapshotsRenameRespx:
                     [
                         "--json",
                         "--yes",
+                        "-w",
+                        WS_GUID,
                         "snapshots",
                         "rename",
                         SNAP_GUID,
                         "RenamedSnapshot",
-                        WS_GUID,
                     ],
                 )
 
@@ -526,11 +530,12 @@ class TestSnapshotsRenameRespx:
                     [
                         "--json",
                         "--yes",
+                        "-w",
+                        WS_GUID,
                         "snapshots",
                         "rename",
                         SNAP_GUID,
                         "RenamedSnapshot",
-                        WS_GUID,
                     ],
                 )
 
@@ -571,11 +576,12 @@ class TestSnapshotsRenameRespx:
                     [
                         "--json",
                         "--yes",
+                        "-w",
+                        WS_GUID,
                         "snapshots",
                         "rename",
                         SNAP_GUID,
                         "RenamedSnapshot",
-                        WS_GUID,
                     ],
                 )
 
@@ -613,10 +619,11 @@ class TestSnapshotsDeleteRespx:
                     cli,
                     [
                         "--yes",
+                        "-w",
+                        WS_GUID,
                         "snapshots",
                         "delete",
                         SNAP_GUID,
-                        WS_GUID,
                     ],
                 )
 
@@ -641,10 +648,11 @@ class TestSnapshotsDeleteRespx:
                     [
                         "--yes",
                         "--json",
+                        "-w",
+                        WS_GUID,
                         "snapshots",
                         "delete",
                         SNAP_GUID,
-                        WS_GUID,
                     ],
                 )
 


### PR DESCRIPTION
## Summary

Part of the CLI-wide refactor that moves the target workspace from a positional `WORKSPACE` argument to the global `-w/--workspace` option. This PR converts the **queries**, **restore-points**, **snapshots** and **dbt** command clusters.

Each affected sub-command now resolves the workspace with `resolve_workspace(ctx)` (precedence: explicit `-w` -> `FABRIC_DW_DEFAULT_WORKSPACE` env -> config default -> helpful `UsageError`). The positional `WORKSPACE` is removed and the remaining positionals shift left in their existing order; nothing else about their behaviour changes.

## Converted commands

**queries** (7)
- `queries list <item>`
- `queries list-connections <item>`
- `queries kill <item> <session_id>`
- `queries request-history <warehouse>`
- `queries session-history <warehouse>`
- `queries frequent <warehouse>`
- `queries long-running <warehouse>`

**restore-points** (6)
- `restore-points list <item>`
- `restore-points get <item> <restore_point_id>`
- `restore-points create <item>`
- `restore-points rename <item> <restore_point_id> <new_name>`
- `restore-points delete <item> <restore_point_id>`
- `restore-points restore <item> <restore_point_id>`

**snapshots** (5)
- `snapshots list <item>`
- `snapshots create <item> <name>`
- `snapshots rename <snapshot> <new_name>` (dropped the trailing positional WORKSPACE; the historical L08 argument-order note is removed)
- `snapshots delete <snapshot>` (dropped the trailing positional WORKSPACE)
- `snapshots roll <item> <snapshot_name>`

**dbt** (1)
- `dbt init <item> <folder>`

## Breaking change

These sub-commands no longer accept `WORKSPACE` as a positional argument. Pass the workspace with the global `-w/--workspace` option **before** the command group, e.g.:

```
fabric-dw -w <workspace> queries list <warehouse>
fabric-dw -w <workspace> dbt init <warehouse> <folder>
```

or rely on `FABRIC_DW_DEFAULT_WORKSPACE` / the configured default workspace.

## Tests

Unit tests updated to the `-w` root form (positional-workspace invocations moved to `-w <ws>` before the group, multi-positional commands keep their remaining args in order). `just check` is green (ruff lint + format, ty, 3424 unit tests pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)