### PR TITLE
feat(cli): add --version flag to print the installed version

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -30,6 +30,7 @@ These options are placed immediately after `fabric-dw` (or `fdw`), before the co
 
 | Flag | Description | Default |
 | --- | --- | --- |
+| `-V` / `--version` | Print the installed `fabric-dw` version and exit. | — |
 | `-w` / `--workspace TEXT` | Target workspace (name or GUID). Overrides the `FABRIC_DW_DEFAULT_WORKSPACE` environment variable and the configured default. See [Selecting a workspace](#selecting-a-workspace). | — |
 | `--json` | Emit machine-readable JSON instead of Rich tables. | off |
 | `--auth {default\|sp\|interactive}` | Override `FABRIC_AUTH` for this invocation. | `default` |

--- a/src/fabric_dw/cli/_main.py
+++ b/src/fabric_dw/cli/_main.py
@@ -11,6 +11,7 @@ from typing import Any
 
 import click
 
+from fabric_dw import __version__
 from fabric_dw.auth import CredentialMode
 from fabric_dw.cli._context import CliContext
 from fabric_dw.logging import setup_logging
@@ -483,6 +484,13 @@ class _LazyGroup(_InstrumentedGroup):
     invoke_without_command=False,
     cls=_LazyGroup,
     context_settings={"help_option_names": ["-h", "--help"], "max_content_width": _HELP_MAX_WIDTH},
+)
+@click.version_option(
+    __version__,
+    "-V",
+    "--version",
+    prog_name="fabric-dw",
+    message="%(prog)s %(version)s",
 )
 @click.option(
     "--json",

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -14,6 +14,7 @@ import fabric_dw
 import fabric_dw.cli as _cli_pkg
 import fabric_dw.cli._main as _main_mod
 import fabric_dw.telemetry as _tel
+import fabric_dw.telemetry as _telemetry_mod
 from fabric_dw.cli._context import CliContext
 from fabric_dw.cli._main import cli
 
@@ -55,6 +56,12 @@ class TestCliHelp:
         runner = CliRunner()
         result = runner.invoke(cli, ["--help"])
         assert "--workspace" in result.output or "-w" in result.output
+
+    def test_no_args_shows_help_or_usage(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, [])
+        # With invoke_without_command=False, missing subcommand should show usage
+        assert result.exit_code != 0 or "Usage" in result.output or "cache" in result.output
 
 
 class TestCliWorkspaceOption:
@@ -103,25 +110,13 @@ class TestCliUnknownCommand:
 
 
 class TestCliVersion:
-    """--version / -V flag: output, exit code, and telemetry suppression."""
-
-    def test_no_args_shows_help_or_usage(self) -> None:
-        runner = CliRunner()
-        result = runner.invoke(cli, [])
-        # With invoke_without_command=False, missing subcommand should show usage
-        assert result.exit_code != 0 or "Usage" in result.output or "cache" in result.output
+    """--version / -V flag: output format, exit code, and telemetry short-circuit."""
 
     def test_version_flag_exits_zero(self) -> None:
         """--version must exit 0."""
         runner = CliRunner()
         result = runner.invoke(cli, ["--version"])
         assert result.exit_code == 0
-
-    def test_version_flag_prints_version(self) -> None:
-        """--version output must contain the version from fabric_dw.__version__."""
-        runner = CliRunner()
-        result = runner.invoke(cli, ["--version"])
-        assert fabric_dw.__version__ in result.output
 
     def test_version_flag_output_format(self) -> None:
         """--version output must be in the form 'fabric-dw <version>'."""
@@ -135,32 +130,64 @@ class TestCliVersion:
         result = runner.invoke(cli, ["-V"])
         assert result.exit_code == 0
 
-    def test_short_version_flag_prints_version(self) -> None:
-        """-V must print the same output as --version."""
+    def test_short_version_flag_output_format(self) -> None:
+        """-V output must match --version: 'fabric-dw <version>'."""
         runner = CliRunner()
         result = runner.invoke(cli, ["-V"])
-        assert fabric_dw.__version__ in result.output
+        assert result.output.strip() == f"fabric-dw {fabric_dw.__version__}"
 
-    def test_version_flag_works_without_subcommand(self) -> None:
-        """--version must work without providing any subcommand."""
-        runner = CliRunner()
-        # No subcommand — eager option must short-circuit before the group body.
-        result = runner.invoke(cli, ["--version"])
-        assert result.exit_code == 0
+    def test_version_flag_emits_no_telemetry(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """--version must short-circuit before any telemetry path is entered.
 
-    def test_version_flag_emits_no_telemetry(self) -> None:
-        """--version must not trigger any telemetry (app_started, command_invoked, app_exited)."""
+        The autouse ``_disable_telemetry_globally`` fixture sets
+        ``FABRIC_DISABLE_TELEMETRY=1`` for every test in this file, which means
+        telemetry calls are silently skipped at the ``telemetry_enabled()`` guard
+        before they reach ``record_app_started`` / ``_InstrumentedGroup.invoke``.
+        That makes a plain ``assert_not_called()`` check vacuous — it would pass
+        even if the eager ``--version`` option were removed.
+
+        To make the assertion meaningful, this test *enables* telemetry for its
+        own scope (by removing all opt-out env vars) and mocks
+        ``configure_azure_monitor`` so no real SDK initialisation or egress can
+        occur.  It then asserts three independent invariants that can only hold
+        simultaneously when the eager option genuinely short-circuits:
+
+        1. ``_InstrumentedGroup.invoke`` was never entered.
+        2. ``record_app_started`` was never called.
+        3. ``fabric_dw.telemetry._sdk_initialised`` is still ``False`` (the SDK
+           was never initialised — no ``configure_azure_monitor`` side-effects).
+        """
+        # Enable telemetry for this test only by removing all opt-out signals.
+        monkeypatch.delenv("FABRIC_DISABLE_TELEMETRY", raising=False)
+        monkeypatch.delenv("FABRIC_TELEMETRY", raising=False)
+        monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+        # Prevent real SDK init / egress by pointing at a localhost dummy endpoint.
+        monkeypatch.setenv(
+            "FABRIC_TELEMETRY_CONNECTION_STRING",
+            "InstrumentationKey=00000000-0000-0000-0000-000000000000;"
+            "IngestionEndpoint=https://localhost/",
+        )
+        # Reset _sdk_initialised so the module is in a clean state.
+        _telemetry_mod._sdk_initialised = False  # type: ignore[attr-defined]
+
         runner = CliRunner()
         with (
+            patch("azure.monitor.opentelemetry.configure_azure_monitor") as mock_configure,
+            patch.object(
+                _main_mod._InstrumentedGroup,
+                "invoke",
+                wraps=_main_mod._InstrumentedGroup.invoke,
+            ) as mock_invoke,
             patch("fabric_dw.cli._main.record_app_started") as mock_started,
-            patch("fabric_dw.cli._main.emit_command_invoked") as mock_invoked,
-            patch("fabric_dw.cli._main.record_app_exited") as mock_exited,
         ):
             result = runner.invoke(cli, ["--version"])
+
         assert result.exit_code == 0
+        # The eager option must short-circuit before any of these are reached.
+        mock_invoke.assert_not_called()
         mock_started.assert_not_called()
-        mock_invoked.assert_not_called()
-        mock_exited.assert_not_called()
+        mock_configure.assert_not_called()
+        assert _telemetry_mod._sdk_initialised is False  # type: ignore[attr-defined]
 
     def test_version_flag_listed_in_help(self) -> None:
         """--version must appear in the root --help output."""

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 import pytest
 from click.testing import CliRunner
 
+import fabric_dw
 import fabric_dw.cli as _cli_pkg
 import fabric_dw.cli._main as _main_mod
 import fabric_dw.telemetry as _tel
@@ -102,13 +103,70 @@ class TestCliUnknownCommand:
 
 
 class TestCliVersion:
-    """CLI version option (smoke test — just checks it runs)."""
+    """--version / -V flag: output, exit code, and telemetry suppression."""
 
     def test_no_args_shows_help_or_usage(self) -> None:
         runner = CliRunner()
         result = runner.invoke(cli, [])
         # With invoke_without_command=False, missing subcommand should show usage
         assert result.exit_code != 0 or "Usage" in result.output or "cache" in result.output
+
+    def test_version_flag_exits_zero(self) -> None:
+        """--version must exit 0."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--version"])
+        assert result.exit_code == 0
+
+    def test_version_flag_prints_version(self) -> None:
+        """--version output must contain the version from fabric_dw.__version__."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--version"])
+        assert fabric_dw.__version__ in result.output
+
+    def test_version_flag_output_format(self) -> None:
+        """--version output must be in the form 'fabric-dw <version>'."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--version"])
+        assert result.output.strip() == f"fabric-dw {fabric_dw.__version__}"
+
+    def test_short_version_flag_exits_zero(self) -> None:
+        """-V must exit 0."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["-V"])
+        assert result.exit_code == 0
+
+    def test_short_version_flag_prints_version(self) -> None:
+        """-V must print the same output as --version."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["-V"])
+        assert fabric_dw.__version__ in result.output
+
+    def test_version_flag_works_without_subcommand(self) -> None:
+        """--version must work without providing any subcommand."""
+        runner = CliRunner()
+        # No subcommand — eager option must short-circuit before the group body.
+        result = runner.invoke(cli, ["--version"])
+        assert result.exit_code == 0
+
+    def test_version_flag_emits_no_telemetry(self) -> None:
+        """--version must not trigger any telemetry (app_started, command_invoked, app_exited)."""
+        runner = CliRunner()
+        with (
+            patch("fabric_dw.cli._main.record_app_started") as mock_started,
+            patch("fabric_dw.cli._main.emit_command_invoked") as mock_invoked,
+            patch("fabric_dw.cli._main.record_app_exited") as mock_exited,
+        ):
+            result = runner.invoke(cli, ["--version"])
+        assert result.exit_code == 0
+        mock_started.assert_not_called()
+        mock_invoked.assert_not_called()
+        mock_exited.assert_not_called()
+
+    def test_version_flag_listed_in_help(self) -> None:
+        """--version must appear in the root --help output."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--help"])
+        assert "--version" in result.output
 
 
 class TestCliVerboseFlag:


### PR DESCRIPTION
## Summary

- Adds an eager `-V` / `--version` option to the root `cli` group via `click.version_option`.
- Output format: `fabric-dw <version>` (single line, exit 0).
- Version is read from `fabric_dw.__version__` — never hardcoded.
- The option short-circuits before the group callback and `_InstrumentedGroup.invoke`, so no telemetry is emitted and no lazy command modules or Azure SDK imports are triggered.
- `-v` / `--verbose` is unaffected; `-V` (capital) is the version alias.
- Adds TDD tests in `tests/unit/cli/test_main.py` covering exit code, output format, both flags, no-subcommand usage, no telemetry, and appearance in `--help`.
- Adds `-V` / `--version` row to the **Global options** table in `docs/concepts.md`.

Closes #662