### PR TITLE
test: block real network I/O in the unit test suite

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,19 @@ just cov
 just cov-html
 ```
 
+**Unit test network policy:** unit tests must not make real network calls.
+`tests/unit/conftest.py` installs an autouse fixture (`_block_real_sockets`) that uses
+[`pytest-socket`](https://github.com/miketheman/pytest-socket) to replace
+`socket.socket` with a stub that raises `SocketBlockedError` immediately.
+Any unit test that accidentally reaches a real HTTP client will fail loudly.
+
+- Mock HTTP calls with [`respx`](https://lundberg.github.io/respx/) (preferred) or
+  patch `build_http_client` / `open_connection` at the service boundary.
+- Unix-domain sockets (AF_UNIX) are permitted because asyncio's event loop requires
+  them internally; they cannot reach the internet.
+- Integration tests (`tests/integration/`) are exempt — they legitimately call
+  real Fabric APIs and are not subject to this fixture.
+
 ### Integration tests
 
 Requires a valid `az login` session and a reachable Fabric workspace.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,7 @@ dev = [
     "ruff>=0.15,<0.16",
     "ty==0.0.49",
     "pyyaml>=6.0",
+    "pytest-socket>=0.8.0",
 ]
 docs = ["zensical>=0.0.42"]
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -7,6 +7,39 @@ from collections.abc import Generator
 from unittest.mock import patch
 
 import pytest
+from pytest_socket import disable_socket, enable_socket
+
+
+@pytest.fixture(autouse=True)
+def _block_real_sockets() -> Generator[None, None, None]:
+    """Block all real network I/O for every unit test.
+
+    Unit tests must not make live HTTP calls (or any TCP/UDP connections) to
+    external hosts.  This fixture calls ``pytest-socket``'s ``disable_socket()``
+    which replaces the ``socket.socket`` constructor with a stub that raises
+    ``SocketBlockedError`` immediately, making accidental network access fail
+    loudly instead of hanging or silently returning stale data.
+
+    If a unit test legitimately needs to connect to ``localhost`` (e.g. an
+    in-process server), pass ``allow_hosts=["localhost", "127.0.0.1", "::1"]``
+    to ``disable_socket()``, or use ``@pytest.mark.allow_hosts(["localhost"])``
+    on that specific test.
+
+    Integration tests (``tests/integration/``) are NOT subject to this fixture
+    because this conftest lives under ``tests/unit/`` and pytest scopes conftest
+    fixtures to their directory tree.
+
+    Unix-domain sockets (AF_UNIX) are allowed because asyncio's internal
+    event-loop uses ``socket.socketpair()`` (AF_UNIX) as a wakeup pipe.
+    Blocking those would crash every async test with ``SocketBlockedError``
+    before the test body even runs.  AF_UNIX sockets cannot reach the internet,
+    so permitting them is safe.
+    """
+    disable_socket(allow_unix_socket=True)
+    try:
+        yield
+    finally:
+        enable_socket()
 
 
 @pytest.fixture(autouse=True)

--- a/uv.lock
+++ b/uv.lock
@@ -691,6 +691,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-randomly" },
+    { name = "pytest-socket" },
     { name = "pytest-xdist" },
     { name = "pyyaml" },
     { name = "respx" },
@@ -728,6 +729,7 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=1.4" },
     { name = "pytest-cov" },
     { name = "pytest-randomly" },
+    { name = "pytest-socket", specifier = ">=0.8.0" },
     { name = "pytest-xdist", specifier = ">=3.5" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "respx", specifier = ">=0.23" },
@@ -2055,6 +2057,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/27/b3/36192dacc0f470ac2cc516f73e01739c9a48a8224f76beada4f85e1c8a89/pytest_randomly-4.1.0.tar.gz", hash = "sha256:47f1d9746c3bc3efabd53ae1ebfb8bb385cf3d4df4b505b6d58d9c97a3dfe70f", size = 14302, upload-time = "2026-04-20T13:01:51.831Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/db/2df9a1fca597a273f957a559c20c2d95d629928384507b2afa43ba6909d1/pytest_randomly-4.1.0-py3-none-any.whl", hash = "sha256:f55e89e53367b090c0c053697d7f9d77595543d0e0516c93978b50c0f6b252f9", size = 8353, upload-time = "2026-04-20T13:01:50.382Z" },
+]
+
+[[package]]
+name = "pytest-socket"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/3c/f9b58e57830e58980dbe8867d0e348f45701d3f3ea065672d448f4366da5/pytest_socket-0.8.0.tar.gz", hash = "sha256:af9bb5f487da72be63573a6194cfac033b6c7a1c1561e150521105970f9e99f2", size = 13912, upload-time = "2026-05-21T16:50:22.552Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/e8/4a8568580bae3dcd678599ed8e86a82d505a44df71c1ced4246c1aa14b4b/pytest_socket-0.8.0-py3-none-any.whl", hash = "sha256:81821ba59f07d7600fe2b551d8714f40b068bd46e8b6704c48664e9d60cdacb8", size = 8414, upload-time = "2026-05-21T16:50:21.022Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds `pytest-socket` as a dev dependency and installs an autouse `_block_real_sockets` fixture in `tests/unit/conftest.py` that blocks all AF_INET/AF_INET6 socket creation for every unit test.
- Unix-domain sockets (AF_UNIX) are allowed so asyncio's internal `socketpair()` wakeup pipe keeps working in async tests — they cannot reach the internet.
- Ran the full unit suite (3 658 tests) with the guard in place: **all pass, zero network-leak failures found**. The existing tests were already properly mocked.
- Documents the convention in `CONTRIBUTING.md` under the Unit tests section.

## Network-leak tests found

**0 tests leaked.** Every unit test was already properly mocked (respx / AsyncMock / patched `build_http_client` / `open_connection`). The guard confirms the existing suite is clean.

Note: `test_create_both_select_and_file_fails` (the motivating example) is addressed separately in #563 (early validation guard before HTTP); with or without #563 it does not leak under this guard because the test either hits the validation gate first or the socket block fires — both behaviours are correct.

## Test plan

- [x] `uv run pytest tests/unit -q` → 3658 passed, 0 failed, 0 errors
- [x] A scratch test placing a real `socket.socket(AF_INET, ...)` inside `tests/unit/` raised `SocketBlockedError` loudly (scratch test removed before commit)
- [x] `uv run ruff check` → All checks passed
- [x] `uv run ty check src tests` → All checks passed

Closes #564

🤖 Generated with [Claude Code](https://claude.com/claude-code)