### PR TITLE
feat(settings): add 'settings' group for result-set-caching & time-travel retention (CLI)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -2443,6 +2443,80 @@ fabric-dw statistics delete [WORKSPACE] [ITEM] QUALIFIED_TABLE STAT_NAME
 
 ---
 
+## fabric-dw settings
+
+Manage **server-side** database settings on a Fabric Data Warehouse or SQL Analytics Endpoint.
+
+> **Note:** `settings` manages server-side warehouse/database configuration. For client-side CLI defaults (workspace, warehouse) use [`fabric-dw config`](#defaults-fabric-dw-config) instead.
+
+`show` works on both Data Warehouses and SQL Analytics Endpoints. The write commands (`result-set-caching`, `retention`) run `ALTER DATABASE CURRENT SET …` — this is supported on Data Warehouses. The behaviour on a SQL Analytics Endpoint is not guaranteed; `retention` in particular is primarily a Warehouse concept and may be a no-op there.
+
+`WORKSPACE` and `ITEM` may be display names or GUIDs.
+
+### settings show
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Display all server-side database settings for an item in a single table.
+
+```shell
+fabric-dw settings show [WORKSPACE] [ITEM]
+```
+
+**Example:**
+
+```shell
+fabric-dw settings show MyWorkspace MyWarehouse
+fabric-dw --json settings show MyWorkspace MyWarehouse
+```
+
+### settings result-set-caching
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Enable or disable result-set caching.
+
+Executes `ALTER DATABASE CURRENT SET RESULT_SET_CACHING { ON | OFF }` on the target.
+
+```shell
+fabric-dw settings result-set-caching [WORKSPACE] [ITEM] (on|off)
+```
+
+`STATE` is case-insensitive (`on`, `off`, `ON`, `OFF`).
+
+**Example:**
+
+```shell
+fabric-dw settings result-set-caching MyWorkspace MyWarehouse on
+fabric-dw settings result-set-caching MyWorkspace MyWarehouse off
+fabric-dw --json settings result-set-caching MyWorkspace MyWarehouse on
+```
+
+### settings retention
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Set the time-travel retention period in days.
+
+Executes `ALTER DATABASE CURRENT SET TIME_TRAVEL_RETENTION_PERIOD = <DAYS> DAYS` on the target.
+
+```shell
+fabric-dw settings retention [WORKSPACE] [ITEM] --days DAYS
+```
+
+| Option | Description | Default |
+| --- | --- | --- |
+| `--days N` | Retention period in days (1-120, required). | — |
+
+**Example:**
+
+```shell
+fabric-dw settings retention MyWorkspace MyWarehouse --days 30
+fabric-dw --json settings retention MyWorkspace MyWarehouse --days 7
+```
+
+---
+
 ## fabric-dw cache
 
 Manage the local name-to-UUID lookup cache. `fabric-dw` caches workspace and item name-to-GUID mappings to avoid repeated API round-trips. Use these commands if you rename items outside the CLI or need to force a fresh lookup.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -2449,9 +2449,9 @@ Manage **server-side** database settings on a Fabric Data Warehouse or SQL Analy
 
 > **Note:** `settings` manages server-side warehouse/database configuration. For client-side CLI defaults (workspace, warehouse) use [`fabric-dw config`](#defaults-fabric-dw-config) instead.
 
-`show` works on both Data Warehouses and SQL Analytics Endpoints. The write commands (`result-set-caching`, `retention`) run `ALTER DATABASE CURRENT SET …` — this is supported on Data Warehouses. The behaviour on a SQL Analytics Endpoint is not guaranteed; `retention` in particular is primarily a Warehouse concept and may be a no-op there.
+`show` and `result-set-caching` work on both Data Warehouses and SQL Analytics Endpoints. The `retention` command sets the time-travel retention period, which is primarily a Warehouse concept and may be a no-op on a SQL Analytics Endpoint.
 
-`WORKSPACE` and `ITEM` may be display names or GUIDs.
+The workspace is resolved from the global `-w/--workspace` option, the `FABRIC_DW_DEFAULT_WORKSPACE` environment variable, or the client-side config default. `ITEM` may be a display name or GUID.
 
 ### settings show
 
@@ -2460,14 +2460,14 @@ Manage **server-side** database settings on a Fabric Data Warehouse or SQL Analy
 Display all server-side database settings for an item in a single table.
 
 ```shell
-fabric-dw settings show [WORKSPACE] [ITEM]
+fabric-dw -w <workspace> settings show [ITEM]
 ```
 
 **Example:**
 
 ```shell
-fabric-dw settings show MyWorkspace MyWarehouse
-fabric-dw --json settings show MyWorkspace MyWarehouse
+fabric-dw -w MyWorkspace settings show MyWarehouse
+fabric-dw -w MyWorkspace --json settings show MyWarehouse
 ```
 
 ### settings result-set-caching
@@ -2479,7 +2479,7 @@ Enable or disable result-set caching.
 Executes `ALTER DATABASE CURRENT SET RESULT_SET_CACHING { ON | OFF }` on the target.
 
 ```shell
-fabric-dw settings result-set-caching [WORKSPACE] [ITEM] (on|off)
+fabric-dw -w <workspace> settings result-set-caching [ITEM] (on|off)
 ```
 
 `STATE` is case-insensitive (`on`, `off`, `ON`, `OFF`).
@@ -2487,9 +2487,9 @@ fabric-dw settings result-set-caching [WORKSPACE] [ITEM] (on|off)
 **Example:**
 
 ```shell
-fabric-dw settings result-set-caching MyWorkspace MyWarehouse on
-fabric-dw settings result-set-caching MyWorkspace MyWarehouse off
-fabric-dw --json settings result-set-caching MyWorkspace MyWarehouse on
+fabric-dw -w MyWorkspace settings result-set-caching MyWarehouse on
+fabric-dw -w MyWorkspace settings result-set-caching MyWarehouse off
+fabric-dw -w MyWorkspace --json settings result-set-caching MyWarehouse on
 ```
 
 ### settings retention
@@ -2501,7 +2501,7 @@ Set the time-travel retention period in days.
 Executes `ALTER DATABASE CURRENT SET TIME_TRAVEL_RETENTION_PERIOD = <DAYS> DAYS` on the target.
 
 ```shell
-fabric-dw settings retention [WORKSPACE] [ITEM] --days DAYS
+fabric-dw -w <workspace> settings retention [ITEM] --days DAYS
 ```
 
 | Option | Description | Default |
@@ -2511,8 +2511,8 @@ fabric-dw settings retention [WORKSPACE] [ITEM] --days DAYS
 **Example:**
 
 ```shell
-fabric-dw settings retention MyWorkspace MyWarehouse --days 30
-fabric-dw --json settings retention MyWorkspace MyWarehouse --days 7
+fabric-dw -w MyWorkspace settings retention MyWarehouse --days 30
+fabric-dw -w MyWorkspace --json settings retention MyWarehouse --days 7
 ```
 
 ---

--- a/src/fabric_dw/cli/_main.py
+++ b/src/fabric_dw/cli/_main.py
@@ -22,6 +22,7 @@ from fabric_dw.cli.commands.procedures import procedures_group
 from fabric_dw.cli.commands.queries import queries_group
 from fabric_dw.cli.commands.restore_points import restore_points_group
 from fabric_dw.cli.commands.schemas import schemas_group
+from fabric_dw.cli.commands.settings import settings_group
 from fabric_dw.cli.commands.snapshots import snapshots_group
 from fabric_dw.cli.commands.sql import sql_cmd
 from fabric_dw.cli.commands.sql_endpoints import sql_endpoints_group
@@ -455,4 +456,5 @@ cli.add_command(tables_group)
 cli.add_command(views_group)
 cli.add_command(procedures_group)
 cli.add_command(statistics_group)
+cli.add_command(settings_group)
 cli.add_command(functions_group)

--- a/src/fabric_dw/cli/commands/settings.py
+++ b/src/fabric_dw/cli/commands/settings.py
@@ -16,7 +16,7 @@ from fabric_dw.cli.commands._utils import (
     build_sql_target,
     coro,
     resolve_warehouse_arg,
-    resolve_workspace_arg,
+    resolve_workspace,
 )
 from fabric_dw.exceptions import FabricError
 from fabric_dw.services import settings as _settings_svc
@@ -30,28 +30,28 @@ def settings_group() -> None:
     (result-set caching, time-travel retention).  For client-side CLI
     defaults (workspace, warehouse) use the ``config`` group instead.
 
-    Both Data Warehouses and SQL Analytics Endpoints support ``show``.
-    The write commands (``result-set-caching``, ``retention``) target
-    Data Warehouses; the behaviour on a SQL Analytics Endpoint is not
-    guaranteed.
+    Both Data Warehouses and SQL Analytics Endpoints support ``show``
+    and ``result-set-caching``.  The ``retention`` command sets the
+    time-travel retention period, which is primarily a Warehouse concept
+    and may be a no-op on a SQL Analytics Endpoint.
     """
 
 
 @settings_group.command("show")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.pass_obj
 @coro
 async def show_cmd(
     ctx: CliContext,
-    workspace: str | None,
     item: str | None,
 ) -> None:
-    """Show all server-side settings for ITEM in WORKSPACE.
+    """Show all server-side settings for ITEM.
 
-    WORKSPACE and ITEM may be display names or GUIDs.
+    ITEM may be a display name or GUID.  The workspace is resolved from
+    the global ``-w`` option, ``FABRIC_DW_DEFAULT_WORKSPACE`` env var, or
+    the client-side config default.
     """
-    ws = resolve_workspace_arg(ctx, workspace)
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     try:
         async with build_http_client(ctx) as http:
@@ -67,27 +67,28 @@ async def show_cmd(
 
 
 @settings_group.command("result-set-caching")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.argument("state", type=click.Choice(["on", "off"], case_sensitive=False))
 @click.pass_obj
 @coro
 async def result_set_caching_cmd(
     ctx: CliContext,
-    workspace: str | None,
     item: str | None,
     state: str,
 ) -> None:
-    """Enable or disable result-set caching on ITEM in WORKSPACE.
+    """Enable or disable result-set caching on ITEM.
 
     STATE must be ``on`` or ``off`` (case-insensitive).
 
     Executes ``ALTER DATABASE CURRENT SET RESULT_SET_CACHING { ON | OFF }``
-    on the target warehouse.
+    on the target.  Supported on both Data Warehouses and SQL Analytics
+    Endpoints.
 
-    WORKSPACE and ITEM may be display names or GUIDs.
+    ITEM may be a display name or GUID.  The workspace is resolved from
+    the global ``-w`` option, ``FABRIC_DW_DEFAULT_WORKSPACE`` env var, or
+    the client-side config default.
     """
-    ws = resolve_workspace_arg(ctx, workspace)
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     enabled = state.lower() == "on"
     try:
@@ -108,7 +109,6 @@ async def result_set_caching_cmd(
 
 
 @settings_group.command("retention")
-@click.argument("workspace", required=False, default=None)
 @click.argument("item", required=False, default=None)
 @click.option(
     "--days",
@@ -125,18 +125,20 @@ async def result_set_caching_cmd(
 @coro
 async def retention_cmd(
     ctx: CliContext,
-    workspace: str | None,
     item: str | None,
     days: int,
 ) -> None:
-    """Set the time-travel retention period on ITEM in WORKSPACE.
+    """Set the time-travel retention period on ITEM.
 
     Executes ``ALTER DATABASE CURRENT SET TIME_TRAVEL_RETENTION_PERIOD = <DAYS> DAYS``
-    on the target warehouse.
+    on the target warehouse.  Primarily a Data Warehouse concept; may be a
+    no-op on a SQL Analytics Endpoint.
 
-    WORKSPACE and ITEM may be display names or GUIDs.
+    ITEM may be a display name or GUID.  The workspace is resolved from
+    the global ``-w`` option, ``FABRIC_DW_DEFAULT_WORKSPACE`` env var, or
+    the client-side config default.
     """
-    ws = resolve_workspace_arg(ctx, workspace)
+    ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     try:
         async with build_http_client(ctx) as http:

--- a/src/fabric_dw/cli/commands/settings.py
+++ b/src/fabric_dw/cli/commands/settings.py
@@ -1,0 +1,150 @@
+"""Settings sub-commands for the fabric-dw CLI.
+
+This group manages **server-side** database settings (stored in the Fabric
+Data Warehouse / SQL Analytics Endpoint).  It is distinct from the ``config``
+group, which manages *client-side* CLI defaults (workspace, warehouse, etc.).
+"""
+
+from __future__ import annotations
+
+import click
+
+from fabric_dw.cli._context import CliContext
+from fabric_dw.cli._render import render
+from fabric_dw.cli.commands._utils import (
+    build_http_client,
+    build_sql_target,
+    coro,
+    resolve_warehouse_arg,
+    resolve_workspace_arg,
+)
+from fabric_dw.exceptions import FabricError
+from fabric_dw.services import settings as _settings_svc
+
+
+@click.group("settings")
+def settings_group() -> None:
+    """Manage server-side database settings on Fabric Data Warehouses.
+
+    ``settings`` manages server-side warehouse/database configuration
+    (result-set caching, time-travel retention).  For client-side CLI
+    defaults (workspace, warehouse) use the ``config`` group instead.
+
+    Both Data Warehouses and SQL Analytics Endpoints support ``show``.
+    The write commands (``result-set-caching``, ``retention``) target
+    Data Warehouses; the behaviour on a SQL Analytics Endpoint is not
+    guaranteed.
+    """
+
+
+@settings_group.command("show")
+@click.argument("workspace", required=False, default=None)
+@click.argument("item", required=False, default=None)
+@click.pass_obj
+@coro
+async def show_cmd(
+    ctx: CliContext,
+    workspace: str | None,
+    item: str | None,
+) -> None:
+    """Show all server-side settings for ITEM in WORKSPACE.
+
+    WORKSPACE and ITEM may be display names or GUIDs.
+    """
+    ws = resolve_workspace_arg(ctx, workspace)
+    wh = resolve_warehouse_arg(ctx, item)
+    try:
+        async with build_http_client(ctx) as http:
+            target, _entry = await build_sql_target(http, ws, wh)
+            result = await _settings_svc.get_settings(target, mode=ctx.auth)
+            render(
+                result.model_dump(by_alias=True, mode="json"),
+                json_output=ctx.json_output,
+                table_title="Warehouse Settings",
+            )
+    except (ValueError, FabricError) as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@settings_group.command("result-set-caching")
+@click.argument("workspace", required=False, default=None)
+@click.argument("item", required=False, default=None)
+@click.argument("state", type=click.Choice(["on", "off"], case_sensitive=False))
+@click.pass_obj
+@coro
+async def result_set_caching_cmd(
+    ctx: CliContext,
+    workspace: str | None,
+    item: str | None,
+    state: str,
+) -> None:
+    """Enable or disable result-set caching on ITEM in WORKSPACE.
+
+    STATE must be ``on`` or ``off`` (case-insensitive).
+
+    Executes ``ALTER DATABASE CURRENT SET RESULT_SET_CACHING { ON | OFF }``
+    on the target warehouse.
+
+    WORKSPACE and ITEM may be display names or GUIDs.
+    """
+    ws = resolve_workspace_arg(ctx, workspace)
+    wh = resolve_warehouse_arg(ctx, item)
+    enabled = state.lower() == "on"
+    try:
+        async with build_http_client(ctx) as http:
+            target, _entry = await build_sql_target(http, ws, wh)
+            result = await _settings_svc.set_result_set_caching(
+                target, enabled=enabled, mode=ctx.auth
+            )
+            if ctx.json_output:
+                render(result.model_dump(by_alias=True, mode="json"), json_output=True)
+            else:
+                click.echo(
+                    f"Result-set caching {'enabled' if enabled else 'disabled'} "
+                    f"on {result.database!r}."
+                )
+    except (ValueError, FabricError) as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@settings_group.command("retention")
+@click.argument("workspace", required=False, default=None)
+@click.argument("item", required=False, default=None)
+@click.option(
+    "--days",
+    required=True,
+    type=click.IntRange(_settings_svc._RETENTION_MIN, _settings_svc._RETENTION_MAX),
+    help=(
+        f"Retention period in days "
+        f"({_settings_svc._RETENTION_MIN}-{_settings_svc._RETENTION_MAX}).  "
+        "Time-travel data older than this many days is no longer retained. "
+        "Primarily a Data Warehouse concept; may be a no-op on a SQL Analytics Endpoint."
+    ),
+)
+@click.pass_obj
+@coro
+async def retention_cmd(
+    ctx: CliContext,
+    workspace: str | None,
+    item: str | None,
+    days: int,
+) -> None:
+    """Set the time-travel retention period on ITEM in WORKSPACE.
+
+    Executes ``ALTER DATABASE CURRENT SET TIME_TRAVEL_RETENTION_PERIOD = <DAYS> DAYS``
+    on the target warehouse.
+
+    WORKSPACE and ITEM may be display names or GUIDs.
+    """
+    ws = resolve_workspace_arg(ctx, workspace)
+    wh = resolve_warehouse_arg(ctx, item)
+    try:
+        async with build_http_client(ctx) as http:
+            target, _entry = await build_sql_target(http, ws, wh)
+            result = await _settings_svc.set_time_travel_retention(target, days, mode=ctx.auth)
+            if ctx.json_output:
+                render(result.model_dump(by_alias=True, mode="json"), json_output=True)
+            else:
+                click.echo(f"Time-travel retention set to {days} day(s) on {result.database!r}.")
+    except (ValueError, FabricError) as exc:
+        raise click.ClickException(str(exc)) from exc

--- a/src/fabric_dw/cli/commands/settings.py
+++ b/src/fabric_dw/cli/commands/settings.py
@@ -90,7 +90,7 @@ async def result_set_caching_cmd(
     """
     ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
-    enabled = state.lower() == "on"
+    enabled = state == "on"
     try:
         async with build_http_client(ctx) as http:
             target, _entry = await build_sql_target(http, ws, wh)
@@ -113,10 +113,10 @@ async def result_set_caching_cmd(
 @click.option(
     "--days",
     required=True,
-    type=click.IntRange(_settings_svc._RETENTION_MIN, _settings_svc._RETENTION_MAX),
+    type=click.IntRange(_settings_svc.RETENTION_MIN, _settings_svc.RETENTION_MAX),
     help=(
         f"Retention period in days "
-        f"({_settings_svc._RETENTION_MIN}-{_settings_svc._RETENTION_MAX}).  "
+        f"({_settings_svc.RETENTION_MIN}-{_settings_svc.RETENTION_MAX}).  "
         "Time-travel data older than this many days is no longer retained. "
         "Primarily a Data Warehouse concept; may be a no-op on a SQL Analytics Endpoint."
     ),

--- a/src/fabric_dw/models.py
+++ b/src/fabric_dw/models.py
@@ -599,7 +599,7 @@ class WarehouseSettings(_FabricBase):
 
     database: str
     result_set_caching: bool
-    time_travel_retention_days: int
+    time_travel_retention_days: int | None
     time_travel_retention_cutoff_date: datetime | None
 
 

--- a/src/fabric_dw/models.py
+++ b/src/fabric_dw/models.py
@@ -577,6 +577,33 @@ class StatisticDetails(_FabricBase):
 
 
 # ---------------------------------------------------------------------------
+# Warehouse Settings
+# ---------------------------------------------------------------------------
+
+
+class WarehouseSettings(_FabricBase):
+    """Server-side database settings read from ``sys.databases``.
+
+    Both Data Warehouses and SQL Analytics Endpoints expose these settings.
+    The two write operations (:func:`~fabric_dw.services.settings.set_result_set_caching`
+    and :func:`~fabric_dw.services.settings.set_time_travel_retention`) require
+    a Data Warehouse (they execute ``ALTER DATABASE CURRENT SET …``).
+
+    Attributes:
+        database: The database name (from ``sys.databases.name``).
+        result_set_caching: Whether result-set caching is enabled.
+        time_travel_retention_days: Time-travel retention period in days.
+        time_travel_retention_cutoff_date: The earliest date for which time-travel
+            data is retained, or ``None`` when not applicable.
+    """
+
+    database: str
+    result_set_caching: bool
+    time_travel_retention_days: int
+    time_travel_retention_cutoff_date: datetime | None
+
+
+# ---------------------------------------------------------------------------
 # SQL Pools (beta)
 # ---------------------------------------------------------------------------
 

--- a/src/fabric_dw/services/settings.py
+++ b/src/fabric_dw/services/settings.py
@@ -39,13 +39,17 @@ from __future__ import annotations
 
 import asyncio
 from datetime import UTC, datetime
+from datetime import date as _date
 from typing import cast
 
 from fabric_dw.auth import CredentialMode
+from fabric_dw.exceptions import FabricError
 from fabric_dw.models import WarehouseSettings
 from fabric_dw.sql import SqlTarget, run_query
 
 __all__ = [
+    "RETENTION_MAX",
+    "RETENTION_MIN",
     "get_settings",
     "set_result_set_caching",
     "set_time_travel_retention",
@@ -55,8 +59,14 @@ __all__ = [
 # Constants
 # ---------------------------------------------------------------------------
 
-_RETENTION_MIN = 1
-_RETENTION_MAX = 120
+#: Minimum allowed time-travel retention period in days.
+RETENTION_MIN = 1
+#: Maximum allowed time-travel retention period in days.
+RETENTION_MAX = 120
+
+# Backward-compatible aliases (private — kept for internal use only).
+_RETENTION_MIN = RETENTION_MIN
+_RETENTION_MAX = RETENTION_MAX
 
 # ---------------------------------------------------------------------------
 # SQL templates
@@ -92,16 +102,20 @@ def _normalize_ts(ts: object) -> datetime | None:
         return None
     if isinstance(ts, datetime):
         return ts.replace(tzinfo=UTC) if ts.tzinfo is None else ts.astimezone(UTC)
+    if isinstance(ts, _date):
+        # Bare date (not datetime) — promote to midnight UTC.
+        return datetime(ts.year, ts.month, ts.day, tzinfo=UTC)
     return None
 
 
 def _row_to_settings(cols: list[str], row: tuple[object, ...]) -> WarehouseSettings:
     """Build a :class:`~fabric_dw.models.WarehouseSettings` from a column-name list and a row."""
     data = dict(zip(cols, row, strict=True))
+    raw_days = data["time_travel_retention_period_days"]
     return WarehouseSettings(
         database=str(data["name"]),
         result_set_caching=bool(data["is_result_set_caching_on"]),
-        time_travel_retention_days=int(cast("int", data["time_travel_retention_period_days"])),
+        time_travel_retention_days=int(cast("int", raw_days)) if raw_days is not None else None,
         time_travel_retention_cutoff_date=_normalize_ts(
             data.get("time_travel_retention_cutoff_date")
         ),
@@ -140,7 +154,9 @@ async def get_settings(
 
     def _run() -> WarehouseSettings:
         cols, rows = run_query(target, _GET_SETTINGS_SQL, mode=mode)
-        # DB_ID() always matches exactly one row.
+        if not rows:
+            msg = "Could not read warehouse settings: sys.databases returned no rows"
+            raise FabricError(msg)
         return _row_to_settings(cols, rows[0])
 
     return await asyncio.to_thread(_run)

--- a/src/fabric_dw/services/settings.py
+++ b/src/fabric_dw/services/settings.py
@@ -1,0 +1,224 @@
+"""Server-side database settings for Fabric Data Warehouses.
+
+Public API
+----------
+- :func:`get_settings`              — read current settings from ``sys.databases``.
+- :func:`set_result_set_caching`    — toggle result-set caching via ``ALTER DATABASE``.
+- :func:`set_time_travel_retention` — set time-travel retention period via ``ALTER DATABASE``.
+
+SQL-level safety
+----------------
+``ALTER DATABASE CURRENT SET …`` statements are DDL that **cannot** be bound via
+SQL parameters.  The two write functions therefore embed values as literals:
+
+- ``set_result_set_caching`` embeds ``ON`` or ``OFF`` — derived from a Python
+  :class:`bool`, never from arbitrary user input.
+- ``set_time_travel_retention`` embeds an integer literal after range-validating
+  the value as a Python :class:`int` (1-120).  Floats and strings are rejected
+  before the literal is formed.
+
+Autocommit
+----------
+Both ``ALTER DATABASE`` statements **must** run with ``autocommit=True``.
+Using a regular (autocommit-off) connection raises:
+
+    "ALTER DATABASE statement not allowed within multi-statement transaction."
+
+The :func:`~fabric_dw.sql.run_query` helper accepts ``autocommit=True`` for
+exactly this use case.
+
+SQL Analytics Endpoint note
+---------------------------
+No client-side guard is applied — both Data Warehouses and SQL Analytics
+Endpoints accept the read query.  The ``ALTER DATABASE`` write operations work
+on Data Warehouses; the behaviour on a SQL Analytics Endpoint is not guaranteed
+and may be a no-op (retention in particular is primarily a Warehouse concept).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from typing import cast
+
+from fabric_dw.auth import CredentialMode
+from fabric_dw.models import WarehouseSettings
+from fabric_dw.sql import SqlTarget, run_query
+
+__all__ = [
+    "get_settings",
+    "set_result_set_caching",
+    "set_time_travel_retention",
+]
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_RETENTION_MIN = 1
+_RETENTION_MAX = 120
+
+# ---------------------------------------------------------------------------
+# SQL templates
+# ---------------------------------------------------------------------------
+
+_GET_SETTINGS_SQL = """\
+SELECT
+    name,
+    is_result_set_caching_on,
+    time_travel_retention_period_days,
+    time_travel_retention_cutoff_date
+FROM sys.databases
+WHERE database_id = DB_ID();
+"""
+
+# ON/OFF are SQL keywords — embedded as a literal derived from a Python bool,
+# never from arbitrary user input.
+_SET_RSC_SQL_ON = "ALTER DATABASE CURRENT SET RESULT_SET_CACHING ON;"
+_SET_RSC_SQL_OFF = "ALTER DATABASE CURRENT SET RESULT_SET_CACHING OFF;"
+
+# <n> is an int literal (range-validated 1-120); not a SQL parameter.
+_SET_RETENTION_SQL_TEMPLATE = "ALTER DATABASE CURRENT SET TIME_TRAVEL_RETENTION_PERIOD = {n} DAYS;"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _normalize_ts(ts: object) -> datetime | None:
+    """Normalise a ``sys.databases`` timestamp column to UTC-aware datetime or None."""
+    if ts is None:
+        return None
+    if isinstance(ts, datetime):
+        return ts.replace(tzinfo=UTC) if ts.tzinfo is None else ts.astimezone(UTC)
+    return None
+
+
+def _row_to_settings(cols: list[str], row: tuple[object, ...]) -> WarehouseSettings:
+    """Build a :class:`~fabric_dw.models.WarehouseSettings` from a column-name list and a row."""
+    data = dict(zip(cols, row, strict=True))
+    return WarehouseSettings(
+        database=str(data["name"]),
+        result_set_caching=bool(data["is_result_set_caching_on"]),
+        time_travel_retention_days=int(cast("int", data["time_travel_retention_period_days"])),
+        time_travel_retention_cutoff_date=_normalize_ts(
+            data.get("time_travel_retention_cutoff_date")
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+async def get_settings(
+    target: SqlTarget,
+    *,
+    mode: CredentialMode = CredentialMode.DEFAULT,
+) -> WarehouseSettings:
+    """Return the current database settings for *target*.
+
+    Reads from ``sys.databases`` using ``DB_ID()`` to scope the query to the
+    connected database.
+
+    Works on both Data Warehouses and SQL Analytics Endpoints.
+
+    Args:
+        target: The warehouse or SQL Analytics Endpoint to query.
+        mode: The credential mode for Entra authentication.
+
+    Returns:
+        A :class:`~fabric_dw.models.WarehouseSettings` instance reflecting
+        the current settings.
+
+    Raises:
+        PermissionDeniedError: If the driver reports a permission error.
+        AuthError: If the driver reports an authentication failure.
+    """
+
+    def _run() -> WarehouseSettings:
+        cols, rows = run_query(target, _GET_SETTINGS_SQL, mode=mode)
+        # DB_ID() always matches exactly one row.
+        return _row_to_settings(cols, rows[0])
+
+    return await asyncio.to_thread(_run)
+
+
+async def set_result_set_caching(
+    target: SqlTarget,
+    *,
+    enabled: bool,
+    mode: CredentialMode = CredentialMode.DEFAULT,
+) -> WarehouseSettings:
+    """Enable or disable result-set caching on *target*.
+
+    Executes ``ALTER DATABASE CURRENT SET RESULT_SET_CACHING { ON | OFF }``
+    with autocommit (required for ``ALTER DATABASE`` statements).
+
+    Args:
+        target: The Data Warehouse to alter.
+        enabled: ``True`` to enable result-set caching, ``False`` to disable it.
+        mode: The credential mode for Entra authentication.
+
+    Returns:
+        A :class:`~fabric_dw.models.WarehouseSettings` reflecting the settings
+        *after* the change (fetched via a follow-up ``get_settings`` call).
+
+    Raises:
+        PermissionDeniedError: If the driver reports a permission error.
+        AuthError: If the driver reports an authentication failure.
+    """
+    ddl = _SET_RSC_SQL_ON if enabled else _SET_RSC_SQL_OFF
+
+    def _run() -> None:
+        run_query(target, ddl, mode=mode, autocommit=True, fetch="none")
+
+    await asyncio.to_thread(_run)
+    return await get_settings(target, mode=mode)
+
+
+async def set_time_travel_retention(
+    target: SqlTarget,
+    days: int,
+    *,
+    mode: CredentialMode = CredentialMode.DEFAULT,
+) -> WarehouseSettings:
+    """Set the time-travel retention period on *target*.
+
+    Executes ``ALTER DATABASE CURRENT SET TIME_TRAVEL_RETENTION_PERIOD = <n> DAYS``
+    with autocommit (required for ``ALTER DATABASE`` statements).
+
+    The time-travel retention feature is primarily a Data Warehouse concept.
+    Running this on a SQL Analytics Endpoint is allowed but may be a no-op.
+
+    Args:
+        target: The Data Warehouse (or SQL Analytics Endpoint) to alter.
+        days: Retention period in days.  Must be in the range 1-120 (inclusive).
+        mode: The credential mode for Entra authentication.
+
+    Returns:
+        A :class:`~fabric_dw.models.WarehouseSettings` reflecting the settings
+        *after* the change (fetched via a follow-up ``get_settings`` call).
+
+    Raises:
+        ValueError: If *days* is outside the valid range 1-120.
+        PermissionDeniedError: If the driver reports a permission error.
+        AuthError: If the driver reports an authentication failure.
+    """
+    days_int = int(days)
+    if not _RETENTION_MIN <= days_int <= _RETENTION_MAX:
+        msg = (
+            f"time_travel_retention_period_days must be between "
+            f"{_RETENTION_MIN} and {_RETENTION_MAX}, got {days_int}"
+        )
+        raise ValueError(msg)
+
+    ddl = _SET_RETENTION_SQL_TEMPLATE.format(n=days_int)
+
+    def _run() -> None:
+        run_query(target, ddl, mode=mode, autocommit=True, fetch="none")
+
+    await asyncio.to_thread(_run)
+    return await get_settings(target, mode=mode)

--- a/tests/unit/cli/commands/test_settings.py
+++ b/tests/unit/cli/commands/test_settings.py
@@ -92,7 +92,7 @@ class TestSettingsShow:
                 new=AsyncMock(return_value=_make_settings()),
             ),
         ):
-            result = runner.invoke(cli, ["settings", "show", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "settings", "show", WH_GUID])
         assert result.exit_code == 0
 
     def test_show_json_output(self, runner: CliRunner) -> None:
@@ -111,7 +111,7 @@ class TestSettingsShow:
                 new=AsyncMock(return_value=_make_settings()),
             ),
         ):
-            result = runner.invoke(cli, ["--json", "settings", "show", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "--json", "settings", "show", WH_GUID])
         assert result.exit_code == 0
         parsed = json.loads(result.output)
         assert parsed["database"] == "SalesWarehouse"
@@ -130,7 +130,7 @@ class TestSettingsShow:
                 new=AsyncMock(side_effect=FabricError("connection error")),
             ),
         ):
-            result = runner.invoke(cli, ["settings", "show", WS_GUID, WH_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "settings", "show", WH_GUID])
         assert result.exit_code != 0
 
 
@@ -156,7 +156,9 @@ class TestResultSetCaching:
                 new=AsyncMock(return_value=_make_settings(result_set_caching=True)),
             ),
         ):
-            result = runner.invoke(cli, ["settings", "result-set-caching", WS_GUID, WH_GUID, "on"])
+            result = runner.invoke(
+                cli, ["-w", WS_GUID, "settings", "result-set-caching", WH_GUID, "on"]
+            )
         assert result.exit_code == 0
         assert "enabled" in result.output
 
@@ -176,7 +178,9 @@ class TestResultSetCaching:
                 new=AsyncMock(return_value=_make_settings(result_set_caching=False)),
             ),
         ):
-            result = runner.invoke(cli, ["settings", "result-set-caching", WS_GUID, WH_GUID, "off"])
+            result = runner.invoke(
+                cli, ["-w", WS_GUID, "settings", "result-set-caching", WH_GUID, "off"]
+            )
         assert result.exit_code == 0
         assert "disabled" in result.output
 
@@ -195,7 +199,9 @@ class TestResultSetCaching:
             ),
             patch("fabric_dw.services.settings.set_result_set_caching", new=mock_svc),
         ):
-            result = runner.invoke(cli, ["settings", "result-set-caching", WS_GUID, WH_GUID, "ON"])
+            result = runner.invoke(
+                cli, ["-w", WS_GUID, "settings", "result-set-caching", WH_GUID, "ON"]
+            )
         assert result.exit_code == 0
         _, kwargs = mock_svc.call_args
         assert kwargs.get("enabled") is True
@@ -217,14 +223,17 @@ class TestResultSetCaching:
             ),
         ):
             result = runner.invoke(
-                cli, ["--json", "settings", "result-set-caching", WS_GUID, WH_GUID, "on"]
+                cli,
+                ["-w", WS_GUID, "--json", "settings", "result-set-caching", WH_GUID, "on"],
             )
         assert result.exit_code == 0
         parsed = json.loads(result.output)
         assert parsed["result_set_caching"] is True
 
     def test_invalid_state_returns_nonzero(self, runner: CliRunner) -> None:
-        result = runner.invoke(cli, ["settings", "result-set-caching", WS_GUID, WH_GUID, "maybe"])
+        result = runner.invoke(
+            cli, ["-w", WS_GUID, "settings", "result-set-caching", WH_GUID, "maybe"]
+        )
         assert result.exit_code != 0
 
     def test_fabric_error_returns_nonzero(self, runner: CliRunner) -> None:
@@ -239,7 +248,9 @@ class TestResultSetCaching:
                 new=AsyncMock(side_effect=FabricError("permission denied")),
             ),
         ):
-            result = runner.invoke(cli, ["settings", "result-set-caching", WS_GUID, WH_GUID, "on"])
+            result = runner.invoke(
+                cli, ["-w", WS_GUID, "settings", "result-set-caching", WH_GUID, "on"]
+            )
         assert result.exit_code != 0
 
 
@@ -265,7 +276,9 @@ class TestRetention:
                 new=AsyncMock(return_value=_make_settings(days=30)),
             ),
         ):
-            result = runner.invoke(cli, ["settings", "retention", WS_GUID, WH_GUID, "--days", "30"])
+            result = runner.invoke(
+                cli, ["-w", WS_GUID, "settings", "retention", WH_GUID, "--days", "30"]
+            )
         assert result.exit_code == 0
         assert "30" in result.output
 
@@ -286,20 +299,21 @@ class TestRetention:
             ),
         ):
             result = runner.invoke(
-                cli, ["--json", "settings", "retention", WS_GUID, WH_GUID, "--days", "14"]
+                cli,
+                ["-w", WS_GUID, "--json", "settings", "retention", WH_GUID, "--days", "14"],
             )
         assert result.exit_code == 0
         parsed = json.loads(result.output)
         assert parsed["time_travel_retention_days"] == 14
 
     def test_days_required(self, runner: CliRunner) -> None:
-        result = runner.invoke(cli, ["settings", "retention", WS_GUID, WH_GUID])
+        result = runner.invoke(cli, ["-w", WS_GUID, "settings", "retention", WH_GUID])
         assert result.exit_code != 0
 
     @pytest.mark.parametrize("days", [0, 121])
     def test_out_of_range_days_returns_nonzero(self, runner: CliRunner, days: int) -> None:
         result = runner.invoke(
-            cli, ["settings", "retention", WS_GUID, WH_GUID, "--days", str(days)]
+            cli, ["-w", WS_GUID, "settings", "retention", WH_GUID, "--days", str(days)]
         )
         assert result.exit_code != 0
 
@@ -319,7 +333,9 @@ class TestRetention:
                 new=AsyncMock(return_value=_make_settings(days=1)),
             ),
         ):
-            result = runner.invoke(cli, ["settings", "retention", WS_GUID, WH_GUID, "--days", "1"])
+            result = runner.invoke(
+                cli, ["-w", WS_GUID, "settings", "retention", WH_GUID, "--days", "1"]
+            )
         assert result.exit_code == 0
 
     def test_boundary_120_accepted(self, runner: CliRunner) -> None:
@@ -339,7 +355,7 @@ class TestRetention:
             ),
         ):
             result = runner.invoke(
-                cli, ["settings", "retention", WS_GUID, WH_GUID, "--days", "120"]
+                cli, ["-w", WS_GUID, "settings", "retention", WH_GUID, "--days", "120"]
             )
         assert result.exit_code == 0
 
@@ -355,5 +371,7 @@ class TestRetention:
                 new=AsyncMock(side_effect=FabricError("permission denied")),
             ),
         ):
-            result = runner.invoke(cli, ["settings", "retention", WS_GUID, WH_GUID, "--days", "7"])
+            result = runner.invoke(
+                cli, ["-w", WS_GUID, "settings", "retention", WH_GUID, "--days", "7"]
+            )
         assert result.exit_code != 0

--- a/tests/unit/cli/commands/test_settings.py
+++ b/tests/unit/cli/commands/test_settings.py
@@ -1,0 +1,359 @@
+"""Unit tests for the settings CLI sub-commands."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+from uuid import UUID
+
+import pytest
+from click.testing import CliRunner
+
+from fabric_dw.cache import ItemEntry
+from fabric_dw.cli._main import cli
+from fabric_dw.exceptions import FabricError
+from fabric_dw.models import WarehouseKind, WarehouseSettings
+from fabric_dw.sql import SqlTarget
+
+WS_GUID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+WH_GUID = "d4e5f6a7-b8c9-0123-def0-123456789abc"
+WS_UUID = UUID(WS_GUID)
+WH_UUID = UUID(WH_GUID)
+
+_NOW = datetime(2024, 6, 1, 12, 0, 0, tzinfo=UTC)
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def _make_sql_target() -> SqlTarget:
+    return SqlTarget(
+        workspace_id=WS_GUID,
+        database="SalesWarehouse",
+        connection_string="wh.datawarehouse.fabric.microsoft.com",
+    )
+
+
+def _make_http_cm(http: object) -> object:
+    @asynccontextmanager
+    async def _cm(_ctx: object) -> AsyncIterator[object]:
+        yield http
+
+    return _cm
+
+
+def _make_item_entry() -> ItemEntry:
+    return ItemEntry(
+        id=WH_UUID,
+        kind=WarehouseKind.WAREHOUSE,
+        connection_string="wh.datawarehouse.fabric.microsoft.com",
+        fetched_at=datetime.now(tz=UTC),
+        display_name="SalesWarehouse",
+    )
+
+
+def _make_settings(
+    *,
+    result_set_caching: bool = True,
+    days: int = 7,
+) -> WarehouseSettings:
+    return WarehouseSettings(
+        database="SalesWarehouse",
+        result_set_caching=result_set_caching,
+        time_travel_retention_days=days,
+        time_travel_retention_cutoff_date=_NOW,
+    )
+
+
+# ===========================================================================
+# settings show
+# ===========================================================================
+
+
+class TestSettingsShow:
+    def test_show_exits_zero(self, runner: CliRunner) -> None:
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.settings.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.settings.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.settings.get_settings",
+                new=AsyncMock(return_value=_make_settings()),
+            ),
+        ):
+            result = runner.invoke(cli, ["settings", "show", WS_GUID, WH_GUID])
+        assert result.exit_code == 0
+
+    def test_show_json_output(self, runner: CliRunner) -> None:
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.settings.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.settings.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.settings.get_settings",
+                new=AsyncMock(return_value=_make_settings()),
+            ),
+        ):
+            result = runner.invoke(cli, ["--json", "settings", "show", WS_GUID, WH_GUID])
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["database"] == "SalesWarehouse"
+        assert parsed["result_set_caching"] is True
+        assert parsed["time_travel_retention_days"] == 7
+
+    def test_show_fabric_error_returns_nonzero(self, runner: CliRunner) -> None:
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.settings.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.settings.build_sql_target",
+                new=AsyncMock(side_effect=FabricError("connection error")),
+            ),
+        ):
+            result = runner.invoke(cli, ["settings", "show", WS_GUID, WH_GUID])
+        assert result.exit_code != 0
+
+
+# ===========================================================================
+# settings result-set-caching
+# ===========================================================================
+
+
+class TestResultSetCaching:
+    def test_enable_exits_zero(self, runner: CliRunner) -> None:
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.settings.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.settings.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.settings.set_result_set_caching",
+                new=AsyncMock(return_value=_make_settings(result_set_caching=True)),
+            ),
+        ):
+            result = runner.invoke(cli, ["settings", "result-set-caching", WS_GUID, WH_GUID, "on"])
+        assert result.exit_code == 0
+        assert "enabled" in result.output
+
+    def test_disable_exits_zero(self, runner: CliRunner) -> None:
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.settings.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.settings.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.settings.set_result_set_caching",
+                new=AsyncMock(return_value=_make_settings(result_set_caching=False)),
+            ),
+        ):
+            result = runner.invoke(cli, ["settings", "result-set-caching", WS_GUID, WH_GUID, "off"])
+        assert result.exit_code == 0
+        assert "disabled" in result.output
+
+    def test_state_case_insensitive(self, runner: CliRunner) -> None:
+        """ON / OFF are accepted case-insensitively."""
+        mock_http = AsyncMock()
+        mock_svc = AsyncMock(return_value=_make_settings(result_set_caching=True))
+        with (
+            patch(
+                "fabric_dw.cli.commands.settings.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.settings.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch("fabric_dw.services.settings.set_result_set_caching", new=mock_svc),
+        ):
+            result = runner.invoke(cli, ["settings", "result-set-caching", WS_GUID, WH_GUID, "ON"])
+        assert result.exit_code == 0
+        _, kwargs = mock_svc.call_args
+        assert kwargs.get("enabled") is True
+
+    def test_json_output_includes_settings(self, runner: CliRunner) -> None:
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.settings.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.settings.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.settings.set_result_set_caching",
+                new=AsyncMock(return_value=_make_settings(result_set_caching=True)),
+            ),
+        ):
+            result = runner.invoke(
+                cli, ["--json", "settings", "result-set-caching", WS_GUID, WH_GUID, "on"]
+            )
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["result_set_caching"] is True
+
+    def test_invalid_state_returns_nonzero(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli, ["settings", "result-set-caching", WS_GUID, WH_GUID, "maybe"])
+        assert result.exit_code != 0
+
+    def test_fabric_error_returns_nonzero(self, runner: CliRunner) -> None:
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.settings.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.settings.build_sql_target",
+                new=AsyncMock(side_effect=FabricError("permission denied")),
+            ),
+        ):
+            result = runner.invoke(cli, ["settings", "result-set-caching", WS_GUID, WH_GUID, "on"])
+        assert result.exit_code != 0
+
+
+# ===========================================================================
+# settings retention
+# ===========================================================================
+
+
+class TestRetention:
+    def test_valid_days_exits_zero(self, runner: CliRunner) -> None:
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.settings.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.settings.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.settings.set_time_travel_retention",
+                new=AsyncMock(return_value=_make_settings(days=30)),
+            ),
+        ):
+            result = runner.invoke(cli, ["settings", "retention", WS_GUID, WH_GUID, "--days", "30"])
+        assert result.exit_code == 0
+        assert "30" in result.output
+
+    def test_json_output_includes_settings(self, runner: CliRunner) -> None:
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.settings.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.settings.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.settings.set_time_travel_retention",
+                new=AsyncMock(return_value=_make_settings(days=14)),
+            ),
+        ):
+            result = runner.invoke(
+                cli, ["--json", "settings", "retention", WS_GUID, WH_GUID, "--days", "14"]
+            )
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["time_travel_retention_days"] == 14
+
+    def test_days_required(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli, ["settings", "retention", WS_GUID, WH_GUID])
+        assert result.exit_code != 0
+
+    @pytest.mark.parametrize("days", [0, 121])
+    def test_out_of_range_days_returns_nonzero(self, runner: CliRunner, days: int) -> None:
+        result = runner.invoke(
+            cli, ["settings", "retention", WS_GUID, WH_GUID, "--days", str(days)]
+        )
+        assert result.exit_code != 0
+
+    def test_boundary_1_accepted(self, runner: CliRunner) -> None:
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.settings.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.settings.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.settings.set_time_travel_retention",
+                new=AsyncMock(return_value=_make_settings(days=1)),
+            ),
+        ):
+            result = runner.invoke(cli, ["settings", "retention", WS_GUID, WH_GUID, "--days", "1"])
+        assert result.exit_code == 0
+
+    def test_boundary_120_accepted(self, runner: CliRunner) -> None:
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.settings.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.settings.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.settings.set_time_travel_retention",
+                new=AsyncMock(return_value=_make_settings(days=120)),
+            ),
+        ):
+            result = runner.invoke(
+                cli, ["settings", "retention", WS_GUID, WH_GUID, "--days", "120"]
+            )
+        assert result.exit_code == 0
+
+    def test_fabric_error_returns_nonzero(self, runner: CliRunner) -> None:
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.settings.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.settings.build_sql_target",
+                new=AsyncMock(side_effect=FabricError("permission denied")),
+            ),
+        ):
+            result = runner.invoke(cli, ["settings", "retention", WS_GUID, WH_GUID, "--days", "7"])
+        assert result.exit_code != 0

--- a/tests/unit/services/test_settings.py
+++ b/tests/unit/services/test_settings.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from unittest.mock import patch
 
 import pytest
 
+from fabric_dw.exceptions import FabricError
 from fabric_dw.models import WarehouseSettings
 from fabric_dw.services import settings
 from tests.unit.services._helpers import _make_conn, _make_conn_for_ddl, _make_target
@@ -42,6 +43,13 @@ _SETTINGS_ROW_NO_CUTOFF: tuple[object, ...] = (
     "SalesWarehouse",
     True,
     30,
+    None,
+)
+
+_SETTINGS_ROW_NULL_DAYS: tuple[object, ...] = (
+    "SalesWarehouse",
+    True,
+    None,  # NULL time_travel_retention_period_days (SQL Analytics Endpoint)
     None,
 )
 
@@ -95,6 +103,34 @@ class TestGetSettings:
         assert result.time_travel_retention_cutoff_date is not None
         assert result.time_travel_retention_cutoff_date.tzinfo == UTC
 
+    async def test_null_days_returns_none(self) -> None:
+        """NULL time_travel_retention_period_days (SQL Analytics Endpoint) must not raise."""
+        target = _make_target()
+        conn = _make_conn([_SETTINGS_ROW_NULL_DAYS], _SETTINGS_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            result = await settings.get_settings(target)
+        assert result.time_travel_retention_days is None
+
+    async def test_empty_rows_raises_fabric_error(self) -> None:
+        """If sys.databases returns no rows, a FabricError must be raised."""
+        target = _make_target()
+        conn = _make_conn([], _SETTINGS_COLS)
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(FabricError, match=r"sys\.databases returned no rows"),
+        ):
+            await settings.get_settings(target)
+
+    async def test_bare_date_cutoff_promoted_to_midnight_utc(self) -> None:
+        """A bare datetime.date returned by the driver must be promoted to midnight UTC."""
+        bare = date(2024, 6, 1)
+        row: tuple[object, ...] = ("SalesWarehouse", True, 7, bare)
+        target = _make_target()
+        conn = _make_conn([row], _SETTINGS_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            result = await settings.get_settings(target)
+        assert result.time_travel_retention_cutoff_date == datetime(2024, 6, 1, tzinfo=UTC)
+
 
 # ===========================================================================
 # set_result_set_caching
@@ -116,17 +152,8 @@ class TestSetResultSetCaching:
         target = _make_target()
         ddl_conn = _make_conn_for_ddl()
         read_conn = _make_conn([_SETTINGS_ROW], _SETTINGS_COLS)
-        call_count = 0
 
-        def _open(_t: object, **_kw: object) -> object:
-            nonlocal call_count
-            call_count += 1
-            # First call is ALTER DATABASE (autocommit=True), second is SELECT
-            if call_count == 1:
-                return ddl_conn
-            return read_conn
-
-        with patch("fabric_dw.sql.open_connection", side_effect=_open):
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, read_conn]):
             result = await settings.set_result_set_caching(target, enabled=True)
         assert isinstance(result, WarehouseSettings)
         assert result.result_set_caching is True
@@ -135,16 +162,8 @@ class TestSetResultSetCaching:
         target = _make_target()
         ddl_conn = _make_conn_for_ddl()
         read_conn = _make_conn([_SETTINGS_ROW_CACHING_OFF], _SETTINGS_COLS)
-        call_count = 0
 
-        def _open(_t: object, **_kw: object) -> object:
-            nonlocal call_count
-            call_count += 1
-            if call_count == 1:
-                return ddl_conn
-            return read_conn
-
-        with patch("fabric_dw.sql.open_connection", side_effect=_open):
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, read_conn]):
             result = await settings.set_result_set_caching(target, enabled=False)
         assert result.result_set_caching is False
 
@@ -153,16 +172,11 @@ class TestSetResultSetCaching:
         target = _make_target()
         ddl_conn = _make_conn_for_ddl()
         read_conn = _make_conn([_SETTINGS_ROW], _SETTINGS_COLS)
-        call_count = 0
         autocommit_values: list[bool] = []
 
         def _open(_t: object, **_kw: object) -> object:
-            nonlocal call_count
-            call_count += 1
             autocommit_values.append(bool(_kw.get("autocommit", False)))
-            if call_count == 1:
-                return ddl_conn
-            return read_conn
+            return ddl_conn if not autocommit_values[:-1] else read_conn
 
         with patch("fabric_dw.sql.open_connection", side_effect=_open):
             await settings.set_result_set_caching(target, enabled=True)
@@ -181,16 +195,8 @@ class TestSetTimeTravelRetention:
         ddl_conn = _make_conn_for_ddl()
         row: tuple[object, ...] = ("SalesWarehouse", True, 30, None)
         read_conn = _make_conn([row], _SETTINGS_COLS)
-        call_count = 0
 
-        def _open(_t: object, **_kw: object) -> object:
-            nonlocal call_count
-            call_count += 1
-            if call_count == 1:
-                return ddl_conn
-            return read_conn
-
-        with patch("fabric_dw.sql.open_connection", side_effect=_open):
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, read_conn]):
             result = await settings.set_time_travel_retention(target, days=30)
         assert isinstance(result, WarehouseSettings)
         assert result.time_travel_retention_days == 30
@@ -206,16 +212,8 @@ class TestSetTimeTravelRetention:
         ddl_conn = _make_conn_for_ddl()
         row: tuple[object, ...] = ("SalesWarehouse", True, 1, None)
         read_conn = _make_conn([row], _SETTINGS_COLS)
-        call_count = 0
 
-        def _open(_t: object, **_kw: object) -> object:
-            nonlocal call_count
-            call_count += 1
-            if call_count == 1:
-                return ddl_conn
-            return read_conn
-
-        with patch("fabric_dw.sql.open_connection", side_effect=_open):
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, read_conn]):
             result = await settings.set_time_travel_retention(target, days=1)
         assert result.time_travel_retention_days == 1
 
@@ -224,16 +222,8 @@ class TestSetTimeTravelRetention:
         ddl_conn = _make_conn_for_ddl()
         row: tuple[object, ...] = ("SalesWarehouse", True, 120, None)
         read_conn = _make_conn([row], _SETTINGS_COLS)
-        call_count = 0
 
-        def _open(_t: object, **_kw: object) -> object:
-            nonlocal call_count
-            call_count += 1
-            if call_count == 1:
-                return ddl_conn
-            return read_conn
-
-        with patch("fabric_dw.sql.open_connection", side_effect=_open):
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, read_conn]):
             result = await settings.set_time_travel_retention(target, days=120)
         assert result.time_travel_retention_days == 120
 
@@ -250,17 +240,31 @@ class TestSetTimeTravelRetention:
         ddl_conn = _make_conn_for_ddl()
         row: tuple[object, ...] = ("SalesWarehouse", True, 7, None)
         read_conn = _make_conn([row], _SETTINGS_COLS)
-        call_count = 0
         autocommit_values: list[bool] = []
 
         def _open(_t: object, **_kw: object) -> object:
-            nonlocal call_count
-            call_count += 1
             autocommit_values.append(bool(_kw.get("autocommit", False)))
-            if call_count == 1:
-                return ddl_conn
-            return read_conn
+            return ddl_conn if not autocommit_values[:-1] else read_conn
 
         with patch("fabric_dw.sql.open_connection", side_effect=_open):
             await settings.set_time_travel_retention(target, days=7)
         assert autocommit_values[0] is True
+
+
+# ===========================================================================
+# Public constants
+# ===========================================================================
+
+
+class TestPublicConstants:
+    def test_retention_min_is_public(self) -> None:
+        """RETENTION_MIN must be accessible without underscore prefix."""
+        assert settings.RETENTION_MIN == 1
+
+    def test_retention_max_is_public(self) -> None:
+        """RETENTION_MAX must be accessible without underscore prefix."""
+        assert settings.RETENTION_MAX == 120
+
+    def test_retention_constants_in_all(self) -> None:
+        assert "RETENTION_MIN" in settings.__all__
+        assert "RETENTION_MAX" in settings.__all__

--- a/tests/unit/services/test_settings.py
+++ b/tests/unit/services/test_settings.py
@@ -1,0 +1,266 @@
+"""Unit tests for services.settings — SQL construction and injection safety."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import patch
+
+import pytest
+
+from fabric_dw.models import WarehouseSettings
+from fabric_dw.services import settings
+from tests.unit.services._helpers import _make_conn, _make_conn_for_ddl, _make_target
+
+# ---------------------------------------------------------------------------
+# Fixture data
+# ---------------------------------------------------------------------------
+
+_NOW = datetime(2024, 6, 1, 12, 0, 0, tzinfo=UTC)
+
+_SETTINGS_COLS = [
+    "name",
+    "is_result_set_caching_on",
+    "time_travel_retention_period_days",
+    "time_travel_retention_cutoff_date",
+]
+
+_SETTINGS_ROW: tuple[object, ...] = (
+    "SalesWarehouse",
+    True,
+    7,
+    _NOW,
+)
+
+_SETTINGS_ROW_CACHING_OFF: tuple[object, ...] = (
+    "SalesWarehouse",
+    False,
+    7,
+    _NOW,
+)
+
+_SETTINGS_ROW_NO_CUTOFF: tuple[object, ...] = (
+    "SalesWarehouse",
+    True,
+    30,
+    None,
+)
+
+
+# ===========================================================================
+# get_settings
+# ===========================================================================
+
+
+class TestGetSettings:
+    async def test_returns_warehouse_settings(self) -> None:
+        target = _make_target()
+        conn = _make_conn([_SETTINGS_ROW], _SETTINGS_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            result = await settings.get_settings(target)
+        assert isinstance(result, WarehouseSettings)
+        assert result.database == "SalesWarehouse"
+        assert result.result_set_caching is True
+        assert result.time_travel_retention_days == 7
+        assert result.time_travel_retention_cutoff_date == _NOW
+
+    async def test_none_cutoff_is_none(self) -> None:
+        target = _make_target()
+        conn = _make_conn([_SETTINGS_ROW_NO_CUTOFF], _SETTINGS_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            result = await settings.get_settings(target)
+        assert result.time_travel_retention_cutoff_date is None
+
+    async def test_caching_off_is_false(self) -> None:
+        target = _make_target()
+        conn = _make_conn([_SETTINGS_ROW_CACHING_OFF], _SETTINGS_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            result = await settings.get_settings(target)
+        assert result.result_set_caching is False
+
+    async def test_selects_correct_columns(self) -> None:
+        """Verify the SQL selects the four expected columns."""
+        sql = settings._GET_SETTINGS_SQL
+        assert "is_result_set_caching_on" in sql
+        assert "time_travel_retention_period_days" in sql
+        assert "time_travel_retention_cutoff_date" in sql
+        assert "DB_ID()" in sql
+
+    async def test_naive_cutoff_converted_to_utc(self) -> None:
+        naive_ts = datetime(2024, 6, 1, 12, 0, 0)  # noqa: DTZ001
+        row: tuple[object, ...] = ("SalesWarehouse", True, 7, naive_ts)
+        target = _make_target()
+        conn = _make_conn([row], _SETTINGS_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            result = await settings.get_settings(target)
+        assert result.time_travel_retention_cutoff_date is not None
+        assert result.time_travel_retention_cutoff_date.tzinfo == UTC
+
+
+# ===========================================================================
+# set_result_set_caching
+# ===========================================================================
+
+
+class TestSetResultSetCaching:
+    async def test_enable_uses_on_sql(self) -> None:
+        """ON keyword is used when enabled=True."""
+        assert "ON" in settings._SET_RSC_SQL_ON
+        assert "OFF" not in settings._SET_RSC_SQL_ON
+
+    async def test_disable_uses_off_sql(self) -> None:
+        """OFF keyword is used when enabled=False."""
+        assert "OFF" in settings._SET_RSC_SQL_OFF
+        assert "ON" not in settings._SET_RSC_SQL_OFF.replace("RESULT_SET_CACHING", "")
+
+    async def test_enable_returns_settings(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        read_conn = _make_conn([_SETTINGS_ROW], _SETTINGS_COLS)
+        call_count = 0
+
+        def _open(_t: object, **_kw: object) -> object:
+            nonlocal call_count
+            call_count += 1
+            # First call is ALTER DATABASE (autocommit=True), second is SELECT
+            if call_count == 1:
+                return ddl_conn
+            return read_conn
+
+        with patch("fabric_dw.sql.open_connection", side_effect=_open):
+            result = await settings.set_result_set_caching(target, enabled=True)
+        assert isinstance(result, WarehouseSettings)
+        assert result.result_set_caching is True
+
+    async def test_disable_returns_settings(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        read_conn = _make_conn([_SETTINGS_ROW_CACHING_OFF], _SETTINGS_COLS)
+        call_count = 0
+
+        def _open(_t: object, **_kw: object) -> object:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return ddl_conn
+            return read_conn
+
+        with patch("fabric_dw.sql.open_connection", side_effect=_open):
+            result = await settings.set_result_set_caching(target, enabled=False)
+        assert result.result_set_caching is False
+
+    async def test_alter_database_runs_with_autocommit(self) -> None:
+        """ALTER DATABASE must use autocommit=True."""
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        read_conn = _make_conn([_SETTINGS_ROW], _SETTINGS_COLS)
+        call_count = 0
+        autocommit_values: list[bool] = []
+
+        def _open(_t: object, **_kw: object) -> object:
+            nonlocal call_count
+            call_count += 1
+            autocommit_values.append(bool(_kw.get("autocommit", False)))
+            if call_count == 1:
+                return ddl_conn
+            return read_conn
+
+        with patch("fabric_dw.sql.open_connection", side_effect=_open):
+            await settings.set_result_set_caching(target, enabled=True)
+        # First connection (ALTER DATABASE) must be autocommit
+        assert autocommit_values[0] is True
+
+
+# ===========================================================================
+# set_time_travel_retention
+# ===========================================================================
+
+
+class TestSetTimeTravelRetention:
+    async def test_valid_days_returns_settings(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        row: tuple[object, ...] = ("SalesWarehouse", True, 30, None)
+        read_conn = _make_conn([row], _SETTINGS_COLS)
+        call_count = 0
+
+        def _open(_t: object, **_kw: object) -> object:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return ddl_conn
+            return read_conn
+
+        with patch("fabric_dw.sql.open_connection", side_effect=_open):
+            result = await settings.set_time_travel_retention(target, days=30)
+        assert isinstance(result, WarehouseSettings)
+        assert result.time_travel_retention_days == 30
+
+    @pytest.mark.parametrize("days", [0, -1, 121, 200])
+    async def test_out_of_range_raises_value_error(self, days: int) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="time_travel_retention_period_days"):
+            await settings.set_time_travel_retention(target, days=days)
+
+    async def test_boundary_min_accepted(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        row: tuple[object, ...] = ("SalesWarehouse", True, 1, None)
+        read_conn = _make_conn([row], _SETTINGS_COLS)
+        call_count = 0
+
+        def _open(_t: object, **_kw: object) -> object:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return ddl_conn
+            return read_conn
+
+        with patch("fabric_dw.sql.open_connection", side_effect=_open):
+            result = await settings.set_time_travel_retention(target, days=1)
+        assert result.time_travel_retention_days == 1
+
+    async def test_boundary_max_accepted(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        row: tuple[object, ...] = ("SalesWarehouse", True, 120, None)
+        read_conn = _make_conn([row], _SETTINGS_COLS)
+        call_count = 0
+
+        def _open(_t: object, **_kw: object) -> object:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return ddl_conn
+            return read_conn
+
+        with patch("fabric_dw.sql.open_connection", side_effect=_open):
+            result = await settings.set_time_travel_retention(target, days=120)
+        assert result.time_travel_retention_days == 120
+
+    async def test_sql_embeds_int_literal(self) -> None:
+        """The DDL template embeds the int directly — no SQL params."""
+        ddl = settings._SET_RETENTION_SQL_TEMPLATE.format(n=42)
+        assert "42" in ddl
+        assert "?" not in ddl
+        assert "DAYS" in ddl
+
+    async def test_alter_database_runs_with_autocommit(self) -> None:
+        """ALTER DATABASE must use autocommit=True."""
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        row: tuple[object, ...] = ("SalesWarehouse", True, 7, None)
+        read_conn = _make_conn([row], _SETTINGS_COLS)
+        call_count = 0
+        autocommit_values: list[bool] = []
+
+        def _open(_t: object, **_kw: object) -> object:
+            nonlocal call_count
+            call_count += 1
+            autocommit_values.append(bool(_kw.get("autocommit", False)))
+            if call_count == 1:
+                return ddl_conn
+            return read_conn
+
+        with patch("fabric_dw.sql.open_connection", side_effect=_open):
+            await settings.set_time_travel_retention(target, days=7)
+        assert autocommit_values[0] is True


### PR DESCRIPTION
## Summary

- Adds a new `fabric-dw settings` command group for managing **server-side** database settings on Fabric Data Warehouses and SQL Analytics Endpoints.
- Distinct from the `config` group (client-side CLI defaults); `settings` reads/writes the warehouse's own database configuration.
- Three commands: `settings show`, `settings result-set-caching on|off`, `settings retention --days N`.

## What's included

| File | Change |
| --- | --- |
| `src/fabric_dw/models.py` | Add `WarehouseSettings` Pydantic model |
| `src/fabric_dw/services/settings.py` | New service: `get_settings`, `set_result_set_caching`, `set_time_travel_retention` |
| `src/fabric_dw/cli/commands/settings.py` | New CLI group with `show`, `result-set-caching`, `retention` commands |
| `src/fabric_dw/cli/_main.py` | Register `settings_group` |
| `tests/unit/services/test_settings.py` | Service unit tests (fake-SQL harness) |
| `tests/unit/cli/commands/test_settings.py` | CLI unit tests (Click runner) |
| `docs/cli.md` | Document the new commands |

## Key implementation decisions

- **`ALTER DATABASE` requires `autocommit=True`** — using a multi-statement transaction raises an error in Fabric. Both write commands use `run_query(..., autocommit=True, fetch="none")`.
- **No SQL endpoint guard** — both Data Warehouses and SQL Analytics Endpoints support the `sys.databases` read query. The write operations are allowed on both item kinds; `retention` is documented as primarily a Warehouse concept that may be a no-op on SQL endpoints.
- **`settings` vs `config` naming** — `config` = client-side CLI defaults; `settings` = server-side warehouse/database configuration. This separation avoids confusion between what the CLI stores locally and what lives in the Fabric service.
- **`set_result_set_caching` uses keyword-only `enabled`** — avoids FBT001 (boolean positional arg) and makes call sites clearer.

## Quality gates

- `just check` (ruff + ty + 3460 unit tests): ✅ all pass
- `just cov`: ✅ 95% total, 96% for new `services/settings.py`

## Not included

MCP tools (`mcp/tools/settings.py`) are deferred to a follow-up PR.

Part of #473