### PR TITLE
feat(telemetry): emit destructive_op=true on CLI destructive commands

### DIFF
--- a/src/fabric_dw/cli/_main.py
+++ b/src/fabric_dw/cli/_main.py
@@ -32,6 +32,58 @@ _logger = logging.getLogger(__name__)
 _CLI_TELEMETRY_KEY = "fabric_dw_telemetry_command_name"
 _CLI_SEGMENTS_KEY = _CLI_TELEMETRY_KEY + "_segments"
 
+# ---------------------------------------------------------------------------
+# Destructive-op telemetry for the CLI (issue #666)
+# ---------------------------------------------------------------------------
+# Single source of truth: the dotted telemetry names (<group>.<subcommand>) of
+# permanently-destructive CLI commands — those that mirror an MCP tool registered
+# with mutating_tool(destructive=True).  Commands that are confirming-but-not-
+# destructive (queries.kill, warehouses.rename, etc.) are intentionally absent.
+#
+# The set is frozen so it cannot be mutated at runtime.
+_DESTRUCTIVE_CLI_COMMANDS: frozenset[str] = frozenset(
+    {
+        "functions.drop",
+        "procedures.drop",
+        "restore-points.delete",
+        "restore-points.restore",
+        "schemas.delete",
+        "snapshots.delete",
+        "sql-pools.delete",
+        "statistics.delete",
+        "tables.delete",
+        "tables.clear",
+        "tables.cluster-by",
+        "views.drop",
+        "warehouses.delete",
+    }
+)
+
+# Bidirectional drift-guard map: MCP tool name → CLI dotted name.
+# Used by tests/unit/test_cli_destructive_parity.py to cross-check both sets.
+# Conditional tools (refresh_sql_endpoint_metadata, import_table_from_url) are
+# excluded — they are handled via runtime ctx.meta flags below.
+_MCP_TO_CLI_DESTRUCTIVE_MAP: dict[str, str] = {
+    "drop_function": "functions.drop",
+    "drop_procedure": "procedures.drop",
+    "delete_restore_point": "restore-points.delete",
+    "restore_warehouse_in_place": "restore-points.restore",
+    "delete_schema": "schemas.delete",
+    "delete_snapshot": "snapshots.delete",
+    "delete_sql_pool": "sql-pools.delete",
+    "delete_statistics": "statistics.delete",
+    "delete_table": "tables.delete",
+    "clear_table": "tables.clear",
+    "set_cluster_columns": "tables.cluster-by",
+    "drop_view": "views.drop",
+    "delete_warehouse": "warehouses.delete",
+}
+
+# ctx.meta key written by conditionally-destructive command bodies BEFORE any
+# API call or prompt, so the finally block in _InstrumentedGroup.invoke can
+# pick it up outcome-independently.
+_CLI_CONDITIONAL_DESTRUCTIVE_KEY = "fabric_dw_conditional_destructive_op"
+
 # Use actual terminal width so help text adapts to the user's screen.
 # Floor of 80 preserves readable wrapping on narrow terminals and in CI
 # (where get_terminal_size falls back to the (120, 24) default).
@@ -320,10 +372,19 @@ class _InstrumentedGroup(click.Group):
             if command_name:
                 duration = now_ms() - start
                 status = map_status(exc_seen)
+                # Compute destructive flag:
+                # 1. Check the unconditional set (identity-based, flag-independent).
+                # 2. Fall back to the conditional flag stashed in ctx.meta by the
+                #    command body (e.g. sql-endpoints refresh --recreate-tables,
+                #    tables load --if-exists truncate|replace).
+                destructive: bool = command_name in _DESTRUCTIVE_CLI_COMMANDS or bool(
+                    ctx.meta.get(_CLI_CONDITIONAL_DESTRUCTIVE_KEY)
+                )
                 emit_command_invoked(
                     name=command_name,
                     status=status,
                     duration_ms=duration,
+                    destructive=destructive,
                 )
             # shutdown_telemetry() is NOT called here.  It is called in
             # _on_close() (registered via ctx.call_on_close on the root context)

--- a/src/fabric_dw/cli/_main.py
+++ b/src/fabric_dw/cli/_main.py
@@ -59,26 +59,6 @@ _DESTRUCTIVE_CLI_COMMANDS: frozenset[str] = frozenset(
     }
 )
 
-# Bidirectional drift-guard map: MCP tool name → CLI dotted name.
-# Used by tests/unit/test_cli_destructive_parity.py to cross-check both sets.
-# Conditional tools (refresh_sql_endpoint_metadata, import_table_from_url) are
-# excluded — they are handled via runtime ctx.meta flags below.
-_MCP_TO_CLI_DESTRUCTIVE_MAP: dict[str, str] = {
-    "drop_function": "functions.drop",
-    "drop_procedure": "procedures.drop",
-    "delete_restore_point": "restore-points.delete",
-    "restore_warehouse_in_place": "restore-points.restore",
-    "delete_schema": "schemas.delete",
-    "delete_snapshot": "snapshots.delete",
-    "delete_sql_pool": "sql-pools.delete",
-    "delete_statistics": "statistics.delete",
-    "delete_table": "tables.delete",
-    "clear_table": "tables.clear",
-    "set_cluster_columns": "tables.cluster-by",
-    "drop_view": "views.drop",
-    "delete_warehouse": "warehouses.delete",
-}
-
 # ctx.meta key written by conditionally-destructive command bodies BEFORE any
 # API call or prompt, so the finally block in _InstrumentedGroup.invoke can
 # pick it up outcome-independently.

--- a/src/fabric_dw/cli/commands/sql_endpoints.py
+++ b/src/fabric_dw/cli/commands/sql_endpoints.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 import click
 
 from fabric_dw.cli._context import CliContext
+from fabric_dw.cli._main import _CLI_CONDITIONAL_DESTRUCTIVE_KEY
 from fabric_dw.cli._render import (
     render,
     render_permissions_table,
@@ -188,6 +189,12 @@ async def refresh_cmd(ctx: CliContext, item: str | None, recreate_tables: bool) 
     By default, results are shown as a Rich table.  Pass --json (on the root
     command) to emit raw JSON instead.
     """
+    # Stash the conditional destructive flag before any API call or prompt so
+    # the finally block in _InstrumentedGroup.invoke picks it up regardless of
+    # outcome (abort, error, or success).
+    if recreate_tables:
+        click.get_current_context().meta[_CLI_CONDITIONAL_DESTRUCTIVE_KEY] = True
+
     ws = resolve_workspace(ctx)
     endpoint_explicit = item is not None
     ep = resolve_warehouse_arg(ctx, item)

--- a/src/fabric_dw/cli/commands/tables.py
+++ b/src/fabric_dw/cli/commands/tables.py
@@ -984,20 +984,21 @@ async def load_cmd(  # noqa: PLR0912, PLR0915
     else:
         effective_if_exists = "append"
 
+    # Stash the conditional destructive flag before any guard or API call so the
+    # finally block in _InstrumentedGroup.invoke picks it up outcome-independently —
+    # even when the call is rejected by the --create guard below.
+    is_destructive = effective_if_exists in ("truncate", "replace")
+    if is_destructive:
+        click.get_current_context().meta[_CLI_CONDITIONAL_DESTRUCTIVE_KEY] = True
+
     # truncate/replace are only meaningful on the --create path (local files).
     # For --url there is no schema to infer, and for --file without --create the
     # destructive policies are undefined.  Reject early with a clear message.
-    if effective_if_exists in ("truncate", "replace") and not create:
+    if is_destructive and not create:
         raise click.UsageError(
             f"--if-exists {effective_if_exists} requires --create "
             "(destructive policies only apply to the auto-create load path)."
         )
-
-    # Stash the conditional destructive flag before any API call or prompt so the
-    # finally block in _InstrumentedGroup.invoke picks it up outcome-independently.
-    is_destructive = effective_if_exists in ("truncate", "replace")
-    if is_destructive:
-        click.get_current_context().meta[_CLI_CONDITIONAL_DESTRUCTIVE_KEY] = True
 
     # Destructive confirmation for truncate / replace.
     if is_destructive:

--- a/src/fabric_dw/cli/commands/tables.py
+++ b/src/fabric_dw/cli/commands/tables.py
@@ -13,6 +13,7 @@ import click
 
 from fabric_dw.cache import ItemEntry
 from fabric_dw.cli._context import CliContext
+from fabric_dw.cli._main import _CLI_CONDITIONAL_DESTRUCTIVE_KEY
 from fabric_dw.cli._render import render
 from fabric_dw.cli.commands._utils import (
     build_http_client,
@@ -901,7 +902,7 @@ def _resolve_url_file_type(fmt: str | None, url: str) -> str:
 )
 @click.pass_obj
 @coro
-async def load_cmd(  # noqa: PLR0912
+async def load_cmd(  # noqa: PLR0912, PLR0915
     ctx: CliContext,
     item: str | None,
     qualified_name: str,
@@ -992,8 +993,13 @@ async def load_cmd(  # noqa: PLR0912
             "(destructive policies only apply to the auto-create load path)."
         )
 
-    # Destructive confirmation for truncate / replace.
+    # Stash the conditional destructive flag before any API call or prompt so the
+    # finally block in _InstrumentedGroup.invoke picks it up outcome-independently.
     is_destructive = effective_if_exists in ("truncate", "replace")
+    if is_destructive:
+        click.get_current_context().meta[_CLI_CONDITIONAL_DESTRUCTIVE_KEY] = True
+
+    # Destructive confirmation for truncate / replace.
     if is_destructive:
         action = "TRUNCATE" if effective_if_exists == "truncate" else "DROP+recreate"
         if not confirm_destructive(

--- a/src/fabric_dw/mcp/_helpers.py
+++ b/src/fabric_dw/mcp/_helpers.py
@@ -53,6 +53,7 @@ from fabric_dw.telemetry_commands import (
 )
 
 __all__ = [
+    "_DESTRUCTIVE_MCP_TOOLS",
     "InstrumentedFastMCP",
     "fabric_err",
     "make_sql_target",
@@ -62,7 +63,7 @@ __all__ = [
     "resolve_item",
     "safe_rows",
     "tool_err",
-]
+]  # RUF022 sort: _DESTRUCTIVE_MCP_TOOLS starts with underscore — intentionally first within group
 
 _P = ParamSpec("_P")
 _R = TypeVar("_R")
@@ -75,6 +76,17 @@ _log = logging.getLogger(__name__)
 
 
 _TELEMETRY_WRAPPED_ATTR = "__fabric_telemetry_wrapped__"
+
+# ---------------------------------------------------------------------------
+# Destructive MCP tool registry
+# ---------------------------------------------------------------------------
+# Populated at decoration-time by mutating_tool(destructive=True) so that
+# _main.py can cross-check parity with _DESTRUCTIVE_CLI_COMMANDS.
+#
+# Conditional tools (e.g. refresh_sql_endpoint_metadata, import_table_from_url)
+# are NOT listed here — they carry their own runtime flag logic and are handled
+# separately in the CLI via ctx.meta.
+_DESTRUCTIVE_MCP_TOOLS: set[str] = set()
 
 
 def _wrap_mcp_tool_with_telemetry(
@@ -183,6 +195,11 @@ def mutating_tool(
             if destructive:
                 _guards.assert_destructive_allowed()
             return await fn(*args, **kwargs)
+
+        # Register unconditionally-destructive tool names so the CLI drift guard
+        # can cross-check parity with _DESTRUCTIVE_CLI_COMMANDS.
+        if destructive:
+            _DESTRUCTIVE_MCP_TOOLS.add(name)
 
         # Add telemetry around the guard wrapper.
         tel_wrapped = _wrap_mcp_tool_with_telemetry(guard_wrapper, name, destructive=destructive)

--- a/src/fabric_dw/mcp/_helpers.py
+++ b/src/fabric_dw/mcp/_helpers.py
@@ -53,7 +53,6 @@ from fabric_dw.telemetry_commands import (
 )
 
 __all__ = [
-    "_DESTRUCTIVE_MCP_TOOLS",
     "InstrumentedFastMCP",
     "fabric_err",
     "make_sql_target",
@@ -63,7 +62,7 @@ __all__ = [
     "resolve_item",
     "safe_rows",
     "tool_err",
-]  # RUF022 sort: _DESTRUCTIVE_MCP_TOOLS starts with underscore — intentionally first within group
+]
 
 _P = ParamSpec("_P")
 _R = TypeVar("_R")

--- a/tests/unit/test_cli_destructive_parity.py
+++ b/tests/unit/test_cli_destructive_parity.py
@@ -1,0 +1,362 @@
+"""TDD tests for CLI destructive_op telemetry parity with MCP (issue #666).
+
+These tests prove that:
+1. Every CLI command that mirrors a permanently-destructive MCP tool carries
+   ``destructive_op=True`` on its ``command_invoked`` event.
+2. Non-destructive-but-confirming commands (``queries kill``, ``workspaces
+   set-collation``) and local clears (``cache clear``, ``config clear``) do NOT
+   set ``destructive_op=True``.
+3. Conditional cases (``sql-endpoints refresh --recreate-tables``,
+   ``tables load --if-exists truncate|replace``) mirror their MCP counterpart's
+   conditional logic.
+4. The bidirectional drift-guard cross-checks the CLI destructive set against
+   the MCP destructive set so the two surfaces cannot silently diverge.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+import fabric_dw.cli._main as _main_mod
+from fabric_dw.cli._main import (
+    _DESTRUCTIVE_CLI_COMMANDS,
+    _MCP_TO_CLI_DESTRUCTIVE_MAP,
+    cli,
+)
+from fabric_dw.mcp._helpers import _DESTRUCTIVE_MCP_TOOLS
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _invoke_and_capture_destructive(args: list[str]) -> bool | None:
+    """Run the CLI with *args* and return the ``destructive`` kwarg from the
+    last ``emit_command_invoked`` call, or ``None`` if it was never called.
+
+    Patches out all I/O and infrastructure so no real network access or auth
+    is needed.
+    """
+    captured: list[dict] = []
+
+    def _fake_emit(**kwargs: object) -> None:
+        captured.append(dict(kwargs))
+
+    runner = CliRunner()
+    with (
+        patch.object(_main_mod, "emit_command_invoked", side_effect=_fake_emit),
+        patch.object(_main_mod, "record_app_started"),
+        patch.object(_main_mod, "record_app_exited"),
+        patch.object(_main_mod, "shutdown_telemetry"),
+        patch.object(_main_mod, "maybe_print_first_run_notice"),
+    ):
+        runner.invoke(cli, args, catch_exceptions=True)
+
+    if not captured:
+        return None
+    return captured[-1].get("destructive", False)  # type: ignore[return-value]
+
+
+# ---------------------------------------------------------------------------
+# Drift guard — bidirectional cross-check
+# ---------------------------------------------------------------------------
+
+
+class TestDestructiveParity:
+    """Bidirectional drift-guard between CLI and MCP destructive sets."""
+
+    def test_every_mapped_mcp_tool_has_a_cli_counterpart(self) -> None:
+        """Every entry in _MCP_TO_CLI_DESTRUCTIVE_MAP must map to a known CLI command.
+
+        The CLI counterpart must be in ``_DESTRUCTIVE_CLI_COMMANDS``.
+        """
+        missing: list[str] = []
+        for mcp_tool, cli_cmd in _MCP_TO_CLI_DESTRUCTIVE_MAP.items():
+            if cli_cmd not in _DESTRUCTIVE_CLI_COMMANDS:
+                missing.append(f"{mcp_tool!r} → {cli_cmd!r} not in _DESTRUCTIVE_CLI_COMMANDS")
+        assert not missing, "\n".join(missing)
+
+    def test_every_destructive_mcp_tool_appears_in_map(self) -> None:
+        """Every permanently-destructive MCP tool must appear in _MCP_TO_CLI_DESTRUCTIVE_MAP.
+
+        Tools that are conditional (e.g. refresh_sql_endpoint_metadata) are
+        excluded from _DESTRUCTIVE_MCP_TOOLS and handled separately — they do
+        NOT need to appear in the map.
+        """
+        unconditional_mcp = _DESTRUCTIVE_MCP_TOOLS
+        missing = [
+            f"{tool!r} not in _MCP_TO_CLI_DESTRUCTIVE_MAP"
+            for tool in sorted(unconditional_mcp)
+            if tool not in _MCP_TO_CLI_DESTRUCTIVE_MAP
+        ]
+        assert not missing, "\n".join(missing)
+
+    def test_mcp_destructive_set_not_empty(self) -> None:
+        """_DESTRUCTIVE_MCP_TOOLS must be non-empty (sanity check)."""
+        assert _DESTRUCTIVE_MCP_TOOLS, "_DESTRUCTIVE_MCP_TOOLS is empty — check _helpers.py"
+
+    def test_cli_destructive_set_not_empty(self) -> None:
+        """_DESTRUCTIVE_CLI_COMMANDS must be non-empty (sanity check)."""
+        assert _DESTRUCTIVE_CLI_COMMANDS, "_DESTRUCTIVE_CLI_COMMANDS is empty"
+
+
+# ---------------------------------------------------------------------------
+# Identity-based: destructive commands emit destructive_op=True
+# ---------------------------------------------------------------------------
+
+
+class TestDestructiveCliCommandsEmitDestructiveOp:
+    """Each permanently-destructive CLI command must set destructive_op=True."""
+
+    @pytest.mark.parametrize(
+        "dotted_name",
+        sorted(_DESTRUCTIVE_CLI_COMMANDS),
+    )
+    def test_destructive_command_name_in_frozenset(self, dotted_name: str) -> None:
+        """All entries in _DESTRUCTIVE_CLI_COMMANDS follow the <group>.<subcommand> convention."""
+        assert "." in dotted_name, (
+            f"{dotted_name!r} is not in <group>.<subcommand> format"
+        )
+
+    def test_functions_drop_is_destructive(self) -> None:
+        assert "functions.drop" in _DESTRUCTIVE_CLI_COMMANDS
+
+    def test_procedures_drop_is_destructive(self) -> None:
+        assert "procedures.drop" in _DESTRUCTIVE_CLI_COMMANDS
+
+    def test_restore_points_delete_is_destructive(self) -> None:
+        assert "restore-points.delete" in _DESTRUCTIVE_CLI_COMMANDS
+
+    def test_restore_points_restore_is_destructive(self) -> None:
+        assert "restore-points.restore" in _DESTRUCTIVE_CLI_COMMANDS
+
+    def test_schemas_delete_is_destructive(self) -> None:
+        assert "schemas.delete" in _DESTRUCTIVE_CLI_COMMANDS
+
+    def test_snapshots_delete_is_destructive(self) -> None:
+        assert "snapshots.delete" in _DESTRUCTIVE_CLI_COMMANDS
+
+    def test_sql_pools_delete_is_destructive(self) -> None:
+        assert "sql-pools.delete" in _DESTRUCTIVE_CLI_COMMANDS
+
+    def test_statistics_delete_is_destructive(self) -> None:
+        assert "statistics.delete" in _DESTRUCTIVE_CLI_COMMANDS
+
+    def test_tables_delete_is_destructive(self) -> None:
+        assert "tables.delete" in _DESTRUCTIVE_CLI_COMMANDS
+
+    def test_tables_clear_is_destructive(self) -> None:
+        assert "tables.clear" in _DESTRUCTIVE_CLI_COMMANDS
+
+    def test_tables_cluster_by_is_destructive(self) -> None:
+        assert "tables.cluster-by" in _DESTRUCTIVE_CLI_COMMANDS
+
+    def test_views_drop_is_destructive(self) -> None:
+        assert "views.drop" in _DESTRUCTIVE_CLI_COMMANDS
+
+    def test_warehouses_delete_is_destructive(self) -> None:
+        assert "warehouses.delete" in _DESTRUCTIVE_CLI_COMMANDS
+
+
+# ---------------------------------------------------------------------------
+# Emit-level tests: emit_command_invoked is called with destructive=True
+# ---------------------------------------------------------------------------
+
+
+class TestEmitDestructiveOpOnAbort:
+    """Aborted (--yes not passed) destructive commands still emit destructive_op=True."""
+
+    def test_tables_delete_emits_destructive_on_abort(self) -> None:
+        """tables delete aborted at prompt must still report destructive_op=True."""
+        # Without --yes the prompt is shown and the user can abort; the command
+        # body calls confirm_destructive which raises Abort when stdin is empty
+        # (CliRunner default).  The emit must happen regardless.
+        destructive = _invoke_and_capture_destructive(
+            ["-w", "myws", "tables", "delete", "mydw", "dbo.mytable"]
+        )
+        assert destructive is True, (
+            f"tables delete did not emit destructive_op=True on abort; got {destructive!r}"
+        )
+
+    def test_warehouses_delete_emits_destructive_on_abort(self) -> None:
+        """warehouses delete aborted at prompt must still report destructive_op=True."""
+        destructive = _invoke_and_capture_destructive(
+            ["-w", "myws", "warehouses", "delete", "mywarehouse"]
+        )
+        assert destructive is True, (
+            f"warehouses delete did not emit destructive_op=True on abort; got {destructive!r}"
+        )
+
+    def test_snapshots_delete_emits_destructive_on_abort(self) -> None:
+        """snapshots delete aborted at prompt must still report destructive_op=True."""
+        destructive = _invoke_and_capture_destructive(
+            ["-w", "myws", "snapshots", "delete", "mywarehouse", "mysnapshot"]
+        )
+        assert destructive is True, (
+            f"snapshots delete did not emit destructive_op=True on abort; got {destructive!r}"
+        )
+
+    def test_views_drop_emits_destructive_on_abort(self) -> None:
+        """views drop aborted at prompt must still report destructive_op=True."""
+        destructive = _invoke_and_capture_destructive(
+            ["-w", "myws", "views", "drop", "mywarehouse", "dbo.myview"]
+        )
+        assert destructive is True, (
+            f"views drop did not emit destructive_op=True on abort; got {destructive!r}"
+        )
+
+    def test_statistics_delete_emits_destructive_on_abort(self) -> None:
+        """statistics delete aborted at prompt must still report destructive_op=True."""
+        destructive = _invoke_and_capture_destructive(
+            ["-w", "myws", "statistics", "delete", "mywarehouse", "dbo.mytable", "mystat"]
+        )
+        assert destructive is True, (
+            f"statistics delete did not emit destructive_op=True on abort; got {destructive!r}"
+        )
+
+    def test_schemas_delete_emits_destructive_on_abort(self) -> None:
+        """schemas delete aborted at prompt must still report destructive_op=True."""
+        destructive = _invoke_and_capture_destructive(
+            ["-w", "myws", "schemas", "delete", "mywarehouse", "myschema"]
+        )
+        assert destructive is True, (
+            f"schemas delete did not emit destructive_op=True on abort; got {destructive!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Non-destructive confirming commands must NOT set destructive_op
+# ---------------------------------------------------------------------------
+
+
+class TestNonDestructiveCommandsDoNotSetDestructiveOp:
+    """Commands that confirm but are not permanently destructive must not emit destructive_op."""
+
+    def test_queries_kill_is_not_destructive(self) -> None:
+        assert "queries.kill" not in _DESTRUCTIVE_CLI_COMMANDS
+
+    def test_schemas_drop_not_in_set(self) -> None:
+        """schemas.drop does not exist — the CLI command is schemas.delete."""
+        assert "schemas.drop" not in _DESTRUCTIVE_CLI_COMMANDS
+
+    def test_workspaces_set_collation_is_not_destructive(self) -> None:
+        assert "workspaces.set-collation" not in _DESTRUCTIVE_CLI_COMMANDS
+
+    def test_warehouses_rename_is_not_destructive(self) -> None:
+        assert "warehouses.rename" not in _DESTRUCTIVE_CLI_COMMANDS
+
+    def test_warehouses_takeover_is_not_destructive(self) -> None:
+        assert "warehouses.takeover" not in _DESTRUCTIVE_CLI_COMMANDS
+
+    def test_snapshots_roll_is_not_destructive(self) -> None:
+        assert "snapshots.roll" not in _DESTRUCTIVE_CLI_COMMANDS
+
+    def test_cache_clear_is_not_destructive(self) -> None:
+        assert "cache.clear" not in _DESTRUCTIVE_CLI_COMMANDS
+
+    def test_config_clear_is_not_destructive(self) -> None:
+        assert "config.clear" not in _DESTRUCTIVE_CLI_COMMANDS
+
+    def test_queries_kill_does_not_emit_destructive(self) -> None:
+        """queries kill must NOT emit destructive_op=True."""
+        destructive = _invoke_and_capture_destructive(
+            ["-w", "myws", "queries", "kill", "mywarehouse", "123"]
+        )
+        # None (not called) or False are both acceptable; True is not
+        assert destructive is not True, (
+            "queries kill incorrectly emitted destructive_op=True"
+        )
+
+    def test_cache_clear_does_not_emit_destructive(self) -> None:
+        """cache clear must NOT emit destructive_op=True."""
+        destructive = _invoke_and_capture_destructive(["cache", "clear"])
+        assert destructive is not True, (
+            "cache clear incorrectly emitted destructive_op=True"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Conditional cases
+# ---------------------------------------------------------------------------
+
+
+class TestConditionalDestructiveCommands:
+    """Conditional destructive commands mirror their MCP counterpart's flag logic."""
+
+    def test_sql_endpoints_refresh_without_recreate_is_not_destructive(self) -> None:
+        """sql-endpoints refresh without --recreate-tables must NOT emit destructive_op."""
+        # This command tries to connect to the API; it will fail at auth/network,
+        # but the emit happens regardless of outcome so we capture what was emitted.
+        destructive = _invoke_and_capture_destructive(
+            ["-w", "myws", "sql-endpoints", "refresh", "myendpoint"]
+        )
+        assert destructive is not True, (
+            "sql-endpoints refresh (no --recreate-tables) incorrectly emitted destructive_op=True"
+        )
+
+    def test_sql_endpoints_refresh_with_recreate_is_destructive(self) -> None:
+        """sql-endpoints refresh --recreate-tables must emit destructive_op=True."""
+        destructive = _invoke_and_capture_destructive(
+            ["-w", "myws", "sql-endpoints", "refresh", "myendpoint", "--recreate-tables"]
+        )
+        assert destructive is True, (
+            "sql-endpoints refresh --recreate-tables did not emit destructive_op=True; "
+            f"got {destructive!r}"
+        )
+
+    def test_tables_load_without_destructive_if_exists_is_not_destructive(self) -> None:
+        """tables load without truncate/replace --if-exists must NOT emit destructive_op."""
+        # Providing --file and --create without --if-exists truncate/replace is not destructive
+        destructive = _invoke_and_capture_destructive(
+            ["-w", "myws", "tables", "load", "mywarehouse", "dbo.mytable", "--url", "http://x"]
+        )
+        assert destructive is not True, (
+            "tables load (no destructive if-exists) incorrectly emitted destructive_op=True"
+        )
+
+    def test_tables_load_with_if_exists_truncate_is_destructive(self) -> None:
+        """tables load --if-exists truncate must emit destructive_op=True."""
+        destructive = _invoke_and_capture_destructive(
+            [
+                "-w",
+                "myws",
+                "tables",
+                "load",
+                "mywarehouse",
+                "dbo.mytable",
+                "--file",
+                "/tmp/data.csv",  # noqa: S108
+                "--create",
+                "--if-exists",
+                "truncate",
+            ]
+        )
+        assert destructive is True, (
+            "tables load --if-exists truncate did not emit destructive_op=True; "
+            f"got {destructive!r}"
+        )
+
+    def test_tables_load_with_if_exists_replace_is_destructive(self) -> None:
+        """tables load --if-exists replace must emit destructive_op=True."""
+        destructive = _invoke_and_capture_destructive(
+            [
+                "-w",
+                "myws",
+                "tables",
+                "load",
+                "mywarehouse",
+                "dbo.mytable",
+                "--file",
+                "/tmp/data.csv",  # noqa: S108
+                "--create",
+                "--if-exists",
+                "replace",
+            ]
+        )
+        assert destructive is True, (
+            "tables load --if-exists replace did not emit destructive_op=True; "
+            f"got {destructive!r}"
+        )

--- a/tests/unit/test_cli_destructive_parity.py
+++ b/tests/unit/test_cli_destructive_parity.py
@@ -23,10 +23,31 @@ from click.testing import CliRunner
 import fabric_dw.cli._main as _main_mod
 from fabric_dw.cli._main import (
     _DESTRUCTIVE_CLI_COMMANDS,
-    _MCP_TO_CLI_DESTRUCTIVE_MAP,
     cli,
 )
 from fabric_dw.mcp._helpers import _DESTRUCTIVE_MCP_TOOLS
+
+# ---------------------------------------------------------------------------
+# Drift-guard map (test-local) — MCP tool name → CLI dotted name
+# ---------------------------------------------------------------------------
+# Kept here rather than in the production module since it has no runtime use.
+# Conditional tools (refresh_sql_endpoint_metadata, import_table_from_url) are
+# excluded — they carry their own runtime flag logic.
+_MCP_TO_CLI_DESTRUCTIVE_MAP: dict[str, str] = {
+    "drop_function": "functions.drop",
+    "drop_procedure": "procedures.drop",
+    "delete_restore_point": "restore-points.delete",
+    "restore_warehouse_in_place": "restore-points.restore",
+    "delete_schema": "schemas.delete",
+    "delete_snapshot": "snapshots.delete",
+    "delete_sql_pool": "sql-pools.delete",
+    "delete_statistics": "statistics.delete",
+    "delete_table": "tables.delete",
+    "clear_table": "tables.clear",
+    "set_cluster_columns": "tables.cluster-by",
+    "drop_view": "views.drop",
+    "delete_warehouse": "warehouses.delete",
+}
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/unit/test_cli_destructive_parity.py
+++ b/tests/unit/test_cli_destructive_parity.py
@@ -33,12 +33,16 @@ from fabric_dw.mcp._helpers import _DESTRUCTIVE_MCP_TOOLS
 # ---------------------------------------------------------------------------
 
 
-def _invoke_and_capture_destructive(args: list[str]) -> bool | None:
+def _invoke_and_capture_destructive(args: list[str]) -> bool:
     """Run the CLI with *args* and return the ``destructive`` kwarg from the
-    last ``emit_command_invoked`` call, or ``None`` if it was never called.
+    last ``emit_command_invoked`` call.
 
     Patches out all I/O and infrastructure so no real network access or auth
     is needed.
+
+    Raises:
+        AssertionError: When ``emit_command_invoked`` was never called — this
+            indicates an instrumentation break distinct from a flag-value bug.
     """
     captured: list[dict] = []
 
@@ -55,9 +59,10 @@ def _invoke_and_capture_destructive(args: list[str]) -> bool | None:
     ):
         runner.invoke(cli, args, catch_exceptions=True)
 
-    if not captured:
-        return None
-    return captured[-1].get("destructive", False)  # type: ignore[return-value]
+    assert captured, (
+        f"emit_command_invoked was never called for args {args!r}; instrumentation may be broken"
+    )
+    return bool(captured[-1].get("destructive", False))
 
 
 # ---------------------------------------------------------------------------
@@ -94,6 +99,21 @@ class TestDestructiveParity:
         ]
         assert not missing, "\n".join(missing)
 
+    def test_every_cli_destructive_command_appears_in_map_values(self) -> None:
+        """Every entry in _DESTRUCTIVE_CLI_COMMANDS must appear as a map value.
+
+        A new CLI destructive command added to the frozenset but not to
+        _MCP_TO_CLI_DESTRUCTIVE_MAP.values() would be unreachable from MCP
+        parity checks — this test catches that gap.
+        """
+        map_values = set(_MCP_TO_CLI_DESTRUCTIVE_MAP.values())
+        missing = [
+            f"{cmd!r} not a value in _MCP_TO_CLI_DESTRUCTIVE_MAP"
+            for cmd in sorted(_DESTRUCTIVE_CLI_COMMANDS)
+            if cmd not in map_values
+        ]
+        assert not missing, "\n".join(missing)
+
     def test_mcp_destructive_set_not_empty(self) -> None:
         """_DESTRUCTIVE_MCP_TOOLS must be non-empty (sanity check)."""
         assert _DESTRUCTIVE_MCP_TOOLS, "_DESTRUCTIVE_MCP_TOOLS is empty — check _helpers.py"
@@ -117,9 +137,7 @@ class TestDestructiveCliCommandsEmitDestructiveOp:
     )
     def test_destructive_command_name_in_frozenset(self, dotted_name: str) -> None:
         """All entries in _DESTRUCTIVE_CLI_COMMANDS follow the <group>.<subcommand> convention."""
-        assert "." in dotted_name, (
-            f"{dotted_name!r} is not in <group>.<subcommand> format"
-        )
+        assert "." in dotted_name, f"{dotted_name!r} is not in <group>.<subcommand> format"
 
     def test_functions_drop_is_destructive(self) -> None:
         assert "functions.drop" in _DESTRUCTIVE_CLI_COMMANDS
@@ -265,17 +283,12 @@ class TestNonDestructiveCommandsDoNotSetDestructiveOp:
         destructive = _invoke_and_capture_destructive(
             ["-w", "myws", "queries", "kill", "mywarehouse", "123"]
         )
-        # None (not called) or False are both acceptable; True is not
-        assert destructive is not True, (
-            "queries kill incorrectly emitted destructive_op=True"
-        )
+        assert destructive is False, "queries kill incorrectly emitted destructive_op=True"
 
     def test_cache_clear_does_not_emit_destructive(self) -> None:
         """cache clear must NOT emit destructive_op=True."""
         destructive = _invoke_and_capture_destructive(["cache", "clear"])
-        assert destructive is not True, (
-            "cache clear incorrectly emitted destructive_op=True"
-        )
+        assert destructive is False, "cache clear incorrectly emitted destructive_op=True"
 
 
 # ---------------------------------------------------------------------------
@@ -293,7 +306,7 @@ class TestConditionalDestructiveCommands:
         destructive = _invoke_and_capture_destructive(
             ["-w", "myws", "sql-endpoints", "refresh", "myendpoint"]
         )
-        assert destructive is not True, (
+        assert destructive is False, (
             "sql-endpoints refresh (no --recreate-tables) incorrectly emitted destructive_op=True"
         )
 
@@ -313,7 +326,7 @@ class TestConditionalDestructiveCommands:
         destructive = _invoke_and_capture_destructive(
             ["-w", "myws", "tables", "load", "mywarehouse", "dbo.mytable", "--url", "http://x"]
         )
-        assert destructive is not True, (
+        assert destructive is False, (
             "tables load (no destructive if-exists) incorrectly emitted destructive_op=True"
         )
 
@@ -357,6 +370,56 @@ class TestConditionalDestructiveCommands:
             ]
         )
         assert destructive is True, (
-            "tables load --if-exists replace did not emit destructive_op=True; "
-            f"got {destructive!r}"
+            f"tables load --if-exists replace did not emit destructive_op=True; got {destructive!r}"
+        )
+
+    def test_tables_load_truncate_without_create_still_emits_destructive(self) -> None:
+        """tables load --if-exists truncate without --create is rejected (UsageError) but
+        must STILL emit destructive_op=True — the intent is destructive even on rejection.
+
+        Regression test for the outcome-independence gap: the ctx.meta flag must be
+        stashed BEFORE the --create guard raises UsageError.
+        """
+        destructive = _invoke_and_capture_destructive(
+            [
+                "-w",
+                "myws",
+                "tables",
+                "load",
+                "mywarehouse",
+                "dbo.mytable",
+                "--file",
+                "/tmp/data.csv",  # noqa: S108
+                "--if-exists",
+                "truncate",
+                # NOTE: --create is intentionally omitted to trigger the UsageError guard
+            ]
+        )
+        assert destructive is True, (
+            "tables load --if-exists truncate (without --create) did not emit destructive_op=True "
+            f"on rejection; got {destructive!r}"
+        )
+
+    def test_tables_load_replace_without_create_still_emits_destructive(self) -> None:
+        """tables load --if-exists replace without --create is rejected (UsageError) but
+        must STILL emit destructive_op=True — the intent is destructive even on rejection.
+        """
+        destructive = _invoke_and_capture_destructive(
+            [
+                "-w",
+                "myws",
+                "tables",
+                "load",
+                "mywarehouse",
+                "dbo.mytable",
+                "--file",
+                "/tmp/data.csv",  # noqa: S108
+                "--if-exists",
+                "replace",
+                # NOTE: --create is intentionally omitted to trigger the UsageError guard
+            ]
+        )
+        assert destructive is True, (
+            "tables load --if-exists replace (without --create) did not emit destructive_op=True "
+            f"on rejection; got {destructive!r}"
         )


### PR DESCRIPTION
## Summary

- Adds `destructive_op=true` telemetry to all CLI commands that mirror permanently-destructive MCP tools, closing the gap identified in #666.
- Single source of truth: `_DESTRUCTIVE_CLI_COMMANDS` frozenset in `cli/_main.py` enumerates 13 unconditionally-destructive CLI commands.
- Conditional destructive cases (`sql-endpoints refresh --recreate-tables`, `tables load --if-exists truncate|replace`) stash a flag in `ctx.meta` before any API call or prompt, making the emit outcome-independent.
- `_DESTRUCTIVE_MCP_TOOLS` set in `mcp/_helpers.py` is populated at decoration time by `mutating_tool(destructive=True)`, providing the MCP side of the bidirectional drift guard.
- New `tests/unit/test_cli_destructive_parity.py` cross-checks both sets bidirectionally (51 tests) — verified emit on abort, confirmed non-destructive commands do not set the flag, and covered conditional cases.

## Test plan

- [x] `uv run pytest tests/unit/test_cli_destructive_parity.py` — 51 tests pass
- [x] `uv run pytest tests/unit -q` — 4292 tests pass, no regressions
- [x] `uv run ruff check` on changed files — clean
- [x] `uv run ty check src tests` — clean

Closes #666