### PR TITLE
fix(models): type query-insights elapsed-time fields as float

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -816,6 +816,8 @@ fabric-dw -w MyWorkspace --yes queries kill SalesWH 42
 
 List completed SQL requests from `queryinsights.exec_requests_history`. Supports optional time-range filtering with `--since` and `--until` (ISO-8601 strings). The `--limit` option caps the number of rows returned (default: 100, max: 10 000).
 
+> **Note:** Elapsed-time and CPU-time fields (e.g. `total_elapsed_time_ms`, `allocated_cpu_time_ms`) are typed as `float` (`number` in JSON) because Fabric returns fractional millisecond values. Count fields (e.g. `row_count`) remain `int`.
+
 **Synopsis**
 
 ```
@@ -841,6 +843,8 @@ fabric-dw -w MyWorkspace queries history SalesWH --limit 50 --since 2026-06-01T0
 **Targets:** Data Warehouse · SQL Analytics Endpoint
 
 List completed sessions from `queryinsights.exec_sessions_history`.
+
+> **Note:** `total_query_elapsed_time_ms` is typed as `float` (`number` in JSON) because Fabric returns fractional millisecond values.
 
 **Synopsis**
 
@@ -868,6 +872,8 @@ fabric-dw -w MyWorkspace queries sessions SalesWH
 
 List frequently-run queries from `queryinsights.frequently_run_queries`.
 
+> **Note:** Elapsed-time fields (e.g. `avg_total_elapsed_time_ms`, `min_run_total_elapsed_time_ms`, `max_run_total_elapsed_time_ms`, `last_run_total_elapsed_time_ms`) are typed as `float` (`number` in JSON) because Fabric returns fractional millisecond values. Count fields (`number_of_runs`, `number_of_successful_runs`, `number_of_failed_runs`, `number_of_canceled_runs`) remain `int`.
+
 **Synopsis**
 
 ```
@@ -893,6 +899,8 @@ fabric-dw -w MyWorkspace queries frequent SalesWH --limit 20
 **Targets:** Data Warehouse · SQL Analytics Endpoint
 
 List long-running queries from `queryinsights.long_running_queries`.
+
+> **Note:** `median_total_elapsed_time_ms` and `last_run_total_elapsed_time_ms` are typed as `float` (`number` in JSON) because Fabric returns fractional millisecond values. `number_of_runs` remains `int`.
 
 **Synopsis**
 

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -425,7 +425,7 @@ Return completed SQL requests from `queryinsights.exec_requests_history`.
 - `since` (`str | null`, optional) — ISO-8601 lower bound on `submit_time`.
 - `until` (`str | null`, optional) — ISO-8601 upper bound on `submit_time`.
 
-**Returns:** `list[dict]` — array of request-history row objects.
+**Returns:** `list[dict]` — array of request-history row objects. Elapsed-time and CPU-time fields (e.g. `total_elapsed_time_ms`, `allocated_cpu_time_ms`) are JSON `number` (float) because Fabric returns fractional millisecond values.
 
 ---
 
@@ -443,7 +443,7 @@ Return completed sessions from `queryinsights.exec_sessions_history`.
 - `since` (`str | null`, optional) — ISO-8601 lower bound on `session_start_time`.
 - `until` (`str | null`, optional) — ISO-8601 upper bound on `session_start_time`.
 
-**Returns:** `list[dict]` — array of session-history row objects.
+**Returns:** `list[dict]` — array of session-history row objects. `total_query_elapsed_time_ms` is JSON `number` (float) because Fabric returns fractional millisecond values.
 
 ---
 
@@ -461,7 +461,7 @@ Return frequently-run queries from `queryinsights.frequently_run_queries`.
 - `since` (`str | null`, optional) — ISO-8601 lower bound on `last_run_start_time`.
 - `until` (`str | null`, optional) — ISO-8601 upper bound on `last_run_start_time`.
 
-**Returns:** `list[dict]` — array of frequently-run query row objects.
+**Returns:** `list[dict]` — array of frequently-run query row objects. Elapsed-time fields (e.g. `avg_total_elapsed_time_ms`, `min_run_total_elapsed_time_ms`, `max_run_total_elapsed_time_ms`, `last_run_total_elapsed_time_ms`) are JSON `number` (float); count fields remain `integer`.
 
 ---
 
@@ -479,7 +479,7 @@ Return long-running queries from `queryinsights.long_running_queries`.
 - `since` (`str | null`, optional) — ISO-8601 lower bound on `last_run_start_time`.
 - `until` (`str | null`, optional) — ISO-8601 upper bound on `last_run_start_time`.
 
-**Returns:** `list[dict]` — array of long-running query row objects.
+**Returns:** `list[dict]` — array of long-running query row objects. `median_total_elapsed_time_ms` and `last_run_total_elapsed_time_ms` are JSON `number` (float); `number_of_runs` remains `integer`.
 
 ---
 

--- a/src/fabric_dw/cli/_render.py
+++ b/src/fabric_dw/cli/_render.py
@@ -157,9 +157,16 @@ def _cell(value: object) -> str:
 
     ``None`` is rendered as ``[dim]NULL[/dim]`` so SQL NULLs are visually
     distinct from the literal string ``'None'``.
+
+    Whole-number ``float`` values (e.g. ``1500.0``) are rendered without the
+    spurious ``.0`` suffix (e.g. ``"1500"``), matching the appearance of the
+    underlying integer.  Fractional floats (e.g. ``1234.5``) are rendered
+    as-is via ``str()``.
     """
     if value is None:
         return "[dim]NULL[/dim]"
+    if isinstance(value, float) and value.is_integer():
+        return str(int(value))
     return str(value)
 
 

--- a/src/fabric_dw/models.py
+++ b/src/fabric_dw/models.py
@@ -289,7 +289,7 @@ class ExecRequestHistory(_FabricBase):
     submit_time: datetime | None = None
     start_time: datetime | None = None
     end_time: datetime | None = None
-    total_elapsed_time_ms: int | None = None
+    total_elapsed_time_ms: float | None = None
 
     # --- details ---
     database_name: str | None = None
@@ -303,7 +303,7 @@ class ExecRequestHistory(_FabricBase):
     label: str | None = None
     result_cache_hit: int | None = None
     sql_pool_name: str | None = None
-    allocated_cpu_time_ms: int | None = None
+    allocated_cpu_time_ms: float | None = None
     data_scanned_remote_storage_mb: float | None = None
     data_scanned_memory_mb: float | None = None
     data_scanned_disk_mb: float | None = None
@@ -328,7 +328,7 @@ class ExecSessionHistory(_FabricBase):
     # --- timing ---
     session_start_time: datetime
     session_end_time: datetime | None = None
-    total_query_elapsed_time_ms: int
+    total_query_elapsed_time_ms: float
     last_request_start_time: datetime
     last_request_end_time: datetime | None = None
 
@@ -368,11 +368,11 @@ class FrequentlyRunQuery(_FabricBase):
     last_run_start_time: datetime | None = None
     last_run_command: str | None = None
     number_of_runs: int
-    avg_total_elapsed_time_ms: int
-    last_run_total_elapsed_time_ms: int
+    avg_total_elapsed_time_ms: float
+    last_run_total_elapsed_time_ms: float
     last_dist_statement_id: UUID | None = None
-    min_run_total_elapsed_time_ms: int
-    max_run_total_elapsed_time_ms: int
+    min_run_total_elapsed_time_ms: float
+    max_run_total_elapsed_time_ms: float
     number_of_successful_runs: int
     number_of_failed_runs: int
     number_of_canceled_runs: int
@@ -384,9 +384,9 @@ class LongRunningQuery(_FabricBase):
 
     last_run_start_time: datetime | None = None
     last_run_command: str | None = None
-    median_total_elapsed_time_ms: int
+    median_total_elapsed_time_ms: float
     number_of_runs: int
-    last_run_total_elapsed_time_ms: int
+    last_run_total_elapsed_time_ms: float
     last_dist_statement_id: UUID | None = None
     query_hash: str | None = None
 

--- a/src/fabric_dw/models.py
+++ b/src/fabric_dw/models.py
@@ -396,7 +396,7 @@ class SqlPoolInsight(_FabricBase):
 
     sql_pool_name: str | None = None
     timestamp: datetime | None = None
-    max_resource_percentage: int | None = None
+    max_resource_percentage: int | None = None  # integer percentage (0-100); reviewed, not widened
     is_optimized_for_reads: bool | None = None
     current_workspace_capacity: str | None = None
     is_pool_under_pressure: bool | None = None

--- a/tests/unit/cli/test_render.py
+++ b/tests/unit/cli/test_render.py
@@ -133,6 +133,22 @@ class TestCellHelper:
         # The actual string "None" must NOT be changed — only Python None
         assert _cell("None") == "None"
 
+    def test_integral_float_renders_without_dot_zero(self) -> None:
+        """Whole-number float values must render as integers (no spurious '.0')."""
+        assert _cell(1500.0) == "1500"
+
+    def test_fractional_float_renders_with_decimal(self) -> None:
+        """Fractional float values must retain their decimal component."""
+        assert _cell(1234.5) == "1234.5"
+
+    def test_negative_integral_float_renders_without_dot_zero(self) -> None:
+        """Negative whole-number floats also suppress the '.0' suffix."""
+        assert _cell(-42.0) == "-42"
+
+    def test_zero_float_renders_as_zero(self) -> None:
+        """0.0 must render as '0', not '0.0'."""
+        assert _cell(0.0) == "0"
+
 
 class TestNullRendering:
     """NULL values in table and panel output are rendered as dim 'NULL', not 'None'."""

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1079,6 +1079,46 @@ class TestExecSessionHistoryFieldParsing:
         with pytest.raises(ValidationError):
             obj.status = "completed"  # type: ignore[misc]
 
+
+# ---------------------------------------------------------------------------
+# ExecSessionHistory — elapsed-time fields are float
+# ---------------------------------------------------------------------------
+
+
+class TestExecSessionHistoryFloatElapsedTime:
+    """queryinsights.exec_sessions_history returns elapsed-time columns as floats.
+
+    Pydantic v2 raises ``int_from_float`` for fractional values on ``int`` fields.
+    ``total_query_elapsed_time_ms`` must be typed ``float``.
+    """
+
+    _MINIMAL: ClassVar[dict] = {
+        "session_id": 1,
+        "connection_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+        "session_start_time": "2024-03-15T10:00:00Z",
+        "total_query_elapsed_time_ms": 0,
+        "last_request_start_time": "2024-03-15T10:00:00Z",
+        "login_name": "user@example.com",
+        "status": "running",
+        "is_user_process": True,
+        "prev_error": 0,
+        "group_id": 0,
+        "text_size": -1,
+        "date_first": 7,
+        "quoted_identifier": True,
+        "arithabort": True,
+        "ansi_null_dflt_on": True,
+        "ansi_defaults": False,
+        "ansi_warnings": True,
+        "ansi_padding": True,
+        "ansi_nulls": True,
+        "concat_null_yields_null": True,
+        "transaction_isolation_level": 2,
+        "lock_timeout": -1,
+        "deadlock_priority": 0,
+        "original_security_id": b"\x01\x02\x03",
+    }
+
     def test_total_query_elapsed_time_ms_accepts_float(self) -> None:
         """Fabric returns total_query_elapsed_time_ms as float — must not raise int_from_float."""
         payload = {**self._MINIMAL, "total_query_elapsed_time_ms": 1234.5}
@@ -1134,6 +1174,20 @@ class TestFrequentlyRunQueryFloatElapsedTime:
         assert isinstance(obj.number_of_failed_runs, int)
         assert isinstance(obj.number_of_canceled_runs, int)
 
+    @pytest.mark.parametrize(
+        "count_field",
+        [
+            "number_of_runs",
+            "number_of_successful_runs",
+            "number_of_failed_runs",
+            "number_of_canceled_runs",
+        ],
+    )
+    def test_count_field_rejects_fractional_float(self, count_field: str) -> None:
+        """Count fields must be int — fractional input must raise int_from_float."""
+        with pytest.raises(ValidationError, match="int_from_float"):
+            FrequentlyRunQuery.model_validate({**self._MINIMAL, count_field: 5.5})
+
 
 # ---------------------------------------------------------------------------
 # LongRunningQuery — elapsed-time fields are float
@@ -1173,6 +1227,11 @@ class TestLongRunningQueryFloatElapsedTime:
         """number_of_runs is a count — must stay int."""
         obj = LongRunningQuery.model_validate(self._MINIMAL)
         assert isinstance(obj.number_of_runs, int)
+
+    def test_number_of_runs_rejects_fractional_float(self) -> None:
+        """number_of_runs is a count — fractional input must raise int_from_float."""
+        with pytest.raises(ValidationError, match="int_from_float"):
+            LongRunningQuery.model_validate({**self._MINIMAL, "number_of_runs": 5.5})
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -14,8 +14,10 @@ from fabric_dw.models import (
     CreationModeType,
     ExecRequestHistory,
     ExecSessionHistory,
+    FrequentlyRunQuery,
     ItemAccess,
     ItemAccessPrincipal,
+    LongRunningQuery,
     PrincipalType,
     RestorePoint,
     RunningQuery,
@@ -1076,3 +1078,125 @@ class TestExecSessionHistoryFieldParsing:
         obj = ExecSessionHistory.model_validate(self._MINIMAL)
         with pytest.raises(ValidationError):
             obj.status = "completed"  # type: ignore[misc]
+
+    def test_total_query_elapsed_time_ms_accepts_float(self) -> None:
+        """Fabric returns total_query_elapsed_time_ms as float — must not raise int_from_float."""
+        payload = {**self._MINIMAL, "total_query_elapsed_time_ms": 1234.5}
+        obj = ExecSessionHistory.model_validate(payload)
+        assert obj.total_query_elapsed_time_ms == 1234.5
+        assert isinstance(obj.total_query_elapsed_time_ms, float)
+
+
+# ---------------------------------------------------------------------------
+# FrequentlyRunQuery — elapsed-time fields are float
+# ---------------------------------------------------------------------------
+
+
+class TestFrequentlyRunQueryFloatElapsedTime:
+    """queryinsights.frequently_run_queries returns elapsed-time columns as floats.
+
+    Pydantic v2 raises ``int_from_float`` for fractional values on ``int`` fields.
+    All ``*_elapsed_time_ms`` fields must be typed ``float``.
+    """
+
+    _MINIMAL: ClassVar[dict] = {
+        "number_of_runs": 5,
+        "avg_total_elapsed_time_ms": 200,
+        "last_run_total_elapsed_time_ms": 180,
+        "min_run_total_elapsed_time_ms": 100,
+        "max_run_total_elapsed_time_ms": 300,
+        "number_of_successful_runs": 4,
+        "number_of_failed_runs": 1,
+        "number_of_canceled_runs": 0,
+    }
+
+    @pytest.mark.parametrize(
+        "field",
+        [
+            "avg_total_elapsed_time_ms",
+            "last_run_total_elapsed_time_ms",
+            "min_run_total_elapsed_time_ms",
+            "max_run_total_elapsed_time_ms",
+        ],
+    )
+    def test_elapsed_time_field_accepts_fractional_float(self, field: str) -> None:
+        """Fractional ms values must validate without int_from_float error."""
+        payload = {**self._MINIMAL, field: 1234.5}
+        obj = FrequentlyRunQuery.model_validate(payload)
+        assert getattr(obj, field) == 1234.5
+        assert isinstance(getattr(obj, field), float)
+
+    def test_number_of_runs_remains_int(self) -> None:
+        """Count fields must stay int — not changed by this fix."""
+        obj = FrequentlyRunQuery.model_validate(self._MINIMAL)
+        assert isinstance(obj.number_of_runs, int)
+        assert isinstance(obj.number_of_successful_runs, int)
+        assert isinstance(obj.number_of_failed_runs, int)
+        assert isinstance(obj.number_of_canceled_runs, int)
+
+
+# ---------------------------------------------------------------------------
+# LongRunningQuery — elapsed-time fields are float
+# ---------------------------------------------------------------------------
+
+
+class TestLongRunningQueryFloatElapsedTime:
+    """queryinsights.long_running_queries returns elapsed-time columns as floats.
+
+    ``median_total_elapsed_time_ms`` is a statistical median and is virtually
+    always fractional.  ``last_run_total_elapsed_time_ms`` is also returned as
+    float by Fabric.  Both must be typed ``float``; ``number_of_runs`` is a
+    genuine integer count and must not change.
+    """
+
+    _MINIMAL: ClassVar[dict] = {
+        "median_total_elapsed_time_ms": 5000,
+        "number_of_runs": 3,
+        "last_run_total_elapsed_time_ms": 6000,
+    }
+
+    def test_median_elapsed_time_accepts_fractional_float(self) -> None:
+        """Fractional median_total_elapsed_time_ms must not raise int_from_float."""
+        payload = {**self._MINIMAL, "median_total_elapsed_time_ms": 1234.5}
+        obj = LongRunningQuery.model_validate(payload)
+        assert obj.median_total_elapsed_time_ms == 1234.5
+        assert isinstance(obj.median_total_elapsed_time_ms, float)
+
+    def test_last_run_elapsed_time_accepts_fractional_float(self) -> None:
+        """Fractional last_run_total_elapsed_time_ms must not raise int_from_float."""
+        payload = {**self._MINIMAL, "last_run_total_elapsed_time_ms": 5999.7}
+        obj = LongRunningQuery.model_validate(payload)
+        assert obj.last_run_total_elapsed_time_ms == 5999.7
+        assert isinstance(obj.last_run_total_elapsed_time_ms, float)
+
+    def test_number_of_runs_remains_int(self) -> None:
+        """number_of_runs is a count — must stay int."""
+        obj = LongRunningQuery.model_validate(self._MINIMAL)
+        assert isinstance(obj.number_of_runs, int)
+
+
+# ---------------------------------------------------------------------------
+# ExecRequestHistory — elapsed-time / cpu-time fields are float
+# ---------------------------------------------------------------------------
+
+
+class TestExecRequestHistoryFloatElapsedTime:
+    """queryinsights.exec_requests_history returns elapsed/cpu time as floats."""
+
+    _MINIMAL: ClassVar[dict] = {
+        "row_count": 0,
+    }
+
+    def test_total_elapsed_time_ms_accepts_fractional_float(self) -> None:
+        """Fractional total_elapsed_time_ms must not raise int_from_float."""
+        payload = {**self._MINIMAL, "total_elapsed_time_ms": 4321.9}
+        obj = ExecRequestHistory.model_validate(payload)
+        assert obj.total_elapsed_time_ms == 4321.9
+        assert isinstance(obj.total_elapsed_time_ms, float)
+
+    def test_allocated_cpu_time_ms_accepts_fractional_float(self) -> None:
+        """Fractional allocated_cpu_time_ms must not raise int_from_float."""
+        payload = {**self._MINIMAL, "allocated_cpu_time_ms": 99.5}
+        obj = ExecRequestHistory.model_validate(payload)
+        assert obj.allocated_cpu_time_ms == 99.5
+        assert isinstance(obj.allocated_cpu_time_ms, float)


### PR DESCRIPTION
## Summary

The `queryinsights.*` views in Fabric return elapsed-time and CPU-time columns as floats. Pydantic v2 raises `int_from_float` ValidationError whenever a live row contains a fractional millisecond value — which is data-dependent and therefore intermittent.

**Fields changed from `int` to `float`:**

| Model | Field |
|---|---|
| `ExecRequestHistory` | `total_elapsed_time_ms`, `allocated_cpu_time_ms` |
| `ExecSessionHistory` | `total_query_elapsed_time_ms` |
| `FrequentlyRunQuery` | `avg_total_elapsed_time_ms`, `last_run_total_elapsed_time_ms`, `min_run_total_elapsed_time_ms`, `max_run_total_elapsed_time_ms` |
| `LongRunningQuery` | `median_total_elapsed_time_ms`, `last_run_total_elapsed_time_ms` |

True count fields (`number_of_runs`, `number_of_successful_runs`, etc.) remain `int`.

Also fixes the intermittent `test_list_long_running_queries_returns_a_list` integration failure, which occurred only when live data contained a fractional elapsed-time value.

Closes #501

## Test plan

- [x] New unit tests in `tests/unit/test_models.py` feed fractional values (e.g. `1234.5`) through `model_validate` for each changed field and assert float type and value
- [x] New tests confirmed FAILING before the fix (reproducible `int_from_float` ValidationError)
- [x] New tests pass after the fix
- [x] `just check` passes (ruff lint + ty type check + 3518 unit tests)
- [x] `just cov` passes at 95% (≥80% required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)