### PR TITLE
feat(tables): add cluster-columns command and get_cluster_columns tool

### DIFF
--- a/docs/commands/tables.md
+++ b/docs/commands/tables.md
@@ -32,6 +32,33 @@ fdw -w MyWorkspace --yes tables clear SalesWH dbo.staging_load
 
 ---
 
+### tables cluster-columns
+
+**Targets:** Data Warehouse only
+
+List the data-clustering columns of a table, ordered by clustering ordinal. Returns an empty table when no clustering is defined (exit 0).
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] tables cluster-columns [WAREHOUSE] QUALIFIED_NAME
+```
+
+**Example**
+
+```shell
+fdw -w MyWorkspace tables cluster-columns SalesWH dbo.orders
+```
+
+```json
+[
+  {"column_name": "city", "clustering_ordinal": 1},
+  {"column_name": "country", "clustering_ordinal": 2}
+]
+```
+
+---
+
 ### tables clone
 
 **Targets:** Data Warehouse only
@@ -452,6 +479,22 @@ Return the total row count of a table via `SELECT COUNT_BIG(*)`.
 - `qualified_name` (`str`) — dot-separated table name, e.g. `dbo.sales`.
 
 **Returns:** `{ "schema": str, "name": str, "row_count": int }` — the schema name, table name, and total row count.
+
+---
+
+### get_cluster_columns
+
+**Targets:** Data Warehouse only
+
+Return the data-clustering columns of a table, ordered by clustering ordinal. Returns an empty list when no clustering is defined (not an error).
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `item` (`str`) — warehouse name or GUID. SQL Analytics Endpoints are rejected.
+- `qualified_name` (`str`) — dot-separated table name, e.g. `dbo.sales`.
+
+**Returns:** `list[{ "column_name": str, "clustering_ordinal": int }]` — ordered by ascending `clustering_ordinal`.
 
 ---
 

--- a/docs/commands/tables.md
+++ b/docs/commands/tables.md
@@ -482,22 +482,6 @@ Return the total row count of a table via `SELECT COUNT_BIG(*)`.
 
 ---
 
-### get_cluster_columns
-
-**Targets:** Data Warehouse only
-
-Return the data-clustering columns of a table, ordered by clustering ordinal. Returns an empty list when no clustering is defined (not an error).
-
-**Parameters:**
-
-- `workspace` (`str`) — workspace name or GUID.
-- `item` (`str`) — warehouse name or GUID. SQL Analytics Endpoints are rejected.
-- `qualified_name` (`str`) — dot-separated table name, e.g. `dbo.sales`.
-
-**Returns:** `list[{ "column_name": str, "clustering_ordinal": int }]` — ordered by ascending `clustering_ordinal`.
-
----
-
 ### create_empty_table
 
 **Targets:** Data Warehouse only
@@ -569,6 +553,22 @@ Drop a SQL table.
 - `qualified_name` (`str`) — dot-separated table name, e.g. `dbo.sales`.
 
 **Returns:** `{ "dropped": true }` — confirmation.
+
+---
+
+### get_cluster_columns
+
+**Targets:** Data Warehouse only
+
+Return the data-clustering columns of a table, ordered by clustering ordinal. Returns an empty list when no clustering is defined (not an error).
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `item` (`str`) — warehouse name or GUID. SQL Analytics Endpoints are rejected.
+- `qualified_name` (`str`) — dot-separated table name, e.g. `dbo.sales`.
+
+**Returns:** `list[{ "column_name": str, "clustering_ordinal": int }]` — ordered by ascending `clustering_ordinal`.
 
 ---
 

--- a/src/fabric_dw/cli/commands/tables.py
+++ b/src/fabric_dw/cli/commands/tables.py
@@ -27,7 +27,7 @@ from fabric_dw.cli.commands._utils import (
     resolve_warehouse_arg,
     resolve_workspace,
 )
-from fabric_dw.exceptions import FabricError, ItemKindError
+from fabric_dw.exceptions import FabricError
 from fabric_dw.http_client import FabricHttpClient
 from fabric_dw.models import ColumnSpec, CopyIntoResult
 from fabric_dw.services import tables as _tables_svc
@@ -536,8 +536,6 @@ async def cluster_columns_cmd(
                 json_output=ctx.json_output,
                 table_title="Cluster Columns",
             )
-    except ItemKindError as exc:
-        raise click.ClickException(str(exc)) from exc
     except (ValueError, FabricError) as exc:
         raise click.ClickException(str(exc)) from exc
 

--- a/src/fabric_dw/cli/commands/tables.py
+++ b/src/fabric_dw/cli/commands/tables.py
@@ -27,7 +27,7 @@ from fabric_dw.cli.commands._utils import (
     resolve_warehouse_arg,
     resolve_workspace,
 )
-from fabric_dw.exceptions import FabricError
+from fabric_dw.exceptions import FabricError, ItemKindError
 from fabric_dw.http_client import FabricHttpClient
 from fabric_dw.models import ColumnSpec, CopyIntoResult
 from fabric_dw.services import tables as _tables_svc
@@ -503,6 +503,41 @@ async def clear_cmd(
                 )
             else:
                 click.echo(f"Table [{schema}].[{table_name}] truncated.")
+    except (ValueError, FabricError) as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@tables_group.command("cluster-columns")
+@click.argument("item", required=False, default=None)
+@click.argument("qualified_name")
+@click.pass_obj
+@coro
+async def cluster_columns_cmd(
+    ctx: CliContext,
+    item: str | None,
+    qualified_name: str,
+) -> None:
+    """List the data-clustering columns of QUALIFIED_NAME (schema.table) on ITEM.
+
+    Only supported on Fabric Data Warehouses (not SQL Analytics Endpoints).
+    Returns an empty table when no clustering is defined.
+    """
+    ws = resolve_workspace(ctx)
+    wh = resolve_warehouse_arg(ctx, item)
+    schema, table_name = parse_qualified_name(qualified_name, kind="table")
+    try:
+        async with build_http_client(ctx) as http:
+            target, entry = await build_sql_target(http, ws, wh)
+            rows = await _tables_svc.get_cluster_columns(
+                target, schema, table_name, kind=entry.kind, mode=ctx.auth
+            )
+            render(
+                rows,
+                json_output=ctx.json_output,
+                table_title="Cluster Columns",
+            )
+    except ItemKindError as exc:
+        raise click.ClickException(str(exc)) from exc
     except (ValueError, FabricError) as exc:
         raise click.ClickException(str(exc)) from exc
 

--- a/src/fabric_dw/mcp/tools/tables.py
+++ b/src/fabric_dw/mcp/tools/tables.py
@@ -9,7 +9,7 @@ from typing import Annotated, Any
 from mcp.server.fastmcp import FastMCP
 from pydantic import Field
 
-from fabric_dw.exceptions import FabricError
+from fabric_dw.exceptions import FabricError, ItemKindError
 from fabric_dw.mcp._context import get_context
 from fabric_dw.mcp._guards import (
     assert_workspace_allowed,
@@ -149,6 +149,44 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         except (ValueError, FabricError) as exc:
             raise tool_err(exc) from exc
         return {"schema": schema, "name": table_name, "row_count": row_count}
+
+    @mcp.tool(name="get_cluster_columns")
+    async def get_cluster_columns(
+        workspace: str,
+        item: str,
+        qualified_name: str,
+    ) -> list[dict[str, object]]:
+        """Return the data-clustering columns of a table, ordered by clustering ordinal.
+
+        Only supported on Fabric Data Warehouses.  SQL Analytics Endpoints raise a
+        ``ToolError``.  Returns an empty list when no clustering columns are defined.
+
+        Args:
+            workspace: Workspace name or GUID.
+            item: Warehouse name or GUID.
+            qualified_name: Dot-separated qualified table name, e.g. ``dbo.sales``.
+        """
+        schema, table_name = parse_qualified_name(qualified_name, kind="table")
+        assert_workspace_allowed(workspace)
+        ctx = get_context()
+        try:
+            ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
+            assert_workspace_allowed(workspace, str(ws_id))
+            _log.debug(
+                "get_cluster_columns ws=%s item=%s table=%s.%s",
+                ws_id,
+                entry.id,
+                schema,
+                table_name,
+            )
+            target = make_sql_target(ws_id, entry, item)
+            return await tables_svc.get_cluster_columns(
+                target, schema, table_name, kind=entry.kind, mode=ctx.auth_mode
+            )
+        except ItemKindError as exc:
+            raise tool_err(exc) from exc
+        except (ValueError, FabricError) as exc:
+            raise tool_err(exc) from exc
 
     @mutating_tool(mcp, "create_table")
     async def create_table(

--- a/src/fabric_dw/mcp/tools/tables.py
+++ b/src/fabric_dw/mcp/tools/tables.py
@@ -9,7 +9,7 @@ from typing import Annotated, Any
 from mcp.server.fastmcp import FastMCP
 from pydantic import Field
 
-from fabric_dw.exceptions import FabricError, ItemKindError
+from fabric_dw.exceptions import FabricError
 from fabric_dw.mcp._context import get_context
 from fabric_dw.mcp._guards import (
     assert_workspace_allowed,
@@ -183,8 +183,6 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             return await tables_svc.get_cluster_columns(
                 target, schema, table_name, kind=entry.kind, mode=ctx.auth_mode
             )
-        except ItemKindError as exc:
-            raise tool_err(exc) from exc
         except (ValueError, FabricError) as exc:
             raise tool_err(exc) from exc
 

--- a/src/fabric_dw/services/tables.py
+++ b/src/fabric_dw/services/tables.py
@@ -65,8 +65,7 @@ _log = logging.getLogger(__name__)
 
 _SQL_ENDPOINT_READONLY_MSG = "SQL Endpoints are read-only; CREATE/DROP/TRUNCATE not supported"
 _SQL_ENDPOINT_CLUSTERING_MSG = (
-    "Data clustering is not supported on SQL Analytics Endpoints; "
-    "use a Fabric Data Warehouse"
+    "Data clustering is not supported on SQL Analytics Endpoints; use a Fabric Data Warehouse"
 )
 
 
@@ -335,9 +334,7 @@ async def get_cluster_columns(
             params=[schema, table_name],
             mode=mode,
         )
-        return [
-            {"column_name": str(row[0]), "clustering_ordinal": int(row[1])} for row in rows
-        ]
+        return [{"column_name": str(row[0]), "clustering_ordinal": int(row[1])} for row in rows]
 
     return await asyncio.to_thread(_run)
 

--- a/src/fabric_dw/services/tables.py
+++ b/src/fabric_dw/services/tables.py
@@ -48,6 +48,7 @@ __all__ = [
     "create_table_from_csv",
     "create_table_from_parquet",
     "delete_table",
+    "get_cluster_columns",
     "infer_columns_from_csv",
     "infer_columns_from_parquet",
     "list_tables",
@@ -99,6 +100,16 @@ _READ_TABLE_SQL = "SELECT TOP ({count}) * FROM {schema_q}.{table_q};"
 
 # COUNT_BIG(*) is bigint-safe (avoids INT overflow on wide tables).
 _COUNT_TABLE_SQL = "SELECT COUNT_BIG(*) AS row_count FROM {schema_q}.{table_q};"
+
+_CLUSTER_COLUMNS_SQL = """\
+SELECT c.name AS column_name, ic.data_clustering_ordinal AS clustering_ordinal
+FROM sys.tables t
+JOIN sys.schemas s ON s.schema_id = t.schema_id
+JOIN sys.columns c ON t.object_id = c.object_id
+JOIN sys.index_columns ic ON c.object_id = ic.object_id AND c.column_id = ic.column_id
+WHERE ic.data_clustering_ordinal > 0 AND s.name = ? AND t.name = ?
+ORDER BY ic.data_clustering_ordinal;
+"""
 
 _FETCH_TABLE_SQL = """\
 SELECT s.name AS schema_name, t.name, t.create_date AS created,
@@ -272,6 +283,60 @@ async def count_table_rows(
             msg = f"Table [{schema}].[{table_name}] not found"
             raise NotFoundError(msg)
         return int(rows[0][0])
+
+    return await asyncio.to_thread(_run)
+
+
+async def get_cluster_columns(
+    target: SqlTarget,
+    schema: str,
+    table_name: str,
+    *,
+    kind: WarehouseKind = WarehouseKind.WAREHOUSE,
+    mode: CredentialMode = CredentialMode.DEFAULT,
+) -> list[dict[str, object]]:
+    """Return the data-clustering columns of *schema*.*table_name*, ordered by ordinal.
+
+    Queries ``sys.index_columns`` filtered on ``data_clustering_ordinal > 0``.
+    Returns an empty list when no clustering is defined — this is not an error.
+
+    Args:
+        target: The warehouse to query.
+        schema: The schema name.  Must pass :func:`validate_identifier`.
+        table_name: The table name.  Must pass :func:`validate_identifier`.
+        kind: The :class:`~fabric_dw.models.WarehouseKind` of the item.
+            SQL Endpoint items are rejected with :class:`~fabric_dw.exceptions.ItemKindError`.
+        mode: The credential mode for Entra authentication.
+
+    Returns:
+        A (possibly empty) list of ``{"column_name": str, "clustering_ordinal": int}``
+        dicts ordered by ascending *clustering_ordinal*.
+
+    Raises:
+        ItemKindError: If *kind* is :attr:`~fabric_dw.models.WarehouseKind.SQL_ENDPOINT`.
+            Message: ``"Data clustering is not supported on SQL Analytics Endpoints;
+            use a Fabric Data Warehouse"``.
+        ValueError: If *schema* or *table_name* fails identifier validation.
+        PermissionDeniedError: If the driver reports a permission error.
+    """
+    if kind == WarehouseKind.SQL_ENDPOINT:
+        raise ItemKindError(
+            "Data clustering is not supported on SQL Analytics Endpoints; "
+            "use a Fabric Data Warehouse"
+        )
+    validate_identifier(schema)
+    validate_identifier(table_name)
+
+    def _run() -> list[dict[str, object]]:
+        _cols, rows = run_query(
+            target,
+            _CLUSTER_COLUMNS_SQL,
+            params=[schema, table_name],
+            mode=mode,
+        )
+        return [
+            {"column_name": str(row[0]), "clustering_ordinal": int(row[1])} for row in rows
+        ]
 
     return await asyncio.to_thread(_run)
 

--- a/src/fabric_dw/services/tables.py
+++ b/src/fabric_dw/services/tables.py
@@ -64,6 +64,10 @@ _log = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 _SQL_ENDPOINT_READONLY_MSG = "SQL Endpoints are read-only; CREATE/DROP/TRUNCATE not supported"
+_SQL_ENDPOINT_CLUSTERING_MSG = (
+    "Data clustering is not supported on SQL Analytics Endpoints; "
+    "use a Fabric Data Warehouse"
+)
 
 
 def _assert_not_sql_endpoint(kind: WarehouseKind) -> None:
@@ -320,10 +324,7 @@ async def get_cluster_columns(
         PermissionDeniedError: If the driver reports a permission error.
     """
     if kind == WarehouseKind.SQL_ENDPOINT:
-        raise ItemKindError(
-            "Data clustering is not supported on SQL Analytics Endpoints; "
-            "use a Fabric Data Warehouse"
-        )
+        raise ItemKindError(_SQL_ENDPOINT_CLUSTERING_MSG)
     validate_identifier(schema)
     validate_identifier(table_name)
 

--- a/src/fabric_dw/telemetry_commands.py
+++ b/src/fabric_dw/telemetry_commands.py
@@ -123,6 +123,7 @@ DOMAIN_MAP: dict[str, str] = {
     "list_tables": "tables",
     "read_table": "tables",
     "count_table_rows": "tables",
+    "get_cluster_columns": "tables",
     "create_table": "tables",
     "create_empty_table": "tables",
     "clone_table": "tables",

--- a/tests/unit/mcp/test_contract.py
+++ b/tests/unit/mcp/test_contract.py
@@ -48,8 +48,8 @@ from tests.unit.mcp.conftest import WS_ID, WS_NAME, make_item_entry
 
 # 77 baseline + 5 statistics + 1 dbt + 3 table-create + 6 functions
 # + 1 load_table_from_url + 1 import_table_from_url + 3 settings
-# + 2 count_table_rows / count_view_rows + 1 get_query_plan
-_EXPECTED_TOOL_COUNT = 93
+# + 2 count_table_rows / count_view_rows + 1 get_query_plan + 1 get_cluster_columns
+_EXPECTED_TOOL_COUNT = 94
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/mcp/test_server.py
+++ b/tests/unit/mcp/test_server.py
@@ -129,6 +129,7 @@ EXPECTED_TOOL_NAMES: frozenset[str] = frozenset(
         "list_tables",
         "read_table",
         "count_table_rows",
+        "get_cluster_columns",
         "create_table",
         "create_empty_table",
         "clone_table",

--- a/tests/unit/mcp/tools/test_tables.py
+++ b/tests/unit/mcp/tools/test_tables.py
@@ -23,7 +23,7 @@ import pytest
 from mcp.server.fastmcp.exceptions import ToolError
 
 from fabric_dw.exceptions import ItemKindError, NotFoundError
-from fabric_dw.models import Table, WarehouseKind
+from fabric_dw.models import Table
 from tests.unit.mcp.conftest import (
     WH_NAME,
     WS_ID,

--- a/tests/unit/mcp/tools/test_tables.py
+++ b/tests/unit/mcp/tools/test_tables.py
@@ -6,6 +6,7 @@ Coverage targets (lines from coverage report):
   163        delete_table: return {"dropped": True} (happy-path success path)
   193        clear_table: return {"truncated": True} (happy-path success path)
   224-227    clone_table: at_dt UTC normalisation (naive timestamp → UTC)
+  get_cluster_columns: happy path, empty result, SQL endpoint guard, error funnel
 
 NOTE: The SQL-endpoint guard tests for create_table / delete_table / clear_table /
 clone_table / rename_table already live in tests/unit/mcp/test_server.py —
@@ -21,13 +22,14 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from mcp.server.fastmcp.exceptions import ToolError
 
-from fabric_dw.exceptions import NotFoundError
-from fabric_dw.models import Table
+from fabric_dw.exceptions import ItemKindError, NotFoundError
+from fabric_dw.models import Table, WarehouseKind
 from tests.unit.mcp.conftest import (
     WH_NAME,
     WS_ID,
     WS_NAME,
     make_item_entry,
+    make_sql_endpoint_entry,
 )
 
 # ---------------------------------------------------------------------------
@@ -649,4 +651,108 @@ async def test_count_table_rows_bad_qualified_name_raises_tool_error(ctx_patch) 
         await mcp._tool_manager.call_tool(
             "count_table_rows",
             {"workspace": WS_NAME, "item": WH_NAME, "qualified_name": "nodot"},
+        )
+
+
+# ---------------------------------------------------------------------------
+# get_cluster_columns — happy path, empty result, SQL endpoint guard, error funnel
+# ---------------------------------------------------------------------------
+
+
+async def test_get_cluster_columns_happy_path(mock_ctx, ctx_patch) -> None:
+    """get_cluster_columns returns list of column dicts ordered by ordinal."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+    expected = [
+        {"column_name": "city", "clustering_ordinal": 1},
+        {"column_name": "country", "clustering_ordinal": 2},
+    ]
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.tables.get_cluster_columns",
+            new=AsyncMock(return_value=expected),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "get_cluster_columns",
+            {"workspace": WS_NAME, "item": WH_NAME, "qualified_name": "dbo.sales"},
+        )
+
+    assert result == expected
+
+
+async def test_get_cluster_columns_empty_result(mock_ctx, ctx_patch) -> None:
+    """get_cluster_columns returns an empty list when no clustering is defined."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.tables.get_cluster_columns",
+            new=AsyncMock(return_value=[]),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "get_cluster_columns",
+            {"workspace": WS_NAME, "item": WH_NAME, "qualified_name": "dbo.sales"},
+        )
+
+    assert result == []
+
+
+async def test_get_cluster_columns_sql_endpoint_raises_tool_error(mock_ctx, ctx_patch) -> None:
+    """get_cluster_columns raises ToolError when target is a SQL Analytics Endpoint."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    endpoint_entry = make_sql_endpoint_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=endpoint_entry)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.tables.get_cluster_columns",
+            new=AsyncMock(
+                side_effect=ItemKindError(
+                    "Data clustering is not supported on SQL Analytics Endpoints; "
+                    "use a Fabric Data Warehouse"
+                )
+            ),
+        ),
+        pytest.raises(ToolError, match="SQL Analytics Endpoints"),
+    ):
+        await mcp._tool_manager.call_tool(
+            "get_cluster_columns",
+            {"workspace": WS_NAME, "item": WH_NAME, "qualified_name": "dbo.sales"},
+        )
+
+
+async def test_get_cluster_columns_fabric_error_becomes_tool_error(mock_ctx, ctx_patch) -> None:
+    """get_cluster_columns wraps FabricError into ToolError."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.tables.get_cluster_columns",
+            new=AsyncMock(side_effect=NotFoundError("table not found")),
+        ),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "get_cluster_columns",
+            {"workspace": WS_NAME, "item": WH_NAME, "qualified_name": "dbo.sales"},
         )

--- a/tests/unit/services/test_tables.py
+++ b/tests/unit/services/test_tables.py
@@ -428,6 +428,87 @@ class TestCountTableRows:
 
 
 # ===========================================================================
+# get_cluster_columns
+# ===========================================================================
+
+
+class TestGetClusterColumns:
+    async def test_returns_columns_ordered_by_ordinal(self) -> None:
+        target = _make_target()
+        rows: list[tuple[object, ...]] = [("city", 1), ("country", 2)]
+        conn = _make_conn(rows, ["column_name", "clustering_ordinal"])
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            result = await tables.get_cluster_columns(target, "dbo", "sales")
+        assert result == [
+            {"column_name": "city", "clustering_ordinal": 1},
+            {"column_name": "country", "clustering_ordinal": 2},
+        ]
+
+    async def test_returns_empty_list_when_no_clustering(self) -> None:
+        target = _make_target()
+        conn = _make_conn([], ["column_name", "clustering_ordinal"])
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            result = await tables.get_cluster_columns(target, "dbo", "sales")
+        assert result == []
+
+    async def test_sql_references_sys_index_columns(self) -> None:
+        target = _make_target()
+        conn = _make_conn([], ["column_name", "clustering_ordinal"])
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await tables.get_cluster_columns(target, "dbo", "sales")
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert "sys.index_columns" in call_sql
+        assert "data_clustering_ordinal" in call_sql
+
+    async def test_sql_uses_bound_params(self) -> None:
+        target = _make_target()
+        conn = _make_conn([], ["column_name", "clustering_ordinal"])
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await tables.get_cluster_columns(target, "myschema", "mytable")
+        cursor = conn.cursor.return_value
+        call_args = cursor.execute.call_args
+        params = call_args[0][1] if len(call_args[0]) > 1 else (call_args[1] or {}).get("params")
+        assert params is not None
+        param_list = list(params)
+        assert "myschema" in param_list
+        assert "mytable" in param_list
+
+    async def test_validates_schema_identifier(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await tables.get_cluster_columns(target, "bad;schema", "sales")
+
+    async def test_validates_table_name_identifier(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await tables.get_cluster_columns(target, "dbo", "bad--table")
+
+    async def test_rejects_sql_endpoint(self) -> None:
+        target = _make_target()
+        conn = _make_conn([], ["column_name", "clustering_ordinal"])
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(ItemKindError, match="SQL Analytics Endpoints"),
+        ):
+            await tables.get_cluster_columns(
+                target, "dbo", "sales", kind=WarehouseKind.SQL_ENDPOINT
+            )
+
+    async def test_permission_denied_propagates(self) -> None:
+        target = _make_target()
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.execute.side_effect = Exception("permission was denied on object sys.index_columns")
+        conn.cursor.return_value = cursor
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(PermissionDeniedError),
+        ):
+            await tables.get_cluster_columns(target, "dbo", "sales")
+
+
+# ===========================================================================
 # create_table
 # ===========================================================================
 


### PR DESCRIPTION
## Summary

- Adds `fdw tables cluster-columns ITEM QUALIFIED_NAME` CLI subcommand (alphabetical: after `clear`, before `clone`) that retrieves a table's data-clustering columns from `sys.index_columns`, rendered as a table ordered by ordinal with `--json` support.
- Adds `get_cluster_columns` MCP read-only tool returning `list[{"column_name": str, "clustering_ordinal": int}]`.
- Adds `get_cluster_columns` service function in `services/tables.py` using verified T-SQL joining `sys.tables / sys.schemas / sys.columns / sys.index_columns` on `data_clustering_ordinal > 0`.
- DW-only: SQL Analytics Endpoints rejected with `ItemKindError("Data clustering is not supported on SQL Analytics Endpoints; use a Fabric Data Warehouse")`.
- Empty result (no clustering defined) returns an empty list/table — exit 0, not an error.
- Telemetry, `TestDomainCoverage`, `EXPECTED_TOOL_NAMES`, and `_EXPECTED_TOOL_COUNT` all updated.
- Docs updated in `docs/commands/tables.md` with CLI + MCP sections in alphabetical order; no Preview/Beta admonition.

## Test plan

- [ ] `tests/unit/services/test_tables.py::TestGetClusterColumns` — 8 tests: returns columns, empty result, SQL references, bound params, schema validation, table name validation, SQL endpoint rejection, permission denied.
- [ ] `tests/unit/mcp/tools/test_tables.py` — 4 new tests: happy path, empty result, SQL endpoint guard, FabricError funnel.
- [ ] `tests/unit/test_telemetry_commands.py::TestDomainCoverage` — coverage enforced.
- [ ] `tests/unit/mcp/test_server.py::test_tools_registered` — tool count / name check.
- [ ] `tests/unit/mcp/test_contract.py::test_list_tools_returns_expected_count` — contract count updated.
- [ ] Full unit suite: 3670 passed.

Closes #546

🤖 Generated with [Claude Code](https://claude.com/claude-code)