### PR TITLE
docs: remove Beta/preview admonition from SQL Pools page

### DIFF
--- a/docs/commands/sql-pools.md
+++ b/docs/commands/sql-pools.md
@@ -4,10 +4,7 @@ title: SQL Pools
 
 # SQL Pools
 
-!!! warning "Beta / preview feature"
-    Manages workspace SQL Pools (currently in preview; the API may change before GA).  Callers must hold the **workspace admin role**.
-
-Manage custom SQL Pools at the workspace level with sub-resource commands that mirror the Azure CLI style.
+Manage custom SQL Pools at the workspace level with sub-resource commands that mirror the Azure CLI style. Callers must hold the **workspace admin role**.
 
 **Targets:** Workspace (not item-specific)
 
@@ -262,8 +259,7 @@ fdw -w MyWorkspace sql-pools update --name ETL --max-percent 40
 
 ## MCP tools
 
-!!! warning "Beta / preview feature"
-    The SQL Pools tools manage the workspace SQL Pools configuration (currently in preview; the API may change before GA). All callers must hold the **workspace admin role**.
+All callers must hold the **workspace admin role**.
 
 ### create_sql_pool
 


### PR DESCRIPTION
## Summary

- Removes both `!!! warning "Beta / preview feature"` admonitions from `docs/commands/sql-pools.md`.
- Folds the **workspace admin role** requirement (previously inside each admonition) into adjacent prose so the access requirement is not lost.
- Drops only the beta/preview framing ("currently in preview; the API may change before GA").

Closes #534

## Test plan

- [ ] `grep -n "Beta / preview\|in preview\|before GA" docs/commands/sql-pools.md` returns no hits
- [ ] `grep -n "workspace admin role" docs/commands/sql-pools.md` returns two hits (intro paragraph + MCP tools section)
- [ ] `uv run ruff check .` and `uv run ruff format --check .` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)