### PR TITLE
test: make MCP tool contract tests robust to parallel additions

### DIFF
--- a/tests/unit/_tool_introspection.py
+++ b/tests/unit/_tool_introspection.py
@@ -1,0 +1,34 @@
+"""Shared live MCP tool introspection helper for unit tests.
+
+Single source of truth: build a fresh MCP server via the production
+registration path (``InstrumentedFastMCP`` + ``register_all``) and
+enumerate all registered tools.  Used by:
+
+- ``tests/unit/test_telemetry_commands.py`` — domain-coverage checks
+- ``tests/unit/mcp/test_contract.py`` — contract / invariant checks
+- ``tests/unit/mcp/test_server.py`` — registration property checks
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+
+# snake_case naming convention enforced for every MCP tool name.
+SNAKE_CASE_RE: re.Pattern[str] = re.compile(r"^[a-z][a-z0-9]*(_[a-z0-9]+)*$")
+
+
+def collect_live_mcp_tool_names() -> frozenset[str]:
+    """Register all MCP tools against a fresh InstrumentedFastMCP; return tool names.
+
+    Uses ``InstrumentedFastMCP`` (the same class the production MCP server
+    instantiates) and ``register_all()`` so that any tool added to the server
+    automatically appears here.  Tool names are enumerated via the public
+    ``asyncio.run(mcp.list_tools())`` API to avoid relying on private internals.
+    """
+    from fabric_dw.mcp._helpers import InstrumentedFastMCP  # noqa: PLC0415
+    from fabric_dw.mcp.tools import register_all  # noqa: PLC0415
+
+    mcp = InstrumentedFastMCP("coverage-check")
+    register_all(mcp)
+    return frozenset(tool.name for tool in asyncio.run(mcp.list_tools()))

--- a/tests/unit/mcp/test_contract.py
+++ b/tests/unit/mcp/test_contract.py
@@ -333,5 +333,3 @@ async def test_destructive_tool_allowed_with_env_flag(
             )
 
     assert not result.isError, f"Expected success; got error: {result!r}"
-
-

--- a/tests/unit/mcp/test_contract.py
+++ b/tests/unit/mcp/test_contract.py
@@ -45,11 +45,11 @@ from tests.unit.mcp.conftest import WS_ID, WS_NAME, make_item_entry
 
 # ---------------------------------------------------------------------------
 # Minimum tool count — guards against catastrophic registration drops.
-# Set comfortably below the current count so adding tools never requires
-# bumping this number; a mass removal is still caught.
+# Set just below the current count (~96) so adding tools never requires a
+# bump, while a whole-domain disappearance (≥6 tools) is still caught.
 # ---------------------------------------------------------------------------
 
-MIN_TOOL_COUNT = 80
+MIN_TOOL_COUNT = 90
 
 
 # ---------------------------------------------------------------------------
@@ -87,6 +87,30 @@ def contract_ctx():
 
 
 # ---------------------------------------------------------------------------
+# Fixture: live tool list via the full MCP protocol round-trip
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def live_tools(contract_ctx):
+    """Return the list of Tool objects enumerated via the MCP protocol.
+
+    Wires a real FastMCP server to a real ClientSession through in-memory
+    streams (no TCP), so this exercises the same JSON-RPC ``tools/list``
+    handshake the production server uses.
+    """
+    from mcp.shared.memory import create_connected_server_and_client_session  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with patch("fabric_dw.mcp._context.build_context", return_value=contract_ctx):
+        async with create_connected_server_and_client_session(mcp) as client:
+            result = await client.list_tools()
+
+    return result.tools
+
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
@@ -107,39 +131,22 @@ def _make_workspace() -> Workspace:
 # ---------------------------------------------------------------------------
 
 
-async def test_list_tools_minimum_count(contract_ctx) -> None:
+async def test_list_tools_minimum_count(live_tools) -> None:
     """list_tools() via the MCP protocol returns at least MIN_TOOL_COUNT tools.
 
-    This exercises the JSON-RPC ``tools/list`` handshake end-to-end.  The
-    minimum threshold catches catastrophic registration regressions while
+    The minimum threshold catches catastrophic registration regressions while
     allowing tools to be added without bumping a hardcoded number.
     """
-    from mcp.shared.memory import create_connected_server_and_client_session  # noqa: PLC0415
-
-    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
-
-    with patch("fabric_dw.mcp._context.build_context", return_value=contract_ctx):
-        async with create_connected_server_and_client_session(mcp) as client:
-            result = await client.list_tools()
-
-    tool_names = {t.name for t in result.tools}
+    tool_names = {t.name for t in live_tools}
     assert len(tool_names) >= MIN_TOOL_COUNT, (
         f"Expected at least {MIN_TOOL_COUNT} tools via MCP protocol; got {len(tool_names)}. "
         "Registration may have silently dropped tools."
     )
 
 
-async def test_list_tools_no_duplicates(contract_ctx) -> None:
+async def test_list_tools_no_duplicates(live_tools) -> None:
     """list_tools() must return no duplicate tool names."""
-    from mcp.shared.memory import create_connected_server_and_client_session  # noqa: PLC0415
-
-    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
-
-    with patch("fabric_dw.mcp._context.build_context", return_value=contract_ctx):
-        async with create_connected_server_and_client_session(mcp) as client:
-            result = await client.list_tools()
-
-    all_names = [t.name for t in result.tools]
+    all_names = [t.name for t in live_tools]
     unique_names = set(all_names)
     assert len(all_names) == len(unique_names), (
         f"Duplicate tool names detected: "
@@ -147,82 +154,43 @@ async def test_list_tools_no_duplicates(contract_ctx) -> None:
     )
 
 
-async def test_list_tools_naming_convention(contract_ctx) -> None:
+async def test_list_tools_naming_convention(live_tools) -> None:
     """Every tool name must follow the snake_case naming convention."""
-    from mcp.shared.memory import create_connected_server_and_client_session  # noqa: PLC0415
-
-    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
-
-    with patch("fabric_dw.mcp._context.build_context", return_value=contract_ctx):
-        async with create_connected_server_and_client_session(mcp) as client:
-            result = await client.list_tools()
-
-    bad = [t.name for t in result.tools if not SNAKE_CASE_RE.match(t.name)]
+    bad = [t.name for t in live_tools if not SNAKE_CASE_RE.match(t.name)]
     assert not bad, f"Tool names violating snake_case convention: {sorted(bad)}"
 
 
-async def test_list_tools_non_empty_descriptions(contract_ctx) -> None:
+async def test_list_tools_non_empty_descriptions(live_tools) -> None:
     """Every tool must have a non-empty description string."""
-    from mcp.shared.memory import create_connected_server_and_client_session  # noqa: PLC0415
-
-    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
-
-    with patch("fabric_dw.mcp._context.build_context", return_value=contract_ctx):
-        async with create_connected_server_and_client_session(mcp) as client:
-            result = await client.list_tools()
-
-    missing = [t.name for t in result.tools if not (t.description or "").strip()]
+    missing = [t.name for t in live_tools if not (t.description or "").strip()]
     assert not missing, f"Tools with missing or empty description: {sorted(missing)}"
 
 
-async def test_list_tools_all_resolve_to_domain(contract_ctx) -> None:
+async def test_list_tools_all_resolve_to_domain(live_tools) -> None:
     """Every tool registered via MCP must resolve to a known telemetry domain.
 
     This replicates the invariant enforced by test_telemetry_commands, but
     exercises it through the full MCP protocol round-trip so contract tests
     are self-contained.
     """
-    from mcp.shared.memory import create_connected_server_and_client_session  # noqa: PLC0415
-
-    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
     from fabric_dw.telemetry_commands import resolve_domain  # noqa: PLC0415
 
-    with patch("fabric_dw.mcp._context.build_context", return_value=contract_ctx):
-        async with create_connected_server_and_client_session(mcp) as client:
-            result = await client.list_tools()
-
-    unknown = [t.name for t in result.tools if resolve_domain(t.name) == "unknown"]
+    unknown = [t.name for t in live_tools if resolve_domain(t.name) == "unknown"]
     assert not unknown, (
         f"MCP tools with no DOMAIN_MAP entry (would log domain='unknown'): {sorted(unknown)}. "
         "Add each missing name to DOMAIN_MAP in fabric_dw.telemetry_commands."
     )
 
 
-async def test_list_tools_contains_read_tool(contract_ctx) -> None:
+async def test_list_tools_contains_read_tool(live_tools) -> None:
     """The tool roster must include the 'list_workspaces' read tool."""
-    from mcp.shared.memory import create_connected_server_and_client_session  # noqa: PLC0415
-
-    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
-
-    with patch("fabric_dw.mcp._context.build_context", return_value=contract_ctx):
-        async with create_connected_server_and_client_session(mcp) as client:
-            result = await client.list_tools()
-
-    tool_names = {t.name for t in result.tools}
+    tool_names = {t.name for t in live_tools}
     assert "list_workspaces" in tool_names
 
 
-async def test_list_tools_contains_destructive_tool(contract_ctx) -> None:
+async def test_list_tools_contains_destructive_tool(live_tools) -> None:
     """The tool roster must include the guarded 'delete_restore_point' tool."""
-    from mcp.shared.memory import create_connected_server_and_client_session  # noqa: PLC0415
-
-    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
-
-    with patch("fabric_dw.mcp._context.build_context", return_value=contract_ctx):
-        async with create_connected_server_and_client_session(mcp) as client:
-            result = await client.list_tools()
-
-    tool_names = {t.name for t in result.tools}
+    tool_names = {t.name for t in live_tools}
     assert "delete_restore_point" in tool_names
 
 

--- a/tests/unit/mcp/test_contract.py
+++ b/tests/unit/mcp/test_contract.py
@@ -40,17 +40,16 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from fabric_dw.models import Workspace
+from tests.unit._tool_introspection import SNAKE_CASE_RE
 from tests.unit.mcp.conftest import WS_ID, WS_NAME, make_item_entry
 
 # ---------------------------------------------------------------------------
-# Expected tool count (sync with test_server.EXPECTED_TOOL_NAMES)
+# Minimum tool count — guards against catastrophic registration drops.
+# Set comfortably below the current count so adding tools never requires
+# bumping this number; a mass removal is still caught.
 # ---------------------------------------------------------------------------
 
-# 77 baseline + 5 statistics + 1 dbt + 3 table-create + 6 functions
-# + 1 load_table_from_url + 1 import_table_from_url + 3 settings
-# + 2 count_table_rows / count_view_rows + 1 get_query_plan + 1 get_cluster_columns
-# + 2 capacity tools (list_capacities + assign_workspace_to_capacity)
-_EXPECTED_TOOL_COUNT = 96
+MIN_TOOL_COUNT = 80
 
 
 # ---------------------------------------------------------------------------
@@ -108,12 +107,12 @@ def _make_workspace() -> Workspace:
 # ---------------------------------------------------------------------------
 
 
-async def test_list_tools_returns_expected_count(contract_ctx) -> None:
-    """list_tools() via the MCP protocol returns all 67 registered tools.
+async def test_list_tools_minimum_count(contract_ctx) -> None:
+    """list_tools() via the MCP protocol returns at least MIN_TOOL_COUNT tools.
 
-    This exercises the JSON-RPC ``tools/list`` handshake end-to-end and
-    verifies that registration (``register_all``) did not silently drop or
-    duplicate any tool.
+    This exercises the JSON-RPC ``tools/list`` handshake end-to-end.  The
+    minimum threshold catches catastrophic registration regressions while
+    allowing tools to be added without bumping a hardcoded number.
     """
     from mcp.shared.memory import create_connected_server_and_client_session  # noqa: PLC0415
 
@@ -124,9 +123,78 @@ async def test_list_tools_returns_expected_count(contract_ctx) -> None:
             result = await client.list_tools()
 
     tool_names = {t.name for t in result.tools}
-    assert len(tool_names) == _EXPECTED_TOOL_COUNT, (
-        f"Expected {_EXPECTED_TOOL_COUNT} tools; got {len(tool_names)}. "
-        f"Diff: {tool_names.symmetric_difference(_expected_tool_names())}"
+    assert len(tool_names) >= MIN_TOOL_COUNT, (
+        f"Expected at least {MIN_TOOL_COUNT} tools via MCP protocol; got {len(tool_names)}. "
+        "Registration may have silently dropped tools."
+    )
+
+
+async def test_list_tools_no_duplicates(contract_ctx) -> None:
+    """list_tools() must return no duplicate tool names."""
+    from mcp.shared.memory import create_connected_server_and_client_session  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with patch("fabric_dw.mcp._context.build_context", return_value=contract_ctx):
+        async with create_connected_server_and_client_session(mcp) as client:
+            result = await client.list_tools()
+
+    all_names = [t.name for t in result.tools]
+    unique_names = set(all_names)
+    assert len(all_names) == len(unique_names), (
+        f"Duplicate tool names detected: "
+        f"{sorted(n for n in unique_names if all_names.count(n) > 1)}"
+    )
+
+
+async def test_list_tools_naming_convention(contract_ctx) -> None:
+    """Every tool name must follow the snake_case naming convention."""
+    from mcp.shared.memory import create_connected_server_and_client_session  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with patch("fabric_dw.mcp._context.build_context", return_value=contract_ctx):
+        async with create_connected_server_and_client_session(mcp) as client:
+            result = await client.list_tools()
+
+    bad = [t.name for t in result.tools if not SNAKE_CASE_RE.match(t.name)]
+    assert not bad, f"Tool names violating snake_case convention: {sorted(bad)}"
+
+
+async def test_list_tools_non_empty_descriptions(contract_ctx) -> None:
+    """Every tool must have a non-empty description string."""
+    from mcp.shared.memory import create_connected_server_and_client_session  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with patch("fabric_dw.mcp._context.build_context", return_value=contract_ctx):
+        async with create_connected_server_and_client_session(mcp) as client:
+            result = await client.list_tools()
+
+    missing = [t.name for t in result.tools if not (t.description or "").strip()]
+    assert not missing, f"Tools with missing or empty description: {sorted(missing)}"
+
+
+async def test_list_tools_all_resolve_to_domain(contract_ctx) -> None:
+    """Every tool registered via MCP must resolve to a known telemetry domain.
+
+    This replicates the invariant enforced by test_telemetry_commands, but
+    exercises it through the full MCP protocol round-trip so contract tests
+    are self-contained.
+    """
+    from mcp.shared.memory import create_connected_server_and_client_session  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+    from fabric_dw.telemetry_commands import resolve_domain  # noqa: PLC0415
+
+    with patch("fabric_dw.mcp._context.build_context", return_value=contract_ctx):
+        async with create_connected_server_and_client_session(mcp) as client:
+            result = await client.list_tools()
+
+    unknown = [t.name for t in result.tools if resolve_domain(t.name) == "unknown"]
+    assert not unknown, (
+        f"MCP tools with no DOMAIN_MAP entry (would log domain='unknown'): {sorted(unknown)}. "
+        "Add each missing name to DOMAIN_MAP in fabric_dw.telemetry_commands."
     )
 
 
@@ -299,13 +367,3 @@ async def test_destructive_tool_allowed_with_env_flag(
     assert not result.isError, f"Expected success; got error: {result!r}"
 
 
-# ---------------------------------------------------------------------------
-# Helper: reproduce expected tool names for diff output
-# ---------------------------------------------------------------------------
-
-
-def _expected_tool_names() -> frozenset[str]:
-    """Mirror of EXPECTED_TOOL_NAMES from test_server.py (for diff output only)."""
-    from tests.unit.mcp.test_server import EXPECTED_TOOL_NAMES  # noqa: PLC0415
-
-    return EXPECTED_TOOL_NAMES

--- a/tests/unit/mcp/test_server.py
+++ b/tests/unit/mcp/test_server.py
@@ -37,6 +37,7 @@ from fabric_dw.models import (
     WarehouseSnapshot,
     Workspace,
 )
+from tests.unit._tool_introspection import SNAKE_CASE_RE, collect_live_mcp_tool_names
 from tests.unit.mcp.conftest import (
     WH_ID,
     WH_NAME,
@@ -47,130 +48,27 @@ from tests.unit.mcp.conftest import (
 )
 
 # ---------------------------------------------------------------------------
-# Expected tool names (canonical list — test fails if any are missing/typo'd)
+# Stable core tools — a small subset that must always be registered.
+# These represent fundamental capabilities across all major domains.
+# Additions never require touching this set; only intentional removal of a
+# core tool should prompt updating it.
 # ---------------------------------------------------------------------------
 
-EXPECTED_TOOL_NAMES: frozenset[str] = frozenset(
+CORE_TOOLS: frozenset[str] = frozenset(
     {
         # Workspaces
-        "assign_workspace_to_capacity",
-        "list_capacities",
         "list_workspaces",
         "get_workspace",
-        "set_workspace_collation",
         # Warehouses
         "list_warehouses",
         "get_warehouse",
-        "create_warehouse",
-        "rename_warehouse",
-        "delete_warehouse",
-        "takeover_warehouse",
-        # SQL Endpoints
-        "list_sql_endpoints",
-        "get_sql_endpoint",
-        "refresh_sql_endpoint_metadata",
-        # Audit
-        "get_audit_settings",
-        "enable_audit",
-        "disable_audit",
-        "set_audit_action_groups",
-        "add_audit_group",
-        "remove_audit_group",
-        "set_audit_retention",
-        # Queries (running + query-insights DMVs)
-        "list_running_queries",
-        "kill_session",
-        "list_request_history",
-        "list_session_history",
-        "list_frequent_queries",
-        "list_long_running_queries",
-        # SQL Pools (incl. pool-insights DMV)
-        # list_sql_pool_insights is grouped with sql_pools below
-        "list_sql_pool_insights",
-        # Generic SQL execution
+        # SQL execution
         "execute_sql",
-        "get_query_plan",
-        # Snapshots
-        "list_snapshots",
-        "create_snapshot",
-        "rename_snapshot",
-        "delete_snapshot",
-        "roll_snapshot_timestamp",
         # Cache
         "clear_cache",
-        # Permissions (admin API)
-        "get_warehouse_permissions",
-        "get_sql_endpoint_permissions",
-        # Schemas
-        "list_schemas",
-        "create_schema",
-        "delete_schema",
-        # Views
-        "list_views",
-        "read_view",
-        "count_view_rows",
-        "get_view",
-        "create_view",
-        "update_view",
-        "drop_view",
-        "rename_view",
-        # Stored Procedures
-        "list_procedures",
-        "get_procedure",
-        "create_procedure",
-        "update_procedure",
-        "drop_procedure",
-        # Functions
-        "list_functions",
-        "get_function",
-        "create_function",
-        "update_function",
-        "drop_function",
-        "rename_function",
-        # Tables
-        "list_tables",
-        "read_table",
-        "count_table_rows",
-        "get_cluster_columns",
-        "create_table",
-        "create_empty_table",
-        "clone_table",
-        "rename_table",
-        "delete_table",
-        "clear_table",
-        # Load
-        "load_table_from_url",
-        "import_table_from_url",
-        # Restore Points
+        # Restore points
         "list_restore_points",
-        "get_restore_point",
-        "create_restore_point",
-        "update_restore_point",
         "delete_restore_point",
-        "restore_warehouse_in_place",
-        # SQL Pools
-        "get_sql_pools_configuration",
-        "list_sql_pools",
-        "get_sql_pool",
-        "create_sql_pool",
-        "update_sql_pool",
-        "delete_sql_pool",
-        "enable_sql_pools",
-        "disable_sql_pools",
-        # Connections
-        "list_connections",
-        # Statistics
-        "list_statistics",
-        "show_statistics",
-        "create_statistics",
-        "update_statistics",
-        "delete_statistics",
-        # Settings
-        "get_warehouse_settings",
-        "set_result_set_caching",
-        "set_time_travel_retention",
-        # dbt scaffold
-        "generate_dbt_profile",
     }
 )
 
@@ -317,13 +215,58 @@ def _make_item_access() -> ItemAccess:
 # ---------------------------------------------------------------------------
 
 
-def test_tools_registered() -> None:
-    """Every expected tool name must be registered in the FastMCP server."""
+def test_core_tools_registered() -> None:
+    """Every core tool must be registered in the FastMCP server.
+
+    ``CORE_TOOLS`` is a stable subset of fundamental tools spanning all major
+    domains.  A registration regression (e.g. a broken ``register_all`` call)
+    is caught here without requiring a full name-set bump when new tools land.
+    """
+    registered_names = collect_live_mcp_tool_names()
+    missing = CORE_TOOLS - registered_names
+    assert not missing, (
+        f"Core tools missing from registration: {sorted(missing)}. "
+        "These tools are considered fundamental and should always be present."
+    )
+
+
+def test_registered_tools_no_duplicates() -> None:
+    """The live tool registration must produce no duplicate tool names."""
+    registered_names = collect_live_mcp_tool_names()
+    # frozenset already deduplicates; verify by checking count via private API too.
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
-    registered = set(mcp._tool_manager._tools.keys())
-    missing = EXPECTED_TOOL_NAMES - registered
-    assert not missing, f"Missing tools: {sorted(missing)}"
+    all_keys = list(mcp._tool_manager._tools.keys())
+    assert len(all_keys) == len(set(all_keys)), (
+        f"Duplicate tool names in _tool_manager: "
+        f"{sorted(k for k in set(all_keys) if all_keys.count(k) > 1)}"
+    )
+    # The frozenset from the live API should match the private key count.
+    assert len(registered_names) == len(all_keys), (
+        f"Mismatch between live API count ({len(registered_names)}) "
+        f"and _tool_manager count ({len(all_keys)})"
+    )
+
+
+def test_registered_tools_naming_convention() -> None:
+    """Every registered tool name must follow the snake_case naming convention."""
+    registered_names = collect_live_mcp_tool_names()
+    bad = [name for name in registered_names if not SNAKE_CASE_RE.match(name)]
+    assert not bad, f"Tool names violating snake_case convention: {sorted(bad)}"
+
+
+def test_registered_tools_non_empty_descriptions() -> None:
+    """Every registered tool must have a non-empty description string."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    missing_desc = [
+        name
+        for name, tool in mcp._tool_manager._tools.items()
+        if not (tool.description or "").strip()
+    ]
+    assert not missing_desc, (
+        f"Tools with missing or empty description: {sorted(missing_desc)}"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/mcp/test_server.py
+++ b/tests/unit/mcp/test_server.py
@@ -64,11 +64,27 @@ CORE_TOOLS: frozenset[str] = frozenset(
         "get_warehouse",
         # SQL execution
         "execute_sql",
-        # Cache
-        "clear_cache",
+        # Audit
+        "get_audit_settings",
+        # Snapshots
+        "list_snapshots",
         # Restore points
         "list_restore_points",
         "delete_restore_point",
+        # Tables
+        "list_tables",
+        # Views
+        "list_views",
+        # Stored procedures
+        "list_procedures",
+        # Functions
+        "list_functions",
+        # Statistics
+        "list_statistics",
+        # Queries
+        "list_running_queries",
+        # Cache
+        "clear_cache",
     }
 )
 
@@ -231,20 +247,24 @@ def test_core_tools_registered() -> None:
 
 
 def test_registered_tools_no_duplicates() -> None:
-    """The live tool registration must produce no duplicate tool names."""
-    registered_names = collect_live_mcp_tool_names()
-    # frozenset already deduplicates; verify by checking count via private API too.
-    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+    """The live tool registration must produce no duplicate tool names.
 
-    all_keys = list(mcp._tool_manager._tools.keys())
-    assert len(all_keys) == len(set(all_keys)), (
-        f"Duplicate tool names in _tool_manager: "
-        f"{sorted(k for k in set(all_keys) if all_keys.count(k) > 1)}"
-    )
-    # The frozenset from the live API should match the private key count.
-    assert len(registered_names) == len(all_keys), (
-        f"Mismatch between live API count ({len(registered_names)}) "
-        f"and _tool_manager count ({len(all_keys)})"
+    ``list_tools()`` is the public API — a duplicate registration would appear
+    as two entries with the same name in the returned list.
+    """
+    import asyncio  # noqa: PLC0415
+
+    from fabric_dw.mcp._helpers import InstrumentedFastMCP  # noqa: PLC0415
+    from fabric_dw.mcp.tools import register_all  # noqa: PLC0415
+
+    mcp = InstrumentedFastMCP("dup-check")
+    register_all(mcp)
+    all_tools = asyncio.run(mcp.list_tools())
+    all_names = [t.name for t in all_tools]
+    unique_names = set(all_names)
+    assert len(all_names) == len(unique_names), (
+        f"Duplicate tool names detected via list_tools(): "
+        f"{sorted(n for n in unique_names if all_names.count(n) > 1)}"
     )
 
 
@@ -256,14 +276,20 @@ def test_registered_tools_naming_convention() -> None:
 
 
 def test_registered_tools_non_empty_descriptions() -> None:
-    """Every registered tool must have a non-empty description string."""
-    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+    """Every registered tool must have a non-empty description string.
 
-    missing_desc = [
-        name
-        for name, tool in mcp._tool_manager._tools.items()
-        if not (tool.description or "").strip()
-    ]
+    Uses the public ``list_tools()`` API so the check mirrors what an MCP
+    client actually receives rather than reading internal state.
+    """
+    import asyncio  # noqa: PLC0415
+
+    from fabric_dw.mcp._helpers import InstrumentedFastMCP  # noqa: PLC0415
+    from fabric_dw.mcp.tools import register_all  # noqa: PLC0415
+
+    mcp = InstrumentedFastMCP("desc-check")
+    register_all(mcp)
+    all_tools = asyncio.run(mcp.list_tools())
+    missing_desc = [t.name for t in all_tools if not (t.description or "").strip()]
     assert not missing_desc, (
         f"Tools with missing or empty description: {sorted(missing_desc)}"
     )

--- a/tests/unit/mcp/test_server.py
+++ b/tests/unit/mcp/test_server.py
@@ -290,9 +290,7 @@ def test_registered_tools_non_empty_descriptions() -> None:
     register_all(mcp)
     all_tools = asyncio.run(mcp.list_tools())
     missing_desc = [t.name for t in all_tools if not (t.description or "").strip()]
-    assert not missing_desc, (
-        f"Tools with missing or empty description: {sorted(missing_desc)}"
-    )
+    assert not missing_desc, f"Tools with missing or empty description: {sorted(missing_desc)}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_telemetry_commands.py
+++ b/tests/unit/test_telemetry_commands.py
@@ -89,15 +89,6 @@ def _collect_live_cli_group_names() -> frozenset[str]:
     return frozenset(cli.commands)
 
 
-def _collect_live_mcp_tool_names() -> frozenset[str]:
-    """Thin alias kept for backwards compatibility; delegates to the shared helper.
-
-    Use ``tests.unit._tool_introspection.collect_live_mcp_tool_names`` directly
-    in new code.
-    """
-    return collect_live_mcp_tool_names()
-
-
 class TestDomainCoverage:
     """Every registered MCP tool and every CLI command must resolve to a known domain.
 
@@ -108,7 +99,7 @@ class TestDomainCoverage:
 
     def test_all_mcp_tools_resolve_to_known_domain(self) -> None:
         """Every MCP tool name must resolve to a domain that is NOT 'unknown'."""
-        tool_names = _collect_live_mcp_tool_names()
+        tool_names = collect_live_mcp_tool_names()
         assert len(tool_names) > 0, (
             "No MCP tools were discovered — register_all() appears to have registered nothing. "
             "Check that fabric_dw.mcp.tools._DOMAINS is populated."

--- a/tests/unit/test_telemetry_commands.py
+++ b/tests/unit/test_telemetry_commands.py
@@ -21,6 +21,7 @@ from fabric_dw.telemetry_commands import (
     now_ms,
     resolve_domain,
 )
+from tests.unit._tool_introspection import collect_live_mcp_tool_names
 
 # Telemetry patch targets (lazily imported inside emit_command_invoked).
 _TELEMETRY_ENABLED = "fabric_dw.telemetry.telemetry_enabled"
@@ -89,21 +90,12 @@ def _collect_live_cli_group_names() -> frozenset[str]:
 
 
 def _collect_live_mcp_tool_names() -> frozenset[str]:
-    """Register all MCP tools against a fresh InstrumentedFastMCP instance; return tool names.
+    """Thin alias kept for backwards compatibility; delegates to the shared helper.
 
-    Uses ``InstrumentedFastMCP`` (the same class the production MCP server
-    instantiates) and ``register_all()`` so that any tool added to the server
-    automatically appears here.  Tool names are enumerated via the public
-    ``asyncio.run(mcp.list_tools())`` API to avoid relying on private internals.
+    Use ``tests.unit._tool_introspection.collect_live_mcp_tool_names`` directly
+    in new code.
     """
-    import asyncio  # noqa: PLC0415
-
-    from fabric_dw.mcp._helpers import InstrumentedFastMCP  # noqa: PLC0415
-    from fabric_dw.mcp.tools import register_all  # noqa: PLC0415
-
-    mcp = InstrumentedFastMCP("coverage-check")
-    register_all(mcp)
-    return frozenset(tool.name for tool in asyncio.run(mcp.list_tools()))
+    return collect_live_mcp_tool_names()
 
 
 class TestDomainCoverage:


### PR DESCRIPTION
## Summary

- Replaces the brittle `_EXPECTED_TOOL_COUNT == N` assertion in `test_contract.py` with a `MIN_TOOL_COUNT >= 80` threshold; a catastrophic registration drop is still caught, but adding tools never requires bumping a number.
- Replaces the exact `EXPECTED_TOOL_NAMES` frozenset in `test_server.py` with a stable `CORE_TOOLS` subset check (~8 tools that must always exist) plus property checks (no dupes, snake_case, non-empty descriptions) over the live-registered set.
- Factors the live MCP tool enumeration into a shared helper (`tests/unit/_tool_introspection.py`) that is now used by `test_telemetry_commands.py`, `test_contract.py`, and `test_server.py` — one source of truth via the production `InstrumentedFastMCP` + `register_all()` path.
- Adds new invariant assertions in both contract and server tests: no duplicate names, snake_case convention, non-empty descriptions, and domain-coverage check (every tool resolves to a known telemetry domain, same invariant as #549).

**Trade-off (intentional):** The "exactly these N tools" guard is dropped. The kept invariants — every tool mapped to a domain, no duplicates, naming convention, core tools present — are what matter; PR review and docs cover intentional surface changes. Parallel tool-adding PRs no longer need to touch `test_contract.py` or `test_server.py`.

## Test plan

- [x] `uv run pytest tests/unit/mcp/test_contract.py tests/unit/mcp/test_server.py tests/unit/test_telemetry_commands.py -q` — 145 passed
- [x] `ruff check` clean on all modified files
- [x] `ty check` clean on all modified files
- [x] Sanity check: registering a fake tool without a DOMAIN_MAP entry causes domain-coverage assertions to catch it (verified via inline Python script)

Closes #561

🤖 Generated with [Claude Code](https://claude.com/claude-code)