### PR TITLE
feat(telemetry): persist resolved tenant_id and read it back to eliminate "unknown"

### DIFF
--- a/src/fabric_dw/telemetry.py
+++ b/src/fabric_dw/telemetry.py
@@ -252,40 +252,48 @@ _install_id_cache: str | None = None
 # ---------------------------------------------------------------------------
 
 _TENANT_ID_FILE = "tenant_id"
-_tenant_id_cache: str | None = None
-_tenant_id_cache_loaded: bool = False
+_UNSET: object = object()  # sentinel — distinguishes "not yet read" from None/"no value"
+_tenant_id_cache: str | None | object = _UNSET  # _UNSET → not yet loaded; None → loaded, absent
 
 
 def _get_cached_tenant_id() -> str | None:
     """Return the persisted tenant UUID, or None if missing/empty/unreadable.
 
-    In-memory cached after the first read.  Never raises.
+    In-memory cached after the first read (sentinel ``_UNSET`` means not yet read).
+    Never raises.
     """
-    global _tenant_id_cache, _tenant_id_cache_loaded  # noqa: PLW0603
-    if _tenant_id_cache_loaded:
-        return _tenant_id_cache
+    global _tenant_id_cache  # noqa: PLW0603
+    if _tenant_id_cache is not _UNSET:
+        # _tenant_id_cache is str | None here (set either below or by _persist_tenant_id).
+        return _tenant_id_cache if isinstance(_tenant_id_cache, str) else None
 
+    result: str | None = None
     with contextlib.suppress(Exception):
         id_file = _config_dir() / _TENANT_ID_FILE
         if id_file.exists():
             value = id_file.read_text(encoding="utf-8").strip()
             if value:
-                _tenant_id_cache = value
+                result = value
 
-    _tenant_id_cache_loaded = True
-    return _tenant_id_cache
+    _tenant_id_cache = result
+    return result
 
 
 def _persist_tenant_id(tid: str) -> None:
-    """Write the tenant UUID to the config directory.  Fail-safe: never raises."""
-    global _tenant_id_cache, _tenant_id_cache_loaded  # noqa: PLW0603
+    """Write the tenant UUID to the config directory.  Fail-safe: never raises.
+
+    The in-memory cache is only updated when the write succeeds, so a
+    read-only-FS failure does not leave the cache in a "loaded but not
+    persisted" state.  The current process stays correct regardless via
+    ``_tenant_id_override``.
+    """
+    global _tenant_id_cache  # noqa: PLW0603
     with contextlib.suppress(Exception):
         config_dir = _config_dir()
         config_dir.mkdir(parents=True, exist_ok=True)
         (config_dir / _TENANT_ID_FILE).write_text(tid, encoding="utf-8")
-    # Keep in-memory cache in sync even if the write silently failed.
-    _tenant_id_cache = tid
-    _tenant_id_cache_loaded = True
+        # Cache only after a successful write (C1: don't cache on FS failure).
+        _tenant_id_cache = tid
 
 
 def _get_install_id() -> str:
@@ -420,6 +428,10 @@ def _build_envelope() -> dict[str, object]:
     # Prefer the runtime-set override (populated by #366 token-claim hook),
     # then fall back to environment variables, then the persisted cache (#652),
     # then "unknown" so the key is always present on every event (Finding 2 / #477).
+    # Bounded staleness: if telemetry was disabled on the previous run, the cache
+    # may hold a tenant from an earlier authenticated run against a different tenant.
+    # This is the accepted trade-off — at most one misattributed lifecycle event
+    # (e.g. app_started) before set_tenant_id() corrects it in the same process.
     tenant_id: str = (
         _tenant_id_override
         or os.environ.get("AZURE_TENANT_ID")
@@ -989,6 +1001,13 @@ def set_tenant_id(tenant_id: str) -> None:
     is propagated here so every subsequent event envelope carries the tenant.
     Env-var fallback (``AZURE_TENANT_ID`` / ``FABRIC_INTERACTIVE_TENANT_ID``) is
     used by :func:`_build_envelope` when this override has not been set.
+
+    **Persistence**: when :func:`telemetry_enabled` returns ``True`` at the time
+    of this call, the resolved tenant is also written to the persistent tenant
+    store (``$XDG_CONFIG_HOME/fabric-dw/tenant_id``) so that subsequent process
+    invocations can read it back before authentication completes.  When telemetry
+    is disabled the value is kept only in-memory for the lifetime of the current
+    process and nothing is written to disk.
 
     Args:
         tenant_id: The tenant UUID string extracted from the access token.

--- a/src/fabric_dw/telemetry.py
+++ b/src/fabric_dw/telemetry.py
@@ -247,6 +247,46 @@ def telemetry_enabled() -> bool:
 _INSTALL_ID_FILE = "install_id"
 _install_id_cache: str | None = None
 
+# ---------------------------------------------------------------------------
+# Tenant-ID persistence (#652)
+# ---------------------------------------------------------------------------
+
+_TENANT_ID_FILE = "tenant_id"
+_tenant_id_cache: str | None = None
+_tenant_id_cache_loaded: bool = False
+
+
+def _get_cached_tenant_id() -> str | None:
+    """Return the persisted tenant UUID, or None if missing/empty/unreadable.
+
+    In-memory cached after the first read.  Never raises.
+    """
+    global _tenant_id_cache, _tenant_id_cache_loaded  # noqa: PLW0603
+    if _tenant_id_cache_loaded:
+        return _tenant_id_cache
+
+    with contextlib.suppress(Exception):
+        id_file = _config_dir() / _TENANT_ID_FILE
+        if id_file.exists():
+            value = id_file.read_text(encoding="utf-8").strip()
+            if value:
+                _tenant_id_cache = value
+
+    _tenant_id_cache_loaded = True
+    return _tenant_id_cache
+
+
+def _persist_tenant_id(tid: str) -> None:
+    """Write the tenant UUID to the config directory.  Fail-safe: never raises."""
+    global _tenant_id_cache, _tenant_id_cache_loaded  # noqa: PLW0603
+    with contextlib.suppress(Exception):
+        config_dir = _config_dir()
+        config_dir.mkdir(parents=True, exist_ok=True)
+        (config_dir / _TENANT_ID_FILE).write_text(tid, encoding="utf-8")
+    # Keep in-memory cache in sync even if the write silently failed.
+    _tenant_id_cache = tid
+    _tenant_id_cache_loaded = True
+
 
 def _get_install_id() -> str:
     """Return the anonymous install UUID, generating and persisting it on first call."""
@@ -378,12 +418,13 @@ def _build_envelope() -> dict[str, object]:
     python_version = f"{python_info.major}.{python_info.minor}"
 
     # Prefer the runtime-set override (populated by #366 token-claim hook),
-    # then fall back to environment variables, then "unknown" so the key is
-    # always present on every event (Finding 2 / #477).
+    # then fall back to environment variables, then the persisted cache (#652),
+    # then "unknown" so the key is always present on every event (Finding 2 / #477).
     tenant_id: str = (
         _tenant_id_override
         or os.environ.get("AZURE_TENANT_ID")
         or os.environ.get("FABRIC_INTERACTIVE_TENANT_ID")
+        or _get_cached_tenant_id()
         or "unknown"
     )
 
@@ -954,6 +995,8 @@ def set_tenant_id(tenant_id: str) -> None:
     """
     global _tenant_id_override  # noqa: PLW0603
     _tenant_id_override = tenant_id
+    if telemetry_enabled():
+        _persist_tenant_id(tenant_id)
 
 
 def decode_tid_from_token(token: str) -> str | None:

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -1367,6 +1367,66 @@ def test_env_var_takes_precedence_over_cache(
     assert envelope["tenant_id"] == "env-tenant-wins"
 
 
+def test_stale_cache_corrected_by_set_tenant_id(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Document the accepted bounded-staleness behaviour (#652, C5).
+
+    Sequence:
+      run1  telemetry ON  → set_tenant_id("tenant-A") persists to cache
+      run2  telemetry OFF → set_tenant_id("tenant-B") does NOT update cache
+      run3  telemetry ON  → app_started fires BEFORE auth (reads stale "tenant-A")
+                          → set_tenant_id("tenant-B") corrects it for every
+                            subsequent event in the same process
+
+    At most one lifecycle event (app_started) is misattributed per run — this is
+    the intentional, bounded trade-off documented in _build_envelope.
+    """
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setenv("FABRIC_TELEMETRY_CONNECTION_STRING", _DUMMY_CONN_STR)
+    monkeypatch.delenv("AZURE_TENANT_ID", raising=False)
+    monkeypatch.delenv("FABRIC_INTERACTIVE_TENANT_ID", raising=False)
+    monkeypatch.delenv("FABRIC_DISABLE_TELEMETRY", raising=False)
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+    monkeypatch.delenv("CI", raising=False)
+    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+    monkeypatch.delenv("JENKINS_URL", raising=False)
+    monkeypatch.delenv("TRAVIS", raising=False)
+    monkeypatch.delenv("CIRCLECI", raising=False)
+    monkeypatch.delenv("GITLAB_CI", raising=False)
+    monkeypatch.delenv("TF_BUILD", raising=False)
+    monkeypatch.delenv("FABRIC_TELEMETRY", raising=False)
+
+    # run1: telemetry ON → tenant-A written to cache
+    mod = _reload_telemetry()
+    assert mod.telemetry_enabled() is True  # type: ignore[attr-defined]
+    mod.set_tenant_id("tenant-A")  # type: ignore[attr-defined]
+
+    # run2: telemetry OFF → tenant-B NOT written to cache
+    monkeypatch.setenv("FABRIC_DISABLE_TELEMETRY", "1")
+    mod2 = _reload_telemetry()
+    assert mod2.telemetry_enabled() is False  # type: ignore[attr-defined]
+    mod2.set_tenant_id("tenant-B")  # type: ignore[attr-defined]
+    # Cache file still holds tenant-A
+    assert (tmp_path / "fabric-dw" / "tenant_id").read_text(encoding="utf-8").strip() == "tenant-A"
+
+    # run3: telemetry re-enabled; app_started fires before auth (no live override)
+    monkeypatch.delenv("FABRIC_DISABLE_TELEMETRY", raising=False)
+    mod3 = _reload_telemetry()
+    mod3._tenant_id_override = None  # type: ignore[attr-defined]
+
+    pre_auth_envelope = mod3._build_envelope()  # type: ignore[attr-defined]
+    # Stale cache value is used for the pre-auth event (bounded misattribution)
+    assert pre_auth_envelope["tenant_id"] == "tenant-A"
+
+    # After authentication, set_tenant_id corrects the override for this process
+    mod3.set_tenant_id("tenant-B")  # type: ignore[attr-defined]
+    post_auth_envelope = mod3._build_envelope()  # type: ignore[attr-defined]
+    assert post_auth_envelope["tenant_id"] == "tenant-B"
+    # And the cache is now updated with the correct tenant for future runs
+    assert (tmp_path / "fabric-dw" / "tenant_id").read_text(encoding="utf-8").strip() == "tenant-B"
+
+
 # ---------------------------------------------------------------------------
 # A3: marker file written AFTER notice is printed
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -1181,6 +1181,193 @@ def test_set_tenant_id_takes_precedence_over_env(
 
 
 # ---------------------------------------------------------------------------
+# Persistent tenant store (#652)
+# ---------------------------------------------------------------------------
+
+_DUMMY_CONN_STR = (
+    "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://localhost/"
+)
+
+
+def test_tenant_id_unknown_on_first_run(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """With no known tenant, _build_envelope must return tenant_id == 'unknown' (#652)."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setenv("FABRIC_TELEMETRY_CONNECTION_STRING", _DUMMY_CONN_STR)
+    monkeypatch.delenv("AZURE_TENANT_ID", raising=False)
+    monkeypatch.delenv("FABRIC_INTERACTIVE_TENANT_ID", raising=False)
+
+    mod = _reload_telemetry()
+    mod._tenant_id_override = None  # type: ignore[attr-defined]
+
+    envelope = mod._build_envelope()  # type: ignore[attr-defined]
+    assert envelope["tenant_id"] == "unknown"
+
+
+def test_set_tenant_id_writes_file_when_enabled(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """set_tenant_id must persist to disk when telemetry is enabled (#652)."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setenv("FABRIC_TELEMETRY_CONNECTION_STRING", _DUMMY_CONN_STR)
+    monkeypatch.delenv("FABRIC_DISABLE_TELEMETRY", raising=False)
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+    monkeypatch.delenv("CI", raising=False)
+    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+    monkeypatch.delenv("JENKINS_URL", raising=False)
+    monkeypatch.delenv("TRAVIS", raising=False)
+    monkeypatch.delenv("CIRCLECI", raising=False)
+    monkeypatch.delenv("GITLAB_CI", raising=False)
+    monkeypatch.delenv("TF_BUILD", raising=False)
+    monkeypatch.delenv("FABRIC_TELEMETRY", raising=False)
+
+    mod = _reload_telemetry()
+    assert mod.telemetry_enabled() is True  # type: ignore[attr-defined]
+
+    mod.set_tenant_id("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")  # type: ignore[attr-defined]
+
+    tenant_file = tmp_path / "fabric-dw" / "tenant_id"
+    assert tenant_file.exists(), "tenant_id file must be written on disk when telemetry is enabled"
+    assert tenant_file.read_text(encoding="utf-8").strip() == "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+
+def test_set_tenant_id_no_write_when_disabled(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """set_tenant_id must NOT write to disk when telemetry is disabled (#652)."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setenv("FABRIC_TELEMETRY_CONNECTION_STRING", _DUMMY_CONN_STR)
+    monkeypatch.setenv("FABRIC_DISABLE_TELEMETRY", "1")
+
+    mod = _reload_telemetry()
+    assert mod.telemetry_enabled() is False  # type: ignore[attr-defined]
+
+    mod.set_tenant_id("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")  # type: ignore[attr-defined]
+
+    tenant_file = tmp_path / "fabric-dw" / "tenant_id"
+    assert not tenant_file.exists(), "tenant_id file must NOT be written when telemetry is disabled"
+
+
+def test_cached_tenant_read_back_on_new_process(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """After set_tenant_id, a fresh module load must read the persisted tenant (#652).
+
+    Simulates process restart: write on first run, then reload (new process) with
+    _tenant_id_override = None to check the cache is the fallback.
+    """
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setenv("FABRIC_TELEMETRY_CONNECTION_STRING", _DUMMY_CONN_STR)
+    monkeypatch.delenv("AZURE_TENANT_ID", raising=False)
+    monkeypatch.delenv("FABRIC_INTERACTIVE_TENANT_ID", raising=False)
+    monkeypatch.delenv("FABRIC_DISABLE_TELEMETRY", raising=False)
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+    monkeypatch.delenv("CI", raising=False)
+    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+    monkeypatch.delenv("JENKINS_URL", raising=False)
+    monkeypatch.delenv("TRAVIS", raising=False)
+    monkeypatch.delenv("CIRCLECI", raising=False)
+    monkeypatch.delenv("GITLAB_CI", raising=False)
+    monkeypatch.delenv("TF_BUILD", raising=False)
+    monkeypatch.delenv("FABRIC_TELEMETRY", raising=False)
+
+    # First run: set the tenant (writes file)
+    mod = _reload_telemetry()
+    mod.set_tenant_id("1111aaaa-2222-bbbb-3333-cccc44445555")  # type: ignore[attr-defined]
+
+    # New process: reload module so in-memory state is gone, simulate no live override
+    mod2 = _reload_telemetry()
+    mod2._tenant_id_override = None  # type: ignore[attr-defined]
+
+    envelope = mod2._build_envelope()  # type: ignore[attr-defined]
+    assert envelope["tenant_id"] == "1111aaaa-2222-bbbb-3333-cccc44445555", (
+        "Persisted tenant must be read back in a fresh process (app_started scenario)"
+    )
+
+
+def test_missing_tenant_file_falls_back_to_unknown(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A missing tenant cache file must not raise and must fall back to 'unknown' (#652)."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setenv("FABRIC_TELEMETRY_CONNECTION_STRING", _DUMMY_CONN_STR)
+    monkeypatch.delenv("AZURE_TENANT_ID", raising=False)
+    monkeypatch.delenv("FABRIC_INTERACTIVE_TENANT_ID", raising=False)
+
+    # Ensure no tenant file exists
+    tenant_file = tmp_path / "fabric-dw" / "tenant_id"
+    assert not tenant_file.exists()
+
+    mod = _reload_telemetry()
+    mod._tenant_id_override = None  # type: ignore[attr-defined]
+
+    envelope = mod._build_envelope()  # type: ignore[attr-defined]
+    assert envelope["tenant_id"] == "unknown"
+
+
+def test_garbage_tenant_file_falls_back_to_unknown(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A malformed/empty tenant cache file must not raise and must return None (#652)."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setenv("FABRIC_TELEMETRY_CONNECTION_STRING", _DUMMY_CONN_STR)
+    monkeypatch.delenv("AZURE_TENANT_ID", raising=False)
+    monkeypatch.delenv("FABRIC_INTERACTIVE_TENANT_ID", raising=False)
+
+    config_dir = tmp_path / "fabric-dw"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    (config_dir / "tenant_id").write_text("   \n", encoding="utf-8")  # whitespace only
+
+    mod = _reload_telemetry()
+    mod._tenant_id_override = None  # type: ignore[attr-defined]
+
+    envelope = mod._build_envelope()  # type: ignore[attr-defined]
+    assert envelope["tenant_id"] == "unknown"
+
+
+def test_live_override_takes_precedence_over_cache(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Live _tenant_id_override must win over persisted cache (#652)."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setenv("FABRIC_TELEMETRY_CONNECTION_STRING", _DUMMY_CONN_STR)
+    monkeypatch.delenv("AZURE_TENANT_ID", raising=False)
+    monkeypatch.delenv("FABRIC_INTERACTIVE_TENANT_ID", raising=False)
+
+    # Write a stale tenant to cache
+    config_dir = tmp_path / "fabric-dw"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    (config_dir / "tenant_id").write_text("stale-tenant-from-cache", encoding="utf-8")
+
+    mod = _reload_telemetry()
+    # Set a live override (different tenant)
+    mod._tenant_id_override = "live-override-tenant"  # type: ignore[attr-defined]
+
+    envelope = mod._build_envelope()  # type: ignore[attr-defined]
+    assert envelope["tenant_id"] == "live-override-tenant"
+
+
+def test_env_var_takes_precedence_over_cache(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """AZURE_TENANT_ID env var must take precedence over persisted cache (#652)."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setenv("FABRIC_TELEMETRY_CONNECTION_STRING", _DUMMY_CONN_STR)
+    monkeypatch.setenv("AZURE_TENANT_ID", "env-tenant-wins")
+    monkeypatch.delenv("FABRIC_INTERACTIVE_TENANT_ID", raising=False)
+
+    # Write a different tenant to cache
+    config_dir = tmp_path / "fabric-dw"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    (config_dir / "tenant_id").write_text("cached-tenant-should-lose", encoding="utf-8")
+
+    mod = _reload_telemetry()
+    mod._tenant_id_override = None  # type: ignore[attr-defined]
+
+    envelope = mod._build_envelope()  # type: ignore[attr-defined]
+    assert envelope["tenant_id"] == "env-tenant-wins"
+
+
+# ---------------------------------------------------------------------------
 # A3: marker file written AFTER notice is printed
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Add `_TENANT_ID_FILE` / `_get_cached_tenant_id()` / `_persist_tenant_id()` helpers in `telemetry.py`, mirroring the existing `_get_install_id` / `_INSTALL_ID_FILE` pattern (in-memory cached, fail-safe, never raises).
- `set_tenant_id()` now writes the resolved tenant through to `$XDG_CONFIG_HOME/fabric-dw/tenant_id` — gated on `telemetry_enabled()` so opt-out is fully respected and nothing is ever written to disk when telemetry is disabled.
- `_build_envelope()` extends the tenant precedence chain to read the persisted cache before falling back to `"unknown"`: live override → env vars → cache → `"unknown"`.

## Test plan

- [ ] `test_tenant_id_unknown_on_first_run` — no file, no override, no env → `"unknown"`
- [ ] `test_set_tenant_id_writes_file_when_enabled` — file written on disk with correct content
- [ ] `test_set_tenant_id_no_write_when_disabled` — no file when telemetry disabled
- [ ] `test_cached_tenant_read_back_on_new_process` — module reload reads cache (simulates `app_started`)
- [ ] `test_missing_tenant_file_falls_back_to_unknown` — missing file → `"unknown"`, no exception
- [ ] `test_garbage_tenant_file_falls_back_to_unknown` — whitespace-only file → `"unknown"`, no exception
- [ ] `test_live_override_takes_precedence_over_cache` — live override wins over stale cache
- [ ] `test_env_var_takes_precedence_over_cache` — `AZURE_TENANT_ID` wins over cache
- [ ] Full suite: 132/132 tests pass, ruff + ty clean

Closes #652

🤖 Generated with [Claude Code](https://claude.com/claude-code)