### PR TITLE
test(integration): give sql-exec smoke test timeout headroom over the connect-retry budget

### DIFF
--- a/tests/integration/test_cli_smoke.py
+++ b/tests/integration/test_cli_smoke.py
@@ -32,6 +32,7 @@ telemetry init → flush → shutdown path is exercised for every command.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import shutil
@@ -42,7 +43,25 @@ from pathlib import Path
 import pytest
 import pytest_asyncio
 
+from fabric_dw.sql import _CONNECT_RETRY_TIMEOUT_S
+
 from .conftest import SharedWarehouseTarget
+
+# ---------------------------------------------------------------------------
+# Subprocess timeout budget for SQL-touching smoke tests.
+#
+# INVARIANT: this value MUST be strictly greater than _CONNECT_RETRY_TIMEOUT_S
+# (the CLI's internal connect-retry budget) plus a generous margin for process
+# startup, authentication, and query execution overhead.  If the two values are
+# equal the subprocess is killed exactly when the CLI's retry loop gives up,
+# leaving zero headroom for the startup/auth/query overhead that is paid on top
+# of the retry budget.
+#
+# A dedicated unit test in tests/unit/ guards this invariant at import time so
+# that it cannot silently drift back to an unsafe value.
+# ---------------------------------------------------------------------------
+_SQL_STARTUP_MARGIN_S: int = 120
+_SQL_SMOKE_SUBPROCESS_TIMEOUT_S: int = int(_CONNECT_RETRY_TIMEOUT_S) + _SQL_STARTUP_MARGIN_S
 
 pytestmark = pytest.mark.integration
 
@@ -169,6 +188,43 @@ async def _cli_smoke_sql_env(shared_warehouse: SharedWarehouseTarget) -> dict[st
         "FABRIC_DW_DEFAULT_WORKSPACE": str(shared_warehouse.workspace_id),
         "FABRIC_DW_DEFAULT_WAREHOUSE": shared_warehouse.warehouse.name,
     }
+
+
+# ---------------------------------------------------------------------------
+# Session-scoped SQL cold-start warmup.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _cli_smoke_sql_warmup(
+    _cli_smoke_sql_env: dict[str, str],
+    _require_binary: None,  # ensure binary is present before we try
+) -> None:
+    """Absorb the SQL cold-start cost once per test session.
+
+    On a cold Fabric capacity the first ``sql exec`` can consume most of the
+    CLI's internal connect-retry budget (_CONNECT_RETRY_TIMEOUT_S = 120 s)
+    before the warehouse becomes reachable.  Running one tolerant warmup call
+    here — with the same generous timeout used by the SQL smoke tests
+    (_SQL_SMOKE_SUBPROCESS_TIMEOUT_S) — ensures that by the time
+    ``test_sql_exec_select1_clean_stderr`` runs the endpoint is already warm.
+
+    A timeout or non-zero exit code is silently swallowed: the warmup is a
+    best-effort probe, not a pass/fail assertion.  If the endpoint truly is
+    unreachable the subsequent per-test assertion will surface the real failure.
+    """
+    if _FABRIC_DW_BIN is None:
+        return  # _require_binary will have skipped tests; nothing to warm
+    child_env = _child_env(_cli_smoke_sql_env)
+    with contextlib.suppress(subprocess.TimeoutExpired):
+        subprocess.run(  # noqa: S603
+            [_FABRIC_DW_BIN, "sql", "exec", "-q", "SELECT 1 AS n"],
+            capture_output=True,
+            text=True,
+            env=child_env,
+            timeout=_SQL_SMOKE_SUBPROCESS_TIMEOUT_S,
+            check=False,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -312,9 +368,17 @@ def test_sql_exec_select1_clean_stderr(
     value (a plain ``dict[str, str]``) is injected here synchronously by
     pytest-asyncio under ``asyncio_mode = "auto"``.  No async machinery is needed
     inside this test function itself.
+
+    The subprocess timeout is _SQL_SMOKE_SUBPROCESS_TIMEOUT_S, which is derived
+    from _CONNECT_RETRY_TIMEOUT_S + a generous margin for startup/auth/query
+    overhead.  See the module-level constant and the unit guard test for details.
+    The session-scoped _cli_smoke_sql_warmup fixture absorbs most of the cold-
+    start cost before this assertion runs.
     """
     child_env = _child_env(_cli_smoke_sql_env)
-    result = _run("sql", "exec", "-q", "SELECT 1 AS n", env=child_env)
+    result = _run(
+        "sql", "exec", "-q", "SELECT 1 AS n", env=child_env, timeout=_SQL_SMOKE_SUBPROCESS_TIMEOUT_S
+    )
     assert result.returncode == 0, (
         f"sql exec exited {result.returncode}; stderr:\n{result.stderr}\nstdout:\n{result.stdout}"
     )

--- a/tests/integration/test_cli_smoke.py
+++ b/tests/integration/test_cli_smoke.py
@@ -32,8 +32,9 @@ telemetry init → flush → shutdown path is exercised for every command.
 
 from __future__ import annotations
 
-import contextlib
 import json
+import logging
+import math
 import os
 import shutil
 import subprocess
@@ -46,6 +47,8 @@ import pytest_asyncio
 from fabric_dw.sql import _CONNECT_RETRY_TIMEOUT_S
 
 from .conftest import SharedWarehouseTarget
+
+_logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Subprocess timeout budget for SQL-touching smoke tests.
@@ -61,7 +64,7 @@ from .conftest import SharedWarehouseTarget
 # that it cannot silently drift back to an unsafe value.
 # ---------------------------------------------------------------------------
 _SQL_STARTUP_MARGIN_S: int = 120
-_SQL_SMOKE_SUBPROCESS_TIMEOUT_S: int = int(_CONNECT_RETRY_TIMEOUT_S) + _SQL_STARTUP_MARGIN_S
+_SQL_SMOKE_SUBPROCESS_TIMEOUT_S: int = math.ceil(_CONNECT_RETRY_TIMEOUT_S) + _SQL_STARTUP_MARGIN_S
 
 pytestmark = pytest.mark.integration
 
@@ -195,10 +198,9 @@ async def _cli_smoke_sql_env(shared_warehouse: SharedWarehouseTarget) -> dict[st
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture(scope="session", autouse=True)
+@pytest.fixture(scope="session")
 def _cli_smoke_sql_warmup(
     _cli_smoke_sql_env: dict[str, str],
-    _require_binary: None,  # ensure binary is present before we try
 ) -> None:
     """Absorb the SQL cold-start cost once per test session.
 
@@ -209,14 +211,20 @@ def _cli_smoke_sql_warmup(
     (_SQL_SMOKE_SUBPROCESS_TIMEOUT_S) — ensures that by the time
     ``test_sql_exec_select1_clean_stderr`` runs the endpoint is already warm.
 
-    A timeout or non-zero exit code is silently swallowed: the warmup is a
-    best-effort probe, not a pass/fail assertion.  If the endpoint truly is
-    unreachable the subsequent per-test assertion will surface the real failure.
+    This fixture is NOT autouse: only SQL-touching tests request it as an
+    explicit parameter.  This prevents non-SQL smoke tests (workspaces, help)
+    from inadvertently triggering the shared_warehouse provisioning and the
+    240 s warmup call.
+
+    Any exception (TimeoutExpired, OSError/FileNotFoundError for a stale binary
+    path, or non-zero exit) is silently suppressed: the warmup is a best-effort
+    probe.  If the endpoint is genuinely unreachable the subsequent per-test
+    assertion will surface the real failure with full context.
     """
     if _FABRIC_DW_BIN is None:
-        return  # _require_binary will have skipped tests; nothing to warm
+        return  # binary guard fixture will skip the SQL tests; nothing to warm
     child_env = _child_env(_cli_smoke_sql_env)
-    with contextlib.suppress(subprocess.TimeoutExpired):
+    try:
         subprocess.run(  # noqa: S603
             [_FABRIC_DW_BIN, "sql", "exec", "-q", "SELECT 1 AS n"],
             capture_output=True,
@@ -224,6 +232,18 @@ def _cli_smoke_sql_warmup(
             env=child_env,
             timeout=_SQL_SMOKE_SUBPROCESS_TIMEOUT_S,
             check=False,
+        )
+    except subprocess.TimeoutExpired:
+        _logger.warning(
+            "SQL cold-start warmup timed out after %ds; "
+            "the per-test assertion may also fail if the endpoint is still unavailable.",
+            _SQL_SMOKE_SUBPROCESS_TIMEOUT_S,
+        )
+    except OSError:
+        # Covers FileNotFoundError (stale _FABRIC_DW_BIN) and other exec errors.
+        _logger.warning(
+            "SQL cold-start warmup could not launch the binary; "
+            "the per-test assertion will surface the real failure.",
         )
 
 
@@ -356,6 +376,7 @@ def test_workspaces_get_json_valid(
 
 def test_sql_exec_select1_clean_stderr(
     _cli_smoke_sql_env: dict[str, str],  # noqa: PT019 — value IS used in the body
+    _cli_smoke_sql_warmup: None,  # noqa: PT019 — absorbs cold-start cost before this assertion
 ) -> None:
     """``sql exec -q 'SELECT 1'`` must exit 0 with a clean stderr.
 

--- a/tests/unit/test_smoke_timeout_invariant.py
+++ b/tests/unit/test_smoke_timeout_invariant.py
@@ -48,6 +48,14 @@ def test_sql_smoke_subprocess_timeout_exceeds_connect_retry_budget() -> None:
     Without this headroom, a cold-start Fabric capacity can legitimately exhaust the
     full retry budget, and the subprocess is killed before the CLI even gets a chance
     to surface an error — resulting in a spurious TimeoutExpired failure.
+
+    NOTE: this test is NOT algebraically redundant with
+    ``test_sql_smoke_startup_margin_is_generous``.  The margin test checks the
+    *addend* (_SQL_STARTUP_MARGIN_S) in isolation; this test checks the *computed
+    sum* (_SQL_SMOKE_SUBPROCESS_TIMEOUT_S) against the *live production constant*
+    (_CONNECT_RETRY_TIMEOUT_S).  If someone changes the derivation formula (e.g.
+    switches from ``math.ceil + margin`` to ``max(…)``) the margin test alone would
+    not catch a resulting sum that still violated the invariant.  Keep both.
     """
     assert _SQL_SMOKE_SUBPROCESS_TIMEOUT_S > _CONNECT_RETRY_TIMEOUT_S, (
         f"Smoke-test subprocess timeout ({_SQL_SMOKE_SUBPROCESS_TIMEOUT_S}s) must be strictly "

--- a/tests/unit/test_smoke_timeout_invariant.py
+++ b/tests/unit/test_smoke_timeout_invariant.py
@@ -1,0 +1,69 @@
+"""Guard test: the smoke-test subprocess timeout must exceed the CLI's connect-retry budget.
+
+This test is intentionally placed in the unit suite so it runs on every ``pytest
+tests/unit`` invocation without needing live Fabric credentials.  It imports the
+real constants from both the production module and the integration smoke module and
+asserts the relationship that prevents flaky cold-start timeouts.
+
+Background
+----------
+The CLI's internal connect-retry loop runs for up to ``_CONNECT_RETRY_TIMEOUT_S``
+seconds before surfacing a connection error.  The integration smoke test wraps the
+CLI in a subprocess with its own wall-clock timeout.  If that subprocess timeout is
+less than or equal to ``_CONNECT_RETRY_TIMEOUT_S`` the subprocess gets killed exactly
+when the retry loop gives up — leaving zero room for process startup, authentication,
+and query execution overhead that is paid *on top of* the retry budget.  The result
+is a flaky ``TimeoutExpired`` failure on cold Fabric capacities.
+
+The required invariant is::
+
+    _SQL_SMOKE_SUBPROCESS_TIMEOUT_S > _CONNECT_RETRY_TIMEOUT_S + minimum_margin
+
+where ``minimum_margin`` is at least 60 s to cover real-world startup/auth costs.
+"""
+
+from __future__ import annotations
+
+from fabric_dw.sql import _CONNECT_RETRY_TIMEOUT_S
+
+# Import the actual constants used by the smoke test module so any future edits
+# to either side of the invariant are immediately caught by this test.
+from tests.integration.test_cli_smoke import (
+    _SQL_SMOKE_SUBPROCESS_TIMEOUT_S,
+    _SQL_STARTUP_MARGIN_S,
+)
+
+# Minimum acceptable margin above the connect-retry budget.
+# This is a separate floor so the test catches someone accidentally halving the
+# margin constant (e.g. changing it from 120 to 10) even if the sum still exceeds
+# _CONNECT_RETRY_TIMEOUT_S by a small amount.
+_MINIMUM_MARGIN_S: int = 60
+
+
+def test_sql_smoke_subprocess_timeout_exceeds_connect_retry_budget() -> None:
+    """The smoke-test subprocess timeout must strictly exceed the CLI's connect-retry budget.
+
+    INVARIANT: _SQL_SMOKE_SUBPROCESS_TIMEOUT_S > _CONNECT_RETRY_TIMEOUT_S
+
+    Without this headroom, a cold-start Fabric capacity can legitimately exhaust the
+    full retry budget, and the subprocess is killed before the CLI even gets a chance
+    to surface an error — resulting in a spurious TimeoutExpired failure.
+    """
+    assert _SQL_SMOKE_SUBPROCESS_TIMEOUT_S > _CONNECT_RETRY_TIMEOUT_S, (
+        f"Smoke-test subprocess timeout ({_SQL_SMOKE_SUBPROCESS_TIMEOUT_S}s) must be strictly "
+        f"greater than the CLI connect-retry budget ({_CONNECT_RETRY_TIMEOUT_S}s). "
+        "Raise _SQL_STARTUP_MARGIN_S in tests/integration/test_cli_smoke.py."
+    )
+
+
+def test_sql_smoke_startup_margin_is_generous() -> None:
+    """The startup/auth/query margin added on top of the retry budget must be at least 60 s.
+
+    A margin of 0-59 s is too small to absorb real-world subprocess startup, Azure AD
+    token acquisition, and query execution overhead on a Fabric SQL endpoint.
+    """
+    assert _SQL_STARTUP_MARGIN_S >= _MINIMUM_MARGIN_S, (
+        f"_SQL_STARTUP_MARGIN_S ({_SQL_STARTUP_MARGIN_S}s) is too small; "
+        f"must be >= {_MINIMUM_MARGIN_S}s to provide meaningful cold-start headroom. "
+        "Update _SQL_STARTUP_MARGIN_S in tests/integration/test_cli_smoke.py."
+    )


### PR DESCRIPTION
## Root cause

The subprocess smoke timeout (`_run(..., timeout=120)`) was **exactly equal** to the CLI's internal connect-retry budget (`_CONNECT_RETRY_TIMEOUT_S = 120.0` in `src/fabric_dw/sql.py`). On a cold Fabric capacity the first `sql exec` call can legitimately exhaust most of the 120 s retry budget; the subprocess then also pays process startup + authentication + query overhead on top, crossing its own 120 s wall and being killed with `TimeoutExpired`. Zero headroom.

## Changes

- **`tests/integration/test_cli_smoke.py`**
  - Import `_CONNECT_RETRY_TIMEOUT_S` from `fabric_dw.sql` and derive  
    `_SQL_SMOKE_SUBPROCESS_TIMEOUT_S = int(_CONNECT_RETRY_TIMEOUT_S) + _SQL_STARTUP_MARGIN_S`  
    (margin = 120 s → effective timeout = **240 s**).  The two values are linked at the source so they cannot drift independently.
  - The SQL smoke test (`test_sql_exec_select1_clean_stderr`) now passes `timeout=_SQL_SMOKE_SUBPROCESS_TIMEOUT_S`.
  - Added a session-scoped `_cli_smoke_sql_warmup` fixture (autouse) that fires one tolerant `sql exec SELECT 1` call with the same generous timeout before timing-sensitive tests run, absorbing cold-start cost once per session.
  - Added a module-level comment documenting the invariant (subprocess timeout must exceed the CLI's connect-retry budget).

- **`tests/unit/test_smoke_timeout_invariant.py`** (new)
  - Two unit tests that run without live Fabric credentials:
    1. `test_sql_smoke_subprocess_timeout_exceeds_connect_retry_budget` — asserts `_SQL_SMOKE_SUBPROCESS_TIMEOUT_S > _CONNECT_RETRY_TIMEOUT_S`.
    2. `test_sql_smoke_startup_margin_is_generous` — asserts `_SQL_STARTUP_MARGIN_S >= 60` so the margin cannot be accidentally reduced to a token value.

`src/fabric_dw/sql.py` is **not modified** — `_CONNECT_RETRY_TIMEOUT_S` and the retry loop are unchanged.

## Effective timeout

`_SQL_SMOKE_SUBPROCESS_TIMEOUT_S = 240 s` (derived as `_CONNECT_RETRY_TIMEOUT_S` 120 s + `_SQL_STARTUP_MARGIN_S` 120 s).

Closes #670