### PR TITLE
docs: add snapshots/restore-points/settings/cache domain pages (RFC #497 B+C)

### DIFF
--- a/docs/commands/cache.md
+++ b/docs/commands/cache.md
@@ -1,0 +1,49 @@
+---
+title: Cache
+---
+
+# Cache
+
+Manage the local name-to-UUID lookup cache. `fabric-dw` caches workspace and item name-to-GUID mappings to avoid repeated API round-trips. Use these commands if you rename items outside the CLI or need to force a fresh lookup.
+
+**Targets:** Workspace (not item-specific)
+
+---
+
+## CLI
+
+### cache clear
+
+**Targets:** Workspace (not item-specific)
+
+Clear all cached entries.
+
+**Synopsis**
+
+```
+fdw cache clear
+```
+
+**Example**
+
+```shell
+fdw cache clear
+```
+
+```
+Cache cleared.
+```
+
+---
+
+## MCP tools
+
+### clear_cache
+
+**Targets:** Workspace (not item-specific)
+
+Erase all cached workspace and item name-to-UUID mappings.
+
+**Parameters:** None
+
+**Returns:** `{ "cleared": true }` — confirmation.

--- a/docs/commands/restore-points.md
+++ b/docs/commands/restore-points.md
@@ -1,0 +1,250 @@
+---
+title: Restore Points
+---
+
+# Restore Points
+
+Manage Microsoft Fabric Warehouse restore points.
+
+A restore point captures the state of a warehouse at a point in time. User-defined restore points can be created, renamed, and deleted. System-created restore points are managed automatically by Fabric and cannot be deleted. Restore point IDs are timestamp-based strings (e.g. `"1726617378000"`), not GUIDs.
+
+**Targets:** Data Warehouse only
+
+---
+
+## CLI
+
+### restore-points create
+
+**Targets:** Data Warehouse only
+
+Create a new restore point for a warehouse at the current timestamp.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] restore-points create [OPTIONS] [WAREHOUSE]
+```
+
+| Option | Description |
+| --- | --- |
+| `--name TEXT` | Optional display name (max 128 chars). |
+| `--description TEXT` | Optional description (max 512 chars). |
+
+**Example**
+
+```shell
+fdw -w MyWorkspace restore-points create SalesWH \
+  --name "Before migration" \
+  --description "Pre-migration checkpoint"
+```
+
+---
+
+### restore-points delete
+
+**Targets:** Data Warehouse only
+
+Delete a user-defined restore point. System-created restore points cannot be deleted. You will be asked to confirm unless `--yes` is passed.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] restore-points delete WAREHOUSE RESTORE_POINT_ID
+```
+
+**Example**
+
+```shell
+fdw -w MyWorkspace --yes restore-points delete SalesWH 1726617378000
+```
+
+---
+
+### restore-points get
+
+**Targets:** Data Warehouse only
+
+Get details for a single restore point by ID.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] restore-points get WAREHOUSE RESTORE_POINT_ID
+```
+
+**Example**
+
+```shell
+fdw -w MyWorkspace restore-points get SalesWH 1726617378000
+```
+
+---
+
+### restore-points list
+
+**Targets:** Data Warehouse only
+
+List all restore points for a warehouse.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] restore-points list [WAREHOUSE]
+```
+
+**Example**
+
+```shell
+fdw -w MyWorkspace restore-points list SalesWH
+```
+
+```
+ id              displayName        creationMode   eventDateTime
+ --------------- ------------------ -------------- ---------------------
+ 1726617378000   Before migration   UserDefined    2024-10-18T22:17:09Z
+```
+
+---
+
+### restore-points rename
+
+**Targets:** Data Warehouse only
+
+Rename a restore point and optionally update its description.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] restore-points rename [OPTIONS] WAREHOUSE RESTORE_POINT_ID NEW_NAME
+```
+
+| Option | Description |
+| --- | --- |
+| `--description TEXT` | Optional new description. |
+
+**Example**
+
+```shell
+fdw -w MyWorkspace restore-points rename SalesWH 1726617378000 "Post-migration backup"
+```
+
+---
+
+### restore-points restore
+
+**Targets:** Data Warehouse only
+
+Restore a warehouse in-place to a restore point. **This is a destructive operation** — the warehouse will be unavailable for approximately 10 minutes. You will be asked to confirm unless `--yes` is passed.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] restore-points restore WAREHOUSE RESTORE_POINT_ID
+```
+
+**Example**
+
+```shell
+fdw -w MyWorkspace --yes restore-points restore SalesWH 1726617378000
+```
+
+---
+
+## MCP tools
+
+### create_restore_point
+
+**Targets:** Data Warehouse only
+
+Create a restore point for a warehouse at the current timestamp.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `warehouse` (`str`) — warehouse name or GUID.
+- `name` (`str | null`, optional) — display name (max 128 chars).
+- `description` (`str | null`, optional) — description (max 512 chars).
+
+**Returns:** `RestorePoint` — the newly-created restore point object.
+
+---
+
+### delete_restore_point
+
+**Targets:** Data Warehouse only
+
+Delete a user-defined restore point. System-created restore points cannot be deleted.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `warehouse` (`str`) — warehouse name or GUID.
+- `restore_point_id` (`str`) — the restore point ID string.
+
+**Returns:** `{ "deleted": true, "restore_point_id": str }` — confirmation.
+
+---
+
+### get_restore_point
+
+**Targets:** Data Warehouse only
+
+Return a single restore point by ID.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `warehouse` (`str`) — warehouse name or GUID.
+- `restore_point_id` (`str`) — the restore point ID string (e.g. `"1726617378000"`).
+
+**Returns:** `RestorePoint` — the restore point object.
+
+---
+
+### list_restore_points
+
+**Targets:** Data Warehouse only
+
+Return all restore points for a warehouse.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `warehouse` (`str`) — warehouse name or GUID.
+
+**Returns:** `list[RestorePoint]` — array of restore point objects.
+
+---
+
+### restore_warehouse_in_place
+
+**Targets:** Data Warehouse only
+
+Restore a warehouse in-place to a restore point. **This is a destructive, long-running operation** — the warehouse will be unavailable for approximately 10 minutes while the restore completes.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `warehouse` (`str`) — warehouse name or GUID.
+- `restore_point_id` (`str`) — the restore point ID string to restore to.
+
+**Returns:** `{ "restored": true, "restore_point_id": str }` — confirmation.
+
+---
+
+### update_restore_point
+
+**Targets:** Data Warehouse only
+
+Rename and/or update the description of a restore point. At least one of `name` or `description` must be supplied.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `warehouse` (`str`) — warehouse name or GUID.
+- `restore_point_id` (`str`) — the restore point ID string.
+- `name` (`str | null`, optional) — new display name (max 128 chars).
+- `description` (`str | null`, optional) — new description (max 512 chars).
+
+**Returns:** `RestorePoint` — the updated restore point object.

--- a/docs/commands/settings.md
+++ b/docs/commands/settings.md
@@ -1,0 +1,148 @@
+---
+title: Settings
+---
+
+# Settings
+
+Manage **server-side** database settings on a Fabric Data Warehouse or SQL Analytics Endpoint.
+
+!!! note
+
+    `settings` manages server-side warehouse/database configuration. For client-side CLI defaults (workspace, warehouse) use [`fdw config`](../cli.md#defaults-fabric-dw-config) instead.
+
+`show` and `result-set-caching` work on both Data Warehouses and SQL Analytics Endpoints. The `retention` command sets the time-travel retention period, which is primarily a Warehouse concept and may be a no-op on a SQL Analytics Endpoint.
+
+The workspace is resolved from the global `-w/--workspace` option, the `FABRIC_DW_DEFAULT_WORKSPACE` environment variable, or the client-side config default. `ITEM` may be a display name or GUID.
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+---
+
+## CLI
+
+### settings result-set-caching
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Enable or disable result-set caching.
+
+Executes `ALTER DATABASE CURRENT SET RESULT_SET_CACHING { ON | OFF }` on the target.
+
+```shell
+fdw -w <workspace> settings result-set-caching [ITEM] (on|off)
+```
+
+`STATE` is case-insensitive (`on`, `off`, `ON`, `OFF`).
+
+**Example:**
+
+```shell
+fdw -w MyWorkspace settings result-set-caching MyWarehouse on
+fdw -w MyWorkspace settings result-set-caching MyWarehouse off
+fdw -w MyWorkspace --json settings result-set-caching MyWarehouse on
+```
+
+---
+
+### settings retention
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Set the time-travel retention period in days.
+
+Executes `ALTER DATABASE CURRENT SET TIME_TRAVEL_RETENTION_PERIOD = <DAYS> DAYS` on the target.
+
+```shell
+fdw -w <workspace> settings retention [ITEM] --days DAYS
+```
+
+| Option | Description | Default |
+| --- | --- | --- |
+| `--days N` | Retention period in days (1-120, required). | — |
+
+**Example:**
+
+```shell
+fdw -w MyWorkspace settings retention MyWarehouse --days 30
+fdw -w MyWorkspace --json settings retention MyWarehouse --days 7
+```
+
+---
+
+### settings show
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Display all server-side database settings for an item in a single table.
+
+```shell
+fdw -w <workspace> settings show [ITEM]
+```
+
+**Example:**
+
+```shell
+fdw -w MyWorkspace settings show MyWarehouse
+fdw -w MyWorkspace --json settings show MyWarehouse
+```
+
+---
+
+## MCP tools
+
+### get_warehouse_settings
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+**Guards:** `assert_workspace_allowed`
+
+Return the current server-side database settings for a warehouse. Reads `result_set_caching`, `time_travel_retention_days`, and `time_travel_retention_cutoff_date` from `sys.databases`.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `workspace` | `str` | Workspace name or GUID. |
+| `item` | `str` | Warehouse or SQL Analytics Endpoint name or GUID. |
+
+**Returns:** `WarehouseSettings` — `{ database, result_set_caching, time_travel_retention_days, time_travel_retention_cutoff_date }`.
+
+---
+
+### set_result_set_caching
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+**Guards:** `assert_writes_allowed`, `assert_workspace_allowed`
+
+Enable or disable result-set caching on a warehouse. Executes `ALTER DATABASE CURRENT SET RESULT_SET_CACHING { ON | OFF }` and returns the effective settings after the change.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `workspace` | `str` | Workspace name or GUID. |
+| `item` | `str` | Warehouse or SQL Analytics Endpoint name or GUID. |
+| `enabled` | `bool` | `true` to enable result-set caching, `false` to disable it. |
+
+**Returns:** `WarehouseSettings` — the effective settings after the change.
+
+---
+
+### set_time_travel_retention
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+**Guards:** `assert_writes_allowed`, `assert_workspace_allowed`
+
+Set the time-travel retention period on a warehouse. Executes `ALTER DATABASE CURRENT SET TIME_TRAVEL_RETENTION_PERIOD = <n> DAYS` and returns the effective settings after the change.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `workspace` | `str` | Workspace name or GUID. |
+| `item` | `str` | Warehouse or SQL Analytics Endpoint name or GUID. |
+| `days` | `int` | Retention period in days. Must be in the range 1–120 (inclusive). |
+
+**Returns:** `WarehouseSettings` — the effective settings after the change.

--- a/docs/commands/snapshots.md
+++ b/docs/commands/snapshots.md
@@ -1,0 +1,216 @@
+---
+title: Snapshots
+---
+
+# Snapshots
+
+Manage Microsoft Fabric Data Warehouse snapshots.
+
+**Targets:** Data Warehouse only
+
+---
+
+## CLI
+
+### snapshots create
+
+**Targets:** Data Warehouse only
+
+Create a new snapshot for a warehouse. Optionally pin it to a specific point in time.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] snapshots create [OPTIONS] [WAREHOUSE] NAME
+```
+
+| Option | Description |
+| --- | --- |
+| `--description TEXT` | Optional description. |
+| `--snapshot-dt TEXT` | Optional snapshot datetime (ISO 8601, UTC). Defaults to the current timestamp. |
+
+**Example**
+
+```shell
+fdw -w MyWorkspace snapshots create SalesWH snap-2026-06-08 \
+  --snapshot-dt 2026-06-08T00:00:00Z
+```
+
+---
+
+### snapshots delete
+
+**Targets:** Data Warehouse only
+
+Delete a snapshot. You will be asked to confirm unless `--yes` is passed.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] snapshots delete SNAPSHOT
+```
+
+**Example**
+
+```shell
+fdw -w MyWorkspace --yes snapshots delete snap-old
+```
+
+---
+
+### snapshots list
+
+**Targets:** Data Warehouse only
+
+List all snapshots for a warehouse.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] snapshots list [WAREHOUSE]
+```
+
+**Example**
+
+```shell
+fdw -w MyWorkspace snapshots list SalesWH
+```
+
+```
+ displayName      id           createdTime
+ ---------------- ------------ ---------------------
+ snap-2026-06-01  d1e2...      2026-06-01T00:00:00Z
+```
+
+---
+
+### snapshots rename
+
+**Targets:** Data Warehouse only
+
+Rename a snapshot and optionally update its description.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] snapshots rename [OPTIONS] SNAPSHOT NEW_NAME
+```
+
+| Option | Description |
+| --- | --- |
+| `--description TEXT` | Optional new description. |
+
+**Example**
+
+```shell
+fdw -w MyWorkspace snapshots rename snap-2026-06-01 snap-june-2026
+```
+
+---
+
+### snapshots roll
+
+**Targets:** Data Warehouse only
+
+Roll a snapshot on a warehouse to a new timestamp. `SNAPSHOT_NAME` must be the display name of the snapshot database. The warehouse and workspace are resolved via the usual precedence rules.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] snapshots roll [OPTIONS] [WAREHOUSE] SNAPSHOT_NAME
+```
+
+| Option | Description |
+| --- | --- |
+| `--at TEXT` | Target datetime (ISO 8601, UTC). Defaults to `CURRENT_TIMESTAMP`. |
+
+**Example**
+
+```shell
+fdw -w MyWorkspace snapshots roll SalesWH snap-june-2026 \
+  --at 2026-06-08T12:00:00Z
+```
+
+---
+
+## MCP tools
+
+### create_snapshot
+
+**Targets:** Data Warehouse only
+
+Create a new warehouse snapshot.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `warehouse` (`str`) — warehouse name or GUID.
+- `name` (`str`) — display name for the new snapshot.
+- `description` (`str | null`, optional) — optional description.
+- `snapshot_dt` (`str | null`, optional) — ISO-8601 datetime string for the snapshot point-in-time; defaults to the current timestamp when omitted.
+
+**Returns:** `WarehouseSnapshot` — the newly-created snapshot object.
+
+---
+
+### delete_snapshot
+
+**Targets:** Data Warehouse only
+
+Delete a warehouse snapshot.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `snapshot` (`str`) — snapshot name or GUID.
+
+**Returns:** `{ "deleted": true, "snapshot_id": str }` — confirmation with the snapshot GUID.
+
+---
+
+### list_snapshots
+
+**Targets:** Data Warehouse only
+
+Return all snapshots belonging to a warehouse.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `warehouse` (`str`) — warehouse name or GUID.
+
+**Returns:** `list[WarehouseSnapshot]` — array of snapshot objects, each with `id`, `displayName`, `parentWarehouseId`, and `snapshotDateTime`.
+
+---
+
+### rename_snapshot
+
+**Targets:** Data Warehouse only
+
+Rename a warehouse snapshot and optionally update its description.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `snapshot` (`str`) — snapshot name or GUID.
+- `new_name` (`str`) — new display name.
+- `description` (`str | null`, optional) — new description; omit to leave unchanged.
+
+**Returns:** `WarehouseSnapshot` — the updated snapshot object.
+
+---
+
+### roll_snapshot_timestamp
+
+**Targets:** Data Warehouse only
+
+Roll a snapshot's timestamp forward, or reset it to the current time.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `warehouse` (`str`) — parent warehouse name or GUID (used for the SQL connection).
+- `snapshot_name` (`str`) — the snapshot database name to roll.
+- `new_dt` (`str | null`, optional) — target ISO-8601 datetime string; defaults to `CURRENT_TIMESTAMP` when omitted.
+
+**Returns:** `{ "rolled": true, "snapshot_name": str, "new_dt": str | null }` — confirmation with the snapshot name and the target datetime.


### PR DESCRIPTION
## Summary

- Adds four per-domain command reference pages under `docs/commands/`, co-locating CLI and MCP tool documentation following the canonical template from `tables.md` and `workspaces.md`
- Pages: `snapshots.md`, `restore-points.md`, `settings.md`, `cache.md`
- Additive only — no edits to `zensical.toml`, `docs/cli.md`, or `docs/mcp-tools.md`

Closes #519. Part of RFC #497 (nav restructure and monolith removal are reserved for the final step).

## Test plan

- [ ] Verify all four pages render correctly in the docs site
- [ ] Confirm `### ...` blocks are alphabetically ordered within `## CLI` and `## MCP tools` sections
- [ ] Confirm all admonitions, option tables, and examples are present and faithful to source
- [ ] Confirm no edits were made to `zensical.toml`, `docs/cli.md`, or `docs/mcp-tools.md`
- [ ] `ruff check` and `ruff format --check` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)