### PR TITLE
ci: report integration coverage to Codecov via flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          flags: python-${{ matrix.python-version }}
+          flags: unit,python-${{ matrix.python-version }}
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
         uses: codecov/test-results-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
         uses: codecov/test-results-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          flags: python-${{ matrix.python-version }}
+          flags: unit,python-${{ matrix.python-version }}
       # Upload coverage to GitHub Code Quality (public preview).
       # Only runs on Python 3.13 to avoid duplicate uploads across matrix entries.
       # Fork-PR guard: skip on PRs from forks (they lack write permissions).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,13 +80,13 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          flags: unit,python-${{ matrix.python-version }}
+          flags: unit
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
         uses: codecov/test-results-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          flags: unit,python-${{ matrix.python-version }}
+          flags: unit
       # Upload coverage to GitHub Code Quality (public preview).
       # Only runs on Python 3.13 to avoid duplicate uploads across matrix entries.
       # Fork-PR guard: skip on PRs from forks (they lack write permissions).

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -226,11 +226,18 @@ jobs:
 
           if [ -n "${PYTEST_K_INPUT}" ]; then
             echo "Running subset: -k '${PYTEST_K_INPUT}' with ${WORKERS} worker(s)"
-            uv run pytest tests/integration -m integration -v -n "${WORKERS}" -k "${PYTEST_K_INPUT}"
+            uv run pytest tests/integration -m integration -v -n "${WORKERS}" -k "${PYTEST_K_INPUT}" --cov --cov-branch --cov-report=xml
           else
             echo "Running full integration suite with ${WORKERS} worker(s)"
-            uv run pytest tests/integration -m integration -v -n "${WORKERS}"
+            uv run pytest tests/integration -m integration -v -n "${WORKERS}" --cov --cov-branch --cov-report=xml
           fi
+
+      - name: Upload coverage reports to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: integration
 
       - name: Post-test full workspace wipe
         if: always()

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -226,15 +226,21 @@ jobs:
 
           if [ -n "${PYTEST_K_INPUT}" ]; then
             echo "Running subset: -k '${PYTEST_K_INPUT}' with ${WORKERS} worker(s)"
-            uv run pytest tests/integration -m integration -v -n "${WORKERS}" -k "${PYTEST_K_INPUT}" --cov --cov-branch --cov-report=xml
+            uv run pytest tests/integration -m integration -v -n "${WORKERS}" -k "${PYTEST_K_INPUT}" --cov --cov-branch --cov-report=xml --junitxml=junit.xml -o junit_family=legacy
           else
             echo "Running full integration suite with ${WORKERS} worker(s)"
-            uv run pytest tests/integration -m integration -v -n "${WORKERS}" --cov --cov-branch --cov-report=xml
+            uv run pytest tests/integration -m integration -v -n "${WORKERS}" --cov --cov-branch --cov-report=xml --junitxml=junit.xml -o junit_family=legacy
           fi
 
       - name: Upload coverage reports to Codecov
         if: ${{ !cancelled() }}
         uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: integration
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: integration

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -226,19 +226,21 @@ jobs:
 
           if [ -n "${PYTEST_K_INPUT}" ]; then
             echo "Running subset: -k '${PYTEST_K_INPUT}' with ${WORKERS} worker(s)"
-            uv run pytest tests/integration -m integration -v -n "${WORKERS}" -k "${PYTEST_K_INPUT}" --cov --cov-branch --cov-report=xml --junitxml=junit.xml -o junit_family=legacy
+            uv run pytest tests/integration -m integration -v -n "${WORKERS}" -k "${PYTEST_K_INPUT}" --cov --cov-report=xml --cov-report=term --junitxml=junit.xml -o junit_family=legacy
           else
             echo "Running full integration suite with ${WORKERS} worker(s)"
-            uv run pytest tests/integration -m integration -v -n "${WORKERS}" --cov --cov-branch --cov-report=xml --junitxml=junit.xml -o junit_family=legacy
+            uv run pytest tests/integration -m integration -v -n "${WORKERS}" --cov --cov-report=xml --cov-report=term --junitxml=junit.xml -o junit_family=legacy
           fi
 
       - name: Upload coverage reports to Codecov
-        if: ${{ !cancelled() }}
+        # success() only: do not propagate partial coverage from a failed run via carry_forward
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: integration
+          files: coverage.xml
       - name: Upload test results to Codecov
+        # !cancelled(): always upload test results so failures appear in Test Analytics
         if: ${{ !cancelled() }}
         uses: codecov/test-results-action@v1
         with:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,38 @@
+# Codecov configuration
+# https://docs.codecov.com/docs/codecovyml-reference
+#
+# Two flags are used to separate unit and integration coverage:
+#   unit        — uploaded by ci.yml on every PR/push
+#   integration — uploaded by integration.yml (push/workflow_dispatch/`integration`-labelled PRs)
+#
+# carry_forward: true ensures that a PR which does not trigger the integration
+# workflow (the common case) still benefits from the most-recent integration
+# coverage on main, so the combined project total reflects reality.
+
+coverage:
+  status:
+    # Project gate: evaluated against the combined coverage of all flags.
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    # Patch gate: lines touched by the PR, combined across flags.
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+
+flags:
+  unit:
+    carry_forward: true
+    paths:
+      - src/
+  integration:
+    carry_forward: true
+    paths:
+      - src/
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default
+  require_changes: false


### PR DESCRIPTION
## Summary

- Adds `--cov --cov-report=xml --cov-report=term --junitxml=junit.xml -o junit_family=legacy` to both pytest branches in `integration.yml` (the `-k`-filtered and full-suite paths). `--cov-branch` is omitted — branch coverage is already on unconditionally via `pyproject.toml`.
- Adds a `codecov/codecov-action@v5` step (success-only, `flags: integration`, `files: coverage.xml`) and a `codecov/test-results-action@v1` step (`if: ${{ !cancelled() }}`, `flags: integration`) after the integration test run. Coverage is success-gated to avoid propagating a partial snapshot via `carry_forward` when tests fail; test results use `!cancelled()` so failures appear in Test Analytics.
- Updates `ci.yml`: both the coverage and test-results uploads now use `flags: unit` only (dropping the per-version `python-3.x` flags), so all three matrix legs combine cleanly under the single declared `unit` flag.
- Adds `codecov.yml` at the repo root to configure `unit` and `integration` flags with `carry_forward: true` and `paths: [src/]`, and project/patch status gates reflecting combined coverage.

## Design: flags + carry-forward

Integration tests only run on push to `main`, `workflow_dispatch`, or `integration`-labelled PRs. With `carry_forward: true` on the `integration` flag, Codecov reuses the last known integration report from `main` for PRs that do not trigger integration — the combined total reflects real coverage. The coverage upload is success-gated so a failed integration run does not propagate a partial snapshot.

pytest-xdist (`-n`) writes a single combined `junit.xml` at the provided path — no extra combine step is needed.

## Validation note

This is a CI/coverage and test-results reporting change. YAML validity is verified locally (`yaml.safe_load` passes for all three files). The actual Codecov flag wiring, carry-forward behavior, and Test Analytics appearance can only be confirmed once the workflows run against the Codecov service.

## Test plan

- [ ] Merge to main triggers integration workflow: confirm `coverage.xml` and `junit.xml` are produced and uploaded with `flags: integration` in the Codecov UI (Coverage and Test Analytics tabs).
- [ ] A normal PR (no `integration` label): confirm unit coverage and test results upload under `flags: unit`, and Codecov shows combined coverage using carried-forward integration data.
- [ ] Codecov project/patch checks no longer fail spuriously on feature PRs due to missing integration coverage.

Closes #569

🤖 Generated with [Claude Code](https://claude.com/claude-code)