### PR TITLE
feat(config): promote FABRIC_SQL_POOL to a 3-layer config knob

### DIFF
--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -100,6 +100,29 @@ To revert to the built-in `INFO` default:
 fdw config unset logging level
 ```
 
+## SQL connection pooling
+
+Connection pooling reuses open TDS connections across queries to avoid the TCP+TLS+TDS handshake overhead on every call. Resolution order (env var > config > built-in):
+
+| Knob | Env var | Config key | Built-in default |
+|---|---|---|---|
+| Connection pooling enabled | `FABRIC_SQL_POOL` | `sql_pool` | true |
+
+Pooling is enabled by default. Disable it only when diagnosing connection issues or when running in an environment where persistent connections are not supported.
+
+To disable connection pooling:
+
+```shell
+fdw config set sql-pool false
+```
+
+To re-enable pooling (or to revert to the built-in default):
+
+```shell
+fdw config set sql-pool true
+fdw config unset sql-pool
+```
+
 For authentication configuration, see [Authentication](../install.md#authentication).
 
 ---
@@ -120,7 +143,7 @@ fdw config clear
 
 ### config set
 
-Set a default value. Accepts `workspace`, `warehouse`, `max-429-retries`, `retry-deadline`, `sql-retry-deadline`, or `sql-retry-executes` as a flat key, or the nested sub-commands `telemetry disabled` and `logging level` for section-scoped knobs.
+Set a default value. Accepts `workspace`, `warehouse`, `max-429-retries`, `retry-deadline`, `sql-retry-deadline`, `sql-retry-executes`, or `sql-pool` as a flat key, or the nested sub-commands `telemetry disabled` and `logging level` for section-scoped knobs.
 
 **Synopsis**
 
@@ -131,6 +154,7 @@ fdw config set max-429-retries N
 fdw config set retry-deadline SECONDS
 fdw config set sql-retry-deadline SECONDS
 fdw config set sql-retry-executes true|false
+fdw config set sql-pool true|false
 fdw config set telemetry disabled true|false
 fdw config set logging level LEVEL
 ```
@@ -144,6 +168,7 @@ fdw config set max-429-retries 20
 fdw config set retry-deadline 600.0
 fdw config set sql-retry-deadline 300.0
 fdw config set sql-retry-executes true
+fdw config set sql-pool false
 fdw config set telemetry disabled true
 fdw config set logging level DEBUG
 ```
@@ -176,7 +201,7 @@ warehouse  MyWarehouse
 
 ### config unset
 
-Clear a single default value. Accepts `workspace`, `warehouse`, `max-429-retries`, `retry-deadline`, `sql-retry-deadline`, or `sql-retry-executes` as a flat key, or the nested sub-commands `telemetry disabled` and `logging level` for section-scoped knobs.
+Clear a single default value. Accepts `workspace`, `warehouse`, `max-429-retries`, `retry-deadline`, `sql-retry-deadline`, `sql-retry-executes`, or `sql-pool` as a flat key, or the nested sub-commands `telemetry disabled` and `logging level` for section-scoped knobs.
 
 **Synopsis**
 
@@ -187,6 +212,7 @@ fdw config unset max-429-retries
 fdw config unset retry-deadline
 fdw config unset sql-retry-deadline
 fdw config unset sql-retry-executes
+fdw config unset sql-pool
 fdw config unset telemetry disabled
 fdw config unset logging level
 ```

--- a/src/fabric_dw/cli/commands/config.py
+++ b/src/fabric_dw/cli/commands/config.py
@@ -12,6 +12,7 @@ config set max-429-retries     — persist the max consecutive 429 retry count
 config set retry-deadline      — persist the combined 429+5xx wall-clock deadline
 config set sql-retry-deadline  — persist the SQL/TDS connect+execute retry budget
 config set sql-retry-executes  — persist whether fetch="none" statements are retried
+config set sql-pool            — persist whether SQL connection pooling is enabled
 config set telemetry disabled  — opt in/out of telemetry via config
 config set logging level       — set the MCP server log level
 config unset workspace         — clear the workspace default
@@ -20,6 +21,7 @@ config unset max-429-retries   — clear the max consecutive 429 retry count
 config unset retry-deadline    — clear the HTTP deadline default
 config unset sql-retry-deadline — clear the SQL retry deadline default
 config unset sql-retry-executes — clear the SQL execute-retry flag
+config unset sql-pool          — clear the SQL pool flag
 config unset telemetry disabled — clear the telemetry opt-out (revert to default-on)
 config unset logging level     — clear the logging level (revert to built-in INFO)
 config clear                   — wipe the entire config file
@@ -57,6 +59,7 @@ def show_cmd(ctx: CliContext) -> None:
             "retry_deadline_s": cfg.defaults.retry_deadline_s,
             "sql_retry_deadline_s": cfg.defaults.sql_retry_deadline_s,
             "sql_retry_executes": cfg.defaults.sql_retry_executes,
+            "sql_pool": cfg.defaults.sql_pool,
         },
         "telemetry": {
             "disabled": cfg.telemetry.disabled,
@@ -130,6 +133,20 @@ def set_sql_retry_executes_cmd(value: str) -> None:
     """
     set_default("sql_retry_executes", value.lower())
     click.echo(f"Default sql_retry_executes set to {value.lower()}.")
+
+
+@set_group.command("sql-pool")
+@click.argument("value", type=click.Choice(["true", "false"], case_sensitive=False))
+def set_sql_pool_cmd(value: str) -> None:
+    """Enable or disable SQL connection pooling.
+
+    When set to false, every query opens a fresh TDS connection and closes it
+    immediately after use.  Disable pooling only when diagnosing connection
+    issues or when running in an environment where persistent connections are
+    not supported.
+    """
+    set_default("sql_pool", value.lower())
+    click.echo(f"Default sql_pool set to {value.lower()}.")
 
 
 @set_group.group("telemetry")
@@ -217,6 +234,13 @@ def unset_sql_retry_executes_cmd() -> None:
     """Clear the sql_retry_executes default (revert to built-in false)."""
     set_default("sql_retry_executes", None)
     click.echo("Default sql_retry_executes cleared.")
+
+
+@unset_group.command("sql-pool")
+def unset_sql_pool_cmd() -> None:
+    """Clear the sql_pool default (revert to built-in true)."""
+    set_default("sql_pool", None)
+    click.echo("Default sql_pool cleared.")
 
 
 @unset_group.group("telemetry")

--- a/src/fabric_dw/config.py
+++ b/src/fabric_dw/config.py
@@ -533,9 +533,7 @@ def _coerce_defaults_key(  # noqa: PLR0912
             elif value.lower() in {"false", "0", "no", "off"}:
                 coerced_bool = False
             else:
-                raise ValueError(
-                    f"{key} {value!r} must be one of: true/1/yes/on or false/0/no/off"
-                )
+                raise ValueError(f"{key} {value!r} must be one of: true/1/yes/on or false/0/no/off")
     return coerced_int, coerced_float, coerced_bool
 
 

--- a/src/fabric_dw/config.py
+++ b/src/fabric_dw/config.py
@@ -107,6 +107,7 @@ class Defaults:
     retry_deadline_s: float | None = None
     sql_retry_deadline_s: float | None = None
     sql_retry_executes: bool | None = None
+    sql_pool: bool | None = None
 
 
 @dataclass(frozen=True)
@@ -191,6 +192,7 @@ def _parse_defaults_section(data: dict[str, object]) -> Defaults:
     raw_deadline = raw.get("retry_deadline_s")
     raw_sql_deadline = raw.get("sql_retry_deadline_s")
     raw_sql_executes = raw.get("sql_retry_executes")
+    raw_sql_pool = raw.get("sql_pool")
     return Defaults(
         workspace=workspace if isinstance(workspace, str) else None,
         warehouse=warehouse if isinstance(warehouse, str) else None,
@@ -202,6 +204,7 @@ def _parse_defaults_section(data: dict[str, object]) -> Defaults:
         if isinstance(raw_sql_deadline, (int, float)) and math.isfinite(raw_sql_deadline)
         else None,
         sql_retry_executes=raw_sql_executes if isinstance(raw_sql_executes, bool) else None,
+        sql_pool=raw_sql_pool if isinstance(raw_sql_pool, bool) else None,
     )
 
 
@@ -372,6 +375,8 @@ def _defaults_to_dict(d: Defaults) -> dict[str, object]:
         out["sql_retry_deadline_s"] = d.sql_retry_deadline_s
     if d.sql_retry_executes is not None:
         out["sql_retry_executes"] = d.sql_retry_executes
+    if d.sql_pool is not None:
+        out["sql_pool"] = d.sql_pool
     return out
 
 
@@ -522,14 +527,14 @@ def _coerce_defaults_key(  # noqa: PLR0912
                 raise ValueError(
                     f"sql_retry_deadline_s must be >= {_MIN_RETRY_DEADLINE_S}, got {coerced_float}"
                 )
-        elif key == "sql_retry_executes":
+        elif key in {"sql_retry_executes", "sql_pool"}:
             if value.lower() in {"true", "1", "yes", "on"}:
                 coerced_bool = True
             elif value.lower() in {"false", "0", "no", "off"}:
                 coerced_bool = False
             else:
                 raise ValueError(
-                    f"sql_retry_executes {value!r} must be one of: true/1/yes/on or false/0/no/off"
+                    f"{key} {value!r} must be one of: true/1/yes/on or false/0/no/off"
                 )
     return coerced_int, coerced_float, coerced_bool
 
@@ -564,6 +569,7 @@ def _make_defaults_setter(
             sql_retry_executes=coerced_bool
             if key == "sql_retry_executes"
             else current.defaults.sql_retry_executes,
+            sql_pool=coerced_bool if key == "sql_pool" else current.defaults.sql_pool,
         )
         return UserConfig(
             defaults=new_defaults,
@@ -669,6 +675,7 @@ _SET_CONFIG_DISPATCH: dict[
     ("defaults", "retry_deadline_s"): _make_defaults_setter("retry_deadline_s"),
     ("defaults", "sql_retry_deadline_s"): _make_defaults_setter("sql_retry_deadline_s"),
     ("defaults", "sql_retry_executes"): _make_defaults_setter("sql_retry_executes"),
+    ("defaults", "sql_pool"): _make_defaults_setter("sql_pool"),
     ("telemetry", "disabled"): _set_telemetry_disabled,
     ("mcp", "workspace_allowlist"): _set_mcp_workspace_allowlist,
     ("logging", "level"): _set_logging_level,
@@ -744,8 +751,8 @@ def set_default(key: str, value: str | None, path: Path | None = None) -> None:
 
     Args:
         key: One of ``"workspace"``, ``"warehouse"``, ``"max_429_retries"``,
-             ``"retry_deadline_s"``, ``"sql_retry_deadline_s"``, or
-             ``"sql_retry_executes"``.
+             ``"retry_deadline_s"``, ``"sql_retry_deadline_s"``,
+             ``"sql_retry_executes"``, or ``"sql_pool"``.
         value: The new value (as a string for numeric keys it is coerced), or
                *None* to clear (unset) the key.
         path: Optional override for the config file path.
@@ -765,6 +772,7 @@ def set_default(key: str, value: str | None, path: Path | None = None) -> None:
         "retry_deadline_s",
         "sql_retry_deadline_s",
         "sql_retry_executes",
+        "sql_pool",
     }
     if key not in allowed:
         raise ValueError(f"Unknown config key {key!r}; must be one of {sorted(allowed)}")

--- a/src/fabric_dw/sql.py
+++ b/src/fabric_dw/sql.py
@@ -26,11 +26,15 @@ module-level constants:
 ``POOL_MAX_IDLE``       — maximum idle connections per key (default 4).
 ``POOL_MAX_IDLE_SECS``  — maximum idle age in seconds before eviction (default 300).
 
-Disable pooling entirely by setting the environment variable
-``FABRIC_SQL_POOL=0`` before process startup, or at runtime by setting
-``os.environ["FABRIC_SQL_POOL"] = "0"`` and then calling :func:`reset_pool` to
-drain existing connections.  When disabled every ``open_connection`` call opens a
-fresh physical connection and ``.close()`` physically closes it.
+Disable pooling by setting the environment variable ``FABRIC_SQL_POOL``
+to a falsy value (``"0"``, ``"false"``, ``"no"``, or ``"off"``) before
+process startup, or at runtime by assigning the same value and then calling
+:func:`reset_pool` to drain existing connections.  Pooling can also be
+disabled via ``config.toml`` ``[defaults] sql_pool = false`` (resolution
+order: env var > config > built-in default on).  An empty or whitespace-only
+``FABRIC_SQL_POOL`` is treated as absent and falls through to the config/default
+layer.  When disabled every ``open_connection`` call opens a fresh physical
+connection and ``.close()`` physically closes it.
 
 Call :func:`reset_pool` on graceful shutdown to close all idle connections.  The
 MCP server lifespan calls ``reset_pool`` in its ``finally`` block so pooled TDS
@@ -559,7 +563,9 @@ def _set_key(connection_string: str, key: str, value: str) -> str:
 # ---------------------------------------------------------------------------
 
 # Pool configuration constants — override at module level before first use.
-# Env var FABRIC_SQL_POOL=0 disables pooling entirely at any time.
+# Pooling is controlled by _pool_enabled() which resolves: env var FABRIC_SQL_POOL
+# (falsy: "0"/"false"/"no"/"off"; empty/whitespace → absent) > config.toml
+# [defaults].sql_pool > built-in default on.
 POOL_MAX_IDLE: int = 4
 """Maximum number of idle connections kept per ``(workspace_id, database, mode)`` key."""
 
@@ -580,11 +586,32 @@ _pool_lock = threading.Lock()
 def _pool_enabled() -> bool:
     """Return True when connection pooling is active.
 
-    Reads ``FABRIC_SQL_POOL`` from the environment at call-time so tests can
-    toggle it without reimporting the module.  Any value other than ``"0"``
-    keeps pooling enabled (the default).
+    Resolution order (3-layer):
+    1. ``FABRIC_SQL_POOL`` env var — read at call-time so tests can toggle
+       it without reimporting the module.  Only a non-empty, non-whitespace
+       value is honoured; an empty or whitespace-only value (e.g. a Docker
+       ``ENV FABRIC_SQL_POOL=`` placeholder) is treated as absent and falls
+       through to the next layer.  Accepted disable values: ``"0"``,
+       ``"false"``, ``"no"``, ``"off"`` (case-insensitive).  Any other
+       non-empty string keeps pooling enabled.
+    2. ``config.toml`` ``[defaults].sql_pool`` — consulted via the existing
+       memoised :func:`_load_sql_config` cache (never calls load_config()
+       per call).
+    3. Built-in default: ``True`` (pooling on).
     """
-    return os.environ.get("FABRIC_SQL_POOL", "1") != "0"
+    raw_env = os.environ.get("FABRIC_SQL_POOL")
+    if raw_env is not None:
+        stripped = raw_env.strip()
+        if stripped:
+            # Non-empty value — honour it (falsy set disables, anything else enables).
+            return stripped.lower() not in _FALSY_STRINGS
+        # Empty / whitespace-only — treat as absent; fall through to config/default.
+
+    cfg_val = _load_sql_config().defaults.sql_pool
+    if cfg_val is not None:
+        return cfg_val
+
+    return True
 
 
 def _pool_time() -> float:
@@ -708,8 +735,8 @@ class _PooledConnection:
     When ``.close()`` is called:
     - If ``_discard`` is ``True`` (set after a failed query), the underlying
       connection is physically closed and NOT returned to the pool.
-    - If pooling is disabled (``FABRIC_SQL_POOL=0``), the underlying connection
-      is physically closed.
+    - If pooling is disabled (``_pool_enabled()`` returns ``False``), the
+      underlying connection is physically closed.
     - Otherwise the underlying connection is returned to the pool for reuse.
 
     All other method calls are forwarded verbatim to the underlying connection,
@@ -839,8 +866,10 @@ def open_connection(
     socket.  Callers do **not** need to change - the ``contextlib.closing``
     pattern works unchanged.
 
-    When pooling is disabled (``FABRIC_SQL_POOL=0``) every call opens a fresh
-    physical connection and ``.close()`` physically closes it.
+    When pooling is disabled (``_pool_enabled()`` returns ``False``, controlled
+    via the ``FABRIC_SQL_POOL`` env var, ``config.toml [defaults] sql_pool``,
+    or the built-in default on) every call opens a fresh physical connection
+    and ``.close()`` physically closes it.
 
     When ``autocommit=True``, the ODBC driver does **not** wrap each statement
     in an explicit ``BEGIN TRANSACTION`` / ``COMMIT`` pair.  This is required

--- a/tests/unit/cli/commands/test_config.py
+++ b/tests/unit/cli/commands/test_config.py
@@ -546,3 +546,78 @@ class TestConfigTelemetryEndToEnd:
         monkeypatch.delenv("DO_NOT_TRACK", raising=False)
 
         assert telemetry_enabled() is True
+
+
+# ---------------------------------------------------------------------------
+# config set/unset sql-pool
+# ---------------------------------------------------------------------------
+
+
+class TestConfigSetSqlPool:
+    def test_set_sql_pool_false_exits_zero(self, runner: CliRunner, config_env: Path) -> None:
+        _ = config_env
+        result = runner.invoke(cli, ["config", "set", "sql-pool", "false"])
+        assert result.exit_code == 0
+
+    def test_set_sql_pool_false_writes_file(self, runner: CliRunner, config_env: Path) -> None:
+        _ = config_env
+        runner.invoke(cli, ["config", "set", "sql-pool", "false"])
+        cfg = load_config(default_path())
+        assert cfg.defaults.sql_pool is False
+
+    def test_set_sql_pool_true_writes_file(self, runner: CliRunner, config_env: Path) -> None:
+        _ = config_env
+        runner.invoke(cli, ["config", "set", "sql-pool", "true"])
+        cfg = load_config(default_path())
+        assert cfg.defaults.sql_pool is True
+
+    def test_set_sql_pool_case_insensitive(self, runner: CliRunner, config_env: Path) -> None:
+        _ = config_env
+        result = runner.invoke(cli, ["config", "set", "sql-pool", "False"])
+        assert result.exit_code == 0
+        cfg = load_config(default_path())
+        assert cfg.defaults.sql_pool is False
+
+    def test_set_sql_pool_preserves_other_keys(self, runner: CliRunner, config_env: Path) -> None:
+        _ = config_env
+        runner.invoke(cli, ["config", "set", "workspace", "MyWS"])
+        runner.invoke(cli, ["config", "set", "sql-retry-executes", "true"])
+        runner.invoke(cli, ["config", "set", "sql-pool", "false"])
+        cfg = load_config(default_path())
+        assert cfg.defaults.sql_pool is False
+        assert cfg.defaults.workspace == "MyWS"
+        assert cfg.defaults.sql_retry_executes is True  # preserved
+
+
+class TestConfigUnsetSqlPool:
+    def test_unset_sql_pool_exits_zero(self, runner: CliRunner, config_env: Path) -> None:
+        _ = config_env
+        runner.invoke(cli, ["config", "set", "sql-pool", "false"])
+        result = runner.invoke(cli, ["config", "unset", "sql-pool"])
+        assert result.exit_code == 0
+
+    def test_unset_sql_pool_clears_key(self, runner: CliRunner, config_env: Path) -> None:
+        _ = config_env
+        runner.invoke(cli, ["config", "set", "sql-pool", "false"])
+        runner.invoke(cli, ["config", "set", "sql-retry-executes", "true"])
+        runner.invoke(cli, ["config", "unset", "sql-pool"])
+        cfg = load_config(default_path())
+        assert cfg.defaults.sql_pool is None
+        assert cfg.defaults.sql_retry_executes is True  # preserved
+
+
+class TestConfigShowSqlPool:
+    def test_show_includes_sql_pool_field(self, runner: CliRunner, config_env: Path) -> None:
+        _ = config_env
+        runner.invoke(cli, ["config", "set", "sql-pool", "false"])
+        result = runner.invoke(cli, ["--json", "config", "show"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["defaults"]["sql_pool"] is False
+
+    def test_show_null_when_sql_pool_not_set(self, runner: CliRunner, config_env: Path) -> None:
+        _ = config_env
+        result = runner.invoke(cli, ["--json", "config", "show"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["defaults"]["sql_pool"] is None

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1037,3 +1037,100 @@ def test_load_config_invalid_logging_level_valid_level_preserved(tmp_path: Path)
     path.write_text('[logging]\nlevel = "debug"\n', encoding="utf-8")
     cfg = load_config(path)
     assert cfg.logging.level == "DEBUG"
+
+
+# ---------------------------------------------------------------------------
+# sql_pool — round-trip and set_default coercion
+# ---------------------------------------------------------------------------
+
+
+def test_round_trip_sql_pool_true(tmp_path: Path) -> None:
+    """sql_pool=True is saved and loaded as a bool."""
+    path = tmp_path / "config.toml"
+    cfg = UserConfig(defaults=Defaults(sql_pool=True))
+    save_config(cfg, path)
+    loaded = load_config(path)
+    assert loaded.defaults.sql_pool is True
+
+
+def test_round_trip_sql_pool_false(tmp_path: Path) -> None:
+    """sql_pool=False is saved and loaded as a bool."""
+    path = tmp_path / "config.toml"
+    cfg = UserConfig(defaults=Defaults(sql_pool=False))
+    save_config(cfg, path)
+    loaded = load_config(path)
+    assert loaded.defaults.sql_pool is False
+
+
+def test_round_trip_sql_pool_none(tmp_path: Path) -> None:
+    """sql_pool=None is not written to the file."""
+    path = tmp_path / "config.toml"
+    cfg = UserConfig(defaults=Defaults(workspace="WS", sql_pool=None))
+    save_config(cfg, path)
+    content = path.read_text(encoding="utf-8")
+    assert "sql_pool" not in content
+    loaded = load_config(path)
+    assert loaded.defaults.sql_pool is None
+    assert loaded.defaults.workspace == "WS"
+
+
+def test_set_default_sql_pool_true_persists(tmp_path: Path) -> None:
+    """set_default('sql_pool', 'true') stores True."""
+    path = tmp_path / "config.toml"
+    set_default("sql_pool", "true", path)
+    loaded = load_config(path)
+    assert loaded.defaults.sql_pool is True
+
+
+def test_set_default_sql_pool_false_persists(tmp_path: Path) -> None:
+    """set_default('sql_pool', 'false') stores False."""
+    path = tmp_path / "config.toml"
+    set_default("sql_pool", "false", path)
+    loaded = load_config(path)
+    assert loaded.defaults.sql_pool is False
+
+
+def test_set_default_sql_pool_none_clears(tmp_path: Path) -> None:
+    """set_default('sql_pool', None) clears the key."""
+    path = tmp_path / "config.toml"
+    save_config(UserConfig(defaults=Defaults(sql_pool=False, sql_retry_executes=True)), path)
+    set_default("sql_pool", None, path)
+    loaded = load_config(path)
+    assert loaded.defaults.sql_pool is None
+    assert loaded.defaults.sql_retry_executes is True  # preserved
+
+
+def test_set_default_sql_pool_garbage_raises(tmp_path: Path) -> None:
+    """An unrecognised value for sql_pool raises ValueError."""
+    path = tmp_path / "config.toml"
+    with pytest.raises(ValueError, match="sql_pool"):
+        set_default("sql_pool", "maybe", path)
+
+
+@pytest.mark.parametrize("truthy", ["true", "True", "TRUE", "1", "yes", "on"])
+def test_set_default_sql_pool_truthy_variants(tmp_path: Path, truthy: str) -> None:
+    """All truthy string variants are accepted for sql_pool."""
+    path = tmp_path / "config.toml"
+    set_default("sql_pool", truthy, path)
+    loaded = load_config(path)
+    assert loaded.defaults.sql_pool is True
+
+
+@pytest.mark.parametrize("falsy", ["false", "False", "FALSE", "0", "no", "off"])
+def test_set_default_sql_pool_falsy_variants(tmp_path: Path, falsy: str) -> None:
+    """All falsy string variants are accepted for sql_pool."""
+    path = tmp_path / "config.toml"
+    set_default("sql_pool", falsy, path)
+    loaded = load_config(path)
+    assert loaded.defaults.sql_pool is False
+
+
+def test_set_default_sql_pool_preserves_other_keys(tmp_path: Path) -> None:
+    """set_default('sql_pool', ...) does not clear unrelated keys."""
+    path = tmp_path / "config.toml"
+    save_config(UserConfig(defaults=Defaults(workspace="WS", sql_retry_executes=True)), path)
+    set_default("sql_pool", "false", path)
+    loaded = load_config(path)
+    assert loaded.defaults.sql_pool is False
+    assert loaded.defaults.workspace == "WS"
+    assert loaded.defaults.sql_retry_executes is True

--- a/tests/unit/test_sql.py
+++ b/tests/unit/test_sql.py
@@ -2991,3 +2991,111 @@ class TestSqlRetryExecutes:
         assert mock_mssql.connect.call_count == 1, (
             "DML (fetch='none') must not retry on execute-phase transient errors by default"
         )
+
+
+# ---------------------------------------------------------------------------
+# _pool_enabled — 3-layer precedence (env > config > default True)
+# ---------------------------------------------------------------------------
+
+
+class TestPoolEnabledConfig:
+    """_pool_enabled follows the 3-layer rule: env > config > built-in True.
+
+    Note: the module-level ``_disable_pool_by_default`` autouse fixture sets
+    ``FABRIC_SQL_POOL=0`` for every test in this module.  Tests that need to
+    remove the env var entirely (to test config or default fall-through) call
+    ``monkeypatch.delenv("FABRIC_SQL_POOL", raising=False)`` to undo it.
+    """
+
+    def test_env_zero_disables_pool(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """FABRIC_SQL_POOL=0 disables pooling even when config says True."""
+        monkeypatch.setenv("FABRIC_SQL_POOL", "0")
+        cfg = UserConfig(defaults=Defaults(sql_pool=True))
+        _sql_module._sql_config_cache = cfg
+        assert _sql_module._pool_enabled() is False
+
+    def test_env_one_enables_pool(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """FABRIC_SQL_POOL=1 enables pooling even when config says False."""
+        monkeypatch.setenv("FABRIC_SQL_POOL", "1")
+        cfg = UserConfig(defaults=Defaults(sql_pool=False))
+        _sql_module._sql_config_cache = cfg
+        assert _sql_module._pool_enabled() is True
+
+    def test_env_false_string_disables_pool(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """FABRIC_SQL_POOL=false (string) disables pooling."""
+        monkeypatch.setenv("FABRIC_SQL_POOL", "false")
+        assert _sql_module._pool_enabled() is False
+
+    def test_env_off_string_disables_pool(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """FABRIC_SQL_POOL=off (string) disables pooling."""
+        monkeypatch.setenv("FABRIC_SQL_POOL", "off")
+        assert _sql_module._pool_enabled() is False
+
+    def test_env_no_string_disables_pool(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """FABRIC_SQL_POOL=no (string) disables pooling."""
+        monkeypatch.setenv("FABRIC_SQL_POOL", "no")
+        assert _sql_module._pool_enabled() is False
+
+    def test_env_empty_string_falls_through_to_default_on(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """FABRIC_SQL_POOL='' (empty string) is treated as absent — pooling stays ON.
+
+        An empty placeholder (e.g. Docker ``ENV FABRIC_SQL_POOL=``) must not
+        silently disable pooling.  Only a non-empty falsy value disables it.
+        """
+        monkeypatch.setenv("FABRIC_SQL_POOL", "")
+        assert _sql_module._pool_enabled() is True
+
+    def test_env_whitespace_only_falls_through_to_default_on(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """FABRIC_SQL_POOL='  ' (whitespace only) is treated as absent — pooling stays ON."""
+        monkeypatch.setenv("FABRIC_SQL_POOL", "   ")
+        assert _sql_module._pool_enabled() is True
+
+    def test_env_true_string_enables_pool(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """FABRIC_SQL_POOL=true enables pooling."""
+        monkeypatch.setenv("FABRIC_SQL_POOL", "true")
+        assert _sql_module._pool_enabled() is True
+
+    def test_env_any_non_falsy_string_enables_pool(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Any non-falsy FABRIC_SQL_POOL value enables pooling."""
+        monkeypatch.setenv("FABRIC_SQL_POOL", "yes")
+        assert _sql_module._pool_enabled() is True
+
+    def test_config_false_disables_pool(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Config sql_pool=False disables pooling when env var is absent."""
+        monkeypatch.delenv("FABRIC_SQL_POOL", raising=False)
+        cfg = UserConfig(defaults=Defaults(sql_pool=False))
+        _sql_module._sql_config_cache = cfg
+        assert _sql_module._pool_enabled() is False
+
+    def test_config_true_enables_pool(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Config sql_pool=True enables pooling when env var is absent."""
+        monkeypatch.delenv("FABRIC_SQL_POOL", raising=False)
+        cfg = UserConfig(defaults=Defaults(sql_pool=True))
+        _sql_module._sql_config_cache = cfg
+        assert _sql_module._pool_enabled() is True
+
+    def test_falls_back_to_true_when_no_env_no_config(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When neither env var nor config is set, pooling is enabled (default True)."""
+        monkeypatch.delenv("FABRIC_SQL_POOL", raising=False)
+        # _isolate_sql_config autouse fixture already cleared the cache.
+        assert _sql_module._pool_enabled() is True
+
+    def test_config_none_falls_back_to_true(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Config sql_pool=None (unset) falls through to the built-in True default."""
+        monkeypatch.delenv("FABRIC_SQL_POOL", raising=False)
+        cfg = UserConfig(defaults=Defaults(sql_pool=None))
+        _sql_module._sql_config_cache = cfg
+        assert _sql_module._pool_enabled() is True
+
+    def test_env_wins_over_config_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """FABRIC_SQL_POOL=1 wins over config sql_pool=False."""
+        monkeypatch.setenv("FABRIC_SQL_POOL", "1")
+        cfg = UserConfig(defaults=Defaults(sql_pool=False))
+        _sql_module._sql_config_cache = cfg
+        assert _sql_module._pool_enabled() is True


### PR DESCRIPTION
## Summary

- Adds `sql_pool: bool | None = None` to `Defaults` and wires it through all config helpers (`_parse_defaults_section`, `_defaults_to_dict`, `_coerce_defaults_key`, `_make_defaults_setter`, `_SET_CONFIG_DISPATCH`, `set_default`).
- Updates `_pool_enabled()` in `sql.py` to resolve env var (call-time) > `config.toml [defaults].sql_pool` via the existing memoised `_load_sql_config()` cache > built-in default `True` — matching the pattern established by #679.
- Adds `fdw config set sql-pool <true|false>` and `fdw config unset sql-pool` CLI commands, mirroring `sql-retry-executes`.
- Exposes `sql_pool` in `config show` JSON output.
- Adds `sql_pool` to the config docs page with an env/config/default table under a new "SQL connection pooling" section.

## Test plan

- [x] Config round-trip: `sql_pool=True`, `sql_pool=False`, `sql_pool=None` (not written to file)
- [x] `set_default`/`set_config` truthy and falsy string variants accepted; invalid value raises `ValueError`
- [x] CLI: `fdw config set sql-pool false/true` writes the file; `fdw config unset sql-pool` clears key; other keys preserved
- [x] `config show` JSON includes `sql_pool` field (null when not set)
- [x] `_pool_enabled()` 3-layer precedence: env wins over config wins over built-in True
- [x] `uv run ruff format --check .` — pass
- [x] `uv run ruff check .` — pass
- [x] `uv run pytest tests/unit -q` — 4460 passed
- [x] `uv run ty check src tests` — pass

Closes #687

🤖 Generated with [Claude Code](https://claude.com/claude-code)