### PR TITLE
docs: convert all blockquote notes to admonitions

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -2397,8 +2397,11 @@ fabric-dw -w MyWorkspace sql-pools insights SalesWH
 
 Manage user-defined statistics on Fabric Data Warehouses and read their details on SQL Analytics Endpoints.
 
-> **Note:** Only **single-column, histogram-based** statistics can be created or updated (Fabric limitation). Multi-column statistics are not supported.
-> DDL operations (`create`, `update`, `delete`) require a **Data Warehouse** — they are rejected client-side on SQL Analytics Endpoints. `list` and `show` work on both item kinds.
+!!! note
+
+    Only **single-column, histogram-based** statistics can be created or updated (Fabric limitation). Multi-column statistics are not supported.
+
+    DDL operations (`create`, `update`, `delete`) require a **Data Warehouse** — they are rejected client-side on SQL Analytics Endpoints. `list` and `show` work on both item kinds.
 
 ### statistics list
 
@@ -2592,7 +2595,9 @@ No dbt installation is required to run these commands — `fabric-dw` generates 
 
 Scaffold a new dbt project directory connected to a Fabric Data Warehouse. The command creates the folder, writes `dbt_project.yml`, `profiles.yml`, `requirements.txt`, `.gitignore`, standard dbt model directories, a sample model, and a README. If `git` is on your PATH and the target folder is not already a git repository, `git init` is run automatically.
 
-> **Security note** — when `--auth sp` (Service Principal) is used, `profiles.yml` emits Jinja2 `env_var()` placeholders (`{{ env_var('AZURE_TENANT_ID') }}` etc.) instead of literal secrets. You must set `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, and `AZURE_CLIENT_SECRET` in your environment before running dbt.
+!!! warning "Security"
+
+    When `--auth sp` (Service Principal) is used, `profiles.yml` emits Jinja2 `env_var()` placeholders (`{{ env_var('AZURE_TENANT_ID') }}` etc.) instead of literal secrets. You must set `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, and `AZURE_CLIENT_SECRET` in your environment before running dbt.
 
 **Usage**
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -61,7 +61,9 @@ Every command that operates on a workspace (everything except `workspaces list` 
 
 The `workspaces` command group is an exception: `workspaces get` and `workspaces set-collation` take the workspace as an explicit positional argument (not via `-w`), and `workspaces list` takes no workspace at all.
 
-> **`-A` / `--all-workspaces` interaction:** passing `-A` on the two list commands that support it (`warehouses list`, `sql-endpoints list`) explicitly scans every visible workspace. This flag is mutually exclusive with `-w` (an explicit `-w` conflicts with scanning all workspaces), but it does **not** conflict with a configured default workspace or `FABRIC_DW_DEFAULT_WORKSPACE` — the configured default is silently ignored when `-A` is used.
+!!! note "-A / --all-workspaces interaction"
+
+    Passing `-A` on the two list commands that support it (`warehouses list`, `sql-endpoints list`) explicitly scans every visible workspace. This flag is mutually exclusive with `-w` (an explicit `-w` conflicts with scanning all workspaces), but it does **not** conflict with a configured default workspace or `FABRIC_DW_DEFAULT_WORKSPACE` — the configured default is silently ignored when `-A` is used.
 
 ---
 
@@ -145,7 +147,9 @@ fabric-dw workspaces list
 
 Get details for a workspace, including its default Data Warehouse collation.
 
-> **Note:** The `workspaces` group is exempt from the global `-w/--workspace` option. Pass the workspace name or GUID as a positional argument instead.
+!!! note
+
+    The `workspaces` group is exempt from the global `-w/--workspace` option. Pass the workspace name or GUID as a positional argument instead.
 
 **Synopsis**
 
@@ -174,7 +178,9 @@ defaultDataWarehouseCollation     Latin1_General_100_CI_AS_KS_WS_SC_UTF8
 
 Set the default Data Warehouse collation for a workspace. `COLLATION` must be one of the supported Fabric collations.
 
-> **Note:** The `workspaces` group is exempt from the global `-w/--workspace` option. Pass the workspace name or GUID as a positional argument instead.
+!!! note
+
+    The `workspaces` group is exempt from the global `-w/--workspace` option. Pass the workspace name or GUID as a positional argument instead.
 
 **Synopsis**
 
@@ -525,7 +531,9 @@ Execute SQL against a Fabric Data Warehouse or SQL Analytics Endpoint.
 
 Execute a SQL statement or file against a warehouse or SQL Analytics Endpoint. Provide the query via `-q`/`--query` or `-f`/`--file` (not both). Multi-statement batches are supported; only the last result set is returned. DDL/DML statements return empty columns and rows.
 
-> **Warning:** This command executes arbitrary SQL, including DDL and DML. Ensure you have the correct target before running destructive statements.
+!!! warning
+
+    This command executes arbitrary SQL, including DDL and DML. Ensure you have the correct target before running destructive statements.
 
 **Synopsis**
 
@@ -1399,7 +1407,9 @@ fabric-dw -w MyWorkspace --yes procedures drop SalesWH dbo.usp_archive_orders
 
 Manage T-SQL user-defined functions on Microsoft Fabric Data Warehouses and SQL Analytics Endpoints.
 
-> **Preview:** Scalar UDFs (`FN`) and inline TVFs (`IF`) are preview features as of mid-2026. Function DDL is supported on both Data Warehouses and SQL Analytics Endpoints — no endpoint guard is applied.
+!!! warning "Preview"
+
+    Scalar UDFs (`FN`) and inline TVFs (`IF`) are preview features as of mid-2026. Function DDL is supported on both Data Warehouses and SQL Analytics Endpoints — no endpoint guard is applied.
 
 ### functions list
 
@@ -1490,7 +1500,9 @@ fabric-dw -w MyWorkspace functions create SalesWH \
 
 Redefine an existing T-SQL user-defined function via `CREATE OR ALTER FUNCTION`.
 
-> **Note:** `ALTER FUNCTION` cannot change the function kind (e.g. scalar to inline TVF). The body must be compatible with the original function's kind.
+!!! note
+
+    `ALTER FUNCTION` cannot change the function kind (e.g. scalar to inline TVF). The body must be compatible with the original function's kind.
 
 **Synopsis**
 
@@ -1569,7 +1581,9 @@ fabric-dw -w MyWorkspace --yes functions rename SalesWH dbo.fn_clean_input \
 
 Manage SQL tables on Microsoft Fabric Data Warehouses and SQL Analytics Endpoints.
 
-> **List-source note** — no public REST API exists for enumerating warehouse tables. `tables list` falls back to TDS via `sys.tables JOIN sys.schemas`, the same approach used by `views list`.
+!!! note "List source"
+
+    No public REST API exists for enumerating warehouse tables. `tables list` falls back to TDS via `sys.tables JOIN sys.schemas`, the same approach used by `views list`.
 
 ### tables list
 
@@ -1861,7 +1875,9 @@ Use `--if-exists` to control behaviour when the table already exists:
 
 Use `--cleanup-on-failure` to drop the table if WE created it in this call and the subsequent `COPY INTO` fails. A pre-existing table is never dropped by this flag.
 
-> **Not atomic.** `CREATE TABLE` and `COPY INTO` are separate statements. A failure between them may leave an empty table. Use `--cleanup-on-failure` to auto-drop in that case.
+!!! warning "Not atomic"
+
+    `CREATE TABLE` and `COPY INTO` are separate statements. A failure between them may leave an empty table. Use `--cleanup-on-failure` to auto-drop in that case.
 
 **Synopsis**
 
@@ -1938,9 +1954,13 @@ fabric-dw -w MyWorkspace tables load SalesWH dbo.events \
 
 Manage SQL schemas on Microsoft Fabric Data Warehouses and SQL Analytics Endpoints.
 
-> **List-source note** — no public REST API exists for enumerating warehouse schemas. `schemas list` falls back to TDS via `sys.schemas`, filtering out well-known system schemas (`sys`, `INFORMATION_SCHEMA`, `guest`, `db_*` fixed-role schemas). `dbo` is always included because it is user-writable.
+!!! note "List source"
 
-> **SQL Analytics Endpoints** — `schemas list`, `schemas create`, and `schemas delete` all work on both Fabric Data Warehouses and SQL Analytics Endpoints. When `schemas delete --cascade` is used on a SQL Analytics Endpoint, views, stored procedures, and functions in the schema are dropped, but tables are **not** dropped (because `DROP TABLE` is a Warehouse-only operation on Fabric). If the schema contains tables, the final `DROP SCHEMA` will be rejected by the engine; remove the tables manually first or omit `--cascade` and drop the schema only after it is empty.
+    No public REST API exists for enumerating warehouse schemas. `schemas list` falls back to TDS via `sys.schemas`, filtering out well-known system schemas (`sys`, `INFORMATION_SCHEMA`, `guest`, `db_*` fixed-role schemas). `dbo` is always included because it is user-writable.
+
+!!! note "SQL Analytics Endpoints"
+
+    `schemas list`, `schemas create`, and `schemas delete` all work on both Fabric Data Warehouses and SQL Analytics Endpoints. When `schemas delete --cascade` is used on a SQL Analytics Endpoint, views, stored procedures, and functions in the schema are dropped, but tables are **not** dropped (because `DROP TABLE` is a Warehouse-only operation on Fabric). If the schema contains tables, the final `DROP SCHEMA` will be rejected by the engine; remove the tables manually first or omit `--cascade` and drop the schema only after it is empty.
 
 ### schemas list
 
@@ -2485,7 +2505,9 @@ fabric-dw [-w WORKSPACE] statistics delete [ITEM] QUALIFIED_TABLE STAT_NAME
 
 Manage **server-side** database settings on a Fabric Data Warehouse or SQL Analytics Endpoint.
 
-> **Note:** `settings` manages server-side warehouse/database configuration. For client-side CLI defaults (workspace, warehouse) use [`fabric-dw config`](#defaults-fabric-dw-config) instead.
+!!! note
+
+    `settings` manages server-side warehouse/database configuration. For client-side CLI defaults (workspace, warehouse) use [`fabric-dw config`](#defaults-fabric-dw-config) instead.
 
 `show` and `result-set-caching` work on both Data Warehouses and SQL Analytics Endpoints. The `retention` command sets the time-travel retention period, which is primarily a Warehouse concept and may be a no-op on a SQL Analytics Endpoint.
 

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -1031,7 +1031,7 @@ Load data from a remote URL into an existing Data Warehouse table with control o
 
 !!! warning "Destructive operation"
 
-    `truncate` and `replace` are destructive and require `FABRIC_MCP_ALLOW_DESTRUCTIVE=1`.
+    **`truncate` and `replace` are destructive** and require `FABRIC_MCP_ALLOW_DESTRUCTIVE=1`.
 
 !!! note "Secret safety"
 

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -169,7 +169,9 @@ Take ownership of a Warehouse. Not supported for SQL analytics endpoints.
 
 Return all principals (users, groups, service principals) with access to a Warehouse, including their effective permissions.
 
-> **Note:** Requires **Fabric Administrator** role (`Tenant.Read.All` or `Tenant.ReadWrite.All` scope). See [Microsoft Fabric admin documentation](https://learn.microsoft.com/en-us/fabric/admin/microsoft-fabric-admin) for how to request the role.
+!!! note
+
+    Requires **Fabric Administrator** role (`Tenant.Read.All` or `Tenant.ReadWrite.All` scope). See [Microsoft Fabric admin documentation](https://learn.microsoft.com/en-us/fabric/admin/microsoft-fabric-admin) for how to request the role.
 
 **Parameters:**
 
@@ -234,7 +236,9 @@ Refresh metadata for a SQL analytics endpoint by syncing from the underlying Lak
 
 Return all principals (users, groups, service principals) with access to a SQL Analytics Endpoint, including their effective permissions.
 
-> **Note:** Requires **Fabric Administrator** role (`Tenant.Read.All` or `Tenant.ReadWrite.All` scope). See [Microsoft Fabric admin documentation](https://learn.microsoft.com/en-us/fabric/admin/microsoft-fabric-admin) for how to request the role.
+!!! note
+
+    Requires **Fabric Administrator** role (`Tenant.Read.All` or `Tenant.ReadWrite.All` scope). See [Microsoft Fabric admin documentation](https://learn.microsoft.com/en-us/fabric/admin/microsoft-fabric-admin) for how to request the role.
 
 **Parameters:**
 
@@ -487,7 +491,9 @@ Return long-running queries from `queryinsights.long_running_queries`.
 
 Execute an arbitrary SQL statement or batch against a warehouse or SQL Analytics Endpoint.
 
-> **Warning:** This tool executes arbitrary SQL, including DDL (DROP, ALTER, TRUNCATE) and DML (DELETE, UPDATE). Use only when the user explicitly requests data modification. Default to SELECT when the user's intent is read-only investigation.
+!!! warning
+
+    This tool executes arbitrary SQL, including DDL (DROP, ALTER, TRUNCATE) and DML (DELETE, UPDATE). Use only when the user explicitly requests data modification. Default to SELECT when the user's intent is read-only investigation.
 
 Multi-statement batches are supported; only the **last** result set is returned. DDL/DML statements that produce no result set return `columns=[]` and `rows=[]`.
 
@@ -809,7 +815,9 @@ Return up to `count` rows from a view as JSON-serialisable columns and rows.
 
 ## Tables
 
-> **List-source note** — no public REST API exists for enumerating warehouse tables. `list_tables` uses TDS `sys.tables JOIN sys.schemas`.
+!!! note "List source"
+
+    No public REST API exists for enumerating warehouse tables. `list_tables` uses TDS `sys.tables JOIN sys.schemas`.
 
 ### list_tables
 
@@ -977,11 +985,17 @@ Rename a SQL table via `sp_rename`. Only supported on Fabric Data Warehouses (SQ
 
 Load data into a Data Warehouse table via `COPY INTO` from a remote URL. For OneLake or same-tenant URLs, no credential is needed. For secured external URLs (Azure Blob Storage, ADLS Gen2), supply `credential_type` and the appropriate `secret`/`identity` values.
 
-> **JSON not supported for remote URLs.** If you need to load JSON, download the file locally and use the CLI `tables load --file` command instead (which converts JSON to Parquet client-side).
+!!! warning "JSON not supported for remote URLs"
 
-> **Secret safety.** The `secret` and `identity` parameters are accepted but are **never** logged or echoed in any server output.
+    If you need to load JSON, download the file locally and use the CLI `tables load --file` command instead (which converts JSON to Parquet client-side).
 
-> **Table must exist.** This tool does not create the target table. Use [`import_table_from_url`](#import_table_from_url) for a load-only flow with `if_exists` control over an existing table, or the CLI `tables load --file --create` for auto-create from a local file with schema inference.
+!!! note "Secret safety"
+
+    The `secret` and `identity` parameters are accepted but are **never** logged or echoed in any server output.
+
+!!! note "Table must exist"
+
+    This tool does not create the target table. Use [`import_table_from_url`](#import_table_from_url) for a load-only flow with `if_exists` control over an existing table, or the CLI `tables load --file --create` for auto-create from a local file with schema inference.
 
 **Parameters:**
 
@@ -1011,11 +1025,17 @@ Load data into a Data Warehouse table via `COPY INTO` from a remote URL. For One
 
 Load data from a remote URL into an existing Data Warehouse table with control over what happens when the table already has data. This tool extends [`load_table_from_url`](#load_table_from_url) with an `if_exists` policy.
 
-> **Schema inference not supported for remote URLs.** This tool does not auto-create the target table from the source schema (downloading the full file just for schema inference is not practical for remote sources). To auto-create a table from schema, use the CLI `tables load --file --create` with a local file. For `if_exists="replace"`, use the CLI instead.
+!!! warning "Schema inference not supported for remote URLs"
 
-> **`truncate` and `replace` are destructive** and require `FABRIC_MCP_ALLOW_DESTRUCTIVE=1`.
+    This tool does not auto-create the target table from the source schema (downloading the full file just for schema inference is not practical for remote sources). To auto-create a table from schema, use the CLI `tables load --file --create` with a local file. For `if_exists="replace"`, use the CLI instead.
 
-> **Secret safety.** The `secret` and `identity` parameters are accepted but are **never** logged or echoed in any server output.
+!!! warning "Destructive operation"
+
+    `truncate` and `replace` are destructive and require `FABRIC_MCP_ALLOW_DESTRUCTIVE=1`.
+
+!!! note "Secret safety"
+
+    The `secret` and `identity` parameters are accepted but are **never** logged or echoed in any server output.
 
 **`if_exists` policy:**
 
@@ -1089,7 +1109,9 @@ Fetch the full definition of a single stored procedure.
 
 Create a new stored procedure.
 
-> **CAUTION:** `body` is executed verbatim as DDL. Ensure the body matches the user's intent before calling this tool.
+!!! warning "Caution"
+
+    `body` is executed verbatim as DDL. Ensure the body matches the user's intent before calling this tool.
 
 **Parameters:**
 
@@ -1108,7 +1130,9 @@ Create a new stored procedure.
 
 Redefine a stored procedure via `CREATE OR ALTER PROCEDURE`.
 
-> **CAUTION:** `body` is executed verbatim as DDL. Ensure the body matches the user's intent before calling this tool.
+!!! warning "Caution"
+
+    `body` is executed verbatim as DDL. Ensure the body matches the user's intent before calling this tool.
 
 **Parameters:**
 
@@ -1139,7 +1163,9 @@ Drop a stored procedure.
 
 ## Functions
 
-> **Preview:** Scalar UDFs (`FN`) and inline TVFs (`IF`) are preview features on Fabric DW as of mid-2026. Function DDL is supported on both Data Warehouses and SQL Analytics Endpoints — no endpoint guard applies.
+!!! warning "Preview"
+
+    Scalar UDFs (`FN`) and inline TVFs (`IF`) are preview features on Fabric DW as of mid-2026. Function DDL is supported on both Data Warehouses and SQL Analytics Endpoints — no endpoint guard applies.
 
 ### list_functions
 
@@ -1180,7 +1206,9 @@ Fetch the full definition of a single T-SQL user-defined function, including its
 
 Create a new T-SQL user-defined function. Scalar UDFs and inline TVFs are preview features.
 
-> **CAUTION:** `body` is executed verbatim as DDL. Ensure the body matches the user's intent before calling this tool.
+!!! warning "Caution"
+
+    `body` is executed verbatim as DDL. Ensure the body matches the user's intent before calling this tool.
 
 **Parameters:**
 
@@ -1199,9 +1227,13 @@ Create a new T-SQL user-defined function. Scalar UDFs and inline TVFs are previe
 
 Redefine a T-SQL user-defined function via `CREATE OR ALTER FUNCTION`.
 
-> **Note:** `ALTER FUNCTION` cannot change the function kind (e.g. scalar to inline TVF). The body must be compatible with the original function's kind.
+!!! note
 
-> **CAUTION:** `body` is executed verbatim as DDL. Ensure the body matches the user's intent before calling this tool.
+    `ALTER FUNCTION` cannot change the function kind (e.g. scalar to inline TVF). The body must be compatible with the original function's kind.
+
+!!! warning "Caution"
+
+    `body` is executed verbatim as DDL. Ensure the body matches the user's intent before calling this tool.
 
 **Parameters:**
 
@@ -1250,9 +1282,13 @@ Rename a T-SQL user-defined function via `sp_rename`. The new name must be a bar
 
 ## Schemas
 
-> **List-source note** — no public REST API exists for enumerating warehouse schemas. `list_schemas` uses TDS `sys.schemas`, filtering out `sys`, `INFORMATION_SCHEMA`, `guest`, and `db_*` fixed-role schemas. `dbo` is always included because it is user-writable.
+!!! note "List source"
 
-> **SQL Analytics Endpoints** — `list_schemas`, `create_schema`, and `delete_schema` all work on both Fabric Data Warehouses and SQL Analytics Endpoints. When `delete_schema` is called with `cascade=True` on a SQL Analytics Endpoint, views, stored procedures, and functions are dropped, but tables are **not** dropped (because `DROP TABLE` is a Warehouse-only operation on Fabric). If the schema still contains tables after the cascade pass, the subsequent `DROP SCHEMA` will be rejected by the engine; remove the tables manually before deleting the schema.
+    No public REST API exists for enumerating warehouse schemas. `list_schemas` uses TDS `sys.schemas`, filtering out `sys`, `INFORMATION_SCHEMA`, `guest`, and `db_*` fixed-role schemas. `dbo` is always included because it is user-writable.
+
+!!! note "SQL Analytics Endpoints"
+
+    `list_schemas`, `create_schema`, and `delete_schema` all work on both Fabric Data Warehouses and SQL Analytics Endpoints. When `delete_schema` is called with `cascade=True` on a SQL Analytics Endpoint, views, stored procedures, and functions are dropped, but tables are **not** dropped (because `DROP TABLE` is a Warehouse-only operation on Fabric). If the schema still contains tables after the cascade pass, the subsequent `DROP SCHEMA` will be rejected by the engine; remove the tables manually before deleting the schema.
 
 ### list_schemas
 
@@ -1459,8 +1495,11 @@ Return SQL pool insight events from `queryinsights.sql_pool_insights`.
 
 Manage user-defined statistics on Fabric Data Warehouses and inspect them on SQL Analytics Endpoints.
 
-> **Note:** Only **single-column, histogram-based** statistics can be created or updated (Fabric limitation). Multi-column statistics are not supported.
-> Write tools (`create_statistics`, `update_statistics`, `delete_statistics`) are rejected on SQL Analytics Endpoints. Read tools (`list_statistics`, `show_statistics`) work on both item kinds.
+!!! note
+
+    Only **single-column, histogram-based** statistics can be created or updated (Fabric limitation). Multi-column statistics are not supported.
+
+    Write tools (`create_statistics`, `update_statistics`, `delete_statistics`) are rejected on SQL Analytics Endpoints. Read tools (`list_statistics`, `show_statistics`) work on both item kinds.
 
 ### list_statistics
 
@@ -1579,7 +1618,9 @@ Drop a statistic via `DROP STATISTICS`. **Destructive and irreversible.** Requir
 
 Generate [dbt-fabric](https://docs.getdbt.com/docs/core/connect-data-platform/fabric-setup) project file contents pre-wired to a Microsoft Fabric Data Warehouse. Unlike the CLI `dbt init` command, these tools return file contents as text rather than writing files to disk, making them suitable for AI-assisted workflows where the AI agent writes the files.
 
-> **Security note** — when `authentication="ServicePrincipal"` is used, the returned `profiles_yml` contains Jinja2 `env_var()` placeholders (`{{ env_var('AZURE_TENANT_ID') }}` etc.) rather than literal secrets. Never hard-code secrets into source-controlled files.
+!!! warning "Security"
+
+    When `authentication="ServicePrincipal"` is used, the returned `profiles_yml` contains Jinja2 `env_var()` placeholders (`{{ env_var('AZURE_TENANT_ID') }}` etc.) rather than literal secrets. Never hard-code secrets into source-controlled files.
 
 ### generate_dbt_profile
 


### PR DESCRIPTION
## Summary

- Convert every blockquote-style note (`> **Label:** ...`) in `docs/cli.md` and `docs/mcp-tools.md` to proper Python-Markdown admonitions (`!!! type "Title"`), matching the style already used throughout the docs.
- The `admonition` extension is already enabled in `zensical.toml` — no config changes needed.
- The `> **Breaking change:**` blockquote in `docs/cli.md` is intentionally left untouched (being deleted in PR #487).

**docs/cli.md** — 11 blockquotes converted:
- `-A / --all-workspaces interaction` → `!!! note`
- `workspaces` group exempt note ×2 → `!!! note`
- SQL `Warning` → `!!! warning`
- Functions `Preview` → `!!! warning "Preview"`
- `ALTER FUNCTION` kind note → `!!! note`
- Tables list-source → `!!! note "List source"`
- Tables not-atomic → `!!! warning "Not atomic"`
- Schemas list-source + SQL Analytics Endpoints → `!!! note` ×2
- Settings note → `!!! note`

**docs/mcp-tools.md** — 16 blockquotes converted:
- Admin role note ×2 → `!!! note`
- SQL `Warning` → `!!! warning`
- Tables list-source → `!!! note "List source"`
- `load_table_from_url`: JSON/secret/table notes → `!!! warning` + `!!! note` ×2
- `import_table_from_url`: schema inference/destructive/secret → `!!! warning` ×2 + `!!! note`
- Stored-proc CAUTION ×2 → `!!! warning "Caution"`
- Functions `Preview` → `!!! warning "Preview"`
- Functions create CAUTION → `!!! warning "Caution"`
- `update_function` note + CAUTION → `!!! note` + `!!! warning "Caution"`
- Schemas list-source + SQL Analytics Endpoints → `!!! note` ×2
- Statistics note (multi-paragraph) → `!!! note`
- dbt security note → `!!! warning "Security"`

## Test plan

- [x] `uv run ruff check .` — all checks passed
- [x] `uv run ruff format --check .` — 232 files already formatted
- [x] `grep -n '^> ' docs/cli.md docs/mcp-tools.md` confirms only the `Breaking change` blockquote remains

Closes #488

🤖 Generated with [Claude Code](https://claude.com/claude-code)