### PR TITLE
docs: clarify schema delete --cascade also drops functions and procedures

### DIFF
--- a/docs/commands/schemas.md
+++ b/docs/commands/schemas.md
@@ -42,7 +42,7 @@ fdw -w MyWorkspace schemas create SalesWH reporting
 
 Drop a schema from a warehouse. You will be asked to confirm unless `--yes` is passed.
 
-Pass `--cascade` to also drop all tables and views inside the schema before dropping the schema itself. **This is a destructive, irreversible operation.**
+Pass `--cascade` to also drop all tables, views, functions, and stored procedures inside the schema before dropping the schema itself. **This is a destructive, irreversible operation.**
 
 **Usage**
 
@@ -52,7 +52,7 @@ fdw [-w WORKSPACE] schemas delete [OPTIONS] [WAREHOUSE] NAME
 
 | Option | Description |
 | --- | --- |
-| `--cascade` | Drop all tables and views in the schema first. **WARNING: permanently deletes all contained objects and data.** |
+| `--cascade` | Drop all tables, views, functions, and stored procedures in the schema first. **WARNING: permanently deletes all contained objects and data.** |
 
 **Example**
 
@@ -60,7 +60,7 @@ fdw [-w WORKSPACE] schemas delete [OPTIONS] [WAREHOUSE] NAME
 # Drop an empty schema
 fdw -w MyWorkspace --yes schemas delete SalesWH staging
 
-# Drop a schema and all its tables/views
+# Drop a schema and all its tables, views, functions, and stored procedures
 fdw -w MyWorkspace --yes schemas delete SalesWH staging --cascade
 ```
 
@@ -120,14 +120,14 @@ Drop a SQL schema from a Fabric Data Warehouse or SQL Analytics Endpoint.
 
 **CAUTION**: This is a destructive, irreversible operation. The schema will be permanently deleted. If the schema still contains tables or views the operation will fail unless `cascade=True`.
 
-**CAUTION**: When `cascade=True`, **all tables and views in the schema are permanently deleted along with their data**. Confirm explicitly with the user before calling with `cascade=True`.
+**CAUTION**: When `cascade=True`, **all tables, views, functions, and stored procedures in the schema are permanently deleted along with their data**. Confirm explicitly with the user before calling with `cascade=True`.
 
 **Parameters:**
 
 - `workspace` (`str`) — workspace name or GUID.
 - `item` (`str`) — warehouse or SQL analytics endpoint name or GUID.
 - `name` (`str`) — the schema name to drop.
-- `cascade` (`bool`, default `False`) — when `True`, drop all tables and views in the schema first.
+- `cascade` (`bool`, default `False`) — when `True`, drop all tables, views, functions, and stored procedures in the schema first.
 
 **Returns:** `{ "deleted": true }` — confirmation.
 

--- a/src/fabric_dw/cli/commands/schemas.py
+++ b/src/fabric_dw/cli/commands/schemas.py
@@ -74,7 +74,8 @@ async def create_cmd(
     is_flag=True,
     default=False,
     help=(
-        "Drop all tables and views in the schema before dropping the schema itself. "
+        "Drop all tables, views, functions, and stored procedures in the schema before "
+        "dropping the schema itself. "
         "WARNING: This permanently deletes all contained objects and their data."
     ),
 )
@@ -88,7 +89,8 @@ async def delete_cmd(
 ) -> None:
     """Drop schema NAME from ITEM.
 
-    Pass --cascade to also drop all tables and views inside the schema first.
+    Pass --cascade to also drop all tables, views, functions, and stored
+    procedures inside the schema first.
     This is a destructive, irreversible operation.
     """
     ws = resolve_workspace(ctx)
@@ -99,8 +101,9 @@ async def delete_cmd(
             prompt = f"Drop schema [{name}] from {entry.display_name!r} ({entry.id})?"
             if cascade:
                 prompt = (
-                    f"--cascade will permanently drop all tables and views "
-                    f"in schema [{name}] on {entry.display_name!r}. " + prompt
+                    f"--cascade will permanently drop all tables, views, functions, "
+                    f"and stored procedures in schema [{name}] on {entry.display_name!r}. "
+                    + prompt
                 )
             if not confirm_destructive(prompt, yes=ctx.yes):
                 click.echo("Aborted.")

--- a/src/fabric_dw/cli/commands/schemas.py
+++ b/src/fabric_dw/cli/commands/schemas.py
@@ -102,8 +102,7 @@ async def delete_cmd(
             if cascade:
                 prompt = (
                     f"--cascade will permanently drop all tables, views, functions, "
-                    f"and stored procedures in schema [{name}] on {entry.display_name!r}. "
-                    + prompt
+                    f"and stored procedures in schema [{name}] on {entry.display_name!r}. " + prompt
                 )
             if not confirm_destructive(prompt, yes=ctx.yes):
                 click.echo("Aborted.")


### PR DESCRIPTION
## Summary

- Update `--cascade` option help string in `schemas delete` to say tables, views, functions, and stored procedures instead of just tables and views
- Update `delete_cmd` docstring and cascade confirmation prompt to match
- Update `docs/commands/schemas.md` (CLI option table, description paragraph, example comment, and MCP `delete_schema` parameters/caution) to reflect the same accurate wording

No behavior change — the cascade drop logic already correctly handles all object types (`U/V/P/FN/IF/TF`). Unit tests covering procedures (`P`) and all function type codes (`FN`/`IF`/`TF`) already exist and pass.

Closes #556

## Test plan

- [ ] All 73 schema unit tests pass (`uv run pytest tests/unit/services/test_schemas.py tests/unit/cli/commands/test_schemas.py`)
- [ ] Verify `fdw schemas delete --help` shows updated cascade description
- [ ] Verify docs render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)