### PR TITLE
docs: add warehouses, sql-endpoints, and audit domain pages

### DIFF
--- a/docs/commands/audit.md
+++ b/docs/commands/audit.md
@@ -1,0 +1,291 @@
+---
+title: Audit
+---
+
+# Audit
+
+Manage SQL audit settings for Microsoft Fabric Data Warehouses.
+
+**Targets:** Data Warehouse only
+
+---
+
+## CLI
+
+### audit add-group
+
+**Targets:** Data Warehouse only
+
+Add a single audit action group without overwriting the others. Idempotent — if the group is already present the command succeeds without modifying the configuration. Auditing must already be enabled.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] audit add-group [WAREHOUSE] GROUP
+```
+
+**Example**
+
+```shell
+fdw -w MyWorkspace audit add-group SalesWH BATCH_COMPLETED_GROUP
+```
+
+---
+
+### audit disable
+
+**Targets:** Data Warehouse only
+
+Disable SQL auditing on a warehouse.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] audit disable [WAREHOUSE]
+```
+
+**Example**
+
+```shell
+fdw -w MyWorkspace audit disable SalesWH
+```
+
+---
+
+### audit enable
+
+**Targets:** Data Warehouse only
+
+Enable SQL auditing on a warehouse.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] audit enable [OPTIONS] [WAREHOUSE]
+```
+
+| Option | Description | Default |
+| --- | --- | --- |
+| `--retention-days INTEGER` | Audit log retention in days (>= 1). Mutually exclusive with `--unlimited`. | — |
+| `--unlimited` | Set unlimited audit log retention (service value 0). Mutually exclusive with `--retention-days`. | off |
+
+Omitting both `--retention-days` and `--unlimited` defaults to unlimited retention. Passing `0` for `--retention-days` is rejected — use `--unlimited` for no-limit retention.
+
+**Example**
+
+```shell
+# Retain logs for 90 days
+fdw -w MyWorkspace audit enable --retention-days 90 SalesWH
+
+# Unlimited retention
+fdw -w MyWorkspace audit enable --unlimited SalesWH
+```
+
+---
+
+### audit get
+
+**Targets:** Data Warehouse only
+
+Get the current audit settings for a warehouse.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] audit get [WAREHOUSE]
+```
+
+**Example**
+
+```shell
+fdw -w MyWorkspace audit get SalesWH
+```
+
+```
+state            Enabled
+retentionDays    7
+actionGroups     BATCH_COMPLETED_GROUP
+```
+
+---
+
+### audit remove-group
+
+**Targets:** Data Warehouse only
+
+Remove a single audit action group without overwriting the others. Idempotent — if the group is not present the command succeeds without modifying the configuration. Auditing must already be enabled.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] audit remove-group [WAREHOUSE] GROUP
+```
+
+**Example**
+
+```shell
+fdw -w MyWorkspace audit remove-group SalesWH BATCH_COMPLETED_GROUP
+```
+
+---
+
+### audit set-groups
+
+**Targets:** Data Warehouse only
+
+Set the audit action groups for a warehouse. Pass `--group` / `-g` once per action group. This replaces the existing list of groups.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] audit set-groups -g GROUP [-g GROUP ...] [WAREHOUSE]
+```
+
+| Option | Description |
+| --- | --- |
+| `-g` / `--group TEXT` | Audit action group name. Repeat for multiple groups. (required) |
+
+**Example**
+
+```shell
+fdw -w MyWorkspace audit set-groups \
+  -g BATCH_COMPLETED_GROUP \
+  -g SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP \
+  SalesWH
+```
+
+---
+
+### audit set-retention
+
+**Targets:** Data Warehouse only
+
+Update the audit log retention period without changing the audit enabled/disabled state. Audit must already be enabled; if it is disabled, run `audit enable` first.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] audit set-retention --days INTEGER [WAREHOUSE]
+```
+
+| Option | Description |
+| --- | --- |
+| `--days INTEGER` | Retention period in days (1–3653; 3653 ≈ 10 years). (required) |
+
+**Example**
+
+```shell
+fdw -w MyWorkspace audit set-retention --days 90 SalesWH
+```
+
+---
+
+## MCP tools
+
+### add_audit_group
+
+**Targets:** Data Warehouse only
+
+Add a single audit action group without overwriting the others. Idempotent — if the group is already present the current settings are returned unchanged. Auditing must already be enabled.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `warehouse` (`str`) — warehouse name or GUID.
+- `group` (`str`) — action group name (e.g. `"BATCH_COMPLETED_GROUP"`).
+
+**Returns:** `AuditSettings` — the updated audit settings.
+
+---
+
+### disable_audit
+
+**Targets:** Data Warehouse only
+
+Disable SQL auditing on a warehouse.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `warehouse` (`str`) — warehouse name or GUID.
+
+**Returns:** `AuditSettings` — the updated audit settings.
+
+---
+
+### enable_audit
+
+**Targets:** Data Warehouse only
+
+Enable SQL auditing on a warehouse.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `warehouse` (`str`) — warehouse name or GUID.
+- `retention_days` (`int`, default `0`) — audit log retention in days; `0` means unlimited.
+
+**Returns:** `AuditSettings` — the updated audit settings.
+
+---
+
+### get_audit_settings
+
+**Targets:** Data Warehouse only
+
+Fetch the current SQL audit settings for a warehouse.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `warehouse` (`str`) — warehouse name or GUID.
+
+**Returns:** `AuditSettings` — object with `state` (`Enabled` or `Disabled`), `retentionDays`, and `auditActionsAndGroups`.
+
+---
+
+### remove_audit_group
+
+**Targets:** Data Warehouse only
+
+Remove a single audit action group without overwriting the others. Idempotent — if the group is not present the current settings are returned unchanged. Auditing must already be enabled.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `warehouse` (`str`) — warehouse name or GUID.
+- `group` (`str`) — action group name (e.g. `"BATCH_COMPLETED_GROUP"`).
+
+**Returns:** `AuditSettings` — the updated audit settings.
+
+---
+
+### set_audit_action_groups
+
+**Targets:** Data Warehouse only
+
+Replace the audited action groups for a warehouse. This overwrites the existing list of groups.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `warehouse` (`str`) — warehouse name or GUID.
+- `action_groups` (`list[str]`) — list of audit action group names (e.g. `["BATCH_COMPLETED_GROUP"]`).
+
+**Returns:** `AuditSettings` — the updated audit settings.
+
+---
+
+### set_audit_retention
+
+**Targets:** Data Warehouse only
+
+Update the audit log retention period without changing the audit enabled/disabled state. Audit must already be enabled; if it is disabled, enable it first with `enable_audit`.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `warehouse` (`str`) — warehouse name or GUID.
+- `days` (`int`) — retention period in days (1–3653; 3653 ≈ 10 years).
+
+**Returns:** `AuditSettings` — the updated audit settings.

--- a/docs/commands/sql-endpoints.md
+++ b/docs/commands/sql-endpoints.md
@@ -1,0 +1,205 @@
+---
+title: SQL Analytics Endpoints
+---
+
+# SQL Analytics Endpoints
+
+Manage Microsoft Fabric SQL Analytics Endpoints.
+
+**Targets:** SQL Analytics Endpoint
+
+---
+
+## CLI
+
+### sql-endpoints get
+
+**Targets:** SQL Analytics Endpoint
+
+Get details for a specific SQL Analytics Endpoint.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] sql-endpoints get ENDPOINT
+```
+
+**Example**
+
+```shell
+fdw -w MyWorkspace sql-endpoints get MyLakehouseEP
+```
+
+---
+
+### sql-endpoints list
+
+**Targets:** SQL Analytics Endpoint
+
+List all SQL Analytics Endpoints in a workspace. Supports `-A` / `--all-workspaces` to scan every visible workspace. `-w` / `--workspace` and `--all-workspaces` are mutually exclusive.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] sql-endpoints list [-A]
+```
+
+| Option | Description |
+| --- | --- |
+| `-A` / `--all-workspaces` | Scan all visible workspaces and aggregate results. Mutually exclusive with `-w`. |
+
+**Example**
+
+```shell
+# List endpoints in the default (or configured) workspace
+fdw sql-endpoints list
+
+# List endpoints in a specific workspace
+fdw -w MyWorkspace sql-endpoints list
+
+# Aggregate across all visible workspaces
+fdw sql-endpoints list --all-workspaces
+```
+
+```
+ displayName        id
+ ------------------ ------------------------------------
+ MyLakehouseEP      f9e1...
+```
+
+---
+
+### sql-endpoints permissions
+
+**Targets:** SQL Analytics Endpoint
+
+List all principals (users, groups, service principals) with access to a SQL Analytics Endpoint, including their effective permissions. Requires **Fabric Administrator** role.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] [--json] sql-endpoints permissions ENDPOINT
+```
+
+| Option | Description |
+| --- | --- |
+| `--json` | Emit raw JSON instead of a Rich table. Pass on the root command. |
+
+**Example**
+
+```shell
+# Tabular output
+fdw -w MyWorkspace sql-endpoints permissions MyLakehouseEP
+
+# Raw JSON
+fdw -w MyWorkspace --json sql-endpoints permissions MyLakehouseEP
+```
+
+```
+ Display Name    UPN / App ID             Type    Permissions    Additional Permissions
+ --------------- ------------------------ ------- -------------- ----------------------
+ Alice           alice@contoso.com        User    Read, Write
+ DataPipeline    00000000-0000-...        ServicePrincipal  Read
+```
+
+---
+
+### sql-endpoints refresh
+
+**Targets:** SQL Analytics Endpoint
+
+Refresh metadata for a SQL Analytics Endpoint by triggering a sync from the underlying Lakehouse delta tables. This is a long-running operation (LRO) that is polled to completion.
+
+Results are shown as a Rich table (Table, Status, End Time, Error). Pass `--json` on the root command to emit raw JSON instead.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] sql-endpoints refresh [--recreate-tables] ENDPOINT
+```
+
+**Options**
+
+| Flag | Description |
+|------|-------------|
+| `--recreate-tables` | Drop and recreate all tables during the refresh. Use to resolve inconsistencies or force a clean rebuild. **Destructive** — use with caution. |
+
+**Example**
+
+```shell
+# Standard refresh — shows a per-table Rich table
+fdw -w MyWorkspace sql-endpoints refresh MyLakehouseEP
+
+# Force a full table recreate
+fdw -w MyWorkspace sql-endpoints refresh --recreate-tables MyLakehouseEP
+
+# Emit raw JSON
+fdw -w MyWorkspace --json sql-endpoints refresh MyLakehouseEP
+```
+
+---
+
+## MCP tools
+
+### get_sql_endpoint
+
+**Targets:** SQL Analytics Endpoint
+
+Return details for a single SQL analytics endpoint.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `endpoint` (`str`) — endpoint name or GUID.
+
+**Returns:** `Warehouse` — single SQL analytics endpoint object.
+
+---
+
+### get_sql_endpoint_permissions
+
+**Targets:** SQL Analytics Endpoint
+
+Return all principals (users, groups, service principals) with access to a SQL Analytics Endpoint, including their effective permissions.
+
+!!! note
+
+    Requires **Fabric Administrator** role (`Tenant.Read.All` or `Tenant.ReadWrite.All` scope). See [Microsoft Fabric admin documentation](https://learn.microsoft.com/en-us/fabric/admin/microsoft-fabric-admin) for how to request the role.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `sql_endpoint` (`str`) — SQL analytics endpoint name or GUID.
+
+**Returns:** `list[ItemAccess]` — array of access records, each with `principal` (containing `id`, `displayName`, `type`, and type-specific fields such as `userPrincipalName` or `aadAppId`) and `itemAccessDetails` (containing `type`, `permissions`, and `additionalPermissions`).
+
+---
+
+### list_sql_endpoints
+
+**Targets:** SQL Analytics Endpoint
+
+List all SQL analytics endpoints in a workspace, or across all visible workspaces.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID; required when `all_workspaces` is `false`; ignored when `true`.
+- `all_workspaces` (`bool`, default `false`) — when `true`, aggregate results across every workspace the caller can see.
+
+**Returns:** `list[Warehouse]` — array of SQL analytics endpoint objects (same fields as Warehouse, `kind` is always `SQLEndpoint`).
+
+---
+
+### refresh_sql_endpoint_metadata
+
+**Targets:** SQL Analytics Endpoint
+
+Refresh metadata for a SQL analytics endpoint by syncing from the underlying Lakehouse delta tables. This is a long-running operation (LRO) polled to completion.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `endpoint` (`str`) — endpoint name or GUID.
+- `recreate_tables` (`bool`, default `False`) — drop and recreate all tables during the refresh. Use to resolve inconsistencies or force a clean rebuild. DESTRUCTIVE — use with caution.
+
+**Returns:** `list[TableSyncStatus]` — array of per-table sync results, each with `tableName`, `status`, `startDateTime`, `endDateTime`, `lastSuccessfulSyncDateTime`, and `error`.

--- a/docs/commands/warehouses.md
+++ b/docs/commands/warehouses.md
@@ -1,0 +1,315 @@
+---
+title: Warehouses
+---
+
+# Warehouses
+
+Manage Microsoft Fabric Data Warehouses and SQL Analytics Endpoints.
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+---
+
+## CLI
+
+### warehouses create
+
+**Targets:** Data Warehouse only
+
+Create a new warehouse in a workspace.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] warehouses create [OPTIONS] NAME
+```
+
+| Option | Description |
+| --- | --- |
+| `--collation TEXT` | Default collation for the new warehouse. |
+| `--description TEXT` | Description for the new warehouse. |
+
+**Example**
+
+```shell
+fdw -w MyWorkspace warehouses create NewWH --description "Staging warehouse"
+```
+
+---
+
+### warehouses delete
+
+**Targets:** Data Warehouse only
+
+Delete a warehouse. You will be asked to confirm unless `--yes` is passed.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] warehouses delete [WAREHOUSE]
+```
+
+**Example**
+
+```shell
+fdw -w MyWorkspace --yes warehouses delete OldWH
+```
+
+---
+
+### warehouses get
+
+**Targets:** Data Warehouse only
+
+Get details for a specific Data Warehouse. Uses the warehouse-scoped REST path (`GET /workspaces/{ws}/warehouses/{id}`); passing a SQL Analytics Endpoint GUID will return a 404. Use `sql-endpoints get` to retrieve endpoint details.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] warehouses get [WAREHOUSE]
+```
+
+**Example**
+
+```shell
+fdw -w MyWorkspace warehouses get SalesWH
+```
+
+```
+id             7c3f...
+displayName    SalesWH
+description    Main sales warehouse
+```
+
+---
+
+### warehouses list
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+List all Data Warehouses and SQL Analytics Endpoints in a workspace. Pass `-A` / `--all-workspaces` to aggregate across every visible workspace. `-w` / `--workspace` and `--all-workspaces` are mutually exclusive.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] warehouses list [-A] [--warehouses-only]
+```
+
+| Option | Description |
+| --- | --- |
+| `-A` / `--all-workspaces` | Scan all visible workspaces and aggregate results. Mutually exclusive with `-w`. |
+| `--warehouses-only` | List only Warehouses; exclude SQL Analytics Endpoints (skips an API call). |
+
+**Example**
+
+```shell
+# List warehouses in the default (or configured) workspace
+fdw warehouses list
+
+# List warehouses in a specific workspace
+fdw -w MyWorkspace warehouses list
+
+# Aggregate across all visible workspaces
+fdw warehouses list --all-workspaces
+```
+
+```
+ workspace      displayName    id
+ -------------- -------------- ------------------------------------
+ MyWorkspace    SalesWH        7c3f...
+ OtherWS        AnalyticsWH    1a2b...
+```
+
+---
+
+### warehouses permissions
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+List all principals (users, groups, service principals) with access to a warehouse, including their effective permissions. Requires **Fabric Administrator** role.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] [--json] warehouses permissions [WAREHOUSE]
+```
+
+| Option | Description |
+| --- | --- |
+| `--json` | Emit raw JSON instead of a Rich table. Pass on the root command. |
+
+**Example**
+
+```shell
+# Tabular output
+fdw -w MyWorkspace warehouses permissions SalesWH
+
+# Raw JSON
+fdw -w MyWorkspace --json warehouses permissions SalesWH
+```
+
+```
+ Display Name    UPN / App ID             Type    Permissions    Additional Permissions
+ --------------- ------------------------ ------- -------------- ----------------------
+ Alice           alice@contoso.com        User    Read, Write
+ DataPipeline    00000000-0000-...        ServicePrincipal  Read
+```
+
+---
+
+### warehouses rename
+
+**Targets:** Data Warehouse only
+
+Rename a warehouse and optionally update its description.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] warehouses rename [OPTIONS] [WAREHOUSE] NEW_NAME
+```
+
+| Option | Description |
+| --- | --- |
+| `--description TEXT` | Optional new description. |
+
+**Example**
+
+```shell
+fdw -w MyWorkspace warehouses rename SalesWH SalesWH_v2 --description "Renamed"
+```
+
+---
+
+### warehouses takeover
+
+**Targets:** Data Warehouse only
+
+Take ownership of a warehouse. Not supported for SQL Analytics Endpoints.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] warehouses takeover [WAREHOUSE]
+```
+
+**Example**
+
+```shell
+fdw -w MyWorkspace warehouses takeover SalesWH
+```
+
+---
+
+## MCP tools
+
+### create_warehouse
+
+**Targets:** Data Warehouse only
+
+Create a new Warehouse in a workspace.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `name` (`str`) — display name for the new warehouse.
+- `collation` (`str | null`, optional) — default collation for the new warehouse.
+- `description` (`str | null`, optional) — description for the new warehouse.
+
+**Returns:** `Warehouse` — the newly-created warehouse object.
+
+---
+
+### delete_warehouse
+
+**Targets:** Data Warehouse only
+
+Delete a Warehouse.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `warehouse` (`str`) — warehouse name or GUID.
+
+**Returns:** `{ "deleted": true, "warehouse_id": str }` — confirmation with the warehouse GUID.
+
+---
+
+### get_warehouse
+
+**Targets:** Data Warehouse only
+
+Return details for a single Data Warehouse. Uses the warehouse-scoped REST path (`GET /workspaces/{ws}/warehouses/{id}`); passing a SQL Analytics Endpoint will return a 404. Use `get_sql_endpoint` to retrieve endpoint details.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `warehouse` (`str`) — warehouse name or GUID.
+
+**Returns:** `Warehouse` — single warehouse object (fields as above).
+
+---
+
+### get_warehouse_permissions
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Return all principals (users, groups, service principals) with access to a Warehouse, including their effective permissions.
+
+!!! note
+
+    Requires **Fabric Administrator** role (`Tenant.Read.All` or `Tenant.ReadWrite.All` scope). See [Microsoft Fabric admin documentation](https://learn.microsoft.com/en-us/fabric/admin/microsoft-fabric-admin) for how to request the role.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `warehouse` (`str`) — warehouse name or GUID.
+
+**Returns:** `list[ItemAccess]` — array of access records, each with `principal` (containing `id`, `displayName`, `type`, and type-specific fields such as `userPrincipalName` or `aadAppId`) and `itemAccessDetails` (containing `type`, `permissions`, and `additionalPermissions`).
+
+---
+
+### list_warehouses
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+List all warehouses and SQL analytics endpoints in a workspace, or across all visible workspaces.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID; required when `all_workspaces` is `false`; ignored when `true`.
+- `all_workspaces` (`bool`, default `false`) — when `true`, aggregate results across every workspace the caller can see.
+
+**Returns:** `list[Warehouse]` — array of warehouse objects, each with `id`, `displayName`, `description`, `workspaceId`, `kind` (`Warehouse` or `SQLEndpoint`), `connectionString`, `defaultCollation`, and `createdDate`.
+
+---
+
+### rename_warehouse
+
+**Targets:** Data Warehouse only
+
+Rename a Warehouse and optionally update its description.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `warehouse` (`str`) — warehouse name or GUID.
+- `new_name` (`str`) — new display name.
+- `description` (`str | null`, optional) — new description; omit to leave unchanged.
+
+**Returns:** `Warehouse` — the updated warehouse object.
+
+---
+
+### takeover_warehouse
+
+**Targets:** Data Warehouse only
+
+Take ownership of a Warehouse. Not supported for SQL analytics endpoints.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `warehouse` (`str`) — warehouse name or GUID.
+
+**Returns:** `{ "taken_over": true, "warehouse_id": str }` — confirmation with the warehouse GUID.


### PR DESCRIPTION
## Summary

- Adds three per-domain reference pages under `docs/commands/` as part of RFC #497 (B+C phase: co-locating CLI + MCP content by domain)
- Content is migrated verbatim from `docs/cli.md` and `docs/mcp-tools.md` — no synthesis, no invented content
- CLI sub-commands and MCP tools are each listed in alphabetical order within their sections

Closes #513

## Pages created

| File | CLI group | MCP section |
| --- | --- | --- |
| `docs/commands/warehouses.md` | `fabric-dw warehouses` | `## Warehouses` |
| `docs/commands/sql-endpoints.md` | `fabric-dw sql-endpoints` | `## SQL analytics endpoints` |
| `docs/commands/audit.md` | `fabric-dw audit` | `## Audit` |

## Out of scope (deferred)

Nav (`zensical.toml`), `docs/cli.md`, and `docs/mcp-tools.md` are intentionally unchanged. Nav wiring and monolith removal are deferred to the final step of RFC #497.

## Test plan

- [ ] Verify `docs/commands/audit.md`, `docs/commands/sql-endpoints.md`, `docs/commands/warehouses.md` exist and render correctly in the docs site
- [ ] Confirm `git diff --stat main` shows only the 3 new files (additive only)
- [ ] Confirm `uv run ruff check .` and `uv run ruff format --check .` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)