### PR TITLE
fix(telemetry): flush and shut down telemetry on MCP server exit

### DIFF
--- a/src/fabric_dw/mcp/server.py
+++ b/src/fabric_dw/mcp/server.py
@@ -65,9 +65,12 @@ from fabric_dw.mcp._helpers import InstrumentedFastMCP
 from fabric_dw.mcp.tools import register_all
 from fabric_dw.telemetry import (
     maybe_print_first_run_notice,
+    record_app_exited,
     record_app_started,
     record_mcp_server_started,
+    shutdown_telemetry,
 )
+from fabric_dw.telemetry_commands import now_ms
 
 __all__ = ["mcp", "run"]
 
@@ -175,4 +178,42 @@ def run(argv: Sequence[str] | None = None) -> None:
     maybe_print_first_run_notice()
     record_app_started("mcp")
     record_mcp_server_started()
-    mcp.run(transport=transport)
+
+    start_ms = now_ms()
+    exc_seen: BaseException | None = None
+    try:
+        mcp.run(transport=transport)
+    except BaseException as exc:
+        exc_seen = exc
+        raise
+    finally:
+        duration_ms = now_ms() - start_ms
+        # Map exit status: graceful stops (KeyboardInterrupt, SIGTERM-driven
+        # SystemExit with code 0 or None, or normal return) → "ok".
+        # Unexpected exceptions → "api_error".
+        # "user_error" is not applicable for the MCP server surface.
+        if exc_seen is None or isinstance(exc_seen, KeyboardInterrupt):
+            exit_status = "ok"
+        elif isinstance(exc_seen, SystemExit):
+            code = getattr(exc_seen, "code", None)
+            exit_status = "ok" if (code is None or code == 0) else "api_error"
+        else:
+            exit_status = "api_error"
+
+        # Emit the session-end lifecycle event then flush/shut down the provider.
+        # Telemetry teardown is fail-safe: errors here must NEVER mask the real
+        # server exit exception (exc_seen, re-raised by the except block above).
+        # shutdown_telemetry() must run even if record_app_exited() raises, so it
+        # is guarded by its own try/finally.  The outer except swallows any
+        # exception from the telemetry teardown path.
+        try:
+            try:
+                record_app_exited(
+                    duration_ms=duration_ms,
+                    exit_status=exit_status,
+                    error_category=None,
+                )
+            finally:
+                shutdown_telemetry()
+        except Exception:  # noqa: S110
+            pass  # telemetry teardown errors must never propagate

--- a/src/fabric_dw/mcp/server.py
+++ b/src/fabric_dw/mcp/server.py
@@ -215,5 +215,5 @@ def run(argv: Sequence[str] | None = None) -> None:
                 )
             finally:
                 shutdown_telemetry()
-        except Exception:  # noqa: S110
+        except BaseException:  # noqa: S110
             pass  # telemetry teardown errors must never propagate

--- a/tests/unit/mcp/test_server_telemetry.py
+++ b/tests/unit/mcp/test_server_telemetry.py
@@ -1,0 +1,334 @@
+"""Tests for telemetry shutdown behaviour in the MCP server entry point.
+
+Verifies that ``run()`` in ``fabric_dw.mcp.server``:
+- calls ``record_app_exited`` with the right ``exit_status`` on every exit path,
+- always calls ``shutdown_telemetry()`` exactly once (even when
+  ``record_app_exited`` raises), and
+- re-raises the original exception so the process exit code is correct.
+
+``mcp.run`` is mocked throughout — no real server is started.
+
+The tests need telemetry *enabled* to assert on emission, so they manage the
+``FABRIC_DW_TELEMETRY_OPT_OUT`` env var themselves and patch
+``configure_azure_monitor`` to a no-op (mirrors the pattern used by
+``test_telemetry.py``).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import fabric_dw.mcp.server as _srv
+
+# ---------------------------------------------------------------------------
+# Module-level fixtures — enable telemetry and stub the Azure SDK
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _enable_telemetry(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Enable telemetry for the duration of the test."""
+    monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+
+
+@pytest.fixture
+def _patch_azure_monitor() -> Generator[None, None, None]:
+    """Prevent any real Azure Monitor SDK calls."""
+    with patch("azure.monitor.opentelemetry.configure_azure_monitor"):
+        yield
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Captured record_app_exited call kwargs.
+_AppExitedCall = dict[str, object]
+
+
+def _run(transport: str = "stdio") -> None:
+    """Call ``fabric_dw.mcp.server.run`` with a minimal argv."""
+    _srv.run(["--transport", transport])
+
+
+# ---------------------------------------------------------------------------
+# Normal return path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("_enable_telemetry", "_patch_azure_monitor")
+def test_normal_return_emits_ok_and_shuts_down() -> None:
+    """Normal mcp.run() return → exit_status 'ok', shutdown_telemetry called once."""
+    calls: list[_AppExitedCall] = []
+    shutdown_calls: list[None] = []
+
+    def fake_record_app_exited(
+        *,
+        duration_ms: float,  # noqa: ARG001
+        exit_status: str,
+        error_category: str | None,
+    ) -> None:
+        calls.append({"exit_status": exit_status, "error_category": error_category})
+
+    def fake_shutdown(**kwargs: object) -> None:  # noqa: ARG001
+        shutdown_calls.append(None)
+
+    with (
+        patch("fabric_dw.mcp.server.mcp") as mock_mcp,
+        patch("fabric_dw.mcp.server.record_app_started"),
+        patch("fabric_dw.mcp.server.record_mcp_server_started"),
+        patch("fabric_dw.mcp.server.maybe_print_first_run_notice"),
+        patch("fabric_dw.mcp.server.record_app_exited", side_effect=fake_record_app_exited),
+        patch("fabric_dw.mcp.server.shutdown_telemetry", side_effect=fake_shutdown),
+    ):
+        mock_mcp.run.return_value = None
+        mock_mcp.settings = MagicMock()
+        _run()
+
+    # record_app_exited should be called exactly once with exit_status="ok"
+    assert len(calls) == 1
+    assert calls[0]["exit_status"] == "ok"
+
+    # shutdown_telemetry must be called exactly once
+    assert len(shutdown_calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# KeyboardInterrupt path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("_enable_telemetry", "_patch_azure_monitor")
+def test_keyboard_interrupt_emits_ok_and_shuts_down_and_reraises() -> None:
+    """KeyboardInterrupt from mcp.run → exit_status 'ok', shutdown called, re-raised."""
+    calls: list[_AppExitedCall] = []
+    shutdown_calls: list[None] = []
+
+    def fake_record_app_exited(
+        *,
+        duration_ms: float,  # noqa: ARG001
+        exit_status: str,
+        error_category: str | None,
+    ) -> None:
+        calls.append({"exit_status": exit_status, "error_category": error_category})
+
+    def fake_shutdown(**kwargs: object) -> None:  # noqa: ARG001
+        shutdown_calls.append(None)
+
+    with (
+        patch("fabric_dw.mcp.server.mcp") as mock_mcp,
+        patch("fabric_dw.mcp.server.record_app_started"),
+        patch("fabric_dw.mcp.server.record_mcp_server_started"),
+        patch("fabric_dw.mcp.server.maybe_print_first_run_notice"),
+        patch("fabric_dw.mcp.server.record_app_exited", side_effect=fake_record_app_exited),
+        patch("fabric_dw.mcp.server.shutdown_telemetry", side_effect=fake_shutdown),
+    ):
+        mock_mcp.run.side_effect = KeyboardInterrupt()
+        mock_mcp.settings = MagicMock()
+
+        with pytest.raises(KeyboardInterrupt):
+            _run()
+
+    assert len(calls) == 1
+    assert calls[0]["exit_status"] == "ok"
+
+    assert len(shutdown_calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# Unexpected exception path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("_enable_telemetry", "_patch_azure_monitor")
+def test_unexpected_exception_emits_api_error_and_shuts_down_and_reraises() -> None:
+    """Unexpected Exception from mcp.run → exit_status 'api_error', shutdown called, re-raised."""
+    calls: list[_AppExitedCall] = []
+    shutdown_calls: list[None] = []
+
+    def fake_record_app_exited(
+        *,
+        duration_ms: float,  # noqa: ARG001
+        exit_status: str,
+        error_category: str | None,
+    ) -> None:
+        calls.append({"exit_status": exit_status, "error_category": error_category})
+
+    def fake_shutdown(**kwargs: object) -> None:  # noqa: ARG001
+        shutdown_calls.append(None)
+
+    with (
+        patch("fabric_dw.mcp.server.mcp") as mock_mcp,
+        patch("fabric_dw.mcp.server.record_app_started"),
+        patch("fabric_dw.mcp.server.record_mcp_server_started"),
+        patch("fabric_dw.mcp.server.maybe_print_first_run_notice"),
+        patch("fabric_dw.mcp.server.record_app_exited", side_effect=fake_record_app_exited),
+        patch("fabric_dw.mcp.server.shutdown_telemetry", side_effect=fake_shutdown),
+    ):
+        mock_mcp.run.side_effect = RuntimeError("boom")
+        mock_mcp.settings = MagicMock()
+
+        with pytest.raises(RuntimeError, match="boom"):
+            _run()
+
+    assert len(calls) == 1
+    assert calls[0]["exit_status"] == "api_error"
+
+    assert len(shutdown_calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# SystemExit paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("code", [0, None])
+@pytest.mark.usefixtures("_enable_telemetry", "_patch_azure_monitor")
+def test_system_exit_zero_emits_ok(code: int | None) -> None:
+    """SystemExit(0) / SystemExit(None) from mcp.run → exit_status 'ok'."""
+    calls: list[_AppExitedCall] = []
+
+    def fake_record_app_exited(
+        *,
+        duration_ms: float,  # noqa: ARG001
+        exit_status: str,
+        error_category: str | None,
+    ) -> None:
+        calls.append({"exit_status": exit_status, "error_category": error_category})
+
+    with (
+        patch("fabric_dw.mcp.server.mcp") as mock_mcp,
+        patch("fabric_dw.mcp.server.record_app_started"),
+        patch("fabric_dw.mcp.server.record_mcp_server_started"),
+        patch("fabric_dw.mcp.server.maybe_print_first_run_notice"),
+        patch("fabric_dw.mcp.server.record_app_exited", side_effect=fake_record_app_exited),
+        patch("fabric_dw.mcp.server.shutdown_telemetry"),
+    ):
+        mock_mcp.run.side_effect = SystemExit(code)
+        mock_mcp.settings = MagicMock()
+
+        with pytest.raises(SystemExit):
+            _run()
+
+    assert len(calls) == 1
+    assert calls[0]["exit_status"] == "ok"
+
+
+@pytest.mark.usefixtures("_enable_telemetry", "_patch_azure_monitor")
+def test_system_exit_nonzero_emits_api_error() -> None:
+    """SystemExit(1) from mcp.run → exit_status 'api_error'."""
+    calls: list[_AppExitedCall] = []
+
+    def fake_record_app_exited(
+        *,
+        duration_ms: float,  # noqa: ARG001
+        exit_status: str,
+        error_category: str | None,
+    ) -> None:
+        calls.append({"exit_status": exit_status, "error_category": error_category})
+
+    with (
+        patch("fabric_dw.mcp.server.mcp") as mock_mcp,
+        patch("fabric_dw.mcp.server.record_app_started"),
+        patch("fabric_dw.mcp.server.record_mcp_server_started"),
+        patch("fabric_dw.mcp.server.maybe_print_first_run_notice"),
+        patch("fabric_dw.mcp.server.record_app_exited", side_effect=fake_record_app_exited),
+        patch("fabric_dw.mcp.server.shutdown_telemetry"),
+    ):
+        mock_mcp.run.side_effect = SystemExit(1)
+        mock_mcp.settings = MagicMock()
+
+        with pytest.raises(SystemExit):
+            _run()
+
+    assert len(calls) == 1
+    assert calls[0]["exit_status"] == "api_error"
+
+
+# ---------------------------------------------------------------------------
+# shutdown_telemetry always runs even when record_app_exited raises
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("_enable_telemetry", "_patch_azure_monitor")
+def test_shutdown_runs_even_if_record_app_exited_raises() -> None:
+    """shutdown_telemetry() is called exactly once even if record_app_exited raises."""
+    shutdown_calls: list[None] = []
+
+    def fake_shutdown(**kwargs: object) -> None:  # noqa: ARG001
+        shutdown_calls.append(None)
+
+    with (
+        patch("fabric_dw.mcp.server.mcp") as mock_mcp,
+        patch("fabric_dw.mcp.server.record_app_started"),
+        patch("fabric_dw.mcp.server.record_mcp_server_started"),
+        patch("fabric_dw.mcp.server.maybe_print_first_run_notice"),
+        patch(
+            "fabric_dw.mcp.server.record_app_exited",
+            side_effect=RuntimeError("telemetry failure"),
+        ),
+        patch("fabric_dw.mcp.server.shutdown_telemetry", side_effect=fake_shutdown),
+    ):
+        mock_mcp.run.return_value = None
+        mock_mcp.settings = MagicMock()
+        # The telemetry error must be swallowed; run() should not propagate it.
+        _run()
+
+    assert len(shutdown_calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# Call ordering: record_app_exited before shutdown_telemetry
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("_enable_telemetry", "_patch_azure_monitor")
+def test_call_order_record_before_shutdown() -> None:
+    """record_app_exited must be called before shutdown_telemetry."""
+    manager = MagicMock()
+    manager.attach_mock(MagicMock(), "record")
+    manager.attach_mock(MagicMock(), "shutdown")
+
+    with (
+        patch("fabric_dw.mcp.server.mcp") as mock_mcp,
+        patch("fabric_dw.mcp.server.record_app_started"),
+        patch("fabric_dw.mcp.server.record_mcp_server_started"),
+        patch("fabric_dw.mcp.server.maybe_print_first_run_notice"),
+        patch("fabric_dw.mcp.server.record_app_exited", new=manager.record),
+        patch("fabric_dw.mcp.server.shutdown_telemetry", new=manager.shutdown),
+    ):
+        mock_mcp.run.return_value = None
+        mock_mcp.settings = MagicMock()
+        _run()
+
+    call_names = [c[0] for c in manager.mock_calls]
+    assert "record" in call_names
+    assert "shutdown" in call_names
+    assert call_names.index("record") < call_names.index("shutdown")
+
+
+# ---------------------------------------------------------------------------
+# No hang: shutdown_telemetry is not called multiple times
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("_enable_telemetry", "_patch_azure_monitor")
+def test_shutdown_called_exactly_once_on_normal_return() -> None:
+    """shutdown_telemetry() is called exactly once — idempotency guard check."""
+    with (
+        patch("fabric_dw.mcp.server.mcp") as mock_mcp,
+        patch("fabric_dw.mcp.server.record_app_started"),
+        patch("fabric_dw.mcp.server.record_mcp_server_started"),
+        patch("fabric_dw.mcp.server.maybe_print_first_run_notice"),
+        patch("fabric_dw.mcp.server.record_app_exited"),
+        patch("fabric_dw.mcp.server.shutdown_telemetry") as mock_shutdown,
+    ):
+        mock_mcp.run.return_value = None
+        mock_mcp.settings = MagicMock()
+        _run()
+
+    mock_shutdown.assert_called_once()

--- a/tests/unit/mcp/test_server_telemetry.py
+++ b/tests/unit/mcp/test_server_telemetry.py
@@ -43,16 +43,41 @@ def _patch_azure_monitor() -> Generator[None, None, None]:
 
 
 # ---------------------------------------------------------------------------
-# Helpers
+# Helpers shared across tests
 # ---------------------------------------------------------------------------
 
-# Captured record_app_exited call kwargs.
+# Type alias for captured record_app_exited kwargs.
 _AppExitedCall = dict[str, object]
 
 
 def _run(transport: str = "stdio") -> None:
     """Call ``fabric_dw.mcp.server.run`` with a minimal argv."""
     _srv.run(["--transport", transport])
+
+
+def _make_record_spy(
+    calls: list[_AppExitedCall],
+) -> object:
+    """Return a ``record_app_exited`` side_effect that captures kwargs."""
+
+    def _spy(
+        *,
+        duration_ms: float,  # noqa: ARG001
+        exit_status: str,
+        error_category: str | None,
+    ) -> None:
+        calls.append({"exit_status": exit_status, "error_category": error_category})
+
+    return _spy
+
+
+def _make_shutdown_counter(shutdown_calls: list[None]) -> object:
+    """Return a ``shutdown_telemetry`` side_effect that counts invocations."""
+
+    def _counter(**kwargs: object) -> None:  # noqa: ARG001
+        shutdown_calls.append(None)
+
+    return _counter
 
 
 # ---------------------------------------------------------------------------
@@ -66,34 +91,23 @@ def test_normal_return_emits_ok_and_shuts_down() -> None:
     calls: list[_AppExitedCall] = []
     shutdown_calls: list[None] = []
 
-    def fake_record_app_exited(
-        *,
-        duration_ms: float,  # noqa: ARG001
-        exit_status: str,
-        error_category: str | None,
-    ) -> None:
-        calls.append({"exit_status": exit_status, "error_category": error_category})
-
-    def fake_shutdown(**kwargs: object) -> None:  # noqa: ARG001
-        shutdown_calls.append(None)
-
     with (
         patch("fabric_dw.mcp.server.mcp") as mock_mcp,
         patch("fabric_dw.mcp.server.record_app_started"),
         patch("fabric_dw.mcp.server.record_mcp_server_started"),
         patch("fabric_dw.mcp.server.maybe_print_first_run_notice"),
-        patch("fabric_dw.mcp.server.record_app_exited", side_effect=fake_record_app_exited),
-        patch("fabric_dw.mcp.server.shutdown_telemetry", side_effect=fake_shutdown),
+        patch("fabric_dw.mcp.server.record_app_exited", side_effect=_make_record_spy(calls)),
+        patch(
+            "fabric_dw.mcp.server.shutdown_telemetry",
+            side_effect=_make_shutdown_counter(shutdown_calls),
+        ),
     ):
         mock_mcp.run.return_value = None
         mock_mcp.settings = MagicMock()
         _run()
 
-    # record_app_exited should be called exactly once with exit_status="ok"
     assert len(calls) == 1
     assert calls[0]["exit_status"] == "ok"
-
-    # shutdown_telemetry must be called exactly once
     assert len(shutdown_calls) == 1
 
 
@@ -108,24 +122,16 @@ def test_keyboard_interrupt_emits_ok_and_shuts_down_and_reraises() -> None:
     calls: list[_AppExitedCall] = []
     shutdown_calls: list[None] = []
 
-    def fake_record_app_exited(
-        *,
-        duration_ms: float,  # noqa: ARG001
-        exit_status: str,
-        error_category: str | None,
-    ) -> None:
-        calls.append({"exit_status": exit_status, "error_category": error_category})
-
-    def fake_shutdown(**kwargs: object) -> None:  # noqa: ARG001
-        shutdown_calls.append(None)
-
     with (
         patch("fabric_dw.mcp.server.mcp") as mock_mcp,
         patch("fabric_dw.mcp.server.record_app_started"),
         patch("fabric_dw.mcp.server.record_mcp_server_started"),
         patch("fabric_dw.mcp.server.maybe_print_first_run_notice"),
-        patch("fabric_dw.mcp.server.record_app_exited", side_effect=fake_record_app_exited),
-        patch("fabric_dw.mcp.server.shutdown_telemetry", side_effect=fake_shutdown),
+        patch("fabric_dw.mcp.server.record_app_exited", side_effect=_make_record_spy(calls)),
+        patch(
+            "fabric_dw.mcp.server.shutdown_telemetry",
+            side_effect=_make_shutdown_counter(shutdown_calls),
+        ),
     ):
         mock_mcp.run.side_effect = KeyboardInterrupt()
         mock_mcp.settings = MagicMock()
@@ -135,7 +141,6 @@ def test_keyboard_interrupt_emits_ok_and_shuts_down_and_reraises() -> None:
 
     assert len(calls) == 1
     assert calls[0]["exit_status"] == "ok"
-
     assert len(shutdown_calls) == 1
 
 
@@ -150,24 +155,16 @@ def test_unexpected_exception_emits_api_error_and_shuts_down_and_reraises() -> N
     calls: list[_AppExitedCall] = []
     shutdown_calls: list[None] = []
 
-    def fake_record_app_exited(
-        *,
-        duration_ms: float,  # noqa: ARG001
-        exit_status: str,
-        error_category: str | None,
-    ) -> None:
-        calls.append({"exit_status": exit_status, "error_category": error_category})
-
-    def fake_shutdown(**kwargs: object) -> None:  # noqa: ARG001
-        shutdown_calls.append(None)
-
     with (
         patch("fabric_dw.mcp.server.mcp") as mock_mcp,
         patch("fabric_dw.mcp.server.record_app_started"),
         patch("fabric_dw.mcp.server.record_mcp_server_started"),
         patch("fabric_dw.mcp.server.maybe_print_first_run_notice"),
-        patch("fabric_dw.mcp.server.record_app_exited", side_effect=fake_record_app_exited),
-        patch("fabric_dw.mcp.server.shutdown_telemetry", side_effect=fake_shutdown),
+        patch("fabric_dw.mcp.server.record_app_exited", side_effect=_make_record_spy(calls)),
+        patch(
+            "fabric_dw.mcp.server.shutdown_telemetry",
+            side_effect=_make_shutdown_counter(shutdown_calls),
+        ),
     ):
         mock_mcp.run.side_effect = RuntimeError("boom")
         mock_mcp.settings = MagicMock()
@@ -177,7 +174,6 @@ def test_unexpected_exception_emits_api_error_and_shuts_down_and_reraises() -> N
 
     assert len(calls) == 1
     assert calls[0]["exit_status"] == "api_error"
-
     assert len(shutdown_calls) == 1
 
 
@@ -192,20 +188,12 @@ def test_system_exit_zero_emits_ok(code: int | None) -> None:
     """SystemExit(0) / SystemExit(None) from mcp.run → exit_status 'ok'."""
     calls: list[_AppExitedCall] = []
 
-    def fake_record_app_exited(
-        *,
-        duration_ms: float,  # noqa: ARG001
-        exit_status: str,
-        error_category: str | None,
-    ) -> None:
-        calls.append({"exit_status": exit_status, "error_category": error_category})
-
     with (
         patch("fabric_dw.mcp.server.mcp") as mock_mcp,
         patch("fabric_dw.mcp.server.record_app_started"),
         patch("fabric_dw.mcp.server.record_mcp_server_started"),
         patch("fabric_dw.mcp.server.maybe_print_first_run_notice"),
-        patch("fabric_dw.mcp.server.record_app_exited", side_effect=fake_record_app_exited),
+        patch("fabric_dw.mcp.server.record_app_exited", side_effect=_make_record_spy(calls)),
         patch("fabric_dw.mcp.server.shutdown_telemetry"),
     ):
         mock_mcp.run.side_effect = SystemExit(code)
@@ -223,20 +211,12 @@ def test_system_exit_nonzero_emits_api_error() -> None:
     """SystemExit(1) from mcp.run → exit_status 'api_error'."""
     calls: list[_AppExitedCall] = []
 
-    def fake_record_app_exited(
-        *,
-        duration_ms: float,  # noqa: ARG001
-        exit_status: str,
-        error_category: str | None,
-    ) -> None:
-        calls.append({"exit_status": exit_status, "error_category": error_category})
-
     with (
         patch("fabric_dw.mcp.server.mcp") as mock_mcp,
         patch("fabric_dw.mcp.server.record_app_started"),
         patch("fabric_dw.mcp.server.record_mcp_server_started"),
         patch("fabric_dw.mcp.server.maybe_print_first_run_notice"),
-        patch("fabric_dw.mcp.server.record_app_exited", side_effect=fake_record_app_exited),
+        patch("fabric_dw.mcp.server.record_app_exited", side_effect=_make_record_spy(calls)),
         patch("fabric_dw.mcp.server.shutdown_telemetry"),
     ):
         mock_mcp.run.side_effect = SystemExit(1)
@@ -256,22 +236,20 @@ def test_system_exit_nonzero_emits_api_error() -> None:
 
 @pytest.mark.usefixtures("_enable_telemetry", "_patch_azure_monitor")
 def test_shutdown_runs_even_if_record_app_exited_raises() -> None:
-    """shutdown_telemetry() is called exactly once even if record_app_exited raises."""
+    """shutdown_telemetry() is called even if record_app_exited raises; error swallowed."""
     shutdown_calls: list[None] = []
-
-    def fake_shutdown(**kwargs: object) -> None:  # noqa: ARG001
-        shutdown_calls.append(None)
+    mock_record = MagicMock(side_effect=RuntimeError("telemetry failure"))
 
     with (
         patch("fabric_dw.mcp.server.mcp") as mock_mcp,
         patch("fabric_dw.mcp.server.record_app_started"),
         patch("fabric_dw.mcp.server.record_mcp_server_started"),
         patch("fabric_dw.mcp.server.maybe_print_first_run_notice"),
+        patch("fabric_dw.mcp.server.record_app_exited", new=mock_record),
         patch(
-            "fabric_dw.mcp.server.record_app_exited",
-            side_effect=RuntimeError("telemetry failure"),
+            "fabric_dw.mcp.server.shutdown_telemetry",
+            side_effect=_make_shutdown_counter(shutdown_calls),
         ),
-        patch("fabric_dw.mcp.server.shutdown_telemetry", side_effect=fake_shutdown),
     ):
         mock_mcp.run.return_value = None
         mock_mcp.settings = MagicMock()
@@ -279,6 +257,8 @@ def test_shutdown_runs_even_if_record_app_exited_raises() -> None:
         _run()
 
     assert len(shutdown_calls) == 1
+    # The exit_status passed before the raise must be "ok" (normal return).
+    assert mock_record.call_args.kwargs["exit_status"] == "ok"
 
 
 # ---------------------------------------------------------------------------
@@ -312,23 +292,28 @@ def test_call_order_record_before_shutdown() -> None:
 
 
 # ---------------------------------------------------------------------------
-# No hang: shutdown_telemetry is not called multiple times
+# KeyboardInterrupt during teardown (second SIGINT) is swallowed
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.usefixtures("_enable_telemetry", "_patch_azure_monitor")
-def test_shutdown_called_exactly_once_on_normal_return() -> None:
-    """shutdown_telemetry() is called exactly once — idempotency guard check."""
+def test_keyboard_interrupt_during_teardown_is_swallowed() -> None:
+    """A second KeyboardInterrupt raised by shutdown_telemetry must not escape run().
+
+    shutdown_telemetry() does t.join(timeout=8.5) on the main thread, which is
+    interruptible.  The teardown guard uses ``except BaseException`` so that a
+    Ctrl-C arriving during the flush window is swallowed and does not replace
+    the original (already re-raised) server exit exception.
+    """
     with (
         patch("fabric_dw.mcp.server.mcp") as mock_mcp,
         patch("fabric_dw.mcp.server.record_app_started"),
         patch("fabric_dw.mcp.server.record_mcp_server_started"),
         patch("fabric_dw.mcp.server.maybe_print_first_run_notice"),
         patch("fabric_dw.mcp.server.record_app_exited"),
-        patch("fabric_dw.mcp.server.shutdown_telemetry") as mock_shutdown,
+        patch("fabric_dw.mcp.server.shutdown_telemetry", side_effect=KeyboardInterrupt()),
     ):
         mock_mcp.run.return_value = None
         mock_mcp.settings = MagicMock()
-        _run()
-
-    mock_shutdown.assert_called_once()
+        # The KeyboardInterrupt from shutdown_telemetry must NOT escape run().
+        _run()  # must return normally without raising


### PR DESCRIPTION
## Root cause

The MCP server (`src/fabric_dw/mcp/server.py`) called `record_app_started("mcp")` and `record_mcp_server_started()` but had no telemetry teardown: no `app_exited` event, no `shutdown_telemetry()` call. With `shutdown_on_exit=False` set on `configure_azure_monitor`, events sitting in the `BatchLogRecordProcessor`'s final batch window at exit were silently dropped. Short-lived MCP processes could lose `app_started`/`mcp_server_started` entirely. The urllib3 connection pool was also never released, risking the `AttributeError: 'NoneType' object has no attribute 'Empty'` GC finaliser at interpreter exit.

## Fix

Wrap `mcp.run(transport=transport)` in `try / except BaseException / finally`:

1. Capture the exception (if any) before re-raising, so the `finally` block can compute `exit_status`.
2. In `finally`, map `exit_status`: `KeyboardInterrupt` / `SystemExit(0|None)` / normal return → `"ok"`; `SystemExit(non-zero)` / unexpected exception → `"api_error"`. (`"user_error"` has no applicable meaning on the long-running MCP server surface.)
3. Call `record_app_exited(duration_ms=..., exit_status=..., error_category=None)` to capture MCP session duration and exit status.
4. Wrap the teardown in its own `try / finally` so `shutdown_telemetry()` always runs even when `record_app_exited()` raises, and swallow any telemetry teardown errors so they never mask the real server exit exception.

This mirrors the CLI's guarded shutdown discipline from #664/#667.

## Tests

New test module `tests/unit/mcp/test_server_telemetry.py` (9 tests, `mcp.run` mocked throughout):

- Normal return → `record_app_exited(exit_status="ok")` then `shutdown_telemetry()` called once, in that order.
- `KeyboardInterrupt` → `exit_status="ok"`, shutdown called once, exception re-raised.
- Unexpected `RuntimeError` → `exit_status="api_error"`, shutdown called once, exception re-raised.
- `SystemExit(0)` / `SystemExit(None)` → `exit_status="ok"`.
- `SystemExit(1)` → `exit_status="api_error"`.
- `record_app_exited` raising → `shutdown_telemetry` still called once, error swallowed.
- Call-order assertion: `record_app_exited` before `shutdown_telemetry`.
- `shutdown_telemetry` called exactly once (idempotency guard).

Closes #672