### PR TITLE
docs: remove List-source note from Tables page

### DIFF
--- a/docs/commands/tables.md
+++ b/docs/commands/tables.md
@@ -8,10 +8,6 @@ Manage SQL tables on Microsoft Fabric Data Warehouses and SQL Analytics Endpoint
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
 
-!!! note "List source"
-
-    No public REST API exists for enumerating warehouse tables. `tables list` (CLI) falls back to TDS via `sys.tables JOIN sys.schemas`, the same approach used by `views list`. `list_tables` (MCP) uses TDS `sys.tables JOIN sys.schemas`.
-
 ---
 
 ## CLI


### PR DESCRIPTION
## Summary

- Removes the `!!! note "List source"` admonition from `docs/commands/tables.md`
- The note explained TDS-fallback internals ("no public REST API exists…") which is low-value implementation detail for end users
- The equivalent note in `docs/commands/schemas.md` is left untouched

Closes #526

## Test plan

- [x] `git diff` confirms exactly 4 lines deleted in `docs/commands/tables.md`, nothing else changed
- [x] `grep -n "List source\|public REST API" docs/commands/tables.md` → no hits
- [x] `uv run ruff check .` passes
- [x] `uv run ruff format --check .` passes
- [x] `uv run pytest tests/unit -q -k docgen` → 10 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)