### PR TITLE
feat(dbt): include table columns in generated _sources.yml

### DIFF
--- a/src/fabric_dw/cli/commands/dbt.py
+++ b/src/fabric_dw/cli/commands/dbt.py
@@ -157,16 +157,19 @@ async def init_cmd(
         async with build_http_client(ctx) as http:
             target_obj, _entry = await build_sql_target(http, ws, wh)
 
-            # When --with-sources, fetch schemas and tables before scaffolding.
+            # When --with-sources, fetch schemas, tables, and columns (bulk) before scaffolding.
             schemas = []
             tables = []
+            columns: dict[tuple[str, str], list[dict[str, object]]] = {}
             if with_sources:
                 from fabric_dw.services import schemas as schemas_svc  # noqa: PLC0415
                 from fabric_dw.services import tables as tables_svc  # noqa: PLC0415
+                from fabric_dw.services.columns import get_columns_for_schemas  # noqa: PLC0415
 
-                schemas, tables = await asyncio.gather(
+                schemas, tables, columns = await asyncio.gather(
                     schemas_svc.list_schemas(target_obj, mode=ctx.auth),
                     tables_svc.list_tables(target_obj, mode=ctx.auth),
+                    get_columns_for_schemas(target_obj, mode=ctx.auth),
                 )
 
             cfg = DbtScaffoldConfig(
@@ -182,6 +185,7 @@ async def init_cmd(
                 with_sources=with_sources,
                 schemas=schemas,
                 tables=tables,
+                columns=columns,
             )
 
             try:

--- a/src/fabric_dw/mcp/tools/dbt.py
+++ b/src/fabric_dw/mcp/tools/dbt.py
@@ -103,19 +103,22 @@ def register(mcp: FastMCP) -> None:
         if dbt_auth not in (DbtAuthMode.AUTO, DbtAuthMode.CLI, DbtAuthMode.SERVICE_PRINCIPAL):
             dbt_auth = DbtAuthMode.AUTO
 
-        # Fetch schemas/tables when with_sources requested.
+        # Fetch schemas, tables, and columns (bulk) when with_sources requested.
         schemas = []
         tables = []
+        columns: dict[tuple[str, str], list[dict[str, object]]] = {}
         if with_sources:
             import asyncio  # noqa: PLC0415
 
             from fabric_dw.services import schemas as schemas_svc  # noqa: PLC0415
             from fabric_dw.services import tables as tables_svc  # noqa: PLC0415
+            from fabric_dw.services.columns import get_columns_for_schemas  # noqa: PLC0415
 
             try:
-                schemas, tables = await asyncio.gather(
+                schemas, tables, columns = await asyncio.gather(
                     schemas_svc.list_schemas(sql_target, mode=ctx.auth_mode),
                     tables_svc.list_tables(sql_target, mode=ctx.auth_mode),
+                    get_columns_for_schemas(sql_target, mode=ctx.auth_mode),
                 )
             except (ValueError, FabricError) as exc:
                 raise tool_err(exc) from exc
@@ -132,6 +135,7 @@ def register(mcp: FastMCP) -> None:
             with_sources=with_sources,
             schemas=schemas,
             tables=tables,
+            columns=columns,
         )
 
         from fabric_dw.services.dbt_scaffold import (  # noqa: PLC0415

--- a/src/fabric_dw/services/columns.py
+++ b/src/fabric_dw/services/columns.py
@@ -7,7 +7,7 @@ Public API
   (table or view) via ``sys.columns JOIN sys.types``, ordered by ``column_id``.
 - :func:`get_object_columns_or_raise` — same, but raises
   :class:`~fabric_dw.exceptions.NotFoundError` when the object does not exist.
-- :func:`get_columns_for_schemas`   — bulk-fetch columns for all tables in a set of schemas,
+- :func:`get_columns_for_schemas`   — bulk-fetch columns for all tables across all schemas,
   returning a dict keyed by ``(schema_name, table_name)``.  One query, no N+1.
 """
 

--- a/src/fabric_dw/services/columns.py
+++ b/src/fabric_dw/services/columns.py
@@ -7,6 +7,8 @@ Public API
   (table or view) via ``sys.columns JOIN sys.types``, ordered by ``column_id``.
 - :func:`get_object_columns_or_raise` — same, but raises
   :class:`~fabric_dw.exceptions.NotFoundError` when the object does not exist.
+- :func:`get_columns_for_schemas`   — bulk-fetch columns for all tables in a set of schemas,
+  returning a dict keyed by ``(schema_name, table_name)``.  One query, no N+1.
 """
 
 from __future__ import annotations
@@ -21,6 +23,7 @@ from fabric_dw.sql import SqlTarget, run_query
 
 __all__ = [
     "format_data_type",
+    "get_columns_for_schemas",
     "get_object_columns",
     "get_object_columns_or_raise",
 ]
@@ -52,6 +55,30 @@ JOIN sys.objects o ON o.object_id = c.object_id
 JOIN sys.schemas s ON s.schema_id = o.schema_id
 WHERE s.name = ? AND o.name = ?
 ORDER BY c.column_id;
+"""
+
+# Bulk variant: fetches columns for all tables (type='U') in a set of schemas
+# in ONE query.  Returns schema_name and object_name alongside each column row
+# so the caller can key by (schema, table) without extra round-trips.
+_GET_COLUMNS_FOR_SCHEMAS_SQL = """\
+SELECT
+    s.name           AS schema_name,
+    o.name           AS object_name,
+    c.column_id      AS ordinal,
+    c.name,
+    t.name           AS type_name,
+    c.max_length,
+    c.precision,
+    c.scale,
+    c.is_nullable    AS nullable,
+    c.collation_name,
+    c.is_identity,
+    c.is_computed
+FROM sys.columns c
+JOIN sys.types t ON t.user_type_id = c.user_type_id
+JOIN sys.objects o ON o.object_id = c.object_id AND o.type = 'U'
+JOIN sys.schemas s ON s.schema_id = o.schema_id
+ORDER BY s.name, o.name, c.column_id;
 """
 
 # ---------------------------------------------------------------------------
@@ -239,3 +266,77 @@ async def get_object_columns_or_raise(
         msg = f"{kind_label.capitalize()} [{schema}].[{object_name}] not found"
         raise NotFoundError(msg)
     return columns
+
+
+async def get_columns_for_schemas(
+    target: SqlTarget,
+    *,
+    mode: CredentialMode = CredentialMode.DEFAULT,
+) -> dict[tuple[str, str], list[dict[str, object]]]:
+    """Bulk-fetch column metadata for all user tables across all schemas in one query.
+
+    Issues a single SQL query (no N+1) and returns a mapping from
+    ``(schema_name, table_name)`` to an ordered list of column dicts — the same
+    shape as :func:`get_object_columns`.  Only user tables (``sys.objects.type = 'U'``)
+    are included; views are excluded.
+
+    This is the preferred entry point when columns are needed for many tables at
+    once (e.g. generating ``_sources.yml`` for an entire warehouse).  Callers
+    should not loop :func:`get_object_columns` per table.
+
+    Args:
+        target: The warehouse or SQL Analytics Endpoint to query.
+        mode: The credential mode for Entra authentication.
+
+    Returns:
+        A dict mapping ``(schema_name, table_name)`` → list of column dicts, each with:
+
+        - ``ordinal`` (:class:`int`) — ``column_id`` (1-based position).
+        - ``name`` (:class:`str`) — column name.
+        - ``data_type`` (:class:`str`) — formatted type string, e.g. ``VARCHAR(50)``.
+        - ``nullable`` (:class:`bool`) — whether the column is nullable.
+        - ``collation_name`` (:class:`str` | ``None``) — collation, if applicable.
+        - ``is_identity`` (:class:`bool`) — whether the column is an identity column.
+        - ``is_computed`` (:class:`bool`) — whether the column is computed.
+
+        Returns an empty dict when the warehouse has no user tables.
+
+    Raises:
+        PermissionDeniedError: If the driver reports a permission error.
+    """
+
+    def _run() -> dict[tuple[str, str], list[dict[str, object]]]:
+        cols, rows = run_query(
+            target,
+            _GET_COLUMNS_FOR_SCHEMAS_SQL,
+            mode=mode,
+        )
+        if not rows:
+            return {}
+        result: dict[tuple[str, str], list[dict[str, object]]] = {}
+        for row in rows:
+            data = dict(zip(cols, row, strict=True))
+            schema_name = str(data["schema_name"])
+            object_name = str(data["object_name"])
+            type_name = str(data["type_name"])
+            max_length = int(data["max_length"])  # type: ignore[arg-type]
+            precision = int(data["precision"])  # type: ignore[arg-type]
+            scale = int(data["scale"])  # type: ignore[arg-type]
+            col_dict: dict[str, object] = {
+                "ordinal": int(data["ordinal"]),  # type: ignore[arg-type]
+                "name": str(data["name"]),
+                "data_type": format_data_type(type_name, max_length, precision, scale),
+                "nullable": bool(data["nullable"]),
+                "collation_name": (
+                    str(data["collation_name"]) if data["collation_name"] is not None else None
+                ),
+                "is_identity": bool(data["is_identity"]),
+                "is_computed": bool(data["is_computed"]),
+            }
+            key = (schema_name, object_name)
+            result.setdefault(key, []).append(col_dict)
+        return result
+
+    result = await asyncio.to_thread(_run)
+    _log.debug("get_columns_for_schemas: fetched columns for %d (schema, table) pairs", len(result))
+    return result

--- a/src/fabric_dw/services/dbt_scaffold.py
+++ b/src/fabric_dw/services/dbt_scaffold.py
@@ -158,6 +158,9 @@ class DbtScaffoldConfig:
         with_sources: Whether to generate a real ``_sources.yml`` from the DW.
         schemas: Pre-fetched schema list (used when *with_sources* is True).
         tables: Pre-fetched table list (used when *with_sources* is True).
+        columns: Pre-fetched column dict keyed by ``(schema_name, table_name)``
+            (populated by :func:`~fabric_dw.services.columns.get_columns_for_schemas`
+            when *with_sources* is True).
     """
 
     host: str
@@ -172,6 +175,7 @@ class DbtScaffoldConfig:
     with_sources: bool = False
     schemas: list[Schema] = field(default_factory=list)
     tables: list[Table] = field(default_factory=list)
+    columns: dict[tuple[str, str], list[dict[str, object]]] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         if not self.profile_name:
@@ -296,11 +300,20 @@ def render_sources_yml(
     sources: list[dict[str, object]] = []
     for schema in cfg.schemas:
         schema_tables = sorted(tables_by_schema.get(schema.name, []))
+        table_entries: list[dict[str, object]] = []
+        for t in schema_tables:
+            table_entry: dict[str, object] = {"name": t}
+            table_columns = cfg.columns.get((schema.name, t), [])
+            if table_columns:
+                table_entry["columns"] = [
+                    {"name": col["name"], "data_type": col["data_type"]} for col in table_columns
+                ]
+            table_entries.append(table_entry)
         source: dict[str, object] = {
             "name": schema.name,
             "database": cfg.database,
             "schema": schema.name,
-            "tables": [{"name": t} for t in schema_tables],
+            "tables": table_entries,
         }
         sources.append(source)
 

--- a/tests/unit/cli/commands/test_dbt.py
+++ b/tests/unit/cli/commands/test_dbt.py
@@ -197,6 +197,10 @@ class TestDbtInitWithSources:
                 "fabric_dw.services.tables.list_tables",
                 new=AsyncMock(return_value=[]),
             ) as mock_tables,
+            patch(
+                "fabric_dw.services.columns.get_columns_for_schemas",
+                new=AsyncMock(return_value={}),
+            ) as mock_columns,
         ):
             mock_scaffold.return_value = []
             result = runner.invoke(
@@ -206,6 +210,7 @@ class TestDbtInitWithSources:
         assert result.exit_code == 0
         mock_schemas.assert_called_once()
         mock_tables.assert_called_once()
+        mock_columns.assert_called_once()
 
 
 class TestDbtInitErrors:

--- a/tests/unit/mcp/tools/test_dbt.py
+++ b/tests/unit/mcp/tools/test_dbt.py
@@ -172,7 +172,7 @@ async def test_generate_dbt_profile_with_sources_calls_list_schemas(
     mock_ctx,  # noqa: ARG001
     ctx_patch,
 ) -> None:
-    """with_sources=True triggers schema and table listing."""
+    """with_sources=True triggers schema, table, and column listing."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
     with (
@@ -185,6 +185,10 @@ async def test_generate_dbt_profile_with_sources_calls_list_schemas(
             "fabric_dw.services.tables.list_tables",
             new=AsyncMock(return_value=[]),
         ) as mock_tables,
+        patch(
+            "fabric_dw.services.columns.get_columns_for_schemas",
+            new=AsyncMock(return_value={}),
+        ) as mock_columns,
     ):
         result = await mcp._tool_manager.call_tool(
             "generate_dbt_profile",
@@ -193,6 +197,7 @@ async def test_generate_dbt_profile_with_sources_calls_list_schemas(
 
     mock_schemas.assert_called_once()
     mock_tables.assert_called_once()
+    mock_columns.assert_called_once()
     assert "sources_yml" in result
 
 

--- a/tests/unit/services/test_columns.py
+++ b/tests/unit/services/test_columns.py
@@ -277,7 +277,7 @@ _BULK_ROWS: list[tuple[object, ...]] = [
         2,
         "dept",
         "nvarchar",
-        100,
+        100,  # max_length=100 bytes → 50 chars (nvarchar stores 2 bytes per char)
         0,
         0,
         True,

--- a/tests/unit/services/test_columns.py
+++ b/tests/unit/services/test_columns.py
@@ -1,4 +1,8 @@
-"""Unit tests for services.columns — format_data_type and get_object_columns."""
+"""Unit tests for services.columns.
+
+Covers: format_data_type, get_object_columns, get_object_columns_or_raise,
+get_columns_for_schemas.
+"""
 
 from __future__ import annotations
 
@@ -9,6 +13,7 @@ import pytest
 from fabric_dw.exceptions import NotFoundError
 from fabric_dw.services.columns import (
     format_data_type,
+    get_columns_for_schemas,
     get_object_columns,
     get_object_columns_or_raise,
 )
@@ -240,3 +245,99 @@ class TestGetObjectColumnsOrRaise:
 
         assert len(result) == 1
         assert result[0]["name"] == "id"
+
+
+# ---------------------------------------------------------------------------
+# get_columns_for_schemas — bulk fetch
+# ---------------------------------------------------------------------------
+
+# Bulk query columns include schema_name and object_name as first two fields.
+_BULK_COLS = [
+    "schema_name",
+    "object_name",
+    "ordinal",
+    "name",
+    "type_name",
+    "max_length",
+    "precision",
+    "scale",
+    "nullable",
+    "collation_name",
+    "is_identity",
+    "is_computed",
+]
+
+# Two tables across two schemas: dbo.Orders (id INT), finance.Budget (amount DECIMAL(18,2))
+_BULK_ROWS: list[tuple[object, ...]] = [
+    ("dbo", "Orders", 1, "id", "int", 4, 10, 0, False, None, False, False),
+    ("finance", "Budget", 1, "amount", "decimal", 9, 18, 2, False, None, False, False),
+    (
+        "finance",
+        "Budget",
+        2,
+        "dept",
+        "nvarchar",
+        100,
+        0,
+        0,
+        True,
+        "Latin1_General_CI_AS",
+        False,
+        False,
+    ),
+]
+
+
+class TestGetColumnsForSchemas:
+    async def test_returns_empty_dict_for_no_tables(self) -> None:
+        with patch("fabric_dw.services.columns.run_query", return_value=(_BULK_COLS, [])):
+            result = await get_columns_for_schemas(_make_target())
+
+        assert result == {}
+
+    async def test_keys_by_schema_and_table(self) -> None:
+        with patch("fabric_dw.services.columns.run_query", return_value=(_BULK_COLS, _BULK_ROWS)):
+            result = await get_columns_for_schemas(_make_target())
+
+        assert ("dbo", "Orders") in result
+        assert ("finance", "Budget") in result
+
+    async def test_single_table_single_column(self) -> None:
+        with patch("fabric_dw.services.columns.run_query", return_value=(_BULK_COLS, _BULK_ROWS)):
+            result = await get_columns_for_schemas(_make_target())
+
+        orders_cols = result[("dbo", "Orders")]
+        assert len(orders_cols) == 1
+        assert orders_cols[0]["name"] == "id"
+        assert orders_cols[0]["data_type"] == "INT"
+        assert orders_cols[0]["nullable"] is False
+
+    async def test_multi_column_table_preserves_order(self) -> None:
+        with patch("fabric_dw.services.columns.run_query", return_value=(_BULK_COLS, _BULK_ROWS)):
+            result = await get_columns_for_schemas(_make_target())
+
+        budget_cols = result[("finance", "Budget")]
+        assert len(budget_cols) == 2
+        assert budget_cols[0]["name"] == "amount"
+        assert budget_cols[0]["data_type"] == "DECIMAL(18,2)"
+        assert budget_cols[1]["name"] == "dept"
+        assert budget_cols[1]["data_type"] == "NVARCHAR(50)"
+
+    async def test_formats_type_correctly(self) -> None:
+        """Ensure format_data_type is applied through the bulk path."""
+        rows: list[tuple[object, ...]] = [
+            ("dbo", "T", 1, "col", "nvarchar", 200, 0, 0, True, None, False, False),
+        ]
+        with patch("fabric_dw.services.columns.run_query", return_value=(_BULK_COLS, rows)):
+            result = await get_columns_for_schemas(_make_target())
+
+        assert result[("dbo", "T")][0]["data_type"] == "NVARCHAR(100)"
+
+    async def test_issues_single_query(self) -> None:
+        """Verify only one run_query call is made — no N+1."""
+        with patch(
+            "fabric_dw.services.columns.run_query", return_value=(_BULK_COLS, _BULK_ROWS)
+        ) as mock_rq:
+            await get_columns_for_schemas(_make_target())
+
+        assert mock_rq.call_count == 1

--- a/tests/unit/services/test_dbt_scaffold.py
+++ b/tests/unit/services/test_dbt_scaffold.py
@@ -341,6 +341,109 @@ class TestRenderSourcesYml:
         source = parsed["sources"][0]
         assert source["database"] == "Sales: DWH #1"
 
+    def test_with_sources_includes_columns_per_table(self) -> None:
+        """Each source table must have a ``columns:`` list with name + data_type."""
+        schemas = [_make_schema("dbo")]
+        tables = [_make_table("dbo", "orders")]
+        columns: dict[tuple[str, str], list[dict[str, object]]] = {
+            ("dbo", "orders"): [
+                {
+                    "ordinal": 1,
+                    "name": "id",
+                    "data_type": "INT",
+                    "nullable": False,
+                    "collation_name": None,
+                    "is_identity": True,
+                    "is_computed": False,
+                },
+                {
+                    "ordinal": 2,
+                    "name": "amount",
+                    "data_type": "DECIMAL(18,2)",
+                    "nullable": True,
+                    "collation_name": None,
+                    "is_identity": False,
+                    "is_computed": False,
+                },
+            ]
+        }
+        cfg = _make_cfg(with_sources=True, schemas=schemas, tables=tables, columns=columns)
+        content = render_sources_yml(cfg)
+        parsed = yaml.safe_load(content)
+        table_entry = parsed["sources"][0]["tables"][0]
+        assert table_entry["name"] == "orders"
+        assert "columns" in table_entry
+        assert table_entry["columns"][0] == {"name": "id", "data_type": "INT"}
+        assert table_entry["columns"][1] == {"name": "amount", "data_type": "DECIMAL(18,2)"}
+
+    def test_with_sources_no_columns_when_dict_empty(self) -> None:
+        """When the columns dict is empty, tables must NOT have a ``columns:`` key."""
+        schemas = [_make_schema("dbo")]
+        tables = [_make_table("dbo", "orders")]
+        cfg = _make_cfg(with_sources=True, schemas=schemas, tables=tables, columns={})
+        content = render_sources_yml(cfg)
+        parsed = yaml.safe_load(content)
+        table_entry = parsed["sources"][0]["tables"][0]
+        assert "columns" not in table_entry
+
+    def test_with_sources_columns_across_multiple_schemas(self) -> None:
+        """Columns must be scoped correctly per (schema, table)."""
+        schemas = [_make_schema("dbo"), _make_schema("finance")]
+        tables = [_make_table("dbo", "customers"), _make_table("finance", "budget")]
+        columns: dict[tuple[str, str], list[dict[str, object]]] = {
+            ("dbo", "customers"): [
+                {
+                    "ordinal": 1,
+                    "name": "customer_id",
+                    "data_type": "INT",
+                    "nullable": False,
+                    "collation_name": None,
+                    "is_identity": True,
+                    "is_computed": False,
+                },
+            ],
+            ("finance", "budget"): [
+                {
+                    "ordinal": 1,
+                    "name": "dept",
+                    "data_type": "NVARCHAR(50)",
+                    "nullable": True,
+                    "collation_name": None,
+                    "is_identity": False,
+                    "is_computed": False,
+                },
+            ],
+        }
+        cfg = _make_cfg(with_sources=True, schemas=schemas, tables=tables, columns=columns)
+        content = render_sources_yml(cfg)
+        parsed = yaml.safe_load(content)
+        dbo_source = next(s for s in parsed["sources"] if s["name"] == "dbo")
+        finance_source = next(s for s in parsed["sources"] if s["name"] == "finance")
+        assert dbo_source["tables"][0]["columns"][0]["name"] == "customer_id"
+        assert finance_source["tables"][0]["columns"][0]["name"] == "dept"
+
+    def test_with_sources_columns_valid_yaml(self) -> None:
+        """_sources.yml with columns must be valid YAML."""
+        schemas = [_make_schema("dbo")]
+        tables = [_make_table("dbo", "orders")]
+        columns: dict[tuple[str, str], list[dict[str, object]]] = {
+            ("dbo", "orders"): [
+                {
+                    "ordinal": 1,
+                    "name": "id",
+                    "data_type": "INT",
+                    "nullable": False,
+                    "collation_name": None,
+                    "is_identity": False,
+                    "is_computed": False,
+                },
+            ]
+        }
+        cfg = _make_cfg(with_sources=True, schemas=schemas, tables=tables, columns=columns)
+        content = render_sources_yml(cfg)
+        parsed = yaml.safe_load(content)
+        assert isinstance(parsed, dict)
+
 
 # ---------------------------------------------------------------------------
 # scaffold (file writing)


### PR DESCRIPTION
## Summary

- Adds `get_columns_for_schemas()` to `services/columns.py`: a **bulk fetch** that issues one SQL query returning columns for all user tables across all schemas, keyed by `(schema_name, table_name)`. No N+1 — a single `sys.columns JOIN sys.types JOIN sys.objects JOIN sys.schemas` query covers the entire warehouse.
- Extends `DbtScaffoldConfig` with a `columns` field (the bulk-fetch result) and updates `render_sources_yml` to emit `columns: [{name, data_type}]` per table when `with_sources` is True.
- Wires the bulk fetch in both the CLI (`dbt init --with-sources`) and the MCP `generate_dbt_profile` tool, using `asyncio.gather` alongside the existing schema/table fetches.

## Bulk-fetch decision

The N+1 alternative (looping `get_object_columns` per table) would issue one query per table. For a warehouse with hundreds of tables this is slow. Instead `get_columns_for_schemas` issues a **single query** and returns a `dict[(schema, table), list[col]]`. This is the only column-fetching path used by the dbt scaffold; no duplicate query exists.

## Test plan

- [x] `TestGetColumnsForSchemas` in `test_columns.py`: empty result, key structure, single-column and multi-column tables, type formatting through the bulk path, single-query assertion (`call_count == 1`).
- [x] `TestRenderSourcesYml` extended: columns per table, no `columns` key when dict is empty, correct scoping across multiple schemas, valid YAML with columns.
- [x] CLI `--with-sources` test updated: `get_columns_for_schemas` is mocked and `assert_called_once()` verified.
- [x] MCP `with_sources=True` test updated: same mock pattern.
- [x] Full unit suite: 3878 passed.

Closes #572

🤖 Generated with [Claude Code](https://claude.com/claude-code)