### PR TITLE
feat(http-client): raise 429 retry budget to 10 retries and 5-minute combined deadline

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -142,10 +142,10 @@ After re-authenticating, retry your command. `FabricSqlClient` opens a fresh con
 **Error you see:**
 
 ```
-fabric_dw.exceptions.RateLimitedError: Received 429 5 consecutive times for https://api.fabric.microsoft.com/v1/...
+fabric_dw.exceptions.RateLimitedError: Received 429 10 consecutive times for https://api.fabric.microsoft.com/v1/...
 ```
 
-**What happened:** The Fabric REST API enforces a rate limit. `fabric-dw` honours the `Retry-After` response header and automatically backs off, but if the API returns 429 more than 5 consecutive times the client raises `RateLimitedError` rather than waiting indefinitely. The internal rate limiter is set to **2 RPS**.
+**What happened:** The Fabric REST API enforces a rate limit. `fabric-dw` honours the `Retry-After` response header and automatically backs off, but if the API returns 429 more than 10 consecutive times the client raises `RateLimitedError` rather than waiting indefinitely. The internal rate limiter is set to **2 RPS**.
 
 **Resolution:**
 

--- a/src/fabric_dw/http_client.py
+++ b/src/fabric_dw/http_client.py
@@ -15,7 +15,7 @@ Tenacity wraps ``_request_with_retry`` and retries on ``FabricServerError``
 (5xx) up to 3 attempts with exponential back-off.  Inside each attempt,
 ``_do_request`` executes a 429-loop of up to ``max_429_retries`` iterations.
 Both mechanisms share a common wall-clock deadline (``_combined_deadline_s``
-seconds from the first attempt, default 120 s) so the combined worst-case
+seconds from the first attempt, default 300 s) so the combined worst-case
 latency is bounded even if the server returns large Retry-After values.
 
 Timeout retry safety
@@ -83,7 +83,7 @@ __all__ = [
 # Module-level defaults (used as constructor defaults)
 _DEFAULT_RPS: int = 2
 _DEFAULT_TIMEOUT: float = 60.0  # bumped from 30.0 to reduce spurious timeouts on slow responses
-_MAX_429_RETRIES: int = 5
+_MAX_429_RETRIES: int = 10
 _DEFAULT_POLL_INTERVAL: float = 2.0
 _TOKEN_REFRESH_BUFFER: float = 300.0  # seconds before expiry to refresh
 
@@ -91,7 +91,7 @@ _TOKEN_REFRESH_BUFFER: float = 300.0  # seconds before expiry to refresh
 # When this deadline is reached, whichever retry loop is active at that point
 # aborts and re-raises; this prevents unbounded waits when a server advertises
 # very large Retry-After values across multiple tenacity attempts.
-_DEFAULT_COMBINED_DEADLINE_S: float = 120.0
+_DEFAULT_COMBINED_DEADLINE_S: float = 300.0
 
 # HTTP methods that are safe to retry on timeout: repeating them cannot duplicate
 # server-side state.  POST/PATCH/DELETE are excluded — a timed-out POST may have
@@ -246,7 +246,7 @@ class FabricHttpClient:
     (5xx) up to 3 attempts.  Inside each tenacity attempt, ``_do_request`` runs
     a 429-loop of up to ``max_429_retries`` iterations.  Both mechanisms share a
     common wall-clock deadline (``combined_deadline_s`` seconds from the first
-    send, default 120 s) so the total latency is bounded even when the server
+    send, default 300 s) so the total latency is bounded even when the server
     advertises large ``Retry-After`` values.
 
     Args:
@@ -254,12 +254,12 @@ class FabricHttpClient:
         rps:                    Maximum requests per second (default 2).
         timeout:                HTTP request timeout in seconds (default 60.0).
         max_429_retries:        Maximum consecutive 429 responses before raising
-                                ``RateLimitedError`` (default 5).
+                                ``RateLimitedError`` (default 10).
         poll_interval:          Default LRO polling interval in seconds (default 2.0).
         token_refresh_buffer:   Seconds before token expiry at which a refresh is
                                 triggered (default 300.0).
         combined_deadline_s:    Maximum wall-clock seconds for the combined
-                                5xx-retry + 429-loop budget (default 120.0).
+                                5xx-retry + 429-loop budget (default 300.0).
     """
 
     def __init__(  # noqa: PLR0913

--- a/tests/unit/test_http_client.py
+++ b/tests/unit/test_http_client.py
@@ -28,7 +28,14 @@ from fabric_dw.exceptions import (
     PermissionDeniedError,
     RateLimitedError,
 )
-from fabric_dw.http_client import _DEFAULT_TIMEOUT, FabricHttpClient, HttpBase, _parse_retry_after
+from fabric_dw.http_client import (
+    _DEFAULT_COMBINED_DEADLINE_S,
+    _DEFAULT_TIMEOUT,
+    _MAX_429_RETRIES,
+    FabricHttpClient,
+    HttpBase,
+    _parse_retry_after,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -186,11 +193,11 @@ async def test_429_retry_after_honored() -> None:
     )
 
 
-async def test_429_raises_after_five_in_a_row() -> None:
-    """Exactly 5 consecutive 429 responses must trigger RateLimitedError (_MAX_429_RETRIES = 5).
+async def test_429_raises_after_ten_in_a_row() -> None:
+    """Exactly 10 consecutive 429 responses must trigger RateLimitedError (_MAX_429_RETRIES = 10).
 
-    The implementation raises when consecutive_429 >= 5, so the 5th 429 response
-    is the one that causes the exception — meaning exactly 5 mocked 429s are consumed.
+    The implementation raises when consecutive_429 >= 10, so the 10th 429 response
+    is the one that causes the exception — meaning exactly 10 mocked 429s are consumed.
     """
     call_count = 0
 
@@ -207,7 +214,7 @@ async def test_429_raises_after_five_in_a_row() -> None:
             with pytest.raises(RateLimitedError):
                 await client.request("GET", HttpBase.FABRIC, "/items")
 
-    assert call_count == 5, f"Expected exactly 5 429 responses before raising; got {call_count}"
+    assert call_count == 10, f"Expected exactly 10 429 responses before raising; got {call_count}"
 
 
 # ---------------------------------------------------------------------------
@@ -1024,6 +1031,22 @@ def test_constructor_parameters_are_stored() -> None:
     assert client._max_429_retries == 3
     assert client._poll_interval == 5.0
     assert client._token_refresh_buffer == 600.0
+
+
+def test_default_429_budget_constants() -> None:
+    """Module constants and FabricHttpClient defaults must reflect the raised budget.
+
+    _MAX_429_RETRIES == 10 and _DEFAULT_COMBINED_DEADLINE_S == 300.0 ensure
+    that transient Fabric throttling under parallel load is absorbed instead of
+    raising RateLimitedError prematurely.
+    """
+    assert _MAX_429_RETRIES == 10
+    assert _DEFAULT_COMBINED_DEADLINE_S == 300.0
+
+    # A client built without explicit overrides must inherit both defaults.
+    client = FabricHttpClient(credential=_make_credential())
+    assert client._max_429_retries == 10
+    assert client._combined_deadline_s == 300.0
 
 
 async def test_timeout_wired_into_http_client() -> None:


### PR DESCRIPTION
Closes #587

## Summary

- `_MAX_429_RETRIES`: 5 → 10
- `_DEFAULT_COMBINED_DEADLINE_S`: 120.0 → 300.0 (5 minutes)
- All docstrings / comments citing the old values updated (module docstring, `FabricHttpClient` class docstring, `_do_request` param docs)
- `docs/troubleshooting.md` updated to reflect 10 consecutive retries
- Renamed `test_429_raises_after_five_in_a_row` → `test_429_raises_after_ten_in_a_row` and updated its count assertion
- New `test_default_429_budget_constants` test asserts both module constants and default client attributes

## Test plan

- [x] `just lint` clean (ruff check + ruff format --check)
- [x] `uv run ty check src tests` clean
- [x] `uv run pytest tests/unit/test_http_client.py` — 69 passed