### PR TITLE
feat(config): add configurable SQL retry budget knobs

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -202,6 +202,8 @@ jobs:
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           XDIST_WORKERS_INPUT: ${{ inputs.xdist_workers }}
           PYTEST_K_INPUT: ${{ inputs.pytest_k }}
+          FABRIC_SQL_RETRY_TIMEOUT_S: "300"
+          FABRIC_SQL_RETRY_EXECUTES: "1"
         run: |
           # Worker-count rationale
           # ----------------------

--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -44,6 +44,38 @@ fdw config unset max-429-retries
 fdw config unset retry-deadline
 ```
 
+## SQL retry budget
+
+The SQL/TDS connect-phase and execute-phase retry budget is a separate layer from the HTTP retry knobs above and operates at the driver level. Resolution order (env var > config > built-in):
+
+| Knob | Env var | Config key | Built-in default |
+|---|---|---|---|
+| Connect+execute deadline (s) | `FABRIC_SQL_RETRY_TIMEOUT_S` | `sql_retry_deadline_s` | 120.0 |
+| Retry non-idempotent statements | `FABRIC_SQL_RETRY_EXECUTES` | `sql_retry_executes` | false |
+
+`sql_retry_deadline_s` sets the total wall-clock budget for both the connect-phase and execute-phase retry loops. The built-in 120 s covers the observed Fabric warehouse warm-up window (~60–90 s).
+
+`sql_retry_executes` opts in to retrying statements that use `fetch="none"` (INSERT, UPDATE, DELETE, DDL) on transient TDS errors. **WARNING: enabling this flag can cause a non-idempotent statement to execute more than once if a transient error occurs after the server begins processing it. Only enable when all such statements are idempotent.**
+
+To persist a longer SQL retry budget:
+
+```shell
+fdw config set sql-retry-deadline 300.0
+```
+
+To opt in to retrying non-idempotent statements:
+
+```shell
+fdw config set sql-retry-executes true
+```
+
+To revert to the built-in defaults:
+
+```shell
+fdw config unset sql-retry-deadline
+fdw config unset sql-retry-executes
+```
+
 For authentication configuration, see [Authentication](../install.md#authentication).
 
 ---
@@ -64,7 +96,7 @@ fdw config clear
 
 ### config set
 
-Set a default value. Accepts `workspace`, `warehouse`, `max-429-retries`, or `retry-deadline` as the key.
+Set a default value. Accepts `workspace`, `warehouse`, `max-429-retries`, `retry-deadline`, `sql-retry-deadline`, or `sql-retry-executes` as the key.
 
 **Synopsis**
 
@@ -73,6 +105,8 @@ fdw config set workspace VALUE
 fdw config set warehouse VALUE
 fdw config set max-429-retries N
 fdw config set retry-deadline SECONDS
+fdw config set sql-retry-deadline SECONDS
+fdw config set sql-retry-executes true|false
 ```
 
 **Example**
@@ -82,6 +116,8 @@ fdw config set workspace MyWorkspace
 fdw config set warehouse MyWarehouse
 fdw config set max-429-retries 20
 fdw config set retry-deadline 600.0
+fdw config set sql-retry-deadline 300.0
+fdw config set sql-retry-executes true
 ```
 
 ---
@@ -112,7 +148,7 @@ warehouse  MyWarehouse
 
 ### config unset
 
-Clear a single default value. Accepts `workspace`, `warehouse`, `max-429-retries`, or `retry-deadline` as the key.
+Clear a single default value. Accepts `workspace`, `warehouse`, `max-429-retries`, `retry-deadline`, `sql-retry-deadline`, or `sql-retry-executes` as the key.
 
 **Synopsis**
 
@@ -121,4 +157,6 @@ fdw config unset workspace
 fdw config unset warehouse
 fdw config unset max-429-retries
 fdw config unset retry-deadline
+fdw config unset sql-retry-deadline
+fdw config unset sql-retry-executes
 ```

--- a/src/fabric_dw/cli/commands/config.py
+++ b/src/fabric_dw/cli/commands/config.py
@@ -5,16 +5,20 @@ workspace / warehouse on every command.
 
 Commands
 --------
-config show                  — print current defaults (JSON or table)
-config set workspace         — persist a workspace default
-config set warehouse         — persist a warehouse default
-config set max-429-retries   — persist the max consecutive 429 retry count
-config set retry-deadline    — persist the combined 429+5xx wall-clock deadline
-config unset workspace       — clear the workspace default
-config unset warehouse       — clear the warehouse default
-config unset max-429-retries — clear the max consecutive 429 retry count
-config unset retry-deadline  — clear the deadline default
-config clear                 — wipe the entire config file
+config show                    — print current defaults (JSON or table)
+config set workspace           — persist a workspace default
+config set warehouse           — persist a warehouse default
+config set max-429-retries     — persist the max consecutive 429 retry count
+config set retry-deadline      — persist the combined 429+5xx wall-clock deadline
+config set sql-retry-deadline  — persist the SQL/TDS connect+execute retry budget
+config set sql-retry-executes  — persist whether fetch="none" statements are retried
+config unset workspace         — clear the workspace default
+config unset warehouse         — clear the warehouse default
+config unset max-429-retries   — clear the max consecutive 429 retry count
+config unset retry-deadline    — clear the HTTP deadline default
+config unset sql-retry-deadline — clear the SQL retry deadline default
+config unset sql-retry-executes — clear the SQL execute-retry flag
+config clear                   — wipe the entire config file
 """
 
 from __future__ import annotations
@@ -47,6 +51,8 @@ def show_cmd(ctx: CliContext) -> None:
             "warehouse": cfg.defaults.warehouse,
             "max_429_retries": cfg.defaults.max_429_retries,
             "retry_deadline_s": cfg.defaults.retry_deadline_s,
+            "sql_retry_deadline_s": cfg.defaults.sql_retry_deadline_s,
+            "sql_retry_executes": cfg.defaults.sql_retry_executes,
         }
     }
     render(data, json_output=ctx.json_output)
@@ -94,6 +100,28 @@ def set_retry_deadline_cmd(value: float) -> None:
     click.echo(f"Default retry_deadline_s set to {value}.")
 
 
+@set_group.command("sql-retry-deadline")
+@click.argument("value", type=click.FloatRange(min=0.1))
+def set_sql_retry_deadline_cmd(value: float) -> None:
+    """Set the SQL/TDS connect+execute retry wall-clock budget in seconds."""
+    set_default("sql_retry_deadline_s", str(value))
+    click.echo(f"Default sql_retry_deadline_s set to {value}.")
+
+
+@set_group.command("sql-retry-executes")
+@click.argument("value", type=click.Choice(["true", "false"], case_sensitive=False))
+def set_sql_retry_executes_cmd(value: str) -> None:
+    """Enable or disable execute-phase retry for fetch=none (non-idempotent) statements.
+
+    WARNING: setting this to true means a transient error on a non-idempotent
+    statement (INSERT, UPDATE, DELETE, DDL) may trigger a retry and cause the
+    statement to execute more than once.  Only enable when all such statements
+    are idempotent.
+    """
+    set_default("sql_retry_executes", value.lower())
+    click.echo(f"Default sql_retry_executes set to {value.lower()}.")
+
+
 # ---------------------------------------------------------------------------
 # config unset  (sub-group with workspace / warehouse sub-commands)
 # ---------------------------------------------------------------------------
@@ -130,6 +158,20 @@ def unset_retry_deadline_cmd() -> None:
     """Clear the retry_deadline_s default (revert to built-in 300.0)."""
     set_default("retry_deadline_s", None)
     click.echo("Default retry_deadline_s cleared.")
+
+
+@unset_group.command("sql-retry-deadline")
+def unset_sql_retry_deadline_cmd() -> None:
+    """Clear the sql_retry_deadline_s default (revert to built-in 120.0)."""
+    set_default("sql_retry_deadline_s", None)
+    click.echo("Default sql_retry_deadline_s cleared.")
+
+
+@unset_group.command("sql-retry-executes")
+def unset_sql_retry_executes_cmd() -> None:
+    """Clear the sql_retry_executes default (revert to built-in false)."""
+    set_default("sql_retry_executes", None)
+    click.echo("Default sql_retry_executes cleared.")
 
 
 # ---------------------------------------------------------------------------

--- a/src/fabric_dw/config.py
+++ b/src/fabric_dw/config.py
@@ -1,8 +1,8 @@
 """User-level configuration for fabric-dw CLI.
 
-Stores persistent defaults (workspace, warehouse, and HTTP retry knobs)
-in a TOML file at ``$XDG_CONFIG_HOME/fabric-dw/config.toml`` (falling
-back to ``~/.config/fabric-dw/config.toml``).
+Stores persistent defaults (workspace, warehouse, HTTP retry knobs, and SQL
+retry knobs) in a TOML file at ``$XDG_CONFIG_HOME/fabric-dw/config.toml``
+(falling back to ``~/.config/fabric-dw/config.toml``).
 
 The TOML shape is intentionally tiny:
 
@@ -13,6 +13,8 @@ The TOML shape is intentionally tiny:
     warehouse = "Sales-DW"
     max_429_retries = 10
     retry_deadline_s = 300.0
+    sql_retry_deadline_s = 120.0
+    sql_retry_executes = false
 
 Reads are done with :mod:`tomllib` (stdlib, Python 3.11+).
 Writes use :mod:`tomli_w` for spec-compliant serialisation (handles newlines,
@@ -58,12 +60,14 @@ class ConfigError(RuntimeError):
 
 @dataclass(frozen=True)
 class Defaults:
-    """Persistent workspace / warehouse defaults and HTTP retry knobs."""
+    """Persistent workspace / warehouse defaults, HTTP retry knobs, and SQL retry knobs."""
 
     workspace: str | None = None
     warehouse: str | None = None
     max_429_retries: int | None = None
     retry_deadline_s: float | None = None
+    sql_retry_deadline_s: float | None = None
+    sql_retry_executes: bool | None = None
 
 
 @dataclass(frozen=True)
@@ -148,6 +152,8 @@ def load_config(path: Path | None = None) -> UserConfig:
     warehouse = defaults_raw.get("warehouse")
     raw_retries = defaults_raw.get("max_429_retries")
     raw_deadline = defaults_raw.get("retry_deadline_s")
+    raw_sql_deadline = defaults_raw.get("sql_retry_deadline_s")
+    raw_sql_executes = defaults_raw.get("sql_retry_executes")
     return UserConfig(
         defaults=Defaults(
             workspace=workspace if isinstance(workspace, str) else None,
@@ -156,6 +162,10 @@ def load_config(path: Path | None = None) -> UserConfig:
             retry_deadline_s=float(raw_deadline)
             if isinstance(raw_deadline, (int, float)) and math.isfinite(raw_deadline)
             else None,
+            sql_retry_deadline_s=float(raw_sql_deadline)
+            if isinstance(raw_sql_deadline, (int, float)) and math.isfinite(raw_sql_deadline)
+            else None,
+            sql_retry_executes=raw_sql_executes if isinstance(raw_sql_executes, bool) else None,
         )
     )
 
@@ -188,6 +198,10 @@ def _defaults_to_dict(d: Defaults) -> dict[str, object]:
         out["max_429_retries"] = d.max_429_retries
     if d.retry_deadline_s is not None:
         out["retry_deadline_s"] = d.retry_deadline_s
+    if d.sql_retry_deadline_s is not None:
+        out["sql_retry_deadline_s"] = d.sql_retry_deadline_s
+    if d.sql_retry_executes is not None:
+        out["sql_retry_executes"] = d.sql_retry_executes
     return out
 
 
@@ -212,18 +226,24 @@ def _read_defaults_locked(resolved: Path) -> Defaults:
     wh = defaults_raw.get("warehouse")
     rr = defaults_raw.get("max_429_retries")
     rd = defaults_raw.get("retry_deadline_s")
+    srd = defaults_raw.get("sql_retry_deadline_s")
+    sre = defaults_raw.get("sql_retry_executes")
     return Defaults(
         workspace=ws if isinstance(ws, str) else None,
         warehouse=wh if isinstance(wh, str) else None,
         max_429_retries=int(rr) if isinstance(rr, int) else None,
         retry_deadline_s=float(rd) if isinstance(rd, (int, float)) and math.isfinite(rd) else None,
+        sql_retry_deadline_s=float(srd)
+        if isinstance(srd, (int, float)) and math.isfinite(srd)
+        else None,
+        sql_retry_executes=sre if isinstance(sre, bool) else None,
     )
 
 
 _MIN_RETRY_DEADLINE_S: float = 0.1
 
 
-def set_default(key: str, value: str | None, path: Path | None = None) -> None:
+def set_default(key: str, value: str | None, path: Path | None = None) -> None:  # noqa: PLR0912, PLR0915
     """Atomically update a single key under ``[defaults]`` without touching other keys.
 
     The read-modify-write is performed under a single :class:`filelock.FileLock`
@@ -245,7 +265,14 @@ def set_default(key: str, value: str | None, path: Path | None = None) -> None:
             silent data loss — set_default will never overwrite a file it could
             not read).
     """
-    allowed = {"workspace", "warehouse", "max_429_retries", "retry_deadline_s"}
+    allowed = {
+        "workspace",
+        "warehouse",
+        "max_429_retries",
+        "retry_deadline_s",
+        "sql_retry_deadline_s",
+        "sql_retry_executes",
+    }
     if key not in allowed:
         raise ValueError(f"Unknown config key {key!r}; must be one of {sorted(allowed)}")
 
@@ -253,10 +280,11 @@ def set_default(key: str, value: str | None, path: Path | None = None) -> None:
     resolved.parent.mkdir(parents=True, exist_ok=True)
     lock = filelock.FileLock(str(resolved) + ".lock", timeout=_LOCK_TIMEOUT)
 
-    # Coerce and validate numeric keys before acquiring the lock so errors
+    # Coerce and validate numeric/boolean keys before acquiring the lock so errors
     # surface early without any lock or I/O.
     coerced_int: int | None = None
     coerced_float: float | None = None
+    coerced_bool: bool | None = None
     if value is not None:
         if key == "max_429_retries":
             try:
@@ -280,6 +308,30 @@ def set_default(key: str, value: str | None, path: Path | None = None) -> None:
                 raise ValueError(
                     f"retry_deadline_s must be >= {_MIN_RETRY_DEADLINE_S}, got {coerced_float}"
                 )
+        elif key == "sql_retry_deadline_s":
+            try:
+                coerced_float = float(value)
+            except (ValueError, OverflowError) as exc:
+                raise ValueError(
+                    f"sql_retry_deadline_s {value!r} cannot be converted to a float: {exc}"
+                ) from exc
+            if not math.isfinite(coerced_float):
+                raise ValueError(
+                    f"sql_retry_deadline_s must be a finite number, got {coerced_float!r}"
+                )
+            if coerced_float < _MIN_RETRY_DEADLINE_S:
+                raise ValueError(
+                    f"sql_retry_deadline_s must be >= {_MIN_RETRY_DEADLINE_S}, got {coerced_float}"
+                )
+        elif key == "sql_retry_executes":
+            if value.lower() in {"true", "1", "yes", "on"}:
+                coerced_bool = True
+            elif value.lower() in {"false", "0", "no", "off"}:
+                coerced_bool = False
+            else:
+                raise ValueError(
+                    f"sql_retry_executes {value!r} must be one of: true/1/yes/on or false/0/no/off"
+                )
 
     try:
         with lock:
@@ -297,6 +349,12 @@ def set_default(key: str, value: str | None, path: Path | None = None) -> None:
                 retry_deadline_s=coerced_float
                 if key == "retry_deadline_s"
                 else current.retry_deadline_s,
+                sql_retry_deadline_s=coerced_float
+                if key == "sql_retry_deadline_s"
+                else current.sql_retry_deadline_s,
+                sql_retry_executes=coerced_bool
+                if key == "sql_retry_executes"
+                else current.sql_retry_executes,
             )
             # _write_config_unlocked is called inside the lock so the full
             # read-modify-write stays within a single lock cycle (C20).

--- a/src/fabric_dw/sql.py
+++ b/src/fabric_dw/sql.py
@@ -42,6 +42,8 @@ from __future__ import annotations
 import contextlib
 import functools
 import importlib
+import logging
+import math
 import os
 import re
 import threading
@@ -53,6 +55,8 @@ from typing import Any, Literal, Protocol
 
 from fabric_dw.auth import CredentialMode, get_sql_token_struct
 from fabric_dw.exceptions import AuthError, NotFoundError, PermissionDeniedError
+
+_log = logging.getLogger(__name__)
 
 __all__ = [
     "POOL_MAX_IDLE",
@@ -86,11 +90,13 @@ __all__ = [
 #
 # The loop retries up to len(_EXECUTE_RETRY_DELAYS) + 1 attempts total
 # (initial attempt + 3 retries = 4 attempts max) AND stops early if the
-# wall-clock deadline (_CONNECT_RETRY_TIMEOUT_S) is exceeded.  Both guards
-# are applied so the worst-case bound is clearly bounded:
+# wall-clock deadline (sql_retry_deadline_s, default 120.0 s) is exceeded.
+# Both guards are applied so the worst-case bound is clearly bounded:
 #   worst case <= (len(_EXECUTE_RETRY_DELAYS) + 1) attempts
-#              x (max connect budget + SQL_QUERY_TIMEOUT_S)
+#              x (configurable deadline default + SQL_QUERY_TIMEOUT_S)
 #            = 4 x (120 s + 300 s) = ~1680 s (~28 minutes absolute max)
+# The deadline is configurable via FABRIC_SQL_RETRY_TIMEOUT_S env var or
+# ``fdw config set sql-retry-deadline``.
 _EXECUTE_RETRY_DELAYS: tuple[float, ...] = (2.0, 5.0, 10.0)
 
 # ---------------------------------------------------------------------------
@@ -101,14 +107,21 @@ _EXECUTE_RETRY_DELAYS: tuple[float, ...] = (2.0, 5.0, 10.0)
 # _with_connect_retry.  The loop keeps retrying while _is_connect_retryable
 # returns True and the elapsed time is less than this budget.
 #
-# 120 s covers the observed Fabric warehouse warm-up window (~60-90 s) with
-# comfortable margin.
+# The built-in default is 120.0 s, which covers the observed Fabric warehouse
+# warm-up window (~60-90 s) with comfortable margin.  It is configurable via
+# the FABRIC_SQL_RETRY_TIMEOUT_S env var or ``fdw config set sql-retry-deadline``.
 #
 # **Trade-off**: a genuinely-wrong credential will now hang up to ~120 s
 # before the AuthError is surfaced to the caller — because the retry loop
 # cannot distinguish "wrong credential" from "warehouse still warming up".
 # This latency is accepted: the warm-up case is far more common in production.
-_CONNECT_RETRY_TIMEOUT_S: float = 120.0
+_SQL_RETRY_DEADLINE_S_DEFAULT: float = 120.0
+_MIN_SQL_RETRY_DEADLINE_S: float = 0.1  # minimum accepted value for env / config
+
+# Backwards-compatible alias used by integration tests and the smoke-timeout invariant test.
+# The old name was _CONNECT_RETRY_TIMEOUT_S; it was renamed to _SQL_RETRY_DEADLINE_S_DEFAULT
+# when the value became configurable.  Remove after all callsites are updated.
+_CONNECT_RETRY_TIMEOUT_S: float = _SQL_RETRY_DEADLINE_S_DEFAULT
 
 # Backoff delays for the connect-phase retry loop.  The delay before attempt
 # N+1 is _CONNECT_RETRY_DELAYS[min(N, len-1)], so the sequence is:
@@ -132,6 +145,101 @@ SQL_LOGIN_TIMEOUT_S: int = 60
 # A generous value prevents long-running administrative queries from being
 # cancelled prematurely.
 SQL_QUERY_TIMEOUT_S: int = 300
+
+# ---------------------------------------------------------------------------
+# SQL retry config resolution — 3-layer precedence
+# ---------------------------------------------------------------------------
+# Both knobs resolve at call-time via the 3-layer rule:
+#   env var (highest) > config.toml [defaults] > built-in fallback
+#
+# A module-level cache avoids re-reading the config file on every query.
+# The cache is protected by a threading.Lock (threading is already imported).
+# _sql_config_cache_clear() is a test-only hook to reset the cache between
+# tests that mutate env vars or the config.
+
+from fabric_dw.config import UserConfig as _UserConfig  # noqa: E402
+
+_sql_config_cache: _UserConfig | None = None
+_sql_config_lock: threading.Lock = threading.Lock()
+
+
+def _load_sql_config() -> _UserConfig:
+    """Return a cached :class:`~fabric_dw.config.UserConfig`, loading on first call.
+
+    Uses a module-level cache so the config file is read at most once per
+    process.  Thread-safe: the cache is guarded by ``_sql_config_lock``.
+    """
+    global _sql_config_cache  # noqa: PLW0603
+    with _sql_config_lock:
+        if _sql_config_cache is None:
+            from fabric_dw.config import load_config  # noqa: PLC0415
+
+            _sql_config_cache = load_config()
+        return _sql_config_cache
+
+
+def _sql_config_cache_clear() -> None:
+    """Reset the SQL config cache.  For use in tests only."""
+    global _sql_config_cache  # noqa: PLW0603
+    with _sql_config_lock:
+        _sql_config_cache = None
+
+
+def _resolve_sql_retry_deadline_s() -> float:
+    """Return the effective SQL retry deadline in seconds.
+
+    Resolution order (3-layer):
+    1. ``FABRIC_SQL_RETRY_TIMEOUT_S`` env var — must be a finite float >= 0.1.
+       Invalid values are ignored (warning logged) and fall through to next layer.
+    2. ``config.toml`` ``[defaults].sql_retry_deadline_s``.
+    3. Built-in fallback: :data:`_SQL_RETRY_DEADLINE_S_DEFAULT` (120.0 s).
+    """
+    raw_env = os.environ.get("FABRIC_SQL_RETRY_TIMEOUT_S")
+    if raw_env is not None:
+        try:
+            v = float(raw_env)
+        except (ValueError, OverflowError):
+            _log.warning("FABRIC_SQL_RETRY_TIMEOUT_S=%r is not a valid float; ignoring", raw_env)
+        else:
+            if math.isfinite(v) and v >= _MIN_SQL_RETRY_DEADLINE_S:
+                return v
+            _log.warning(
+                "FABRIC_SQL_RETRY_TIMEOUT_S=%r must be a finite number >= %s; ignoring",
+                raw_env,
+                _MIN_SQL_RETRY_DEADLINE_S,
+            )
+
+    cfg_val = _load_sql_config().defaults.sql_retry_deadline_s
+    if cfg_val is not None:
+        return cfg_val
+
+    return _SQL_RETRY_DEADLINE_S_DEFAULT
+
+
+# Truthy/falsy string sets for _resolve_sql_retry_executes.
+# Kept inline to avoid importing telemetry's private helpers.
+_FALSY_STRINGS: frozenset[str] = frozenset({"", "0", "false", "no", "off"})
+
+
+def _resolve_sql_retry_executes() -> bool:
+    """Return True if execute-phase retry should be widened to include fetch="none".
+
+    Resolution order (3-layer):
+    1. ``FABRIC_SQL_RETRY_EXECUTES`` env var — falsy: ``{"","0","false","no","off"}``
+       (case-insensitive); anything else is truthy.
+    2. ``config.toml`` ``[defaults].sql_retry_executes``.
+    3. Built-in fallback: ``False`` (non-idempotent DML is not retried by default).
+    """
+    raw_env = os.environ.get("FABRIC_SQL_RETRY_EXECUTES")
+    if raw_env is not None:
+        return raw_env.lower() not in _FALSY_STRINGS
+
+    cfg_val = _load_sql_config().defaults.sql_retry_executes
+    if cfg_val is not None:
+        return cfg_val
+
+    return False
+
 
 # ---------------------------------------------------------------------------
 # Lazy driver import — @functools.cache avoids the module-level global and the
@@ -1016,7 +1124,7 @@ def _with_connect_retry(
         Any non-retryable exception from ``open_connection`` immediately.
         The last retryable exception when the wall-clock deadline passes.
     """
-    deadline = time.monotonic() + _CONNECT_RETRY_TIMEOUT_S
+    deadline = time.monotonic() + _resolve_sql_retry_deadline_s()
     last_exc: BaseException | None = None
     attempt = 0
 
@@ -1144,9 +1252,11 @@ def run_query(  # noqa: PLR0913, PLR0915
         Exception: Any other driver error is propagated unchanged.
     """
     # Whether execute-phase transient errors are safe to retry.
-    # Only non-DML fetches (fetch != "none") can safely be retried after
-    # execute has started — DML could have already been applied server-side.
-    execute_retry_allowed = fetch != "none"
+    # Default: only non-DML fetches (fetch != "none") can safely be retried
+    # after execute has started — DML could have already been applied server-side.
+    # When sql_retry_executes is enabled (opt-in), fetch="none" statements are
+    # also retried; callers must ensure idempotency of those statements.
+    execute_retry_allowed = fetch != "none" or _resolve_sql_retry_executes()
 
     # Maximum number of execute-phase attempts: initial + len(_EXECUTE_RETRY_DELAYS) retries.
     # Both this cap AND the wall-clock deadline must be satisfied for a retry to fire.
@@ -1210,8 +1320,8 @@ def run_query(  # noqa: PLR0913, PLR0915
     # and the attempt cap).  Starts at 1 for the first attempt.
     execute_attempt = 1
     # deadline is set on the first execute-phase transient failure.  The total
-    # wall-clock budget for execute-phase retries is _CONNECT_RETRY_TIMEOUT_S
-    # (~120 s), reusing the same constant as the connect-phase loop.
+    # wall-clock budget for execute-phase retries matches the connect-phase
+    # budget (sql_retry_deadline_s, default 120.0 s), resolved at call-time.
     execute_deadline: float | None = None
 
     while True:
@@ -1235,7 +1345,7 @@ def run_query(  # noqa: PLR0913, PLR0915
                 raise
             # Set the deadline on the first execute-phase transient failure.
             if execute_deadline is None:
-                execute_deadline = time.monotonic() + _CONNECT_RETRY_TIMEOUT_S
+                execute_deadline = time.monotonic() + _resolve_sql_retry_deadline_s()
             # Close the tainted connection before sleeping.  _PooledConnection
             # is idempotent so a later close() call is a no-op.
             conn.close()

--- a/src/fabric_dw/sql.py
+++ b/src/fabric_dw/sql.py
@@ -93,8 +93,13 @@ __all__ = [
 # wall-clock deadline (sql_retry_deadline_s, default 120.0 s) is exceeded.
 # Both guards are applied so the worst-case bound is clearly bounded:
 #   worst case <= (len(_EXECUTE_RETRY_DELAYS) + 1) attempts
-#              x (configurable deadline default + SQL_QUERY_TIMEOUT_S)
-#            = 4 x (120 s + 300 s) = ~1680 s (~28 minutes absolute max)
+#              x (effective deadline + SQL_QUERY_TIMEOUT_S)
+#
+# With the built-in default deadline (120.0 s):
+#   = 4 x (120 s + 300 s) = ~1680 s (~28 minutes)
+# With FABRIC_SQL_RETRY_TIMEOUT_S=300 (integration CI):
+#   = 4 x (300 s + 300 s) = ~2400 s (~40 minutes)
+#
 # The deadline is configurable via FABRIC_SQL_RETRY_TIMEOUT_S env var or
 # ``fdw config set sql-retry-deadline``.
 _EXECUTE_RETRY_DELAYS: tuple[float, ...] = (2.0, 5.0, 10.0)
@@ -167,10 +172,18 @@ def _load_sql_config() -> _UserConfig:
     """Return a cached :class:`~fabric_dw.config.UserConfig`, loading on first call.
 
     Uses a module-level cache so the config file is read at most once per
-    process.  Thread-safe: the cache is guarded by ``_sql_config_lock``.
+    process.  Thread-safe via double-checked locking: the fast path (cache
+    already populated) avoids acquiring the lock entirely; the slow path
+    (first call) acquires the lock and re-checks before loading.  Safe
+    because ``_UserConfig`` is a frozen dataclass — once assigned the
+    reference is immutable and visible to all threads after the lock release.
     """
     global _sql_config_cache  # noqa: PLW0603
+    # Fast path: check without the lock (common case after first load).
+    if _sql_config_cache is not None:
+        return _sql_config_cache
     with _sql_config_lock:
+        # Re-check inside the lock to handle a concurrent first-loader.
         if _sql_config_cache is None:
             from fabric_dw.config import load_config  # noqa: PLC0415
 

--- a/tests/integration/test_cli_smoke.py
+++ b/tests/integration/test_cli_smoke.py
@@ -44,7 +44,7 @@ from pathlib import Path
 import pytest
 import pytest_asyncio
 
-from fabric_dw.sql import _CONNECT_RETRY_TIMEOUT_S
+from fabric_dw.sql import _resolve_sql_retry_deadline_s
 
 from .conftest import SharedWarehouseTarget
 
@@ -53,17 +53,23 @@ _logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 # Subprocess timeout budget for SQL-touching smoke tests.
 #
-# INVARIANT: this value MUST be strictly greater than _CONNECT_RETRY_TIMEOUT_S
-# (the CLI's internal connect-retry budget) plus a generous margin for process
-# startup, authentication, and query execution overhead.  If the two values are
-# equal the subprocess is killed exactly when the CLI's retry loop gives up,
-# leaving zero headroom for the startup/auth/query overhead that is paid on top
-# of the retry budget.
+# INVARIANT: this value MUST be strictly greater than the *resolved* SQL retry
+# deadline (the CLI's internal connect-retry budget, which is now configurable
+# via FABRIC_SQL_RETRY_TIMEOUT_S) plus a generous margin for process startup,
+# authentication, and query execution overhead.  If the two values are equal
+# the subprocess is killed exactly when the CLI's retry loop gives up, leaving
+# zero headroom for the startup/auth/query overhead that is paid on top of the
+# retry budget.
+#
+# The resolved value is read at module load so that when FABRIC_SQL_RETRY_TIMEOUT_S
+# is set (e.g. to 300 in the integration CI job) the subprocess timeout scales up
+# accordingly and the invariant cannot be violated by env configuration.
 #
 # A dedicated unit test in tests/unit/ guards this invariant at import time so
 # that it cannot silently drift back to an unsafe value.
 # ---------------------------------------------------------------------------
 _SQL_STARTUP_MARGIN_S: int = 120
+_CONNECT_RETRY_TIMEOUT_S: float = _resolve_sql_retry_deadline_s()
 _SQL_SMOKE_SUBPROCESS_TIMEOUT_S: int = math.ceil(_CONNECT_RETRY_TIMEOUT_S) + _SQL_STARTUP_MARGIN_S
 
 pytestmark = pytest.mark.integration

--- a/tests/unit/cli/commands/test_config.py
+++ b/tests/unit/cli/commands/test_config.py
@@ -252,3 +252,122 @@ class TestConfigShowRetryBudget:
         data = json.loads(result.output)
         assert data["defaults"]["max_429_retries"] is None
         assert data["defaults"]["retry_deadline_s"] is None
+
+
+# ---------------------------------------------------------------------------
+# config set / unset / show for SQL retry knobs
+# ---------------------------------------------------------------------------
+
+
+class TestConfigSetSqlRetry:
+    def test_set_sql_retry_deadline_exits_zero(self, runner: CliRunner, config_env: Path) -> None:
+        _ = config_env
+        result = runner.invoke(cli, ["config", "set", "sql-retry-deadline", "300.0"])
+        assert result.exit_code == 0
+
+    def test_set_sql_retry_deadline_writes_file(self, runner: CliRunner, config_env: Path) -> None:
+        _ = config_env
+        runner.invoke(cli, ["config", "set", "sql-retry-deadline", "250.5"])
+        cfg = load_config(default_path())
+        assert cfg.defaults.sql_retry_deadline_s == 250.5
+
+    def test_set_sql_retry_deadline_invalid_rejected(
+        self, runner: CliRunner, config_env: Path
+    ) -> None:
+        _ = config_env
+        result = runner.invoke(cli, ["config", "set", "sql-retry-deadline", "0.0"])
+        assert result.exit_code != 0
+
+    def test_set_sql_retry_deadline_preserves_workspace(
+        self, runner: CliRunner, config_env: Path
+    ) -> None:
+        _ = config_env
+        runner.invoke(cli, ["config", "set", "workspace", "MyWS"])
+        runner.invoke(cli, ["config", "set", "sql-retry-deadline", "180.0"])
+        cfg = load_config(default_path())
+        assert cfg.defaults.sql_retry_deadline_s == 180.0
+        assert cfg.defaults.workspace == "MyWS"
+
+    def test_set_sql_retry_executes_true_exits_zero(
+        self, runner: CliRunner, config_env: Path
+    ) -> None:
+        _ = config_env
+        result = runner.invoke(cli, ["config", "set", "sql-retry-executes", "true"])
+        assert result.exit_code == 0
+
+    def test_set_sql_retry_executes_true_writes_file(
+        self, runner: CliRunner, config_env: Path
+    ) -> None:
+        _ = config_env
+        runner.invoke(cli, ["config", "set", "sql-retry-executes", "true"])
+        cfg = load_config(default_path())
+        assert cfg.defaults.sql_retry_executes is True
+
+    def test_set_sql_retry_executes_false_writes_file(
+        self, runner: CliRunner, config_env: Path
+    ) -> None:
+        _ = config_env
+        runner.invoke(cli, ["config", "set", "sql-retry-executes", "false"])
+        cfg = load_config(default_path())
+        assert cfg.defaults.sql_retry_executes is False
+
+    def test_set_sql_retry_executes_case_insensitive(
+        self, runner: CliRunner, config_env: Path
+    ) -> None:
+        _ = config_env
+        result = runner.invoke(cli, ["config", "set", "sql-retry-executes", "True"])
+        assert result.exit_code == 0
+        cfg = load_config(default_path())
+        assert cfg.defaults.sql_retry_executes is True
+
+
+class TestConfigUnsetSqlRetry:
+    def test_unset_sql_retry_deadline_exits_zero(self, runner: CliRunner, config_env: Path) -> None:
+        _ = config_env
+        runner.invoke(cli, ["config", "set", "sql-retry-deadline", "200.0"])
+        result = runner.invoke(cli, ["config", "unset", "sql-retry-deadline"])
+        assert result.exit_code == 0
+
+    def test_unset_sql_retry_deadline_clears_key(self, runner: CliRunner, config_env: Path) -> None:
+        _ = config_env
+        runner.invoke(cli, ["config", "set", "sql-retry-deadline", "200.0"])
+        runner.invoke(cli, ["config", "set", "sql-retry-executes", "true"])
+        runner.invoke(cli, ["config", "unset", "sql-retry-deadline"])
+        cfg = load_config(default_path())
+        assert cfg.defaults.sql_retry_deadline_s is None
+        assert cfg.defaults.sql_retry_executes is True  # preserved
+
+    def test_unset_sql_retry_executes_exits_zero(self, runner: CliRunner, config_env: Path) -> None:
+        _ = config_env
+        runner.invoke(cli, ["config", "set", "sql-retry-executes", "true"])
+        result = runner.invoke(cli, ["config", "unset", "sql-retry-executes"])
+        assert result.exit_code == 0
+
+    def test_unset_sql_retry_executes_clears_key(self, runner: CliRunner, config_env: Path) -> None:
+        _ = config_env
+        runner.invoke(cli, ["config", "set", "sql-retry-deadline", "150.0"])
+        runner.invoke(cli, ["config", "set", "sql-retry-executes", "true"])
+        runner.invoke(cli, ["config", "unset", "sql-retry-executes"])
+        cfg = load_config(default_path())
+        assert cfg.defaults.sql_retry_executes is None
+        assert cfg.defaults.sql_retry_deadline_s == 150.0  # preserved
+
+
+class TestConfigShowSqlRetry:
+    def test_show_includes_sql_retry_fields(self, runner: CliRunner, config_env: Path) -> None:
+        _ = config_env
+        runner.invoke(cli, ["config", "set", "sql-retry-deadline", "300.0"])
+        runner.invoke(cli, ["config", "set", "sql-retry-executes", "true"])
+        result = runner.invoke(cli, ["--json", "config", "show"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["defaults"]["sql_retry_deadline_s"] == 300.0
+        assert data["defaults"]["sql_retry_executes"] is True
+
+    def test_show_null_when_sql_retry_not_set(self, runner: CliRunner, config_env: Path) -> None:
+        _ = config_env
+        result = runner.invoke(cli, ["--json", "config", "show"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["defaults"]["sql_retry_deadline_s"] is None
+        assert data["defaults"]["sql_retry_executes"] is None

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -9,6 +9,8 @@ from unittest.mock import patch
 import pytest
 from pytest_socket import disable_socket, enable_socket
 
+import fabric_dw.sql as _sql_module
+
 
 @pytest.fixture(autouse=True)
 def _block_real_sockets() -> Generator[None, None, None]:
@@ -88,3 +90,26 @@ def _reset_fabric_dw_logger() -> Generator[None, None, None]:
         pkg.removeHandler(h)
     for h in orig_handlers:
         pkg.addHandler(h)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_sql_config(tmp_path: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Isolate SQL retry config resolution for every unit test.
+
+    Three sources of contamination are neutralised here so that any unit test
+    can safely call _resolve_sql_retry_deadline_s() / _resolve_sql_retry_executes()
+    or exercise code that does (e.g. _with_connect_retry in test_sql_exec.py):
+
+    1. **Module-level cache** — _load_sql_config() memoise result; cleared so each
+       test starts with a clean read.
+    2. **Env vars** — FABRIC_SQL_RETRY_TIMEOUT_S / FABRIC_SQL_RETRY_EXECUTES leaked
+       from one test can change resolution in a later test (pytest-randomly makes order
+       non-deterministic); both are removed after every test via monkeypatch.
+    3. **On-disk config** — a developer who ran ``fdw config set sql-retry-executes true``
+       locally would see resolution tests fail; XDG_CONFIG_HOME is redirected to an
+       empty tmp dir so load_config() reads nothing.
+    """
+    _sql_module._sql_config_cache_clear()
+    monkeypatch.delenv("FABRIC_SQL_RETRY_TIMEOUT_S", raising=False)
+    monkeypatch.delenv("FABRIC_SQL_RETRY_EXECUTES", raising=False)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -474,3 +474,156 @@ def test_set_default_retry_deadline_s_below_minimum_raises(tmp_path: Path) -> No
     path = tmp_path / "config.toml"
     with pytest.raises(ValueError, match=r">= 0\.1"):
         set_default("retry_deadline_s", "0.0", path)
+
+
+# ---------------------------------------------------------------------------
+# SQL retry fields — round-trip and set_default validation
+# ---------------------------------------------------------------------------
+
+
+def test_round_trip_sql_retry_deadline_s(tmp_path: Path) -> None:
+    """sql_retry_deadline_s is saved and loaded as a float."""
+    path = tmp_path / "config.toml"
+    cfg = UserConfig(defaults=Defaults(sql_retry_deadline_s=300.0))
+    save_config(cfg, path)
+    loaded = load_config(path)
+    assert loaded.defaults.sql_retry_deadline_s == 300.0
+    assert loaded.defaults.sql_retry_executes is None
+
+
+def test_round_trip_sql_retry_executes_true(tmp_path: Path) -> None:
+    """sql_retry_executes=True is saved and loaded as a bool."""
+    path = tmp_path / "config.toml"
+    cfg = UserConfig(defaults=Defaults(sql_retry_executes=True))
+    save_config(cfg, path)
+    loaded = load_config(path)
+    assert loaded.defaults.sql_retry_executes is True
+
+
+def test_round_trip_sql_retry_executes_false(tmp_path: Path) -> None:
+    """sql_retry_executes=False is saved and loaded as a bool."""
+    path = tmp_path / "config.toml"
+    cfg = UserConfig(defaults=Defaults(sql_retry_executes=False))
+    save_config(cfg, path)
+    loaded = load_config(path)
+    assert loaded.defaults.sql_retry_executes is False
+
+
+def test_round_trip_all_six_defaults(tmp_path: Path) -> None:
+    """All six Defaults fields survive a save/load cycle together."""
+    path = tmp_path / "config.toml"
+    cfg = UserConfig(
+        defaults=Defaults(
+            workspace="SalesWS",
+            warehouse="SalesDW",
+            max_429_retries=7,
+            retry_deadline_s=180.0,
+            sql_retry_deadline_s=240.0,
+            sql_retry_executes=True,
+        )
+    )
+    save_config(cfg, path)
+    loaded = load_config(path)
+    assert loaded.defaults.workspace == "SalesWS"
+    assert loaded.defaults.warehouse == "SalesDW"
+    assert loaded.defaults.max_429_retries == 7
+    assert loaded.defaults.retry_deadline_s == 180.0
+    assert loaded.defaults.sql_retry_deadline_s == 240.0
+    assert loaded.defaults.sql_retry_executes is True
+
+
+def test_set_default_sql_retry_deadline_s_persists(tmp_path: Path) -> None:
+    """set_default('sql_retry_deadline_s', '300.0') stores 300.0 and preserves other keys."""
+    path = tmp_path / "config.toml"
+    save_config(UserConfig(defaults=Defaults(workspace="WS")), path)
+    set_default("sql_retry_deadline_s", "300.0", path)
+    loaded = load_config(path)
+    assert loaded.defaults.sql_retry_deadline_s == 300.0
+    assert loaded.defaults.workspace == "WS"  # preserved
+
+
+def test_set_default_sql_retry_deadline_s_none_clears(tmp_path: Path) -> None:
+    """set_default('sql_retry_deadline_s', None) clears the key."""
+    path = tmp_path / "config.toml"
+    save_config(
+        UserConfig(defaults=Defaults(sql_retry_deadline_s=300.0, sql_retry_executes=True)), path
+    )
+    set_default("sql_retry_deadline_s", None, path)
+    loaded = load_config(path)
+    assert loaded.defaults.sql_retry_deadline_s is None
+    assert loaded.defaults.sql_retry_executes is True  # preserved
+
+
+def test_set_default_sql_retry_deadline_s_bad_value_raises(tmp_path: Path) -> None:
+    """set_default('sql_retry_deadline_s', 'bad') raises ValueError."""
+    path = tmp_path / "config.toml"
+    with pytest.raises(ValueError, match="cannot be converted"):
+        set_default("sql_retry_deadline_s", "bad", path)
+
+
+def test_set_default_sql_retry_deadline_s_below_minimum_raises(tmp_path: Path) -> None:
+    """sql_retry_deadline_s must be >= 0.1; 0.0 raises ValueError."""
+    path = tmp_path / "config.toml"
+    with pytest.raises(ValueError, match=r">= 0\.1"):
+        set_default("sql_retry_deadline_s", "0.0", path)
+
+
+@pytest.mark.parametrize("val", ["inf", "-inf", "nan"])
+def test_set_default_sql_retry_deadline_s_non_finite_raises(tmp_path: Path, val: str) -> None:
+    """Non-finite values for sql_retry_deadline_s must raise ValueError."""
+    path = tmp_path / "config.toml"
+    with pytest.raises(ValueError, match="finite"):
+        set_default("sql_retry_deadline_s", val, path)
+
+
+def test_set_default_sql_retry_executes_true_persists(tmp_path: Path) -> None:
+    """set_default('sql_retry_executes', 'true') stores True."""
+    path = tmp_path / "config.toml"
+    set_default("sql_retry_executes", "true", path)
+    loaded = load_config(path)
+    assert loaded.defaults.sql_retry_executes is True
+
+
+def test_set_default_sql_retry_executes_false_persists(tmp_path: Path) -> None:
+    """set_default('sql_retry_executes', 'false') stores False."""
+    path = tmp_path / "config.toml"
+    set_default("sql_retry_executes", "false", path)
+    loaded = load_config(path)
+    assert loaded.defaults.sql_retry_executes is False
+
+
+def test_set_default_sql_retry_executes_none_clears(tmp_path: Path) -> None:
+    """set_default('sql_retry_executes', None) clears the key."""
+    path = tmp_path / "config.toml"
+    save_config(
+        UserConfig(defaults=Defaults(sql_retry_executes=True, sql_retry_deadline_s=120.0)), path
+    )
+    set_default("sql_retry_executes", None, path)
+    loaded = load_config(path)
+    assert loaded.defaults.sql_retry_executes is None
+    assert loaded.defaults.sql_retry_deadline_s == 120.0  # preserved
+
+
+def test_set_default_sql_retry_executes_garbage_raises(tmp_path: Path) -> None:
+    """An unrecognised value for sql_retry_executes raises ValueError."""
+    path = tmp_path / "config.toml"
+    with pytest.raises(ValueError, match="sql_retry_executes"):
+        set_default("sql_retry_executes", "maybe", path)
+
+
+@pytest.mark.parametrize("truthy", ["true", "True", "TRUE", "1", "yes", "on"])
+def test_set_default_sql_retry_executes_truthy_variants(tmp_path: Path, truthy: str) -> None:
+    """All truthy string variants are accepted for sql_retry_executes."""
+    path = tmp_path / "config.toml"
+    set_default("sql_retry_executes", truthy, path)
+    loaded = load_config(path)
+    assert loaded.defaults.sql_retry_executes is True
+
+
+@pytest.mark.parametrize("falsy", ["false", "False", "FALSE", "0", "no", "off"])
+def test_set_default_sql_retry_executes_falsy_variants(tmp_path: Path, falsy: str) -> None:
+    """All falsy string variants are accepted for sql_retry_executes."""
+    path = tmp_path / "config.toml"
+    set_default("sql_retry_executes", falsy, path)
+    loaded = load_config(path)
+    assert loaded.defaults.sql_retry_executes is False

--- a/tests/unit/test_smoke_timeout_invariant.py
+++ b/tests/unit/test_smoke_timeout_invariant.py
@@ -7,13 +7,15 @@ asserts the relationship that prevents flaky cold-start timeouts.
 
 Background
 ----------
-The CLI's internal connect-retry loop runs for up to ``_CONNECT_RETRY_TIMEOUT_S``
-seconds before surfacing a connection error.  The integration smoke test wraps the
+The CLI's internal connect-retry loop runs for up to the *resolved* SQL retry
+deadline (``_CONNECT_RETRY_TIMEOUT_S`` in the smoke module — runtime-resolved from
+the ``FABRIC_SQL_RETRY_TIMEOUT_S`` env var if set, else the built-in default of
+120 s) before surfacing a connection error.  The integration smoke test wraps the
 CLI in a subprocess with its own wall-clock timeout.  If that subprocess timeout is
-less than or equal to ``_CONNECT_RETRY_TIMEOUT_S`` the subprocess gets killed exactly
-when the retry loop gives up — leaving zero room for process startup, authentication,
-and query execution overhead that is paid *on top of* the retry budget.  The result
-is a flaky ``TimeoutExpired`` failure on cold Fabric capacities.
+less than or equal to the resolved budget the subprocess is killed exactly when the
+retry loop gives up — leaving zero room for process startup, authentication, and
+query execution overhead paid *on top of* the retry budget.  The result is a flaky
+``TimeoutExpired`` failure on cold Fabric capacities.
 
 The required invariant is::
 
@@ -24,11 +26,12 @@ where ``minimum_margin`` is at least 60 s to cover real-world startup/auth costs
 
 from __future__ import annotations
 
-from fabric_dw.sql import _CONNECT_RETRY_TIMEOUT_S
-
 # Import the actual constants used by the smoke test module so any future edits
 # to either side of the invariant are immediately caught by this test.
+# _CONNECT_RETRY_TIMEOUT_S in the smoke module is the runtime-resolved retry budget
+# (reads FABRIC_SQL_RETRY_TIMEOUT_S if set, so it scales with env configuration).
 from tests.integration.test_cli_smoke import (
+    _CONNECT_RETRY_TIMEOUT_S,
     _SQL_SMOKE_SUBPROCESS_TIMEOUT_S,
     _SQL_STARTUP_MARGIN_S,
 )

--- a/tests/unit/test_sql.py
+++ b/tests/unit/test_sql.py
@@ -80,18 +80,6 @@ def _disable_pool_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
     reset_pool()
 
 
-@pytest.fixture(autouse=True)
-def _clear_sql_config_cache(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Reset the SQL config cache and SQL retry env vars between tests.
-
-    Prevents cross-test contamination from _load_sql_config() memoisation and
-    from lingering FABRIC_SQL_RETRY_* env vars set by individual tests.
-    """
-    _sql_module._sql_config_cache_clear()
-    monkeypatch.delenv("FABRIC_SQL_RETRY_TIMEOUT_S", raising=False)
-    monkeypatch.delenv("FABRIC_SQL_RETRY_EXECUTES", raising=False)
-
-
 # ---------------------------------------------------------------------------
 # SqlTarget dataclass
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_sql.py
+++ b/tests/unit/test_sql.py
@@ -10,6 +10,7 @@ import pytest
 
 import fabric_dw.sql as _sql_module
 from fabric_dw.auth import CredentialMode
+from fabric_dw.config import Defaults, UserConfig
 from fabric_dw.exceptions import AuthError, NotFoundError, PermissionDeniedError
 from fabric_dw.sql import (
     SqlTarget,
@@ -77,6 +78,18 @@ def _disable_pool_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
     """Disable the connection pool for all tests unless they opt in."""
     monkeypatch.setenv("FABRIC_SQL_POOL", "0")
     reset_pool()
+
+
+@pytest.fixture(autouse=True)
+def _clear_sql_config_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reset the SQL config cache and SQL retry env vars between tests.
+
+    Prevents cross-test contamination from _load_sql_config() memoisation and
+    from lingering FABRIC_SQL_RETRY_* env vars set by individual tests.
+    """
+    _sql_module._sql_config_cache_clear()
+    monkeypatch.delenv("FABRIC_SQL_RETRY_TIMEOUT_S", raising=False)
+    monkeypatch.delenv("FABRIC_SQL_RETRY_EXECUTES", raising=False)
 
 
 # ---------------------------------------------------------------------------
@@ -1074,7 +1087,7 @@ class TestTransientRetry:
         """When the time budget is exhausted the last transient error is re-raised.
 
         The execute-phase retry loop is time-budgeted: it keeps retrying until
-        _CONNECT_RETRY_TIMEOUT_S seconds have elapsed since the first failure.
+        _SQL_RETRY_DEADLINE_S_DEFAULT seconds have elapsed since the first failure.
         With the clock advanced past the deadline immediately after the first
         failure, the attempt-cap/deadline check fires before sleeping and the
         loop stops after the first attempt — no retry connection is opened.
@@ -1088,11 +1101,11 @@ class TestTransientRetry:
         """
         # Monotonic values consumed in order:
         #   [0] deadline base inside _with_connect_retry
-        #   [1] sets execute_deadline = 0 + _CONNECT_RETRY_TIMEOUT_S
+        #   [1] sets execute_deadline = 0 + _SQL_RETRY_DEADLINE_S_DEFAULT
         #   [2] first deadline check after sleep: returns value past deadline
         # The connect-phase _with_connect_retry for the retry conn also needs
         # a value for its own deadline calculation.
-        timeout = _sql_module._CONNECT_RETRY_TIMEOUT_S  # type: ignore[attr-defined]
+        timeout = _sql_module._SQL_RETRY_DEADLINE_S_DEFAULT  # type: ignore[attr-defined]
         fake_time = _make_fake_time_module(
             monotonic_values=[
                 0.0,  # _with_connect_retry deadline base (initial conn)
@@ -1128,7 +1141,7 @@ class TestTransientRetry:
           connect 4 → execute succeeds
         Total connect calls: 4.  Clock stays within budget throughout.
         """
-        timeout = _sql_module._CONNECT_RETRY_TIMEOUT_S  # type: ignore[attr-defined]
+        timeout = _sql_module._SQL_RETRY_DEADLINE_S_DEFAULT  # type: ignore[attr-defined]
         # Monotonic values:
         #  [0]  _with_connect_retry deadline base (initial conn)
         #  [1]  execute_deadline = 0 + timeout (set on first failure)
@@ -1326,7 +1339,7 @@ class TestTransientRetry:
           [2] deadline check: past deadline → stop, raise
         Total connect calls: 1.
         """
-        timeout = _sql_module._CONNECT_RETRY_TIMEOUT_S  # type: ignore[attr-defined]
+        timeout = _sql_module._SQL_RETRY_DEADLINE_S_DEFAULT  # type: ignore[attr-defined]
         fake_time = _make_fake_time_module(
             monotonic_values=[
                 0.0,  # _with_connect_retry deadline base
@@ -2163,7 +2176,7 @@ class TestOpenConnectionTimeoutAPI:
 class TestAuthFailedConnectRetry:
     """_with_connect_retry must retry auth-failed / 18456 errors on the connect path.
 
-    The connect-phase retry is time-bounded (``_CONNECT_RETRY_TIMEOUT_S``, ~120 s)
+    The connect-phase retry is time-bounded (``_SQL_RETRY_DEADLINE_S_DEFAULT``, ~120 s)
     rather than attempt-count-bounded.  Tests inject a fake monotonic clock so
     that deadlines are exercised deterministically without any real wall-clock
     delay.
@@ -2210,7 +2223,7 @@ class TestAuthFailedConnectRetry:
     def _fake_time_within_deadline(n_failures: int) -> MagicMock:
         """Return a fake time module where all deadline checks are within budget.
 
-        The deadline is set to ``t0 + _CONNECT_RETRY_TIMEOUT_S``.  We use t0=0
+        The deadline is set to ``t0 + _SQL_RETRY_DEADLINE_S_DEFAULT``.  We use t0=0
         and all post-failure monotonic() calls return 1.0 (well within budget).
         This simulates the warehouse recovering before the deadline.
         """
@@ -2227,7 +2240,7 @@ class TestAuthFailedConnectRetry:
         within the ~120 s window.  After the single failure the monotonic clock
         jumps past the deadline so the loop raises immediately.
         """
-        timeout = _sql_module._CONNECT_RETRY_TIMEOUT_S
+        timeout = _sql_module._SQL_RETRY_DEADLINE_S_DEFAULT
         # call 0: t0=0  →  deadline = 0 + timeout
         # call 1: t0 + timeout + 1.0  →  past deadline
         mono_values = [0.0, timeout + 1.0]
@@ -2381,8 +2394,8 @@ class TestAuthFailedConnectRetry:
         assert mock_mssql.connect.call_count == 1
 
     def test_retry_policy_constants(self) -> None:
-        """Connect-phase uses a ~120 s deadline; execute-phase constants are set."""
-        assert _sql_module._CONNECT_RETRY_TIMEOUT_S == 120.0
+        """Connect+execute-phase default deadline is 120 s; backoff arrays are set."""
+        assert _sql_module._SQL_RETRY_DEADLINE_S_DEFAULT == 120.0
         assert _sql_module._CONNECT_RETRY_DELAYS == (5.0, 10.0, 15.0)
         assert _sql_module._EXECUTE_RETRY_DELAYS == (2.0, 5.0, 10.0)
 
@@ -2837,3 +2850,156 @@ class TestFetchAllDescriptionNoneGuard:
         assert cols == []
         assert rows == []
         assert fake_conn._committed[0] is True
+
+
+# ---------------------------------------------------------------------------
+# SQL retry config resolution — 3-layer precedence
+# ---------------------------------------------------------------------------
+
+
+class TestSqlRetryConfig:
+    """_resolve_sql_retry_deadline_s and _resolve_sql_retry_executes follow the 3-layer rule."""
+
+    def test_deadline_env_wins_over_config_and_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """FABRIC_SQL_RETRY_TIMEOUT_S takes precedence over config and built-in default."""
+        monkeypatch.setenv("FABRIC_SQL_RETRY_TIMEOUT_S", "999.0")
+        assert _sql_module._resolve_sql_retry_deadline_s() == 999.0
+
+    def test_deadline_config_wins_over_default(self) -> None:
+        """Config sql_retry_deadline_s beats the built-in 120.0 default."""
+        cfg = UserConfig(defaults=Defaults(sql_retry_deadline_s=250.0))
+        _sql_module._sql_config_cache = cfg
+        assert _sql_module._resolve_sql_retry_deadline_s() == 250.0
+
+    def test_deadline_falls_back_to_default(self) -> None:
+        """When no env var and no config value, the default 120.0 is returned."""
+        assert _sql_module._resolve_sql_retry_deadline_s() == 120.0
+
+    def test_deadline_invalid_env_falls_through_to_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A non-numeric FABRIC_SQL_RETRY_TIMEOUT_S is ignored; default used instead."""
+        monkeypatch.setenv("FABRIC_SQL_RETRY_TIMEOUT_S", "not-a-float")
+        assert _sql_module._resolve_sql_retry_deadline_s() == 120.0
+
+    def test_deadline_negative_env_falls_through_to_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A value < 0.1 in FABRIC_SQL_RETRY_TIMEOUT_S is ignored; default used instead."""
+        monkeypatch.setenv("FABRIC_SQL_RETRY_TIMEOUT_S", "0.0")
+        assert _sql_module._resolve_sql_retry_deadline_s() == 120.0
+
+    def test_deadline_invalid_env_falls_through_to_config(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Invalid env var falls through to config value."""
+        monkeypatch.setenv("FABRIC_SQL_RETRY_TIMEOUT_S", "bad")
+        cfg = UserConfig(defaults=Defaults(sql_retry_deadline_s=88.0))
+        _sql_module._sql_config_cache = cfg
+        assert _sql_module._resolve_sql_retry_deadline_s() == 88.0
+
+    def test_executes_env_wins_over_config_and_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """FABRIC_SQL_RETRY_EXECUTES=1 takes precedence over config and built-in default."""
+        monkeypatch.setenv("FABRIC_SQL_RETRY_EXECUTES", "1")
+        assert _sql_module._resolve_sql_retry_executes() is True
+
+    def test_executes_env_false_wins(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """FABRIC_SQL_RETRY_EXECUTES=false → False."""
+        monkeypatch.setenv("FABRIC_SQL_RETRY_EXECUTES", "false")
+        cfg = UserConfig(defaults=Defaults(sql_retry_executes=True))
+        _sql_module._sql_config_cache = cfg
+        assert _sql_module._resolve_sql_retry_executes() is False
+
+    def test_executes_config_wins_over_default(self) -> None:
+        """Config sql_retry_executes=True beats the built-in False default."""
+        cfg = UserConfig(defaults=Defaults(sql_retry_executes=True))
+        _sql_module._sql_config_cache = cfg
+        assert _sql_module._resolve_sql_retry_executes() is True
+
+    def test_executes_falls_back_to_false(self) -> None:
+        """When no env var and no config value, False is returned."""
+        assert _sql_module._resolve_sql_retry_executes() is False
+
+    def test_executes_truthy_strings(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Various truthy env values are all recognised."""
+        for v in ("1", "true", "TRUE", "True", "yes", "on", "anything-else"):
+            monkeypatch.setenv("FABRIC_SQL_RETRY_EXECUTES", v)
+            _sql_module._sql_config_cache_clear()
+            assert _sql_module._resolve_sql_retry_executes() is True, f"expected True for {v!r}"
+
+    def test_executes_falsy_strings(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """All recognised falsy env values map to False."""
+        for v in ("0", "false", "FALSE", "False", "no", "off", ""):
+            monkeypatch.setenv("FABRIC_SQL_RETRY_EXECUTES", v)
+            _sql_module._sql_config_cache_clear()
+            assert _sql_module._resolve_sql_retry_executes() is False, f"expected False for {v!r}"
+
+
+# ---------------------------------------------------------------------------
+# SQL retry execute-widening — fetch="none" opt-in
+# ---------------------------------------------------------------------------
+
+
+class TestSqlRetryExecutes:
+    """sql_retry_executes=True widens execute retry to cover fetch='none' statements."""
+
+    @pytest.fixture(autouse=True)
+    def _disable_sleep(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(_sql_module, "time", _make_fake_time_module())
+
+    def test_fetch_none_retried_when_sql_retry_executes_enabled(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """With FABRIC_SQL_RETRY_EXECUTES=1, a transient error on fetch='none' IS retried."""
+        monkeypatch.setenv("FABRIC_SQL_RETRY_EXECUTES", "1")
+        _sql_module._sql_config_cache_clear()
+
+        mock_mssql, _, _ = _make_mock_mssql()
+
+        bad_cursor = MagicMock()
+        bad_cursor.execute.side_effect = Exception("communication link failure")
+        bad_conn = MagicMock()
+        bad_conn.cursor.return_value = bad_cursor
+
+        good_cursor = MagicMock()
+        good_cursor.description = None
+        good_conn = MagicMock()
+        good_conn.cursor.return_value = good_cursor
+
+        mock_mssql.connect.side_effect = [bad_conn, good_conn]
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        cols, rows = run_query(_make_target(), "INSERT INTO t VALUES (1)", fetch="none")
+
+        # Retry fired — two connect calls.
+        assert mock_mssql.connect.call_count == 2
+        assert cols == []
+        assert rows == []
+
+    def test_fetch_none_not_retried_by_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Default (sql_retry_executes=False): fetch='none' transient error is NOT retried.
+
+        This is the D10 idempotency guarantee — re-validates it with the new
+        _resolve_sql_retry_executes() path.
+        """
+        # env var is already unset by _clear_sql_config_cache autouse fixture.
+        mock_mssql, _, _ = _make_mock_mssql()
+
+        bad_cursor = MagicMock()
+        bad_cursor.execute.side_effect = Exception("communication link failure")
+        bad_conn = MagicMock()
+        bad_conn.cursor.return_value = bad_cursor
+        mock_mssql.connect.return_value = bad_conn
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        with pytest.raises(Exception, match="communication link failure"):
+            run_query(_make_target(), "INSERT INTO t VALUES (1)", fetch="none")
+
+        # Must NOT retry — exactly 1 connect attempt.
+        assert mock_mssql.connect.call_count == 1, (
+            "DML (fetch='none') must not retry on execute-phase transient errors by default"
+        )


### PR DESCRIPTION
## Summary

- Adds `sql_retry_deadline_s` (float, built-in default 120.0 s) — total wall-clock budget for both the connect-phase and execute-phase retry loops in `sql.py`. Resolved via `FABRIC_SQL_RETRY_TIMEOUT_S` env var > `config.toml [defaults].sql_retry_deadline_s` > 120.0.
- Adds `sql_retry_executes` (bool, built-in default `false`) — opt-in flag that widens execute-phase retry to also cover non-idempotent `fetch="none"` statements. Resolved via `FABRIC_SQL_RETRY_EXECUTES` env var > `config.toml [defaults].sql_retry_executes` > `false`.
- Both knobs are settable via `fdw config set sql-retry-deadline` / `fdw config set sql-retry-executes`, clearable via `fdw config unset`, and visible in `fdw config show` (including `--json`).
- `sql.py` resolves config at call-time using a thread-safe memoised cache (`_sql_config_cache` guarded by `_sql_config_lock`) with a `_sql_config_cache_clear()` test hook to prevent cross-test contamination.
- Integration workflow (`integration.yml`) sets `FABRIC_SQL_RETRY_TIMEOUT_S: "300"` and `FABRIC_SQL_RETRY_EXECUTES: "1"` on the integration test step.
- Documentation added to `docs/commands/config.md` with a table, `fdw config set/unset` usage, and a WARNING about `sql_retry_executes=true` and non-idempotent statements.
- Existing `_CONNECT_RETRY_TIMEOUT_S` aliased from `_SQL_RETRY_DEADLINE_S_DEFAULT` to preserve backwards compatibility with smoke/integration tests.

## Test plan

- [ ] `uv run ruff format --check .` — passes (263 files already formatted)
- [ ] `uv run ruff check .` — all checks passed
- [ ] `uv run ty check src tests` — all checks passed
- [ ] `uv run pytest tests/unit -q` — **4302 passed, 3 deselected, 2 warnings in 29.58s**
- [ ] Config round-trip tests for both new fields (save/load, set/unset, invalid values)
- [ ] CLI `config set`/`unset`/`show` tests for both knobs including `--json` output
- [ ] sql.py 3-layer resolution precedence tests for both knobs (env > config > default; invalid env falls through)
- [ ] `sql_retry_executes=True` widens execute retry for `fetch="none"` (opt-in test)
- [ ] D10 idempotency boundary remains green — `fetch="none"` not retried by default

Closes #679

🤖 Generated with [Claude Code](https://claude.com/claude-code)