### PR TITLE
docs(telemetry): fix opt-out table line break and drop dead Do-Not-Track link

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -86,8 +86,8 @@ Any of the following fully disables telemetry — no events are emitted and the 
 |---|---|
 | Environment variable | `FABRIC_DISABLE_TELEMETRY=1` |
 | Environment variable | `FABRIC_TELEMETRY=0` (also accepts `false`, `no`, `off`) |
-| Console Do Not Track | `DO_NOT_TRACK=1` ([consoledonottrack.com](https://consoledonottrack.com)) |
+| Do Not Track | `DO_NOT_TRACK=1` |
 | CI detection | Automatic when `CI`, `GITHUB_ACTIONS`, `TRAVIS`, `CIRCLECI`, `GITLAB_CI`, `JENKINS_URL`, or `TF_BUILD` is set |
-| Config file | Add `[telemetry]\ndisabled = true` to `$XDG_CONFIG_HOME/fabric-dw/config.toml` |
+| Config file | Add `disabled = true` under a `[telemetry]` section in `$XDG_CONFIG_HOME/fabric-dw/config.toml` |
 
 Telemetry is **always off in CI environments** — no action needed for automated pipelines.


### PR DESCRIPTION
## Summary

- **Config-file row**: the cell previously contained a literal `\n` inside an inline code span (`[telemetry]\ndisabled = true`), which renders as the text `\n` rather than a line break. Rewrote as prose: _Add `disabled = true` under a `[telemetry]` section in `$XDG_CONFIG_HOME/fabric-dw/config.toml`_.
- **Do Not Track row**: removed the dead `([consoledonottrack.com](https://consoledonottrack.com))` link (site does not exist). `DO_NOT_TRACK=1` is kept — it remains a valid, working opt-out. Row label simplified to "Do Not Track".

Only `docs/telemetry.md` is touched (two rows in the "How to opt out" table).

Closes #648