### PR TITLE
docs: add Agent Skills card to the home page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -28,4 +28,8 @@ Both the CLI and the MCP server surfaces are built from a single Python package 
 
     MCP server tools for AI assistant integration.
 
+- :material-puzzle: **[Agent Skills](skills.md)**
+
+    Multi-step admin workflows for AI assistants.
+
 </div>


### PR DESCRIPTION
Add a fourth grid card on the docs home page linking to `skills.md`, matching the style and order of the existing Install, Commands, and MCP Reference cards.