### PR TITLE
feat(telemetry): map dimensions to native Part A fields, drop hostname leak

### DIFF
--- a/src/fabric_dw/cli/_main.py
+++ b/src/fabric_dw/cli/_main.py
@@ -245,7 +245,6 @@ class _InstrumentedGroup(click.Group):
                 status = map_status(exc_seen)
                 emit_command_invoked(
                     name=command_name,
-                    surface="cli",
                     status=status,
                     duration_ms=duration,
                 )

--- a/src/fabric_dw/mcp/_helpers.py
+++ b/src/fabric_dw/mcp/_helpers.py
@@ -117,7 +117,6 @@ def _wrap_mcp_tool_with_telemetry(
             status = map_status(exc_seen)
             emit_command_invoked(
                 name=name,
-                surface="mcp",
                 status=status,
                 duration_ms=duration,
                 destructive=destructive,

--- a/src/fabric_dw/telemetry.py
+++ b/src/fabric_dw/telemetry.py
@@ -351,7 +351,7 @@ def _detect_auth_mode() -> str:
 _tenant_id_override: str | None = None
 
 
-def _build_envelope(surface: str) -> dict[str, object]:  # noqa: ARG001
+def _build_envelope() -> dict[str, object]:
     """Build the shared telemetry envelope attached to every event.
 
     Custom dimensions included here are those with no native Part A mapping.
@@ -363,7 +363,9 @@ def _build_envelope(surface: str) -> dict[str, object]:  # noqa: ARG001
 
     Fields omitted entirely (dropped in #477):
     - ``anonymous_install_id`` — already shipped natively as ``user_Id`` (← ``enduser.pseudo.id``)
-    - ``is_ci``                — telemetry is disabled entirely in CI; this was always ``False``
+    - ``is_ci``                — ``is_ci=True`` never reached the backend (telemetry is suppressed
+                                 in CI); ``is_ci=False`` carries no signal.  The dimension was
+                                 always either absent or constant, so it was dropped.
 
     ``tenant_id`` is always present (``"unknown"`` when unresolved) so it is
     reliably queryable on every event.  No native Part A slot is reachable for
@@ -396,7 +398,7 @@ def _build_envelope(surface: str) -> dict[str, object]:  # noqa: ARG001
     }
 
 
-def _build_otel_resource(surface: str) -> object:
+def _build_otel_resource(surface: str) -> object | None:
     """Build an OTel Resource that populates native Part A context fields.
 
     The Resource is passed to ``configure_azure_monitor`` so the exporter
@@ -830,7 +832,7 @@ def emit_event(name: str, attributes: dict[str, object]) -> None:
 
         from opentelemetry._logs import LogRecord  # noqa: PLC0415
 
-        envelope = _build_envelope(_current_surface)
+        envelope = _build_envelope()
         merged: dict[str, object] = {**envelope, **attributes}
 
         # Add the special attributes that drive native App Insights mapping:

--- a/src/fabric_dw/telemetry.py
+++ b/src/fabric_dw/telemetry.py
@@ -18,8 +18,9 @@ Architecture notes
 - All public functions are fire-and-forget: they catch every exception and
   never propagate errors to the caller.
 - No network calls are made when telemetry is disabled.
-- ``tenant_id`` is included in the envelope only when telemetry is enabled
-  (it comes from env vars; token-claim extraction is deferred to #366).
+- ``tenant_id`` is always present in the envelope (``"unknown"`` when unresolved)
+  so it is reliably queryable on every event.  Token-claim extraction is via
+  ``cache_tenant_id_from_token()`` (#366).
 - Auto-HTTP instrumentation is explicitly disabled to prevent MSAL OAuth
   request URLs (containing tenant IDs) from leaking as span attributes.
 - ``shutdown_on_exit`` is disabled; a bounded ``force_flush`` + ``provider.shutdown()``
@@ -39,9 +40,27 @@ land in the ``customEvents`` table and populate the App Insights
 
 Key attribute mappings in azure-monitor-opentelemetry-exporter 1.0.0b53:
 
+Record-level (per-event):
 - ``microsoft.custom_event.name`` → EventData.name  (``customEvents`` table)
 - ``enduser.pseudo.id``            → tags["ai.user.id"] ("Users" blade)
   (DO NOT use ``enduser.id`` — that maps to ``ai.user.authUserId``, a PII field)
+- ``ai.operation.name``            → tags["ai.operation.name"] ("operation_Name")
+  Set to the command/tool name on ``command_invoked`` events.
+
+Resource-level (set once, apply to all events via the OTel Resource):
+- ``service.namespace`` + ``service.name`` → tags["ai.cloud.role"] (``cloud_RoleName``)
+  Set to ``"fabric-dw"`` + surface (``"cli"`` | ``"mcp"``).
+- ``service.instance.id``          → tags["ai.cloud.roleInstance"] (``cloud_RoleInstance``)
+  Set to ``anonymous_install_id`` — NOT the machine hostname (#477 privacy fix).
+- ``service.version``              → tags["ai.application.ver"] (``application_Version``)
+  Populated from the package version.
+- ``device.id``                    → tags["ai.device.id"]
+  Set to ``anonymous_install_id`` to prevent hostname fallback (#477 privacy fix).
+
+Privacy: setting ``service.instance.id`` and ``device.id`` on the Resource prevents
+the exporter's hostname fallback (``platform.node()``) for ``cloud_RoleInstance``
+and ``ai.device.id`` respectively.  Hostnames often embed the user's real name
+(``sam-macbook``, ``DESKTOP-...``), which contradicts the project's anonymity stance.
 
 Sessions limitation: ``ai.session.id`` has NO attribute mapping in exporter
 1.0.0b53 (AI_SESSION_ID is never written to tags by the log exporter).  Native
@@ -332,41 +351,94 @@ def _detect_auth_mode() -> str:
 _tenant_id_override: str | None = None
 
 
-def _build_envelope(surface: str) -> dict[str, object]:
-    """Build the shared telemetry envelope attached to every event."""
-    import platform as _platform  # noqa: PLC0415
+def _build_envelope(surface: str) -> dict[str, object]:  # noqa: ARG001
+    """Build the shared telemetry envelope attached to every event.
 
-    try:
-        from fabric_dw._version import __version__ as _version  # noqa: PLC0415
-    except Exception:
-        _version = "unknown"
+    Custom dimensions included here are those with no native Part A mapping.
+    Fields that have native App Insights homes are set via the OTel Resource
+    (``_build_otel_resource``) and are NOT duplicated here:
+
+    - ``app_version``  → native ``application_Version`` (resource ``service.version``)
+    - ``surface``      → native ``cloud_RoleName``       (resource ``service.name``)
+
+    Fields omitted entirely (dropped in #477):
+    - ``anonymous_install_id`` — already shipped natively as ``user_Id`` (← ``enduser.pseudo.id``)
+    - ``is_ci``                — telemetry is disabled entirely in CI; this was always ``False``
+
+    ``tenant_id`` is always present (``"unknown"`` when unresolved) so it is
+    reliably queryable on every event.  No native Part A slot is reachable for
+    tenant on the log-record path in this exporter version; ``customDimensions``
+    is the correct mechanism here.
+    """
+    import platform as _platform  # noqa: PLC0415
 
     python_info = sys.version_info
     python_version = f"{python_info.major}.{python_info.minor}"
 
     # Prefer the runtime-set override (populated by #366 token-claim hook),
-    # then fall back to environment variables.
-    tenant_id = _tenant_id_override or (
-        os.environ.get("AZURE_TENANT_ID") or os.environ.get("FABRIC_INTERACTIVE_TENANT_ID") or None
+    # then fall back to environment variables, then "unknown" so the key is
+    # always present on every event (Finding 2 / #477).
+    tenant_id: str = (
+        _tenant_id_override
+        or os.environ.get("AZURE_TENANT_ID")
+        or os.environ.get("FABRIC_INTERACTIVE_TENANT_ID")
+        or "unknown"
     )
 
-    envelope: dict[str, object] = {
-        "anonymous_install_id": _get_install_id(),
+    return {
         "session_id": _SESSION_ID,
-        "app_version": _version,
         "python_version": python_version,
         "os": _platform.system().lower(),
         "arch": _platform.machine().lower(),
         "install_method": _detect_install_method(),
-        "surface": surface,
-        "is_ci": _is_ci(),
         "auth_mode": _detect_auth_mode(),
+        "tenant_id": tenant_id,
     }
-    # Only include tenant_id when a value is known — OTel attributes do not
-    # accept None, and omitting the key is cleaner than an empty string.
-    if tenant_id is not None:
-        envelope["tenant_id"] = tenant_id
-    return envelope
+
+
+def _build_otel_resource(surface: str) -> object:
+    """Build an OTel Resource that populates native Part A context fields.
+
+    The Resource is passed to ``configure_azure_monitor`` so the exporter
+    sets Part A tags from it rather than using hostname fallbacks.
+
+    Mappings (#477):
+    - ``service.namespace`` + ``service.name`` → ``cloud_RoleName`` / ``AppRoleName``
+      Gives a meaningful role name (e.g. ``"fabric-dw.cli"``) instead of
+      ``unknown_service:*``, and creates two Application Map nodes.
+    - ``service.instance.id`` = install_id → ``cloud_RoleInstance`` / ``AppRoleInstance``
+      Prevents hostname fallback (``platform.node()``).  The pseudonymous install UUID
+      is non-identifying and gives meaningful per-install instance counts.
+    - ``service.version`` = app_version → ``application_Version`` / ``AppVersion``
+      Enables version-adoption and release-regression views.
+    - ``device.id`` = install_id → ``ai.device.id``
+      ``_populate_part_a_fields`` overrides ``ai.device.id`` with this value only when
+      it is truthy; an empty string would leave the hostname default in place.
+
+    Returns the ``opentelemetry.sdk.resources.Resource`` object, or ``None`` if
+    the SDK import fails (the caller falls back to the default resource).
+    """
+    try:
+        from opentelemetry.sdk.resources import Resource  # noqa: PLC0415
+
+        try:
+            from fabric_dw._version import __version__ as _version  # noqa: PLC0415
+        except Exception:
+            _version = "unknown"
+
+        install_id = _get_install_id()
+
+        return Resource.create(
+            {
+                "service.namespace": "fabric-dw",
+                "service.name": surface,  # "cli" | "mcp" → cloud_RoleName = "fabric-dw.cli|mcp"
+                "service.instance.id": install_id,  # → cloud_RoleInstance (not hostname)
+                "service.version": _version,  # → application_Version
+                "device.id": install_id,  # → ai.device.id (not hostname)
+            }
+        )
+    except Exception:
+        return None
 
 
 # ---------------------------------------------------------------------------
@@ -464,6 +536,11 @@ def _get_tracer() -> object | None:
 
     Privacy / hang safeguards
     -------------------------
+    - ``resource`` is built via ``_build_otel_resource`` and passed to
+      ``configure_azure_monitor`` so ``service.instance.id`` and ``device.id``
+      are set explicitly.  This prevents the exporter from falling back to
+      ``platform.node()`` for ``cloud_RoleInstance`` / ``ai.device.id``, which
+      would leak the machine hostname on every event (#477 privacy fix).
     - ``instrumentation_options`` explicitly disables all auto-HTTP and Azure SDK
       instrumentors so MSAL OAuth URLs (containing tenant IDs) are never captured
       as span attributes (B1).
@@ -515,29 +592,39 @@ def _get_tracer() -> object | None:
         # respected.
         os.environ.setdefault("APPLICATIONINSIGHTS_STATSBEAT_DISABLED_ALL", "true")
 
-        configure_azure_monitor(
-            connection_string=_get_connection_string(),
-            logger_name="fabric_dw.telemetry",
+        # Build the OTel Resource that populates native Part A fields and prevents
+        # hostname fallback for cloud_RoleInstance / ai.device.id (#477).
+        resource = _build_otel_resource(_current_surface)
+
+        configure_kwargs: dict[str, object] = {
+            "connection_string": _get_connection_string(),
+            "logger_name": "fabric_dw.telemetry",
             # disable_logging=False (default) is intentional: the log/event
             # exporter must be active so customEvents land in the customEvents
             # table.  Without the logs pipeline, log records carrying
             # microsoft.custom_event.name are silently dropped and events never
             # appear in the App Insights "Usage → Events" or "Usage → Users" blades.
-            disable_logging=False,
-            disable_metrics=True,
+            "disable_logging": False,
+            "disable_metrics": True,
             # A1: disable PerformanceCounters — not covered by disable_metrics in
             # azure-monitor-opentelemetry 1.8+; its _get_processor_time callback
             # divides by zero on short-lived processes and logs a traceback (#399).
-            enable_performance_counters=False,
+            "enable_performance_counters": False,
             # A2: belt-and-suspenders — QuickPulse must never ping the LiveEndpoint.
             # Suppresses _quickpulse/_exporter.py::_ping tracebacks on connection
             # refused even if the default changes in a future SDK version (#411).
-            enable_live_metrics=False,
+            "enable_live_metrics": False,
             # B2: disable unbounded (30 s) atexit flush — we do our own bounded flush.
-            shutdown_on_exit=False,
+            "shutdown_on_exit": False,
             # B1: disable all auto-HTTP / Azure SDK instrumentors (privacy).
-            instrumentation_options=_INSTRUMENTATION_OPTIONS,
-        )
+            "instrumentation_options": _INSTRUMENTATION_OPTIONS,
+        }
+        # Pass the resource when available so native Part A fields are populated
+        # (cloud_RoleName, cloud_RoleInstance, application_Version, ai.device.id).
+        if resource is not None:
+            configure_kwargs["resource"] = resource
+
+        configure_azure_monitor(**configure_kwargs)
         # Obtain the OTel Logger via the global LoggerProvider set up by
         # configure_azure_monitor.  This logger is used in emit_event to fire
         # customEvents as log records (not spans).
@@ -720,6 +807,11 @@ def emit_event(name: str, attributes: dict[str, object]) -> None:
     carries ``ai.user.id`` (→ "Usage → Users" blade).  This is a randomly
     generated UUID — not a username, email, or any PII.
 
+    Callers may pass ``ai.operation.name`` in *attributes* to populate the
+    native ``operation_Name`` Part A field.  ``emit_command_invoked`` sets
+    this to the command/tool name so it appears in the portal's "Operation
+    Name" column instead of being blank.
+
     Sessions note: ``ai.session.id`` has no attribute mapping in
     azure-monitor-opentelemetry-exporter 1.0.0b53.  ``session_id`` is therefore
     kept as a custom dimension (customDimensions) so it is query-able in the
@@ -741,7 +833,7 @@ def emit_event(name: str, attributes: dict[str, object]) -> None:
         envelope = _build_envelope(_current_surface)
         merged: dict[str, object] = {**envelope, **attributes}
 
-        # Add the two special attributes that drive native App Insights mapping:
+        # Add the special attributes that drive native App Insights mapping:
         #   microsoft.custom_event.name → EventData.name (customEvents table)
         #   enduser.pseudo.id           → ai.user.id ("Users" blade)
         # NOTE: enduser.pseudo.id contains the anonymous install UUID — a random
@@ -750,6 +842,10 @@ def emit_event(name: str, attributes: dict[str, object]) -> None:
         # which maps to ai.user.authUserId (authenticated / PII field).
         merged["microsoft.custom_event.name"] = name
         merged["enduser.pseudo.id"] = _get_install_id()
+        # ai.operation.name may already be in merged (set by caller e.g. emit_command_invoked).
+        # It is left as-is when present; only set the event name as fallback for lifecycle events.
+        if "ai.operation.name" not in merged:
+            merged["ai.operation.name"] = name
 
         record = LogRecord(  # ty: ignore[no-matching-overload]
             attributes=merged,  # type: ignore[arg-type]
@@ -773,7 +869,9 @@ def record_app_started(surface: str) -> None:
     """
     global _current_surface  # noqa: PLW0603
     _current_surface = surface
-    emit_event("app_started", {"surface": surface})
+    # ``surface`` is no longer sent as a custom dimension: it is shipped natively
+    # as ``cloud_RoleName`` via the OTel Resource (``service.name`` = surface).
+    emit_event("app_started", {})
 
 
 def record_app_exited(

--- a/src/fabric_dw/telemetry_commands.py
+++ b/src/fabric_dw/telemetry_commands.py
@@ -346,7 +346,7 @@ def duration_bucket(duration_ms: float) -> str:
 def emit_command_invoked(
     *,
     name: str,
-    surface: str,
+    surface: str,  # noqa: ARG001
     status: str,
     duration_ms: float,
     destructive: bool = False,
@@ -359,7 +359,10 @@ def emit_command_invoked(
     Args:
         name: The command name — for CLI: ``"<group>.<subcommand>"``,
               for MCP: the tool name.
-        surface: ``"cli"`` or ``"mcp"``.
+        surface: ``"cli"`` or ``"mcp"``.  Kept as a parameter for call-site
+              compatibility but no longer emitted as a custom dimension — it is
+              now shipped natively as ``cloud_RoleName`` via the OTel Resource
+              (``service.name`` = surface, set in ``record_app_started``).
         status: One of ``"success"``, ``"user_error"``, ``"api_error"``.
         duration_ms: Wall-clock duration in milliseconds.
         destructive: Whether this is a permanently-destructive operation.
@@ -372,11 +375,15 @@ def emit_command_invoked(
 
         domain = resolve_domain(name.split(".", maxsplit=1)[0] if "." in name else name)
         attrs: dict[str, object] = {
+            # ``name`` is kept as a custom dimension for convenience (queryable),
+            # even though it is also set as ``ai.operation.name`` (native field).
             "name": name,
             "domain": domain,
-            "surface": surface,
             "status": status,
             "duration_ms_bucket": duration_bucket(duration_ms),
+            # ai.operation.name → native operation_Name / AppRoleInstance portal column.
+            # Set to the command/tool name so it appears in the portal instead of blank.
+            "ai.operation.name": name,
         }
         if destructive:
             attrs["destructive_op"] = True

--- a/src/fabric_dw/telemetry_commands.py
+++ b/src/fabric_dw/telemetry_commands.py
@@ -346,7 +346,6 @@ def duration_bucket(duration_ms: float) -> str:
 def emit_command_invoked(
     *,
     name: str,
-    surface: str,  # noqa: ARG001
     status: str,
     duration_ms: float,
     destructive: bool = False,
@@ -359,10 +358,6 @@ def emit_command_invoked(
     Args:
         name: The command name — for CLI: ``"<group>.<subcommand>"``,
               for MCP: the tool name.
-        surface: ``"cli"`` or ``"mcp"``.  Kept as a parameter for call-site
-              compatibility but no longer emitted as a custom dimension — it is
-              now shipped natively as ``cloud_RoleName`` via the OTel Resource
-              (``service.name`` = surface, set in ``record_app_started``).
         status: One of ``"success"``, ``"user_error"``, ``"api_error"``.
         duration_ms: Wall-clock duration in milliseconds.
         destructive: Whether this is a permanently-destructive operation.

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -283,7 +283,7 @@ def test_envelope_contains_required_fields(monkeypatch: pytest.MonkeyPatch, tmp_
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
 
     mod = _reload_telemetry()
-    envelope = mod._build_envelope("cli")  # type: ignore[attr-defined]
+    envelope = mod._build_envelope()  # type: ignore[attr-defined]
 
     # Fields that must remain as custom dimensions (no native Part A mapping).
     required = {
@@ -324,8 +324,8 @@ def test_envelope_surface_not_in_custom_dimensions(
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
 
     mod = _reload_telemetry()
-    assert "surface" not in mod._build_envelope("cli")  # type: ignore[attr-defined]
-    assert "surface" not in mod._build_envelope("mcp")  # type: ignore[attr-defined]
+    assert "surface" not in mod._build_envelope()  # type: ignore[attr-defined]
+    assert "surface" not in mod._build_envelope()  # type: ignore[attr-defined]
 
 
 def test_envelope_is_ci_not_in_custom_dimensions(
@@ -336,7 +336,7 @@ def test_envelope_is_ci_not_in_custom_dimensions(
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
 
     mod = _reload_telemetry()
-    envelope = mod._build_envelope("cli")  # type: ignore[attr-defined]
+    envelope = mod._build_envelope()  # type: ignore[attr-defined]
     assert "is_ci" not in envelope, "is_ci must not be emitted as a custom dimension (#477)"
 
 
@@ -351,7 +351,7 @@ def test_envelope_anonymous_install_id_not_in_custom_dimensions(
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
 
     mod = _reload_telemetry()
-    envelope = mod._build_envelope("cli")  # type: ignore[attr-defined]
+    envelope = mod._build_envelope()  # type: ignore[attr-defined]
     assert "anonymous_install_id" not in envelope
 
 
@@ -359,7 +359,7 @@ def test_envelope_python_version_is_minor(monkeypatch: pytest.MonkeyPatch, tmp_p
     """python_version must be 'major.minor' format (e.g. '3.12')."""
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
     mod = _reload_telemetry()
-    envelope = mod._build_envelope("cli")  # type: ignore[attr-defined]
+    envelope = mod._build_envelope()  # type: ignore[attr-defined]
     pv = envelope["python_version"]
     parts = str(pv).split(".")
     assert len(parts) == 2, f"Expected 'major.minor', got {pv!r}"
@@ -370,7 +370,7 @@ def test_envelope_os_is_lowercase(monkeypatch: pytest.MonkeyPatch, tmp_path: Pat
     """os field must be lowercase."""
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
     mod = _reload_telemetry()
-    envelope = mod._build_envelope("cli")  # type: ignore[attr-defined]
+    envelope = mod._build_envelope()  # type: ignore[attr-defined]
     assert envelope["os"] == envelope["os"].lower()
 
 
@@ -383,7 +383,7 @@ def test_envelope_tenant_id_from_azure_tenant_id(
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
 
     mod = _reload_telemetry()
-    envelope = mod._build_envelope("cli")  # type: ignore[attr-defined]
+    envelope = mod._build_envelope()  # type: ignore[attr-defined]
     assert envelope["tenant_id"] == "my-tenant-123"
 
 
@@ -396,7 +396,7 @@ def test_envelope_tenant_id_from_fabric_interactive_when_no_azure(
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
 
     mod = _reload_telemetry()
-    envelope = mod._build_envelope("cli")  # type: ignore[attr-defined]
+    envelope = mod._build_envelope()  # type: ignore[attr-defined]
     assert envelope["tenant_id"] == "interactive-tenant"
 
 
@@ -415,7 +415,7 @@ def test_envelope_tenant_id_unknown_when_no_env(
 
     mod = _reload_telemetry()
     mod._tenant_id_override = None  # type: ignore[attr-defined]
-    envelope = mod._build_envelope("cli")  # type: ignore[attr-defined]
+    envelope = mod._build_envelope()  # type: ignore[attr-defined]
     assert envelope.get("tenant_id") == "unknown"
 
 
@@ -1162,7 +1162,7 @@ def test_set_tenant_id_reflected_in_envelope(
     mod = _reload_telemetry()
     mod.set_tenant_id("runtime-tenant-xyz")  # type: ignore[attr-defined]
 
-    envelope = mod._build_envelope("cli")  # type: ignore[attr-defined]
+    envelope = mod._build_envelope()  # type: ignore[attr-defined]
     assert envelope["tenant_id"] == "runtime-tenant-xyz"
 
 
@@ -1176,7 +1176,7 @@ def test_set_tenant_id_takes_precedence_over_env(
     mod = _reload_telemetry()
     mod.set_tenant_id("runtime-tenant")  # type: ignore[attr-defined]
 
-    envelope = mod._build_envelope("cli")  # type: ignore[attr-defined]
+    envelope = mod._build_envelope()  # type: ignore[attr-defined]
     assert envelope["tenant_id"] == "runtime-tenant"
 
 
@@ -1494,7 +1494,7 @@ def test_envelope_uses_token_tid_over_env_var(
     tid_value = "token-tenant-id-from-tid-claim"
     mod._tenant_id_override = tid_value  # type: ignore[attr-defined]
 
-    envelope = mod._build_envelope("cli")  # type: ignore[attr-defined]
+    envelope = mod._build_envelope()  # type: ignore[attr-defined]
     assert envelope.get("tenant_id") == tid_value
 
 
@@ -1523,7 +1523,7 @@ def test_envelope_falls_back_to_azure_tenant_id_env_when_no_override(
     # Ensure no override is set
     mod._tenant_id_override = None  # type: ignore[attr-defined]
 
-    envelope = mod._build_envelope("cli")  # type: ignore[attr-defined]
+    envelope = mod._build_envelope()  # type: ignore[attr-defined]
     assert envelope.get("tenant_id") == "fallback-env-tenant"
 
 
@@ -1554,7 +1554,7 @@ def test_envelope_tenant_id_unknown_when_no_source(
     mod = _reload_telemetry()
     mod._tenant_id_override = None  # type: ignore[attr-defined]
 
-    envelope = mod._build_envelope("cli")  # type: ignore[attr-defined]
+    envelope = mod._build_envelope()  # type: ignore[attr-defined]
     assert envelope.get("tenant_id") == "unknown"
 
 
@@ -2269,7 +2269,7 @@ def _build_test_envelope(
     mod = _reload_telemetry()
     mod._tenant_id_override = None  # type: ignore[attr-defined]
 
-    envelope_attrs = mod._build_envelope("cli")  # type: ignore[attr-defined]
+    envelope_attrs = mod._build_envelope()  # type: ignore[attr-defined]
     merged: dict[str, object] = {**envelope_attrs}
     merged["microsoft.custom_event.name"] = event_name
     merged["enduser.pseudo.id"] = mod._get_install_id()  # type: ignore[attr-defined]
@@ -2325,7 +2325,7 @@ def test_emit_event_produces_eventdata_envelope(
     )
 
     assert envelope.data.base_data is not None
-    event_data_name = envelope.data.base_data.name  # ty: ignore[unresolved-attribute]
+    event_data_name = envelope.data.base_data.name  # type: ignore[union-attr]
     assert event_data_name == event_name, (
         f"Expected event name {event_name!r} in EventData, got {event_data_name!r}."
     )
@@ -2605,7 +2605,7 @@ def test_emit_event_sets_ai_operation_name(monkeypatch: pytest.MonkeyPatch, tmp_
 
     # Simulate the attribute building done inside emit_event for a lifecycle event.
     event_name = "app_started"
-    envelope_attrs = mod._build_envelope("cli")  # type: ignore[attr-defined]
+    envelope_attrs = mod._build_envelope()  # type: ignore[attr-defined]
     merged: dict[str, object] = {**envelope_attrs}
     merged["microsoft.custom_event.name"] = event_name
     merged["enduser.pseudo.id"] = mod._get_install_id()  # type: ignore[attr-defined]
@@ -2690,4 +2690,69 @@ def test_cloud_role_instance_from_resource_not_hostname(
         f"cloud_RoleInstance must be the pseudonymous install_id {known_install_id!r}, "
         f"got {role_instance!r}.  "
         "Set via resource attribute service.instance.id (#477)."
+    )
+
+
+def test_ai_device_id_from_resource_not_hostname(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """ai.device.id must come from install_id via the OTel Resource, not platform.node().
+
+    This is the privacy test for #477 (parallel to the cloud_RoleInstance check above).
+    The exporter falls back to platform.node() for ai.device.id when device.id is absent
+    from the resource.  We must ensure the device.id resource attribute is set so the
+    hostname is never shipped.
+    """
+    import platform as _platform  # noqa: PLC0415
+
+    from azure.monitor.opentelemetry.exporter.export.logs._exporter import (  # noqa: PLC0415
+        _convert_log_to_envelope,
+    )
+    from opentelemetry.sdk._logs._internal import (  # noqa: PLC0415
+        InstrumentationScope,
+        ReadableLogRecord,
+    )
+    from opentelemetry.sdk._logs._internal import LogRecord as SDKLogRecord  # noqa: PLC0415
+
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    known_install_id = "ffff6666-dead-beef-1234-aaaaaaaaaaaa"
+    config_dir = tmp_path / "fabric-dw"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    (config_dir / "install_id").write_text(known_install_id, encoding="utf-8")
+
+    mod = _reload_telemetry()
+
+    # Build a log record using the production resource (as _get_tracer would do).
+    attrs: dict[str, object] = {
+        "microsoft.custom_event.name": "test_event",
+        "enduser.pseudo.id": known_install_id,
+        "ai.operation.name": "test_event",
+    }
+    sdk_record = SDKLogRecord(attributes=attrs)  # type: ignore[arg-type]  # ty: ignore[no-matching-overload]
+
+    # Use the resource built by _build_otel_resource (the production code path).
+    resource = mod._build_otel_resource("cli")  # type: ignore[attr-defined]
+    scope = InstrumentationScope("fabric_dw.telemetry")
+    readable = ReadableLogRecord(
+        log_record=sdk_record,
+        resource=resource,
+        instrumentation_scope=scope,  # type: ignore[arg-type]
+    )
+
+    envelope = _convert_log_to_envelope(readable)
+    assert envelope.tags is not None
+
+    hostname = _platform.node()
+    device_id = envelope.tags.get("ai.device.id")
+
+    assert device_id != hostname, (
+        f"ai.device.id must NOT be the machine hostname {hostname!r} — "
+        "hostnames often embed the user's real name (#477 privacy fix).  "
+        f"Got ai.device.id={device_id!r}."
+    )
+    assert device_id == known_install_id, (
+        f"ai.device.id must be the pseudonymous install_id {known_install_id!r}, "
+        f"got {device_id!r}.  "
+        "Set via resource attribute device.id (#477)."
     )

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -260,7 +260,14 @@ def test_emit_event_no_op_when_disabled(monkeypatch: pytest.MonkeyPatch, tmp_pat
 
 
 def test_envelope_contains_required_fields(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """_build_envelope must return a dict with all required fields."""
+    """_build_envelope must return a dict with all required custom-dimension fields.
+
+    Fields moved to native Part A via the OTel Resource (#477) are NOT present
+    here: ``app_version`` (→ application_Version), ``surface`` (→ cloud_RoleName).
+    Fields dropped entirely (#477): ``anonymous_install_id`` (duplicate of user_Id),
+    ``is_ci`` (always False — telemetry is disabled in CI).
+    ``tenant_id`` is now always present (``"unknown"`` when unresolved).
+    """
     monkeypatch.delenv("FABRIC_TELEMETRY", raising=False)
     monkeypatch.delenv("FABRIC_DISABLE_TELEMETRY", raising=False)
     monkeypatch.delenv("DO_NOT_TRACK", raising=False)
@@ -271,29 +278,41 @@ def test_envelope_contains_required_fields(monkeypatch: pytest.MonkeyPatch, tmp_
     monkeypatch.delenv("CIRCLECI", raising=False)
     monkeypatch.delenv("GITLAB_CI", raising=False)
     monkeypatch.delenv("TF_BUILD", raising=False)
+    monkeypatch.delenv("AZURE_TENANT_ID", raising=False)
+    monkeypatch.delenv("FABRIC_INTERACTIVE_TENANT_ID", raising=False)
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
 
     mod = _reload_telemetry()
     envelope = mod._build_envelope("cli")  # type: ignore[attr-defined]
 
+    # Fields that must remain as custom dimensions (no native Part A mapping).
     required = {
-        "anonymous_install_id",
         "session_id",
-        "app_version",
         "python_version",
         "os",
         "arch",
         "install_method",
-        "surface",
-        "is_ci",
         "auth_mode",
+        "tenant_id",  # always present, "unknown" when unresolved (#477 Finding 2)
     }
     for field in required:
         assert field in envelope, f"Missing envelope field: {field}"
 
+    # Fields that were dropped or moved to native (#477) must NOT appear.
+    dropped = {"anonymous_install_id", "is_ci", "app_version", "surface"}
+    for field in dropped:
+        assert field not in envelope, f"Field should have been removed from envelope: {field}"
 
-def test_envelope_surface_field(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """Surface field must match the argument passed to _build_envelope."""
+
+def test_envelope_surface_not_in_custom_dimensions(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """surface must NOT be a custom dimension — it is now native cloud_RoleName (#477).
+
+    The surface is set via the OTel Resource (``service.name``), which the exporter
+    maps to ``cloud_RoleName``.  Emitting it again as a custom dimension would be
+    redundant.
+    """
     monkeypatch.delenv("FABRIC_DISABLE_TELEMETRY", raising=False)
     monkeypatch.delenv("CI", raising=False)
     monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
@@ -305,34 +324,35 @@ def test_envelope_surface_field(monkeypatch: pytest.MonkeyPatch, tmp_path: Path)
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
 
     mod = _reload_telemetry()
-    assert mod._build_envelope("cli")["surface"] == "cli"  # type: ignore[attr-defined]
-    assert mod._build_envelope("mcp")["surface"] == "mcp"  # type: ignore[attr-defined]
+    assert "surface" not in mod._build_envelope("cli")  # type: ignore[attr-defined]
+    assert "surface" not in mod._build_envelope("mcp")  # type: ignore[attr-defined]
 
 
-def test_envelope_is_ci_true_when_ci_env_set(
+def test_envelope_is_ci_not_in_custom_dimensions(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """is_ci must be True when CI env var is set."""
+    """is_ci must NOT be in the envelope — telemetry is disabled in CI so it was always False."""
     monkeypatch.setenv("CI", "true")
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
 
     mod = _reload_telemetry()
     envelope = mod._build_envelope("cli")  # type: ignore[attr-defined]
-    assert envelope["is_ci"] is True
+    assert "is_ci" not in envelope, "is_ci must not be emitted as a custom dimension (#477)"
 
 
-def test_envelope_is_ci_false_when_no_ci_markers(
+def test_envelope_anonymous_install_id_not_in_custom_dimensions(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """is_ci must be False when no CI env vars are present."""
-    ci_vars = ["CI", "GITHUB_ACTIONS", "JENKINS_URL", "TRAVIS", "CIRCLECI", "GITLAB_CI", "TF_BUILD"]
-    for var in ci_vars:
-        monkeypatch.delenv(var, raising=False)
+    """anonymous_install_id must NOT be in the envelope.
+
+    It is already shipped natively as ``user_Id`` via ``enduser.pseudo.id``.
+    Emitting it again as a custom dimension would be redundant (#477 Finding 5).
+    """
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
 
     mod = _reload_telemetry()
     envelope = mod._build_envelope("cli")  # type: ignore[attr-defined]
-    assert envelope["is_ci"] is False
+    assert "anonymous_install_id" not in envelope
 
 
 def test_envelope_python_version_is_minor(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -380,22 +400,23 @@ def test_envelope_tenant_id_from_fabric_interactive_when_no_azure(
     assert envelope["tenant_id"] == "interactive-tenant"
 
 
-def test_envelope_tenant_id_absent_when_no_env(
+def test_envelope_tenant_id_unknown_when_no_env(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """tenant_id is absent from the envelope when neither AZURE_TENANT_ID nor
-    FABRIC_INTERACTIVE_TENANT_ID is set.
+    """tenant_id is always present in the envelope (#477 Finding 2).
 
-    OTel attribute values may not be None; the key is omitted entirely when no
-    tenant ID is available.
+    When neither AZURE_TENANT_ID nor FABRIC_INTERACTIVE_TENANT_ID is set and no
+    runtime override has been stored, ``tenant_id`` is ``"unknown"`` so the key
+    is reliably queryable on every event.
     """
     monkeypatch.delenv("AZURE_TENANT_ID", raising=False)
     monkeypatch.delenv("FABRIC_INTERACTIVE_TENANT_ID", raising=False)
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
 
     mod = _reload_telemetry()
+    mod._tenant_id_override = None  # type: ignore[attr-defined]
     envelope = mod._build_envelope("cli")  # type: ignore[attr-defined]
-    assert "tenant_id" not in envelope
+    assert envelope.get("tenant_id") == "unknown"
 
 
 # ---------------------------------------------------------------------------
@@ -1506,10 +1527,13 @@ def test_envelope_falls_back_to_azure_tenant_id_env_when_no_override(
     assert envelope.get("tenant_id") == "fallback-env-tenant"
 
 
-def test_envelope_omits_tenant_id_when_no_source(
+def test_envelope_tenant_id_unknown_when_no_source(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """_build_envelope omits tenant_id when neither override nor env vars are set."""
+    """_build_envelope uses ``"unknown"`` for tenant_id when neither override nor env vars are set.
+
+    tenant_id is always present (#477 Finding 2) so it is reliably queryable on every event.
+    """
     for var in [
         "FABRIC_TELEMETRY",
         "FABRIC_DISABLE_TELEMETRY",
@@ -1531,7 +1555,7 @@ def test_envelope_omits_tenant_id_when_no_source(
     mod._tenant_id_override = None  # type: ignore[attr-defined]
 
     envelope = mod._build_envelope("cli")  # type: ignore[attr-defined]
-    assert "tenant_id" not in envelope
+    assert envelope.get("tenant_id") == "unknown"
 
 
 # ---------------------------------------------------------------------------
@@ -2200,29 +2224,27 @@ def test_emit_event_noop_when_telemetry_disabled(
     assert called == [], "_get_tracer must not be called when telemetry is disabled"
 
 
-def test_emit_event_produces_eventdata_envelope(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
-    """emit_event must produce a customEvent log record that converts to EventData.
+def _build_test_envelope(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    install_id: str = "ccccdddd-dead-beef-1234-aaaaaaaaaaaa",
+    event_name: str = "test_custom_event",
+    resource_version: str = "1.2.3",
+) -> tuple[Any, Any, dict[str, Any]]:
+    """Shared helper: build and convert a log record through the real exporter.
 
-    Runs the emitted log record through the REAL Azure Monitor log exporter
-    conversion function (``_convert_log_to_envelope``) and asserts:
-    - ``envelope.data.base_type == "EventData"``  (lands in customEvents table)
-    - ``envelope.tags["ai.user.id"] == <install_id>``  (Users blade)
-    - event name present in envelope
-    - ``session_id`` in custom properties (customDimensions fallback for Sessions)
-
-    This test does NOT require a real network connection — it only exercises the
-    local envelope-construction logic, not the HTTP transport.
+    Returns ``(envelope, mod, custom_props)`` for assertions.
     """
-    # Lazy imports: the Azure Monitor SDK is not required at collection time.
-    from azure.monitor.opentelemetry.exporter.export.logs._exporter import _convert_log_to_envelope  # noqa: I001, PLC0415
-    from opentelemetry.sdk._logs._internal import InstrumentationScope  # noqa: PLC0415
+    from azure.monitor.opentelemetry.exporter.export.logs._exporter import (  # noqa: PLC0415
+        _convert_log_to_envelope,
+    )
+    from opentelemetry.sdk._logs._internal import (  # noqa: PLC0415
+        InstrumentationScope,
+        ReadableLogRecord,
+    )
     from opentelemetry.sdk._logs._internal import LogRecord as SDKLogRecord  # noqa: PLC0415
-    from opentelemetry.sdk._logs._internal import ReadableLogRecord  # noqa: PLC0415
     from opentelemetry.sdk.resources import Resource  # noqa: PLC0415
 
-    # Force telemetry on with a deterministic install ID.
     for var in (
         "FABRIC_TELEMETRY",
         "FABRIC_DISABLE_TELEMETRY",
@@ -2234,42 +2256,63 @@ def test_emit_event_produces_eventdata_envelope(
         "CIRCLECI",
         "GITLAB_CI",
         "TF_BUILD",
+        "AZURE_TENANT_ID",
+        "FABRIC_INTERACTIVE_TENANT_ID",
     ):
         monkeypatch.delenv(var, raising=False)
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
 
-    # Write a known install ID so the test is deterministic.
-    known_install_id = "ccccdddd-dead-beef-1234-aaaaaaaaaaaa"
     config_dir = tmp_path / "fabric-dw"
     config_dir.mkdir(parents=True, exist_ok=True)
-    (config_dir / "install_id").write_text(known_install_id, encoding="utf-8")
+    (config_dir / "install_id").write_text(install_id, encoding="utf-8")
 
     mod = _reload_telemetry()
+    mod._tenant_id_override = None  # type: ignore[attr-defined]
 
-    # Construct the attributes exactly as emit_event would build them.
-    event_name = "test_custom_event"
     envelope_attrs = mod._build_envelope("cli")  # type: ignore[attr-defined]
     merged: dict[str, object] = {**envelope_attrs}
     merged["microsoft.custom_event.name"] = event_name
     merged["enduser.pseudo.id"] = mod._get_install_id()  # type: ignore[attr-defined]
     merged["extra_dimension"] = "extra_value"
+    merged["ai.operation.name"] = event_name
 
-    # Build a real SDK log record (what the OTel Logger.emit() path would create).
     sdk_record = SDKLogRecord(attributes=merged)  # type: ignore[arg-type]  # ty: ignore[no-matching-overload]
-    resource = Resource.create({"service.name": "fabric_dw.telemetry"})
+    resource = Resource.create(
+        {
+            "service.namespace": "fabric-dw",
+            "service.name": "cli",
+            "service.instance.id": install_id,
+            "service.version": resource_version,
+            "device.id": install_id,
+        }
+    )
     scope = InstrumentationScope("fabric_dw.telemetry")
     readable = ReadableLogRecord(
         log_record=sdk_record, resource=resource, instrumentation_scope=scope
     )
-
-    # Run it through the real exporter conversion (no network call).
     envelope = _convert_log_to_envelope(readable)
+    assert envelope.data is not None
+    assert envelope.data.base_data is not None
+    custom_props: dict[str, Any] = envelope.data.base_data.properties or {}  # ty: ignore[unresolved-attribute]
+    return envelope, mod, custom_props
 
-    # --- Assertions ---
-    # The Azure Monitor SDK types have Optional fields; assert non-None before
-    # accessing nested attributes so the assertions are self-documenting.
-    assert envelope.data is not None, "envelope.data must not be None"
+
+def test_emit_event_produces_eventdata_envelope(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """emit_event must produce an EventData envelope with correct base fields.
+
+    Verifies: base_type, ai.user.id, event name, session_id (#460).
+    Does NOT require a real network connection.
+    """
+    known_install_id = "ccccdddd-dead-beef-1234-aaaaaaaaaaaa"
+    event_name = "test_custom_event"
+    envelope, _mod, custom_props = _build_test_envelope(
+        monkeypatch, tmp_path, install_id=known_install_id, event_name=event_name
+    )
+
     assert envelope.tags is not None, "envelope.tags must not be None"
+    assert envelope.data is not None
     assert envelope.data.base_type == "EventData", (
         f"Expected base_type='EventData' (customEvents), got {envelope.data.base_type!r}.  "
         "This means the log record would land in 'traces', not 'customEvents'."
@@ -2281,15 +2324,370 @@ def test_emit_event_produces_eventdata_envelope(
         "enduser.pseudo.id must map to ai.user.id for the Users blade."
     )
 
-    assert envelope.data.base_data is not None, "envelope.data.base_data must not be None"
+    assert envelope.data.base_data is not None
     event_data_name = envelope.data.base_data.name  # ty: ignore[unresolved-attribute]
     assert event_data_name == event_name, (
         f"Expected event name {event_name!r} in EventData, got {event_data_name!r}."
     )
 
-    custom_props = envelope.data.base_data.properties or {}  # ty: ignore[unresolved-attribute]
     assert "session_id" in custom_props, (
         "session_id must appear in customDimensions (custom properties).  "
         "ai.session.id has no attribute mapping in azure-monitor-opentelemetry-exporter "
         "1.0.0b53, so session_id is kept as a custom dimension for Logs blade queries."
+    )
+
+
+def test_emit_event_envelope_tenant_id_always_present(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """tenant_id must always be in customDimensions, never absent (#477 Finding 2)."""
+    _envelope, _mod, custom_props = _build_test_envelope(monkeypatch, tmp_path)
+
+    assert "tenant_id" in custom_props, (
+        "tenant_id must always appear in customDimensions so it is reliably queryable "
+        "on every event even when no tenant has been resolved yet (#477 Finding 2)."
+    )
+    assert custom_props["tenant_id"] == "unknown", (
+        "tenant_id must be 'unknown' when no tenant is resolved "
+        "(not absent — must be queryable on every event)."
+    )
+
+
+def test_emit_event_envelope_redundant_dimensions_dropped(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """anonymous_install_id and is_ci must NOT be in customDimensions (#477 Finding 5)."""
+    _envelope, _mod, custom_props = _build_test_envelope(monkeypatch, tmp_path)
+
+    assert "anonymous_install_id" not in custom_props, (
+        "anonymous_install_id must not appear in customDimensions — it is already shipped "
+        "natively as user_Id (← enduser.pseudo.id).  Sending it twice is redundant (#477)."
+    )
+    assert "is_ci" not in custom_props, (
+        "is_ci must not appear in customDimensions — telemetry is disabled entirely in CI "
+        "so this was always False and carries no signal (#477)."
+    )
+
+
+def test_emit_event_envelope_part_a_native_fields(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Native Part A fields must be populated from the OTel Resource (#477).
+
+    Checks: cloud_RoleInstance = install_id (not hostname), cloud_RoleName not
+    unknown_service:*, application_Version, operation_Name.
+    """
+    import platform as _platform  # noqa: PLC0415
+
+    known_install_id = "ccccdddd-dead-beef-1234-aaaaaaaaaaaa"
+    event_name = "test_custom_event"
+    envelope, _mod, _custom_props = _build_test_envelope(
+        monkeypatch, tmp_path, install_id=known_install_id, event_name=event_name
+    )
+
+    assert envelope.tags is not None
+
+    # cloud_RoleInstance must be install_id, NOT platform.node() (#477 privacy fix).
+    role_instance = envelope.tags.get("ai.cloud.roleInstance")
+    hostname = _platform.node()
+    assert role_instance != hostname, (
+        f"cloud_RoleInstance must not be the machine hostname {hostname!r}.  "
+        "This would leak the user's real name on every event (#477 privacy fix)."
+    )
+    assert role_instance == known_install_id, (
+        f"cloud_RoleInstance must be the pseudonymous install_id {known_install_id!r}, "
+        f"got {role_instance!r}.  Set via resource service.instance.id (#477)."
+    )
+
+    # cloud_RoleName must be meaningful (not unknown_service:*) (#477 Finding 3).
+    role_name = envelope.tags.get("ai.cloud.role")
+    assert role_name is not None, "cloud_RoleName must not be None"
+    assert "unknown_service" not in role_name, (
+        f"cloud_RoleName must not be 'unknown_service:*', got {role_name!r}.  "
+        "Set via resource service.namespace + service.name (#477 Finding 3)."
+    )
+
+    # application_Version must be populated (#477 Finding 3).
+    app_version_tag = envelope.tags.get("ai.application.ver")
+    assert app_version_tag == "1.2.3", (
+        f"application_Version must be '1.2.3', got {app_version_tag!r}.  "
+        "Set via resource service.version (#477 Finding 3)."
+    )
+
+    # operation_Name must be set (#477 Finding 4).
+    op_name = envelope.tags.get("ai.operation.name")
+    assert op_name == event_name, (
+        f"operation_Name must be the event name {event_name!r}, got {op_name!r}.  "
+        "Set via ai.operation.name record attribute (#477 Finding 4)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# #477: hostname privacy — _build_otel_resource prevents platform.node() fallback
+# ---------------------------------------------------------------------------
+
+
+def test_build_otel_resource_sets_service_instance_id_to_install_id(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """_build_otel_resource must set service.instance.id to the anonymous install_id.
+
+    This prevents the exporter from falling back to platform.node() for
+    cloud_RoleInstance, which would leak the machine hostname (#477 privacy fix).
+    """
+    from opentelemetry.sdk.resources import Resource  # noqa: PLC0415
+
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    known_install_id = "aaaa1111-dead-beef-1234-bbbbbbbbbbbb"
+    config_dir = tmp_path / "fabric-dw"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    (config_dir / "install_id").write_text(known_install_id, encoding="utf-8")
+
+    mod = _reload_telemetry()
+    resource = mod._build_otel_resource("cli")  # type: ignore[attr-defined]
+
+    assert isinstance(resource, Resource), "_build_otel_resource must return a Resource"
+    attrs = dict(resource.attributes)
+    assert attrs.get("service.instance.id") == known_install_id, (
+        f"service.instance.id must be install_id {known_install_id!r}, "
+        f"got {attrs.get('service.instance.id')!r}.  "
+        "This prevents hostname fallback for cloud_RoleInstance (#477)."
+    )
+
+
+def test_build_otel_resource_sets_device_id_to_install_id(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """_build_otel_resource must set device.id to the anonymous install_id.
+
+    This prevents the exporter from falling back to platform.node() for
+    ai.device.id (#477 privacy fix).
+    """
+    from opentelemetry.sdk.resources import Resource  # noqa: PLC0415
+
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    known_install_id = "cccc3333-dead-beef-1234-dddddddddddd"
+    config_dir = tmp_path / "fabric-dw"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    (config_dir / "install_id").write_text(known_install_id, encoding="utf-8")
+
+    mod = _reload_telemetry()
+    resource = mod._build_otel_resource("mcp")  # type: ignore[attr-defined]
+
+    assert isinstance(resource, Resource), "_build_otel_resource must return a Resource"
+    attrs = dict(resource.attributes)
+    assert attrs.get("device.id") == known_install_id, (
+        f"device.id must be install_id {known_install_id!r}, "
+        f"got {attrs.get('device.id')!r}.  "
+        "This prevents hostname fallback for ai.device.id (#477)."
+    )
+
+
+def test_build_otel_resource_service_instance_id_is_not_hostname(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """service.instance.id in the OTel Resource must never be the machine hostname.
+
+    The hostname is the fallback used by the exporter when service.instance.id
+    is absent.  We must always set a non-identifying value (#477 privacy fix).
+    """
+    import platform as _platform  # noqa: PLC0415
+
+    from opentelemetry.sdk.resources import Resource  # noqa: PLC0415
+
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    mod = _reload_telemetry()
+    resource = mod._build_otel_resource("cli")  # type: ignore[attr-defined]
+
+    assert isinstance(resource, Resource), "_build_otel_resource must return a Resource"
+    attrs = dict(resource.attributes)
+
+    hostname = _platform.node()
+    assert attrs.get("service.instance.id") != hostname, (
+        f"service.instance.id must not be the machine hostname {hostname!r}.  "
+        "This would leak the user's real name on every telemetry event (#477)."
+    )
+
+
+def test_build_otel_resource_sets_service_name_to_surface(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """_build_otel_resource must set service.name to the surface (cloud_RoleName)."""
+    from opentelemetry.sdk.resources import Resource  # noqa: PLC0415
+
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    mod = _reload_telemetry()
+    for surface in ("cli", "mcp"):
+        resource = mod._build_otel_resource(surface)  # type: ignore[attr-defined]
+        assert isinstance(resource, Resource)
+        attrs = dict(resource.attributes)
+        assert attrs.get("service.name") == surface, (
+            f"service.name must be {surface!r}, got {attrs.get('service.name')!r}"
+        )
+        assert attrs.get("service.namespace") == "fabric-dw", (
+            f"service.namespace must be 'fabric-dw', got {attrs.get('service.namespace')!r}"
+        )
+
+
+def test_get_tracer_passes_resource_to_configure_azure_monitor(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """_get_tracer must pass a ``resource`` kwarg to configure_azure_monitor (#477).
+
+    The resource is what sets native Part A fields (cloud_RoleName, cloud_RoleInstance,
+    application_Version, ai.device.id) and prevents the hostname fallback.
+    """
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.delenv("FABRIC_DISABLE_TELEMETRY", raising=False)
+    monkeypatch.delenv("CI", raising=False)
+    for ci_var in ("GITHUB_ACTIONS", "JENKINS_URL", "TRAVIS", "CIRCLECI", "GITLAB_CI", "TF_BUILD"):
+        monkeypatch.delenv(ci_var, raising=False)
+
+    mod = _reload_telemetry()
+
+    captured_kwargs: dict[str, object] = {}
+
+    def fake_configure(**kwargs: object) -> None:
+        captured_kwargs.update(kwargs)
+
+    fake_otel_logger = object()
+
+    fake_azure_mod: Any = types.ModuleType("azure.monitor.opentelemetry")
+    fake_azure_mod.configure_azure_monitor = fake_configure
+
+    fake_logs_mod: Any = types.ModuleType("opentelemetry._logs")
+    fake_logs_mod.get_logger = lambda *_a, **_kw: fake_otel_logger
+    fake_logs_mod.LogRecord = object
+    fake_logs_mod.SeverityNumber = object
+
+    mod._sdk_initialised = False
+    mod._tracer = None
+    mod._otel_logger = None
+
+    monkeypatch.setitem(sys.modules, "azure.monitor.opentelemetry", fake_azure_mod)
+    monkeypatch.setitem(sys.modules, "opentelemetry._logs", fake_logs_mod)
+
+    mod._get_tracer()
+
+    assert "resource" in captured_kwargs, (
+        "configure_azure_monitor must receive a 'resource' kwarg so native Part A fields "
+        "are set from the OTel Resource instead of hostname fallback (#477)."
+    )
+
+    mod._sdk_initialised = False
+    mod._tracer = None
+    mod._otel_logger = None
+
+
+def test_emit_event_sets_ai_operation_name(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """emit_event must set ai.operation.name on the log record (#477 Finding 4).
+
+    Callers can override by passing it in attributes; the event name is used as
+    a fallback for lifecycle events when it is not explicitly provided.
+    """
+    from azure.monitor.opentelemetry.exporter.export.logs._exporter import (  # noqa: PLC0415
+        _convert_log_to_envelope,
+    )
+    from opentelemetry.sdk._logs._internal import (  # noqa: PLC0415
+        InstrumentationScope,
+        ReadableLogRecord,
+    )
+    from opentelemetry.sdk._logs._internal import LogRecord as SDKLogRecord  # noqa: PLC0415
+    from opentelemetry.sdk.resources import Resource  # noqa: PLC0415
+
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    mod = _reload_telemetry()
+
+    # Simulate the attribute building done inside emit_event for a lifecycle event.
+    event_name = "app_started"
+    envelope_attrs = mod._build_envelope("cli")  # type: ignore[attr-defined]
+    merged: dict[str, object] = {**envelope_attrs}
+    merged["microsoft.custom_event.name"] = event_name
+    merged["enduser.pseudo.id"] = mod._get_install_id()  # type: ignore[attr-defined]
+    # emit_event sets ai.operation.name = event_name when not already present.
+    if "ai.operation.name" not in merged:
+        merged["ai.operation.name"] = event_name
+
+    sdk_record = SDKLogRecord(attributes=merged)  # type: ignore[arg-type]  # ty: ignore[no-matching-overload]
+    resource = Resource.create({"service.name": "cli", "service.namespace": "fabric-dw"})
+    scope = InstrumentationScope("fabric_dw.telemetry")
+    readable = ReadableLogRecord(
+        log_record=sdk_record, resource=resource, instrumentation_scope=scope
+    )
+
+    envelope = _convert_log_to_envelope(readable)
+    assert envelope.tags is not None
+    op_name = envelope.tags.get("ai.operation.name")
+    assert op_name == event_name, (
+        f"ai.operation.name must be {event_name!r} on the envelope, got {op_name!r}.  "
+        "operation_Name should be populated for lifecycle events (#477 Finding 4)."
+    )
+
+
+def test_cloud_role_instance_from_resource_not_hostname(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """cloud_RoleInstance must come from service.instance.id, not platform.node().
+
+    This is the key privacy test for #477 Finding 1.  The exporter falls back to
+    platform.node() when service.instance.id is absent.  We must ensure our
+    resource attribute is set so the hostname is never shipped.
+    """
+    import platform as _platform  # noqa: PLC0415
+
+    from azure.monitor.opentelemetry.exporter.export.logs._exporter import (  # noqa: PLC0415
+        _convert_log_to_envelope,
+    )
+    from opentelemetry.sdk._logs._internal import (  # noqa: PLC0415
+        InstrumentationScope,
+        ReadableLogRecord,
+    )
+    from opentelemetry.sdk._logs._internal import LogRecord as SDKLogRecord  # noqa: PLC0415
+
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    known_install_id = "eeee5555-dead-beef-1234-ffffffffffff"
+    config_dir = tmp_path / "fabric-dw"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    (config_dir / "install_id").write_text(known_install_id, encoding="utf-8")
+
+    mod = _reload_telemetry()
+
+    # Build a log record with our resource (as _get_tracer would do in production).
+    attrs: dict[str, object] = {
+        "microsoft.custom_event.name": "test_event",
+        "enduser.pseudo.id": known_install_id,
+        "ai.operation.name": "test_event",
+    }
+    sdk_record = SDKLogRecord(attributes=attrs)  # type: ignore[arg-type]  # ty: ignore[no-matching-overload]
+
+    # Use the resource built by _build_otel_resource (the production code path).
+    resource = mod._build_otel_resource("cli")  # type: ignore[attr-defined]
+    scope = InstrumentationScope("fabric_dw.telemetry")
+    readable = ReadableLogRecord(
+        log_record=sdk_record,
+        resource=resource,
+        instrumentation_scope=scope,  # type: ignore[arg-type]
+    )
+
+    envelope = _convert_log_to_envelope(readable)
+    assert envelope.tags is not None
+
+    hostname = _platform.node()
+    role_instance = envelope.tags.get("ai.cloud.roleInstance")
+
+    assert role_instance != hostname, (
+        f"cloud_RoleInstance must NOT be the machine hostname {hostname!r} — "
+        "hostnames often embed the user's real name (#477 privacy fix, Finding 1).  "
+        f"Got cloud_RoleInstance={role_instance!r}."
+    )
+    assert role_instance == known_install_id, (
+        f"cloud_RoleInstance must be the pseudonymous install_id {known_install_id!r}, "
+        f"got {role_instance!r}.  "
+        "Set via resource attribute service.instance.id (#477)."
     )

--- a/tests/unit/test_telemetry_commands.py
+++ b/tests/unit/test_telemetry_commands.py
@@ -340,7 +340,6 @@ class TestEmitCommandInvokedDisabled:
         with patch(_EMIT_EVENT) as mock_emit, patch(_TELEMETRY_ENABLED, return_value=False):
             emit_command_invoked(
                 name="warehouses.list",
-                surface="cli",
                 status="success",
                 duration_ms=50.0,
             )
@@ -375,7 +374,6 @@ class TestEmitCommandInvokedEnabled:
     def test_emits_one_event(self) -> None:
         mock = self._run(
             name="warehouses.list",
-            surface="cli",
             status="success",
             duration_ms=50.0,
         )
@@ -384,7 +382,6 @@ class TestEmitCommandInvokedEnabled:
     def test_event_name_is_command_invoked(self) -> None:
         mock = self._run(
             name="warehouses.list",
-            surface="cli",
             status="success",
             duration_ms=50.0,
         )
@@ -394,7 +391,6 @@ class TestEmitCommandInvokedEnabled:
     def test_attributes_contain_name(self) -> None:
         mock = self._run(
             name="warehouses.list",
-            surface="cli",
             status="success",
             duration_ms=50.0,
         )
@@ -404,7 +400,6 @@ class TestEmitCommandInvokedEnabled:
     def test_attributes_contain_domain(self) -> None:
         mock = self._run(
             name="warehouses.list",
-            surface="cli",
             status="success",
             duration_ms=50.0,
         )
@@ -415,7 +410,6 @@ class TestEmitCommandInvokedEnabled:
         """surface must NOT appear as a custom dimension — native cloud_RoleName now (#477)."""
         mock = self._run(
             name="warehouses.list",
-            surface="cli",
             status="success",
             duration_ms=50.0,
         )
@@ -429,7 +423,6 @@ class TestEmitCommandInvokedEnabled:
         """ai.operation.name must be set to the command name for native operation_Name (#477)."""
         mock = self._run(
             name="warehouses.list",
-            surface="cli",
             status="success",
             duration_ms=50.0,
         )
@@ -442,7 +435,6 @@ class TestEmitCommandInvokedEnabled:
     def test_attributes_contain_status(self) -> None:
         mock = self._run(
             name="warehouses.list",
-            surface="cli",
             status="success",
             duration_ms=50.0,
         )
@@ -452,7 +444,6 @@ class TestEmitCommandInvokedEnabled:
     def test_attributes_contain_duration_bucket(self) -> None:
         mock = self._run(
             name="warehouses.list",
-            surface="cli",
             status="success",
             duration_ms=50.0,
         )
@@ -462,7 +453,6 @@ class TestEmitCommandInvokedEnabled:
     def test_destructive_op_attribute_when_true(self) -> None:
         mock = self._run(
             name="delete_warehouse",
-            surface="mcp",
             status="success",
             duration_ms=200.0,
             destructive=True,
@@ -473,7 +463,6 @@ class TestEmitCommandInvokedEnabled:
     def test_destructive_op_absent_when_false(self) -> None:
         mock = self._run(
             name="list_warehouses",
-            surface="mcp",
             status="success",
             duration_ms=50.0,
             destructive=False,
@@ -485,7 +474,6 @@ class TestEmitCommandInvokedEnabled:
         """The emitted attributes must not contain any identifier-like strings."""
         mock = self._run(
             name="warehouses.list",
-            surface="cli",
             status="success",
             duration_ms=50.0,
         )
@@ -509,7 +497,6 @@ class TestEmitCommandInvokedEnabled:
             # Must not raise.
             emit_command_invoked(
                 name="warehouses.list",
-                surface="cli",
                 status="success",
                 duration_ms=50.0,
             )

--- a/tests/unit/test_telemetry_commands.py
+++ b/tests/unit/test_telemetry_commands.py
@@ -411,7 +411,8 @@ class TestEmitCommandInvokedEnabled:
         attrs: dict = mock.call_args[0][1]
         assert attrs["domain"] == "warehouses"
 
-    def test_attributes_contain_surface_cli(self) -> None:
+    def test_surface_not_in_custom_dimensions(self) -> None:
+        """surface must NOT appear as a custom dimension — native cloud_RoleName now (#477)."""
         mock = self._run(
             name="warehouses.list",
             surface="cli",
@@ -419,17 +420,24 @@ class TestEmitCommandInvokedEnabled:
             duration_ms=50.0,
         )
         attrs: dict = mock.call_args[0][1]
-        assert attrs["surface"] == "cli"
+        assert "surface" not in attrs, (
+            "surface must not be in emit_event attrs — it is now shipped natively as "
+            "cloud_RoleName via the OTel Resource (#477 Finding 3)."
+        )
 
-    def test_attributes_contain_surface_mcp(self) -> None:
+    def test_attributes_contain_ai_operation_name(self) -> None:
+        """ai.operation.name must be set to the command name for native operation_Name (#477)."""
         mock = self._run(
-            name="list_warehouses",
-            surface="mcp",
+            name="warehouses.list",
+            surface="cli",
             status="success",
             duration_ms=50.0,
         )
         attrs: dict = mock.call_args[0][1]
-        assert attrs["surface"] == "mcp"
+        assert attrs.get("ai.operation.name") == "warehouses.list", (
+            "ai.operation.name must equal the command name so operation_Name is "
+            "populated in the portal (#477 Finding 4)."
+        )
 
     def test_attributes_contain_status(self) -> None:
         mock = self._run(
@@ -548,12 +556,17 @@ class TestCliCommandInvokedInstrumentation:
         attrs: dict = command_invoked_calls[0][0][1]
         assert attrs["name"] == "cache.clear"
 
-    def test_cache_clear_surface_is_cli(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_cache_clear_surface_not_in_custom_dimensions(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """surface must not be in command_invoked attrs — it is native cloud_RoleName (#477)."""
         mock = self._run_cli(["cache", "clear"], monkeypatch)
         command_invoked_calls = [c for c in mock.call_args_list if c[0][0] == "command_invoked"]
         assert command_invoked_calls
         attrs: dict = command_invoked_calls[0][0][1]
-        assert attrs["surface"] == "cli"
+        assert "surface" not in attrs, (
+            "surface must not appear in command_invoked attrs (#477 Finding 3)"
+        )
 
     def test_cache_clear_domain_is_cache(self, monkeypatch: pytest.MonkeyPatch) -> None:
         mock = self._run_cli(["cache", "clear"], monkeypatch)
@@ -589,13 +602,17 @@ class TestCliCommandInvokedInstrumentation:
         attrs: dict = command_invoked_calls[0][0][1]
         assert attrs["name"] == "sql"
 
-    def test_sql_direct_surface_is_cli(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """command_invoked surface for the direct ``sql`` command is ``"cli"``."""
+    def test_sql_direct_surface_not_in_custom_dimensions(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """command_invoked must not include surface as a custom dimension (#477)."""
         mock = self._run_cli(["sql", "--help"], monkeypatch)
         command_invoked_calls = [c for c in mock.call_args_list if c[0][0] == "command_invoked"]
         assert command_invoked_calls
         attrs: dict = command_invoked_calls[0][0][1]
-        assert attrs["surface"] == "cli"
+        assert "surface" not in attrs, (
+            "surface must not appear in command_invoked attrs (#477 Finding 3)"
+        )
 
     def test_sql_direct_domain_is_sql(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """command_invoked domain for the direct ``sql`` command is ``"sql"``."""
@@ -744,7 +761,8 @@ class TestMcpCommandInvokedInstrumentation:
         attrs: dict = mock_emit.call_args_list[-1][0][1]
         assert attrs["name"] == "list_warehouses"
 
-    def test_wrap_surface_is_mcp(self) -> None:
+    def test_wrap_surface_not_in_custom_dimensions(self) -> None:
+        """surface must not appear in MCP command_invoked attrs (#477 Finding 3)."""
         import asyncio  # noqa: PLC0415
 
         from fabric_dw.mcp._helpers import _wrap_mcp_tool_with_telemetry  # noqa: PLC0415
@@ -758,7 +776,10 @@ class TestMcpCommandInvokedInstrumentation:
             asyncio.run(wrapped())
 
         attrs: dict = mock_emit.call_args_list[-1][0][1]
-        assert attrs["surface"] == "mcp"
+        assert "surface" not in attrs, (
+            "surface must not appear in MCP command_invoked attrs — it is now "
+            "native cloud_RoleName via the OTel Resource (#477 Finding 3)."
+        )
 
     def test_wrap_destructive_flag(self) -> None:
         import asyncio  # noqa: PLC0415


### PR DESCRIPTION
## Summary

- **Privacy fix (Finding 1)**: Build an explicit OTel `Resource` with `service.instance.id = anonymous_install_id` and `device.id = install_id`. The exporter previously fell back to `platform.node()` for `cloud_RoleInstance` and `ai.device.id` when these attributes were absent, leaking the machine hostname on every event.
- **Native Part A fields (Finding 3)**: Set `service.namespace = "fabric-dw"`, `service.name = surface` → `cloud_RoleName`; `service.version = app_version` → `application_Version`. Drop the now-redundant `surface` and `app_version` custom dimensions.
- **tenant_id always present (Finding 2)**: Emit `"unknown"` when no tenant has been resolved instead of omitting the key, so it is reliably queryable on every event.
- **operation_Name populated (Finding 4)**: Set `ai.operation.name` attribute to command/tool name on `command_invoked` events (and event name as fallback on lifecycle events) so `operation_Name` is no longer blank in the portal.
- **Drop redundant dimensions (Finding 5)**: Remove `anonymous_install_id` (already native as `user_Id`) and `is_ci` (always `False` in the telemetry path — telemetry is disabled entirely in CI).

## Fields moved / changed

| Field | Before | After |
|---|---|---|
| `cloud_RoleName` | `unknown_service:*` | `fabric-dw.cli` or `fabric-dw.mcp` (Resource `service.namespace` + `service.name`) |
| `cloud_RoleInstance` | `platform.node()` (hostname leak) | `anonymous_install_id` (Resource `service.instance.id`) |
| `ai.device.id` | `platform.node()` (hostname leak) | `anonymous_install_id` (Resource `device.id`) |
| `application_Version` | empty | package version (Resource `service.version`) |
| `operation_Name` | blank | command/tool name (`ai.operation.name` record attribute) |
| `tenant_id` (customDimensions) | omitted when unknown | always `"unknown"` when unresolved |
| `surface` (customDimensions) | present | **removed** — now native `cloud_RoleName` |
| `app_version` (customDimensions) | present | **removed** — now native `application_Version` |
| `anonymous_install_id` (customDimensions) | present | **removed** — already native `user_Id` |
| `is_ci` (customDimensions) | always `False` | **removed** — telemetry disabled in CI |

## Hostname leak fix

`_build_otel_resource(surface)` creates an OTel `Resource` with `service.instance.id` and `device.id` both set to the pseudonymous `anonymous_install_id`. This is passed as `resource=` to `configure_azure_monitor`. The exporter's `_populate_part_a_fields` then reads these attributes instead of calling `platform.node()`.

## Test plan

- [x] `test_cloud_role_instance_from_resource_not_hostname`: asserts `cloud_RoleInstance != platform.node()` and `== install_id`
- [x] `test_build_otel_resource_service_instance_id_is_not_hostname`: Resource attribute check
- [x] `test_build_otel_resource_sets_device_id_to_install_id`: `device.id` = install_id
- [x] `test_get_tracer_passes_resource_to_configure_azure_monitor`: `resource` kwarg is passed
- [x] `test_emit_event_envelope_tenant_id_always_present`: `tenant_id = "unknown"` when unresolved
- [x] `test_emit_event_envelope_redundant_dimensions_dropped`: `anonymous_install_id` and `is_ci` absent
- [x] `test_emit_event_envelope_part_a_native_fields`: `cloud_RoleInstance`, `cloud_RoleName`, `application_Version`, `operation_Name` all populated correctly
- [x] `test_surface_not_in_custom_dimensions` (CLI + MCP): `surface` no longer in `command_invoked` attrs
- [x] `test_attributes_contain_ai_operation_name`: `ai.operation.name` set on `command_invoked`
- [x] `just check` fully clean: ruff lint + format, ty, 3435 unit tests

Closes #477

🤖 Generated with [Claude Code](https://claude.com/claude-code)