### PR TITLE
feat(config): promote FABRIC_AUTH to a 3-layer config knob ([defaults] auth_mode)

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -131,12 +131,15 @@ The package uses [`ClientSecretCredential`](https://learn.microsoft.com/python/a
 | `AZURE_CLIENT_ID` | _(unset)_ | Required for `FABRIC_AUTH=sp` |
 | `AZURE_CLIENT_SECRET` | _(unset)_ | Required for `FABRIC_AUTH=sp` |
 
-To persist the credential mode across MCP server restarts without setting an environment variable:
+To persist the credential mode for the **MCP server** across restarts without setting an environment variable:
 
 ```shell
 fdw config set auth-mode interactive   # persist 'interactive' in config.toml
 fdw config unset auth-mode             # revert to built-in default
 ```
+
+!!! note "MCP server only"
+    `[defaults] auth_mode` is consumed by the MCP server (`fdw mcp`) only.  The `fdw` CLI credential is controlled by the `--auth` / `-a` flag and does not fall back to this config key.  A follow-up issue will unify the CLI credential path with the config default.
 
 ---
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -22,13 +22,24 @@ If neither of those works for you, read on for the alternatives.
 
 ---
 
-`fabric-dw` selects a credential source via the `FABRIC_AUTH` environment variable:
+`fabric-dw` selects a credential source via a 3-layer resolution stack:
 
-| `FABRIC_AUTH` value | What it uses |
+| Layer | Mechanism | Description |
+| --- | --- | --- |
+| 1 | `FABRIC_AUTH` env var | Wins when non-empty and non-whitespace. An empty/whitespace value is treated as absent (falls through). An unrecognised non-empty value raises an error. |
+| 2 | `[defaults] auth_mode` in `config.toml` | Set with `fdw config set auth-mode MODE`. Invalid values are discarded (treated as unset) with a warning. |
+| 3 | Built-in default | `default` (DefaultAzureCredential chain) |
+
+Valid values: `default`, `interactive`, `sp` (case-insensitive).
+
+| Value | What it uses |
 | --- | --- |
-| `default` (default) | [`azure-identity` `DefaultAzureCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.defaultazurecredential?WT.mc_id=MVP_310840) — see [credential chain](#fabric_authdefault-defaultazurecredential-chain) below |
+| `default` | [`azure-identity` `DefaultAzureCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.defaultazurecredential?WT.mc_id=MVP_310840) — see [credential chain](#fabric_authdefault-defaultazurecredential-chain) below |
 | `interactive` | Browser pop-up — see [interactive sign-in](#interactive-browser-sign-in-zero-setup) below |
 | `sp` | Service-principal — see [service principal](#fabric_authsp-service-principal) below |
+
+!!! note "Empty-value semantics"
+    An empty or whitespace-only `FABRIC_AUTH` (e.g. `FABRIC_AUTH=`) is treated as absent and falls through to `config.toml` / the built-in default. An unrecognised non-empty value (e.g. `FABRIC_AUTH=typo`) raises a configuration error immediately at server start so the credential is never silently wrong.
 
 ---
 
@@ -113,12 +124,19 @@ The package uses [`ClientSecretCredential`](https://learn.microsoft.com/python/a
 
 | Variable | Default | Description |
 | --- | --- | --- |
-| `FABRIC_AUTH` | `default` | Credential mode: `default`, `interactive`, or `sp` |
+| `FABRIC_AUTH` | _(unset — falls through to config / built-in default)_ | Credential mode: `default`, `interactive`, or `sp`. Empty/whitespace falls through; unrecognised non-empty value raises an error at startup. |
 | `FABRIC_INTERACTIVE_CLIENT_ID` | `f666e5ee-2149-4c6a-87eb-13c9e1fdc70d` | Override the shared app client ID for browser sign-in |
 | `FABRIC_INTERACTIVE_TENANT_ID` | _(unset)_ | Pin a specific Entra tenant for browser sign-in |
 | `AZURE_TENANT_ID` | _(unset)_ | Required for `FABRIC_AUTH=sp` |
 | `AZURE_CLIENT_ID` | _(unset)_ | Required for `FABRIC_AUTH=sp` |
 | `AZURE_CLIENT_SECRET` | _(unset)_ | Required for `FABRIC_AUTH=sp` |
+
+To persist the credential mode across MCP server restarts without setting an environment variable:
+
+```shell
+fdw config set auth-mode interactive   # persist 'interactive' in config.toml
+fdw config unset auth-mode             # revert to built-in default
+```
 
 ---
 

--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -125,6 +125,9 @@ fdw config unset sql-pool
 
 ## MCP server credential mode
 
+!!! note "MCP server only"
+    `[defaults] auth_mode` is read exclusively by the **MCP server** (`fdw mcp`).  The `fdw` CLI selects its credential via the `--auth` / `-a` flag (default: `default`) and does not yet fall back to this config key.  A follow-up issue will unify the CLI credential path with the config default.
+
 The MCP server credential mode can be configured via a 3-layer stack. Resolution order (highest priority first):
 
 | Layer | Mechanism | Description |
@@ -138,7 +141,7 @@ Valid modes: `default`, `interactive`, `sp` (case-insensitive).
 !!! note "Security note"
     An empty or invalid value is never silently downgraded or substituted with an unexpected credential. Empty/whitespace `FABRIC_AUTH` always falls through to config/default; a non-empty but unrecognised value raises an error.
 
-To persist a credential mode:
+To persist a credential mode for the MCP server:
 
 ```shell
 fdw config set auth-mode interactive

--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -123,7 +123,34 @@ fdw config set sql-pool true
 fdw config unset sql-pool
 ```
 
-For authentication configuration, see [Authentication](../install.md#authentication).
+## MCP server credential mode
+
+The MCP server credential mode can be configured via a 3-layer stack. Resolution order (highest priority first):
+
+| Layer | Mechanism | Description |
+|---|---|---|
+| 1 | `FABRIC_AUTH` env var | Read at server start-up; takes precedence over everything else. An empty or whitespace-only value is treated as absent (falls through to the next layer). An unrecognised non-empty value raises a configuration error. |
+| 2 | `[defaults] auth_mode` in `config.toml` | Stored with `fdw config set auth-mode`. Invalid values are discarded (treated as unset) with a warning. |
+| 3 | Built-in default | `default` (DefaultAzureCredential chain) |
+
+Valid modes: `default`, `interactive`, `sp` (case-insensitive).
+
+!!! note "Security note"
+    An empty or invalid value is never silently downgraded or substituted with an unexpected credential. Empty/whitespace `FABRIC_AUTH` always falls through to config/default; a non-empty but unrecognised value raises an error.
+
+To persist a credential mode:
+
+```shell
+fdw config set auth-mode interactive
+```
+
+To revert to the built-in default:
+
+```shell
+fdw config unset auth-mode
+```
+
+See [Authentication](../authentication.md) for the full list of valid modes and their requirements.
 
 ---
 
@@ -143,7 +170,7 @@ fdw config clear
 
 ### config set
 
-Set a default value. Accepts `workspace`, `warehouse`, `max-429-retries`, `retry-deadline`, `sql-retry-deadline`, `sql-retry-executes`, or `sql-pool` as a flat key, or the nested sub-commands `telemetry disabled` and `logging level` for section-scoped knobs.
+Set a default value. Accepts `workspace`, `warehouse`, `max-429-retries`, `retry-deadline`, `sql-retry-deadline`, `sql-retry-executes`, `sql-pool`, or `auth-mode` as a flat key, or the nested sub-commands `telemetry disabled` and `logging level` for section-scoped knobs.
 
 **Synopsis**
 
@@ -155,6 +182,7 @@ fdw config set retry-deadline SECONDS
 fdw config set sql-retry-deadline SECONDS
 fdw config set sql-retry-executes true|false
 fdw config set sql-pool true|false
+fdw config set auth-mode MODE
 fdw config set telemetry disabled true|false
 fdw config set logging level LEVEL
 ```
@@ -169,6 +197,7 @@ fdw config set retry-deadline 600.0
 fdw config set sql-retry-deadline 300.0
 fdw config set sql-retry-executes true
 fdw config set sql-pool false
+fdw config set auth-mode interactive
 fdw config set telemetry disabled true
 fdw config set logging level DEBUG
 ```
@@ -201,7 +230,7 @@ warehouse  MyWarehouse
 
 ### config unset
 
-Clear a single default value. Accepts `workspace`, `warehouse`, `max-429-retries`, `retry-deadline`, `sql-retry-deadline`, `sql-retry-executes`, or `sql-pool` as a flat key, or the nested sub-commands `telemetry disabled` and `logging level` for section-scoped knobs.
+Clear a single default value. Accepts `workspace`, `warehouse`, `max-429-retries`, `retry-deadline`, `sql-retry-deadline`, `sql-retry-executes`, `sql-pool`, or `auth-mode` as a flat key, or the nested sub-commands `telemetry disabled` and `logging level` for section-scoped knobs.
 
 **Synopsis**
 
@@ -213,6 +242,7 @@ fdw config unset retry-deadline
 fdw config unset sql-retry-deadline
 fdw config unset sql-retry-executes
 fdw config unset sql-pool
+fdw config unset auth-mode
 fdw config unset telemetry disabled
 fdw config unset logging level
 ```

--- a/src/fabric_dw/cli/commands/config.py
+++ b/src/fabric_dw/cli/commands/config.py
@@ -13,6 +13,7 @@ config set retry-deadline      — persist the combined 429+5xx wall-clock deadl
 config set sql-retry-deadline  — persist the SQL/TDS connect+execute retry budget
 config set sql-retry-executes  — persist whether fetch="none" statements are retried
 config set sql-pool            — persist whether SQL connection pooling is enabled
+config set auth-mode           — persist the MCP server credential mode
 config set telemetry disabled  — opt in/out of telemetry via config
 config set logging level       — set the MCP server log level
 config unset workspace         — clear the workspace default
@@ -22,6 +23,7 @@ config unset retry-deadline    — clear the HTTP deadline default
 config unset sql-retry-deadline — clear the SQL retry deadline default
 config unset sql-retry-executes — clear the SQL execute-retry flag
 config unset sql-pool          — clear the SQL pool flag
+config unset auth-mode         — clear the credential mode (revert to built-in default)
 config unset telemetry disabled — clear the telemetry opt-out (revert to default-on)
 config unset logging level     — clear the logging level (revert to built-in INFO)
 config clear                   — wipe the entire config file
@@ -33,7 +35,13 @@ import click
 
 from fabric_dw.cli._context import CliContext
 from fabric_dw.cli._render import confirm, render
-from fabric_dw.config import VALID_LOG_LEVELS, clear_config, set_config, set_default
+from fabric_dw.config import (
+    VALID_AUTH_MODES,
+    VALID_LOG_LEVELS,
+    clear_config,
+    set_config,
+    set_default,
+)
 
 
 @click.group("config")
@@ -60,6 +68,7 @@ def show_cmd(ctx: CliContext) -> None:
             "sql_retry_deadline_s": cfg.defaults.sql_retry_deadline_s,
             "sql_retry_executes": cfg.defaults.sql_retry_executes,
             "sql_pool": cfg.defaults.sql_pool,
+            "auth_mode": cfg.defaults.auth_mode,
         },
         "telemetry": {
             "disabled": cfg.telemetry.disabled,
@@ -147,6 +156,31 @@ def set_sql_pool_cmd(value: str) -> None:
     """
     set_default("sql_pool", value.lower())
     click.echo(f"Default sql_pool set to {value.lower()}.")
+
+
+_AUTH_MODE_CHOICES = click.Choice(sorted(VALID_AUTH_MODES), case_sensitive=False)
+
+
+@set_group.command("auth-mode")
+@click.argument("value", type=_AUTH_MODE_CHOICES)
+def set_auth_mode_cmd(value: str) -> None:
+    """Set the MCP server credential mode (default, interactive, or sp).
+
+    This persists the credential mode used by the MCP server.  The
+    ``FABRIC_AUTH`` environment variable takes precedence over this setting
+    when non-empty.
+
+    Valid modes:
+
+    \b
+    default      DefaultAzureCredential chain (Azure CLI, Managed Identity, etc.)
+    interactive  Interactive browser sign-in
+    sp           Service principal (requires AZURE_TENANT_ID, AZURE_CLIENT_ID,
+                 AZURE_CLIENT_SECRET)
+    """
+    normalised = value.strip().lower()
+    set_default("auth_mode", normalised)
+    click.echo(f"Default auth_mode set to {normalised!r}.")
 
 
 @set_group.group("telemetry")
@@ -241,6 +275,13 @@ def unset_sql_pool_cmd() -> None:
     """Clear the sql_pool default (revert to built-in true)."""
     set_default("sql_pool", None)
     click.echo("Default sql_pool cleared.")
+
+
+@unset_group.command("auth-mode")
+def unset_auth_mode_cmd() -> None:
+    """Clear the auth_mode default (revert to built-in default credential mode)."""
+    set_default("auth_mode", None)
+    click.echo("Default auth_mode cleared.")
 
 
 @unset_group.group("telemetry")

--- a/src/fabric_dw/config.py
+++ b/src/fabric_dw/config.py
@@ -656,9 +656,13 @@ def _set_mcp_workspace_allowlist(current: UserConfig, value: str | None) -> User
 
 VALID_LOG_LEVELS: frozenset[str] = frozenset({"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"})
 
-# Valid credential modes — kept in sync with :class:`~fabric_dw.auth.CredentialMode`.
-# Duplicated here to avoid importing auth.py at module level (keeps the dependency
-# graph acyclic and the import lightweight).
+# Valid credential modes — literal copy of :class:`~fabric_dw.auth.CredentialMode` values.
+# Kept as a literal rather than derived at import time (``frozenset(m.value for m in
+# CredentialMode)``) to avoid pulling the azure-identity / msal import chain into
+# config.py's startup path — config.py is imported very early (CLI boot, test fixtures)
+# and should remain a lightweight leaf.  The drift-guard test in tests/unit/test_config.py
+# asserts ``VALID_AUTH_MODES == {m.value for m in CredentialMode}`` and will fail fast
+# if a new mode is added to the enum but not mirrored here.
 VALID_AUTH_MODES: frozenset[str] = frozenset({"default", "sp", "interactive"})
 
 

--- a/src/fabric_dw/config.py
+++ b/src/fabric_dw/config.py
@@ -1,7 +1,8 @@
 """User-level configuration for fabric-dw CLI.
 
-Stores persistent defaults (workspace, warehouse, HTTP retry knobs, and SQL
-retry knobs) in a TOML file at ``$XDG_CONFIG_HOME/fabric-dw/config.toml``
+Stores persistent defaults (workspace, warehouse, HTTP retry knobs, SQL
+retry knobs, and auth mode) in a TOML file at
+``$XDG_CONFIG_HOME/fabric-dw/config.toml``
 (falling back to ``~/.config/fabric-dw/config.toml``).
 
 The TOML shape supports multiple named sections:
@@ -15,6 +16,7 @@ The TOML shape supports multiple named sections:
     retry_deadline_s = 300.0
     sql_retry_deadline_s = 120.0
     sql_retry_executes = false
+    auth_mode = "default"
 
     [telemetry]
     disabled = true
@@ -68,6 +70,7 @@ import filelock
 import tomli_w
 
 __all__ = [
+    "VALID_AUTH_MODES",
     "VALID_LOG_LEVELS",
     "AuthConfig",
     "ConfigError",
@@ -99,7 +102,7 @@ class ConfigError(RuntimeError):
 
 @dataclass(frozen=True)
 class Defaults:
-    """Persistent workspace / warehouse defaults, HTTP retry knobs, and SQL retry knobs."""
+    """Persistent workspace / warehouse defaults, HTTP + SQL retry knobs, and auth mode."""
 
     workspace: str | None = None
     warehouse: str | None = None
@@ -108,6 +111,7 @@ class Defaults:
     sql_retry_deadline_s: float | None = None
     sql_retry_executes: bool | None = None
     sql_pool: bool | None = None
+    auth_mode: str | None = None
 
 
 @dataclass(frozen=True)
@@ -193,6 +197,19 @@ def _parse_defaults_section(data: dict[str, object]) -> Defaults:
     raw_sql_deadline = raw.get("sql_retry_deadline_s")
     raw_sql_executes = raw.get("sql_retry_executes")
     raw_sql_pool = raw.get("sql_pool")
+    raw_auth_mode = raw.get("auth_mode")
+    auth_mode: str | None = None
+    if isinstance(raw_auth_mode, str):
+        normalised = raw_auth_mode.strip().lower()
+        if normalised in VALID_AUTH_MODES:
+            auth_mode = normalised
+        else:
+            _log.warning(
+                "[defaults] auth_mode %r is not a recognised credential mode "
+                "(valid: %s); ignoring.",
+                raw_auth_mode,
+                ", ".join(sorted(VALID_AUTH_MODES)),
+            )
     return Defaults(
         workspace=workspace if isinstance(workspace, str) else None,
         warehouse=warehouse if isinstance(warehouse, str) else None,
@@ -205,6 +222,7 @@ def _parse_defaults_section(data: dict[str, object]) -> Defaults:
         else None,
         sql_retry_executes=raw_sql_executes if isinstance(raw_sql_executes, bool) else None,
         sql_pool=raw_sql_pool if isinstance(raw_sql_pool, bool) else None,
+        auth_mode=auth_mode,
     )
 
 
@@ -377,6 +395,8 @@ def _defaults_to_dict(d: Defaults) -> dict[str, object]:
         out["sql_retry_executes"] = d.sql_retry_executes
     if d.sql_pool is not None:
         out["sql_pool"] = d.sql_pool
+    if d.auth_mode is not None:
+        out["auth_mode"] = d.auth_mode
     return out
 
 
@@ -534,6 +554,14 @@ def _coerce_defaults_key(  # noqa: PLR0912
                 coerced_bool = False
             else:
                 raise ValueError(f"{key} {value!r} must be one of: true/1/yes/on or false/0/no/off")
+        elif key == "auth_mode":
+            normalised = value.strip().lower()
+            if normalised not in VALID_AUTH_MODES:
+                valid_sorted = ", ".join(sorted(VALID_AUTH_MODES))
+                raise ValueError(
+                    f"auth_mode {value!r} is not a valid credential mode; "
+                    f"must be one of {valid_sorted}"
+                )
     return coerced_int, coerced_float, coerced_bool
 
 
@@ -552,6 +580,12 @@ def _make_defaults_setter(
 
     def _set(current: UserConfig, value: str | None) -> UserConfig:
         coerced_int, coerced_float, coerced_bool = _coerce_defaults_key(key, value)
+        # For auth_mode, normalise to lowercase when setting (None clears the key).
+        auth_mode_value: str | None
+        if key == "auth_mode":
+            auth_mode_value = value.strip().lower() if value is not None else None
+        else:
+            auth_mode_value = current.defaults.auth_mode
         new_defaults = Defaults(
             workspace=value if key == "workspace" else current.defaults.workspace,
             warehouse=value if key == "warehouse" else current.defaults.warehouse,
@@ -568,6 +602,7 @@ def _make_defaults_setter(
             if key == "sql_retry_executes"
             else current.defaults.sql_retry_executes,
             sql_pool=coerced_bool if key == "sql_pool" else current.defaults.sql_pool,
+            auth_mode=auth_mode_value,
         )
         return UserConfig(
             defaults=new_defaults,
@@ -620,6 +655,11 @@ def _set_mcp_workspace_allowlist(current: UserConfig, value: str | None) -> User
 
 
 VALID_LOG_LEVELS: frozenset[str] = frozenset({"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"})
+
+# Valid credential modes — kept in sync with :class:`~fabric_dw.auth.CredentialMode`.
+# Duplicated here to avoid importing auth.py at module level (keeps the dependency
+# graph acyclic and the import lightweight).
+VALID_AUTH_MODES: frozenset[str] = frozenset({"default", "sp", "interactive"})
 
 
 def _set_logging_level(current: UserConfig, value: str | None) -> UserConfig:
@@ -674,6 +714,7 @@ _SET_CONFIG_DISPATCH: dict[
     ("defaults", "sql_retry_deadline_s"): _make_defaults_setter("sql_retry_deadline_s"),
     ("defaults", "sql_retry_executes"): _make_defaults_setter("sql_retry_executes"),
     ("defaults", "sql_pool"): _make_defaults_setter("sql_pool"),
+    ("defaults", "auth_mode"): _make_defaults_setter("auth_mode"),
     ("telemetry", "disabled"): _set_telemetry_disabled,
     ("mcp", "workspace_allowlist"): _set_mcp_workspace_allowlist,
     ("logging", "level"): _set_logging_level,
@@ -771,6 +812,7 @@ def set_default(key: str, value: str | None, path: Path | None = None) -> None:
         "sql_retry_deadline_s",
         "sql_retry_executes",
         "sql_pool",
+        "auth_mode",
     }
     if key not in allowed:
         raise ValueError(f"Unknown config key {key!r}; must be one of {sorted(allowed)}")

--- a/src/fabric_dw/mcp/_context.py
+++ b/src/fabric_dw/mcp/_context.py
@@ -136,7 +136,9 @@ def build_context(
     env = environ if environ is not None else os.environ
 
     # 1. Env var (wins when non-empty/non-whitespace).
-    raw_env_mode = env.get("FABRIC_AUTH", "").strip()
+    # Normalise to lowercase so FABRIC_AUTH=SP / Interactive / DEFAULT all work,
+    # matching the case-insensitive behaviour documented for config/CLI.
+    raw_env_mode = env.get("FABRIC_AUTH", "").strip().lower()
 
     cfg = load_config(config_path)
 
@@ -150,7 +152,12 @@ def build_context(
                 f"expected one of {[m.value for m in _auth.CredentialMode]}"
             ) from exc
     elif cfg.defaults.auth_mode is not None:
-        # 2. Config file value — already validated at write time, but guard anyway.
+        # 2. Config file value.  In normal operation this branch is guaranteed to
+        # hold an exact lowercase enum member because `_parse_defaults_section`
+        # already discards invalid values to ``None`` and lowercases valid ones.
+        # The try/except is a belt-and-suspenders guard against parse-time
+        # validation regressing (e.g. a direct ``save_config`` bypass) and cannot
+        # be reached by any test without monkeypatching ``load_config``.
         try:
             mode = _auth.CredentialMode(cfg.defaults.auth_mode)
         except ValueError:

--- a/src/fabric_dw/mcp/_context.py
+++ b/src/fabric_dw/mcp/_context.py
@@ -110,6 +110,16 @@ def build_context(
     default (10 / 300.0) via the shared :func:`~fabric_dw.config_resolve.resolve_int_knob`
     and :func:`~fabric_dw.config_resolve.resolve_float_knob` helpers.
 
+    The credential mode is resolved with precedence:
+
+    1. ``FABRIC_AUTH`` environment variable (when non-empty/non-whitespace).
+    2. ``[defaults] auth_mode`` in ``config.toml``.
+    3. Built-in default: ``default`` (``DefaultAzureCredential``).
+
+    An empty or whitespace-only ``FABRIC_AUTH`` is treated as absent (falls
+    through to config/default) rather than raising an error.  An unrecognised
+    non-empty value raises :class:`~fabric_dw.exceptions.ConfigError`.
+
     Args:
         environ: Mapping to read environment variables from.  Defaults to
             ``os.environ`` when ``None``.
@@ -121,21 +131,40 @@ def build_context(
 
     Raises:
         :class:`~fabric_dw.exceptions.ConfigError`: When ``FABRIC_AUTH``
-            contains an unrecognised value.
+            contains an unrecognised non-empty value.
     """
     env = environ if environ is not None else os.environ
-    raw_mode = env.get("FABRIC_AUTH", "default")
-    try:
-        mode = _auth.CredentialMode(raw_mode)
-    except ValueError as exc:
-        raise ConfigError(
-            f"invalid FABRIC_AUTH value {raw_mode!r}; "
-            f"expected one of {[m.value for m in _auth.CredentialMode]}"
-        ) from exc
 
-    credential = _auth.get_credential(mode)
+    # 1. Env var (wins when non-empty/non-whitespace).
+    raw_env_mode = env.get("FABRIC_AUTH", "").strip()
 
     cfg = load_config(config_path)
+
+    if raw_env_mode:
+        # Non-empty env value — must be a recognised mode or we raise.
+        try:
+            mode = _auth.CredentialMode(raw_env_mode)
+        except ValueError as exc:
+            raise ConfigError(
+                f"invalid FABRIC_AUTH value {raw_env_mode!r}; "
+                f"expected one of {[m.value for m in _auth.CredentialMode]}"
+            ) from exc
+    elif cfg.defaults.auth_mode is not None:
+        # 2. Config file value — already validated at write time, but guard anyway.
+        try:
+            mode = _auth.CredentialMode(cfg.defaults.auth_mode)
+        except ValueError:
+            _logger.warning(
+                "[defaults] auth_mode %r from config is not a recognised credential mode; "
+                "falling back to built-in default.",
+                cfg.defaults.auth_mode,
+            )
+            mode = _auth.CredentialMode.DEFAULT
+    else:
+        # 3. Built-in default.
+        mode = _auth.CredentialMode.DEFAULT
+
+    credential = _auth.get_credential(mode)
 
     retries = resolve_int_knob(
         cli_value=None,

--- a/tests/unit/cli/commands/test_config.py
+++ b/tests/unit/cli/commands/test_config.py
@@ -621,3 +621,95 @@ class TestConfigShowSqlPool:
         assert result.exit_code == 0
         data = json.loads(result.output)
         assert data["defaults"]["sql_pool"] is None
+
+
+# ---------------------------------------------------------------------------
+# config set / unset / show for auth-mode
+# ---------------------------------------------------------------------------
+
+
+class TestConfigSetAuthMode:
+    def test_set_auth_mode_default_exits_zero(self, runner: CliRunner, config_env: Path) -> None:
+        _ = config_env
+        result = runner.invoke(cli, ["config", "set", "auth-mode", "default"])
+        assert result.exit_code == 0
+
+    def test_set_auth_mode_interactive_exits_zero(
+        self, runner: CliRunner, config_env: Path
+    ) -> None:
+        _ = config_env
+        result = runner.invoke(cli, ["config", "set", "auth-mode", "interactive"])
+        assert result.exit_code == 0
+
+    def test_set_auth_mode_sp_exits_zero(self, runner: CliRunner, config_env: Path) -> None:
+        _ = config_env
+        result = runner.invoke(cli, ["config", "set", "auth-mode", "sp"])
+        assert result.exit_code == 0
+
+    def test_set_auth_mode_writes_file(self, runner: CliRunner, config_env: Path) -> None:
+        _ = config_env
+        runner.invoke(cli, ["config", "set", "auth-mode", "interactive"])
+        cfg = load_config(default_path())
+        assert cfg.defaults.auth_mode == "interactive"
+
+    def test_set_auth_mode_sp_writes_file(self, runner: CliRunner, config_env: Path) -> None:
+        _ = config_env
+        runner.invoke(cli, ["config", "set", "auth-mode", "sp"])
+        cfg = load_config(default_path())
+        assert cfg.defaults.auth_mode == "sp"
+
+    def test_set_auth_mode_case_insensitive(self, runner: CliRunner, config_env: Path) -> None:
+        """auth-mode choice is case-insensitive; stored as lowercase."""
+        _ = config_env
+        result = runner.invoke(cli, ["config", "set", "auth-mode", "INTERACTIVE"])
+        assert result.exit_code == 0
+        cfg = load_config(default_path())
+        assert cfg.defaults.auth_mode == "interactive"
+
+    def test_set_auth_mode_invalid_rejected(self, runner: CliRunner, config_env: Path) -> None:
+        """An invalid auth-mode value must be rejected by click.Choice."""
+        _ = config_env
+        result = runner.invoke(cli, ["config", "set", "auth-mode", "managed_identity"])
+        assert result.exit_code != 0
+
+    def test_set_auth_mode_preserves_workspace(self, runner: CliRunner, config_env: Path) -> None:
+        _ = config_env
+        runner.invoke(cli, ["config", "set", "workspace", "MyWS"])
+        runner.invoke(cli, ["config", "set", "auth-mode", "interactive"])
+        cfg = load_config(default_path())
+        assert cfg.defaults.auth_mode == "interactive"
+        assert cfg.defaults.workspace == "MyWS"
+
+
+class TestConfigUnsetAuthMode:
+    def test_unset_auth_mode_exits_zero(self, runner: CliRunner, config_env: Path) -> None:
+        _ = config_env
+        runner.invoke(cli, ["config", "set", "auth-mode", "interactive"])
+        result = runner.invoke(cli, ["config", "unset", "auth-mode"])
+        assert result.exit_code == 0
+
+    def test_unset_auth_mode_clears_key(self, runner: CliRunner, config_env: Path) -> None:
+        _ = config_env
+        runner.invoke(cli, ["config", "set", "auth-mode", "interactive"])
+        runner.invoke(cli, ["config", "set", "workspace", "WS1"])
+        runner.invoke(cli, ["config", "unset", "auth-mode"])
+        cfg = load_config(default_path())
+        assert cfg.defaults.auth_mode is None
+        assert cfg.defaults.workspace == "WS1"  # preserved
+
+
+class TestConfigShowAuthMode:
+    def test_show_includes_auth_mode_field(self, runner: CliRunner, config_env: Path) -> None:
+        _ = config_env
+        runner.invoke(cli, ["config", "set", "auth-mode", "interactive"])
+        result = runner.invoke(cli, ["--json", "config", "show"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["defaults"]["auth_mode"] == "interactive"
+
+    def test_show_null_when_auth_mode_not_set(self, runner: CliRunner, config_env: Path) -> None:
+        _ = config_env
+        result = runner.invoke(cli, ["--json", "config", "show"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["defaults"]["auth_mode"] is None

--- a/tests/unit/mcp/test_context.py
+++ b/tests/unit/mcp/test_context.py
@@ -445,3 +445,44 @@ class TestBuildContextAuthModeResolution:
         with patch("fabric_dw.mcp._context.FabricHttpClient", return_value=fake_http):
             ctx = build_context(environ={}, config_path=path)
         assert ctx.auth_mode == _auth.CredentialMode.DEFAULT
+
+    def test_env_fabric_auth_interactive_maps_to_interactive(self) -> None:
+        """FABRIC_AUTH=interactive selects CredentialMode.INTERACTIVE via the env path."""
+        fake_http = MagicMock()
+        with (
+            patch("fabric_dw.mcp._context.FabricHttpClient", return_value=fake_http),
+            patch("fabric_dw.mcp._context._auth.get_credential", return_value=MagicMock()),
+        ):
+            ctx = build_context(environ={"FABRIC_AUTH": "interactive"})
+        assert ctx.auth_mode == _auth.CredentialMode.INTERACTIVE
+
+    def test_env_fabric_auth_uppercase_sp_accepted(self) -> None:
+        """FABRIC_AUTH=SP (uppercase) is accepted and maps to SERVICE_PRINCIPAL.
+
+        The env path normalises to lowercase before lookup, so mixed-case values
+        must work identically to their lowercase equivalents.
+        """
+        fake_http = MagicMock()
+        with (
+            patch("fabric_dw.mcp._context.FabricHttpClient", return_value=fake_http),
+            patch("fabric_dw.mcp._context._auth.get_credential", return_value=MagicMock()),
+        ):
+            ctx = build_context(environ={"FABRIC_AUTH": "SP"})
+        assert ctx.auth_mode == _auth.CredentialMode.SERVICE_PRINCIPAL
+
+    def test_env_fabric_auth_mixed_case_interactive_accepted(self) -> None:
+        """FABRIC_AUTH=Interactive (mixed case) is accepted and maps to INTERACTIVE."""
+        fake_http = MagicMock()
+        with (
+            patch("fabric_dw.mcp._context.FabricHttpClient", return_value=fake_http),
+            patch("fabric_dw.mcp._context._auth.get_credential", return_value=MagicMock()),
+        ):
+            ctx = build_context(environ={"FABRIC_AUTH": "Interactive"})
+        assert ctx.auth_mode == _auth.CredentialMode.INTERACTIVE
+
+    def test_env_fabric_auth_uppercase_default_accepted(self) -> None:
+        """FABRIC_AUTH=DEFAULT (uppercase) is accepted and maps to DEFAULT."""
+        fake_http = MagicMock()
+        with patch("fabric_dw.mcp._context.FabricHttpClient", return_value=fake_http):
+            ctx = build_context(environ={"FABRIC_AUTH": "DEFAULT"})
+        assert ctx.auth_mode == _auth.CredentialMode.DEFAULT

--- a/tests/unit/mcp/test_context.py
+++ b/tests/unit/mcp/test_context.py
@@ -337,3 +337,111 @@ class TestBuildContextConfigRead:
             # This should not raise even if the default config file doesn't exist.
             ctx = build_context(environ={"FABRIC_AUTH": "default"}, config_path=None)
         assert isinstance(ctx, ServerContext)
+
+
+# ---------------------------------------------------------------------------
+# build_context — 3-layer auth_mode resolution
+# ---------------------------------------------------------------------------
+
+
+class TestBuildContextAuthModeResolution:
+    """Tests for the 3-layer auth_mode resolution: env > config > built-in default."""
+
+    def test_env_fabric_auth_takes_precedence_over_config(self, tmp_path: Path) -> None:
+        """FABRIC_AUTH env var overrides [defaults] auth_mode in config."""
+        path = tmp_path / "config.toml"
+        save_config(UserConfig(defaults=Defaults(auth_mode="interactive")), path)
+        fake_http = MagicMock()
+        with (
+            patch("fabric_dw.mcp._context.FabricHttpClient", return_value=fake_http),
+            patch("fabric_dw.mcp._context._auth.get_credential", return_value=MagicMock()),
+        ):
+            ctx = build_context(environ={"FABRIC_AUTH": "sp"}, config_path=path)
+        assert ctx.auth_mode == _auth.CredentialMode.SERVICE_PRINCIPAL
+
+    def test_config_auth_mode_used_when_env_absent(self, tmp_path: Path) -> None:
+        """[defaults] auth_mode is used when FABRIC_AUTH is absent."""
+        path = tmp_path / "config.toml"
+        save_config(UserConfig(defaults=Defaults(auth_mode="interactive")), path)
+        fake_http = MagicMock()
+        with (
+            patch("fabric_dw.mcp._context.FabricHttpClient", return_value=fake_http),
+            patch("fabric_dw.mcp._context._auth.get_credential", return_value=MagicMock()),
+        ):
+            ctx = build_context(environ={}, config_path=path)
+        assert ctx.auth_mode == _auth.CredentialMode.INTERACTIVE
+
+    def test_builtin_default_used_when_env_and_config_absent(self, tmp_path: Path) -> None:
+        """Built-in default (CredentialMode.DEFAULT) is used when neither env nor config is set."""
+        path = tmp_path / "config.toml"
+        save_config(UserConfig(), path)
+        fake_http = MagicMock()
+        with patch("fabric_dw.mcp._context.FabricHttpClient", return_value=fake_http):
+            ctx = build_context(environ={}, config_path=path)
+        assert ctx.auth_mode == _auth.CredentialMode.DEFAULT
+
+    def test_empty_fabric_auth_falls_through_to_config(self, tmp_path: Path) -> None:
+        """Empty FABRIC_AUTH (whitespace) falls through to config, not treated as invalid."""
+        path = tmp_path / "config.toml"
+        save_config(UserConfig(defaults=Defaults(auth_mode="interactive")), path)
+        fake_http = MagicMock()
+        with (
+            patch("fabric_dw.mcp._context.FabricHttpClient", return_value=fake_http),
+            patch("fabric_dw.mcp._context._auth.get_credential", return_value=MagicMock()),
+        ):
+            ctx = build_context(environ={"FABRIC_AUTH": ""}, config_path=path)
+        assert ctx.auth_mode == _auth.CredentialMode.INTERACTIVE
+
+    def test_whitespace_only_fabric_auth_falls_through_to_config(self, tmp_path: Path) -> None:
+        """Whitespace-only FABRIC_AUTH falls through to config."""
+        path = tmp_path / "config.toml"
+        save_config(UserConfig(defaults=Defaults(auth_mode="interactive")), path)
+        fake_http = MagicMock()
+        with (
+            patch("fabric_dw.mcp._context.FabricHttpClient", return_value=fake_http),
+            patch("fabric_dw.mcp._context._auth.get_credential", return_value=MagicMock()),
+        ):
+            ctx = build_context(environ={"FABRIC_AUTH": "   "}, config_path=path)
+        assert ctx.auth_mode == _auth.CredentialMode.INTERACTIVE
+
+    def test_empty_fabric_auth_falls_through_to_builtin_default(self, tmp_path: Path) -> None:
+        """Empty FABRIC_AUTH with no config falls through to built-in default."""
+        path = tmp_path / "no-config.toml"  # does not exist
+        fake_http = MagicMock()
+        with patch("fabric_dw.mcp._context.FabricHttpClient", return_value=fake_http):
+            ctx = build_context(environ={"FABRIC_AUTH": ""}, config_path=path)
+        assert ctx.auth_mode == _auth.CredentialMode.DEFAULT
+
+    def test_invalid_fabric_auth_raises_config_error(self) -> None:
+        """A non-empty but unrecognised FABRIC_AUTH value raises ConfigError."""
+        with pytest.raises(ConfigError, match="invalid FABRIC_AUTH"):
+            build_context(environ={"FABRIC_AUTH": "managed_identity"})
+
+    def test_invalid_fabric_auth_does_not_fall_through_to_config(self, tmp_path: Path) -> None:
+        """An invalid non-empty FABRIC_AUTH must NOT silently fall through to a different mode."""
+        path = tmp_path / "config.toml"
+        save_config(UserConfig(defaults=Defaults(auth_mode="interactive")), path)
+        # Should raise, not silently pick 'interactive' from config.
+        with pytest.raises(ConfigError, match="invalid FABRIC_AUTH"):
+            build_context(environ={"FABRIC_AUTH": "bad-mode"}, config_path=path)
+
+    def test_config_sp_mode_wired(self, tmp_path: Path) -> None:
+        """[defaults] auth_mode = 'sp' selects SERVICE_PRINCIPAL."""
+        path = tmp_path / "config.toml"
+        save_config(UserConfig(defaults=Defaults(auth_mode="sp")), path)
+        fake_http = MagicMock()
+        with (
+            patch("fabric_dw.mcp._context.FabricHttpClient", return_value=fake_http),
+            patch("fabric_dw.mcp._context._auth.get_credential", return_value=MagicMock()),
+        ):
+            ctx = build_context(environ={}, config_path=path)
+        assert ctx.auth_mode == _auth.CredentialMode.SERVICE_PRINCIPAL
+
+    def test_config_default_mode_wired(self, tmp_path: Path) -> None:
+        """[defaults] auth_mode = 'default' selects DEFAULT."""
+        path = tmp_path / "config.toml"
+        save_config(UserConfig(defaults=Defaults(auth_mode="default")), path)
+        fake_http = MagicMock()
+        with patch("fabric_dw.mcp._context.FabricHttpClient", return_value=fake_http):
+            ctx = build_context(environ={}, config_path=path)
+        assert ctx.auth_mode == _auth.CredentialMode.DEFAULT

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -9,7 +9,9 @@ from unittest.mock import patch
 import filelock
 import pytest
 
+from fabric_dw.auth import CredentialMode
 from fabric_dw.config import (
+    VALID_AUTH_MODES,
     VALID_LOG_LEVELS,
     AuthConfig,
     ConfigError,
@@ -1141,9 +1143,6 @@ def test_set_default_sql_pool_preserves_other_keys(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-from fabric_dw.config import VALID_AUTH_MODES  # noqa: E402  (appended after top-level imports)
-
-
 @pytest.mark.parametrize("mode", sorted(VALID_AUTH_MODES))
 def test_round_trip_auth_mode(tmp_path: Path, mode: str) -> None:
     """Each valid auth_mode value survives a save/load cycle."""
@@ -1253,3 +1252,19 @@ def test_set_default_auth_mode_preserves_other_keys(tmp_path: Path) -> None:
     assert loaded.defaults.workspace == "WS"
     assert loaded.defaults.warehouse == "WH"
     assert loaded.defaults.sql_pool is True
+
+
+# ---------------------------------------------------------------------------
+# Drift guard — VALID_AUTH_MODES must mirror CredentialMode enum values
+# ---------------------------------------------------------------------------
+
+
+def test_valid_auth_modes_mirrors_credential_mode_enum() -> None:
+    """VALID_AUTH_MODES must be exactly the set of CredentialMode values.
+
+    This test guards against VALID_AUTH_MODES drifting out of sync with
+    :class:`~fabric_dw.auth.CredentialMode`.  If a new mode is added to the
+    enum but not mirrored here (or vice-versa), this test will fail fast
+    instead of silently rejecting/accepting the wrong modes at runtime.
+    """
+    assert frozenset(m.value for m in CredentialMode) == VALID_AUTH_MODES

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1134,3 +1134,122 @@ def test_set_default_sql_pool_preserves_other_keys(tmp_path: Path) -> None:
     assert loaded.defaults.sql_pool is False
     assert loaded.defaults.workspace == "WS"
     assert loaded.defaults.sql_retry_executes is True
+
+
+# ---------------------------------------------------------------------------
+# auth_mode — round-trip, set_default, validation, case normalisation
+# ---------------------------------------------------------------------------
+
+
+from fabric_dw.config import VALID_AUTH_MODES  # noqa: E402  (appended after top-level imports)
+
+
+@pytest.mark.parametrize("mode", sorted(VALID_AUTH_MODES))
+def test_round_trip_auth_mode(tmp_path: Path, mode: str) -> None:
+    """Each valid auth_mode value survives a save/load cycle."""
+    path = tmp_path / "config.toml"
+    cfg = UserConfig(defaults=Defaults(auth_mode=mode))
+    save_config(cfg, path)
+    loaded = load_config(path)
+    assert loaded.defaults.auth_mode == mode
+
+
+def test_auth_mode_none_not_written(tmp_path: Path) -> None:
+    """When auth_mode is None, the key is absent from the file."""
+    path = tmp_path / "config.toml"
+    cfg = UserConfig(defaults=Defaults(workspace="WS", auth_mode=None))
+    save_config(cfg, path)
+    content = path.read_text(encoding="utf-8")
+    assert "auth_mode" not in content
+    loaded = load_config(path)
+    assert loaded.defaults.auth_mode is None
+
+
+@pytest.mark.parametrize("mode", sorted(VALID_AUTH_MODES))
+def test_set_default_auth_mode_persists(tmp_path: Path, mode: str) -> None:
+    """set_default('auth_mode', mode) stores the mode and preserves other keys."""
+    path = tmp_path / "config.toml"
+    save_config(UserConfig(defaults=Defaults(workspace="WS")), path)
+    set_default("auth_mode", mode, path)
+    loaded = load_config(path)
+    assert loaded.defaults.auth_mode == mode
+    assert loaded.defaults.workspace == "WS"  # preserved
+
+
+def test_set_default_auth_mode_none_clears(tmp_path: Path) -> None:
+    """set_default('auth_mode', None) clears the key."""
+    path = tmp_path / "config.toml"
+    save_config(UserConfig(defaults=Defaults(auth_mode="interactive", workspace="WS")), path)
+    set_default("auth_mode", None, path)
+    loaded = load_config(path)
+    assert loaded.defaults.auth_mode is None
+    assert loaded.defaults.workspace == "WS"  # preserved
+
+
+def test_set_default_auth_mode_invalid_raises(tmp_path: Path) -> None:
+    """An unrecognised auth_mode raises ValueError."""
+    path = tmp_path / "config.toml"
+    with pytest.raises(ValueError, match="auth_mode"):
+        set_default("auth_mode", "managed_identity", path)
+
+
+def test_set_default_auth_mode_invalid_gibberish_raises(tmp_path: Path) -> None:
+    """Gibberish auth_mode values raise ValueError."""
+    path = tmp_path / "config.toml"
+    with pytest.raises(ValueError, match="auth_mode"):
+        set_default("auth_mode", "notamode", path)
+
+
+@pytest.mark.parametrize("raw", ["DEFAULT", "Default", "default"])
+def test_set_default_auth_mode_normalises_to_lower(tmp_path: Path, raw: str) -> None:
+    """auth_mode is normalised to lowercase when set."""
+    path = tmp_path / "config.toml"
+    set_default("auth_mode", raw, path)
+    loaded = load_config(path)
+    assert loaded.defaults.auth_mode == "default"
+
+
+@pytest.mark.parametrize("raw", ["INTERACTIVE", "Interactive"])
+def test_set_default_auth_mode_interactive_normalised(tmp_path: Path, raw: str) -> None:
+    """'interactive' auth_mode variant cases are normalised."""
+    path = tmp_path / "config.toml"
+    set_default("auth_mode", raw, path)
+    loaded = load_config(path)
+    assert loaded.defaults.auth_mode == "interactive"
+
+
+@pytest.mark.parametrize("raw", ["SP", "Sp"])
+def test_set_default_auth_mode_sp_normalised(tmp_path: Path, raw: str) -> None:
+    """'sp' auth_mode variant cases are normalised."""
+    path = tmp_path / "config.toml"
+    set_default("auth_mode", raw, path)
+    loaded = load_config(path)
+    assert loaded.defaults.auth_mode == "sp"
+
+
+def test_load_config_invalid_auth_mode_discarded(tmp_path: Path) -> None:
+    """A hand-edited [defaults] auth_mode with an invalid value is discarded (treated as None)."""
+    path = tmp_path / "config.toml"
+    path.write_text('[defaults]\nauth_mode = "not_valid"\n', encoding="utf-8")
+    cfg = load_config(path)
+    assert cfg.defaults.auth_mode is None
+
+
+def test_load_config_auth_mode_valid_normalised(tmp_path: Path) -> None:
+    """A valid but uppercased [defaults] auth_mode is normalised to lowercase on load."""
+    path = tmp_path / "config.toml"
+    path.write_text('[defaults]\nauth_mode = "DEFAULT"\n', encoding="utf-8")
+    cfg = load_config(path)
+    assert cfg.defaults.auth_mode == "default"
+
+
+def test_set_default_auth_mode_preserves_other_keys(tmp_path: Path) -> None:
+    """set_default('auth_mode', ...) does not clear unrelated keys."""
+    path = tmp_path / "config.toml"
+    save_config(UserConfig(defaults=Defaults(workspace="WS", warehouse="WH", sql_pool=True)), path)
+    set_default("auth_mode", "interactive", path)
+    loaded = load_config(path)
+    assert loaded.defaults.auth_mode == "interactive"
+    assert loaded.defaults.workspace == "WS"
+    assert loaded.defaults.warehouse == "WH"
+    assert loaded.defaults.sql_pool is True


### PR DESCRIPTION
## Summary

- Adds `auth_mode: str | None = None` to `Defaults` with full config plumbing: parse, serialise, validate, `set_config`/`set_default` dispatch, and `config show` output.
- `build_context` in `mcp/_context.py` resolves credential mode with precedence **env `FABRIC_AUTH` (non-empty) > `[defaults] auth_mode` in config.toml > built-in default (`default`)**. Empty/whitespace `FABRIC_AUTH` falls through; unrecognised non-empty value raises `ConfigError` immediately (never silently wrong).
- CLI: `fdw config set auth-mode <mode>` (click.Choice, case-insensitive) and `fdw config unset auth-mode`.
- Docs: `docs/commands/config.md` and `docs/authentication.md` updated with the 3-layer resolution table, valid modes, and empty-value semantics.
- Tests cover config round-trip, set/unset, case normalisation, invalid-mode rejection at both write time and load time, `build_context` precedence, empty-env fall-through, invalid-env hard error, and CLI set/unset/show commands (all new: 42 tests).

## CLI auth path scope note

The CLI (`fdw`) has its own `--auth` / `-a` flag in `cli/_context.py` that accepts a `CredentialMode`. That path is a direct per-invocation flag (not a persisted default) and is already a first-class CLI argument; it is out of scope for this issue. This PR only promotes `auth_mode` as a persistent config default for the **MCP server** path (`build_context`).

## Test plan

- [x] `uv run ruff format --check .` — clean
- [x] `uv run ruff check .` — clean
- [x] `uv run ty check src tests` — clean
- [x] `uv run pytest tests/unit -q` — 4539 passed, 3 deselected

Closes #693

🤖 Generated with [Claude Code](https://claude.com/claude-code)