### PR TITLE
docs: drop preview framing from Copilot desktop app instructions

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -205,12 +205,9 @@ You can also add the server interactively without editing the file: start the CL
 
 To share the configuration with a project instead of setting it globally, add a `.mcp.json` file (or `.github/mcp.json`) in the project root with the same `mcpServers` block. Project-level configuration takes precedence over user-level when server names conflict.
 
-### Desktop (preview)
+### Desktop
 
 Source: <https://docs.github.com/en/copilot/how-tos/github-copilot-app/customize-github-copilot-app>
-
-!!! warning "Technical preview"
-    The GitHub Copilot desktop app is in technical preview and subject to change. The configuration approach described here reflects the current state of the preview.
 
 The GitHub Copilot desktop app is built on top of Copilot CLI and shares the same MCP configuration. **Any MCP servers you have added to `~/.copilot/mcp-config.json` for the CLI are automatically available in the desktop app.** No separate config file is needed.
 


### PR DESCRIPTION
## Summary

- Rename `### Desktop (preview)` heading to `### Desktop` in `docs/mcp.md`
- Remove the `!!! warning "Technical preview"` admonition that followed the `Source:` line
- The GitHub Copilot desktop app is no longer in technical preview; the framing was outdated

Closes #490

## Test plan

- [ ] Confirm heading reads `### Desktop` (no `(preview)` suffix)
- [ ] Confirm the `!!! warning "Technical preview"` admonition block is gone
- [ ] Confirm no orphaned blank lines were introduced
- [ ] Confirm ruff check and format pass (docs-only change, unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)