### PR TITLE
docs: fix two broken intra-page anchors (format-options, caveats-limits)

### DIFF
--- a/docs/commands/sql.md
+++ b/docs/commands/sql.md
@@ -248,7 +248,7 @@ The plan XML uses the standard namespace `http://schemas.microsoft.com/sqlserver
 - `query` (`str`) — SQL statement to generate an estimated execution plan for.
 - `format` (`"xml" | "tree" | "json" | "mermaid"`, default `"xml"`) — output format. See [Format options](#format-options) below.
 
-**Format options**
+#### Format options
 
 | `format` | Return key | Value type | Description |
 | --- | --- | --- | --- |

--- a/docs/guides/query-performance.md
+++ b/docs/guides/query-performance.md
@@ -46,7 +46,7 @@ The `queryinsights` views are documented in [Query insights in Fabric Data Wareh
 
 !!! warning "New-warehouse delay"
 
-    The `queryinsights.*` views are **not populated immediately** on a brand-new warehouse and completed queries lag behind real time. If a view comes back empty on a fresh item, give it time and re-run. See [Caveats & limits](#caveats--limits).
+    The `queryinsights.*` views are **not populated immediately** on a brand-new warehouse and completed queries lag behind real time. If a view comes back empty on a fresh item, give it time and re-run. See [Caveats & limits](#caveats-limits).
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes two broken intra-page anchor links flagged by the zensical/Cloudflare docs build.

- **`docs/commands/sql.md`**: the `**Format options**` bold label below line 249 generated no anchor. Changed to `#### Format options` (matching the existing `#### Export formats` heading level) so the existing `[Format options](#format-options)` link resolves.
- **`docs/guides/query-performance.md`**: the link at line 49 used `#caveats--limits` (double dash) but the target heading `## Caveats & limits` slugifies to `#caveats-limits` (single dash). Fixed the link anchor.

`uv run --group docs zensical build` now reports **No issues found** (was 2 anchor warnings).

Closes #642