### PR TITLE
docs: remove Preview admonition from Functions page

### DIFF
--- a/docs/commands/functions.md
+++ b/docs/commands/functions.md
@@ -8,10 +8,6 @@ Manage T-SQL user-defined functions on Microsoft Fabric Data Warehouses and SQL 
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
 
-!!! warning "Preview"
-
-    Scalar UDFs (`FN`) and inline TVFs (`IF`) are preview features as of mid-2026. Function DDL is supported on both Data Warehouses and SQL Analytics Endpoints — no endpoint guard is applied.
-
 ---
 
 ## CLI


### PR DESCRIPTION
## Summary

- Removes the top-of-page `!!! warning "Preview"` admonition from `docs/commands/functions.md`
- Inline prose noting that scalar UDFs and inline TVFs are preview features is preserved in the individual command descriptions

Closes #528