### PR TITLE
build: single-source plugin.json version from stable release tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,6 +48,29 @@ jobs:
         with:
           python-version: "3.13"
 
+      - name: Verify plugin.json version matches tag (stable releases only)
+        # Run only for tag/dispatch releases; skip for dev builds pushed to main.
+        # Prerelease tags (aN/bN/rcN/.devN) are exempt — plugin.json tracks stable only.
+        # Fails fast before uv build if the version bump was not merged before tagging.
+        if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
+        run: |
+          # Determine the effective tag: prefer the workflow_dispatch input, fall back to ref name.
+          effective_tag="${{ inputs.tag || github.ref_name }}"
+          # Strip a leading 'v'.
+          version="${effective_tag#v}"
+          # Skip prerelease tags (aN/bN/rcN suffixes or .dev in the version string).
+          if echo "$version" | grep -qE '(a|b|rc)[0-9]*$|\.dev'; then
+            echo "Prerelease tag '$version' detected — plugin.json tracks stable only; skipping version check."
+            exit 0
+          fi
+          # Stable tag: read plugin.json version and compare.
+          plugin_version=$(python -c "import json; print(json.load(open('.claude-plugin/plugin.json'))['version'])")
+          if [ "$plugin_version" != "$version" ]; then
+            echo "::error::plugin.json version ('$plugin_version') does not match tag '$version'. Run 'just release $version', open a release-prep PR, merge it, then retag."
+            exit 1
+          fi
+          echo "plugin.json version '$plugin_version' matches tag '$version' — OK."
+
       - run: uv sync --frozen --no-dev
 
       - run: uv build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,19 +52,20 @@ jobs:
         # Run only for tag/dispatch releases; skip for dev builds pushed to main.
         # Prerelease tags (aN/bN/rcN/.devN) are exempt — plugin.json tracks stable only.
         # Fails fast before uv build if the version bump was not merged before tagging.
+        # The context value is passed via env: to avoid ${{ }} script-injection into the run body.
         if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
+        env:
+          EFFECTIVE_TAG: ${{ inputs.tag || github.ref_name }}
         run: |
-          # Determine the effective tag: prefer the workflow_dispatch input, fall back to ref name.
-          effective_tag="${{ inputs.tag || github.ref_name }}"
-          # Strip a leading 'v'.
-          version="${effective_tag#v}"
+          # Strip a leading 'v' from the env-provided tag value.
+          version="${EFFECTIVE_TAG#v}"
           # Skip prerelease tags (aN/bN/rcN suffixes or .dev in the version string).
           if echo "$version" | grep -qE '(a|b|rc)[0-9]*$|\.dev'; then
             echo "Prerelease tag '$version' detected — plugin.json tracks stable only; skipping version check."
             exit 0
           fi
           # Stable tag: read plugin.json version and compare.
-          plugin_version=$(python -c "import json; print(json.load(open('.claude-plugin/plugin.json'))['version'])")
+          plugin_version=$(python3 -c "import json; print(json.load(open('.claude-plugin/plugin.json'))['version'])")
           if [ "$plugin_version" != "$version" ]; then
             echo "::error::plugin.json version ('$plugin_version') does not match tag '$version'. Run 'just release $version', open a release-prep PR, merge it, then retag."
             exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,6 +119,16 @@ just audit
 just build
 ```
 
+## Releasing
+
+The plugin version (`plugin.json`) is single-sourced from stable git tags. The flow:
+
+1. **Bump** — run `just release X.Y.Z` (e.g. `just release 2026.6.0`) to write the stable calver into `plugin.json`. Open a release-prep PR and merge it.
+2. **Tag** — after the bump PR is merged, run `just tag X.Y.Z`. This asserts `plugin.json` agrees with the version before creating and pushing the annotated tag.
+3. **Publish** — the `Publish` CI workflow fires on the tag push. It enforces the same version match (failing fast before the build if they disagree), then ships the package to PyPI and creates a GitHub Release.
+
+Prerelease tags (`aN`/`bN`/`rcN`/`.devN`) skip the `plugin.json` check — plugin.json always reflects the latest stable release only.
+
 ## Code of Conduct
 
 By participating in this project you agree to abide by the [Code of Conduct](CODE_OF_CONDUCT.md).

--- a/justfile
+++ b/justfile
@@ -34,6 +34,45 @@ integration:
 build:
     uv build
 
+# Bump plugin.json to VERSION (must be a stable calver like 2026.6.0; no prerelease suffixes).
+# Run: just release VERSION  →  open a release-prep PR  →  merge  →  just tag VERSION
+release VERSION:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if ! echo "{{ VERSION }}" | grep -qE '^[0-9]{4}\.[0-9]{1,2}\.[0-9]+$'; then
+        echo "error: '{{ VERSION }}' is not a stable calver (expected YYYY.M.N with no prerelease suffix)" >&2
+        exit 1
+    fi
+    plugin_json=".claude-plugin/plugin.json"
+    # Replace only the version value; keep key order, indentation, and trailing newline byte-identical.
+    # sed -i '' on macOS; sed -i on Linux — detect via uname.
+    if [ "$(uname)" = "Darwin" ]; then
+        sed -i '' 's/"version": "[^"]*"/"version": "{{ VERSION }}"/' "$plugin_json"
+    else
+        sed -i 's/"version": "[^"]*"/"version": "{{ VERSION }}"/' "$plugin_json"
+    fi
+    echo "plugin.json version set to {{ VERSION }}"
+    echo ""
+    echo "Next steps:"
+    echo "  1. git add .claude-plugin/plugin.json && git commit -m 'build: release {{ VERSION }}'"
+    echo "  2. Open a release-prep PR and merge it to main."
+    echo "  3. After merge: just tag {{ VERSION }}"
+
+# Assert plugin.json version matches VERSION, then create and push an annotated git tag.
+# Run after the release-prep PR (from 'just release VERSION') has been merged to main.
+tag VERSION:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    plugin_version=$(python3 -c "import json; print(json.load(open('.claude-plugin/plugin.json'))['version'])")
+    if [ "$plugin_version" != "{{ VERSION }}" ]; then
+        echo "error: plugin.json version ('$plugin_version') does not match '{{ VERSION }}'" >&2
+        echo "       Run 'just release {{ VERSION }}', open a PR, merge it, then retry 'just tag {{ VERSION }}'." >&2
+        exit 1
+    fi
+    git tag -a "v{{ VERSION }}" -m "Release v{{ VERSION }}"
+    git push origin "v{{ VERSION }}"
+    echo "Tagged and pushed v{{ VERSION }}"
+
 audit:
     uvx 'bandit[sarif]==1.9.4' -r src/ -ll
     uvx 'pip-audit==2.10.1' --strict


### PR DESCRIPTION
## Summary

- Adds `just release VERSION` to validate and write a stable calver into `plugin.json` (targeted sed replace, byte-identical aside from the version value).
- Adds `just tag VERSION` to assert `plugin.json` matches the intended version before creating and pushing the annotated git tag.
- Adds a CI guard step in `publish.yml` (runs **before** `uv build`, tag/dispatch only): prerelease tags skip silently; stable tags fail with an actionable `::error::` message if `plugin.json.version` != the tag.
- Adds a concise **Releasing** section to `CONTRIBUTING.md` documenting the bump-PR → tag flow.

`plugin.json`'s current version value (`2026.6.0`) is **unchanged** — it represents the pending stable line and is only enforced when a stable `v2026.6.0` tag is pushed.

> **Note for reviewers:** this diff touches the release pipeline (`publish.yml`); please scrutinize the guard step and its prerelease-skip logic.

## Test plan

- [x] `just lint` passes
- [x] `just type` passes
- [x] `uv run pytest tests/unit -q` — 4078 passed
- [x] `plugin.json` remains valid JSON with unchanged key order/indentation (`2026.6.0`)
- [x] `just release 2026.6.0a0` exits non-zero (rejects prerelease input)
- [x] `just release 2026.6.1` writes `2026.6.1` into `plugin.json` with only the value changed, then `git checkout -- .claude-plugin/plugin.json` resets it
- [x] `.github/workflows/publish.yml` is valid YAML

Closes #610

🤖 Generated with [Claude Code](https://claude.com/claude-code)