### PR TITLE
docs: align output examples with --json flag and fix home Commands link

### DIFF
--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -29,4 +29,4 @@ Each page below covers one command domain: CLI synopsis, options, and examples a
 - **[Tables](tables.md)** — Manage SQL tables, including CTAS, clone, load, and clustering.
 - **[Views](views.md)** — Manage SQL views.
 - **[Warehouses](warehouses.md)** — Manage Data Warehouses and SQL Analytics Endpoints.
-- **[Workspaces](workspaces.md)** — List and inspect workspaces.
+- **[Workspaces](workspaces.md)** — List, inspect, and manage workspaces — capacity assignment, collation, and more.

--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -1,0 +1,32 @@
+---
+title: Commands
+---
+
+# Commands
+
+`fabric-dw` exposes every operation as both a CLI command and an MCP tool. The two surfaces share the same authentication, connection, and business logic — a fix or new feature lands in both at once.
+
+Each page below covers one command domain: CLI synopsis, options, and examples alongside the corresponding MCP tool parameters and return values.
+
+## Domains
+
+- **[Audit](audit.md)** — Manage SQL audit settings for Data Warehouses and SQL Analytics Endpoints.
+- **[Cache](cache.md)** — Manage the local name-to-UUID lookup cache.
+- **[Completion](completion.md)** — Install and manage shell completion scripts.
+- **[Configuration & defaults](config.md)** — Store a default workspace and/or warehouse to avoid repeating them on every invocation.
+- **[dbt](dbt.md)** — Scaffold a dbt project pre-wired to a Fabric Data Warehouse.
+- **[Functions](functions.md)** — Manage T-SQL user-defined functions.
+- **[Queries](queries.md)** — Inspect and manage running queries.
+- **[Restore Points](restore-points.md)** — Create, list, rename, and delete warehouse restore points.
+- **[Running SQL](sql.md)** — Execute SQL statements and capture estimated execution plans.
+- **[Schemas](schemas.md)** — Manage SQL schemas.
+- **[Settings](settings.md)** — Manage server-side database settings.
+- **[Snapshots](snapshots.md)** — Manage Data Warehouse snapshots.
+- **[SQL Analytics Endpoints](sql-endpoints.md)** — Manage SQL Analytics Endpoints.
+- **[SQL Pools](sql-pools.md)** — Manage custom SQL Pools at the workspace level.
+- **[Statistics](statistics.md)** — Manage user-defined statistics.
+- **[Stored procedures](procedures.md)** — Manage stored procedures.
+- **[Tables](tables.md)** — Manage SQL tables, including CTAS, clone, load, and clustering.
+- **[Views](views.md)** — Manage SQL views.
+- **[Warehouses](warehouses.md)** — Manage Data Warehouses and SQL Analytics Endpoints.
+- **[Workspaces](workspaces.md)** — List and inspect workspaces.

--- a/docs/commands/sql-pools.md
+++ b/docs/commands/sql-pools.md
@@ -182,7 +182,7 @@ fdw [-w WORKSPACE] sql-pools list
 **Example**
 
 ```shell
-fdw -w MyWorkspace sql-pools list
+fdw -w MyWorkspace --json sql-pools list
 ```
 
 **Output**

--- a/docs/commands/tables.md
+++ b/docs/commands/tables.md
@@ -97,7 +97,7 @@ fdw [-w WORKSPACE] tables cluster-columns [WAREHOUSE] QUALIFIED_NAME
 **Example**
 
 ```shell
-fdw -w MyWorkspace tables cluster-columns SalesWH dbo.orders
+fdw -w MyWorkspace --json tables cluster-columns SalesWH dbo.orders
 ```
 
 ```json
@@ -160,7 +160,7 @@ fdw [-w WORKSPACE] tables count [WAREHOUSE] QUALIFIED_NAME
 **Example**
 
 ```shell
-fdw -w MyWorkspace tables count SalesWH dbo.orders
+fdw -w MyWorkspace --json tables count SalesWH dbo.orders
 ```
 
 ```json

--- a/docs/commands/views.md
+++ b/docs/commands/views.md
@@ -56,7 +56,7 @@ fdw [-w WORKSPACE] views count [WAREHOUSE] QUALIFIED_NAME
 **Example**
 
 ```shell
-fdw -w MyWorkspace views count SalesWH dbo.vw_sales
+fdw -w MyWorkspace --json views count SalesWH dbo.vw_sales
 ```
 
 ```json

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,9 +20,9 @@ Both the CLI and the MCP server surfaces are built from a single Python package 
 
     Get the package installed and verify your setup.
 
-- :material-console: **[Commands](concepts.md)**
+- :material-console: **[Commands](commands/index.md)**
 
-    Cross-cutting concepts plus per-domain CLI commands and MCP tools.
+    Per-domain CLI commands and MCP tools.
 
 - :material-server: **[MCP Reference](mcp.md)**
 

--- a/zensical.toml
+++ b/zensical.toml
@@ -16,6 +16,7 @@ nav = [
   { "Install" = "install.md" },
   { "Concepts" = "concepts.md" },
   { "Commands" = [
+    { "Overview" = "commands/index.md" },
     { "Audit" = "commands/audit.md" },
     { "Cache" = "commands/cache.md" },
     { "Completion" = "commands/completion.md" },


### PR DESCRIPTION
Closes #589

## Task A — JSON/--json flag consistency

Four CLI examples showed JSON output without the `--json` global flag. Fixed by adding `--json` to the command (output data unchanged):

| File | Command | Fix |
| --- | --- | --- |
| `docs/commands/tables.md` | `tables cluster-columns` | Added `--json` |
| `docs/commands/tables.md` | `tables count` | Added `--json` |
| `docs/commands/views.md` | `views count` | Added `--json` |
| `docs/commands/sql-pools.md` | `sql-pools list` | Added `--json` (the surrounding prose already referenced `--json`; the command was missing it) |

The `tables read` and `views read` examples were left unchanged — those commands have their own `--format {json|csv|parquet}` option (JSON is the default output format for those commands, independent of the global `--json` flag).

## Task B — Home "Commands" card nav fix

- Created `docs/commands/index.md`: a concise overview page listing all 20 command domains with one-line descriptions and links.
- Updated `docs/index.md` line 23: the "Commands" card now links to `commands/index.md` instead of `concepts.md`.
- Added `{ "Overview" = "commands/index.md" }` as the first entry in the Commands section of `zensical.toml` so the landing page appears in the sidebar.