### PR TITLE
ci(docs): set Cloudflare build env vars in wrangler.toml to skip the project install

### DIFF
--- a/docs_build/cloudflare_pages.sh
+++ b/docs_build/cloudflare_pages.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Required CF dashboard env vars (Settings → Environment variables):
+# Build environment variables are set in wrangler.toml [vars]:
 #   SKIP_DEPENDENCY_INSTALL=1   — prevents CF from running `pip install .`,
 #                                 which would pull in all runtime deps the docs
 #                                 build doesn't need (~17 s saved).

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,3 +1,7 @@
 name = "fabric-dw"
 pages_build_output_dir = "docs_build/site"
 compatibility_date = "2026-06-07"
+
+[vars]
+SKIP_DEPENDENCY_INSTALL = "1"
+PYTHON_VERSION = "3.13.3"


### PR DESCRIPTION
## Summary

- Cloudflare Pages was running `pip install .` on every docs build, pulling in the full runtime stack (~90 packages, including pyarrow, mssql-python, azure/opentelemetry) that the `zensical` docs build does not need.
- When `PYTHON_VERSION` was not set, CF's build image fell back to compiling Python from source via pyenv (~95 s overhead).
- Both env vars (`SKIP_DEPENDENCY_INSTALL=1` and `PYTHON_VERSION=3.13.3`) are now declared in `wrangler.toml [vars]`, version-controlled and applied automatically — no manual dashboard config required.
- The script header comment in `docs_build/cloudflare_pages.sh` is updated to reflect the new source of truth; the script body is unchanged.

Closes #644

🤖 Generated with [Claude Code](https://claude.com/claude-code)