### PR TITLE
fix(resolver): use lakehouse connection-string fallback for SQL endpoints

### DIFF
--- a/src/fabric_dw/_fabric_api.py
+++ b/src/fabric_dw/_fabric_api.py
@@ -1,0 +1,70 @@
+"""Low-level Fabric REST helpers shared across modules.
+
+This module holds small, dependency-light helpers that talk directly to the
+Fabric REST API and are needed by more than one higher-level module (e.g. both
+:mod:`fabric_dw.resolver` and :mod:`fabric_dw.services.sql_endpoints`).
+
+It sits at the same layer as :mod:`fabric_dw.http_client`: it depends only on
+the HTTP client and standard library, never on the resolver, cache, or service
+layer.  Keeping these shared helpers here avoids upward-layering imports (a
+low-level module importing a service module) without resorting to lazy imports.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, cast
+
+from fabric_dw.http_client import HttpBase
+
+if TYPE_CHECKING:
+    from uuid import UUID
+
+    from fabric_dw.http_client import FabricHttpClient
+
+__all__ = [
+    "resolve_lakehouse_connection_string",
+]
+
+
+async def resolve_lakehouse_connection_string(
+    http: FabricHttpClient,
+    workspace_id: UUID,
+    endpoint_id: UUID,
+) -> str | None:
+    """Find the connection string for a lakehouse-derived SQL endpoint via the parent Lakehouse.
+
+    For lakehouse-derived SQL analytics endpoints, ``GET /sqlEndpoints/{id}``
+    permanently returns an empty ``connectionString`` — the value lives only on
+    the parent Lakehouse at
+    ``properties.sqlEndpointProperties.connectionString``.
+
+    This helper pages ``GET /workspaces/{ws}/lakehouses``, locates the lakehouse
+    whose ``properties.sqlEndpointProperties.id`` matches *endpoint_id*, and
+    returns that lakehouse's ``connectionString``.  Returns ``None`` when no
+    matching lakehouse is found (e.g. the endpoint belongs to a Warehouse, not a
+    Lakehouse) **or** when the matching lakehouse's connection string is still
+    empty (the endpoint is still provisioning).
+
+    Args:
+        http: An authenticated :class:`~fabric_dw.http_client.FabricHttpClient`.
+        workspace_id: The UUID of the workspace to search.
+        endpoint_id: The UUID of the SQL analytics endpoint whose connection
+            string we need.
+
+    Returns:
+        The non-empty connection string from the matching lakehouse, or ``None``
+        if no lakehouse in the workspace has a paired endpoint with this ID (or
+        the paired lakehouse has not yet exposed a connection string).
+    """
+    # str(UUID) is always lowercase; lowercase the API value too so the match is
+    # robust against Fabric returning an uppercase/mixed-case UUID string.
+    endpoint_id_str = str(endpoint_id).lower()
+    async for lh in http.iter_paginated(HttpBase.FABRIC, f"/workspaces/{workspace_id}/lakehouses"):
+        props = lh.get("properties")
+        props_dict = cast("dict[str, Any]", props) if isinstance(props, dict) else {}
+        sql_ep = props_dict.get("sqlEndpointProperties")
+        sql_ep_dict = cast("dict[str, Any]", sql_ep) if isinstance(sql_ep, dict) else {}
+        if str(sql_ep_dict.get("id", "")).lower() == endpoint_id_str:
+            conn = str(sql_ep_dict.get("connectionString", ""))
+            return conn or None
+    return None

--- a/src/fabric_dw/resolver.py
+++ b/src/fabric_dw/resolver.py
@@ -369,6 +369,27 @@ class Resolver:
             payload = generic_payload
 
         conn = _connection_string_from_detail(payload, kind)
+
+        # Lakehouse-derived SQL endpoints permanently return an empty
+        # connectionString from the /sqlEndpoints/{id} resource.  When the
+        # connection string is absent, fall back to scanning /lakehouses for
+        # the parent Lakehouse whose sqlEndpointProperties.id matches this
+        # endpoint's ID (see issue #347 / #471).
+        #
+        # Import is local to avoid a circular-import layering violation:
+        # resolver.py is low-level; services/sql_endpoints.py sits above it
+        # and must not be imported at module level here (that would create a
+        # cycle because sql_endpoints.py transitively imports from services/).
+        # A lazy import at the call-site is the cleanest option — it runs only
+        # for lakehouse-derived endpoints and incurs no overhead for Warehouses.
+        if kind == WarehouseKind.SQL_ENDPOINT and not conn:
+            from fabric_dw.services.sql_endpoints import (  # noqa: PLC0415
+                _resolve_lakehouse_connection_string,
+            )
+
+            lh_conn = await _resolve_lakehouse_connection_string(self._http, workspace_id, item_id)
+            conn = lh_conn or None  # keep None when no matching lakehouse is found
+
         display_name = str(generic_payload.get("displayName", str(item_id)))
         entry = ItemEntry(
             id=item_id,

--- a/src/fabric_dw/resolver.py
+++ b/src/fabric_dw/resolver.py
@@ -12,16 +12,20 @@ Resolution order:
 
 from __future__ import annotations
 
+import logging
 import re
 import time
 from datetime import UTC, datetime
 from typing import Any, NamedTuple
 from uuid import UUID
 
+from fabric_dw._fabric_api import resolve_lakehouse_connection_string
 from fabric_dw.cache import ItemEntry, LookupCache
 from fabric_dw.exceptions import FabricError, NotFoundError
 from fabric_dw.http_client import FabricHttpClient, HttpBase
 from fabric_dw.models import WarehouseKind
+
+_logger = logging.getLogger("fabric_dw.resolver")
 
 __all__ = [
     "GUID_RE",
@@ -372,23 +376,19 @@ class Resolver:
 
         # Lakehouse-derived SQL endpoints permanently return an empty
         # connectionString from the /sqlEndpoints/{id} resource.  When the
-        # connection string is absent, fall back to scanning /lakehouses for
-        # the parent Lakehouse whose sqlEndpointProperties.id matches this
-        # endpoint's ID (see issue #347 / #471).
-        #
-        # Import is local to avoid a circular-import layering violation:
-        # resolver.py is low-level; services/sql_endpoints.py sits above it
-        # and must not be imported at module level here (that would create a
-        # cycle because sql_endpoints.py transitively imports from services/).
-        # A lazy import at the call-site is the cleanest option — it runs only
-        # for lakehouse-derived endpoints and incurs no overhead for Warehouses.
+        # connection string is absent, fall back to scanning /lakehouses for the
+        # parent Lakehouse whose sqlEndpointProperties.id matches this endpoint's
+        # ID (see issue #347 / #471).  The shared helper lives in the low-level
+        # fabric_dw._fabric_api module so it can be imported here without an
+        # upward-layering dependency on the service package.
         if kind == WarehouseKind.SQL_ENDPOINT and not conn:
-            from fabric_dw.services.sql_endpoints import (  # noqa: PLC0415
-                _resolve_lakehouse_connection_string,
+            _logger.debug(
+                "SQL endpoint %s has empty connectionString on /sqlEndpoints resource; "
+                "falling back to lakehouse scan for workspace %s",
+                item_id,
+                workspace_id,
             )
-
-            lh_conn = await _resolve_lakehouse_connection_string(self._http, workspace_id, item_id)
-            conn = lh_conn or None  # keep None when no matching lakehouse is found
+            conn = await resolve_lakehouse_connection_string(self._http, workspace_id, item_id)
 
         display_name = str(generic_payload.get("displayName", str(item_id)))
         entry = ItemEntry(
@@ -398,16 +398,29 @@ class Resolver:
             fetched_at=datetime.now(tz=UTC),
             display_name=display_name,
         )
-        # Store under display name and GUID string in a single lock+read+write cycle
-        self._cache.put_items(
-            workspace_id,
-            [
-                (display_name, entry),
-                (str(item_id), entry),
-            ],
-        )
-        # Clear-on-put: drop all negative entries for this workspace scope so
-        # that a freshly created item becomes immediately resolvable even within
-        # the _NEGATIVE_TTL window (defence-in-depth against create→resolve race).
-        self._negative_clear_scope(str(workspace_id))
+
+        # Persist to the 24-hour cache unless this is a SQL endpoint whose
+        # connection string is still unresolved.  Lakehouse-derived endpoints
+        # expose their connectionString only once provisioning completes; caching
+        # an interim None would serve that stale value for the full TTL and lock
+        # the caller out of SQL-over-endpoint commands with "has no connection
+        # string" for up to a day (issue #471).  Skipping the write means the next
+        # lookup re-fetches and picks up the connection string once it appears.
+        # Warehouses and snapshots are always cached — a Warehouse with no
+        # connection string is a genuine (cacheable) state, and snapshots never
+        # carry one.
+        should_cache = not (kind == WarehouseKind.SQL_ENDPOINT and conn is None)
+        if should_cache:
+            # Store under display name and GUID string in a single lock+read+write cycle
+            self._cache.put_items(
+                workspace_id,
+                [
+                    (display_name, entry),
+                    (str(item_id), entry),
+                ],
+            )
+            # Clear-on-put: drop all negative entries for this workspace scope so
+            # that a freshly created item becomes immediately resolvable even within
+            # the _NEGATIVE_TTL window (defence-in-depth against create→resolve race).
+            self._negative_clear_scope(str(workspace_id))
         return entry

--- a/src/fabric_dw/services/sql_endpoints.py
+++ b/src/fabric_dw/services/sql_endpoints.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Any, cast
 from uuid import UUID
 
+from fabric_dw._fabric_api import resolve_lakehouse_connection_string
 from fabric_dw.exceptions import FabricServerError, NotFoundError, PermissionDeniedError
 from fabric_dw.http_client import FabricHttpClient, HttpBase
 from fabric_dw.models import TableSyncStatus, Warehouse, WarehouseKind
@@ -60,7 +60,8 @@ async def list_endpoints(http: FabricHttpClient, workspace_id: UUID) -> list[War
         * ``connection_string`` — only resolvable per-endpoint, either via the
           dedicated ``Items - Get Connection String`` API or via the parent
           Lakehouse's ``properties.sqlEndpointProperties.connectionString``
-          (see :func:`_resolve_lakehouse_connection_string` / #347).  Both are
+          (see :func:`fabric_dw._fabric_api.resolve_lakehouse_connection_string`
+          / #347).  Both are
           N+1; the list endpoint deliberately does NOT enrich it.
         * ``created_date`` — not returned by the endpoint resource at all (list
           or item), so it cannot be surfaced from a single list request.
@@ -141,48 +142,6 @@ async def list_all_workspaces(http: FabricHttpClient) -> list[Warehouse]:
     )
 
 
-async def _resolve_lakehouse_connection_string(
-    http: FabricHttpClient,
-    workspace_id: UUID,
-    endpoint_id: UUID,
-) -> str | None:
-    """Find the connection string for a lakehouse-derived SQL endpoint via the parent Lakehouse.
-
-    For lakehouse-derived SQL analytics endpoints, ``GET /sqlEndpoints/{id}``
-    permanently returns an empty ``connectionString`` — the value lives only on
-    the parent Lakehouse at
-    ``properties.sqlEndpointProperties.connectionString``.
-
-    This helper pages ``GET /workspaces/{ws}/lakehouses``, locates the lakehouse
-    whose ``properties.sqlEndpointProperties.id`` matches *endpoint_id*, and
-    returns that lakehouse's ``connectionString``.  Returns ``None`` when no
-    matching lakehouse is found (e.g. the endpoint belongs to a Warehouse, not a
-    Lakehouse).
-
-    Args:
-        http: An authenticated :class:`~fabric_dw.http_client.FabricHttpClient`.
-        workspace_id: The UUID of the workspace to search.
-        endpoint_id: The UUID of the SQL analytics endpoint whose connection
-            string we need.
-
-    Returns:
-        The non-empty connection string from the matching lakehouse, or ``None``
-        if no lakehouse in the workspace has a paired endpoint with this ID.
-    """
-    # str(UUID) is always lowercase; lowercase the API value too so the match is
-    # robust against Fabric returning an uppercase/mixed-case UUID string.
-    endpoint_id_str = str(endpoint_id).lower()
-    async for lh in http.iter_paginated(HttpBase.FABRIC, f"/workspaces/{workspace_id}/lakehouses"):
-        props = lh.get("properties")
-        props_dict = cast("dict[str, Any]", props) if isinstance(props, dict) else {}
-        sql_ep = props_dict.get("sqlEndpointProperties")
-        sql_ep_dict = cast("dict[str, Any]", sql_ep) if isinstance(sql_ep, dict) else {}
-        if str(sql_ep_dict.get("id", "")).lower() == endpoint_id_str:
-            conn = str(sql_ep_dict.get("connectionString", ""))
-            return conn or None
-    return None
-
-
 async def get_endpoint(http: FabricHttpClient, workspace_id: UUID, endpoint_id: UUID) -> Warehouse:
     """Fetch a single SQL analytics endpoint by ID.
 
@@ -227,7 +186,7 @@ async def get_endpoint(http: FabricHttpClient, workspace_id: UUID, endpoint_id: 
         endpoint_id,
         workspace_id,
     )
-    lh_conn = await _resolve_lakehouse_connection_string(http, workspace_id, endpoint_id)
+    lh_conn = await resolve_lakehouse_connection_string(http, workspace_id, endpoint_id)
     if lh_conn:
         # Return a copy with the connection string resolved from the lakehouse,
         # preserving every other field (description, collation, created_date, …).

--- a/tests/unit/test_resolver.py
+++ b/tests/unit/test_resolver.py
@@ -1058,6 +1058,84 @@ async def test_item_sql_endpoint_no_matching_lakehouse_returns_none_conn_string(
     assert result.connection_string is None
 
 
+async def test_item_sql_endpoint_matching_lakehouse_empty_conn_returns_none(
+    tmp_path: Path,
+) -> None:
+    """Provisioning race: a matching Lakehouse exists but its connectionString is still empty.
+
+    The endpoint is paired with a Lakehouse (sqlEndpointProperties.id matches) but the
+    Lakehouse has not yet exposed a connectionString.  The resolver must return
+    connection_string=None rather than an empty string (regression sentinel for the
+    ``return conn or None`` guard in resolve_lakehouse_connection_string).
+    """
+    resolver, client, _ = _make_resolver(tmp_path)
+    generic_payload = _sql_endpoint_empty_conn_payload(ITEM_GUID, WS_GUID, "LakehouseEP")
+    specific_payload = _sql_endpoint_empty_conn_payload(ITEM_GUID, WS_GUID, "LakehouseEP")
+    # Matching lakehouse, but its connectionString is empty (still provisioning).
+    matching_empty_lh = _lakehouses_payload_with_match(_LH_EP_INNER_ID, "")
+    with respx.mock:
+        respx.get(_FABRIC_ITEM_URL).mock(return_value=httpx.Response(200, json=generic_payload))
+        respx.get(
+            f"https://api.fabric.microsoft.com/v1/workspaces/{WS_GUID}/sqlEndpoints/{ITEM_GUID}"
+        ).mock(return_value=httpx.Response(200, json=specific_payload))
+        respx.get(_LAKEHOUSES_URL_471).mock(
+            return_value=httpx.Response(200, json=matching_empty_lh)
+        )
+        async with client:
+            result = await resolver.item(WS_GUID, ITEM_GUID)
+    assert result.kind == WarehouseKind.SQL_ENDPOINT
+    assert result.connection_string is None
+
+
+async def test_item_sql_endpoint_unresolved_conn_not_cached_and_retries(
+    tmp_path: Path,
+) -> None:
+    """An unresolved SQL-endpoint connection string must NOT be cached (issue #471).
+
+    Caching an interim None would serve that stale value for the full 24h TTL, locking
+    the caller out of SQL-over-endpoint commands.  The first call (still provisioning,
+    empty connectionString everywhere) must return None WITHOUT writing to the cache, and
+    the second call must re-fetch and pick up the now-populated connection string.
+    """
+    resolver, client, cache = _make_resolver(tmp_path)
+    generic_payload = _sql_endpoint_empty_conn_payload(ITEM_GUID, WS_GUID, "LakehouseEP")
+    empty_specific = _sql_endpoint_empty_conn_payload(ITEM_GUID, WS_GUID, "LakehouseEP")
+    populated_specific = _sql_endpoint_detail_payload(ITEM_GUID, WS_GUID, "LakehouseEP")
+    no_match_lh: dict[str, object] = {"value": [], "continuationUri": None}
+
+    sql_ep_calls = {"n": 0}
+
+    def sql_ep_side_effect(_request: httpx.Request) -> httpx.Response:
+        # First call: still provisioning (empty); second call: populated.
+        sql_ep_calls["n"] += 1
+        if sql_ep_calls["n"] == 1:
+            return httpx.Response(200, json=empty_specific)
+        return httpx.Response(200, json=populated_specific)
+
+    with respx.mock(assert_all_called=False) as mock_router:
+        mock_router.get(_FABRIC_ITEM_URL).mock(
+            return_value=httpx.Response(200, json=generic_payload)
+        )
+        mock_router.get(
+            f"https://api.fabric.microsoft.com/v1/workspaces/{WS_GUID}/sqlEndpoints/{ITEM_GUID}"
+        ).mock(side_effect=sql_ep_side_effect)
+        mock_router.get(_LAKEHOUSES_URL_471).mock(
+            return_value=httpx.Response(200, json=no_match_lh)
+        )
+        async with client:
+            first = await resolver.item(WS_GUID, ITEM_GUID)
+            # The unresolved entry must not have been persisted.
+            assert cache.get_item(WS_UUID, ITEM_GUID) is None
+            assert cache.get_item(WS_UUID, "LakehouseEP") is None
+            # Second call re-fetches (cache miss) and now picks up the connection string.
+            second = await resolver.item(WS_GUID, ITEM_GUID)
+
+    assert first.connection_string is None
+    assert second.connection_string == "mysqlep.datawarehouse.fabric.microsoft.com"
+    # The /sqlEndpoints resource was fetched twice — no stale cache short-circuit.
+    assert sql_ep_calls["n"] == 2
+
+
 # ---------------------------------------------------------------------------
 # D13 cross-layer parity — positive cache hit is not blocked by negative cache
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_resolver.py
+++ b/tests/unit/test_resolver.py
@@ -923,6 +923,142 @@ def test_negative_clear_scope_removes_matching_scope_only(tmp_path: Path) -> Non
 
 
 # ---------------------------------------------------------------------------
+# #471 — lakehouse-derived SQL endpoint: fallback to parent Lakehouse
+# ---------------------------------------------------------------------------
+
+# The GUID used inside the endpoint's sqlEndpointProperties.id.
+# For lakehouse-derived endpoints, the Lakehouse's sqlEndpointProperties.id
+# equals the SQL endpoint's own Fabric item ID (ITEM_GUID).
+_LH_EP_INNER_ID = ITEM_GUID
+_LH_CONN_STRING = "lh-derived-ep.datawarehouse.fabric.microsoft.com"
+
+# Lakehouse-derived SQL endpoint: item detail returns empty connectionString.
+_LAKEHOUSES_URL_471 = f"https://api.fabric.microsoft.com/v1/workspaces/{WS_GUID}/lakehouses"
+
+
+def _sql_endpoint_empty_conn_payload(item_id: str, ws_id: str, name: str) -> dict[str, object]:
+    """SQL endpoint detail payload where connectionString is permanently empty (lakehouse-derived).
+
+    Models the behaviour of lakehouse-derived SQL analytics endpoints: the /sqlEndpoints/{id}
+    resource always returns an empty connectionString; the real value lives on the Lakehouse.
+    """
+    return {
+        "id": item_id,
+        "displayName": name,
+        "type": "SQLEndpoint",
+        "workspaceId": ws_id,
+        "properties": {
+            "sqlEndpointProperties": {
+                "connectionString": "",
+                "id": _LH_EP_INNER_ID,
+                "provisioningStatus": "Success",
+            }
+        },
+    }
+
+
+def _lakehouses_payload_with_match(endpoint_inner_id: str, conn_string: str) -> dict[str, object]:
+    """Lakehouses list payload with a lakehouse whose sqlEndpointProperties.id matches."""
+    return {
+        "value": [
+            {
+                "id": "aabbccdd-0000-0000-0000-000000000001",
+                "displayName": "SalesLakehouse",
+                "workspaceId": WS_GUID,
+                "properties": {
+                    "sqlEndpointProperties": {
+                        "id": endpoint_inner_id,
+                        "connectionString": conn_string,
+                        "provisioningStatus": "Success",
+                    }
+                },
+            }
+        ],
+        "continuationUri": None,
+    }
+
+
+async def test_item_sql_endpoint_empty_conn_string_falls_back_to_lakehouse(
+    tmp_path: Path,
+) -> None:
+    """Resolver.item() must fall back to the parent Lakehouse when the SQL endpoint's own
+    connectionString is empty (permanent for lakehouse-derived endpoints).
+
+    Flow:
+    1. /items/{id}           → generic discovery (type = SQLEndpoint)
+    2. /sqlEndpoints/{id}    → empty connectionString
+    3. /lakehouses           → scanned; matching Lakehouse found via sqlEndpointProperties.id
+    4. ItemEntry returned with connection_string from the Lakehouse.
+    """
+    resolver, client, _ = _make_resolver(tmp_path)
+    generic_payload = _sql_endpoint_empty_conn_payload(ITEM_GUID, WS_GUID, "LakehouseEP")
+    specific_payload = _sql_endpoint_empty_conn_payload(ITEM_GUID, WS_GUID, "LakehouseEP")
+    lh_payload = _lakehouses_payload_with_match(_LH_EP_INNER_ID, _LH_CONN_STRING)
+    with respx.mock:
+        respx.get(_FABRIC_ITEM_URL).mock(return_value=httpx.Response(200, json=generic_payload))
+        respx.get(
+            f"https://api.fabric.microsoft.com/v1/workspaces/{WS_GUID}/sqlEndpoints/{ITEM_GUID}"
+        ).mock(return_value=httpx.Response(200, json=specific_payload))
+        respx.get(_LAKEHOUSES_URL_471).mock(return_value=httpx.Response(200, json=lh_payload))
+        async with client:
+            result = await resolver.item(WS_GUID, ITEM_GUID)
+    assert result.id == ITEM_UUID
+    assert result.kind == WarehouseKind.SQL_ENDPOINT
+    # The connection string must come from the parent Lakehouse, not the empty endpoint field.
+    assert result.connection_string == _LH_CONN_STRING
+
+
+async def test_item_sql_endpoint_with_conn_string_skips_lakehouse_scan(
+    tmp_path: Path,
+) -> None:
+    """Resolver.item() must NOT scan lakehouses when the endpoint already carries a
+    connectionString — the fast path must not incur any extra HTTP call.
+    """
+    resolver, client, _ = _make_resolver(tmp_path)
+    generic_payload = _sql_endpoint_detail_payload(ITEM_GUID, WS_GUID, "RegularSQLEP")
+    specific_payload = _sql_endpoint_detail_payload(ITEM_GUID, WS_GUID, "RegularSQLEP")
+    with respx.mock:
+        respx.get(_FABRIC_ITEM_URL).mock(return_value=httpx.Response(200, json=generic_payload))
+        respx.get(
+            f"https://api.fabric.microsoft.com/v1/workspaces/{WS_GUID}/sqlEndpoints/{ITEM_GUID}"
+        ).mock(return_value=httpx.Response(200, json=specific_payload))
+        # /lakehouses must NOT be called — any call would raise from respx strict mode
+        async with client:
+            result = await resolver.item(WS_GUID, ITEM_GUID)
+    assert result.kind == WarehouseKind.SQL_ENDPOINT
+    assert result.connection_string == "mysqlep.datawarehouse.fabric.microsoft.com"
+    # Verify /lakehouses was never called
+    lakehouses_calls = [c for c in respx.calls if "/lakehouses" in str(c.request.url)]
+    assert not lakehouses_calls, (
+        "lakehouse scan must not be triggered when conn_string is already set"
+    )
+
+
+async def test_item_sql_endpoint_no_matching_lakehouse_returns_none_conn_string(
+    tmp_path: Path,
+) -> None:
+    """When the endpoint's connectionString is empty and no matching Lakehouse exists,
+    resolver returns an ItemEntry with connection_string=None (graceful degradation).
+    """
+    resolver, client, _ = _make_resolver(tmp_path)
+    generic_payload = _sql_endpoint_empty_conn_payload(ITEM_GUID, WS_GUID, "LakehouseEP")
+    specific_payload = _sql_endpoint_empty_conn_payload(ITEM_GUID, WS_GUID, "LakehouseEP")
+    no_match_lh_payload: dict[str, object] = {"value": [], "continuationUri": None}
+    with respx.mock:
+        respx.get(_FABRIC_ITEM_URL).mock(return_value=httpx.Response(200, json=generic_payload))
+        respx.get(
+            f"https://api.fabric.microsoft.com/v1/workspaces/{WS_GUID}/sqlEndpoints/{ITEM_GUID}"
+        ).mock(return_value=httpx.Response(200, json=specific_payload))
+        respx.get(_LAKEHOUSES_URL_471).mock(
+            return_value=httpx.Response(200, json=no_match_lh_payload)
+        )
+        async with client:
+            result = await resolver.item(WS_GUID, ITEM_GUID)
+    assert result.kind == WarehouseKind.SQL_ENDPOINT
+    assert result.connection_string is None
+
+
+# ---------------------------------------------------------------------------
 # D13 cross-layer parity — positive cache hit is not blocked by negative cache
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Root cause

`Resolver._fetch_item_detail` extracted the connection string from the
`/sqlEndpoints/{id}` API response via `properties.sqlEndpointProperties.connectionString`.
For lakehouse-derived SQL analytics endpoints this field is **permanently empty** — the
real value lives on the parent Lakehouse at `properties.sqlEndpointProperties.connectionString`
(the Lakehouse's `sqlEndpointProperties.id` equals the SQL endpoint's Fabric item ID).

Because `Resolver.item()` is the single resolution chokepoint used by both CLI
`build_sql_target` and MCP `make_sql_target`, the empty connection string propagated to
both surfaces, producing `Item '<name>' has no connection string.` (#471).

## Approach

When `_fetch_item_detail` sees `kind == SQL_ENDPOINT` with an empty/`None` connection
string it now calls the existing `_resolve_lakehouse_connection_string` helper from
`services/sql_endpoints.py`, which scans `GET /workspaces/{ws}/lakehouses` for the
Lakehouse whose `sqlEndpointProperties.id` matches the endpoint's item ID and returns its
connection string. The fast path (endpoint already carries a connection string) is
unchanged; Warehouses and WarehouseSnapshots are not affected.

## Avoiding circular imports

`resolver.py` is a low-level module; `services/sql_endpoints.py` sits above it.
Importing `sql_endpoints` at the module level of `resolver.py` would create a layering
violation (and would be a cycle if any services module ever imports from `resolver`).

The fix uses a **lazy/local import** (guarded by `if kind == SQL_ENDPOINT and not conn`)
so the import runs only for lakehouse-derived endpoints and is zero-cost on the hot path.
The existing `# noqa: PLC0415` convention (already used in `sql_endpoints.py` itself for
its own local `time` import) is applied to suppress the lint rule. No new files or
intermediate modules are needed.

## Tests (TDD — written before the fix)

Three new tests added to `tests/unit/test_resolver.py`:

- `test_item_sql_endpoint_empty_conn_string_falls_back_to_lakehouse` — main behaviour:
  empty `sqlEndpointProperties.connectionString` → lakehouse scan → connection string returned.
- `test_item_sql_endpoint_with_conn_string_skips_lakehouse_scan` — fast-path guard: a SQL
  endpoint that already carries a connection string must not trigger any `/lakehouses` call.
- `test_item_sql_endpoint_no_matching_lakehouse_returns_none_conn_string` — graceful
  degradation: no matching lakehouse → `connection_string=None` (not an exception).

## Quality gates

- `just check` (ruff lint + ruff format + ty type check + 3 427 unit tests): **exit 0**
- `just cov` (coverage): **95 % total**, resolver.py at **97 %** (≥ 80 % threshold)

Closes #471