### PR TITLE
feat(cli): render sql plan as a Rich terminal tree

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -570,6 +570,8 @@ fdw -w MyWorkspace --json sql exec SalesWH -f ./queries/report.sql
 
 Capture the **estimated** SHOWPLAN_XML execution plan for a SQL statement without executing it. The query is **not** run — only the plan is returned. This means DDL/DML query text is safe to plan without modifying any data.
 
+By default the plan is rendered as a **Rich terminal tree**: each operator is shown with its physical/logical op name, estimated row count, cost percentage (colour-coded), and badges for parallel execution or warnings. For multi-statement batches, one tree is printed per statement.
+
 The plan XML uses the standard namespace `http://schemas.microsoft.com/sqlserver/2004/07/showplan` and can be opened in SSMS, Azure Data Studio, or uploaded to [pastetheplan.com](https://www.pastetheplan.com) for visual analysis.
 
 **Synopsis**
@@ -582,16 +584,25 @@ fdw [-w WORKSPACE] sql plan [OPTIONS] [ITEM]
 | --- | --- |
 | `-q` / `--query TEXT` | SQL statement to plan. |
 | `-f` / `--file PATH` | Path to a `.sql` file to plan. |
-| `-o` / `--output PATH` | Write the plan XML to this file (recommended extension: `.sqlplan`). When omitted, the XML is printed to stdout. |
+| `-o` / `--output PATH` | Write the raw plan XML to this file (recommended extension: `.sqlplan`). Opens in SSMS / Azure Data Studio. |
+| `--raw` / `--xml` | Print the raw SHOWPLAN XML to stdout instead of the Rich terminal tree. Useful for piping or inspection. |
+
+Pass the root `--json` flag to emit the parsed operator tree as machine-readable JSON instead of the Rich tree.
 
 **Example**
 
 ```shell
-# Print plan XML to stdout
+# Default: render a Rich terminal tree in the console
 fdw -w MyWorkspace sql plan SalesWH -q "SELECT TOP 5 * FROM dbo.Sales"
 
-# Save plan to file (opens in SSMS / Azure Data Studio)
+# Save raw plan XML to file (opens in SSMS / Azure Data Studio)
 fdw -w MyWorkspace sql plan SalesWH -q "SELECT TOP 5 * FROM dbo.Sales" -o plan.sqlplan
+
+# Print raw SHOWPLAN XML to stdout (pipe-friendly)
+fdw -w MyWorkspace sql plan SalesWH -q "SELECT TOP 5 * FROM dbo.Sales" --raw
+
+# Emit the operator tree as JSON
+fdw -w MyWorkspace --json sql plan SalesWH -q "SELECT TOP 5 * FROM dbo.Sales"
 ```
 
 ---

--- a/src/fabric_dw/cli/_plan_parse.py
+++ b/src/fabric_dw/cli/_plan_parse.py
@@ -14,6 +14,7 @@ Public API
 
 from __future__ import annotations
 
+import math
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass, field
 
@@ -115,6 +116,8 @@ def humanise_rows(rows: float) -> str:
         >>> humanise_rows(5.7)
         '5.7'
     """
+    if not math.isfinite(rows):
+        return str(rows)
     if rows >= _BILLION:
         return f"{rows / _BILLION:.1f}B"
     if rows >= _MILLION:
@@ -158,21 +161,27 @@ def _assign_cost_pct(node: PlanOperator, root_total_cost: float) -> None:
     """Recursively set :attr:`PlanOperator.cost_pct` on *node* and its children.
 
     ``node_own_cost = node.estimated_total_subtree_cost
-                      - max(child.estimated_total_subtree_cost)``
+                      - sum(child.estimated_total_subtree_cost for each child)``
+
+    A node's subtree cost already includes the sum of all children's subtree
+    costs, so subtracting the sum gives the cost attributable solely to this
+    node's own work.  The whole plan tree then sums to exactly 100 % (within
+    floating-point precision).
 
     For leaf nodes (no children) the subtree cost is entirely the node's own.
     Guarded against zero or missing root cost — no division by zero.
+    Clamped to ≥ 0 to absorb tiny float-noise artefacts.
 
     Args:
         node: The operator whose cost % is to be set.
         root_total_cost: Total cost of the root node (denominator).
     """
     if node.children:
-        max_child_cost = max(c.estimated_total_subtree_cost for c in node.children)
+        children_cost = sum(c.estimated_total_subtree_cost for c in node.children)
     else:
-        max_child_cost = 0.0
+        children_cost = 0.0
 
-    own_cost = max(0.0, node.estimated_total_subtree_cost - max_child_cost)
+    own_cost = max(0.0, node.estimated_total_subtree_cost - children_cost)
 
     if root_total_cost > 0.0:
         node.cost_pct = own_cost / root_total_cost * 100.0
@@ -250,9 +259,13 @@ def parse_showplan(xml_text: str) -> list[PlanOperator]:
         ``StmtSimple``, with :attr:`~PlanOperator.cost_pct` already set.
 
     Raises:
-        xml.etree.ElementTree.ParseError: When *xml_text* is not valid XML.
+        ValueError: When *xml_text* is not valid XML or is not a recognised
+            ShowPlan document.
     """
-    root_elem = ET.fromstring(xml_text)  # noqa: S314  (stdlib, trusted internal XML)
+    try:
+        root_elem = ET.fromstring(xml_text)  # noqa: S314  (stdlib, trusted internal XML)
+    except ET.ParseError as exc:
+        raise ValueError(f"Malformed SHOWPLAN XML: {exc}") from exc
 
     results: list[PlanOperator] = []
 

--- a/src/fabric_dw/cli/_plan_parse.py
+++ b/src/fabric_dw/cli/_plan_parse.py
@@ -263,7 +263,7 @@ def parse_showplan(xml_text: str) -> list[PlanOperator]:
             ShowPlan document.
     """
     try:
-        root_elem = ET.fromstring(xml_text)  # noqa: S314  (stdlib, trusted internal XML)
+        root_elem = ET.fromstring(xml_text)  # noqa: S314  # nosec B314  (stdlib, trusted Fabric API XML)
     except ET.ParseError as exc:
         raise ValueError(f"Malformed SHOWPLAN XML: {exc}") from exc
 

--- a/src/fabric_dw/cli/_plan_parse.py
+++ b/src/fabric_dw/cli/_plan_parse.py
@@ -1,0 +1,284 @@
+"""Pure SHOWPLAN XML parser — zero Rich dependency, fully unit-testable.
+
+Parses the ``ShowPlanXML`` format produced by ``SET SHOWPLAN_XML ON`` (or the
+``sql plan`` command) into a small dataclass tree.  Uses stdlib
+``xml.etree.ElementTree`` only; no third-party XML libraries required.
+
+Public API
+----------
+- :class:`PlanOperator` — one node in the operator tree.
+- :func:`parse_showplan` — top-level entry point; returns one
+  :class:`PlanOperator` per ``StmtSimple`` in the batch.
+- :func:`humanise_rows` — format a float row-count as ``1.2K`` / ``3.4M`` etc.
+"""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass, field
+
+__all__ = [
+    "PlanOperator",
+    "humanise_rows",
+    "parse_showplan",
+]
+
+# ---------------------------------------------------------------------------
+# ShowPlan XML namespace
+# ---------------------------------------------------------------------------
+
+_NS = "http://schemas.microsoft.com/sqlserver/2004/07/showplan"
+_TAG = f"{{{_NS}}}"  # prefix for ElementTree qualified names
+
+# ---------------------------------------------------------------------------
+# Row-count humanisation thresholds
+# ---------------------------------------------------------------------------
+
+_BILLION = 1_000_000_000
+_MILLION = 1_000_000
+_THOUSAND = 1_000
+
+
+def _tag(local: str) -> str:
+    """Return the namespace-qualified tag name for *local*."""
+    return f"{_TAG}{local}"
+
+
+# ---------------------------------------------------------------------------
+# Dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PlanOperator:
+    """A single operator node in a SHOWPLAN_XML execution plan.
+
+    Attributes:
+        physical_op: Value of the ``PhysicalOp`` XML attribute (e.g.
+            ``"Hash Match"``, ``"Clustered Index Scan"``, etc.).
+            ``"Unknown"`` when the attribute is absent.
+        logical_op: Value of the ``LogicalOp`` XML attribute.
+            ``"Unknown"`` when absent.
+        node_id: Integer ``NodeId`` attribute; ``-1`` when absent.
+        estimate_rows: Estimated row count from ``EstimateRows``; ``0.0``
+            when absent or unparseable.
+        estimated_total_subtree_cost: From ``EstimatedTotalSubtreeCost``;
+            ``0.0`` when absent or unparseable.
+        parallel: ``True`` when ``Parallel="1"`` on the ``RelOp`` element.
+        has_warnings: ``True`` when the operator element contains a
+            ``<Warnings>`` child element.
+        cost_pct: Percentage of the total plan cost attributable to this
+            node's *own* work (i.e. excluding child subtrees).  Populated
+            by :func:`_assign_cost_pct` after the tree is built.
+        children: Child :class:`PlanOperator` nodes.
+        stmt_text: Statement text — only set on the root node of each
+            ``StmtSimple`` sub-plan.
+    """
+
+    physical_op: str = "Unknown"
+    logical_op: str = "Unknown"
+    node_id: int = -1
+    estimate_rows: float = 0.0
+    estimated_total_subtree_cost: float = 0.0
+    parallel: bool = False
+    has_warnings: bool = False
+    cost_pct: float = 0.0
+    children: list[PlanOperator] = field(default_factory=list)
+    stmt_text: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def humanise_rows(rows: float) -> str:
+    """Return a compact human-readable representation of a row-count float.
+
+    Args:
+        rows: Estimated row count (may be fractional).
+
+    Returns:
+        A compact string:
+        - ``"1.0B"`` for >= 1 000 000 000
+        - ``"1.2M"`` for >= 1 000 000
+        - ``"12.3K"`` for >= 1 000
+        - ``"5"`` for < 1 000 (integer if whole-number, 1 dp otherwise)
+
+    Examples:
+        >>> humanise_rows(1_234_567)
+        '1.2M'
+        >>> humanise_rows(12_300)
+        '12.3K'
+        >>> humanise_rows(5.0)
+        '5'
+        >>> humanise_rows(5.7)
+        '5.7'
+    """
+    if rows >= _BILLION:
+        return f"{rows / _BILLION:.1f}B"
+    if rows >= _MILLION:
+        return f"{rows / _MILLION:.1f}M"
+    if rows >= _THOUSAND:
+        return f"{rows / _THOUSAND:.1f}K"
+    # Sub-thousand: suppress trailing .0
+    if rows == int(rows):
+        return str(int(rows))
+    return f"{rows:.1f}"
+
+
+def _float_attr(element: ET.Element, attr: str) -> float:
+    """Return the float value of *attr* on *element*, or ``0.0`` on failure."""
+    raw = element.get(attr)
+    if raw is None:
+        return 0.0
+    try:
+        return float(raw)
+    except ValueError:
+        return 0.0
+
+
+def _int_attr(element: ET.Element, attr: str, default: int = -1) -> int:
+    """Return the int value of *attr* on *element*, or *default* on failure."""
+    raw = element.get(attr)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        return default
+
+
+# ---------------------------------------------------------------------------
+# Cost percentage assignment
+# ---------------------------------------------------------------------------
+
+
+def _assign_cost_pct(node: PlanOperator, root_total_cost: float) -> None:
+    """Recursively set :attr:`PlanOperator.cost_pct` on *node* and its children.
+
+    ``node_own_cost = node.estimated_total_subtree_cost
+                      - max(child.estimated_total_subtree_cost)``
+
+    For leaf nodes (no children) the subtree cost is entirely the node's own.
+    Guarded against zero or missing root cost — no division by zero.
+
+    Args:
+        node: The operator whose cost % is to be set.
+        root_total_cost: Total cost of the root node (denominator).
+    """
+    if node.children:
+        max_child_cost = max(c.estimated_total_subtree_cost for c in node.children)
+    else:
+        max_child_cost = 0.0
+
+    own_cost = max(0.0, node.estimated_total_subtree_cost - max_child_cost)
+
+    if root_total_cost > 0.0:
+        node.cost_pct = own_cost / root_total_cost * 100.0
+    else:
+        node.cost_pct = 0.0
+
+    for child in node.children:
+        _assign_cost_pct(child, root_total_cost)
+
+
+# ---------------------------------------------------------------------------
+# RelOp walker
+# ---------------------------------------------------------------------------
+
+
+def _parse_rel_op(rel_op_elem: ET.Element) -> PlanOperator:
+    """Parse a ``<RelOp>`` element (and its descendants) into a :class:`PlanOperator`.
+
+    The concrete operator child element (e.g. ``<HashMatch>``, ``<IndexScan>``)
+    is the first child element of the ``<RelOp>``; child ``<RelOp>`` nodes live
+    inside that concrete child.  Unknown/future operator elements are handled
+    gracefully — child ``<RelOp>`` nodes are still recursed into.
+
+    Args:
+        rel_op_elem: The ``<RelOp>`` XML element to parse.
+
+    Returns:
+        A fully-populated :class:`PlanOperator` (children included).
+    """
+    node = PlanOperator(
+        physical_op=rel_op_elem.get("PhysicalOp", "Unknown"),
+        logical_op=rel_op_elem.get("LogicalOp", "Unknown"),
+        node_id=_int_attr(rel_op_elem, "NodeId"),
+        estimate_rows=_float_attr(rel_op_elem, "EstimateRows"),
+        estimated_total_subtree_cost=_float_attr(rel_op_elem, "EstimatedTotalSubtreeCost"),
+        parallel=rel_op_elem.get("Parallel") == "1",
+    )
+
+    # The concrete operator element is the first (and only expected) child element.
+    # Child RelOps live inside it.
+    for concrete_child in rel_op_elem:
+        # Check for a Warnings sibling at this level (Fabric plans may place it here)
+        if concrete_child.tag == _tag("Warnings"):
+            node.has_warnings = True
+            continue
+
+        # Recurse into child RelOps nested inside the concrete operator element.
+        for grandchild in concrete_child:
+            if grandchild.tag == _tag("Warnings"):
+                node.has_warnings = True
+            elif grandchild.tag == _tag("RelOp"):
+                node.children.append(_parse_rel_op(grandchild))
+
+    return node
+
+
+# ---------------------------------------------------------------------------
+# Top-level entry point
+# ---------------------------------------------------------------------------
+
+
+def parse_showplan(xml_text: str) -> list[PlanOperator]:
+    """Parse a SHOWPLAN_XML document into a list of operator trees.
+
+    One root :class:`PlanOperator` is returned per ``<StmtSimple>`` element
+    in the plan (multi-statement batches produce multiple trees).
+    Malformed / empty ``<StmtSimple>`` elements (no ``<QueryPlan>`` /
+    ``<RelOp>``) are silently skipped.
+
+    Args:
+        xml_text: The raw SHOWPLAN_XML string.
+
+    Returns:
+        A (possibly empty) list of root :class:`PlanOperator` nodes, one per
+        ``StmtSimple``, with :attr:`~PlanOperator.cost_pct` already set.
+
+    Raises:
+        xml.etree.ElementTree.ParseError: When *xml_text* is not valid XML.
+    """
+    root_elem = ET.fromstring(xml_text)  # noqa: S314  (stdlib, trusted internal XML)
+
+    results: list[PlanOperator] = []
+
+    # Walk ShowPlanXML -> BatchSequence* / Batch -> Statements -> StmtSimple
+    # The outermost element may be <ShowPlanXML> (with <BatchSequence>) or
+    # <Batch> directly, depending on the Fabric driver response.  We handle both
+    # by using .iter() to find all StmtSimple elements anywhere in the tree.
+    for stmt in root_elem.iter(_tag("StmtSimple")):
+        stmt_text = stmt.get("StatementText")
+
+        # Each StmtSimple has exactly one QueryPlan child.
+        query_plan = stmt.find(_tag("QueryPlan"))
+        if query_plan is None:
+            continue
+
+        # The root RelOp is a direct child of QueryPlan.
+        root_rel_op = query_plan.find(_tag("RelOp"))
+        if root_rel_op is None:
+            continue
+
+        root_node = _parse_rel_op(root_rel_op)
+        root_node.stmt_text = stmt_text
+
+        # Assign cost percentages relative to this statement's total cost.
+        _assign_cost_pct(root_node, root_node.estimated_total_subtree_cost)
+
+        results.append(root_node)
+
+    return results

--- a/src/fabric_dw/cli/_plan_render.py
+++ b/src/fabric_dw/cli/_plan_render.py
@@ -1,0 +1,175 @@
+"""Rich terminal tree renderer for SHOWPLAN_XML execution plans.
+
+Converts a list of :class:`~fabric_dw.cli._plan_parse.PlanOperator` trees
+(produced by :func:`~fabric_dw.cli._plan_parse.parse_showplan`) into Rich
+``Tree`` objects and prints them to a console.
+
+Public API
+----------
+- :func:`render_plan_tree` — build and print Rich trees for all statements.
+- :func:`operator_to_dict` — convert a :class:`PlanOperator` to a plain dict
+  for JSON output.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from rich.console import Console
+from rich.tree import Tree
+
+from fabric_dw.cli._plan_parse import PlanOperator, humanise_rows
+
+__all__ = [
+    "operator_to_dict",
+    "render_plan_tree",
+]
+
+# ---------------------------------------------------------------------------
+# Cost colour thresholds
+# ---------------------------------------------------------------------------
+
+_GREEN_THRESHOLD = 10.0  # < 10%  => green
+_YELLOW_THRESHOLD = 30.0  # < 30%  => yellow; >= 30% => red
+
+
+def _cost_colour(pct: float) -> str:
+    """Return the Rich colour name for a given cost percentage."""
+    if pct < _GREEN_THRESHOLD:
+        return "green"
+    if pct < _YELLOW_THRESHOLD:
+        return "yellow"
+    return "red"
+
+
+# ---------------------------------------------------------------------------
+# Label builder
+# ---------------------------------------------------------------------------
+
+
+def _node_label(node: PlanOperator) -> str:
+    """Compose the Rich-markup label for a single operator node.
+
+    Format (elements separated by spaces, absent parts omitted):
+    ``[bold]PhysicalOp[/bold] (LogicalOp)  rows  [colour]XX.X%[/colour]
+    [Parallel]  [!Warnings]``
+
+    Args:
+        node: The operator to label.
+
+    Returns:
+        A Rich markup string.
+    """
+    parts: list[str] = []
+
+    # Operator names
+    parts.append(f"[bold]{node.physical_op}[/bold]")
+    unknown = "Unknown"
+    if node.logical_op not in {node.physical_op, unknown, ""}:
+        parts.append(f"({node.logical_op})")
+
+    # Estimated rows
+    parts.append(humanise_rows(node.estimate_rows))
+
+    # Cost percentage
+    colour = _cost_colour(node.cost_pct)
+    parts.append(f"[{colour}]{node.cost_pct:.1f}%[/{colour}]")
+
+    # Badges
+    if node.parallel:
+        parts.append("[cyan][Parallel][/cyan]")
+    if node.has_warnings:
+        parts.append("[yellow bold][!Warnings][/yellow bold]")
+
+    return "  ".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Tree builder
+# ---------------------------------------------------------------------------
+
+
+def _build_rich_tree(node: PlanOperator, parent: Tree | None = None) -> Tree:
+    """Recursively build a ``rich.tree.Tree`` from a :class:`PlanOperator` tree.
+
+    Args:
+        node: The operator node to render.
+        parent: The parent Rich ``Tree`` node to attach to; when *None* a new
+            root ``Tree`` is created.
+
+    Returns:
+        The Rich ``Tree`` node for *node*.
+    """
+    label = _node_label(node)
+    if parent is None:
+        rich_node: Tree = Tree(label)
+    else:
+        rich_node = parent.add(label)
+
+    for child in node.children:
+        _build_rich_tree(child, rich_node)
+
+    return rich_node
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def render_plan_tree(
+    operators: list[PlanOperator],
+    *,
+    console: Console | None = None,
+) -> None:
+    """Print Rich terminal trees for each statement plan to *console*.
+
+    One tree per :class:`PlanOperator` root (i.e. one per ``StmtSimple``).
+    When the list is empty, a plain message is printed instead.
+
+    Args:
+        operators: The list of root operator nodes returned by
+            :func:`~fabric_dw.cli._plan_parse.parse_showplan`.
+        console: Optional Rich ``Console`` to print to; defaults to stdout.
+    """
+    con = console if console is not None else Console()
+
+    if not operators:
+        con.print("[dim]No plan operators found in the SHOWPLAN_XML.[/dim]")
+        return
+
+    for idx, root in enumerate(operators):
+        # Statement header
+        if root.stmt_text:
+            con.print(f"\n[bold dim]Statement {idx + 1}:[/bold dim] {root.stmt_text.strip()}")
+        elif len(operators) > 1:
+            con.print(f"\n[bold dim]Statement {idx + 1}[/bold dim]")
+
+        tree = _build_rich_tree(root)
+        con.print(tree)
+
+
+def operator_to_dict(node: PlanOperator) -> dict[str, Any]:
+    """Convert a :class:`PlanOperator` tree to a plain JSON-serialisable dict.
+
+    Used by the ``--json`` output path of ``sql plan``.
+
+    Args:
+        node: The operator node to serialise.
+
+    Returns:
+        A nested dict with keys matching the :class:`PlanOperator` attributes.
+        The ``children`` key contains a list of similarly-structured dicts.
+    """
+    return {
+        "physicalOp": node.physical_op,
+        "logicalOp": node.logical_op,
+        "nodeId": node.node_id,
+        "estimateRows": node.estimate_rows,
+        "estimatedTotalSubtreeCost": node.estimated_total_subtree_cost,
+        "parallel": node.parallel,
+        "hasWarnings": node.has_warnings,
+        "costPct": round(node.cost_pct, 2),
+        "stmtText": node.stmt_text,
+        "children": [operator_to_dict(c) for c in node.children],
+    }

--- a/src/fabric_dw/cli/_plan_render.py
+++ b/src/fabric_dw/cli/_plan_render.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 from typing import Any
 
 from rich.console import Console
+from rich.markup import escape
 from rich.tree import Tree
 
 from fabric_dw.cli._plan_parse import PlanOperator, humanise_rows
@@ -62,11 +63,11 @@ def _node_label(node: PlanOperator) -> str:
     """
     parts: list[str] = []
 
-    # Operator names
-    parts.append(f"[bold]{node.physical_op}[/bold]")
+    # Operator names (escaped so bracket characters in op names render literally)
+    parts.append(f"[bold]{escape(node.physical_op)}[/bold]")
     unknown = "Unknown"
     if node.logical_op not in {node.physical_op, unknown, ""}:
-        parts.append(f"({node.logical_op})")
+        parts.append(f"({escape(node.logical_op)})")
 
     # Estimated rows
     parts.append(humanise_rows(node.estimate_rows))
@@ -139,9 +140,10 @@ def render_plan_tree(
         return
 
     for idx, root in enumerate(operators):
-        # Statement header
+        # Statement header (stmt_text escaped so SQL bracket identifiers render literally)
         if root.stmt_text:
-            con.print(f"\n[bold dim]Statement {idx + 1}:[/bold dim] {root.stmt_text.strip()}")
+            stmt = escape(root.stmt_text.strip())
+            con.print(f"\n[bold dim]Statement {idx + 1}:[/bold dim] {stmt}")
         elif len(operators) > 1:
             con.print(f"\n[bold dim]Statement {idx + 1}[/bold dim]")
 

--- a/src/fabric_dw/cli/commands/sql.py
+++ b/src/fabric_dw/cli/commands/sql.py
@@ -8,9 +8,13 @@ Commands
 
 from __future__ import annotations
 
+import json as _json
+
 import click
 
 from fabric_dw.cli._context import CliContext
+from fabric_dw.cli._plan_parse import parse_showplan
+from fabric_dw.cli._plan_render import operator_to_dict, render_plan_tree
 from fabric_dw.cli._render import render
 from fabric_dw.cli.commands._utils import (
     build_http_client,
@@ -111,9 +115,16 @@ async def sql_exec_cmd(
     type=click.Path(file_okay=True, dir_okay=False, writable=True),
     help=(
         "Write the plan XML to this file (recommend .sqlplan extension). "
-        "Opens in SSMS, Azure Data Studio, or pastetheplan.com. "
-        "When omitted, the XML is printed to stdout."
+        "Opens in SSMS, Azure Data Studio, or pastetheplan.com."
     ),
+)
+@click.option(
+    "--raw",
+    "--xml",
+    "raw",
+    is_flag=True,
+    default=False,
+    help="Print the raw SHOWPLAN XML to stdout instead of the Rich terminal tree.",
 )
 @click.pass_obj
 @coro
@@ -123,6 +134,7 @@ async def sql_plan_cmd(
     query_text: str | None,
     query_file: str | None,
     output_path: str | None,
+    raw: bool,
 ) -> None:
     """Capture the estimated SHOWPLAN_XML for ITEM (warehouse or SQL endpoint).
 
@@ -130,9 +142,12 @@ async def sql_plan_cmd(
     The query is NOT executed — only the estimated execution plan is captured.
     This means DDL/DML query text is safe to plan without modifying any data.
 
-    The plan XML can be opened in SSMS, Azure Data Studio, or uploaded to
-    pastetheplan.com for visual analysis.  Use -o/--output to save to a file
-    (recommended extension: .sqlplan).  Without -o, the XML is printed to stdout.
+    By default the plan is rendered as a Rich terminal tree showing each
+    operator with estimated rows, cost percentage, and parallel/warning badges.
+    Use --raw/--xml to print the raw SHOWPLAN XML to stdout (e.g. for piping).
+    Use -o/--output to save the raw XML to a file (recommended extension:
+    .sqlplan); opens in SSMS, Azure Data Studio, or pastetheplan.com.
+    Pass the root --json flag for machine-readable JSON of the operator tree.
     """
     query = load_sql_body(query_text, query_file, inline_opt="-q/--query", file_opt="-f/--file")
 
@@ -144,10 +159,21 @@ async def sql_plan_cmd(
             plan_xml = await _sql_exec_svc.get_plan(target, query, mode=ctx.auth)
 
             if output_path is not None:
+                # Always write raw XML to file, regardless of other flags.
                 with open(output_path, "w", encoding="utf-8") as fh:
                     fh.write(plan_xml)
                 click.echo(f"Execution plan written to {output_path}")
-            else:
+            elif raw:
+                # --raw/--xml: pipe-friendly raw XML to stdout.
                 click.echo(plan_xml)
+            elif ctx.json_output:
+                # Global --json: emit the parsed operator tree as JSON.
+                operators = parse_showplan(plan_xml)
+                payload = [operator_to_dict(op) for op in operators]
+                click.echo(_json.dumps(payload, indent=2))
+            else:
+                # Default: render a Rich terminal tree.
+                operators = parse_showplan(plan_xml)
+                render_plan_tree(operators)
     except (ValueError, FabricError) as exc:
         raise click.ClickException(str(exc)) from exc

--- a/tests/unit/cli/commands/test_sql.py
+++ b/tests/unit/cli/commands/test_sql.py
@@ -370,8 +370,8 @@ class TestSqlExecErrors:
 class TestSqlPlan:
     """sql plan — happy paths."""
 
-    def test_plan_stdout_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
-        """sql plan prints plan XML to stdout and exits 0."""
+    def test_plan_default_renders_tree(self, runner: CliRunner, cache_env: Path) -> None:
+        """sql plan default output is a Rich terminal tree (not raw XML)."""
         _ = cache_env
         mock_http = AsyncMock()
         with (
@@ -393,10 +393,11 @@ class TestSqlPlan:
                 ["-w", WS_GUID, "sql", "plan", WH_GUID, "-q", "SELECT 1"],
             )
         assert result.exit_code == 0
-        assert "ShowPlanXML" in result.output
+        # Raw XML must NOT appear in terminal tree output
+        assert "<ShowPlanXML" not in result.output
 
-    def test_plan_stdout_contains_xml(self, runner: CliRunner, cache_env: Path) -> None:
-        """sql plan without -o writes the XML to stdout."""
+    def test_plan_raw_flag_prints_xml(self, runner: CliRunner, cache_env: Path) -> None:
+        """sql plan --raw prints the raw SHOWPLAN XML to stdout."""
         _ = cache_env
         mock_http = AsyncMock()
         with (
@@ -415,10 +416,61 @@ class TestSqlPlan:
         ):
             result = runner.invoke(
                 cli,
-                ["-w", WS_GUID, "sql", "plan", WH_GUID, "-q", "SELECT 1 AS n"],
+                ["-w", WS_GUID, "sql", "plan", WH_GUID, "-q", "SELECT 1", "--raw"],
             )
         assert result.exit_code == 0
         assert _PLAN_XML in result.output
+
+    def test_plan_xml_alias_prints_xml(self, runner: CliRunner, cache_env: Path) -> None:
+        """sql plan --xml is an alias for --raw."""
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.sql_exec.get_plan",
+                new=AsyncMock(return_value=_PLAN_XML),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                ["-w", WS_GUID, "sql", "plan", WH_GUID, "-q", "SELECT 1", "--xml"],
+            )
+        assert result.exit_code == 0
+        assert "ShowPlanXML" in result.output
+
+    def test_plan_json_flag_emits_operator_tree(self, runner: CliRunner, cache_env: Path) -> None:
+        """sql plan --json emits the parsed operator tree as JSON."""
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.sql_exec.get_plan",
+                new=AsyncMock(return_value=_PLAN_XML),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                ["-w", WS_GUID, "--json", "sql", "plan", WH_GUID, "-q", "SELECT 1"],
+            )
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert isinstance(parsed, list)
 
     def test_plan_output_file(self, runner: CliRunner, cache_env: Path, tmp_path: Path) -> None:
         """sql plan -o FILE writes the XML to the file and echoes a confirmation."""

--- a/tests/unit/cli/commands/test_sql.py
+++ b/tests/unit/cli/commands/test_sql.py
@@ -70,6 +70,38 @@ _PLAN_XML = (
     "<Batch><Statements><StmtSimple /></Statements></Batch></ShowPlanXML>"
 )
 
+_NS = "http://schemas.microsoft.com/sqlserver/2004/07/showplan"
+
+# A realistic plan XML that exercises the tree-render path: Hash Match over two
+# Clustered Index Scans, one Parallel node, one Warnings node.
+_RICH_PLAN_XML = (
+    f'<ShowPlanXML xmlns="{_NS}" Version="1.6" Build="16.0.0.0">'  # noqa: S608
+    f"<BatchSequence><Batch><Statements>"
+    f'<StmtSimple StatementText="SELECT o.id FROM dbo.Orders o" StatementId="1">'
+    f"<QueryPlan>"
+    f'<RelOp NodeId="0" PhysicalOp="Hash Match" LogicalOp="Inner Join"'
+    f' EstimateRows="5000" EstimatedTotalSubtreeCost="1.5" Parallel="0">'
+    f"<Hash>"
+    f'<RelOp NodeId="1" PhysicalOp="Clustered Index Scan"'
+    f' LogicalOp="Clustered Index Scan"'
+    f' EstimateRows="10000" EstimatedTotalSubtreeCost="0.9" Parallel="1">'
+    f'<IndexScan Ordered="false">'
+    f"<Warnings><PlanAffectingConvert ConvertIssue='Cardinality Estimate'/></Warnings>"
+    f"</IndexScan>"
+    f"</RelOp>"
+    f'<RelOp NodeId="2" PhysicalOp="Clustered Index Scan"'
+    f' LogicalOp="Clustered Index Scan"'
+    f' EstimateRows="3000" EstimatedTotalSubtreeCost="0.5" Parallel="0">'
+    f'<IndexScan Ordered="false"/>'
+    f"</RelOp>"
+    f"</Hash>"
+    f"</RelOp>"
+    f"</QueryPlan>"
+    f"</StmtSimple>"
+    f"</Statements></Batch></BatchSequence>"
+    f"</ShowPlanXML>"
+)
+
 
 class TestSqlExec:
     """sql exec — happy paths (regression: was 'sql' before #507)."""
@@ -385,7 +417,7 @@ class TestSqlPlan:
             ),
             patch(
                 "fabric_dw.services.sql_exec.get_plan",
-                new=AsyncMock(return_value=_PLAN_XML),
+                new=AsyncMock(return_value=_RICH_PLAN_XML),
             ),
         ):
             result = runner.invoke(
@@ -393,8 +425,12 @@ class TestSqlPlan:
                 ["-w", WS_GUID, "sql", "plan", WH_GUID, "-q", "SELECT 1"],
             )
         assert result.exit_code == 0
-        # Raw XML must NOT appear in terminal tree output
         assert "<ShowPlanXML" not in result.output
+        assert "Hash Match" in result.output
+        assert "Clustered Index Scan" in result.output
+        assert "%" in result.output
+        assert "[Parallel]" in result.output
+        assert "[!Warnings]" in result.output
 
     def test_plan_raw_flag_prints_xml(self, runner: CliRunner, cache_env: Path) -> None:
         """sql plan --raw prints the raw SHOWPLAN XML to stdout."""
@@ -581,3 +617,32 @@ class TestSqlPlanErrors:
                 ["-w", WS_GUID, "sql", "plan", WH_GUID, "-q", "SELECT 1"],
             )
         assert result.exit_code != 0
+
+    def test_plan_malformed_xml_returns_clean_error(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """Malformed XML from the API must produce a clean CLI error, not a traceback."""
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.sql_exec.get_plan",
+                new=AsyncMock(return_value="not valid xml at all"),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                ["-w", WS_GUID, "sql", "plan", WH_GUID, "-q", "SELECT 1"],
+            )
+        assert result.exit_code != 0
+        # Must show a clean Error: message, not a raw Python traceback
+        assert "Error:" in result.output
+        assert "ParseError" not in result.output

--- a/tests/unit/cli/test_plan_parse.py
+++ b/tests/unit/cli/test_plan_parse.py
@@ -1,0 +1,382 @@
+"""Unit tests for the SHOWPLAN XML parser (_plan_parse) and Rich renderer (_plan_render).
+
+Fixture: a hand-crafted SHOWPLAN_XML document that exercises:
+- Hash Match (Inner Join) over two Clustered Index Scans
+- One operator marked Parallel="1"
+- One operator with a <Warnings> child
+- A second StmtSimple (multi-statement batch)
+- Realistic EstimateRows / EstimatedTotalSubtreeCost values
+
+The live Fabric API is NOT accessed — all tests run against the hand-built XML.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from rich.console import Console
+
+from fabric_dw.cli._plan_parse import (
+    PlanOperator,
+    _assign_cost_pct,
+    humanise_rows,
+    parse_showplan,
+)
+from fabric_dw.cli._plan_render import operator_to_dict, render_plan_tree
+
+_NS = "http://schemas.microsoft.com/sqlserver/2004/07/showplan"
+
+_STMT1_TEXT = "SELECT o.id, c.name FROM dbo.Orders o JOIN dbo.Customers c ON o.cust_id = c.id"
+_STMT2_TEXT = "SELECT TOP 1 id FROM dbo.Orders"
+_WARNINGS_EXPR = "CONVERT_IMPLICIT(int, [c].[id], 0)"
+
+_FIXTURE_XML = (
+    f'<?xml version="1.0" encoding="utf-16"?>'
+    f'<ShowPlanXML xmlns="{_NS}" Version="1.6" Build="16.0.0.0">'
+    f"<BatchSequence><Batch><Statements>"
+    f'<StmtSimple StatementText="{_STMT1_TEXT}"'
+    f' StatementId="1" StatementCompId="1" StatementType="SELECT">'
+    f'<QueryPlan DegreeOfParallelism="4" MemoryGrant="2048">'
+    f'<RelOp NodeId="0" PhysicalOp="Hash Match" LogicalOp="Inner Join"'
+    f' EstimateRows="5000" EstimatedTotalSubtreeCost="1.5" Parallel="0">'
+    f"<Hash>"
+    f'<RelOp NodeId="1" PhysicalOp="Clustered Index Scan"'
+    f' LogicalOp="Clustered Index Scan"'
+    f' EstimateRows="10000" EstimatedTotalSubtreeCost="0.9" Parallel="1">'
+    f'<IndexScan Ordered="false">'
+    f"<Warnings>"
+    f'<PlanAffectingConvert ConvertIssue="Cardinality Estimate"'
+    f' Expression="{_WARNINGS_EXPR}"/>'
+    f"</Warnings>"
+    f"</IndexScan>"
+    f"</RelOp>"
+    f'<RelOp NodeId="2" PhysicalOp="Clustered Index Scan"'
+    f' LogicalOp="Clustered Index Scan"'
+    f' EstimateRows="3000" EstimatedTotalSubtreeCost="0.5" Parallel="0">'
+    f'<IndexScan Ordered="false"/>'
+    f"</RelOp>"
+    f"</Hash>"
+    f"</RelOp>"
+    f"</QueryPlan>"
+    f"</StmtSimple>"
+    f'<StmtSimple StatementText="{_STMT2_TEXT}"'
+    f' StatementId="2" StatementCompId="2" StatementType="SELECT">'
+    f'<QueryPlan DegreeOfParallelism="1">'
+    f'<RelOp NodeId="3" PhysicalOp="Clustered Index Scan"'
+    f' LogicalOp="Clustered Index Scan"'
+    f' EstimateRows="1" EstimatedTotalSubtreeCost="0.003" Parallel="0">'
+    f'<IndexScan Ordered="true" ScanDirection="FORWARD"/>'
+    f"</RelOp>"
+    f"</QueryPlan>"
+    f"</StmtSimple>"
+    f"</Statements></Batch></BatchSequence>"
+    f"</ShowPlanXML>"
+)
+
+_EMPTY_STMT_XML = (
+    f'<ShowPlanXML xmlns="{_NS}">'
+    f"<BatchSequence><Batch><Statements>"
+    f'<StmtSimple StatementText="SET NOCOUNT ON"/>'
+    f"</Statements></Batch></BatchSequence>"
+    f"</ShowPlanXML>"
+)
+
+_UNKNOWN_OP_XML = (
+    f'<ShowPlanXML xmlns="{_NS}">'
+    f"<BatchSequence><Batch><Statements>"
+    f'<StmtSimple StatementText="SELECT 1" StatementId="1">'
+    f"<QueryPlan>"
+    f'<RelOp NodeId="0" PhysicalOp="FabricDistributedShuffle"'
+    f' EstimateRows="100" EstimatedTotalSubtreeCost="0.1">'
+    f"<GenericOp/>"
+    f"</RelOp>"
+    f"</QueryPlan>"
+    f"</StmtSimple>"
+    f"</Statements></Batch></BatchSequence>"
+    f"</ShowPlanXML>"
+)
+
+_MISSING_ATTRS_XML = (
+    f'<ShowPlanXML xmlns="{_NS}">'
+    f"<BatchSequence><Batch><Statements>"
+    f'<StmtSimple StatementId="1">'
+    f"<QueryPlan>"
+    f'<RelOp NodeId="0">'
+    f"<GenericOp/>"
+    f"</RelOp>"
+    f"</QueryPlan>"
+    f"</StmtSimple>"
+    f"</Statements></Batch></BatchSequence>"
+    f"</ShowPlanXML>"
+)
+
+
+class TestHumaniseRows:
+    def test_billions(self) -> None:
+        assert humanise_rows(2_500_000_000) == "2.5B"
+
+    def test_millions(self) -> None:
+        assert humanise_rows(1_234_567) == "1.2M"
+
+    def test_thousands(self) -> None:
+        assert humanise_rows(12_300) == "12.3K"
+
+    def test_sub_thousand_whole(self) -> None:
+        assert humanise_rows(5.0) == "5"
+
+    def test_sub_thousand_fractional(self) -> None:
+        assert humanise_rows(5.7) == "5.7"
+
+    def test_zero(self) -> None:
+        assert humanise_rows(0.0) == "0"
+
+    def test_exactly_one_thousand(self) -> None:
+        assert humanise_rows(1000.0) == "1.0K"
+
+    def test_exactly_one_million(self) -> None:
+        assert humanise_rows(1_000_000.0) == "1.0M"
+
+
+class TestParseShowplan:
+    def test_returns_two_statements(self) -> None:
+        operators = parse_showplan(_FIXTURE_XML)
+        assert len(operators) == 2
+
+    def test_first_stmt_is_hash_match(self) -> None:
+        root = parse_showplan(_FIXTURE_XML)[0]
+        assert root.physical_op == "Hash Match"
+
+    def test_first_stmt_logical_op(self) -> None:
+        root = parse_showplan(_FIXTURE_XML)[0]
+        assert root.logical_op == "Inner Join"
+
+    def test_first_stmt_node_id(self) -> None:
+        root = parse_showplan(_FIXTURE_XML)[0]
+        assert root.node_id == 0
+
+    def test_first_stmt_estimate_rows(self) -> None:
+        root = parse_showplan(_FIXTURE_XML)[0]
+        assert root.estimate_rows == 5000.0
+
+    def test_first_stmt_subtree_cost(self) -> None:
+        root = parse_showplan(_FIXTURE_XML)[0]
+        assert root.estimated_total_subtree_cost == pytest.approx(1.5)
+
+    def test_first_stmt_two_children(self) -> None:
+        root = parse_showplan(_FIXTURE_XML)[0]
+        assert len(root.children) == 2
+
+    def test_first_child_is_parallel(self) -> None:
+        root = parse_showplan(_FIXTURE_XML)[0]
+        assert root.children[0].parallel is True
+
+    def test_second_child_not_parallel(self) -> None:
+        root = parse_showplan(_FIXTURE_XML)[0]
+        assert root.children[1].parallel is False
+
+    def test_first_child_has_warnings(self) -> None:
+        root = parse_showplan(_FIXTURE_XML)[0]
+        assert root.children[0].has_warnings is True
+
+    def test_second_child_no_warnings(self) -> None:
+        root = parse_showplan(_FIXTURE_XML)[0]
+        assert root.children[1].has_warnings is False
+
+    def test_root_not_parallel(self) -> None:
+        root = parse_showplan(_FIXTURE_XML)[0]
+        assert root.parallel is False
+
+    def test_first_stmt_text(self) -> None:
+        root = parse_showplan(_FIXTURE_XML)[0]
+        assert root.stmt_text is not None
+        assert "Orders" in root.stmt_text
+
+    def test_second_stmt_is_index_scan(self) -> None:
+        second = parse_showplan(_FIXTURE_XML)[1]
+        assert second.physical_op == "Clustered Index Scan"
+
+    def test_second_stmt_no_children(self) -> None:
+        second = parse_showplan(_FIXTURE_XML)[1]
+        assert second.children == []
+
+    def test_second_stmt_text(self) -> None:
+        second = parse_showplan(_FIXTURE_XML)[1]
+        assert second.stmt_text is not None
+        assert "TOP 1" in second.stmt_text
+
+    def test_empty_stmt_returns_empty_list(self) -> None:
+        operators = parse_showplan(_EMPTY_STMT_XML)
+        assert operators == []
+
+    def test_unknown_physical_op_does_not_crash(self) -> None:
+        operators = parse_showplan(_UNKNOWN_OP_XML)
+        assert len(operators) == 1
+        assert operators[0].physical_op == "FabricDistributedShuffle"
+
+    def test_missing_attributes_use_defaults(self) -> None:
+        operators = parse_showplan(_MISSING_ATTRS_XML)
+        assert len(operators) == 1
+        root = operators[0]
+        assert root.physical_op == "Unknown"
+        assert root.logical_op == "Unknown"
+        assert root.estimate_rows == 0.0
+        assert root.estimated_total_subtree_cost == 0.0
+        assert root.parallel is False
+        assert root.node_id == 0
+
+    def test_missing_all_attributes_node_id_default(self) -> None:
+        xml = (
+            f'<ShowPlanXML xmlns="{_NS}">'
+            f"<BatchSequence><Batch><Statements>"
+            f'<StmtSimple StatementId="1">'
+            f"<QueryPlan>"
+            f'<RelOp PhysicalOp="GenericOp"><GenericOp/></RelOp>'
+            f"</QueryPlan>"
+            f"</StmtSimple>"
+            f"</Statements></Batch></BatchSequence>"
+            f"</ShowPlanXML>"
+        )
+        operators = parse_showplan(xml)
+        assert operators[0].node_id == -1
+
+
+class TestCostPct:
+    def test_root_cost_pct_via_parse(self) -> None:
+        root = parse_showplan(_FIXTURE_XML)[0]
+        assert root.cost_pct == pytest.approx(40.0)
+
+    def test_first_child_cost_pct(self) -> None:
+        root = parse_showplan(_FIXTURE_XML)[0]
+        child = root.children[0]
+        assert child.cost_pct == pytest.approx(60.0)
+
+    def test_second_child_cost_pct(self) -> None:
+        root = parse_showplan(_FIXTURE_XML)[0]
+        child = root.children[1]
+        assert child.cost_pct == pytest.approx(33.33, rel=1e-2)
+
+    def test_zero_root_cost_guard(self) -> None:
+        root = PlanOperator(
+            physical_op="Op",
+            estimated_total_subtree_cost=0.0,
+        )
+        _assign_cost_pct(root, 0.0)
+        assert root.cost_pct == 0.0
+
+    def test_leaf_cost_pct_equals_full_subtree_cost(self) -> None:
+        second = parse_showplan(_FIXTURE_XML)[1]
+        assert second.cost_pct == pytest.approx(100.0)
+
+    def test_cost_pcts_do_not_exceed_100_for_leaf(self) -> None:
+        root = parse_showplan(_FIXTURE_XML)[0]
+        all_nodes = [root, *root.children]
+        for node in all_nodes:
+            assert node.cost_pct <= 100.0 + 1e-6
+
+
+class TestOperatorToDict:
+    def test_root_keys_present(self) -> None:
+        root = parse_showplan(_FIXTURE_XML)[0]
+        d = operator_to_dict(root)
+        expected_keys = {
+            "physicalOp",
+            "logicalOp",
+            "nodeId",
+            "estimateRows",
+            "estimatedTotalSubtreeCost",
+            "parallel",
+            "hasWarnings",
+            "costPct",
+            "stmtText",
+            "children",
+        }
+        assert set(d.keys()) == expected_keys
+
+    def test_children_serialised(self) -> None:
+        root = parse_showplan(_FIXTURE_XML)[0]
+        d = operator_to_dict(root)
+        assert len(d["children"]) == 2
+
+    def test_json_serialisable(self) -> None:
+        root = parse_showplan(_FIXTURE_XML)[0]
+        d = operator_to_dict(root)
+        payload = json.dumps(d)
+        parsed = json.loads(payload)
+        assert parsed["physicalOp"] == "Hash Match"
+
+    def test_parallel_flag_serialised(self) -> None:
+        root = parse_showplan(_FIXTURE_XML)[0]
+        d = operator_to_dict(root)
+        assert d["parallel"] is False
+        assert d["children"][0]["parallel"] is True
+
+    def test_has_warnings_serialised(self) -> None:
+        root = parse_showplan(_FIXTURE_XML)[0]
+        d = operator_to_dict(root)
+        assert d["children"][0]["hasWarnings"] is True
+        assert d["children"][1]["hasWarnings"] is False
+
+
+def _render_to_str(operators: list[PlanOperator]) -> str:
+    """Render *operators* to a string via a record-mode Console."""
+    console = Console(record=True, highlight=False, width=120)
+    render_plan_tree(operators, console=console)
+    return console.export_text()
+
+
+class TestRenderPlanTree:
+    def test_renders_physical_op(self) -> None:
+        operators = parse_showplan(_FIXTURE_XML)
+        output = _render_to_str(operators)
+        assert "Hash Match" in output
+
+    def test_renders_logical_op_when_different(self) -> None:
+        operators = parse_showplan(_FIXTURE_XML)
+        output = _render_to_str(operators)
+        assert "Inner Join" in output
+
+    def test_renders_estimate_rows_humanised(self) -> None:
+        operators = parse_showplan(_FIXTURE_XML)
+        output = _render_to_str(operators)
+        assert "5.0K" in output
+
+    def test_renders_cost_pct(self) -> None:
+        operators = parse_showplan(_FIXTURE_XML)
+        output = _render_to_str(operators)
+        assert "40.0%" in output
+
+    def test_renders_parallel_badge(self) -> None:
+        operators = parse_showplan(_FIXTURE_XML)
+        output = _render_to_str(operators)
+        assert "[Parallel]" in output
+
+    def test_renders_warnings_badge(self) -> None:
+        operators = parse_showplan(_FIXTURE_XML)
+        output = _render_to_str(operators)
+        assert "[!Warnings]" in output
+
+    def test_renders_statement_text_header(self) -> None:
+        operators = parse_showplan(_FIXTURE_XML)
+        output = _render_to_str(operators)
+        assert "Orders" in output
+
+    def test_renders_multiple_statements(self) -> None:
+        operators = parse_showplan(_FIXTURE_XML)
+        output = _render_to_str(operators)
+        assert "Statement 1" in output
+        assert "Statement 2" in output
+
+    def test_empty_operators_shows_message(self) -> None:
+        output = _render_to_str([])
+        assert "No plan operators" in output
+
+    def test_unknown_op_renders_gracefully(self) -> None:
+        operators = parse_showplan(_UNKNOWN_OP_XML)
+        output = _render_to_str(operators)
+        assert "FabricDistributedShuffle" in output
+
+    def test_same_physical_and_logical_op_not_duplicated(self) -> None:
+        second = parse_showplan(_FIXTURE_XML)[1]
+        output = _render_to_str([second])
+        assert "(Clustered Index Scan)" not in output

--- a/tests/unit/cli/test_plan_parse.py
+++ b/tests/unit/cli/test_plan_parse.py
@@ -243,8 +243,9 @@ class TestParseShowplan:
 
 class TestCostPct:
     def test_root_cost_pct_via_parse(self) -> None:
+        # root own = 1.5 - (0.9 + 0.5) = 0.1  => 0.1/1.5*100 ≈ 6.67%
         root = parse_showplan(_FIXTURE_XML)[0]
-        assert root.cost_pct == pytest.approx(40.0)
+        assert root.cost_pct == pytest.approx(100.0 * 0.1 / 1.5, rel=1e-3)
 
     def test_first_child_cost_pct(self) -> None:
         root = parse_showplan(_FIXTURE_XML)[0]
@@ -255,6 +256,13 @@ class TestCostPct:
         root = parse_showplan(_FIXTURE_XML)[0]
         child = root.children[1]
         assert child.cost_pct == pytest.approx(33.33, rel=1e-2)
+
+    def test_cost_pcts_sum_to_100(self) -> None:
+        """All operator cost percentages in a plan must sum to ≈ 100%."""
+        root = parse_showplan(_FIXTURE_XML)[0]
+        all_nodes = [root, *root.children]
+        total = sum(node.cost_pct for node in all_nodes)
+        assert total == pytest.approx(100.0, abs=0.5)
 
     def test_zero_root_cost_guard(self) -> None:
         root = PlanOperator(
@@ -268,7 +276,7 @@ class TestCostPct:
         second = parse_showplan(_FIXTURE_XML)[1]
         assert second.cost_pct == pytest.approx(100.0)
 
-    def test_cost_pcts_do_not_exceed_100_for_leaf(self) -> None:
+    def test_cost_pcts_do_not_exceed_100_per_node(self) -> None:
         root = parse_showplan(_FIXTURE_XML)[0]
         all_nodes = [root, *root.children]
         for node in all_nodes:
@@ -342,9 +350,10 @@ class TestRenderPlanTree:
         assert "5.0K" in output
 
     def test_renders_cost_pct(self) -> None:
+        # root own cost = 1.5 - (0.9 + 0.5) = 0.1 => 6.7%
         operators = parse_showplan(_FIXTURE_XML)
         output = _render_to_str(operators)
-        assert "40.0%" in output
+        assert "6.7%" in output
 
     def test_renders_parallel_badge(self) -> None:
         operators = parse_showplan(_FIXTURE_XML)
@@ -380,3 +389,61 @@ class TestRenderPlanTree:
         second = parse_showplan(_FIXTURE_XML)[1]
         output = _render_to_str([second])
         assert "(Clustered Index Scan)" not in output
+
+    def test_bracket_identifiers_not_stripped_from_stmt_text(self) -> None:
+        """SQL bracket identifiers in stmt_text must survive Rich rendering."""
+        bracket_xml = (
+            f'<ShowPlanXML xmlns="{_NS}">'  # noqa: S608
+            f"<BatchSequence><Batch><Statements>"
+            f'<StmtSimple StatementText="SELECT [name] FROM [dbo].[Orders]"'
+            f' StatementId="1">'
+            f"<QueryPlan>"
+            f'<RelOp NodeId="0" PhysicalOp="Clustered Index Scan"'
+            f' LogicalOp="Clustered Index Scan"'
+            f' EstimateRows="1" EstimatedTotalSubtreeCost="0.003" Parallel="0">'
+            f'<IndexScan Ordered="true"/>'
+            f"</RelOp>"
+            f"</QueryPlan>"
+            f"</StmtSimple>"
+            f"</Statements></Batch></BatchSequence>"
+            f"</ShowPlanXML>"
+        )
+        operators = parse_showplan(bracket_xml)
+        output = _render_to_str(operators)
+        assert "[name]" in output
+        assert "[dbo]" in output
+        assert "[Orders]" in output
+
+
+class TestParseShowplanErrors:
+    """Error-path tests for parse_showplan and humanise_rows."""
+
+    def test_malformed_xml_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="Malformed SHOWPLAN XML"):
+            parse_showplan("not valid xml at all")
+
+    def test_truncated_xml_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="Malformed SHOWPLAN XML"):
+            parse_showplan("<ShowPlanXML")
+
+    def test_valid_xml_not_showplan_returns_empty(self) -> None:
+        # Well-formed XML that is not a ShowPlanXML document — no StmtSimple nodes
+        operators = parse_showplan("<root><child/></root>")
+        assert operators == []
+
+
+class TestHumaniseRowsEdgeCases:
+    def test_nan_returns_string(self) -> None:
+        result = humanise_rows(float("nan"))
+        assert isinstance(result, str)
+        # Must not raise
+
+    def test_inf_returns_string(self) -> None:
+        result = humanise_rows(float("inf"))
+        assert isinstance(result, str)
+        # Must not raise
+
+    def test_neg_inf_returns_string(self) -> None:
+        result = humanise_rows(float("-inf"))
+        assert isinstance(result, str)
+        # Must not raise


### PR DESCRIPTION
## Summary

- Adds a pure stdlib SHOWPLAN XML parser (`_plan_parse.py`) that walks the operator tree and computes per-node cost percentages.
- Adds a Rich terminal tree renderer (`_plan_render.py`) that shows each operator with op name, humanised row count, colour-coded cost %, and `[Parallel]`/`[!Warnings]` badges.
- Evolves `sql plan` to four output modes: Rich tree (default), `--raw`/`--xml` (raw XML to stdout), `-o PATH` (XML to file, unchanged), and `--json` (parsed operator tree as JSON).
- 50 new unit tests over a hand-built SHOWPLAN XML fixture covering parser shape, cost-% logic, humanise helper, unknown-op tolerance, multi-statement batches, and Rich output assertions.
- `docs/cli.md` updated for all four modes.

Closes #510. Part of #508 — export formats (HTML/Mermaid/DOT) remain deferred.

## Test plan

- [x] `just check` passes (ruff lint + format, ty type check, unit tests — 3641 passed)
- [x] `just cov` passes (95% overall, well above 80% threshold)
- [x] Drift guard (`test_generated_page_matches_committed_file`) passes
- [x] 50 new plan-parser/renderer tests all pass
- [x] Updated `sql plan` tests (default tree, `--raw`, `--xml`, `--json`, `-o` file) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)