### PR TITLE
docs(guides): polish guides — defaults, fix cross-refs, refocus dbt on source provisioning, drop boilerplate

### DIFF
--- a/docs/guides/dbt-setup.md
+++ b/docs/guides/dbt-setup.md
@@ -4,18 +4,18 @@ title: dbt setup
 
 # Set up a dbt environment
 
-This guide walks an analytics engineer end-to-end through standing up a working [dbt](https://docs.getdbt.com/) environment on a Microsoft Fabric Data Warehouse, using `fabric-dw` to do the provisioning and to generate a correct `profiles.yml` automatically:
+This guide walks an analytics engineer end-to-end through standing up a working [dbt](https://docs.getdbt.com/) environment on a Microsoft Fabric Data Warehouse with `fabric-dw`. The headline feature is `fdw dbt init --with-sources`: it **introspects the live warehouse and writes a complete `models/staging/_sources.yml`** — one dbt `source:` per schema, listing every table (with column names and types) — so you never hand-author source definitions:
 
 1. **Provision** a new Warehouse.
-2. **Get the SQL connection details** dbt needs (host + database).
-3. **Scaffold and configure** a dbt project for the [dbt-fabric](https://docs.getdbt.com/docs/core/connect-data-platform/fabric-setup) adapter.
+2. **Scaffold** a dbt project for the [dbt-fabric](https://docs.getdbt.com/docs/core/connect-data-platform/fabric-setup) adapter, with the connection details (host + database) filled in automatically.
+3. **Provision all your dbt sources** — `--with-sources` generates `_sources.yml` from the warehouse's real schemas and tables.
 4. **Verify** the connection with `dbt debug` and build a model with `dbt run`.
 
-Microsoft's own [tutorial](https://learn.microsoft.com/fabric/data-warehouse/tutorial-setup-dbt?WT.mc_id=MVP_310840) requires you to find the SQL analytics endpoint in the portal and hand-author `profiles.yml`. `fabric-dw` automates exactly that step, so this guide closes the gap between Microsoft's manual portal steps and a fully scriptable path.
+Microsoft's own [tutorial](https://learn.microsoft.com/fabric/data-warehouse/tutorial-setup-dbt?WT.mc_id=MVP_310840) requires you to find the SQL analytics endpoint in the portal, hand-author `profiles.yml`, and write every source definition yourself. `fabric-dw` automates all of that, so this guide closes the gap between Microsoft's manual portal steps and a fully scriptable path.
 
 !!! tip "Using an AI assistant? The `dbt-setup` skill does all of this for you"
 
-    Everything below is the **human, copy-pasteable narrative** for someone driving `fabric-dw` from a terminal. If you drive an AI assistant (Claude) against the [MCP server](../mcp.md), the shipped [`dbt-setup` Agent Skill](../skills.md#dbt-setup) automates the same provision → inspect → scaffold → verify flow through the MCP tools. The CLI commands here and the skill are two front-ends to the same logic — pick whichever fits your workflow.
+    Everything below is the **human, copy-pasteable narrative** for someone driving `fabric-dw` from a terminal. If you drive an AI assistant (Claude) against the [MCP server](../mcp.md), the shipped [`dbt-setup` Agent Skill](../skills.md#dbt-setup) automates the same provision → scaffold → sources → verify flow through the MCP tools. The CLI commands here and the skill are two front-ends to the same logic — pick whichever fits your workflow.
 
 ---
 
@@ -60,7 +60,7 @@ export AZURE_CLIENT_ID=<your-client-id>
 export AZURE_CLIENT_SECRET=<your-client-secret>
 ```
 
-Microsoft recommends interactive (`CLI`) auth for working on a warehouse by hand, and service principals for automation — see the [tutorial's considerations](https://learn.microsoft.com/fabric/data-warehouse/tutorial-setup-dbt?WT.mc_id=MVP_310840#considerations). The mode you choose here is also what the scaffolder maps into the dbt profile in [Step 4](#step-4-scaffold-the-dbt-project).
+Microsoft recommends interactive (`CLI`) auth for working on a warehouse by hand, and service principals for automation — see the [tutorial's considerations](https://learn.microsoft.com/fabric/data-warehouse/tutorial-setup-dbt?WT.mc_id=MVP_310840#considerations). The mode you choose here is also what the scaffolder maps into the dbt profile in [Step 3](#step-3-scaffold-the-dbt-project).
 
 See the [Authentication reference](../authentication.md) for the full credential chain and every environment variable.
 
@@ -100,28 +100,7 @@ If a service principal or team needs access (for example, the identity that will
 
 ---
 
-## Step 3 — Inspect the connection details
-
-dbt's `profiles.yml` needs two values, and Fabric maps them like this:
-
-- **`host`** — the **SQL analytics endpoint** connection string (the TDS server, `<guid>.datawarehouse.fabric.microsoft.com`).
-- **`database`** — the **warehouse display name** (Fabric uses the item name as the Initial Catalog). For `SalesWH`, the database is simply `SalesWH`.
-
-You can read the host with [`fdw sql-endpoints get`](../commands/sql-endpoints.md#sql-endpoints-get):
-
-```shell
-fdw sql-endpoints get SalesWH
-```
-
-!!! note "Eventual consistency right after `create`"
-
-    The SQL analytics endpoint is provisioned with eventual consistency, so its connection string can be empty for a short window after `warehouses create`. `fabric-dw` **polls until the connection string is non-empty** (default timeout 120 s), so you do not normally have to retry by hand.
-
-You **do not** have to copy this value anywhere: `fdw dbt init` in the next step resolves the host itself, so the inspection here is just to understand what ends up in the profile. The [Find the warehouse connection string](https://learn.microsoft.com/fabric/data-warehouse/how-to-connect?WT.mc_id=MVP_310840) page confirms the same `host` = SQL connection string, `database` = item name mapping.
-
----
-
-## Step 4 — Scaffold the dbt project
+## Step 3 — Scaffold the dbt project
 
 [`fdw dbt init`](../commands/dbt.md#dbt-init) creates the whole project directory pre-wired to the warehouse. `ITEM` (the warehouse name or GUID) is optional if you set a default warehouse; `FOLDER` is the target directory.
 
@@ -129,96 +108,84 @@ You **do not** have to copy this value anywhere: `fdw dbt init` in the next step
 fdw dbt init SalesWH ./sales_dbt
 ```
 
-This writes `dbt_project.yml`, `profiles.yml`, `requirements.txt`, `.gitignore`, the standard dbt directories, a sample model, a `README.md`, and (with `--with-sources`) a real `models/staging/_sources.yml` introspected from the warehouse. If `git` is on your PATH and the folder is not already a repository, `git init` runs automatically. No dbt installation is required to scaffold — `fabric-dw` writes every file itself.
+This writes `dbt_project.yml`, `profiles.yml`, `requirements.txt`, `.gitignore`, the standard dbt directories, a sample model, a `README.md`, and a `models/staging/_sources.yml` (a placeholder, or **real source definitions** with `--with-sources` — see [Step 4](#step-4-provision-all-your-dbt-sources)). If `git` is on your PATH and the folder is not already a repository, `git init` runs automatically. No dbt installation is required to scaffold — `fabric-dw` writes every file itself.
 
-Useful options (see the [dbt command reference](../commands/dbt.md#dbt-init) for the full list):
+### The connection is configured for you
 
-| Option | Default | Description |
-| --- | --- | --- |
-| `--project-name TEXT` | sanitised folder name | dbt project name. |
-| `--profile-name TEXT` | same as project name | dbt profile name. |
-| `--schema TEXT` | `dbo` | Default target schema for models. |
-| `--target TEXT` | `dev` | dbt target name. |
-| `--threads INTEGER` | `4` | Number of dbt threads (1–64). |
-| `--auth [auto\|CLI\|ServicePrincipal\|interactive\|sp]` | from the active `--auth` mode | dbt-fabric authentication override. |
-| `--profiles-dir [project\|home]` | `project` | `project` writes `profiles.yml` in the folder; `home` merges into `~/.dbt/profiles.yml` (backs up an existing file). |
-| `--with-sources` | off | Introspect the live warehouse and generate `models/staging/_sources.yml` from its real schemas, tables, and column types. |
-| `--force` | off | Scaffold into a non-empty folder instead of refusing. |
+You do **not** hand-author `profiles.yml`. `fdw dbt init` resolves the warehouse's SQL analytics endpoint itself and fills in the two values dbt needs:
 
-### How the CLI fills in `profiles.yml`
+- **`host`** — the SQL analytics endpoint TDS server (`<guid>.datawarehouse.fabric.microsoft.com`), polled until the connection string is ready (the endpoint is eventually consistent right after `create`).
+- **`database`** — the warehouse display name (Fabric uses the item name as the Initial Catalog). For `SalesWH`, the database is simply `SalesWH`.
 
-| dbt `profiles.yml` key | Fabric value | How `fabric-dw` supplies it |
-| --- | --- | --- |
-| `type` | `fabric` | hard-coded by the scaffolder |
-| `driver` | `ODBC Driver 18 for SQL Server` | hard-coded by the scaffolder |
-| `host` | SQL analytics endpoint (TDS server) | resolved connection string, polled until ready |
-| `database` | warehouse display name (Initial Catalog) | resolved item name |
-| `schema` | `dbo` (default) | `--schema` |
-| `threads` | `4` (default) | `--threads` |
-| `authentication` | `auto` / `CLI` / `ServicePrincipal` | mapped from `--auth` |
+The `authentication` value is mapped from your sign-in mode (`default` → `auto`, `interactive` → `CLI`, `sp` → `ServicePrincipal`). With `--auth sp`, secrets are emitted as Jinja2 `env_var()` placeholders — never literal secrets — so the file is safe to commit. The full option list (`--schema`, `--target`, `--threads`, `--profiles-dir`, `--auth`, …), the exact generated `profiles.yml`, and the auth mapping live in the [dbt command reference](../commands/dbt.md#dbt-init); the credential chain is in the [Authentication reference](../authentication.md).
 
-The **authentication** value is mapped from your CLI auth mode:
+---
 
-| CLI `--auth` | dbt `authentication` |
-| --- | --- |
-| `default` | `auto` |
-| `interactive` | `CLI` |
-| `sp` | `ServicePrincipal` |
+## Step 4 — Provision all your dbt sources
 
-You can override it independently with `fdw dbt init … --auth`, where `interactive` and `sp` are accepted aliases for `CLI` and `ServicePrincipal`.
-
-### The generated `profiles.yml`
-
-With the default (`auto`) authentication, the generated `profiles.yml` looks like this — note the top-level `config: partial_parse` block:
-
-```yaml
-config:
-  partial_parse: true
-saleswh:
-  target: dev
-  outputs:
-    dev:
-      type: fabric
-      driver: ODBC Driver 18 for SQL Server
-      host: abc123def456ghij.datawarehouse.fabric.microsoft.com
-      database: SalesWH
-      schema: dbo
-      threads: 4
-      authentication: auto
-```
-
-### Service principal: secrets become `env_var()` placeholders
-
-When you scaffold with `--auth sp` (or `--auth ServicePrincipal`), the profile uses `authentication: ServicePrincipal` and emits the credentials as Jinja2 `env_var()` placeholders — **never literal secrets**:
-
-```yaml
-config:
-  partial_parse: true
-saleswh:
-  target: dev
-  outputs:
-    dev:
-      type: fabric
-      driver: ODBC Driver 18 for SQL Server
-      host: abc123def456ghij.datawarehouse.fabric.microsoft.com
-      database: SalesWH
-      schema: dbo
-      threads: 4
-      authentication: ServicePrincipal
-      tenant_id: '{{ env_var(''AZURE_TENANT_ID'') }}'
-      client_id: '{{ env_var(''AZURE_CLIENT_ID'') }}'
-      client_secret: '{{ env_var(''AZURE_CLIENT_SECRET'') }}'
-```
-
-Set the matching environment variables before running dbt, so the placeholders resolve at runtime:
+This is the part you would otherwise do by hand. Add `--with-sources` and `fdw dbt init` **introspects the live warehouse** and writes a complete `models/staging/_sources.yml` — so you never type out a source definition:
 
 ```shell
-export AZURE_TENANT_ID=<your-tenant-id>
-export AZURE_CLIENT_ID=<your-client-id>
-export AZURE_CLIENT_SECRET=<your-client-secret>
+fdw dbt init SalesWH ./sales_dbt --with-sources
 ```
 
-This keeps the generated file safe to commit. See the [dbt-fabric resource configs](https://docs.getdbt.com/reference/resource-configs/fabric-configs) for the full set of profile fields.
+The `--with-sources` flag generates `models/staging/_sources.yml` **from the warehouse's actual schemas and tables**: one dbt `source:` entry **per schema**, each listing every table in that schema (with its column names and data types). Without `--with-sources`, you get a minimal placeholder `_sources.yml` to fill in yourself.
+
+### The generated `models/staging/_sources.yml`
+
+With `--with-sources`, the file has one `sources:` entry per schema. Each source's `database` is the warehouse name and its `schema` is the schema name; every table is listed under `tables:`, with columns and their data types:
+
+```yaml
+version: 2
+sources:
+  - name: sales
+    database: SalesWH
+    schema: sales
+    tables:
+      - name: customer
+        columns:
+          - name: customer_id
+            data_type: bigint
+          - name: region
+            data_type: varchar
+      - name: orders
+        columns:
+          - name: order_id
+            data_type: bigint
+          - name: order_date
+            data_type: date
+  - name: dbo
+    database: SalesWH
+    schema: dbo
+    tables:
+      - name: my_first_model
+```
+
+Without `--with-sources`, the placeholder looks like this — replace it with your own definitions:
+
+```yaml
+version: 2
+sources:
+  - name: placeholder
+    description: Replace with your source definitions.
+    database: "{{ env_var('DBT_DATABASE', 'SalesWH') }}"
+    schema: dbo
+    tables: []
+```
+
+### Reference the sources from your models
+
+dbt models read from these sources with the [`source()`](https://docs.getdbt.com/reference/dbt-jinja-functions/source) function — `{{ source('<schema>', '<table>') }}`, where the first argument is the `source:` name (the schema) and the second is the table:
+
+```sql
+-- models/staging/stg_customers.sql
+select
+    customer_id,
+    region
+from {{ source('sales', 'customer') }}
+```
+
+Because every schema and table is already declared in `_sources.yml`, `source()` resolves immediately and `dbt run` / `dbt test` can build on top of the real warehouse objects without any manual source authoring.
 
 ---
 
@@ -261,11 +228,11 @@ If you drive an AI client over the [MCP server](../mcp.md), the same scaffold is
 
 - `profiles_yml`
 - `dbt_project_yml`
-- `sources_yml`
+- `sources_yml` — the same `models/staging/_sources.yml` content as the CLI: **real source definitions for every schema and table when called with `with_sources=True`**, otherwise the placeholder.
 - `requirements_txt`
 - `gitignore`
 
-The AI agent writes those strings to disk itself. The shipped [`dbt-setup` Agent Skill](../skills.md#dbt-setup) orchestrates the whole flow — it resolves the warehouse with `get_warehouse`, confirms connectivity with `list_schemas` / `list_tables`, calls `generate_dbt_profile` (with `with_sources=true` for column-rich sources), writes the files, and tells you to run `pip install -r requirements.txt`, `dbt debug`, and `dbt run`. In short: **the guide is the CLI narrative; the skill is the assistant-driven equivalent.**
+The AI agent writes those strings to disk itself. The shipped [`dbt-setup` Agent Skill](../skills.md#dbt-setup) orchestrates the whole flow — it resolves the warehouse with `get_warehouse`, confirms connectivity with `list_schemas` / `list_tables`, calls `generate_dbt_profile` with `with_sources=True` to provision the sources, writes the files, and tells you to run `pip install -r requirements.txt`, `dbt debug`, and `dbt run`. In short: **the guide is the CLI narrative; the skill is the assistant-driven equivalent.**
 
 ---
 

--- a/docs/guides/dbt-setup.md
+++ b/docs/guides/dbt-setup.md
@@ -64,16 +64,18 @@ Microsoft recommends interactive (`CLI`) auth for working on a warehouse by hand
 
 See the [Authentication reference](../authentication.md) for the full credential chain and every environment variable.
 
-!!! info "Set a default workspace to type less"
+---
 
-    Every command below takes its target workspace from the global `-w/--workspace NAME|GUID` option. To avoid repeating it, set a default once:
+## Set your defaults
 
-    ```shell
-    fdw config set workspace "Sales Workspace"
-    fdw config set warehouse SalesWH        # optional: a default warehouse too
-    ```
+Once you are signed in, store the workspace so you do not repeat it on every command:
 
-    The examples below show the explicit `-w` form so they are self-contained.
+```shell
+fdw config set workspace "Sales Workspace"
+fdw config set warehouse SalesWH        # optional — once the warehouse exists (Step 2)
+```
+
+The rest of this guide assumes the workspace default is set, so the examples omit `-w "Sales Workspace"`. Any command still accepts an explicit `-w`/`--workspace NAME|GUID` to override it. The warehouse default fills optional `[ITEM]` positionals once the warehouse has been provisioned; commands here that take a required name (`warehouses create NAME`, `dbt init … FOLDER`, `sql-endpoints get ENDPOINT`) still spell out the warehouse. See [Configuration & defaults](../commands/config.md).
 
 ---
 
@@ -82,7 +84,7 @@ See the [Authentication reference](../authentication.md) for the full credential
 Create a new warehouse with [`fdw warehouses create`](../commands/warehouses.md#warehouses-create). `NAME` is positional; the workspace comes from the global `-w` option.
 
 ```shell
-fdw -w "Sales Workspace" warehouses create SalesWH --description "dbt target warehouse"
+fdw warehouses create SalesWH --description "dbt target warehouse"
 ```
 
 `fabric-dw` issues the create request, **polls the create operation to completion**, and re-reads the warehouse so the returned object is fully populated — when the command returns, the warehouse is ready to connect to.
@@ -108,7 +110,7 @@ dbt's `profiles.yml` needs two values, and Fabric maps them like this:
 You can read the host with [`fdw sql-endpoints get`](../commands/sql-endpoints.md#sql-endpoints-get):
 
 ```shell
-fdw -w "Sales Workspace" sql-endpoints get SalesWH
+fdw sql-endpoints get SalesWH
 ```
 
 !!! note "Eventual consistency right after `create`"
@@ -124,7 +126,7 @@ You **do not** have to copy this value anywhere: `fdw dbt init` in the next step
 [`fdw dbt init`](../commands/dbt.md#dbt-init) creates the whole project directory pre-wired to the warehouse. `ITEM` (the warehouse name or GUID) is optional if you set a default warehouse; `FOLDER` is the target directory.
 
 ```shell
-fdw -w "Sales Workspace" dbt init SalesWH ./sales_dbt
+fdw dbt init SalesWH ./sales_dbt
 ```
 
 This writes `dbt_project.yml`, `profiles.yml`, `requirements.txt`, `.gitignore`, the standard dbt directories, a sample model, a `README.md`, and (with `--with-sources`) a real `models/staging/_sources.yml` introspected from the warehouse. If `git` is on your PATH and the folder is not already a repository, `git init` runs automatically. No dbt installation is required to scaffold — `fabric-dw` writes every file itself.
@@ -240,11 +242,11 @@ A passing `dbt debug` confirms the host, database, ODBC driver, and authenticati
 You can cross-check from `fabric-dw` itself that the model landed:
 
 ```shell
-# Confirm the warehouse answers SQL
-fdw -w "Sales Workspace" sql exec SalesWH -q "select 1"
+# Confirm the warehouse answers SQL (warehouse positional spelled out — the warehouse default is optional in this guide)
+fdw sql exec SalesWH -q "select 1"
 
 # List the tables/views the run produced
-fdw -w "Sales Workspace" tables list SalesWH
+fdw tables list SalesWH
 ```
 
 !!! warning "Use `sql exec`, not `sql query`"

--- a/docs/guides/ingesting-data.md
+++ b/docs/guides/ingesting-data.md
@@ -34,10 +34,10 @@ Fabric offers several ingestion mechanisms. `COPY INTO` — what this tool uses 
     The target workspace is a **global** option: `fdw -w <workspace> …`, falling back to your configured default. The warehouse is a positional `[ITEM]`. So every command below has the shape:
 
     ```
-    fdw -w <workspace> <group> <command> [ITEM] …
+    fdw [-w <workspace>] <group> <command> [ITEM] …
     ```
 
-    not `<command> <workspace> <item> …`. `fdw` is the short alias for `fabric-dw`.
+    not `<command> <workspace> <item> …`. Once the [defaults](#set-your-defaults) are set, both `-w <workspace>` and the optional `[ITEM]` positional can be omitted (the examples below do). `fdw` is the short alias for `fabric-dw`.
 
 ---
 
@@ -65,6 +65,19 @@ Two decisions shape the whole workflow:
 
 ---
 
+## Set your defaults
+
+Store the workspace and warehouse once so you do not repeat them on every command:
+
+```shell
+fdw config set workspace MyWorkspace
+fdw config set warehouse SalesWH
+```
+
+The rest of this guide assumes these defaults are set, so the examples omit `-w MyWorkspace` and drop the warehouse positional where it is optional. Any command still accepts an explicit `-w`/`--workspace` or a positional `[ITEM]` to override them. Commands that take a trailing required argument (such as `tables load … QUALIFIED_NAME`) keep the warehouse positional so the remaining arguments stay unambiguous. See [Configuration & defaults](../commands/config.md).
+
+---
+
 ## Step 1 — (optional) create the schema
 
 If your destination schema does not exist yet, create it. `dbo` always exists, so this step is only needed for custom schemas such as `staging` or `reporting`.
@@ -72,7 +85,7 @@ If your destination schema does not exist yet, create it. `dbo` always exists, s
 === "CLI"
 
     ```shell
-    fdw -w MyWorkspace schemas create SalesWH staging
+    fdw schemas create SalesWH staging
     ```
 
 === "MCP"
@@ -96,30 +109,30 @@ Skip this step if you plan to auto-create with `tables load --create` (see [Step
 
     ```shell
     # Empty table, schema from a Parquet footer (no rows read)
-    fdw -w MyWorkspace tables create SalesWH \
+    fdw tables create \
       --name dbo.sales \
       --from-parquet ./exports/sales.parquet
 
     # Empty table, schema inferred from a CSV header + sample
-    fdw -w MyWorkspace tables create SalesWH \
+    fdw tables create \
       --name staging.raw_products \
       --from-csv ./data/products.csv --varchar-length 500
 
     # Empty table from explicit inline columns
-    fdw -w MyWorkspace tables create SalesWH \
+    fdw tables create \
       --name dbo.events \
       --column "event_id:BIGINT:notnull" \
       --column "event_type:VARCHAR(100)" \
       --column "occurred_at:DATETIME2(7)"
 
     # Explicit schema from JSON, plus an extra column
-    fdw -w MyWorkspace tables create SalesWH \
+    fdw tables create \
       --name dbo.audit_log \
       --from-schema ./schemas/audit_log.json \
       --column "inserted_at:DATETIME2(7):notnull"
 
     # CTAS — populate from a query
-    fdw -w MyWorkspace tables create SalesWH \
+    fdw tables create \
       --name dbo.orders_2026 \
       --select "SELECT * FROM dbo.orders WHERE YEAR(sale_date) = 2026"
     ```
@@ -169,13 +182,13 @@ Supported formats:
 
 ```shell
 # Load a local CSV into an existing table (header row present)
-fdw -w MyWorkspace tables load SalesWH dbo.sales --file data.csv
+fdw tables load SalesWH dbo.sales --file data.csv
 
 # Load a local Parquet file
-fdw -w MyWorkspace tables load SalesWH dbo.events --file events.parquet
+fdw tables load SalesWH dbo.events --file events.parquet
 
 # Load a local JSON file (converted to Parquet internally; requires pyarrow)
-fdw -w MyWorkspace tables load SalesWH dbo.products --file products.json
+fdw tables load SalesWH dbo.products --file products.json
 ```
 
 ### Remote URL (`--url`)
@@ -194,12 +207,12 @@ For OneLake or same-tenant URLs no credential is needed (`COPY INTO` runs under 
 
 ```shell
 # Load from a remote OneLake URL (no credential needed)
-fdw -w MyWorkspace tables load SalesWH dbo.orders \
+fdw tables load SalesWH dbo.orders \
     --url "https://onelake.dfs.fabric.microsoft.com/ws/lh.Lakehouse/Files/orders.parquet" \
     --format parquet
 
 # Load from Azure Blob Storage with a SAS token
-fdw -w MyWorkspace tables load SalesWH dbo.events \
+fdw tables load SalesWH dbo.events \
     --url "https://myaccount.blob.core.windows.net/data/events.csv" \
     --format csv --credential-type sas --secret "?sv=2021&..."
 ```
@@ -227,17 +240,17 @@ Pass `--create` (local files only; requires `pyarrow`) to infer the schema from 
 
 ```shell
 # Auto-create from a Parquet schema, then load
-fdw -w MyWorkspace tables load SalesWH dbo.sales --file data.parquet --create
+fdw tables load SalesWH dbo.sales --file data.parquet --create
 
 # Auto-create from CSV, forcing all columns to VARCHAR
-fdw -w MyWorkspace tables load SalesWH dbo.raw --file raw.csv --create --all-varchar
+fdw tables load SalesWH dbo.raw --file raw.csv --create --all-varchar
 
 # Replace the table (drop + recreate + load), skip the confirmation, drop on failure
-fdw -w MyWorkspace tables load SalesWH dbo.sales --file data.parquet --create \
+fdw tables load SalesWH dbo.sales --file data.parquet --create \
     --if-exists replace -y --cleanup-on-failure
 
 # Auto-create with CLUSTER BY (columns must exist in the inferred schema)
-fdw -w MyWorkspace tables load SalesWH dbo.sales --file data.parquet --create \
+fdw tables load SalesWH dbo.sales --file data.parquet --create \
     --cluster-by SaleDate --cluster-by CustomerID
 ```
 
@@ -258,17 +271,17 @@ Confirm the data landed:
 === "CLI"
 
     ```shell
-    # Row count
-    fdw -w MyWorkspace tables count SalesWH dbo.sales
+    # Row count (warehouse positional kept — table name follows)
+    fdw tables count SalesWH dbo.sales
 
     # Sample some rows
-    fdw -w MyWorkspace tables read SalesWH dbo.sales --count 5
+    fdw tables read SalesWH dbo.sales --count 5
 
     # Inspect column metadata (names, types, nullability)
-    fdw -w MyWorkspace tables columns SalesWH dbo.sales
+    fdw tables columns SalesWH dbo.sales
 
     # List tables in the schema
-    fdw -w MyWorkspace tables list SalesWH --schema dbo
+    fdw tables list --schema dbo
     ```
 
 === "MCP"
@@ -291,14 +304,14 @@ Statistics are **not** updated automatically after a load. Create or update sing
 
     ```shell
     # Create a statistic on a column (full scan; --name optional, auto-generated when omitted)
-    fdw -w MyWorkspace statistics create SalesWH \
+    fdw statistics create \
       --table dbo.sales --column SaleDate
 
-    # Update an existing statistic after a subsequent load
-    fdw -w MyWorkspace statistics update SalesWH dbo.sales _stat_sales_saledate
+    # Update an existing statistic after a subsequent load (warehouse positional kept — names follow)
+    fdw statistics update SalesWH dbo.sales _stat_sales_saledate
 
     # Inspect a statistic (header, density vector, histogram)
-    fdw -w MyWorkspace statistics show SalesWH dbo.sales _stat_sales_saledate
+    fdw statistics show SalesWH dbo.sales _stat_sales_saledate
     ```
 
 === "MCP"

--- a/docs/guides/ingesting-data.md
+++ b/docs/guides/ingesting-data.md
@@ -37,7 +37,7 @@ Fabric offers several ingestion mechanisms. `COPY INTO` — what this tool uses 
     fdw [-w <workspace>] <group> <command> [ITEM] …
     ```
 
-    not `<command> <workspace> <item> …`. Once the [defaults](#set-your-defaults) are set, both `-w <workspace>` and the optional `[ITEM]` positional can be omitted (the examples below do). `fdw` is the short alias for `fabric-dw`.
+    not `<command> <workspace> <item> …`. Once the [defaults](#set-your-defaults) are set, both `-w <workspace>` and the optional `[ITEM]` positional can be omitted (the examples below do).
 
 ---
 

--- a/docs/guides/ingesting-data.md
+++ b/docs/guides/ingesting-data.md
@@ -303,15 +303,15 @@ Statistics are **not** updated automatically after a load. Create or update sing
 === "CLI"
 
     ```shell
-    # Create a statistic on a column (full scan; --name optional, auto-generated when omitted)
+    # Create a single-column statistic (full scan; --name is required)
     fdw statistics create \
-      --table dbo.sales --column SaleDate
+      --table dbo.sales --column SaleDate --name stat_sales_saledate
 
     # Update an existing statistic after a subsequent load (warehouse positional kept — names follow)
-    fdw statistics update SalesWH dbo.sales _stat_sales_saledate
+    fdw statistics update SalesWH dbo.sales stat_sales_saledate
 
     # Inspect a statistic (header, density vector, histogram)
-    fdw statistics show SalesWH dbo.sales _stat_sales_saledate
+    fdw statistics show SalesWH dbo.sales stat_sales_saledate
     ```
 
 === "MCP"

--- a/docs/guides/query-performance.md
+++ b/docs/guides/query-performance.md
@@ -50,16 +50,29 @@ The `queryinsights` views are documented in [Query insights in Fabric Data Wareh
 
 ---
 
+## Set your defaults
+
+Store the workspace and warehouse once so you do not repeat them on every command:
+
+```shell
+fdw config set workspace MyWorkspace
+fdw config set warehouse SalesWH
+```
+
+The rest of this guide assumes these defaults are set, so the examples omit `-w MyWorkspace` and the warehouse positional. Any command still accepts an explicit `-w`/`--workspace` or a positional `[WAREHOUSE]`/`[ITEM]` to override them. See [Configuration & defaults](../commands/config.md).
+
+---
+
 ## Step 1 — Investigate live activity
 
 Start with what is happening **right now**.
 
 ```shell
 # Queries executing this instant (live DMVs — Admin)
-fdw -w MyWorkspace queries running SalesWH
+fdw queries running
 
 # Active SQL connections/sessions, including idle ones not shown above
-fdw -w MyWorkspace queries connections SalesWH
+fdw queries connections
 ```
 
 `queries running` (MCP [`list_running_queries`](../commands/queries.md#list_running_queries)) returns each in-flight query with its `session_id`, `start_time`, `total_elapsed_time`, `login_name`, and `query_text` — enough to spot a single session that is dominating the warehouse. `queries connections` (MCP [`list_connections`](../commands/queries.md#list_connections)) reads `sys.dm_exec_connections` and surfaces lower-level connection detail (including idle connections) that the running view omits.
@@ -74,10 +87,10 @@ Live DMVs only show the present moment. To see what *happened*, read the per-req
 
 ```shell
 # Completed requests in a time window (queryinsights.exec_requests_history)
-fdw -w MyWorkspace queries history SalesWH --limit 50 --since 2026-06-01T00:00:00
+fdw queries history --limit 50 --since 2026-06-01T00:00:00
 
 # Completed sessions (queryinsights.exec_sessions_history)
-fdw -w MyWorkspace queries sessions SalesWH --since 2026-06-01T00:00:00 --until 2026-06-08T00:00:00
+fdw queries sessions --since 2026-06-01T00:00:00 --until 2026-06-08T00:00:00
 ```
 
 Both commands accept `--limit` (1–10 000, default 100), `--since`, and `--until` (ISO-8601). `queries history` (MCP [`list_request_history`](../commands/queries.md#list_request_history)) is the raw per-request feed — one row per execution — carrying the columns you will lean on for diagnosis: `total_elapsed_time_ms`, `data_scanned_remote_storage_mb`, `data_scanned_memory_mb`, `data_scanned_disk_mb`, `result_cache_hit`, `query_hash`, and `label`. `queries sessions` (MCP [`list_session_history`](../commands/queries.md#list_session_history)) rolls the same activity up per session.
@@ -92,13 +105,13 @@ Rather than eyeballing raw history, let Fabric rank the queries for you.
 
 ```shell
 # Ranked by median total elapsed time DESC
-fdw -w MyWorkspace queries long-running SalesWH
+fdw queries long-running
 
 # High-frequency queries (biggest aggregate cost), ranked by run count DESC
-fdw -w MyWorkspace queries frequent SalesWH --limit 20
+fdw queries frequent --limit 20
 
 # Capacity-pressure / read-optimization signals (beta/preview)
-fdw -w MyWorkspace sql-pools insights SalesWH
+fdw sql-pools insights
 ```
 
 - `queries long-running` (MCP [`list_long_running_queries`](../commands/queries.md#list_long_running_queries)) reads `queryinsights.long_running_queries`, ordered server-side by `median_total_elapsed_time_ms` DESC. "Top N" is simply `--limit N`.
@@ -117,21 +130,21 @@ With a specific slow query in hand, capture its **estimated** execution plan. `s
 
 ```shell
 # Default: a colour-coded Rich operator tree in the terminal
-fdw -w MyWorkspace sql plan SalesWH -q "SELECT * FROM dbo.Sales s JOIN dbo.Customer c ON s.cust_id = c.id WHERE c.region = 'EU'"
+fdw sql plan -q "SELECT * FROM dbo.Sales s JOIN dbo.Customer c ON s.cust_id = c.id WHERE c.region = 'EU'"
 
 # Raw SHOWPLAN_XML to stdout (pipe-friendly)
-fdw -w MyWorkspace sql plan SalesWH -q "..." --raw
+fdw sql plan -q "..." --raw
 
 # Save a .sqlplan that opens graphically in SSMS / Azure Data Studio
-fdw -w MyWorkspace sql plan SalesWH -q "..." -o plan.sqlplan
+fdw sql plan -q "..." -o plan.sqlplan
 
 # Parsed operator tree as JSON (root --json flag)
-fdw -w MyWorkspace --json sql plan SalesWH -q "..."
+fdw --json sql plan -q "..."
 
 # Diagram exports
-fdw -w MyWorkspace sql plan SalesWH -q "..." --format mermaid          # paste into mermaid.live or GitHub Markdown
-fdw -w MyWorkspace sql plan SalesWH -q "..." --format svg  -o plan.svg  # requires Graphviz
-fdw -w MyWorkspace sql plan SalesWH -q "..." --format html -o plan.html # self-contained, offline-viewable
+fdw sql plan -q "..." --format mermaid          # paste into mermaid.live or GitHub Markdown
+fdw sql plan -q "..." --format svg  -o plan.svg  # requires Graphviz
+fdw sql plan -q "..." --format html -o plan.html # self-contained, offline-viewable
 ```
 
 Representation (`--raw`/`--xml`, root `--json`, `--format mermaid|dot|svg|html`) and destination (`-o FILE`) are orthogonal — see [`sql plan`](../commands/sql.md#sql-plan) for the full matrix. Via MCP, `get_query_plan` takes a `format` parameter (`xml` | `tree` | `json` | `mermaid`); the artifact formats **SVG, HTML, and DOT are CLI-only** because the MCP server never writes files.
@@ -169,7 +182,7 @@ Caching in Fabric is **automatic and not user-clearable** — the in-memory and 
 To drill into a specific shape, run ad-hoc T-SQL with `sql exec` (MCP [`execute_sql`](../commands/sql.md#execute_sql)) and filter `exec_requests_history` by `query_hash` or `label`:
 
 ```shell
-fdw -w MyWorkspace sql exec SalesWH -q "SELECT TOP 20 submit_time, total_elapsed_time_ms, data_scanned_remote_storage_mb, result_cache_hit FROM queryinsights.exec_requests_history WHERE label = 'sales-eu-report' ORDER BY submit_time DESC"
+fdw sql exec -q "SELECT TOP 20 submit_time, total_elapsed_time_ms, data_scanned_remote_storage_mb, result_cache_hit FROM queryinsights.exec_requests_history WHERE label = 'sales-eu-report' ORDER BY submit_time DESC"
 ```
 
 Using a **query label** to track and compare one query across executions is a first-class Microsoft pattern — see [Query labeling](https://learn.microsoft.com/fabric/data-warehouse/query-label?WT.mc_id=MVP_310840).
@@ -182,10 +195,10 @@ Bad row estimates in the plan (Step 4) almost always trace back to missing or st
 
 ```shell
 # List statistics on the referenced tables (spot missing ones)
-fdw -w MyWorkspace statistics list SalesWH --schema dbo --table Customer
+fdw statistics list --schema dbo --table Customer
 
-# Inspect a statistic's histogram and staleness
-fdw -w MyWorkspace statistics show SalesWH dbo.Customer _WA_Sys_00000003_12345678 --histogram
+# Inspect a statistic's histogram and staleness (warehouse positional kept — names follow)
+fdw statistics show SalesWH dbo.Customer _WA_Sys_00000003_12345678 --histogram
 ```
 
 `statistics list` (MCP [`list_statistics`](../commands/statistics.md#list_statistics)) shows both user-created and Fabric's automatic `_WA_Sys_*` statistics; `statistics show` (MCP [`show_statistics`](../commands/statistics.md#show_statistics)) runs `DBCC SHOW_STATISTICS` to return the header, density vector, and histogram so you can judge staleness. Verifying the auto-created stats and inspecting them via `DBCC SHOW_STATISTICS` is the documented diagnostic — see [Automatic statistics at query time](https://learn.microsoft.com/fabric/data-warehouse/statistics?WT.mc_id=MVP_310840#automatic-statistics-at-query).
@@ -194,13 +207,13 @@ When a column in a `GROUP BY` / `ORDER BY` / `WHERE` / `JOIN` lacks a good stati
 
 ```shell
 # Create a single-column histogram statistic (--name is required)
-fdw -w MyWorkspace statistics create SalesWH --table dbo.Customer --column region --name stat_customer_region --fullscan
+fdw statistics create --table dbo.Customer --column region --name stat_customer_region --fullscan
 
-# Refresh after a large data change
-fdw -w MyWorkspace statistics update SalesWH dbo.Customer stat_customer_region --fullscan
+# Refresh after a large data change (warehouse positional kept — table/stat names follow)
+fdw statistics update SalesWH dbo.Customer stat_customer_region --fullscan
 
-# Drop a redundant user statistic (prompts unless -y)
-fdw -w MyWorkspace statistics delete SalesWH dbo.Customer stat_customer_region
+# Drop a redundant user statistic (prompts unless -y; warehouse positional kept)
+fdw statistics delete SalesWH dbo.Customer stat_customer_region
 ```
 
 These map to MCP [`create_statistics`](../commands/statistics.md#create_statistics), [`update_statistics`](../commands/statistics.md#update_statistics), and [`delete_statistics`](../commands/statistics.md#delete_statistics). All three are **mutating** MCP tools gated behind the write-guard (`delete_statistics` is additionally destructive-gated via `FABRIC_MCP_ALLOW_DESTRUCTIVE`); they do **not** pop a confirmation dialog, so an AI assistant must ask before calling them.
@@ -220,7 +233,7 @@ With statistics healthy, turn to the query text itself. Common, high-leverage re
 Re-run the improved query through `sql exec` with a label (and any hint):
 
 ```shell
-fdw -w MyWorkspace sql exec SalesWH -q "SELECT s.id, s.amount FROM dbo.Sales s JOIN dbo.Customer c ON s.cust_id = c.id WHERE c.region = 'EU' OPTION (LABEL='sales-eu-report')"
+fdw sql exec -q "SELECT s.id, s.amount FROM dbo.Sales s JOIN dbo.Customer c ON s.cust_id = c.id WHERE c.region = 'EU' OPTION (LABEL='sales-eu-report')"
 ```
 
 ---
@@ -233,15 +246,15 @@ Confirm the fix actually helped, on the **warm** path.
 2. Pull the history filtered by your label and compare `total_elapsed_time_ms` against the original:
 
    ```shell
-   fdw -w MyWorkspace queries history SalesWH --limit 10 --since 2026-06-08T00:00:00
+   fdw queries history --limit 10 --since 2026-06-08T00:00:00
    ```
 
    Or filter precisely with `sql exec` on `label` / `query_hash` as in Step 5.
 3. If the query (or an identical one) is run repeatedly, consider enabling **result-set caching** so identical re-runs skip compute entirely:
 
    ```shell
-   fdw -w MyWorkspace settings show SalesWH                      # check current state
-   fdw -w MyWorkspace settings result-set-caching SalesWH on     # enable (DW only)
+   fdw settings show                                # check current state
+   fdw settings result-set-caching SalesWH on       # enable (DW only; on/off follows, so warehouse positional kept)
    ```
 
    `settings result-set-caching` maps to MCP [`set_result_set_caching`](../commands/settings.md#set_result_set_caching); `settings show` maps to [`get_warehouse_settings`](../commands/settings.md#get_warehouse_settings).
@@ -260,10 +273,10 @@ When a live query is clearly out of control and you have Admin rights, terminate
 
 ```shell
 # Find the runaway session
-fdw -w MyWorkspace queries running SalesWH
+fdw queries running
 
-# Terminate it (prompts unless -y)
-fdw -w MyWorkspace --yes queries kill SalesWH 42
+# Terminate it (prompts unless -y; warehouse positional kept — SESSION_ID follows)
+fdw --yes queries kill SalesWH 42
 ```
 
 `queries kill` maps to MCP [`kill_session`](../commands/queries.md#kill_session), which is write-gated. Identifying and killing a long-running query via DMVs is the documented incident path — see [Monitor using DMVs](https://learn.microsoft.com/fabric/data-warehouse/monitor-using-dmv?WT.mc_id=MVP_310840).
@@ -276,29 +289,29 @@ A nightly EU sales report is slow. The full loop:
 
 ```shell
 # 1. INVESTIGATE — confirm it is not a one-off live spike
-fdw -w MyWorkspace queries running SalesWH
+fdw queries running
 
 # 2. DIAGNOSE — it tops the long-running list
-fdw -w MyWorkspace queries long-running SalesWH --limit 10
+fdw queries long-running --limit 10
 
 # 3. CAPTURE THE PLAN — a Hash Join with a huge estimated row count on Customer,
 #    plus CONVERT_IMPLICIT on c.region
-fdw -w MyWorkspace sql plan SalesWH -q "SELECT * FROM dbo.Sales s JOIN dbo.Customer c ON s.cust_id = c.id WHERE c.region = N'EU'"
+fdw sql plan -q "SELECT * FROM dbo.Sales s JOIN dbo.Customer c ON s.cust_id = c.id WHERE c.region = N'EU'"
 
 # 4. READ HISTORY — the slow runs all show non-zero data_scanned_remote_storage_mb
 #    on the first execution only (cold start); warm runs are still slow
-fdw -w MyWorkspace queries history SalesWH --limit 20 --since 2026-06-01T00:00:00
+fdw queries history --limit 20 --since 2026-06-01T00:00:00
 
 # 5. CHECK STATISTICS — no user statistic on Customer.region
-fdw -w MyWorkspace statistics list SalesWH --schema dbo --table Customer
+fdw statistics list --schema dbo --table Customer
 
 # 6. IMPROVE — create the missing statistic, and fix the type mismatch (region is varchar, not nvarchar)
-fdw -w MyWorkspace statistics create SalesWH --table dbo.Customer --column region --name stat_customer_region --fullscan
-fdw -w MyWorkspace sql exec SalesWH -q "SELECT s.id, s.amount FROM dbo.Sales s JOIN dbo.Customer c ON s.cust_id = c.id WHERE c.region = 'EU' OPTION (LABEL='sales-eu-report')"
+fdw statistics create --table dbo.Customer --column region --name stat_customer_region --fullscan
+fdw sql exec -q "SELECT s.id, s.amount FROM dbo.Sales s JOIN dbo.Customer c ON s.cust_id = c.id WHERE c.region = 'EU' OPTION (LABEL='sales-eu-report')"
 
 # 7. VERIFY — run twice (discard the cold-start run), then compare warm runs by label
-fdw -w MyWorkspace sql exec SalesWH -q "SELECT s.id, s.amount FROM dbo.Sales s JOIN dbo.Customer c ON s.cust_id = c.id WHERE c.region = 'EU' OPTION (LABEL='sales-eu-report')"
-fdw -w MyWorkspace sql exec SalesWH -q "SELECT TOP 10 submit_time, total_elapsed_time_ms, data_scanned_remote_storage_mb, result_cache_hit FROM queryinsights.exec_requests_history WHERE label = 'sales-eu-report' ORDER BY submit_time DESC"
+fdw sql exec -q "SELECT s.id, s.amount FROM dbo.Sales s JOIN dbo.Customer c ON s.cust_id = c.id WHERE c.region = 'EU' OPTION (LABEL='sales-eu-report')"
+fdw sql exec -q "SELECT TOP 10 submit_time, total_elapsed_time_ms, data_scanned_remote_storage_mb, result_cache_hit FROM queryinsights.exec_requests_history WHERE label = 'sales-eu-report' ORDER BY submit_time DESC"
 ```
 
 Median elapsed time on the warm runs drops once the statistic gives the optimizer an accurate estimate and the implicit conversion is gone. Because the report runs identically every night, enabling `settings result-set-caching SalesWH on` lets unchanged re-runs return instantly.

--- a/docs/guides/query-performance.md
+++ b/docs/guides/query-performance.md
@@ -110,7 +110,7 @@ fdw queries long-running
 # High-frequency queries (biggest aggregate cost), ranked by run count DESC
 fdw queries frequent --limit 20
 
-# Capacity-pressure / read-optimization signals (beta/preview)
+# Capacity-pressure / read-optimization signals
 fdw sql-pools insights
 ```
 

--- a/docs/guides/query-performance.md
+++ b/docs/guides/query-performance.md
@@ -10,7 +10,7 @@ A task-oriented walkthrough for using `fabric-dw` (binary alias **`fdw`**) to fi
 
 !!! tip "Driving `fabric-dw` from an AI assistant?"
 
-    The [`query-optimizer`](../skills.md#query-optimizer) Agent Skill automates exactly this single-query workflow — capture the plan, pull history, audit statistics, inspect clustering, then propose or apply fixes. This page is the human-facing version of the same loop, followed by hand at the terminal. For the **warehouse-wide** angle (hotspots across every query, SQL-pool pressure, caching health) see the [`warehouse-performance`](../skills.md#warehouse-performance) skill and its companion human guide tracked in [#433](https://github.com/sdebruyn/fabric-dw-mcp-cli/issues/433).
+    The [`query-optimizer`](../skills.md#query-optimizer) Agent Skill automates exactly this single-query workflow — capture the plan, pull history, audit statistics, inspect clustering, then propose or apply fixes. This page is the human-facing version of the same loop, followed by hand at the terminal. For the **warehouse-wide** angle (hotspots across every query, SQL-pool pressure, caching health) see the [`warehouse-performance`](../skills.md#warehouse-performance) skill and its companion [Warehouse performance guide](warehouse-performance.md).
 
 ---
 

--- a/docs/guides/tables-and-views.md
+++ b/docs/guides/tables-and-views.md
@@ -45,6 +45,19 @@ You'll then maintain and iterate on the model — clone, rename, re-cluster, cle
 
 ---
 
+## Set your defaults
+
+Store the workspace and warehouse once so you do not repeat them on every command:
+
+```shell
+fdw config set workspace MyWorkspace
+fdw config set warehouse SalesWH
+```
+
+The rest of this guide assumes these defaults are set, so the examples omit `-w MyWorkspace` and drop the warehouse positional where it is optional. Any command still accepts an explicit `-w`/`--workspace` or a positional `[WAREHOUSE]`/`[ITEM]` to override them. Commands that take a trailing required argument (such as `tables clear … QUALIFIED_NAME` or `schemas create … NAME`) keep the warehouse positional so the remaining arguments stay unambiguous. See [Configuration & defaults](../commands/config.md).
+
+---
+
 ## Step 1 — Create a schema
 
 Schemas are the namespace for your tables and views. `dbo` always exists; create custom schemas to group related objects.
@@ -52,11 +65,11 @@ Schemas are the namespace for your tables and views. `dbo` always exists; create
 **Targets:** Data Warehouse · SQL Analytics Endpoint
 
 ```shell
-# Create the schema
-fdw -w MyWorkspace schemas create SalesWH sales
+# Create the schema (warehouse positional kept — schema NAME follows)
+fdw schemas create SalesWH sales
 
 # Confirm it exists (system schemas like sys / INFORMATION_SCHEMA are excluded; dbo is shown)
-fdw -w MyWorkspace schemas list SalesWH
+fdw schemas list
 ```
 
 **MCP:** `create_schema`, `list_schemas`.
@@ -78,7 +91,7 @@ fdw -w MyWorkspace schemas list SalesWH
 The most direct way to scaffold a dimension table. `--column NAME:TYPE[:null|notnull]` is repeatable; columns are nullable unless you append `:notnull`.
 
 ```shell
-fdw -w MyWorkspace tables create SalesWH \
+fdw tables create \
   --name sales.customer \
   --column "customer_id:BIGINT:notnull" \
   --column "name:VARCHAR(200):notnull" \
@@ -111,7 +124,7 @@ Keep a column spec under version control as a JSON array of `{name, type, nullab
 # [{"name": "id", "type": "BIGINT", "nullable": false},
 #  {"name": "action", "type": "VARCHAR(100)"}]
 
-fdw -w MyWorkspace tables create SalesWH \
+fdw tables create \
   --name sales.audit_log \
   --from-schema ./schemas/audit_log.json \
   --column "inserted_at:DATETIME2(7):notnull"
@@ -125,12 +138,12 @@ Point `--from-parquet` / `--from-csv` at a file and `fabric-dw` reads only the s
 
 ```shell
 # From a Parquet footer (exact types)
-fdw -w MyWorkspace tables create SalesWH \
+fdw tables create \
   --name sales.orders \
   --from-parquet ./exports/orders.parquet
 
 # From a CSV header with type inference
-fdw -w MyWorkspace tables create SalesWH \
+fdw tables create \
   --name staging.raw_products \
   --from-csv ./data/products.csv --varchar-length 500
 ```
@@ -145,12 +158,12 @@ fdw -w MyWorkspace tables create SalesWH \
 
 ```shell
 # Inline SELECT
-fdw -w MyWorkspace tables create SalesWH \
+fdw tables create \
   --name sales.orders_2026 \
   --select "SELECT * FROM sales.orders WHERE YEAR(sale_date) = 2026"
 
 # Body from a versioned .sql file, with CLUSTER BY
-fdw -w MyWorkspace tables create SalesWH \
+fdw tables create \
   --name sales.orders_2026 \
   --from-file ./sql/orders_2026.sql \
   --cluster-by customer_id --cluster-by sale_date
@@ -166,13 +179,13 @@ fdw -w MyWorkspace tables create SalesWH \
 
 ```shell
 # Column metadata (name, type, nullability, ordinal, collation, identity/computed)
-fdw -w MyWorkspace tables columns SalesWH sales.customer
+fdw tables columns SalesWH sales.customer
 
 # Row count via COUNT_BIG(*)
-fdw -w MyWorkspace --json tables count SalesWH sales.orders
+fdw --json tables count SalesWH sales.orders
 
 # List tables in a schema
-fdw -w MyWorkspace tables list SalesWH --schema sales
+fdw tables list --schema sales
 ```
 
 ---
@@ -182,7 +195,7 @@ fdw -w MyWorkspace tables list SalesWH --schema sales
 Loading data is its own topic. The bridge from "empty table" to "populated table" is **`tables load`**, which issues `COPY INTO` from a local file or a remote URL (and can auto-create the table from the source schema with `--create`):
 
 ```shell
-fdw -w MyWorkspace tables load SalesWH sales.orders --file ./data/orders.parquet
+fdw tables load SalesWH sales.orders --file ./data/orders.parquet
 ```
 
 **Targets:** Data Warehouse only. There is **no MCP `load` tool for local files**; the MCP server exposes `load_table_from_url` / `import_table_from_url` for remote URLs only (local staging needs reliable file access). For the full loading surface — `--create`, `--if-exists`, credentials for secured external URLs, CSV options — see the [`tables load`](../commands/tables.md#tables-load) reference rather than this guide.
@@ -208,7 +221,7 @@ Keeping the view body in a `.sql` file (rather than inlining SQL) makes it revie
 # FROM sales.orders
 # GROUP BY region, DATETRUNC(month, sale_date)
 
-fdw -w MyWorkspace views create SalesWH \
+fdw views create \
   --name sales.vw_orders_by_month \
   --from-file ./sql/vw_orders_by_month.sql
 ```
@@ -218,14 +231,14 @@ You can also create inline with `--select "<SELECT>"`. **MCP:** `create_view` (p
 ### Inspect and update a view
 
 ```shell
-# Full definition (from sys.sql_modules)
-fdw -w MyWorkspace views get SalesWH sales.vw_orders_by_month
+# Full definition (from sys.sql_modules) — warehouse positional kept, view name follows
+fdw views get SalesWH sales.vw_orders_by_month
 
 # Column metadata
-fdw -w MyWorkspace views columns SalesWH sales.vw_orders_by_month
+fdw views columns SalesWH sales.vw_orders_by_month
 
 # Redefine in place via CREATE OR ALTER VIEW (prompts for confirmation)
-fdw -w MyWorkspace views update SalesWH sales.vw_orders_by_month \
+fdw views update SalesWH sales.vw_orders_by_month \
   --from-file ./sql/vw_orders_by_month.sql
 ```
 
@@ -245,15 +258,15 @@ After you load data, give the query optimizer the statistics it needs. `fabric-d
 
 ```shell
 # Create a single-column statistic
-fdw -w MyWorkspace statistics create SalesWH \
+fdw statistics create \
   --table sales.orders --column region --name stat_orders_region
 
-# Refresh it after a load
-fdw -w MyWorkspace statistics update SalesWH sales.orders stat_orders_region
+# Refresh it after a load (warehouse positional kept — table/stat names follow)
+fdw statistics update SalesWH sales.orders stat_orders_region
 
 # List / inspect
-fdw -w MyWorkspace statistics list SalesWH --table orders
-fdw -w MyWorkspace statistics show SalesWH sales.orders stat_orders_region
+fdw statistics list --table orders
+fdw statistics show SalesWH sales.orders stat_orders_region
 ```
 
 **MCP:** `create_statistics`, `update_statistics`, `list_statistics`, `show_statistics`. The mutating statistics tools are DW-only; `list_statistics` / `show_statistics` also work on a SQL Analytics Endpoint.
@@ -264,14 +277,14 @@ Beyond statistics, `CLUSTER BY` controls physical data layout. You set clusterin
 
 ```shell
 # Re-cluster an existing table (transactional CTAS-swap; copies the whole table)
-fdw -w MyWorkspace --yes tables cluster-by SalesWH sales.orders \
+fdw --yes tables cluster-by SalesWH sales.orders \
   --cluster-by customer_id --cluster-by sale_date
 
 # Remove clustering (omit --cluster-by entirely)
-fdw -w MyWorkspace --yes tables cluster-by SalesWH sales.orders
+fdw --yes tables cluster-by SalesWH sales.orders
 
 # Inspect current clustering columns
-fdw -w MyWorkspace tables cluster-columns SalesWH sales.orders
+fdw tables cluster-columns SalesWH sales.orders
 ```
 
 **Targets:** Data Warehouse only · **MCP:** `set_cluster_columns` (destructive — copies the full table), `get_cluster_columns`.
@@ -288,10 +301,10 @@ fdw -w MyWorkspace tables cluster-columns SalesWH sales.orders
 
 ```shell
 # Current-state clone
-fdw -w MyWorkspace tables clone SalesWH --source sales.orders --name sales.orders_backup
+fdw tables clone --source sales.orders --name sales.orders_backup
 
 # Point-in-time clone (UTC, within retention)
-fdw -w MyWorkspace tables clone SalesWH \
+fdw tables clone \
   --source sales.orders --name sales.orders_may_snapshot \
   --at 2026-05-20T14:00:00
 ```
@@ -299,28 +312,28 @@ fdw -w MyWorkspace tables clone SalesWH \
 **Rename** a table or view (`sp_rename`; the new name must be **unqualified** — you can't move objects across schemas):
 
 ```shell
-fdw -w MyWorkspace tables rename SalesWH sales.orders_2025 --new-name orders_archive_2025
-fdw -w MyWorkspace views rename SalesWH sales.vw_recent --new-name vw_revenue
+fdw tables rename SalesWH sales.orders_2025 --new-name orders_archive_2025
+fdw views rename SalesWH sales.vw_recent --new-name vw_revenue
 ```
 
 **Clear** a table (`TRUNCATE TABLE` — removes all rows, keeps the structure):
 
 ```shell
-fdw -w MyWorkspace --yes tables clear SalesWH staging.raw_products
+fdw --yes tables clear SalesWH staging.raw_products
 ```
 
 **Health-check** a table on a **SQL Analytics Endpoint** — this is the inverse of the usual guard: `tables health-check` runs `sp_get_table_health_metrics` (Delta/Parquet layout diagnostics) and is **rejected on a Data Warehouse**:
 
 ```shell
-fdw -w MyWorkspace tables health-check MySqlEndpoint dbo.FactSales
+fdw tables health-check MySqlEndpoint dbo.FactSales
 ```
 
 **Tear down** when you're done:
 
 ```shell
-fdw -w MyWorkspace --yes views drop SalesWH sales.vw_orders_by_month
-fdw -w MyWorkspace --yes tables delete SalesWH sales.orders
-fdw -w MyWorkspace --yes schemas delete SalesWH sales --cascade
+fdw --yes views drop SalesWH sales.vw_orders_by_month
+fdw --yes tables delete SalesWH sales.orders
+fdw --yes schemas delete SalesWH sales --cascade
 ```
 
 `schemas delete --cascade` first drops **all tables, views, functions, and stored procedures** in the schema. Without `--cascade`, the engine rejects `DROP SCHEMA` on a non-empty schema. On a SQL Analytics Endpoint, cascade can't drop tables (no `DROP TABLE` there), so a schema still holding tables won't drop — remove them from the warehouse first.

--- a/docs/guides/tables-and-views.md
+++ b/docs/guides/tables-and-views.md
@@ -8,10 +8,6 @@ This guide walks through building out a schema model on a Microsoft Fabric Data 
 
 The flat per-command references stay the source of truth for every flag and parameter: [Schemas](../commands/schemas.md), [Tables](../commands/tables.md), [Views](../commands/views.md), and [Statistics](../commands/statistics.md). This guide ties them together as a single narrative.
 
-!!! note "`fdw` is the short alias"
-
-    `fdw` is the short alias for the `fabric-dw` binary. Both invoke the same program; this guide uses `fdw` throughout.
-
 ---
 
 ## What you'll build

--- a/docs/guides/warehouse-performance.md
+++ b/docs/guides/warehouse-performance.md
@@ -92,7 +92,7 @@ Even with no custom configuration, the engine isolates work into two pools, spli
 - a **`NON-SELECT`** pool for DML/DDL/ETL/ingestion statements.
 
 This keeps ingestion from starving interactive reads (and vice-versa) by default. You can change
-this baseline with **custom SQL pools** (preview) — covered in [Step 3](#step-3-tune-apply-the-right-lever).
+this baseline with **custom SQL pools** — covered in [Step 3](#step-3-tune-apply-the-right-lever).
 See [Workload management — compute pool isolation](https://learn.microsoft.com/fabric/data-warehouse/workload-management?WT.mc_id=MVP_310840#compute-pool-isolation).
 
 ---
@@ -176,12 +176,8 @@ direct *"is compute the bottleneck?"* read.
 fdw sql-pools insights --since 2026-06-13T00:00:00
 ```
 
-!!! warning "Preview feature"
-
-    `sql-pools insights` (and the wider custom SQL pools feature it reports on) is a **preview /
-    beta** capability and may change. See
-    [Custom SQL pools (preview)](https://learn.microsoft.com/fabric/data-warehouse/custom-sql-pools?WT.mc_id=MVP_310840)
-    and the [`queryinsights.sql_pool_insights` column reference](https://learn.microsoft.com/sql/relational-databases/system-views/queryinsights-sql-pool-insights-transact-sql?view=fabric&WT.mc_id=MVP_310840).
+See [Custom SQL pools](https://learn.microsoft.com/fabric/data-warehouse/custom-sql-pools?WT.mc_id=MVP_310840)
+and the [`queryinsights.sql_pool_insights` column reference](https://learn.microsoft.com/sql/relational-databases/system-views/queryinsights-sql-pool-insights-transact-sql?view=fabric&WT.mc_id=MVP_310840).
 
 ### Check the capacity state
 
@@ -347,7 +343,7 @@ The MCP equivalents **exist and are not read-only**: `create_statistics`, `updat
 `delete_statistics` (the last flagged destructive) all run behind the MCP write/destructive guards.
 SQL Analytics Endpoints are rejected for these DDL operations.
 
-### Workload isolation via custom SQL pools (preview, workspace admin)
+### Workload isolation via custom SQL pools (workspace admin)
 
 If [Step 2](#read-sql-pool-pressure) showed one workload (e.g. heavy ETL) starving interactive
 reads, override the default 50/50 split with **custom SQL pools**: you cap each workload's
@@ -376,13 +372,12 @@ fdw sql-pools create \
   --classifier-value "Load"
 ```
 
-!!! warning "Preview feature"
+!!! note "Default pool behaviour"
 
-    Custom SQL pools are a **preview / beta** capability. When no custom pools exist, `sql-pools list`
-    reports the default autonomous **50/50 split** (one `SELECT` pool, one `NON-SELECT` pool) rather
-    than an empty list. The sum of every pool's `maxResourcePercentage` must be ≤ 100 and exactly one
-    pool is the default. See
-    [Custom SQL pools (preview)](https://learn.microsoft.com/fabric/data-warehouse/custom-sql-pools?WT.mc_id=MVP_310840)
+    When no custom pools exist, `sql-pools list` reports the default autonomous **50/50 split**
+    (one `SELECT` pool, one `NON-SELECT` pool) rather than an empty list. The sum of every pool's
+    `maxResourcePercentage` must be ≤ 100 and exactly one pool is the default. See
+    [Custom SQL pools](https://learn.microsoft.com/fabric/data-warehouse/custom-sql-pools?WT.mc_id=MVP_310840)
     and [Configure custom SQL pools via REST API](https://learn.microsoft.com/fabric/data-warehouse/configure-custom-sql-pools-api?WT.mc_id=MVP_310840).
 
 ### Relieve live contention
@@ -487,7 +482,6 @@ of scope:
 - **No Capacity Metrics app.** For CU-usage and throttling trends over time, use the
   [Capacity Metrics app](https://learn.microsoft.com/fabric/enterprise/metrics-app?WT.mc_id=MVP_310840) —
   this tool does not replace it.
-- **Custom SQL pools are preview** and may change.
 - **Application-name classifier only.** The only SQL-pool routing key today is the application-name
   classifier; statement-type routing is observe-only with no API
   ([#596](https://github.com/sdebruyn/fabric-dw-mcp-cli/issues/596)).

--- a/docs/guides/warehouse-performance.md
+++ b/docs/guides/warehouse-performance.md
@@ -110,6 +110,19 @@ If instead a *specific* query regressed, start with the [`query-optimizer` skill
 
 ---
 
+## Set your defaults
+
+Store the workspace and warehouse once so you do not repeat them on every command:
+
+```shell
+fdw config set workspace MyWorkspace
+fdw config set warehouse SalesWH
+```
+
+The rest of this guide assumes these defaults are set, so the examples omit `-w MyWorkspace` and drop the warehouse positional where it is optional. Any command still accepts an explicit `-w`/`--workspace` or a positional `[WAREHOUSE]`/`[ITEM]` to override them. Commands that take a trailing required argument (such as `queries kill … SESSION_ID` or `settings result-set-caching … on|off`) keep the warehouse positional so the remaining arguments stay unambiguous. The workspace-wide commands (`warehouses list`, `workspaces list-capacities`) take no per-warehouse target. See [Configuration & defaults](../commands/config.md).
+
+---
+
 ## Step 1 — Monitor: is there a problem, and where?
 
 Establish what exists, what is running right now, and whether the capacity itself is the constraint.
@@ -139,8 +152,8 @@ What is executing right now, and how many connections are open?
 | Active SQL connections (incl. idle) | [`fdw queries connections`](../commands/queries.md#queries-connections) | `list_connections` |
 
 ```shell
-fdw -w MyWorkspace queries running SalesWH
-fdw -w MyWorkspace queries connections SalesWH
+fdw queries running
+fdw queries connections
 ```
 
 !!! note "CLI vs MCP names diverge here"
@@ -160,7 +173,7 @@ direct *"is compute the bottleneck?"* read.
 | SQL pool insight events | [`fdw sql-pools insights`](../commands/sql-pools.md#sql-pools-insights) | `list_sql_pool_insights` |
 
 ```shell
-fdw -w MyWorkspace sql-pools insights SalesWH --since 2026-06-13T00:00:00
+fdw sql-pools insights --since 2026-06-13T00:00:00
 ```
 
 !!! warning "Preview feature"
@@ -214,10 +227,10 @@ and [Monitor Fabric Data Warehouse](https://learn.microsoft.com/fabric/data-ware
 
 ```shell
 # Top 20 slowest queries over the last week
-fdw -w MyWorkspace queries long-running SalesWH --limit 20
+fdw queries long-running --limit 20
 
 # Top 20 most-frequently-run queries — a cheap query run 100k times is also a cost driver
-fdw -w MyWorkspace queries frequent SalesWH --limit 20
+fdw queries frequent --limit 20
 ```
 
 A query that is individually fast but runs *constantly* can dominate CU usage just as much as one
@@ -235,7 +248,7 @@ whether the result-set cache helped.
 | Completed sessions (`exec_sessions_history`) | [`fdw queries sessions`](../commands/queries.md#queries-sessions) | `list_session_history` |
 
 ```shell
-fdw -w MyWorkspace queries history SalesWH --limit 50 --since 2026-06-13T00:00:00
+fdw queries history --limit 50 --since 2026-06-13T00:00:00
 ```
 
 Useful fields in `queries history` include `allocated_cpu_time_ms`,
@@ -268,8 +281,8 @@ warehouse-wide. Audit whether the optimizer has good statistics on hot columns. 
 | Show one statistic's histogram | [`fdw statistics show … [--histogram]`](../commands/statistics.md#statistics-show) | `show_statistics` |
 
 ```shell
-fdw -w MyWorkspace statistics list SalesWH --table dbo.sales --user-only
-fdw -w MyWorkspace statistics show SalesWH dbo.sales _stat_order_date --histogram
+fdw statistics list --table dbo.sales --user-only
+fdw statistics show SalesWH dbo.sales _stat_order_date --histogram   # warehouse positional kept — names follow
 ```
 
 See [Statistics in Fabric Data Warehouse](https://learn.microsoft.com/fabric/data-warehouse/statistics?WT.mc_id=MVP_310840)
@@ -300,8 +313,8 @@ result-set caching can cut elapsed time for repeated identical queries dramatica
 | Toggle result-set caching on/off | [`fdw settings result-set-caching … on\|off`](../commands/settings.md#settings-result-set-caching) | `set_result_set_caching` |
 
 ```shell
-fdw -w MyWorkspace settings show SalesWH
-fdw -w MyWorkspace settings result-set-caching SalesWH on
+fdw settings show
+fdw settings result-set-caching SalesWH on   # warehouse positional kept — on|off follows
 ```
 
 `settings result-set-caching` runs `ALTER DATABASE CURRENT SET RESULT_SET_CACHING { ON | OFF }`.
@@ -326,7 +339,7 @@ refresh them. Fabric supports **single-column, histogram-based** statistics only
 | Drop a statistic | [`fdw statistics delete …`](../commands/statistics.md#statistics-delete) | `delete_statistics` | **destructive** |
 
 ```shell
-fdw -w MyWorkspace statistics create SalesWH \
+fdw statistics create \
   --table dbo.sales --column order_date --name _stat_order_date --fullscan
 ```
 
@@ -354,7 +367,7 @@ workspace-scoped and require the **workspace admin** role.
 
 ```shell
 # Carve out an isolated ETL pool capped at 30% so it can't starve interactive reads
-fdw -w MyWorkspace sql-pools create \
+fdw sql-pools create \
   --name ETL \
   --max-percent 30 \
   --no-optimize-for-reads \
@@ -381,7 +394,7 @@ If a single runaway session is blocking everything else, terminate it.
 | Kill a session | [`fdw queries kill … <session_id>`](../commands/queries.md#queries-kill) | `kill_session` |
 
 ```shell
-fdw -w MyWorkspace --yes queries kill SalesWH 42
+fdw --yes queries kill SalesWH 42   # warehouse positional kept — SESSION_ID follows
 ```
 
 ---
@@ -433,28 +446,28 @@ A copy-pasteable session that walks the whole loop on a warehouse that "feels sl
 
 ```shell
 # 1. MONITOR — confirm the warehouse exists, check live load and pool pressure, check the SKU
-fdw -w MyWorkspace warehouses get SalesWH
-fdw -w MyWorkspace queries running SalesWH
-fdw -w MyWorkspace sql-pools insights SalesWH --since 2026-06-13T00:00:00
+fdw warehouses get
+fdw queries running
+fdw sql-pools insights --since 2026-06-13T00:00:00
 fdw workspaces list-capacities
 
 # 2. DIAGNOSE — find the worst offenders and inspect their CPU / data-scanned / cache hits
-fdw -w MyWorkspace queries long-running SalesWH --limit 20
-fdw -w MyWorkspace queries frequent SalesWH --limit 20
-fdw -w MyWorkspace queries history SalesWH --limit 50 --since 2026-06-13T00:00:00
-fdw -w MyWorkspace statistics list SalesWH --table dbo.sales --user-only
+fdw queries long-running --limit 20
+fdw queries frequent --limit 20
+fdw queries history --limit 50 --since 2026-06-13T00:00:00
+fdw statistics list --table dbo.sales --user-only
 
 # 3. TUNE — apply the cheapest effective lever(s) for what you found
-fdw -w MyWorkspace settings result-set-caching SalesWH on          # repeated identical queries
-fdw -w MyWorkspace statistics create SalesWH \
+fdw settings result-set-caching SalesWH on          # repeated identical queries (on|off follows, so warehouse positional kept)
+fdw statistics create \
   --table dbo.sales --column order_date --name _stat_order_date --fullscan   # stale/missing stats
-fdw -w MyWorkspace sql-pools create \
+fdw sql-pools create \
   --name ETL --max-percent 30 --no-optimize-for-reads \
   --classifier-type "Application Name" --classifier-value "ETL"     # ETL starving reads
 
 # 4. RE-MEASURE — confirm the change helped before reaching for a capacity change
-fdw -w MyWorkspace queries long-running SalesWH --limit 20
-fdw -w MyWorkspace sql-pools insights SalesWH --since 2026-06-13T00:00:00
+fdw queries long-running --limit 20
+fdw sql-pools insights --since 2026-06-13T00:00:00
 ```
 
 Only if throttling persists after re-measuring should you consider


### PR DESCRIPTION
## What

A polish sweep over the five feature guides under `docs/guides/` (scope: guides only — command reference pages under `docs/commands/` are untouched).

### 1. Set workspace/warehouse defaults at the top, stop repeating `-w`

Each guide gains a short **"Set your defaults"** section near the top showing the one-time `config set workspace` / `config set warehouse` (linking [Configuration & defaults](../commands/config.md)), then drops the repeated `-w MyWorkspace` global flag from every subsequent example.

The warehouse positional is dropped **only where safe** — verified against each command's synopsis / `--help`:

- **Dropped** (optional trailing `[WAREHOUSE]`/`[ITEM]`, only flags follow): `queries running/connections/history/sessions/long-running/frequent`, `sql plan`, `sql exec`, `sql-pools insights`, `statistics list`, `statistics create`, `settings show`, `tables create`/`clone`, `views create`, `tables list`, `schemas list`, `warehouses get`.
- **Kept** (a required positional follows, or the argument is itself required): `queries kill … SESSION_ID`; `settings result-set-caching … on|off`; `statistics show/update/delete … QUALIFIED_TABLE STAT_NAME`; `tables load/count/read/columns/cluster-by/cluster-columns/rename/clear/delete … QUALIFIED_NAME`; `tables health-check ENDPOINT QUALIFIED_NAME`; `views get/columns/update/rename/drop … QUALIFIED_NAME`; `schemas create/delete … NAME`; `warehouses create NAME`; `dbt init … FOLDER`; `sql-endpoints get ENDPOINT`. In `dbt-setup.md`, `sql exec`/`tables list` keep the positional because the warehouse default is documented as optional there (the warehouse is only provisioned mid-guide).

### 2. Fix a broken guide-to-guide cross-reference; drop alias boilerplate

- `query-performance.md`: replace the stale "companion human guide tracked in #433" GitHub-issue reference with a relative link to `warehouse-performance.md` (now published). The `#595`/`#596` links (tracked feature-gap/limitation issues, not guides) are left untouched.
- Remove the redundant "`fdw` is the short alias" boilerplate (already documented in install/index): the whole admonition in `tables-and-views.md` and the trailing clause in the `ingesting-data.md` command-shape note.

### 3. Drop preview/beta admonitions, state capabilities factually

Matches the project convention (cf. PR #535). In `warehouse-performance.md`, remove both `!!! warning "Preview feature"` blocks for custom SQL pools — the first becomes a plain "See …" line keeping the Learn links; the second is reworded as `!!! note "Default pool behaviour"` preserving the useful behaviour (default 50/50 split when no custom pools exist, the ≤100 sum, exactly-one-default). Drop the `(preview)` parentheticals and the "Custom SQL pools are preview and may change" bullet. In `query-performance.md`, drop the `(beta/preview)` qualifier from the `sql-pools insights` example comment (the factual result-set-caching known-issue link is kept).

### 4. Refocus the dbt guide on automatic source provisioning

`dbt-setup.md` over-weighted `profiles.yml`/auth mechanics. Make `fdw dbt init --with-sources` the centerpiece: trim the connection step (point to `../commands/dbt.md` + `../authentication.md` for the option list, generated `profiles.yml`, and `env_var()` mechanics) and add a dedicated **"Provision all your dbt sources"** step explaining what `--with-sources` does (one dbt `source:` per schema, every table with column names and data types), the shape of the generated `models/staging/_sources.yml` (and the placeholder without the flag), and how models reference it via `{{ source('<schema>', '<table>') }}`. The MCP `generate_dbt_profile` path returns `sources_yml` with real entries when `with_sources=True`. Verified against `fdw dbt init --help` and the `render_sources_yml` source.

## Checks

- `zensical build` succeeds; the only warning is a pre-existing dead anchor in `commands/sql.md` (`#format-options`), out of scope. No `guides/` warnings.
- All `learn.microsoft.com` links keep `?WT.mc_id=MVP_310840`; internal links and structure are intact; docs-only diff.

Closes #624

🤖 Generated with [Claude Code](https://claude.com/claude-code)