### PR TITLE
test(integration): run object-DDL (views/procs/functions/schemas) against SQL endpoints via mutable_schema_target (endpoint coverage 3/5)

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1136,6 +1136,63 @@ def read_target(
 
 
 # ---------------------------------------------------------------------------
+# Dual-target mutable schema fixture (warehouse + SQL analytics endpoint)
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture(
+    params=[
+        pytest.param(_PARAM_WAREHOUSE),
+        pytest.param(_PARAM_SQL_ENDPOINT, marks=pytest.mark.sql_endpoint),
+    ]
+)
+async def mutable_schema_target(
+    request: pytest.FixtureRequest,
+    shared_warehouse: SharedWarehouseTarget,
+) -> AsyncIterator[tuple[SqlTarget, str]]:
+    """Parametrized fixture that creates an isolated schema on each SQL target.
+
+    Runs each requesting test TWICE: once on the shared warm warehouse and once
+    on the shared SQL analytics endpoint.  The endpoint leg carries
+    ``pytest.mark.sql_endpoint`` so it is excluded from local runs (via
+    ``addopts = "-m 'not … sql_endpoint'"`` in pyproject.toml) and opted-in
+    explicitly on CI.
+
+    Yields ``(sql_target, schema_name)`` where *schema_name* is a uniquely-named
+    schema (``pytest_<8-hex-chars>``) that has already been created on *sql_target*.
+    Teardown cascade-drops the schema on the same target, so any views/procedures/
+    functions created inside it are cleaned up automatically.
+
+    Implementation note
+    -------------------
+    ``shared_sql_endpoint`` is resolved LAZILY via ``request.getfixturevalue``
+    only on the ``sql_endpoint`` leg — identical pattern to ``read_target``.  It
+    is intentionally NOT declared as a signature parameter to avoid provisioning
+    the SQL analytics endpoint during local runs or the ``[warehouse]`` leg.
+
+    Both ``create_schema`` and ``delete_schema(cascade=True)`` are themselves
+    dual-target (no ``_assert_not_sql_endpoint`` guard), so the isolation and
+    teardown mechanism works identically on both targets.
+    """
+    if request.param == _PARAM_WAREHOUSE:
+        sql_target = shared_warehouse.sql_target
+    elif request.param == _PARAM_SQL_ENDPOINT:
+        ep: SharedSqlEndpointTarget = request.getfixturevalue("shared_sql_endpoint")
+        sql_target = ep.sql_target
+    else:
+        msg = f"Unknown mutable_schema_target param: {request.param!r}"
+        raise ValueError(msg)
+
+    schema_name = f"pytest_{uuid.uuid4().hex[:8]}"
+    await schemas.create_schema(sql_target, schema_name)
+    try:
+        yield sql_target, schema_name
+    finally:
+        with contextlib.suppress(Exception):
+            await schemas.delete_schema(sql_target, schema_name, cascade=True)
+
+
+# ---------------------------------------------------------------------------
 # Legacy function-scoped fixtures (kept for tests that need a dedicated item)
 # ---------------------------------------------------------------------------
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -72,7 +72,8 @@ _SNAP_SQL_READINESS_POLL_S = 5.0
 
 # Name of the read-only seed schema pre-populated in the shared warehouse.
 # Tests that only READ data (list / get / query) may use this schema directly.
-# Tests that mutate state MUST use the ``warehouse_schema`` fixture instead.
+# Dual-target mutating tests MUST use the ``mutable_schema_target`` fixture;
+# ``warehouse_schema`` is for DWH-only DDL (e.g. tables) only.
 SEED_SCHEMA_NAME = "sample"
 
 
@@ -1115,7 +1116,7 @@ def read_target(
     to refer to it in assertions.
 
     **Tests that request this fixture MUST NOT mutate the seed schema.**
-    Mutating dual-target tests will use a future fixture (see #592).
+    Mutating dual-target tests use the ``mutable_schema_target`` fixture instead.
 
     Implementation note
     -------------------

--- a/tests/integration/test_services_functions.py
+++ b/tests/integration/test_services_functions.py
@@ -64,11 +64,10 @@ RETURN (SELECT 1 AS id WHERE 1 >= @min_val)
 
 
 async def test_list_functions_returns_list(
-    mutable_schema_target: tuple[SqlTarget, str],
+    read_target: SqlTarget,
 ) -> None:
-    """list_functions on the shared warehouse must return a (possibly empty) list."""
-    sql_target, _schema = mutable_schema_target
-    result = await functions.list_functions(sql_target)
+    """list_functions on either target must return a (possibly empty) list."""
+    result = await functions.list_functions(read_target)
     assert isinstance(result, list)
 
 

--- a/tests/integration/test_services_functions.py
+++ b/tests/integration/test_services_functions.py
@@ -2,14 +2,15 @@
 
 Run with: pytest -m integration tests/integration/test_services_functions.py
 
-Fixture note: uses ``warehouse_schema`` from conftest, which creates a uniquely-named
-schema inside the session-shared warm warehouse and cascade-drops it on teardown.
-All functions created here are created inside that schema; the schema cascade drop
-handles cleanup, with additional try/finally guards for mid-test failures.
+Fixture note: uses ``mutable_schema_target`` from conftest, which creates a
+uniquely-named schema on BOTH the shared warm warehouse and the shared SQL analytics
+endpoint, then cascade-drops it on teardown.  All functions are created inside that
+schema; the cascade drop handles cleanup, with additional try/finally guards for
+mid-test failures.
 
-The SQL Analytics Endpoint read test uses ``ephemeral_sql_endpoint`` (SQL Analytics
-Endpoint, a ``Warehouse`` object typed as ``WarehouseKind.SQL_ENDPOINT``) because
-the shared warehouse fixture does not cover endpoint-only behaviour.
+The ``mutable_schema_target`` fixture is parametrized over two targets:
+  - ``[warehouse]``     — Data Warehouse (always runs)
+  - ``[sql_endpoint]``  — SQL Analytics Endpoint (``pytest.mark.sql_endpoint``, CI only)
 
 Note on scope:
 - Scalar UDFs and inline TVFs are **preview** features on Fabric DW as of mid-2026.
@@ -22,12 +23,11 @@ Note on scope:
 from __future__ import annotations
 
 import contextlib
-from uuid import UUID
 
 import pytest
 
 from fabric_dw.exceptions import NotFoundError
-from fabric_dw.models import FunctionDetails, FunctionKind, Warehouse
+from fabric_dw.models import FunctionDetails, FunctionKind
 from fabric_dw.services import functions
 from fabric_dw.sql import SqlTarget
 
@@ -64,19 +64,19 @@ RETURN (SELECT 1 AS id WHERE 1 >= @min_val)
 
 
 async def test_list_functions_returns_list(
-    warehouse_schema: tuple[SqlTarget, str],
+    mutable_schema_target: tuple[SqlTarget, str],
 ) -> None:
     """list_functions on the shared warehouse must return a (possibly empty) list."""
-    sql_target, _schema = warehouse_schema
+    sql_target, _schema = mutable_schema_target
     result = await functions.list_functions(sql_target)
     assert isinstance(result, list)
 
 
 async def test_create_scalar_function_returns_function_details(
-    warehouse_schema: tuple[SqlTarget, str],
+    mutable_schema_target: tuple[SqlTarget, str],
 ) -> None:
     """create_function must return FunctionDetails with correct schema/name/kind."""
-    sql_target, schema = warehouse_schema
+    sql_target, schema = mutable_schema_target
     fn_name = "pytest_fns_create_scalar"
 
     try:
@@ -96,10 +96,10 @@ async def test_create_scalar_function_returns_function_details(
 
 
 async def test_list_functions_includes_created_function(
-    warehouse_schema: tuple[SqlTarget, str],
+    mutable_schema_target: tuple[SqlTarget, str],
 ) -> None:
     """A newly created function must appear in list_functions results."""
-    sql_target, schema = warehouse_schema
+    sql_target, schema = mutable_schema_target
     fn_name = "pytest_fns_list"
 
     try:
@@ -123,10 +123,10 @@ async def test_list_functions_includes_created_function(
 
 
 async def test_list_functions_kind_filter_scalar(
-    warehouse_schema: tuple[SqlTarget, str],
+    mutable_schema_target: tuple[SqlTarget, str],
 ) -> None:
     """list_functions with kind='scalar' must only return FN functions."""
-    sql_target, schema = warehouse_schema
+    sql_target, schema = mutable_schema_target
     fn_name = "pytest_fns_kind_scalar"
 
     try:
@@ -141,10 +141,10 @@ async def test_list_functions_kind_filter_scalar(
 
 
 async def test_get_function_returns_definition(
-    warehouse_schema: tuple[SqlTarget, str],
+    mutable_schema_target: tuple[SqlTarget, str],
 ) -> None:
     """get_function must return FunctionDetails with definition and parameters populated."""
-    sql_target, schema = warehouse_schema
+    sql_target, schema = mutable_schema_target
     fn_name = "pytest_fns_get"
 
     try:
@@ -164,19 +164,19 @@ async def test_get_function_returns_definition(
 
 
 async def test_get_function_raises_not_found_for_missing_function(
-    warehouse_schema: tuple[SqlTarget, str],
+    mutable_schema_target: tuple[SqlTarget, str],
 ) -> None:
     """get_function must raise NotFoundError when the function does not exist."""
-    sql_target, schema = warehouse_schema
+    sql_target, schema = mutable_schema_target
     with pytest.raises(NotFoundError):
         await functions.get_function(sql_target, schema, "pytest_fns_does_not_exist_xyz")
 
 
 async def test_update_function_changes_definition(
-    warehouse_schema: tuple[SqlTarget, str],
+    mutable_schema_target: tuple[SqlTarget, str],
 ) -> None:
     """update_function must redefine the function and return the updated definition."""
-    sql_target, schema = warehouse_schema
+    sql_target, schema = mutable_schema_target
     fn_name = "pytest_fns_update"
 
     try:
@@ -192,10 +192,10 @@ async def test_update_function_changes_definition(
 
 
 async def test_drop_function_removes_function(
-    warehouse_schema: tuple[SqlTarget, str],
+    mutable_schema_target: tuple[SqlTarget, str],
 ) -> None:
     """drop_function must remove the function so it no longer appears in list_functions."""
-    sql_target, schema = warehouse_schema
+    sql_target, schema = mutable_schema_target
     fn_name = "pytest_fns_drop"
 
     await functions.create_function(sql_target, schema, fn_name, _SCALAR_INLINEABLE_BODY)
@@ -216,10 +216,10 @@ async def test_drop_function_removes_function(
 
 
 async def test_rename_function_roundtrip(
-    warehouse_schema: tuple[SqlTarget, str],
+    mutable_schema_target: tuple[SqlTarget, str],
 ) -> None:
     """rename_function must rename the function and return updated details."""
-    sql_target, schema = warehouse_schema
+    sql_target, schema = mutable_schema_target
     fn_name = "pytest_fns_rename_src"
     new_name = "pytest_fns_rename_dst"
 
@@ -243,10 +243,10 @@ async def test_rename_function_roundtrip(
 
 
 async def test_create_function_full_roundtrip(
-    warehouse_schema: tuple[SqlTarget, str],
+    mutable_schema_target: tuple[SqlTarget, str],
 ) -> None:
     """End-to-end: create -> list -> get -> update -> rename -> drop."""
-    sql_target, schema = warehouse_schema
+    sql_target, schema = mutable_schema_target
     fn_name = "pytest_fns_roundtrip"
     renamed = "pytest_fns_roundtrip_v2"
 
@@ -289,11 +289,11 @@ async def test_create_function_full_roundtrip(
 
 
 async def test_create_inline_tvf_and_list_by_kind(
-    warehouse_schema: tuple[SqlTarget, str],
+    mutable_schema_target: tuple[SqlTarget, str],
 ) -> None:
     """create_function with an inline TVF body must return kind=inline_tvf
     and list_functions with kind='inline_tvf' must include it."""
-    sql_target, schema = warehouse_schema
+    sql_target, schema = mutable_schema_target
     fn_name = "pytest_fns_inline_tvf"
 
     try:
@@ -315,24 +315,3 @@ async def test_create_inline_tvf_and_list_by_kind(
     finally:
         with contextlib.suppress(Exception):
             await functions.drop_function(sql_target, schema, fn_name)
-
-
-# ---------------------------------------------------------------------------
-# SQL Analytics Endpoint — list is allowed (no endpoint guard on functions)
-# ---------------------------------------------------------------------------
-
-
-async def test_list_functions_on_sql_analytics_endpoint(
-    ephemeral_sql_endpoint: Warehouse,
-    workspace_id: UUID,
-) -> None:
-    """list_functions on a SQL analytics endpoint must succeed (read OK, no guard)."""
-    if ephemeral_sql_endpoint.connection_string is None:
-        pytest.skip("SQL analytics endpoint has no connection string")
-    target = SqlTarget(
-        workspace_id=str(workspace_id),
-        database=ephemeral_sql_endpoint.name,
-        connection_string=ephemeral_sql_endpoint.connection_string,
-    )
-    result = await functions.list_functions(target)
-    assert isinstance(result, list)

--- a/tests/integration/test_services_procedures.py
+++ b/tests/integration/test_services_procedures.py
@@ -2,15 +2,19 @@
 
 Run with: pytest -m integration tests/integration/test_services_procedures.py
 
-Fixture note: uses ``warehouse_schema`` from conftest, which creates a uniquely-named
-schema inside the session-shared warm warehouse and cascade-drops it on teardown.
-All procedures created here are created inside that schema; the schema cascade drop
-handles cleanup, with additional try/finally guards for mid-test failures.
+Fixture note: uses ``mutable_schema_target`` from conftest, which creates a
+uniquely-named schema on BOTH the shared warm warehouse and the shared SQL analytics
+endpoint, then cascade-drops it on teardown.  All procedures are created inside that
+schema; the cascade drop handles cleanup, with additional try/finally guards for
+mid-test failures.
 
-Note on scope: stored procedures are supported on **both** Fabric Data Warehouses
-and SQL Analytics Endpoints.  The ``warehouse_schema`` fixture points at a warehouse;
-a separate endpoint variant is not set up here because endpoint tests require a
-Lakehouse, which is out of scope.  The service itself has no endpoint guard.
+The ``mutable_schema_target`` fixture is parametrized over two targets:
+  - ``[warehouse]``     — Data Warehouse (always runs)
+  - ``[sql_endpoint]``  — SQL Analytics Endpoint (``pytest.mark.sql_endpoint``, CI only)
+
+Stored procedures are supported on **both** Fabric Data Warehouses and SQL Analytics
+Endpoints.  The service has no ``_assert_not_sql_endpoint`` guard — this file proves
+it on both targets.
 """
 
 from __future__ import annotations
@@ -28,19 +32,19 @@ pytestmark = pytest.mark.integration
 
 
 async def test_list_procedures_returns_list(
-    warehouse_schema: tuple[SqlTarget, str],
+    mutable_schema_target: tuple[SqlTarget, str],
 ) -> None:
     """list_procedures on the shared warehouse must return a list."""
-    sql_target, _schema = warehouse_schema
+    sql_target, _schema = mutable_schema_target
     result = await procedures.list_procedures(sql_target)
     assert isinstance(result, list)
 
 
 async def test_create_procedure_returns_procedure_object(
-    warehouse_schema: tuple[SqlTarget, str],
+    mutable_schema_target: tuple[SqlTarget, str],
 ) -> None:
     """create_procedure must return a StoredProcedure with the correct schema/name."""
-    sql_target, schema = warehouse_schema
+    sql_target, schema = mutable_schema_target
     proc_name = "pytest_procs_create"
     body = "BEGIN SELECT 1 AS id, 'hello' AS greeting END"
 
@@ -58,10 +62,10 @@ async def test_create_procedure_returns_procedure_object(
 
 
 async def test_list_procedures_includes_created_procedure(
-    warehouse_schema: tuple[SqlTarget, str],
+    mutable_schema_target: tuple[SqlTarget, str],
 ) -> None:
     """A newly created procedure must appear in list_procedures results."""
-    sql_target, schema = warehouse_schema
+    sql_target, schema = mutable_schema_target
     proc_name = "pytest_procs_list"
     body = "BEGIN SELECT 42 AS answer END"
 
@@ -85,10 +89,10 @@ async def test_list_procedures_includes_created_procedure(
 
 
 async def test_get_procedure_returns_definition(
-    warehouse_schema: tuple[SqlTarget, str],
+    mutable_schema_target: tuple[SqlTarget, str],
 ) -> None:
     """get_procedure must return the StoredProcedure with its definition populated."""
-    sql_target, schema = warehouse_schema
+    sql_target, schema = mutable_schema_target
     proc_name = "pytest_procs_get"
     body = "BEGIN SELECT 99 AS magic_number END"
 
@@ -107,19 +111,19 @@ async def test_get_procedure_returns_definition(
 
 
 async def test_get_procedure_raises_not_found_for_missing_procedure(
-    warehouse_schema: tuple[SqlTarget, str],
+    mutable_schema_target: tuple[SqlTarget, str],
 ) -> None:
     """get_procedure must raise NotFoundError when the procedure does not exist."""
-    sql_target, schema = warehouse_schema
+    sql_target, schema = mutable_schema_target
     with pytest.raises(NotFoundError):
         await procedures.get_procedure(sql_target, schema, "pytest_procs_does_not_exist")
 
 
 async def test_update_procedure_changes_definition(
-    warehouse_schema: tuple[SqlTarget, str],
+    mutable_schema_target: tuple[SqlTarget, str],
 ) -> None:
     """update_procedure must redefine the procedure and return the updated definition."""
-    sql_target, schema = warehouse_schema
+    sql_target, schema = mutable_schema_target
     proc_name = "pytest_procs_update"
     original_body = "BEGIN SELECT 1 AS version END"
     updated_body = "BEGIN SELECT 2 AS version, 'updated' AS status END"
@@ -137,10 +141,10 @@ async def test_update_procedure_changes_definition(
 
 
 async def test_drop_procedure_removes_procedure(
-    warehouse_schema: tuple[SqlTarget, str],
+    mutable_schema_target: tuple[SqlTarget, str],
 ) -> None:
     """drop_procedure must remove the procedure so it no longer appears in list_procedures."""
-    sql_target, schema = warehouse_schema
+    sql_target, schema = mutable_schema_target
     proc_name = "pytest_procs_drop"
     body = "BEGIN SELECT 0 AS placeholder END"
 
@@ -162,12 +166,12 @@ async def test_drop_procedure_removes_procedure(
 
 
 async def test_create_procedure_full_roundtrip(
-    warehouse_schema: tuple[SqlTarget, str],
+    mutable_schema_target: tuple[SqlTarget, str],
 ) -> None:
     """End-to-end: create -> list -> get (definition contains body) -> update (definition
     changes) -> drop.
     """
-    sql_target, schema = warehouse_schema
+    sql_target, schema = mutable_schema_target
     proc_name = "pytest_procs_roundtrip"
     v1_body = "BEGIN SELECT 1 AS n END"
     v2_body = "BEGIN SELECT 2 AS n, 'v2' AS label END"

--- a/tests/integration/test_services_procedures.py
+++ b/tests/integration/test_services_procedures.py
@@ -32,11 +32,10 @@ pytestmark = pytest.mark.integration
 
 
 async def test_list_procedures_returns_list(
-    mutable_schema_target: tuple[SqlTarget, str],
+    read_target: SqlTarget,
 ) -> None:
-    """list_procedures on the shared warehouse must return a list."""
-    sql_target, _schema = mutable_schema_target
-    result = await procedures.list_procedures(sql_target)
+    """list_procedures on either target must return a list."""
+    result = await procedures.list_procedures(read_target)
     assert isinstance(result, list)
 
 

--- a/tests/integration/test_services_schemas.py
+++ b/tests/integration/test_services_schemas.py
@@ -5,15 +5,21 @@ Run with: pytest -m integration tests/integration/test_services_schemas.py
 Fixture notes:
 - ``read_target`` (parametrized): runs read-only listing tests against both the shared
   warm warehouse and the shared SQL analytics endpoint.
+- ``mutable_schema_target``: creates a uniquely-named schema on BOTH the shared warm
+  warehouse and the shared SQL analytics endpoint, then cascade-drops it on teardown.
+  Used for schema-CRUD tests that create additional schemas on the same target.
 - ``warehouse_schema``: creates a uniquely-named schema in the shared warm warehouse
-  and cascade-drops it on teardown.  Used for tests that create or delete schemas
-  (warehouse-only for now; dual-target schema DDL will be added in a follow-up, see #592).
+  and cascade-drops it on teardown.  Used only for the cascade-drops-table test,
+  which relies on ``tables.create_table`` (Data Warehouse only).
 
-Design: The schema-CRUD tests below create *additional* schemas inside the
-shared warehouse (not inside ``warehouse_schema``'s isolation schema, because
-schemas cannot be nested on Fabric).  Each test is responsible for deleting
-its own schema in a finally block.  The shared warehouse teardown at session
-end provides a backstop.
+The ``mutable_schema_target`` fixture is parametrized over two targets:
+  - ``[warehouse]``     — Data Warehouse (always runs)
+  - ``[sql_endpoint]``  — SQL Analytics Endpoint (``pytest.mark.sql_endpoint``, CI only)
+
+Design: The schema-CRUD tests below create *additional* schemas inside the target
+(not inside ``mutable_schema_target``'s isolation schema, because schemas cannot be
+nested on Fabric).  Each test is responsible for deleting its own schema in a finally
+block.  The shared warehouse/endpoint teardown at session end provides a backstop.
 """
 
 from __future__ import annotations
@@ -24,7 +30,7 @@ import uuid
 import pytest
 
 from fabric_dw.models import Schema
-from fabric_dw.services import schemas, tables
+from fabric_dw.services import schemas, tables, views
 from fabric_dw.sql import SqlTarget
 
 from .conftest import SEED_SCHEMA_NAME
@@ -101,16 +107,19 @@ async def test_list_schemas_excludes_system_schemas(
 
 
 # ---------------------------------------------------------------------------
-# Mutating tests — each creates its own uniquely-named schema on the shared
-# warehouse and cleans it up in a finally block.
+# Mutating tests — dual-target via ``mutable_schema_target``.
+#
+# Each test creates an *additional* uniquely-named schema on the same target
+# that ``mutable_schema_target`` already points at, then cleans it up in a
+# finally block.
 # ---------------------------------------------------------------------------
 
 
 async def test_create_schema_returns_schema_model(
-    warehouse_schema: tuple[SqlTarget, str],
+    mutable_schema_target: tuple[SqlTarget, str],
 ) -> None:
-    """create_schema returns a Schema with the correct name."""
-    sql_target, _parent_schema = warehouse_schema
+    """create_schema returns a Schema with the correct name on both targets."""
+    sql_target, _parent_schema = mutable_schema_target
     name = _unique_schema_name()
     try:
         created = await schemas.create_schema(sql_target, name)
@@ -123,10 +132,10 @@ async def test_create_schema_returns_schema_model(
 
 
 async def test_create_list_delete_roundtrip(
-    warehouse_schema: tuple[SqlTarget, str],
+    mutable_schema_target: tuple[SqlTarget, str],
 ) -> None:
-    """Create a schema, verify it appears in list_schemas, then delete it."""
-    sql_target, _parent_schema = warehouse_schema
+    """Create a schema, verify it appears in list_schemas, then delete it on both targets."""
+    sql_target, _parent_schema = mutable_schema_target
     name = _unique_schema_name()
     try:
         await schemas.create_schema(sql_target, name)
@@ -157,6 +166,11 @@ async def test_delete_schema_cascade_drops_table(
     2. Create a table inside that schema.
     3. Call delete_schema(cascade=True) — must succeed without a "schema not empty" error.
     4. Verify the schema is gone from list_schemas.
+
+    Note: kept on ``warehouse_schema`` (Data Warehouse only) because
+    ``tables.create_table`` is rejected on SQL Analytics Endpoints.  The
+    endpoint variant of cascade is covered by
+    ``test_delete_schema_cascade_drops_view_on_endpoint``.
     """
     sql_target, _parent_schema = warehouse_schema
     schema_name = _unique_schema_name()
@@ -189,11 +203,45 @@ async def test_delete_schema_cascade_drops_table(
             await schemas.delete_schema(sql_target, schema_name)
 
 
-async def test_delete_plain_schema_no_cascade(
-    warehouse_schema: tuple[SqlTarget, str],
+async def test_delete_schema_cascade_drops_view_on_endpoint(
+    mutable_schema_target: tuple[SqlTarget, str],
 ) -> None:
-    """delete_schema without cascade succeeds on an empty schema."""
-    sql_target, _parent_schema = warehouse_schema
+    """delete_schema(cascade=True) drops contained views before dropping the schema.
+
+    Mirrors ``test_delete_schema_cascade_drops_table`` but uses a view (dual-target)
+    instead of a table (DWH-only), so this test runs on both the warehouse and the
+    SQL analytics endpoint via ``mutable_schema_target``.
+    """
+    sql_target, _parent_schema = mutable_schema_target
+    schema_name = _unique_schema_name()
+    view_name = "pytest_cascade_view"
+
+    try:
+        await schemas.create_schema(sql_target, schema_name)
+
+        # Create a view inside the new schema so the schema is non-empty.
+        await views.create_view(sql_target, schema_name, view_name, "SELECT 1 AS id")
+
+        # cascade=True must drop the view then the schema without raising.
+        await schemas.delete_schema(sql_target, schema_name, cascade=True)
+
+        after_delete = await schemas.list_schemas(sql_target)
+        after_names = {s.name for s in after_delete}
+        assert schema_name not in after_names, (
+            f"Schema {schema_name!r} still present after cascade delete"
+        )
+    finally:
+        with contextlib.suppress(Exception):
+            await views.drop_view(sql_target, schema_name, view_name)
+        with contextlib.suppress(Exception):
+            await schemas.delete_schema(sql_target, schema_name)
+
+
+async def test_delete_plain_schema_no_cascade(
+    mutable_schema_target: tuple[SqlTarget, str],
+) -> None:
+    """delete_schema without cascade succeeds on an empty schema on both targets."""
+    sql_target, _parent_schema = mutable_schema_target
     name = _unique_schema_name()
     try:
         await schemas.create_schema(sql_target, name)

--- a/tests/integration/test_services_schemas.py
+++ b/tests/integration/test_services_schemas.py
@@ -200,7 +200,7 @@ async def test_delete_schema_cascade_drops_table(
         with contextlib.suppress(Exception):
             await tables.delete_table(sql_target, schema_name, table_name)
         with contextlib.suppress(Exception):
-            await schemas.delete_schema(sql_target, schema_name)
+            await schemas.delete_schema(sql_target, schema_name, cascade=True)
 
 
 async def test_delete_schema_cascade_drops_view_on_endpoint(
@@ -234,7 +234,7 @@ async def test_delete_schema_cascade_drops_view_on_endpoint(
         with contextlib.suppress(Exception):
             await views.drop_view(sql_target, schema_name, view_name)
         with contextlib.suppress(Exception):
-            await schemas.delete_schema(sql_target, schema_name)
+            await schemas.delete_schema(sql_target, schema_name, cascade=True)
 
 
 async def test_delete_plain_schema_no_cascade(

--- a/tests/integration/test_services_views.py
+++ b/tests/integration/test_services_views.py
@@ -28,11 +28,10 @@ pytestmark = pytest.mark.integration
 
 
 async def test_list_views_returns_list(
-    mutable_schema_target: tuple[SqlTarget, str],
+    read_target: SqlTarget,
 ) -> None:
     """list_views on either target must return a list (may be non-empty)."""
-    sql_target, _schema = mutable_schema_target
-    result = await views.list_views(sql_target)
+    result = await views.list_views(read_target)
     assert isinstance(result, list)
 
 

--- a/tests/integration/test_services_views.py
+++ b/tests/integration/test_services_views.py
@@ -2,10 +2,15 @@
 
 Run with: pytest -m integration tests/integration/test_services_views.py
 
-Fixture note: uses ``warehouse_schema`` from conftest, which creates a uniquely-named
-schema inside the session-shared warm warehouse and cascade-drops it on teardown.
-All views created here are created inside that schema and cleaned up by the schema
-cascade drop, with additional try/finally guards for mid-test failures.
+Fixture note: uses ``mutable_schema_target`` from conftest, which creates a
+uniquely-named schema on BOTH the shared warm warehouse and the shared SQL analytics
+endpoint, then cascade-drops it on teardown.  All views are created inside that
+schema and cleaned up by the cascade drop, with additional try/finally guards for
+mid-test failures.
+
+The ``mutable_schema_target`` fixture is parametrized over two targets:
+  - ``[warehouse]``     — Data Warehouse (always runs)
+  - ``[sql_endpoint]``  — SQL Analytics Endpoint (``pytest.mark.sql_endpoint``, CI only)
 """
 
 from __future__ import annotations
@@ -23,19 +28,19 @@ pytestmark = pytest.mark.integration
 
 
 async def test_list_views_returns_list(
-    warehouse_schema: tuple[SqlTarget, str],
+    mutable_schema_target: tuple[SqlTarget, str],
 ) -> None:
-    """list_views on the shared warehouse must return a list (may be non-empty)."""
-    sql_target, _schema = warehouse_schema
+    """list_views on either target must return a list (may be non-empty)."""
+    sql_target, _schema = mutable_schema_target
     result = await views.list_views(sql_target)
     assert isinstance(result, list)
 
 
 async def test_create_view_returns_view_object(
-    warehouse_schema: tuple[SqlTarget, str],
+    mutable_schema_target: tuple[SqlTarget, str],
 ) -> None:
     """create_view must return a View with the correct schema/name."""
-    sql_target, schema = warehouse_schema
+    sql_target, schema = mutable_schema_target
     view_name = "pytest_views_create"
     select_body = "SELECT 1 AS id, 'hello' AS greeting"
 
@@ -53,10 +58,10 @@ async def test_create_view_returns_view_object(
 
 
 async def test_list_views_includes_created_view(
-    warehouse_schema: tuple[SqlTarget, str],
+    mutable_schema_target: tuple[SqlTarget, str],
 ) -> None:
     """A newly created view must appear in list_views results."""
-    sql_target, schema = warehouse_schema
+    sql_target, schema = mutable_schema_target
     view_name = "pytest_views_list"
     select_body = "SELECT 42 AS answer"
 
@@ -81,10 +86,10 @@ async def test_list_views_includes_created_view(
 
 
 async def test_get_view_returns_definition(
-    warehouse_schema: tuple[SqlTarget, str],
+    mutable_schema_target: tuple[SqlTarget, str],
 ) -> None:
     """get_view must return the View with its definition populated."""
-    sql_target, schema = warehouse_schema
+    sql_target, schema = mutable_schema_target
     view_name = "pytest_views_get"
     select_body = "SELECT 99 AS magic_number"
 
@@ -103,19 +108,19 @@ async def test_get_view_returns_definition(
 
 
 async def test_get_view_raises_not_found_for_missing_view(
-    warehouse_schema: tuple[SqlTarget, str],
+    mutable_schema_target: tuple[SqlTarget, str],
 ) -> None:
     """get_view must raise NotFoundError when the view does not exist."""
-    sql_target, schema = warehouse_schema
+    sql_target, schema = mutable_schema_target
     with pytest.raises(NotFoundError):
         await views.get_view(sql_target, schema, "pytest_views_does_not_exist")
 
 
 async def test_read_view_returns_columns_and_rows(
-    warehouse_schema: tuple[SqlTarget, str],
+    mutable_schema_target: tuple[SqlTarget, str],
 ) -> None:
     """read_view must return (columns, rows) where columns contains expected names."""
-    sql_target, schema = warehouse_schema
+    sql_target, schema = mutable_schema_target
     view_name = "pytest_views_read"
     select_body = "SELECT 7 AS lucky_number, 'world' AS message"
 
@@ -139,19 +144,19 @@ async def test_read_view_returns_columns_and_rows(
 
 
 async def test_read_view_raises_not_found_for_missing_view(
-    warehouse_schema: tuple[SqlTarget, str],
+    mutable_schema_target: tuple[SqlTarget, str],
 ) -> None:
     """read_view must raise NotFoundError when the view does not exist."""
-    sql_target, schema = warehouse_schema
+    sql_target, schema = mutable_schema_target
     with pytest.raises(NotFoundError):
         await views.read_view(sql_target, schema, "pytest_views_read_missing")
 
 
 async def test_update_view_changes_definition(
-    warehouse_schema: tuple[SqlTarget, str],
+    mutable_schema_target: tuple[SqlTarget, str],
 ) -> None:
     """update_view must redefine the view and return the updated definition."""
-    sql_target, schema = warehouse_schema
+    sql_target, schema = mutable_schema_target
     view_name = "pytest_views_update"
     original_body = "SELECT 1 AS version"
     updated_body = "SELECT 2 AS version, 'updated' AS status"
@@ -175,10 +180,10 @@ async def test_update_view_changes_definition(
 
 
 async def test_drop_view_removes_view(
-    warehouse_schema: tuple[SqlTarget, str],
+    mutable_schema_target: tuple[SqlTarget, str],
 ) -> None:
     """drop_view must remove the view so it no longer appears in list_views."""
-    sql_target, schema = warehouse_schema
+    sql_target, schema = mutable_schema_target
     view_name = "pytest_views_drop"
     select_body = "SELECT 0 AS placeholder"
 
@@ -200,10 +205,10 @@ async def test_drop_view_removes_view(
 
 
 async def test_create_view_full_roundtrip(
-    warehouse_schema: tuple[SqlTarget, str],
+    mutable_schema_target: tuple[SqlTarget, str],
 ) -> None:
     """End-to-end: create → list → get → read → update → read → drop."""
-    sql_target, schema = warehouse_schema
+    sql_target, schema = mutable_schema_target
     view_name = "pytest_views_roundtrip"
     v1_body = "SELECT 1 AS n"
     v2_body = "SELECT 2 AS n, 'v2' AS label"
@@ -242,10 +247,10 @@ async def test_create_view_full_roundtrip(
 
 
 async def test_rename_view_creates_new_and_removes_old(
-    warehouse_schema: tuple[SqlTarget, str],
+    mutable_schema_target: tuple[SqlTarget, str],
 ) -> None:
     """rename_view must make the old name disappear and the new name appear."""
-    sql_target, schema = warehouse_schema
+    sql_target, schema = mutable_schema_target
     old_name = "pytest_views_rename_old"
     new_name = "pytest_views_rename_new"
     qualified = f"{schema}.{old_name}"
@@ -289,10 +294,10 @@ async def test_rename_view_creates_new_and_removes_old(
 
 
 async def test_count_view_rows_returns_nonnegative_int(
-    warehouse_schema: tuple[SqlTarget, str],
+    mutable_schema_target: tuple[SqlTarget, str],
 ) -> None:
     """count_view_rows must return a non-negative integer for a real view."""
-    sql_target, schema = warehouse_schema
+    sql_target, schema = mutable_schema_target
     view_name = "pytest_views_count"
     select_body = "SELECT 1 AS id UNION ALL SELECT 2 AS id"
 


### PR DESCRIPTION
## Summary

- Add `mutable_schema_target` fixture to `conftest.py`: a parametrized session-scoped fixture that mirrors `warehouse_schema` but runs against **both** the shared Data Warehouse and the shared SQL Analytics Endpoint (endpoint leg gated behind `pytest.mark.sql_endpoint`). Each parameter creates a uniquely-named schema on its target and cascade-drops it on teardown.
- Migrate all mutating object-DDL integration tests to `mutable_schema_target` so each runs once per target: views CRUD (`create/list/get/read/update/drop/rename/count`), procedures CRUD, functions CRUD, schemas create/delete/cascade.
- Remove the now-redundant `test_list_functions_on_sql_analytics_endpoint` (was using the legacy per-test `ephemeral_sql_endpoint` — the endpoint leg is now covered by the parametrized fixture).
- Add `test_delete_schema_cascade_drops_view_on_endpoint` (dual-target cascade variant using a view, since `tables.create_table` is DWH-only; the table-based cascade test is kept on `warehouse_schema`).

## Discovery results (live, run before migrating)

All four domains CRUD on the SQL Analytics Endpoint — **PASSED**:

| Domain | Operations tested | Result |
|---|---|---|
| schemas | `create_schema`, `delete_schema`, `delete_schema(cascade=True)` | PASSED |
| views | `create_view`, `list_views`, `get_view`, `update_view`, `drop_view` | PASSED |
| procedures | `create_procedure`, `get_procedure`, `update_procedure`, `drop_procedure` | PASSED |
| functions | `create_function`, `get_function`, `update_function`, `drop_function` | PASSED |

No domain was found to be broken — all four are confirmed dual-target. No PR3b split needed.

## Files changed

- `tests/integration/conftest.py` — `mutable_schema_target` fixture added after `read_target`
- `tests/integration/test_services_views.py` — all tests migrated from `warehouse_schema` → `mutable_schema_target`
- `tests/integration/test_services_procedures.py` — all tests migrated from `warehouse_schema` → `mutable_schema_target`
- `tests/integration/test_services_functions.py` — migrated + old `ephemeral_sql_endpoint` test removed
- `tests/integration/test_services_schemas.py` — CRUD tests migrated + new view-based cascade test added

Part of #592

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>