### PR TITLE
feat(tables): add table health-check command and tool (sp_get_table_health_metrics, SQL endpoint only)

### DIFF
--- a/docs/commands/tables.md
+++ b/docs/commands/tables.md
@@ -207,6 +207,29 @@ fdw -w MyWorkspace --json tables count SalesWH dbo.orders
 
 ---
 
+### tables health-check
+
+**Targets:** SQL Analytics Endpoint
+
+Run `sp_get_table_health_metrics` against a single table to surface Delta/Parquet layout issues (small files, fragmentation, excessive deletes/updates, delayed checkpoints) and decide whether maintenance is needed.
+
+The proc is Generally Available (announced at Build 2026) but Microsoft Learn has no dedicated reference page yet. Output columns are passed through verbatim — the exact column names and types are determined by the proc and may change across Fabric releases.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] tables health-check [ENDPOINT] QUALIFIED_NAME
+```
+
+**Example**
+
+```shell
+fdw -w MyWorkspace tables health-check MySqlEndpoint dbo.FactSales
+fdw -w MyWorkspace --json tables health-check MySqlEndpoint dbo.FactSales
+```
+
+---
+
 ### tables create
 
 **Targets:** Data Warehouse only
@@ -709,6 +732,26 @@ Return the data-clustering columns of a table, ordered by clustering ordinal. Re
 - `qualified_name` (`str`) — dot-separated table name, e.g. `dbo.sales`.
 
 **Returns:** `list[{ "column_name": str, "clustering_ordinal": int }]` — ordered by ascending `clustering_ordinal`.
+
+---
+
+### get_table_health_metrics
+
+**Targets:** SQL Analytics Endpoint
+
+Return health metrics for a table via `sp_get_table_health_metrics`. Only supported on SQL Analytics Endpoints (not Data Warehouses).
+
+The proc surfaces Delta/Parquet layout issues such as small files, fragmentation, excessive deletes/updates, and delayed checkpoints — useful for deciding whether table maintenance is needed.
+
+The proc is Generally Available (announced at Build 2026) but its output column schema is not yet documented by Microsoft. Columns and rows are passed through verbatim.
+
+**Parameters:**
+
+- `workspace` (`str`) — workspace name or GUID.
+- `item` (`str`) — SQL Analytics Endpoint name or GUID. Data Warehouses are rejected with a `ToolError`.
+- `qualified_name` (`str`) — dot-separated table name, e.g. `dbo.FactSales`.
+
+**Returns:** `{ "columns": list[str], "rows": list[list] }` — column names and rows passed through verbatim from the proc.
 
 ---
 

--- a/docs/commands/tables.md
+++ b/docs/commands/tables.md
@@ -207,29 +207,6 @@ fdw -w MyWorkspace --json tables count SalesWH dbo.orders
 
 ---
 
-### tables health-check
-
-**Targets:** SQL Analytics Endpoint
-
-Run `sp_get_table_health_metrics` against a single table to surface Delta/Parquet layout issues (small files, fragmentation, excessive deletes/updates, delayed checkpoints) and decide whether maintenance is needed.
-
-The proc is Generally Available (announced at Build 2026) but Microsoft Learn has no dedicated reference page yet. Output columns are passed through verbatim — the exact column names and types are determined by the proc and may change across Fabric releases.
-
-**Synopsis**
-
-```
-fdw [-w WORKSPACE] tables health-check [ENDPOINT] QUALIFIED_NAME
-```
-
-**Example**
-
-```shell
-fdw -w MyWorkspace tables health-check MySqlEndpoint dbo.FactSales
-fdw -w MyWorkspace --json tables health-check MySqlEndpoint dbo.FactSales
-```
-
----
-
 ### tables create
 
 **Targets:** Data Warehouse only
@@ -356,6 +333,29 @@ fdw [-w WORKSPACE] tables delete [OPTIONS] [WAREHOUSE] QUALIFIED_NAME
 
 ```shell
 fdw -w MyWorkspace --yes tables delete SalesWH dbo.orders_2026
+```
+
+---
+
+### tables health-check
+
+**Targets:** SQL Analytics Endpoint
+
+Run `sp_get_table_health_metrics` against a single table to surface Delta/Parquet layout issues (small files, fragmentation, excessive deletes/updates, delayed checkpoints) and decide whether maintenance is needed.
+
+The proc is Generally Available (announced at Build 2026) but Microsoft Learn has no dedicated reference page yet. Output columns are passed through verbatim — the exact column names and types are determined by the proc and may change across Fabric releases.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] tables health-check [ENDPOINT] QUALIFIED_NAME
+```
+
+**Example**
+
+```shell
+fdw -w MyWorkspace tables health-check MySqlEndpoint dbo.FactSales
+fdw -w MyWorkspace --json tables health-check MySqlEndpoint dbo.FactSales
 ```
 
 ---

--- a/src/fabric_dw/cli/commands/tables.py
+++ b/src/fabric_dw/cli/commands/tables.py
@@ -256,6 +256,42 @@ async def count_cmd(
         raise click.ClickException(str(exc)) from exc
 
 
+@tables_group.command("health-check")
+@click.argument("item", required=False, default=None)
+@click.argument("qualified_name")
+@click.pass_obj
+@coro
+async def health_check_cmd(
+    ctx: CliContext,
+    item: str | None,
+    qualified_name: str,
+) -> None:
+    """Run sp_get_table_health_metrics on QUALIFIED_NAME (schema.table) on ITEM.
+
+    Only supported on SQL Analytics Endpoints (not Data Warehouses).
+    The proc surfaces Delta/Parquet layout issues such as small files,
+    fragmentation, excessive deletes/updates, and delayed checkpoints.
+    Output columns are passed through verbatim — the proc is GA but its
+    column schema is not yet documented by Microsoft.
+    """
+    ws = resolve_workspace(ctx)
+    wh = resolve_warehouse_arg(ctx, item)
+    schema, table_name = parse_qualified_name(qualified_name, kind="table")
+    try:
+        async with build_http_client(ctx) as http:
+            target, entry = await build_sql_target(http, ws, wh)
+            columns, rows = await _tables_svc.get_table_health_metrics(
+                target, schema, table_name, kind=entry.kind, mode=ctx.auth
+            )
+            render(
+                [dict(zip(columns, row, strict=True)) for row in rows],
+                json_output=ctx.json_output,
+                table_title="Table Health Metrics",
+            )
+    except (ValueError, FabricError) as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
 @tables_group.command("create")
 @click.argument("item", required=False, default=None)
 @click.option("--name", "qualified_name", required=True, help="Qualified name: schema.table.")

--- a/src/fabric_dw/mcp/tools/tables.py
+++ b/src/fabric_dw/mcp/tools/tables.py
@@ -455,6 +455,52 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         ctx.resolver.clear_negative_cache()
         return result.model_dump(mode="json")
 
+    @mcp.tool(name="get_table_health_metrics")
+    async def get_table_health_metrics(
+        workspace: str,
+        item: str,
+        qualified_name: str,
+    ) -> dict[str, Any]:
+        """Return health metrics for a table via ``sp_get_table_health_metrics``.
+
+        Only supported on SQL Analytics Endpoints (not Data Warehouses).  The
+        proc surfaces Delta/Parquet layout issues such as small files,
+        fragmentation, excessive deletes/updates, and delayed checkpoints.
+
+        The stored procedure is Generally Available (announced at Build 2026)
+        but its output column schema is not yet documented by Microsoft.
+        Columns and rows are passed through verbatim.
+
+        Args:
+            workspace: Workspace name or GUID.
+            item: SQL Analytics Endpoint name or GUID.  Data Warehouses are
+                rejected with a ``ToolError``.
+            qualified_name: Dot-separated qualified table name, e.g. ``dbo.sales``.
+        """
+        schema, table_name = parse_qualified_name(qualified_name, kind="table")
+        assert_workspace_allowed(workspace)
+        ctx = get_context()
+        try:
+            ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
+            assert_workspace_allowed(workspace, str(ws_id))
+            _log.debug(
+                "get_table_health_metrics ws=%s item=%s table=%s.%s",
+                ws_id,
+                entry.id,
+                schema,
+                table_name,
+            )
+            target = make_sql_target(ws_id, entry, item)
+            columns, rows = await tables_svc.get_table_health_metrics(
+                target, schema, table_name, kind=entry.kind, mode=ctx.auth_mode
+            )
+        except (ValueError, FabricError) as exc:
+            raise tool_err(exc) from exc
+        return {
+            "columns": columns,
+            "rows": safe_rows(rows),
+        }
+
     @mutating_tool(mcp, "rename_table")
     async def rename_table(
         workspace: str, item: str, qualified_name: str, new_name: str

--- a/src/fabric_dw/services/tables.py
+++ b/src/fabric_dw/services/tables.py
@@ -15,6 +15,7 @@ Public API
 - :func:`clear_table`             — ``TRUNCATE TABLE [schema].[table]``.
 - :func:`rename_table`            — ``EXEC sp_rename`` (Data-Warehouse-only).
 - :func:`recluster_table`         — transactional CTAS-swap to change (or remove) clustering.
+- :func:`get_table_health_metrics` — ``EXEC sp_get_table_health_metrics`` (SQL endpoint only).
 
 List-source note
 ----------------
@@ -51,6 +52,7 @@ __all__ = [
     "create_table_from_parquet",
     "delete_table",
     "get_cluster_columns",
+    "get_table_health_metrics",
     "infer_columns_from_csv",
     "infer_columns_from_parquet",
     "list_tables",
@@ -70,6 +72,10 @@ _SQL_ENDPOINT_READONLY_MSG = "SQL Endpoints are read-only; CREATE/DROP/TRUNCATE 
 _SQL_ENDPOINT_CLUSTERING_MSG = (
     "Data clustering is not supported on SQL Analytics Endpoints; use a Fabric Data Warehouse"
 )
+_WAREHOUSE_HEALTH_CHECK_MSG = (
+    "Table health-check (sp_get_table_health_metrics) is only "
+    "available on SQL Analytics Endpoints, not Data Warehouses."
+)
 
 
 def _assert_not_sql_endpoint(kind: WarehouseKind) -> None:
@@ -83,6 +89,22 @@ def _assert_not_sql_endpoint(kind: WarehouseKind) -> None:
     """
     if kind == WarehouseKind.SQL_ENDPOINT:
         raise ItemKindError(_SQL_ENDPOINT_READONLY_MSG)
+
+
+def _assert_sql_endpoint(kind: WarehouseKind) -> None:
+    """Raise :class:`~fabric_dw.exceptions.ItemKindError` for non-SQL-Endpoint items.
+
+    ``sp_get_table_health_metrics`` targets the SQL Analytics Endpoint over
+    lakehouse Delta tables only — it is not available on Data Warehouses.
+
+    Args:
+        kind: The :class:`~fabric_dw.models.WarehouseKind` of the resolved item.
+
+    Raises:
+        ItemKindError: If *kind* is not :attr:`~fabric_dw.models.WarehouseKind.SQL_ENDPOINT`.
+    """
+    if kind != WarehouseKind.SQL_ENDPOINT:
+        raise ItemKindError(_WAREHOUSE_HEALTH_CHECK_MSG)
 
 
 # ---------------------------------------------------------------------------
@@ -128,6 +150,12 @@ WHERE s.name = ? AND t.name = ?;
 # sp_rename: @objname = 'schema.oldtable', @newname = 'newtable', @objtype = 'OBJECT'
 # Names are bound as ? parameters (string args to the proc, not SQL identifiers).
 _SP_RENAME_SQL = "EXEC sp_rename ?, ?, 'OBJECT'"
+
+# sp_get_table_health_metrics: single positional arg is the two-part name as a string
+# literal.  The name is built from validated/quoted identifiers so no raw user input
+# is ever embedded.  The literal is enclosed in single quotes as T-SQL requires.
+# The output schema is GA-but-undocumented; columns are passed through generically.
+_SP_TABLE_HEALTH_METRICS_SQL = "EXEC sp_get_table_health_metrics '{schema}.{table}'"
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -1100,6 +1128,68 @@ async def recluster_table(
 
     await asyncio.to_thread(_run)
     return await _fetch_table(target, schema, table_name, mode=mode)
+
+
+async def get_table_health_metrics(
+    target: SqlTarget,
+    schema: str,
+    table_name: str,
+    *,
+    kind: WarehouseKind = WarehouseKind.WAREHOUSE,
+    mode: CredentialMode = CredentialMode.DEFAULT,
+) -> tuple[list[str], list[tuple[object, ...]]]:
+    """Return health metrics for *schema*.*table_name* via ``sp_get_table_health_metrics``.
+
+    Executes ``EXEC sp_get_table_health_metrics 'schema.table'`` against the
+    SQL Analytics Endpoint and passes the result set through generically.  The
+    stored procedure was announced as Generally Available at Build 2026 but has
+    no dedicated Microsoft Learn reference page yet, so the exact output columns
+    are undocumented — they are returned as-is (columns + rows).
+
+    The proc surfaces common Delta/Parquet layout problems — small files,
+    fragmentation, excessive deletes/updates, and delayed checkpoints — so
+    callers can decide whether maintenance is needed.
+
+    Args:
+        target: The SQL Analytics Endpoint to query.  Data Warehouses are
+            rejected with :class:`~fabric_dw.exceptions.ItemKindError`.
+        schema: The schema name.  Must pass :func:`validate_identifier`.
+        table_name: The table name.  Must pass :func:`validate_identifier`.
+        kind: The :class:`~fabric_dw.models.WarehouseKind` of the item.
+            Only :attr:`~fabric_dw.models.WarehouseKind.SQL_ENDPOINT` is
+            accepted; Warehouse items raise :class:`~fabric_dw.exceptions.ItemKindError`.
+        mode: The credential mode for Entra authentication.
+
+    Returns:
+        A ``(columns, rows)`` tuple where *columns* is a list of column name
+        strings and *rows* is a list of row tuples.  The exact columns are
+        determined by the proc and are passed through verbatim.
+
+    Raises:
+        ItemKindError: If *kind* is not
+            :attr:`~fabric_dw.models.WarehouseKind.SQL_ENDPOINT`.
+            Message: ``"Table health-check (sp_get_table_health_metrics) is
+            only available on SQL Analytics Endpoints, not Data Warehouses."``.
+        ValueError: If *schema* or *table_name* fails identifier validation.
+        PermissionDeniedError: If the driver reports a permission error.
+        FabricError: If the engine reports an error executing the proc.
+    """
+    _assert_sql_endpoint(kind)
+    validate_identifier(schema)
+    validate_identifier(table_name)
+
+    # Build the two-part name from validated identifiers.  The identifier
+    # validator already rejects characters that could escape a string literal
+    # (quotes, brackets, semicolons, etc.) so this embedding is safe.
+    # We use the plain names (not bracket-quoted) because sp_get_table_health_metrics
+    # expects a plain 'schema.table' string literal, not an ODBC-quoted name.
+    sql = _SP_TABLE_HEALTH_METRICS_SQL.format(schema=schema, table=table_name)
+
+    def _run() -> tuple[list[str], list[tuple[object, ...]]]:
+        cols, rows = run_query(target, sql, mode=mode)
+        return cols, list(rows)
+
+    return await asyncio.to_thread(_run)
 
 
 async def rename_table(

--- a/src/fabric_dw/telemetry_commands.py
+++ b/src/fabric_dw/telemetry_commands.py
@@ -123,6 +123,7 @@ DOMAIN_MAP: dict[str, str] = {
     "delete_schema": "schemas",
     # Tables
     "get_table_columns": "tables",
+    "get_table_health_metrics": "tables",
     "list_tables": "tables",
     "read_table": "tables",
     "count_table_rows": "tables",

--- a/tests/unit/cli/commands/test_tables.py
+++ b/tests/unit/cli/commands/test_tables.py
@@ -2373,3 +2373,122 @@ class TestTablesClusterBy:
         # default on the runner fixture).
         assert "WARNING" in result.output
         assert "sp_rename" in result.output
+
+
+# ===========================================================================
+# tables health-check
+# ===========================================================================
+
+
+class TestTablesHealthCheck:
+    def test_health_check_exits_zero_on_endpoint(self, runner: CliRunner, cache_env: Path) -> None:
+        """health-check succeeds on a SQL Analytics Endpoint and renders table output."""
+        _ = cache_env
+        mock_http = AsyncMock()
+        fake_cols = ["issue", "severity"]
+        fake_rows: list[tuple[object, ...]] = [("small files", "medium")]
+        with (
+            patch(
+                "fabric_dw.cli.commands.tables.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.tables.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_sql_endpoint_entry())),
+            ),
+            patch(
+                "fabric_dw.services.tables.get_table_health_metrics",
+                new=AsyncMock(return_value=(fake_cols, fake_rows)),
+            ),
+        ):
+            result = runner.invoke(
+                cli, ["-w", WS_GUID, "tables", "health-check", SE_GUID, "dbo.FactSales"]
+            )
+        assert result.exit_code == 0, result.output
+
+    def test_health_check_json_output(self, runner: CliRunner, cache_env: Path) -> None:
+        """health-check with --json returns a list of dicts."""
+        _ = cache_env
+        mock_http = AsyncMock()
+        fake_cols = ["issue", "severity"]
+        fake_rows: list[tuple[object, ...]] = [("fragmentation", "high")]
+        with (
+            patch(
+                "fabric_dw.cli.commands.tables.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.tables.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_sql_endpoint_entry())),
+            ),
+            patch(
+                "fabric_dw.services.tables.get_table_health_metrics",
+                new=AsyncMock(return_value=(fake_cols, fake_rows)),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                ["-w", WS_GUID, "--json", "tables", "health-check", SE_GUID, "dbo.FactSales"],
+            )
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.output)
+        assert isinstance(parsed, list)
+        assert parsed[0]["issue"] == "fragmentation"
+        assert parsed[0]["severity"] == "high"
+
+    def test_health_check_warehouse_raises_click_exception(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """health-check on a Warehouse surfaces the ItemKindError as a ClickException."""
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.tables.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.tables.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.tables.get_table_health_metrics",
+                new=AsyncMock(
+                    side_effect=ItemKindError(
+                        "Table health-check (sp_get_table_health_metrics) is only "
+                        "available on SQL Analytics Endpoints, not Data Warehouses."
+                    )
+                ),
+            ),
+        ):
+            result = runner.invoke(
+                cli, ["-w", WS_GUID, "tables", "health-check", WH_GUID, "dbo.FactSales"]
+            )
+        assert result.exit_code != 0
+        assert "SQL Analytics Endpoints" in result.output
+
+    def test_health_check_empty_result(self, runner: CliRunner, cache_env: Path) -> None:
+        """health-check with an empty result set exits zero."""
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.tables.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.tables.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_sql_endpoint_entry())),
+            ),
+            patch(
+                "fabric_dw.services.tables.get_table_health_metrics",
+                new=AsyncMock(return_value=([], [])),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                ["-w", WS_GUID, "--json", "tables", "health-check", SE_GUID, "dbo.FactSales"],
+            )
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.output)
+        assert parsed == []

--- a/tests/unit/cli/commands/test_tables.py
+++ b/tests/unit/cli/commands/test_tables.py
@@ -2439,7 +2439,13 @@ class TestTablesHealthCheck:
     def test_health_check_warehouse_raises_click_exception(
         self, runner: CliRunner, cache_env: Path
     ) -> None:
-        """health-check on a Warehouse surfaces the ItemKindError as a ClickException."""
+        """health-check on a Warehouse raises via the real _assert_sql_endpoint guard.
+
+        The test passes a Warehouse-kind entry so that health_check_cmd forwards
+        kind=WarehouseKind.WAREHOUSE to the real service function, which calls
+        _assert_sql_endpoint and raises ItemKindError.  This verifies the CLI
+        wiring (kind=entry.kind) rather than just patching the service.
+        """
         _ = cache_env
         mock_http = AsyncMock()
         with (
@@ -2449,17 +2455,12 @@ class TestTablesHealthCheck:
             ),
             patch(
                 "fabric_dw.cli.commands.tables.build_sql_target",
+                # Warehouse entry — kind=WarehouseKind.WAREHOUSE
                 new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
             ),
-            patch(
-                "fabric_dw.services.tables.get_table_health_metrics",
-                new=AsyncMock(
-                    side_effect=ItemKindError(
-                        "Table health-check (sp_get_table_health_metrics) is only "
-                        "available on SQL Analytics Endpoints, not Data Warehouses."
-                    )
-                ),
-            ),
+            # Do NOT mock the service — let _assert_sql_endpoint fire for real.
+            # Patch open_connection so no real DB call is attempted.
+            patch("fabric_dw.sql.open_connection", return_value=MagicMock()),
         ):
             result = runner.invoke(
                 cli, ["-w", WS_GUID, "tables", "health-check", WH_GUID, "dbo.FactSales"]

--- a/tests/unit/mcp/tools/test_tables.py
+++ b/tests/unit/mcp/tools/test_tables.py
@@ -853,3 +853,124 @@ async def test_get_table_columns_works_on_sql_endpoint(mock_ctx, ctx_patch) -> N
         )
 
     assert isinstance(result, list)
+
+
+# ---------------------------------------------------------------------------
+# get_table_health_metrics — contract tests (read-only, SQL-endpoint-only)
+# ---------------------------------------------------------------------------
+
+
+async def test_get_table_health_metrics_is_registered() -> None:
+    """get_table_health_metrics is registered as an MCP tool."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    tool_names = {t.name for t in mcp._tool_manager.list_tools()}
+    assert "get_table_health_metrics" in tool_names
+
+
+async def test_get_table_health_metrics_is_not_mutating(
+    mock_ctx, ctx_patch, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """get_table_health_metrics must NOT require the FABRIC_MCP_ALLOW_MUTATING flag.
+
+    Mutating tools call ``assert_writes_allowed`` which raises ToolError when
+    ``FABRIC_MCP_ALLOW_MUTATING`` is unset.  A read-only tool must succeed
+    without that flag.
+    """
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    # Remove the mutating flag to ensure a read-only tool succeeds without it.
+    monkeypatch.delenv("FABRIC_MCP_ALLOW_MUTATING", raising=False)
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_sql_endpoint_entry())
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.tables.get_table_health_metrics",
+            new=AsyncMock(return_value=([], [])),
+        ),
+    ):
+        # Must NOT raise ToolError — read-only tools don't check writes_allowed.
+        result = await mcp._tool_manager.call_tool(
+            "get_table_health_metrics",
+            {"workspace": WS_NAME, "item": WH_NAME, "qualified_name": "dbo.FactSales"},
+        )
+    assert isinstance(result, dict)
+
+
+async def test_get_table_health_metrics_happy_path(mock_ctx, ctx_patch) -> None:
+    """get_table_health_metrics forwards args to the service and returns columns+rows."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_sql_endpoint_entry())
+
+    fake_cols = ["issue_type", "severity"]
+    fake_rows: list[tuple[object, ...]] = [("small_files", "medium")]
+    mock_svc = AsyncMock(return_value=(fake_cols, fake_rows))
+
+    with (
+        ctx_patch,
+        patch("fabric_dw.services.tables.get_table_health_metrics", new=mock_svc),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "get_table_health_metrics",
+            {"workspace": WS_NAME, "item": WH_NAME, "qualified_name": "dbo.FactSales"},
+        )
+
+    assert isinstance(result, dict)
+    assert result["columns"] == fake_cols
+    assert len(result["rows"]) == 1
+
+
+async def test_get_table_health_metrics_forwards_qualified_name(mock_ctx, ctx_patch) -> None:
+    """get_table_health_metrics parses the qualified name and passes schema + table to service."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_sql_endpoint_entry())
+    mock_svc = AsyncMock(return_value=([], []))
+
+    with (
+        ctx_patch,
+        patch("fabric_dw.services.tables.get_table_health_metrics", new=mock_svc),
+    ):
+        await mcp._tool_manager.call_tool(
+            "get_table_health_metrics",
+            {"workspace": WS_NAME, "item": WH_NAME, "qualified_name": "sales.Transactions"},
+        )
+
+    args, _kwargs = mock_svc.call_args
+    # service is called with positional: target, schema, table_name
+    assert args[1] == "sales"
+    assert args[2] == "Transactions"
+
+
+async def test_get_table_health_metrics_warehouse_raises_tool_error(mock_ctx, ctx_patch) -> None:
+    """get_table_health_metrics raises ToolError when service raises ItemKindError."""
+    from fabric_dw.exceptions import ItemKindError  # noqa: PLC0415
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    # Use a Warehouse entry so the service receives WarehouseKind.WAREHOUSE
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.tables.get_table_health_metrics",
+            new=AsyncMock(
+                side_effect=ItemKindError(
+                    "Table health-check (sp_get_table_health_metrics) is only "
+                    "available on SQL Analytics Endpoints, not Data Warehouses."
+                )
+            ),
+        ),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "get_table_health_metrics",
+            {"workspace": WS_NAME, "item": WH_NAME, "qualified_name": "dbo.FactSales"},
+        )

--- a/tests/unit/services/test_tables.py
+++ b/tests/unit/services/test_tables.py
@@ -1902,3 +1902,129 @@ class TestReclusterTable:
 
         assert call_kwargs["autocommit"] is False
         assert call_kwargs["commit_per_statement"] is False
+
+
+# ===========================================================================
+# get_table_health_metrics
+# ===========================================================================
+
+
+class TestGetTableHealthMetrics:
+    """Tests for the sp_get_table_health_metrics service function."""
+
+    async def test_emits_correct_sql(self) -> None:
+        """The exact SQL string emitted matches the expected EXEC statement."""
+        target = _make_target()
+        conn = _make_conn([], [])
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await tables.get_table_health_metrics(
+                target,
+                "dbo",
+                "FactSales",
+                kind=WarehouseKind.SQL_ENDPOINT,
+            )
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert call_sql == "EXEC sp_get_table_health_metrics 'dbo.FactSales'"
+
+    async def test_emits_correct_sql_other_schema(self) -> None:
+        """SQL is built correctly for a non-dbo schema."""
+        target = _make_target()
+        conn = _make_conn([], [])
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await tables.get_table_health_metrics(
+                target,
+                "sales",
+                "Transactions",
+                kind=WarehouseKind.SQL_ENDPOINT,
+            )
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert call_sql == "EXEC sp_get_table_health_metrics 'sales.Transactions'"
+
+    async def test_returns_columns_and_rows(self) -> None:
+        """Columns and rows are returned as-is (generic passthrough)."""
+        target = _make_target()
+        fake_cols = ["col_a", "col_b", "col_c"]
+        fake_rows: list[tuple[object, ...]] = [("v1", 42, True), ("v2", 0, False)]
+        conn = _make_conn(fake_rows, fake_cols)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            result_cols, result_rows = await tables.get_table_health_metrics(
+                target,
+                "dbo",
+                "FactSales",
+                kind=WarehouseKind.SQL_ENDPOINT,
+            )
+        assert result_cols == fake_cols
+        assert result_rows == fake_rows
+
+    async def test_returns_empty_rows_when_proc_returns_nothing(self) -> None:
+        """An empty result set is valid (no rows, but columns may be present)."""
+        target = _make_target()
+        conn = _make_conn([], [])
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            _cols, rows = await tables.get_table_health_metrics(
+                target,
+                "dbo",
+                "FactSales",
+                kind=WarehouseKind.SQL_ENDPOINT,
+            )
+        assert rows == []
+
+    async def test_warehouse_kind_raises_item_kind_error(self) -> None:
+        """Passing a Warehouse kind raises ItemKindError (inverse guard)."""
+        target = _make_target()
+        conn = _make_conn([], [])
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(ItemKindError, match="SQL Analytics Endpoints"),
+        ):
+            await tables.get_table_health_metrics(
+                target,
+                "dbo",
+                "FactSales",
+                kind=WarehouseKind.WAREHOUSE,
+            )
+
+    async def test_sql_endpoint_kind_is_allowed(self) -> None:
+        """SQL_ENDPOINT kind does not raise — the guard passes."""
+        target = _make_target()
+        conn = _make_conn([], [])
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            # Must not raise:
+            await tables.get_table_health_metrics(
+                target,
+                "dbo",
+                "FactSales",
+                kind=WarehouseKind.SQL_ENDPOINT,
+            )
+
+    async def test_invalid_schema_raises_value_error(self) -> None:
+        """Invalid schema identifier is rejected before SQL is emitted."""
+        target = _make_target()
+        conn = _make_conn([], [])
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(ValueError, match="Invalid SQL identifier"),
+        ):
+            await tables.get_table_health_metrics(
+                target,
+                "bad]schema",
+                "FactSales",
+                kind=WarehouseKind.SQL_ENDPOINT,
+            )
+
+    async def test_invalid_table_name_raises_value_error(self) -> None:
+        """Invalid table name identifier is rejected before SQL is emitted."""
+        target = _make_target()
+        conn = _make_conn([], [])
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(ValueError, match="Invalid SQL identifier"),
+        ):
+            await tables.get_table_health_metrics(
+                target,
+                "dbo",
+                "bad;table",
+                kind=WarehouseKind.SQL_ENDPOINT,
+            )


### PR DESCRIPTION
Closes #594

## Summary

- Adds `tables health-check [ENDPOINT] QUALIFIED_NAME` CLI command that executes `EXEC sp_get_table_health_metrics '<schema>.<table>'` against a SQL Analytics Endpoint.
- Adds `get_table_health_metrics(workspace, item, qualified_name)` MCP tool (read-only, not a mutating tool).
- Adds `_assert_sql_endpoint(kind)` inverse guard in `services/tables.py` that rejects Warehouses and allows only `WarehouseKind.SQL_ENDPOINT`.
- Output columns/rows are passed through generically — the proc is GA (announced Build 2026) but its column schema is not yet documented by Microsoft.
- Telemetry: `"get_table_health_metrics": "tables"` added to `DOMAIN_MAP`.
- Docs: new alphabetical section in `docs/commands/tables.md` with CLI + MCP co-located, `fdw` examples, and a note about the GA-but-undocumented columns.

## Live integration test deferred

The integration test needs a seeded SQL Analytics Endpoint table via the `shared_sql_endpoint` fixture currently being built in a separate PR (#592 PR1) that is not yet merged. Unit coverage is complete; the live integration test will be added once #592 PR1 lands.