### PR TITLE
docs: drop obvious sentence from Workspaces note

### DIFF
--- a/docs/commands/workspaces.md
+++ b/docs/commands/workspaces.md
@@ -10,7 +10,7 @@ Manage Microsoft Fabric workspaces — list all workspaces the authenticated pri
 
 !!! note "Workspace selection"
 
-    The `workspaces` CLI group is exempt from the global `-w/--workspace` option. Pass the workspace name or GUID as a positional argument to `workspaces get` and `workspaces set-collation` instead. `workspaces list` takes no workspace argument at all.
+    The `workspaces` CLI group is exempt from the global `-w/--workspace` option. Pass the workspace name or GUID as a positional argument to `workspaces get` and `workspaces set-collation` instead.
 
 ---
 


### PR DESCRIPTION
## Summary

- Removes the redundant "`workspaces list` takes no workspace argument at all." sentence from the `!!! note` admonition in `docs/commands/workspaces.md`.
- The sentence states something self-evident and adds no value alongside the existing note.

Closes #538