### PR TITLE
ci: stop gating the integration run on the unit-suite coverage threshold

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -229,12 +229,14 @@ jobs:
           # than query/schema tests), unlike "loadscope" which would bin every
           # module onto one worker and starve the rest.
 
+          # --cov-fail-under=0: the 80% fail_under in pyproject.toml is a unit-suite gate;
+          # integration coverage is informational/codecov-only and must not block this run.
           if [ -n "${PYTEST_K_INPUT}" ]; then
             echo "Running subset: -k '${PYTEST_K_INPUT}' with ${WORKERS} worker(s)"
-            uv run pytest tests/integration -m integration -v -n "${WORKERS}" --dist loadgroup -k "${PYTEST_K_INPUT}" --cov --cov-report=xml --cov-report=term --junitxml=junit.xml -o junit_family=legacy
+            uv run pytest tests/integration -m integration -v -n "${WORKERS}" --dist loadgroup -k "${PYTEST_K_INPUT}" --cov --cov-report=xml --cov-report=term --cov-fail-under=0 --junitxml=junit.xml -o junit_family=legacy
           else
             echo "Running full integration suite with ${WORKERS} worker(s)"
-            uv run pytest tests/integration -m integration -v -n "${WORKERS}" --dist loadgroup --cov --cov-report=xml --cov-report=term --junitxml=junit.xml -o junit_family=legacy
+            uv run pytest tests/integration -m integration -v -n "${WORKERS}" --dist loadgroup --cov --cov-report=xml --cov-report=term --cov-fail-under=0 --junitxml=junit.xml -o junit_family=legacy
           fi
 
       - name: Upload coverage reports to Codecov


### PR DESCRIPTION
## Problem

The Integration tests workflow reported `failure` even when all tests passed (`196 passed, 11 skipped, 0 failed`). The failure came solely from the coverage gate:

```
ERROR: Coverage failure: total of 30 is less than fail-under=80
```

`pyproject.toml` sets `[tool.coverage.report] fail_under = 80`, and `integration.yml` runs pytest with `--cov … --cov-report=term`, so `coverage report` enforced the 80% threshold on the integration-only run. Integration tests inherently exercise ~30% of the codebase — the 80% gate is meant for the unit suite — making the integration run **perpetually red** regardless of test health.

## Fix

Added `--cov-fail-under=0` to both `uv run pytest tests/integration …` invocations in `.github/workflows/integration.yml` (the `-k` subset branch and the full-suite branch), with a short comment explaining that the 80% `fail_under` is a unit-suite gate and integration coverage is informational/codecov-only.

- `--cov`, `--cov-report=xml`, `--cov-report=term` retained; codecov upload unaffected.
- `pyproject.toml fail_under = 80` unchanged; the unit suite remains gated.
- Only `.github/workflows/integration.yml` was changed (2 lines modified, 1 comment added).

## Lines changed

- `.github/workflows/integration.yml` line 234: added `--cov-fail-under=0`
- `.github/workflows/integration.yml` line 237: added `--cov-fail-under=0`
- `.github/workflows/integration.yml` lines 232–233: added explanatory comment

Closes #634