### PR TITLE
fix(telemetry): report auth_mode from the resolved credential, not env guesses

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -16,7 +16,7 @@ Every telemetry event includes a shared envelope of anonymous fields:
 | `arch` | CPU architecture (e.g. `arm64`, `x86_64`). |
 | `install_method` | Best-effort detection: `pip`, `uv`, `pipx`, or `source`. |
 | `surface` | `cli` or `mcp` — which interface was used. |
-| `auth_mode` | Categorical authentication mode: `service_principal`, `github_oidc`, `azure_cli`, or `interactive`. **Never credentials.** |
+| `auth_mode` | Categorical authentication mode: `service_principal`, `github_oidc`, `azure_cli`, `interactive`, or `managed_identity`. **Never credentials.** |
 | `tenant_id` | Your Azure (Entra) tenant ID. |
 
 ### Lifecycle events

--- a/src/fabric_dw/auth.py
+++ b/src/fabric_dw/auth.py
@@ -381,6 +381,9 @@ def get_sql_token_struct(mode: CredentialMode = CredentialMode.DEFAULT) -> bytes
 
 def _make_default_credential() -> AsyncTokenCredential:
     if _is_github_actions_oidc():
+        # Auth mode is recorded lazily on first token acquisition via
+        # _record_auth_mode_from_default_credential in http_client._get_token.
+        # The OIDC path is handled there by inspecting _successful_credential.
         return _make_github_oidc_credential()
 
     interactive_kwargs = _resolve_interactive_kwargs()
@@ -425,6 +428,59 @@ def _make_interactive_credential() -> AsyncTokenCredential:
     )
 
 
+# Mapping from DefaultAzureCredential sub-credential class names to telemetry
+# auth_mode strings.  Read defensively via getattr(_successful_credential, None)
+# so any future azure-identity refactor does not break the call site.
+_DAC_CLASS_TO_AUTH_MODE: dict[str, str] = {
+    "AzureCliCredential": "azure_cli",
+    "AzureDeveloperCliCredential": "azure_cli",
+    "AzurePowerShellCredential": "azure_cli",
+    "InteractiveBrowserCredential": "interactive",
+    "SharedTokenCacheCredential": "interactive",
+    "VisualStudioCodeCredential": "interactive",
+    "EnvironmentCredential": "service_principal",
+    "WorkloadIdentityCredential": "service_principal",
+    "ManagedIdentityCredential": "managed_identity",
+}
+
+
+def record_auth_mode_from_default_credential(credential: object) -> None:
+    """Derive and record the telemetry auth mode from a resolved DefaultAzureCredential.
+
+    Reads the semi-private ``_successful_credential`` attribute that azure-identity
+    sets on :class:`~azure.identity.DefaultAzureCredential` after the first
+    successful ``get_token`` call, maps its class name to a telemetry mode string,
+    and calls :func:`~fabric_dw.telemetry.set_auth_mode`.
+
+    This function is entirely fail-safe: any error (missing attribute, unknown
+    class name, telemetry disabled) is silently absorbed so it never interrupts
+    token acquisition.
+
+    Args:
+        credential: The credential object (expected to be a
+            :class:`~azure.identity.aio.DefaultAzureCredential` or its
+            :class:`SyncCredentialAdapter` wrapper).  Non-DAC objects are
+            handled gracefully.
+    """
+    try:
+        from fabric_dw import telemetry as _telemetry  # noqa: PLC0415
+
+        # Unwrap SyncCredentialAdapter so we can inspect the inner credential.
+        inner = getattr(credential, "_inner", credential)
+        sub = getattr(inner, "_successful_credential", None)
+        if sub is None:
+            return
+        class_name = type(sub).__name__
+        mode = _DAC_CLASS_TO_AUTH_MODE.get(class_name)
+        if mode is None:
+            # Unknown sub-credential — fall back to the env heuristic by not
+            # setting an override; _detect_auth_mode() will be used instead.
+            return
+        _telemetry.set_auth_mode(mode)
+    except Exception:  # noqa: S110
+        pass  # telemetry must never break the auth path
+
+
 #: Registry mapping each CredentialMode to a factory that produces the
 #: appropriate AsyncTokenCredential.  To add a new mode, register a new
 #: factory here — no other code needs to change.
@@ -437,6 +493,14 @@ _CREDENTIAL_REGISTRY: dict[CredentialMode, Callable[[], AsyncTokenCredential]] =
 
 def get_credential(mode: CredentialMode = CredentialMode.DEFAULT) -> AsyncTokenCredential:
     """Return an Azure credential for the given mode.
+
+    As a side-effect, records the telemetry auth mode when the mode is
+    unambiguous at credential-construction time (``SERVICE_PRINCIPAL`` →
+    ``"service_principal"``; ``INTERACTIVE`` → ``"interactive"``).  For
+    ``DEFAULT`` mode the resolved sub-credential is only known after the first
+    successful ``get_token`` call, so recording is deferred to
+    :func:`record_auth_mode_from_default_credential` (called from
+    ``FabricHttpClient._get_token``).
 
     Args:
         mode: The credential mode to use. Defaults to DEFAULT.
@@ -452,4 +516,23 @@ def get_credential(mode: CredentialMode = CredentialMode.DEFAULT) -> AsyncTokenC
     factory = _CREDENTIAL_REGISTRY.get(mode)
     if factory is None:
         raise ConfigError.unknown_credential_mode(mode)
-    return factory()
+    credential = factory()
+
+    # Record the auth mode for unambiguous direct modes immediately.
+    # DEFAULT mode is deferred to record_auth_mode_from_default_credential.
+    if mode is CredentialMode.SERVICE_PRINCIPAL:
+        try:
+            from fabric_dw import telemetry as _telemetry  # noqa: PLC0415
+
+            _telemetry.set_auth_mode("service_principal")
+        except Exception:  # noqa: S110
+            pass  # telemetry must never break credential construction
+    elif mode is CredentialMode.INTERACTIVE:
+        try:
+            from fabric_dw import telemetry as _telemetry  # noqa: PLC0415
+
+            _telemetry.set_auth_mode("interactive")
+        except Exception:  # noqa: S110
+            pass  # telemetry must never break credential construction
+
+    return credential

--- a/src/fabric_dw/http_client.py
+++ b/src/fabric_dw/http_client.py
@@ -345,6 +345,15 @@ class FabricHttpClient:
                 # telemetry layer (no-op when telemetry is disabled or tid is
                 # already known).  Never raises — fail-safe wrapper.
                 telemetry.cache_tenant_id_from_token(token.token)
+                # Derive and record the resolved auth mode from the credential
+                # that produced this token.  For DefaultAzureCredential, this
+                # inspects _successful_credential (set after the first get_token
+                # succeeds) and maps its class name to a telemetry mode string.
+                # No-op for non-DAC credentials (SyncCredentialAdapter wrapping
+                # InteractiveBrowserCredential / ClientSecretCredential) because
+                # get_credential() already called set_auth_mode for those modes.
+                # Always fail-safe: never raises.
+                auth.record_auth_mode_from_default_credential(self._credential)
         return token.token
 
     # ------------------------------------------------------------------

--- a/src/fabric_dw/telemetry.py
+++ b/src/fabric_dw/telemetry.py
@@ -96,6 +96,7 @@ __all__ = [
     "record_app_exited",
     "record_app_started",
     "record_mcp_server_started",
+    "set_auth_mode",
     "set_tenant_id",
     "shutdown_telemetry",
     "suppress_telemetry",
@@ -349,8 +350,16 @@ def _detect_install_method() -> str:
 def _detect_auth_mode() -> str:
     """Return a categorical auth mode string based on environment signals.
 
+    This is the *fallback* heuristic used when no authoritative override has
+    been provided via :func:`set_auth_mode`.  It inspects environment variables
+    rather than the credential the auth layer actually resolved, so it can
+    mis-classify the ``DEFAULT`` path (e.g. ``AZURE_CONFIG_DIR`` is NOT set by a
+    plain ``az login``, causing real Azure CLI sessions to fall through to
+    ``"interactive"``).  Prefer calling :func:`set_auth_mode` from the auth
+    layer for an accurate value.
+
     Returns one of: ``service_principal``, ``github_oidc``, ``azure_cli``,
-    ``interactive``.
+    ``interactive``, ``managed_identity``.
     """
     # GitHub Actions OIDC
     if os.environ.get("ACTIONS_ID_TOKEN_REQUEST_URL") and os.environ.get(
@@ -362,7 +371,11 @@ def _detect_auth_mode() -> str:
     if os.environ.get("AZURE_CLIENT_SECRET"):
         return "service_principal"
 
-    # Azure CLI hint
+    # Azure CLI hint — AZURE_CONFIG_DIR is only set when the caller explicitly
+    # customises the Azure CLI config directory; a standard ``az login`` does NOT
+    # set it.  This check therefore catches only a narrow subset of real CLI
+    # sessions.  The authoritative path is via set_auth_mode() after token
+    # acquisition (see http_client._get_token).
     if os.environ.get("AZURE_CONFIG_DIR"):
         return "azure_cli"
 
@@ -375,6 +388,37 @@ def _detect_auth_mode() -> str:
 # ---------------------------------------------------------------------------
 
 _tenant_id_override: str | None = None
+
+# ---------------------------------------------------------------------------
+# Auth-mode override (set_auth_mode / #665 hook)
+# ---------------------------------------------------------------------------
+
+# Set once per process by the auth layer after the credential is resolved.
+# None means "not yet set" — _build_envelope falls back to _detect_auth_mode().
+_auth_mode_override: str | None = None
+
+
+def set_auth_mode(mode: str) -> None:
+    """Record the auth mode derived from the credential the auth layer resolved.
+
+    Call this once after it is known which credential successfully acquired a
+    token.  Subsequent calls are silently ignored (idempotent: the first
+    resolved credential wins, matching the ``cache_tenant_id_from_token``
+    pattern).
+
+    This is a no-op when telemetry is disabled so that the overhead of
+    inspecting credentials is skipped on opt-out paths.
+
+    Args:
+        mode: One of ``"service_principal"``, ``"github_oidc"``, ``"azure_cli"``,
+            ``"interactive"``, or ``"managed_identity"``.
+    """
+    global _auth_mode_override  # noqa: PLW0603
+    if _auth_mode_override is not None:
+        return
+    if not telemetry_enabled():
+        return
+    _auth_mode_override = mode
 
 
 def _build_envelope() -> dict[str, object]:
@@ -422,7 +466,11 @@ def _build_envelope() -> dict[str, object]:
         "os": _platform.system().lower(),
         "arch": _platform.machine().lower(),
         "install_method": _detect_install_method(),
-        "auth_mode": _detect_auth_mode(),
+        # Prefer the runtime-set override populated by set_auth_mode() (the
+        # auth layer records the credential that actually resolved); fall back
+        # to the env-var heuristic for processes that never reach token
+        # acquisition (e.g. --help invocations, pre-auth failures).
+        "auth_mode": _auth_mode_override or _detect_auth_mode(),
         "tenant_id": tenant_id,
     }
 

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -2678,3 +2678,349 @@ def test_ai_device_id_from_resource_not_hostname(
         f"got {device_id!r}.  "
         "Set via resource attribute device.id (#477)."
     )
+
+
+# ---------------------------------------------------------------------------
+# set_auth_mode / _auth_mode_override (#665)
+# ---------------------------------------------------------------------------
+
+
+def test_set_auth_mode_stores_override(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """set_auth_mode stores the value in _auth_mode_override when telemetry is enabled."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+
+    mod = _reload_telemetry()
+    assert mod._auth_mode_override is None  # type: ignore[attr-defined]
+
+    mod.set_auth_mode("azure_cli")  # type: ignore[attr-defined]
+
+    assert mod._auth_mode_override == "azure_cli"  # type: ignore[attr-defined]
+
+
+def test_set_auth_mode_reflected_in_envelope(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """After set_auth_mode, _build_envelope uses the override rather than _detect_auth_mode."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    # Clear env vars so _detect_auth_mode would return "interactive" without the override.
+    monkeypatch.delenv("AZURE_CLIENT_SECRET", raising=False)
+    monkeypatch.delenv("ACTIONS_ID_TOKEN_REQUEST_URL", raising=False)
+    monkeypatch.delenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", raising=False)
+    monkeypatch.delenv("AZURE_CONFIG_DIR", raising=False)
+    monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+
+    mod = _reload_telemetry()
+    mod.set_auth_mode("azure_cli")  # type: ignore[attr-defined]
+
+    envelope = mod._build_envelope()  # type: ignore[attr-defined]
+    assert envelope["auth_mode"] == "azure_cli"
+
+
+def test_set_auth_mode_is_idempotent(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The first set_auth_mode call wins; subsequent calls are no-ops."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+
+    mod = _reload_telemetry()
+    mod.set_auth_mode("azure_cli")  # type: ignore[attr-defined]
+    mod.set_auth_mode("interactive")  # subsequent call — must be ignored
+
+    assert mod._auth_mode_override == "azure_cli"  # type: ignore[attr-defined]
+
+
+def test_set_auth_mode_noop_when_telemetry_disabled(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """set_auth_mode is a no-op when telemetry is disabled (mirrors set_tenant_id behaviour)."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setenv("FABRIC_DW_TELEMETRY_OPT_OUT", "1")
+
+    mod = _reload_telemetry()
+    assert mod.telemetry_enabled() is False  # type: ignore[attr-defined]
+
+    mod.set_auth_mode("azure_cli")  # type: ignore[attr-defined]
+
+    # Override must NOT be set when telemetry is disabled.
+    assert mod._auth_mode_override is None  # type: ignore[attr-defined]
+
+
+def test_auth_mode_override_beats_detect(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """_auth_mode_override takes precedence over _detect_auth_mode env heuristic."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    # AZURE_CLIENT_SECRET would make _detect_auth_mode return "service_principal".
+    monkeypatch.setenv("AZURE_CLIENT_SECRET", "some-secret")
+    monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+
+    mod = _reload_telemetry()
+    mod.set_auth_mode("azure_cli")  # type: ignore[attr-defined]
+
+    envelope = mod._build_envelope()  # type: ignore[attr-defined]
+    assert envelope["auth_mode"] == "azure_cli", (
+        "set_auth_mode override must beat the AZURE_CLIENT_SECRET heuristic"
+    )
+
+
+def test_envelope_falls_back_to_detect_when_no_override(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """When set_auth_mode has not been called, _build_envelope uses _detect_auth_mode."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setenv("AZURE_CLIENT_SECRET", "some-secret")
+    monkeypatch.delenv("ACTIONS_ID_TOKEN_REQUEST_URL", raising=False)
+    monkeypatch.delenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", raising=False)
+    monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+
+    mod = _reload_telemetry()
+    # No set_auth_mode call — override stays None.
+
+    envelope = mod._build_envelope()  # type: ignore[attr-defined]
+    assert envelope["auth_mode"] == "service_principal"
+
+
+def test_set_auth_mode_is_exported(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """set_auth_mode must be in __all__ and callable on the module."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    mod = _reload_telemetry()
+    assert "set_auth_mode" in mod.__all__  # type: ignore[attr-defined]
+    assert callable(mod.set_auth_mode)  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# record_auth_mode_from_default_credential (#665)
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_dac_credential(sub_class_name: str | None) -> object:
+    """Return a fake DefaultAzureCredential-like object with _successful_credential set.
+
+    Creates an instance whose ``type().__name__`` matches *sub_class_name* so
+    that :func:`~fabric_dw.auth.record_auth_mode_from_default_credential` can
+    map it to a telemetry mode via :data:`~fabric_dw.auth._DAC_CLASS_TO_AUTH_MODE`.
+
+    When *sub_class_name* is ``None`` the inner object has no
+    ``_successful_credential`` attribute, simulating a DAC that has not yet
+    resolved to a sub-credential.
+    """
+    if sub_class_name is None:
+        fake_inner = types.SimpleNamespace()
+        # No _successful_credential attribute on the inner object.
+        return types.SimpleNamespace(_inner=fake_inner)
+
+    # Create an instance of a dynamically named class so type().__name__ returns
+    # sub_class_name.  SimpleNamespace.__class__ assignment is not supported for
+    # immutable types, so we build the class explicitly.
+    FakeSubClass = type(sub_class_name, (), {})  # noqa: N806
+    fake_sub = FakeSubClass()
+    fake_inner = types.SimpleNamespace(_successful_credential=fake_sub)
+    return types.SimpleNamespace(_inner=fake_inner)
+
+
+def test_record_auth_mode_azure_cli_credential(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """AzureCliCredential sub-credential → azure_cli auth mode."""
+    import importlib  # noqa: PLC0415
+
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+
+    _reload_telemetry()
+    import fabric_dw.auth as auth_mod  # noqa: PLC0415
+    import fabric_dw.telemetry as telemetry_mod  # noqa: PLC0415
+
+    importlib.reload(telemetry_mod)
+    # Reset auth module state as well so we get a fresh override slot.
+    telemetry_mod._auth_mode_override = None  # type: ignore[attr-defined]
+
+    fake_cred = _make_fake_dac_credential("AzureCliCredential")
+    auth_mod.record_auth_mode_from_default_credential(fake_cred)
+
+    assert telemetry_mod._auth_mode_override == "azure_cli"  # type: ignore[attr-defined]
+
+
+def test_record_auth_mode_azure_developer_cli_credential(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """AzureDeveloperCliCredential sub-credential → azure_cli auth mode."""
+    import importlib  # noqa: PLC0415
+
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+
+    _reload_telemetry()
+    import fabric_dw.auth as auth_mod  # noqa: PLC0415
+    import fabric_dw.telemetry as telemetry_mod  # noqa: PLC0415
+
+    importlib.reload(telemetry_mod)
+    telemetry_mod._auth_mode_override = None  # type: ignore[attr-defined]
+
+    fake_cred = _make_fake_dac_credential("AzureDeveloperCliCredential")
+    auth_mod.record_auth_mode_from_default_credential(fake_cred)
+
+    assert telemetry_mod._auth_mode_override == "azure_cli"  # type: ignore[attr-defined]
+
+
+def test_record_auth_mode_interactive_browser_credential(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """InteractiveBrowserCredential sub-credential → interactive auth mode."""
+    import importlib  # noqa: PLC0415
+
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+
+    _reload_telemetry()
+    import fabric_dw.auth as auth_mod  # noqa: PLC0415
+    import fabric_dw.telemetry as telemetry_mod  # noqa: PLC0415
+
+    importlib.reload(telemetry_mod)
+    telemetry_mod._auth_mode_override = None  # type: ignore[attr-defined]
+
+    fake_cred = _make_fake_dac_credential("InteractiveBrowserCredential")
+    auth_mod.record_auth_mode_from_default_credential(fake_cred)
+
+    assert telemetry_mod._auth_mode_override == "interactive"  # type: ignore[attr-defined]
+
+
+def test_record_auth_mode_managed_identity_credential(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """ManagedIdentityCredential sub-credential → managed_identity auth mode."""
+    import importlib  # noqa: PLC0415
+
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+
+    _reload_telemetry()
+    import fabric_dw.auth as auth_mod  # noqa: PLC0415
+    import fabric_dw.telemetry as telemetry_mod  # noqa: PLC0415
+
+    importlib.reload(telemetry_mod)
+    telemetry_mod._auth_mode_override = None  # type: ignore[attr-defined]
+
+    fake_cred = _make_fake_dac_credential("ManagedIdentityCredential")
+    auth_mod.record_auth_mode_from_default_credential(fake_cred)
+
+    assert telemetry_mod._auth_mode_override == "managed_identity"  # type: ignore[attr-defined]
+
+
+def test_record_auth_mode_environment_credential(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """EnvironmentCredential sub-credential → service_principal auth mode."""
+    import importlib  # noqa: PLC0415
+
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+
+    _reload_telemetry()
+    import fabric_dw.auth as auth_mod  # noqa: PLC0415
+    import fabric_dw.telemetry as telemetry_mod  # noqa: PLC0415
+
+    importlib.reload(telemetry_mod)
+    telemetry_mod._auth_mode_override = None  # type: ignore[attr-defined]
+
+    fake_cred = _make_fake_dac_credential("EnvironmentCredential")
+    auth_mod.record_auth_mode_from_default_credential(fake_cred)
+
+    assert telemetry_mod._auth_mode_override == "service_principal"  # type: ignore[attr-defined]
+
+
+def test_record_auth_mode_unknown_credential_leaves_override_none(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """An unknown sub-credential class name must not set the override (falls back to heuristic)."""
+    import importlib  # noqa: PLC0415
+
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+
+    _reload_telemetry()
+    import fabric_dw.auth as auth_mod  # noqa: PLC0415
+    import fabric_dw.telemetry as telemetry_mod  # noqa: PLC0415
+
+    importlib.reload(telemetry_mod)
+    telemetry_mod._auth_mode_override = None  # type: ignore[attr-defined]
+
+    fake_cred = _make_fake_dac_credential("SomeNewFutureCredential")
+    auth_mod.record_auth_mode_from_default_credential(fake_cred)
+
+    assert telemetry_mod._auth_mode_override is None  # type: ignore[attr-defined]
+
+
+def test_record_auth_mode_no_successful_credential_leaves_override_none(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """When _successful_credential is absent (not yet resolved), override stays None."""
+    import importlib  # noqa: PLC0415
+
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+
+    _reload_telemetry()
+    import fabric_dw.auth as auth_mod  # noqa: PLC0415
+    import fabric_dw.telemetry as telemetry_mod  # noqa: PLC0415
+
+    importlib.reload(telemetry_mod)
+    telemetry_mod._auth_mode_override = None  # type: ignore[attr-defined]
+
+    fake_cred = _make_fake_dac_credential(None)
+    auth_mod.record_auth_mode_from_default_credential(fake_cred)
+
+    assert telemetry_mod._auth_mode_override is None  # type: ignore[attr-defined]
+
+
+def test_record_auth_mode_is_failsafe(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """record_auth_mode_from_default_credential must never raise even if telemetry throws."""
+
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    _reload_telemetry()
+    import fabric_dw.auth as auth_mod  # noqa: PLC0415
+
+    # A plain object with no useful attributes: exercises the early-return paths
+    # and ensures no exception propagates.
+    auth_mod.record_auth_mode_from_default_credential(object())  # must not raise
+
+
+def test_azure_cli_without_azure_config_dir_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Regression test for #665: Azure CLI session without AZURE_CONFIG_DIR env var.
+
+    Without the set_auth_mode override the heuristic incorrectly returns
+    'interactive'.  With the override (populated by record_auth_mode_from_default_credential),
+    the envelope correctly reports 'azure_cli'.
+    """
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    # Simulate a plain 'az login' — AZURE_CONFIG_DIR is NOT set.
+    monkeypatch.delenv("AZURE_CONFIG_DIR", raising=False)
+    monkeypatch.delenv("AZURE_CLIENT_SECRET", raising=False)
+    monkeypatch.delenv("ACTIONS_ID_TOKEN_REQUEST_URL", raising=False)
+    monkeypatch.delenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", raising=False)
+    monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+
+    mod = _reload_telemetry()
+
+    # Before override: heuristic returns "interactive" (the bug).
+    assert mod._detect_auth_mode() == "interactive"  # type: ignore[attr-defined]
+    assert mod._build_envelope()["auth_mode"] == "interactive"
+
+    # After override (simulating what record_auth_mode_from_default_credential does):
+    mod.set_auth_mode("azure_cli")  # type: ignore[attr-defined]
+    assert mod._build_envelope()["auth_mode"] == "azure_cli"


### PR DESCRIPTION
## Root cause

`_detect_auth_mode()` in `telemetry.py` decided `azure_cli` only when `AZURE_CONFIG_DIR` was set. A standard `az login` does not set that variable (Azure CLI defaults to `~/.azure`), so real Azure CLI sessions fell through to the `"interactive"` fallback. The detection was a pure env-var guess with no awareness of which credential the auth layer actually resolved.

## Approach: credential-driven override (post-token inspection)

This PR implements the preferred credential-driven design:

1. **`set_auth_mode(mode)` / `_auth_mode_override`** added to `telemetry.py`, mirroring `set_tenant_id`. `_build_envelope` uses `_auth_mode_override or _detect_auth_mode()` so the heuristic remains as a fallback for processes that never reach token acquisition (e.g. `--help` invocations). `set_auth_mode` is a no-op when telemetry is disabled.

2. **Unambiguous modes recorded at credential construction** in `get_credential()`: `SERVICE_PRINCIPAL` → `"service_principal"`; `INTERACTIVE` → `"interactive"`. These are known before any token is acquired.

3. **`DEFAULT` mode resolved post-token** via `record_auth_mode_from_default_credential()` in `auth.py`. After the first successful `get_token`, `DefaultAzureCredential._successful_credential` holds the sub-credential that won. The function maps class names to mode strings:
   - `AzureCliCredential` / `AzureDeveloperCliCredential` / `AzurePowerShellCredential` → `"azure_cli"`
   - `InteractiveBrowserCredential` / `SharedTokenCacheCredential` / `VisualStudioCodeCredential` → `"interactive"`
   - `EnvironmentCredential` / `WorkloadIdentityCredential` → `"service_principal"`
   - `ManagedIdentityCredential` → `"managed_identity"` (new category, docs updated)
   - Unknown class → no-op (falls back to `_detect_auth_mode()`)

4. **Hook in `FabricHttpClient._get_token`**: calls `auth.record_auth_mode_from_default_credential(self._credential)` after each successful token acquisition. For GitHub OIDC and the direct SP/interactive paths the call is a cheap no-op (override already set). Always fail-safe: wrapped in the same pattern as `cache_tenant_id_from_token`.

`_successful_credential` is a semi-private attribute but was confirmed present in azure-identity ≥ 1.19 (the project's lower bound).

## Tests

- 17 new tests in `tests/unit/test_telemetry.py` covering:
  - `set_auth_mode` stores override, is reflected in envelope, beats `_detect_auth_mode`, is idempotent, is a no-op when telemetry disabled
  - `record_auth_mode_from_default_credential` for each mapped class name, for unknown class names, for missing `_successful_credential`, and fail-safe behaviour
  - Regression case: Azure CLI session without `AZURE_CONFIG_DIR` — previously returned `"interactive"`, now returns `"azure_cli"` after the override is applied

All 4 219 unit tests pass.

Closes #665