### PR TITLE
docs: add MVP tracking param to remaining Microsoft Learn links

### DIFF
--- a/docs/commands/sql-endpoints.md
+++ b/docs/commands/sql-endpoints.md
@@ -164,7 +164,7 @@ Return all principals (users, groups, service principals) with access to a SQL A
 
 !!! note
 
-    Requires **Fabric Administrator** role (`Tenant.Read.All` or `Tenant.ReadWrite.All` scope). See [Microsoft Fabric admin documentation](https://learn.microsoft.com/en-us/fabric/admin/microsoft-fabric-admin) for how to request the role.
+    Requires **Fabric Administrator** role (`Tenant.Read.All` or `Tenant.ReadWrite.All` scope). See [Microsoft Fabric admin documentation](https://learn.microsoft.com/en-us/fabric/admin/microsoft-fabric-admin?WT.mc_id=MVP_310840) for how to request the role.
 
 **Parameters:**
 

--- a/docs/commands/sql-pools.md
+++ b/docs/commands/sql-pools.md
@@ -170,8 +170,8 @@ split evenly (50/50) into two isolated pools, `SELECT` (read/analytics queries)
 and `NON-SELECT` (DML/DDL/ETL/ingestion statements). In that case this command
 reports the default pools rather than printing an empty list. The default split
 is documented in
-[Workload management](https://learn.microsoft.com/fabric/data-warehouse/workload-management#compute-pool-isolation)
-and [Custom SQL pools](https://learn.microsoft.com/fabric/data-warehouse/custom-sql-pools).
+[Workload management](https://learn.microsoft.com/fabric/data-warehouse/workload-management?WT.mc_id=MVP_310840#compute-pool-isolation)
+and [Custom SQL pools](https://learn.microsoft.com/fabric/data-warehouse/custom-sql-pools?WT.mc_id=MVP_310840).
 
 **Synopsis**
 

--- a/docs/commands/warehouses.md
+++ b/docs/commands/warehouses.md
@@ -258,7 +258,7 @@ Return all principals (users, groups, service principals) with access to a Wareh
 
 !!! note
 
-    Requires **Fabric Administrator** role (`Tenant.Read.All` or `Tenant.ReadWrite.All` scope). See [Microsoft Fabric admin documentation](https://learn.microsoft.com/en-us/fabric/admin/microsoft-fabric-admin) for how to request the role.
+    Requires **Fabric Administrator** role (`Tenant.Read.All` or `Tenant.ReadWrite.All` scope). See [Microsoft Fabric admin documentation](https://learn.microsoft.com/en-us/fabric/admin/microsoft-fabric-admin?WT.mc_id=MVP_310840) for how to request the role.
 
 **Parameters:**
 


### PR DESCRIPTION
## Summary

Every `learn.microsoft.com` URL in the docs must carry `?WT.mc_id=MVP_310840` for MVP attribution tracking. Four links were missing the parameter:

- `docs/commands/sql-pools.md` — workload-management link (fragment `#compute-pool-isolation` kept after the param) and custom-sql-pools link
- `docs/commands/warehouses.md` — microsoft-fabric-admin link
- `docs/commands/sql-endpoints.md` — microsoft-fabric-admin link

Fragment ordering follows the rule: `?WT.mc_id=MVP_310840` is inserted **before** the `#fragment`, never after.

## Compliance proof

```
grep -rnE "https?://(learn|docs)\.microsoft\.com[^ )\"'\`>]*" docs/ skills/ README.md \
  | grep -vE "WT\.mc_id=MVP_310840" \
  || echo "ALL COMPLIANT"
```

Result: `ALL COMPLIANT`

🤖 Generated with [Claude Code](https://claude.com/claude-code)