### PR TITLE
docs: remove Breaking-change admonition from Running SQL page

### DIFF
--- a/docs/commands/sql.md
+++ b/docs/commands/sql.md
@@ -8,10 +8,6 @@ SQL execution and query-plan capture against a Fabric Data Warehouse or SQL Anal
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
 
-!!! warning "Breaking change (v0.x → current)"
-
-    `fdw sql -q "…"` has been renamed to `fdw sql exec -q "…"`.  Update any scripts or aliases that use the old form.
-
 ---
 
 ## CLI


### PR DESCRIPTION
## Summary

- Removes the pre-stable breaking-change/migration note (`fdw sql` → `fdw sql exec`) from `docs/commands/sql.md`
- The project is pre-stable so migration notes are not kept long-term
- Docs-only change; no code affected

Closes #530