### PR TITLE
docs: drop pre-stable "sql exec promoted to sql" breaking-change note

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -518,9 +518,6 @@ fabric-dw -w MyWorkspace --json sql-endpoints permissions MyLakehouseEP
 
 Execute SQL against a Fabric Data Warehouse or SQL Analytics Endpoint.
 
-> **Breaking change:** The former `sql exec` subcommand was promoted to `sql` itself.
-> Replace `fdw sql exec ...` with `fdw sql ...`.
-
 **Targets:** Data Warehouse · SQL Analytics Endpoint
 
 Execute a SQL statement or file against a warehouse or SQL Analytics Endpoint. Provide the query via `-q`/`--query` or `-f`/`--file` (not both). Multi-statement batches are supported; only the last result set is returned. DDL/DML statements return empty columns and rows.

--- a/src/fabric_dw/cli/commands/sql.py
+++ b/src/fabric_dw/cli/commands/sql.py
@@ -3,10 +3,6 @@
 Commands
 --------
 - ``sql <item>`` — execute an arbitrary SQL statement or file.
-
-.. note::
-   **Breaking change (v0.x → v0.y):** The former ``sql exec`` sub-command was
-   promoted to ``sql`` itself.  Replace ``fdw sql exec ...`` with ``fdw sql ...``.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

Removes two leftover notes that describe the former `sql exec` → `sql` promotion as a breaking change. Because the project has not yet reached a stable release, migration/history notes for past breaking changes are unnecessary and add noise.

**Changes:**

- `docs/cli.md` — deleted the blockquote under `## fabric-dw sql` that read:
  > **Breaking change:** The former `sql exec` subcommand was promoted to `sql` itself. Replace `fdw sql exec ...` with `fdw sql ...`.

- `src/fabric_dw/cli/commands/sql.py` — deleted the `.. note::` block from the module docstring referencing the same promotion.

No replacement text, deprecation hint, or changelog entry was added.

## Quality gates

- `ruff check` and `ruff format --check` pass
- `ty check src tests` passes
- 773 unit tests pass (including all SQL command tests)

Closes #486