### PR TITLE
docs: use the fdw alias in CLI examples

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -10,12 +10,12 @@ If you are already signed in via [Azure CLI](https://learn.microsoft.com/cli/azu
 
 ```bash
 az login          # or: az login --tenant <tenant-id>
-fabric-dw -w "Sales Workspace" warehouses list
+fdw -w "Sales Workspace" warehouses list
 ```
 
 ```powershell
 Connect-AzAccount
-fabric-dw -w "Sales Workspace" warehouses list
+fdw -w "Sales Workspace" warehouses list
 ```
 
 If neither of those works for you, read on for the alternatives.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -7,14 +7,15 @@ title: CLI reference
 `fabric-dw` is a command-line interface for administering Microsoft Fabric Data Warehouses and SQL Analytics Endpoints. The general invocation pattern is:
 
 ```
-fabric-dw [-w WORKSPACE] [GLOBAL OPTIONS] <noun> <verb> [ARGS] [OPTIONS]
+fdw [-w WORKSPACE] [GLOBAL OPTIONS] <noun> <verb> [ARGS] [OPTIONS]
 ```
 
-The short alias `fdw` is identical to `fabric-dw` in every respect.
+!!! tip "`fdw` and `fabric-dw` are the same command"
+    The CLI is installed as two interchangeable entry points: every example below can be run as either `fdw …` or `fabric-dw …`. The examples use the shorter `fdw`.
 
-**Name-or-GUID arguments** — wherever a synopsis shows `WAREHOUSE`, `ENDPOINT`, `SNAPSHOT`, or `WORKSPACE` (positional in the `workspaces` group only), the value can be either the display name or the item's GUID. The CLI resolves names to GUIDs automatically and caches the mapping locally (see [`fabric-dw cache`](#fabric-dw-cache)).
+**Name-or-GUID arguments** — wherever a synopsis shows `WAREHOUSE`, `ENDPOINT`, `SNAPSHOT`, or `WORKSPACE` (positional in the `workspaces` group only), the value can be either the display name or the item's GUID. The CLI resolves names to GUIDs automatically and caches the mapping locally (see [`fdw cache`](#fabric-dw-cache)).
 
-**Positional arguments with defaults** — positional arguments shown in `[brackets]` may be omitted when a default has been set with [`fabric-dw config set`](#defaults-fabric-dw-config). See [Defaults — fabric-dw config](#defaults-fabric-dw-config) for details.
+**Positional arguments with defaults** — positional arguments shown in `[brackets]` may be omitted when a default has been set with [`fdw config set`](#defaults-fabric-dw-config). See [Defaults — fabric-dw config](#defaults-fabric-dw-config) for details.
 
 ---
 
@@ -54,9 +55,9 @@ The `--auth` flag and the `FABRIC_AUTH` environment variable accept the same thr
 
 Every command that operates on a workspace (everything except `workspaces list` and `cache clear`) resolves the target workspace from the following sources, in priority order:
 
-1. **`-w` / `--workspace` flag** — explicit value passed on the root command, e.g. `fabric-dw -w MyWorkspace warehouses list`.
+1. **`-w` / `--workspace` flag** — explicit value passed on the root command, e.g. `fdw -w MyWorkspace warehouses list`.
 2. **`FABRIC_DW_DEFAULT_WORKSPACE` environment variable** — if the flag is absent, the CLI reads this variable.
-3. **Configured default** — set with `fabric-dw config set workspace VALUE`; used when neither the flag nor the environment variable is present.
+3. **Configured default** — set with `fdw config set workspace VALUE`; used when neither the flag nor the environment variable is present.
 4. **Error** — if none of the above is set, the CLI prints a helpful message suggesting you set one of the above.
 
 The `workspaces` command group is an exception: `workspaces get` and `workspaces set-collation` take the workspace as an explicit positional argument (not via `-w`), and `workspaces list` takes no workspace at all.
@@ -72,8 +73,8 @@ The `workspaces` command group is an exception: `workspaces get` and `workspaces
 `fabric-dw` can store a default workspace and/or warehouse so you do not have to repeat them on every invocation.
 
 ```shell
-fabric-dw config set workspace MyWorkspace
-fabric-dw config set warehouse MyWarehouse
+fdw config set workspace MyWorkspace
+fdw config set warehouse MyWarehouse
 ```
 
 Once set, the stored workspace is used whenever `-w` / `--workspace` is not passed and `FABRIC_DW_DEFAULT_WORKSPACE` is not set. The stored warehouse value fills in optional `[WAREHOUSE]` / `[ITEM]` positionals shown in `[brackets]` in the synopsis below. All stored values are resolved in the same way as explicit arguments (name or GUID).
@@ -82,7 +83,7 @@ Resolution order for the workspace (see also [Selecting a workspace](#selecting-
 
 1. `-w` / `--workspace` flag on the root command.
 2. `FABRIC_DW_DEFAULT_WORKSPACE` environment variable.
-3. Value stored by `fabric-dw config set workspace`.
+3. Value stored by `fdw config set workspace`.
 
 The warehouse follows the same order using the optional `[WAREHOUSE]` / `[ITEM]` positional or `FABRIC_DW_DEFAULT_WAREHOUSE`.
 
@@ -92,16 +93,16 @@ Manage your defaults with:
 
 | Command | Effect |
 | --- | --- |
-| `fabric-dw config show` | Print the current defaults. |
-| `fabric-dw config set workspace VALUE` | Set the default workspace (name or GUID). |
-| `fabric-dw config set warehouse VALUE` | Set the default warehouse (name or GUID). |
-| `fabric-dw config unset workspace` | Clear the default workspace. |
-| `fabric-dw config unset warehouse` | Clear the default warehouse. |
-| `fabric-dw config clear` | Wipe **all** configuration defaults. |
+| `fdw config show` | Print the current defaults. |
+| `fdw config set workspace VALUE` | Set the default workspace (name or GUID). |
+| `fdw config set warehouse VALUE` | Set the default warehouse (name or GUID). |
+| `fdw config unset workspace` | Clear the default workspace. |
+| `fdw config unset warehouse` | Clear the default warehouse. |
+| `fdw config clear` | Wipe **all** configuration defaults. |
 
 ```shell
 # Example — show current config
-fabric-dw config show
+fdw config show
 ```
 
 ```
@@ -124,13 +125,13 @@ List all workspaces the authenticated principal has access to.
 **Synopsis**
 
 ```
-fabric-dw workspaces list
+fdw workspaces list
 ```
 
 **Example**
 
 ```shell
-fabric-dw workspaces list
+fdw workspaces list
 ```
 
 ```
@@ -154,13 +155,13 @@ Get details for a workspace, including its default Data Warehouse collation.
 **Synopsis**
 
 ```
-fabric-dw workspaces get [WORKSPACE]
+fdw workspaces get [WORKSPACE]
 ```
 
 **Example**
 
 ```shell
-fabric-dw workspaces get MyWorkspace
+fdw workspaces get MyWorkspace
 ```
 
 ```
@@ -185,13 +186,13 @@ Set the default Data Warehouse collation for a workspace. `COLLATION` must be on
 **Synopsis**
 
 ```
-fabric-dw workspaces set-collation [WORKSPACE] COLLATION
+fdw workspaces set-collation [WORKSPACE] COLLATION
 ```
 
 **Example**
 
 ```shell
-fabric-dw workspaces set-collation MyWorkspace Latin1_General_100_CI_AS_KS_WS_SC_UTF8
+fdw workspaces set-collation MyWorkspace Latin1_General_100_CI_AS_KS_WS_SC_UTF8
 ```
 
 ---
@@ -209,7 +210,7 @@ List all Data Warehouses and SQL Analytics Endpoints in a workspace. Pass `-A` /
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] warehouses list [-A] [--warehouses-only]
+fdw [-w WORKSPACE] warehouses list [-A] [--warehouses-only]
 ```
 
 | Option | Description |
@@ -221,13 +222,13 @@ fabric-dw [-w WORKSPACE] warehouses list [-A] [--warehouses-only]
 
 ```shell
 # List warehouses in the default (or configured) workspace
-fabric-dw warehouses list
+fdw warehouses list
 
 # List warehouses in a specific workspace
-fabric-dw -w MyWorkspace warehouses list
+fdw -w MyWorkspace warehouses list
 
 # Aggregate across all visible workspaces
-fabric-dw warehouses list --all-workspaces
+fdw warehouses list --all-workspaces
 ```
 
 ```
@@ -248,13 +249,13 @@ Get details for a specific Data Warehouse. Uses the warehouse-scoped REST path (
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] warehouses get [WAREHOUSE]
+fdw [-w WORKSPACE] warehouses get [WAREHOUSE]
 ```
 
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace warehouses get SalesWH
+fdw -w MyWorkspace warehouses get SalesWH
 ```
 
 ```
@@ -274,7 +275,7 @@ Create a new warehouse in a workspace.
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] warehouses create [OPTIONS] NAME
+fdw [-w WORKSPACE] warehouses create [OPTIONS] NAME
 ```
 
 | Option | Description |
@@ -285,7 +286,7 @@ fabric-dw [-w WORKSPACE] warehouses create [OPTIONS] NAME
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace warehouses create NewWH --description "Staging warehouse"
+fdw -w MyWorkspace warehouses create NewWH --description "Staging warehouse"
 ```
 
 ---
@@ -299,7 +300,7 @@ Rename a warehouse and optionally update its description.
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] warehouses rename [OPTIONS] [WAREHOUSE] NEW_NAME
+fdw [-w WORKSPACE] warehouses rename [OPTIONS] [WAREHOUSE] NEW_NAME
 ```
 
 | Option | Description |
@@ -309,7 +310,7 @@ fabric-dw [-w WORKSPACE] warehouses rename [OPTIONS] [WAREHOUSE] NEW_NAME
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace warehouses rename SalesWH SalesWH_v2 --description "Renamed"
+fdw -w MyWorkspace warehouses rename SalesWH SalesWH_v2 --description "Renamed"
 ```
 
 ---
@@ -323,13 +324,13 @@ Delete a warehouse. You will be asked to confirm unless `--yes` is passed.
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] warehouses delete [WAREHOUSE]
+fdw [-w WORKSPACE] warehouses delete [WAREHOUSE]
 ```
 
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace --yes warehouses delete OldWH
+fdw -w MyWorkspace --yes warehouses delete OldWH
 ```
 
 ---
@@ -343,13 +344,13 @@ Take ownership of a warehouse. Not supported for SQL Analytics Endpoints.
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] warehouses takeover [WAREHOUSE]
+fdw [-w WORKSPACE] warehouses takeover [WAREHOUSE]
 ```
 
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace warehouses takeover SalesWH
+fdw -w MyWorkspace warehouses takeover SalesWH
 ```
 
 ---
@@ -363,7 +364,7 @@ List all principals (users, groups, service principals) with access to a warehou
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] [--json] warehouses permissions [WAREHOUSE]
+fdw [-w WORKSPACE] [--json] warehouses permissions [WAREHOUSE]
 ```
 
 | Option | Description |
@@ -374,10 +375,10 @@ fabric-dw [-w WORKSPACE] [--json] warehouses permissions [WAREHOUSE]
 
 ```shell
 # Tabular output
-fabric-dw -w MyWorkspace warehouses permissions SalesWH
+fdw -w MyWorkspace warehouses permissions SalesWH
 
 # Raw JSON
-fabric-dw -w MyWorkspace --json warehouses permissions SalesWH
+fdw -w MyWorkspace --json warehouses permissions SalesWH
 ```
 
 ```
@@ -402,7 +403,7 @@ List all SQL Analytics Endpoints in a workspace. Supports `-A` / `--all-workspac
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] sql-endpoints list [-A]
+fdw [-w WORKSPACE] sql-endpoints list [-A]
 ```
 
 | Option | Description |
@@ -413,13 +414,13 @@ fabric-dw [-w WORKSPACE] sql-endpoints list [-A]
 
 ```shell
 # List endpoints in the default (or configured) workspace
-fabric-dw sql-endpoints list
+fdw sql-endpoints list
 
 # List endpoints in a specific workspace
-fabric-dw -w MyWorkspace sql-endpoints list
+fdw -w MyWorkspace sql-endpoints list
 
 # Aggregate across all visible workspaces
-fabric-dw sql-endpoints list --all-workspaces
+fdw sql-endpoints list --all-workspaces
 ```
 
 ```
@@ -439,13 +440,13 @@ Get details for a specific SQL Analytics Endpoint.
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] sql-endpoints get ENDPOINT
+fdw [-w WORKSPACE] sql-endpoints get ENDPOINT
 ```
 
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace sql-endpoints get MyLakehouseEP
+fdw -w MyWorkspace sql-endpoints get MyLakehouseEP
 ```
 
 ---
@@ -461,7 +462,7 @@ Results are shown as a Rich table (Table, Status, End Time, Error). Pass `--json
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] sql-endpoints refresh [--recreate-tables] ENDPOINT
+fdw [-w WORKSPACE] sql-endpoints refresh [--recreate-tables] ENDPOINT
 ```
 
 **Options**
@@ -474,13 +475,13 @@ fabric-dw [-w WORKSPACE] sql-endpoints refresh [--recreate-tables] ENDPOINT
 
 ```shell
 # Standard refresh — shows a per-table Rich table
-fabric-dw -w MyWorkspace sql-endpoints refresh MyLakehouseEP
+fdw -w MyWorkspace sql-endpoints refresh MyLakehouseEP
 
 # Force a full table recreate
-fabric-dw -w MyWorkspace sql-endpoints refresh --recreate-tables MyLakehouseEP
+fdw -w MyWorkspace sql-endpoints refresh --recreate-tables MyLakehouseEP
 
 # Emit raw JSON
-fabric-dw -w MyWorkspace --json sql-endpoints refresh MyLakehouseEP
+fdw -w MyWorkspace --json sql-endpoints refresh MyLakehouseEP
 ```
 
 ---
@@ -494,7 +495,7 @@ List all principals (users, groups, service principals) with access to a SQL Ana
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] [--json] sql-endpoints permissions ENDPOINT
+fdw [-w WORKSPACE] [--json] sql-endpoints permissions ENDPOINT
 ```
 
 | Option | Description |
@@ -505,10 +506,10 @@ fabric-dw [-w WORKSPACE] [--json] sql-endpoints permissions ENDPOINT
 
 ```shell
 # Tabular output
-fabric-dw -w MyWorkspace sql-endpoints permissions MyLakehouseEP
+fdw -w MyWorkspace sql-endpoints permissions MyLakehouseEP
 
 # Raw JSON
-fabric-dw -w MyWorkspace --json sql-endpoints permissions MyLakehouseEP
+fdw -w MyWorkspace --json sql-endpoints permissions MyLakehouseEP
 ```
 
 ```
@@ -535,7 +536,7 @@ Execute a SQL statement or file against a warehouse or SQL Analytics Endpoint. P
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] sql [OPTIONS] [ITEM]
+fdw [-w WORKSPACE] sql [OPTIONS] [ITEM]
 ```
 
 | Option | Description |
@@ -549,10 +550,10 @@ Output defaults to a Rich table (rows/columns). Pass `--json` on the root comman
 
 ```shell
 # Inline query, Rich table output (default)
-fabric-dw -w MyWorkspace sql SalesWH -q "SELECT TOP 5 * FROM dbo.Sales"
+fdw -w MyWorkspace sql SalesWH -q "SELECT TOP 5 * FROM dbo.Sales"
 
 # File input, JSON output
-fabric-dw -w MyWorkspace --json sql SalesWH -f ./queries/report.sql
+fdw -w MyWorkspace --json sql SalesWH -f ./queries/report.sql
 ```
 
 ```json
@@ -574,13 +575,13 @@ Get the current audit settings for a warehouse.
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] audit get [WAREHOUSE]
+fdw [-w WORKSPACE] audit get [WAREHOUSE]
 ```
 
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace audit get SalesWH
+fdw -w MyWorkspace audit get SalesWH
 ```
 
 ```
@@ -600,7 +601,7 @@ Enable SQL auditing on a warehouse.
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] audit enable [OPTIONS] [WAREHOUSE]
+fdw [-w WORKSPACE] audit enable [OPTIONS] [WAREHOUSE]
 ```
 
 | Option | Description | Default |
@@ -614,10 +615,10 @@ Omitting both `--retention-days` and `--unlimited` defaults to unlimited retenti
 
 ```shell
 # Retain logs for 90 days
-fabric-dw -w MyWorkspace audit enable --retention-days 90 SalesWH
+fdw -w MyWorkspace audit enable --retention-days 90 SalesWH
 
 # Unlimited retention
-fabric-dw -w MyWorkspace audit enable --unlimited SalesWH
+fdw -w MyWorkspace audit enable --unlimited SalesWH
 ```
 
 ---
@@ -631,13 +632,13 @@ Disable SQL auditing on a warehouse.
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] audit disable [WAREHOUSE]
+fdw [-w WORKSPACE] audit disable [WAREHOUSE]
 ```
 
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace audit disable SalesWH
+fdw -w MyWorkspace audit disable SalesWH
 ```
 
 ---
@@ -651,7 +652,7 @@ Update the audit log retention period without changing the audit enabled/disable
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] audit set-retention --days INTEGER [WAREHOUSE]
+fdw [-w WORKSPACE] audit set-retention --days INTEGER [WAREHOUSE]
 ```
 
 | Option | Description |
@@ -661,7 +662,7 @@ fabric-dw [-w WORKSPACE] audit set-retention --days INTEGER [WAREHOUSE]
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace audit set-retention --days 90 SalesWH
+fdw -w MyWorkspace audit set-retention --days 90 SalesWH
 ```
 
 ---
@@ -675,7 +676,7 @@ Set the audit action groups for a warehouse. Pass `--group` / `-g` once per acti
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] audit set-groups -g GROUP [-g GROUP ...] [WAREHOUSE]
+fdw [-w WORKSPACE] audit set-groups -g GROUP [-g GROUP ...] [WAREHOUSE]
 ```
 
 | Option | Description |
@@ -685,7 +686,7 @@ fabric-dw [-w WORKSPACE] audit set-groups -g GROUP [-g GROUP ...] [WAREHOUSE]
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace audit set-groups \
+fdw -w MyWorkspace audit set-groups \
   -g BATCH_COMPLETED_GROUP \
   -g SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP \
   SalesWH
@@ -702,13 +703,13 @@ Add a single audit action group without overwriting the others. Idempotent — i
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] audit add-group [WAREHOUSE] GROUP
+fdw [-w WORKSPACE] audit add-group [WAREHOUSE] GROUP
 ```
 
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace audit add-group SalesWH BATCH_COMPLETED_GROUP
+fdw -w MyWorkspace audit add-group SalesWH BATCH_COMPLETED_GROUP
 ```
 
 ---
@@ -722,13 +723,13 @@ Remove a single audit action group without overwriting the others. Idempotent �
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] audit remove-group [WAREHOUSE] GROUP
+fdw [-w WORKSPACE] audit remove-group [WAREHOUSE] GROUP
 ```
 
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace audit remove-group SalesWH BATCH_COMPLETED_GROUP
+fdw -w MyWorkspace audit remove-group SalesWH BATCH_COMPLETED_GROUP
 ```
 
 ---
@@ -746,13 +747,13 @@ List all currently running queries on a warehouse or SQL Analytics Endpoint.
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] queries running [WAREHOUSE]
+fdw [-w WORKSPACE] queries running [WAREHOUSE]
 ```
 
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace queries running SalesWH
+fdw -w MyWorkspace queries running SalesWH
 ```
 
 ```
@@ -772,13 +773,13 @@ List all active SQL connections on a warehouse or SQL Analytics Endpoint. This q
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] queries connections [WAREHOUSE]
+fdw [-w WORKSPACE] queries connections [WAREHOUSE]
 ```
 
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace queries connections SalesWH
+fdw -w MyWorkspace queries connections SalesWH
 ```
 
 ```
@@ -799,13 +800,13 @@ Kill a specific session on a warehouse or SQL Analytics Endpoint. You will be as
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] queries kill [WAREHOUSE] SESSION_ID
+fdw [-w WORKSPACE] queries kill [WAREHOUSE] SESSION_ID
 ```
 
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace --yes queries kill SalesWH 42
+fdw -w MyWorkspace --yes queries kill SalesWH 42
 ```
 
 ---
@@ -819,7 +820,7 @@ List completed SQL requests from `queryinsights.exec_requests_history`. Supports
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] queries history [OPTIONS] [WAREHOUSE]
+fdw [-w WORKSPACE] queries history [OPTIONS] [WAREHOUSE]
 ```
 
 | Option | Description | Default |
@@ -831,7 +832,7 @@ fabric-dw [-w WORKSPACE] queries history [OPTIONS] [WAREHOUSE]
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace queries history SalesWH --limit 50 --since 2026-06-01T00:00:00
+fdw -w MyWorkspace queries history SalesWH --limit 50 --since 2026-06-01T00:00:00
 ```
 
 ---
@@ -845,7 +846,7 @@ List completed sessions from `queryinsights.exec_sessions_history`.
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] queries sessions [OPTIONS] [WAREHOUSE]
+fdw [-w WORKSPACE] queries sessions [OPTIONS] [WAREHOUSE]
 ```
 
 | Option | Description | Default |
@@ -857,7 +858,7 @@ fabric-dw [-w WORKSPACE] queries sessions [OPTIONS] [WAREHOUSE]
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace queries sessions SalesWH
+fdw -w MyWorkspace queries sessions SalesWH
 ```
 
 ---
@@ -871,7 +872,7 @@ List frequently-run queries from `queryinsights.frequently_run_queries`.
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] queries frequent [OPTIONS] [WAREHOUSE]
+fdw [-w WORKSPACE] queries frequent [OPTIONS] [WAREHOUSE]
 ```
 
 | Option | Description | Default |
@@ -883,7 +884,7 @@ fabric-dw [-w WORKSPACE] queries frequent [OPTIONS] [WAREHOUSE]
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace queries frequent SalesWH --limit 20
+fdw -w MyWorkspace queries frequent SalesWH --limit 20
 ```
 
 ---
@@ -897,7 +898,7 @@ List long-running queries from `queryinsights.long_running_queries`.
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] queries long-running [OPTIONS] [WAREHOUSE]
+fdw [-w WORKSPACE] queries long-running [OPTIONS] [WAREHOUSE]
 ```
 
 | Option | Description | Default |
@@ -909,7 +910,7 @@ fabric-dw [-w WORKSPACE] queries long-running [OPTIONS] [WAREHOUSE]
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace queries long-running SalesWH
+fdw -w MyWorkspace queries long-running SalesWH
 ```
 
 ---
@@ -929,13 +930,13 @@ List all restore points for a warehouse.
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] restore-points list [WAREHOUSE]
+fdw [-w WORKSPACE] restore-points list [WAREHOUSE]
 ```
 
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace restore-points list SalesWH
+fdw -w MyWorkspace restore-points list SalesWH
 ```
 
 ```
@@ -955,13 +956,13 @@ Get details for a single restore point by ID.
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] restore-points get WAREHOUSE RESTORE_POINT_ID
+fdw [-w WORKSPACE] restore-points get WAREHOUSE RESTORE_POINT_ID
 ```
 
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace restore-points get SalesWH 1726617378000
+fdw -w MyWorkspace restore-points get SalesWH 1726617378000
 ```
 
 ---
@@ -975,7 +976,7 @@ Create a new restore point for a warehouse at the current timestamp.
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] restore-points create [OPTIONS] [WAREHOUSE]
+fdw [-w WORKSPACE] restore-points create [OPTIONS] [WAREHOUSE]
 ```
 
 | Option | Description |
@@ -986,7 +987,7 @@ fabric-dw [-w WORKSPACE] restore-points create [OPTIONS] [WAREHOUSE]
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace restore-points create SalesWH \
+fdw -w MyWorkspace restore-points create SalesWH \
   --name "Before migration" \
   --description "Pre-migration checkpoint"
 ```
@@ -1002,7 +1003,7 @@ Rename a restore point and optionally update its description.
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] restore-points rename [OPTIONS] WAREHOUSE RESTORE_POINT_ID NEW_NAME
+fdw [-w WORKSPACE] restore-points rename [OPTIONS] WAREHOUSE RESTORE_POINT_ID NEW_NAME
 ```
 
 | Option | Description |
@@ -1012,7 +1013,7 @@ fabric-dw [-w WORKSPACE] restore-points rename [OPTIONS] WAREHOUSE RESTORE_POINT
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace restore-points rename SalesWH 1726617378000 "Post-migration backup"
+fdw -w MyWorkspace restore-points rename SalesWH 1726617378000 "Post-migration backup"
 ```
 
 ---
@@ -1026,13 +1027,13 @@ Delete a user-defined restore point. System-created restore points cannot be del
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] restore-points delete WAREHOUSE RESTORE_POINT_ID
+fdw [-w WORKSPACE] restore-points delete WAREHOUSE RESTORE_POINT_ID
 ```
 
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace --yes restore-points delete SalesWH 1726617378000
+fdw -w MyWorkspace --yes restore-points delete SalesWH 1726617378000
 ```
 
 ---
@@ -1046,13 +1047,13 @@ Restore a warehouse in-place to a restore point. **This is a destructive operati
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] restore-points restore WAREHOUSE RESTORE_POINT_ID
+fdw [-w WORKSPACE] restore-points restore WAREHOUSE RESTORE_POINT_ID
 ```
 
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace --yes restore-points restore SalesWH 1726617378000
+fdw -w MyWorkspace --yes restore-points restore SalesWH 1726617378000
 ```
 
 ---
@@ -1070,7 +1071,7 @@ List all views on a warehouse or SQL Analytics Endpoint. Pass `--schema` to filt
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] views list [OPTIONS] [WAREHOUSE]
+fdw [-w WORKSPACE] views list [OPTIONS] [WAREHOUSE]
 ```
 
 | Option | Description |
@@ -1080,7 +1081,7 @@ fabric-dw [-w WORKSPACE] views list [OPTIONS] [WAREHOUSE]
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace views list SalesWH --schema dbo
+fdw -w MyWorkspace views list SalesWH --schema dbo
 ```
 
 ```
@@ -1101,7 +1102,7 @@ Get the full definition of a single view.
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] views get [WAREHOUSE] QUALIFIED_NAME
+fdw [-w WORKSPACE] views get [WAREHOUSE] QUALIFIED_NAME
 ```
 
 `QUALIFIED_NAME` must be a dot-separated `schema.view_name` string, e.g. `dbo.vw_sales`.
@@ -1109,7 +1110,7 @@ fabric-dw [-w WORKSPACE] views get [WAREHOUSE] QUALIFIED_NAME
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace views get SalesWH dbo.vw_sales
+fdw -w MyWorkspace views get SalesWH dbo.vw_sales
 ```
 
 ```
@@ -1132,7 +1133,7 @@ Create a new SQL view.
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] views create [OPTIONS] [WAREHOUSE]
+fdw [-w WORKSPACE] views create [OPTIONS] [WAREHOUSE]
 ```
 
 | Option | Description |
@@ -1146,7 +1147,7 @@ Exactly one of `--select` or `--from-file` must be provided.
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace views create SalesWH \
+fdw -w MyWorkspace views create SalesWH \
   --name dbo.vw_recent \
   --select "SELECT id, amount FROM dbo.sales WHERE sale_date >= '2026-01-01'"
 ```
@@ -1162,7 +1163,7 @@ Redefine an existing view using `CREATE OR ALTER VIEW`.
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] views update [OPTIONS] [WAREHOUSE] QUALIFIED_NAME
+fdw [-w WORKSPACE] views update [OPTIONS] [WAREHOUSE] QUALIFIED_NAME
 ```
 
 `QUALIFIED_NAME` is the dot-separated `schema.view_name` to update.
@@ -1177,7 +1178,7 @@ Exactly one of `--select` or `--from-file` must be provided.
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace views update SalesWH dbo.vw_recent \
+fdw -w MyWorkspace views update SalesWH dbo.vw_recent \
   --select "SELECT id, amount, region FROM dbo.sales WHERE sale_date >= '2026-01-01'"
 ```
 
@@ -1192,13 +1193,13 @@ Drop a SQL view. You will be asked to confirm unless `--yes` is passed.
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] views drop [WAREHOUSE] QUALIFIED_NAME
+fdw [-w WORKSPACE] views drop [WAREHOUSE] QUALIFIED_NAME
 ```
 
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace --yes views drop SalesWH dbo.vw_recent
+fdw -w MyWorkspace --yes views drop SalesWH dbo.vw_recent
 ```
 
 ---
@@ -1212,7 +1213,7 @@ Rename a SQL view via `sp_rename`. The new name must be an unqualified (bare) id
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] views rename [OPTIONS] [WAREHOUSE] QUALIFIED_NAME
+fdw [-w WORKSPACE] views rename [OPTIONS] [WAREHOUSE] QUALIFIED_NAME
 ```
 
 `QUALIFIED_NAME` is the current dot-separated `schema.view_name`.
@@ -1224,7 +1225,7 @@ fabric-dw [-w WORKSPACE] views rename [OPTIONS] [WAREHOUSE] QUALIFIED_NAME
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace views rename SalesWH dbo.vw_recent --new-name vw_revenue
+fdw -w MyWorkspace views rename SalesWH dbo.vw_recent --new-name vw_revenue
 ```
 
 ---
@@ -1264,7 +1265,7 @@ CSV and Parquet formats require `--output`. JSON is emitted to stdout by default
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] views read [OPTIONS] [WAREHOUSE] QUALIFIED_NAME
+fdw [-w WORKSPACE] views read [OPTIONS] [WAREHOUSE] QUALIFIED_NAME
 ```
 
 | Option | Description | Default |
@@ -1276,7 +1277,7 @@ fabric-dw [-w WORKSPACE] views read [OPTIONS] [WAREHOUSE] QUALIFIED_NAME
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace views read SalesWH dbo.vw_sales --count 5
+fdw -w MyWorkspace views read SalesWH dbo.vw_sales --count 5
 ```
 
 ```json
@@ -1301,7 +1302,7 @@ List stored procedures on a warehouse or SQL Analytics Endpoint. Pass `--schema`
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] procedures list [OPTIONS] [ITEM]
+fdw [-w WORKSPACE] procedures list [OPTIONS] [ITEM]
 ```
 
 | Option | Description |
@@ -1311,7 +1312,7 @@ fabric-dw [-w WORKSPACE] procedures list [OPTIONS] [ITEM]
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace procedures list SalesWH --schema dbo
+fdw -w MyWorkspace procedures list SalesWH --schema dbo
 ```
 
 ```
@@ -1331,7 +1332,7 @@ Get the full definition of a single stored procedure.
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] procedures get [ITEM] QUALIFIED_NAME
+fdw [-w WORKSPACE] procedures get [ITEM] QUALIFIED_NAME
 ```
 
 `QUALIFIED_NAME` must be a dot-separated `schema.proc_name` string, e.g. `dbo.usp_load_sales`.
@@ -1339,7 +1340,7 @@ fabric-dw [-w WORKSPACE] procedures get [ITEM] QUALIFIED_NAME
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace procedures get SalesWH dbo.usp_load_sales
+fdw -w MyWorkspace procedures get SalesWH dbo.usp_load_sales
 ```
 
 ---
@@ -1353,7 +1354,7 @@ Create a new stored procedure.
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] procedures create [OPTIONS] [ITEM]
+fdw [-w WORKSPACE] procedures create [OPTIONS] [ITEM]
 ```
 
 | Option | Description |
@@ -1367,7 +1368,7 @@ Exactly one of `--body` or `--from-file` must be provided.
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace procedures create SalesWH \
+fdw -w MyWorkspace procedures create SalesWH \
   --name dbo.usp_archive_orders \
   --body "BEGIN INSERT INTO dbo.archive SELECT * FROM dbo.orders; END"
 ```
@@ -1383,7 +1384,7 @@ Redefine an existing stored procedure via `CREATE OR ALTER PROCEDURE`.
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] procedures update [OPTIONS] [ITEM] QUALIFIED_NAME
+fdw [-w WORKSPACE] procedures update [OPTIONS] [ITEM] QUALIFIED_NAME
 ```
 
 `QUALIFIED_NAME` is the dot-separated `schema.proc_name` to update.
@@ -1398,7 +1399,7 @@ Exactly one of `--body` or `--from-file` must be provided. You will be asked to 
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace procedures update SalesWH dbo.usp_archive_orders \
+fdw -w MyWorkspace procedures update SalesWH dbo.usp_archive_orders \
   --from-file ./procs/usp_archive_orders_v2.sql
 ```
 
@@ -1413,13 +1414,13 @@ Drop a stored procedure. You will be asked to confirm unless `--yes` is passed.
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] procedures drop [ITEM] QUALIFIED_NAME
+fdw [-w WORKSPACE] procedures drop [ITEM] QUALIFIED_NAME
 ```
 
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace --yes procedures drop SalesWH dbo.usp_archive_orders
+fdw -w MyWorkspace --yes procedures drop SalesWH dbo.usp_archive_orders
 ```
 
 ---
@@ -1441,7 +1442,7 @@ List T-SQL user-defined functions on a warehouse or SQL Analytics Endpoint. Pass
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] functions list [OPTIONS] [ITEM]
+fdw [-w WORKSPACE] functions list [OPTIONS] [ITEM]
 ```
 
 | Option | Description |
@@ -1452,7 +1453,7 @@ fabric-dw [-w WORKSPACE] functions list [OPTIONS] [ITEM]
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace functions list SalesWH --schema dbo --kind scalar
+fdw -w MyWorkspace functions list SalesWH --schema dbo --kind scalar
 ```
 
 ```
@@ -1472,7 +1473,7 @@ Get the full definition of a single T-SQL user-defined function, including its p
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] functions get [ITEM] QUALIFIED_NAME
+fdw [-w WORKSPACE] functions get [ITEM] QUALIFIED_NAME
 ```
 
 `QUALIFIED_NAME` must be a dot-separated `schema.fn_name` string, e.g. `dbo.fn_clean_input`.
@@ -1480,7 +1481,7 @@ fabric-dw [-w WORKSPACE] functions get [ITEM] QUALIFIED_NAME
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace functions get SalesWH dbo.fn_clean_input
+fdw -w MyWorkspace functions get SalesWH dbo.fn_clean_input
 ```
 
 ---
@@ -1494,7 +1495,7 @@ Create a new T-SQL user-defined function. Scalar UDFs and inline TVFs are previe
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] functions create [OPTIONS] [ITEM]
+fdw [-w WORKSPACE] functions create [OPTIONS] [ITEM]
 ```
 
 | Option | Description |
@@ -1508,7 +1509,7 @@ Exactly one of `--body` or `--from-file` must be provided.
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace functions create SalesWH \
+fdw -w MyWorkspace functions create SalesWH \
   --name dbo.fn_clean_input \
   --body "(@input NVARCHAR(100)) RETURNS NVARCHAR(100) AS BEGIN RETURN LTRIM(RTRIM(@input)) END"
 ```
@@ -1528,7 +1529,7 @@ Redefine an existing T-SQL user-defined function via `CREATE OR ALTER FUNCTION`.
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] functions update [OPTIONS] [ITEM] QUALIFIED_NAME
+fdw [-w WORKSPACE] functions update [OPTIONS] [ITEM] QUALIFIED_NAME
 ```
 
 `QUALIFIED_NAME` is the dot-separated `schema.fn_name` to update.
@@ -1543,7 +1544,7 @@ Exactly one of `--body` or `--from-file` must be provided. You will be asked to 
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace functions update SalesWH dbo.fn_clean_input \
+fdw -w MyWorkspace functions update SalesWH dbo.fn_clean_input \
   --from-file ./fns/fn_clean_input_v2.sql
 ```
 
@@ -1558,7 +1559,7 @@ Drop a T-SQL user-defined function. You will be asked to confirm unless `--yes` 
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] functions drop [OPTIONS] [ITEM] QUALIFIED_NAME
+fdw [-w WORKSPACE] functions drop [OPTIONS] [ITEM] QUALIFIED_NAME
 ```
 
 | Option | Description |
@@ -1568,7 +1569,7 @@ fabric-dw [-w WORKSPACE] functions drop [OPTIONS] [ITEM] QUALIFIED_NAME
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace --yes functions drop SalesWH dbo.fn_clean_input
+fdw -w MyWorkspace --yes functions drop SalesWH dbo.fn_clean_input
 ```
 
 ---
@@ -1582,7 +1583,7 @@ Rename a T-SQL user-defined function via `EXEC sp_rename`. The new name must be 
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] functions rename [OPTIONS] [ITEM] QUALIFIED_NAME
+fdw [-w WORKSPACE] functions rename [OPTIONS] [ITEM] QUALIFIED_NAME
 ```
 
 | Option | Description |
@@ -1592,7 +1593,7 @@ fabric-dw [-w WORKSPACE] functions rename [OPTIONS] [ITEM] QUALIFIED_NAME
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace --yes functions rename SalesWH dbo.fn_clean_input \
+fdw -w MyWorkspace --yes functions rename SalesWH dbo.fn_clean_input \
   --new-name fn_sanitize_input
 ```
 
@@ -1615,7 +1616,7 @@ List all tables on a warehouse or SQL Analytics Endpoint. Pass `--schema` to fil
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] tables list [OPTIONS] [WAREHOUSE]
+fdw [-w WORKSPACE] tables list [OPTIONS] [WAREHOUSE]
 ```
 
 | Option | Description |
@@ -1625,7 +1626,7 @@ fabric-dw [-w WORKSPACE] tables list [OPTIONS] [WAREHOUSE]
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace tables list SalesWH --schema dbo
+fdw -w MyWorkspace tables list SalesWH --schema dbo
 ```
 
 ```
@@ -1672,7 +1673,7 @@ CSV and Parquet formats require `--output`. JSON is emitted to stdout by default
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] tables read [OPTIONS] [WAREHOUSE] QUALIFIED_NAME
+fdw [-w WORKSPACE] tables read [OPTIONS] [WAREHOUSE] QUALIFIED_NAME
 ```
 
 | Option | Description | Default |
@@ -1684,7 +1685,7 @@ fabric-dw [-w WORKSPACE] tables read [OPTIONS] [WAREHOUSE] QUALIFIED_NAME
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace tables read SalesWH dbo.orders --count 5
+fdw -w MyWorkspace tables read SalesWH dbo.orders --count 5
 ```
 
 ```json
@@ -1708,7 +1709,7 @@ Create a new table on a Fabric Data Warehouse. Two modes are available:
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] tables create [OPTIONS] [WAREHOUSE]
+fdw [-w WORKSPACE] tables create [OPTIONS] [WAREHOUSE]
 ```
 
 #### CTAS options
@@ -1760,29 +1761,29 @@ Exactly one of `--select` or `--from-file` must be provided for the CTAS path. C
 
 ```shell
 # CTAS
-fabric-dw -w MyWorkspace tables create SalesWH \
+fdw -w MyWorkspace tables create SalesWH \
   --name dbo.orders_2026 \
   --select "SELECT * FROM dbo.orders WHERE YEAR(sale_date) = 2026"
 
 # Empty table from Parquet schema
-fabric-dw -w MyWorkspace tables create SalesWH \
+fdw -w MyWorkspace tables create SalesWH \
   --name dbo.sales_empty \
   --from-parquet ./exports/sales.parquet
 
 # Empty table from CSV header (type inference)
-fabric-dw -w MyWorkspace tables create SalesWH \
+fdw -w MyWorkspace tables create SalesWH \
   --name staging.raw_products \
   --from-csv ./data/products.csv --varchar-length 500
 
 # Empty table with explicit inline columns
-fabric-dw -w MyWorkspace tables create SalesWH \
+fdw -w MyWorkspace tables create SalesWH \
   --name dbo.events \
   --column "event_id:BIGINT:notnull" \
   --column "event_type:VARCHAR(100)" \
   --column "occurred_at:DATETIME2(7)"
 
 # Explicit schema from JSON file + extra columns
-fabric-dw -w MyWorkspace tables create SalesWH \
+fdw -w MyWorkspace tables create SalesWH \
   --name dbo.audit_log \
   --from-schema ./schemas/audit_log.json \
   --column "inserted_at:DATETIME2(7):notnull"
@@ -1799,13 +1800,13 @@ Drop a table. You will be asked to confirm unless `--yes` is passed.
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] tables delete [OPTIONS] [WAREHOUSE] QUALIFIED_NAME
+fdw [-w WORKSPACE] tables delete [OPTIONS] [WAREHOUSE] QUALIFIED_NAME
 ```
 
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace --yes tables delete SalesWH dbo.orders_2026
+fdw -w MyWorkspace --yes tables delete SalesWH dbo.orders_2026
 ```
 
 ---
@@ -1819,13 +1820,13 @@ Truncate a table (delete all rows, keep structure). You will be asked to confirm
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] tables clear [OPTIONS] [WAREHOUSE] QUALIFIED_NAME
+fdw [-w WORKSPACE] tables clear [OPTIONS] [WAREHOUSE] QUALIFIED_NAME
 ```
 
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace --yes tables clear SalesWH dbo.staging_load
+fdw -w MyWorkspace --yes tables clear SalesWH dbo.staging_load
 ```
 
 ---
@@ -1839,7 +1840,7 @@ Create a zero-copy clone of a table using `CREATE TABLE … AS CLONE OF`. Pass `
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] tables clone [OPTIONS] [ITEM]
+fdw [-w WORKSPACE] tables clone [OPTIONS] [ITEM]
 ```
 
 | Option | Description |
@@ -1852,12 +1853,12 @@ fabric-dw [-w WORKSPACE] tables clone [OPTIONS] [ITEM]
 
 ```shell
 # Clone to the current state
-fabric-dw -w MyWorkspace tables clone SalesWH \
+fdw -w MyWorkspace tables clone SalesWH \
   --source dbo.orders \
   --name dbo.orders_backup
 
 # Point-in-time clone
-fabric-dw -w MyWorkspace tables clone SalesWH \
+fdw -w MyWorkspace tables clone SalesWH \
   --source dbo.orders \
   --name dbo.orders_may_snapshot \
   --at 2024-05-20T14:00:00
@@ -1874,7 +1875,7 @@ Rename a table via `sp_rename`. The new name must be an unqualified (bare) ident
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] tables rename [OPTIONS] [ITEM] QUALIFIED_NAME
+fdw [-w WORKSPACE] tables rename [OPTIONS] [ITEM] QUALIFIED_NAME
 ```
 
 `QUALIFIED_NAME` is the current dot-separated `schema.table_name`.
@@ -1886,7 +1887,7 @@ fabric-dw [-w WORKSPACE] tables rename [OPTIONS] [ITEM] QUALIFIED_NAME
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace tables rename SalesWH dbo.orders_2025 --new-name orders_archive_2025
+fdw -w MyWorkspace tables rename SalesWH dbo.orders_2025 --new-name orders_archive_2025
 ```
 
 ---
@@ -1927,7 +1928,7 @@ Use `--cleanup-on-failure` to drop the table if WE created it in this call and t
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] tables load [OPTIONS] [ITEM] QUALIFIED_NAME
+fdw [-w WORKSPACE] tables load [OPTIONS] [ITEM] QUALIFIED_NAME
 ```
 
 `QUALIFIED_NAME` is the dot-separated `schema.table_name` of the destination table.
@@ -1960,35 +1961,35 @@ fabric-dw [-w WORKSPACE] tables load [OPTIONS] [ITEM] QUALIFIED_NAME
 
 ```shell
 # Load a local CSV into an existing table (header row present)
-fabric-dw -w MyWorkspace tables load SalesWH dbo.sales --file data.csv
+fdw -w MyWorkspace tables load SalesWH dbo.sales --file data.csv
 
 # Load a local Parquet file into an existing table
-fabric-dw -w MyWorkspace tables load SalesWH dbo.events --file events.parquet
+fdw -w MyWorkspace tables load SalesWH dbo.events --file events.parquet
 
 # Load a local JSON file (converts to Parquet internally; requires pyarrow)
-fabric-dw -w MyWorkspace tables load SalesWH dbo.products --file products.json
+fdw -w MyWorkspace tables load SalesWH dbo.products --file products.json
 
 # Auto-create the table from a Parquet schema, then load
-fabric-dw -w MyWorkspace tables load SalesWH dbo.sales --file data.parquet --create
+fdw -w MyWorkspace tables load SalesWH dbo.sales --file data.parquet --create
 
 # Auto-create from CSV, force all columns to VARCHAR
-fabric-dw -w MyWorkspace tables load SalesWH dbo.raw --file raw.csv --create --all-varchar
+fdw -w MyWorkspace tables load SalesWH dbo.raw --file raw.csv --create --all-varchar
 
 # Replace the existing table (drop + recreate schema + load), skip confirmation
-fabric-dw -w MyWorkspace tables load SalesWH dbo.sales --file data.parquet --create \
+fdw -w MyWorkspace tables load SalesWH dbo.sales --file data.parquet --create \
     --if-exists replace -y
 
 # Auto-create; drop the table if the load fails (cleanup_on_failure)
-fabric-dw -w MyWorkspace tables load SalesWH dbo.sales --file data.parquet --create \
+fdw -w MyWorkspace tables load SalesWH dbo.sales --file data.parquet --create \
     --cleanup-on-failure
 
 # Load from a remote OneLake URL (no credential needed)
-fabric-dw -w MyWorkspace tables load SalesWH dbo.orders \
+fdw -w MyWorkspace tables load SalesWH dbo.orders \
     --url "https://onelake.dfs.fabric.microsoft.com/ws/lh.Lakehouse/Files/orders.parquet" \
     --format parquet
 
 # Load from Azure Blob with SAS token
-fabric-dw -w MyWorkspace tables load SalesWH dbo.events \
+fdw -w MyWorkspace tables load SalesWH dbo.events \
     --url "https://myaccount.blob.core.windows.net/data/events.csv" \
     --format csv --credential-type sas --secret "?sv=2021&..."
 ```
@@ -2016,13 +2017,13 @@ List all user-defined schemas on a warehouse or SQL Analytics Endpoint. System s
 **Usage**
 
 ```shell
-fabric-dw [-w WORKSPACE] schemas list [OPTIONS] [WAREHOUSE]
+fdw [-w WORKSPACE] schemas list [OPTIONS] [WAREHOUSE]
 ```
 
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace schemas list SalesWH
+fdw -w MyWorkspace schemas list SalesWH
 ```
 
 ```
@@ -2042,13 +2043,13 @@ Create a new SQL schema on a warehouse.
 **Usage**
 
 ```shell
-fabric-dw [-w WORKSPACE] schemas create [OPTIONS] [WAREHOUSE] NAME
+fdw [-w WORKSPACE] schemas create [OPTIONS] [WAREHOUSE] NAME
 ```
 
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace schemas create SalesWH reporting
+fdw -w MyWorkspace schemas create SalesWH reporting
 ```
 
 ### schemas delete
@@ -2062,7 +2063,7 @@ Pass `--cascade` to also drop all tables and views inside the schema before drop
 **Usage**
 
 ```shell
-fabric-dw [-w WORKSPACE] schemas delete [OPTIONS] [WAREHOUSE] NAME
+fdw [-w WORKSPACE] schemas delete [OPTIONS] [WAREHOUSE] NAME
 ```
 
 | Option | Description |
@@ -2073,10 +2074,10 @@ fabric-dw [-w WORKSPACE] schemas delete [OPTIONS] [WAREHOUSE] NAME
 
 ```shell
 # Drop an empty schema
-fabric-dw -w MyWorkspace --yes schemas delete SalesWH staging
+fdw -w MyWorkspace --yes schemas delete SalesWH staging
 
 # Drop a schema and all its tables/views
-fabric-dw -w MyWorkspace --yes schemas delete SalesWH staging --cascade
+fdw -w MyWorkspace --yes schemas delete SalesWH staging --cascade
 ```
 
 ---
@@ -2094,13 +2095,13 @@ List all snapshots for a warehouse.
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] snapshots list [WAREHOUSE]
+fdw [-w WORKSPACE] snapshots list [WAREHOUSE]
 ```
 
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace snapshots list SalesWH
+fdw -w MyWorkspace snapshots list SalesWH
 ```
 
 ```
@@ -2120,7 +2121,7 @@ Create a new snapshot for a warehouse. Optionally pin it to a specific point in 
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] snapshots create [OPTIONS] [WAREHOUSE] NAME
+fdw [-w WORKSPACE] snapshots create [OPTIONS] [WAREHOUSE] NAME
 ```
 
 | Option | Description |
@@ -2131,7 +2132,7 @@ fabric-dw [-w WORKSPACE] snapshots create [OPTIONS] [WAREHOUSE] NAME
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace snapshots create SalesWH snap-2026-06-08 \
+fdw -w MyWorkspace snapshots create SalesWH snap-2026-06-08 \
   --snapshot-dt 2026-06-08T00:00:00Z
 ```
 
@@ -2146,7 +2147,7 @@ Rename a snapshot and optionally update its description.
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] snapshots rename [OPTIONS] SNAPSHOT NEW_NAME
+fdw [-w WORKSPACE] snapshots rename [OPTIONS] SNAPSHOT NEW_NAME
 ```
 
 | Option | Description |
@@ -2156,7 +2157,7 @@ fabric-dw [-w WORKSPACE] snapshots rename [OPTIONS] SNAPSHOT NEW_NAME
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace snapshots rename snap-2026-06-01 snap-june-2026
+fdw -w MyWorkspace snapshots rename snap-2026-06-01 snap-june-2026
 ```
 
 ---
@@ -2170,13 +2171,13 @@ Delete a snapshot. You will be asked to confirm unless `--yes` is passed.
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] snapshots delete SNAPSHOT
+fdw [-w WORKSPACE] snapshots delete SNAPSHOT
 ```
 
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace --yes snapshots delete snap-old
+fdw -w MyWorkspace --yes snapshots delete snap-old
 ```
 
 ---
@@ -2190,7 +2191,7 @@ Roll a snapshot on a warehouse to a new timestamp. `SNAPSHOT_NAME` must be the d
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] snapshots roll [OPTIONS] [WAREHOUSE] SNAPSHOT_NAME
+fdw [-w WORKSPACE] snapshots roll [OPTIONS] [WAREHOUSE] SNAPSHOT_NAME
 ```
 
 | Option | Description |
@@ -2200,7 +2201,7 @@ fabric-dw [-w WORKSPACE] snapshots roll [OPTIONS] [WAREHOUSE] SNAPSHOT_NAME
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace snapshots roll SalesWH snap-june-2026 \
+fdw -w MyWorkspace snapshots roll SalesWH snap-june-2026 \
   --at 2026-06-08T12:00:00Z
 ```
 
@@ -2222,13 +2223,13 @@ Fetch the full SQL Pools configuration (enabled flag + pool list) for a workspac
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] sql-pools get
+fdw [-w WORKSPACE] sql-pools get
 ```
 
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace sql-pools get
+fdw -w MyWorkspace sql-pools get
 ```
 
 ---
@@ -2251,13 +2252,13 @@ and [Custom SQL pools](https://learn.microsoft.com/fabric/data-warehouse/custom-
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] sql-pools list
+fdw [-w WORKSPACE] sql-pools list
 ```
 
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace sql-pools list
+fdw -w MyWorkspace sql-pools list
 ```
 
 **Output**
@@ -2288,7 +2289,7 @@ Show details for a single SQL pool.
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] sql-pools show --name POOL
+fdw [-w WORKSPACE] sql-pools show --name POOL
 ```
 
 | Option | Description |
@@ -2298,7 +2299,7 @@ fabric-dw [-w WORKSPACE] sql-pools show --name POOL
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace sql-pools show --name ETL
+fdw -w MyWorkspace sql-pools show --name ETL
 ```
 
 ---
@@ -2312,7 +2313,7 @@ Add a new SQL pool to a workspace.
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] sql-pools create [OPTIONS]
+fdw [-w WORKSPACE] sql-pools create [OPTIONS]
 ```
 
 | Option | Description |
@@ -2327,7 +2328,7 @@ fabric-dw [-w WORKSPACE] sql-pools create [OPTIONS]
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace sql-pools create \
+fdw -w MyWorkspace sql-pools create \
   --name ETL \
   --max-percent 30 \
   --no-optimize-for-reads \
@@ -2347,7 +2348,7 @@ Update an existing SQL pool. Only the flags you provide are changed; all other f
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] sql-pools update [OPTIONS]
+fdw [-w WORKSPACE] sql-pools update [OPTIONS]
 ```
 
 | Option | Description |
@@ -2362,7 +2363,7 @@ fabric-dw [-w WORKSPACE] sql-pools update [OPTIONS]
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace sql-pools update --name ETL --max-percent 40
+fdw -w MyWorkspace sql-pools update --name ETL --max-percent 40
 ```
 
 ---
@@ -2376,7 +2377,7 @@ Remove a SQL pool from a workspace. You will be asked to confirm unless `--yes` 
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] sql-pools delete [OPTIONS]
+fdw [-w WORKSPACE] sql-pools delete [OPTIONS]
 ```
 
 | Option | Description |
@@ -2387,7 +2388,7 @@ fabric-dw [-w WORKSPACE] sql-pools delete [OPTIONS]
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace --yes sql-pools delete --name ETL
+fdw -w MyWorkspace --yes sql-pools delete --name ETL
 ```
 
 ---
@@ -2401,13 +2402,13 @@ Enable custom SQL Pools for a workspace. Preserves the existing pool configurati
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] sql-pools enable
+fdw [-w WORKSPACE] sql-pools enable
 ```
 
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace sql-pools enable
+fdw -w MyWorkspace sql-pools enable
 ```
 
 ---
@@ -2421,13 +2422,13 @@ Disable custom SQL Pools for a workspace without deleting pool definitions. Re-e
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] sql-pools disable
+fdw [-w WORKSPACE] sql-pools disable
 ```
 
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace sql-pools disable
+fdw -w MyWorkspace sql-pools disable
 ```
 
 ---
@@ -2441,7 +2442,7 @@ List SQL pool insight events from `queryinsights.sql_pool_insights`. Supports op
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] sql-pools insights [OPTIONS] [WAREHOUSE]
+fdw [-w WORKSPACE] sql-pools insights [OPTIONS] [WAREHOUSE]
 ```
 
 | Option | Description | Default |
@@ -2453,7 +2454,7 @@ fabric-dw [-w WORKSPACE] sql-pools insights [OPTIONS] [WAREHOUSE]
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace sql-pools insights SalesWH
+fdw -w MyWorkspace sql-pools insights SalesWH
 ```
 
 ---
@@ -2475,7 +2476,7 @@ Manage user-defined statistics on Fabric Data Warehouses and read their details 
 List statistics on an item.
 
 ```
-fabric-dw [-w WORKSPACE] statistics list [ITEM] [OPTIONS]
+fdw [-w WORKSPACE] statistics list [ITEM] [OPTIONS]
 ```
 
 | Option | Description | Default |
@@ -2492,7 +2493,7 @@ fabric-dw [-w WORKSPACE] statistics list [ITEM] [OPTIONS]
 Show details of a named statistic using `DBCC SHOW_STATISTICS`. Returns the stat header, density vector, and histogram steps.
 
 ```
-fabric-dw [-w WORKSPACE] statistics show [ITEM] QUALIFIED_TABLE STAT_NAME [OPTIONS]
+fdw [-w WORKSPACE] statistics show [ITEM] QUALIFIED_TABLE STAT_NAME [OPTIONS]
 ```
 
 `QUALIFIED_TABLE` must be a dot-separated qualified name, e.g. `dbo.sales`.
@@ -2508,7 +2509,7 @@ fabric-dw [-w WORKSPACE] statistics show [ITEM] QUALIFIED_TABLE STAT_NAME [OPTIO
 Create a new single-column statistic.
 
 ```
-fabric-dw [-w WORKSPACE] statistics create [ITEM] --table schema.table --column COL --name NAME [OPTIONS]
+fdw [-w WORKSPACE] statistics create [ITEM] --table schema.table --column COL --name NAME [OPTIONS]
 ```
 
 | Option | Description | Default |
@@ -2526,7 +2527,7 @@ fabric-dw [-w WORKSPACE] statistics create [ITEM] --table schema.table --column 
 Update an existing statistic via `UPDATE STATISTICS`.
 
 ```
-fabric-dw [-w WORKSPACE] statistics update [ITEM] QUALIFIED_TABLE STAT_NAME [OPTIONS]
+fdw [-w WORKSPACE] statistics update [ITEM] QUALIFIED_TABLE STAT_NAME [OPTIONS]
 ```
 
 | Option | Description | Default |
@@ -2541,7 +2542,7 @@ fabric-dw [-w WORKSPACE] statistics update [ITEM] QUALIFIED_TABLE STAT_NAME [OPT
 Drop a statistic via `DROP STATISTICS`. Prompts for confirmation unless `--yes` is passed.
 
 ```
-fabric-dw [-w WORKSPACE] statistics delete [ITEM] QUALIFIED_TABLE STAT_NAME
+fdw [-w WORKSPACE] statistics delete [ITEM] QUALIFIED_TABLE STAT_NAME
 ```
 
 ---
@@ -2552,7 +2553,7 @@ Manage **server-side** database settings on a Fabric Data Warehouse or SQL Analy
 
 !!! note
 
-    `settings` manages server-side warehouse/database configuration. For client-side CLI defaults (workspace, warehouse) use [`fabric-dw config`](#defaults-fabric-dw-config) instead.
+    `settings` manages server-side warehouse/database configuration. For client-side CLI defaults (workspace, warehouse) use [`fdw config`](#defaults-fabric-dw-config) instead.
 
 `show` and `result-set-caching` work on both Data Warehouses and SQL Analytics Endpoints. The `retention` command sets the time-travel retention period, which is primarily a Warehouse concept and may be a no-op on a SQL Analytics Endpoint.
 
@@ -2565,14 +2566,14 @@ The workspace is resolved from the global `-w/--workspace` option, the `FABRIC_D
 Display all server-side database settings for an item in a single table.
 
 ```shell
-fabric-dw -w <workspace> settings show [ITEM]
+fdw -w <workspace> settings show [ITEM]
 ```
 
 **Example:**
 
 ```shell
-fabric-dw -w MyWorkspace settings show MyWarehouse
-fabric-dw -w MyWorkspace --json settings show MyWarehouse
+fdw -w MyWorkspace settings show MyWarehouse
+fdw -w MyWorkspace --json settings show MyWarehouse
 ```
 
 ### settings result-set-caching
@@ -2584,7 +2585,7 @@ Enable or disable result-set caching.
 Executes `ALTER DATABASE CURRENT SET RESULT_SET_CACHING { ON | OFF }` on the target.
 
 ```shell
-fabric-dw -w <workspace> settings result-set-caching [ITEM] (on|off)
+fdw -w <workspace> settings result-set-caching [ITEM] (on|off)
 ```
 
 `STATE` is case-insensitive (`on`, `off`, `ON`, `OFF`).
@@ -2592,9 +2593,9 @@ fabric-dw -w <workspace> settings result-set-caching [ITEM] (on|off)
 **Example:**
 
 ```shell
-fabric-dw -w MyWorkspace settings result-set-caching MyWarehouse on
-fabric-dw -w MyWorkspace settings result-set-caching MyWarehouse off
-fabric-dw -w MyWorkspace --json settings result-set-caching MyWarehouse on
+fdw -w MyWorkspace settings result-set-caching MyWarehouse on
+fdw -w MyWorkspace settings result-set-caching MyWarehouse off
+fdw -w MyWorkspace --json settings result-set-caching MyWarehouse on
 ```
 
 ### settings retention
@@ -2606,7 +2607,7 @@ Set the time-travel retention period in days.
 Executes `ALTER DATABASE CURRENT SET TIME_TRAVEL_RETENTION_PERIOD = <DAYS> DAYS` on the target.
 
 ```shell
-fabric-dw -w <workspace> settings retention [ITEM] --days DAYS
+fdw -w <workspace> settings retention [ITEM] --days DAYS
 ```
 
 | Option | Description | Default |
@@ -2616,8 +2617,8 @@ fabric-dw -w <workspace> settings retention [ITEM] --days DAYS
 **Example:**
 
 ```shell
-fabric-dw -w MyWorkspace settings retention MyWarehouse --days 30
-fabric-dw -w MyWorkspace --json settings retention MyWarehouse --days 7
+fdw -w MyWorkspace settings retention MyWarehouse --days 30
+fdw -w MyWorkspace --json settings retention MyWarehouse --days 7
 ```
 
 ---
@@ -2635,13 +2636,13 @@ Clear all cached entries.
 **Synopsis**
 
 ```
-fabric-dw cache clear
+fdw cache clear
 ```
 
 **Example**
 
 ```shell
-fabric-dw cache clear
+fdw cache clear
 ```
 
 ```
@@ -2669,14 +2670,14 @@ Scaffold a new dbt project directory connected to a Fabric Data Warehouse. The c
 **Usage**
 
 ```shell
-fabric-dw [-w WORKSPACE] dbt init [OPTIONS] [ITEM] FOLDER
+fdw [-w WORKSPACE] dbt init [OPTIONS] [ITEM] FOLDER
 ```
 
 **Arguments**
 
 | Argument | Description |
 | --- | --- |
-| `ITEM` | Name or ID of the Fabric Data Warehouse item (optional if set via `fabric-dw config set warehouse`). |
+| `ITEM` | Name or ID of the Fabric Data Warehouse item (optional if set via `fdw config set warehouse`). |
 | `FOLDER` | Path to the folder to create. Must not exist (unless `--force` is passed). |
 
 **Options**
@@ -2697,20 +2698,20 @@ fabric-dw [-w WORKSPACE] dbt init [OPTIONS] [ITEM] FOLDER
 
 ```shell
 # Minimal — uses configured default workspace and warehouse
-fabric-dw dbt init SalesWH ./my_dbt_project
+fdw dbt init SalesWH ./my_dbt_project
 
 # Explicit workspace via -w
-fabric-dw -w MyWorkspace dbt init SalesWH ./my_dbt_project
+fdw -w MyWorkspace dbt init SalesWH ./my_dbt_project
 
 # Service Principal auth; write profiles.yml to ~/.dbt/
-fabric-dw -w MyWorkspace dbt init SalesWH ./sales_dbt \
+fdw -w MyWorkspace dbt init SalesWH ./sales_dbt \
   --auth sp --profiles-dir home
 
 # Scaffold with live source introspection (auto-generates _sources.yml)
-fabric-dw -w MyWorkspace dbt init SalesWH ./sales_dbt --with-sources
+fdw -w MyWorkspace dbt init SalesWH ./sales_dbt --with-sources
 
 # Force-overwrite an existing folder
-fabric-dw -w MyWorkspace dbt init SalesWH ./sales_dbt --force
+fdw -w MyWorkspace dbt init SalesWH ./sales_dbt --force
 ```
 
 **Scaffolded layout**
@@ -2748,7 +2749,7 @@ Generate and optionally install the tab-completion script for `bash`, `zsh`, or 
 **Synopsis**
 
 ```
-fabric-dw completion install [--print] {bash|zsh|fish}
+fdw completion install [--print] {bash|zsh|fish}
 ```
 
 | Option | Description |
@@ -2765,10 +2766,10 @@ fabric-dw completion install [--print] {bash|zsh|fish}
 
 ```shell
 # Install for zsh
-fabric-dw completion install zsh
+fdw completion install zsh
 
 # Inspect the bash script before installing
-fabric-dw completion install bash --print
+fdw completion install bash --print
 ```
 
 For AI-assistant (MCP) usage there is no shell completion — see [MCP server](mcp.md) instead.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -13,7 +13,7 @@ fdw [-w WORKSPACE] [GLOBAL OPTIONS] <noun> <verb> [ARGS] [OPTIONS]
 !!! tip "`fdw` and `fabric-dw` are the same command"
     The CLI is installed as two interchangeable entry points: every example below can be run as either `fdw …` or `fabric-dw …`. The examples use the shorter `fdw`.
 
-**Name-or-GUID arguments** — wherever a synopsis shows `WAREHOUSE`, `ENDPOINT`, `SNAPSHOT`, or `WORKSPACE` (positional in the `workspaces` group only), the value can be either the display name or the item's GUID. The CLI resolves names to GUIDs automatically and caches the mapping locally (see [`fdw cache`](#fabric-dw-cache)).
+**Name-or-GUID arguments** — wherever a synopsis shows `WAREHOUSE`, `ENDPOINT`, `SNAPSHOT`, or `WORKSPACE` (positional in the `workspaces` group only), the value can be either the display name or the item's GUID. The CLI resolves names to GUIDs automatically and caches the mapping locally (see [`fabric-dw cache`](#fabric-dw-cache)).
 
 **Positional arguments with defaults** — positional arguments shown in `[brackets]` may be omitted when a default has been set with [`fdw config set`](#defaults-fabric-dw-config). See [Defaults — fabric-dw config](#defaults-fabric-dw-config) for details.
 
@@ -1239,13 +1239,13 @@ Return the total row count of a view using `SELECT COUNT_BIG(*)`.
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] views count [WAREHOUSE] QUALIFIED_NAME
+fdw [-w WORKSPACE] views count [WAREHOUSE] QUALIFIED_NAME
 ```
 
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace views count SalesWH dbo.vw_sales
+fdw -w MyWorkspace views count SalesWH dbo.vw_sales
 ```
 
 ```json
@@ -1647,13 +1647,13 @@ Return the total row count of a table using `SELECT COUNT_BIG(*)`.
 **Synopsis**
 
 ```
-fabric-dw [-w WORKSPACE] tables count [WAREHOUSE] QUALIFIED_NAME
+fdw [-w WORKSPACE] tables count [WAREHOUSE] QUALIFIED_NAME
 ```
 
 **Example**
 
 ```shell
-fabric-dw -w MyWorkspace tables count SalesWH dbo.orders
+fdw -w MyWorkspace tables count SalesWH dbo.orders
 ```
 
 ```json

--- a/docs/completion.md
+++ b/docs/completion.md
@@ -8,7 +8,7 @@
 The easiest way to install completion for your shell is the built-in command:
 
 ```shell
-fabric-dw completion install bash   # or zsh / fish
+fdw completion install bash   # or zsh / fish
 ```
 
 This writes the script to the conventional location for your shell and prints
@@ -17,7 +17,7 @@ the command you need to reload it.
 Add `--print` to inspect the script before installing:
 
 ```shell
-fabric-dw completion install bash --print
+fdw completion install bash --print
 ```
 
 ## Manual setup

--- a/docs/install.md
+++ b/docs/install.md
@@ -34,7 +34,7 @@ uvx fabric-dw --help
 After installation, confirm the CLI is available:
 
 ```bash
-fabric-dw --help
+fdw --help
 ```
 
 You should see the top-level help output listing available commands.

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -909,7 +909,7 @@ Create a new SQL table via CTAS (`CREATE TABLE … AS SELECT`).
 
 Create an empty SQL table from an explicit column specification (DDL only — no data is ever read or inserted). This scaffolds the table structure so that data can be loaded separately.
 
-Server-side file access is unreliable in MCP deployments, so CSV/Parquet schema inference is not available via this tool. Use `fabric-dw tables create --from-parquet` or `--from-csv` (CLI) for file-based schema inference.
+Server-side file access is unreliable in MCP deployments, so CSV/Parquet schema inference is not available via this tool. Use `fdw tables create --from-parquet` or `--from-csv` (CLI) for file-based schema inference.
 
 **Parameters:**
 
@@ -1652,7 +1652,7 @@ Read and modify server-side database settings on Fabric Data Warehouses and SQL 
 
 > **Note:** The read tool (`get_warehouse_settings`) works on both Data Warehouses and SQL Analytics Endpoints. The write tools (`set_result_set_caching`, `set_time_travel_retention`) execute `ALTER DATABASE CURRENT SET …` statements, which require autocommit and are primarily meaningful on Data Warehouses. Both setters return the effective `WarehouseSettings` read back after the change.
 
-CLI equivalents: `fabric-dw settings get`, `fabric-dw settings set-result-set-caching`, `fabric-dw settings set-time-travel-retention`.
+CLI equivalents: `fdw settings get`, `fdw settings set-result-set-caching`, `fdw settings set-time-travel-retention`.
 
 ### get_warehouse_settings
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -159,7 +159,7 @@ The client automatically retries on each 429 and waits exactly as long as the se
 
 ## Restore points not appearing
 
-**Symptom:** `fabric-dw snapshots list` returns an empty list, or user-defined restore points that you created are not visible.
+**Symptom:** `fdw snapshots list` returns an empty list, or user-defined restore points that you created are not visible.
 
 **What happened:** Warehouse restore points are tied to capacity state:
 


### PR DESCRIPTION
## Summary

- Replaces `fabric-dw` with `fdw` in all runnable CLI command examples across `docs/cli.md`, `docs/completion.md`, `docs/authentication.md`, `docs/install.md`, `docs/troubleshooting.md`, and `docs/mcp-tools.md`.
- Adds a `!!! tip` admonition near the top of `docs/cli.md` explaining that `fdw` and `fabric-dw` are interchangeable entry points.
- Package/install references (`pip install fabric-dw`, `uvx fabric-dw`, `fabric-dw-mcp`), section headings (`## fabric-dw workspaces` etc.), and prose descriptions are intentionally left unchanged.

Closes #502

## Test plan

- [ ] Guardrail grep confirms `fabric-dw-mcp` is untouched (25 occurrences).
- [ ] Guardrail grep for wrongly-replaced package/URL references (`pip install fdw`, `uvx fdw`, `fdw-mcp`, etc.) returns zero hits.
- [ ] `uv run ruff check .` passes.
- [ ] `uv run ruff format --check .` passes.
- [ ] All `## fabric-dw <group>` section headings unchanged; anchor links resolve correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)