### PR TITLE
docs: add concepts and exit-codes pages

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,0 +1,54 @@
+---
+title: Concepts
+---
+
+# Concepts
+
+The sections below describe cross-cutting concepts that apply to all `fabric-dw` commands: how the CLI distinguishes between item kinds, which global flags are available on every invocation, and how the target workspace is resolved. Understanding these concepts first makes the rest of the [CLI reference](cli.md) easier to follow.
+
+---
+
+## Item targets: Data Warehouse vs SQL Analytics Endpoint
+
+Fabric has two SQL-surface item kinds:
+
+- **Data Warehouse** — read-write, supports full DDL (CREATE/DROP/TRUNCATE TABLE, CREATE/DROP SCHEMA, CREATE/ALTER VIEW, etc.).
+- **SQL Analytics Endpoint** — read-only SQL surface auto-generated over a Lakehouse. DDL and mutating operations are not supported; only read/query operations are allowed.
+
+Each command below is labelled with one of:
+
+- **`Targets: Data Warehouse · SQL Analytics Endpoint`** — the command works on both item kinds.
+- **`Targets: Data Warehouse only`** — the command is blocked on SQL Analytics Endpoints (either by an explicit client-side guard in the source code, because it requires write/DDL capability that endpoints do not have, or because it calls warehouse-scoped REST API paths that are not available for SQL Analytics Endpoints).
+- **`Targets: SQL Analytics Endpoint`** — the command operates on SQL Analytics Endpoints specifically (not on Data Warehouses).
+- **`Targets: Workspace (not item-specific)`** — the command operates at the workspace level and does not target a specific DW or SQL Analytics Endpoint item.
+
+---
+
+## Global options
+
+These options are placed immediately after `fabric-dw` (or `fdw`), before the command group.
+
+| Flag | Description | Default |
+| --- | --- | --- |
+| `-w` / `--workspace TEXT` | Target workspace (name or GUID). Overrides the `FABRIC_DW_DEFAULT_WORKSPACE` environment variable and the configured default. See [Selecting a workspace](#selecting-a-workspace). | — |
+| `--json` | Emit machine-readable JSON instead of Rich tables. | off |
+| `--auth {default\|sp\|interactive}` | Override `FABRIC_AUTH` for this invocation. | `default` |
+| `-y` / `--yes` | Skip confirmation prompts on destructive commands. | off |
+| `-v` / `--verbose` | Enable DEBUG-level logging. | INFO |
+
+The `--auth` flag and the `FABRIC_AUTH` environment variable accept the same three values. See [Authentication](install.md#authentication) for the full credential chain.
+
+---
+
+## Selecting a workspace
+
+Every command that operates on a workspace (everything except `workspaces list` and `cache clear`) resolves the target workspace from the following sources, in priority order:
+
+1. **`-w` / `--workspace` flag** — explicit value passed on the root command, e.g. `fabric-dw -w MyWorkspace warehouses list`.
+2. **`FABRIC_DW_DEFAULT_WORKSPACE` environment variable** — if the flag is absent, the CLI reads this variable.
+3. **Configured default** — set with `fabric-dw config set workspace VALUE`; used when neither the flag nor the environment variable is present.
+4. **Error** — if none of the above is set, the CLI prints a helpful message suggesting you set one of the above.
+
+The `workspaces` command group is an exception: `workspaces get` and `workspaces set-collation` take the workspace as an explicit positional argument (not via `-w`), and `workspaces list` takes no workspace at all.
+
+> **`-A` / `--all-workspaces` interaction:** passing `-A` on the two list commands that support it (`warehouses list`, `sql-endpoints list`) explicitly scans every visible workspace. This flag is mutually exclusive with `-w` (an explicit `-w` conflicts with scanning all workspaces), but it does **not** conflict with a configured default workspace or `FABRIC_DW_DEFAULT_WORKSPACE` — the configured default is silently ignored when `-A` is used.

--- a/docs/reference/exit-codes.md
+++ b/docs/reference/exit-codes.md
@@ -1,0 +1,11 @@
+---
+title: Exit codes
+---
+
+# Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| `0` | Success. |
+| `1` | Usage error, aborted confirmation prompt, or a Fabric API error. |
+| `2` | Reserved. |


### PR DESCRIPTION
## Summary

Additive step B+C of RFC #497 docs restructure. Closes #512.

- Adds `docs/concepts.md` — combines the three cross-cutting sections from `docs/cli.md` verbatim: item targets (Data Warehouse vs SQL Analytics Endpoint), global options, and workspace selection. A one-paragraph intro explains these are the concepts that apply to all commands.
- Adds `docs/reference/exit-codes.md` — migrates the exit codes table from `docs/cli.md` verbatim.

No existing files are modified (`cli.md`, `mcp-tools.md`, `zensical.toml` are all unchanged). Nav wiring and removal of migrated sections from `cli.md` are handled in the final restructure step.

## Test plan

- [ ] Confirm `git diff --stat origin/main` shows only 2 new files added
- [ ] Verify `docs/concepts.md` contains the three `##` sections verbatim (item targets, global options, selecting a workspace)
- [ ] Verify `docs/reference/exit-codes.md` contains the exit codes table verbatim
- [ ] Confirm `cli.md`, `mcp-tools.md`, and `zensical.toml` are unmodified

🤖 Generated with [Claude Code](https://claude.com/claude-code)