### PR TITLE
feat(telemetry): derive tenant from the Fabric connection-string hostname

### DIFF
--- a/src/fabric_dw/resolver.py
+++ b/src/fabric_dw/resolver.py
@@ -395,12 +395,19 @@ class Resolver:
         # no network request) and forward it to telemetry so subsequent events
         # carry the correct tenant even before the first token round-trip.
         # Fail-safe: tenant_from_connection_string_host never raises; ignore None.
+        #
+        # Token tid (identity tenant) takes precedence; the connection-string host
+        # (resource tenant) is a fallback only.  For B2B guest scenarios the two
+        # differ, and the JWT tid is the authoritative identity-plane value.
+        # cache_tenant_id_from_token() early-exits when _tenant_id_override is
+        # already set, so we only fill from the host when no token has been seen yet.
         if conn is not None:
             tenant_id = tenant_from_connection_string_host(conn)
             if tenant_id is not None:
                 import fabric_dw.telemetry as _tel  # noqa: PLC0415
 
-                _tel.set_tenant_id(tenant_id)
+                if _tel._tenant_id_override is None:
+                    _tel.set_tenant_id(tenant_id)
 
         display_name = str(generic_payload.get("displayName", str(item_id)))
         entry = ItemEntry(

--- a/src/fabric_dw/resolver.py
+++ b/src/fabric_dw/resolver.py
@@ -24,6 +24,7 @@ from fabric_dw.cache import ItemEntry, LookupCache
 from fabric_dw.exceptions import FabricError, NotFoundError
 from fabric_dw.http_client import FabricHttpClient, HttpBase
 from fabric_dw.models import WarehouseKind
+from fabric_dw.sql import tenant_from_connection_string_host
 
 _logger = logging.getLogger("fabric_dw.resolver")
 
@@ -389,6 +390,17 @@ class Resolver:
                 workspace_id,
             )
             conn = await resolve_lakehouse_connection_string(self._http, workspace_id, item_id)
+
+        # Decode the tenant ID from the connection-string hostname (zero-cost,
+        # no network request) and forward it to telemetry so subsequent events
+        # carry the correct tenant even before the first token round-trip.
+        # Fail-safe: tenant_from_connection_string_host never raises; ignore None.
+        if conn is not None:
+            tenant_id = tenant_from_connection_string_host(conn)
+            if tenant_id is not None:
+                import fabric_dw.telemetry as _tel  # noqa: PLC0415
+
+                _tel.set_tenant_id(tenant_id)
 
         display_name = str(generic_payload.get("displayName", str(item_id)))
         entry = ItemEntry(

--- a/src/fabric_dw/sql.py
+++ b/src/fabric_dw/sql.py
@@ -366,9 +366,10 @@ def tenant_from_connection_string_host(host: object) -> str | None:
             return None
 
         # Strip an optional "Server=" prefix that the raw API value may carry.
+        # Also strip any whitespace between '=' and the hostname (e.g. "Server= host").
         raw = host.strip()
         if raw.lower().startswith("server="):
-            raw = raw[len("server=") :]
+            raw = raw[len("server=") :].strip()
 
         # Validate the *.datawarehouse.fabric.microsoft.com suffix.
         if not raw.lower().endswith(_FABRIC_DW_SUFFIX):
@@ -398,7 +399,12 @@ def tenant_from_connection_string_host(host: object) -> str | None:
 
         tenant_id = _b32_to_uuid(tenant_b32)
 
-        # Round-trip validate: the decoded value must parse as a UUID.
+        # Validate the workspace segment decodes to a well-formed UUID too.
+        # A 26-char segment with garbage content would otherwise let a host with
+        # a valid tenant prefix but garbage workspace slip through as a match.
+        _b32_to_uuid(workspace_b32)
+
+        # Round-trip validate: the decoded tenant must parse as a UUID.
         # uuid.UUID() above already does this, but be explicit.
         uuid.UUID(tenant_id)
     except Exception:

--- a/src/fabric_dw/sql.py
+++ b/src/fabric_dw/sql.py
@@ -70,6 +70,7 @@ __all__ = [
     "reset_pool",
     "run_query",
     "run_statements",
+    "tenant_from_connection_string_host",
 ]
 
 # ---------------------------------------------------------------------------
@@ -314,6 +315,96 @@ class SqlTarget:
     workspace_id: str
     database: str
     connection_string: str
+
+
+# ---------------------------------------------------------------------------
+# Fabric host → tenant GUID helper
+# ---------------------------------------------------------------------------
+
+# The Fabric DW / SQL-analytics-endpoint connection-string hostname encodes
+# both the tenant and workspace IDs in its first label:
+#
+#   <b32(tenantId)>-<b32(workspaceId)>.datawarehouse.fabric.microsoft.com
+#
+# where b32(guid) = RFC-4648 base32 (lowercase, no padding) of the GUID's
+# .NET little-endian byte order (Python: uuid.UUID(...).bytes_le).
+#
+# Each encoded GUID is exactly 26 base32 characters (128 bits / 5 bits per
+# char = 25.6 → rounded up to 26 with one trailing padding position stripped).
+_FABRIC_DW_SUFFIX = ".datawarehouse.fabric.microsoft.com"
+_B32_GUID_LEN = 26
+
+
+def tenant_from_connection_string_host(host: object) -> str | None:
+    """Decode the tenant GUID from a Fabric DW connection-string hostname.
+
+    The Fabric connection-string hostname encodes both the tenant and workspace
+    IDs in its first DNS label:
+
+        <b32(tenantId)>-<b32(workspaceId)>.datawarehouse.fabric.microsoft.com
+
+    Each encoded GUID is exactly 26 base32 characters.  This function decodes
+    the first segment (tenant) and returns it as a UUID string.
+
+    The function is entirely fail-safe: any non-matching or garbage input
+    returns ``None`` and never raises.
+
+    Args:
+        host: A Fabric connection-string hostname, or any other string/value.
+            A full ODBC connection string (``Server=<host>``) is also accepted;
+            the host is extracted from it first.
+
+    Returns:
+        The tenant UUID string (e.g. ``"9064c167-4885-40ef-9f34-1853218aea86"``),
+        or ``None`` if *host* does not match the expected Fabric DW shape.
+    """
+    import base64  # noqa: PLC0415 (stdlib, always available)
+    import uuid  # noqa: PLC0415
+
+    try:
+        if not isinstance(host, str):
+            return None
+
+        # Strip an optional "Server=" prefix that the raw API value may carry.
+        raw = host.strip()
+        if raw.lower().startswith("server="):
+            raw = raw[len("server="):]
+
+        # Validate the *.datawarehouse.fabric.microsoft.com suffix.
+        if not raw.lower().endswith(_FABRIC_DW_SUFFIX):
+            return None
+
+        # The first DNS label is everything before the first '.'.
+        first_label = raw[: raw.index(".")]
+
+        # The label has the form "<tenant_b32>-<workspace_b32>".
+        # Split on the last '-' separator between the two 26-char segments.
+        sep_pos = first_label.find("-")
+        if sep_pos < 0:
+            return None
+
+        tenant_b32 = first_label[:sep_pos]
+        workspace_b32 = first_label[sep_pos + 1 :]
+
+        # Both segments must be exactly 26 characters.
+        if len(tenant_b32) != _B32_GUID_LEN or len(workspace_b32) != _B32_GUID_LEN:
+            return None
+
+        # Pad to a multiple of 8 and base32-decode (RFC 4648; uppercase alphabet).
+        def _b32_to_uuid(segment: str) -> str:
+            padded = segment.upper() + "=" * ((8 - len(segment) % 8) % 8)
+            raw_bytes = base64.b32decode(padded)
+            return str(uuid.UUID(bytes_le=raw_bytes))
+
+        tenant_id = _b32_to_uuid(tenant_b32)
+
+        # Round-trip validate: the decoded value must parse as a UUID.
+        # uuid.UUID() above already does this, but be explicit.
+        uuid.UUID(tenant_id)
+    except Exception:
+        return None
+    else:
+        return tenant_id
 
 
 # ---------------------------------------------------------------------------

--- a/src/fabric_dw/sql.py
+++ b/src/fabric_dw/sql.py
@@ -368,7 +368,7 @@ def tenant_from_connection_string_host(host: object) -> str | None:
         # Strip an optional "Server=" prefix that the raw API value may carry.
         raw = host.strip()
         if raw.lower().startswith("server="):
-            raw = raw[len("server="):]
+            raw = raw[len("server=") :]
 
         # Validate the *.datawarehouse.fabric.microsoft.com suffix.
         if not raw.lower().endswith(_FABRIC_DW_SUFFIX):

--- a/tests/unit/test_tenant_from_host.py
+++ b/tests/unit/test_tenant_from_host.py
@@ -6,7 +6,9 @@ helper is added to fabric_dw.sql.
 
 from __future__ import annotations
 
+import sys
 import time
+import types
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import UUID
@@ -17,11 +19,24 @@ import respx
 from azure.core.credentials import AccessToken
 from azure.core.credentials_async import AsyncTokenCredential
 
-import fabric_dw.telemetry as _tel
 from fabric_dw.cache import LookupCache
 from fabric_dw.http_client import FabricHttpClient
 from fabric_dw.resolver import Resolver
 from fabric_dw.sql import tenant_from_connection_string_host
+
+
+def _live_tel() -> types.ModuleType:
+    """Return the live telemetry module from sys.modules.
+
+    test_telemetry.py reloads the module between tests via _reload_telemetry(),
+    which replaces the object in sys.modules with a fresh one.  The module-level
+    ``_tel`` alias in this file may point to a stale object after such a reload.
+    Always using the sys.modules entry ensures monkeypatch and patch.object
+    operate on the same object that the resolver's deferred
+    ``import fabric_dw.telemetry`` will resolve to at call time.
+    """
+    return sys.modules["fabric_dw.telemetry"]
+
 
 # ---------------------------------------------------------------------------
 # Verified example from the issue description
@@ -131,6 +146,10 @@ async def test_resolver_feeds_tenant_to_telemetry(
 ) -> None:
     """When item() resolves a connection string whose host encodes a tenant,
     set_tenant_id() is called with the decoded tenant GUID."""
+    # Resolve the live module object at call time — test_telemetry.py may have
+    # reloaded it between tests, making the module-level _tel alias stale.
+    tel = _live_tel()
+
     # Safe telemetry setup: dummy instrumentation key, isolated XDG dir, reset override
     monkeypatch.setenv(
         "FABRIC_TELEMETRY_CONNECTION_STRING",
@@ -142,10 +161,9 @@ async def test_resolver_feeds_tenant_to_telemetry(
     monkeypatch.delenv("FABRIC_DISABLE_TELEMETRY", raising=False)
     monkeypatch.delenv("CI", raising=False)
     monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
-    monkeypatch.setattr(_tel, "_tenant_id_override", None)
+    monkeypatch.setattr(tel, "_tenant_id_override", None)
     # Reset the warm in-memory cache sentinel so XDG redirection takes full effect.
-    monkeypatch.setattr(_tel, "_tenant_id_cache", _tel._UNSET)
-
+    monkeypatch.setattr(tel, "_tenant_id_cache", tel._UNSET)
     resolver, client, _cache = _make_resolver(tmp_path)
 
     recorded_tenant: list[str] = []
@@ -155,7 +173,7 @@ async def test_resolver_feeds_tenant_to_telemetry(
 
     with (
         respx.mock(assert_all_called=False) as mock,
-        patch.object(_tel, "set_tenant_id", side_effect=_capture_set_tenant),
+        patch.object(tel, "set_tenant_id", side_effect=_capture_set_tenant),
     ):
         # Generic item endpoint returns Warehouse type
         mock.get(_FABRIC_ITEM_GENERIC_URL).mock(
@@ -202,14 +220,19 @@ async def test_resolver_does_not_override_token_tenant(
     host-derived tenant must NOT overwrite it — token tid (identity) takes precedence."""
     existing_token_tenant = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"  # noqa: S105
 
+    # Resolve the live module object at call time (see test_resolver_feeds_tenant_to_telemetry).
+    tel = _live_tel()
+
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
     monkeypatch.delenv("FABRIC_TELEMETRY", raising=False)
     monkeypatch.delenv("FABRIC_DISABLE_TELEMETRY", raising=False)
     monkeypatch.delenv("CI", raising=False)
     monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
-    # Simulate a token tid that was already captured before connection-string resolution.
-    monkeypatch.setattr(_tel, "_tenant_id_override", existing_token_tenant)
-    monkeypatch.setattr(_tel, "_tenant_id_cache", _tel._UNSET)
+    # Baseline: reset override first, then set it to the simulated token value.
+    monkeypatch.setattr(tel, "_tenant_id_override", None)
+    monkeypatch.setattr(tel, "_tenant_id_cache", tel._UNSET)
+    # Now set the simulated token tid — must survive connection-string resolution.
+    monkeypatch.setattr(tel, "_tenant_id_override", existing_token_tenant)
 
     resolver, client, _cache = _make_resolver(tmp_path)
 
@@ -220,7 +243,7 @@ async def test_resolver_does_not_override_token_tenant(
 
     with (
         respx.mock(assert_all_called=False) as mock,
-        patch.object(_tel, "set_tenant_id", side_effect=_capture_set_tenant),
+        patch.object(tel, "set_tenant_id", side_effect=_capture_set_tenant),
     ):
         mock.get(_FABRIC_ITEM_GENERIC_URL).mock(
             return_value=httpx.Response(

--- a/tests/unit/test_tenant_from_host.py
+++ b/tests/unit/test_tenant_from_host.py
@@ -48,10 +48,13 @@ class TestTenantFromConnectionStringHost:
         """The verified host decodes to the expected tenant GUID."""
         assert tenant_from_connection_string_host(_VERIFIED_HOST) == _VERIFIED_TENANT
 
-    def test_full_connection_string_also_works(self) -> None:
-        """The helper accepts a full ODBC connection string, not just the bare host."""
-        # Fabric API returns the host as the connection string (no Server= prefix yet)
-        assert tenant_from_connection_string_host(_VERIFIED_HOST) == _VERIFIED_TENANT
+    def test_server_prefix_stripped(self) -> None:
+        """A bare 'Server=<host>' prefix is stripped before decoding."""
+        assert tenant_from_connection_string_host(f"Server={_VERIFIED_HOST}") == _VERIFIED_TENANT
+
+    def test_server_prefix_with_space_stripped(self) -> None:
+        """'Server= <host>' (space after '=') is also stripped correctly."""
+        assert tenant_from_connection_string_host(f"Server= {_VERIFIED_HOST}") == _VERIFIED_TENANT
 
     def test_garbage_host_returns_none(self) -> None:
         """A completely garbage input returns None and never raises."""
@@ -140,6 +143,8 @@ async def test_resolver_feeds_tenant_to_telemetry(
     monkeypatch.delenv("CI", raising=False)
     monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
     monkeypatch.setattr(_tel, "_tenant_id_override", None)
+    # Reset the warm in-memory cache sentinel so XDG redirection takes full effect.
+    monkeypatch.setattr(_tel, "_tenant_id_cache", _tel._UNSET)
 
     resolver, client, _cache = _make_resolver(tmp_path)
 
@@ -186,4 +191,67 @@ async def test_resolver_feeds_tenant_to_telemetry(
     assert entry.connection_string == _VERIFIED_HOST
     assert recorded_tenant == [_VERIFIED_TENANT], (
         f"Expected set_tenant_id({_VERIFIED_TENANT!r}), got {recorded_tenant!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_resolver_does_not_override_token_tenant(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When _tenant_id_override is already set (e.g. from a JWT tid), the
+    host-derived tenant must NOT overwrite it — token tid (identity) takes precedence."""
+    existing_token_tenant = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"  # noqa: S105
+
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.delenv("FABRIC_TELEMETRY", raising=False)
+    monkeypatch.delenv("FABRIC_DISABLE_TELEMETRY", raising=False)
+    monkeypatch.delenv("CI", raising=False)
+    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+    # Simulate a token tid that was already captured before connection-string resolution.
+    monkeypatch.setattr(_tel, "_tenant_id_override", existing_token_tenant)
+    monkeypatch.setattr(_tel, "_tenant_id_cache", _tel._UNSET)
+
+    resolver, client, _cache = _make_resolver(tmp_path)
+
+    recorded_tenant: list[str] = []
+
+    def _capture_set_tenant(tid: str) -> None:
+        recorded_tenant.append(tid)
+
+    with (
+        respx.mock(assert_all_called=False) as mock,
+        patch.object(_tel, "set_tenant_id", side_effect=_capture_set_tenant),
+    ):
+        mock.get(_FABRIC_ITEM_GENERIC_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "id": _ITEM_GUID,
+                    "displayName": "MyWarehouse",
+                    "type": "Warehouse",
+                    "workspaceId": _WS_GUID,
+                },
+            )
+        )
+        mock.get(_FABRIC_WAREHOUSE_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "id": _ITEM_GUID,
+                    "displayName": "MyWarehouse",
+                    "type": "Warehouse",
+                    "workspaceId": _WS_GUID,
+                    "properties": {
+                        "connectionString": _VERIFIED_HOST,
+                    },
+                },
+            )
+        )
+
+        async with client:
+            await resolver._fetch_item_detail(UUID(_WS_GUID), UUID(_ITEM_GUID))
+
+    # set_tenant_id must NOT have been called — the existing token override must remain.
+    assert recorded_tenant == [], (
+        f"set_tenant_id should not be called when override is already set; got {recorded_tenant!r}"
     )

--- a/tests/unit/test_tenant_from_host.py
+++ b/tests/unit/test_tenant_from_host.py
@@ -1,0 +1,190 @@
+"""Tests for tenant_from_connection_string_host — TDD-first.
+
+These tests are written BEFORE the implementation and must fail until the
+helper is added to fabric_dw.sql.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID
+
+import httpx
+import pytest
+import respx
+from azure.core.credentials import AccessToken
+from azure.core.credentials_async import AsyncTokenCredential
+
+import fabric_dw.telemetry as _tel
+from fabric_dw.cache import LookupCache
+from fabric_dw.http_client import FabricHttpClient
+from fabric_dw.resolver import Resolver
+from fabric_dw.sql import tenant_from_connection_string_host
+
+# ---------------------------------------------------------------------------
+# Verified example from the issue description
+# ---------------------------------------------------------------------------
+
+# Host decoded from the issue body:
+# tenant  → 9064c167-4885-40ef-9f34-1853218aea86
+# workspace → 78b883eb-50f8-4ca3-8732-e4043dffb635
+_VERIFIED_HOST = (
+    "m7awjeefjdxubhzudbjsdcxkqy-5ob3q6hykcruzbzs4qcd375wgu"
+    ".datawarehouse.fabric.microsoft.com"
+)
+_VERIFIED_TENANT = "9064c167-4885-40ef-9f34-1853218aea86"
+_VERIFIED_WORKSPACE = "78b883eb-50f8-4ca3-8732-e4043dffb635"
+
+# ---------------------------------------------------------------------------
+# Unit tests: tenant_from_connection_string_host
+# ---------------------------------------------------------------------------
+
+
+class TestTenantFromConnectionStringHost:
+    """Pure helper — no network, no auth, no telemetry side-effects."""
+
+    def test_verified_example_returns_correct_tenant(self) -> None:
+        """The verified host decodes to the expected tenant GUID."""
+        assert tenant_from_connection_string_host(_VERIFIED_HOST) == _VERIFIED_TENANT
+
+    def test_full_connection_string_also_works(self) -> None:
+        """The helper accepts a full ODBC connection string, not just the bare host."""
+        # Fabric API returns the host as the connection string (no Server= prefix yet)
+        assert tenant_from_connection_string_host(_VERIFIED_HOST) == _VERIFIED_TENANT
+
+    def test_garbage_host_returns_none(self) -> None:
+        """A completely garbage input returns None and never raises."""
+        assert tenant_from_connection_string_host("not-a-real-host.example.com") is None
+
+    def test_non_fabric_host_returns_none(self) -> None:
+        """A valid-looking host that is not *.datawarehouse.fabric.microsoft.com returns None."""
+        assert tenant_from_connection_string_host("something.database.windows.net") is None
+
+    def test_wrong_segment_count_returns_none(self) -> None:
+        """A fabric host with only one base32 segment (no '-') returns None."""
+        # Only one segment — can't split on '-' into two 26-char parts
+        host = "m7awjeefjdxubhzudbjsdcxkqy.datawarehouse.fabric.microsoft.com"
+        assert tenant_from_connection_string_host(host) is None
+
+    def test_wrong_segment_length_returns_none(self) -> None:
+        """A fabric host whose first segment has the wrong length returns None."""
+        # First segment is only 10 chars — too short to be a valid b32-encoded GUID
+        host = "shortvalue-5ob3q6hykcruzbzs4qcd375wgu.datawarehouse.fabric.microsoft.com"
+        assert tenant_from_connection_string_host(host) is None
+
+    def test_empty_string_returns_none(self) -> None:
+        """Empty input returns None without raising."""
+        assert tenant_from_connection_string_host("") is None
+
+    def test_garbage_base32_returns_none(self) -> None:
+        """A 26-char non-base32 string in the first segment returns None."""
+        # '!' is not valid base32
+        bad_first = "!!!!!!!!!!!!!!!!!!!!!!!!!!"
+        host = f"{bad_first}-5ob3q6hykcruzbzs4qcd375wgu.datawarehouse.fabric.microsoft.com"
+        assert tenant_from_connection_string_host(host) is None
+
+    def test_none_input_returns_none(self) -> None:
+        """None input returns None without raising."""
+        assert tenant_from_connection_string_host(None) is None  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Integration: resolver feeds decoded tenant into telemetry.set_tenant_id
+# ---------------------------------------------------------------------------
+
+_FAKE_TOKEN = "fake-token"  # noqa: S105
+
+
+def _make_credential() -> AsyncTokenCredential:
+    cred = MagicMock(spec=AsyncTokenCredential)
+    cred.get_token = AsyncMock(
+        return_value=AccessToken(token=_FAKE_TOKEN, expires_on=int(time.time()) + 3600)
+    )
+    return cred
+
+
+def _make_resolver(tmp_path: Path) -> tuple[Resolver, FabricHttpClient, LookupCache]:
+    cache = LookupCache(path=tmp_path / "lookup.json")
+    client = FabricHttpClient(credential=_make_credential(), rps=100)
+    resolver = Resolver(http=client, cache=cache)
+    return resolver, client, cache
+
+
+_WS_GUID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+_ITEM_GUID = "d4e5f6a7-b8c9-0123-def0-123456789abc"
+
+_FABRIC_ITEM_GENERIC_URL = (
+    f"https://api.fabric.microsoft.com/v1/workspaces/{_WS_GUID}/items/{_ITEM_GUID}"
+)
+_FABRIC_WAREHOUSE_URL = (
+    f"https://api.fabric.microsoft.com/v1/workspaces/{_WS_GUID}/warehouses/{_ITEM_GUID}"
+)
+
+
+@pytest.mark.asyncio
+async def test_resolver_feeds_tenant_to_telemetry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When item() resolves a connection string whose host encodes a tenant,
+    set_tenant_id() is called with the decoded tenant GUID."""
+    # Safe telemetry setup: dummy instrumentation key, isolated XDG dir, reset override
+    monkeypatch.setenv(
+        "FABRIC_TELEMETRY_CONNECTION_STRING",
+        "InstrumentationKey=00000000-0000-0000-0000-000000000000;"
+        "IngestionEndpoint=https://localhost/",
+    )
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.delenv("FABRIC_TELEMETRY", raising=False)
+    monkeypatch.delenv("FABRIC_DISABLE_TELEMETRY", raising=False)
+    monkeypatch.delenv("CI", raising=False)
+    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+    monkeypatch.setattr(_tel, "_tenant_id_override", None)
+
+    resolver, client, _cache = _make_resolver(tmp_path)
+
+    recorded_tenant: list[str] = []
+
+    def _capture_set_tenant(tid: str) -> None:
+        recorded_tenant.append(tid)
+
+    with (
+        respx.mock(assert_all_called=False) as mock,
+        patch.object(_tel, "set_tenant_id", side_effect=_capture_set_tenant),
+    ):
+        # Generic item endpoint returns Warehouse type
+        mock.get(_FABRIC_ITEM_GENERIC_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "id": _ITEM_GUID,
+                    "displayName": "MyWarehouse",
+                    "type": "Warehouse",
+                    "workspaceId": _WS_GUID,
+                },
+            )
+        )
+        # Warehouse detail endpoint returns the verified Fabric host as connection string
+        mock.get(_FABRIC_WAREHOUSE_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "id": _ITEM_GUID,
+                    "displayName": "MyWarehouse",
+                    "type": "Warehouse",
+                    "workspaceId": _WS_GUID,
+                    "properties": {
+                        "connectionString": _VERIFIED_HOST,
+                    },
+                },
+            )
+        )
+
+        async with client:
+            entry = await resolver._fetch_item_detail(UUID(_WS_GUID), UUID(_ITEM_GUID))
+
+    assert entry.connection_string == _VERIFIED_HOST
+    assert recorded_tenant == [_VERIFIED_TENANT], (
+        f"Expected set_tenant_id({_VERIFIED_TENANT!r}), got {recorded_tenant!r}"
+    )

--- a/tests/unit/test_tenant_from_host.py
+++ b/tests/unit/test_tenant_from_host.py
@@ -31,8 +31,7 @@ from fabric_dw.sql import tenant_from_connection_string_host
 # tenant  → 9064c167-4885-40ef-9f34-1853218aea86
 # workspace → 78b883eb-50f8-4ca3-8732-e4043dffb635
 _VERIFIED_HOST = (
-    "m7awjeefjdxubhzudbjsdcxkqy-5ob3q6hykcruzbzs4qcd375wgu"
-    ".datawarehouse.fabric.microsoft.com"
+    "m7awjeefjdxubhzudbjsdcxkqy-5ob3q6hykcruzbzs4qcd375wgu.datawarehouse.fabric.microsoft.com"
 )
 _VERIFIED_TENANT = "9064c167-4885-40ef-9f34-1853218aea86"
 _VERIFIED_WORKSPACE = "78b883eb-50f8-4ca3-8732-e4043dffb635"


### PR DESCRIPTION
## Summary

- Adds `tenant_from_connection_string_host` helper to `sql.py` that base32-decodes the .NET little-endian GUID from the first DNS label of a Fabric DW hostname to recover the tenant UUID. Entirely fail-safe: returns `None` for any non-matching or garbage input, never raises.
- Wires the helper into `Resolver._fetch_item_detail`: whenever a connection string is resolved, the decoded tenant is fed to `telemetry.set_tenant_id`, populating the telemetry envelope before the first token round-trip, at zero extra cost (no network request, no new dependency).
- 10 new unit tests cover the verified b32 example, garbage/non-Fabric hosts, wrong segment lengths, `None` input, and the resolver→telemetry integration path.

Closes #654

🤖 Generated with [Claude Code](https://claude.com/claude-code)