### PR TITLE
docs: add the Telemetry page to the site nav

### DIFF
--- a/zensical.toml
+++ b/zensical.toml
@@ -43,7 +43,8 @@ nav = [
     { "Agent Skills" = "skills.md" },
     { "Exit codes" = "reference/exit-codes.md" },
     { "Shell Completion" = "completion.md" },
-    { "Troubleshooting" = "troubleshooting.md" }
+    { "Troubleshooting" = "troubleshooting.md" },
+    { "Telemetry" = "telemetry.md" }
   ] },
   { "Guides" = [
     { "Overview" = "guides/index.md" },


### PR DESCRIPTION
## Summary

- `docs/telemetry.md` existed and documented telemetry collection, opt-out env vars, and the config-file toggle, but was **orphaned** — it had no entry in the site nav (`zensical.toml`) and was therefore undiscoverable from the docs site.
- Adds `{ "Telemetry" = "telemetry.md" }` to the **Reference** section in `zensical.toml`, placed after "Troubleshooting".
- TOML validates cleanly; docs build completes with no missing-page error.

Closes #640

## Test plan

- [x] `uv run python -c "import tomllib; tomllib.load(open('zensical.toml','rb')); print('ok')"` → `ok`
- [x] `uv run --group docs zensical build` → build finished, no missing-page error for `telemetry.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)