### PR TITLE
fix(test): robust sql_pools config reset + graceful skip for health-metrics on SQL endpoints

### DIFF
--- a/tests/integration/test_services_sql_pools.py
+++ b/tests/integration/test_services_sql_pools.py
@@ -34,11 +34,61 @@ pytestmark = [pytest.mark.integration, pytest.mark.xdist_group("sql_pools")]
 _PYTEST_POOL_PREFIX = "pytest-"
 
 
+def _reset_config_without_pytest_pools(
+    current: SqlPoolsConfiguration,
+) -> SqlPoolsConfiguration | None:
+    """Build a config that drops every ``pytest-``-prefixed pool, or ``None`` if clean.
+
+    Returns ``None`` when the workspace contains no pytest-owned pools (so the
+    caller can skip the PATCH entirely — a clean workspace is a no-op).  When
+    pytest pools are present, returns a :class:`SqlPoolsConfiguration` with every
+    pytest-prefixed pool removed, adjusted so it satisfies the API's rules:
+
+    * **Default-pool rule** — the API cannot delete a pool marked ``isDefault``
+      via a per-pool delete, but a config-level PATCH that simply omits it can.
+      If the removed default was a pytest pool and non-pytest custom pools remain,
+      the first remaining pool is re-pointed as the default so exactly one default
+      survives.
+    * **Enabled-vs-empty rule** — the API refuses ``customSQLPoolsEnabled=True``
+      with an empty pool list.  When removing pytest pools leaves no non-pytest
+      custom pools, custom pools are disabled so the resulting config is valid.
+    * **Budget rule** — removing pools only lowers the ``maxResourcePercentage``
+      sum, so the ≤100 budget is preserved by construction.
+
+    The non-pytest pools are returned untouched (including their ``isDefault`` and
+    ``maxResourcePercentage`` values) unless a default re-point is required.
+    """
+    kept = [p for p in current.custom_sql_pools if not p.name.startswith(_PYTEST_POOL_PREFIX)]
+    if len(kept) == len(current.custom_sql_pools):
+        # No pytest-owned pools — nothing to reset.
+        return None
+
+    if not kept:
+        # No non-pytest custom pools remain.  The API rejects enabled+empty, so
+        # disable custom pools (autonomous workload management takes over).
+        return SqlPoolsConfiguration.model_validate(
+            {"customSQLPoolsEnabled": False, "customSQLPools": []}
+        )
+
+    # Re-point the default if none of the kept pools is currently the default
+    # (e.g. the removed default was a pytest pool).  Exactly one default must
+    # remain; mark the first kept pool and clear the flag on the rest.
+    if not any(p.is_default for p in kept):
+        kept = [p.model_copy(update={"is_default": i == 0}) for i, p in enumerate(kept)]
+
+    return SqlPoolsConfiguration.model_validate(
+        {
+            "customSQLPoolsEnabled": current.custom_sql_pools_enabled,
+            "customSQLPools": [p.model_dump(by_alias=True, mode="json") for p in kept],
+        }
+    )
+
+
 async def _remove_stale_pytest_pools(
     http: FabricHttpClient,
     workspace_id: UUID,
 ) -> None:
-    """Remove any leftover pytest-created custom SQL pools from the workspace.
+    """Reset the workspace config so no leftover pytest-created SQL pool remains.
 
     Pools whose name starts with ``_PYTEST_POOL_PREFIX`` are considered
     test-owned.  They may be left behind when a previous run is interrupted
@@ -46,15 +96,25 @@ async def _remove_stale_pytest_pools(
     Calling this helper before creating new pools prevents the sum of
     ``maxResourcePercentage`` across all pools from exceeding 100.
 
-    The operation is best-effort: individual delete failures are suppressed so
-    that a partial cleanup does not mask the original test failure.  If no
-    stale pools exist, this is a no-op (one GET, zero PATCHes).
+    Unlike a per-pool ``delete_pool`` sweep, this resets at the **config level**:
+    it builds a new :class:`SqlPoolsConfiguration` that excludes every pytest pool
+    and PATCHes it in a single ``update_configuration`` call.  A per-pool delete
+    cannot remove a pool marked ``isDefault=True`` (the API forbids it), so an
+    orphaned 100% default pytest pool would survive every sweep and push the next
+    create over the 100 budget; the config-level PATCH omits it outright and
+    re-points / disables defaults as needed (see
+    :func:`_reset_config_without_pytest_pools`).
+
+    The operation is best-effort: the PATCH is suppressed on failure so that a
+    transient cleanup error does not mask the original test failure.  If no
+    pytest pools exist, this is a no-op (one GET, zero PATCHes).
     """
     current = await sql_pools.get_configuration(http, workspace_id)
-    stale = [p for p in current.custom_sql_pools if p.name.startswith(_PYTEST_POOL_PREFIX)]
-    for pool in stale:
-        with contextlib.suppress(Exception):
-            await sql_pools.delete_pool(http, workspace_id, pool.name)
+    reset = _reset_config_without_pytest_pools(current)
+    if reset is None:
+        return
+    with contextlib.suppress(Exception):
+        await sql_pools.update_configuration(http, workspace_id, reset)
 
 
 @pytest_asyncio.fixture(autouse=True, scope="function")
@@ -110,11 +170,16 @@ async def test_enable_disable_roundtrip(http: FabricHttpClient, workspace_id: UU
         enabled = await sql_pools.enable(http, workspace_id)
         assert enabled.custom_sql_pools_enabled is True
     finally:
-        # Best-effort targeted delete before the full config restore so the
-        # pool does not accumulate in the workspace if the restore call raises.
+        # The seed pool is ``isDefault=True`` at 100%, which a per-pool
+        # ``delete_pool`` cannot remove (the API forbids deleting the default).
+        # Reset at the config level first so an orphaned 100% default pool can
+        # never survive an interrupted teardown and push a later run over the
+        # 100 budget; only then restore the original configuration.  Both steps
+        # are best-effort so a transient failure does not mask a test failure.
         with contextlib.suppress(Exception):
-            await sql_pools.delete_pool(http, workspace_id, pool_name)
-        await sql_pools.update_configuration(http, workspace_id, original)
+            await _remove_stale_pytest_pools(http, workspace_id)
+        with contextlib.suppress(Exception):
+            await sql_pools.update_configuration(http, workspace_id, original)
 
 
 async def test_create_update_delete_roundtrip(http: FabricHttpClient, workspace_id: UUID) -> None:
@@ -173,8 +238,11 @@ async def test_create_update_delete_roundtrip(http: FabricHttpClient, workspace_
             await sql_pools.delete_pool(http, workspace_id, pool_name)
 
     finally:
-        # Best-effort targeted delete before the full config restore so the
-        # pool does not accumulate in the workspace if the restore call raises.
+        # Reset at the config level first so no pytest pool can accumulate in the
+        # workspace if the restore call is interrupted, then restore the original
+        # configuration.  Both steps are best-effort so a transient cleanup
+        # failure does not mask a test failure.
         with contextlib.suppress(Exception):
-            await sql_pools.delete_pool(http, workspace_id, pool_name)
-        await sql_pools.update_configuration(http, workspace_id, original)
+            await _remove_stale_pytest_pools(http, workspace_id)
+        with contextlib.suppress(Exception):
+            await sql_pools.update_configuration(http, workspace_id, original)

--- a/tests/integration/test_services_tables.py
+++ b/tests/integration/test_services_tables.py
@@ -315,6 +315,30 @@ async def test_count_table_rows_returns_nonnegative_int(
 # parent Lakehouse during fixture setup) is the probe table — it is guaranteed
 # to be visible on the endpoint before the fixture yields.
 
+# Driver message fragments that mean the proc is not yet implemented by the
+# endpoint's SQL engine version (a tenant-level GA rollout gap, not a bug).
+# Lower-cased before matching.
+_HEALTH_METRICS_UNAVAILABLE_FRAGMENTS = (
+    # SQL engine version predates the proc: "The stored procedure is not
+    # available in this version of SQL Server."
+    "is not available in this version",
+    # Defensive variants of the same condition surfaced by the engine.
+    "stored procedure is not available",
+)
+
+
+def _is_health_metrics_unavailable(exc: BaseException) -> bool:
+    """Return True when *exc* means sp_get_table_health_metrics is not yet deployed.
+
+    Catches the "not available in this version of SQL Server" condition that the
+    raw driver raises when the proc name is recognised but the endpoint's engine
+    version does not yet implement it.  ``map_driver_error`` does not classify
+    this (it is neither a not-found error number nor an auth/permission fragment),
+    so the test must string-match the driver message to skip gracefully.
+    """
+    msg = str(exc).lower()
+    return any(frag in msg for frag in _HEALTH_METRICS_UNAVAILABLE_FRAGMENTS)
+
 
 @pytest.mark.sql_endpoint
 async def test_get_table_health_metrics_on_sql_endpoint(
@@ -355,6 +379,20 @@ async def test_get_table_health_metrics_on_sql_endpoint(
         pytest.skip(
             f"sp_get_table_health_metrics is not yet available on this tenant "
             f"({exc}); skipping — re-run when the GA rollout reaches this tenant"
+        )
+    except Exception as exc:
+        # The proc exists by name but the endpoint's SQL engine version doesn't
+        # implement it yet: the driver raises "The stored procedure is not
+        # available in this version of SQL Server."  map_driver_error() does NOT
+        # map this to a typed exception (it's neither error 208/2812 nor an auth/
+        # permission fragment), so the raw driver error propagates here.  Treat it
+        # the same way as the NotFoundError path: a GA-rollout gap, not a code bug.
+        if not _is_health_metrics_unavailable(exc):
+            raise
+        pytest.skip(
+            f"sp_get_table_health_metrics is not available in this SQL Analytics "
+            f"Endpoint's engine version ({exc}); skipping — re-run when the GA "
+            f"rollout reaches this endpoint"
         )
 
     # The proc must return at least one column (output schema is undocumented

--- a/tests/unit/test_integration_sql_pools_reset.py
+++ b/tests/unit/test_integration_sql_pools_reset.py
@@ -1,0 +1,89 @@
+"""Tests for the config-level pytest-pool reset helper in test_services_sql_pools.
+
+``_reset_config_without_pytest_pools`` is a pure function (no live Fabric call):
+it takes a fetched :class:`SqlPoolsConfiguration` and returns the configuration to
+PATCH back so that every ``pytest-``-prefixed pool is removed while honouring the
+API's default-pool and enabled-vs-empty rules.  These tests exercise every branch
+with synthetic configurations — no admin credentials or network access required.
+"""
+
+from __future__ import annotations
+
+from fabric_dw.models import SqlPoolsConfiguration
+from tests.integration.test_services_sql_pools import _reset_config_without_pytest_pools
+
+
+def _config(pools: list[dict[str, object]], *, enabled: bool) -> SqlPoolsConfiguration:
+    return SqlPoolsConfiguration.model_validate(
+        {"customSQLPoolsEnabled": enabled, "customSQLPools": pools}
+    )
+
+
+def test_clean_workspace_is_a_noop() -> None:
+    """A config with no pytest pools returns None so the caller skips the PATCH."""
+    config = _config(
+        [{"name": "prod", "isDefault": True, "maxResourcePercentage": 50}],
+        enabled=True,
+    )
+    assert _reset_config_without_pytest_pools(config) is None
+
+
+def test_empty_workspace_is_a_noop() -> None:
+    """An empty pool list (autonomous mode) has nothing to reset."""
+    assert _reset_config_without_pytest_pools(_config([], enabled=False)) is None
+
+
+def test_orphaned_default_pytest_pool_is_removed_by_disabling() -> None:
+    """An orphaned isDefault=True pytest pool is the only pool → disable custom pools.
+
+    This is the exact orphan state from the bug: a 100% ``isDefault=True``
+    ``pytest-`` pool left behind that a per-pool delete cannot remove.  With no
+    non-pytest custom pools remaining, the reset disables custom pools (the API
+    rejects ``enabled=True`` with an empty list).
+    """
+    config = _config(
+        [{"name": "pytest-roundtrip-pool", "isDefault": True, "maxResourcePercentage": 100}],
+        enabled=True,
+    )
+    reset = _reset_config_without_pytest_pools(config)
+    assert reset is not None
+    assert reset.custom_sql_pools_enabled is False
+    assert reset.custom_sql_pools == []
+    # The result must be a valid PATCH body.
+    reset.validate_for_patch()
+
+
+def test_default_repointed_when_removed_default_was_pytest() -> None:
+    """Removing the pytest default re-points the default onto a kept pool."""
+    config = _config(
+        [
+            {"name": "pytest-roundtrip-pool", "isDefault": True, "maxResourcePercentage": 60},
+            {"name": "prod-a", "isDefault": False, "maxResourcePercentage": 20},
+            {"name": "prod-b", "isDefault": False, "maxResourcePercentage": 20},
+        ],
+        enabled=True,
+    )
+    reset = _reset_config_without_pytest_pools(config)
+    assert reset is not None
+    assert reset.custom_sql_pools_enabled is True
+    kept_names = {p.name for p in reset.custom_sql_pools}
+    assert kept_names == {"prod-a", "prod-b"}
+    defaults = [p.name for p in reset.custom_sql_pools if p.is_default]
+    assert defaults == ["prod-a"]  # first kept pool is re-pointed as default
+    reset.validate_for_patch()
+
+
+def test_existing_default_is_preserved_when_pytest_pool_was_not_default() -> None:
+    """A non-default pytest pool is dropped; the existing default stays untouched."""
+    config = _config(
+        [
+            {"name": "prod", "isDefault": True, "maxResourcePercentage": 50},
+            {"name": "pytest-integration-pool", "isDefault": False, "maxResourcePercentage": 10},
+        ],
+        enabled=True,
+    )
+    reset = _reset_config_without_pytest_pools(config)
+    assert reset is not None
+    assert [p.name for p in reset.custom_sql_pools] == ["prod"]
+    assert reset.custom_sql_pools[0].is_default is True
+    reset.validate_for_patch()


### PR DESCRIPTION
## Summary

Two integration-test-harness robustness fixes for the remaining failures after #615/#621 (run [27883582215](https://github.com/sdebruyn/fabric-dw-mcp-cli/actions/runs/27883582215)). No production behaviour changes — the `validate_for_patch` ≤100 rule is untouched.

## 1. sql_pools: config-level reset of pytest pools

**Root cause:** the `_clean_stale_pools` autouse sweep did a best-effort *per-pool* `delete_pool`, but the API **cannot delete the default pool**. An orphaned `isDefault=True, maxResourcePercentage=100` `pytest-roundtrip-pool` (left by an interrupted `test_enable_disable_roundtrip` teardown) therefore survived every sweep, so the next 10% `create_pool` pushed the sum to 110 → `ValueError: Sum of maxResourcePercentage … is 110, which exceeds 100`.

**Fix:** reset at the **config level** instead of per-pool. A new pure helper `_reset_config_without_pytest_pools` builds a `SqlPoolsConfiguration` that excludes every `pytest-`-prefixed pool and PATCHes it in a single `update_configuration` call, honouring the API's rules:

- **Default-pool rule** — a config-level PATCH that simply omits the default pool removes it (unlike a per-pool delete). If the removed default was a pytest pool and non-pytest custom pools remain, the first kept pool is re-pointed as the default so exactly one default survives.
- **Enabled-vs-empty rule** — when removing pytest pools leaves no non-pytest custom pools, custom pools are disabled (the API rejects `customSQLPoolsEnabled=True` with an empty list).
- **Budget rule** — removing pools only lowers the sum, so ≤100 is preserved by construction.

It's idempotent: a clean workspace returns `None` and the caller skips the PATCH (one GET, zero PATCHes). Both roundtrip teardowns now run this config-level reset before restoring the original config, so an interrupted teardown can no longer leave a 100% default pool behind. Added `tests/unit/test_integration_sql_pools_reset.py` (5 cases) covering every branch of the pure helper.

## 2. health-metrics: graceful skip on SQL Analytics Endpoints

`test_get_table_health_metrics_on_sql_endpoint` failed with `ProgrammingError: … The stored procedure is not available in this version of SQL Server.` `sp_get_table_health_metrics` is GA-announced but not yet rolled out to every SQL Analytics Endpoint engine version. `map_driver_error()` does not classify this message (it's neither error 208/2812 nor an auth/permission fragment), so it escaped the existing `NotFoundError`-only skip and surfaced as a raw driver error.

**Fix:** detect the "not available in this version" / "stored procedure is not available" condition and `pytest.skip(...)` with a clear reason, mirroring the query-insights graceful-skip pattern. The proc is genuinely SQL-endpoint-only (the production `get_table_health_metrics` already enforces this via `_assert_sql_endpoint`); it has no dedicated Microsoft Learn page yet, confirming the GA-rollout framing, so the skip is the correct behaviour.

## Validation

- `just lint`, `just type` (ty), and the full unit suite (4102 passed, 5 new) are green.
- Local env lacks `FABRIC_TEST_WORKSPACE_ID` and the suite is destructive, so integration tests are not run locally; both target tests collect cleanly. The Integration CI run is the live gate — `integration` label applied to observe it (non-required, not a merge gate).

Closes #626