### PR TITLE
ci: dispatch integration tests via a dedicated workflow to stop no-op PR runs

### DIFF
--- a/.github/workflows/integration-dispatch.yml
+++ b/.github/workflows/integration-dispatch.yml
@@ -48,10 +48,12 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           REPO: ${{ github.repository }}
         run: |
           gh workflow run integration.yml \
             --repo "$REPO" \
             --ref "$PR_HEAD_REF" \
-            -f pytest_k="" \
-            -f xdist_workers="8"
+            -f pr_number="$PR_NUMBER" \
+            -f head_sha="$PR_HEAD_SHA"

--- a/.github/workflows/integration-dispatch.yml
+++ b/.github/workflows/integration-dispatch.yml
@@ -1,0 +1,57 @@
+# Lightweight dispatcher for integration tests on labeled pull requests.
+#
+# WHY THIS FILE EXISTS
+# --------------------
+# integration.yml guards a shared Fabric test capacity with a global
+# concurrency group (integration-tests, cancel-in-progress: false) that
+# serialises real runs. Before this split, integration.yml also triggered
+# on pull_request [labeled, synchronize], so every push to any open PR
+# created a no-op "Integration tests" run that still entered that concurrency
+# group — churning the queue and occasionally cancelling real runs that had
+# been waiting.
+#
+# This dispatcher is cheap: its own per-PR concurrency group is separate from
+# integration-tests, so skipped runs here never affect the real queue.  When
+# the integration label IS present, it issues a workflow_dispatch to the real
+# workflow against the PR head branch, which then enters integration-tests as
+# usual.
+#
+# NOTE: dispatcher-triggered runs appear as workflow_dispatch in the Actions
+# tab, not as PR status checks.  The integration job is not a required check,
+# so merges are unaffected.
+
+name: Integration test dispatcher
+
+on:
+  pull_request:
+    types: [labeled, synchronize]
+
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: integration-dispatch-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  dispatch:
+    # Only dispatch for labeled PRs from within this repository.
+    # Fork PRs are excluded: their head branch lives in a different repo and
+    # cannot be dispatched with GITHUB_TOKEN from this repo.
+    if: >
+      contains(github.event.pull_request.labels.*.name, 'integration') &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch integration workflow against PR head
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh workflow run integration.yml \
+            --repo "$REPO" \
+            --ref "$PR_HEAD_REF" \
+            -f pytest_k="" \
+            -f xdist_workers="8"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,5 +1,7 @@
 name: Integration tests
 
+run-name: ${{ inputs.pr_number != '' && format('Integration tests - PR {0} @ {1}', inputs.pr_number, inputs.head_sha) || 'Integration tests' }}
+
 on:
   push:
     branches: [main]
@@ -13,6 +15,14 @@ on:
         description: "Number of parallel pytest-xdist workers (1 = serial, default 8)"
         required: false
         default: "8"
+      pr_number:
+        description: "PR number this run was dispatched for (set by dispatcher; leave empty for manual runs)"
+        required: false
+        default: ""
+      head_sha:
+        description: "HEAD SHA of the PR branch at dispatch time (set by dispatcher; for identification only)"
+        required: false
+        default: ""
 
 permissions:
   id-token: write
@@ -32,6 +42,26 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
+      - name: Stale-SHA guard
+        # When this run was dispatched from a PR, check that the checked-out
+        # HEAD still matches the SHA recorded at dispatch time.  A near-
+        # simultaneous push can cause the dispatcher's cancel-in-progress to
+        # kill the newer dispatcher run while the earlier gh-workflow-run call
+        # has already been issued, queueing a run on a stale SHA.  Skipping
+        # early here avoids wasting capacity-resume time on outdated code.
+        # (The condition is skipped entirely for push/manual runs where
+        # inputs.head_sha is empty.)
+        if: ${{ inputs.head_sha != '' }}
+        env:
+          EXPECTED_SHA: ${{ inputs.head_sha }}
+        run: |
+          ACTUAL_SHA=$(git rev-parse HEAD)
+          if [[ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]]; then
+            echo "Stale run detected: dispatched for $EXPECTED_SHA but HEAD is $ACTUAL_SHA — skipping." >&2
+            exit 0
+          fi
+          echo "SHA matches ($ACTUAL_SHA) — proceeding."
 
       - uses: azure/login@v3
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -43,26 +43,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Stale-SHA guard
-        # When this run was dispatched from a PR, check that the checked-out
-        # HEAD still matches the SHA recorded at dispatch time.  A near-
-        # simultaneous push can cause the dispatcher's cancel-in-progress to
-        # kill the newer dispatcher run while the earlier gh-workflow-run call
-        # has already been issued, queueing a run on a stale SHA.  Skipping
-        # early here avoids wasting capacity-resume time on outdated code.
-        # (The condition is skipped entirely for push/manual runs where
-        # inputs.head_sha is empty.)
-        if: ${{ inputs.head_sha != '' }}
-        env:
-          EXPECTED_SHA: ${{ inputs.head_sha }}
-        run: |
-          ACTUAL_SHA=$(git rev-parse HEAD)
-          if [[ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]]; then
-            echo "Stale run detected: dispatched for $EXPECTED_SHA but HEAD is $ACTUAL_SHA — skipping." >&2
-            exit 0
-          fi
-          echo "SHA matches ($ACTUAL_SHA) — proceeding."
-
       - uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,8 +1,6 @@
 name: Integration tests
 
 on:
-  pull_request:
-    types: [labeled, synchronize]
   push:
     branches: [main]
   workflow_dispatch:
@@ -26,7 +24,7 @@ concurrency:
 
 jobs:
   integration:
-    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'integration') }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     environment: integration
     timeout-minutes: 150


### PR DESCRIPTION
## What changed

- **\`integration.yml\`**: removed the \`pull_request: types: [labeled, synchronize]\` trigger. The workflow now only fires on \`push: branches: [main]\` and \`workflow_dispatch\`. The \`integration\` job \`if:\` is simplified accordingly (the \`contains(labels, 'integration')\` clause was dead once no \`pull_request\` event can reach this workflow). Added optional \`pr_number\` and \`head_sha\` workflow_dispatch inputs and a \`run-name:\` that surfaces them for dispatcher-triggered runs (e.g. \`Integration tests - PR 123 @ abc1234\`).
- **\`.github/workflows/integration-dispatch.yml\`** (new): lightweight dispatcher that triggers on \`pull_request: types: [labeled, synchronize]\`. When the \`integration\` label is present on a non-fork PR, it issues a \`gh workflow run integration.yml\` against the PR's head branch, passing \`pr_number\` and \`head_sha\` for traceability. Uses its own per-PR concurrency group (\`integration-dispatch-<pr-number>\`) with \`cancel-in-progress: true\`, entirely separate from the \`integration-tests\` group.

## Why

Every push to any open PR was creating a no-op "Integration tests" workflow run. The run's job immediately skipped, but not before entering the global \`concurrency: group: integration-tests\` queue (which has \`cancel-in-progress: false\` to protect the shared Fabric capacity). These no-op entries churned the queue and could delay or interfere with real integration runs triggered by pushes to \`main\` or manual dispatches.

## Behaviour change

Dispatcher-triggered integration runs are \`workflow_dispatch\` events, so they appear in the Actions tab, **not** as PR status checks. The \`integration\` job is not a required check, so merges are unaffected. If PR-linked visibility is later desired, convert \`integration.yml\` to a reusable \`workflow_call\` invoked by the dispatcher instead.

## Double-dispatch edge case

Two near-simultaneous PR events (e.g. a push immediately after labeling) can cause the dispatcher's \`cancel-in-progress: true\` to kill the newer dispatcher run after the older \`gh workflow run\` call has already been issued, resulting in two integration runs queued for one PR — one of them on a potentially stale SHA. This is a low-frequency edge case. A correct guard (a \`needs\`-gated precheck job, or \`if:\` conditions on every downstream step including the \`always()\` capacity-suspend step) would add significant complexity and is intentionally left as a possible follow-up. The \`head_sha\` in the run name already makes a stale double-dispatch run diagnosable in the Actions tab.

## Validation

- actionlint clean on both files (two pre-existing SC2034 shellcheck warnings in \`integration.yml\` are unchanged).
- YAML structure verified via Python \`yaml.safe_load\`.

Closes #668