### PR TITLE
feat(tables): add CLUSTER BY options to all create-table commands and MCP tools

### DIFF
--- a/docs/commands/tables.md
+++ b/docs/commands/tables.md
@@ -191,6 +191,7 @@ fdw [-w WORKSPACE] tables create [OPTIONS] [WAREHOUSE]
 | `--name SCHEMA.TABLE` | **Required.** Qualified table name. |
 | `--select TEXT` | Inline SELECT statement for CTAS. |
 | `--from-file PATH` | Path to a `.sql` file containing the SELECT body (UTF-8/UTF-8-sig). |
+| `--cluster-by COL` | Column name for `CLUSTER BY` (repeatable, up to 4). Column existence is not validated on the CTAS path because result columns come from the SELECT. |
 
 Exactly one of `--select` or `--from-file` must be provided for the CTAS path. Cannot be combined with empty-DDL options.
 
@@ -203,6 +204,7 @@ Exactly one of `--select` or `--from-file` must be provided for the CTAS path. C
 | `--from-csv PATH` | Derive schema from a CSV header + bounded sample (no data loaded). |
 | `--from-schema PATH` | JSON file with column specs: `[{"name": "…", "type": "…", "nullable": true}]`. |
 | `--column NAME:TYPE[:null\|notnull]` | Inline column definition (repeatable). Can be combined with `--from-schema`. |
+| `--cluster-by COL` | Column name for `CLUSTER BY` (repeatable, up to 4). Each name must appear in the table schema. |
 | `--all-varchar` | (CSV) Force all columns to `VARCHAR`; skip type inference. |
 | `--varchar-length N` | Default VARCHAR/VARBINARY length for string/binary columns (1–8000, default `8000`). |
 | `--delimiter CHAR` | (CSV) Field delimiter (default `,`). |
@@ -259,6 +261,20 @@ fdw -w MyWorkspace tables create SalesWH \
   --name dbo.audit_log \
   --from-schema ./schemas/audit_log.json \
   --column "inserted_at:DATETIME2(7):notnull"
+
+# CTAS with CLUSTER BY (column existence not validated on CTAS path)
+fdw -w MyWorkspace tables create SalesWH \
+  --name dbo.orders_2026 \
+  --select "SELECT CustomerID, SaleDate, Amount FROM dbo.orders WHERE YEAR(SaleDate) = 2026" \
+  --cluster-by CustomerID --cluster-by SaleDate
+
+# Empty table with explicit columns and CLUSTER BY
+fdw -w MyWorkspace tables create SalesWH \
+  --name dbo.events \
+  --column "CustomerID:INT:notnull" \
+  --column "SaleDate:DATE:notnull" \
+  --column "Amount:DECIMAL(18,2)" \
+  --cluster-by CustomerID --cluster-by SaleDate
 ```
 
 ---
@@ -378,6 +394,7 @@ fdw [-w WORKSPACE] tables load [OPTIONS] [ITEM] QUALIFIED_NAME
 | `--varchar-length INT` | `8000` | (`--create`) Default VARCHAR/VARBINARY length for inferred columns. |
 | `--sample-rows INT` | `1000` | (CSV, `--create`) Maximum rows to sample for type inference. |
 | `--cleanup-on-failure` | off | Drop the table if WE created it and the load fails. Never drops a pre-existing table. |
+| `--cluster-by COL` | — | (`--create`) Column name for `CLUSTER BY` (repeatable, up to 4). Each name must appear in the inferred schema. |
 
 **Examples**
 
@@ -404,6 +421,10 @@ fdw -w MyWorkspace tables load SalesWH dbo.sales --file data.parquet --create \
 # Auto-create; drop the table if the load fails (cleanup_on_failure)
 fdw -w MyWorkspace tables load SalesWH dbo.sales --file data.parquet --create \
     --cleanup-on-failure
+
+# Auto-create with CLUSTER BY (columns must exist in the inferred schema)
+fdw -w MyWorkspace tables load SalesWH dbo.sales --file data.parquet --create \
+    --cluster-by SaleDate --cluster-by CustomerID
 
 # Load from a remote OneLake URL (no credential needed)
 fdw -w MyWorkspace tables load SalesWH dbo.orders \
@@ -576,6 +597,7 @@ Server-side file access is unreliable in MCP deployments, so CSV/Parquet schema 
   - `name` (`str`) — column identifier (must be a valid SQL identifier).
   - `sql_type` (`str`) — Fabric-DW-supported T-SQL type, e.g. `"INT"`, `"VARCHAR(255)"`, `"DECIMAL(18,2)"`.
   - `nullable` (`bool`, optional, default `true`) — whether the column allows `NULL`.
+- `cluster_by` (`list[str]`, optional) — column names for the `CLUSTER BY` clause (up to 4). Each name must appear in `columns`.
 
 **Returns:** `Table` — the newly-created table record.
 
@@ -604,12 +626,15 @@ Create a new SQL table via CTAS (`CREATE TABLE … AS SELECT`).
 
 **CAUTION**: `select_body` is executed verbatim as DDL. Confirm intent before calling. The first non-comment keyword must be `SELECT`.
 
+When `cluster_by` is supplied the DDL becomes `CREATE TABLE … WITH (CLUSTER BY ([c1], [c2])) AS SELECT …`. Column existence is not validated on the CTAS path because result columns come from the SELECT and are not known ahead of time.
+
 **Parameters:**
 
 - `workspace` (`str`) — workspace name or GUID.
 - `item` (`str`) — warehouse or SQL analytics endpoint name or GUID.
 - `qualified_name` (`str`) — dot-separated table name, e.g. `dbo.sales`.
 - `select_body` (`str`) — the SELECT statement for the CTAS source.
+- `cluster_by` (`list[str]`, optional) — column names for the `CLUSTER BY` clause (up to 4). Column existence is not validated on the CTAS path.
 
 **Returns:** `Table` — the newly-created table record.
 

--- a/src/fabric_dw/cli/commands/tables.py
+++ b/src/fabric_dw/cli/commands/tables.py
@@ -966,7 +966,7 @@ async def load_cmd(  # noqa: PLR0912
                         varchar_length,
                         sample_rows,
                         cleanup_on_failure,
-                        list(cluster_by) or None,
+                        cluster_by=list(cluster_by) or None,
                     )
                 else:
                     result = await _load_cmd_local(

--- a/src/fabric_dw/cli/commands/tables.py
+++ b/src/fabric_dw/cli/commands/tables.py
@@ -296,6 +296,13 @@ async def count_cmd(
         "Can be combined with --from-schema."
     ),
 )
+@click.option(
+    "--cluster-by",
+    "cluster_by",
+    multiple=True,
+    metavar="COL",
+    help="Column to use for CLUSTER BY (repeatable, up to 4).",
+)
 # CSV-specific options
 @click.option(
     "--all-varchar",
@@ -341,6 +348,7 @@ async def create_cmd(  # noqa: PLR0912
     csv_path: str | None,
     schema_file: str | None,
     column_specs: tuple[str, ...],
+    cluster_by: tuple[str, ...],
     all_varchar: bool,
     varchar_length: int,
     delimiter: str,
@@ -414,10 +422,18 @@ async def create_cmd(  # noqa: PLR0912
         async with build_http_client(ctx) as http:
             target, entry = await build_sql_target(http, ws, wh)
 
+            cluster_by_list = list(cluster_by) or None
+
             if has_ctas:
                 body = load_sql_body(select_body, from_file)
                 t = await _tables_svc.create_table(
-                    target, schema, table_name, body, kind=entry.kind, mode=ctx.auth
+                    target,
+                    schema,
+                    table_name,
+                    body,
+                    cluster_by=cluster_by_list,
+                    kind=entry.kind,
+                    mode=ctx.auth,
                 )
 
             elif has_parquet:
@@ -426,6 +442,7 @@ async def create_cmd(  # noqa: PLR0912
                     schema,
                     table_name,
                     Path(parquet_path),  # type: ignore[arg-type]
+                    cluster_by=cluster_by_list,
                     kind=entry.kind,
                     mode=ctx.auth,
                     varchar_length=varchar_length,
@@ -437,6 +454,7 @@ async def create_cmd(  # noqa: PLR0912
                     schema,
                     table_name,
                     Path(csv_path),  # type: ignore[arg-type]
+                    cluster_by=cluster_by_list,
                     kind=entry.kind,
                     mode=ctx.auth,
                     all_varchar=all_varchar,
@@ -457,7 +475,13 @@ async def create_cmd(  # noqa: PLR0912
                         "--from-schema or at least one --column is required for the DDL path."
                     )
                 t = await _tables_svc.create_empty_table(
-                    target, schema, table_name, cols, kind=entry.kind, mode=ctx.auth
+                    target,
+                    schema,
+                    table_name,
+                    cols,
+                    cluster_by=cluster_by_list,
+                    kind=entry.kind,
+                    mode=ctx.auth,
                 )
 
             render(t.model_dump(by_alias=True, mode="json"), json_output=ctx.json_output)
@@ -790,6 +814,13 @@ def _resolve_url_file_type(fmt: str | None, url: str) -> str:
         "Never drops a pre-existing table."
     ),
 )
+@click.option(
+    "--cluster-by",
+    "cluster_by",
+    multiple=True,
+    metavar="COL",
+    help="Column to use for CLUSTER BY (repeatable, up to 4).",
+)
 @click.pass_obj
 @coro
 async def load_cmd(  # noqa: PLR0912
@@ -817,6 +848,7 @@ async def load_cmd(  # noqa: PLR0912
     varchar_length: int,
     sample_rows: int,
     cleanup_on_failure: bool,
+    cluster_by: tuple[str, ...],
 ) -> None:
     """Load data into QUALIFIED_NAME (schema.table) on ITEM via COPY INTO.
 
@@ -934,6 +966,7 @@ async def load_cmd(  # noqa: PLR0912
                         varchar_length,
                         sample_rows,
                         cleanup_on_failure,
+                        list(cluster_by) or None,
                     )
                 else:
                     result = await _load_cmd_local(
@@ -1076,6 +1109,7 @@ async def _load_cmd_create_and_load(
     varchar_length: int,
     sample_rows: int,
     cleanup_on_failure: bool,
+    cluster_by: list[str] | None = None,
 ) -> CopyIntoResult:
     """Dispatch the create-and-load sub-path (--create)."""
     from fabric_dw import auth as _auth  # noqa: PLC0415
@@ -1133,6 +1167,7 @@ async def _load_cmd_create_and_load(
         sample_rows=sample_rows,
         csv_delimiter=infer_delimiter,
         csv_encoding=infer_encoding,
+        cluster_by=cluster_by,
     )
 
 

--- a/src/fabric_dw/mcp/tools/tables.py
+++ b/src/fabric_dw/mcp/tools/tables.py
@@ -225,7 +225,11 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
 
     @mutating_tool(mcp, "create_table")
     async def create_table(
-        workspace: str, item: str, qualified_name: str, select_body: str
+        workspace: str,
+        item: str,
+        qualified_name: str,
+        select_body: str,
+        cluster_by: list[str] | None = None,
     ) -> dict[str, Any]:
         """Create a new SQL table via CTAS (CREATE TABLE AS SELECT).
 
@@ -233,11 +237,18 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         Ensure the body matches the user's intent before calling this tool.
         The first non-comment keyword of ``select_body`` must be SELECT.
 
+        When ``cluster_by`` is supplied, the DDL becomes
+        ``CREATE TABLE … WITH (CLUSTER BY ([c1], [c2])) AS SELECT …``.
+        Column existence is not validated for CTAS because the result columns
+        come from the SELECT and are not known ahead of time.
+
         Args:
             workspace: Workspace name or GUID.
             item: Warehouse or SQL endpoint name or GUID.
             qualified_name: Dot-separated qualified table name, e.g. ``dbo.sales``.
             select_body: The SELECT statement that becomes the CTAS source.
+            cluster_by: Optional list of column names for the ``CLUSTER BY`` clause
+                (up to 4).
         """
         schema, table_name = parse_qualified_name(qualified_name, kind="table")
         assert_workspace_allowed(workspace)
@@ -250,7 +261,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             )
             target = make_sql_target(ws_id, entry, item)
             result = await tables_svc.create_table(
-                target, schema, table_name, select_body, kind=entry.kind, mode=ctx.auth_mode
+                target,
+                schema,
+                table_name,
+                select_body,
+                cluster_by=cluster_by,
+                kind=entry.kind,
+                mode=ctx.auth_mode,
             )
         except (ValueError, FabricError) as exc:
             raise tool_err(exc) from exc
@@ -320,6 +337,7 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         item: str,
         qualified_name: str,
         columns: list[dict[str, Any]],
+        cluster_by: list[str] | None = None,
     ) -> dict[str, Any]:
         """Create an empty table from an explicit column spec (DDL only, no data).
 
@@ -333,6 +351,8 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
 
         Only supported on Fabric Data Warehouses (not SQL Analytics Endpoints).
 
+        When ``cluster_by`` is supplied, each column must appear in ``columns``.
+
         Args:
             workspace: Workspace name or GUID.
             item: Warehouse name or GUID.
@@ -341,6 +361,8 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
                 ``name`` (str) — column identifier;
                 ``sql_type`` (str) — Fabric-DW T-SQL type, e.g. ``"INT"``, ``"VARCHAR(255)"``;
                 ``nullable`` (bool, optional, default true) — whether the column allows NULL.
+            cluster_by: Optional list of column names for the ``CLUSTER BY`` clause
+                (up to 4).  Each name must appear in ``columns``.
         """
         schema, table_name = parse_qualified_name(qualified_name, kind="table")
         assert_workspace_allowed(workspace)
@@ -359,7 +381,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             )
             target = make_sql_target(ws_id, entry, item)
             result = await tables_svc.create_empty_table(
-                target, schema, table_name, col_specs, kind=entry.kind, mode=ctx.auth_mode
+                target,
+                schema,
+                table_name,
+                col_specs,
+                cluster_by=cluster_by,
+                kind=entry.kind,
+                mode=ctx.auth_mode,
             )
         except (TypeError, ValueError, FabricError) as exc:
             raise tool_err(exc) from exc

--- a/src/fabric_dw/services/load.py
+++ b/src/fabric_dw/services/load.py
@@ -1183,6 +1183,7 @@ async def create_and_load(
     sample_rows: int = 1000,
     csv_delimiter: str = ",",
     csv_encoding: str = "utf-8-sig",
+    cluster_by: list[str] | None = None,
 ) -> CopyIntoResult:
     """Create the target table from the source schema and load data into it.
 
@@ -1233,6 +1234,9 @@ async def create_and_load(
         sample_rows: Maximum rows to sample for CSV type inference.
         csv_delimiter: CSV field delimiter (used for schema inference only).
         csv_encoding: CSV encoding for schema inference.
+        cluster_by: Optional list of column names for the ``CLUSTER BY`` clause
+            (up to 4).  Passed through to :func:`~fabric_dw.services.tables.create_empty_table`
+            when a table is created.  Each name must appear in the inferred schema.
 
     Returns:
         A :class:`~fabric_dw.models.CopyIntoResult`.
@@ -1240,7 +1244,9 @@ async def create_and_load(
     Raises:
         ItemKindError: If *kind* is SQL_ENDPOINT.
         ValueError: If the table exists and *if_exists* is ``"fail"``, or if
-            the file format is unrecognised or unsupported.
+            the file format is unrecognised or unsupported, or if a *cluster_by*
+            column is not in the inferred schema, or if more than 4 *cluster_by*
+            columns are supplied.
         FileNotFoundError: If *local_path* does not exist.
     """
     _assert_not_sql_endpoint(kind)
@@ -1284,13 +1290,17 @@ async def create_and_load(
         elif if_exists == "replace":
             _logger.info("create_and_load: DROP + recreate TABLE [%s].[%s]", schema, table)
             await _drop_table_sql(target, schema, table, mode=mode)
-            await _create_table_from_columns(target, schema, table, columns, kind=kind, mode=mode)
+            await _create_table_from_columns(
+                target, schema, table, columns, kind=kind, mode=mode, cluster_by=cluster_by
+            )
             we_created = True
         # "append": do nothing — COPY INTO will add rows to the existing table.
     else:
         # Table does not exist — create it (for "fail", "replace", "append" with no table).
         _logger.info("create_and_load: CREATE TABLE [%s].[%s]", schema, table)
-        await _create_table_from_columns(target, schema, table, columns, kind=kind, mode=mode)
+        await _create_table_from_columns(
+            target, schema, table, columns, kind=kind, mode=mode, cluster_by=cluster_by
+        )
         we_created = True
 
     # Step 3: load data.
@@ -1339,6 +1349,7 @@ async def _create_table_from_columns(
     *,
     kind: WarehouseKind = WarehouseKind.WAREHOUSE,
     mode: object = None,
+    cluster_by: list[str] | None = None,
 ) -> None:
     """Create an empty table from an inferred column list.
 
@@ -1349,4 +1360,6 @@ async def _create_table_from_columns(
     from fabric_dw.services.tables import create_empty_table  # noqa: PLC0415
 
     _mode = mode if isinstance(mode, CredentialMode) else CredentialMode.DEFAULT
-    await create_empty_table(target, schema, table, columns, kind=kind, mode=_mode)
+    await create_empty_table(
+        target, schema, table, columns, cluster_by=cluster_by, kind=kind, mode=_mode
+    )

--- a/src/fabric_dw/services/load.py
+++ b/src/fabric_dw/services/load.py
@@ -1284,6 +1284,16 @@ async def create_and_load(
                 "Use --if-exists append/truncate/replace to handle existing tables."
             )
             raise ValueError(msg)
+        # Guard: CLUSTER BY can only be applied when a table is (re)created.
+        # truncate keeps the existing schema; append leaves the table as-is.
+        # Neither recreates the table, so cluster_by would be silently ignored.
+        if cluster_by and if_exists in ("truncate", "append"):
+            msg = (
+                "CLUSTER BY can only be applied when the table is created; "
+                f"it cannot be combined with --if-exists {if_exists!r} on an existing table. "
+                "Use --if-exists replace (or drop the table first)."
+            )
+            raise ValueError(msg)
         if if_exists == "truncate":
             _logger.info("create_and_load: TRUNCATE TABLE [%s].[%s]", schema, table)
             await _truncate_table_sql(target, schema, table, mode=mode)

--- a/src/fabric_dw/services/tables.py
+++ b/src/fabric_dw/services/tables.py
@@ -369,10 +369,12 @@ def _build_cluster_by_clause(
         msg = f"CLUSTER BY supports at most 4 columns; got {len(cluster_by)}"
         raise ValueError(msg)
 
+    known_lower: set[str] = {n.casefold() for n in known_cols} if known_cols is not None else set()
+
     quoted: list[str] = []
     for col in cluster_by:
         validate_identifier(col)
-        if known_cols is not None and col not in known_cols:
+        if known_cols is not None and col.casefold() not in known_lower:
             available = ", ".join(known_cols)
             msg = (
                 f"CLUSTER BY column {col!r} is not defined in the table schema. "

--- a/src/fabric_dw/services/tables.py
+++ b/src/fabric_dw/services/tables.py
@@ -339,16 +339,70 @@ async def get_cluster_columns(
     return await asyncio.to_thread(_run)
 
 
+def _build_cluster_by_clause(
+    cluster_by: list[str] | None,
+    known_cols: list[str] | None,
+) -> str:
+    """Build the ``WITH (CLUSTER BY ([c1], [c2], …))`` clause string.
+
+    Args:
+        cluster_by: Column names to cluster by, or ``None`` / empty list for
+            no clause.
+        known_cols: When provided, validates that every *cluster_by* name
+            appears in this list.  Pass ``None`` to skip existence validation
+            (CTAS path, where columns come from a SELECT).
+
+    Returns:
+        A string like ``" WITH (CLUSTER BY ([CustomerID], [SaleDate]))"``
+        (note the leading space), or an empty string when *cluster_by* is
+        ``None`` or empty.
+
+    Raises:
+        ValueError: If ``len(cluster_by) > 4`` (Fabric limit), or if
+            *known_cols* is provided and a column name is not found in it, or
+            if any name fails :func:`validate_identifier`.
+    """
+    if not cluster_by:
+        return ""
+
+    if len(cluster_by) > 4:  # noqa: PLR2004
+        msg = f"CLUSTER BY supports at most 4 columns; got {len(cluster_by)}"
+        raise ValueError(msg)
+
+    quoted: list[str] = []
+    for col in cluster_by:
+        validate_identifier(col)
+        if known_cols is not None and col not in known_cols:
+            available = ", ".join(known_cols)
+            msg = (
+                f"CLUSTER BY column {col!r} is not defined in the table schema. "
+                f"Available columns: {available}"
+            )
+            raise ValueError(msg)
+        quoted.append(quote_identifier(col))
+
+    return f" WITH (CLUSTER BY ({', '.join(quoted)}))"
+
+
 async def create_table(
     target: SqlTarget,
     schema: str,
     table_name: str,
     select_body: str,
     *,
+    cluster_by: list[str] | None = None,
     kind: WarehouseKind = WarehouseKind.WAREHOUSE,
     mode: CredentialMode = CredentialMode.DEFAULT,
 ) -> Table:
     """Create a new table via ``CREATE TABLE [schema].[table] AS <select_body>`` (CTAS).
+
+    When *cluster_by* is provided, the DDL becomes::
+
+        CREATE TABLE [schema].[table] WITH (CLUSTER BY ([c1], [c2])) AS <select_body>
+
+    Column existence is **not** validated for the CTAS path because the result
+    columns are determined by the SELECT and are not known ahead of time.  Each
+    column name is still validated via :func:`validate_identifier`.
 
     Args:
         target: The warehouse to connect to.
@@ -357,6 +411,9 @@ async def create_table(
         select_body: The SELECT statement (or CTE) used as the CTAS source.
             The first non-comment keyword **must** be ``SELECT`` or ``WITH``
             (for CTE-based queries); anything else raises :class:`ValueError`.
+        cluster_by: Optional list of column names for the ``CLUSTER BY`` clause
+            (up to 4).  For CTAS, columns come from the SELECT so existence is
+            not checked — only identifier validation is applied.
         kind: The :class:`~fabric_dw.models.WarehouseKind` of the item.
             SQL Endpoint items are rejected with :class:`~fabric_dw.exceptions.ItemKindError`.
         mode: The credential mode for Entra authentication.
@@ -367,8 +424,10 @@ async def create_table(
 
     Raises:
         ItemKindError: If *kind* is :attr:`~fabric_dw.models.WarehouseKind.SQL_ENDPOINT`.
-        ValueError: If *schema* or *table_name* fails identifier validation, or
-            if *select_body* does not start with SELECT or WITH (CTE).
+        ValueError: If *schema* or *table_name* fails identifier validation, if
+            *select_body* does not start with SELECT or WITH (CTE), if more
+            than 4 *cluster_by* columns are supplied, or if any *cluster_by*
+            name fails identifier validation.
         PermissionDeniedError: If the driver reports a CREATE TABLE permission error.
     """
     _assert_not_sql_endpoint(kind)
@@ -376,7 +435,12 @@ async def create_table(
     validate_identifier(table_name)
     reject_non_select(select_body)
 
-    ddl = f"CREATE TABLE {quote_identifier(schema)}.{quote_identifier(table_name)} AS {select_body}"
+    # CTAS: WITH (CLUSTER BY (...)) goes BEFORE AS SELECT.
+    cluster_clause = _build_cluster_by_clause(cluster_by, known_cols=None)
+    ddl = (
+        f"CREATE TABLE {quote_identifier(schema)}.{quote_identifier(table_name)}"
+        f"{cluster_clause} AS {select_body}"
+    )
 
     def _run_ddl() -> None:
         run_query(target, ddl, mode=mode, commit=True, fetch="none")
@@ -391,6 +455,7 @@ async def create_empty_table(
     table_name: str,
     columns: list[ColumnSpec],
     *,
+    cluster_by: list[str] | None = None,
     kind: WarehouseKind = WarehouseKind.WAREHOUSE,
     mode: CredentialMode = CredentialMode.DEFAULT,
 ) -> Table:
@@ -400,12 +465,23 @@ async def create_empty_table(
     the validated :class:`~fabric_dw.models.ColumnSpec` list.  No data is ever
     read or inserted; this is a pure DDL operation.
 
+    When *cluster_by* is provided, the DDL becomes::
+
+        CREATE TABLE [schema].[table] (
+            …
+        ) WITH (CLUSTER BY ([c1], [c2]))
+
+    Each *cluster_by* column must appear in *columns*; unknown names raise
+    :class:`ValueError`.
+
     Args:
         target: The warehouse to connect to.
         schema: The schema name.  Must pass :func:`validate_identifier`.
         table_name: The table name.  Must pass :func:`validate_identifier`.
         columns: Non-empty list of :class:`~fabric_dw.models.ColumnSpec` instances
             describing each column.
+        cluster_by: Optional list of column names for the ``CLUSTER BY`` clause
+            (up to 4).  Each name must appear in *columns*.
         kind: The :class:`~fabric_dw.models.WarehouseKind` of the item.
             SQL Endpoint items are rejected with :class:`~fabric_dw.exceptions.ItemKindError`.
         mode: The credential mode for Entra authentication.
@@ -418,7 +494,9 @@ async def create_empty_table(
         ItemKindError: If *kind* is :attr:`~fabric_dw.models.WarehouseKind.SQL_ENDPOINT`.
         ValueError: If *schema* or *table_name* fails identifier validation,
             if *columns* is empty, if any column name fails identifier validation,
-            or if any column ``sql_type`` is not on the Fabric DW type allowlist.
+            if any column ``sql_type`` is not on the Fabric DW type allowlist,
+            if more than 4 *cluster_by* columns are supplied, or if a
+            *cluster_by* column is not defined in *columns*.
         PermissionDeniedError: If the driver reports a CREATE TABLE permission error.
     """
     _assert_not_sql_endpoint(kind)
@@ -436,9 +514,13 @@ async def create_empty_table(
         null_clause = "NULL" if col.nullable else "NOT NULL"
         col_defs.append(f"    {quote_identifier(col.name)} {validated_type} {null_clause}")
 
+    known_col_names = [col.name for col in columns]
+    cluster_clause = _build_cluster_by_clause(cluster_by, known_cols=known_col_names)
+
     col_block = ",\n".join(col_defs)
     ddl = (
-        f"CREATE TABLE {quote_identifier(schema)}.{quote_identifier(table_name)} (\n{col_block}\n)"
+        f"CREATE TABLE {quote_identifier(schema)}.{quote_identifier(table_name)}"
+        f" (\n{col_block}\n){cluster_clause}"
     )
 
     def _run_ddl() -> None:
@@ -497,6 +579,7 @@ async def create_table_from_parquet(
     table_name: str,
     parquet_path: Path,
     *,
+    cluster_by: list[str] | None = None,
     kind: WarehouseKind = WarehouseKind.WAREHOUSE,
     mode: CredentialMode = CredentialMode.DEFAULT,
     varchar_length: int = 8000,
@@ -514,6 +597,8 @@ async def create_table_from_parquet(
         table_name: The table name.  Must pass :func:`validate_identifier`.
         parquet_path: Path to the Parquet file.  Only the file footer (schema)
             is accessed — no data rows are read.
+        cluster_by: Optional list of column names for the ``CLUSTER BY`` clause
+            (up to 4).  Each name must appear in the inferred columns.
         kind: The :class:`~fabric_dw.models.WarehouseKind` of the item.
             SQL Endpoint items are rejected with :class:`~fabric_dw.exceptions.ItemKindError`.
         mode: The credential mode for Entra authentication.
@@ -526,13 +611,16 @@ async def create_table_from_parquet(
     Raises:
         ItemKindError: If *kind* is :attr:`~fabric_dw.models.WarehouseKind.SQL_ENDPOINT`.
         ValueError: If any Parquet field maps to an unsupported T-SQL type,
-            or if any derived identifier fails validation.
+            or if any derived identifier fails validation, or if a *cluster_by*
+            column is not defined in the inferred schema.
         FileNotFoundError: If *parquet_path* does not exist.
     """
     _assert_not_sql_endpoint(kind)
     columns = await infer_columns_from_parquet(parquet_path, varchar_length=varchar_length)
     _log.debug("create_table_from_parquet: %d columns from %s", len(columns), parquet_path.name)
-    return await create_empty_table(target, schema, table_name, columns, kind=kind, mode=mode)
+    return await create_empty_table(
+        target, schema, table_name, columns, cluster_by=cluster_by, kind=kind, mode=mode
+    )
 
 
 async def infer_columns_from_csv(
@@ -667,6 +755,7 @@ async def create_table_from_csv(
     table_name: str,
     csv_path: Path,
     *,
+    cluster_by: list[str] | None = None,
     kind: WarehouseKind = WarehouseKind.WAREHOUSE,
     mode: CredentialMode = CredentialMode.DEFAULT,
     infer_types: bool = True,
@@ -695,6 +784,8 @@ async def create_table_from_csv(
         table_name: The table name.  Must pass :func:`validate_identifier`.
         csv_path: Path to the CSV file.  Only the header + a bounded sample of
             rows are read — this is schema inference, not data loading.
+        cluster_by: Optional list of column names for the ``CLUSTER BY`` clause
+            (up to 4).  Each name must appear in the inferred columns.
         kind: The :class:`~fabric_dw.models.WarehouseKind` of the item.
             SQL Endpoint items are rejected with :class:`~fabric_dw.exceptions.ItemKindError`.
         mode: The credential mode for Entra authentication.
@@ -713,7 +804,8 @@ async def create_table_from_csv(
     Raises:
         ItemKindError: If *kind* is :attr:`~fabric_dw.models.WarehouseKind.SQL_ENDPOINT`.
         ValueError: If any inferred type maps to an unsupported T-SQL type,
-            or if any column name fails identifier validation.
+            or if any column name fails identifier validation, or if a
+            *cluster_by* column is not defined in the inferred schema.
         FileNotFoundError: If *csv_path* does not exist.
     """
     _assert_not_sql_endpoint(kind)
@@ -726,7 +818,9 @@ async def create_table_from_csv(
         encoding=encoding,
     )
     _log.debug("create_table_from_csv: %d columns from %s", len(columns), csv_path.name)
-    return await create_empty_table(target, schema, table_name, columns, kind=kind, mode=mode)
+    return await create_empty_table(
+        target, schema, table_name, columns, cluster_by=cluster_by, kind=kind, mode=mode
+    )
 
 
 async def clone_table(

--- a/tests/unit/services/test_create_and_load.py
+++ b/tests/unit/services/test_create_and_load.py
@@ -643,3 +643,212 @@ async def test_table_exists_returns_false_when_no_rows() -> None:
         result = await _table_exists(mock_target, "dbo", "sales")
 
     assert result is False
+
+
+# ---------------------------------------------------------------------------
+# cluster_by guard — existing table + non-recreating if_exists
+# ---------------------------------------------------------------------------
+
+
+async def test_cluster_by_raises_on_truncate_existing_table(tmp_path: Path) -> None:
+    """cluster_by with if_exists='truncate' on an existing table must raise ValueError."""
+    import uuid  # noqa: PLC0415
+
+    from fabric_dw.models import ColumnSpec  # noqa: PLC0415
+    from fabric_dw.services.load import create_and_load  # noqa: PLC0415
+
+    parquet_file = tmp_path / "data.parquet"
+    parquet_file.write_bytes(b"PAR1")
+    _columns = [ColumnSpec(name="SaleDate", sql_type="DATE", nullable=True)]
+
+    with (
+        patch(
+            "fabric_dw.services.load._infer_columns_from_local",
+            new=AsyncMock(return_value=_columns),
+        ),
+        patch("fabric_dw.services.load._table_exists", new=AsyncMock(return_value=True)),
+        patch("fabric_dw.services.load._truncate_table_sql", new=AsyncMock()),
+        patch("fabric_dw.services.load._create_table_from_columns", new=AsyncMock()),
+        patch(
+            "fabric_dw.services.load.load_local_file",
+            new=AsyncMock(return_value=_make_result()),
+        ),
+        pytest.raises(ValueError, match="CLUSTER BY can only be applied when the table is created"),
+    ):
+        await create_and_load(
+            AsyncMock(),
+            AsyncMock(),
+            uuid.UUID(_WS_ID),
+            MagicMock(),
+            _SCHEMA,
+            _TABLE,
+            parquet_file,
+            if_exists="truncate",
+            file_format="parquet",
+            cluster_by=["SaleDate"],
+        )
+
+
+async def test_cluster_by_raises_on_append_existing_table(tmp_path: Path) -> None:
+    """cluster_by with if_exists='append' on an existing table must raise ValueError."""
+    import uuid  # noqa: PLC0415
+
+    from fabric_dw.models import ColumnSpec  # noqa: PLC0415
+    from fabric_dw.services.load import create_and_load  # noqa: PLC0415
+
+    parquet_file = tmp_path / "data.parquet"
+    parquet_file.write_bytes(b"PAR1")
+    _columns = [ColumnSpec(name="SaleDate", sql_type="DATE", nullable=True)]
+
+    with (
+        patch(
+            "fabric_dw.services.load._infer_columns_from_local",
+            new=AsyncMock(return_value=_columns),
+        ),
+        patch("fabric_dw.services.load._table_exists", new=AsyncMock(return_value=True)),
+        patch("fabric_dw.services.load._create_table_from_columns", new=AsyncMock()),
+        patch(
+            "fabric_dw.services.load.load_local_file",
+            new=AsyncMock(return_value=_make_result()),
+        ),
+        pytest.raises(ValueError, match="CLUSTER BY can only be applied when the table is created"),
+    ):
+        await create_and_load(
+            AsyncMock(),
+            AsyncMock(),
+            uuid.UUID(_WS_ID),
+            MagicMock(),
+            _SCHEMA,
+            _TABLE,
+            parquet_file,
+            if_exists="append",
+            file_format="parquet",
+            cluster_by=["SaleDate"],
+        )
+
+
+async def test_cluster_by_allowed_on_replace_existing_table(tmp_path: Path) -> None:
+    """cluster_by with if_exists='replace' must succeed (table is dropped + recreated)."""
+    import uuid  # noqa: PLC0415
+
+    from fabric_dw.models import ColumnSpec  # noqa: PLC0415
+    from fabric_dw.services.load import create_and_load  # noqa: PLC0415
+
+    parquet_file = tmp_path / "data.parquet"
+    parquet_file.write_bytes(b"PAR1")
+    _columns = [ColumnSpec(name="SaleDate", sql_type="DATE", nullable=True)]
+
+    mock_create = AsyncMock()
+    with (
+        patch(
+            "fabric_dw.services.load._infer_columns_from_local",
+            new=AsyncMock(return_value=_columns),
+        ),
+        patch("fabric_dw.services.load._table_exists", new=AsyncMock(return_value=True)),
+        patch("fabric_dw.services.load._drop_table_sql", new=AsyncMock()),
+        patch("fabric_dw.services.load._truncate_table_sql", new=AsyncMock()),
+        patch("fabric_dw.services.load._create_table_from_columns", new=mock_create),
+        patch(
+            "fabric_dw.services.load.load_local_file",
+            new=AsyncMock(return_value=_make_result()),
+        ),
+    ):
+        result = await create_and_load(
+            AsyncMock(),
+            AsyncMock(),
+            uuid.UUID(_WS_ID),
+            MagicMock(),
+            _SCHEMA,
+            _TABLE,
+            parquet_file,
+            if_exists="replace",
+            file_format="parquet",
+            cluster_by=["SaleDate"],
+        )
+
+    assert result.rows_loaded == 5
+    # confirm cluster_by was passed through to create
+    _kw = mock_create.call_args.kwargs
+    assert _kw.get("cluster_by") == ["SaleDate"]
+
+
+async def test_cluster_by_allowed_on_append_new_table(tmp_path: Path) -> None:
+    """cluster_by with if_exists='append' when table does NOT exist must succeed (creates it)."""
+    import uuid  # noqa: PLC0415
+
+    from fabric_dw.models import ColumnSpec  # noqa: PLC0415
+    from fabric_dw.services.load import create_and_load  # noqa: PLC0415
+
+    parquet_file = tmp_path / "data.parquet"
+    parquet_file.write_bytes(b"PAR1")
+    _columns = [ColumnSpec(name="SaleDate", sql_type="DATE", nullable=True)]
+
+    mock_create = AsyncMock()
+    with (
+        patch(
+            "fabric_dw.services.load._infer_columns_from_local",
+            new=AsyncMock(return_value=_columns),
+        ),
+        patch("fabric_dw.services.load._table_exists", new=AsyncMock(return_value=False)),
+        patch("fabric_dw.services.load._create_table_from_columns", new=mock_create),
+        patch(
+            "fabric_dw.services.load.load_local_file",
+            new=AsyncMock(return_value=_make_result()),
+        ),
+    ):
+        result = await create_and_load(
+            AsyncMock(),
+            AsyncMock(),
+            uuid.UUID(_WS_ID),
+            MagicMock(),
+            _SCHEMA,
+            _TABLE,
+            parquet_file,
+            if_exists="append",
+            file_format="parquet",
+            cluster_by=["SaleDate"],
+        )
+
+    assert result.rows_loaded == 5
+    _kw = mock_create.call_args.kwargs
+    assert _kw.get("cluster_by") == ["SaleDate"]
+
+
+async def test_cluster_by_none_on_truncate_existing_table_allowed(tmp_path: Path) -> None:
+    """cluster_by=None with if_exists='truncate' on an existing table must NOT raise."""
+    import uuid  # noqa: PLC0415
+
+    from fabric_dw.models import ColumnSpec  # noqa: PLC0415
+    from fabric_dw.services.load import create_and_load  # noqa: PLC0415
+
+    parquet_file = tmp_path / "data.parquet"
+    parquet_file.write_bytes(b"PAR1")
+    _columns = [ColumnSpec(name="id", sql_type="INT", nullable=True)]
+
+    with (
+        patch(
+            "fabric_dw.services.load._infer_columns_from_local",
+            new=AsyncMock(return_value=_columns),
+        ),
+        patch("fabric_dw.services.load._table_exists", new=AsyncMock(return_value=True)),
+        patch("fabric_dw.services.load._truncate_table_sql", new=AsyncMock()),
+        patch("fabric_dw.services.load._create_table_from_columns", new=AsyncMock()),
+        patch(
+            "fabric_dw.services.load.load_local_file",
+            new=AsyncMock(return_value=_make_result()),
+        ),
+    ):
+        result = await create_and_load(
+            AsyncMock(),
+            AsyncMock(),
+            uuid.UUID(_WS_ID),
+            MagicMock(),
+            _SCHEMA,
+            _TABLE,
+            parquet_file,
+            if_exists="truncate",
+            file_format="parquet",
+            cluster_by=None,
+        )
+
+    assert result.rows_loaded == 5

--- a/tests/unit/services/test_tables.py
+++ b/tests/unit/services/test_tables.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import time
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import ClassVar
 from unittest.mock import MagicMock, patch
 
 import pyarrow as pa
@@ -1454,3 +1455,260 @@ class TestCreateTableFromCsv:
         sql: str = ddl_cursor.execute.call_args[0][0]
         assert "[col_a]" in sql
         assert "[col_b]" in sql
+
+
+# ===========================================================================
+# _build_cluster_by_clause
+# ===========================================================================
+
+
+class TestBuildClusterByClause:
+    def test_none_returns_empty(self) -> None:
+        assert tables._build_cluster_by_clause(None, None) == ""
+
+    def test_empty_list_returns_empty(self) -> None:
+        assert tables._build_cluster_by_clause([], None) == ""
+
+    def test_single_col_no_known(self) -> None:
+        result = tables._build_cluster_by_clause(["SaleDate"], None)
+        assert result == " WITH (CLUSTER BY ([SaleDate]))"
+
+    def test_two_cols_with_known(self) -> None:
+        result = tables._build_cluster_by_clause(
+            ["CustomerID", "SaleDate"], ["CustomerID", "SaleDate", "Amount"]
+        )
+        assert result == " WITH (CLUSTER BY ([CustomerID], [SaleDate]))"
+
+    def test_four_cols_allowed(self) -> None:
+        cols = ["a", "b", "c", "d"]
+        result = tables._build_cluster_by_clause(cols, None)
+        assert "CLUSTER BY" in result
+        assert "[a]" in result
+        assert "[d]" in result
+
+    def test_five_cols_raises(self) -> None:
+        with pytest.raises(ValueError, match="at most 4 columns"):
+            tables._build_cluster_by_clause(["a", "b", "c", "d", "e"], None)
+
+    def test_unknown_column_raises_with_known(self) -> None:
+        with pytest.raises(ValueError, match="not defined in the table schema"):
+            tables._build_cluster_by_clause(["Missing"], ["id", "name"])
+
+    def test_unknown_column_error_lists_available(self) -> None:
+        with pytest.raises(ValueError, match="id, name"):
+            tables._build_cluster_by_clause(["Missing"], ["id", "name"])
+
+    def test_invalid_identifier_raises(self) -> None:
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            tables._build_cluster_by_clause(["bad--col"], None)
+
+    def test_clause_has_leading_space(self) -> None:
+        result = tables._build_cluster_by_clause(["col"], None)
+        assert result.startswith(" ")
+
+
+# ===========================================================================
+# create_table (CTAS) — cluster_by tests
+# ===========================================================================
+
+
+class TestCreateTableClusterBy:
+    async def test_ctas_without_cluster_by_unchanged(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_TABLE_ROW_1], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            await tables.create_table(target, "dbo", "sales", "SELECT 1 AS id")
+        cursor = ddl_conn.cursor.return_value
+        sql: str = cursor.execute.call_args[0][0]
+        assert "WITH" not in sql
+        assert "CLUSTER BY" not in sql
+
+    async def test_ctas_single_cluster_col(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_TABLE_ROW_1], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            await tables.create_table(
+                target, "dbo", "sales", "SELECT 1 AS SaleDate", cluster_by=["SaleDate"]
+            )
+        cursor = ddl_conn.cursor.return_value
+        sql: str = cursor.execute.call_args[0][0]
+        assert "WITH (CLUSTER BY ([SaleDate]))" in sql
+        # WITH clause comes BEFORE AS SELECT
+        assert sql.index("WITH (CLUSTER BY") < sql.index("AS SELECT")
+
+    async def test_ctas_multiple_cluster_cols(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_TABLE_ROW_1], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            await tables.create_table(
+                target,
+                "dbo",
+                "sales",
+                "SELECT 1",
+                cluster_by=["CustomerID", "SaleDate"],
+            )
+        cursor = ddl_conn.cursor.return_value
+        sql: str = cursor.execute.call_args[0][0]
+        assert "[CustomerID]" in sql
+        assert "[SaleDate]" in sql
+
+    async def test_ctas_too_many_cluster_cols_raises(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="at most 4 columns"):
+            await tables.create_table(
+                target, "dbo", "sales", "SELECT 1", cluster_by=["a", "b", "c", "d", "e"]
+            )
+
+    async def test_ctas_no_existence_check(self) -> None:
+        """CTAS cluster_by does NOT validate column existence — columns come from SELECT."""
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_TABLE_ROW_1], _LIST_COLS)
+        # No known_cols provided — should not raise even for an arbitrary name.
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            result = await tables.create_table(
+                target, "dbo", "sales", "SELECT 1", cluster_by=["AnyColumnFromSelect"]
+            )
+        assert isinstance(result, Table)
+
+
+# ===========================================================================
+# create_empty_table — cluster_by tests
+# ===========================================================================
+
+
+class TestCreateEmptyTableClusterBy:
+    _COLS: ClassVar[list[ColumnSpec]] = [
+        ColumnSpec(name="CustomerID", sql_type="INT", nullable=False),
+        ColumnSpec(name="SaleDate", sql_type="DATE", nullable=True),
+    ]
+
+    async def test_without_cluster_by_unchanged(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_TABLE_ROW_1], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            await tables.create_empty_table(target, "dbo", "orders", self._COLS)
+        cursor = ddl_conn.cursor.return_value
+        sql: str = cursor.execute.call_args[0][0]
+        assert "CLUSTER BY" not in sql
+
+    async def test_ddl_contains_cluster_by(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_TABLE_ROW_1], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            await tables.create_empty_table(
+                target, "dbo", "orders", self._COLS, cluster_by=["CustomerID", "SaleDate"]
+            )
+        cursor = ddl_conn.cursor.return_value
+        sql: str = cursor.execute.call_args[0][0]
+        assert "WITH (CLUSTER BY ([CustomerID], [SaleDate]))" in sql
+
+    async def test_cluster_by_after_closing_paren(self) -> None:
+        """WITH clause must appear after the column-list closing parenthesis."""
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_TABLE_ROW_1], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            await tables.create_empty_table(
+                target, "dbo", "orders", self._COLS, cluster_by=["CustomerID"]
+            )
+        cursor = ddl_conn.cursor.return_value
+        sql: str = cursor.execute.call_args[0][0]
+        # The column-list ends with \n) followed by " WITH (CLUSTER BY ...)".
+        # Confirm the overall structure: col-list block ends before CLUSTER BY.
+        cluster_idx = sql.index("CLUSTER BY")
+        # The ") WITH" pattern marks where the column-list block closes.
+        col_block_end = sql.index(") WITH")
+        assert col_block_end < cluster_idx
+
+    async def test_unknown_cluster_col_raises(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="not defined in the table schema"):
+            await tables.create_empty_table(
+                target, "dbo", "orders", self._COLS, cluster_by=["UnknownCol"]
+            )
+
+    async def test_too_many_cluster_cols_raises(self) -> None:
+        target = _make_target()
+        cols = [ColumnSpec(name=f"c{i}", sql_type="INT", nullable=True) for i in range(5)]
+        with pytest.raises(ValueError, match="at most 4 columns"):
+            await tables.create_empty_table(
+                target, "dbo", "orders", cols, cluster_by=["c0", "c1", "c2", "c3", "c4"]
+            )
+
+    async def test_returns_table_with_cluster_by(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_TABLE_ROW_1], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            result = await tables.create_empty_table(
+                target, "dbo", "orders", self._COLS, cluster_by=["CustomerID"]
+            )
+        assert isinstance(result, Table)
+
+
+# ===========================================================================
+# create_table_from_parquet — cluster_by tests
+# ===========================================================================
+
+
+class TestCreateTableFromParquetClusterBy:
+    async def test_passes_cluster_by_to_create_empty(self, tmp_path: Path) -> None:
+        parquet_file = tmp_path / "data.parquet"
+        pq.write_table(pa.table({"SaleDate": pa.array([], type=pa.date32())}), parquet_file)
+
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_TABLE_ROW_1], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            await tables.create_table_from_parquet(
+                target, "dbo", "sales", parquet_file, cluster_by=["SaleDate"]
+            )
+        cursor = ddl_conn.cursor.return_value
+        sql: str = cursor.execute.call_args[0][0]
+        assert "CLUSTER BY ([SaleDate])" in sql
+
+    async def test_unknown_cluster_col_raises(self, tmp_path: Path) -> None:
+        parquet_file = tmp_path / "data.parquet"
+        pq.write_table(pa.table({"id": pa.array([], type=pa.int32())}), parquet_file)
+        target = _make_target()
+        with pytest.raises(ValueError, match="not defined in the table schema"):
+            await tables.create_table_from_parquet(
+                target, "dbo", "sales", parquet_file, cluster_by=["MissingCol"]
+            )
+
+
+# ===========================================================================
+# create_table_from_csv — cluster_by tests
+# ===========================================================================
+
+
+class TestCreateTableFromCsvClusterBy:
+    async def test_passes_cluster_by_to_create_empty(self, tmp_path: Path) -> None:
+        csv_file = tmp_path / "data.csv"
+        csv_file.write_text("CustomerID,SaleDate\n1,2024-01-01\n")
+
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_TABLE_ROW_1], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            await tables.create_table_from_csv(
+                target, "dbo", "sales", csv_file, cluster_by=["CustomerID"]
+            )
+        cursor = ddl_conn.cursor.return_value
+        sql: str = cursor.execute.call_args[0][0]
+        assert "CLUSTER BY ([CustomerID])" in sql
+
+    async def test_unknown_cluster_col_raises(self, tmp_path: Path) -> None:
+        csv_file = tmp_path / "data.csv"
+        csv_file.write_text("id,name\n1,foo\n")
+        target = _make_target()
+        with pytest.raises(ValueError, match="not defined in the table schema"):
+            await tables.create_table_from_csv(
+                target, "dbo", "sales", csv_file, cluster_by=["MissingCol"]
+            )

--- a/tests/unit/services/test_tables.py
+++ b/tests/unit/services/test_tables.py
@@ -1482,9 +1482,7 @@ class TestBuildClusterByClause:
     def test_four_cols_allowed(self) -> None:
         cols = ["a", "b", "c", "d"]
         result = tables._build_cluster_by_clause(cols, None)
-        assert "CLUSTER BY" in result
-        assert "[a]" in result
-        assert "[d]" in result
+        assert result == " WITH (CLUSTER BY ([a], [b], [c], [d]))"
 
     def test_five_cols_raises(self) -> None:
         with pytest.raises(ValueError, match="at most 4 columns"):
@@ -1505,6 +1503,21 @@ class TestBuildClusterByClause:
     def test_clause_has_leading_space(self) -> None:
         result = tables._build_cluster_by_clause(["col"], None)
         assert result.startswith(" ")
+
+    def test_case_insensitive_match_accepted(self) -> None:
+        """'customerid' must match a known column 'CustomerID' (T-SQL is case-insensitive)."""
+        result = tables._build_cluster_by_clause(["customerid"], ["CustomerID", "SaleDate"])
+        # User's original casing is preserved in the quoted DDL.
+        assert result == " WITH (CLUSTER BY ([customerid]))"
+
+    def test_case_insensitive_uppercase_accepted(self) -> None:
+        result = tables._build_cluster_by_clause(["SALEDATE"], ["CustomerID", "SaleDate"])
+        assert result == " WITH (CLUSTER BY ([SALEDATE]))"
+
+    def test_case_mismatch_raises_when_truly_missing(self) -> None:
+        """A column that genuinely doesn't exist must still raise."""
+        with pytest.raises(ValueError, match="not defined in the table schema"):
+            tables._build_cluster_by_clause(["TotallyMissing"], ["id", "name"])
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

- Adds `cluster_by: list[str] | None = None` to `create_table` (CTAS), `create_empty_table`, `create_table_from_parquet`, `create_table_from_csv` in `services/tables.py` and to `create_and_load` / `_create_table_from_columns` in `services/load.py`.
- DDL path: `CREATE TABLE [s].[t] ( ... ) WITH (CLUSTER BY ([c1], [c2]))`. CTAS path: `CREATE TABLE [s].[t] WITH (CLUSTER BY ([c1])) AS SELECT ...` (WITH clause before AS SELECT).
- New helper `_build_cluster_by_clause` validates identifiers, enforces max 4 columns (Fabric limit), and checks column existence against the known schema (skipped on CTAS path).
- Adds `--cluster-by COL` (repeatable, up to 4) to `tables create` and `tables load --create` CLI commands.
- Adds `cluster_by: list[str] | None = None` to `create_table` and `create_empty_table` MCP tools.
- Documents all new options in `docs/commands/tables.md` (no Preview/Beta admonition).
- Full unit test coverage; 3893 tests pass; ruff + ty clean.

## Test plan

- [x] `_build_cluster_by_clause` unit tests: None/empty → no clause; 1–4 cols → correct DDL; 5 cols → ValueError; unknown col → ValueError; invalid identifier → ValueError.
- [x] `create_table` (CTAS): no clause when absent; WITH clause before AS SELECT; no existence check on CTAS path; >4 cols → ValueError.
- [x] `create_empty_table`: clause appended after `)` closing the column list; existence validated against columns; >4 → ValueError; unknown col → ValueError.
- [x] `create_table_from_parquet` and `create_table_from_csv`: thread `cluster_by` through; unknown col propagates ValueError.
- [x] `cluster_by=None` → behaviour unchanged throughout.

Closes #547

🤖 Generated with [Claude Code](https://claude.com/claude-code)