### PR TITLE
refactor(telemetry): single opt-out env var, drop CI detection, and tidy telemetry docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for dev setup, branch flow, and how to ru
 
 ## Telemetry
 
-`fabric-dw` collects anonymous, opt-out usage telemetry (install counts, surface usage, Python/OS version). No SQL, identifiers, or credentials are ever sent. To opt out, set `FABRIC_DISABLE_TELEMETRY=1`. See the [Telemetry docs](https://fdw.debruyn.dev/telemetry/) for the full list of collected fields and all opt-out methods. Telemetry is automatically disabled in CI environments.
+`fabric-dw` collects anonymous, opt-out usage telemetry (install counts, surface usage, Python/OS version). No SQL, identifiers, or credentials are ever sent. To opt out, set `FABRIC_DW_TELEMETRY_OPT_OUT=1`. See the [Telemetry docs](https://fdw.debruyn.dev/telemetry/) for the full list of collected fields and all opt-out methods.
 
 ## Security
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -17,7 +17,7 @@ Every telemetry event includes a shared envelope of anonymous fields:
 | `install_method` | Best-effort detection: `pip`, `uv`, `pipx`, or `source`. |
 | `surface` | `cli` or `mcp` — which interface was used. |
 | `auth_mode` | Categorical authentication mode: `service_principal`, `github_oidc`, `azure_cli`, or `interactive`. **Never credentials.** |
-| `tenant_id` | Your Azure tenant ID, read from `AZURE_TENANT_ID` or `FABRIC_INTERACTIVE_TENANT_ID` **only when telemetry is enabled**. This identifies the organisation (not an individual). |
+| `tenant_id` | Your Azure tenant ID, resolved from the access-token `tid` claim, the Fabric connection-string hostname, `AZURE_TENANT_ID`/`FABRIC_INTERACTIVE_TENANT_ID`, and a locally-cached value. This identifies the organisation (not an individual). |
 
 ### Lifecycle events
 
@@ -72,11 +72,11 @@ One `command_invoked` event is emitted after every CLI command and every MCP too
 - File paths or environment variable values
 - Any other personally-identifiable information
 
-`tenant_id` is the only organisation-identifying field and is only emitted when telemetry is enabled (it is omitted when you opt out).
+`tenant_id` is the only organisation-identifying field.
 
 ## Where telemetry data goes
 
-Events are sent to **Azure Application Insights** (`appi-fabric-dw-mcp-cli`, `westeurope`), owned and operated by the `fabric-dw` maintainers. Data is ingested via a write-only connection string embedded in the package. The backing Log Analytics workspace has a daily ingestion cap to control costs.
+Events are sent to a private Azure Application Insights resource operated by the `fabric-dw` maintainers, via a write-only connection string embedded in the package. The backing Log Analytics workspace has a daily ingestion cap to control costs.
 
 ## How to opt out
 
@@ -84,10 +84,6 @@ Any of the following fully disables telemetry — no events are emitted and the 
 
 | Method | How |
 |---|---|
-| Environment variable | `FABRIC_DISABLE_TELEMETRY=1` |
-| Environment variable | `FABRIC_TELEMETRY=0` (also accepts `false`, `no`, `off`) |
+| Environment variable | `FABRIC_DW_TELEMETRY_OPT_OUT=1` |
 | Do Not Track | `DO_NOT_TRACK=1` |
-| CI detection | Automatic when `CI`, `GITHUB_ACTIONS`, `TRAVIS`, `CIRCLECI`, `GITLAB_CI`, `JENKINS_URL`, or `TF_BUILD` is set |
 | Config file | Add `disabled = true` under a `[telemetry]` section in `$XDG_CONFIG_HOME/fabric-dw/config.toml` |
-
-Telemetry is **always off in CI environments** — no action needed for automated pipelines.

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -17,7 +17,7 @@ Every telemetry event includes a shared envelope of anonymous fields:
 | `install_method` | Best-effort detection: `pip`, `uv`, `pipx`, or `source`. |
 | `surface` | `cli` or `mcp` — which interface was used. |
 | `auth_mode` | Categorical authentication mode: `service_principal`, `github_oidc`, `azure_cli`, or `interactive`. **Never credentials.** |
-| `tenant_id` | Your Azure tenant ID, resolved from the access-token `tid` claim, the Fabric connection-string hostname, `AZURE_TENANT_ID`/`FABRIC_INTERACTIVE_TENANT_ID`, and a locally-cached value. This identifies the organisation (not an individual). |
+| `tenant_id` | Your Azure (Entra) tenant ID. |
 
 ### Lifecycle events
 
@@ -71,8 +71,6 @@ One `command_invoked` event is emitted after every CLI command and every MCP too
 - Connection strings or any credentials
 - File paths or environment variable values
 - Any other personally-identifiable information
-
-`tenant_id` is the only organisation-identifying field.
 
 ## Where telemetry data goes
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -82,6 +82,6 @@ Any of the following fully disables telemetry — no events are emitted and the 
 
 | Method | How |
 |---|---|
-| Environment variable | `FABRIC_DW_TELEMETRY_OPT_OUT=1` |
-| Do Not Track | `DO_NOT_TRACK=1` |
+| Environment variable | Set `FABRIC_DW_TELEMETRY_OPT_OUT` to any value except the falsy set (`""`, `0`, `false`, `no`, `off`, case-insensitive). Setting it to `0` or `false` does **not** opt out. |
+| Do Not Track | Set `DO_NOT_TRACK` to any value except the falsy set (same rules as above). |
 | Config file | Add `disabled = true` under a `[telemetry]` section in `$XDG_CONFIG_HOME/fabric-dw/config.toml` |

--- a/src/fabric_dw/telemetry.py
+++ b/src/fabric_dw/telemetry.py
@@ -501,11 +501,6 @@ _INSTRUMENTATION_OPTIONS: dict[str, dict[str, bool]] = {
 }
 
 
-def _get_connection_string() -> str:
-    """Return the active App Insights connection string."""
-    return os.environ.get("FABRIC_TELEMETRY_CONNECTION_STRING", _DEFAULT_CONNECTION_STRING)
-
-
 def _harden_azure_sdk_logging() -> None:
     """Raise the level of noisy Azure SDK loggers to CRITICAL and detach them from root.
 
@@ -628,7 +623,7 @@ def _get_tracer() -> object | None:
         resource = _build_otel_resource(_current_surface)
 
         configure_kwargs: dict[str, object] = {
-            "connection_string": _get_connection_string(),
+            "connection_string": _DEFAULT_CONNECTION_STRING,
             "logger_name": "fabric_dw.telemetry",
             # disable_logging=False (default) is intentional: the log/event
             # exporter must be active so customEvents land in the customEvents

--- a/src/fabric_dw/telemetry.py
+++ b/src/fabric_dw/telemetry.py
@@ -2,10 +2,8 @@
 
 Telemetry is **on by default** but can be disabled via:
 
-- ``FABRIC_TELEMETRY=0`` (or ``false``, ``no``, ``off``)
-- ``FABRIC_DISABLE_TELEMETRY=1`` (or any truthy value)
+- ``FABRIC_DW_TELEMETRY_OPT_OUT=1`` (or any truthy value)
 - ``DO_NOT_TRACK=1`` (consoledonottrack.com standard)
-- Any CI environment (``CI``, ``GITHUB_ACTIONS``, ``JENKINS_URL``, etc.)
 - Config file: ``[telemetry] disabled = true`` in
   ``$XDG_CONFIG_HOME/fabric-dw/config.toml``
 
@@ -19,7 +17,10 @@ Architecture notes
   never propagate errors to the caller.
 - No network calls are made when telemetry is disabled.
 - ``tenant_id`` is always present in the envelope (``"unknown"`` when unresolved)
-  so it is reliably queryable on every event.  Token-claim extraction is via
+  so it is reliably queryable on every event.  The tenant is resolved from the
+  access-token ``tid`` claim, the Fabric connection-string hostname,
+  ``AZURE_TENANT_ID``/``FABRIC_INTERACTIVE_TENANT_ID``, and a locally-cached
+  value (persisted under the config dir).  Token-claim extraction is via
   ``cache_tenant_id_from_token()`` (#366).
 - Auto-HTTP instrumentation is explicitly disabled to prevent MSAL OAuth
   request URLs (containing tenant IDs) from leaking as span attributes.
@@ -121,28 +122,6 @@ _DEFAULT_CONNECTION_STRING = (
 _SESSION_ID: str = str(uuid.uuid4())
 
 # ---------------------------------------------------------------------------
-# CI environment variable markers
-# ---------------------------------------------------------------------------
-
-_CI_VARS = frozenset(
-    {
-        "CI",
-        "GITHUB_ACTIONS",
-        "JENKINS_URL",
-        "TRAVIS",
-        "CIRCLECI",
-        "GITLAB_CI",
-        "TF_BUILD",
-    }
-)
-
-
-def _is_ci() -> bool:
-    """Return True when any known CI marker is present in the environment."""
-    return any(os.environ.get(var) for var in _CI_VARS)
-
-
-# ---------------------------------------------------------------------------
 # Process-level suppression (used for --help/-h invocations)
 # ---------------------------------------------------------------------------
 
@@ -172,12 +151,18 @@ def suppress_telemetry(value: bool = True) -> None:  # noqa: FBT001, FBT002
 # Opt-out helpers
 # ---------------------------------------------------------------------------
 
-_FALSY_VALUES = frozenset({"0", "false", "no", "off"})
+_FALSY_VALUES = frozenset({"", "0", "false", "no", "off"})
 
 
 def _is_truthy(value: str) -> bool:
-    """Return True when *value* looks like an affirmative string."""
-    return value.strip().lower() in {"1", "true", "yes", "on"}
+    """Return True when *value* is set and not in the falsy set.
+
+    A value is truthy when it is non-empty and not one of ``""``, ``"0"``,
+    ``"false"``, ``"no"``, or ``"off"`` (case-insensitive).  This matches the
+    consoledonottrack.com convention and avoids the surprising case where an
+    empty string is treated as truthy.
+    """
+    return value.strip().lower() not in _FALSY_VALUES
 
 
 def _config_dir() -> Path:
@@ -209,31 +194,21 @@ def telemetry_enabled() -> bool:
     - :func:`suppress_telemetry` has been called (process-level suppression,
       checked first — used by ``--help``/``-h`` invocations to skip all
       telemetry init and network I/O)
-    - ``FABRIC_TELEMETRY`` in ``{"0", "false", "no", "off"}``
-    - ``FABRIC_DISABLE_TELEMETRY`` is truthy
-    - ``DO_NOT_TRACK`` is truthy
-    - A CI environment is detected (``CI``, ``GITHUB_ACTIONS``, etc.)
+    - ``FABRIC_DW_TELEMETRY_OPT_OUT`` is truthy (set and not in
+      ``{"", "0", "false", "no", "off"}``, case-insensitive)
+    - ``DO_NOT_TRACK`` is truthy (same definition)
     - The config file has ``[telemetry] disabled = true``
     """
     # Process-level suppression (e.g. --help/-h) — checked first, always wins.
     if _SUPPRESSED:
         return False
 
-    # Explicit opt-out via FABRIC_TELEMETRY=<falsy>
-    fabric_tel = os.environ.get("FABRIC_TELEMETRY", "").strip().lower()
-    if fabric_tel in _FALSY_VALUES:
-        return False
-
-    # FABRIC_DISABLE_TELEMETRY truthy → disabled
-    if _is_truthy(os.environ.get("FABRIC_DISABLE_TELEMETRY", "")):
+    # FABRIC_DW_TELEMETRY_OPT_OUT truthy → disabled
+    if _is_truthy(os.environ.get("FABRIC_DW_TELEMETRY_OPT_OUT", "")):
         return False
 
     # DO_NOT_TRACK standard (consoledonottrack.com)
     if _is_truthy(os.environ.get("DO_NOT_TRACK", "")):
-        return False
-
-    # CI detection
-    if _is_ci():
         return False
 
     # Config-file opt-out
@@ -333,9 +308,12 @@ def _detect_install_method() -> str:
     Detection priority:
     1. ``UV`` / ``UV_VIRTUAL_ENV`` env vars → ``"uv"`` (set by uv runner).
     2. ``PIPX_HOME`` or ``"pipx"`` in ``sys.executable`` → ``"pipx"``.
-    3. Editable / source checkout (no dist-info or ``.egg-link``) → ``"source"``.
-    4. ``importlib.metadata`` resolves the package version → ``"pip"``.
-    5. Fallback → ``"unknown"``.
+    3. ``importlib.metadata`` resolves the package dist-info and the install
+       was editable (``"editable": true`` in ``direct_url.json``) → ``"source"``.
+    4. ``importlib.metadata`` resolves the package version without an editable
+       marker → ``"pip"``.
+    5. ``importlib.metadata`` raises ``PackageNotFoundError`` (running from
+       source tree, no dist-info installed) → ``"source"``.
 
     Note: a plain ``.venv`` in ``sys.executable`` is NOT used to infer ``"uv"``
     because pip can also install into a ``.venv``; that would be a false positive.
@@ -411,9 +389,7 @@ def _build_envelope() -> dict[str, object]:
 
     Fields omitted entirely (dropped in #477):
     - ``anonymous_install_id`` — already shipped natively as ``user_Id`` (← ``enduser.pseudo.id``)
-    - ``is_ci``                — ``is_ci=True`` never reached the backend (telemetry is suppressed
-                                 in CI); ``is_ci=False`` carries no signal.  The dimension was
-                                 always either absent or constant, so it was dropped.
+    - ``is_ci``                — dropped; carries no useful signal.
 
     ``tenant_id`` is always present (``"unknown"`` when unresolved) so it is
     reliably queryable on every event.  No native Part A slot is reachable for
@@ -960,8 +936,7 @@ def maybe_print_first_run_notice() -> None:
     """Print a one-line telemetry notice to stderr on first invocation.
 
     The notice is suppressed when:
-    - Telemetry is disabled.
-    - Running in a CI environment.
+    - Telemetry is disabled (via env var, DO_NOT_TRACK, or config file).
     - The marker file already exists (notice was already shown).
 
     The marker file is written **after** the notice is successfully printed
@@ -970,8 +945,6 @@ def maybe_print_first_run_notice() -> None:
     The output always goes to stderr so it can never pollute MCP stdio output.
     """
     if not telemetry_enabled():
-        return
-    if _is_ci():
         return
 
     marker_file = _config_dir() / ".telemetry_notice_shown"
@@ -983,7 +956,7 @@ def maybe_print_first_run_notice() -> None:
     # Print the notice first; only write the marker if this succeeds (A3).
     print(  # noqa: T201
         "fabric-dw collects anonymous usage telemetry to improve the tool. "
-        "To opt out: set FABRIC_DISABLE_TELEMETRY=1. "
+        "To opt out: set FABRIC_DW_TELEMETRY_OPT_OUT=1. "
         "See https://fdw.debruyn.dev/telemetry/ for details.",
         file=sys.stderr,
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,8 +43,8 @@ _FABRIC_MCP_VARS = (
 )
 
 # Test modules that exercise telemetry behaviour directly and therefore manage
-# their own FABRIC_DISABLE_TELEMETRY / FABRIC_TELEMETRY env state.  They are
-# exempt from the global telemetry-disable fixture below.
+# their own FABRIC_DW_TELEMETRY_OPT_OUT env state.  They are exempt from the
+# global telemetry-disable fixture below.
 _TELEMETRY_SELF_MANAGED_MODULES = frozenset(
     {
         "test_telemetry.py",
@@ -85,23 +85,19 @@ def _disable_telemetry_globally(
 ) -> None:
     """Disable anonymous telemetry for the entire test run — no real network sends.
 
-    On a typical developer machine ``telemetry_enabled()`` returns ``True`` (not
-    CI, no opt-out env var, no config opt-out), so without this fixture every
-    in-process ``CliRunner`` test — and every integration smoke test that spawns
-    the real ``fdw`` binary as a subprocess — would emit **real** telemetry to the
+    On a typical developer machine ``telemetry_enabled()`` returns ``True`` (no
+    opt-out env var, no config opt-out), so without this fixture every in-process
+    ``CliRunner`` test — and every integration smoke test that spawns the real
+    ``fdw`` binary as a subprocess — would emit **real** telemetry to the
     **production** Application Insights resource, drowning genuine usage in test
     noise (see issue tracking this).
 
-    Setting ``FABRIC_DISABLE_TELEMETRY=1`` via ``monkeypatch.setenv`` makes
+    Setting ``FABRIC_DW_TELEMETRY_OPT_OUT=1`` via ``monkeypatch.setenv`` makes
     :func:`fabric_dw.telemetry.telemetry_enabled` return ``False``, so
-    ``emit_event`` / provider init / flush all become no-ops:
-
-    - The truthy ``FABRIC_DISABLE_TELEMETRY`` check wins even over the forced
-      ``FABRIC_TELEMETRY=1`` that ``tests/integration/test_cli_smoke.py`` injects
-      into its child env, because it is evaluated first in ``telemetry_enabled``.
-    - ``monkeypatch`` mutates ``os.environ`` in place, so subprocess tests that do
-      ``os.environ.copy()`` inherit the disable; ``monkeypatch`` auto-restores it
-      after each test.
+    ``emit_event`` / provider init / flush all become no-ops.
+    ``monkeypatch`` mutates ``os.environ`` in place, so subprocess tests that do
+    ``os.environ.copy()`` inherit the disable; ``monkeypatch`` auto-restores it
+    after each test.
 
     ``tests/unit/test_telemetry.py`` and ``tests/unit/test_telemetry_commands.py``
     are exempt: they exercise telemetry behaviour directly and manage their own env
@@ -112,7 +108,7 @@ def _disable_telemetry_globally(
     """
     if request.path is not None and request.path.name in _TELEMETRY_SELF_MANAGED_MODULES:
         return
-    monkeypatch.setenv("FABRIC_DISABLE_TELEMETRY", "1")
+    monkeypatch.setenv("FABRIC_DW_TELEMETRY_OPT_OUT", "1")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,9 +19,10 @@ For the self-managed telemetry modules (``test_telemetry.py`` and
 ``test_telemetry_commands.py``) two additional defence-in-depth fixtures are
 applied:
 
-- ``_isolate_telemetry_endpoint`` — points the SDK at a localhost dummy
-  endpoint so nothing can reach the production Application Insights resource
-  even when telemetry is intentionally enabled.
+- ``_mock_configure_azure_monitor`` — patches ``configure_azure_monitor``
+  (the function imported inside ``telemetry.py``'s SDK-init path) to a no-op
+  so no real connection to the production App Insights resource is ever
+  attempted, even when telemetry is intentionally enabled in a test.
 - ``_reset_telemetry_module_globals`` — resets ``_tenant_id_override`` and the
   ``_tenant_id_cache`` sentinel between tests so values cannot bleed across tests
   in the same process.
@@ -31,6 +32,7 @@ from __future__ import annotations
 
 import sys
 from collections.abc import Generator
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -50,18 +52,6 @@ _TELEMETRY_SELF_MANAGED_MODULES = frozenset(
         "test_telemetry.py",
         "test_telemetry_commands.py",
     }
-)
-
-# Dummy connection string used by self-managed telemetry tests.  Instructs the
-# SDK to target a localhost endpoint so that even if configure_azure_monitor is
-# initialised, no traffic can reach the production App Insights resource.
-# Individual tests may override this with monkeypatch.setenv; this fixture only
-# installs it as a safe default.
-#
-# Single source of truth: ``test_telemetry.py`` imports this as ``_DUMMY_CONN_STR``
-# so both files always use the same value.
-TELEMETRY_FAKE_CONNECTION_STRING = (
-    "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://localhost/"
 )
 
 
@@ -112,31 +102,29 @@ def _disable_telemetry_globally(
 
 
 @pytest.fixture(autouse=True)
-def _isolate_telemetry_endpoint(
-    request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Point the telemetry SDK at a localhost dummy endpoint in self-managed modules.
+def _mock_configure_azure_monitor(
+    request: pytest.FixtureRequest,
+) -> Generator[MagicMock, None, None]:
+    """Patch configure_azure_monitor to a no-op in self-managed telemetry modules.
 
     Applied only to ``test_telemetry.py`` and ``test_telemetry_commands.py``
     (the ``_TELEMETRY_SELF_MANAGED_MODULES``).  Those modules deliberately exercise
     the enabled-telemetry code path and are exempt from ``_disable_telemetry_globally``,
-    so without this fixture the real production App Insights connection string would
-    be used whenever ``configure_azure_monitor`` is initialised.
+    so without this fixture a real call to ``configure_azure_monitor`` inside
+    ``_get_tracer`` would attempt to connect to the production App Insights resource.
 
-    ``monkeypatch.setenv`` is used rather than a direct dict mutation so:
-    - Individual tests that want a specific connection string can override it with
-      their own ``monkeypatch.setenv(...)`` call — pytest runs fixture setup before
-      the test body and test-body monkeypatches win.
-    - The env var is automatically restored after each test.
-
-    The instrumentation key ``00000000-0000-0000-0000-000000000000`` is a
-    well-known null GUID and the endpoint is ``https://localhost/`` — traffic to
-    this address is refused immediately by the OS, guaranteeing no egress to the
-    real resource even if the SDK is initialised.
+    The patch targets the import site inside ``telemetry.py``'s local import
+    (``from azure.monitor.opentelemetry import configure_azure_monitor``), so only
+    the telemetry module's SDK-init path is affected; the real SDK is never reached.
+    Individual tests that need to inspect the mock can access it via the fixture
+    value; tests that patch ``_get_tracer`` or ``emit_event`` directly are
+    unaffected because those patches take effect before the SDK init path is reached.
     """
     if request.path is None or request.path.name not in _TELEMETRY_SELF_MANAGED_MODULES:
+        yield MagicMock()
         return
-    monkeypatch.setenv("FABRIC_TELEMETRY_CONNECTION_STRING", TELEMETRY_FAKE_CONNECTION_STRING)
+    with patch("azure.monitor.opentelemetry.configure_azure_monitor") as mock_configure:
+        yield mock_configure
 
 
 @pytest.fixture(autouse=True)

--- a/tests/integration/test_cli_smoke.py
+++ b/tests/integration/test_cli_smoke.py
@@ -26,8 +26,7 @@ silently swallowed.
 
 Telemetry
 ---------
-CI environments (``GITHUB_ACTIONS=true``) disable telemetry in the subprocess.  The
-child env deliberately unsets the CI marker and injects ``FABRIC_TELEMETRY=1`` so the
+The child env deliberately removes ``FABRIC_DW_TELEMETRY_OPT_OUT`` so the
 telemetry init → flush → shutdown path is exercised for every command.
 """
 
@@ -63,18 +62,6 @@ _STDERR_FORBIDDEN = (
     # unless enable_performance_counters=False is passed at SDK init time.
     "Error getting processor time",
     "_get_processor_time",
-)
-
-# Known CI environment variable names that disable telemetry; unset in child env
-# so that the telemetry init / flush / shutdown code path is exercised.
-_CI_ENV_VARS = (
-    "CI",
-    "GITHUB_ACTIONS",
-    "JENKINS_URL",
-    "TRAVIS",
-    "CIRCLECI",
-    "GITLAB_CI",
-    "TF_BUILD",
 )
 
 # ---------------------------------------------------------------------------
@@ -146,8 +133,8 @@ def _child_env(extra: dict[str, str] | None = None) -> dict[str, str]:
 
     - Inherits the current process environment so credentials pass through.
     - Promotes ResourceWarnings to errors via PYTHONWARNINGS + PYTHONDEVMODE.
-    - Unsets CI detection vars and forces ``FABRIC_TELEMETRY=1`` so the
-      telemetry init / flush / shutdown path is exercised even in CI.
+    - Removes ``FABRIC_DW_TELEMETRY_OPT_OUT`` so the telemetry init / flush /
+      shutdown path is exercised even when the caller has opted out.
     """
     env = os.environ.copy()
 
@@ -155,10 +142,9 @@ def _child_env(extra: dict[str, str] | None = None) -> dict[str, str]:
     env["PYTHONWARNINGS"] = "error::ResourceWarning"
     env["PYTHONDEVMODE"] = "1"
 
-    # Unset CI markers so the child process activates telemetry, then force it on.
-    for ci_var in _CI_ENV_VARS:
-        env.pop(ci_var, None)
-    env["FABRIC_TELEMETRY"] = "1"
+    # Ensure the child process exercises the telemetry path regardless of caller opt-out.
+    env.pop("FABRIC_DW_TELEMETRY_OPT_OUT", None)
+    env.pop("DO_NOT_TRACK", None)
 
     if extra:
         env.update(extra)

--- a/tests/unit/test_global_telemetry_disable.py
+++ b/tests/unit/test_global_telemetry_disable.py
@@ -18,8 +18,8 @@ from fabric_dw.telemetry import telemetry_enabled
 
 
 def test_disable_telemetry_env_is_set_by_global_fixture() -> None:
-    """The global autouse fixture exports FABRIC_DISABLE_TELEMETRY=1."""
-    assert os.environ.get("FABRIC_DISABLE_TELEMETRY") == "1"
+    """The global autouse fixture exports FABRIC_DW_TELEMETRY_OPT_OUT=1."""
+    assert os.environ.get("FABRIC_DW_TELEMETRY_OPT_OUT") == "1"
 
 
 def test_telemetry_is_disabled_inside_a_test() -> None:

--- a/tests/unit/test_shutdown_clean.py
+++ b/tests/unit/test_shutdown_clean.py
@@ -1,9 +1,9 @@
 """End-to-end subprocess test: verify clean stderr at CLI shutdown.
 
 Runs the real ``fabric-dw`` entry point as a child process with telemetry
-**enabled** (but pointing at a bogus, non-routable exporter endpoint) and
-asserts that the process exits without printing any of the shutdown-noise
-signatures that indicate leaked connection pools or unclosed sessions:
+**enabled** and asserts that the process exits without printing any of the
+shutdown-noise signatures that indicate leaked connection pools or unclosed
+sessions:
 
 - ``Unclosed client session``          ← aiohttp ResourceWarning (#385/#387)
 - ``Exception ignored in``             ← GC finalizer crash
@@ -17,16 +17,23 @@ Design notes
 ------------
 - ``FABRIC_DW_TELEMETRY_OPT_OUT`` is removed so ``telemetry_enabled()`` returns
   True and the real SDK code path (SDK init, urllib3 pool creation, bounded
-  flush + shutdown) is exercised.  The exporter targets the hardcoded production
-  endpoint; the bounded shutdown (≤8 s) caps any HTTP attempt, and
-  ``_harden_azure_sdk_logging`` prevents retry/timeout noise on stderr.
+  flush + shutdown) is exercised.
+- Egress is blocked at the network layer: ``HTTPS_PROXY`` and ``HTTP_PROXY``
+  are set to ``http://127.0.0.1:1`` (a port that is always refused) and
+  ``NO_PROXY`` is cleared.  The Azure Monitor exporter uses
+  ``RequestsTransport`` (``azure-core``), which reads ``HTTPS_PROXY`` from the
+  environment by default.  The exporter therefore initialises and tears down
+  normally, but its POST is refused immediately — no real telemetry reaches
+  production, and the bounded shutdown (≤8 s) caps any retry wait.
+  ``_harden_azure_sdk_logging`` silences the resulting retry-error noise on
+  stderr.
 - ``PYTHONWARNINGS=error`` is **not** set here because the subprocess has
   its own warning filters; the test relies on observing stderr text rather
   than exit code.
 - The ``--help`` variant runs in the default ``not slow`` suite because
   ``--help`` exits immediately without any auth or Fabric network call and
-  the bogus exporter connection is refused instantly.  Total wall-clock time
-  is typically < 5 s.
+  the proxy connection is refused instantly.  Total wall-clock time is
+  typically < 5 s.
 """
 
 from __future__ import annotations
@@ -72,12 +79,26 @@ _CLI_RUNNER = [
 
 
 def _build_subprocess_env() -> dict[str, str]:
-    """Build an environment dict that forces telemetry on for shutdown testing."""
+    """Build an environment dict that forces telemetry on for shutdown testing.
+
+    Egress is blocked at the network layer via ``HTTPS_PROXY``/``HTTP_PROXY``
+    pointing at ``http://127.0.0.1:1`` (always refused).  ``RequestsTransport``
+    in ``azure-core`` honours these env vars by default, so the exporter
+    initialises and tears down normally but cannot reach production.
+    """
     env = dict(os.environ)
 
     # Remove opt-out vars so telemetry_enabled() returns True.
     env.pop("FABRIC_DW_TELEMETRY_OPT_OUT", None)
     env.pop("DO_NOT_TRACK", None)
+
+    # Block telemetry egress at the network layer: point the proxy at a port
+    # that is always refused.  azure-core's RequestsTransport reads HTTPS_PROXY
+    # from the environment (use_env_settings=True by default), so the exporter
+    # POST is refused immediately instead of reaching production.
+    env["HTTPS_PROXY"] = "http://127.0.0.1:1"
+    env["HTTP_PROXY"] = "http://127.0.0.1:1"
+    env["NO_PROXY"] = ""
 
     # Strip any caller-side statsbeat override so our setdefault in _get_tracer
     # is always exercised — a runner env with this set to "false" would otherwise
@@ -103,8 +124,9 @@ def test_cli_exits_without_shutdown_noise_on_help() -> None:
     via the teardown path (shutdown_telemetry, which flushes internally).
 
     ``--help`` exits without any auth/network call to Fabric.  The telemetry
-    exporter targets the hardcoded endpoint; the bounded shutdown caps any
-    HTTP attempt so the test completes quickly even without a refused port.
+    exporter targets the hardcoded endpoint via the proxy set in
+    ``_build_subprocess_env``; the proxy is refused immediately so the test
+    completes quickly.
 
     Note on the ``Unclosed client session`` assertion: ``--help`` does not
     create a credential and therefore never opens an aiohttp session, so this

--- a/tests/unit/test_shutdown_clean.py
+++ b/tests/unit/test_shutdown_clean.py
@@ -19,7 +19,7 @@ Design notes
   App Insights connection string pointing at a non-routable / refused endpoint
   so the exporter is fully initialised (SDK + urllib3 pool created) but the
   HTTP flush is a no-op (connection refused, quickly discarded).
-- All CI detection env vars are removed so ``telemetry_enabled()`` returns
+- ``FABRIC_DW_TELEMETRY_OPT_OUT`` is removed so ``telemetry_enabled()`` returns
   True and the real SDK code path is exercised.
 - ``PYTHONWARNINGS=error`` is **not** set here because the subprocess has
   its own warning filters; the test relies on observing stderr text rather
@@ -87,21 +87,8 @@ def _build_subprocess_env() -> dict[str, str]:
     # Point telemetry at the non-routable bogus endpoint.
     env["FABRIC_TELEMETRY_CONNECTION_STRING"] = _BOGUS_CONNECTION_STRING
 
-    # Remove all CI detection vars so telemetry_enabled() returns True.
-    for ci_var in (
-        "CI",
-        "GITHUB_ACTIONS",
-        "JENKINS_URL",
-        "TRAVIS",
-        "CIRCLECI",
-        "GITLAB_CI",
-        "TF_BUILD",
-    ):
-        env.pop(ci_var, None)
-
-    # Remove opt-out vars.
-    env.pop("FABRIC_TELEMETRY", None)
-    env.pop("FABRIC_DISABLE_TELEMETRY", None)
+    # Remove opt-out vars so telemetry_enabled() returns True.
+    env.pop("FABRIC_DW_TELEMETRY_OPT_OUT", None)
     env.pop("DO_NOT_TRACK", None)
 
     # Strip any caller-side statsbeat override so our setdefault in _get_tracer

--- a/tests/unit/test_shutdown_clean.py
+++ b/tests/unit/test_shutdown_clean.py
@@ -15,12 +15,11 @@ only the *absence* of the above stderr substrings is asserted.
 
 Design notes
 ------------
-- ``FABRIC_TELEMETRY_CONNECTION_STRING`` is set to a syntactically valid
-  App Insights connection string pointing at a non-routable / refused endpoint
-  so the exporter is fully initialised (SDK + urllib3 pool created) but the
-  HTTP flush is a no-op (connection refused, quickly discarded).
 - ``FABRIC_DW_TELEMETRY_OPT_OUT`` is removed so ``telemetry_enabled()`` returns
-  True and the real SDK code path is exercised.
+  True and the real SDK code path (SDK init, urllib3 pool creation, bounded
+  flush + shutdown) is exercised.  The exporter targets the hardcoded production
+  endpoint; the bounded shutdown (≤8 s) caps any HTTP attempt, and
+  ``_harden_azure_sdk_logging`` prevents retry/timeout noise on stderr.
 - ``PYTHONWARNINGS=error`` is **not** set here because the subprocess has
   its own warning filters; the test relies on observing stderr text rather
   than exit code.
@@ -41,14 +40,6 @@ import pytest
 # ---------------------------------------------------------------------------
 # Subprocess helpers
 # ---------------------------------------------------------------------------
-
-# A syntactically-valid but non-routable App Insights connection string.
-# Port 1 on 127.0.0.1 is reliably refused so the exporter fails fast.
-_BOGUS_CONNECTION_STRING = (
-    "InstrumentationKey=00000000-0000-0000-0000-000000000001;"  # gitleaks:allow
-    "IngestionEndpoint=http://127.0.0.1:1/;"
-    "LiveEndpoint=http://127.0.0.1:1/"
-)
 
 # Stderr substrings that indicate a leaked pool / broken teardown, or a
 # PerformanceCounters crash (ZeroDivisionError from _get_processor_time on
@@ -81,11 +72,8 @@ _CLI_RUNNER = [
 
 
 def _build_subprocess_env() -> dict[str, str]:
-    """Build an environment dict that forces telemetry on with a bogus endpoint."""
+    """Build an environment dict that forces telemetry on for shutdown testing."""
     env = dict(os.environ)
-
-    # Point telemetry at the non-routable bogus endpoint.
-    env["FABRIC_TELEMETRY_CONNECTION_STRING"] = _BOGUS_CONNECTION_STRING
 
     # Remove opt-out vars so telemetry_enabled() returns True.
     env.pop("FABRIC_DW_TELEMETRY_OPT_OUT", None)
@@ -114,9 +102,9 @@ def test_cli_exits_without_shutdown_noise_on_help() -> None:
     initialisation, tracer creation, provider setup) and then exits cleanly
     via the teardown path (shutdown_telemetry, which flushes internally).
 
-    ``--help`` exits without any auth/network call to Fabric, so the test is
-    fully hermetic; only the telemetry exporter endpoint is attempted (and
-    immediately refused by the bogus endpoint, completing fast).
+    ``--help`` exits without any auth/network call to Fabric.  The telemetry
+    exporter targets the hardcoded endpoint; the bounded shutdown caps any
+    HTTP attempt so the test completes quickly even without a refused port.
 
     Note on the ``Unclosed client session`` assertion: ``--help`` does not
     create a credential and therefore never opens an aiohttp session, so this

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -19,8 +19,6 @@ from unittest.mock import patch
 
 import pytest
 
-from tests.conftest import TELEMETRY_FAKE_CONNECTION_STRING
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -693,30 +691,6 @@ def test_default_connection_string_is_set(monkeypatch: pytest.MonkeyPatch, tmp_p
     assert "InstrumentationKey" in mod._DEFAULT_CONNECTION_STRING  # type: ignore[attr-defined]
 
 
-def test_connection_string_overridable_via_env(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
-    """FABRIC_TELEMETRY_CONNECTION_STRING must override the default."""
-    monkeypatch.setenv("FABRIC_TELEMETRY_CONNECTION_STRING", "InstrumentationKey=custom-key")
-    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
-
-    mod = _reload_telemetry()
-    conn_str = mod._get_connection_string()  # type: ignore[attr-defined]
-    assert conn_str == "InstrumentationKey=custom-key"
-
-
-def test_connection_string_default_when_env_not_set(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
-    """_get_connection_string returns the default when env var is absent."""
-    monkeypatch.delenv("FABRIC_TELEMETRY_CONNECTION_STRING", raising=False)
-    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
-
-    mod = _reload_telemetry()
-    conn_str = mod._get_connection_string()  # type: ignore[attr-defined]
-    assert conn_str == mod._DEFAULT_CONNECTION_STRING  # type: ignore[attr-defined]
-
-
 # ---------------------------------------------------------------------------
 # B1: privacy — auto-HTTP instrumentation is disabled
 # ---------------------------------------------------------------------------
@@ -1041,14 +1015,10 @@ def test_set_tenant_id_takes_precedence_over_env(
 # Persistent tenant store (#652)
 # ---------------------------------------------------------------------------
 
-# Single source of truth lives in tests/conftest.py; imported above.
-_DUMMY_CONN_STR = TELEMETRY_FAKE_CONNECTION_STRING
-
 
 def test_tenant_id_unknown_on_first_run(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """With no known tenant, _build_envelope must return tenant_id == 'unknown' (#652)."""
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
-    monkeypatch.setenv("FABRIC_TELEMETRY_CONNECTION_STRING", _DUMMY_CONN_STR)
     monkeypatch.delenv("AZURE_TENANT_ID", raising=False)
     monkeypatch.delenv("FABRIC_INTERACTIVE_TENANT_ID", raising=False)
 
@@ -1064,7 +1034,6 @@ def test_set_tenant_id_writes_file_when_enabled(
 ) -> None:
     """set_tenant_id must persist to disk when telemetry is enabled (#652)."""
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
-    monkeypatch.setenv("FABRIC_TELEMETRY_CONNECTION_STRING", _DUMMY_CONN_STR)
     monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
     monkeypatch.delenv("DO_NOT_TRACK", raising=False)
 
@@ -1083,7 +1052,6 @@ def test_set_tenant_id_no_write_when_disabled(
 ) -> None:
     """set_tenant_id must NOT write to disk when telemetry is disabled (#652)."""
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
-    monkeypatch.setenv("FABRIC_TELEMETRY_CONNECTION_STRING", _DUMMY_CONN_STR)
     monkeypatch.setenv("FABRIC_DW_TELEMETRY_OPT_OUT", "1")
 
     mod = _reload_telemetry()
@@ -1104,7 +1072,6 @@ def test_cached_tenant_read_back_on_new_process(
     _tenant_id_override = None to check the cache is the fallback.
     """
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
-    monkeypatch.setenv("FABRIC_TELEMETRY_CONNECTION_STRING", _DUMMY_CONN_STR)
     monkeypatch.delenv("AZURE_TENANT_ID", raising=False)
     monkeypatch.delenv("FABRIC_INTERACTIVE_TENANT_ID", raising=False)
     monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
@@ -1129,7 +1096,6 @@ def test_missing_tenant_file_falls_back_to_unknown(
 ) -> None:
     """A missing tenant cache file must not raise and must fall back to 'unknown' (#652)."""
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
-    monkeypatch.setenv("FABRIC_TELEMETRY_CONNECTION_STRING", _DUMMY_CONN_STR)
     monkeypatch.delenv("AZURE_TENANT_ID", raising=False)
     monkeypatch.delenv("FABRIC_INTERACTIVE_TENANT_ID", raising=False)
 
@@ -1149,7 +1115,6 @@ def test_garbage_tenant_file_falls_back_to_unknown(
 ) -> None:
     """A malformed/empty tenant cache file must not raise and must return None (#652)."""
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
-    monkeypatch.setenv("FABRIC_TELEMETRY_CONNECTION_STRING", _DUMMY_CONN_STR)
     monkeypatch.delenv("AZURE_TENANT_ID", raising=False)
     monkeypatch.delenv("FABRIC_INTERACTIVE_TENANT_ID", raising=False)
 
@@ -1169,7 +1134,6 @@ def test_live_override_takes_precedence_over_cache(
 ) -> None:
     """Live _tenant_id_override must win over persisted cache (#652)."""
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
-    monkeypatch.setenv("FABRIC_TELEMETRY_CONNECTION_STRING", _DUMMY_CONN_STR)
     monkeypatch.delenv("AZURE_TENANT_ID", raising=False)
     monkeypatch.delenv("FABRIC_INTERACTIVE_TENANT_ID", raising=False)
 
@@ -1191,7 +1155,6 @@ def test_env_var_takes_precedence_over_cache(
 ) -> None:
     """AZURE_TENANT_ID env var must take precedence over persisted cache (#652)."""
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
-    monkeypatch.setenv("FABRIC_TELEMETRY_CONNECTION_STRING", _DUMMY_CONN_STR)
     monkeypatch.setenv("AZURE_TENANT_ID", "env-tenant-wins")
     monkeypatch.delenv("FABRIC_INTERACTIVE_TENANT_ID", raising=False)
 
@@ -1223,7 +1186,6 @@ def test_stale_cache_corrected_by_set_tenant_id(
     the intentional, bounded trade-off documented in _build_envelope.
     """
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
-    monkeypatch.setenv("FABRIC_TELEMETRY_CONNECTION_STRING", _DUMMY_CONN_STR)
     monkeypatch.delenv("AZURE_TENANT_ID", raising=False)
     monkeypatch.delenv("FABRIC_INTERACTIVE_TENANT_ID", raising=False)
     monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -72,7 +72,7 @@ def test_telemetry_enabled_when_fabric_dw_telemetry_opt_out_falsy(
     assert mod.telemetry_enabled() is True  # type: ignore[attr-defined]
 
 
-@pytest.mark.parametrize("value", ["1", "true", "yes", "TRUE"])
+@pytest.mark.parametrize("value", ["1", "true", "yes", "TRUE", "anything"])
 def test_telemetry_disabled_by_do_not_track(
     value: str, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -709,8 +709,6 @@ def test_get_tracer_passes_instrumentation_options_to_configure(
     """
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
     monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
-    for ci_var in ("GITHUB_ACTIONS", "JENKINS_URL", "TRAVIS", "CIRCLECI", "GITLAB_CI", "TF_BUILD"):
-        monkeypatch.delenv(ci_var, raising=False)
 
     mod = _reload_telemetry()
 
@@ -771,8 +769,6 @@ def test_get_tracer_passes_enable_performance_counters_false(
     """
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
     monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
-    for ci_var in ("GITHUB_ACTIONS", "JENKINS_URL", "TRAVIS", "CIRCLECI", "GITLAB_CI", "TF_BUILD"):
-        monkeypatch.delenv(ci_var, raising=False)
 
     mod = _reload_telemetry()
 
@@ -2472,8 +2468,6 @@ def test_get_tracer_passes_resource_to_configure_azure_monitor(
     """
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
     monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
-    for ci_var in ("GITHUB_ACTIONS", "JENKINS_URL", "TRAVIS", "CIRCLECI", "GITLAB_CI", "TF_BUILD"):
-        monkeypatch.delenv(ci_var, raising=False)
 
     mod = _reload_telemetry()
 

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -40,70 +40,38 @@ def _reload_telemetry() -> Any:
 
 def test_telemetry_enabled_by_default(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """Telemetry is ON by default when no opt-out signal is present."""
-    monkeypatch.delenv("FABRIC_TELEMETRY", raising=False)
-    monkeypatch.delenv("FABRIC_DISABLE_TELEMETRY", raising=False)
+    monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
     monkeypatch.delenv("DO_NOT_TRACK", raising=False)
-    monkeypatch.delenv("CI", raising=False)
-    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
-    monkeypatch.delenv("JENKINS_URL", raising=False)
-    monkeypatch.delenv("TRAVIS", raising=False)
-    monkeypatch.delenv("CIRCLECI", raising=False)
-    monkeypatch.delenv("GITLAB_CI", raising=False)
-    monkeypatch.delenv("TF_BUILD", raising=False)
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
 
     mod = _reload_telemetry()
     assert mod.telemetry_enabled() is True  # type: ignore[attr-defined]
 
 
-@pytest.mark.parametrize("value", ["0", "false", "FALSE", "no", "NO", "off", "OFF"])
-def test_telemetry_disabled_by_fabric_telemetry_falsy(
+@pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "YES", "on", "ON", "anything"])
+def test_telemetry_disabled_by_fabric_dw_telemetry_opt_out_truthy(
     value: str, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """FABRIC_TELEMETRY in {0, false, no, off} disables telemetry."""
-    monkeypatch.setenv("FABRIC_TELEMETRY", value)
-    monkeypatch.delenv("FABRIC_DISABLE_TELEMETRY", raising=False)
+    """FABRIC_DW_TELEMETRY_OPT_OUT set to a truthy value disables telemetry."""
+    monkeypatch.setenv("FABRIC_DW_TELEMETRY_OPT_OUT", value)
     monkeypatch.delenv("DO_NOT_TRACK", raising=False)
-    monkeypatch.delenv("CI", raising=False)
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
 
     mod = _reload_telemetry()
     assert mod.telemetry_enabled() is False  # type: ignore[attr-defined]
 
 
-def test_telemetry_not_disabled_by_fabric_telemetry_truthy(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+@pytest.mark.parametrize("value", ["0", "false", "FALSE", "no", "NO", "off", "OFF", ""])
+def test_telemetry_enabled_when_fabric_dw_telemetry_opt_out_falsy(
+    value: str, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """FABRIC_TELEMETRY=1 does NOT disable telemetry (opt-in is a no-op; it is on by default)."""
-    monkeypatch.setenv("FABRIC_TELEMETRY", "1")
-    monkeypatch.delenv("FABRIC_DISABLE_TELEMETRY", raising=False)
+    """FABRIC_DW_TELEMETRY_OPT_OUT set to a falsy value does NOT disable telemetry."""
+    monkeypatch.setenv("FABRIC_DW_TELEMETRY_OPT_OUT", value)
     monkeypatch.delenv("DO_NOT_TRACK", raising=False)
-    monkeypatch.delenv("CI", raising=False)
-    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
-    monkeypatch.delenv("JENKINS_URL", raising=False)
-    monkeypatch.delenv("TRAVIS", raising=False)
-    monkeypatch.delenv("CIRCLECI", raising=False)
-    monkeypatch.delenv("GITLAB_CI", raising=False)
-    monkeypatch.delenv("TF_BUILD", raising=False)
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
 
     mod = _reload_telemetry()
     assert mod.telemetry_enabled() is True  # type: ignore[attr-defined]
-
-
-@pytest.mark.parametrize("value", ["1", "true", "yes", "TRUE"])
-def test_telemetry_disabled_by_fabric_disable_telemetry(
-    value: str, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
-    """FABRIC_DISABLE_TELEMETRY set to a truthy value disables telemetry."""
-    monkeypatch.delenv("FABRIC_TELEMETRY", raising=False)
-    monkeypatch.setenv("FABRIC_DISABLE_TELEMETRY", value)
-    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
-    monkeypatch.delenv("CI", raising=False)
-    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
-
-    mod = _reload_telemetry()
-    assert mod.telemetry_enabled() is False  # type: ignore[attr-defined]
 
 
 @pytest.mark.parametrize("value", ["1", "true", "yes", "TRUE"])
@@ -111,45 +79,8 @@ def test_telemetry_disabled_by_do_not_track(
     value: str, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """DO_NOT_TRACK truthy disables telemetry (consoledonottrack.com standard)."""
-    monkeypatch.delenv("FABRIC_TELEMETRY", raising=False)
-    monkeypatch.delenv("FABRIC_DISABLE_TELEMETRY", raising=False)
+    monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
     monkeypatch.setenv("DO_NOT_TRACK", value)
-    monkeypatch.delenv("CI", raising=False)
-    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
-
-    mod = _reload_telemetry()
-    assert mod.telemetry_enabled() is False  # type: ignore[attr-defined]
-
-
-def test_telemetry_disabled_when_ci_set(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """CI=true disables telemetry."""
-    monkeypatch.delenv("FABRIC_TELEMETRY", raising=False)
-    monkeypatch.delenv("FABRIC_DISABLE_TELEMETRY", raising=False)
-    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
-    monkeypatch.setenv("CI", "true")
-    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
-
-    mod = _reload_telemetry()
-    assert mod.telemetry_enabled() is False  # type: ignore[attr-defined]
-
-
-@pytest.mark.parametrize(
-    "var",
-    ["GITHUB_ACTIONS", "JENKINS_URL", "TRAVIS", "CIRCLECI", "GITLAB_CI", "TF_BUILD"],
-)
-def test_telemetry_disabled_by_ci_marker(
-    var: str, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
-    """Common CI marker env vars disable telemetry."""
-    monkeypatch.delenv("FABRIC_TELEMETRY", raising=False)
-    monkeypatch.delenv("FABRIC_DISABLE_TELEMETRY", raising=False)
-    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
-    monkeypatch.delenv("CI", raising=False)
-    # Clear other CI markers
-    for other in ["GITHUB_ACTIONS", "JENKINS_URL", "TRAVIS", "CIRCLECI", "GITLAB_CI", "TF_BUILD"]:
-        if other != var:
-            monkeypatch.delenv(other, raising=False)
-    monkeypatch.setenv(var, "true")
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
 
     mod = _reload_telemetry()
@@ -167,16 +98,8 @@ def test_telemetry_disabled_by_config_setting(
     """telemetry_enabled() returns False when config file has telemetry_disabled=true."""
     import tomli_w  # noqa: PLC0415
 
-    monkeypatch.delenv("FABRIC_TELEMETRY", raising=False)
-    monkeypatch.delenv("FABRIC_DISABLE_TELEMETRY", raising=False)
+    monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
     monkeypatch.delenv("DO_NOT_TRACK", raising=False)
-    monkeypatch.delenv("CI", raising=False)
-    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
-    monkeypatch.delenv("JENKINS_URL", raising=False)
-    monkeypatch.delenv("TRAVIS", raising=False)
-    monkeypatch.delenv("CIRCLECI", raising=False)
-    monkeypatch.delenv("GITLAB_CI", raising=False)
-    monkeypatch.delenv("TF_BUILD", raising=False)
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
 
     config_dir = tmp_path / "fabric-dw"
@@ -197,7 +120,7 @@ def test_azure_monitor_sdk_not_imported_when_disabled(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """When telemetry is disabled, azure.monitor.opentelemetry must never be imported."""
-    monkeypatch.setenv("FABRIC_DISABLE_TELEMETRY", "1")
+    monkeypatch.setenv("FABRIC_DW_TELEMETRY_OPT_OUT", "1")
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
 
     # Remove SDK from sys.modules to detect a fresh import
@@ -221,16 +144,8 @@ def test_emit_event_never_raises_on_sdk_error(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """emit_event must swallow all exceptions and never propagate them."""
-    monkeypatch.delenv("FABRIC_TELEMETRY", raising=False)
-    monkeypatch.delenv("FABRIC_DISABLE_TELEMETRY", raising=False)
+    monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
     monkeypatch.delenv("DO_NOT_TRACK", raising=False)
-    monkeypatch.delenv("CI", raising=False)
-    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
-    monkeypatch.delenv("JENKINS_URL", raising=False)
-    monkeypatch.delenv("TRAVIS", raising=False)
-    monkeypatch.delenv("CIRCLECI", raising=False)
-    monkeypatch.delenv("GITLAB_CI", raising=False)
-    monkeypatch.delenv("TF_BUILD", raising=False)
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
 
     mod = _reload_telemetry()
@@ -243,7 +158,7 @@ def test_emit_event_never_raises_on_sdk_error(
 
 def test_emit_event_no_op_when_disabled(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """emit_event is a no-op (does not import SDK) when telemetry is disabled."""
-    monkeypatch.setenv("FABRIC_DISABLE_TELEMETRY", "1")
+    monkeypatch.setenv("FABRIC_DW_TELEMETRY_OPT_OUT", "1")
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
 
     mod = _reload_telemetry()
@@ -267,19 +182,11 @@ def test_envelope_contains_required_fields(monkeypatch: pytest.MonkeyPatch, tmp_
     Fields moved to native Part A via the OTel Resource (#477) are NOT present
     here: ``app_version`` (→ application_Version), ``surface`` (→ cloud_RoleName).
     Fields dropped entirely (#477): ``anonymous_install_id`` (duplicate of user_Id),
-    ``is_ci`` (always False — telemetry is disabled in CI).
+    ``is_ci`` (no useful signal).
     ``tenant_id`` is now always present (``"unknown"`` when unresolved).
     """
-    monkeypatch.delenv("FABRIC_TELEMETRY", raising=False)
-    monkeypatch.delenv("FABRIC_DISABLE_TELEMETRY", raising=False)
+    monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
     monkeypatch.delenv("DO_NOT_TRACK", raising=False)
-    monkeypatch.delenv("CI", raising=False)
-    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
-    monkeypatch.delenv("JENKINS_URL", raising=False)
-    monkeypatch.delenv("TRAVIS", raising=False)
-    monkeypatch.delenv("CIRCLECI", raising=False)
-    monkeypatch.delenv("GITLAB_CI", raising=False)
-    monkeypatch.delenv("TF_BUILD", raising=False)
     monkeypatch.delenv("AZURE_TENANT_ID", raising=False)
     monkeypatch.delenv("FABRIC_INTERACTIVE_TENANT_ID", raising=False)
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
@@ -315,14 +222,7 @@ def test_envelope_surface_not_in_custom_dimensions(
     maps to ``cloud_RoleName``.  Emitting it again as a custom dimension would be
     redundant.
     """
-    monkeypatch.delenv("FABRIC_DISABLE_TELEMETRY", raising=False)
-    monkeypatch.delenv("CI", raising=False)
-    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
-    monkeypatch.delenv("JENKINS_URL", raising=False)
-    monkeypatch.delenv("TRAVIS", raising=False)
-    monkeypatch.delenv("CIRCLECI", raising=False)
-    monkeypatch.delenv("GITLAB_CI", raising=False)
-    monkeypatch.delenv("TF_BUILD", raising=False)
+    monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
 
     mod = _reload_telemetry()
@@ -333,8 +233,7 @@ def test_envelope_surface_not_in_custom_dimensions(
 def test_envelope_is_ci_not_in_custom_dimensions(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """is_ci must NOT be in the envelope — telemetry is disabled in CI so it was always False."""
-    monkeypatch.setenv("CI", "true")
+    """is_ci must NOT be in the envelope — it carries no useful signal (#477)."""
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
 
     mod = _reload_telemetry()
@@ -577,16 +476,8 @@ def test_first_run_notice_printed_to_stderr(
 ) -> None:
     """First-run notice must be printed to stderr the first time."""
     for var in [
-        "FABRIC_TELEMETRY",
-        "FABRIC_DISABLE_TELEMETRY",
+        "FABRIC_DW_TELEMETRY_OPT_OUT",
         "DO_NOT_TRACK",
-        "CI",
-        "GITHUB_ACTIONS",
-        "JENKINS_URL",
-        "TRAVIS",
-        "CIRCLECI",
-        "GITLAB_CI",
-        "TF_BUILD",
     ]:
         monkeypatch.delenv(var, raising=False)
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
@@ -604,16 +495,8 @@ def test_first_run_notice_printed_only_once(
 ) -> None:
     """First-run notice must not be repeated after the marker file is written."""
     for var in [
-        "FABRIC_TELEMETRY",
-        "FABRIC_DISABLE_TELEMETRY",
+        "FABRIC_DW_TELEMETRY_OPT_OUT",
         "DO_NOT_TRACK",
-        "CI",
-        "GITHUB_ACTIONS",
-        "JENKINS_URL",
-        "TRAVIS",
-        "CIRCLECI",
-        "GITLAB_CI",
-        "TF_BUILD",
     ]:
         monkeypatch.delenv(var, raising=False)
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
@@ -632,7 +515,7 @@ def test_first_run_notice_not_printed_when_disabled(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     """No first-run notice when telemetry is disabled."""
-    monkeypatch.setenv("FABRIC_DISABLE_TELEMETRY", "1")
+    monkeypatch.setenv("FABRIC_DW_TELEMETRY_OPT_OUT", "1")
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
 
     mod = _reload_telemetry()
@@ -642,20 +525,18 @@ def test_first_run_notice_not_printed_when_disabled(
     assert captured.err == "", "No notice should be printed when telemetry is disabled"
 
 
-def test_first_run_notice_not_printed_in_ci(
+def test_first_run_notice_not_printed_when_opt_out(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """No first-run notice when running in CI."""
-    for var in ["FABRIC_TELEMETRY", "FABRIC_DISABLE_TELEMETRY", "DO_NOT_TRACK"]:
-        monkeypatch.delenv(var, raising=False)
-    monkeypatch.setenv("CI", "true")
+    """No first-run notice when FABRIC_DW_TELEMETRY_OPT_OUT=1."""
+    monkeypatch.setenv("FABRIC_DW_TELEMETRY_OPT_OUT", "1")
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
 
     mod = _reload_telemetry()
     mod.maybe_print_first_run_notice()  # type: ignore[attr-defined]
 
     captured = capsys.readouterr()
-    assert captured.err == "", "No notice should be printed in CI"
+    assert captured.err == "", "No notice should be printed when telemetry is opted out"
 
 
 # ---------------------------------------------------------------------------
@@ -665,7 +546,7 @@ def test_first_run_notice_not_printed_in_ci(
 
 def test_record_app_started_does_not_raise(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """record_app_started must not raise even when telemetry is disabled."""
-    monkeypatch.setenv("FABRIC_DISABLE_TELEMETRY", "1")
+    monkeypatch.setenv("FABRIC_DW_TELEMETRY_OPT_OUT", "1")
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
 
     mod = _reload_telemetry()
@@ -674,7 +555,7 @@ def test_record_app_started_does_not_raise(monkeypatch: pytest.MonkeyPatch, tmp_
 
 def test_record_app_exited_does_not_raise(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """record_app_exited must not raise even when telemetry is disabled."""
-    monkeypatch.setenv("FABRIC_DISABLE_TELEMETRY", "1")
+    monkeypatch.setenv("FABRIC_DW_TELEMETRY_OPT_OUT", "1")
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
 
     mod = _reload_telemetry()
@@ -685,7 +566,7 @@ def test_record_mcp_server_started_does_not_raise(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """record_mcp_server_started must not raise even when telemetry is disabled."""
-    monkeypatch.setenv("FABRIC_DISABLE_TELEMETRY", "1")
+    monkeypatch.setenv("FABRIC_DW_TELEMETRY_OPT_OUT", "1")
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
 
     mod = _reload_telemetry()
@@ -697,16 +578,8 @@ def test_record_app_started_enabled_calls_emit(
 ) -> None:
     """When telemetry is enabled, record_app_started must call emit_event."""
     for var in [
-        "FABRIC_TELEMETRY",
-        "FABRIC_DISABLE_TELEMETRY",
+        "FABRIC_DW_TELEMETRY_OPT_OUT",
         "DO_NOT_TRACK",
-        "CI",
-        "GITHUB_ACTIONS",
-        "JENKINS_URL",
-        "TRAVIS",
-        "CIRCLECI",
-        "GITLAB_CI",
-        "TF_BUILD",
     ]:
         monkeypatch.delenv(var, raising=False)
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
@@ -730,16 +603,8 @@ def test_record_app_exited_enabled_calls_emit(
 ) -> None:
     """When telemetry is enabled, record_app_exited must call emit_event."""
     for var in [
-        "FABRIC_TELEMETRY",
-        "FABRIC_DISABLE_TELEMETRY",
+        "FABRIC_DW_TELEMETRY_OPT_OUT",
         "DO_NOT_TRACK",
-        "CI",
-        "GITHUB_ACTIONS",
-        "JENKINS_URL",
-        "TRAVIS",
-        "CIRCLECI",
-        "GITLAB_CI",
-        "TF_BUILD",
     ]:
         monkeypatch.delenv(var, raising=False)
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
@@ -764,16 +629,8 @@ def test_record_mcp_server_started_enabled_calls_emit(
 ) -> None:
     """When telemetry is enabled, record_mcp_server_started must call emit_event."""
     for var in [
-        "FABRIC_TELEMETRY",
-        "FABRIC_DISABLE_TELEMETRY",
+        "FABRIC_DW_TELEMETRY_OPT_OUT",
         "DO_NOT_TRACK",
-        "CI",
-        "GITHUB_ACTIONS",
-        "JENKINS_URL",
-        "TRAVIS",
-        "CIRCLECI",
-        "GITLAB_CI",
-        "TF_BUILD",
     ]:
         monkeypatch.delenv(var, raising=False)
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
@@ -877,8 +734,7 @@ def test_get_tracer_passes_instrumentation_options_to_configure(
     reference to avoid corrupting sys.modules for other tests.
     """
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
-    monkeypatch.delenv("FABRIC_DISABLE_TELEMETRY", raising=False)
-    monkeypatch.delenv("CI", raising=False)
+    monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
     for ci_var in ("GITHUB_ACTIONS", "JENKINS_URL", "TRAVIS", "CIRCLECI", "GITLAB_CI", "TF_BUILD"):
         monkeypatch.delenv(ci_var, raising=False)
 
@@ -940,8 +796,7 @@ def test_get_tracer_passes_enable_performance_counters_false(
     and writes a full traceback to stderr (#399).
     """
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
-    monkeypatch.delenv("FABRIC_DISABLE_TELEMETRY", raising=False)
-    monkeypatch.delenv("CI", raising=False)
+    monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
     for ci_var in ("GITHUB_ACTIONS", "JENKINS_URL", "TRAVIS", "CIRCLECI", "GITLAB_CI", "TF_BUILD"):
         monkeypatch.delenv(ci_var, raising=False)
 
@@ -1210,16 +1065,8 @@ def test_set_tenant_id_writes_file_when_enabled(
     """set_tenant_id must persist to disk when telemetry is enabled (#652)."""
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
     monkeypatch.setenv("FABRIC_TELEMETRY_CONNECTION_STRING", _DUMMY_CONN_STR)
-    monkeypatch.delenv("FABRIC_DISABLE_TELEMETRY", raising=False)
+    monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
     monkeypatch.delenv("DO_NOT_TRACK", raising=False)
-    monkeypatch.delenv("CI", raising=False)
-    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
-    monkeypatch.delenv("JENKINS_URL", raising=False)
-    monkeypatch.delenv("TRAVIS", raising=False)
-    monkeypatch.delenv("CIRCLECI", raising=False)
-    monkeypatch.delenv("GITLAB_CI", raising=False)
-    monkeypatch.delenv("TF_BUILD", raising=False)
-    monkeypatch.delenv("FABRIC_TELEMETRY", raising=False)
 
     mod = _reload_telemetry()
     assert mod.telemetry_enabled() is True  # type: ignore[attr-defined]
@@ -1237,7 +1084,7 @@ def test_set_tenant_id_no_write_when_disabled(
     """set_tenant_id must NOT write to disk when telemetry is disabled (#652)."""
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
     monkeypatch.setenv("FABRIC_TELEMETRY_CONNECTION_STRING", _DUMMY_CONN_STR)
-    monkeypatch.setenv("FABRIC_DISABLE_TELEMETRY", "1")
+    monkeypatch.setenv("FABRIC_DW_TELEMETRY_OPT_OUT", "1")
 
     mod = _reload_telemetry()
     assert mod.telemetry_enabled() is False  # type: ignore[attr-defined]
@@ -1260,16 +1107,8 @@ def test_cached_tenant_read_back_on_new_process(
     monkeypatch.setenv("FABRIC_TELEMETRY_CONNECTION_STRING", _DUMMY_CONN_STR)
     monkeypatch.delenv("AZURE_TENANT_ID", raising=False)
     monkeypatch.delenv("FABRIC_INTERACTIVE_TENANT_ID", raising=False)
-    monkeypatch.delenv("FABRIC_DISABLE_TELEMETRY", raising=False)
+    monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
     monkeypatch.delenv("DO_NOT_TRACK", raising=False)
-    monkeypatch.delenv("CI", raising=False)
-    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
-    monkeypatch.delenv("JENKINS_URL", raising=False)
-    monkeypatch.delenv("TRAVIS", raising=False)
-    monkeypatch.delenv("CIRCLECI", raising=False)
-    monkeypatch.delenv("GITLAB_CI", raising=False)
-    monkeypatch.delenv("TF_BUILD", raising=False)
-    monkeypatch.delenv("FABRIC_TELEMETRY", raising=False)
 
     # First run: set the tenant (writes file)
     mod = _reload_telemetry()
@@ -1387,16 +1226,8 @@ def test_stale_cache_corrected_by_set_tenant_id(
     monkeypatch.setenv("FABRIC_TELEMETRY_CONNECTION_STRING", _DUMMY_CONN_STR)
     monkeypatch.delenv("AZURE_TENANT_ID", raising=False)
     monkeypatch.delenv("FABRIC_INTERACTIVE_TENANT_ID", raising=False)
-    monkeypatch.delenv("FABRIC_DISABLE_TELEMETRY", raising=False)
+    monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
     monkeypatch.delenv("DO_NOT_TRACK", raising=False)
-    monkeypatch.delenv("CI", raising=False)
-    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
-    monkeypatch.delenv("JENKINS_URL", raising=False)
-    monkeypatch.delenv("TRAVIS", raising=False)
-    monkeypatch.delenv("CIRCLECI", raising=False)
-    monkeypatch.delenv("GITLAB_CI", raising=False)
-    monkeypatch.delenv("TF_BUILD", raising=False)
-    monkeypatch.delenv("FABRIC_TELEMETRY", raising=False)
 
     # run1: telemetry ON → tenant-A written to cache
     mod = _reload_telemetry()
@@ -1404,7 +1235,7 @@ def test_stale_cache_corrected_by_set_tenant_id(
     mod.set_tenant_id("tenant-A")  # type: ignore[attr-defined]
 
     # run2: telemetry OFF → tenant-B NOT written to cache
-    monkeypatch.setenv("FABRIC_DISABLE_TELEMETRY", "1")
+    monkeypatch.setenv("FABRIC_DW_TELEMETRY_OPT_OUT", "1")
     mod2 = _reload_telemetry()
     assert mod2.telemetry_enabled() is False  # type: ignore[attr-defined]
     mod2.set_tenant_id("tenant-B")  # type: ignore[attr-defined]
@@ -1412,7 +1243,7 @@ def test_stale_cache_corrected_by_set_tenant_id(
     assert (tmp_path / "fabric-dw" / "tenant_id").read_text(encoding="utf-8").strip() == "tenant-A"
 
     # run3: telemetry re-enabled; app_started fires before auth (no live override)
-    monkeypatch.delenv("FABRIC_DISABLE_TELEMETRY", raising=False)
+    monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
     mod3 = _reload_telemetry()
     mod3._tenant_id_override = None  # type: ignore[attr-defined]
 
@@ -1443,16 +1274,8 @@ def test_first_run_notice_marker_written_after_print(
     future notices.
     """
     for var in [
-        "FABRIC_TELEMETRY",
-        "FABRIC_DISABLE_TELEMETRY",
+        "FABRIC_DW_TELEMETRY_OPT_OUT",
         "DO_NOT_TRACK",
-        "CI",
-        "GITHUB_ACTIONS",
-        "JENKINS_URL",
-        "TRAVIS",
-        "CIRCLECI",
-        "GITLAB_CI",
-        "TF_BUILD",
     ]:
         monkeypatch.delenv(var, raising=False)
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
@@ -1623,16 +1446,8 @@ def test_cache_tenant_id_sets_override_when_enabled(
 ) -> None:
     """cache_tenant_id_from_token sets _tenant_id_override when telemetry is on."""
     for var in [
-        "FABRIC_TELEMETRY",
-        "FABRIC_DISABLE_TELEMETRY",
+        "FABRIC_DW_TELEMETRY_OPT_OUT",
         "DO_NOT_TRACK",
-        "CI",
-        "GITHUB_ACTIONS",
-        "JENKINS_URL",
-        "TRAVIS",
-        "CIRCLECI",
-        "GITLAB_CI",
-        "TF_BUILD",
     ]:
         monkeypatch.delenv(var, raising=False)
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
@@ -1649,7 +1464,7 @@ def test_cache_tenant_id_does_not_decode_when_telemetry_disabled(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """cache_tenant_id_from_token is a no-op (no decode) when telemetry is disabled."""
-    monkeypatch.setenv("FABRIC_DISABLE_TELEMETRY", "1")
+    monkeypatch.setenv("FABRIC_DW_TELEMETRY_OPT_OUT", "1")
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
 
     mod = _reload_telemetry()
@@ -1676,16 +1491,8 @@ def test_cache_tenant_id_is_idempotent_skips_decode_when_override_set(
 ) -> None:
     """cache_tenant_id_from_token skips decode when _tenant_id_override is already set."""
     for var in [
-        "FABRIC_TELEMETRY",
-        "FABRIC_DISABLE_TELEMETRY",
+        "FABRIC_DW_TELEMETRY_OPT_OUT",
         "DO_NOT_TRACK",
-        "CI",
-        "GITHUB_ACTIONS",
-        "JENKINS_URL",
-        "TRAVIS",
-        "CIRCLECI",
-        "GITLAB_CI",
-        "TF_BUILD",
     ]:
         monkeypatch.delenv(var, raising=False)
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
@@ -1723,16 +1530,8 @@ def test_envelope_uses_token_tid_over_env_var(
     wins over the env-var fallback in _build_envelope.
     """
     for var in [
-        "FABRIC_TELEMETRY",
-        "FABRIC_DISABLE_TELEMETRY",
+        "FABRIC_DW_TELEMETRY_OPT_OUT",
         "DO_NOT_TRACK",
-        "CI",
-        "GITHUB_ACTIONS",
-        "JENKINS_URL",
-        "TRAVIS",
-        "CIRCLECI",
-        "GITLAB_CI",
-        "TF_BUILD",
     ]:
         monkeypatch.delenv(var, raising=False)
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
@@ -1751,16 +1550,8 @@ def test_envelope_falls_back_to_azure_tenant_id_env_when_no_override(
 ) -> None:
     """_build_envelope falls back to AZURE_TENANT_ID when no token override is set."""
     for var in [
-        "FABRIC_TELEMETRY",
-        "FABRIC_DISABLE_TELEMETRY",
+        "FABRIC_DW_TELEMETRY_OPT_OUT",
         "DO_NOT_TRACK",
-        "CI",
-        "GITHUB_ACTIONS",
-        "JENKINS_URL",
-        "TRAVIS",
-        "CIRCLECI",
-        "GITLAB_CI",
-        "TF_BUILD",
         "FABRIC_INTERACTIVE_TENANT_ID",
     ]:
         monkeypatch.delenv(var, raising=False)
@@ -1783,16 +1574,8 @@ def test_envelope_tenant_id_unknown_when_no_source(
     tenant_id is always present (#477 Finding 2) so it is reliably queryable on every event.
     """
     for var in [
-        "FABRIC_TELEMETRY",
-        "FABRIC_DISABLE_TELEMETRY",
+        "FABRIC_DW_TELEMETRY_OPT_OUT",
         "DO_NOT_TRACK",
-        "CI",
-        "GITHUB_ACTIONS",
-        "JENKINS_URL",
-        "TRAVIS",
-        "CIRCLECI",
-        "GITLAB_CI",
-        "TF_BUILD",
         "AZURE_TENANT_ID",
         "FABRIC_INTERACTIVE_TENANT_ID",
     ]:
@@ -2135,16 +1918,8 @@ def _clear_statsbeat_env(monkeypatch: pytest.MonkeyPatch) -> None:
 def _enable_telemetry(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """Remove all opt-out signals so telemetry_enabled() returns True."""
     for var in (
-        "FABRIC_TELEMETRY",
-        "FABRIC_DISABLE_TELEMETRY",
+        "FABRIC_DW_TELEMETRY_OPT_OUT",
         "DO_NOT_TRACK",
-        "CI",
-        "GITHUB_ACTIONS",
-        "JENKINS_URL",
-        "TRAVIS",
-        "CIRCLECI",
-        "GITLAB_CI",
-        "TF_BUILD",
     ):
         monkeypatch.delenv(var, raising=False)
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
@@ -2264,16 +2039,8 @@ def test_suppress_telemetry_makes_telemetry_enabled_return_false(
     """suppress_telemetry() must cause telemetry_enabled() to return False."""
     # Start with telemetry ON (all opt-out signals absent).
     for var in [
-        "FABRIC_TELEMETRY",
-        "FABRIC_DISABLE_TELEMETRY",
+        "FABRIC_DW_TELEMETRY_OPT_OUT",
         "DO_NOT_TRACK",
-        "CI",
-        "GITHUB_ACTIONS",
-        "JENKINS_URL",
-        "TRAVIS",
-        "CIRCLECI",
-        "GITLAB_CI",
-        "TF_BUILD",
     ]:
         monkeypatch.delenv(var, raising=False)
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
@@ -2290,16 +2057,8 @@ def test_suppress_telemetry_makes_telemetry_enabled_return_false(
 def test_suppress_telemetry_is_resettable(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """suppress_telemetry(False) must restore normal enable/disable evaluation."""
     for var in [
-        "FABRIC_TELEMETRY",
-        "FABRIC_DISABLE_TELEMETRY",
+        "FABRIC_DW_TELEMETRY_OPT_OUT",
         "DO_NOT_TRACK",
-        "CI",
-        "GITHUB_ACTIONS",
-        "JENKINS_URL",
-        "TRAVIS",
-        "CIRCLECI",
-        "GITLAB_CI",
-        "TF_BUILD",
     ]:
         monkeypatch.delenv(var, raising=False)
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
@@ -2317,16 +2076,8 @@ def test_suppress_telemetry_prevents_get_tracer_call(
 ) -> None:
     """When suppressed, emit_event must not call _get_tracer (no SDK init)."""
     for var in [
-        "FABRIC_TELEMETRY",
-        "FABRIC_DISABLE_TELEMETRY",
+        "FABRIC_DW_TELEMETRY_OPT_OUT",
         "DO_NOT_TRACK",
-        "CI",
-        "GITHUB_ACTIONS",
-        "JENKINS_URL",
-        "TRAVIS",
-        "CIRCLECI",
-        "GITLAB_CI",
-        "TF_BUILD",
     ]:
         monkeypatch.delenv(var, raising=False)
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
@@ -2346,16 +2097,8 @@ def test_suppress_telemetry_prevents_configure_azure_monitor(
 ) -> None:
     """When suppressed, _get_tracer must not call configure_azure_monitor."""
     for var in [
-        "FABRIC_TELEMETRY",
-        "FABRIC_DISABLE_TELEMETRY",
+        "FABRIC_DW_TELEMETRY_OPT_OUT",
         "DO_NOT_TRACK",
-        "CI",
-        "GITHUB_ACTIONS",
-        "JENKINS_URL",
-        "TRAVIS",
-        "CIRCLECI",
-        "GITLAB_CI",
-        "TF_BUILD",
     ]:
         monkeypatch.delenv(var, raising=False)
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
@@ -2394,16 +2137,8 @@ def test_suppress_telemetry_prevents_first_run_notice(
 ) -> None:
     """maybe_print_first_run_notice must be a no-op when telemetry is suppressed."""
     for var in [
-        "FABRIC_TELEMETRY",
-        "FABRIC_DISABLE_TELEMETRY",
+        "FABRIC_DW_TELEMETRY_OPT_OUT",
         "DO_NOT_TRACK",
-        "CI",
-        "GITHUB_ACTIONS",
-        "JENKINS_URL",
-        "TRAVIS",
-        "CIRCLECI",
-        "GITLAB_CI",
-        "TF_BUILD",
     ]:
         monkeypatch.delenv(var, raising=False)
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
@@ -2424,16 +2159,8 @@ def test_suppress_telemetry_shutdown_is_noop(
 ) -> None:
     """shutdown_telemetry must be a no-op when suppressed (SDK was never initialised)."""
     for var in [
-        "FABRIC_TELEMETRY",
-        "FABRIC_DISABLE_TELEMETRY",
+        "FABRIC_DW_TELEMETRY_OPT_OUT",
         "DO_NOT_TRACK",
-        "CI",
-        "GITHUB_ACTIONS",
-        "JENKINS_URL",
-        "TRAVIS",
-        "CIRCLECI",
-        "GITLAB_CI",
-        "TF_BUILD",
     ]:
         monkeypatch.delenv(var, raising=False)
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
@@ -2460,7 +2187,7 @@ def test_emit_event_noop_when_telemetry_disabled(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """emit_event is a no-op when telemetry is disabled — _get_tracer is never called."""
-    monkeypatch.setenv("FABRIC_DISABLE_TELEMETRY", "1")
+    monkeypatch.setenv("FABRIC_DW_TELEMETRY_OPT_OUT", "1")
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
 
     mod = _reload_telemetry()
@@ -2494,16 +2221,8 @@ def _build_test_envelope(
     from opentelemetry.sdk.resources import Resource  # noqa: PLC0415
 
     for var in (
-        "FABRIC_TELEMETRY",
-        "FABRIC_DISABLE_TELEMETRY",
+        "FABRIC_DW_TELEMETRY_OPT_OUT",
         "DO_NOT_TRACK",
-        "CI",
-        "GITHUB_ACTIONS",
-        "JENKINS_URL",
-        "TRAVIS",
-        "CIRCLECI",
-        "GITLAB_CI",
-        "TF_BUILD",
         "AZURE_TENANT_ID",
         "FABRIC_INTERACTIVE_TENANT_ID",
     ):
@@ -2790,8 +2509,7 @@ def test_get_tracer_passes_resource_to_configure_azure_monitor(
     application_Version, ai.device.id) and prevents the hostname fallback.
     """
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
-    monkeypatch.delenv("FABRIC_DISABLE_TELEMETRY", raising=False)
-    monkeypatch.delenv("CI", raising=False)
+    monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
     for ci_var in ("GITHUB_ACTIONS", "JENKINS_URL", "TRAVIS", "CIRCLECI", "GITLAB_CI", "TF_BUILD"):
         monkeypatch.delenv(ci_var, raising=False)
 

--- a/tests/unit/test_telemetry_commands.py
+++ b/tests/unit/test_telemetry_commands.py
@@ -36,7 +36,7 @@ _EMIT_EVENT = "fabric_dw.telemetry.emit_event"
 @pytest.fixture(autouse=True)
 def disable_telemetry(monkeypatch: pytest.MonkeyPatch) -> None:
     """Disable real telemetry by default (safe tests, no network)."""
-    monkeypatch.setenv("FABRIC_DISABLE_TELEMETRY", "1")
+    monkeypatch.setenv("FABRIC_DW_TELEMETRY_OPT_OUT", "1")
 
 
 # ---------------------------------------------------------------------------
@@ -254,7 +254,7 @@ class TestNowMs:
 class TestEmitCommandInvokedDisabled:
     def test_disabled_emits_nothing(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """When telemetry is disabled, emit_event must never be called."""
-        monkeypatch.setenv("FABRIC_DISABLE_TELEMETRY", "1")
+        monkeypatch.setenv("FABRIC_DW_TELEMETRY_OPT_OUT", "1")
 
         with patch(_EMIT_EVENT) as mock_emit, patch(_TELEMETRY_ENABLED, return_value=False):
             emit_command_invoked(
@@ -273,16 +273,9 @@ class TestEmitCommandInvokedDisabled:
 class TestEmitCommandInvokedEnabled:
     @pytest.fixture(autouse=True)
     def enable_telemetry(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.delenv("FABRIC_DISABLE_TELEMETRY", raising=False)
-        monkeypatch.delenv("FABRIC_TELEMETRY", raising=False)
+        monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
+        monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
         monkeypatch.delenv("DO_NOT_TRACK", raising=False)
-        monkeypatch.delenv("CI", raising=False)
-        monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
-        monkeypatch.delenv("JENKINS_URL", raising=False)
-        monkeypatch.delenv("TRAVIS", raising=False)
-        monkeypatch.delenv("CIRCLECI", raising=False)
-        monkeypatch.delenv("GITLAB_CI", raising=False)
-        monkeypatch.delenv("TF_BUILD", raising=False)
 
     def _run(self, **kwargs):  # type: ignore[no-untyped-def]
         """Call emit_command_invoked with telemetry_enabled patched to True."""
@@ -434,14 +427,7 @@ class TestCliCommandInvokedInstrumentation:
         from fabric_dw.cli._main import cli  # noqa: PLC0415
 
         # Enable telemetry for these tests.
-        monkeypatch.delenv("FABRIC_DISABLE_TELEMETRY", raising=False)
-        monkeypatch.delenv("CI", raising=False)
-        monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
-        monkeypatch.delenv("JENKINS_URL", raising=False)
-        monkeypatch.delenv("TRAVIS", raising=False)
-        monkeypatch.delenv("CIRCLECI", raising=False)
-        monkeypatch.delenv("GITLAB_CI", raising=False)
-        monkeypatch.delenv("TF_BUILD", raising=False)
+        monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
 
         runner = CliRunner()
         # Patch telemetry_enabled at the source (fabric_dw.telemetry) so both
@@ -485,7 +471,7 @@ class TestCliCommandInvokedInstrumentation:
         """When telemetry is disabled, no command_invoked event is emitted."""
         from fabric_dw.cli._main import cli  # noqa: PLC0415
 
-        monkeypatch.setenv("FABRIC_DISABLE_TELEMETRY", "1")
+        monkeypatch.setenv("FABRIC_DW_TELEMETRY_OPT_OUT", "1")
         runner = CliRunner()
         with patch(_EMIT_EVENT) as mock_emit, patch(_TELEMETRY_ENABLED, return_value=False):
             runner.invoke(cli, ["cache", "clear"], catch_exceptions=True)
@@ -539,14 +525,7 @@ class TestMcpCommandInvokedInstrumentation:
 
     @pytest.fixture(autouse=True)
     def enable_telemetry(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.delenv("FABRIC_DISABLE_TELEMETRY", raising=False)
-        monkeypatch.delenv("CI", raising=False)
-        monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
-        monkeypatch.delenv("JENKINS_URL", raising=False)
-        monkeypatch.delenv("TRAVIS", raising=False)
-        monkeypatch.delenv("CIRCLECI", raising=False)
-        monkeypatch.delenv("GITLAB_CI", raising=False)
-        monkeypatch.delenv("TF_BUILD", raising=False)
+        monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
 
     def _make_spy(self) -> MagicMock:
         return MagicMock()
@@ -799,14 +778,7 @@ class TestCliShutdownOrdering:
         """Run CLI and return the sequence of telemetry calls in invocation order."""
         from fabric_dw.cli._main import cli  # noqa: PLC0415
 
-        monkeypatch.delenv("FABRIC_DISABLE_TELEMETRY", raising=False)
-        monkeypatch.delenv("CI", raising=False)
-        monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
-        monkeypatch.delenv("JENKINS_URL", raising=False)
-        monkeypatch.delenv("TRAVIS", raising=False)
-        monkeypatch.delenv("CIRCLECI", raising=False)
-        monkeypatch.delenv("GITLAB_CI", raising=False)
-        monkeypatch.delenv("TF_BUILD", raising=False)
+        monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
 
         call_order: list[str] = []
 

--- a/tests/unit/test_telemetry_commands.py
+++ b/tests/unit/test_telemetry_commands.py
@@ -274,7 +274,6 @@ class TestEmitCommandInvokedEnabled:
     @pytest.fixture(autouse=True)
     def enable_telemetry(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
-        monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
         monkeypatch.delenv("DO_NOT_TRACK", raising=False)
 
     def _run(self, **kwargs):  # type: ignore[no-untyped-def]

--- a/tests/unit/test_tenant_from_host.py
+++ b/tests/unit/test_tenant_from_host.py
@@ -157,10 +157,8 @@ async def test_resolver_feeds_tenant_to_telemetry(
         "IngestionEndpoint=https://localhost/",
     )
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
-    monkeypatch.delenv("FABRIC_TELEMETRY", raising=False)
-    monkeypatch.delenv("FABRIC_DISABLE_TELEMETRY", raising=False)
-    monkeypatch.delenv("CI", raising=False)
-    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+    monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
+    monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
     monkeypatch.setattr(tel, "_tenant_id_override", None)
     # Reset the warm in-memory cache sentinel so XDG redirection takes full effect.
     monkeypatch.setattr(tel, "_tenant_id_cache", tel._UNSET)
@@ -224,10 +222,8 @@ async def test_resolver_does_not_override_token_tenant(
     tel = _live_tel()
 
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
-    monkeypatch.delenv("FABRIC_TELEMETRY", raising=False)
-    monkeypatch.delenv("FABRIC_DISABLE_TELEMETRY", raising=False)
-    monkeypatch.delenv("CI", raising=False)
-    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+    monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
+    monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
     # Baseline: reset override first, then set it to the simulated token value.
     monkeypatch.setattr(tel, "_tenant_id_override", None)
     monkeypatch.setattr(tel, "_tenant_id_cache", tel._UNSET)

--- a/tests/unit/test_tenant_from_host.py
+++ b/tests/unit/test_tenant_from_host.py
@@ -151,13 +151,7 @@ async def test_resolver_feeds_tenant_to_telemetry(
     tel = _live_tel()
 
     # Safe telemetry setup: dummy instrumentation key, isolated XDG dir, reset override
-    monkeypatch.setenv(
-        "FABRIC_TELEMETRY_CONNECTION_STRING",
-        "InstrumentationKey=00000000-0000-0000-0000-000000000000;"
-        "IngestionEndpoint=https://localhost/",
-    )
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
-    monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
     monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
     monkeypatch.setattr(tel, "_tenant_id_override", None)
     # Reset the warm in-memory cache sentinel so XDG redirection takes full effect.
@@ -222,7 +216,6 @@ async def test_resolver_does_not_override_token_tenant(
     tel = _live_tel()
 
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
-    monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
     monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
     # Baseline: reset override first, then set it to the simulated token value.
     monkeypatch.setattr(tel, "_tenant_id_override", None)


### PR DESCRIPTION
## Summary

- Replaces `FABRIC_DISABLE_TELEMETRY`, `FABRIC_TELEMETRY`, and CI auto-detection with a single `FABRIC_DW_TELEMETRY_OPT_OUT` env var; "truthy" is defined once as set and not in `{"", "0", "false", "no", "off"}` (case-insensitive) and applied to both `FABRIC_DW_TELEMETRY_OPT_OUT` and `DO_NOT_TRACK`
- Removes `_is_ci()` / `_CI_VARS` from `telemetry.py`; telemetry is no longer suppressed in CI environments automatically
- Cleans up `docs/telemetry.md`: removes CI-detection row, consolidates env-var rows, rewrites `tenant_id` description to reflect actual multi-source resolution (#652/#654), removes `appi-fabric-dw-mcp-cli` resource name, drops redundant "only emitted when telemetry is enabled" phrasing
- Updates all tests, conftest, README, and integration smoke test to use the new opt-out variable
- Fixes `_detect_install_method` docstring: step 5 returns `"source"` (not `"unknown"`)

## Test plan

- [x] `uv run pytest tests/unit/` — 4198 passed
- [x] `uv run ruff check src/ tests/` — no issues
- [x] `uv run ruff format --check src/ tests/` — all formatted
- [x] `uv run ty check src tests` — all checks passed
- [x] No remaining references to `FABRIC_DISABLE_TELEMETRY`, `FABRIC_TELEMETRY` (disable usage), `_is_ci`, or CI-suppression in the codebase

Closes #660

🤖 Generated with [Claude Code](https://claude.com/claude-code)