### PR TITLE
fix(test): restore integration suite (nested-loop sql_endpoint fixture + sql_pools xdist isolation)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -218,18 +218,23 @@ jobs:
             exit 1
           }
 
-          # Default dist mode is "load" (xdist default): work-stealing scheduler
-          # that keeps all workers busy.  This is the right choice here because
-          # test durations vary widely (snapshot/restore tests are 10x slower than
-          # query/schema tests).  "loadscope" would bin by module, which could
-          # serialise the slow tests onto one worker and starve the rest.
+          # Dist mode is "loadgroup": a work-stealing scheduler (like the default
+          # "load") that keeps all workers busy, with the one extra guarantee that
+          # tests sharing an xdist_group mark run on the SAME worker.  We need this
+          # for the sql_pools tests, which all mutate the single shared workspace's
+          # maxResourcePercentage budget (sum ≤ 100) and would collide if run
+          # concurrently; they carry @pytest.mark.xdist_group("sql_pools").
+          # "loadgroup" keeps the work-stealing behaviour the suite relies on
+          # (test durations vary widely — snapshot/restore tests are 10x slower
+          # than query/schema tests), unlike "loadscope" which would bin every
+          # module onto one worker and starve the rest.
 
           if [ -n "${PYTEST_K_INPUT}" ]; then
             echo "Running subset: -k '${PYTEST_K_INPUT}' with ${WORKERS} worker(s)"
-            uv run pytest tests/integration -m integration -v -n "${WORKERS}" -k "${PYTEST_K_INPUT}" --cov --cov-report=xml --cov-report=term --junitxml=junit.xml -o junit_family=legacy
+            uv run pytest tests/integration -m integration -v -n "${WORKERS}" --dist loadgroup -k "${PYTEST_K_INPUT}" --cov --cov-report=xml --cov-report=term --junitxml=junit.xml -o junit_family=legacy
           else
             echo "Running full integration suite with ${WORKERS} worker(s)"
-            uv run pytest tests/integration -m integration -v -n "${WORKERS}" --cov --cov-report=xml --cov-report=term --junitxml=junit.xml -o junit_family=legacy
+            uv run pytest tests/integration -m integration -v -n "${WORKERS}" --dist loadgroup --cov --cov-report=xml --cov-report=term --junitxml=junit.xml -o junit_family=legacy
           fi
 
       - name: Upload coverage reports to Codecov

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -90,6 +90,34 @@ leg.  This prevents pytest from provisioning the SQL analytics endpoint
 `[warehouse]` leg — provisioning is paid only when the endpoint leg actually
 runs.
 
+`read_target` is a sync fixture, so its `getfixturevalue` runs outside any
+event loop.  `mutable_schema_target` is async, so it **must not** call
+`getfixturevalue` on the async `shared_sql_endpoint` itself — doing so makes
+pytest-asyncio call `runner.run()` nested inside the running loop and raises
+`RuntimeError: Runner.run() cannot be called from a running event loop`.
+Instead, the parametrisation and the lazy resolution live on a **sync**
+indirection fixture (`_mutable_schema_sql_target`) that the async fixture
+depends on, so the endpoint is materialised outside the loop while the marks
+still propagate through the dependency closure.
+
+**Rule of thumb:** never lazily resolve an async session fixture from inside an
+`async def` fixture.  Put the `getfixturevalue` call on a sync fixture and
+depend on it.
+
+## Parallelism and shared-budget tests
+
+The integration suite runs under `pytest-xdist` with `--dist loadgroup` (see
+`.github/workflows/integration.yml`).  `loadgroup` keeps xdist's work-stealing
+scheduler but guarantees that tests sharing an `xdist_group` mark run on the
+**same** worker.
+
+`test_services_sql_pools.py` carries `pytest.mark.xdist_group("sql_pools")` at
+module scope because every test there mutates the single shared workspace's
+`maxResourcePercentage` budget (a global per-workspace quota that must sum to
+≤ 100).  Pinning the module to one worker serialises those tests so a 100%
+default pool from one test can never coexist with another test's pool and push
+the sum over 100.
+
 ## Meta-guard
 
 `tests/unit/test_dual_target_coverage.py` contains a unit test

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1141,15 +1141,51 @@ def read_target(
 # ---------------------------------------------------------------------------
 
 
-@pytest_asyncio.fixture(
+@pytest.fixture(
     params=[
         pytest.param(_PARAM_WAREHOUSE),
         pytest.param(_PARAM_SQL_ENDPOINT, marks=pytest.mark.sql_endpoint),
     ]
 )
-async def mutable_schema_target(
+def _mutable_schema_sql_target(
     request: pytest.FixtureRequest,
     shared_warehouse: SharedWarehouseTarget,
+) -> SqlTarget:
+    """Sync indirection that routes ``mutable_schema_target`` to the right SQL target.
+
+    Carries the ``[warehouse]`` / ``[sql_endpoint]`` parametrisation (and the
+    ``pytest.mark.sql_endpoint`` mark on the endpoint leg) and resolves the
+    ``shared_sql_endpoint`` session fixture LAZILY via ``request.getfixturevalue``
+    — mirroring the ``read_target`` path exactly.
+
+    Why this exists as a separate **sync** fixture
+    ----------------------------------------------
+    ``mutable_schema_target`` is an ``async`` fixture, so its setup runs inside a
+    running event loop.  Calling ``request.getfixturevalue("shared_sql_endpoint")``
+    (itself an async fixture) from there makes pytest-asyncio call ``runner.run()``
+    nested inside that loop, raising
+    ``RuntimeError: Runner.run() cannot be called from a running event loop``.
+    Resolving the endpoint here, in a **sync** fixture that the async fixture
+    depends on, materialises it OUTSIDE the loop and avoids the nesting.
+
+    The lazy-provisioning optimisation is preserved: ``shared_sql_endpoint`` is
+    intentionally NOT a signature parameter, so the ~6-min endpoint provisioning
+    never runs on the ``[warehouse]`` leg or during local ``-m "not sql_endpoint"``
+    runs.  The parametrisation marks propagate to the requesting test through the
+    fixture dependency closure.
+    """
+    if request.param == _PARAM_WAREHOUSE:
+        return shared_warehouse.sql_target
+    if request.param == _PARAM_SQL_ENDPOINT:
+        ep: SharedSqlEndpointTarget = request.getfixturevalue("shared_sql_endpoint")
+        return ep.sql_target
+    msg = f"Unknown mutable_schema_target param: {request.param!r}"
+    raise ValueError(msg)
+
+
+@pytest_asyncio.fixture
+async def mutable_schema_target(
+    _mutable_schema_sql_target: SqlTarget,
 ) -> AsyncIterator[tuple[SqlTarget, str]]:
     """Parametrized fixture that creates an isolated schema on each SQL target.
 
@@ -1166,24 +1202,18 @@ async def mutable_schema_target(
 
     Implementation note
     -------------------
-    ``shared_sql_endpoint`` is resolved LAZILY via ``request.getfixturevalue``
-    only on the ``sql_endpoint`` leg — identical pattern to ``read_target``.  It
-    is intentionally NOT declared as a signature parameter to avoid provisioning
-    the SQL analytics endpoint during local runs or the ``[warehouse]`` leg.
+    The parametrisation and lazy ``shared_sql_endpoint`` resolution live on the
+    sync :func:`_mutable_schema_sql_target` indirection fixture this depends on.
+    That keeps the async setup from resolving another async fixture from inside
+    the running event loop (which raised ``RuntimeError: Runner.run() cannot be
+    called from a running event loop``) while preserving the lazy-provisioning
+    optimisation.
 
     Both ``create_schema`` and ``delete_schema(cascade=True)`` are themselves
     dual-target (no ``_assert_not_sql_endpoint`` guard), so the isolation and
     teardown mechanism works identically on both targets.
     """
-    if request.param == _PARAM_WAREHOUSE:
-        sql_target = shared_warehouse.sql_target
-    elif request.param == _PARAM_SQL_ENDPOINT:
-        ep: SharedSqlEndpointTarget = request.getfixturevalue("shared_sql_endpoint")
-        sql_target = ep.sql_target
-    else:
-        msg = f"Unknown mutable_schema_target param: {request.param!r}"
-        raise ValueError(msg)
-
+    sql_target = _mutable_schema_sql_target
     schema_name = f"pytest_{uuid.uuid4().hex[:8]}"
     await schemas.create_schema(sql_target, schema_name)
     try:

--- a/tests/integration/test_services_sql_pools.py
+++ b/tests/integration/test_services_sql_pools.py
@@ -16,7 +16,15 @@ from fabric_dw.http_client import FabricHttpClient
 from fabric_dw.models import SqlPool, SqlPoolsConfiguration
 from fabric_dw.services import sql_pools
 
-pytestmark = pytest.mark.integration
+# ``maxResourcePercentage`` is a single global budget per workspace (sum ≤ 100),
+# and every test here mutates the one shared ``FABRIC_TEST_WORKSPACE_ID`` config.
+# ``xdist_group`` pins the whole module onto a single xdist worker so these
+# config-mutating tests never run concurrently and cannot push the sum over 100
+# (e.g. a 100% default pool from one test coexisting with another's 10% create).
+# Requires ``--dist loadgroup`` for xdist to honour the group; the integration
+# workflow runs with that dist mode.  The ``_clean_stale_pools`` autouse sweep
+# below remains the safety net for pools left behind by an interrupted prior run.
+pytestmark = [pytest.mark.integration, pytest.mark.xdist_group("sql_pools")]
 
 # Prefix used to identify pools created by test runs so stale pools can be
 # cleaned up before a new run tries to create pools with the same names or


### PR DESCRIPTION
## Summary

The Integration tests workflow on `main` was red (50 errors + 1 failure) from two independent root causes in the integration harness. This restores it.

### 1. `sql_endpoint` leg — nested `Runner.run()` (50 setup errors)

The async `mutable_schema_target` fixture lazily resolved the **async** session fixture `shared_sql_endpoint` via `request.getfixturevalue()` from inside its own running event loop. pytest-asyncio then called `runner.run()` nested in that loop, raising `RuntimeError: Runner.run() cannot be called from a running event loop`. Under `pytest-randomly` + session-scope caching, whichever `[sql_endpoint]` test materialised the session fixture first decided the outcome: an async leg winning poisoned the cached setup and failed **all 50** `sql_endpoint` tests with the same error. The sibling `read_target` fixture used the same lazy trick but is **sync**, so it always worked — that asymmetry was the whole bug.

**Fix:** the param routing and the lazy `shared_sql_endpoint` resolution now live on a new **sync** indirection fixture `_mutable_schema_sql_target`, which the async fixture depends on. The endpoint is materialised **outside** the loop (mirroring the working `read_target` path), so there is no nested run. The `sql_endpoint` parametrisation mark still propagates to requesting tests through the fixture dependency closure. The lazy-provisioning optimisation is preserved — the `[warehouse]` leg and local `-m "not sql_endpoint"` runs never provision the ~6-min SQL analytics endpoint. Audited the tree: the only other `getfixturevalue`-on-async call site is `read_target`, which is already sync and safe.

### 2. `sql_pools` — `maxResourcePercentage` collision (1 failure)

`maxResourcePercentage` is a single global per-workspace budget (sum ≤ 100). All `sql_pools` tests mutate the one shared `FABRIC_TEST_WORKSPACE_ID` config and ran concurrently under xdist, so a 100% default pool from one test could coexist with another test's 10% create → 110.

**Fix:** pin the module with `@pytest.mark.xdist_group("sql_pools")` so its config-mutating tests run on the same worker, and run the integration suite with `--dist loadgroup` so xdist honours the group while keeping its work-stealing scheduler. The `_clean_stale_pools` autouse sweep stays as the interrupted-run safety net.

## Validation (local, no live tenant mutation)

The repo has no dedicated `FABRIC_TEST_WORKSPACE_ID` provisioned locally and the integration suite is destructive (creates/deletes warehouses, mutates workspace config), so the fixture mechanisms were validated in isolation rather than by mutating a real workspace; the Integration tests workflow (triggered by the `integration` label on this PR) is the final live gate.

- **Bug 1 mechanism, reproduced and fixed:** a standalone repro mirroring the exact fixture topology shows the old pattern raises `RuntimeError: Runner.run() cannot be called from a running event loop` on the `[sql_endpoint]` leg, and the sync-indirection fix makes both `[warehouse]` and `[sql_endpoint]` legs set up & pass — with `-p no:randomly` and the endpoint leg first (the poisoning trigger).
- **Mark propagation:** `pytest tests/integration/test_services_schemas.py -m "integration and sql_endpoint" --collect-only` selects exactly the `[sql_endpoint]` legs, confirming the mark flows through the new dependency closure.
- **Bug 2 mechanism:** under `-n 4 --dist loadgroup`, all `xdist_group("sql_pools")` tests land on a single worker while ungrouped tests spread across all four — group serialisation holds without losing parallelism.
- **Full suite collects clean** under `--dist loadgroup -n 2` (207 tests).
- `just lint`, `just type` (`ty`), and the unit suite (4097 passed) are green.

Closes #615