### PR TITLE
docs: add SQL & performance domain pages

### DIFF
--- a/docs/commands/queries.md
+++ b/docs/commands/queries.md
@@ -1,0 +1,318 @@
+---
+title: Queries
+---
+
+# Queries
+
+Inspect and manage running queries on Microsoft Fabric Data Warehouses and SQL Analytics Endpoints.
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+---
+
+## CLI
+
+### queries connections
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+List all active SQL connections on a warehouse or SQL Analytics Endpoint. This queries `sys.dm_exec_connections` and shows lower-level connection info (including idle connections) that is not visible in `queries running`.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] queries connections [WAREHOUSE]
+```
+
+**Example**
+
+```shell
+fdw -w MyWorkspace queries connections SalesWH
+```
+
+```
+ session_id  connect_time          client_net_address  auth_scheme  encrypt_option  net_transport  most_recent_session_id
+ ----------  --------------------  ------------------  -----------  --------------  -------------  ----------------------
+ 10          2026-06-08T10:00:00Z  192.168.1.100       NTLM         TRUE            TCP            10
+ 20          2026-06-08T10:01:00Z  192.168.1.101       KERBEROS     FALSE           TCP            20
+```
+
+---
+
+### queries frequent
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+List frequently-run queries from `queryinsights.frequently_run_queries`.
+
+> **Note:** Elapsed-time fields (e.g. `avg_total_elapsed_time_ms`, `min_run_total_elapsed_time_ms`, `max_run_total_elapsed_time_ms`, `last_run_total_elapsed_time_ms`) are typed as `float` (`number` in JSON) because Fabric returns fractional millisecond values. Count fields (`number_of_runs`, `number_of_successful_runs`, `number_of_failed_runs`, `number_of_canceled_runs`) remain `int`.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] queries frequent [OPTIONS] [WAREHOUSE]
+```
+
+| Option | Description | Default |
+| --- | --- | --- |
+| `--limit INTEGER` | Maximum rows to return (1–10 000). | `100` |
+| `--since ISO8601` | Return rows with last_run_start_time >= this value. | — |
+| `--until ISO8601` | Return rows with last_run_start_time <= this value. | — |
+
+**Example**
+
+```shell
+fdw -w MyWorkspace queries frequent SalesWH --limit 20
+```
+
+---
+
+### queries history
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+List completed SQL requests from `queryinsights.exec_requests_history`. Supports optional time-range filtering with `--since` and `--until` (ISO-8601 strings). The `--limit` option caps the number of rows returned (default: 100, max: 10 000).
+
+> **Note:** Elapsed-time and CPU-time fields (e.g. `total_elapsed_time_ms`, `allocated_cpu_time_ms`) are typed as `float` (`number` in JSON) because Fabric returns fractional millisecond values. Count fields (e.g. `row_count`) remain `int`.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] queries history [OPTIONS] [WAREHOUSE]
+```
+
+| Option | Description | Default |
+| --- | --- | --- |
+| `--limit INTEGER` | Maximum rows to return (1–10 000). | `100` |
+| `--since ISO8601` | Return rows with timestamp >= this value. | — |
+| `--until ISO8601` | Return rows with timestamp <= this value. | — |
+
+**Example**
+
+```shell
+fdw -w MyWorkspace queries history SalesWH --limit 50 --since 2026-06-01T00:00:00
+```
+
+---
+
+### queries kill
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Kill a specific session on a warehouse or SQL Analytics Endpoint. You will be asked to confirm unless `--yes` is passed.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] queries kill [WAREHOUSE] SESSION_ID
+```
+
+**Example**
+
+```shell
+fdw -w MyWorkspace --yes queries kill SalesWH 42
+```
+
+---
+
+### queries long-running
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+List long-running queries from `queryinsights.long_running_queries`.
+
+> **Note:** `median_total_elapsed_time_ms` and `last_run_total_elapsed_time_ms` are typed as `float` (`number` in JSON) because Fabric returns fractional millisecond values. `number_of_runs` remains `int`.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] queries long-running [OPTIONS] [WAREHOUSE]
+```
+
+| Option | Description | Default |
+| --- | --- | --- |
+| `--limit INTEGER` | Maximum rows to return (1–10 000). | `100` |
+| `--since ISO8601` | Return rows with last_run_start_time >= this value. | — |
+| `--until ISO8601` | Return rows with last_run_start_time <= this value. | — |
+
+**Example**
+
+```shell
+fdw -w MyWorkspace queries long-running SalesWH
+```
+
+---
+
+### queries running
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+List all currently running queries on a warehouse or SQL Analytics Endpoint.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] queries running [WAREHOUSE]
+```
+
+**Example**
+
+```shell
+fdw -w MyWorkspace queries running SalesWH
+```
+
+```
+ sessionId   loginName   startTime             commandText
+ ----------- ----------- --------------------- -------------------------
+ 42          user@co.io  2026-06-08T10:01:00Z  SELECT * FROM sales ...
+```
+
+---
+
+### queries sessions
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+List completed sessions from `queryinsights.exec_sessions_history`.
+
+> **Note:** `total_query_elapsed_time_ms` is typed as `float` (`number` in JSON) because Fabric returns fractional millisecond values.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] queries sessions [OPTIONS] [WAREHOUSE]
+```
+
+| Option | Description | Default |
+| --- | --- | --- |
+| `--limit INTEGER` | Maximum rows to return (1–10 000). | `100` |
+| `--since ISO8601` | Return rows with session_start_time >= this value. | — |
+| `--until ISO8601` | Return rows with session_start_time <= this value. | — |
+
+**Example**
+
+```shell
+fdw -w MyWorkspace queries sessions SalesWH
+```
+
+---
+
+## MCP tools
+
+The following four tools query the `queryinsights` schema DMVs via TDS. They share the same parameter shape — `workspace`, `warehouse`, optional `limit`, optional `since`, and optional `until`.
+
+### kill_session
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Terminate a session on a warehouse.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `warehouse` (`str`) — warehouse name or GUID.
+- `session_id` (`int`) — the session ID to terminate.
+
+**Returns:** `{ "killed": true, "session_id": int }` — confirmation with the terminated session ID.
+
+---
+
+### list_connections
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Return all active SQL connections on a warehouse or SQL Analytics Endpoint. Queries `sys.dm_exec_connections`, which includes idle connections not visible via `list_running_queries`.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `warehouse` (`str`) — warehouse name or GUID.
+
+**Returns:** `list[Connection]` — array of connection objects, each with `session_id`, `connect_time`, `client_net_address`, `auth_scheme`, `encrypt_option`, and `net_transport`.
+
+---
+
+### list_frequent_queries
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Return frequently-run queries from `queryinsights.frequently_run_queries`.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `warehouse` (`str`) — warehouse or SQL Analytics Endpoint name or GUID.
+- `limit` (`int`, default `100`) — maximum rows to return (1–10 000).
+- `since` (`str | null`, optional) — ISO-8601 lower bound on `last_run_start_time`.
+- `until` (`str | null`, optional) — ISO-8601 upper bound on `last_run_start_time`.
+
+**Returns:** `list[dict]` — array of frequently-run query row objects. Elapsed-time fields (e.g. `avg_total_elapsed_time_ms`, `min_run_total_elapsed_time_ms`, `max_run_total_elapsed_time_ms`, `last_run_total_elapsed_time_ms`) are JSON `number` (float); count fields remain `integer`.
+
+---
+
+### list_long_running_queries
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Return long-running queries from `queryinsights.long_running_queries`.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `warehouse` (`str`) — warehouse or SQL Analytics Endpoint name or GUID.
+- `limit` (`int`, default `100`) — maximum rows to return (1–10 000).
+- `since` (`str | null`, optional) — ISO-8601 lower bound on `last_run_start_time`.
+- `until` (`str | null`, optional) — ISO-8601 upper bound on `last_run_start_time`.
+
+**Returns:** `list[dict]` — array of long-running query row objects. `median_total_elapsed_time_ms` and `last_run_total_elapsed_time_ms` are JSON `number` (float); `number_of_runs` remains `integer`.
+
+---
+
+### list_request_history
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Return completed SQL requests from `queryinsights.exec_requests_history`.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `warehouse` (`str`) — warehouse or SQL Analytics Endpoint name or GUID.
+- `limit` (`int`, default `100`) — maximum rows to return (1–10 000).
+- `since` (`str | null`, optional) — ISO-8601 lower bound on `submit_time`.
+- `until` (`str | null`, optional) — ISO-8601 upper bound on `submit_time`.
+
+**Returns:** `list[dict]` — array of request-history row objects. Elapsed-time and CPU-time fields (e.g. `total_elapsed_time_ms`, `allocated_cpu_time_ms`) are JSON `number` (float) because Fabric returns fractional millisecond values.
+
+---
+
+### list_running_queries
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Return all currently-executing queries on a warehouse.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `warehouse` (`str`) — warehouse name or GUID.
+
+**Returns:** `list[RunningQuery]` — array of query objects, each with `session_id`, `request_id`, `status`, `start_time`, `total_elapsed_time` (ms), `login_name`, `command`, and `query_text`.
+
+---
+
+### list_session_history
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Return completed sessions from `queryinsights.exec_sessions_history`.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `warehouse` (`str`) — warehouse or SQL Analytics Endpoint name or GUID.
+- `limit` (`int`, default `100`) — maximum rows to return (1–10 000).
+- `since` (`str | null`, optional) — ISO-8601 lower bound on `session_start_time`.
+- `until` (`str | null`, optional) — ISO-8601 upper bound on `session_start_time`.
+
+**Returns:** `list[dict]` — array of session-history row objects. `total_query_elapsed_time_ms` is JSON `number` (float) because Fabric returns fractional millisecond values.

--- a/docs/commands/sql-pools.md
+++ b/docs/commands/sql-pools.md
@@ -1,0 +1,408 @@
+---
+title: SQL Pools
+---
+
+# SQL Pools
+
+!!! warning "Beta / preview feature"
+    Manages workspace SQL Pools (currently in preview; the API may change before GA).  Callers must hold the **workspace admin role**.
+
+Manage custom SQL Pools at the workspace level with sub-resource commands that mirror the Azure CLI style.
+
+**Targets:** Workspace (not item-specific)
+
+---
+
+## CLI
+
+### sql-pools create
+
+**Targets:** Workspace (not item-specific)
+
+Add a new SQL pool to a workspace.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] sql-pools create [OPTIONS]
+```
+
+| Option | Description |
+| --- | --- |
+| `--name TEXT` | Pool name. (required) |
+| `--max-percent INTEGER` | Max resource percentage (1–100). (required) |
+| `--default` / `--no-default` | Mark as default pool. Default: `--no-default`. |
+| `--optimize-for-reads` / `--no-optimize-for-reads` | Enable read optimisation. Default: `--optimize-for-reads`. |
+| `--classifier-type TEXT` | Classifier type (e.g. `Application Name`). |
+| `--classifier-value TEXT` | Classifier value. Repeat for multiple values. |
+
+**Example**
+
+```shell
+fdw -w MyWorkspace sql-pools create \
+  --name ETL \
+  --max-percent 30 \
+  --no-optimize-for-reads \
+  --classifier-type "Application Name" \
+  --classifier-value "ETL" \
+  --classifier-value "Load"
+```
+
+---
+
+### sql-pools delete
+
+**Targets:** Workspace (not item-specific)
+
+Remove a SQL pool from a workspace. You will be asked to confirm unless `--yes` is passed.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] sql-pools delete [OPTIONS]
+```
+
+| Option | Description |
+| --- | --- |
+| `--name TEXT` | Pool name to delete. (required) |
+| `--yes` | Skip confirmation prompt. |
+
+**Example**
+
+```shell
+fdw -w MyWorkspace --yes sql-pools delete --name ETL
+```
+
+---
+
+### sql-pools disable
+
+**Targets:** Workspace (not item-specific)
+
+Disable custom SQL Pools for a workspace without deleting pool definitions. Re-enabling with `sql-pools enable` restores the previously saved configuration.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] sql-pools disable
+```
+
+**Example**
+
+```shell
+fdw -w MyWorkspace sql-pools disable
+```
+
+---
+
+### sql-pools enable
+
+**Targets:** Workspace (not item-specific)
+
+Enable custom SQL Pools for a workspace. Preserves the existing pool configuration.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] sql-pools enable
+```
+
+**Example**
+
+```shell
+fdw -w MyWorkspace sql-pools enable
+```
+
+---
+
+### sql-pools get
+
+**Targets:** Workspace (not item-specific)
+
+Fetch the full SQL Pools configuration (enabled flag + pool list) for a workspace.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] sql-pools get
+```
+
+**Example**
+
+```shell
+fdw -w MyWorkspace sql-pools get
+```
+
+---
+
+### sql-pools insights
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+List SQL pool insight events from `queryinsights.sql_pool_insights`. Supports optional time-range filtering with `--since` and `--until` (ISO-8601 strings). The `--limit` option caps the number of rows returned (default: 100, max: 10 000).
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] sql-pools insights [OPTIONS] [WAREHOUSE]
+```
+
+| Option | Description | Default |
+| --- | --- | --- |
+| `--limit INTEGER` | Maximum rows to return (1–10 000). | `100` |
+| `--since ISO8601` | Return rows with timestamp >= this value. | — |
+| `--until ISO8601` | Return rows with timestamp <= this value. | — |
+
+**Example**
+
+```shell
+fdw -w MyWorkspace sql-pools insights SalesWH
+```
+
+---
+
+### sql-pools list
+
+**Targets:** Workspace (not item-specific)
+
+List all SQL pools in a workspace.
+
+When no custom SQL pools are defined, Fabric Data Warehouse uses the default
+(autonomous) workload management instead: the SQL analytics endpoint compute is
+split evenly (50/50) into two isolated pools, `SELECT` (read/analytics queries)
+and `NON-SELECT` (DML/DDL/ETL/ingestion statements). In that case this command
+reports the default pools rather than printing an empty list. The default split
+is documented in
+[Workload management](https://learn.microsoft.com/fabric/data-warehouse/workload-management#compute-pool-isolation)
+and [Custom SQL pools](https://learn.microsoft.com/fabric/data-warehouse/custom-sql-pools).
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] sql-pools list
+```
+
+**Example**
+
+```shell
+fdw -w MyWorkspace sql-pools list
+```
+
+**Output**
+
+When custom pools exist, `--json` returns the array of custom pool objects (as
+before). When none are defined, `--json` returns an object that stays honest
+about there being no custom pools:
+
+```json
+{
+  "customSQLPools": [],
+  "default_workload_active": true,
+  "default_pools": [
+    {"name": "SELECT", "maxResourcePercentage": 50, "isDefault": true, "description": "Handles SELECT (read/analytics) queries."},
+    {"name": "NON-SELECT", "maxResourcePercentage": 50, "isDefault": true, "description": "Handles non-SELECT (DML/DDL/ETL/ingestion) statements."}
+  ]
+}
+```
+
+---
+
+### sql-pools show
+
+**Targets:** Workspace (not item-specific)
+
+Show details for a single SQL pool.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] sql-pools show --name POOL
+```
+
+| Option | Description |
+| --- | --- |
+| `--name TEXT` | Pool name to show. (required) |
+
+**Example**
+
+```shell
+fdw -w MyWorkspace sql-pools show --name ETL
+```
+
+---
+
+### sql-pools update
+
+**Targets:** Workspace (not item-specific)
+
+Update an existing SQL pool. Only the flags you provide are changed; all other fields are preserved.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] sql-pools update [OPTIONS]
+```
+
+| Option | Description |
+| --- | --- |
+| `--name TEXT` | Pool name to update. (required) |
+| `--max-percent INTEGER` | New max resource percentage. |
+| `--default` / `--no-default` | Set or clear the default flag. |
+| `--optimize-for-reads` / `--no-optimize-for-reads` | Enable or disable read optimisation. |
+| `--classifier-type TEXT` | New classifier type. |
+| `--classifier-value TEXT` | New classifier value(s). Replaces all existing values. |
+
+**Example**
+
+```shell
+fdw -w MyWorkspace sql-pools update --name ETL --max-percent 40
+```
+
+---
+
+## MCP tools
+
+!!! warning "Beta / preview feature"
+    The SQL Pools tools manage the workspace SQL Pools configuration (currently in preview; the API may change before GA). All callers must hold the **workspace admin role**.
+
+### create_sql_pool
+
+**Targets:** Workspace (not item-specific)
+
+Add a new SQL pool to a workspace.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `name` (`str`) — pool name (must be unique within the workspace).
+- `max_percent` (`int`) — max resource percentage (1–100).
+- `is_default` (`bool`, default `false`) — whether this is the default pool.
+- `optimize_for_reads` (`bool`, default `true`) — enable read optimisation.
+- `classifier_type` (`str | null`, optional) — classifier type (e.g. `"Application Name"`).
+- `classifier_values` (`list[str] | null`, optional) — classifier value list.
+
+**Returns:** `SqlPool` — the newly-created pool object.
+
+---
+
+### delete_sql_pool
+
+**Targets:** Workspace (not item-specific)
+
+Delete an SQL pool from a workspace.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `pool_name` (`str`) — name of the pool to delete.
+
+**Returns:** `{ "deleted": true, "pool_name": str }` — confirmation.
+
+---
+
+### disable_sql_pools
+
+**Targets:** Workspace (not item-specific)
+
+Disable custom SQL Pools for a workspace, preserving the pool configuration. Re-enabling with `enable_sql_pools` restores the previously saved configuration.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+
+**Returns:** `SqlPoolsConfiguration` — the updated configuration.
+
+---
+
+### enable_sql_pools
+
+**Targets:** Workspace (not item-specific)
+
+Enable custom SQL Pools for a workspace without modifying pool definitions.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+
+**Returns:** `SqlPoolsConfiguration` — the updated configuration.
+
+---
+
+### get_sql_pool
+
+**Targets:** Workspace (not item-specific)
+
+Return details for a single SQL pool by name.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `pool_name` (`str`) — pool name.
+
+**Returns:** `SqlPool` — single pool object (fields as above).
+
+---
+
+### get_sql_pools_configuration
+
+**Targets:** Workspace (not item-specific)
+
+Fetch the full SQL Pools configuration (enabled flag + pool list) for a workspace.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+
+**Returns:** `SqlPoolsConfiguration` — object with `customSQLPoolsEnabled` (bool) and `customSQLPools` (list of pool objects, each with `name`, `maxResourcePercentage`, `isDefault`, `optimizeForReads`, and optional `classifier`).
+
+---
+
+### list_sql_pool_insights
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Return SQL pool insight events from `queryinsights.sql_pool_insights`.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `warehouse` (`str`) — warehouse or SQL Analytics Endpoint name or GUID.
+- `limit` (`int`, default `100`) — maximum rows to return (1–10 000).
+- `since` (`str | null`, optional) — ISO-8601 lower bound on `timestamp`.
+- `until` (`str | null`, optional) — ISO-8601 upper bound on `timestamp`.
+
+**Returns:** `list[dict]` — array of SQL pool insight row objects.
+
+---
+
+### list_sql_pools
+
+**Targets:** Workspace (not item-specific)
+
+Return the list of SQL pools for a workspace.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+
+**Returns:** `list[SqlPool]` — array of pool objects, each with `name`, `isDefault`, `maxResourcePercentage`, `optimizeForReads`, and optional `classifier`.
+
+---
+
+### update_sql_pool
+
+**Targets:** Workspace (not item-specific)
+
+Update an existing SQL pool.  Only the parameters you supply are changed; all other fields are preserved.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `name` (`str`) — name of the pool to update.
+- `max_percent` (`int | null`, optional) — new max resource percentage.
+- `is_default` (`bool | null`, optional) — set or clear the default flag.
+- `optimize_for_reads` (`bool | null`, optional) — enable or disable read optimisation.
+- `classifier_type` (`str | null`, optional) — new classifier type.
+- `classifier_values` (`list[str] | null`, optional) — new classifier value list (replaces all existing values).
+
+**Returns:** `SqlPool` — the updated pool object.

--- a/docs/commands/sql.md
+++ b/docs/commands/sql.md
@@ -1,0 +1,128 @@
+---
+title: Running SQL
+---
+
+# Running SQL
+
+SQL execution and query-plan capture against a Fabric Data Warehouse or SQL Analytics Endpoint.
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+!!! warning "Breaking change (v0.x → current)"
+
+    `fdw sql -q "…"` has been renamed to `fdw sql exec -q "…"`.  Update any scripts or aliases that use the old form.
+
+---
+
+## CLI
+
+### sql exec
+
+Execute a SQL statement or file against a warehouse or SQL Analytics Endpoint. Provide the query via `-q`/`--query` or `-f`/`--file` (not both). Multi-statement batches are supported; only the last result set is returned. DDL/DML statements return empty columns and rows.
+
+!!! warning
+
+    This command executes arbitrary SQL, including DDL and DML. Ensure you have the correct target before running destructive statements.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] sql exec [OPTIONS] [ITEM]
+```
+
+| Option | Description |
+| --- | --- |
+| `-q` / `--query TEXT` | SQL statement or batch to execute inline. |
+| `-f` / `--file PATH` | Path to a `.sql` file to execute. UTF-8 and UTF-8 BOM files are both supported. |
+
+Output defaults to a Rich table (rows/columns). Pass `--json` on the root command to emit machine-readable JSON (`{"columns": [...], "rows": [...], "rowcount": N}`).
+
+**Example**
+
+```shell
+# Inline query, Rich table output (default)
+fdw -w MyWorkspace sql exec SalesWH -q "SELECT TOP 5 * FROM dbo.Sales"
+
+# File input, JSON output
+fdw -w MyWorkspace --json sql exec SalesWH -f ./queries/report.sql
+```
+
+```json
+{"columns": ["id", "name"], "rows": [[1, "Alice"], [2, "Bob"]], "rowcount": 2}
+```
+
+---
+
+### sql plan
+
+Capture the **estimated** SHOWPLAN_XML execution plan for a SQL statement without executing it. The query is **not** run — only the plan is returned. This means DDL/DML query text is safe to plan without modifying any data.
+
+The plan XML uses the standard namespace `http://schemas.microsoft.com/sqlserver/2004/07/showplan` and can be opened in SSMS, Azure Data Studio, or uploaded to [pastetheplan.com](https://www.pastetheplan.com) for visual analysis.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] sql plan [OPTIONS] [ITEM]
+```
+
+| Option | Description |
+| --- | --- |
+| `-q` / `--query TEXT` | SQL statement to plan. |
+| `-f` / `--file PATH` | Path to a `.sql` file to plan. |
+| `-o` / `--output PATH` | Write the plan XML to this file (recommended extension: `.sqlplan`). When omitted, the XML is printed to stdout. |
+
+**Example**
+
+```shell
+# Print plan XML to stdout
+fdw -w MyWorkspace sql plan SalesWH -q "SELECT TOP 5 * FROM dbo.Sales"
+
+# Save plan to file (opens in SSMS / Azure Data Studio)
+fdw -w MyWorkspace sql plan SalesWH -q "SELECT TOP 5 * FROM dbo.Sales" -o plan.sqlplan
+```
+
+---
+
+## MCP tools
+
+### execute_sql
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Execute an arbitrary SQL statement or batch against a warehouse or SQL Analytics Endpoint.
+
+!!! warning
+
+    This tool executes arbitrary SQL, including DDL (DROP, ALTER, TRUNCATE) and DML (DELETE, UPDATE). Use only when the user explicitly requests data modification. Default to SELECT when the user's intent is read-only investigation.
+
+Multi-statement batches are supported; only the **last** result set is returned. DDL/DML statements that produce no result set return `columns=[]` and `rows=[]`.
+
+`datetime` and `Decimal` column values are pre-serialised to strings. `bytes`/varbinary columns are base64-encoded and their column names are suffixed with `__base64`.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `item` (`str`) — warehouse or SQL Analytics Endpoint name or GUID.
+- `query` (`str`) — SQL statement or batch to execute.
+
+**Returns:** `{ "columns": list[str], "rows": list[list[Any]], "rowcount": int }` — `rowcount` is `-1` when the driver does not report a count.
+
+---
+
+### get_query_plan
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Capture the **estimated** SHOWPLAN_XML execution plan for a SQL query without executing it.
+
+This tool does **not** execute the query — it only retrieves the estimated plan. Because no data is modified, this tool is permitted even when `FABRIC_MCP_READONLY=1`. DDL/DML query text is safe to plan without modifying any data.
+
+The plan XML uses the standard namespace `http://schemas.microsoft.com/sqlserver/2004/07/showplan` and can be opened in SSMS, Azure Data Studio, or uploaded to [pastetheplan.com](https://www.pastetheplan.com) for visual analysis.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `item` (`str`) — warehouse or SQL Analytics Endpoint name or GUID.
+- `query` (`str`) — SQL statement to generate an estimated execution plan for.
+
+**Returns:** `{ "plan_xml": str }` — the SHOWPLAN_XML string.

--- a/docs/commands/statistics.md
+++ b/docs/commands/statistics.md
@@ -1,0 +1,226 @@
+---
+title: Statistics
+---
+
+# Statistics
+
+Manage user-defined statistics on Fabric Data Warehouses and read their details on SQL Analytics Endpoints.
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+!!! note
+
+    Only **single-column, histogram-based** statistics can be created or updated (Fabric limitation). Multi-column statistics are not supported.
+
+    DDL operations (`create`, `update`, `delete`) require a **Data Warehouse** — they are rejected client-side on SQL Analytics Endpoints. `list` and `show` work on both item kinds.
+
+---
+
+## CLI
+
+### statistics create
+
+**Targets:** Data Warehouse only
+
+Create a new single-column statistic.
+
+```
+fdw [-w WORKSPACE] statistics create [ITEM] --table schema.table --column COL --name NAME [OPTIONS]
+```
+
+| Option | Description | Default |
+| --- | --- | --- |
+| `--table schema.table` | Qualified table name (required). | — |
+| `--column COL` | Column name to build the statistic on (required). Single column only. | — |
+| `--name NAME` | Statistic name (required). | — |
+| `--fullscan` | Use `WITH FULLSCAN` (default). Mutually exclusive with `--sample-percent`. | on |
+| `--sample-percent N` | Sample `N`% of the table (1–100). Overrides `--fullscan`. | — |
+
+---
+
+### statistics delete
+
+**Targets:** Data Warehouse only
+
+Drop a statistic via `DROP STATISTICS`. Prompts for confirmation unless `--yes` is passed.
+
+```
+fdw [-w WORKSPACE] statistics delete [ITEM] QUALIFIED_TABLE STAT_NAME
+```
+
+---
+
+### statistics list
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+List statistics on an item.
+
+```
+fdw [-w WORKSPACE] statistics list [ITEM] [OPTIONS]
+```
+
+| Option | Description | Default |
+| --- | --- | --- |
+| `--schema NAME` | Filter by schema name. | (all schemas) |
+| `--table NAME` | Filter by table name (unqualified). | (all tables) |
+| `--user-only` | Only show user-created statistics. | off |
+| `--auto-only` | Only show auto-created statistics. | off |
+
+---
+
+### statistics show
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+Show details of a named statistic using `DBCC SHOW_STATISTICS`. Returns the stat header, density vector, and histogram steps.
+
+```
+fdw [-w WORKSPACE] statistics show [ITEM] QUALIFIED_TABLE STAT_NAME [OPTIONS]
+```
+
+`QUALIFIED_TABLE` must be a dot-separated qualified name, e.g. `dbo.sales`.
+
+| Option | Description | Default |
+| --- | --- | --- |
+| `--histogram` | Show only the histogram steps (skip header and density vector). | off |
+
+---
+
+### statistics update
+
+**Targets:** Data Warehouse only
+
+Update an existing statistic via `UPDATE STATISTICS`.
+
+```
+fdw [-w WORKSPACE] statistics update [ITEM] QUALIFIED_TABLE STAT_NAME [OPTIONS]
+```
+
+| Option | Description | Default |
+| --- | --- | --- |
+| `--fullscan` | Use `WITH FULLSCAN` (default). | on |
+| `--sample-percent N` | Sample `N`% of the table (1–100). Overrides `--fullscan`. | — |
+
+---
+
+## MCP tools
+
+Manage user-defined statistics on Fabric Data Warehouses and inspect them on SQL Analytics Endpoints.
+
+!!! note
+
+    Only **single-column, histogram-based** statistics can be created or updated (Fabric limitation). Multi-column statistics are not supported.
+
+    Write tools (`create_statistics`, `update_statistics`, `delete_statistics`) are rejected on SQL Analytics Endpoints. Read tools (`list_statistics`, `show_statistics`) work on both item kinds.
+
+### create_statistics
+
+**Targets:** Data Warehouse only
+
+**Guards:** `assert_writes_allowed`, `assert_workspace_allowed`
+
+Create a single-column statistic on a table. Only single-column statistics are supported (Fabric limitation). SQL Analytics Endpoints are rejected.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `workspace` | `str` | Workspace name or GUID. |
+| `item` | `str` | Warehouse name or GUID. |
+| `qualified_table` | `str` | Qualified table name, e.g. `dbo.sales`. |
+| `column` | `str` | Column name. |
+| `stat_name` | `str` | Name for the new statistic. |
+| `fullscan` | `bool` | Use `WITH FULLSCAN` (default `true`). |
+| `sample_percent` | `int \| None` | Sample percentage (1–100). Overrides `fullscan`. |
+
+**Returns:** `Statistic` — the newly-created statistic.
+
+---
+
+### delete_statistics
+
+**Targets:** Data Warehouse only
+
+**Guards:** `assert_writes_allowed`, `assert_destructive_allowed`, `assert_workspace_allowed`
+
+Drop a statistic via `DROP STATISTICS`. **Destructive and irreversible.** Requires `FABRIC_MCP_ALLOW_DESTRUCTIVE=1`. SQL Analytics Endpoints are rejected.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `workspace` | `str` | Workspace name or GUID. |
+| `item` | `str` | Warehouse name or GUID. |
+| `qualified_table` | `str` | Qualified table name, e.g. `dbo.sales`. |
+| `stat_name` | `str` | Name of the statistic to drop. |
+
+**Returns:** `{ "dropped": true }` — confirmation.
+
+---
+
+### list_statistics
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+**Guards:** `assert_workspace_allowed`
+
+List statistics on a warehouse or SQL Analytics Endpoint.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `workspace` | `str` | Workspace name or GUID. |
+| `item` | `str` | Warehouse or SQL endpoint name or GUID. |
+| `schema` | `str \| None` | Filter by schema name. |
+| `table` | `str \| None` | Filter by table name (unqualified). |
+| `user_only` | `bool` | Only return user-created statistics. |
+| `auto_only` | `bool` | Only return auto-created statistics. |
+
+**Returns:** `list[dict]` — array of `Statistic` objects.
+
+---
+
+### show_statistics
+
+**Targets:** Data Warehouse · SQL Analytics Endpoint
+
+**Guards:** `assert_workspace_allowed`
+
+Show details of a statistic using `DBCC SHOW_STATISTICS`. Returns the stat header, density vector, and histogram steps.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `workspace` | `str` | Workspace name or GUID. |
+| `item` | `str` | Warehouse or SQL endpoint name or GUID. |
+| `qualified_table` | `str` | Qualified table name, e.g. `dbo.sales`. |
+| `stat_name` | `str` | Name of the statistic to show. |
+| `histogram_only` | `bool` | When `true`, return only the histogram steps. |
+
+**Returns:** `StatisticDetails` — `{ stat_header, density_vector, histogram }`.
+
+---
+
+### update_statistics
+
+**Targets:** Data Warehouse only
+
+**Guards:** `assert_writes_allowed`, `assert_workspace_allowed`
+
+Update an existing statistic via `UPDATE STATISTICS`. SQL Analytics Endpoints are rejected.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `workspace` | `str` | Workspace name or GUID. |
+| `item` | `str` | Warehouse name or GUID. |
+| `qualified_table` | `str` | Qualified table name, e.g. `dbo.sales`. |
+| `stat_name` | `str` | Name of the statistic to update. |
+| `fullscan` | `bool` | Use `WITH FULLSCAN` (default `true`). |
+| `sample_percent` | `int \| None` | Sample percentage (1–100). Overrides `fullscan`. |
+
+**Returns:** `{ "updated": true }` — confirmation.


### PR DESCRIPTION
## Summary

- Adds four co-located per-domain pages as part of RFC #497 B+C restructure (additive only; no nav or monolith changes)
- `docs/commands/sql.md` — Running SQL: CLI `sql exec` + `sql plan` ↔ MCP `execute_sql` + `get_query_plan`
- `docs/commands/queries.md` — Queries: full CLI `queries` group ↔ MCP Queries section (7 tools)
- `docs/commands/statistics.md` — Statistics: CLI `statistics` group ↔ MCP Statistics section (5 tools)
- `docs/commands/sql-pools.md` — SQL Pools: CLI `sql-pools` group ↔ MCP SQL Pools (beta) section (9 tools)

All content is verbatim migration from `docs/cli.md` and `docs/mcp-tools.md`. No content invented. CLI subcommand blocks and MCP tool blocks are in alphabetical order within each section. `docs/cli.md`, `docs/mcp-tools.md`, and `zensical.toml` are untouched.

Closes #522

## Test plan

- [ ] Confirm `docs/cli.md`, `docs/mcp-tools.md`, and `zensical.toml` are unchanged (`git diff main -- docs/cli.md docs/mcp-tools.md zensical.toml` shows nothing)
- [ ] Confirm the 4 new files exist under `docs/commands/`
- [ ] Spot-check content against source files for verbatim accuracy
- [ ] Confirm CLI and MCP blocks are alphabetically ordered within each page

🤖 Generated with [Claude Code](https://claude.com/claude-code)