### PR TITLE
feat(cli): rename queries subcommands for clarity

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -732,7 +732,7 @@ fabric-dw -w MyWorkspace audit remove-group SalesWH BATCH_COMPLETED_GROUP
 
 Inspect and manage running queries on Microsoft Fabric Data Warehouses and SQL Analytics Endpoints.
 
-### queries list
+### queries running
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
 
@@ -741,13 +741,13 @@ List all currently running queries on a warehouse or SQL Analytics Endpoint.
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] queries list [WAREHOUSE]
+fabric-dw [-w WORKSPACE] queries running [WAREHOUSE]
 ```
 
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace queries list SalesWH
+fabric-dw -w MyWorkspace queries running SalesWH
 ```
 
 ```
@@ -758,22 +758,22 @@ fabric-dw -w MyWorkspace queries list SalesWH
 
 ---
 
-### queries list-connections
+### queries connections
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
 
-List all active SQL connections on a warehouse or SQL Analytics Endpoint. This queries `sys.dm_exec_connections` and shows lower-level connection info (including idle connections) that is not visible in `queries list`.
+List all active SQL connections on a warehouse or SQL Analytics Endpoint. This queries `sys.dm_exec_connections` and shows lower-level connection info (including idle connections) that is not visible in `queries running`.
 
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] queries list-connections [WAREHOUSE]
+fabric-dw [-w WORKSPACE] queries connections [WAREHOUSE]
 ```
 
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace queries list-connections SalesWH
+fabric-dw -w MyWorkspace queries connections SalesWH
 ```
 
 ```
@@ -805,7 +805,7 @@ fabric-dw -w MyWorkspace --yes queries kill SalesWH 42
 
 ---
 
-### queries request-history
+### queries history
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
 
@@ -814,7 +814,7 @@ List completed SQL requests from `queryinsights.exec_requests_history`. Supports
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] queries request-history [OPTIONS] [WAREHOUSE]
+fabric-dw [-w WORKSPACE] queries history [OPTIONS] [WAREHOUSE]
 ```
 
 | Option | Description | Default |
@@ -826,12 +826,12 @@ fabric-dw [-w WORKSPACE] queries request-history [OPTIONS] [WAREHOUSE]
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace queries request-history SalesWH --limit 50 --since 2026-06-01T00:00:00
+fabric-dw -w MyWorkspace queries history SalesWH --limit 50 --since 2026-06-01T00:00:00
 ```
 
 ---
 
-### queries session-history
+### queries sessions
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
 
@@ -840,7 +840,7 @@ List completed sessions from `queryinsights.exec_sessions_history`.
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] queries session-history [OPTIONS] [WAREHOUSE]
+fabric-dw [-w WORKSPACE] queries sessions [OPTIONS] [WAREHOUSE]
 ```
 
 | Option | Description | Default |
@@ -852,7 +852,7 @@ fabric-dw [-w WORKSPACE] queries session-history [OPTIONS] [WAREHOUSE]
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace queries session-history SalesWH
+fabric-dw -w MyWorkspace queries sessions SalesWH
 ```
 
 ---

--- a/src/fabric_dw/cli/commands/queries.py
+++ b/src/fabric_dw/cli/commands/queries.py
@@ -28,11 +28,11 @@ def queries_group() -> None:
     """Inspect and manage running queries on Fabric warehouses and SQL Analytics Endpoints."""
 
 
-@queries_group.command("list")
+@queries_group.command("running")
 @click.argument("item", required=False, default=None)
 @click.pass_obj
 @coro
-async def list_cmd(ctx: CliContext, item: str | None) -> None:
+async def running_cmd(ctx: CliContext, item: str | None) -> None:
     """List currently running queries on ITEM (warehouse or endpoint)."""
     ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
@@ -49,11 +49,11 @@ async def list_cmd(ctx: CliContext, item: str | None) -> None:
         raise click.ClickException(str(exc)) from exc
 
 
-@queries_group.command("list-connections")
+@queries_group.command("connections")
 @click.argument("item", required=False, default=None)
 @click.pass_obj
 @coro
-async def list_connections_cmd(ctx: CliContext, item: str | None) -> None:
+async def connections_cmd(ctx: CliContext, item: str | None) -> None:
     """List active SQL connections on ITEM (warehouse or endpoint)."""
     ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
@@ -98,18 +98,18 @@ async def kill_cmd(ctx: CliContext, item: str | None, session_id: int) -> None:
 
 
 # ---------------------------------------------------------------------------
-# request-history
+# history
 # ---------------------------------------------------------------------------
 
 
-@queries_group.command("request-history")
+@queries_group.command("history")
 @click.argument("warehouse", required=False, default=None)
 @LIMIT_OPTION
 @SINCE_OPTION
 @UNTIL_OPTION
 @click.pass_obj
 @coro
-async def request_history_cmd(
+async def history_cmd(
     ctx: CliContext,
     warehouse: str | None,
     limit: int,
@@ -137,18 +137,18 @@ async def request_history_cmd(
 
 
 # ---------------------------------------------------------------------------
-# session-history
+# sessions
 # ---------------------------------------------------------------------------
 
 
-@queries_group.command("session-history")
+@queries_group.command("sessions")
 @click.argument("warehouse", required=False, default=None)
 @LIMIT_OPTION
 @SINCE_OPTION
 @UNTIL_OPTION
 @click.pass_obj
 @coro
-async def session_history_cmd(
+async def sessions_cmd(
     ctx: CliContext,
     warehouse: str | None,
     limit: int,

--- a/tests/unit/cli/commands/test_queries.py
+++ b/tests/unit/cli/commands/test_queries.py
@@ -69,7 +69,7 @@ def _make_running_query() -> RunningQuery:
 
 
 class TestQueriesList:
-    """queries list — happy path and error path."""
+    """queries running — happy path and error path."""
 
     def test_list_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
@@ -88,7 +88,7 @@ class TestQueriesList:
                 new=AsyncMock(return_value=[_make_running_query()]),
             ),
         ):
-            result = runner.invoke(cli, ["-w", WS_GUID, "queries", "list", WH_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "queries", "running", WH_GUID])
         assert result.exit_code == 0
 
     def test_list_json_output(self, runner: CliRunner, cache_env: Path) -> None:
@@ -108,7 +108,7 @@ class TestQueriesList:
                 new=AsyncMock(return_value=[_make_running_query()]),
             ),
         ):
-            result = runner.invoke(cli, ["--json", "-w", WS_GUID, "queries", "list", WH_GUID])
+            result = runner.invoke(cli, ["--json", "-w", WS_GUID, "queries", "running", WH_GUID])
         assert result.exit_code == 0
         parsed = json.loads(result.output)
         assert isinstance(parsed, list)
@@ -126,7 +126,7 @@ class TestQueriesList:
                 new=AsyncMock(side_effect=NotFoundError("not found")),
             ),
         ):
-            result = runner.invoke(cli, ["-w", WS_GUID, "queries", "list", WH_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "queries", "running", WH_GUID])
         assert result.exit_code != 0
 
 
@@ -228,7 +228,7 @@ class TestQueriesDefaultFallback:
                 new=AsyncMock(return_value=[_make_running_query()]),
             ),
         ):
-            result = runner.invoke(cli, ["queries", "list"])
+            result = runner.invoke(cli, ["queries", "running"])
         assert result.exit_code == 0
 
     def test_list_missing_workspace_raises_usage_error(
@@ -238,12 +238,12 @@ class TestQueriesDefaultFallback:
         monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
         monkeypatch.delenv("FABRIC_DW_DEFAULT_WORKSPACE", raising=False)
         monkeypatch.delenv("FABRIC_DW_DEFAULT_WAREHOUSE", raising=False)
-        result = runner.invoke(cli, ["queries", "list"])
+        result = runner.invoke(cli, ["queries", "running"])
         assert result.exit_code != 0
 
 
 class TestQueriesListConnections:
-    """queries list-connections — happy path + FabricError (lines 89-101)."""
+    """queries connections — happy path + FabricError (lines 89-101)."""
 
     def test_list_connections_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
@@ -262,7 +262,7 @@ class TestQueriesListConnections:
                 new=AsyncMock(return_value=[]),
             ),
         ):
-            result = runner.invoke(cli, ["-w", WS_GUID, "queries", "list-connections", WH_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "queries", "connections", WH_GUID])
         assert result.exit_code == 0
 
     def test_list_connections_fabric_error_exits_nonzero(
@@ -280,12 +280,12 @@ class TestQueriesListConnections:
                 new=AsyncMock(side_effect=FabricError("server error")),
             ),
         ):
-            result = runner.invoke(cli, ["-w", WS_GUID, "queries", "list-connections", WH_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "queries", "connections", WH_GUID])
         assert result.exit_code != 0
 
 
 class TestQueriesRequestHistory:
-    """queries request-history — happy path."""
+    """queries history — happy path."""
 
     def test_request_history_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
@@ -304,12 +304,12 @@ class TestQueriesRequestHistory:
                 new=AsyncMock(return_value=[]),
             ),
         ):
-            result = runner.invoke(cli, ["-w", WS_GUID, "queries", "request-history", WH_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "queries", "history", WH_GUID])
         assert result.exit_code == 0
 
 
 class TestQueriesSessionHistory:
-    """queries session-history — happy path + FabricError (lines 210-211)."""
+    """queries sessions — happy path + FabricError (lines 210-211)."""
 
     def test_session_history_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
@@ -328,7 +328,7 @@ class TestQueriesSessionHistory:
                 new=AsyncMock(return_value=[]),
             ),
         ):
-            result = runner.invoke(cli, ["-w", WS_GUID, "queries", "session-history", WH_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "queries", "sessions", WH_GUID])
         assert result.exit_code == 0
 
     def test_session_history_fabric_error_exits_nonzero(
@@ -346,7 +346,7 @@ class TestQueriesSessionHistory:
                 new=AsyncMock(side_effect=FabricError("server error")),
             ),
         ):
-            result = runner.invoke(cli, ["-w", WS_GUID, "queries", "session-history", WH_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "queries", "sessions", WH_GUID])
         assert result.exit_code != 0
 
 

--- a/tests/unit/cli/commands/test_queries.py
+++ b/tests/unit/cli/commands/test_queries.py
@@ -243,7 +243,7 @@ class TestQueriesDefaultFallback:
 
 
 class TestQueriesListConnections:
-    """queries connections — happy path + FabricError (lines 89-101)."""
+    """queries connections — happy path + FabricError."""
 
     def test_list_connections_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
@@ -309,7 +309,7 @@ class TestQueriesRequestHistory:
 
 
 class TestQueriesSessionHistory:
-    """queries sessions — happy path + FabricError (lines 210-211)."""
+    """queries sessions — happy path + FabricError."""
 
     def test_session_history_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env

--- a/tests/unit/cli/commands/test_query_insights.py
+++ b/tests/unit/cli/commands/test_query_insights.py
@@ -142,7 +142,7 @@ def _make_pool_insight_row() -> SqlPoolInsight:
 
 
 # ---------------------------------------------------------------------------
-# request-history (now under queries group)
+# history (now under queries group)
 # ---------------------------------------------------------------------------
 
 
@@ -164,7 +164,7 @@ class TestRequestHistory:
                 new=AsyncMock(return_value=[_make_request_history_row()]),
             ),
         ):
-            result = runner.invoke(cli, ["-w", WS_GUID, "queries", "request-history", WH_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "queries", "history", WH_GUID])
         assert result.exit_code == 0
 
     def test_json_output(self, runner: CliRunner, cache_env: Path) -> None:
@@ -186,7 +186,7 @@ class TestRequestHistory:
         ):
             result = runner.invoke(
                 cli,
-                ["--json", "-w", WS_GUID, "queries", "request-history", WH_GUID],
+                ["--json", "-w", WS_GUID, "queries", "history", WH_GUID],
             )
         assert result.exit_code == 0
         parsed = json.loads(result.output)
@@ -205,7 +205,7 @@ class TestRequestHistory:
                 new=AsyncMock(side_effect=NotFoundError("not found")),
             ),
         ):
-            result = runner.invoke(cli, ["-w", WS_GUID, "queries", "request-history", WH_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "queries", "history", WH_GUID])
         assert result.exit_code != 0
 
     def test_permission_denied_returns_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
@@ -225,7 +225,7 @@ class TestRequestHistory:
                 new=AsyncMock(side_effect=PermissionDeniedError("no permission")),
             ),
         ):
-            result = runner.invoke(cli, ["-w", WS_GUID, "queries", "request-history", WH_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "queries", "history", WH_GUID])
         assert result.exit_code != 0
 
     def test_invalid_since_returns_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
@@ -236,7 +236,7 @@ class TestRequestHistory:
                 "-w",
                 WS_GUID,
                 "queries",
-                "request-history",
+                "history",
                 WH_GUID,
                 "--since",
                 "not-a-date",
@@ -252,7 +252,7 @@ class TestRequestHistory:
                 "-w",
                 WS_GUID,
                 "queries",
-                "request-history",
+                "history",
                 WH_GUID,
                 "--until",
                 "not-a-date",
@@ -262,7 +262,7 @@ class TestRequestHistory:
 
 
 # ---------------------------------------------------------------------------
-# session-history (now under queries group)
+# sessions (now under queries group)
 # ---------------------------------------------------------------------------
 
 
@@ -284,7 +284,7 @@ class TestSessionHistory:
                 new=AsyncMock(return_value=[_make_session_history_row()]),
             ),
         ):
-            result = runner.invoke(cli, ["-w", WS_GUID, "queries", "session-history", WH_GUID])
+            result = runner.invoke(cli, ["-w", WS_GUID, "queries", "sessions", WH_GUID])
         assert result.exit_code == 0
 
     def test_json_output(self, runner: CliRunner, cache_env: Path) -> None:
@@ -306,7 +306,7 @@ class TestSessionHistory:
         ):
             result = runner.invoke(
                 cli,
-                ["--json", "-w", WS_GUID, "queries", "session-history", WH_GUID],
+                ["--json", "-w", WS_GUID, "queries", "sessions", WH_GUID],
             )
         assert result.exit_code == 0
         parsed = json.loads(result.output)
@@ -499,7 +499,7 @@ class TestQueryInsightsDefaultFallback:
                 new=AsyncMock(return_value=[_make_request_history_row()]),
             ),
         ):
-            result = runner.invoke(cli, ["queries", "request-history"])
+            result = runner.invoke(cli, ["queries", "history"])
         assert result.exit_code == 0
 
     def test_missing_workspace_raises_usage_error(
@@ -509,5 +509,5 @@ class TestQueryInsightsDefaultFallback:
         monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
         monkeypatch.delenv("FABRIC_DW_DEFAULT_WORKSPACE", raising=False)
         monkeypatch.delenv("FABRIC_DW_DEFAULT_WAREHOUSE", raising=False)
-        result = runner.invoke(cli, ["queries", "request-history"])
+        result = runner.invoke(cli, ["queries", "history"])
         assert result.exit_code != 0


### PR DESCRIPTION
## Summary

- Rename `queries list` → `queries running`
- Rename `queries list-connections` → `queries connections`
- Rename `queries request-history` → `queries history`
- Rename `queries session-history` → `queries sessions`

Service-layer functions (`list_running`, `list_connections`, `list_request_history`, `list_session_history`) and MCP tool names are unchanged. Only the user-facing CLI command strings are renamed.

## Files changed

- `src/fabric_dw/cli/commands/queries.py` — four command strings renamed; local handler function names tidied to match; section comments updated
- `tests/unit/cli/commands/test_queries.py` — all CLI runner invocations updated
- `tests/unit/cli/commands/test_query_insights.py` — all CLI runner invocations updated
- `docs/cli.md` — headings, synopsis lines, examples, and the cross-reference from `connections` to `queries running` updated

## Test plan

- [x] Full unit suite passes: 3490 tests, 0 failures
- [x] `ruff check .` passes
- [x] `ruff format --check .` passes
- [x] `ty check src tests` passes
- [x] Sanity grep confirms no old CLI tokens remain in `docs/cli.md`, `src/`, or `tests/`
- [x] MCP tool names, service functions, `docs/mcp-tools.md`, and `docs/integration-coverage.md` are untouched

Closes #494

🤖 Generated with [Claude Code](https://claude.com/claude-code)