### PR TITLE
feat(config): promote FABRIC_LOG_LEVEL to a 3-layer config knob

### DIFF
--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -76,6 +76,30 @@ fdw config unset sql-retry-deadline
 fdw config unset sql-retry-executes
 ```
 
+## MCP server log level
+
+The MCP server log level can be configured via a 3-layer stack. Resolution order (highest priority first):
+
+| Layer | Mechanism | Description |
+|---|---|---|
+| 1 | `FABRIC_LOG_LEVEL` env var | Read at server start-up; takes precedence over everything else. Invalid or empty values fall through to the next layer with a warning. |
+| 2 | `[logging] level` in `config.toml` | Stored with `fdw config set logging level`. Invalid values are discarded (treated as unset). |
+| 3 | Built-in default | `INFO` |
+
+Valid levels: `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL` (case-insensitive).
+
+To persist a level across MCP server restarts:
+
+```shell
+fdw config set logging level DEBUG
+```
+
+To revert to the built-in `INFO` default:
+
+```shell
+fdw config unset logging level
+```
+
 For authentication configuration, see [Authentication](../install.md#authentication).
 
 ---
@@ -96,7 +120,7 @@ fdw config clear
 
 ### config set
 
-Set a default value. Accepts `workspace`, `warehouse`, `max-429-retries`, `retry-deadline`, `sql-retry-deadline`, or `sql-retry-executes` as a flat key, or the nested sub-command `telemetry disabled` to configure the telemetry opt-out.
+Set a default value. Accepts `workspace`, `warehouse`, `max-429-retries`, `retry-deadline`, `sql-retry-deadline`, or `sql-retry-executes` as a flat key, or the nested sub-commands `telemetry disabled` and `logging level` for section-scoped knobs.
 
 **Synopsis**
 
@@ -108,6 +132,7 @@ fdw config set retry-deadline SECONDS
 fdw config set sql-retry-deadline SECONDS
 fdw config set sql-retry-executes true|false
 fdw config set telemetry disabled true|false
+fdw config set logging level LEVEL
 ```
 
 **Example**
@@ -120,6 +145,7 @@ fdw config set retry-deadline 600.0
 fdw config set sql-retry-deadline 300.0
 fdw config set sql-retry-executes true
 fdw config set telemetry disabled true
+fdw config set logging level DEBUG
 ```
 
 ---
@@ -150,7 +176,7 @@ warehouse  MyWarehouse
 
 ### config unset
 
-Clear a single default value. Accepts `workspace`, `warehouse`, `max-429-retries`, `retry-deadline`, `sql-retry-deadline`, or `sql-retry-executes` as a flat key, or the nested sub-command `telemetry disabled` to remove the config-file telemetry opt-out.
+Clear a single default value. Accepts `workspace`, `warehouse`, `max-429-retries`, `retry-deadline`, `sql-retry-deadline`, or `sql-retry-executes` as a flat key, or the nested sub-commands `telemetry disabled` and `logging level` for section-scoped knobs.
 
 **Synopsis**
 
@@ -162,4 +188,5 @@ fdw config unset retry-deadline
 fdw config unset sql-retry-deadline
 fdw config unset sql-retry-executes
 fdw config unset telemetry disabled
+fdw config unset logging level
 ```

--- a/docs/install.md
+++ b/docs/install.md
@@ -371,7 +371,16 @@ The MCP server reads the following environment variables to restrict what it may
 | `FABRIC_MCP_ALLOW_DESTRUCTIVE` | unset | Set to `1` to enable permanently-destructive tools (`delete_*`, `clear_table`, `restore_warehouse_in_place`). Disabled by default. |
 | `FABRIC_MCP_WORKSPACES` | unset | Comma-separated workspace names or GUIDs the server may touch. Unset = all workspaces allowed. |
 | `FABRIC_MCP_ALLOW_REMOTE` | unset | Set to `1` to allow the HTTP transport (`--transport http`) to bind on a non-loopback address. Always front with an authenticating reverse proxy that handles TLS. |
-| `FABRIC_LOG_LEVEL` | `INFO` | Log level for the MCP server (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`). Overrides `[logging] level` from `config.toml`. Persist with `fdw config set logging level`. |
+
+### Logging
+
+The MCP server log level is resolved in priority order: `FABRIC_LOG_LEVEL` env var (highest) > `[logging] level` in `config.toml` > `INFO` (built-in default).
+
+| Variable | Default | Description |
+|---|---|---|
+| `FABRIC_LOG_LEVEL` | `INFO` | Log level for the MCP server (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`). Empty or unrecognised values fall through to the config/default layer with a warning. |
+
+To persist the log level across restarts without setting an env var each time, use the config knob — see [MCP server log level](commands/config.md#mcp-server-log-level).
 
 ### HTTP transport
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -371,6 +371,7 @@ The MCP server reads the following environment variables to restrict what it may
 | `FABRIC_MCP_ALLOW_DESTRUCTIVE` | unset | Set to `1` to enable permanently-destructive tools (`delete_*`, `clear_table`, `restore_warehouse_in_place`). Disabled by default. |
 | `FABRIC_MCP_WORKSPACES` | unset | Comma-separated workspace names or GUIDs the server may touch. Unset = all workspaces allowed. |
 | `FABRIC_MCP_ALLOW_REMOTE` | unset | Set to `1` to allow the HTTP transport (`--transport http`) to bind on a non-loopback address. Always front with an authenticating reverse proxy that handles TLS. |
+| `FABRIC_LOG_LEVEL` | `INFO` | Log level for the MCP server (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`). Overrides `[logging] level` from `config.toml`. Persist with `fdw config set logging level`. |
 
 ### HTTP transport
 

--- a/src/fabric_dw/cli/commands/config.py
+++ b/src/fabric_dw/cli/commands/config.py
@@ -13,6 +13,7 @@ config set retry-deadline      — persist the combined 429+5xx wall-clock deadl
 config set sql-retry-deadline  — persist the SQL/TDS connect+execute retry budget
 config set sql-retry-executes  — persist whether fetch="none" statements are retried
 config set telemetry disabled  — opt in/out of telemetry via config
+config set logging level       — set the MCP server log level
 config unset workspace         — clear the workspace default
 config unset warehouse         — clear the warehouse default
 config unset max-429-retries   — clear the max consecutive 429 retry count
@@ -20,6 +21,7 @@ config unset retry-deadline    — clear the HTTP deadline default
 config unset sql-retry-deadline — clear the SQL retry deadline default
 config unset sql-retry-executes — clear the SQL execute-retry flag
 config unset telemetry disabled — clear the telemetry opt-out (revert to default-on)
+config unset logging level     — clear the logging level (revert to built-in INFO)
 config clear                   — wipe the entire config file
 """
 
@@ -29,7 +31,7 @@ import click
 
 from fabric_dw.cli._context import CliContext
 from fabric_dw.cli._render import confirm, render
-from fabric_dw.config import clear_config, set_config, set_default
+from fabric_dw.config import VALID_LOG_LEVELS, clear_config, set_config, set_default
 
 
 @click.group("config")
@@ -58,6 +60,9 @@ def show_cmd(ctx: CliContext) -> None:
         },
         "telemetry": {
             "disabled": cfg.telemetry.disabled,
+        },
+        "logging": {
+            "level": cfg.logging.level,
         },
     }
     render(data, json_output=ctx.json_output)
@@ -145,6 +150,23 @@ def set_telemetry_disabled_cmd(value: str) -> None:
     click.echo(f"Telemetry disabled set to {value.lower()}.")
 
 
+@set_group.group("logging")
+def set_logging_group() -> None:
+    """Set logging configuration."""
+
+
+_LOG_LEVEL_CHOICES = click.Choice(sorted(VALID_LOG_LEVELS), case_sensitive=False)
+
+
+@set_logging_group.command("level")
+@click.argument("value", type=_LOG_LEVEL_CHOICES)
+def set_logging_level_cmd(value: str) -> None:
+    """Set the MCP server log level (DEBUG, INFO, WARNING, ERROR, or CRITICAL)."""
+    normalised = value.upper()
+    set_config("logging", "level", normalised)
+    click.echo(f"Logging level set to {normalised!r}.")
+
+
 # ---------------------------------------------------------------------------
 # config unset  (sub-group with workspace / warehouse sub-commands)
 # ---------------------------------------------------------------------------
@@ -211,6 +233,18 @@ def unset_telemetry_disabled_cmd() -> None:
     """
     set_config("telemetry", "disabled", None)
     click.echo("Telemetry disabled cleared.")
+
+
+@unset_group.group("logging")
+def unset_logging_group() -> None:
+    """Clear logging configuration."""
+
+
+@unset_logging_group.command("level")
+def unset_logging_level_cmd() -> None:
+    """Clear the logging level (revert to built-in INFO)."""
+    set_config("logging", "level", None)
+    click.echo("Logging level cleared.")
 
 
 # ---------------------------------------------------------------------------

--- a/src/fabric_dw/config.py
+++ b/src/fabric_dw/config.py
@@ -250,12 +250,29 @@ def _parse_mcp_section(data: dict[str, object]) -> McpConfig:
 
 
 def _parse_logging_section(data: dict[str, object]) -> LoggingConfig:
-    """Parse the ``[logging]`` section from *data*."""
+    """Parse the ``[logging]`` section from *data*.
+
+    The ``level`` value is validated case-insensitively against
+    :data:`VALID_LOG_LEVELS`.  An unrecognised value is discarded (treated as
+    ``None``) and a :func:`logging.warning` is emitted so users notice the
+    misconfiguration.
+    """
     raw = data.get("logging", {})
     if not isinstance(raw, dict):
         raw = {}
     raw_level = raw.get("level")
-    return LoggingConfig(level=raw_level if isinstance(raw_level, str) else None)
+    level: str | None = None
+    if isinstance(raw_level, str):
+        normalised = raw_level.strip().upper()
+        if normalised in VALID_LOG_LEVELS:
+            level = normalised
+        else:
+            _log.warning(
+                "[logging] level %r is not a recognised log level (valid: %s); ignoring.",
+                raw_level,
+                ", ".join(sorted(VALID_LOG_LEVELS)),
+            )
+    return LoggingConfig(level=level)
 
 
 def _parse_auth_section(data: dict[str, object]) -> AuthConfig:

--- a/src/fabric_dw/config.py
+++ b/src/fabric_dw/config.py
@@ -68,6 +68,7 @@ import filelock
 import tomli_w
 
 __all__ = [
+    "VALID_LOG_LEVELS",
     "AuthConfig",
     "ConfigError",
     "Defaults",
@@ -597,7 +598,18 @@ def _set_mcp_workspace_allowlist(current: UserConfig, value: str | None) -> User
     )
 
 
+VALID_LOG_LEVELS: frozenset[str] = frozenset({"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"})
+
+
 def _set_logging_level(current: UserConfig, value: str | None) -> UserConfig:
+    if value is not None:
+        normalised = value.strip().upper()
+        if normalised not in VALID_LOG_LEVELS:
+            valid_sorted = ", ".join(sorted(VALID_LOG_LEVELS))
+            raise ValueError(
+                f"logging.level {value!r} is not a valid log level; must be one of {valid_sorted}"
+            )
+        value = normalised
     new_logging = LoggingConfig(level=value)
     return UserConfig(
         defaults=current.defaults,

--- a/src/fabric_dw/mcp/server.py
+++ b/src/fabric_dw/mcp/server.py
@@ -58,6 +58,7 @@ import sys
 from collections.abc import Sequence
 from typing import Literal
 
+from fabric_dw.config import load_config
 from fabric_dw.logging import setup_logging
 from fabric_dw.mcp._context import fabric_lifespan
 from fabric_dw.mcp._guards import env_flag as _guards_env_flag
@@ -93,6 +94,21 @@ register_all(mcp)
 _LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost"})
 
 
+def _resolve_log_level() -> int:
+    """Return the effective log level integer.
+
+    Resolution order: env ``FABRIC_LOG_LEVEL`` > ``[logging] level`` in
+    ``config.toml`` > :data:`logging.INFO`.
+    """
+    env_level = os.environ.get("FABRIC_LOG_LEVEL")
+    if env_level is not None:
+        raw = env_level.upper()
+    else:
+        cfg_level = load_config().logging.level
+        raw = cfg_level.upper() if cfg_level is not None else "INFO"
+    return getattr(logging, raw, logging.INFO)
+
+
 def run(argv: Sequence[str] | None = None) -> None:
     """Parse CLI arguments and start the FastMCP server.
 
@@ -114,10 +130,7 @@ def run(argv: Sequence[str] | None = None) -> None:
     ``--port PORT``
         TCP port for HTTP transport (default ``8000``).
     """
-    # Configure structured logging from env var (default INFO)
-    raw_level = os.environ.get("FABRIC_LOG_LEVEL", "INFO").upper()
-    log_level = getattr(logging, raw_level, logging.INFO)
-    setup_logging(log_level)
+    setup_logging(_resolve_log_level())
 
     logger = logging.getLogger(__name__)
 

--- a/src/fabric_dw/mcp/server.py
+++ b/src/fabric_dw/mcp/server.py
@@ -99,14 +99,32 @@ def _resolve_log_level() -> int:
 
     Resolution order: env ``FABRIC_LOG_LEVEL`` > ``[logging] level`` in
     ``config.toml`` > :data:`logging.INFO`.
+
+    Empty or whitespace-only values of ``FABRIC_LOG_LEVEL`` are treated as
+    absent and fall through to the config/default layer.  Unrecognised
+    (non-empty) values emit a :func:`logging.warning` to *stderr* via the root
+    logger and also fall through rather than silently producing :data:`logging.INFO`.
     """
-    env_level = os.environ.get("FABRIC_LOG_LEVEL")
-    if env_level is not None:
-        raw = env_level.upper()
-    else:
-        cfg_level = load_config().logging.level
-        raw = cfg_level.upper() if cfg_level is not None else "INFO"
-    return getattr(logging, raw, logging.INFO)
+    from fabric_dw.config import VALID_LOG_LEVELS  # noqa: PLC0415
+
+    env_raw = os.environ.get("FABRIC_LOG_LEVEL", "").strip()
+    if env_raw:
+        env_upper = env_raw.upper()
+        if env_upper in VALID_LOG_LEVELS:
+            return getattr(logging, env_upper)
+        # Non-empty but unrecognised — warn to stderr and fall through to
+        # config/default.  We write to stderr directly because setup_logging()
+        # has not yet run so no handlers are attached to the named logger.
+        print(  # noqa: T201
+            f"WARNING: FABRIC_LOG_LEVEL={env_raw!r} is not a recognised log level "
+            f"(valid: {', '.join(sorted(VALID_LOG_LEVELS))}); "
+            "ignoring and falling through to config/default.",
+            file=sys.stderr,
+        )
+    cfg_level = load_config().logging.level
+    if cfg_level is not None:
+        return getattr(logging, cfg_level.upper(), logging.INFO)
+    return logging.INFO
 
 
 def run(argv: Sequence[str] | None = None) -> None:

--- a/tests/unit/mcp/test_server.py
+++ b/tests/unit/mcp/test_server.py
@@ -2103,3 +2103,73 @@ async def test_set_cluster_columns_sql_endpoint_raises_tool_error(mock_ctx, ctx_
 
     err_str = str(exc_info.value).lower()
     assert "sql endpoint" in err_str or "itemkinderror" in err_str
+
+
+# ---------------------------------------------------------------------------
+# Log-level resolution: env > config > INFO
+# ---------------------------------------------------------------------------
+
+
+def test_run_log_level_env_takes_precedence() -> None:
+    """FABRIC_LOG_LEVEL env var overrides [logging] level in config.toml."""
+    from fabric_dw.config import LoggingConfig, UserConfig  # noqa: PLC0415
+    from fabric_dw.mcp import run  # noqa: PLC0415
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    cfg_with_warning = UserConfig(logging=LoggingConfig(level="WARNING"))
+
+    with (
+        patch.object(mcp, "run"),
+        patch("fabric_dw.mcp.server.load_config", return_value=cfg_with_warning),
+        patch("fabric_dw.mcp.server.setup_logging") as mock_setup,
+        patch.dict(os.environ, {"FABRIC_LOG_LEVEL": "DEBUG"}),
+    ):
+        run([])
+
+    import logging  # noqa: PLC0415
+
+    mock_setup.assert_called_once_with(logging.DEBUG)
+
+
+def test_run_log_level_config_used_when_no_env() -> None:
+    """[logging] level from config.toml is used when FABRIC_LOG_LEVEL is unset."""
+    from fabric_dw.config import LoggingConfig, UserConfig  # noqa: PLC0415
+    from fabric_dw.mcp import run  # noqa: PLC0415
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    cfg_with_error = UserConfig(logging=LoggingConfig(level="ERROR"))
+
+    env_without_log = {k: v for k, v in os.environ.items() if k != "FABRIC_LOG_LEVEL"}
+    with (
+        patch.object(mcp, "run"),
+        patch("fabric_dw.mcp.server.load_config", return_value=cfg_with_error),
+        patch("fabric_dw.mcp.server.setup_logging") as mock_setup,
+        patch.dict(os.environ, env_without_log, clear=True),
+    ):
+        run([])
+
+    import logging  # noqa: PLC0415
+
+    mock_setup.assert_called_once_with(logging.ERROR)
+
+
+def test_run_log_level_defaults_to_info_when_no_env_and_no_config() -> None:
+    """INFO is used when neither FABRIC_LOG_LEVEL nor [logging] level is set."""
+    from fabric_dw.config import UserConfig  # noqa: PLC0415
+    from fabric_dw.mcp import run  # noqa: PLC0415
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    cfg_empty = UserConfig()
+
+    env_without_log = {k: v for k, v in os.environ.items() if k != "FABRIC_LOG_LEVEL"}
+    with (
+        patch.object(mcp, "run"),
+        patch("fabric_dw.mcp.server.load_config", return_value=cfg_empty),
+        patch("fabric_dw.mcp.server.setup_logging") as mock_setup,
+        patch.dict(os.environ, env_without_log, clear=True),
+    ):
+        run([])
+
+    import logging  # noqa: PLC0415
+
+    mock_setup.assert_called_once_with(logging.INFO)

--- a/tests/unit/mcp/test_server.py
+++ b/tests/unit/mcp/test_server.py
@@ -2173,3 +2173,68 @@ def test_run_log_level_defaults_to_info_when_no_env_and_no_config() -> None:
     import logging  # noqa: PLC0415
 
     mock_setup.assert_called_once_with(logging.INFO)
+
+
+def test_run_log_level_empty_env_falls_through_to_config() -> None:
+    """An empty FABRIC_LOG_LEVEL is treated as absent and config layer is used."""
+    import logging  # noqa: PLC0415
+
+    from fabric_dw.config import LoggingConfig, UserConfig  # noqa: PLC0415
+    from fabric_dw.mcp import run  # noqa: PLC0415
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    cfg_with_critical = UserConfig(logging=LoggingConfig(level="CRITICAL"))
+
+    with (
+        patch.object(mcp, "run"),
+        patch("fabric_dw.mcp.server.load_config", return_value=cfg_with_critical),
+        patch("fabric_dw.mcp.server.setup_logging") as mock_setup,
+        patch.dict(os.environ, {"FABRIC_LOG_LEVEL": ""}),
+    ):
+        run([])
+
+    mock_setup.assert_called_once_with(logging.CRITICAL)
+
+
+def test_run_log_level_invalid_env_warns_and_falls_through() -> None:
+    """An invalid FABRIC_LOG_LEVEL emits a warning and falls through to config/default."""
+    import logging  # noqa: PLC0415
+
+    from fabric_dw.config import UserConfig  # noqa: PLC0415
+    from fabric_dw.mcp import run  # noqa: PLC0415
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    cfg_empty = UserConfig()
+    env_with_invalid = {k: v for k, v in os.environ.items() if k != "FABRIC_LOG_LEVEL"}
+    env_with_invalid["FABRIC_LOG_LEVEL"] = "VERBOSE"
+
+    with (
+        patch.object(mcp, "run"),
+        patch("fabric_dw.mcp.server.load_config", return_value=cfg_empty),
+        patch("fabric_dw.mcp.server.setup_logging") as mock_setup,
+        patch.dict(os.environ, env_with_invalid, clear=True),
+    ):
+        run([])
+
+    # Falls through to built-in default INFO; warning is emitted but not asserted
+    # here since it goes to the root logger pre-setup.
+    mock_setup.assert_called_once_with(logging.INFO)
+
+
+def test_run_log_level_invalid_config_value_discarded_uses_default() -> None:
+    """An invalid [logging] level in config.toml is discarded and INFO is used."""
+    import logging  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import _resolve_log_level  # noqa: PLC0415
+
+    # Write a config file with an invalid level and resolve without going through run().
+    with patch(
+        "fabric_dw.mcp.server.load_config",
+        return_value=__import__("fabric_dw.config", fromlist=["UserConfig"]).UserConfig(),
+    ):
+        # load_config() returns LoggingConfig(level=None) for an invalid stored level
+        # because _parse_logging_section discards unrecognised values; here we simulate
+        # that already-discarded state by providing an empty UserConfig.
+        level = _resolve_log_level()
+
+    assert level == logging.INFO

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -10,6 +10,7 @@ import filelock
 import pytest
 
 from fabric_dw.config import (
+    VALID_LOG_LEVELS,
     AuthConfig,
     ConfigError,
     Defaults,
@@ -955,3 +956,68 @@ def test_set_config_concurrent_different_sections_no_lost_update(tmp_path: Path)
     loaded = load_config(path)
     assert loaded.defaults.workspace == "ConcurrentWS"
     assert loaded.telemetry.disabled is True
+
+
+# ---------------------------------------------------------------------------
+# set_config logging.level — round-trip, unset, validation, normalisation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("level", sorted(VALID_LOG_LEVELS))
+def test_set_config_logging_level_valid_values(tmp_path: Path, level: str) -> None:
+    """All valid log levels can be written and round-trip correctly."""
+    path = tmp_path / "config.toml"
+    set_config("logging", "level", level, path)
+    loaded = load_config(path)
+    assert loaded.logging.level == level.upper()
+
+
+@pytest.mark.parametrize("raw", ["debug", "Debug", "DEBUG"])
+def test_set_config_logging_level_normalises_to_upper(tmp_path: Path, raw: str) -> None:
+    """Levels written in any case are normalised to upper-case."""
+    path = tmp_path / "config.toml"
+    set_config("logging", "level", raw, path)
+    loaded = load_config(path)
+    assert loaded.logging.level == "DEBUG"
+
+
+def test_set_config_logging_level_unset(tmp_path: Path) -> None:
+    """set_config('logging', 'level', None) clears the key."""
+    path = tmp_path / "config.toml"
+    set_config("logging", "level", "WARNING", path)
+    assert load_config(path).logging.level == "WARNING"
+    set_config("logging", "level", None, path)
+    loaded = load_config(path)
+    assert loaded.logging.level is None
+
+
+def test_set_config_logging_level_invalid_raises(tmp_path: Path) -> None:
+    """An unrecognised log level raises ValueError."""
+    path = tmp_path / "config.toml"
+    with pytest.raises(ValueError, match=r"logging\.level"):
+        set_config("logging", "level", "VERBOSE", path)
+
+
+def test_set_config_logging_level_preserves_other_sections(tmp_path: Path) -> None:
+    """Writing logging.level does not disturb unrelated sections."""
+    path = tmp_path / "config.toml"
+    save_config(
+        UserConfig(
+            defaults=Defaults(workspace="WS"),
+            telemetry=TelemetryConfig(disabled=True),
+        ),
+        path,
+    )
+    set_config("logging", "level", "DEBUG", path)
+    loaded = load_config(path)
+    assert loaded.logging.level == "DEBUG"
+    assert loaded.defaults.workspace == "WS"
+    assert loaded.telemetry.disabled is True
+
+
+def test_logging_section_absent_when_level_none(tmp_path: Path) -> None:
+    """When logging.level is None, the [logging] section is not written."""
+    path = tmp_path / "config.toml"
+    save_config(UserConfig(defaults=Defaults(workspace="WS")), path)
+    content = path.read_text(encoding="utf-8")
+    assert "[logging]" not in content

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1021,3 +1021,19 @@ def test_logging_section_absent_when_level_none(tmp_path: Path) -> None:
     save_config(UserConfig(defaults=Defaults(workspace="WS")), path)
     content = path.read_text(encoding="utf-8")
     assert "[logging]" not in content
+
+
+def test_load_config_invalid_logging_level_discarded(tmp_path: Path) -> None:
+    """A hand-edited [logging] level with an invalid value is discarded (treated as None)."""
+    path = tmp_path / "config.toml"
+    path.write_text('[logging]\nlevel = "VERBOSE"\n', encoding="utf-8")
+    cfg = load_config(path)
+    assert cfg.logging.level is None
+
+
+def test_load_config_invalid_logging_level_valid_level_preserved(tmp_path: Path) -> None:
+    """A valid (but lowercased) [logging] level is normalised to upper-case on load."""
+    path = tmp_path / "config.toml"
+    path.write_text('[logging]\nlevel = "debug"\n', encoding="utf-8")
+    cfg = load_config(path)
+    assert cfg.logging.level == "DEBUG"


### PR DESCRIPTION
## Summary

- Promotes `FABRIC_LOG_LEVEL` (previously env-only) to a full 3-layer knob: `FABRIC_LOG_LEVEL` env var (highest) > `[logging] level` in `config.toml` > `INFO` (built-in default).
- Adds `fdw config set logging level <LEVEL>` and `fdw config unset logging level` CLI commands with case-insensitive `click.Choice` validation.
- Exposes `[logging]` block in `fdw config show` output.
- Extracts `_resolve_log_level()` helper in `mcp/server.py` (env > config > INFO) to keep `run()` within the PLR0915 statement limit.

## Test plan

- [ ] `set_config("logging", "level", ...)` round-trip for all 5 valid levels
- [ ] Case normalisation: `"debug"` / `"Debug"` stored as `"DEBUG"`
- [ ] `set_config("logging", "level", None)` clears the key
- [ ] Invalid level raises `ValueError` matching `logging.level`
- [ ] Setting `logging.level` does not disturb other sections
- [ ] `[logging]` section absent from TOML when level is `None`
- [ ] Server: env `FABRIC_LOG_LEVEL=DEBUG` overrides `[logging] level = WARNING`
- [ ] Server: `[logging] level = ERROR` used when env is unset
- [ ] Server: defaults to `logging.INFO` when neither env nor config is set

Closes #688

🤖 Generated with [Claude Code](https://claude.com/claude-code)