### PR TITLE
fix(tables): reject --select with --from-file before opening the HTTP client

### DIFF
--- a/src/fabric_dw/cli/commands/tables.py
+++ b/src/fabric_dw/cli/commands/tables.py
@@ -378,6 +378,10 @@ async def create_cmd(  # noqa: PLR0912
     if all_varchar and not has_csv:
         raise click.UsageError("--all-varchar requires --from-csv.")
 
+    # --select and --from-file are mutually exclusive.
+    if select_body and from_file:
+        raise click.UsageError("Provide either --select or --from-file, not both.")
+
     try:
         async with build_http_client(ctx) as http:
             target, entry = await build_sql_target(http, ws, wh)


### PR DESCRIPTION
## Summary

- Adds an early guard in `create_cmd` that raises `click.UsageError` when both `--select` and `--from-file` are passed together.
- The guard is placed with the other early argument checks, before `build_http_client()` is called, so no auth token or HTTP round-trip is performed on this validation error.
- The existing defensive check in `load_sql_body()` is kept intact for other callers.

## Before / after

| | Before | After |
|---|---|---|
| `test_create_both_select_and_file_fails` | ~1.5–7 s (real network call) | 0.94 s (sub-second, no HTTP) |

## Test plan

- [x] `test_create_both_select_and_file_fails` passes and is sub-second (no mock needed)
- [x] All `TestTablesCreate` tests pass (30 passed)
- [x] `ruff check` — no issues
- [x] `ty check` — no issues
- [x] No behavior change for valid invocations

Closes #563

🤖 Generated with [Claude Code](https://claude.com/claude-code)