### PR TITLE
docs: merge Concepts page into the Reference nav section

### DIFF
--- a/zensical.toml
+++ b/zensical.toml
@@ -14,7 +14,6 @@ watch = ["README.md", "CONTRIBUTING.md", "LICENSE", "SECURITY.md", "CODE_OF_COND
 nav = [
   { "Home" = "index.md" },
   { "Install" = "install.md" },
-  { "Concepts" = "concepts.md" },
   { "Commands" = [
     { "Overview" = "commands/index.md" },
     { "Audit" = "commands/audit.md" },
@@ -39,6 +38,7 @@ nav = [
     { "Workspaces" = "commands/workspaces.md" }
   ] },
   { "Reference" = [
+    { "Concepts" = "concepts.md" },
     { "Authentication" = "authentication.md" },
     { "Agent Skills" = "skills.md" },
     { "Exit codes" = "reference/exit-codes.md" },


### PR DESCRIPTION
## Summary

- Removes the standalone top-level `Concepts` tab from the docs nav.
- Adds `Concepts` as the first child of the `Reference` section (before Authentication), keeping all other Reference entries in their current order.
- `docs/concepts.md` is untouched — its URL (`/concepts/`) and all inbound relative links (from `guides/ingesting-data.md`, `guides/query-performance.md`, `commands/config.md`) continue to work unchanged.

This is a pure structural/nav change with no content edits.

Closes #650