### PR TITLE
feat(skills): ship fabric-dw Agent Skills as a Claude Code plugin (query-optimizer + dbt-setup)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "fabric-dw",
+  "displayName": "Fabric DW Agent Skills",
+  "version": "2026.6.0",
+  "description": "Agent skills for Fabric Data Warehouse: query performance analysis and dbt project bootstrap.",
+  "homepage": "https://github.com/sdebruyn/fabric-dw-mcp-cli"
+}

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,0 +1,96 @@
+---
+title: Agent Skills
+---
+
+# Agent Skills
+
+`fabric-dw` ships two [Claude Code Agent Skills](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview) that orchestrate multi-step administration workflows on top of the MCP server.
+
+| Skill | Trigger phrases | What it does |
+| --- | --- | --- |
+| `query-optimizer` | "optimize this query", "why is my query slow", "analyze execution plan", "missing statistics", "fix clustering" | Captures the estimated execution plan, inspects query insights history, audits statistics, examines clustering, and proposes or applies optimizations |
+| `dbt-setup` | "set up dbt", "scaffold a dbt project", "create dbt profile", "generate dbt sources" | Generates a complete dbt-fabric scaffold (profiles, project, column-rich sources, requirements) and writes it to disk |
+
+Both skills require the [fabric-dw MCP server](mcp.md) to be configured in your AI client.
+
+## Install via Claude Code Plugin
+
+The recommended installation path for Claude Code users is the **fabric-dw plugin**. Skills are installed from GitHub without cloning the repo and are namespaced as `/fabric-dw:query-optimizer` and `/fabric-dw:dbt-setup`.
+
+Add the following to your `.claude/settings.json` (project-scoped) or `~/.claude/settings.json` (personal):
+
+```json
+{
+  "extraKnownMarketplaces": {
+    "fabric-dw": {
+      "source": { "source": "github", "repo": "sdebruyn/fabric-dw-mcp-cli" }
+    }
+  },
+  "enabledPlugins": {
+    "fabric-dw@fabric-dw": true
+  }
+}
+```
+
+After saving, the skills are available as slash commands:
+
+```
+/fabric-dw:query-optimizer
+/fabric-dw:dbt-setup
+```
+
+!!! note "Version caching"
+    The plugin version is pinned in `.claude-plugin/plugin.json`. If a new release changes skill content, bump the plugin version to force cached copies to update.
+
+## Install as raw SKILL.md files
+
+If you are using a different AI assistant, the Claude API directly, or any tool that supports the `SKILL.md` format but not the Claude Code plugin mechanism, download or reference the raw skill files:
+
+- **query-optimizer**: [`https://raw.githubusercontent.com/sdebruyn/fabric-dw-mcp-cli/main/skills/query-optimizer/SKILL.md`](https://raw.githubusercontent.com/sdebruyn/fabric-dw-mcp-cli/main/skills/query-optimizer/SKILL.md)
+- **dbt-setup**: [`https://raw.githubusercontent.com/sdebruyn/fabric-dw-mcp-cli/main/skills/dbt-setup/SKILL.md`](https://raw.githubusercontent.com/sdebruyn/fabric-dw-mcp-cli/main/skills/dbt-setup/SKILL.md)
+
+Place each file at one of the Claude Code personal or project skill paths:
+
+| Path | Scope |
+| --- | --- |
+| `~/.claude/skills/<name>/SKILL.md` | Personal — applies to all projects |
+| `.claude/skills/<name>/SKILL.md` | Project-scoped — committed to repo |
+
+For example, to install `query-optimizer` at project scope:
+
+```bash
+mkdir -p .claude/skills/query-optimizer
+curl -fsSL https://raw.githubusercontent.com/sdebruyn/fabric-dw-mcp-cli/main/skills/query-optimizer/SKILL.md \
+  -o .claude/skills/query-optimizer/SKILL.md
+```
+
+## Skill reference
+
+### query-optimizer
+
+Performs a structured query performance analysis on a Fabric Data Warehouse:
+
+1. Captures the estimated execution plan via `get_query_plan` (no query execution)
+2. Parses the SHOWPLAN_XML for costly operators, residual predicates, and implicit type conversions
+3. Inspects query insights history via `list_request_history` and `list_long_running_queries`
+4. Audits statistics per referenced table with `list_statistics` and `show_statistics`
+5. Fetches column metadata (types, nullability, identity, computed) via `get_table_columns`
+6. Reads current data-clustering columns via `get_cluster_columns` (DW-only; skipped for SQL Analytics Endpoints)
+7. Reports findings and recommendations; optionally applies statistics changes (`create_statistics` / `update_statistics`) and re-clustering (`set_cluster_columns`) after explicit user confirmation
+
+To visualize the execution plan, use the CLI:
+
+```bash
+fdw sql plan "<query>" --format html   # opens in browser
+fdw sql plan "<query>" --format svg    # saves as SVG image
+```
+
+### dbt-setup
+
+Bootstraps a dbt-fabric project for a Fabric Data Warehouse:
+
+1. Resolves the warehouse connection string via `get_warehouse`
+2. Lists schemas and tables with `list_schemas` and `list_tables` to confirm connectivity
+3. Generates all scaffold files with `generate_dbt_profile` using `with_sources=true` — the tool performs a bulk column fetch and emits a `models/staging/_sources.yml` with `columns:` blocks (name and formatted `data_type`) for every table, ready for dbt contract enforcement
+4. Writes `profiles.yml`, `dbt_project.yml`, `models/staging/_sources.yml`, `requirements.txt`, and `.gitignore` to disk; confirms before overwriting existing files
+5. Provides next steps: `pip install -r requirements.txt`, `dbt debug`, `dbt run`

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -78,12 +78,14 @@ Performs a structured query performance analysis on a Fabric Data Warehouse:
 6. Reads current data-clustering columns via `get_cluster_columns` (DW-only; skipped for SQL Analytics Endpoints)
 7. Reports findings and recommendations; optionally applies statistics changes (`create_statistics` / `update_statistics`) and re-clustering (`set_cluster_columns`) after explicit user confirmation
 
-To visualize the execution plan, use the CLI:
+To visualize the execution plan, use the CLI (pass the warehouse name as the first positional argument and the query via `-q`):
 
 ```bash
-fdw sql plan "<query>" --format html   # opens in browser
-fdw sql plan "<query>" --format svg    # saves as SVG image
+fdw sql plan <warehouse> -q "<query>" --format html -o plan.html   # writes self-contained HTML file; open plan.html in any browser
+fdw sql plan <workspace>/<warehouse> -q "<query>" --format svg -o plan.svg   # renders SVG via system dot binary (requires Graphviz)
 ```
+
+`--format html` requires `-o/--output` and writes a file — it does not open the browser automatically.
 
 ### dbt-setup
 

--- a/skills/dbt-setup/SKILL.md
+++ b/skills/dbt-setup/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: dbt-setup
+description: >
+  Scaffolds a complete dbt-fabric project for a Fabric Data Warehouse: generates
+  profiles.yml, dbt_project.yml, a column-rich _sources.yml (with data types for
+  every table column, ready for dbt contracts), requirements.txt, and .gitignore,
+  then writes them to the local filesystem. Use when the user asks to "set up dbt",
+  "scaffold a dbt project", "create dbt profile", "initialize dbt for my warehouse",
+  "generate dbt sources", or "bootstrap dbt-fabric".
+user-invocable: true
+---
+
+# dbt Project Bootstrap for Fabric DW
+
+Generates a complete dbt-fabric project scaffold using the fabric-dw MCP tools and writes all files to the local filesystem.
+
+## Inputs
+
+Gather these from the user (via `$ARGUMENTS` or natural language) before starting:
+
+- **workspace** — workspace name or GUID
+- **warehouse** — Fabric Data Warehouse name or GUID
+- **project_name** — desired dbt project name (default: warehouse name, lowercased, spaces replaced with underscores)
+- **schema** — default dbt schema (default: `dbo`)
+- **authentication** — `default` (DefaultAzureCredential), `sp` (service principal), or `interactive` (default: `default`)
+- **with_sources** — whether to generate a column-rich `_sources.yml` (default: `true`, recommended)
+
+## Workflow
+
+### Step 1 — Resolve the warehouse connection
+
+Call `get_warehouse` with the workspace and warehouse name. This returns the warehouse metadata including the connection string used in the dbt profile.
+
+### Step 2 — Confirm connectivity and list objects
+
+Call `list_schemas` and `list_tables` to confirm that the warehouse is reachable and to identify the schemas and tables that will appear as dbt sources.
+
+Show the user a summary: number of schemas found, number of tables found.
+
+### Step 3 — Generate the dbt scaffold
+
+Call `generate_dbt_profile` with:
+
+- `workspace`, `warehouse`, `project_name`, `schema`, `authentication` as provided
+- `with_sources=true` (unless the user explicitly opted out)
+
+When `with_sources=true`, the tool performs a bulk column fetch and emits a `models/staging/_sources.yml` that already includes each table's `columns:` block with `name` and formatted `data_type` for every column. This output is ready for dbt [contract enforcement](https://docs.getdbt.com/docs/collaborate/govern/model-contracts) and column-level documentation without any manual assembly.
+
+### Step 4 — Write files to the local filesystem
+
+Write all file contents returned by `generate_dbt_profile` to the user's working directory. The expected set of files:
+
+| Path | Purpose |
+| --- | --- |
+| `profiles.yml` | dbt connection profile |
+| `dbt_project.yml` | dbt project definition |
+| `models/staging/_sources.yml` | Source definitions with column types (when `with_sources=true`) |
+| `requirements.txt` | Python package dependencies (`dbt-fabric`) |
+| `.gitignore` | Excludes secrets and build artefacts |
+
+Before writing, check whether any of these files already exist and confirm with the user before overwriting.
+
+### Step 5 — Provide next steps
+
+After writing the files, give the user the following instructions:
+
+```bash
+# Install dependencies
+pip install -r requirements.txt
+
+# Verify the connection
+dbt debug
+
+# Run your first dbt project
+dbt run
+```
+
+Also remind the user to:
+
+1. Review `profiles.yml` and fill in any `{{ env_var(...) }}` placeholders (service-principal credentials are never written as literals — they are templated).
+2. Check that environment variables (`AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`) are set before running `dbt debug` if using service-principal auth.
+
+## Guardrails
+
+- **Service-principal auth**: when `authentication=sp`, the generated `profiles.yml` uses `{{ env_var(...) }}` placeholders for tenant ID, client ID, and client secret. Never write literal credential values. Remind the user that these must be set in environment before committing `profiles.yml` to version control.
+- **Overwrite protection**: if any target file already exists, list them and ask the user to confirm before overwriting.
+- **Fabric auth only**: dbt-fabric requires Entra (Azure AD) authentication. Warn the user if they ask about username/password auth — it is not supported by the dbt-fabric adapter.
+- **Column inspection**: `get_table_columns` and `get_view_columns` are available for ad-hoc schema inspection (e.g., if the user wants to review a specific table before deciding which columns to expose), but explicit calls to those tools are not required — column data is built into `generate_dbt_profile` with `with_sources=true`.

--- a/skills/query-optimizer/SKILL.md
+++ b/skills/query-optimizer/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: query-optimizer
+description: >
+  Analyzes query performance on a Fabric Data Warehouse: captures the estimated
+  execution plan, inspects query insights history, identifies costly operators and
+  missing or stale statistics, inspects data-clustering columns, and proposes or
+  applies optimizations. Use when the user asks to "optimize a query", "why is my
+  query slow", "check query performance", "analyze execution plan", "missing
+  statistics", "fix clustering", "re-cluster table", or any variant of diagnosing
+  slow Fabric DW SQL.
+user-invocable: true
+---
+
+# Query Performance Analysis & Optimization
+
+Analyzes and optimizes a query on a Fabric Data Warehouse using the fabric-dw MCP tools.
+
+## Inputs
+
+Gather these from the user (via `$ARGUMENTS` or natural language) before starting:
+
+- **workspace** — workspace name or GUID
+- **warehouse** — warehouse name or GUID (must be a Fabric Data Warehouse, not a SQL Analytics Endpoint, for clustering steps)
+- **query** — the SQL query text to analyze (or a historical query ID / text snippet to look up)
+
+If the warehouse is a SQL Analytics Endpoint, skip steps 8, 9, 11 (clustering), and 13 (`set_cluster_columns`).
+
+## Workflow
+
+### Step 1 — Capture the estimated execution plan
+
+Call `get_query_plan` with the query text. This returns a SHOWPLAN_XML document without executing the query.
+
+To visualize the plan, use the CLI:
+
+```bash
+fdw sql plan "<query>" --format html   # open in browser for visual inspection
+fdw sql plan "<query>" --format svg    # embed or save as image
+```
+
+### Step 2 — Parse the plan XML
+
+Analyze the returned SHOWPLAN_XML for:
+
+- **Costly operators**: Hash Join, Sort, nested-loop Scan on large row estimates, Spool
+- **Residual predicates**: predicates that cannot be applied early (non-SARGable)
+- **Missing-index hints** embedded in the plan
+- **Data skew warnings** or large estimated vs. actual row count mismatches (if available)
+- **Type mismatch conversions**: e.g. `CONVERT_IMPLICIT` on a column used in a predicate
+
+### Step 3 — Pull recent history
+
+Use `list_request_history` (filter by SQL text substring if supported) and `list_long_running_queries` to see whether this query pattern has a history of slow executions. Note elapsed time and status.
+
+### Step 4 — List statistics on referenced tables
+
+For every table referenced in the query, call `list_statistics` to enumerate existing statistics objects. Note which columns lack statistics.
+
+### Step 5 — Inspect histogram for stale or missing stats
+
+For any statistic that appears potentially stale or absent, call `show_statistics` to examine its header (last_updated timestamp, row count, rows sampled) and histogram. Flag statistics whose sample rate or update date suggests staleness — this is heuristic; flag rather than assert.
+
+### Step 6 — Fetch column metadata
+
+For each table referenced in the query, call `get_table_columns` to retrieve: column name, formatted data type (e.g. `VARCHAR(50)`, `DECIMAL(18,2)`), nullable flag, identity flag, computed flag.
+
+### Step 7 — Refine plan analysis with column metadata
+
+Use column types and nullable flags to identify:
+
+- **Implicit type conversions**: e.g. a VARCHAR predicate applied to an NVARCHAR column — causes CONVERT_IMPLICIT, preventing index use
+- **Non-nullable columns used in outer joins** — potential over-broad join semantics
+- **Computed columns that block predicate pushdown** — the optimizer cannot always push a predicate through a computed expression
+
+### Step 8 — Inspect current clustering columns (DW only)
+
+Call `get_cluster_columns` for each table (skip for SQL Analytics Endpoints). Returns the ordered list of CLUSTER BY columns, or an empty list if no clustering is defined.
+
+### Step 9 — Analyze clustering fit
+
+Compare current clustering columns (and their data types from step 6) against the WHERE predicates, JOIN keys, and aggregation patterns in the query plan. A good clustering candidate:
+
+- Appears frequently in range or equality predicates
+- Has relatively low cardinality
+- Is non-nullable
+- Uses a fixed-width type (INT, DATE, SMALLINT) rather than variable-length (VARCHAR)
+
+Note whether a table lacks clustering entirely but would benefit from it.
+
+### Step 10 — Present findings
+
+Summarize all findings in a structured report:
+
+1. **Expensive operators** — operator name, estimated subtree cost, row estimates
+2. **Missing or stale statistics** — table, column(s), issue description
+3. **Type-mismatch anti-patterns** — column, expected type vs. predicate type
+4. **Non-SARGable predicates** — expression and rewrite suggestion
+5. **Clustering assessment** — current columns vs. recommended columns per table
+
+### Step 11 — Propose optimizations
+
+For each finding, propose a concrete action:
+
+- **Statistics**: CREATE or UPDATE with FULLSCAN (or SAMPLE n PERCENT for large tables)
+- **Query rewrite**: explicit CAST to avoid CONVERT_IMPLICIT, predicate restructuring for SARGability
+- **Clustering**: recommend clustering column(s) with rationale from column metadata
+
+### Step 12 — Apply statistics changes (optional, confirm first)
+
+> **Requires explicit user confirmation before proceeding.** This is a write operation.
+
+If the user approves, apply statistics changes using `create_statistics` (for absent stats) or `update_statistics` (for stale stats). For large tables, prefer `update_statistics` with a SAMPLE percentage rather than FULLSCAN to limit execution time.
+
+### Step 13 — Re-cluster the table (optional, confirm first — destructive)
+
+> **Requires explicit user confirmation before proceeding.**
+>
+> **Warning:** `set_cluster_columns` performs a full transactional CTAS-swap. This is a complete copy of the table and may take significant time on large tables. During the operation the table is briefly unavailable. Dependent views and stored procedures that reference the table may need to be refreshed or re-validated after the rename completes. Only proceed after the user explicitly acknowledges these consequences.
+
+If the user approves and acknowledges the above, call `set_cluster_columns` with the recommended clustering columns.
+
+## Guardrails
+
+- Steps 12 and 13 each require separate, explicit user confirmation
+- Steps 8, 9, 11, and 13 apply only to Fabric Data Warehouses — skip them for SQL Analytics Endpoints
+- Stale-statistics detection is heuristic; always frame it as a flag, not a certainty
+- Do not run the original query against the warehouse during analysis — `get_query_plan` obtains the plan without execution

--- a/skills/query-optimizer/SKILL.md
+++ b/skills/query-optimizer/SKILL.md
@@ -31,12 +31,14 @@ If the warehouse is a SQL Analytics Endpoint, skip steps 8, 9, 11 (clustering), 
 
 Call `get_query_plan` with the query text. This returns a SHOWPLAN_XML document without executing the query.
 
-To visualize the plan, use the CLI:
+To visualize the plan, use the CLI (pass the warehouse name as the first argument and the query via `-q`):
 
 ```bash
-fdw sql plan "<query>" --format html   # open in browser for visual inspection
-fdw sql plan "<query>" --format svg    # embed or save as image
+fdw sql plan <warehouse> -q "<query>" --format html -o plan.html   # writes self-contained HTML; open plan.html in any browser
+fdw sql plan <workspace>/<warehouse> -q "<query>" --format svg -o plan.svg   # renders SVG via system dot binary (requires Graphviz)
 ```
+
+Note: `--format html` requires `-o/--output`; it writes a file and does not open the browser automatically.
 
 ### Step 2 — Parse the plan XML
 
@@ -105,23 +107,21 @@ For each finding, propose a concrete action:
 - **Query rewrite**: explicit CAST to avoid CONVERT_IMPLICIT, predicate restructuring for SARGability
 - **Clustering**: recommend clustering column(s) with rationale from column metadata
 
-### Step 12 — Apply statistics changes (optional, confirm first)
+### Step 12 — Apply statistics changes (optional — ask the user first)
 
-> **Requires explicit user confirmation before proceeding.** This is a write operation.
+> **Before calling any statistics tool, ask the user explicitly:** "Should I apply the statistics changes now?" The MCP server enforces its own write-guard (controlled by `FABRIC_MCP_ALLOW_WRITES` / `FABRIC_MCP_ALLOW_DESTRUCTIVE` server config), but it does not pop a user dialog — the agent must ask before proceeding.
 
-If the user approves, apply statistics changes using `create_statistics` (for absent stats) or `update_statistics` (for stale stats). For large tables, prefer `update_statistics` with a SAMPLE percentage rather than FULLSCAN to limit execution time.
+If the user confirms, apply statistics changes using `create_statistics` (for absent stats) or `update_statistics` (for stale stats). For large tables, prefer `update_statistics` with a SAMPLE percentage rather than FULLSCAN to limit execution time.
 
-### Step 13 — Re-cluster the table (optional, confirm first — destructive)
+### Step 13 — Re-cluster the table (optional — ask the user first, destructive)
 
-> **Requires explicit user confirmation before proceeding.**
->
-> **Warning:** `set_cluster_columns` performs a full transactional CTAS-swap. This is a complete copy of the table and may take significant time on large tables. During the operation the table is briefly unavailable. Dependent views and stored procedures that reference the table may need to be refreshed or re-validated after the rename completes. Only proceed after the user explicitly acknowledges these consequences.
+> **Before calling `set_cluster_columns`, ask the user explicitly and surface the following:** "`set_cluster_columns` performs a full transactional CTAS-swap — a complete physical copy of the table. This may take significant time on large tables, the table will be briefly unavailable during the swap, and dependent views or stored procedures may need refreshing afterwards. Should I proceed?" Only call the tool after the user explicitly acknowledges and approves.
 
-If the user approves and acknowledges the above, call `set_cluster_columns` with the recommended clustering columns.
+If the user confirms and acknowledges, call `set_cluster_columns` with the recommended clustering columns.
 
 ## Guardrails
 
-- Steps 12 and 13 each require separate, explicit user confirmation
+- Steps 12 and 13 are opt-in: the agent must ask the user for explicit confirmation before calling any write or destructive tool. The tools enforce a server-side write/destructive guard, but they do not prompt the user — that is the agent's responsibility.
 - Steps 8, 9, 11, and 13 apply only to Fabric Data Warehouses — skip them for SQL Analytics Endpoints
 - Stale-statistics detection is heuristic; always frame it as a flag, not a certainty
 - Do not run the original query against the warehouse during analysis — `get_query_plan` obtains the plan without execution

--- a/zensical.toml
+++ b/zensical.toml
@@ -40,6 +40,7 @@ nav = [
   ] },
   { "Reference" = [
     { "Authentication" = "authentication.md" },
+    { "Agent Skills" = "skills.md" },
     { "MCP server setup" = "mcp.md" },
     { "Exit codes" = "reference/exit-codes.md" },
     { "Shell Completion" = "completion.md" },


### PR DESCRIPTION
Closes #565

## Summary

- Adds `.claude-plugin/plugin.json` (CalVer `2026.6.0`) — must be bumped on every release that changes skill content
- Adds `skills/query-optimizer/SKILL.md` — 13-step query performance analysis workflow
- Adds `skills/dbt-setup/SKILL.md` — dbt-fabric project bootstrap workflow
- Adds `docs/skills.md` — documents both install paths (Claude Code plugin and raw SKILL.md download); added to nav in `zensical.toml`

## Test plan

- [x] `just lint` passes (ruff check + format)
- [x] Unit suite: 3981 tests pass, 0 failures
- [x] SKILL.md frontmatter validated: `name` ≤64 chars, `description` ≤1024 chars, lowercase-hyphen format
- [x] `plugin.json` is valid JSON
- [x] All referenced MCP tools verified to exist in `src/fabric_dw/mcp/tools/`
- [x] No reference to pastetheplan.com — plan visualisation uses `fdw sql plan --format html/svg`
- [x] `set_cluster_columns` referenced as intended (merging via #593)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LbL9CHHnzGrJTawxitHbWG