### PR TITLE
test(integration): run cheap read commands against SQL endpoints via read_target (endpoint coverage 2/5)

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1082,6 +1082,43 @@ async def warehouse_schema(
 
 
 # ---------------------------------------------------------------------------
+# Dual-target read fixture (warehouse + SQL analytics endpoint)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(
+    params=[
+        pytest.param("warehouse"),
+        pytest.param("sql_endpoint", marks=pytest.mark.sql_endpoint),
+    ]
+)
+def read_target(
+    request: pytest.FixtureRequest,
+    shared_warehouse: SharedWarehouseTarget,
+    shared_sql_endpoint: SharedSqlEndpointTarget,
+) -> SqlTarget:
+    """Parametrized fixture that yields the read :class:`~fabric_dw.sql.SqlTarget`.
+
+    Runs each requesting test TWICE: once against the shared warm warehouse and
+    once against the shared SQL analytics endpoint.  The endpoint leg carries
+    ``pytest.mark.sql_endpoint`` so it is excluded from local runs (via
+    ``addopts = "-m 'not … sql_endpoint'"`` in pyproject.toml) and opted-in
+    explicitly on CI.
+
+    Both targets expose the same read-only seed schema (``sample``) with
+    ``sample.colors`` and ``sample.numbers`` — use :data:`SEED_SCHEMA_NAME`
+    to refer to it in assertions.
+
+    **Tests that request this fixture MUST NOT mutate the seed schema.**
+    For mutating (DDL) tests on both targets, use the ``mutable_schema_target``
+    fixture (added in PR 3).
+    """
+    if request.param == "warehouse":
+        return shared_warehouse.sql_target
+    return shared_sql_endpoint.sql_target
+
+
+# ---------------------------------------------------------------------------
 # Legacy function-scoped fixtures (kept for tests that need a dedicated item)
 # ---------------------------------------------------------------------------
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1085,19 +1085,24 @@ async def warehouse_schema(
 # Dual-target read fixture (warehouse + SQL analytics endpoint)
 # ---------------------------------------------------------------------------
 
+# Symbolic constants for the two read_target param values.  Reused in both
+# pytest.param() calls and the if-branch so a typo is caught at definition
+# time rather than silently routing tests to the wrong target.
+_PARAM_WAREHOUSE = "warehouse"
+_PARAM_SQL_ENDPOINT = "sql_endpoint"
+
 
 @pytest.fixture(
     params=[
-        pytest.param("warehouse"),
-        pytest.param("sql_endpoint", marks=pytest.mark.sql_endpoint),
+        pytest.param(_PARAM_WAREHOUSE),
+        pytest.param(_PARAM_SQL_ENDPOINT, marks=pytest.mark.sql_endpoint),
     ]
 )
 def read_target(
     request: pytest.FixtureRequest,
     shared_warehouse: SharedWarehouseTarget,
-    shared_sql_endpoint: SharedSqlEndpointTarget,
 ) -> SqlTarget:
-    """Parametrized fixture that yields the read :class:`~fabric_dw.sql.SqlTarget`.
+    """Parametrized fixture that returns the read :class:`~fabric_dw.sql.SqlTarget`.
 
     Runs each requesting test TWICE: once against the shared warm warehouse and
     once against the shared SQL analytics endpoint.  The endpoint leg carries
@@ -1110,12 +1115,24 @@ def read_target(
     to refer to it in assertions.
 
     **Tests that request this fixture MUST NOT mutate the seed schema.**
-    For mutating (DDL) tests on both targets, use the ``mutable_schema_target``
-    fixture (added in PR 3).
+    Mutating dual-target tests will use a future fixture (see #592).
+
+    Implementation note
+    -------------------
+    ``shared_sql_endpoint`` is resolved LAZILY via ``request.getfixturevalue``
+    only on the ``sql_endpoint`` leg.  It is intentionally NOT declared as a
+    signature parameter — that would cause pytest to provision the SQL analytics
+    endpoint (~6 min Lakehouse create + poll + seed) even for the ``[warehouse]``
+    leg and during local ``-m "not sql_endpoint"`` runs, which must stay fast and
+    free of endpoint provisioning.
     """
-    if request.param == "warehouse":
+    if request.param == _PARAM_WAREHOUSE:
         return shared_warehouse.sql_target
-    return shared_sql_endpoint.sql_target
+    if request.param == _PARAM_SQL_ENDPOINT:
+        ep: SharedSqlEndpointTarget = request.getfixturevalue("shared_sql_endpoint")
+        return ep.sql_target
+    msg = f"Unknown read_target param: {request.param!r}"
+    raise ValueError(msg)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_services_schemas.py
+++ b/tests/integration/test_services_schemas.py
@@ -7,7 +7,7 @@ Fixture notes:
   warm warehouse and the shared SQL analytics endpoint.
 - ``warehouse_schema``: creates a uniquely-named schema in the shared warm warehouse
   and cascade-drops it on teardown.  Used for tests that create or delete schemas
-  (warehouse-only, because schema DDL on the endpoint is covered in PR 3).
+  (warehouse-only for now; dual-target schema DDL will be added in a follow-up, see #592).
 
 Design: The schema-CRUD tests below create *additional* schemas inside the
 shared warehouse (not inside ``warehouse_schema``'s isolation schema, because

--- a/tests/integration/test_services_schemas.py
+++ b/tests/integration/test_services_schemas.py
@@ -2,12 +2,12 @@
 
 Run with: pytest -m integration tests/integration/test_services_schemas.py
 
-Fixture note: uses ``shared_warehouse`` (for read-only / listing tests) and
-``warehouse_schema`` (for tests that create or delete schemas) from conftest.
-``warehouse_schema`` itself creates a uniquely-named schema in the shared warm
-warehouse and cascade-drops it on teardown, so all nested schemas created by
-the tests below are cleaned up by that outer cascade or by the test's own
-try/finally block.
+Fixture notes:
+- ``read_target`` (parametrized): runs read-only listing tests against both the shared
+  warm warehouse and the shared SQL analytics endpoint.
+- ``warehouse_schema``: creates a uniquely-named schema in the shared warm warehouse
+  and cascade-drops it on teardown.  Used for tests that create or delete schemas
+  (warehouse-only, because schema DDL on the endpoint is covered in PR 3).
 
 Design: The schema-CRUD tests below create *additional* schemas inside the
 shared warehouse (not inside ``warehouse_schema``'s isolation schema, because
@@ -27,6 +27,8 @@ from fabric_dw.models import Schema
 from fabric_dw.services import schemas, tables
 from fabric_dw.sql import SqlTarget
 
+from .conftest import SEED_SCHEMA_NAME
+
 pytestmark = pytest.mark.integration
 
 
@@ -38,6 +40,22 @@ pytestmark = pytest.mark.integration
 def _unique_schema_name() -> str:
     """Return a short, collision-resistant schema name safe for Fabric DDL."""
     return f"pytest_{uuid.uuid4().hex[:8]}"
+
+
+# ---------------------------------------------------------------------------
+# Dual-target read test — runs against both warehouse and SQL analytics endpoint
+# via the parametrized ``read_target`` fixture.
+# ---------------------------------------------------------------------------
+
+
+async def test_list_schemas_includes_seed_schema(
+    read_target: SqlTarget,
+) -> None:
+    """list_schemas must include the pre-seeded ``sample`` schema on both targets."""
+    result = await schemas.list_schemas(read_target)
+    assert isinstance(result, list)
+    schema_names = {s.name for s in result}
+    assert SEED_SCHEMA_NAME in schema_names
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_services_sql_exec.py
+++ b/tests/integration/test_services_sql_exec.py
@@ -1,7 +1,7 @@
 """Integration tests for services.sql_exec — requires a live Fabric warehouse.
 
-Fixture note: uses ``shared_warehouse`` from conftest.  The SELECT 1 probe is
-read-only and safe to run on the shared warm warehouse without any schema isolation.
+Fixture note: the SELECT 1 probe is read-only and runs against both the shared
+warm warehouse and the shared SQL analytics endpoint via ``read_target``.
 """
 
 from __future__ import annotations
@@ -11,16 +11,13 @@ import pytest
 from fabric_dw.services import sql_exec
 from fabric_dw.sql import SqlTarget
 
-from .conftest import SharedWarehouseTarget
-
 pytestmark = pytest.mark.integration
 
 
 async def test_select_1_returns_expected_result(
-    shared_warehouse: SharedWarehouseTarget,
+    read_target: SqlTarget,
 ) -> None:
     """SELECT 1 AS hello must return columns=['hello'] and rows=[[1]]."""
-    sql_target: SqlTarget = shared_warehouse.sql_target
-    result = await sql_exec.execute(sql_target, "SELECT 1 AS hello")
+    result = await sql_exec.execute(read_target, "SELECT 1 AS hello")
     assert result.columns == ["hello"]
     assert result.rows == [[1]]

--- a/tests/integration/test_services_tables.py
+++ b/tests/integration/test_services_tables.py
@@ -2,9 +2,13 @@
 
 Run with: pytest -m integration tests/integration/test_services_tables.py
 
-Fixture note: uses ``warehouse_schema`` from conftest, which creates a uniquely-named
-schema inside the session-shared warm warehouse and cascade-drops it on teardown.
-All tables are created inside that schema so tests are fully isolated from one another.
+Fixture notes:
+- ``read_target`` (parametrized): runs read-only tests against both the shared warm
+  warehouse and the shared SQL analytics endpoint.  Tests use the pre-seeded
+  ``sample`` schema (``sample.colors`` / ``sample.numbers``).
+- ``warehouse_schema``: creates a uniquely-named schema inside the session-shared
+  warm warehouse and cascade-drops it on teardown.  Used exclusively for mutating
+  tests (CREATE / DROP / CLEAR / RENAME / CLONE).
 """
 
 from __future__ import annotations
@@ -17,11 +21,52 @@ import pytest
 
 from fabric_dw.exceptions import FabricError, NotFoundError
 from fabric_dw.models import Table
+from fabric_dw.services import columns as columns_svc
 from fabric_dw.services import tables
 from fabric_dw.sql import SqlTarget, run_query
 
+from .conftest import SEED_SCHEMA_NAME
+
 pytestmark = pytest.mark.integration
 
+# ---------------------------------------------------------------------------
+# Dual-target read tests — run against both warehouse and SQL analytics endpoint
+# via the parametrized ``read_target`` fixture.  All assertions are made against
+# the pre-seeded ``sample`` schema (sample.colors / sample.numbers).
+# ---------------------------------------------------------------------------
+
+
+async def test_read_table_returns_seeded_rows(
+    read_target: SqlTarget,
+) -> None:
+    """read_table against sample.colors must return the three seeded rows."""
+    cols, rows = await tables.read_table(read_target, SEED_SCHEMA_NAME, "colors", count=10)
+    assert "id" in cols
+    assert "name" in cols
+    # Exactly three rows were seeded (red / green / blue).
+    assert len(rows) == 3
+
+
+async def test_count_table_rows_on_seeded_table(
+    read_target: SqlTarget,
+) -> None:
+    """count_table_rows on sample.colors must return 3 (the seeded row count)."""
+    count = await tables.count_table_rows(read_target, SEED_SCHEMA_NAME, "colors")
+    assert isinstance(count, int)
+    assert count == 3
+
+
+async def test_get_table_columns_on_seeded_table(
+    read_target: SqlTarget,
+) -> None:
+    """get_object_columns on sample.colors must return id and name columns."""
+    result = await columns_svc.get_object_columns(read_target, SEED_SCHEMA_NAME, "colors")
+    assert len(result) == 2
+    col_names = {c["name"] for c in result}
+    assert col_names == {"id", "name"}
+
+
+# ---------------------------------------------------------------------------
 # Fragments that indicate the SQL engine rejected an AT timestamp because the
 # table has no committed history at the requested point in time.  These are
 # expected and trigger a pytest.skip rather than a test failure.

--- a/tests/integration/test_services_tables.py
+++ b/tests/integration/test_services_tables.py
@@ -8,7 +8,8 @@ Fixture notes:
   ``sample`` schema (``sample.colors`` / ``sample.numbers``).
 - ``warehouse_schema``: creates a uniquely-named schema inside the session-shared
   warm warehouse and cascade-drops it on teardown.  Used exclusively for mutating
-  tests (CREATE / DROP / CLEAR / RENAME / CLONE).
+  tests (CREATE / DROP / CLEAR / RENAME / CLONE — warehouse-only for now; dual-target
+  mutating tests will follow in a later PR, see #592).
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Part of #592

## Changes

Add a parametrized `read_target` fixture in `conftest.py` with two params:
- `"warehouse"` → `shared_warehouse.sql_target`
- `"sql_endpoint"` → `shared_sql_endpoint.sql_target` (carries `pytest.mark.sql_endpoint`)

Migrate the cheapest read tests to use `read_target` so they run against both targets:

- `test_services_sql_exec.py` — `SELECT 1` test
- `test_services_tables.py` — three new read-only tests (`read_table`, `count_table_rows`, `get_table_columns`) querying the pre-seeded `sample.colors` table
- `test_services_schemas.py` — `list_schemas` test asserting the seeded `sample` schema is present

All existing warehouse-only mutating tests (`warehouse_schema`-based) are untouched.

## Verification

Live smoke run against workspace `5279405f-0122-4c18-b476-e1c4ec22a367`:
```
22 passed in 120.85s
```
Both `[warehouse]` and `[sql_endpoint]` parametrizations passed for every migrated test.