### PR TITLE
fix(telemetry): omit auth_mode on lifecycle-start events and fix auth_mode docs/comments

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -23,9 +23,11 @@ Every telemetry event includes a shared envelope of anonymous fields:
 
 | Event | When | Extra fields |
 |---|---|---|
-| `app_started` | Once per process | — |
-| `mcp_server_started` | When the MCP server boots | — |
+| `app_started` | Once per process | — (`auth_mode` omitted — see note below) |
+| `mcp_server_started` | When the MCP server boots | — (`auth_mode` omitted — see note below) |
 | `app_exited` | On process exit | `duration_ms`, `exit_status` (ok / user_error / api_error), `error_category` |
+
+> **Note on `auth_mode` in lifecycle-start events:** `app_started` and `mcp_server_started` fire at process start, before any token is acquired. Emitting `auth_mode` at that point would produce a possibly-wrong value derived from environment-variable heuristics (e.g. `interactive` for a plain `az login`). The accurate value is only available after the first token acquisition and is emitted on `command_invoked` and `app_exited`.
 
 ### `command_invoked` — per-command usage
 

--- a/src/fabric_dw/auth.py
+++ b/src/fabric_dw/auth.py
@@ -381,9 +381,11 @@ def get_sql_token_struct(mode: CredentialMode = CredentialMode.DEFAULT) -> bytes
 
 def _make_default_credential() -> AsyncTokenCredential:
     if _is_github_actions_oidc():
-        # Auth mode is recorded lazily on first token acquisition via
-        # _record_auth_mode_from_default_credential in http_client._get_token.
-        # The OIDC path is handled there by inspecting _successful_credential.
+        # Auth mode for the OIDC path is NOT recorded via
+        # record_auth_mode_from_default_credential (ClientAssertionCredential
+        # has no _successful_credential attribute and the function early-returns).
+        # Instead, _detect_auth_mode() picks up the GitHub Actions env-var
+        # signals and returns "github_oidc" automatically.
         return _make_github_oidc_credential()
 
     interactive_kwargs = _resolve_interactive_kwargs()
@@ -431,6 +433,13 @@ def _make_interactive_credential() -> AsyncTokenCredential:
 # Mapping from DefaultAzureCredential sub-credential class names to telemetry
 # auth_mode strings.  Read defensively via getattr(_successful_credential, None)
 # so any future azure-identity refactor does not break the call site.
+#
+# NOTE: AzurePowerShellCredential is intentionally grouped under "azure_cli".
+# All local developer-tool auth methods (Azure CLI, Azure Developer CLI, and
+# Azure PowerShell) are treated as a single category because they represent the
+# same usage pattern: a developer who has authenticated locally with a Microsoft
+# tool.  Do NOT add a separate "azure_powershell" category — the intent is to
+# distinguish interactive-browser from local-tool auth, not to enumerate tools.
 _DAC_CLASS_TO_AUTH_MODE: dict[str, str] = {
     "AzureCliCredential": "azure_cli",
     "AzureDeveloperCliCredential": "azure_cli",

--- a/src/fabric_dw/telemetry.py
+++ b/src/fabric_dw/telemetry.py
@@ -359,7 +359,7 @@ def _detect_auth_mode() -> str:
     layer for an accurate value.
 
     Returns one of: ``service_principal``, ``github_oidc``, ``azure_cli``,
-    ``interactive``, ``managed_identity``.
+    ``interactive``.
     """
     # GitHub Actions OIDC
     if os.environ.get("ACTIONS_ID_TOKEN_REQUEST_URL") and os.environ.get(
@@ -869,7 +869,12 @@ def shutdown_telemetry(timeout_ms: int = 8000) -> None:
 # ---------------------------------------------------------------------------
 
 
-def emit_event(name: str, attributes: dict[str, object]) -> None:
+def emit_event(
+    name: str,
+    attributes: dict[str, object],
+    *,
+    omit_keys: set[str] | None = None,
+) -> None:
     """Emit a telemetry event as an Application Insights customEvent.
 
     The event is emitted via the OpenTelemetry logs API as a log record
@@ -893,6 +898,16 @@ def emit_event(name: str, attributes: dict[str, object]) -> None:
 
     Fire-and-forget: never raises, never blocks the caller noticeably.
     When telemetry is disabled, this is a guaranteed no-op.
+
+    Args:
+        name: The event name (e.g. ``"app_started"``).
+        attributes: Extra per-event dimensions merged on top of the shared
+            envelope.  Caller-supplied keys win over envelope keys of the
+            same name.
+        omit_keys: Optional set of envelope keys to drop from the merged
+            record before emission.  Use this for lifecycle-start events that
+            fire before auth is resolved so that a potentially-wrong
+            ``auth_mode`` value is never emitted (e.g. ``omit_keys={"auth_mode"}``).
     """
     if not telemetry_enabled():
         return
@@ -906,6 +921,14 @@ def emit_event(name: str, attributes: dict[str, object]) -> None:
 
         envelope = _build_envelope()
         merged: dict[str, object] = {**envelope, **attributes}
+
+        # Drop any keys the caller asked to exclude.  This is used by
+        # lifecycle-start events (app_started, mcp_server_started) that fire
+        # before auth is resolved — omitting auth_mode avoids emitting a
+        # possibly-wrong value derived from _detect_auth_mode()'s env heuristic.
+        if omit_keys:
+            for key in omit_keys:
+                merged.pop(key, None)
 
         # Add the special attributes that drive native App Insights mapping:
         #   microsoft.custom_event.name → EventData.name (customEvents table)
@@ -938,6 +961,13 @@ def emit_event(name: str, attributes: dict[str, object]) -> None:
 def record_app_started(surface: str) -> None:
     """Emit an ``app_started`` lifecycle event.
 
+    ``auth_mode`` is intentionally omitted from this event: it fires at process
+    start before any token is acquired, so ``_auth_mode_override`` is still
+    ``None`` and the env-heuristic fallback (``_detect_auth_mode()``) can
+    mis-classify the session (e.g. ``interactive`` for a plain ``az login``).
+    The accurate value is emitted on ``command_invoked`` and ``app_exited``
+    after the auth layer calls :func:`set_auth_mode`.
+
     Args:
         surface: Either ``"cli"`` or ``"mcp"``.
     """
@@ -945,7 +975,7 @@ def record_app_started(surface: str) -> None:
     _current_surface = surface
     # ``surface`` is no longer sent as a custom dimension: it is shipped natively
     # as ``cloud_RoleName`` via the OTel Resource (``service.name`` = surface).
-    emit_event("app_started", {})
+    emit_event("app_started", {}, omit_keys={"auth_mode"})
 
 
 def record_app_exited(
@@ -971,8 +1001,14 @@ def record_app_exited(
 
 
 def record_mcp_server_started() -> None:
-    """Emit an ``mcp_server_started`` lifecycle event."""
-    emit_event("mcp_server_started", {})
+    """Emit an ``mcp_server_started`` lifecycle event.
+
+    ``auth_mode`` is omitted for the same reason as :func:`record_app_started`:
+    the MCP server boots before any token is acquired and the env-heuristic can
+    mis-classify the session.  The accurate value is emitted on subsequent
+    ``command_invoked`` events after the auth layer calls :func:`set_auth_mode`.
+    """
+    emit_event("mcp_server_started", {}, omit_keys={"auth_mode"})
 
 
 def maybe_print_first_run_notice() -> None:

--- a/src/fabric_dw/telemetry.py
+++ b/src/fabric_dw/telemetry.py
@@ -908,6 +908,10 @@ def emit_event(
             record before emission.  Use this for lifecycle-start events that
             fire before auth is resolved so that a potentially-wrong
             ``auth_mode`` value is never emitted (e.g. ``omit_keys={"auth_mode"}``).
+            Only envelope keys (those present in the ``merged`` dict at the
+            time of the pop) can be suppressed.  The three special App Insights
+            keys written *after* the pop — ``microsoft.custom_event.name``,
+            ``enduser.pseudo.id``, and ``ai.operation.name`` — are unaffected.
     """
     if not telemetry_enabled():
         return
@@ -926,7 +930,7 @@ def emit_event(
         # lifecycle-start events (app_started, mcp_server_started) that fire
         # before auth is resolved — omitting auth_mode avoids emitting a
         # possibly-wrong value derived from _detect_auth_mode()'s env heuristic.
-        if omit_keys:
+        if omit_keys is not None:
             for key in omit_keys:
                 merged.pop(key, None)
 

--- a/tests/unit/test_app_exited_emission.py
+++ b/tests/unit/test_app_exited_emission.py
@@ -410,7 +410,12 @@ class TestAppExitedDelivery:
         """emit_event is called with 'app_exited' and exit_status='ok' on clean exit."""
         emitted: list[tuple[str, dict]] = []
 
-        def _spy(name: str, attributes: dict) -> None:
+        def _spy(
+            name: str,
+            attributes: dict,
+            *,
+            omit_keys: set[str] | None = None,  # noqa: ARG001
+        ) -> None:
             emitted.append((name, dict(attributes)))
 
         tel_globals = _telemetry_globals()
@@ -440,7 +445,12 @@ class TestAppExitedDelivery:
         """emit_event is called with 'app_exited' and exit_status='api_error' on error."""
         emitted: list[tuple[str, dict]] = []
 
-        def _spy(name: str, attributes: dict) -> None:
+        def _spy(
+            name: str,
+            attributes: dict,
+            *,
+            omit_keys: set[str] | None = None,  # noqa: ARG001
+        ) -> None:
             emitted.append((name, dict(attributes)))
 
         ws_group = _workspaces_group()

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -585,7 +585,12 @@ def test_record_app_started_enabled_calls_emit(
     mod = _reload_telemetry()
     emitted: list[tuple[str, dict[str, object]]] = []
 
-    def fake_emit(name: str, attrs: dict[str, object]) -> None:
+    def fake_emit(
+        name: str,
+        attrs: dict[str, object],
+        *,
+        omit_keys: set[str] | None = None,  # noqa: ARG001
+    ) -> None:
         emitted.append((name, attrs))
 
     with patch.object(mod, "emit_event", side_effect=fake_emit):  # type: ignore[attr-defined]
@@ -636,13 +641,139 @@ def test_record_mcp_server_started_enabled_calls_emit(
     mod = _reload_telemetry()
     emitted: list[tuple[str, dict[str, object]]] = []
 
-    def fake_emit(name: str, attrs: dict[str, object]) -> None:
+    def fake_emit(
+        name: str,
+        attrs: dict[str, object],
+        *,
+        omit_keys: set[str] | None = None,  # noqa: ARG001
+    ) -> None:
         emitted.append((name, attrs))
 
     with patch.object(mod, "emit_event", side_effect=fake_emit):  # type: ignore[attr-defined]
         mod.record_mcp_server_started()  # type: ignore[attr-defined]
 
     assert len(emitted) == 1
+
+
+# ---------------------------------------------------------------------------
+# auth_mode omission on lifecycle-start events (#677)
+# ---------------------------------------------------------------------------
+
+
+def _setup_telemetry_with_fake_logger(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> tuple[Any, list[dict[str, object]]]:
+    """Set up a reloaded telemetry module with a fake OTel logger that captures emissions.
+
+    Returns ``(mod, captured)`` where *captured* is the list that grows as
+    events are emitted.  Egress is blocked — no real Azure Monitor calls occur.
+    """
+    for var in ("FABRIC_DW_TELEMETRY_OPT_OUT", "DO_NOT_TRACK"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    mod = _reload_telemetry()
+
+    captured: list[dict[str, object]] = []
+
+    # A minimal stand-in for OTel LogRecord: just holds its attributes.
+    class _FakeLogRecord:
+        def __init__(self, **kwargs: object) -> None:
+            self.attributes: dict[str, object] = dict(kwargs.get("attributes") or {})  # type: ignore[arg-type]  # ty: ignore[no-matching-overload]
+
+    class _FakeLogger:
+        def emit(self, record: _FakeLogRecord) -> None:
+            captured.append(dict(record.attributes))
+
+    fake_logger = _FakeLogger()
+
+    # Inject our fake logger so _get_tracer() returns it without real SDK init.
+    mod._otel_logger = fake_logger  # type: ignore[attr-defined]
+    mod._tracer = fake_logger  # type: ignore[attr-defined]
+    mod._sdk_initialised = True  # type: ignore[attr-defined]
+
+    # Inject the fake LogRecord class into sys.modules so the `from … import`
+    # inside emit_event picks it up instead of the real OTel class.
+    fake_logs_mod: Any = types.ModuleType("opentelemetry._logs")
+    fake_logs_mod.LogRecord = _FakeLogRecord
+    monkeypatch.setitem(sys.modules, "opentelemetry._logs", fake_logs_mod)
+
+    return mod, captured
+
+
+def test_app_started_omits_auth_mode(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """app_started events must NOT carry auth_mode (fired before auth is resolved).
+
+    Lifecycle-start events fire before any token is acquired, so _auth_mode_override
+    is still None and _detect_auth_mode() falls back to env heuristics that can
+    mis-classify the session.  Omitting the field is safer than emitting a wrong value.
+    """
+    mod, captured = _setup_telemetry_with_fake_logger(monkeypatch, tmp_path)
+    mod.record_app_started("cli")  # type: ignore[attr-defined]
+
+    assert len(captured) == 1
+    assert "auth_mode" not in captured[0], (
+        "app_started must NOT include auth_mode — it fires before auth is resolved and "
+        "_detect_auth_mode() can mis-classify the session (#677)."
+    )
+
+
+def test_mcp_server_started_omits_auth_mode(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """mcp_server_started events must NOT carry auth_mode (fired before auth is resolved).
+
+    Same rationale as app_started: the MCP server boots before any token is acquired.
+    """
+    mod, captured = _setup_telemetry_with_fake_logger(monkeypatch, tmp_path)
+    mod.record_mcp_server_started()  # type: ignore[attr-defined]
+
+    assert len(captured) == 1
+    assert "auth_mode" not in captured[0], (
+        "mcp_server_started must NOT include auth_mode — it fires before auth is resolved "
+        "and _detect_auth_mode() can mis-classify the session (#677)."
+    )
+
+
+def test_app_exited_includes_auth_mode(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """app_exited events MUST carry auth_mode (emitted after the first token acquisition)."""
+    mod, captured = _setup_telemetry_with_fake_logger(monkeypatch, tmp_path)
+    mod.record_app_exited(duration_ms=10.0, exit_status="ok", error_category=None)  # type: ignore[attr-defined]
+
+    assert len(captured) == 1
+    assert "auth_mode" in captured[0], (
+        "app_exited must include auth_mode — it is emitted after auth is resolved and "
+        "the value is accurate by that point (#677)."
+    )
+
+
+def test_emit_event_omit_keys_removes_from_merged(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """emit_event(omit_keys=...) must drop the listed keys from the merged envelope."""
+    mod, captured = _setup_telemetry_with_fake_logger(monkeypatch, tmp_path)
+    mod.emit_event("test_event", {}, omit_keys={"auth_mode", "session_id"})  # type: ignore[attr-defined]
+
+    assert len(captured) == 1
+    merged = captured[0]
+    assert "auth_mode" not in merged, "omit_keys must remove 'auth_mode' from the emitted record"
+    assert "session_id" not in merged, "omit_keys must remove 'session_id' from the emitted record"
+    # Other envelope keys must still be present.
+    assert "python_version" in merged, "Other envelope keys must remain after omit_keys filter"
+
+
+def test_emit_event_omit_keys_none_is_no_op(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """emit_event with omit_keys=None (default) must include all envelope keys."""
+    mod, captured = _setup_telemetry_with_fake_logger(monkeypatch, tmp_path)
+    mod.emit_event("test_event", {})  # type: ignore[attr-defined]
+
+    assert len(captured) == 1
+    assert "auth_mode" in captured[0], (
+        "When omit_keys is not provided (default None), auth_mode must be present in the envelope."
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -615,7 +615,12 @@ def test_record_app_exited_enabled_calls_emit(
     mod = _reload_telemetry()
     emitted: list[tuple[str, dict[str, object]]] = []
 
-    def fake_emit(name: str, attrs: dict[str, object]) -> None:
+    def fake_emit(
+        name: str,
+        attrs: dict[str, object],
+        *,
+        omit_keys: set[str] | None = None,  # noqa: ARG001
+    ) -> None:
         emitted.append((name, attrs))
 
     with patch.object(mod, "emit_event", side_effect=fake_emit):  # type: ignore[attr-defined]
@@ -744,6 +749,25 @@ def test_app_exited_includes_auth_mode(monkeypatch: pytest.MonkeyPatch, tmp_path
     assert len(captured) == 1
     assert "auth_mode" in captured[0], (
         "app_exited must include auth_mode — it is emitted after auth is resolved and "
+        "the value is accurate by that point (#677)."
+    )
+
+
+def test_command_invoked_includes_auth_mode(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """command_invoked events MUST carry auth_mode (emitted after the first token acquisition).
+
+    Unlike lifecycle-start events (app_started, mcp_server_started), command_invoked
+    fires after the auth layer has called set_auth_mode(), so the value is accurate
+    and should always be present in the emitted envelope.
+    """
+    mod, captured = _setup_telemetry_with_fake_logger(monkeypatch, tmp_path)
+    mod.emit_event("command_invoked", {"name": "workspace.list", "status": "success"})  # type: ignore[attr-defined]
+
+    assert len(captured) == 1
+    assert "auth_mode" in captured[0], (
+        "command_invoked must include auth_mode — it fires after auth is resolved and "
         "the value is accurate by that point (#677)."
     )
 

--- a/tests/unit/test_telemetry_commands.py
+++ b/tests/unit/test_telemetry_commands.py
@@ -781,7 +781,9 @@ class TestCliShutdownOrdering:
 
         call_order: list[str] = []
 
-        def _track_emit(event_name: str, _attrs: dict) -> None:
+        def _track_emit(
+            event_name: str, _attrs: dict, *, omit_keys: set[str] | None = None
+        ) -> None:
             call_order.append(f"emit:{event_name}")
 
         def _track_shutdown(_timeout_ms: int = 2000) -> None:

--- a/tests/unit/test_telemetry_commands.py
+++ b/tests/unit/test_telemetry_commands.py
@@ -782,7 +782,7 @@ class TestCliShutdownOrdering:
         call_order: list[str] = []
 
         def _track_emit(
-            event_name: str, _attrs: dict, *, omit_keys: set[str] | None = None
+            event_name: str, _attrs: dict, *, omit_keys: set[str] | None = None  # noqa: ARG001
         ) -> None:
             call_order.append(f"emit:{event_name}")
 

--- a/tests/unit/test_telemetry_commands.py
+++ b/tests/unit/test_telemetry_commands.py
@@ -782,7 +782,10 @@ class TestCliShutdownOrdering:
         call_order: list[str] = []
 
         def _track_emit(
-            event_name: str, _attrs: dict, *, omit_keys: set[str] | None = None  # noqa: ARG001
+            event_name: str,
+            _attrs: dict,
+            *,
+            omit_keys: set[str] | None = None,  # noqa: ARG001
         ) -> None:
             call_order.append(f"emit:{event_name}")
 


### PR DESCRIPTION
## Summary

Three groups of changes, all follow-up to #671:

**1. Omit `auth_mode` on `app_started` and `mcp_server_started`**
Both events fire before any token is acquired, so `_auth_mode_override` is still `None` and `_build_envelope()` fell back to `_detect_auth_mode()`'s env-var heuristic — which mis-classifies a plain `az login` as `interactive`. Added an `omit_keys: set[str] | None = None` parameter to `emit_event()` and pass `omit_keys={"auth_mode"}` from both lifecycle-start callers. `command_invoked` and `app_exited` (emitted after the first token) are unaffected and still carry the accurate value. Updated `docs/telemetry.md` to document the omission.

**2. `AzurePowerShellCredential` intentional grouping comment**
Added a code comment at `_DAC_CLASS_TO_AUTH_MODE` in `auth.py` explaining that all local developer-tool auth methods (Azure CLI, Azure Developer CLI, Azure PowerShell) are intentionally grouped under `azure_cli`. No category or mapping changes.

**3. Doc/comment fixes**
- `telemetry.py` `_detect_auth_mode()` docstring: removed `managed_identity` from the "Returns one of:" list — the function body never returns it; only `set_auth_mode()` can produce that value.
- `auth.py` OIDC branch comment: fixed the function name (removed erroneous leading underscore) and corrected the description — `ClientAssertionCredential` has no `_successful_credential`; the hook early-returns and `_detect_auth_mode()`'s env-var check is what actually produces `"github_oidc"`.

Tests added: five new unit tests asserting the `auth_mode` omission contract (`app_started`, `mcp_server_started`, `app_exited`, `emit_event` with and without `omit_keys`). All 4224 existing unit tests continue to pass.

Closes #677

🤖 Generated with [Claude Code](https://claude.com/claude-code)