### PR TITLE
feat(cli): rebuild table-from-JSON as --from-json (data inference)

### DIFF
--- a/docs/commands/tables.md
+++ b/docs/commands/tables.md
@@ -214,7 +214,7 @@ fdw -w MyWorkspace --json tables count SalesWH dbo.orders
 Create a new table on a Fabric Data Warehouse. Two modes are available:
 
 - **CTAS** (`CREATE TABLE … AS SELECT`) — supply `--select` or `--from-file`. The body must start with `SELECT` (leading block/line comments are allowed).
-- **Empty DDL** (`CREATE TABLE … (col TYPE, …)`) — supply one or more of `--from-parquet`, `--from-csv`, `--from-schema`, or `--column`. No data is ever read or inserted; this scaffolds the table structure only.
+- **Empty DDL** (`CREATE TABLE … (col TYPE, …)`) — supply exactly one of `--from-parquet`, `--from-csv`, `--from-json`, or one-or-more `--column`. The schema is derived (Parquet/CSV/JSON inference) or listed explicitly; no data is ever read or inserted — this scaffolds the table structure only. To load data afterwards, use [`tables load`](#tables-load).
 
 **Synopsis**
 
@@ -240,18 +240,18 @@ Exactly one of `--select` or `--from-file` must be provided for the CTAS path. C
 | `--name SCHEMA.TABLE` | **Required.** Qualified table name. |
 | `--from-parquet PATH` | Derive schema from a Parquet file (reads footer only — no data loaded). |
 | `--from-csv PATH` | Derive schema from a CSV header + bounded sample (no data loaded). |
-| `--from-schema PATH` | JSON file with column specs: `[{"name": "…", "type": "…", "nullable": true}]`. |
-| `--column NAME:TYPE[:null\|notnull]` | Inline column definition (repeatable). Can be combined with `--from-schema`. |
+| `--from-json PATH` | Derive schema from JSON **data** — a JSONL file or a JSON file containing an array of objects; types are inferred from a bounded sample (no data loaded). JSONL streams; a JSON array is fully loaded into memory — for very large data prefer JSONL. |
+| `--column NAME:TYPE[:null\|notnull]` | Inline column definition (repeatable). |
 | `--cluster-by COL` | Column name for `CLUSTER BY` (repeatable, up to 4). Each name must appear in the table schema. |
-| `--all-varchar` | (CSV) Force all columns to `VARCHAR`; skip type inference. |
-| `--varchar-length N` | Default VARCHAR/VARBINARY length for string/binary columns (1–8000, default `8000`). |
+| `--all-varchar` | (CSV/JSON) Force all columns to `VARCHAR`; skip type inference. |
+| `--varchar-length N` | (CSV/JSON) Default VARCHAR/VARBINARY length for string/binary columns (1–8000, default `8000`). |
 | `--delimiter CHAR` | (CSV) Field delimiter (default `,`). |
 | `--encoding ENC` | (CSV) File encoding (default `utf-8-sig`). |
-| `--sample-rows N` | (CSV) Rows to sample for type inference (1–100 000, default `1000`). |
+| `--sample-rows N` | (CSV/JSON) Rows/records to sample for type inference (1–100 000, default `1000`). |
 
-`--from-parquet`, `--from-csv`, and `--from-schema`/`--column` are mutually exclusive with each other and with the CTAS path. For the explicit-schema path at least one `--from-schema` or `--column` must be provided.
+`--from-parquet`, `--from-csv`, `--from-json`, and `--column` are mutually exclusive with each other and with the CTAS path. For the explicit path at least one `--column` must be provided.
 
-**Arrow → T-SQL type mapping (Parquet / CSV inference)**
+**Arrow → T-SQL type mapping (Parquet / CSV / JSON inference)**
 
 | Arrow type | T-SQL type |
 | --- | --- |
@@ -267,7 +267,7 @@ Exactly one of `--select` or `--from-file` must be provided for the CTAS path. C
 | `timestamp*` | `DATETIME2(7)` |
 | `string`, `large_string` | `VARCHAR(n)` |
 | `binary`, `large_binary` | `VARBINARY(n)` |
-| nested / list / struct | **Error** — use `--all-varchar` or `--from-schema` to override |
+| nested / list / struct | CSV/JSON: falls back to `VARCHAR(n)` with a warning (or use `--all-varchar`). Parquet: **Error** — define the column explicitly with `--column` instead. |
 
 **Examples**
 
@@ -294,11 +294,15 @@ fdw -w MyWorkspace tables create SalesWH \
   --column "event_type:VARCHAR(100)" \
   --column "occurred_at:DATETIME2(7)"
 
-# Explicit schema from JSON file + extra columns
+# Empty table from JSON data — JSONL (schema inferred from the data)
+fdw -w MyWorkspace tables create SalesWH \
+  --name staging.events \
+  --from-json ./data/events.jsonl
+
+# Empty table from JSON data — a JSON array of objects
 fdw -w MyWorkspace tables create SalesWH \
   --name dbo.audit_log \
-  --from-schema ./schemas/audit_log.json \
-  --column "inserted_at:DATETIME2(7):notnull"
+  --from-json ./data/audit_log.json --varchar-length 500
 
 # CTAS with CLUSTER BY (column existence not validated on CTAS path)
 fdw -w MyWorkspace tables create SalesWH \

--- a/src/fabric_dw/cli/commands/tables.py
+++ b/src/fabric_dw/cli/commands/tables.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import json
 import re
 from collections.abc import Mapping
 from pathlib import Path
@@ -154,52 +153,6 @@ def _parse_column_spec(value: str) -> ColumnSpec:
     return ColumnSpec(name=name, sql_type=sql_type, nullable=nullable)
 
 
-def _parse_schema_file(path: str) -> list[ColumnSpec]:
-    """Load a JSON column spec file as a list of :class:`~fabric_dw.models.ColumnSpec`.
-
-    The file must contain a JSON array of objects, each with ``name`` and ``type``
-    keys, and an optional ``nullable`` boolean.
-
-    Args:
-        path: Path to the JSON file.
-
-    Returns:
-        A list of :class:`~fabric_dw.models.ColumnSpec` instances.
-
-    Raises:
-        click.UsageError: If the file does not exist, is not valid JSON,
-            or does not match the expected schema.
-    """
-    p = Path(path)
-    if not p.is_file():
-        raise click.UsageError(f"Schema file not found: {path}")
-    try:
-        raw = json.loads(p.read_text(encoding="utf-8"))
-    except json.JSONDecodeError as exc:
-        raise click.UsageError(f"Invalid JSON in --from-schema {path!r}: {exc}") from exc
-    if not isinstance(raw, list):
-        raise click.UsageError(
-            f"--from-schema {path!r} must be a JSON array of objects, got {type(raw).__name__}"
-        )
-    specs: list[ColumnSpec] = []
-    for i, item in enumerate(raw):
-        if not isinstance(item, dict):
-            raise click.UsageError(
-                f"--from-schema {path!r}: element {i} must be an object, got {type(item).__name__}"
-            )
-        name = item.get("name")
-        sql_type = item.get("type")
-        if not name or not sql_type:
-            raise click.UsageError(
-                f"--from-schema {path!r}: element {i} must have 'name' and 'type' keys"
-            )
-        nullable = bool(item.get("nullable", True))
-        specs.append(ColumnSpec(name=str(name), sql_type=str(sql_type), nullable=nullable))
-    if not specs:
-        raise click.UsageError(f"--from-schema {path!r}: schema file contains no columns")
-    return specs
-
-
 @tables_group.command("columns")
 @click.argument("item", required=False, default=None)
 @click.argument("qualified_name")
@@ -314,12 +267,14 @@ async def health_check_cmd(
     help="Create an empty table whose schema is derived from a CSV file header.",
 )
 @click.option(
-    "--from-schema",
-    "schema_file",
+    "--from-json",
+    "json_path",
     default=None,
     metavar="PATH",
     help=(
-        "Create an empty table from a JSON spec file (array of {name, type, nullable?} objects)."
+        "Path to a JSONL file or a JSON file containing an array of objects; "
+        "the table schema is inferred from the data (no data is loaded). "
+        "JSONL streams; a JSON array is fully loaded — for very large data prefer JSONL."
     ),
 )
 @click.option(
@@ -327,10 +282,7 @@ async def health_check_cmd(
     "column_specs",
     multiple=True,
     metavar="NAME:TYPE[:null|notnull]",
-    help=(
-        "Add a column in NAME:TYPE[:null|notnull] format (repeatable). "
-        "Can be combined with --from-schema."
-    ),
+    help="Add a column in NAME:TYPE[:null|notnull] format (repeatable).",
 )
 @click.option(
     "--cluster-by",
@@ -344,14 +296,14 @@ async def health_check_cmd(
     "--all-varchar",
     is_flag=True,
     default=False,
-    help="(CSV) Force all columns to VARCHAR; skip type inference.",
+    help="(CSV/JSON) Force all columns to VARCHAR; skip type inference.",
 )
 @click.option(
     "--varchar-length",
     default=8000,
     show_default=True,
     type=click.IntRange(1, 8000),
-    help="Default VARCHAR/VARBINARY length for string/binary columns.",
+    help="(CSV/JSON) Default VARCHAR/VARBINARY length for string/binary columns.",
 )
 @click.option(
     "--delimiter",
@@ -370,11 +322,11 @@ async def health_check_cmd(
     default=1000,
     show_default=True,
     type=click.IntRange(1, 100_000),
-    help="(CSV) Maximum number of rows to sample for type inference.",
+    help="(CSV/JSON) Maximum number of rows/records to sample for type inference.",
 )
 @click.pass_obj
 @coro
-async def create_cmd(  # noqa: PLR0912
+async def create_cmd(  # noqa: PLR0912, PLR0915
     ctx: CliContext,
     item: str | None,
     qualified_name: str,
@@ -382,7 +334,7 @@ async def create_cmd(  # noqa: PLR0912
     from_file: str | None,
     parquet_path: str | None,
     csv_path: str | None,
-    schema_file: str | None,
+    json_path: str | None,
     column_specs: tuple[str, ...],
     cluster_by: tuple[str, ...],
     all_varchar: bool,
@@ -396,17 +348,21 @@ async def create_cmd(  # noqa: PLR0912
     \b
     Two modes are available:
       CTAS (CREATE TABLE AS SELECT) — supply --select or --from-file.
-      Empty DDL — supply one of --from-parquet, --from-csv, --from-schema,
-                  or --column (repeatable).  These can be combined:
-                  --from-schema adds base columns and --column appends extras.
+      Empty DDL — supply exactly one of --from-parquet, --from-csv,
+                  --from-json, or one-or-more --column (repeatable).
+                  --from-json infers the schema from JSONL or a JSON array
+                  of objects; --column lists explicit columns inline.
 
     \b
-    CSV options (only with --from-csv):
+    CSV/JSON inference options (with --from-csv or --from-json):
       --all-varchar     Force all columns to VARCHAR, skipping type inference.
       --varchar-length  Default VARCHAR length (1-8000, default 8000).
+      --sample-rows     Rows/records to sample for inference (default 1000).
+
+    \b
+    CSV-only options (with --from-csv):
       --delimiter       Field delimiter (default ',').
       --encoding        File encoding (default 'utf-8-sig').
-      --sample-rows     Rows to sample for inference (default 1000).
     """
     ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
@@ -416,39 +372,42 @@ async def create_cmd(  # noqa: PLR0912
     has_ctas = bool(select_body or from_file)
     has_parquet = parquet_path is not None
     has_csv = csv_path is not None
-    has_explicit = schema_file is not None or bool(column_specs)
+    has_json = json_path is not None
+    has_explicit = bool(column_specs)
 
     # Count distinct source groups.
-    source_count = sum([has_ctas, has_parquet, has_csv, has_explicit])
+    source_count = sum([has_ctas, has_parquet, has_csv, has_json, has_explicit])
 
     if source_count == 0:
         raise click.UsageError(
             "Specify a source: --select/--from-file (CTAS), --from-parquet, "
-            "--from-csv, --from-schema, or --column."
+            "--from-csv, --from-json, or --column."
         )
 
     # CTAS cannot be combined with empty-DDL sources.
-    if has_ctas and (has_parquet or has_csv or has_explicit):
+    if has_ctas and (has_parquet or has_csv or has_json or has_explicit):
         raise click.UsageError(
             "--select/--from-file (CTAS) cannot be combined with "
-            "--from-parquet, --from-csv, --from-schema, or --column."
+            "--from-parquet, --from-csv, --from-json, or --column."
         )
 
-    # Parquet, CSV, and explicit schema are mutually exclusive with each other.
+    # Parquet, CSV, JSON, and explicit columns are mutually exclusive with each other.
     if has_parquet and has_csv:
         raise click.UsageError("--from-parquet and --from-csv are mutually exclusive.")
-    if has_parquet and schema_file:
-        raise click.UsageError("--from-parquet and --from-schema are mutually exclusive.")
+    if has_parquet and has_json:
+        raise click.UsageError("--from-parquet and --from-json are mutually exclusive.")
     if has_parquet and column_specs:
         raise click.UsageError("--from-parquet and --column are mutually exclusive.")
-    if has_csv and schema_file:
-        raise click.UsageError("--from-csv and --from-schema are mutually exclusive.")
+    if has_csv and has_json:
+        raise click.UsageError("--from-csv and --from-json are mutually exclusive.")
     if has_csv and column_specs:
         raise click.UsageError("--from-csv and --column are mutually exclusive.")
+    if has_json and column_specs:
+        raise click.UsageError("--from-json and --column are mutually exclusive.")
 
-    # --all-varchar only makes sense with --from-csv.
-    if all_varchar and not has_csv:
-        raise click.UsageError("--all-varchar requires --from-csv.")
+    # --all-varchar only makes sense with --from-csv or --from-json.
+    if all_varchar and not (has_csv or has_json):
+        raise click.UsageError("--all-varchar requires --from-csv or --from-json.")
 
     # --select and --from-file are mutually exclusive.
     if select_body and from_file:
@@ -500,15 +459,26 @@ async def create_cmd(  # noqa: PLR0912
                     sample_rows=sample_rows,
                 )
 
+            elif has_json:
+                t = await _tables_svc.create_table_from_json(
+                    target,
+                    schema,
+                    table_name,
+                    Path(json_path),  # type: ignore[arg-type]
+                    cluster_by=cluster_by_list,
+                    kind=entry.kind,
+                    mode=ctx.auth,
+                    all_varchar=all_varchar,
+                    varchar_length=varchar_length,
+                    sample_rows=sample_rows,
+                )
+
             else:
-                # Explicit schema via --from-schema and/or --column.
-                cols: list[ColumnSpec] = []
-                if schema_file:
-                    cols.extend(_parse_schema_file(schema_file))
-                cols.extend(_parse_column_spec(s) for s in column_specs)
+                # Explicit columns via --column.
+                cols = [_parse_column_spec(s) for s in column_specs]
                 if not cols:
                     raise click.UsageError(
-                        "--from-schema or at least one --column is required for the DDL path."
+                        "At least one --column is required for the explicit DDL path."
                     )
                 t = await _tables_svc.create_empty_table(
                     target,

--- a/src/fabric_dw/services/tables.py
+++ b/src/fabric_dw/services/tables.py
@@ -10,6 +10,7 @@ Public API
 - :func:`create_empty_table`      — ``CREATE TABLE … (col TYPE [NULL|NOT NULL], …)`` (DDL only).
 - :func:`create_table_from_parquet` — infer schema from Parquet file → :func:`create_empty_table`.
 - :func:`create_table_from_csv`   — infer schema from CSV file → :func:`create_empty_table`.
+- :func:`create_table_from_json`  — infer schema from JSON data → :func:`create_empty_table`.
 - :func:`clone_table`             — ``CREATE TABLE … AS CLONE OF …`` (zero-copy clone).
 - :func:`delete_table`            — ``DROP TABLE [schema].[table]``.
 - :func:`clear_table`             — ``TRUNCATE TABLE [schema].[table]``.
@@ -31,8 +32,11 @@ import asyncio
 import logging
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import cast
+from typing import TYPE_CHECKING, cast
 from uuid import uuid4
+
+if TYPE_CHECKING:
+    import pyarrow as pa
 
 from fabric_dw.auth import CredentialMode
 from fabric_dw.exceptions import ItemKindError, NotFoundError
@@ -49,11 +53,13 @@ __all__ = [
     "create_empty_table",
     "create_table",
     "create_table_from_csv",
+    "create_table_from_json",
     "create_table_from_parquet",
     "delete_table",
     "get_cluster_columns",
     "get_table_health_metrics",
     "infer_columns_from_csv",
+    "infer_columns_from_json",
     "infer_columns_from_parquet",
     "list_tables",
     "read_table",
@@ -851,6 +857,350 @@ async def create_table_from_csv(
         encoding=encoding,
     )
     _log.debug("create_table_from_csv: %d columns from %s", len(columns), csv_path.name)
+    return await create_empty_table(
+        target, schema, table_name, columns, cluster_by=cluster_by, kind=kind, mode=mode
+    )
+
+
+def _json_sample_source(json_path: Path, sample_rows: int) -> str | pa.Buffer:
+    """Detect the JSON shape and return a pyarrow ``open_json`` input source.
+
+    Peeks the first non-whitespace byte (after stripping any UTF-8 BOM):
+
+    - ``[`` → a **JSON array** of objects: the whole file is parsed with
+      :func:`json.loads`, validated as a non-empty list of objects, and the
+      first *sample_rows* records are re-emitted as JSONL into an in-memory
+      buffer.  The full file is loaded into memory in this case — for very
+      large data prefer JSONL.
+    - otherwise → **JSONL** (newline-delimited objects): the file path is
+      returned so :func:`pyarrow.json.open_json` streams it directly.
+
+    Args:
+        json_path: Path to the JSONL file or JSON array file.
+        sample_rows: Maximum number of records to keep (array form only;
+            JSONL is bounded later during batch iteration).
+
+    Returns:
+        Either the file-path string (JSONL) or a :class:`pyarrow.Buffer`
+        holding a bounded JSONL sample (array form), ready for ``open_json``.
+
+    Raises:
+        ValueError: If the file is empty, or a JSON array is malformed or is
+            not a non-empty list of objects.
+    """
+    import json  # noqa: PLC0415
+
+    import pyarrow as pa  # noqa: PLC0415
+
+    raw = json_path.read_bytes()
+    # Strip a UTF-8 BOM if present so the first-byte peek is reliable.
+    if raw.startswith(b"\xef\xbb\xbf"):
+        raw = raw[3:]
+
+    stripped = raw.lstrip()
+    if not stripped:
+        msg = f"JSON file is empty: {json_path}"
+        raise ValueError(msg)
+
+    if stripped[:1] != b"[":
+        # JSONL (newline-delimited objects) — stream the file directly.
+        return str(json_path)
+
+    # JSON array of records — parse fully, then re-emit a bounded sample as JSONL.
+    try:
+        records = json.loads(stripped)
+    except json.JSONDecodeError as exc:
+        msg = f"Invalid JSON in {json_path}: {exc}"
+        raise ValueError(msg) from exc
+    if not isinstance(records, list) or not records:
+        msg = (
+            f"JSON array in {json_path} must be a non-empty list of objects "
+            f"(got {type(records).__name__})."
+        )
+        raise ValueError(msg)
+    if not all(isinstance(rec, dict) for rec in records):
+        msg = f"JSON array in {json_path} must contain only objects (records)."
+        raise ValueError(msg)
+    sample = records[:sample_rows]
+    buffer = "\n".join(json.dumps(rec) for rec in sample).encode("utf-8")
+    return pa.py_buffer(buffer)
+
+
+def _json_sample_to_arrow_schema(json_path: Path, sample_rows: int) -> pa.Schema:
+    """Read a bounded sample of JSON data and return the inferred Arrow schema.
+
+    The file shape (JSONL vs JSON array of objects) is auto-detected by
+    :func:`_json_sample_source`.  pyarrow unifies types across records
+    (``int64``/``double``/``bool``/``string``/``timestamp[s]``) and forms the
+    union of keys across records.
+
+    Args:
+        json_path: Path to the JSONL file or JSON array file.
+        sample_rows: Maximum number of records to read for type inference.
+
+    Returns:
+        A :class:`pyarrow.Schema` reflecting the inferred column types.
+
+    Raises:
+        ValueError: If the file is empty / contains zero records, if a JSON
+            array is malformed or is not a non-empty list of objects, or if
+            pyarrow cannot parse the data (e.g. a whole-file number↔string
+            conflict — the message suggests ``--all-varchar``).
+    """
+    import pyarrow as pa  # noqa: PLC0415
+    import pyarrow.json as pa_json  # noqa: PLC0415
+
+    source = _json_sample_source(json_path, sample_rows)
+    read_opts = pa_json.ReadOptions(block_size=1 << 20) if isinstance(source, str) else None
+
+    reader = pa_json.open_json(source, read_options=read_opts)
+    # reader.schema is available before iteration and reflects inferred types.
+    inferred_schema = reader.schema
+    batches: list[pa.RecordBatch] = []
+    rows_seen = 0
+    for batch in reader:
+        remaining = sample_rows - rows_seen
+        chunk = batch.slice(0, remaining) if batch.num_rows > remaining else batch
+        batches.append(chunk)
+        rows_seen += chunk.num_rows
+        if rows_seen >= sample_rows:
+            break
+
+    if not batches:
+        # Zero records read — schema may still be empty (no columns).
+        if not inferred_schema.names:
+            msg = f"JSON file contains no records: {json_path}"
+            raise ValueError(msg)
+        return inferred_schema
+    return pa.Table.from_batches(batches).schema
+
+
+def _json_sample_keys(json_path: Path, sample_rows: int) -> list[str]:
+    """Return the union of record keys from a bounded JSON sample, in first-seen order.
+
+    Used by the ``all_varchar`` path: it only needs column names, and must not
+    fail on type conflicts (e.g. a column that mixes numbers and strings) — that
+    is the very situation ``--all-varchar`` exists to rescue.  The file shape is
+    auto-detected by :func:`_json_sample_source`; the JSONL sample is parsed
+    line-by-line with the stdlib :mod:`json` module rather than pyarrow.
+
+    Args:
+        json_path: Path to the JSONL file or JSON array file.
+        sample_rows: Maximum number of records to scan for keys.
+
+    Returns:
+        The union of keys across the sampled records, ordered by first appearance.
+
+    Raises:
+        ValueError: If the file is empty / contains zero records, or is malformed.
+    """
+    import json  # noqa: PLC0415
+
+    source = _json_sample_source(json_path, sample_rows)
+
+    # Ordered set of keys (first-seen order preserved by dict insertion order).
+    keys: dict[str, None] = {}
+
+    def _collect(record: object, line_no: int) -> None:
+        if not isinstance(record, dict):
+            # Invalid file data (not a programming type error); surface as ValueError
+            # so the CLI maps it to a user-facing ClickException like the other checks.
+            msg = f"JSON record {line_no} in {json_path} is not an object."
+            raise ValueError(msg)  # noqa: TRY004
+        # JSON object keys are always strings.
+        for key in record:
+            keys[str(key)] = None
+
+    if isinstance(source, str):
+        # JSONL — parse each non-blank line up to *sample_rows* records.
+        with json_path.open(encoding="utf-8-sig") as fh:
+            seen = 0
+            for line_no, line in enumerate(fh, start=1):
+                if not line.strip():
+                    continue
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError as exc:
+                    msg = f"Invalid JSON on line {line_no} of {json_path}: {exc}"
+                    raise ValueError(msg) from exc
+                _collect(record, line_no)
+                seen += 1
+                if seen >= sample_rows:
+                    break
+    else:
+        # JSON array — the buffer already holds the bounded JSONL sample.
+        text = source.to_pybytes().decode("utf-8")
+        for line_no, line in enumerate(text.splitlines(), start=1):
+            if not line.strip():
+                continue
+            _collect(json.loads(line), line_no)
+
+    if not keys:
+        msg = f"JSON file contains no records: {json_path}"
+        raise ValueError(msg)
+    return list(keys)
+
+
+async def infer_columns_from_json(
+    json_path: Path,
+    *,
+    all_varchar: bool = False,
+    varchar_length: int = 8000,
+    sample_rows: int = 1000,
+) -> list[ColumnSpec]:
+    """Infer a :class:`~fabric_dw.models.ColumnSpec` list from JSON **data**.
+
+    The file may be either **JSONL** (one JSON object per line) or a **JSON
+    array of objects**; the shape is auto-detected by peeking the first
+    non-whitespace byte (after stripping any BOM).  A bounded sample of
+    *sample_rows* records is read and pyarrow infers the column types
+    (``int64``/``double``/``bool``/``string``/``timestamp[s]`` — ISO strings
+    auto-detected); the union of keys across records becomes the column set.
+    No data is inserted into the warehouse; this is a pure inference operation.
+
+    All inferred columns are **nullable** (any key may be omitted from any
+    record).  Each Arrow type is mapped via
+    :func:`~fabric_dw.types.arrow_type_to_tsql`; a column whose inferred type
+    has no scalar T-SQL equivalent (a nested ``struct``/``list``, or a mixed
+    number↔string column that pyarrow surfaced per-column) falls back to
+    ``VARCHAR(*varchar_length*)`` with a warning.  When *all_varchar* is
+    ``True``, every column becomes ``VARCHAR(*varchar_length*)`` up front,
+    skipping type inference.
+
+    Performance: JSONL is **streamed** (only a bounded prefix is loaded,
+    regardless of file size); a JSON array is **fully loaded** into memory via
+    :func:`json.loads` — for very large data prefer JSONL.
+
+    Args:
+        json_path: Path to the JSONL file or JSON array file.
+        all_varchar: Force all columns to ``VARCHAR(*varchar_length*)``,
+            overriding inference.  Useful when inference produces unexpected
+            results or a whole-file number↔string conflict.
+        varchar_length: Length for VARCHAR columns (default 8000).
+        sample_rows: Maximum number of records to read for type inference
+            (default 1000).
+
+    Returns:
+        A list of :class:`~fabric_dw.models.ColumnSpec` instances (one per column).
+
+    Raises:
+        FileNotFoundError: If *json_path* does not exist.
+        ValueError: If the file is empty / contains zero records, is malformed,
+            is not a non-empty list of objects (array form), or if pyarrow
+            cannot parse the data (e.g. a whole-file number↔string conflict —
+            the message suggests ``--all-varchar``).
+    """
+    if not json_path.exists():
+        msg = f"JSON file not found: {json_path}"
+        raise FileNotFoundError(msg)
+
+    if all_varchar:
+        # Only the key union is needed.  Read keys with the stdlib (not pyarrow)
+        # so this path still works when a column mixes numbers and strings — the
+        # exact case --all-varchar exists to rescue.
+        names = await asyncio.to_thread(_json_sample_keys, json_path, sample_rows)
+        return [
+            ColumnSpec(name=name, sql_type=f"VARCHAR({varchar_length})", nullable=True)
+            for name in names
+        ]
+
+    import pyarrow as pa  # noqa: PLC0415
+
+    try:
+        arrow_schema = await asyncio.to_thread(_json_sample_to_arrow_schema, json_path, sample_rows)
+    except pa.ArrowInvalid as exc:
+        # Whole-file parse failure (e.g. a column changes from number to string
+        # across records — pyarrow raises before per-column fallback is possible).
+        msg = (
+            f"Could not infer a schema from {json_path}: {exc}. "
+            "If a column mixes numbers and strings, use --all-varchar."
+        )
+        raise ValueError(msg) from exc
+
+    columns: list[ColumnSpec] = []
+    for i, name in enumerate(arrow_schema.names):
+        field = arrow_schema.field(i)
+        try:
+            sql_type = arrow_type_to_tsql(field.type, name, varchar_length=varchar_length)
+        except ValueError:
+            # Fall back to VARCHAR for non-mappable inferred types (nested
+            # struct/list, or a per-column number↔string conflict).
+            _log.warning(
+                "Column %r: inferred Arrow type %r has no T-SQL equivalent; "
+                "falling back to VARCHAR(%d)",
+                name,
+                field.type,
+                varchar_length,
+            )
+            sql_type = f"VARCHAR({varchar_length})"
+        # JSON columns are always nullable (keys may be omitted from any record).
+        columns.append(ColumnSpec(name=name, sql_type=sql_type, nullable=True))
+
+    _log.debug("infer_columns_from_json: %d columns from %s", len(columns), json_path.name)
+    return columns
+
+
+async def create_table_from_json(
+    target: SqlTarget,
+    schema: str,
+    table_name: str,
+    json_path: Path,
+    *,
+    cluster_by: list[str] | None = None,
+    kind: WarehouseKind = WarehouseKind.WAREHOUSE,
+    mode: CredentialMode = CredentialMode.DEFAULT,
+    all_varchar: bool = False,
+    varchar_length: int = 8000,
+    sample_rows: int = 1000,
+) -> Table:
+    """Create an empty table whose schema is inferred from JSON **data**.
+
+    Mirrors :func:`create_table_from_csv`/:func:`create_table_from_parquet`:
+    the column schema is inferred from a bounded sample of JSON records via
+    :func:`infer_columns_from_json` and an **empty** table is created — no data
+    is inserted (data loading stays in ``tables load --format json``).
+
+    The file may be either **JSONL** (one JSON object per line) or a **JSON
+    array of objects**; the shape is auto-detected.  JSONL is streamed (only a
+    bounded prefix is read); a JSON array is fully loaded into memory — for very
+    large data prefer JSONL.
+
+    Args:
+        target: The warehouse to connect to.
+        schema: The schema name.  Must pass :func:`validate_identifier`.
+        table_name: The table name.  Must pass :func:`validate_identifier`.
+        json_path: Path to the JSONL file or JSON array file.  Only a bounded
+            sample of records is read — this is schema inference, not data loading.
+        cluster_by: Optional list of column names for the ``CLUSTER BY`` clause
+            (up to 4).  Each name must appear in the inferred columns.
+        kind: The :class:`~fabric_dw.models.WarehouseKind` of the item.
+            SQL Endpoint items are rejected with :class:`~fabric_dw.exceptions.ItemKindError`.
+        mode: The credential mode for Entra authentication.
+        all_varchar: Force all columns to ``VARCHAR(*varchar_length*)``,
+            overriding inference.
+        varchar_length: Length for VARCHAR columns (default 8000).
+        sample_rows: Maximum number of records to read for type inference
+            (default 1000).
+
+    Returns:
+        A :class:`~fabric_dw.models.Table` reflecting the newly-created table.
+
+    Raises:
+        ItemKindError: If *kind* is :attr:`~fabric_dw.models.WarehouseKind.SQL_ENDPOINT`.
+        ValueError: If the file is empty / malformed / not a non-empty list of
+            objects, if pyarrow cannot infer a schema, if any column name fails
+            identifier validation, or if a *cluster_by* column is not defined in
+            the inferred schema.
+        FileNotFoundError: If *json_path* does not exist.
+    """
+    _assert_not_sql_endpoint(kind)
+    columns = await infer_columns_from_json(
+        json_path,
+        all_varchar=all_varchar,
+        varchar_length=varchar_length,
+        sample_rows=sample_rows,
+    )
+    _log.debug("create_table_from_json: %d columns from %s", len(columns), json_path.name)
     return await create_empty_table(
         target, schema, table_name, columns, cluster_by=cluster_by, kind=kind, mode=mode
     )

--- a/tests/unit/cli/commands/test_tables.py
+++ b/tests/unit/cli/commands/test_tables.py
@@ -20,7 +20,7 @@ from fabric_dw.auth import CredentialMode
 from fabric_dw.cache import ItemEntry
 from fabric_dw.cli._context import CliContext
 from fabric_dw.cli._main import cli
-from fabric_dw.cli.commands.tables import _load_cmd_local, _parse_column_spec, _parse_schema_file
+from fabric_dw.cli.commands.tables import _load_cmd_local, _parse_column_spec
 from fabric_dw.exceptions import ItemKindError, NotFoundError, PermissionDeniedError
 from fabric_dw.models import CopyIntoResult, Table, WarehouseKind
 from fabric_dw.sql import SqlTarget
@@ -1461,17 +1461,14 @@ class TestTablesCreateEmpty:
         parsed = json.loads(result.output)
         assert parsed["name"] == "sales"
 
-    def test_from_schema_file_exits_zero(
+    def test_from_json_jsonl_exits_zero(
         self, runner: CliRunner, cache_env: Path, tmp_path: Path
     ) -> None:
         _ = cache_env
-        schema_file = tmp_path / "schema.json"
-        schema_file.write_text(
-            '[{"name": "id", "type": "INT", "nullable": false}, '
-            '{"name": "label", "type": "VARCHAR(100)"}]'
-        )
+        json_file = tmp_path / "data.jsonl"
+        json_file.write_text('{"id": 1, "name": "Alice"}\n{"id": 2, "name": "Bob"}\n')
         mock_http = AsyncMock()
-        mock_create_empty = AsyncMock(return_value=_make_table())
+        mock_create = AsyncMock(return_value=_make_table())
         with (
             patch(
                 "fabric_dw.cli.commands.tables.build_http_client",
@@ -1482,8 +1479,8 @@ class TestTablesCreateEmpty:
                 new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
             ),
             patch(
-                "fabric_dw.services.tables.create_empty_table",
-                new=mock_create_empty,
+                "fabric_dw.services.tables.create_table_from_json",
+                new=mock_create,
             ),
         ):
             result = runner.invoke(
@@ -1497,12 +1494,85 @@ class TestTablesCreateEmpty:
                     WH_GUID,
                     "--name",
                     "dbo.sales",
-                    "--from-schema",
-                    str(schema_file),
+                    "--from-json",
+                    str(json_file),
                 ],
             )
         assert result.exit_code == 0, result.output
-        mock_create_empty.assert_awaited_once()
+        mock_create.assert_awaited_once()
+
+    def test_from_json_array_exits_zero(
+        self, runner: CliRunner, cache_env: Path, tmp_path: Path
+    ) -> None:
+        _ = cache_env
+        json_file = tmp_path / "data.json"
+        json_file.write_text('[{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}]')
+        mock_http = AsyncMock()
+        mock_create = AsyncMock(return_value=_make_table())
+        with (
+            patch(
+                "fabric_dw.cli.commands.tables.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.tables.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.tables.create_table_from_json",
+                new=mock_create,
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "-w",
+                    WS_GUID,
+                    "--json",
+                    "tables",
+                    "create",
+                    WH_GUID,
+                    "--name",
+                    "dbo.sales",
+                    "--from-json",
+                    str(json_file),
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        mock_create.assert_awaited_once()
+
+    def test_from_json_bad_file_fails(
+        self, runner: CliRunner, cache_env: Path, tmp_path: Path
+    ) -> None:
+        _ = cache_env
+        json_file = tmp_path / "bad.jsonl"
+        json_file.write_text("{not valid json")
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.tables.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.tables.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "-w",
+                    WS_GUID,
+                    "tables",
+                    "create",
+                    WH_GUID,
+                    "--name",
+                    "dbo.sales",
+                    "--from-json",
+                    str(json_file),
+                ],
+            )
+        assert result.exit_code != 0
 
     def test_from_parquet_exits_zero(
         self, runner: CliRunner, cache_env: Path, tmp_path: Path
@@ -1647,6 +1717,106 @@ class TestTablesCreateEmpty:
         )
         assert result.exit_code != 0
 
+    def test_csv_and_json_mutually_exclusive(
+        self, runner: CliRunner, cache_env: Path, tmp_path: Path
+    ) -> None:
+        _ = cache_env
+        csv_file = tmp_path / "data.csv"
+        json_file = tmp_path / "data.jsonl"
+        csv_file.write_text("id\n1\n")
+        json_file.write_text('{"id": 1}\n')
+        result = runner.invoke(
+            cli,
+            [
+                "-w",
+                WS_GUID,
+                "tables",
+                "create",
+                WH_GUID,
+                "--name",
+                "dbo.sales",
+                "--from-csv",
+                str(csv_file),
+                "--from-json",
+                str(json_file),
+            ],
+        )
+        assert result.exit_code != 0
+
+    def test_parquet_and_json_mutually_exclusive(
+        self, runner: CliRunner, cache_env: Path, tmp_path: Path
+    ) -> None:
+        _ = cache_env
+        parquet_file = tmp_path / "data.parquet"
+        json_file = tmp_path / "data.jsonl"
+        pq.write_table(pa.table({"id": pa.array([], type=pa.int32())}), str(parquet_file))
+        json_file.write_text('{"id": 1}\n')
+        result = runner.invoke(
+            cli,
+            [
+                "-w",
+                WS_GUID,
+                "tables",
+                "create",
+                WH_GUID,
+                "--name",
+                "dbo.sales",
+                "--from-parquet",
+                str(parquet_file),
+                "--from-json",
+                str(json_file),
+            ],
+        )
+        assert result.exit_code != 0
+
+    def test_json_and_column_mutually_exclusive(
+        self, runner: CliRunner, cache_env: Path, tmp_path: Path
+    ) -> None:
+        _ = cache_env
+        json_file = tmp_path / "data.jsonl"
+        json_file.write_text('{"id": 1}\n')
+        result = runner.invoke(
+            cli,
+            [
+                "-w",
+                WS_GUID,
+                "tables",
+                "create",
+                WH_GUID,
+                "--name",
+                "dbo.sales",
+                "--from-json",
+                str(json_file),
+                "--column",
+                "extra:INT",
+            ],
+        )
+        assert result.exit_code != 0
+
+    def test_ctas_and_json_mutually_exclusive(
+        self, runner: CliRunner, cache_env: Path, tmp_path: Path
+    ) -> None:
+        _ = cache_env
+        json_file = tmp_path / "data.jsonl"
+        json_file.write_text('{"id": 1}\n')
+        result = runner.invoke(
+            cli,
+            [
+                "-w",
+                WS_GUID,
+                "tables",
+                "create",
+                WH_GUID,
+                "--name",
+                "dbo.sales",
+                "--select",
+                "SELECT 1",
+                "--from-json",
+                str(json_file),
+            ],
+        )
+        assert result.exit_code != 0
+
     def test_parse_column_spec_null(self) -> None:
         spec = _parse_column_spec("my_col:VARCHAR(100):null")
         assert spec.name == "my_col"
@@ -1667,28 +1837,8 @@ class TestTablesCreateEmpty:
         with pytest.raises(click.UsageError):
             _parse_column_spec("notype")
 
-    def test_parse_schema_file_valid(self, tmp_path: Path) -> None:
-        f = tmp_path / "s.json"
-        f.write_text(
-            '[{"name": "id", "type": "INT"},'
-            ' {"name": "lbl", "type": "VARCHAR(100)", "nullable": false}]'
-        )
-        specs = _parse_schema_file(str(f))
-        assert len(specs) == 2
-        assert specs[0].name == "id"
-        assert specs[1].nullable is False
-
-    def test_parse_schema_file_missing(self) -> None:
-        with pytest.raises(click.UsageError, match="not found"):
-            _parse_schema_file("/nonexistent/path.json")
-
-    def test_parse_schema_file_invalid_json(self, tmp_path: Path) -> None:
-        f = tmp_path / "bad.json"
-        f.write_text("not json")
-        with pytest.raises(click.UsageError, match="Invalid JSON"):
-            _parse_schema_file(str(f))
-
-    def test_all_varchar_requires_from_csv(self, runner: CliRunner, cache_env: Path) -> None:
+    def test_all_varchar_requires_csv_or_json(self, runner: CliRunner, cache_env: Path) -> None:
+        """--all-varchar without --from-csv or --from-json is a usage error."""
         _ = cache_env
         result = runner.invoke(
             cli,
@@ -1706,6 +1856,49 @@ class TestTablesCreateEmpty:
             ],
         )
         assert result.exit_code != 0
+
+    def test_all_varchar_satisfied_by_from_json(
+        self, runner: CliRunner, cache_env: Path, tmp_path: Path
+    ) -> None:
+        """--all-varchar is accepted together with --from-json."""
+        _ = cache_env
+        json_file = tmp_path / "data.jsonl"
+        json_file.write_text('{"id": 1, "name": "Alice"}\n')
+        mock_http = AsyncMock()
+        mock_create = AsyncMock(return_value=_make_table())
+        with (
+            patch(
+                "fabric_dw.cli.commands.tables.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.tables.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.tables.create_table_from_json",
+                new=mock_create,
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "-w",
+                    WS_GUID,
+                    "--json",
+                    "tables",
+                    "create",
+                    WH_GUID,
+                    "--name",
+                    "dbo.sales",
+                    "--from-json",
+                    str(json_file),
+                    "--all-varchar",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        mock_create.assert_awaited_once()
+        assert mock_create.call_args.kwargs["all_varchar"] is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/services/test_tables.py
+++ b/tests/unit/services/test_tables.py
@@ -1729,6 +1729,263 @@ class TestCreateTableFromCsvClusterBy:
 
 
 # ===========================================================================
+# infer_columns_from_json
+# ===========================================================================
+
+
+class TestInferColumnsFromJson:
+    async def test_jsonl_infers_types(self, tmp_path: Path) -> None:
+        json_file = tmp_path / "data.jsonl"
+        json_file.write_text(
+            '{"id": 1, "name": "Alice", "price": 1.5, "ok": true, "ts": "2024-01-01T00:00:00"}\n'
+            '{"id": 2, "name": "Bob", "price": 2.0, "ok": false, "ts": "2024-02-01T00:00:00"}\n'
+        )
+        cols = await tables.infer_columns_from_json(json_file)
+        by_name = {c.name: c.sql_type for c in cols}
+        assert by_name["id"] == "BIGINT"
+        assert by_name["price"] == "FLOAT"
+        assert by_name["ok"] == "BIT"
+        assert "VARCHAR" in by_name["name"]
+        assert by_name["ts"].startswith("DATETIME2")
+        # All JSON columns are nullable.
+        assert all(c.nullable for c in cols)
+
+    async def test_json_array_happy_path(self, tmp_path: Path) -> None:
+        json_file = tmp_path / "data.json"
+        json_file.write_text('[{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}]')
+        cols = await tables.infer_columns_from_json(json_file)
+        by_name = {c.name: c.sql_type for c in cols}
+        assert by_name["id"] == "BIGINT"
+        assert "VARCHAR" in by_name["name"]
+
+    async def test_json_array_with_bom(self, tmp_path: Path) -> None:
+        json_file = tmp_path / "data.json"
+        json_file.write_bytes(b"\xef\xbb\xbf" + b'[{"id": 1}]')
+        cols = await tables.infer_columns_from_json(json_file)
+        assert [c.name for c in cols] == ["id"]
+        assert cols[0].sql_type == "BIGINT"
+
+    async def test_key_union_across_records(self, tmp_path: Path) -> None:
+        """Keys absent from some records still produce nullable columns."""
+        json_file = tmp_path / "data.jsonl"
+        json_file.write_text('{"a": 1}\n{"b": 2}\n')
+        cols = await tables.infer_columns_from_json(json_file)
+        names = {c.name for c in cols}
+        assert names == {"a", "b"}
+        assert all(c.nullable for c in cols)
+
+    async def test_mixed_int_float_widens_to_float(self, tmp_path: Path) -> None:
+        json_file = tmp_path / "data.jsonl"
+        json_file.write_text('{"x": 1}\n{"x": 1.5}\n')
+        cols = await tables.infer_columns_from_json(json_file)
+        assert cols[0].sql_type == "FLOAT"
+
+    async def test_number_then_string_conflict_errors(self, tmp_path: Path) -> None:
+        json_file = tmp_path / "data.jsonl"
+        json_file.write_text('{"x": 1}\n{"x": "hello"}\n')
+        with pytest.raises(ValueError, match="all-varchar"):
+            await tables.infer_columns_from_json(json_file)
+
+    async def test_nested_struct_falls_back_to_varchar(self, tmp_path: Path) -> None:
+        json_file = tmp_path / "data.jsonl"
+        json_file.write_text('{"obj": {"a": 1}}\n')
+        cols = await tables.infer_columns_from_json(json_file)
+        assert cols[0].name == "obj"
+        assert "VARCHAR" in cols[0].sql_type
+
+    async def test_nested_list_falls_back_to_varchar(self, tmp_path: Path) -> None:
+        json_file = tmp_path / "data.jsonl"
+        json_file.write_text('{"arr": [1, 2, 3]}\n')
+        cols = await tables.infer_columns_from_json(json_file)
+        assert cols[0].name == "arr"
+        assert "VARCHAR" in cols[0].sql_type
+
+    async def test_all_varchar_forces_varchar(self, tmp_path: Path) -> None:
+        json_file = tmp_path / "data.jsonl"
+        json_file.write_text('{"id": 1, "price": 1.5}\n')
+        cols = await tables.infer_columns_from_json(json_file, all_varchar=True)
+        assert all(c.sql_type == "VARCHAR(8000)" for c in cols)
+        assert {c.name for c in cols} == {"id", "price"}
+
+    async def test_all_varchar_survives_number_string_conflict(self, tmp_path: Path) -> None:
+        """--all-varchar must succeed even when a column mixes numbers and strings."""
+        json_file = tmp_path / "data.jsonl"
+        json_file.write_text('{"x": 1, "y": 2}\n{"x": "hello"}\n')
+        cols = await tables.infer_columns_from_json(json_file, all_varchar=True)
+        assert {c.name for c in cols} == {"x", "y"}
+        assert all(c.sql_type == "VARCHAR(8000)" for c in cols)
+
+    async def test_all_varchar_array_survives_conflict(self, tmp_path: Path) -> None:
+        json_file = tmp_path / "data.json"
+        json_file.write_text('[{"x": 1}, {"x": "s", "z": true}]')
+        cols = await tables.infer_columns_from_json(json_file, all_varchar=True)
+        assert {c.name for c in cols} == {"x", "z"}
+
+    async def test_custom_varchar_length(self, tmp_path: Path) -> None:
+        json_file = tmp_path / "data.jsonl"
+        json_file.write_text('{"name": "Alice"}\n')
+        cols = await tables.infer_columns_from_json(json_file, varchar_length=255)
+        assert cols[0].sql_type == "VARCHAR(255)"
+
+    async def test_empty_file_raises(self, tmp_path: Path) -> None:
+        json_file = tmp_path / "empty.jsonl"
+        json_file.write_text("")
+        with pytest.raises(ValueError, match="empty"):
+            await tables.infer_columns_from_json(json_file)
+
+    async def test_empty_file_raises_all_varchar(self, tmp_path: Path) -> None:
+        json_file = tmp_path / "empty.jsonl"
+        json_file.write_text("   \n")
+        with pytest.raises(ValueError, match="empty"):
+            await tables.infer_columns_from_json(json_file, all_varchar=True)
+
+    async def test_empty_array_raises(self, tmp_path: Path) -> None:
+        json_file = tmp_path / "empty.json"
+        json_file.write_text("[]")
+        with pytest.raises(ValueError, match="non-empty list of objects"):
+            await tables.infer_columns_from_json(json_file)
+
+    async def test_array_of_non_objects_raises(self, tmp_path: Path) -> None:
+        json_file = tmp_path / "bad.json"
+        json_file.write_text("[1, 2, 3]")
+        with pytest.raises(ValueError, match="only objects"):
+            await tables.infer_columns_from_json(json_file)
+
+    async def test_malformed_jsonl_raises(self, tmp_path: Path) -> None:
+        json_file = tmp_path / "bad.jsonl"
+        json_file.write_text("{not valid json")
+        with pytest.raises(ValueError, match="Could not infer a schema"):
+            await tables.infer_columns_from_json(json_file)
+
+    async def test_malformed_array_raises(self, tmp_path: Path) -> None:
+        json_file = tmp_path / "bad.json"
+        json_file.write_text('[{"a": 1},')
+        with pytest.raises(ValueError, match="Invalid JSON"):
+            await tables.infer_columns_from_json(json_file)
+
+    async def test_file_not_found_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            await tables.infer_columns_from_json(tmp_path / "nonexistent.jsonl")
+
+    async def test_sample_rows_bounds_returned_sample(self, tmp_path: Path) -> None:
+        """A bounded sample drives inference on a multi-record JSONL file.
+
+        pyarrow parses a whole read block at once, so *sample_rows* bounds the
+        records reflected in the returned schema (and the JSONL prefix actually
+        accumulated) rather than guaranteeing later bytes are never parsed.  We
+        write 10 consistent records and confirm inference produced the expected
+        typed column.
+        """
+        json_file = tmp_path / "big.jsonl"
+        lines = [f'{{"id": {i}, "value": {i * 10}}}' for i in range(10)]
+        json_file.write_text("\n".join(lines) + "\n")
+        cols = await tables.infer_columns_from_json(json_file, sample_rows=3)
+        by_name = {c.name: c.sql_type for c in cols}
+        assert by_name["id"] == "BIGINT"
+        assert by_name["value"] == "BIGINT"
+
+
+# ===========================================================================
+# create_table_from_json
+# ===========================================================================
+
+
+class TestCreateTableFromJson:
+    async def test_creates_table_from_jsonl(self, tmp_path: Path) -> None:
+        json_file = tmp_path / "data.jsonl"
+        json_file.write_text('{"id": 1, "name": "Alice"}\n')
+
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_TABLE_ROW_1], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            result = await tables.create_table_from_json(target, "dbo", "sales", json_file)
+        assert isinstance(result, Table)
+        ddl_cursor = ddl_conn.cursor.return_value
+        sql: str = ddl_cursor.execute.call_args[0][0]
+        assert "[id]" in sql
+        assert "[name]" in sql
+
+    async def test_creates_table_from_json_array(self, tmp_path: Path) -> None:
+        json_file = tmp_path / "data.json"
+        json_file.write_text('[{"id": 1, "name": "Alice"}]')
+
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_TABLE_ROW_1], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            result = await tables.create_table_from_json(target, "dbo", "sales", json_file)
+        assert isinstance(result, Table)
+
+    async def test_all_varchar_uses_varchar(self, tmp_path: Path) -> None:
+        json_file = tmp_path / "data.jsonl"
+        json_file.write_text('{"count": 1, "label": "foo"}\n')
+
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_TABLE_ROW_1], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            await tables.create_table_from_json(target, "dbo", "sales", json_file, all_varchar=True)
+        ddl_cursor = ddl_conn.cursor.return_value
+        sql: str = ddl_cursor.execute.call_args[0][0]
+        assert "VARCHAR" in sql
+
+    async def test_json_rejects_sql_endpoint(self, tmp_path: Path) -> None:
+        json_file = tmp_path / "data.jsonl"
+        json_file.write_text('{"id": 1}\n')
+        target = _make_target()
+        with pytest.raises(ItemKindError):
+            await tables.create_table_from_json(
+                target, "dbo", "sales", json_file, kind=WarehouseKind.SQL_ENDPOINT
+            )
+
+    async def test_json_raises_file_not_found(self, tmp_path: Path) -> None:
+        target = _make_target()
+        with pytest.raises(FileNotFoundError):
+            await tables.create_table_from_json(
+                target, "dbo", "sales", tmp_path / "nonexistent.jsonl"
+            )
+
+    async def test_json_empty_file_raises(self, tmp_path: Path) -> None:
+        json_file = tmp_path / "empty.jsonl"
+        json_file.write_text("")
+        target = _make_target()
+        with pytest.raises(ValueError, match="empty"):
+            await tables.create_table_from_json(target, "dbo", "sales", json_file)
+
+
+# ===========================================================================
+# create_table_from_json — cluster_by tests
+# ===========================================================================
+
+
+class TestCreateTableFromJsonClusterBy:
+    async def test_passes_cluster_by_to_create_empty(self, tmp_path: Path) -> None:
+        json_file = tmp_path / "data.jsonl"
+        json_file.write_text('{"CustomerID": 1, "SaleDate": "2024-01-01"}\n')
+
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_TABLE_ROW_1], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            await tables.create_table_from_json(
+                target, "dbo", "sales", json_file, cluster_by=["CustomerID"]
+            )
+        cursor = ddl_conn.cursor.return_value
+        sql: str = cursor.execute.call_args[0][0]
+        assert "CLUSTER BY ([CustomerID])" in sql
+
+    async def test_unknown_cluster_col_raises(self, tmp_path: Path) -> None:
+        json_file = tmp_path / "data.jsonl"
+        json_file.write_text('{"id": 1, "name": "foo"}\n')
+        target = _make_target()
+        with pytest.raises(ValueError, match="not defined in the table schema"):
+            await tables.create_table_from_json(
+                target, "dbo", "sales", json_file, cluster_by=["MissingCol"]
+            )
+
+
+# ===========================================================================
 # recluster_table
 # ===========================================================================
 


### PR DESCRIPTION
## What

Replaces `fdw tables create --from-schema <file>` (which read a JSON file literally containing column specs — a misunderstanding) with `--from-json <file>`, a peer of `--from-csv`/`--from-parquet` that builds a table from JSON **data** by inferring the schema. An empty table is created; data loading stays in `tables load --format json`. CLI-only — no MCP tool (same rationale as csv/parquet: unreliable server-side file access).

The file may be **JSONL** or a **JSON array of objects**; the shape is auto-detected by peeking the first non-whitespace byte (after stripping any BOM). One inference engine handles both.

```shell
# JSONL — schema inferred from the data
fdw tables create SalesWH --name staging.events --from-json ./data/events.jsonl

# A JSON array of objects
fdw tables create SalesWH --name dbo.audit_log --from-json ./data/audit_log.json --varchar-length 500
```

## Inference rules

- pyarrow unifies types across records (`int64`/`double`/`bool`/`string`/`timestamp[s]`, ISO strings auto-detected) and forms the **union of keys** across records.
- All inferred columns are **nullable** (any key may be omitted from any record).
- Each Arrow type maps via the existing `arrow_type_to_tsql` helper.
- **Per-column fallback:** a nested `struct`/`list` (no scalar T-SQL equivalent) → `VARCHAR(varchar_length)` with a warning, exactly as the CSV path does.
- **Whole-file conflict:** when a column changes from number to string across records, pyarrow raises during parsing (before any per-column fallback is possible) → surfaced as a clear error suggesting `--all-varchar`.
- **`--all-varchar`** reads the key union with the stdlib `json` module rather than pyarrow, so it still succeeds on a number↔string conflict — the exact case the flag exists to rescue — and forces every column to `VARCHAR(varchar_length)`.
- **Empty / zero-record / malformed** files raise clear `ValueError`s.

## Performance

JSONL **streams** (a bounded sample is read via `pyarrow.json.open_json` with a 1 MiB block; memory-safe regardless of file size). A JSON array is **fully loaded** via `json.loads` — documented in help + docstrings ("for very large data prefer JSONL").

## CLI changes

- Added `--from-json PATH`; removed `--from-schema` and `_parse_schema_file` entirely (option, branch, exclusivity rules, help, tests).
- `--from-json` is mutually exclusive with `--from-parquet`/`--from-csv`/`--column`/CTAS.
- `--all-varchar`/`--varchar-length`/`--sample-rows` now apply to `--from-json`; the `--all-varchar` gate is now "requires `--from-csv` or `--from-json`". `--delimiter`/`--encoding` stay CSV-only.

## Docs

`docs/commands/tables.md` documents `--from-json` (JSONL or JSON array, schema inferred from data); no `--from-schema` remains. (Guide files under `docs/guides/*` are out of scope — they follow in PR B after #624 merges.)

## Tests

`just lint`, `just type` (ty), and the full unit suite all green (4180 passed). New `TestInferColumnsFromJson` / `TestCreateTableFromJson` (+ cluster_by) cover JSONL & array happy paths, type inference, key-union nullability, int→float widening, number↔string fallback/whole-file error, nested struct/list fallback, `--all-varchar` (including surviving a conflict), empty/malformed/not-found. CLI tests add `--from-json` JSONL+array success, the four mutual-exclusivity rules, a bad-file failure, and the updated `--all-varchar` gating.

Closes #629