### PR TITLE
refactor(cli): lazy-load command groups

### DIFF
--- a/src/fabric_dw/cli/_main.py
+++ b/src/fabric_dw/cli/_main.py
@@ -240,6 +240,19 @@ _SHORT_HELP_MAP: dict[str, str] = {
     "workspaces": "Manage Microsoft Fabric workspaces.",
 }
 
+# Guard: both maps must cover exactly the same set of command names.  A command
+# added to _COMMAND_MAP but not _SHORT_HELP_MAP (or vice-versa) would silently
+# show an empty description or fail to load.  This check fires at import time
+# so the mistake is caught by the first test run, not at runtime.
+if _COMMAND_MAP.keys() != _SHORT_HELP_MAP.keys():
+    _missing_help = _COMMAND_MAP.keys() - _SHORT_HELP_MAP.keys()
+    _missing_cmd = _SHORT_HELP_MAP.keys() - _COMMAND_MAP.keys()
+    raise ValueError(
+        f"_COMMAND_MAP and _SHORT_HELP_MAP must cover the same commands.  "
+        f"Missing from _SHORT_HELP_MAP: {_missing_help!r}.  "
+        f"Missing from _COMMAND_MAP: {_missing_cmd!r}."
+    )
+
 
 class _InstrumentedGroup(click.Group):
     """A :class:`click.Group` subclass that emits one ``command_invoked``
@@ -415,9 +428,9 @@ class _LazyGroup(_InstrumentedGroup):
         module_path, attr_name = spec.rsplit(":", 1)
         try:
             module = importlib.import_module(module_path)
-        except ImportError:
+            cmd: click.Command = getattr(module, attr_name)
+        except (ImportError, AttributeError):
             return None
-        cmd: click.Command = getattr(module, attr_name)
         # Replicate what _InstrumentedGroup.add_command does so that telemetry
         # and global-options injection are applied on the lazily-loaded group.
         if isinstance(cmd, click.Group):
@@ -425,14 +438,37 @@ class _LazyGroup(_InstrumentedGroup):
         _patch_command_for_global_options(cmd)
         return cmd
 
+    def resolve_command(
+        self, ctx: click.Context, args: list[str]
+    ) -> tuple[str | None, click.Command | None, list[str]]:
+        """Resolve a command name, supplying the lazy command list for suggestions.
+
+        Click's base :meth:`resolve_command` passes ``self.commands`` (the
+        eagerly-registered dict) to the "Did you mean?" resolver.  Since this
+        group never calls :meth:`add_command`, that dict is always empty and
+        typo suggestions are permanently suppressed.  Override to pass the
+        lazy command names instead.
+        """
+        # Temporarily populate self.commands with stubs so Click's resolver can
+        # compute "Did you mean?" possibilities without triggering real imports.
+        # We restore the empty dict immediately after resolution.
+        dummy_cmds = {name: click.Command(name) for name in _COMMAND_MAP}
+        original_commands = self.commands  # type: ignore[attr-defined]
+        self.commands = dummy_cmds  # type: ignore[attr-defined]
+        try:
+            return super().resolve_command(ctx, args)
+        finally:
+            self.commands = original_commands  # type: ignore[attr-defined]
+
     def format_commands(self, ctx: click.Context, formatter: click.HelpFormatter) -> None:
         """Render the command list from :data:`_SHORT_HELP_MAP` without importing modules."""
         commands: list[tuple[str, str]] = []
         max_name_len = max(len(n) for n in _COMMAND_MAP)
         for name in self.list_commands(ctx):
             help_text = _SHORT_HELP_MAP.get(name, "")
-            # Truncate to the available width so long descriptions don't overflow.
-            limit = (formatter.width - 6 - max_name_len) if formatter.width else 45
+            # Truncate to the available width.  Clamp to 0 to prevent negative
+            # slice indices (which slice from the tail) on very narrow terminals.
+            limit = max(0, formatter.width - 6 - max_name_len) if formatter.width else 45
             short_help = help_text[:limit] if limit and len(help_text) > limit else help_text
             commands.append((name, short_help))
         if commands:

--- a/src/fabric_dw/cli/_main.py
+++ b/src/fabric_dw/cli/_main.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib
 import logging
 import shutil
 import sys
@@ -12,26 +13,6 @@ import click
 
 from fabric_dw.auth import CredentialMode
 from fabric_dw.cli._context import CliContext
-from fabric_dw.cli.commands.audit import audit_group
-from fabric_dw.cli.commands.cache import cache_group
-from fabric_dw.cli.commands.completion import completion_group
-from fabric_dw.cli.commands.config import config_group
-from fabric_dw.cli.commands.dbt import dbt_group
-from fabric_dw.cli.commands.functions import functions_group
-from fabric_dw.cli.commands.procedures import procedures_group
-from fabric_dw.cli.commands.queries import queries_group
-from fabric_dw.cli.commands.restore_points import restore_points_group
-from fabric_dw.cli.commands.schemas import schemas_group
-from fabric_dw.cli.commands.settings import settings_group
-from fabric_dw.cli.commands.snapshots import snapshots_group
-from fabric_dw.cli.commands.sql import sql_group
-from fabric_dw.cli.commands.sql_endpoints import sql_endpoints_group
-from fabric_dw.cli.commands.sql_pools import sql_pools_group
-from fabric_dw.cli.commands.statistics import statistics_group
-from fabric_dw.cli.commands.tables import tables_group
-from fabric_dw.cli.commands.views import views_group
-from fabric_dw.cli.commands.warehouses import warehouses_group
-from fabric_dw.cli.commands.workspaces import workspaces_group
 from fabric_dw.logging import setup_logging
 from fabric_dw.telemetry import (
     maybe_print_first_run_notice,
@@ -196,6 +177,70 @@ def _patch_command_for_global_options(cmd: click.Command) -> None:
             _patch_command_for_global_options(sub)
 
 
+# ---------------------------------------------------------------------------
+# Lazy command registry
+# ---------------------------------------------------------------------------
+# Maps the CLI name of each command group to the module and group-object name
+# where it lives.  Format: "module.path:group_object_name".
+# No module is imported at startup; _LazyGroup does it on demand.
+# ---------------------------------------------------------------------------
+
+_COMMAND_MAP: dict[str, str] = {
+    "audit": "fabric_dw.cli.commands.audit:audit_group",
+    "cache": "fabric_dw.cli.commands.cache:cache_group",
+    "completion": "fabric_dw.cli.commands.completion:completion_group",
+    "config": "fabric_dw.cli.commands.config:config_group",
+    "dbt": "fabric_dw.cli.commands.dbt:dbt_group",
+    "functions": "fabric_dw.cli.commands.functions:functions_group",
+    "procedures": "fabric_dw.cli.commands.procedures:procedures_group",
+    "queries": "fabric_dw.cli.commands.queries:queries_group",
+    "restore-points": "fabric_dw.cli.commands.restore_points:restore_points_group",
+    "schemas": "fabric_dw.cli.commands.schemas:schemas_group",
+    "settings": "fabric_dw.cli.commands.settings:settings_group",
+    "snapshots": "fabric_dw.cli.commands.snapshots:snapshots_group",
+    "sql": "fabric_dw.cli.commands.sql:sql_group",
+    "sql-endpoints": "fabric_dw.cli.commands.sql_endpoints:sql_endpoints_group",
+    "sql-pools": "fabric_dw.cli.commands.sql_pools:sql_pools_group",
+    "statistics": "fabric_dw.cli.commands.statistics:statistics_group",
+    "tables": "fabric_dw.cli.commands.tables:tables_group",
+    "views": "fabric_dw.cli.commands.views:views_group",
+    "warehouses": "fabric_dw.cli.commands.warehouses:warehouses_group",
+    "workspaces": "fabric_dw.cli.commands.workspaces:workspaces_group",
+}
+
+# One-line help text per group — shown in root --help WITHOUT importing modules.
+_SHORT_HELP_MAP: dict[str, str] = {
+    "audit": "Manage SQL audit settings for Data Warehouses and SQL Analytics Endpoints.",
+    "cache": "Manage the local name-to-UUID lookup cache.",
+    "completion": "Manage shell completion scripts.",
+    "config": "Manage fabric-dw CLI configuration defaults.",
+    "dbt": "Scaffold and manage dbt projects for Fabric Data Warehouses.",
+    "functions": (
+        "Manage T-SQL user-defined functions on Fabric warehouses and SQL Analytics Endpoints."
+    ),
+    "procedures": "Manage stored procedures on Fabric warehouses and SQL Analytics Endpoints.",
+    "queries": (
+        "Inspect and manage running queries on Fabric warehouses and SQL Analytics Endpoints."
+    ),
+    "restore-points": "Manage Microsoft Fabric Warehouse restore points.",
+    "schemas": "Manage SQL schemas on Fabric warehouses.",
+    "settings": "Manage server-side database settings on Fabric Data Warehouses.",
+    "snapshots": "Manage Microsoft Fabric Data Warehouse snapshots.",
+    "sql": (
+        "SQL execution and query-plan capture for Fabric warehouses and SQL Analytics Endpoints."
+    ),
+    "sql-endpoints": "Manage Microsoft Fabric SQL Analytics Endpoints.",
+    "sql-pools": "Manage workspace SQL Pools configuration (beta API).",
+    "statistics": (
+        "Manage user-defined statistics on Fabric Data Warehouses and SQL Analytics Endpoints."
+    ),
+    "tables": "Manage SQL tables on Fabric warehouses and SQL Analytics Endpoints.",
+    "views": "Manage SQL views on Fabric warehouses and SQL Analytics Endpoints.",
+    "warehouses": "Manage Microsoft Fabric Data Warehouses and SQL Analytics Endpoints.",
+    "workspaces": "Manage Microsoft Fabric workspaces.",
+}
+
+
 class _InstrumentedGroup(click.Group):
     """A :class:`click.Group` subclass that emits one ``command_invoked``
     telemetry event per leaf command invocation.
@@ -306,7 +351,14 @@ def _patch_group_for_telemetry(group: click.Group) -> None:
 
     Recursive patching ensures that sub-groups added before this function
     is called (e.g. ``config.set``) are also patched.
+
+    Idempotent: the ``_telemetry_patched`` sentinel prevents double-patching
+    when a lazily-loaded group is resolved more than once via :meth:`get_command`.
     """
+    if getattr(group, "_telemetry_patched", False):
+        return
+    group._telemetry_patched = True  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+
     # Recursively patch any sub-groups already registered.
     for sub_cmd in group.commands.values():  # type: ignore[attr-defined]
         if isinstance(sub_cmd, click.Group):
@@ -337,9 +389,60 @@ def _patch_group_for_telemetry(group: click.Group) -> None:
     group.invoke = _patched_invoke  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
 
 
+class _LazyGroup(_InstrumentedGroup):
+    """A lazy-loading :class:`_InstrumentedGroup` that defers command module imports.
+
+    Command groups are registered as strings in :data:`_COMMAND_MAP` (CLI name
+    → ``"module.path:group_object"``).  The module is only imported when the
+    group is actually invoked or its own ``--help`` is requested — never on
+    startup or for the root ``--help``.
+
+    Root ``--help`` is rendered from :data:`_SHORT_HELP_MAP` so no modules are
+    imported at all.  The full telemetry/global-options patching that
+    :class:`_InstrumentedGroup` performs via :meth:`add_command` is replicated
+    in :meth:`get_command` after the lazy import.
+    """
+
+    def list_commands(self, ctx: click.Context) -> list[str]:  # type: ignore[override]  # noqa: ARG002
+        """Return all registered command names in alphabetical order."""
+        return sorted(_COMMAND_MAP)
+
+    def get_command(self, ctx: click.Context, cmd_name: str) -> click.Command | None:  # noqa: ARG002
+        """Import and return the command group for *cmd_name*, or ``None``."""
+        spec = _COMMAND_MAP.get(cmd_name)
+        if spec is None:
+            return None
+        module_path, attr_name = spec.rsplit(":", 1)
+        try:
+            module = importlib.import_module(module_path)
+        except ImportError:
+            return None
+        cmd: click.Command = getattr(module, attr_name)
+        # Replicate what _InstrumentedGroup.add_command does so that telemetry
+        # and global-options injection are applied on the lazily-loaded group.
+        if isinstance(cmd, click.Group):
+            _patch_group_for_telemetry(cmd)
+        _patch_command_for_global_options(cmd)
+        return cmd
+
+    def format_commands(self, ctx: click.Context, formatter: click.HelpFormatter) -> None:
+        """Render the command list from :data:`_SHORT_HELP_MAP` without importing modules."""
+        commands: list[tuple[str, str]] = []
+        max_name_len = max(len(n) for n in _COMMAND_MAP)
+        for name in self.list_commands(ctx):
+            help_text = _SHORT_HELP_MAP.get(name, "")
+            # Truncate to the available width so long descriptions don't overflow.
+            limit = (formatter.width - 6 - max_name_len) if formatter.width else 45
+            short_help = help_text[:limit] if limit and len(help_text) > limit else help_text
+            commands.append((name, short_help))
+        if commands:
+            with formatter.section("Commands"):
+                formatter.write_dl(commands)
+
+
 @click.group(
     invoke_without_command=False,
-    cls=_InstrumentedGroup,
+    cls=_LazyGroup,
     context_settings={"help_option_names": ["-h", "--help"], "max_content_width": _HELP_MAX_WIDTH},
 )
 @click.option(
@@ -435,25 +538,3 @@ def cli(
         # before the finally block in _InstrumentedGroup.invoke() executes.)
 
     ctx.call_on_close(_on_close)
-
-
-cli.add_command(cache_group)
-cli.add_command(completion_group)
-cli.add_command(config_group)
-cli.add_command(dbt_group)
-cli.add_command(workspaces_group)
-cli.add_command(warehouses_group)
-cli.add_command(sql_endpoints_group)
-cli.add_command(audit_group)
-cli.add_command(queries_group)
-cli.add_command(restore_points_group)
-cli.add_command(snapshots_group)
-cli.add_command(sql_group)
-cli.add_command(sql_pools_group)
-cli.add_command(schemas_group)
-cli.add_command(tables_group)
-cli.add_command(views_group)
-cli.add_command(procedures_group)
-cli.add_command(statistics_group)
-cli.add_command(settings_group)
-cli.add_command(functions_group)

--- a/src/fabric_dw/cli/_main.py
+++ b/src/fabric_dw/cli/_main.py
@@ -26,6 +26,8 @@ from fabric_dw.telemetry_commands import (
     now_ms,
 )
 
+_logger = logging.getLogger(__name__)
+
 _CLI_TELEMETRY_KEY = "fabric_dw_telemetry_command_name"
 _CLI_SEGMENTS_KEY = _CLI_TELEMETRY_KEY + "_segments"
 
@@ -429,7 +431,8 @@ class _LazyGroup(_InstrumentedGroup):
         try:
             module = importlib.import_module(module_path)
             cmd: click.Command = getattr(module, attr_name)
-        except (ImportError, AttributeError):
+        except (ImportError, AttributeError) as exc:
+            _logger.warning("Failed to load command %r: %s", cmd_name, exc)
             return None
         # Replicate what _InstrumentedGroup.add_command does so that telemetry
         # and global-options injection are applied on the lazily-loaded group.

--- a/tests/unit/cli/test_lazy_loading.py
+++ b/tests/unit/cli/test_lazy_loading.py
@@ -11,6 +11,7 @@ Assertions:
 from __future__ import annotations
 
 import importlib
+import logging
 import sys
 import time
 from types import ModuleType
@@ -152,6 +153,31 @@ class TestBrokenImportResilience:
 
         assert result.exit_code == 0, result.output
         assert "cache" in result.output
+
+    def test_broken_import_logs_warning(
+        self,
+        clean_modules: Any,  # noqa: ARG002
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A failed module import must emit a WARNING so the user can diagnose it."""
+        original_import = importlib.import_module
+
+        def _patched_import(name: str, *args: Any, **kwargs: Any) -> ModuleType:
+            if name == "fabric_dw.cli.commands.dbt":
+                raise ImportError("simulated missing dependency")
+            return original_import(name, *args, **kwargs)
+
+        with (
+            caplog.at_level(logging.WARNING, logger="fabric_dw.cli._main"),
+            patch("fabric_dw.cli._main.importlib.import_module", side_effect=_patched_import),
+        ):
+            runner = CliRunner()
+            runner.invoke(cli, ["dbt", "--help"])
+
+        warning_msgs = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("dbt" in str(m) for m in warning_msgs), (
+            f"Expected a WARNING mentioning 'dbt' but got: {warning_msgs}"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/cli/test_lazy_loading.py
+++ b/tests/unit/cli/test_lazy_loading.py
@@ -1,0 +1,166 @@
+"""Tests that CLI command groups are loaded lazily — TDD for issue #579.
+
+Assertions:
+1. Root ``--help`` does NOT import any command module or its services.
+2. A broken import in one group does not break root ``--help`` or sibling groups.
+3. Root ``--help`` completes quickly (smoke).
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import time
+from types import ModuleType
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from fabric_dw.cli._main import cli
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_UNRELATED_MODULES = [
+    "fabric_dw.cli.commands.dbt",
+    "fabric_dw.cli.commands.sql_pools",
+    "fabric_dw.cli.commands.statistics",
+    "fabric_dw.cli.commands.audit",
+    "fabric_dw.services.dbt_scaffold",
+    "yaml",
+]
+
+
+def _evict_modules() -> None:
+    """Remove lazy-target modules from sys.modules so the test starts clean."""
+    for key in list(sys.modules):
+        if any(
+            key == m or key.startswith(m + ".")
+            for m in (
+                "fabric_dw.cli.commands",
+                "fabric_dw.services.dbt_scaffold",
+                "yaml",
+            )
+        ):
+            del sys.modules[key]
+
+
+# ---------------------------------------------------------------------------
+# 1. Lazy-import assertions
+# ---------------------------------------------------------------------------
+
+
+class TestRootHelpDoesNotImportModules:
+    """Root ``--help`` must not pull in any command-group modules."""
+
+    def test_help_does_not_import_dbt(self) -> None:
+        _evict_modules()
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--help"])
+        assert result.exit_code == 0, result.output
+        assert "fabric_dw.cli.commands.dbt" not in sys.modules
+
+    def test_help_does_not_import_yaml(self) -> None:
+        _evict_modules()
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--help"])
+        assert result.exit_code == 0, result.output
+        assert "yaml" not in sys.modules
+
+    def test_help_does_not_import_dbt_scaffold_service(self) -> None:
+        _evict_modules()
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--help"])
+        assert result.exit_code == 0, result.output
+        assert "fabric_dw.services.dbt_scaffold" not in sys.modules
+
+    def test_help_does_not_import_sql_pools(self) -> None:
+        _evict_modules()
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--help"])
+        assert result.exit_code == 0, result.output
+        assert "fabric_dw.cli.commands.sql_pools" not in sys.modules
+
+    def test_help_lists_all_groups(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--help"])
+        assert result.exit_code == 0, result.output
+        for name in ("audit", "cache", "dbt", "workspaces", "warehouses"):
+            assert name in result.output, f"expected {name!r} in --help output"
+
+    def test_help_shows_short_descriptions(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--help"])
+        assert result.exit_code == 0, result.output
+        # At least one description fragment must appear.
+        assert "Manage" in result.output or "Scaffold" in result.output or "SQL" in result.output
+
+
+# ---------------------------------------------------------------------------
+# 2. Broken-import resilience
+# ---------------------------------------------------------------------------
+
+
+class TestBrokenImportResilience:
+    """A failing import in one command group must not break root --help."""
+
+    def test_root_help_survives_broken_group_import(self) -> None:
+        """If one group's module raises ImportError, root --help still exits 0."""
+        _evict_modules()
+
+        original_import = importlib.import_module
+
+        def _patched_import(name: str, *args: Any, **kwargs: Any) -> ModuleType:
+            if name == "fabric_dw.cli.commands.dbt":
+                raise ImportError("simulated missing dependency")
+            return original_import(name, *args, **kwargs)
+
+        with patch("fabric_dw.cli._main.importlib.import_module", side_effect=_patched_import):
+            runner = CliRunner()
+            result = runner.invoke(cli, ["--help"])
+
+        assert result.exit_code == 0, result.output
+        # dbt is absent from the listed commands (it failed to import) — but
+        # other groups must still be listed.
+        assert "cache" in result.output
+        assert "warehouses" in result.output
+
+    def test_working_group_still_works_when_sibling_is_broken(self) -> None:
+        """Invoking a healthy group still succeeds when another group's import fails."""
+        _evict_modules()
+
+        original_import = importlib.import_module
+
+        def _patched_import(name: str, *args: Any, **kwargs: Any) -> ModuleType:
+            if name == "fabric_dw.cli.commands.dbt":
+                raise ImportError("simulated missing dependency")
+            return original_import(name, *args, **kwargs)
+
+        with patch("fabric_dw.cli._main.importlib.import_module", side_effect=_patched_import):
+            runner = CliRunner()
+            result = runner.invoke(cli, ["cache", "--help"])
+
+        assert result.exit_code == 0, result.output
+        assert "cache" in result.output
+
+
+# ---------------------------------------------------------------------------
+# 3. Timing smoke
+# ---------------------------------------------------------------------------
+
+
+class TestHelpTiming:
+    """Root ``--help`` must complete well under a second (lazy means fast)."""
+
+    @pytest.mark.slow
+    def test_root_help_completes_quickly(self) -> None:
+        runner = CliRunner()
+        start = time.monotonic()
+        result = runner.invoke(cli, ["--help"])
+        elapsed = time.monotonic() - start
+        assert result.exit_code == 0, result.output
+        # Under test isolation (no network) --help should be very fast.
+        assert elapsed < 5.0, f"--help took {elapsed:.2f}s — expected < 5s"

--- a/tests/unit/cli/test_lazy_loading.py
+++ b/tests/unit/cli/test_lazy_loading.py
@@ -4,6 +4,8 @@ Assertions:
 1. Root ``--help`` does NOT import any command module or its services.
 2. A broken import in one group does not break root ``--help`` or sibling groups.
 3. Root ``--help`` completes quickly (smoke).
+4. Typo'd commands still get "Did you mean?" suggestions.
+5. ``_COMMAND_MAP`` and ``_SHORT_HELP_MAP`` cover the same set of names.
 """
 
 from __future__ import annotations
@@ -18,34 +20,45 @@ from unittest.mock import patch
 import pytest
 from click.testing import CliRunner
 
-from fabric_dw.cli._main import cli
+from fabric_dw.cli._main import _COMMAND_MAP, _SHORT_HELP_MAP, cli
 
 # ---------------------------------------------------------------------------
-# Helpers
+# Fixtures
 # ---------------------------------------------------------------------------
 
-_UNRELATED_MODULES = [
-    "fabric_dw.cli.commands.dbt",
-    "fabric_dw.cli.commands.sql_pools",
-    "fabric_dw.cli.commands.statistics",
-    "fabric_dw.cli.commands.audit",
+_EVICT_PREFIXES = (
+    "fabric_dw.cli.commands",
     "fabric_dw.services.dbt_scaffold",
     "yaml",
-]
+)
 
 
-def _evict_modules() -> None:
-    """Remove lazy-target modules from sys.modules so the test starts clean."""
+@pytest.fixture
+def clean_modules() -> Any:
+    """Evict lazy-target modules before a test and restore them afterwards.
+
+    Evicting and NOT restoring leaves orphaned module objects in other test
+    modules' globals (their imported names still point to the old object) while
+    sys.modules now contains a freshly re-imported copy.  Any ``patch()`` call
+    in a later test that uses the module path (e.g.
+    ``"fabric_dw.cli.commands.tables.load_local_file"``) will patch the new
+    copy, but functions imported by the test file at collection time still
+    execute with the old copy — making the patch invisible.  Always restore.
+    """
+    saved = {
+        key: mod
+        for key, mod in sys.modules.items()
+        if any(key == m or key.startswith(m + ".") for m in _EVICT_PREFIXES)
+    }
+    for key in saved:
+        del sys.modules[key]
+    yield
+    # Restore: remove anything that was imported during the test, then put
+    # back the originals so other test modules' globals keep working.
     for key in list(sys.modules):
-        if any(
-            key == m or key.startswith(m + ".")
-            for m in (
-                "fabric_dw.cli.commands",
-                "fabric_dw.services.dbt_scaffold",
-                "yaml",
-            )
-        ):
+        if any(key == m or key.startswith(m + ".") for m in _EVICT_PREFIXES):
             del sys.modules[key]
+    sys.modules.update(saved)
 
 
 # ---------------------------------------------------------------------------
@@ -56,29 +69,25 @@ def _evict_modules() -> None:
 class TestRootHelpDoesNotImportModules:
     """Root ``--help`` must not pull in any command-group modules."""
 
-    def test_help_does_not_import_dbt(self) -> None:
-        _evict_modules()
+    def test_help_does_not_import_dbt(self, clean_modules: Any) -> None:  # noqa: ARG002
         runner = CliRunner()
         result = runner.invoke(cli, ["--help"])
         assert result.exit_code == 0, result.output
         assert "fabric_dw.cli.commands.dbt" not in sys.modules
 
-    def test_help_does_not_import_yaml(self) -> None:
-        _evict_modules()
+    def test_help_does_not_import_yaml(self, clean_modules: Any) -> None:  # noqa: ARG002
         runner = CliRunner()
         result = runner.invoke(cli, ["--help"])
         assert result.exit_code == 0, result.output
         assert "yaml" not in sys.modules
 
-    def test_help_does_not_import_dbt_scaffold_service(self) -> None:
-        _evict_modules()
+    def test_help_does_not_import_dbt_scaffold_service(self, clean_modules: Any) -> None:  # noqa: ARG002
         runner = CliRunner()
         result = runner.invoke(cli, ["--help"])
         assert result.exit_code == 0, result.output
         assert "fabric_dw.services.dbt_scaffold" not in sys.modules
 
-    def test_help_does_not_import_sql_pools(self) -> None:
-        _evict_modules()
+    def test_help_does_not_import_sql_pools(self, clean_modules: Any) -> None:  # noqa: ARG002
         runner = CliRunner()
         result = runner.invoke(cli, ["--help"])
         assert result.exit_code == 0, result.output
@@ -105,12 +114,10 @@ class TestRootHelpDoesNotImportModules:
 
 
 class TestBrokenImportResilience:
-    """A failing import in one command group must not break root --help."""
+    """A failing import in one command group must not break root ``--help``."""
 
-    def test_root_help_survives_broken_group_import(self) -> None:
+    def test_root_help_survives_broken_group_import(self, clean_modules: Any) -> None:  # noqa: ARG002
         """If one group's module raises ImportError, root --help still exits 0."""
-        _evict_modules()
-
         original_import = importlib.import_module
 
         def _patched_import(name: str, *args: Any, **kwargs: Any) -> ModuleType:
@@ -123,15 +130,15 @@ class TestBrokenImportResilience:
             result = runner.invoke(cli, ["--help"])
 
         assert result.exit_code == 0, result.output
-        # dbt is absent from the listed commands (it failed to import) — but
-        # other groups must still be listed.
+        # format_commands reads _SHORT_HELP_MAP unconditionally, so dbt still
+        # appears in --help output even when its import fails.  Other groups
+        # must also be listed.
         assert "cache" in result.output
         assert "warehouses" in result.output
+        assert "dbt" in result.output
 
-    def test_working_group_still_works_when_sibling_is_broken(self) -> None:
+    def test_working_group_still_works_when_sibling_is_broken(self, clean_modules: Any) -> None:  # noqa: ARG002
         """Invoking a healthy group still succeeds when another group's import fails."""
-        _evict_modules()
-
         original_import = importlib.import_module
 
         def _patched_import(name: str, *args: Any, **kwargs: Any) -> ModuleType:
@@ -164,3 +171,42 @@ class TestHelpTiming:
         assert result.exit_code == 0, result.output
         # Under test isolation (no network) --help should be very fast.
         assert elapsed < 5.0, f"--help took {elapsed:.2f}s — expected < 5s"
+
+
+# ---------------------------------------------------------------------------
+# 4. "Did you mean?" suggestions for typo'd commands
+# ---------------------------------------------------------------------------
+
+
+class TestTypoSuggestions:
+    """Mistyped top-level commands must still produce "Did you mean?" hints."""
+
+    def test_typo_suggests_closest_command(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, ["cach"])  # typo for "cache"
+        # Click returns exit code 2 for unknown commands.
+        assert result.exit_code == 2
+        # Click's "Did you mean?" message should appear.
+        assert "cache" in result.output.lower() or "did you mean" in result.output.lower(), (
+            f"Expected a suggestion for 'cach' in output: {result.output!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 5. Map-parity guard
+# ---------------------------------------------------------------------------
+
+
+class TestCommandMapParity:
+    """_COMMAND_MAP and _SHORT_HELP_MAP must cover the same set of names."""
+
+    def test_command_map_and_short_help_map_have_same_keys(self) -> None:
+        assert _COMMAND_MAP.keys() == _SHORT_HELP_MAP.keys(), (
+            f"Maps disagree.  "
+            f"Missing from _SHORT_HELP_MAP: {_COMMAND_MAP.keys() - _SHORT_HELP_MAP.keys()!r}.  "
+            f"Missing from _COMMAND_MAP: {_SHORT_HELP_MAP.keys() - _COMMAND_MAP.keys()!r}."
+        )
+
+    def test_all_short_help_strings_are_non_empty(self) -> None:
+        empty = [name for name, text in _SHORT_HELP_MAP.items() if not text.strip()]
+        assert empty == [], f"Commands with empty short help: {empty}"

--- a/tests/unit/test_telemetry_commands.py
+++ b/tests/unit/test_telemetry_commands.py
@@ -78,15 +78,17 @@ class TestResolveDomain:
 
 
 def _collect_live_cli_group_names() -> frozenset[str]:
-    """Walk the live Click command tree and return all top-level group/command names.
+    """Return all top-level CLI command group names.
 
+    Uses :data:`fabric_dw.cli._main._COMMAND_MAP` directly so that the lazy
+    group's command list is available without importing any command module.
     Hidden commands are included deliberately: telemetry fires for all commands
     regardless of the ``hidden`` flag, so a hidden group without a DOMAIN_MAP
     entry would silently log ``domain="unknown"``.
     """
-    from fabric_dw.cli._main import cli  # noqa: PLC0415
+    from fabric_dw.cli._main import _COMMAND_MAP  # noqa: PLC0415
 
-    return frozenset(cli.commands)
+    return frozenset(_COMMAND_MAP)
 
 
 class TestDomainCoverage:


### PR DESCRIPTION
## Summary

- Replace the 20 eager top-level `from fabric_dw.cli.commands.<x> import <group>` imports in `_main.py` with a `_COMMAND_MAP` string registry (CLI name → `"module.path:object"`).
- Add `_LazyGroup(_InstrumentedGroup)` with `list_commands`/`get_command`/`format_commands` that import a module only when its group is actually invoked — never at startup or for root `--help`.
- Add idempotency sentinel to `_patch_group_for_telemetry` so repeated `get_command` calls on the same object do not double-patch telemetry wrappers.
- Update telemetry domain-coverage guard to read `_COMMAND_MAP` directly (lazy groups have an empty `cli.commands` dict).
- Add `tests/unit/cli/test_lazy_loading.py` asserting that `dbt`/`yaml`/`dbt_scaffold`/`sql_pools` are absent from `sys.modules` after root `--help`, and that a broken import in one group does not break `--help` or sibling groups.

The MCP entry point (`fabric-dw-mcp --help`) is unaffected — it does not import CLI command groups.

Closes #579