### PR TITLE
fix(deps): add missing pyyaml runtime dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,24 @@ jobs:
           language: Python
           label: code-coverage/pytest
 
+  runtime-smoke:
+    name: Runtime smoke (no dev deps)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: astral-sh/setup-uv@v8.2.0
+        with:
+          enable-cache: true
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      # Install only runtime (production) dependencies — no dev group.
+      # This mirrors what `uvx fabric-dw` / `pip install fabric-dw` produces.
+      - run: uv sync --frozen --no-dev
+      - run: uv run --no-dev fabric-dw --help
+
   slow:
     name: Slow tests (wall-clock timing)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,9 @@ jobs:
   runtime-smoke:
     name: Runtime smoke (no dev deps)
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.13"]
     steps:
       - uses: actions/checkout@v6
         with:
@@ -117,11 +120,14 @@ jobs:
           enable-cache: true
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: ${{ matrix.python-version }}
       # Install only runtime (production) dependencies — no dev group.
       # This mirrors what `uvx fabric-dw` / `pip install fabric-dw` produces.
       - run: uv sync --frozen --no-dev
+      # Smoke-test both entry points: a missing runtime dep in either import
+      # chain will exit non-zero and fail the job.
       - run: uv run --no-dev fabric-dw --help
+      - run: uv run --no-dev fabric-dw-mcp --help
 
   slow:
     name: Slow tests (wall-clock timing)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ dependencies = [
     "pyarrow>=17.0",
     "tomli-w>=1.0",
     "azure-monitor-opentelemetry>=1.6",
+    "pyyaml>=6.0",
 ]
 
 [project.urls]
@@ -89,7 +90,7 @@ dev = [
     "pytest-cov",
     "ruff>=0.15,<0.16",
     "ty==0.0.49",
-    "pyyaml>=6.0",
+    "types-pyyaml>=6.0",
     "pytest-socket>=0.8.0",
 ]
 docs = ["zensical>=0.0.42"]

--- a/uv.lock
+++ b/uv.lock
@@ -678,6 +678,7 @@ dependencies = [
     { name = "mssql-python" },
     { name = "pyarrow" },
     { name = "pydantic" },
+    { name = "pyyaml" },
     { name = "rich" },
     { name = "tenacity" },
     { name = "tomli-w" },
@@ -693,10 +694,10 @@ dev = [
     { name = "pytest-randomly" },
     { name = "pytest-socket" },
     { name = "pytest-xdist" },
-    { name = "pyyaml" },
     { name = "respx" },
     { name = "ruff" },
     { name = "ty" },
+    { name = "types-pyyaml" },
 ]
 docs = [
     { name = "zensical" },
@@ -716,6 +717,7 @@ requires-dist = [
     { name = "mssql-python", specifier = ">=1.9.0" },
     { name = "pyarrow", specifier = ">=17.0" },
     { name = "pydantic", specifier = ">=2.9" },
+    { name = "pyyaml", specifier = ">=6.0" },
     { name = "rich", specifier = ">=14" },
     { name = "tenacity", specifier = ">=9" },
     { name = "tomli-w", specifier = ">=1.0" },
@@ -731,10 +733,10 @@ dev = [
     { name = "pytest-randomly" },
     { name = "pytest-socket", specifier = ">=0.8.0" },
     { name = "pytest-xdist", specifier = ">=3.5" },
-    { name = "pyyaml", specifier = ">=6.0" },
     { name = "respx", specifier = ">=0.23" },
     { name = "ruff", specifier = ">=0.15,<0.16" },
     { name = "ty", specifier = "==0.0.49" },
+    { name = "types-pyyaml", specifier = ">=6.0" },
 ]
 docs = [{ name = "zensical", specifier = ">=0.0.42" }]
 
@@ -2609,6 +2611,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5e/ed/ef06584ccdd5c410df0837951ecd7e15d9a6144ea1bd4c73cecab1a89891/typer-0.26.7.tar.gz", hash = "sha256:e314a34c617e419c091b2830dda3ea1f257134ff593061a8f5b9717ab8dddb3a", size = 201709, upload-time = "2026-06-03T07:18:06.843Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/24/25/2201973529af2c954de0bb725323c3aaed6d7f0ceee8f550dec9185df013/typer-0.26.7-py3-none-any.whl", hash = "sha256:5c87cfbc5d34491c5346ebf49c23e18d56ccb863268d3a8d592b26087c2f5e58", size = 122456, upload-time = "2026-06-03T07:18:05.732Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20260518"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/83/4a1afc3fbfcf5b8d46fc390cd95ed6b0dc9010a265f4e9f46314efffa37a/types_pyyaml-6.0.12.20260518.tar.gz", hash = "sha256:d917f83fb38462550338c1297faedd860b3ec83912b96b1e3d73255f7473e466", size = 17850, upload-time = "2026-05-18T06:01:58.675Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl", hash = "sha256:d2150f75a231c9fe9c7463bd29487d93e60bac90400287351384bc2284eba7cd", size = 20312, upload-time = "2026-05-18T06:01:57.368Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds `pyyaml>=6.0` to `[project] dependencies` in `pyproject.toml` — it was only in the `dev` group, which caused `ModuleNotFoundError: No module named 'yaml'` on a clean `uvx fabric-dw` install.
- Replaces `pyyaml>=6.0` in the `dev` group with `types-pyyaml>=6.0` to supply type-checker stubs (`ty check` still passes).
- Runs `uv lock` to update `uv.lock`.

## Regression guard

A new `runtime-smoke` job added to `ci.yml` installs the package with `uv sync --frozen --no-dev` (runtime deps only — no dev group) and then runs `fabric-dw --help`. Any future module-level import of an undeclared runtime dep will fail this job before it reaches users.

## Test plan

- [x] `uv run --no-dev python -c "import yaml; print(yaml.__version__)"` returns `6.0.3`
- [x] `uv run ty check src tests` passes (`All checks passed!`)
- [x] `uv lock` succeeds and adds `types-pyyaml v6.0.12.20260518`

Closes #578

🤖 Generated with [Claude Code](https://claude.com/claude-code)