### PR TITLE
fix(sql): time-budgeted multi-attempt execute-phase retry for transient TDS failures

### DIFF
--- a/src/fabric_dw/sql.py
+++ b/src/fabric_dw/sql.py
@@ -941,10 +941,9 @@ def _with_connect_retry(
             continue
         else:
             # Connection succeeded.
-            # Return a max_attempts value that is always > attempt + 1 so that
-            # the execute-phase retry gate in run_query (``attempt < max_attempts - 1``)
-            # continues to fire correctly: the execute phase is allowed at most
-            # one retry regardless of how many connect retries occurred.
+            # ``max_attempts`` is returned as ``attempt + 2`` purely for API
+            # compatibility; ``run_query`` ignores it (prefixed ``_max_attempts``)
+            # and gates execute-phase retries on ``_max_execute_attempts`` instead.
             return conn, attempt, attempt + 2, last_exc
 
 

--- a/src/fabric_dw/sql.py
+++ b/src/fabric_dw/sql.py
@@ -972,8 +972,15 @@ def run_query(  # noqa: PLR0913
     Transient errors during the **connect** phase (``open_connection``) are
     always safe to retry — no statement has reached the server yet.
 
-    Transient errors during the **execute** phase are only retried when
-    ``fetch != "none"`` (i.e. the statement is a read-only SELECT or similar).
+    Transient errors during the **execute** phase are retried when
+    ``fetch != "none"`` — that is, for **all** fetch modes except ``"none"``:
+
+    * ``"all"`` / ``"one"`` — read-only SELECT / row-returning queries.
+    * ``"rowcount"`` — statements such as ``COPY INTO`` that produce no result
+      set but report an affected-row count.  These are safe to retry because a
+      mid-operation TDS drop means the server did NOT commit the statement; the
+      COPY INTO bulk-loader is idempotent on a fresh connection.
+
     DML / DDL statements (``fetch="none"``) are **never** retried after
     ``cursor.execute`` has begun, because the server may have already applied
     the change — retrying non-idempotent statements could cause duplicate rows

--- a/src/fabric_dw/sql.py
+++ b/src/fabric_dw/sql.py
@@ -60,7 +60,6 @@ __all__ = [
     "SQL_COPT_SS_ACCESS_TOKEN",
     "SQL_LOGIN_TIMEOUT_S",
     "SQL_QUERY_TIMEOUT_S",
-    "SQL_TRANSIENT_MAX_RETRIES",
     "SqlTarget",
     "build_connection_string",
     "is_auth_failed_message",
@@ -77,27 +76,21 @@ __all__ = [
 # Transient-retry configuration
 # ---------------------------------------------------------------------------
 
-# Retained for backward compatibility — exported in __all__ and referenced in
-# some tests / downstream code.  No longer used by the execute-phase retry logic
-# in run_query, which now uses a wall-clock deadline (_CONNECT_RETRY_TIMEOUT_S)
-# and _EXECUTE_RETRY_DELAYS instead of a fixed attempt count.
-SQL_TRANSIENT_MAX_RETRIES: int = 2
-
 # Backoff delays (seconds) for the *execute-phase* retry loop.
 # The delay before attempt N+1 is _EXECUTE_RETRY_DELAYS[min(N, len-1)],
 # so the sequence is:
 #   attempt 1 → fails → sleep 2 s → attempt 2
 #   attempt 2 → fails → sleep 5 s → attempt 3
 #   attempt 3+ → fails → sleep 10 s → attempt 4 … (capped at 10 s)
-# The loop continues until the wall-clock deadline (based on
-# _CONNECT_RETRY_TIMEOUT_S) is exceeded, at which point the last
-# transient error is re-raised.
+#
+# The loop retries up to len(_EXECUTE_RETRY_DELAYS) + 1 attempts total
+# (initial attempt + 3 retries = 4 attempts max) AND stops early if the
+# wall-clock deadline (_CONNECT_RETRY_TIMEOUT_S) is exceeded.  Both guards
+# are applied so the worst-case bound is clearly bounded:
+#   worst case <= (len(_EXECUTE_RETRY_DELAYS) + 1) attempts
+#              x (max connect budget + SQL_QUERY_TIMEOUT_S)
+#            = 4 x (120 s + 300 s) = ~1680 s (~28 minutes absolute max)
 _EXECUTE_RETRY_DELAYS: tuple[float, ...] = (2.0, 5.0, 10.0)
-
-# Retained for backward compatibility — no longer used internally.
-# The execute-phase retry is now governed by _EXECUTE_RETRY_DELAYS and the
-# _CONNECT_RETRY_TIMEOUT_S wall-clock deadline instead of a fixed attempt count.
-_TRANSIENT_RETRY_DELAYS: tuple[float, ...] = (10.0, 10.0)
 
 # ---------------------------------------------------------------------------
 # Connect-phase retry configuration
@@ -916,11 +909,8 @@ def _with_connect_retry(
         - ``conn`` is the open connection (ready to use).
         - ``attempt`` is the zero-based attempt index that succeeded (0 on the
           first attempt, 1 on the first retry, etc.).
-        - ``max_attempts`` is always ``attempt + 2``.  This sentinel ensures that
-          the execute-phase retry gate in :func:`run_query`
-          (``attempt < max_attempts - 1``) evaluates to ``True``, preserving the
-          "at most one execute-phase retry" behaviour regardless of how many
-          connect-phase retries occurred.
+        - ``max_attempts`` is always ``attempt + 2`` (a sentinel value retained
+          for API compatibility; callers no longer use it as a retry gate).
         - ``last_exc`` is the last transient exception seen before success
           (``None`` on first-attempt success).
 
@@ -977,35 +967,38 @@ def run_query(  # noqa: PLR0913, PLR0915
     ``execute(sql, params)`` where *params* is a ``Sequence`` (list or tuple).
     Use ``?`` placeholders in *statement*.
 
-    Retry boundary (D10)
-    --------------------
-    Transient errors during the **connect** phase (``open_connection``) are
-    always safe to retry — no statement has reached the server yet.
+    Retry boundary — commit-phase safety
+    -------------------------------------
+    The retry loop covers ONLY the **execute + fetch** phase (up to and
+    including reading ``cursor.rowcount`` or calling ``fetchall``/``fetchone``).
+    The **commit** is performed ONCE, outside the retry loop, after a
+    successful execute+fetch.
 
-    Transient errors during the **execute** phase are retried when
-    ``fetch != "none"`` — that is, for **all** fetch modes except ``"none"``:
+    This split is the key safety guarantee for COPY INTO / DML:
 
-    * ``"all"`` / ``"one"`` — read-only SELECT / row-returning queries.
-    * ``"rowcount"`` — statements such as ``COPY INTO`` that produce no result
-      set but report an affected-row count.  These are safe to retry because a
-      mid-operation TDS drop means the server did NOT commit the statement; the
-      COPY INTO bulk-loader is idempotent on a fresh connection.
+    * If a transient TDS error occurs **during execute**, the statement has NOT
+      been sent to (or committed on) the server — it is safe to discard the
+      connection and retry on a fresh one.
+    * If a transient error occurs **during or after commit**, the load may
+      already have been committed server-side — retrying the statement could
+      cause a double-load.  Such errors are therefore **re-raised immediately**
+      without retrying the statement.
 
-    DML / DDL statements (``fetch="none"``) are **never** retried after
-    ``cursor.execute`` has begun, because the server may have already applied
-    the change — retrying non-idempotent statements could cause duplicate rows
-    or double-DDL errors.
+    Transient execute-phase errors are retried only when ``fetch != "none"``
+    (i.e. for ``"all"``, ``"one"``, and ``"rowcount"``).  DML / DDL
+    (``fetch="none"``) is never retried after ``cursor.execute`` has begun.
 
-    The execute-phase retry uses a **time-budgeted loop**: when a transient
-    connection error occurs during ``cursor.execute``, the tainted connection is
-    discarded and a fresh one is opened via :func:`_with_connect_retry`.  This
-    repeats until either an attempt succeeds or the total elapsed time since the
-    first execute-phase failure exceeds ``_CONNECT_RETRY_TIMEOUT_S`` (~120 s).
-    Between retry attempts the loop sleeps with a small exponential backoff
-    (starting at ~2 s, capped at ~10 s — see ``_EXECUTE_RETRY_DELAYS``).
+    Attempt cap and time budget
+    ---------------------------
+    The loop retries at most ``len(_EXECUTE_RETRY_DELAYS)`` times (3 retries =
+    4 total attempts: initial + 3) **in addition** to the wall-clock deadline
+    (``_CONNECT_RETRY_TIMEOUT_S``, ~120 s).  Both guards are applied so the
+    worst case is clearly bounded.  Between retries the loop sleeps with
+    exponential backoff (starting at ~2 s, capped at ~10 s — see
+    ``_EXECUTE_RETRY_DELAYS``).
 
-    If the time budget is exhausted before any attempt succeeds, the last
-    transient error is re-raised.
+    If the attempt cap or the time budget is exhausted before any attempt
+    succeeds, the last transient error is re-raised.
 
     Args:
         target: The :class:`SqlTarget` identifying the warehouse.
@@ -1054,12 +1047,23 @@ def run_query(  # noqa: PLR0913, PLR0915
         Exception: Any other driver error is propagated unchanged.
     """
     # Whether execute-phase transient errors are safe to retry.
-    # Only read-only fetches (fetch != "none") can safely be retried after
+    # Only non-DML fetches (fetch != "none") can safely be retried after
     # execute has started — DML could have already been applied server-side.
     execute_retry_allowed = fetch != "none"
 
-    def _execute_once(c: _Connection) -> tuple[list[str], list[tuple[Any, ...]]]:
-        """Run the statement on *c* and return (cols, rows)."""
+    # Maximum number of execute-phase attempts: initial + len(_EXECUTE_RETRY_DELAYS) retries.
+    # Both this cap AND the wall-clock deadline must be satisfied for a retry to fire.
+    _max_execute_attempts = len(_EXECUTE_RETRY_DELAYS) + 1  # = 4
+
+    def _execute_and_fetch(c: _Connection) -> tuple[list[str], list[tuple[Any, ...]]]:
+        """Run the statement on *c*, fetch results, and return (cols, rows).
+
+        This helper covers ONLY the execute + fetch phase.  It deliberately
+        does NOT call c.commit() — the caller is responsible for committing
+        after this function returns successfully.  This split ensures that
+        the retry loop never re-executes a statement that may already have
+        been committed server-side.
+        """
         cur = c.cursor()
         if params:
             cur.execute(statement, params)
@@ -1067,9 +1071,8 @@ def run_query(  # noqa: PLR0913, PLR0915
             cur.execute(statement)
 
         if fetch == "none":
-            # No result set to read; commit now (if requested) and return.
-            if commit and not autocommit:
-                c.commit()
+            # No result set to read.  Return without committing — commit is
+            # the caller's responsibility (or suppressed for fetch="none").
             return [], []
 
         if fetch == "rowcount":
@@ -1078,24 +1081,19 @@ def run_query(  # noqa: PLR0913, PLR0915
             # cursor.description is None and fetchall() raises
             # ProgrammingError: Invalid cursor state.
             # cursor.rowcount is correctly set to the number of affected rows.
-            rc = cur.rowcount
-            if commit and not autocommit:
-                c.commit()
-            return [], [(rc,)]
+            return [], [(cur.rowcount,)]
 
         # Defensive guard: if the driver returns no result set (description is
-        # None) for an "all" or "one" fetch, commit (when requested) and return
-        # empty results instead of calling fetchall()/fetchone() which would
-        # raise "ProgrammingError: Invalid cursor state".
+        # None) for an "all" or "one" fetch, return empty results instead of
+        # calling fetchall()/fetchone() which would raise
+        # "ProgrammingError: Invalid cursor state".
         if cur.description is None:
-            if commit and not autocommit:
-                c.commit()
             return [], []
 
-        # Fetch the result set BEFORE committing.  Committing first invalidates
-        # the cursor's prepared statement on mssql-python, which causes
-        # "Associated statement is not prepared" on the subsequent fetchall/
-        # fetchone call.
+        # Fetch the result set BEFORE the caller commits.  Committing first
+        # invalidates the cursor's prepared statement on mssql-python, which
+        # causes "Associated statement is not prepared" on the subsequent
+        # fetchall/fetchone call.
         cols = [col[0] for col in cur.description]
 
         if fetch == "one":
@@ -1105,16 +1103,15 @@ def run_query(  # noqa: PLR0913, PLR0915
                 ([row] if row is not None else []),
             )
         else:
-            rows: list[tuple[Any, ...]] = cur.fetchall()
-            result = cols, rows
+            fetched_rows: list[tuple[Any, ...]] = cur.fetchall()
+            result = cols, fetched_rows
 
-        if commit and not autocommit:
-            c.commit()
         return result
 
     conn, _attempt, _max_attempts, _ = _with_connect_retry(target, mode, autocommit)
-    # execute_attempt counts execute-phase failures so far (for backoff indexing).
-    execute_attempt = 0
+    # execute_attempt counts execute-phase attempts so far (for backoff indexing
+    # and the attempt cap).  Starts at 1 for the first attempt.
+    execute_attempt = 1
     # deadline is set on the first execute-phase transient failure.  The total
     # wall-clock budget for execute-phase retries is _CONNECT_RETRY_TIMEOUT_S
     # (~120 s), reusing the same constant as the connect-phase loop.
@@ -1122,7 +1119,7 @@ def run_query(  # noqa: PLR0913, PLR0915
 
     while True:
         try:
-            result = _execute_once(conn)
+            result = _execute_and_fetch(conn)
         except Exception as exc:
             # Mark tainted so close() physically closes instead of pooling.
             if isinstance(conn, _PooledConnection):
@@ -1145,17 +1142,32 @@ def run_query(  # noqa: PLR0913, PLR0915
             # Close the tainted connection before sleeping.  _PooledConnection
             # is idempotent so a later close() call is a no-op.
             conn.close()
-            # If the total execute-phase budget is exhausted, stop retrying.
-            if time.monotonic() >= execute_deadline:
+            # Check both guards: attempt cap and wall-clock deadline.
+            if execute_attempt >= _max_execute_attempts or time.monotonic() >= execute_deadline:
                 raise
             # Sleep with exponential backoff before opening a fresh connection.
-            delay = _EXECUTE_RETRY_DELAYS[min(execute_attempt, len(_EXECUTE_RETRY_DELAYS) - 1)]
-            time.sleep(delay)
+            # Backoff index is 0-based from the first failure (attempt 1 failed
+            # → delay index 0, attempt 2 failed → delay index 1, etc.).
+            delay_idx = min(execute_attempt - 1, len(_EXECUTE_RETRY_DELAYS) - 1)
+            time.sleep(_EXECUTE_RETRY_DELAYS[delay_idx])
             execute_attempt += 1
             # Open a fresh connection for the next execute attempt.
             conn, _attempt, _max_attempts, _ = _with_connect_retry(target, mode, autocommit)
         else:
-            # Execute succeeded — return the pooled connection and surface the result.
+            # Execute + fetch succeeded.  Now commit (if requested) OUTSIDE the
+            # retry loop.  If commit raises, the error propagates directly to
+            # the caller — we do NOT retry here.  Retrying after a commit
+            # failure would risk re-executing the statement and causing a
+            # double-load (e.g. double COPY INTO).  The connection is marked
+            # for discard on commit failure (unknown transaction state).
+            try:
+                if commit and not autocommit:
+                    conn.commit()
+            except Exception:
+                if isinstance(conn, _PooledConnection):
+                    conn.mark_discard()
+                conn.close()
+                raise
             conn.close()
             return result
 

--- a/src/fabric_dw/sql.py
+++ b/src/fabric_dw/sql.py
@@ -77,16 +77,26 @@ __all__ = [
 # Transient-retry configuration
 # ---------------------------------------------------------------------------
 
-# Maximum number of retry attempts for transient TDS connection drops.
-# Set to 0 to disable execute-phase retries.  Unit tests can monkeypatch this.
-# NOTE: this constant is only used by the *execute-phase* retry logic inside
-# run_query.  The *connect-phase* helper (_with_connect_retry) uses a
-# wall-clock deadline (_CONNECT_RETRY_TIMEOUT_S) instead of a fixed attempt
-# count so that slow warehouse warm-ups are fully covered.
+# Retained for backward compatibility — exported in __all__ and referenced in
+# some tests / downstream code.  No longer used by the execute-phase retry logic
+# in run_query, which now uses a wall-clock deadline (_CONNECT_RETRY_TIMEOUT_S)
+# and _EXECUTE_RETRY_DELAYS instead of a fixed attempt count.
 SQL_TRANSIENT_MAX_RETRIES: int = 2
 
-# Fixed delays (seconds) between retry attempts for the *execute phase*.
-# Index 0 = delay before attempt 2, index 1 = delay before attempt 3, etc.
+# Backoff delays (seconds) for the *execute-phase* retry loop.
+# The delay before attempt N+1 is _EXECUTE_RETRY_DELAYS[min(N, len-1)],
+# so the sequence is:
+#   attempt 1 → fails → sleep 2 s → attempt 2
+#   attempt 2 → fails → sleep 5 s → attempt 3
+#   attempt 3+ → fails → sleep 10 s → attempt 4 … (capped at 10 s)
+# The loop continues until the wall-clock deadline (based on
+# _CONNECT_RETRY_TIMEOUT_S) is exceeded, at which point the last
+# transient error is re-raised.
+_EXECUTE_RETRY_DELAYS: tuple[float, ...] = (2.0, 5.0, 10.0)
+
+# Retained for backward compatibility — no longer used internally.
+# The execute-phase retry is now governed by _EXECUTE_RETRY_DELAYS and the
+# _CONNECT_RETRY_TIMEOUT_S wall-clock deadline instead of a fixed attempt count.
 _TRANSIENT_RETRY_DELAYS: tuple[float, ...] = (10.0, 10.0)
 
 # ---------------------------------------------------------------------------
@@ -948,7 +958,7 @@ def _with_connect_retry(
             return conn, attempt, attempt + 2, last_exc
 
 
-def run_query(  # noqa: PLR0913
+def run_query(  # noqa: PLR0913, PLR0915
     target: SqlTarget,
     statement: str,
     *,
@@ -986,10 +996,16 @@ def run_query(  # noqa: PLR0913
     the change — retrying non-idempotent statements could cause duplicate rows
     or double-DDL errors.
 
-    The execute-phase retry fires **at most once**: one extra connect + execute
-    attempt, regardless of ``SQL_TRANSIENT_MAX_RETRIES``.  If that second
-    attempt also fails, the error is propagated immediately — there is no
-    execute-phase retry loop.
+    The execute-phase retry uses a **time-budgeted loop**: when a transient
+    connection error occurs during ``cursor.execute``, the tainted connection is
+    discarded and a fresh one is opened via :func:`_with_connect_retry`.  This
+    repeats until either an attempt succeeds or the total elapsed time since the
+    first execute-phase failure exceeds ``_CONNECT_RETRY_TIMEOUT_S`` (~120 s).
+    Between retry attempts the loop sleeps with a small exponential backoff
+    (starting at ~2 s, capped at ~10 s — see ``_EXECUTE_RETRY_DELAYS``).
+
+    If the time budget is exhausted before any attempt succeeds, the last
+    transient error is re-raised.
 
     Args:
         target: The :class:`SqlTarget` identifying the warehouse.
@@ -1096,38 +1112,52 @@ def run_query(  # noqa: PLR0913
             c.commit()
         return result
 
-    conn, attempt, max_attempts, _ = _with_connect_retry(target, mode, autocommit)
-    try:
+    conn, _attempt, _max_attempts, _ = _with_connect_retry(target, mode, autocommit)
+    # execute_attempt counts execute-phase failures so far (for backoff indexing).
+    execute_attempt = 0
+    # deadline is set on the first execute-phase transient failure.  The total
+    # wall-clock budget for execute-phase retries is _CONNECT_RETRY_TIMEOUT_S
+    # (~120 s), reusing the same constant as the connect-phase loop.
+    execute_deadline: float | None = None
+
+    while True:
         try:
-            return _execute_once(conn)
+            result = _execute_once(conn)
         except Exception as exc:
             # Mark tainted so close() physically closes instead of pooling.
             if isinstance(conn, _PooledConnection):
                 conn.mark_discard()
             mapped = map_driver_error(exc)
             if mapped:
-                # Auth/permission errors are never transient — raise immediately.
-                raise mapped from exc
-            # Only retry execute-phase transient errors when the statement is
-            # read-only (fetch != "none").  Non-idempotent DML must not be
-            # re-executed (D10 retry boundary).
-            if (
-                execute_retry_allowed
-                and is_transient_connection_error(exc)
-                and attempt < max_attempts - 1
-            ):
-                # Retry: close the tainted connection and open a fresh one.
-                # The outer finally also calls conn.close(); _PooledConnection.close()
-                # is idempotent (_closed guard) so the second call is a no-op.
+                # Auth/permission/not-found errors are deterministic —
+                # raise immediately without retrying.
                 conn.close()
-                conn2, _a, _m, _ = _with_connect_retry(target, mode, autocommit)
-                try:
-                    return _execute_once(conn2)
-                finally:
-                    conn2.close()
-            raise
-    finally:
-        conn.close()
+                raise mapped from exc
+            # Only retry execute-phase transient errors when the statement
+            # is safe to re-run (fetch != "none").  Non-idempotent DML must
+            # not be re-executed (D10 retry boundary).
+            if not (execute_retry_allowed and is_transient_connection_error(exc)):
+                conn.close()
+                raise
+            # Set the deadline on the first execute-phase transient failure.
+            if execute_deadline is None:
+                execute_deadline = time.monotonic() + _CONNECT_RETRY_TIMEOUT_S
+            # Close the tainted connection before sleeping.  _PooledConnection
+            # is idempotent so a later close() call is a no-op.
+            conn.close()
+            # If the total execute-phase budget is exhausted, stop retrying.
+            if time.monotonic() >= execute_deadline:
+                raise
+            # Sleep with exponential backoff before opening a fresh connection.
+            delay = _EXECUTE_RETRY_DELAYS[min(execute_attempt, len(_EXECUTE_RETRY_DELAYS) - 1)]
+            time.sleep(delay)
+            execute_attempt += 1
+            # Open a fresh connection for the next execute attempt.
+            conn, _attempt, _max_attempts, _ = _with_connect_retry(target, mode, autocommit)
+        else:
+            # Execute succeeded — return the pooled connection and surface the result.
+            conn.close()
+            return result
 
 
 def run_statements(

--- a/tests/unit/test_sql.py
+++ b/tests/unit/test_sql.py
@@ -1076,15 +1076,15 @@ class TestTransientRetry:
         The execute-phase retry loop is time-budgeted: it keeps retrying until
         _CONNECT_RETRY_TIMEOUT_S seconds have elapsed since the first failure.
         With the clock advanced past the deadline immediately after the first
-        failure, the loop stops after the first retry (connect call 2) and
-        raises the error on the second failure.
+        failure, the attempt-cap/deadline check fires before sleeping and the
+        loop stops after the first attempt — no retry connection is opened.
 
         Clock sequence (injected via _make_fake_time_module):
           - connect-phase _with_connect_retry: call 0 → deadline base
           - first execute fails → call 1 → sets execute_deadline (t=0)
           - call 2 → time.monotonic() check: t > deadline → stop, raise
 
-        Total connect calls: 2 (initial + 1 retry before deadline check fires).
+        Total connect calls: 1 (deadline already expired after first failure).
         """
         # Monotonic values consumed in order:
         #   [0] deadline base inside _with_connect_retry
@@ -1172,49 +1172,6 @@ class TestTransientRetry:
 
         assert rows == [(7,)]
         assert mock_mssql.connect.call_count == 4
-
-    def test_sql_transient_max_retries_constant_is_backward_compatible(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """SQL_TRANSIENT_MAX_RETRIES is exported but no longer controls the execute-phase retry.
-
-        The execute-phase retry is now governed by _CONNECT_RETRY_TIMEOUT_S and
-        _EXECUTE_RETRY_DELAYS.  SQL_TRANSIENT_MAX_RETRIES is retained for backward
-        compatibility only.  Changing it has no effect on the retry count.
-        """
-        original_retries = _sql_module.SQL_TRANSIENT_MAX_RETRIES
-        _sql_module.SQL_TRANSIENT_MAX_RETRIES = 0
-        try:
-            # With the clock staying well within budget, at least one retry fires
-            # regardless of SQL_TRANSIENT_MAX_RETRIES.
-            timeout = _sql_module._CONNECT_RETRY_TIMEOUT_S  # type: ignore[attr-defined]
-            fake_time = _make_fake_time_module(
-                monotonic_values=[
-                    0.0,  # initial _with_connect_retry deadline base
-                    0.0,  # execute_deadline set
-                    timeout / 2,  # deadline check: within budget → retry
-                    timeout / 2,  # retry conn _with_connect_retry deadline base
-                    timeout + 1,  # deadline check after second failure → expired
-                ]
-            )
-            monkeypatch.setattr(_sql_module, "time", fake_time)
-
-            mock_mssql, _, _ = _make_mock_mssql()
-            bad_cursor = MagicMock()
-            bad_cursor.execute.side_effect = Exception("communication link failure")
-            bad_conn = MagicMock()
-            bad_conn.cursor.return_value = bad_cursor
-            mock_mssql.connect.return_value = bad_conn
-            _patch_mssql(monkeypatch, mock_mssql)
-
-            with pytest.raises(Exception, match="communication link failure"):
-                run_query(_make_target(), "SELECT 1")
-
-            # At least 2 connect calls: the retry loop fired at least once
-            # even with SQL_TRANSIENT_MAX_RETRIES=0.
-            assert mock_mssql.connect.call_count >= 2
-        finally:
-            _sql_module.SQL_TRANSIENT_MAX_RETRIES = original_retries
 
     def test_run_statements_retries_transient_connect_failure(
         self, monkeypatch: pytest.MonkeyPatch
@@ -1414,6 +1371,144 @@ class TestTransientRetry:
 
         # fetch="none" → execute_retry_allowed=False → only one connect.
         assert mock_mssql.connect.call_count == 1
+
+    # ------------------------------------------------------------------
+    # Commit-phase safety: transient error during COMMIT must NOT retry
+    # ------------------------------------------------------------------
+
+    def test_commit_phase_transient_not_retried_statement_executed_once(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """CRITICAL: a transient error during COMMIT is NOT retried; the statement executes once.
+
+        This is the key safety guarantee for COPY INTO / bulk-load operations.
+        If a TDS drop occurs after the statement has executed but during the
+        commit, the load may already be committed server-side.  Retrying the
+        statement would risk a double-load.
+
+        The expected behaviour:
+          1. connect → execute COPY INTO succeeds (cursor.rowcount read)
+          2. commit() raises transient "Communication link failure"
+          3. run_query re-raises the error immediately — NO second execute
+
+        Assertions:
+          - cursor.execute called exactly once (no double-load)
+          - the transient error propagates to the caller
+          - connect called exactly once (no retry connection opened)
+        """
+        mock_mssql, _, _ = _make_mock_mssql()
+
+        # Cursor that succeeds on execute but commit raises transient.
+        execute_cursor = MagicMock()
+        execute_cursor.description = None  # COPY INTO: no result set
+        execute_cursor.rowcount = 100
+
+        execute_conn = MagicMock()
+        execute_conn.cursor.return_value = execute_cursor
+        execute_conn.commit.side_effect = Exception("Communication link failure")
+
+        mock_mssql.connect.return_value = execute_conn
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        with pytest.raises(Exception, match="Communication link failure"):
+            run_query(
+                _make_target(),
+                "COPY INTO [dbo].[t] FROM 'https://onelake.dfs.fabric.microsoft.com/...'",
+                fetch="rowcount",
+                commit=True,
+            )
+
+        # The statement must have been executed exactly once — no retry.
+        execute_cursor.execute.assert_called_once()
+        # Only one connect attempt — the retry loop never fires for commit errors.
+        assert mock_mssql.connect.call_count == 1
+
+    def test_execute_phase_retried_commit_called_once_on_success(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Execute-phase retry: multiple connects, but commit is called exactly once.
+
+        Sequence:
+          1. connect 1 → execute fails (transient)
+          2. connect 2 → execute succeeds (rowcount=7)
+          3. commit() called once (outside the retry loop)
+
+        Asserts: connect called twice, commit called exactly once.
+        """
+        mock_mssql, _, _ = _make_mock_mssql()
+
+        bad_cursor = MagicMock()
+        bad_cursor.execute.side_effect = Exception("communication link failure")
+        bad_conn = MagicMock()
+        bad_conn.cursor.return_value = bad_cursor
+
+        good_cursor = MagicMock()
+        good_cursor.description = None  # COPY INTO: no result set
+        good_cursor.rowcount = 7
+        good_conn = MagicMock()
+        good_conn.cursor.return_value = good_cursor
+
+        mock_mssql.connect.side_effect = [bad_conn, good_conn]
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        cols, rows = run_query(
+            _make_target(),
+            "COPY INTO [dbo].[t] FROM 'https://onelake.dfs.fabric.microsoft.com/...' WITH (...);",
+            fetch="rowcount",
+            commit=True,
+        )
+
+        assert cols == []
+        assert rows == [(7,)]
+        # Two connections were opened (initial + 1 retry).
+        assert mock_mssql.connect.call_count == 2
+        # The bad connection's execute was never committed.
+        bad_conn.commit.assert_not_called()
+        # Commit was called exactly once — on the successful connection.
+        good_conn.commit.assert_called_once()
+
+    def test_execute_retry_bounded_by_attempt_cap(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Persistent transient execute errors give up after the attempt cap (4 connects).
+
+        The attempt cap is len(_EXECUTE_RETRY_DELAYS) + 1 = 4 attempts max.
+        With the clock staying well within the wall-clock deadline, the loop
+        must stop after exactly 4 connect+execute attempts (initial + 3 retries)
+        regardless of the deadline.
+
+        Clock sequence: all deadline checks return a time within budget so that
+        only the attempt cap terminates the loop.
+        """
+        delays = _sql_module._EXECUTE_RETRY_DELAYS  # type: ignore[attr-defined]
+        max_attempts = len(delays) + 1  # = 4
+
+        # Provide enough monotonic values for the retry loop:
+        # _with_connect_retry is called once per attempt (4 times), each call
+        # consumes one monotonic value for its own deadline base.
+        # The execute deadline is set on the first failure (1 monotonic call).
+        # Each subsequent failure does an attempt-cap check first (before the
+        # time check), so we need time values that are within budget for the
+        # deadline checks that do fire.
+        mono_values = [0.0] * 20  # all within budget (t=0 << deadline)
+
+        fake_time = _make_fake_time_module(monotonic_values=mono_values)
+        monkeypatch.setattr(_sql_module, "time", fake_time)
+
+        mock_mssql, _, _ = _make_mock_mssql()
+        bad_cursor = MagicMock()
+        bad_cursor.execute.side_effect = Exception("communication link failure")
+        bad_conn = MagicMock()
+        bad_conn.cursor.return_value = bad_cursor
+        mock_mssql.connect.return_value = bad_conn
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        with pytest.raises(Exception, match="communication link failure"):
+            run_query(_make_target(), "SELECT 1")
+
+        # Must have stopped at exactly max_attempts connects.
+        assert mock_mssql.connect.call_count == max_attempts, (
+            f"expected {max_attempts} connect calls (attempt cap), "
+            f"got {mock_mssql.connect.call_count}"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -2286,12 +2381,10 @@ class TestAuthFailedConnectRetry:
         assert mock_mssql.connect.call_count == 1
 
     def test_retry_policy_constants(self) -> None:
-        """Connect-phase uses a ~120 s deadline; execute-phase constants unchanged."""
+        """Connect-phase uses a ~120 s deadline; execute-phase constants are set."""
         assert _sql_module._CONNECT_RETRY_TIMEOUT_S == 120.0
         assert _sql_module._CONNECT_RETRY_DELAYS == (5.0, 10.0, 15.0)
-        # Execute-phase constants remain as before.
-        assert _sql_module.SQL_TRANSIENT_MAX_RETRIES == 2
-        assert _sql_module._TRANSIENT_RETRY_DELAYS == (10.0, 10.0)
+        assert _sql_module._EXECUTE_RETRY_DELAYS == (2.0, 5.0, 10.0)
 
     def test_dml_not_retried_execute_phase_unchanged(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """fetch='none' DML must still NOT be retried after execute raises transient (D10).

--- a/tests/unit/test_sql.py
+++ b/tests/unit/test_sql.py
@@ -1070,59 +1070,135 @@ class TestTransientRetry:
         # Only one connect attempt — no retry.
         assert mock_mssql.connect.call_count == 1
 
-    def test_run_query_raises_after_all_retries_exhausted(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """When transient execute errors persist the last error is re-raised.
+    def test_run_query_raises_after_budget_exhausted(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When the time budget is exhausted the last transient error is re-raised.
 
-        D10 boundary: execute-phase transient errors for read-only fetches get
-        exactly ONE extra connect+execute attempt (not a full retry loop).
-        With SQL_TRANSIENT_MAX_RETRIES=2 and both connects succeeding, the
-        sequence is:
-          1. _with_connect_retry -> conn (connect call 1)
-          2. _execute_once(conn) raises transient
-          3. execute_retry_allowed=True, attempt=0 < max_attempts-1=2 -> retry
-          4. _with_connect_retry -> conn2 (connect call 2)
-          5. _execute_once(conn2) raises transient -> re-raise (no third attempt)
-        Total connect calls: 2.
+        The execute-phase retry loop is time-budgeted: it keeps retrying until
+        _CONNECT_RETRY_TIMEOUT_S seconds have elapsed since the first failure.
+        With the clock advanced past the deadline immediately after the first
+        failure, the loop stops after the first retry (connect call 2) and
+        raises the error on the second failure.
+
+        Clock sequence (injected via _make_fake_time_module):
+          - connect-phase _with_connect_retry: call 0 → deadline base
+          - first execute fails → call 1 → sets execute_deadline (t=0)
+          - call 2 → time.monotonic() check: t > deadline → stop, raise
+
+        Total connect calls: 2 (initial + 1 retry before deadline check fires).
         """
-        original_retries = _sql_module.SQL_TRANSIENT_MAX_RETRIES
-        _sql_module.SQL_TRANSIENT_MAX_RETRIES = 2
-        try:
-            mock_mssql, _, _ = _make_mock_mssql()
-            bad_cursor = MagicMock()
-            bad_cursor.execute.side_effect = Exception("communication link failure")
-            bad_conn = MagicMock()
-            bad_conn.cursor.return_value = bad_cursor
-            mock_mssql.connect.return_value = bad_conn
-            _patch_mssql(monkeypatch, mock_mssql)
+        # Monotonic values consumed in order:
+        #   [0] deadline base inside _with_connect_retry
+        #   [1] sets execute_deadline = 0 + _CONNECT_RETRY_TIMEOUT_S
+        #   [2] first deadline check after sleep: returns value past deadline
+        # The connect-phase _with_connect_retry for the retry conn also needs
+        # a value for its own deadline calculation.
+        timeout = _sql_module._CONNECT_RETRY_TIMEOUT_S  # type: ignore[attr-defined]
+        fake_time = _make_fake_time_module(
+            monotonic_values=[
+                0.0,  # _with_connect_retry deadline base (initial conn)
+                0.0,  # execute_deadline = 0 + timeout
+                timeout + 1,  # deadline check after first execute failure → expired
+            ]
+        )
+        monkeypatch.setattr(_sql_module, "time", fake_time)
 
-            with pytest.raises(Exception, match="communication link failure"):
-                run_query(_make_target(), "SELECT 1")
+        mock_mssql, _, _ = _make_mock_mssql()
+        bad_cursor = MagicMock()
+        bad_cursor.execute.side_effect = Exception("communication link failure")
+        bad_conn = MagicMock()
+        bad_conn.cursor.return_value = bad_cursor
+        mock_mssql.connect.return_value = bad_conn
+        _patch_mssql(monkeypatch, mock_mssql)
 
-            # 1 initial + 1 execute-phase retry = 2 connect calls (D10 boundary)
-            assert mock_mssql.connect.call_count == 2
-        finally:
-            _sql_module.SQL_TRANSIENT_MAX_RETRIES = original_retries
+        with pytest.raises(Exception, match="communication link failure"):
+            run_query(_make_target(), "SELECT 1")
 
-    def test_sql_transient_max_retries_zero_does_not_affect_execute_retry(
+        # Only 1 connect call: deadline already expired after first failure.
+        assert mock_mssql.connect.call_count == 1
+
+    def test_run_query_retries_multiple_times_before_success(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """SQL_TRANSIENT_MAX_RETRIES=0 no longer controls the execute-phase retry.
+        """The retry loop keeps retrying transient execute failures until one succeeds.
 
-        Since PR #448 the connect-phase retry is time-based and SQL_TRANSIENT_MAX_RETRIES
-        only affects the execute-phase guard.  However, run_query always allows
-        exactly one execute-phase retry for read-only (SELECT) queries — regardless
-        of SQL_TRANSIENT_MAX_RETRIES — so setting it to 0 no longer suppresses that
-        retry.  The constant is retained for backward compatibility (it is exported
-        in __all__), but it no longer gates the execute-phase path.
+        Scenario (3 failures then success):
+          connect 1 → execute fails (transient)
+          connect 2 → execute fails (transient)
+          connect 3 → execute fails (transient)
+          connect 4 → execute succeeds
+        Total connect calls: 4.  Clock stays within budget throughout.
+        """
+        timeout = _sql_module._CONNECT_RETRY_TIMEOUT_S  # type: ignore[attr-defined]
+        # Monotonic values:
+        #  [0]  _with_connect_retry deadline base (initial conn)
+        #  [1]  execute_deadline = 0 + timeout (set on first failure)
+        #  [2]  deadline check after failure 1 → within budget
+        #  [3]  _with_connect_retry deadline base (retry conn 2)
+        #  [4]  deadline check after failure 2 → within budget
+        #  [5]  _with_connect_retry deadline base (retry conn 3)
+        #  [6]  deadline check after failure 3 → within budget
+        #  [7]  _with_connect_retry deadline base (retry conn 4)
+        fake_time = _make_fake_time_module(
+            monotonic_values=[
+                0.0,
+                0.0,
+                timeout / 2,
+                timeout / 2,
+                timeout / 2,
+                timeout / 2,
+                timeout / 2,
+                timeout / 2,
+            ]
+        )
+        monkeypatch.setattr(_sql_module, "time", fake_time)
 
-        This test documents the NEW behaviour: 2 connect calls even with
-        SQL_TRANSIENT_MAX_RETRIES=0 (one initial + one execute-phase retry).
+        mock_mssql, _, _ = _make_mock_mssql()
+
+        bad_cursor = MagicMock()
+        bad_cursor.execute.side_effect = Exception("communication link failure")
+        bad_conn = MagicMock()
+        bad_conn.cursor.return_value = bad_cursor
+
+        good_cursor = MagicMock()
+        good_cursor.description = [("n",)]
+        good_cursor.fetchall.return_value = [(7,)]
+        good_conn = MagicMock()
+        good_conn.cursor.return_value = good_cursor
+
+        mock_mssql.connect.side_effect = [bad_conn, bad_conn, bad_conn, good_conn]
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        _cols, rows = run_query(_make_target(), "SELECT 1")
+
+        assert rows == [(7,)]
+        assert mock_mssql.connect.call_count == 4
+
+    def test_sql_transient_max_retries_constant_is_backward_compatible(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """SQL_TRANSIENT_MAX_RETRIES is exported but no longer controls the execute-phase retry.
+
+        The execute-phase retry is now governed by _CONNECT_RETRY_TIMEOUT_S and
+        _EXECUTE_RETRY_DELAYS.  SQL_TRANSIENT_MAX_RETRIES is retained for backward
+        compatibility only.  Changing it has no effect on the retry count.
         """
         original_retries = _sql_module.SQL_TRANSIENT_MAX_RETRIES
         _sql_module.SQL_TRANSIENT_MAX_RETRIES = 0
         try:
+            # With the clock staying well within budget, at least one retry fires
+            # regardless of SQL_TRANSIENT_MAX_RETRIES.
+            timeout = _sql_module._CONNECT_RETRY_TIMEOUT_S  # type: ignore[attr-defined]
+            fake_time = _make_fake_time_module(
+                monotonic_values=[
+                    0.0,  # initial _with_connect_retry deadline base
+                    0.0,  # execute_deadline set
+                    timeout / 2,  # deadline check: within budget → retry
+                    timeout / 2,  # retry conn _with_connect_retry deadline base
+                    timeout + 1,  # deadline check after second failure → expired
+                ]
+            )
+            monkeypatch.setattr(_sql_module, "time", fake_time)
+
             mock_mssql, _, _ = _make_mock_mssql()
             bad_cursor = MagicMock()
             bad_cursor.execute.side_effect = Exception("communication link failure")
@@ -1134,8 +1210,9 @@ class TestTransientRetry:
             with pytest.raises(Exception, match="communication link failure"):
                 run_query(_make_target(), "SELECT 1")
 
-            # The execute-phase retry still fires once (D10 boundary): 2 connect calls.
-            assert mock_mssql.connect.call_count == 2
+            # At least 2 connect calls: the retry loop fired at least once
+            # even with SQL_TRANSIENT_MAX_RETRIES=0.
+            assert mock_mssql.connect.call_count >= 2
         finally:
             _sql_module.SQL_TRANSIENT_MAX_RETRIES = original_retries
 
@@ -1280,12 +1357,28 @@ class TestTransientRetry:
     def test_rowcount_transient_budget_exhausted_raises(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """COPY INTO (fetch='rowcount'): when both attempts fail, the error is re-raised.
+        """COPY INTO (fetch='rowcount'): when the time budget is exhausted the error is re-raised.
 
-        The execute-phase retry fires at most ONCE (D10 boundary).  With both
-        fresh connections failing transiently, the second failure propagates.
-        Total connect calls: 2.
+        The execute-phase retry is time-budgeted.  With the clock advanced past the
+        deadline after the first execute-phase failure, no second attempt is made
+        and the transient error propagates.
+
+        Clock sequence:
+          [0] _with_connect_retry deadline base (initial conn)
+          [1] execute_deadline = 0 + timeout (first failure)
+          [2] deadline check: past deadline → stop, raise
+        Total connect calls: 1.
         """
+        timeout = _sql_module._CONNECT_RETRY_TIMEOUT_S  # type: ignore[attr-defined]
+        fake_time = _make_fake_time_module(
+            monotonic_values=[
+                0.0,  # _with_connect_retry deadline base
+                0.0,  # execute_deadline = 0 + timeout
+                timeout + 1,  # deadline check after first failure → expired
+            ]
+        )
+        monkeypatch.setattr(_sql_module, "time", fake_time)
+
         mock_mssql, _, _ = _make_mock_mssql()
 
         bad_cursor = MagicMock()
@@ -1302,8 +1395,8 @@ class TestTransientRetry:
                 fetch="rowcount",
             )
 
-        # 1 initial + 1 execute-phase retry = 2 connect calls; no third attempt.
-        assert mock_mssql.connect.call_count == 2
+        # Deadline expired immediately after first failure — only 1 connect call.
+        assert mock_mssql.connect.call_count == 1
 
     def test_fetch_none_does_not_retry_transient(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """fetch='none' (DML/DDL): a transient execute error is NOT retried.

--- a/tests/unit/test_sql.py
+++ b/tests/unit/test_sql.py
@@ -1208,6 +1208,120 @@ class TestTransientRetry:
         # Must NOT retry — only one connect attempt.
         assert mock_mssql.connect.call_count == 1
 
+    # ------------------------------------------------------------------
+    # fetch="rowcount" (COPY INTO) execute-phase transient retry
+    # ------------------------------------------------------------------
+
+    def test_rowcount_transient_retries_then_succeeds(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """COPY INTO (fetch='rowcount'): transient execute error is retried on a fresh connection.
+
+        Sequence:
+          1. _with_connect_retry -> bad_conn (connect call 1)
+          2. _execute_once(bad_conn) raises transient "Communication link failure"
+          3. execute_retry_allowed=True (rowcount != none) -> retry on fresh conn
+          4. _with_connect_retry -> good_conn (connect call 2)
+          5. _execute_once(good_conn) succeeds; rowcount == 5
+        Result: ([], [(5,)]) — the COPY INTO rowcount path succeeds.
+        """
+        mock_mssql, _, _ = _make_mock_mssql()
+
+        bad_cursor = MagicMock()
+        bad_cursor.execute.side_effect = Exception(
+            "Driver Error: Communication link failure; "
+            "DDBC Error: [Microsoft]Communication link failure"
+        )
+        bad_conn = MagicMock()
+        bad_conn.cursor.return_value = bad_cursor
+
+        good_cursor = MagicMock()
+        good_cursor.description = None  # COPY INTO produces no result set
+        good_cursor.rowcount = 5
+        good_conn = MagicMock()
+        good_conn.cursor.return_value = good_cursor
+
+        mock_mssql.connect.side_effect = [bad_conn, good_conn]
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        cols, rows = run_query(
+            _make_target(),
+            "COPY INTO [dbo].[t] FROM 'https://onelake.dfs.fabric.microsoft.com/...' WITH (...);",
+            fetch="rowcount",
+            commit=True,
+        )
+
+        assert mock_mssql.connect.call_count == 2
+        assert cols == []
+        assert rows == [(5,)]
+
+    def test_rowcount_deterministic_error_not_retried(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """COPY INTO (fetch='rowcount'): a deterministic (non-transient) error is NOT retried.
+
+        A syntax / permission / programming error raised during execute must
+        surface immediately without opening a second connection.
+        """
+        mock_mssql, _, mock_cursor = _make_mock_mssql()
+        mock_cursor.execute.side_effect = Exception("Incorrect syntax near 'COPY'")
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        with pytest.raises(Exception, match="Incorrect syntax near"):
+            run_query(
+                _make_target(),
+                "COPY BADSTATEMENT",
+                fetch="rowcount",
+            )
+
+        # Only one connection should have been opened — no retry.
+        assert mock_mssql.connect.call_count == 1
+
+    def test_rowcount_transient_budget_exhausted_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """COPY INTO (fetch='rowcount'): when both attempts fail, the error is re-raised.
+
+        The execute-phase retry fires at most ONCE (D10 boundary).  With both
+        fresh connections failing transiently, the second failure propagates.
+        Total connect calls: 2.
+        """
+        mock_mssql, _, _ = _make_mock_mssql()
+
+        bad_cursor = MagicMock()
+        bad_cursor.execute.side_effect = Exception("Communication link failure")
+        bad_conn = MagicMock()
+        bad_conn.cursor.return_value = bad_cursor
+        mock_mssql.connect.return_value = bad_conn
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        with pytest.raises(Exception, match="Communication link failure"):
+            run_query(
+                _make_target(),
+                "COPY INTO [dbo].[t] FROM 'https://...' WITH (...);",
+                fetch="rowcount",
+            )
+
+        # 1 initial + 1 execute-phase retry = 2 connect calls; no third attempt.
+        assert mock_mssql.connect.call_count == 2
+
+    def test_fetch_none_does_not_retry_transient(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """fetch='none' (DML/DDL): a transient execute error is NOT retried.
+
+        Non-idempotent statements (INSERT / UPDATE / DDL) must never be
+        re-executed after cursor.execute has been called, because the server
+        may have already applied the change.
+        """
+        mock_mssql, _, mock_cursor = _make_mock_mssql()
+        mock_cursor.execute.side_effect = Exception("Communication link failure")
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        with pytest.raises(Exception, match="Communication link failure"):
+            run_query(_make_target(), "INSERT INTO t VALUES (1)", fetch="none")
+
+        # fetch="none" → execute_retry_allowed=False → only one connect.
+        assert mock_mssql.connect.call_count == 1
+
 
 # ---------------------------------------------------------------------------
 # GitHub OIDC SQL token injection — build_connection_string + open_connection


### PR DESCRIPTION
## Summary

- **Critical safety fix**: split the execute-and-fetch phase from the commit phase in \`run_query\`. The retry loop now wraps ONLY \`cursor.execute\` + result capture. Commit is performed once, outside the retry loop, after a successful execute. A transient error during commit is re-raised immediately — the statement is never re-executed — preventing double COPY INTO loads.
- Add an **attempt cap** (\`len(_EXECUTE_RETRY_DELAYS) + 1 = 4 attempts max\`) alongside the existing wall-clock deadline (\`_CONNECT_RETRY_TIMEOUT_S\` ~120 s) so worst-case retry time is clearly bounded (~28 minutes absolute max = 4 × (120 s connect budget + 300 s query timeout)).
- Remove dead constants \`SQL_TRANSIENT_MAX_RETRIES\` (from \`__all__\` and module) and \`_TRANSIENT_RETRY_DELAYS\` which were no longer used internally.
- Fix stale docstrings: \`_with_connect_retry\` Returns block, \`test_run_query_raises_after_budget_exhausted\` docstring/assertion mismatch.

## Commit-phase safety guarantee

The key correctness property: if a TDS drop occurs **after** \`cursor.execute\` has returned but **during** or **after** \`conn.commit()\`, the load may already be committed server-side. Re-executing the statement would risk a double-load (e.g. double COPY INTO). The new structure ensures:

1. Retry loop tries \`_execute_and_fetch(conn)\` — no commit inside.
2. On transient execute failure → discard connection → sleep → fresh connection → retry (up to 4 attempts or deadline).
3. After **successful** execute+fetch → call \`conn.commit()\` exactly once, outside the loop.
4. If \`commit()\` raises → propagate immediately, connection marked discard. No re-execute.

## Changes

- **\`src/fabric_dw/sql.py\`**:
  - Remove \`SQL_TRANSIENT_MAX_RETRIES\` from \`__all__\` and delete constant definition.
  - Remove \`_TRANSIENT_RETRY_DELAYS\` constant.
  - Update \`_EXECUTE_RETRY_DELAYS\` docstring to document the attempt cap.
  - Fix \`_with_connect_retry\` Returns docstring (stale sentinel description).
  - Rename \`_execute_once\` → \`_execute_and_fetch\` (no commit inside).
  - Add \`_max_execute_attempts = len(_EXECUTE_RETRY_DELAYS) + 1\` cap check.
  - Commit is now performed after the retry loop exits successfully, with error handling that marks the connection for discard and re-raises (no retry).

- **\`tests/unit/test_sql.py\`**:
  - Remove \`test_sql_transient_max_retries_constant_is_backward_compatible\` (obsolete).
  - Update \`test_retry_policy_constants\` to remove references to deleted constants.
  - Fix \`test_run_query_raises_after_budget_exhausted\` docstring to match the assertion (\`== 1\` connect call, not 2).
  - **New** \`test_commit_phase_transient_not_retried_statement_executed_once\`: verifies the CRITICAL safety guarantee — execute fires once, commit raises transient, error propagates, no retry.
  - **New** \`test_execute_phase_retried_commit_called_once_on_success\`: 2 connects (1 execute failure + 1 success), commit called exactly once on the successful connection.
  - **New** \`test_execute_retry_bounded_by_attempt_cap\`: persistent transient errors stop after exactly 4 connect calls regardless of wall-clock deadline.

## Test plan

- \`just check\` fully clean: ruff lint + format, ty, 3490 unit tests pass, 2 deselected.
- No real sleeps or wall-clock delays: \`time\` module monkeypatched with fake monotonic clock.

Closes #481

🤖 Generated with [Claude Code](https://claude.com/claude-code)