### PR TITLE
chore: harden release tooling (calver validation, committed-tree tag check, dispatch release name)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -138,3 +138,4 @@ jobs:
           fail_on_unmatched_files: false
           generate_release_notes: true
           name: ${{ inputs.tag || github.ref_name }}
+          tag_name: ${{ inputs.tag || github.ref_name }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -84,7 +84,7 @@ jobs:
         continue-on-error: true
         run: |
           uvx --from 'cyclonedx-bom==7.3.0' cyclonedx-py environment --of JSON -o dist/sbom.cdx.json "$(uv python find)"
-          python -c "import json,sys; d=json.load(open('dist/sbom.cdx.json')); print(f'SBOM: {len(d.get(\"components\",[]))} components')"
+          python3 -c "import json,sys; d=json.load(open('dist/sbom.cdx.json')); print(f'SBOM: {len(d.get(\"components\",[]))} components')"
 
       - name: Upload SBOM artifact
         # Only upload if the SBOM was actually generated (SBOM step may have been skipped/failed).
@@ -137,4 +137,4 @@ jobs:
             dist/sbom.cdx.json
           fail_on_unmatched_files: false
           generate_release_notes: true
-          name: ${{ github.ref_name }}
+          name: ${{ inputs.tag || github.ref_name }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,11 +123,11 @@ just build
 
 The plugin version (`plugin.json`) is single-sourced from stable git tags. The flow:
 
-1. **Bump** — run `just release X.Y.Z` (e.g. `just release 2026.6.0`) to write the stable calver into `plugin.json`. Open a release-prep PR and merge it.
-2. **Tag** — after the bump PR is merged, run `just tag X.Y.Z`. This asserts `plugin.json` agrees with the version before creating and pushing the annotated tag.
+1. **Bump** — run `just release X.Y.Z` (e.g. `just release 2026.7.0`) to write the stable calver into `plugin.json`. The version must follow `YYYY.M.N` (year `20xx`, month `1–12` with no leading zero, patch `0` or a positive integer without a leading zero). Open a release-prep PR and merge it.
+2. **Tag** — after the bump PR is merged, run `just tag X.Y.Z` **from a clean, up-to-date local `main`**. This reads the committed `plugin.json` (not the working tree) and verifies the version matches before creating and pushing the annotated tag.
 3. **Publish** — the `Publish` CI workflow fires on the tag push. It enforces the same version match (failing fast before the build if they disagree), then ships the package to PyPI and creates a GitHub Release.
 
-Prerelease tags (`aN`/`bN`/`rcN`/`.devN`) skip the `plugin.json` check — plugin.json always reflects the latest stable release only.
+`just release` and `just tag` both reject out-of-range or leading-zero months/patches and any prerelease suffix (`aN`/`bN`/`rcN`/`.devN`). Prerelease builds (`.devN` suffix derived by hatch-vcs from commits since the last tag) are published automatically on every push to `main`; `plugin.json` always reflects the latest stable release only.
 
 ## Code of Conduct
 

--- a/justfile
+++ b/justfile
@@ -72,12 +72,16 @@ tag VERSION:
     #!/usr/bin/env bash
     set -euo pipefail
     # Validate VERSION with the same tightened calver check used by 'release'.
+    # Also reject any embedded newlines (multi-line input can fool line-anchored grep).
+    case "{{ VERSION }}" in
+        *$'\n'*) echo "error: VERSION contains a newline — must be a single-line value" >&2; exit 1 ;;
+    esac
     if ! echo "{{ VERSION }}" | grep -qE '{{ _CALVER_RE }}'; then
         echo "error: '{{ VERSION }}' is not a stable calver (expected YYYY.M.N, month 1–12, no leading zeros, no prerelease suffix)" >&2
         exit 1
     fi
-    # Guard: working tree must be clean.
-    if ! git diff --quiet || ! git diff --cached --quiet; then
+    # Guard: working tree must be clean (tracked and untracked files).
+    if [ -n "$(git status --porcelain)" ]; then
         echo "error: working tree is dirty — commit or stash changes before tagging" >&2
         exit 1
     fi
@@ -88,9 +92,11 @@ tag VERSION:
         exit 1
     fi
     # Guard: branch must be up to date with origin/main.
+    # Compare HEAD against FETCH_HEAD so the check always uses the freshly fetched SHA,
+    # regardless of whether the local remote-tracking ref (origin/main) was up to date.
     git fetch origin main --quiet
     local_sha=$(git rev-parse HEAD)
-    remote_sha=$(git rev-parse origin/main)
+    remote_sha=$(cat "$(git rev-parse --git-dir)/FETCH_HEAD" | awk '{print $1; exit}')
     if [ "$local_sha" != "$remote_sha" ]; then
         echo "error: local main is not up to date with origin/main — run 'git pull' first" >&2
         exit 1

--- a/justfile
+++ b/justfile
@@ -34,13 +34,19 @@ integration:
 build:
     uv build
 
-# Bump plugin.json to VERSION (must be a stable calver like 2026.6.0; no prerelease suffixes).
+# Shared calver validator — used by both 'release' and 'tag'.
+# Accepts YYYY.M.N where year is 20xx, month is 1–12 (no leading zero), patch is 0 or
+# any positive integer without a leading zero.  Rejects prerelease suffixes (aN/bN/rcN/.devN).
+# Single source of truth: update this regex in one place only.
+_CALVER_RE := '^20[0-9]{2}\.([1-9]|1[0-2])\.(0|[1-9][0-9]*)$'
+
+# Bump plugin.json to VERSION (must be a stable calver like 2026.6.1; no prerelease suffixes).
 # Run: just release VERSION  →  open a release-prep PR  →  merge  →  just tag VERSION
 release VERSION:
     #!/usr/bin/env bash
     set -euo pipefail
-    if ! echo "{{ VERSION }}" | grep -qE '^[0-9]{4}\.[0-9]{1,2}\.[0-9]+$'; then
-        echo "error: '{{ VERSION }}' is not a stable calver (expected YYYY.M.N with no prerelease suffix)" >&2
+    if ! echo "{{ VERSION }}" | grep -qE '{{ _CALVER_RE }}'; then
+        echo "error: '{{ VERSION }}' is not a stable calver (expected YYYY.M.N, month 1–12, no leading zeros, no prerelease suffix)" >&2
         exit 1
     fi
     plugin_json=".claude-plugin/plugin.json"
@@ -54,18 +60,45 @@ release VERSION:
     echo "plugin.json version set to {{ VERSION }}"
     echo ""
     echo "Next steps:"
-    echo "  1. git add .claude-plugin/plugin.json && git commit -m 'build: release {{ VERSION }}'"
+    echo "  1. git add .claude-plugin/plugin.json && git commit -m 'chore: release {{ VERSION }}'"
     echo "  2. Open a release-prep PR and merge it to main."
     echo "  3. After merge: just tag {{ VERSION }}"
 
-# Assert plugin.json version matches VERSION, then create and push an annotated git tag.
+# Assert plugin.json version (from the committed tree) matches VERSION, then create and push an
+# annotated git tag.  Refuses to tag on a dirty working tree, a non-main branch, or when the
+# branch is behind origin/main.
 # Run after the release-prep PR (from 'just release VERSION') has been merged to main.
 tag VERSION:
     #!/usr/bin/env bash
     set -euo pipefail
-    plugin_version=$(python3 -c "import json; print(json.load(open('.claude-plugin/plugin.json'))['version'])")
+    # Validate VERSION with the same tightened calver check used by 'release'.
+    if ! echo "{{ VERSION }}" | grep -qE '{{ _CALVER_RE }}'; then
+        echo "error: '{{ VERSION }}' is not a stable calver (expected YYYY.M.N, month 1–12, no leading zeros, no prerelease suffix)" >&2
+        exit 1
+    fi
+    # Guard: working tree must be clean.
+    if ! git diff --quiet || ! git diff --cached --quiet; then
+        echo "error: working tree is dirty — commit or stash changes before tagging" >&2
+        exit 1
+    fi
+    # Guard: must be on main.
+    current_branch=$(git rev-parse --abbrev-ref HEAD)
+    if [ "$current_branch" != "main" ]; then
+        echo "error: must be on 'main' to tag (currently on '$current_branch')" >&2
+        exit 1
+    fi
+    # Guard: branch must be up to date with origin/main.
+    git fetch origin main --quiet
+    local_sha=$(git rev-parse HEAD)
+    remote_sha=$(git rev-parse origin/main)
+    if [ "$local_sha" != "$remote_sha" ]; then
+        echo "error: local main is not up to date with origin/main — run 'git pull' first" >&2
+        exit 1
+    fi
+    # Read version from the committed tree, not the working tree.
+    plugin_version=$(git show HEAD:.claude-plugin/plugin.json | python3 -c "import json,sys; print(json.load(sys.stdin)['version'])")
     if [ "$plugin_version" != "{{ VERSION }}" ]; then
-        echo "error: plugin.json version ('$plugin_version') does not match '{{ VERSION }}'" >&2
+        echo "error: plugin.json version in HEAD ('$plugin_version') does not match '{{ VERSION }}'" >&2
         echo "       Run 'just release {{ VERSION }}', open a PR, merge it, then retry 'just tag {{ VERSION }}'." >&2
         exit 1
     fi


### PR DESCRIPTION
## Summary

- **Tightened calver validator** (`justfile`): single `_CALVER_RE` variable shared by both `release` and `tag` recipes. Rejects out-of-range months (>12), leading-zero months/patches, and any prerelease suffix. Regex: `^20[0-9]{2}\.([1-9]|1[0-2])\.(0|[1-9][0-9]*)$`.
- **`just tag` reads the committed tree**: uses `git show HEAD:.claude-plugin/plugin.json` (not the working-tree file). Also guards: dirty working tree, non-`main` branch, branch behind `origin/main`.
- **`just tag` validates VERSION**: same tightened calver check before any git operations.
- **`publish.yml` Release name**: changed `name: ${{ github.ref_name }}` → `name: ${{ inputs.tag || github.ref_name }}` so `workflow_dispatch` names the GitHub Release after the tag, not the branch. This is a `with:` field — NOT the guard step's `env:`/`run:` body (which is already correct and was not touched).
- **Nits**: `python` → `python3` in SBOM step for consistency; suggested commit prefix changed `build:` → `chore:` (`build:` is not a recognized type in `.github/release-drafter.yml` categories — no autolabeler rule, no category; `chore:` maps to CI/Tooling); CONTRIBUTING.md Releasing prose tightened.

## Reviewer notes

The `publish.yml` diff touches the release pipeline — please scrutinize it. The only changes are:
1. `name: ${{ inputs.tag || github.ref_name }}` in the `softprops/action-gh-release` `with:` block (line 140).
2. `python` → `python3` in the SBOM step (line 87).

The injection-safe guard step (`env: EFFECTIVE_TAG: ...` / `run: |`) is **not altered** — it was already correct on `main`.

## Validation performed locally

- `just release 2026.13.0`, `just release 2026.06.0`, `just release 2026.6.0a0`, `just release 2026.6.00` — all rejected.
- `just release 2026.6.1` — accepted, then reverted.
- `just tag 2026.13.0` — rejected (calver).
- `just tag 2026.6.1` on dirty/non-main worktree — rejected (dirty tree guard fires first).
- `publish.yml` YAML: `python3 -c "import yaml; yaml.safe_load(...)"` — valid.
- `just lint`, `just type`, `uv run pytest tests/unit -q` — all green (4097 passed).

Closes #612
Follow-up to #610/#611