### PR TITLE
feat(config): add CLI command to set/unset telemetry opt-out

### DIFF
--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -96,7 +96,7 @@ fdw config clear
 
 ### config set
 
-Set a default value. Accepts `workspace`, `warehouse`, `max-429-retries`, `retry-deadline`, `sql-retry-deadline`, or `sql-retry-executes` as the key.
+Set a default value. Accepts `workspace`, `warehouse`, `max-429-retries`, `retry-deadline`, `sql-retry-deadline`, `sql-retry-executes`, or `telemetry disabled` as the key.
 
 **Synopsis**
 
@@ -107,6 +107,7 @@ fdw config set max-429-retries N
 fdw config set retry-deadline SECONDS
 fdw config set sql-retry-deadline SECONDS
 fdw config set sql-retry-executes true|false
+fdw config set telemetry disabled true|false
 ```
 
 **Example**
@@ -118,6 +119,7 @@ fdw config set max-429-retries 20
 fdw config set retry-deadline 600.0
 fdw config set sql-retry-deadline 300.0
 fdw config set sql-retry-executes true
+fdw config set telemetry disabled true
 ```
 
 ---
@@ -148,7 +150,7 @@ warehouse  MyWarehouse
 
 ### config unset
 
-Clear a single default value. Accepts `workspace`, `warehouse`, `max-429-retries`, `retry-deadline`, `sql-retry-deadline`, or `sql-retry-executes` as the key.
+Clear a single default value. Accepts `workspace`, `warehouse`, `max-429-retries`, `retry-deadline`, `sql-retry-deadline`, `sql-retry-executes`, or `telemetry disabled` as the key.
 
 **Synopsis**
 
@@ -159,4 +161,5 @@ fdw config unset max-429-retries
 fdw config unset retry-deadline
 fdw config unset sql-retry-deadline
 fdw config unset sql-retry-executes
+fdw config unset telemetry disabled
 ```

--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -96,7 +96,7 @@ fdw config clear
 
 ### config set
 
-Set a default value. Accepts `workspace`, `warehouse`, `max-429-retries`, `retry-deadline`, `sql-retry-deadline`, `sql-retry-executes`, or `telemetry disabled` as the key.
+Set a default value. Accepts `workspace`, `warehouse`, `max-429-retries`, `retry-deadline`, `sql-retry-deadline`, or `sql-retry-executes` as a flat key, or the nested sub-command `telemetry disabled` to configure the telemetry opt-out.
 
 **Synopsis**
 
@@ -150,7 +150,7 @@ warehouse  MyWarehouse
 
 ### config unset
 
-Clear a single default value. Accepts `workspace`, `warehouse`, `max-429-retries`, `retry-deadline`, `sql-retry-deadline`, `sql-retry-executes`, or `telemetry disabled` as the key.
+Clear a single default value. Accepts `workspace`, `warehouse`, `max-429-retries`, `retry-deadline`, `sql-retry-deadline`, or `sql-retry-executes` as a flat key, or the nested sub-command `telemetry disabled` to remove the config-file telemetry opt-out.
 
 **Synopsis**
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -86,4 +86,5 @@ Any of the following fully disables telemetry — no events are emitted and the 
 |---|---|
 | Environment variable | Set `FABRIC_DW_TELEMETRY_OPT_OUT` to any value except the falsy set (`""`, `0`, `false`, `no`, `off`, case-insensitive). Setting it to `0` or `false` does **not** opt out. |
 | Do Not Track | Set `DO_NOT_TRACK` to any value except the falsy set (same rules as above). |
+| CLI command | Run `fdw config set telemetry disabled true`. To re-enable, run `fdw config set telemetry disabled false` or `fdw config unset telemetry disabled`. |
 | Config file | Add `disabled = true` under a `[telemetry]` section in `$XDG_CONFIG_HOME/fabric-dw/config.toml` |

--- a/src/fabric_dw/cli/commands/config.py
+++ b/src/fabric_dw/cli/commands/config.py
@@ -12,12 +12,14 @@ config set max-429-retries     — persist the max consecutive 429 retry count
 config set retry-deadline      — persist the combined 429+5xx wall-clock deadline
 config set sql-retry-deadline  — persist the SQL/TDS connect+execute retry budget
 config set sql-retry-executes  — persist whether fetch="none" statements are retried
+config set telemetry disabled  — opt in/out of telemetry via config
 config unset workspace         — clear the workspace default
 config unset warehouse         — clear the warehouse default
 config unset max-429-retries   — clear the max consecutive 429 retry count
 config unset retry-deadline    — clear the HTTP deadline default
 config unset sql-retry-deadline — clear the SQL retry deadline default
 config unset sql-retry-executes — clear the SQL execute-retry flag
+config unset telemetry disabled — clear the telemetry opt-out (revert to default-on)
 config clear                   — wipe the entire config file
 """
 
@@ -27,7 +29,7 @@ import click
 
 from fabric_dw.cli._context import CliContext
 from fabric_dw.cli._render import confirm, render
-from fabric_dw.config import clear_config, set_default
+from fabric_dw.config import clear_config, set_config, set_default
 
 
 @click.group("config")
@@ -125,6 +127,24 @@ def set_sql_retry_executes_cmd(value: str) -> None:
     click.echo(f"Default sql_retry_executes set to {value.lower()}.")
 
 
+@set_group.group("telemetry")
+def set_telemetry_group() -> None:
+    """Set a telemetry configuration value."""
+
+
+@set_telemetry_group.command("disabled")
+@click.argument("value", type=click.Choice(["true", "false"], case_sensitive=False))
+def set_telemetry_disabled_cmd(value: str) -> None:
+    """Opt in or out of telemetry via the config file.
+
+    Pass ``true`` to disable telemetry (opt out); ``false`` to re-enable it.
+    Setting this to ``false`` does NOT override the env-var opt-out
+    (``FABRIC_DW_TELEMETRY_OPT_OUT`` / ``DO_NOT_TRACK`` still take precedence).
+    """
+    set_config("telemetry", "disabled", value.lower())
+    click.echo(f"Telemetry disabled set to {value.lower()}.")
+
+
 # ---------------------------------------------------------------------------
 # config unset  (sub-group with workspace / warehouse sub-commands)
 # ---------------------------------------------------------------------------
@@ -175,6 +195,22 @@ def unset_sql_retry_executes_cmd() -> None:
     """Clear the sql_retry_executes default (revert to built-in false)."""
     set_default("sql_retry_executes", None)
     click.echo("Default sql_retry_executes cleared.")
+
+
+@unset_group.group("telemetry")
+def unset_telemetry_group() -> None:
+    """Clear a telemetry configuration value."""
+
+
+@unset_telemetry_group.command("disabled")
+def unset_telemetry_disabled_cmd() -> None:
+    """Clear the telemetry opt-out from the config file (revert to default-on).
+
+    Note: env-var opt-outs (``FABRIC_DW_TELEMETRY_OPT_OUT`` / ``DO_NOT_TRACK``)
+    still take precedence over this setting.
+    """
+    set_config("telemetry", "disabled", None)
+    click.echo("Telemetry disabled cleared.")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/cli/commands/test_config.py
+++ b/tests/unit/cli/commands/test_config.py
@@ -10,6 +10,7 @@ from click.testing import CliRunner
 
 from fabric_dw.cli._main import cli
 from fabric_dw.config import Defaults, UserConfig, default_path, load_config
+from fabric_dw.telemetry import telemetry_enabled
 
 
 @pytest.fixture
@@ -371,3 +372,171 @@ class TestConfigShowSqlRetry:
         data = json.loads(result.output)
         assert data["defaults"]["sql_retry_deadline_s"] is None
         assert data["defaults"]["sql_retry_executes"] is None
+
+
+# ---------------------------------------------------------------------------
+# config set / unset / show for telemetry disabled
+# ---------------------------------------------------------------------------
+
+
+class TestConfigSetTelemetryDisabled:
+    def test_set_telemetry_disabled_true_exits_zero(
+        self, runner: CliRunner, config_env: Path
+    ) -> None:
+        _ = config_env
+        result = runner.invoke(cli, ["config", "set", "telemetry", "disabled", "true"])
+        assert result.exit_code == 0
+
+    def test_set_telemetry_disabled_false_exits_zero(
+        self, runner: CliRunner, config_env: Path
+    ) -> None:
+        _ = config_env
+        result = runner.invoke(cli, ["config", "set", "telemetry", "disabled", "false"])
+        assert result.exit_code == 0
+
+    def test_set_telemetry_disabled_true_writes_file(
+        self, runner: CliRunner, config_env: Path
+    ) -> None:
+        _ = config_env
+        runner.invoke(cli, ["config", "set", "telemetry", "disabled", "true"])
+        cfg = load_config(default_path())
+        assert cfg.telemetry.disabled is True
+
+    def test_set_telemetry_disabled_false_writes_file(
+        self, runner: CliRunner, config_env: Path
+    ) -> None:
+        _ = config_env
+        runner.invoke(cli, ["config", "set", "telemetry", "disabled", "false"])
+        cfg = load_config(default_path())
+        assert cfg.telemetry.disabled is False
+
+    def test_set_telemetry_disabled_case_insensitive(
+        self, runner: CliRunner, config_env: Path
+    ) -> None:
+        _ = config_env
+        result = runner.invoke(cli, ["config", "set", "telemetry", "disabled", "True"])
+        assert result.exit_code == 0
+        cfg = load_config(default_path())
+        assert cfg.telemetry.disabled is True
+
+    def test_set_telemetry_disabled_preserves_other_keys(
+        self, runner: CliRunner, config_env: Path
+    ) -> None:
+        _ = config_env
+        runner.invoke(cli, ["config", "set", "workspace", "WS1"])
+        runner.invoke(cli, ["config", "set", "telemetry", "disabled", "true"])
+        cfg = load_config(default_path())
+        assert cfg.telemetry.disabled is True
+        assert cfg.defaults.workspace == "WS1"
+
+    def test_set_telemetry_disabled_invalid_rejected(
+        self, runner: CliRunner, config_env: Path
+    ) -> None:
+        _ = config_env
+        result = runner.invoke(cli, ["config", "set", "telemetry", "disabled", "maybe"])
+        assert result.exit_code != 0
+
+
+class TestConfigUnsetTelemetryDisabled:
+    def test_unset_telemetry_disabled_exits_zero(self, runner: CliRunner, config_env: Path) -> None:
+        _ = config_env
+        runner.invoke(cli, ["config", "set", "telemetry", "disabled", "true"])
+        result = runner.invoke(cli, ["config", "unset", "telemetry", "disabled"])
+        assert result.exit_code == 0
+
+    def test_unset_telemetry_disabled_clears_key(self, runner: CliRunner, config_env: Path) -> None:
+        _ = config_env
+        runner.invoke(cli, ["config", "set", "telemetry", "disabled", "true"])
+        runner.invoke(cli, ["config", "unset", "telemetry", "disabled"])
+        cfg = load_config(default_path())
+        assert cfg.telemetry.disabled is None
+
+    def test_unset_telemetry_disabled_preserves_other_keys(
+        self, runner: CliRunner, config_env: Path
+    ) -> None:
+        _ = config_env
+        runner.invoke(cli, ["config", "set", "workspace", "WS1"])
+        runner.invoke(cli, ["config", "set", "telemetry", "disabled", "true"])
+        runner.invoke(cli, ["config", "unset", "telemetry", "disabled"])
+        cfg = load_config(default_path())
+        assert cfg.telemetry.disabled is None
+        assert cfg.defaults.workspace == "WS1"
+
+    def test_unset_telemetry_disabled_nonexistent_exits_zero(
+        self, runner: CliRunner, config_env: Path
+    ) -> None:
+        _ = config_env
+        result = runner.invoke(cli, ["config", "unset", "telemetry", "disabled"])
+        assert result.exit_code == 0
+
+
+class TestConfigShowTelemetry:
+    def test_show_includes_telemetry_section(self, runner: CliRunner, config_env: Path) -> None:
+        _ = config_env
+        runner.invoke(cli, ["config", "set", "telemetry", "disabled", "true"])
+        result = runner.invoke(cli, ["--json", "config", "show"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "telemetry" in data
+        assert data["telemetry"]["disabled"] is True
+
+    def test_show_null_when_telemetry_not_set(self, runner: CliRunner, config_env: Path) -> None:
+        _ = config_env
+        result = runner.invoke(cli, ["--json", "config", "show"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["telemetry"]["disabled"] is None
+
+
+class TestConfigTelemetryEndToEnd:
+    """End-to-end: CLI set → telemetry_enabled() reflects the change."""
+
+    def test_set_telemetry_disabled_true_disables_telemetry(
+        self,
+        runner: CliRunner,
+        config_env: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """config set telemetry disabled true → telemetry_enabled() is False."""
+        _ = config_env
+        # Remove env-var opt-outs so the config-file layer is in control.
+        monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
+        monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+
+        result = runner.invoke(cli, ["config", "set", "telemetry", "disabled", "true"])
+        assert result.exit_code == 0
+
+        assert telemetry_enabled() is False
+
+    def test_set_telemetry_disabled_false_enables_telemetry(
+        self,
+        runner: CliRunner,
+        config_env: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """config set telemetry disabled false → telemetry_enabled() is True."""
+        _ = config_env
+        monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
+        monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+
+        # First opt out, then opt back in.
+        runner.invoke(cli, ["config", "set", "telemetry", "disabled", "true"])
+        runner.invoke(cli, ["config", "set", "telemetry", "disabled", "false"])
+
+        assert telemetry_enabled() is True
+
+    def test_unset_telemetry_disabled_enables_telemetry(
+        self,
+        runner: CliRunner,
+        config_env: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """config unset telemetry disabled → telemetry_enabled() is True."""
+        _ = config_env
+        monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
+        monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+
+        runner.invoke(cli, ["config", "set", "telemetry", "disabled", "true"])
+        runner.invoke(cli, ["config", "unset", "telemetry", "disabled"])
+
+        assert telemetry_enabled() is True

--- a/tests/unit/cli/commands/test_config.py
+++ b/tests/unit/cli/commands/test_config.py
@@ -499,12 +499,15 @@ class TestConfigTelemetryEndToEnd:
     ) -> None:
         """config set telemetry disabled true → telemetry_enabled() is False."""
         _ = config_env
-        # Remove env-var opt-outs so the config-file layer is in control.
-        monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
-        monkeypatch.delenv("DO_NOT_TRACK", raising=False)
-
+        # Run the CLI while the autouse env-var guard (_disable_telemetry_globally)
+        # is still active so no real socket connection is attempted.
         result = runner.invoke(cli, ["config", "set", "telemetry", "disabled", "true"])
         assert result.exit_code == 0
+
+        # Strip the env-var opt-out AFTER the CLI call so telemetry_enabled()
+        # reflects only the config-file layer.
+        monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
+        monkeypatch.delenv("DO_NOT_TRACK", raising=False)
 
         assert telemetry_enabled() is False
 
@@ -516,12 +519,13 @@ class TestConfigTelemetryEndToEnd:
     ) -> None:
         """config set telemetry disabled false → telemetry_enabled() is True."""
         _ = config_env
-        monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
-        monkeypatch.delenv("DO_NOT_TRACK", raising=False)
-
-        # First opt out, then opt back in.
+        # Run CLI invocations while the env-var guard is still active.
         runner.invoke(cli, ["config", "set", "telemetry", "disabled", "true"])
         runner.invoke(cli, ["config", "set", "telemetry", "disabled", "false"])
+
+        # Only strip the env-var guard for the final assertion.
+        monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
+        monkeypatch.delenv("DO_NOT_TRACK", raising=False)
 
         assert telemetry_enabled() is True
 
@@ -533,10 +537,12 @@ class TestConfigTelemetryEndToEnd:
     ) -> None:
         """config unset telemetry disabled → telemetry_enabled() is True."""
         _ = config_env
-        monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
-        monkeypatch.delenv("DO_NOT_TRACK", raising=False)
-
+        # Run CLI invocations while the env-var guard is still active.
         runner.invoke(cli, ["config", "set", "telemetry", "disabled", "true"])
         runner.invoke(cli, ["config", "unset", "telemetry", "disabled"])
+
+        # Only strip the env-var guard for the final assertion.
+        monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
+        monkeypatch.delenv("DO_NOT_TRACK", raising=False)
 
         assert telemetry_enabled() is True


### PR DESCRIPTION
## Summary

- Adds `fdw config set telemetry disabled <true|false>` sub-command under the existing `config set` group, wired to `set_config("telemetry", "disabled", value)`.
- Adds `fdw config unset telemetry disabled` to clear the config-file opt-out (revert to default-on).
- Updates the `config` module docstring and the config docs page (`docs/commands/config.md`) to list the new sub-commands.
- Updates `docs/telemetry.md` opt-out table with the CLI command alongside the env var and TOML methods.
- Adds tests: CLI set/unset round-trip writes/clears the TOML; end-to-end tests that `config set telemetry disabled true` → `telemetry_enabled()` is `False`, and that unsetting/setting to `false` restores it.

## Test plan

- [ ] `uv run ruff format --check .` — passes
- [ ] `uv run ruff check .` — passes
- [ ] `uv run ty check src tests` — passes
- [ ] `uv run pytest tests/unit -q` — 4434 passed, 0 failed

Closes #686

🤖 Generated with [Claude Code](https://claude.com/claude-code)