### PR TITLE
docs: drop the DDL/endpoint sentence from the Statistics note

### DIFF
--- a/docs/commands/statistics.md
+++ b/docs/commands/statistics.md
@@ -12,8 +12,6 @@ Manage user-defined statistics on Fabric Data Warehouses and read their details 
 
     Only **single-column, histogram-based** statistics can be created or updated (Fabric limitation). Multi-column statistics are not supported.
 
-    DDL operations (`create`, `update`, `delete`) require a **Data Warehouse** — they are rejected client-side on SQL Analytics Endpoints. `list` and `show` work on both item kinds.
-
 ---
 
 ## CLI


### PR DESCRIPTION
## Summary

- Removes the "DDL operations (`create`, `update`, `delete`) require a **Data Warehouse** — they are rejected client-side on SQL Analytics Endpoints. `list` and `show` work on both item kinds." paragraph from the first `!!! note` admonition in `docs/commands/statistics.md`.
- The second `!!! note` admonition in the `## MCP tools` section uses different wording (about write/read MCP tools) and is left untouched.

Closes #536

## Test plan

- [ ] Verify `grep -n "DDL operations" docs/commands/statistics.md` returns no hits.
- [ ] Verify the single-column/histogram paragraph and all other content remain intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)