### PR TITLE
docs: add SQL-object domain pages (views, schemas, procedures, functions)

### DIFF
--- a/docs/commands/functions.md
+++ b/docs/commands/functions.md
@@ -1,0 +1,296 @@
+---
+title: Functions
+---
+
+# Functions
+
+Manage T-SQL user-defined functions on Microsoft Fabric Data Warehouses and SQL Analytics Endpoints.
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+!!! warning "Preview"
+
+    Scalar UDFs (`FN`) and inline TVFs (`IF`) are preview features as of mid-2026. Function DDL is supported on both Data Warehouses and SQL Analytics Endpoints — no endpoint guard is applied.
+
+---
+
+## CLI
+
+### functions create
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Create a new T-SQL user-defined function. Scalar UDFs and inline TVFs are preview features.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] functions create [OPTIONS] [ITEM]
+```
+
+| Option | Description |
+| --- | --- |
+| `--name SCHEMA.FN` | **Required.** Qualified function name (e.g. `dbo.fn_clean_input`). |
+| `--body TEXT` | Inline function body (parameter list, RETURNS clause, and implementation). |
+| `--from-file PATH` | Path to a `.sql` file containing the function body. |
+
+Exactly one of `--body` or `--from-file` must be provided.
+
+**Example**
+
+```shell
+fdw -w MyWorkspace functions create SalesWH \
+  --name dbo.fn_clean_input \
+  --body "(@input NVARCHAR(100)) RETURNS NVARCHAR(100) AS BEGIN RETURN LTRIM(RTRIM(@input)) END"
+```
+
+---
+
+### functions drop
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Drop a T-SQL user-defined function. You will be asked to confirm unless `--yes` is passed.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] functions drop [OPTIONS] [ITEM] QUALIFIED_NAME
+```
+
+| Option | Description |
+| --- | --- |
+| `--if-exists` | No-op when the function does not exist (`DROP FUNCTION IF EXISTS`). |
+
+**Example**
+
+```shell
+fdw -w MyWorkspace --yes functions drop SalesWH dbo.fn_clean_input
+```
+
+---
+
+### functions get
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Get the full definition of a single T-SQL user-defined function, including its parameter list.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] functions get [ITEM] QUALIFIED_NAME
+```
+
+`QUALIFIED_NAME` must be a dot-separated `schema.fn_name` string, e.g. `dbo.fn_clean_input`.
+
+**Example**
+
+```shell
+fdw -w MyWorkspace functions get SalesWH dbo.fn_clean_input
+```
+
+---
+
+### functions list
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+List T-SQL user-defined functions on a warehouse or SQL Analytics Endpoint. Pass `--schema` to filter by schema, or `--kind` to filter by function kind.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] functions list [OPTIONS] [ITEM]
+```
+
+| Option | Description |
+| --- | --- |
+| `--schema TEXT` | Only list functions in this schema. |
+| `--kind [scalar\|inline-tvf\|all]` | Filter by function kind: `scalar` (FN), `inline-tvf` (IF), or `all` (default). |
+
+**Example**
+
+```shell
+fdw -w MyWorkspace functions list SalesWH --schema dbo --kind scalar
+```
+
+```
+ schema_name  name           kind    is_inlineable  created               modified
+ ------------ -------------- ------- -------------- --------------------- ---------------------
+ dbo          fn_clean_input  scalar  True           2026-06-01T08:00:00Z  2026-06-10T12:00:00Z
+```
+
+---
+
+### functions rename
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Rename a T-SQL user-defined function via `EXEC sp_rename`. The new name must be a bare (unqualified) identifier — `sp_rename` cannot move a function to a different schema. You will be asked to confirm unless `--yes` is passed.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] functions rename [OPTIONS] [ITEM] QUALIFIED_NAME
+```
+
+| Option | Description |
+| --- | --- |
+| `--new-name TEXT` | **Required.** New bare (unqualified) function name. |
+
+**Example**
+
+```shell
+fdw -w MyWorkspace --yes functions rename SalesWH dbo.fn_clean_input \
+  --new-name fn_sanitize_input
+```
+
+---
+
+### functions update
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Redefine an existing T-SQL user-defined function via `CREATE OR ALTER FUNCTION`.
+
+!!! note
+
+    `ALTER FUNCTION` cannot change the function kind (e.g. scalar to inline TVF). The body must be compatible with the original function's kind.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] functions update [OPTIONS] [ITEM] QUALIFIED_NAME
+```
+
+`QUALIFIED_NAME` is the dot-separated `schema.fn_name` to update.
+
+| Option | Description |
+| --- | --- |
+| `--body TEXT` | Inline function body. |
+| `--from-file PATH` | Path to a `.sql` file containing the function body. |
+
+Exactly one of `--body` or `--from-file` must be provided. You will be asked to confirm unless `--yes` is passed.
+
+**Example**
+
+```shell
+fdw -w MyWorkspace functions update SalesWH dbo.fn_clean_input \
+  --from-file ./fns/fn_clean_input_v2.sql
+```
+
+---
+
+## MCP tools
+
+### create_function
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Create a new T-SQL user-defined function. Scalar UDFs and inline TVFs are preview features.
+
+!!! warning "Caution"
+
+    `body` is executed verbatim as DDL. Ensure the body matches the user's intent before calling this tool.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `item` (`str`) — warehouse or SQL Analytics Endpoint name or GUID.
+- `qualified_name` (`str`) — dot-separated qualified function name, e.g. `dbo.fn_clean_input`.
+- `body` (`str`) — the function body (parameter list, RETURNS clause, and implementation).
+
+**Returns:** `FunctionDetails` — the newly-created function object.
+
+---
+
+### drop_function
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Drop a T-SQL user-defined function.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `item` (`str`) — warehouse or SQL Analytics Endpoint name or GUID.
+- `qualified_name` (`str`) — dot-separated qualified function name, e.g. `dbo.fn_clean_input`.
+- `if_exists` (`bool`, optional) — when `true`, emits `DROP FUNCTION IF EXISTS` (no-op when function does not exist). Defaults to `false`.
+
+**Returns:** `{ "dropped": true }` — confirmation.
+
+---
+
+### get_function
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Fetch the full definition of a single T-SQL user-defined function, including its parameter list.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `item` (`str`) — warehouse or SQL Analytics Endpoint name or GUID.
+- `qualified_name` (`str`) — dot-separated qualified function name, e.g. `dbo.fn_clean_input`.
+
+**Returns:** `FunctionDetails` — single function object with `definition` (from `sys.sql_modules`) and `parameters` (from `sys.parameters`).
+
+---
+
+### list_functions
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+List T-SQL user-defined functions on a warehouse or SQL Analytics Endpoint, optionally filtered by schema or kind.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `item` (`str`) — warehouse or SQL Analytics Endpoint name or GUID.
+- `schema` (`str | null`, optional) — when provided, only functions in this schema are returned.
+- `kind` (`str`, optional) — filter by function kind: `"scalar"` (FN only), `"inline-tvf"` (IF only), or `"all"` (FN + IF + TF, the default).
+
+**Returns:** `list[Function]` — array of function objects, each with `schema_name`, `name`, `qualified_name`, `kind`, `is_inlineable`, `created`, and `modified`.
+
+---
+
+### rename_function
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Rename a T-SQL user-defined function via `sp_rename`. The new name must be a bare (unqualified) identifier — `sp_rename` cannot move a function across schemas.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `item` (`str`) — warehouse or SQL Analytics Endpoint name or GUID.
+- `qualified_name` (`str`) — current dot-separated qualified function name, e.g. `dbo.fn_clean_input`.
+- `new_name` (`str`) — new bare function name (no schema prefix), e.g. `fn_sanitize_input`.
+
+**Returns:** `FunctionDetails` — the renamed function record.
+
+---
+
+### update_function
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Redefine a T-SQL user-defined function via `CREATE OR ALTER FUNCTION`.
+
+!!! note
+
+    `ALTER FUNCTION` cannot change the function kind (e.g. scalar to inline TVF). The body must be compatible with the original function's kind.
+
+!!! warning "Caution"
+
+    `body` is executed verbatim as DDL. Ensure the body matches the user's intent before calling this tool.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `item` (`str`) — warehouse or SQL Analytics Endpoint name or GUID.
+- `qualified_name` (`str`) — dot-separated qualified function name, e.g. `dbo.fn_clean_input`.
+- `body` (`str`) — the new function body (parameter list, RETURNS clause, and implementation).
+
+**Returns:** `FunctionDetails` — the updated function object.

--- a/docs/commands/procedures.md
+++ b/docs/commands/procedures.md
@@ -1,0 +1,235 @@
+---
+title: Stored procedures
+---
+
+# Stored procedures
+
+Manage stored procedures on Microsoft Fabric Data Warehouses and SQL Analytics Endpoints.
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+---
+
+## CLI
+
+### procedures create
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Create a new stored procedure.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] procedures create [OPTIONS] [ITEM]
+```
+
+| Option | Description |
+| --- | --- |
+| `--name SCHEMA.PROC` | **Required.** Qualified procedure name (e.g. `dbo.usp_load_sales`). |
+| `--body TEXT` | Inline procedure body (the `AS …` section). |
+| `--from-file PATH` | Path to a `.sql` file containing the procedure body. |
+
+Exactly one of `--body` or `--from-file` must be provided.
+
+**Example**
+
+```shell
+fdw -w MyWorkspace procedures create SalesWH \
+  --name dbo.usp_archive_orders \
+  --body "BEGIN INSERT INTO dbo.archive SELECT * FROM dbo.orders; END"
+```
+
+---
+
+### procedures drop
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Drop a stored procedure. You will be asked to confirm unless `--yes` is passed.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] procedures drop [ITEM] QUALIFIED_NAME
+```
+
+**Example**
+
+```shell
+fdw -w MyWorkspace --yes procedures drop SalesWH dbo.usp_archive_orders
+```
+
+---
+
+### procedures get
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Get the full definition of a single stored procedure.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] procedures get [ITEM] QUALIFIED_NAME
+```
+
+`QUALIFIED_NAME` must be a dot-separated `schema.proc_name` string, e.g. `dbo.usp_load_sales`.
+
+**Example**
+
+```shell
+fdw -w MyWorkspace procedures get SalesWH dbo.usp_load_sales
+```
+
+---
+
+### procedures list
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+List stored procedures on a warehouse or SQL Analytics Endpoint. Pass `--schema` to filter to a single schema.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] procedures list [OPTIONS] [ITEM]
+```
+
+| Option | Description |
+| --- | --- |
+| `--schema TEXT` | Only list procedures in this schema. |
+
+**Example**
+
+```shell
+fdw -w MyWorkspace procedures list SalesWH --schema dbo
+```
+
+```
+ schema_name  name            created               modified
+ ------------ --------------- --------------------- ---------------------
+ dbo          usp_load_sales  2026-01-10T08:00:00Z  2026-06-01T12:00:00Z
+```
+
+---
+
+### procedures update
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Redefine an existing stored procedure via `CREATE OR ALTER PROCEDURE`.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] procedures update [OPTIONS] [ITEM] QUALIFIED_NAME
+```
+
+`QUALIFIED_NAME` is the dot-separated `schema.proc_name` to update.
+
+| Option | Description |
+| --- | --- |
+| `--body TEXT` | Inline procedure body. |
+| `--from-file PATH` | Path to a `.sql` file containing the procedure body. |
+
+Exactly one of `--body` or `--from-file` must be provided. You will be asked to confirm unless `--yes` is passed.
+
+**Example**
+
+```shell
+fdw -w MyWorkspace procedures update SalesWH dbo.usp_archive_orders \
+  --from-file ./procs/usp_archive_orders_v2.sql
+```
+
+---
+
+## MCP tools
+
+### create_procedure
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Create a new stored procedure.
+
+!!! warning "Caution"
+
+    `body` is executed verbatim as DDL. Ensure the body matches the user's intent before calling this tool.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `item` (`str`) — warehouse or SQL analytics endpoint name or GUID.
+- `qualified_name` (`str`) — dot-separated qualified procedure name, e.g. `dbo.usp_load`.
+- `body` (`str`) — the procedure body (the `AS …` section).
+
+**Returns:** `StoredProcedure` — the newly-created procedure object.
+
+---
+
+### drop_procedure
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Drop a stored procedure.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `item` (`str`) — warehouse or SQL analytics endpoint name or GUID.
+- `qualified_name` (`str`) — dot-separated qualified procedure name, e.g. `dbo.usp_load`.
+
+**Returns:** `{ "dropped": true }` — confirmation.
+
+---
+
+### get_procedure
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Fetch the full definition of a single stored procedure.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `item` (`str`) — warehouse or SQL analytics endpoint name or GUID.
+- `qualified_name` (`str`) — dot-separated qualified procedure name, e.g. `dbo.usp_load`.
+
+**Returns:** `StoredProcedure` — single procedure object with `definition` populated from `sys.sql_modules`.
+
+---
+
+### list_procedures
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+List stored procedures on a warehouse or SQL Analytics Endpoint, optionally filtered to a single schema.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `item` (`str`) — warehouse or SQL analytics endpoint name or GUID.
+- `schema` (`str | null`, optional) — when provided, only procedures in this schema are returned.
+
+**Returns:** `list[StoredProcedure]` — array of procedure objects, each with `schema_name`, `name`, `qualified_name`, `created`, and `modified`.
+
+---
+
+### update_procedure
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Redefine a stored procedure via `CREATE OR ALTER PROCEDURE`.
+
+!!! warning "Caution"
+
+    `body` is executed verbatim as DDL. Ensure the body matches the user's intent before calling this tool.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `item` (`str`) — warehouse or SQL analytics endpoint name or GUID.
+- `qualified_name` (`str`) — dot-separated qualified procedure name, e.g. `dbo.usp_load`.
+- `body` (`str`) — the new procedure body (the `AS …` section).
+
+**Returns:** `StoredProcedure` — the updated procedure object.

--- a/docs/commands/schemas.md
+++ b/docs/commands/schemas.md
@@ -1,0 +1,151 @@
+---
+title: Schemas
+---
+
+# Schemas
+
+Manage SQL schemas on Microsoft Fabric Data Warehouses and SQL Analytics Endpoints.
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+!!! note "List source"
+
+    No public REST API exists for enumerating warehouse schemas. `schemas list` (CLI) falls back to TDS via `sys.schemas`, filtering out well-known system schemas (`sys`, `INFORMATION_SCHEMA`, `guest`, `db_*` fixed-role schemas). `dbo` is always included because it is user-writable. `list_schemas` (MCP) uses the same TDS approach.
+
+!!! note "SQL Analytics Endpoints"
+
+    `schemas list`, `schemas create`, and `schemas delete` (CLI) and `list_schemas`, `create_schema`, and `delete_schema` (MCP) all work on both Fabric Data Warehouses and SQL Analytics Endpoints. When `schemas delete --cascade` (CLI) or `delete_schema` with `cascade=True` (MCP) is used on a SQL Analytics Endpoint, views, stored procedures, and functions in the schema are dropped, but tables are **not** dropped (because `DROP TABLE` is a Warehouse-only operation on Fabric). If the schema contains tables, the final `DROP SCHEMA` will be rejected by the engine; remove the tables manually first or omit `--cascade` and drop the schema only after it is empty.
+
+---
+
+## CLI
+
+### schemas create
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Create a new SQL schema on a warehouse.
+
+**Usage**
+
+```shell
+fdw [-w WORKSPACE] schemas create [OPTIONS] [WAREHOUSE] NAME
+```
+
+**Example**
+
+```shell
+fdw -w MyWorkspace schemas create SalesWH reporting
+```
+
+---
+
+### schemas delete
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Drop a schema from a warehouse. You will be asked to confirm unless `--yes` is passed.
+
+Pass `--cascade` to also drop all tables and views inside the schema before dropping the schema itself. **This is a destructive, irreversible operation.**
+
+**Usage**
+
+```shell
+fdw [-w WORKSPACE] schemas delete [OPTIONS] [WAREHOUSE] NAME
+```
+
+| Option | Description |
+| --- | --- |
+| `--cascade` | Drop all tables and views in the schema first. **WARNING: permanently deletes all contained objects and data.** |
+
+**Example**
+
+```shell
+# Drop an empty schema
+fdw -w MyWorkspace --yes schemas delete SalesWH staging
+
+# Drop a schema and all its tables/views
+fdw -w MyWorkspace --yes schemas delete SalesWH staging --cascade
+```
+
+---
+
+### schemas list
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+List all user-defined schemas on a warehouse or SQL Analytics Endpoint. System schemas are excluded.
+
+**Usage**
+
+```shell
+fdw [-w WORKSPACE] schemas list [OPTIONS] [WAREHOUSE]
+```
+
+**Example**
+
+```shell
+fdw -w MyWorkspace schemas list SalesWH
+```
+
+```
+ name     principal_id
+ ───────────────────────
+ dbo      1
+ sales    5
+ staging  7
+```
+
+---
+
+## MCP tools
+
+### create_schema
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Create a new SQL schema on a Fabric Data Warehouse or SQL Analytics Endpoint.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `item` (`str`) — warehouse or SQL analytics endpoint name or GUID.
+- `name` (`str`) — the schema name; must be a valid SQL identifier.
+
+**Returns:** `Schema` — the newly-created schema record with `name` and `principal_id`.
+
+---
+
+### delete_schema
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Drop a SQL schema from a Fabric Data Warehouse or SQL Analytics Endpoint.
+
+**CAUTION**: This is a destructive, irreversible operation. The schema will be permanently deleted. If the schema still contains tables or views the operation will fail unless `cascade=True`.
+
+**CAUTION**: When `cascade=True`, **all tables and views in the schema are permanently deleted along with their data**. Confirm explicitly with the user before calling with `cascade=True`.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `item` (`str`) — warehouse or SQL analytics endpoint name or GUID.
+- `name` (`str`) — the schema name to drop.
+- `cascade` (`bool`, default `False`) — when `True`, drop all tables and views in the schema first.
+
+**Returns:** `{ "deleted": true }` — confirmation.
+
+---
+
+### list_schemas
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+List user-defined SQL schemas on a warehouse or SQL Analytics Endpoint. System schemas are excluded automatically.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `item` (`str`) — warehouse or SQL Analytics Endpoint name or GUID.
+
+**Returns:** `list[Schema]` — array of schema objects, each with `name` and `principal_id`.

--- a/docs/commands/views.md
+++ b/docs/commands/views.md
@@ -1,0 +1,372 @@
+---
+title: Views
+---
+
+# Views
+
+Manage SQL views on Microsoft Fabric Data Warehouses and SQL Analytics Endpoints.
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+---
+
+## CLI
+
+### views count
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Return the total row count of a view using `SELECT COUNT_BIG(*)`.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] views count [WAREHOUSE] QUALIFIED_NAME
+```
+
+**Example**
+
+```shell
+fdw -w MyWorkspace views count SalesWH dbo.vw_sales
+```
+
+```json
+{"schema": "dbo", "name": "vw_sales", "row_count": 12345}
+```
+
+---
+
+### views create
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Create a new SQL view.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] views create [OPTIONS] [WAREHOUSE]
+```
+
+| Option | Description |
+| --- | --- |
+| `--name SCHEMA.VIEW` | **Required.** Qualified view name (e.g. `dbo.vw_sales`). |
+| `--select TEXT` | Inline SELECT statement for the view body. |
+| `--from-file PATH` | Path to a `.sql` file containing the SELECT statement. |
+
+Exactly one of `--select` or `--from-file` must be provided.
+
+**Example**
+
+```shell
+fdw -w MyWorkspace views create SalesWH \
+  --name dbo.vw_recent \
+  --select "SELECT id, amount FROM dbo.sales WHERE sale_date >= '2026-01-01'"
+```
+
+---
+
+### views drop
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Drop a SQL view. You will be asked to confirm unless `--yes` is passed.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] views drop [WAREHOUSE] QUALIFIED_NAME
+```
+
+**Example**
+
+```shell
+fdw -w MyWorkspace --yes views drop SalesWH dbo.vw_recent
+```
+
+---
+
+### views get
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Get the full definition of a single view.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] views get [WAREHOUSE] QUALIFIED_NAME
+```
+
+`QUALIFIED_NAME` must be a dot-separated `schema.view_name` string, e.g. `dbo.vw_sales`.
+
+**Example**
+
+```shell
+fdw -w MyWorkspace views get SalesWH dbo.vw_sales
+```
+
+```
+schema_name    dbo
+name           vw_sales
+qualified_name dbo.vw_sales
+created        2026-01-10T08:00:00Z
+modified       2026-06-01T12:00:00Z
+definition     SELECT id, amount FROM dbo.sales
+```
+
+---
+
+### views list
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+List all views on a warehouse or SQL Analytics Endpoint. Pass `--schema` to filter to a single schema.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] views list [OPTIONS] [WAREHOUSE]
+```
+
+| Option | Description |
+| --- | --- |
+| `--schema TEXT` | Only list views in this schema. |
+
+**Example**
+
+```shell
+fdw -w MyWorkspace views list SalesWH --schema dbo
+```
+
+```
+ schema_name  name         created               modified
+ ------------ ------------ --------------------- ---------------------
+ dbo          vw_sales     2026-01-10T08:00:00Z  2026-06-01T12:00:00Z
+ dbo          vw_monthly   2026-02-01T09:00:00Z  2026-05-15T14:00:00Z
+```
+
+---
+
+### views read
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Read up to `--count` rows from a view and emit them as JSON (default), CSV, or Parquet.
+
+CSV and Parquet formats require `--output`. JSON is emitted to stdout by default.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] views read [OPTIONS] [WAREHOUSE] QUALIFIED_NAME
+```
+
+| Option | Description | Default |
+| --- | --- | --- |
+| `--count N` | Maximum rows to return. | `10` |
+| `--format {json\|csv\|parquet}` | Output format. | `json` |
+| `--output PATH` | Write to file instead of stdout. Required for `csv` and `parquet`. | |
+
+**Example**
+
+```shell
+fdw -w MyWorkspace views read SalesWH dbo.vw_sales --count 5
+```
+
+```json
+[
+  {"id": 1, "amount": 99.99, "customer_id": 42},
+  ...
+]
+```
+
+---
+
+### views rename
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Rename a SQL view via `sp_rename`. The new name must be an unqualified (bare) identifier — `sp_rename` cannot move a view to a different schema.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] views rename [OPTIONS] [WAREHOUSE] QUALIFIED_NAME
+```
+
+`QUALIFIED_NAME` is the current dot-separated `schema.view_name`.
+
+| Option | Description |
+| --- | --- |
+| `--new-name TEXT` | **Required.** New bare view name (no schema prefix). |
+
+**Example**
+
+```shell
+fdw -w MyWorkspace views rename SalesWH dbo.vw_recent --new-name vw_revenue
+```
+
+---
+
+### views update
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Redefine an existing view using `CREATE OR ALTER VIEW`.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] views update [OPTIONS] [WAREHOUSE] QUALIFIED_NAME
+```
+
+`QUALIFIED_NAME` is the dot-separated `schema.view_name` to update.
+
+| Option | Description |
+| --- | --- |
+| `--select TEXT` | Inline SELECT statement for the new view body. |
+| `--from-file PATH` | Path to a `.sql` file containing the new SELECT statement. |
+
+Exactly one of `--select` or `--from-file` must be provided.
+
+**Example**
+
+```shell
+fdw -w MyWorkspace views update SalesWH dbo.vw_recent \
+  --select "SELECT id, amount, region FROM dbo.sales WHERE sale_date >= '2026-01-01'"
+```
+
+---
+
+## MCP tools
+
+### count_view_rows
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Return the total row count of a view via `SELECT COUNT_BIG(*)`.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `item` (`str`) — warehouse or SQL analytics endpoint name or GUID.
+- `qualified_name` (`str`) — dot-separated schema and view name, e.g. `dbo.vw_sales`.
+
+**Returns:** `{ "schema": str, "name": str, "row_count": int }` — the schema name, view name, and total row count.
+
+---
+
+### create_view
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Create a new SQL view.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `item` (`str`) — warehouse or SQL analytics endpoint name or GUID.
+- `qualified_name` (`str`) — dot-separated schema and view name, e.g. `dbo.vw_sales`.
+- `select_body` (`str`) — the SELECT statement that forms the view body; executed verbatim as DDL.
+
+**Returns:** `View` — the newly-created view object (fetched after DDL, includes `definition`).
+
+---
+
+### drop_view
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Drop a SQL view.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `item` (`str`) — warehouse or SQL analytics endpoint name or GUID.
+- `qualified_name` (`str`) — dot-separated schema and view name, e.g. `dbo.vw_sales`.
+
+**Returns:** `{ "dropped": true }` — confirmation.
+
+---
+
+### get_view
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Fetch the full definition of a single SQL view.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `item` (`str`) — warehouse or SQL analytics endpoint name or GUID.
+- `qualified_name` (`str`) — dot-separated schema and view name, e.g. `dbo.vw_sales`.
+
+**Returns:** `View` — single view object with `definition` populated from `sys.sql_modules`.
+
+---
+
+### list_views
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+List SQL views on a warehouse or SQL Analytics Endpoint, optionally filtered to a single schema.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `item` (`str`) — warehouse or SQL analytics endpoint name or GUID.
+- `schema` (`str | null`, optional) — when provided, only views in this schema are returned; must be a valid SQL identifier.
+
+**Returns:** `list[View]` — array of view objects, each with `schema_name`, `name`, `qualified_name`, `created`, `modified`, and `definition` (always `null` for list results).
+
+---
+
+### read_view
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Return up to `count` rows from a view as JSON-serialisable columns and rows.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `item` (`str`) — warehouse or SQL analytics endpoint name or GUID.
+- `qualified_name` (`str`) — dot-separated schema and view name, e.g. `dbo.vw_sales`.
+- `count` (`int`, default `10`) — maximum rows to return.
+
+**Returns:** `{ "columns": list[str], "rows": list[list] }` — column names and row arrays.
+
+---
+
+### rename_view
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Rename a SQL view via `sp_rename`. Works on both Data Warehouses and SQL Analytics Endpoints. The new name must be a bare (unqualified) identifier — `sp_rename` cannot move a view across schemas.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `item` (`str`) — warehouse or SQL analytics endpoint name or GUID.
+- `qualified_name` (`str`) — current dot-separated qualified view name, e.g. `dbo.vw_sales`.
+- `new_name` (`str`) — new bare view name (no schema prefix), e.g. `vw_revenue`.
+
+**Returns:** `View` — the updated view object (fetched after rename, includes `definition`).
+
+---
+
+### update_view
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Redefine an existing SQL view using `CREATE OR ALTER VIEW`.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `item` (`str`) — warehouse or SQL analytics endpoint name or GUID.
+- `qualified_name` (`str`) — dot-separated schema and view name, e.g. `dbo.vw_sales`.
+- `select_body` (`str`) — the new SELECT statement; executed verbatim as DDL.
+
+**Returns:** `View` — the updated view object (fetched after DDL, includes `definition`).


### PR DESCRIPTION
## Summary

- Additive batch B+C of the RFC #497 docs restructure
- Creates four per-domain pages under `docs/commands/` that co-locate CLI and MCP tool reference following the canonical template (`tables.md`, `workspaces.md`)
- Pages created: `views.md`, `schemas.md`, `procedures.md`, `functions.md`
- No edits to `zensical.toml`, `docs/cli.md`, or `docs/mcp-tools.md` — nav wiring and monolith removal are deferred to the final restructure step

## Pages

| File | CLI group | MCP section |
| --- | --- | --- |
| `docs/commands/views.md` | `fabric-dw views` | SQL Views |
| `docs/commands/schemas.md` | `fabric-dw schemas` | Schemas |
| `docs/commands/procedures.md` | `fabric-dw procedures` | Procedures |
| `docs/commands/functions.md` | `fabric-dw functions` | Functions |

## Test plan

- [ ] `uv run ruff check .` passes
- [ ] `uv run ruff format --check .` passes
- [ ] `git diff --stat` shows only 4 new files added under `docs/commands/`
- [ ] Each page follows the canonical template: title, overview, Targets, CLI section (alphabetical `### <group> <sub>`), MCP tools section (alphabetical `### <tool>`)
- [ ] All admonitions, option tables, and examples are preserved verbatim from source files
- [ ] No content invented beyond what exists in `docs/cli.md` and `docs/mcp-tools.md`

Closes #516