### PR TITLE
feat(config): promote FABRIC_MCP_WORKSPACES to 3-layer config knob

### DIFF
--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -76,6 +76,35 @@ fdw config unset sql-retry-deadline
 fdw config unset sql-retry-executes
 ```
 
+## MCP workspace allowlist {#mcp-workspace-allowlist}
+
+!!! warning "Security control"
+    The workspace allowlist is an **access-control** setting. Mistakes here can silently allow or deny access to workspaces. Read the empty-value semantics carefully before configuring this knob.
+
+The MCP server workspace allowlist restricts which workspaces the server may operate on. It is resolved in the following priority order (highest first):
+
+| Layer | Mechanism | Description |
+|---|---|---|
+| 1 | `FABRIC_MCP_WORKSPACES` env var | Comma-separated workspace names or GUIDs. An empty or whitespace-only value (including `FABRIC_MCP_WORKSPACES=`) is treated as **absent** and falls through to the next layer — it does **not** block all workspaces. |
+| 2 | `[mcp] workspace_allowlist` in `config.toml` | Stored with `fdw config set mcp workspace-allowlist`. An empty TOML array `[]` is treated as absent (no restriction) — consistent with the unset case. |
+| 3 | Built-in default | No restriction — all workspaces allowed. |
+
+Matching is case-insensitive and whitespace-trimmed. Both workspace names and GUIDs are accepted.
+
+To restrict the MCP server to specific workspaces:
+
+```shell
+fdw config set mcp workspace-allowlist "Sales WS,Finance WS"
+```
+
+To revert to the built-in default (no restriction):
+
+```shell
+fdw config unset mcp workspace-allowlist
+```
+
+The env var takes highest priority. When both are set, `FABRIC_MCP_WORKSPACES` wins over the config file value.
+
 ## MCP server log level
 
 The MCP server log level can be configured via a 3-layer stack. Resolution order (highest priority first):
@@ -173,7 +202,7 @@ fdw config clear
 
 ### config set
 
-Set a default value. Accepts `workspace`, `warehouse`, `max-429-retries`, `retry-deadline`, `sql-retry-deadline`, `sql-retry-executes`, `sql-pool`, or `auth-mode` as a flat key, or the nested sub-commands `telemetry disabled` and `logging level` for section-scoped knobs.
+Set a default value. Accepts `workspace`, `warehouse`, `max-429-retries`, `retry-deadline`, `sql-retry-deadline`, `sql-retry-executes`, `sql-pool`, or `auth-mode` as a flat key, or the nested sub-commands `telemetry disabled`, `logging level`, and `mcp workspace-allowlist` for section-scoped knobs.
 
 **Synopsis**
 
@@ -188,6 +217,7 @@ fdw config set sql-pool true|false
 fdw config set auth-mode MODE
 fdw config set telemetry disabled true|false
 fdw config set logging level LEVEL
+fdw config set mcp workspace-allowlist WS1,WS2,...
 ```
 
 **Example**
@@ -203,6 +233,7 @@ fdw config set sql-pool false
 fdw config set auth-mode interactive
 fdw config set telemetry disabled true
 fdw config set logging level DEBUG
+fdw config set mcp workspace-allowlist "Sales WS,Finance WS"
 ```
 
 ---
@@ -233,7 +264,7 @@ warehouse  MyWarehouse
 
 ### config unset
 
-Clear a single default value. Accepts `workspace`, `warehouse`, `max-429-retries`, `retry-deadline`, `sql-retry-deadline`, `sql-retry-executes`, `sql-pool`, or `auth-mode` as a flat key, or the nested sub-commands `telemetry disabled` and `logging level` for section-scoped knobs.
+Clear a single default value. Accepts `workspace`, `warehouse`, `max-429-retries`, `retry-deadline`, `sql-retry-deadline`, `sql-retry-executes`, `sql-pool`, or `auth-mode` as a flat key, or the nested sub-commands `telemetry disabled`, `logging level`, and `mcp workspace-allowlist` for section-scoped knobs.
 
 **Synopsis**
 
@@ -248,4 +279,5 @@ fdw config unset sql-pool
 fdw config unset auth-mode
 fdw config unset telemetry disabled
 fdw config unset logging level
+fdw config unset mcp workspace-allowlist
 ```

--- a/docs/install.md
+++ b/docs/install.md
@@ -369,8 +369,18 @@ The MCP server reads the following environment variables to restrict what it may
 |---|---|---|
 | `FABRIC_MCP_READONLY` | unset | Set to `1` to restrict `execute_sql` to SELECT/WITH and block all mutating tools. |
 | `FABRIC_MCP_ALLOW_DESTRUCTIVE` | unset | Set to `1` to enable permanently-destructive tools (`delete_*`, `clear_table`, `restore_warehouse_in_place`). Disabled by default. |
-| `FABRIC_MCP_WORKSPACES` | unset | Comma-separated workspace names or GUIDs the server may touch. Unset = all workspaces allowed. |
+| `FABRIC_MCP_WORKSPACES` | unset | Comma-separated workspace names or GUIDs the server may touch. Highest-priority layer of the workspace allowlist knob — see below. An empty or whitespace-only value is treated as absent (falls through to the config layer). |
 | `FABRIC_MCP_ALLOW_REMOTE` | unset | Set to `1` to allow the HTTP transport (`--transport http`) to bind on a non-loopback address. Always front with an authenticating reverse proxy that handles TLS. |
+
+#### Workspace allowlist
+
+`FABRIC_MCP_WORKSPACES` is the highest-priority layer of a 3-layer workspace allowlist knob. Resolution order (highest first):
+
+1. `FABRIC_MCP_WORKSPACES` env var — an empty or whitespace-only value falls through to layer 2.
+2. `[mcp] workspace_allowlist` in `config.toml`, set via `fdw config set mcp workspace-allowlist` — an empty array `[]` falls through to layer 3.
+3. Built-in default: no restriction (all workspaces allowed).
+
+An empty list at any layer is **not** treated as "block everything"; it falls through to the next layer. This prevents an accidental `FABRIC_MCP_WORKSPACES=` from locking out all workspaces. See [MCP workspace allowlist](commands/config.md#mcp-workspace-allowlist) for the config knob.
 
 ### Logging
 

--- a/src/fabric_dw/cli/commands/config.py
+++ b/src/fabric_dw/cli/commands/config.py
@@ -5,28 +5,30 @@ workspace / warehouse on every command.
 
 Commands
 --------
-config show                    — print current defaults (JSON or table)
-config set workspace           — persist a workspace default
-config set warehouse           — persist a warehouse default
-config set max-429-retries     — persist the max consecutive 429 retry count
-config set retry-deadline      — persist the combined 429+5xx wall-clock deadline
-config set sql-retry-deadline  — persist the SQL/TDS connect+execute retry budget
-config set sql-retry-executes  — persist whether fetch="none" statements are retried
-config set sql-pool            — persist whether SQL connection pooling is enabled
-config set auth-mode           — persist the MCP server credential mode
-config set telemetry disabled  — opt in/out of telemetry via config
-config set logging level       — set the MCP server log level
-config unset workspace         — clear the workspace default
-config unset warehouse         — clear the warehouse default
-config unset max-429-retries   — clear the max consecutive 429 retry count
-config unset retry-deadline    — clear the HTTP deadline default
-config unset sql-retry-deadline — clear the SQL retry deadline default
-config unset sql-retry-executes — clear the SQL execute-retry flag
-config unset sql-pool          — clear the SQL pool flag
-config unset auth-mode         — clear the credential mode (revert to built-in default)
-config unset telemetry disabled — clear the telemetry opt-out (revert to default-on)
-config unset logging level     — clear the logging level (revert to built-in INFO)
-config clear                   — wipe the entire config file
+config show                          — print current defaults (JSON or table)
+config set workspace                 — persist a workspace default
+config set warehouse                 — persist a warehouse default
+config set max-429-retries           — persist the max consecutive 429 retry count
+config set retry-deadline            — persist the combined 429+5xx wall-clock deadline
+config set sql-retry-deadline        — persist the SQL/TDS connect+execute retry budget
+config set sql-retry-executes        — persist whether fetch="none" statements are retried
+config set sql-pool                  — persist whether SQL connection pooling is enabled
+config set auth-mode                 — persist the MCP server credential mode
+config set telemetry disabled        — opt in/out of telemetry via config
+config set logging level             — set the MCP server log level
+config set mcp workspace-allowlist   — set the MCP workspace allowlist (comma-separated)
+config unset workspace               — clear the workspace default
+config unset warehouse               — clear the warehouse default
+config unset max-429-retries         — clear the max consecutive 429 retry count
+config unset retry-deadline          — clear the HTTP deadline default
+config unset sql-retry-deadline      — clear the SQL retry deadline default
+config unset sql-retry-executes      — clear the SQL execute-retry flag
+config unset sql-pool                — clear the SQL pool flag
+config unset auth-mode               — clear the credential mode (revert to built-in default)
+config unset telemetry disabled      — clear the telemetry opt-out (revert to default-on)
+config unset logging level           — clear the logging level (revert to built-in INFO)
+config unset mcp workspace-allowlist — clear the MCP workspace allowlist (no restriction)
+config clear                         — wipe the entire config file
 """
 
 from __future__ import annotations
@@ -72,6 +74,9 @@ def show_cmd(ctx: CliContext) -> None:
         },
         "telemetry": {
             "disabled": cfg.telemetry.disabled,
+        },
+        "mcp": {
+            "workspace_allowlist": cfg.mcp.workspace_allowlist,
         },
         "logging": {
             "level": cfg.logging.level,
@@ -218,6 +223,31 @@ def set_logging_level_cmd(value: str) -> None:
     click.echo(f"Logging level set to {normalised!r}.")
 
 
+@set_group.group("mcp")
+def set_mcp_group() -> None:
+    """Set MCP server configuration."""
+
+
+@set_mcp_group.command("workspace-allowlist")
+@click.argument("value")
+def set_mcp_workspace_allowlist_cmd(value: str) -> None:
+    """Set the MCP workspace allowlist (comma-separated workspace names or GUIDs).
+
+    Restricts the MCP server to the named workspaces only.  The allowlist is
+    matched case-insensitively against workspace names and GUIDs.
+
+    This is the config-layer knob: ``FABRIC_MCP_WORKSPACES`` (env var) takes
+    precedence when set.  An empty string is not accepted; use
+    ``fdw config unset mcp workspace-allowlist`` to remove all restrictions.
+
+    Example::
+
+        fdw config set mcp workspace-allowlist "Sales WS,Finance WS"
+    """
+    set_config("mcp", "workspace_allowlist", value)
+    click.echo(f"MCP workspace allowlist set to {value!r}.")
+
+
 # ---------------------------------------------------------------------------
 # config unset  (sub-group with workspace / warehouse sub-commands)
 # ---------------------------------------------------------------------------
@@ -310,6 +340,18 @@ def unset_logging_level_cmd() -> None:
     """Clear the logging level (revert to built-in INFO)."""
     set_config("logging", "level", None)
     click.echo("Logging level cleared.")
+
+
+@unset_group.group("mcp")
+def unset_mcp_group() -> None:
+    """Clear MCP server configuration."""
+
+
+@unset_mcp_group.command("workspace-allowlist")
+def unset_mcp_workspace_allowlist_cmd() -> None:
+    """Clear the MCP workspace allowlist (revert to no restriction — all workspaces allowed)."""
+    set_config("mcp", "workspace_allowlist", None)
+    click.echo("MCP workspace allowlist cleared.")
 
 
 # ---------------------------------------------------------------------------

--- a/src/fabric_dw/cli/commands/config.py
+++ b/src/fabric_dw/cli/commands/config.py
@@ -237,13 +237,26 @@ def set_mcp_workspace_allowlist_cmd(value: str) -> None:
     matched case-insensitively against workspace names and GUIDs.
 
     This is the config-layer knob: ``FABRIC_MCP_WORKSPACES`` (env var) takes
-    precedence when set.  An empty string is not accepted; use
-    ``fdw config unset mcp workspace-allowlist`` to remove all restrictions.
+    precedence when set.
+
+    To remove all workspace restrictions, use the explicit unset command rather
+    than passing an empty string:
+
+        fdw config unset mcp workspace-allowlist
 
     Example::
 
         fdw config set mcp workspace-allowlist "Sales WS,Finance WS"
     """
+    # Reject empty or whitespace-only input explicitly so the operator gets a
+    # clear error instead of silently clearing the allowlist via a typo.
+    stripped = value.strip()
+    if not stripped or not any(e.strip() for e in stripped.split(",")):
+        raise click.UsageError(
+            "VALUE must not be empty. "
+            "To remove all workspace restrictions use: "
+            "fdw config unset mcp workspace-allowlist"
+        )
     set_config("mcp", "workspace_allowlist", value)
     click.echo(f"MCP workspace allowlist set to {value!r}.")
 

--- a/src/fabric_dw/mcp/_context.py
+++ b/src/fabric_dw/mcp/_context.py
@@ -61,12 +61,17 @@ class ServerContext:
         cache: Name-to-UUID lookup cache.
         resolver: Workspace / item resolver backed by *http* and *cache*.
         auth_mode: The active credential mode (e.g. ``"default"``).
+        workspace_allowlist: The ``[mcp] workspace_allowlist`` value from
+            ``config.toml``, or ``None`` when the key is absent.  The guard
+            functions in :mod:`fabric_dw.mcp._guards` resolve the effective
+            allowlist from env var (highest) > this value > no restriction.
     """
 
     http: FabricHttpClient
     cache: LookupCache
     resolver: Resolver
     auth_mode: _auth.CredentialMode
+    workspace_allowlist: list[str] | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -197,7 +202,13 @@ def build_context(
     )
     cache = LookupCache()
     resolver = Resolver(http=http, cache=cache)
-    return ServerContext(http=http, cache=cache, resolver=resolver, auth_mode=mode)
+    return ServerContext(
+        http=http,
+        cache=cache,
+        resolver=resolver,
+        auth_mode=mode,
+        workspace_allowlist=cfg.mcp.workspace_allowlist,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/fabric_dw/mcp/_guards.py
+++ b/src/fabric_dw/mcp/_guards.py
@@ -20,8 +20,11 @@ Environment variables
 
 ``FABRIC_MCP_WORKSPACES``
     Comma-separated list of workspace names or GUIDs the MCP server is
-    allowed to touch.  When unset every workspace is allowed.  Matching is
-    case-insensitive and whitespace-trimmed.
+    allowed to touch.  This is the highest-priority layer of the 3-layer
+    workspace allowlist knob; see :func:`resolve_workspace_allowlist` for
+    the full resolution order.  An empty or whitespace-only value is treated
+    as absent (falls through to the config layer).  When unset every
+    workspace is allowed.  Matching is case-insensitive and whitespace-trimmed.
 
 ``FABRIC_MCP_ALLOW_REMOTE``
     Set to ``1``, ``true``, or ``yes`` to allow the HTTP transport to bind on
@@ -29,6 +32,23 @@ Environment variables
     ``--host`` is not 127.0.0.1, ::1, or localhost.  When the flag is set a
     prominent WARNING is logged reminding operators to front the transport with
     an authenticating reverse proxy.
+
+Workspace allowlist — 3-layer resolution
+-----------------------------------------
+The workspace allowlist controls which workspaces the MCP server may operate
+on.  It is resolved in the following priority order (highest first):
+
+1. ``FABRIC_MCP_WORKSPACES`` env var (comma-separated list of names / GUIDs).
+   An empty or whitespace-only value is treated as absent and falls through to
+   the next layer.
+2. ``[mcp] workspace_allowlist`` in ``config.toml`` (a TOML array of strings).
+   An empty array ``[]`` is treated as absent (no restriction) — consistent
+   with the unset case; it does NOT mean "block all workspaces".
+3. Built-in default: no restriction (all workspaces allowed).
+
+Use :func:`resolve_workspace_allowlist` to obtain the effective frozenset,
+and :func:`workspace_allowlist_active` to check whether any restriction is in
+effect without materialising the full set.
 """
 
 from __future__ import annotations
@@ -36,6 +56,7 @@ from __future__ import annotations
 import os
 import re
 import uuid as _uuid_mod
+from collections.abc import Sequence
 
 from mcp.server.fastmcp.exceptions import ToolError
 
@@ -45,6 +66,7 @@ __all__ = [
     "assert_workspace_allowed",
     "assert_writes_allowed",
     "env_flag",
+    "resolve_workspace_allowlist",
     "workspace_allowlist_active",
 ]
 
@@ -64,20 +86,71 @@ def env_flag(name: str) -> bool:
 _env_flag = env_flag
 
 
-def workspace_allowlist_active() -> bool:
-    """Return True when ``FABRIC_MCP_WORKSPACES`` is set to a non-empty, non-whitespace value.
+def resolve_workspace_allowlist(
+    config_allowlist: Sequence[str] | None = None,
+) -> frozenset[str] | None:
+    """Resolve the effective workspace allowlist from 3 layers (env > config > no restriction).
 
-    The check mirrors the parsing in :func:`assert_workspace_allowed`: a value
-    that consists solely of commas and/or whitespace is treated as unset (no
-    allowlist in effect).  This is the single source of truth for
-    "is the allowlist active?" used by tools that need to guard
-    ``all_workspaces=True`` requests.
+    Resolution order (highest priority first):
+
+    1. ``FABRIC_MCP_WORKSPACES`` env var (comma-separated names / GUIDs).
+       An empty or whitespace-only value — including one that contains only
+       commas and/or spaces — is treated as **absent** and falls through to
+       the next layer.  This prevents an accidental ``FABRIC_MCP_WORKSPACES=``
+       from silently blocking all workspaces.
+    2. ``[mcp] workspace_allowlist`` from ``config.toml`` (passed in as
+       *config_allowlist*).  An empty list ``[]`` is treated as **absent**
+       (no restriction) rather than "block everything" — consistent with
+       the unset case and the least-surprising interpretation of an empty
+       list.
+    3. Built-in default: ``None`` — no restriction, all workspaces allowed.
+
+    Args:
+        config_allowlist: The ``McpConfig.workspace_allowlist`` value loaded
+            from ``config.toml``.  Pass ``None`` when no config is available
+            or when the key is absent.
+
+    Returns:
+        A non-empty :class:`frozenset` of lower-cased, trimmed workspace
+        names / GUIDs when a restriction is in effect, or ``None`` when
+        every workspace is allowed.
     """
-    raw = os.environ.get("FABRIC_MCP_WORKSPACES", "").strip()
-    if not raw:
-        return False
-    entries = {entry.strip() for entry in raw.split(",") if entry.strip()}
-    return bool(entries)
+    # Layer 1: env var
+    raw_env = os.environ.get("FABRIC_MCP_WORKSPACES", "").strip()
+    if raw_env:
+        env_entries = frozenset(
+            entry.strip().lower() for entry in raw_env.split(",") if entry.strip()
+        )
+        if env_entries:
+            return env_entries
+
+    # Layer 2: config.toml
+    if config_allowlist is not None:
+        config_entries = frozenset(
+            entry.strip().lower() for entry in config_allowlist if entry.strip()
+        )
+        if config_entries:
+            return config_entries
+
+    # Layer 3: no restriction
+    return None
+
+
+def workspace_allowlist_active(config_allowlist: Sequence[str] | None = None) -> bool:
+    """Return True when the effective workspace allowlist imposes a restriction.
+
+    Consults all 3 layers via :func:`resolve_workspace_allowlist`.  A value
+    that consists solely of commas and/or whitespace in the env var, or an
+    empty list in the config, is treated as absent (no restriction).
+
+    This is the single source of truth for "is the allowlist active?" used by
+    tools that need to guard ``all_workspaces=True`` requests.
+
+    Args:
+        config_allowlist: The ``McpConfig.workspace_allowlist`` value loaded
+            from ``config.toml``.  Pass ``None`` when no config is available.
+    """
+    return resolve_workspace_allowlist(config_allowlist) is not None
 
 
 # ---------------------------------------------------------------------------
@@ -314,12 +387,18 @@ def _looks_like_uuid(value: str) -> bool:
         return True
 
 
-def assert_workspace_allowed(workspace_arg: str, resolved_id: str | None = None) -> None:
+def assert_workspace_allowed(
+    workspace_arg: str,
+    resolved_id: str | None = None,
+    config_allowlist: Sequence[str] | None = None,
+) -> None:
     """Raise :class:`ToolError` when *workspace_arg* is not in the allowlist.
 
-    When ``FABRIC_MCP_WORKSPACES`` is unset or empty every workspace is
-    allowed.  When set, the raw argument **or** the resolved GUID must match
-    an entry (case-insensitive, whitespace-trimmed).
+    The effective allowlist is resolved via the 3-layer stack (env > config >
+    no restriction) using :func:`resolve_workspace_allowlist`.  When no
+    restriction is in effect every workspace is allowed.  When a restriction
+    is active, the raw argument **or** the resolved GUID must match an entry
+    (case-insensitive, whitespace-trimmed).
 
     Pre-resolve vs post-resolve behaviour
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -338,17 +417,15 @@ def assert_workspace_allowed(workspace_arg: str, resolved_id: str | None = None)
             (name or GUID).
         resolved_id: The resolved workspace GUID string, if already available.
             Pass ``None`` when the ID has not been resolved yet.
+        config_allowlist: The ``McpConfig.workspace_allowlist`` value loaded
+            from ``config.toml``.  Pass ``None`` when no config is available.
 
     Raises:
-        ToolError: When the workspace is not in the allowlist.
+        ToolError: When the workspace is not in the effective allowlist.
     """
-    raw = os.environ.get("FABRIC_MCP_WORKSPACES", "").strip()
-    if not raw:
-        return  # unset — everything allowed
-
-    allowed = {entry.strip().lower() for entry in raw.split(",") if entry.strip()}
-    if not allowed:
-        return  # only commas / whitespace — treat as unset
+    allowed = resolve_workspace_allowlist(config_allowlist)
+    if allowed is None:
+        return  # no restriction — every workspace is allowed
 
     candidates = {workspace_arg.strip().lower()}
     if resolved_id is not None:
@@ -362,6 +439,4 @@ def assert_workspace_allowed(workspace_arg: str, resolved_id: str | None = None)
             return  # cannot decide pre-resolve; post-resolve call will gate
 
     if candidates.isdisjoint(allowed):
-        raise ToolError(
-            f"workspace {workspace_arg!r} is not in the FABRIC_MCP_WORKSPACES allowlist"
-        )
+        raise ToolError(f"workspace {workspace_arg!r} is not in the workspace allowlist")

--- a/src/fabric_dw/mcp/tools/audit.py
+++ b/src/fabric_dw/mcp/tools/audit.py
@@ -30,11 +30,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             workspace: Workspace name or GUID.
             warehouse: Warehouse or SQL analytics endpoint name or GUID.
         """
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, item = await resolve_item(ctx.resolver, workspace, warehouse)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug("get_audit_settings ws=%s item=%s kind=%s", ws_id, item.id, item.kind)
             result = await audit.get_settings(ctx.http, ws_id, item.id, item.kind)
         except (ValueError, FabricError) as exc:
@@ -55,11 +57,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             retention_days: Log retention in days (0-3650; 0 = unlimited). Default 0.
         """
         assert_writes_allowed("enable_audit")
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, item = await resolve_item(ctx.resolver, workspace, warehouse)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug(
                 "enable_audit ws=%s item=%s kind=%s retention=%d",
                 ws_id,
@@ -83,11 +87,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             warehouse: Warehouse or SQL analytics endpoint name or GUID.
         """
         assert_writes_allowed("disable_audit")
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, item = await resolve_item(ctx.resolver, workspace, warehouse)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug("disable_audit ws=%s item=%s kind=%s", ws_id, item.id, item.kind)
             result = await audit.disable(ctx.http, ws_id, item.id, item.kind)
         except (ValueError, FabricError) as exc:
@@ -106,11 +112,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             action_groups: List of audit action group names.
         """
         assert_writes_allowed("set_audit_action_groups")
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, item = await resolve_item(ctx.resolver, workspace, warehouse)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug(
                 "set_audit_action_groups ws=%s item=%s kind=%s groups=%s",
                 ws_id,
@@ -140,11 +148,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             group: Action group name, e.g. ``BATCH_COMPLETED_GROUP``.
         """
         assert_writes_allowed("add_audit_group")
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, item = await resolve_item(ctx.resolver, workspace, warehouse)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug(
                 "add_audit_group ws=%s item=%s kind=%s group=%r", ws_id, item.id, item.kind, group
             )
@@ -168,11 +178,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             group: Action group name, e.g. ``BATCH_COMPLETED_GROUP``.
         """
         assert_writes_allowed("remove_audit_group")
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, item = await resolve_item(ctx.resolver, workspace, warehouse)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug(
                 "remove_audit_group ws=%s item=%s kind=%s group=%r",
                 ws_id,
@@ -201,11 +213,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             days: Retention period in days (1-3650). The API enforces its own upper bound.
         """
         assert_writes_allowed("set_audit_retention")
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, item = await resolve_item(ctx.resolver, workspace, warehouse)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug(
                 "set_audit_retention ws=%s item=%s kind=%s days=%d",
                 ws_id,

--- a/src/fabric_dw/mcp/tools/dbt.py
+++ b/src/fabric_dw/mcp/tools/dbt.py
@@ -80,12 +80,14 @@ def register(mcp: FastMCP) -> None:
             - ``requirements_txt``: content for ``requirements.txt``.
             - ``gitignore``: content for ``.gitignore``.
         """
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
 
         try:
             ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug("generate_dbt_profile ws=%s item=%s", ws_id, entry.id)
             sql_target = make_sql_target(ws_id, entry, item)
         except (ValueError, FabricError) as exc:

--- a/src/fabric_dw/mcp/tools/functions.py
+++ b/src/fabric_dw/mcp/tools/functions.py
@@ -55,11 +55,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             kind: Filter by function kind — ``"scalar"`` (FN only),
                 ``"inline-tvf"`` (IF only), or ``"all"`` (FN + IF + TF, the default).
         """
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug(
                 "list_functions ws=%s item=%s schema=%r kind=%r",
                 ws_id,
@@ -92,11 +94,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             qualified_name: Dot-separated qualified function name, e.g. ``dbo.fn_clean_input``.
         """
         schema, fn_name = parse_qualified_name(qualified_name, kind="function")
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug("get_function ws=%s item=%s fn=%s.%s", ws_id, entry.id, schema, fn_name)
             target = make_sql_target(ws_id, entry, item)
             result = await functions_svc.get_function(target, schema, fn_name, mode=ctx.auth_mode)
@@ -126,11 +130,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             body: The function body (parameter list, RETURNS clause, and implementation).
         """
         schema, fn_name = parse_qualified_name(qualified_name, kind="function")
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug("create_function ws=%s item=%s fn=%s.%s", ws_id, entry.id, schema, fn_name)
             target = make_sql_target(ws_id, entry, item)
             result = await functions_svc.create_function(
@@ -163,11 +169,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             body: The new function body (parameter list, RETURNS clause, and implementation).
         """
         schema, fn_name = parse_qualified_name(qualified_name, kind="function")
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug("update_function ws=%s item=%s fn=%s.%s", ws_id, entry.id, schema, fn_name)
             target = make_sql_target(ws_id, entry, item)
             result = await functions_svc.update_function(
@@ -197,11 +205,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
                 does not exist). Defaults to ``false``.
         """
         schema, fn_name = parse_qualified_name(qualified_name, kind="function")
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug("drop_function ws=%s item=%s fn=%s.%s", ws_id, entry.id, schema, fn_name)
             target = make_sql_target(ws_id, entry, item)
             await functions_svc.drop_function(
@@ -229,12 +239,14 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
                 e.g. ``dbo.fn_clean_input``.
             new_name: New bare function name (no schema prefix), e.g. ``fn_sanitize_input``.
         """
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         schema, old_fn_name = parse_qualified_name(qualified_name, kind="function")
         try:
             ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug(
                 "rename_function ws=%s item=%s fn=%s.%s -> %s",
                 ws_id,

--- a/src/fabric_dw/mcp/tools/load.py
+++ b/src/fabric_dw/mcp/tools/load.py
@@ -144,8 +144,8 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             rejected_row_location: URL for rejected-row output.
         """
         schema, table_name = parse_qualified_name(qualified_name, kind="table")
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
 
         # Validate file_type
         if file_type not in ("CSV", "PARQUET"):
@@ -167,7 +167,9 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
 
         try:
             ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             # Log without secrets.
             _log.debug(
                 "load_table_from_url ws=%s item=%s table=%s.%s url=%s file_type=%s cred_type=%s",
@@ -343,8 +345,8 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         from fabric_dw.models import WarehouseKind  # noqa: PLC0415
 
         schema, table_name = parse_qualified_name(qualified_name, kind="table")
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
 
         # SQL Endpoint guard: COPY INTO is Warehouse-only.
         if file_type not in ("CSV", "PARQUET"):
@@ -366,7 +368,9 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
 
         try:
             ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
 
             # SQL Endpoint: COPY INTO is Warehouse-only.
             if entry.kind == WarehouseKind.SQL_ENDPOINT:

--- a/src/fabric_dw/mcp/tools/procedures.py
+++ b/src/fabric_dw/mcp/tools/procedures.py
@@ -43,11 +43,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             item: Warehouse or SQL endpoint name or GUID.
             schema: When provided, only procedures in this schema are returned.
         """
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug("list_procedures ws=%s item=%s schema=%r", ws_id, entry.id, schema)
             target = make_sql_target(ws_id, entry, item)
             result = await procedures_svc.list_procedures(target, schema=schema, mode=ctx.auth_mode)
@@ -68,11 +70,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             qualified_name: Dot-separated qualified procedure name, e.g. ``dbo.usp_load``.
         """
         schema, proc_name = parse_qualified_name(qualified_name, kind="procedure")
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug("get_procedure ws=%s item=%s proc=%s.%s", ws_id, entry.id, schema, proc_name)
             target = make_sql_target(ws_id, entry, item)
             result = await procedures_svc.get_procedure(
@@ -101,11 +105,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             body: The procedure body (the AS … section).
         """
         schema, proc_name = parse_qualified_name(qualified_name, kind="procedure")
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug(
                 "create_procedure ws=%s item=%s proc=%s.%s", ws_id, entry.id, schema, proc_name
             )
@@ -137,11 +143,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             body: The new procedure body (the AS … section).
         """
         schema, proc_name = parse_qualified_name(qualified_name, kind="procedure")
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug(
                 "update_procedure ws=%s item=%s proc=%s.%s", ws_id, entry.id, schema, proc_name
             )
@@ -166,11 +174,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             qualified_name: Dot-separated qualified procedure name, e.g. ``dbo.usp_load``.
         """
         schema, proc_name = parse_qualified_name(qualified_name, kind="procedure")
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug(
                 "drop_procedure ws=%s item=%s proc=%s.%s", ws_id, entry.id, schema, proc_name
             )

--- a/src/fabric_dw/mcp/tools/queries.py
+++ b/src/fabric_dw/mcp/tools/queries.py
@@ -37,11 +37,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             workspace: Workspace name or GUID.
             item: Warehouse or SQL Analytics Endpoint name or GUID.
         """
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug("list_running_queries ws=%s item=%s", ws_id, entry.id)
             target = make_sql_target(ws_id, entry, item)
             result = await queries.list_running(target, mode=ctx.auth_mode)
@@ -57,11 +59,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             workspace: Workspace name or GUID.
             item: Warehouse or SQL Analytics Endpoint name or GUID.
         """
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug("list_connections ws=%s item=%s", ws_id, entry.id)
             target = make_sql_target(ws_id, entry, item)
             result = await queries.list_connections(target, mode=ctx.auth_mode)
@@ -83,11 +87,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             session_id: Session ID to terminate (must be a positive integer).
         """
         assert_writes_allowed("kill_session")
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug("kill_session ws=%s item=%s session=%s", ws_id, entry.id, session_id)
             target = make_sql_target(ws_id, entry, item)
             await queries.kill(target, session_id, mode=ctx.auth_mode)
@@ -114,11 +120,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         """
         since_dt = parse_iso8601(since, "since")
         until_dt = parse_iso8601(until, "until")
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug("list_request_history ws=%s item=%s limit=%d", ws_id, entry.id, limit)
             target = make_sql_target(ws_id, entry, item)
             result = await _qi_svc.list_request_history(
@@ -147,11 +155,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         """
         since_dt = parse_iso8601(since, "since")
         until_dt = parse_iso8601(until, "until")
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug("list_session_history ws=%s item=%s limit=%d", ws_id, entry.id, limit)
             target = make_sql_target(ws_id, entry, item)
             result = await _qi_svc.list_session_history(
@@ -180,11 +190,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         """
         since_dt = parse_iso8601(since, "since")
         until_dt = parse_iso8601(until, "until")
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug("list_frequent_queries ws=%s item=%s limit=%d", ws_id, entry.id, limit)
             target = make_sql_target(ws_id, entry, item)
             result = await _qi_svc.list_frequent_queries(
@@ -213,11 +225,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         """
         since_dt = parse_iso8601(since, "since")
         until_dt = parse_iso8601(until, "until")
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug("list_long_running_queries ws=%s item=%s limit=%d", ws_id, entry.id, limit)
             target = make_sql_target(ws_id, entry, item)
             result = await _qi_svc.list_long_running_queries(

--- a/src/fabric_dw/mcp/tools/restore.py
+++ b/src/fabric_dw/mcp/tools/restore.py
@@ -26,11 +26,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
     @mcp.tool(name="list_restore_points")
     async def list_restore_points(workspace: str, warehouse: str) -> list[dict[str, Any]]:
         """Return all restore points for a warehouse."""
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, item = await resolve_item(ctx.resolver, workspace, warehouse)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug("list_restore_points ws=%s item=%s", ws_id, item.id)
             result = await restore_svc.list_points(ctx.http, ws_id, item.id)
         except FabricError as exc:
@@ -48,11 +50,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             warehouse: Warehouse name or GUID.
             restore_point_id: The restore point ID string (e.g. ``"1726617378000"``).
         """
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, item = await resolve_item(ctx.resolver, workspace, warehouse)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug("get_restore_point ws=%s item=%s rp=%r", ws_id, item.id, restore_point_id)
             result = await restore_svc.get_point(ctx.http, ws_id, item.id, restore_point_id)
         except FabricError as exc:
@@ -74,11 +78,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             name: Optional display name (max 128 chars).
             description: Optional description (max 512 chars).
         """
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, item = await resolve_item(ctx.resolver, workspace, warehouse)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug("create_restore_point ws=%s item=%s name=%r", ws_id, item.id, name)
             result = await restore_svc.create_point(
                 ctx.http, ws_id, item.id, name=name, description=description
@@ -106,11 +112,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             name: New display name (max 128 chars).
             description: New description (max 512 chars).
         """
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, item = await resolve_item(ctx.resolver, workspace, warehouse)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug("update_restore_point ws=%s item=%s rp=%r", ws_id, item.id, restore_point_id)
             result = await restore_svc.update_point(
                 ctx.http,
@@ -137,11 +145,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             warehouse: Warehouse name or GUID.
             restore_point_id: The restore point ID string.
         """
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, item = await resolve_item(ctx.resolver, workspace, warehouse)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug("delete_restore_point ws=%s item=%s rp=%r", ws_id, item.id, restore_point_id)
             await restore_svc.delete_point(ctx.http, ws_id, item.id, restore_point_id)
         except FabricError as exc:
@@ -163,11 +173,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             warehouse: Warehouse name or GUID.
             restore_point_id: The restore point ID string to restore to.
         """
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, item = await resolve_item(ctx.resolver, workspace, warehouse)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug(
                 "restore_warehouse_in_place ws=%s item=%s rp=%r",
                 ws_id,

--- a/src/fabric_dw/mcp/tools/schemas.py
+++ b/src/fabric_dw/mcp/tools/schemas.py
@@ -43,11 +43,13 @@ def register(mcp: FastMCP) -> None:
             workspace: Workspace name or GUID.
             item: Warehouse or SQL Analytics Endpoint name or GUID.
         """
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug("list_schemas ws=%s item=%s", ws_id, entry.id)
             target = make_sql_target(ws_id, entry, item)
             result = await schemas_svc.list_schemas(target, mode=ctx.auth_mode)
@@ -67,11 +69,13 @@ def register(mcp: FastMCP) -> None:
             item: Warehouse or SQL Analytics Endpoint name or GUID.
             name: The schema name.  Must be a valid SQL identifier.
         """
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug("create_schema ws=%s item=%s name=%r", ws_id, entry.id, name)
             target = make_sql_target(ws_id, entry, item)
             result = await schemas_svc.create_schema(target, name, mode=ctx.auth_mode)
@@ -106,11 +110,13 @@ def register(mcp: FastMCP) -> None:
             cascade: When ``True``, drop all tables and views in the schema first.
                 Defaults to ``False``.
         """
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug("delete_schema ws=%s item=%s name=%r", ws_id, entry.id, name)
             target = make_sql_target(ws_id, entry, item)
             await schemas_svc.delete_schema(

--- a/src/fabric_dw/mcp/tools/settings.py
+++ b/src/fabric_dw/mcp/tools/settings.py
@@ -46,11 +46,13 @@ def register(mcp: FastMCP) -> None:
             workspace: Workspace name or GUID.
             item: Warehouse or SQL Analytics Endpoint name or GUID.
         """
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug(
                 "get_warehouse_settings ws=%s item=%s",
                 ws_id,
@@ -84,11 +86,13 @@ def register(mcp: FastMCP) -> None:
             item: Warehouse name or GUID.  SQL Analytics Endpoints are rejected.
             enabled: ``True`` to enable result-set caching, ``False`` to disable it.
         """
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug(
                 "set_result_set_caching ws=%s item=%s enabled=%s",
                 ws_id,
@@ -125,11 +129,13 @@ def register(mcp: FastMCP) -> None:
             item: Warehouse name or GUID.  SQL Analytics Endpoints are rejected.
             days: Retention period in days. Must be in the range 1-120 (inclusive).
         """
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug(
                 "set_time_travel_retention ws=%s item=%s days=%s",
                 ws_id,

--- a/src/fabric_dw/mcp/tools/snapshots.py
+++ b/src/fabric_dw/mcp/tools/snapshots.py
@@ -33,11 +33,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
     @mcp.tool(name="list_snapshots")
     async def list_snapshots(workspace: str, warehouse: str) -> list[dict[str, Any]]:
         """Return all snapshots belonging to a warehouse."""
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, item = await resolve_item(ctx.resolver, workspace, warehouse)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug("list_snapshots ws=%s item=%s", ws_id, item.id)
             result = await snapshots.list_snapshots(ctx.http, ws_id, item.id)
         except FabricError as exc:
@@ -61,12 +63,14 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             description: Optional description.
             snapshot_dt: Optional ISO-8601 datetime string for the snapshot point-in-time.
         """
-        assert_workspace_allowed(workspace)
-        parsed_dt = parse_iso8601(snapshot_dt, "snapshot_dt")
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
+        parsed_dt = parse_iso8601(snapshot_dt, "snapshot_dt")
         try:
             ws_id, item = await resolve_item(ctx.resolver, workspace, warehouse)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug("create_snapshot ws=%s item=%s name=%r", ws_id, item.id, name)
             result = await snapshots.create(
                 ctx.http,
@@ -89,11 +93,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         description: str | None = None,
     ) -> dict[str, Any]:
         """Rename a warehouse snapshot."""
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, snap_item = await resolve_item(ctx.resolver, workspace, snapshot)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug("rename_snapshot ws=%s item=%s new=%r", ws_id, snap_item.id, new_name)
             result = await snapshots.rename(
                 ctx.http,
@@ -110,11 +116,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
     @mutating_tool(mcp, "delete_snapshot", destructive=True)
     async def delete_snapshot(workspace: str, snapshot: str) -> dict[str, Any]:
         """Delete a warehouse snapshot."""
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, snap_item = await resolve_item(ctx.resolver, workspace, snapshot)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug("delete_snapshot ws=%s item=%s", ws_id, snap_item.id)
             await snapshots.delete(ctx.http, ws_id, snap_item.id)
         except (ValueError, FabricError) as exc:
@@ -136,12 +144,14 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             snapshot_name: The snapshot database name to roll.
             new_dt: Optional ISO-8601 datetime string; defaults to CURRENT_TIMESTAMP.
         """
-        assert_workspace_allowed(workspace)
-        parsed_dt = parse_iso8601(new_dt, "new_dt")
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
+        parsed_dt = parse_iso8601(new_dt, "new_dt")
         try:
             ws_id, item = await resolve_item(ctx.resolver, workspace, warehouse)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug(
                 "roll_snapshot_timestamp ws=%s item=%s snap=%r", ws_id, item.id, snapshot_name
             )

--- a/src/fabric_dw/mcp/tools/sql_endpoints.py
+++ b/src/fabric_dw/mcp/tools/sql_endpoints.py
@@ -37,21 +37,23 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         When *all_workspaces* is ``True``, ignore *workspace* and aggregate results
         across every workspace the caller can see.
         """
-        if all_workspaces and workspace_allowlist_active():
+        ctx = get_context()
+        if all_workspaces and workspace_allowlist_active(ctx.workspace_allowlist):
             raise ToolError(
                 "all_workspaces=True is not permitted when FABRIC_MCP_WORKSPACES is configured; "
                 "specify an individual workspace instead"
             )
         if not all_workspaces:
-            assert_workspace_allowed(workspace)
-        ctx = get_context()
+            assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             if all_workspaces:
                 _log.debug("list_sql_endpoints all_workspaces=True")
                 result = await sql_endpoints.list_all_workspaces(ctx.http)
             else:
                 ws_id = await ctx.resolver.workspace_id(workspace)
-                assert_workspace_allowed(workspace, str(ws_id))
+                assert_workspace_allowed(
+                    workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+                )
                 _log.debug("list_sql_endpoints ws=%s", ws_id)
                 result = await sql_endpoints.list_endpoints(ctx.http, ws_id)
         except FabricError as exc:
@@ -61,11 +63,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
     @mcp.tool(name="get_sql_endpoint")
     async def get_sql_endpoint(workspace: str, endpoint: str) -> dict[str, Any]:
         """Return details for a single SQL analytics endpoint (name or GUID)."""
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, item = await resolve_item(ctx.resolver, workspace, endpoint)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug("get_sql_endpoint ws=%s item=%s", ws_id, item.id)
             result = await sql_endpoints.get_endpoint(ctx.http, ws_id, item.id)
         except FabricError as exc:
@@ -96,11 +100,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         # checked here rather than via mutating_tool(destructive=True).
         if recreate_tables:
             assert_destructive_allowed()
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, item = await resolve_item(ctx.resolver, workspace, endpoint)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug(
                 "refresh_sql_endpoint_metadata ws=%s item=%s recreate=%s",
                 ws_id,
@@ -124,11 +130,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
 
         See https://learn.microsoft.com/en-us/fabric/admin/microsoft-fabric-admin for details.
         """
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, item = await resolve_item(ctx.resolver, workspace, sql_endpoint)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug("get_sql_endpoint_permissions ws=%s item=%s", ws_id, item.id)
             result = await _permissions_svc.list_item_access(ctx.http, ws_id, item.id)
         except FabricError as exc:

--- a/src/fabric_dw/mcp/tools/sql_endpoints.py
+++ b/src/fabric_dw/mcp/tools/sql_endpoints.py
@@ -40,7 +40,8 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         ctx = get_context()
         if all_workspaces and workspace_allowlist_active(ctx.workspace_allowlist):
             raise ToolError(
-                "all_workspaces=True is not permitted when FABRIC_MCP_WORKSPACES is configured; "
+                "all_workspaces=True is not permitted when a workspace allowlist is configured "
+                "(env FABRIC_MCP_WORKSPACES or [mcp] workspace_allowlist in config.toml); "
                 "specify an individual workspace instead"
             )
         if not all_workspaces:

--- a/src/fabric_dw/mcp/tools/sql_exec.py
+++ b/src/fabric_dw/mcp/tools/sql_exec.py
@@ -69,11 +69,13 @@ def register(mcp: FastMCP) -> None:
         """
         if env_flag("FABRIC_MCP_READONLY"):
             assert_readonly_sql(query)
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug("execute_sql ws=%s item=%s max_rows=%d", ws_id, entry.id, max_rows)
             target = make_sql_target(ws_id, entry, item)
             result = await _sql_exec_svc.execute(
@@ -146,11 +148,13 @@ def register(mcp: FastMCP) -> None:
             - ``json``    → ``{"format": "json",    "plan_json":  str}``
             - ``mermaid`` → ``{"format": "mermaid", "mermaid":    str}``
         """
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug("get_query_plan ws=%s item=%s format=%s", ws_id, entry.id, format)
             target = make_sql_target(ws_id, entry, item)
             plan_xml = await _sql_exec_svc.get_plan(target, query, mode=ctx.auth_mode)

--- a/src/fabric_dw/mcp/tools/sql_pools.py
+++ b/src/fabric_dw/mcp/tools/sql_pools.py
@@ -40,11 +40,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         Requires workspace admin role.  This tool targets a **beta / preview** API
         endpoint that may change before general availability.
         """
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id = await ctx.resolver.workspace_id(workspace)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug("get_sql_pools_configuration ws=%s", ws_id)
             result = await sql_pools_svc.get_configuration(ctx.http, ws_id)
         except FabricError as exc:
@@ -57,11 +59,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
 
         Requires workspace admin role.  This tool targets a **beta / preview** API.
         """
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id = await ctx.resolver.workspace_id(workspace)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug("list_sql_pools ws=%s", ws_id)
             config = await sql_pools_svc.get_configuration(ctx.http, ws_id)
         except FabricError as exc:
@@ -78,11 +82,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
 
         Requires workspace admin role.  This tool targets a **beta / preview** API.
         """
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id = await ctx.resolver.workspace_id(workspace)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug("get_sql_pool ws=%s pool=%r", ws_id, pool_name)
             config = await sql_pools_svc.get_configuration(ctx.http, ws_id)
         except FabricError as exc:
@@ -115,7 +121,8 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
 
         Requires workspace admin role.  This tool targets a **beta / preview** API.
         """
-        assert_workspace_allowed(workspace)
+        ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         classifier: SqlPoolClassifier | None = None
         if classifier_type is not None:
             classifier = SqlPoolClassifier.model_validate(
@@ -137,10 +144,11 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         except ValidationError as exc:
             raise ToolError(f"Invalid pool: {exc}") from exc
 
-        ctx = get_context()
         try:
             ws_id = await ctx.resolver.workspace_id(workspace)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug("create_sql_pool ws=%s name=%r max_percent=%d", ws_id, name, max_percent)
             result = await sql_pools_svc.create_pool(ctx.http, ws_id, pool)
         except AlreadyExistsError as exc:
@@ -179,11 +187,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
 
         Requires workspace admin role.  This tool targets a **beta / preview** API.
         """
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id = await ctx.resolver.workspace_id(workspace)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug("update_sql_pool ws=%s name=%r", ws_id, name)
             result = await sql_pools_svc.update_pool(
                 ctx.http,
@@ -217,11 +227,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
 
         Requires workspace admin role.  This tool targets a **beta / preview** API.
         """
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id = await ctx.resolver.workspace_id(workspace)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug("delete_sql_pool ws=%s pool=%r", ws_id, pool_name)
             await sql_pools_svc.delete_pool(ctx.http, ws_id, pool_name)
         except NotFoundError as exc:
@@ -236,11 +248,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
 
         Requires workspace admin role.  This tool targets a **beta / preview** API.
         """
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id = await ctx.resolver.workspace_id(workspace)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug("enable_sql_pools ws=%s", ws_id)
             result = await sql_pools_svc.enable(ctx.http, ws_id)
         except FabricError as exc:
@@ -255,11 +269,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
 
         Requires workspace admin role.  This tool targets a **beta / preview** API.
         """
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id = await ctx.resolver.workspace_id(workspace)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug("disable_sql_pools ws=%s", ws_id)
             result = await sql_pools_svc.disable(ctx.http, ws_id)
         except FabricError as exc:
@@ -285,11 +301,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         """
         since_dt = parse_iso8601(since, "since")
         until_dt = parse_iso8601(until, "until")
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, item = await resolve_item(ctx.resolver, workspace, warehouse)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug("list_sql_pool_insights ws=%s item=%s limit=%d", ws_id, item.id, limit)
             target = make_sql_target(ws_id, item, warehouse)
             result = await _qi_svc.list_sql_pool_insights(

--- a/src/fabric_dw/mcp/tools/statistics.py
+++ b/src/fabric_dw/mcp/tools/statistics.py
@@ -52,11 +52,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             user_only: When True, only user-created statistics are returned.
             auto_only: When True, only auto-created statistics are returned.
         """
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug(
                 "list_statistics ws=%s item=%s schema=%r table=%r user_only=%s auto_only=%s",
                 ws_id,
@@ -101,11 +103,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             histogram_only: When True, return only the histogram steps.
         """
         parse_qualified_name(qualified_table, kind="table")
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug(
                 "show_statistics ws=%s item=%s table=%r stat=%r",
                 ws_id,
@@ -153,11 +157,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
                 and uses WITH SAMPLE n PERCENT.
         """
         parse_qualified_name(qualified_table, kind="table")
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug(
                 "create_statistics ws=%s item=%s table=%r col=%r name=%r",
                 ws_id,
@@ -206,11 +212,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
                 and uses WITH SAMPLE n PERCENT.
         """
         parse_qualified_name(qualified_table, kind="table")
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug(
                 "update_statistics ws=%s item=%s table=%r stat=%r",
                 ws_id,
@@ -251,11 +259,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             stat_name: Name of the statistic to drop.
         """
         parse_qualified_name(qualified_table, kind="table")
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug(
                 "delete_statistics ws=%s item=%s table=%r stat=%r",
                 ws_id,

--- a/src/fabric_dw/mcp/tools/tables.py
+++ b/src/fabric_dw/mcp/tools/tables.py
@@ -63,11 +63,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             item: Warehouse or SQL endpoint name or GUID.
             schema: When provided, only tables in this schema are returned.
         """
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug("list_tables ws=%s item=%s schema=%r", ws_id, entry.id, schema)
             target = make_sql_target(ws_id, entry, item)
             result = await tables_svc.list_tables(target, schema=schema, mode=ctx.auth_mode)
@@ -91,11 +93,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             count: Maximum number of rows to return (1-10000, default 10).
         """
         schema, table_name = parse_qualified_name(qualified_name, kind="table")
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug(
                 "read_table ws=%s item=%s table=%s.%s count=%d",
                 ws_id,
@@ -131,11 +135,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             qualified_name: Dot-separated qualified table name, e.g. ``dbo.sales``.
         """
         schema, table_name = parse_qualified_name(qualified_name, kind="table")
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug(
                 "count_table_rows ws=%s item=%s table=%s.%s",
                 ws_id,
@@ -168,11 +174,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             qualified_name: Dot-separated qualified table name, e.g. ``dbo.sales``.
         """
         schema, table_name = parse_qualified_name(qualified_name, kind="table")
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug(
                 "get_cluster_columns ws=%s item=%s table=%s.%s",
                 ws_id,
@@ -203,11 +211,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             qualified_name: Dot-separated qualified table name, e.g. ``dbo.sales``.
         """
         schema, table_name = parse_qualified_name(qualified_name, kind="table")
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug(
                 "get_table_columns ws=%s item=%s table=%s.%s",
                 ws_id,
@@ -254,11 +264,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
                 (up to 4).
         """
         schema, table_name = parse_qualified_name(qualified_name, kind="table")
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug(
                 "create_table ws=%s item=%s table=%s.%s", ws_id, entry.id, schema, table_name
             )
@@ -293,11 +305,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             qualified_name: Dot-separated qualified table name, e.g. ``dbo.sales``.
         """
         schema, table_name = parse_qualified_name(qualified_name, kind="table")
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug(
                 "delete_table ws=%s item=%s table=%s.%s", ws_id, entry.id, schema, table_name
             )
@@ -326,11 +340,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             qualified_name: Dot-separated qualified table name, e.g. ``dbo.sales``.
         """
         schema, table_name = parse_qualified_name(qualified_name, kind="table")
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug("clear_table ws=%s item=%s table=%s.%s", ws_id, entry.id, schema, table_name)
             target = make_sql_target(ws_id, entry, item)
             await tables_svc.clear_table(
@@ -374,12 +390,14 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
                 (up to 4).  Each name must appear in ``columns``.
         """
         schema, table_name = parse_qualified_name(qualified_name, kind="table")
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             col_specs = [_parse_column_dict(i, col) for i, col in enumerate(columns)]
             ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug(
                 "create_empty_table ws=%s item=%s table=%s.%s cols=%d",
                 ws_id,
@@ -425,7 +443,8 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
                 window (30 days by default).  When omitted, the clone reflects the
                 current state of the source table.
         """
-        assert_workspace_allowed(workspace)
+        ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
 
         at_dt_raw = parse_iso8601(at, "at")
         at_dt: datetime | None = (
@@ -438,10 +457,11 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             )
         )
 
-        ctx = get_context()
         try:
             ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug(
                 "clone_table ws=%s item=%s source=%s new_table=%s at=%s",
                 ws_id,
@@ -487,11 +507,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             qualified_name: Dot-separated qualified table name, e.g. ``dbo.sales``.
         """
         schema, table_name = parse_qualified_name(qualified_name, kind="table")
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug(
                 "get_table_health_metrics ws=%s item=%s table=%s.%s",
                 ws_id,
@@ -532,11 +554,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
                 contain a dot.
         """
         parse_qualified_name(qualified_name, kind="table")
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug(
                 "rename_table ws=%s item=%s qualified=%r new_name=%r",
                 ws_id,
@@ -588,11 +612,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
                 (rebuilds table without ``CLUSTER BY``).
         """
         schema, table_name = parse_qualified_name(qualified_name, kind="table")
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug(
                 "set_cluster_columns ws=%s item=%s table=%s.%s cluster_by=%r",
                 ws_id,

--- a/src/fabric_dw/mcp/tools/views.py
+++ b/src/fabric_dw/mcp/tools/views.py
@@ -43,11 +43,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             item: Warehouse or SQL endpoint name or GUID.
             schema: When provided, only views in this schema are returned.
         """
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug("list_views ws=%s item=%s schema=%r", ws_id, entry.id, schema)
             target = make_sql_target(ws_id, entry, item)
             result = await views_svc.list_views(target, schema=schema, mode=ctx.auth_mode)
@@ -71,11 +73,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             count: Maximum number of rows to return (1-10000, default 10).
         """
         schema, view_name = parse_qualified_name(qualified_name, kind="view")
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug(
                 "read_view ws=%s item=%s view=%s.%s count=%d",
                 ws_id,
@@ -111,11 +115,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             qualified_name: Dot-separated qualified view name, e.g. ``dbo.vw_sales``.
         """
         schema, view_name = parse_qualified_name(qualified_name, kind="view")
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug(
                 "count_view_rows ws=%s item=%s view=%s.%s",
                 ws_id,
@@ -147,11 +153,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             qualified_name: Dot-separated qualified view name, e.g. ``dbo.vw_sales``.
         """
         schema, view_name = parse_qualified_name(qualified_name, kind="view")
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug(
                 "get_view_columns ws=%s item=%s view=%s.%s",
                 ws_id,
@@ -177,11 +185,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             qualified_name: Dot-separated qualified view name, e.g. ``dbo.vw_sales``.
         """
         schema, view_name = parse_qualified_name(qualified_name, kind="view")
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug("get_view ws=%s item=%s view=%s.%s", ws_id, entry.id, schema, view_name)
             target = make_sql_target(ws_id, entry, item)
             result = await views_svc.get_view(target, schema, view_name, mode=ctx.auth_mode)
@@ -205,11 +215,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             select_body: The SELECT statement that forms the view body.
         """
         schema, view_name = parse_qualified_name(qualified_name, kind="view")
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug("create_view ws=%s item=%s view=%s.%s", ws_id, entry.id, schema, view_name)
             target = make_sql_target(ws_id, entry, item)
             result = await views_svc.create_view(
@@ -236,11 +248,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             select_body: The new SELECT statement.
         """
         schema, view_name = parse_qualified_name(qualified_name, kind="view")
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug("update_view ws=%s item=%s view=%s.%s", ws_id, entry.id, schema, view_name)
             target = make_sql_target(ws_id, entry, item)
             result = await views_svc.update_view(
@@ -261,11 +275,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             qualified_name: Dot-separated qualified view name, e.g. ``dbo.vw_sales``.
         """
         schema, view_name = parse_qualified_name(qualified_name, kind="view")
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug("drop_view ws=%s item=%s view=%s.%s", ws_id, entry.id, schema, view_name)
             target = make_sql_target(ws_id, entry, item)
             await views_svc.drop_view(target, schema, view_name, mode=ctx.auth_mode)
@@ -292,12 +308,14 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
                 e.g. ``dbo.vw_sales``.
             new_name: New bare view name (no schema prefix), e.g. ``vw_revenue``.
         """
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         schema, old_view_name = parse_qualified_name(qualified_name, kind="view")
         try:
             ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug(
                 "rename_view ws=%s item=%s view=%s.%s -> %s",
                 ws_id,

--- a/src/fabric_dw/mcp/tools/warehouses.py
+++ b/src/fabric_dw/mcp/tools/warehouses.py
@@ -37,21 +37,23 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         When *all_workspaces* is ``True``, ignore *workspace* and aggregate results
         across every workspace the caller can see.
         """
-        if all_workspaces and workspace_allowlist_active():
+        ctx = get_context()
+        if all_workspaces and workspace_allowlist_active(ctx.workspace_allowlist):
             raise ToolError(
                 "all_workspaces=True is not permitted when FABRIC_MCP_WORKSPACES is configured; "
                 "specify an individual workspace instead"
             )
         if not all_workspaces:
-            assert_workspace_allowed(workspace)
-        ctx = get_context()
+            assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             if all_workspaces:
                 _log.debug("list_warehouses all_workspaces=True")
                 result = await warehouses.list_all_workspaces(ctx.http)
             else:
                 ws_id = await ctx.resolver.workspace_id(workspace)
-                assert_workspace_allowed(workspace, str(ws_id))
+                assert_workspace_allowed(
+                    workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+                )
                 _log.debug("list_warehouses ws=%s", ws_id)
                 result = await warehouses.list_warehouses(ctx.http, ws_id)
         except FabricError as exc:
@@ -61,11 +63,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
     @mcp.tool(name="get_warehouse")
     async def get_warehouse(workspace: str, warehouse: str) -> dict[str, Any]:
         """Return details for a single warehouse (name or GUID)."""
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, item = await resolve_item(ctx.resolver, workspace, warehouse)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug("get_warehouse ws=%s item=%s", ws_id, item.id)
             result = await warehouses.get_warehouse(ctx.http, ws_id, item.id)
         except FabricError as exc:
@@ -99,11 +103,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
                 list of supported collations.
             description: Optional description for the new warehouse.
         """
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id = await ctx.resolver.workspace_id(workspace)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug("create_warehouse ws=%s name=%r", ws_id, name)
             result = await warehouses.create(
                 ctx.http, ws_id, name, collation=collation, description=description
@@ -121,11 +127,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         description: str | None = None,
     ) -> dict[str, Any]:
         """Rename a Warehouse (and optionally update its description)."""
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, item = await resolve_item(ctx.resolver, workspace, warehouse)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug("rename_warehouse ws=%s item=%s new=%r", ws_id, item.id, new_name)
             result = await warehouses.rename(
                 ctx.http, ws_id, item.id, new_name, description=description
@@ -138,11 +146,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
     @mutating_tool(mcp, "delete_warehouse", destructive=True)
     async def delete_warehouse(workspace: str, warehouse: str) -> dict[str, Any]:
         """Delete a Warehouse."""
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, item = await resolve_item(ctx.resolver, workspace, warehouse)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug("delete_warehouse ws=%s item=%s", ws_id, item.id)
             await warehouses.delete(ctx.http, ws_id, item.id)
         except FabricError as exc:
@@ -152,11 +162,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
     @mutating_tool(mcp, "takeover_warehouse")
     async def takeover_warehouse(workspace: str, warehouse: str) -> dict[str, Any]:
         """Take ownership of a Warehouse."""
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, item = await resolve_item(ctx.resolver, workspace, warehouse)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug("takeover_warehouse ws=%s item=%s", ws_id, item.id)
             await ownership_svc.takeover(ctx.http, ws_id, item.id)
         except FabricError as exc:
@@ -171,11 +183,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
 
         See https://learn.microsoft.com/en-us/fabric/admin/microsoft-fabric-admin for details.
         """
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id, item = await resolve_item(ctx.resolver, workspace, warehouse)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug("get_warehouse_permissions ws=%s item=%s", ws_id, item.id)
             result = await _permissions_svc.list_item_access(ctx.http, ws_id, item.id)
         except FabricError as exc:

--- a/src/fabric_dw/mcp/tools/warehouses.py
+++ b/src/fabric_dw/mcp/tools/warehouses.py
@@ -40,7 +40,8 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         ctx = get_context()
         if all_workspaces and workspace_allowlist_active(ctx.workspace_allowlist):
             raise ToolError(
-                "all_workspaces=True is not permitted when FABRIC_MCP_WORKSPACES is configured; "
+                "all_workspaces=True is not permitted when a workspace allowlist is configured "
+                "(env FABRIC_MCP_WORKSPACES or [mcp] workspace_allowlist in config.toml); "
                 "specify an individual workspace instead"
             )
         if not all_workspaces:

--- a/src/fabric_dw/mcp/tools/workspaces.py
+++ b/src/fabric_dw/mcp/tools/workspaces.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import os
 from typing import Any
 from uuid import UUID
 
@@ -12,7 +11,7 @@ from mcp.server.fastmcp.exceptions import ToolError
 
 from fabric_dw.exceptions import FabricError
 from fabric_dw.mcp._context import get_context
-from fabric_dw.mcp._guards import assert_workspace_allowed
+from fabric_dw.mcp._guards import assert_workspace_allowed, resolve_workspace_allowlist
 from fabric_dw.mcp._helpers import fabric_err, mutating_tool
 from fabric_dw.models import Workspace
 from fabric_dw.services import capacities, workspaces
@@ -38,15 +37,17 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             workspace: Workspace name or GUID.
             capacity_id: UUID of the capacity to assign the workspace to.
         """
-        assert_workspace_allowed(workspace)
+        ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             cap_uuid = UUID(capacity_id)
         except ValueError as exc:
             raise ToolError(f"Invalid capacity_id {capacity_id!r}: must be a UUID.") from exc
-        ctx = get_context()
         try:
             ws_id = await ctx.resolver.workspace_id(workspace)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug("assign_workspace_to_capacity ws=%s capacity=%s", ws_id, cap_uuid)
             await workspaces.assign_to_capacity(ctx.http, ws_id, cap_uuid)
         except FabricError as exc:
@@ -72,8 +73,9 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
     async def list_workspaces() -> list[dict[str, Any]]:
         """List all Fabric workspaces the caller has access to.
 
-        When ``FABRIC_MCP_WORKSPACES`` is configured only the workspaces that
-        match the allowlist (by name or GUID) are returned.
+        When a workspace allowlist is configured (via ``FABRIC_MCP_WORKSPACES``
+        env var or ``[mcp] workspace_allowlist`` in ``config.toml``) only the
+        workspaces that match the allowlist (by name or GUID) are returned.
         """
         _log.debug("list_workspaces called")
         ctx = get_context()
@@ -81,23 +83,21 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             result = await workspaces.list_all(ctx.http)
         except FabricError as exc:
             raise fabric_err(exc) from exc
-        raw_allowlist = os.environ.get("FABRIC_MCP_WORKSPACES", "").strip()
-        if raw_allowlist:
-            allowed: frozenset[str] = frozenset(
-                entry.strip().lower() for entry in raw_allowlist.split(",") if entry.strip()
-            )
-            if allowed:
-                result = [ws for ws in result if _workspace_in_allowlist(ws, allowed)]
+        allowed = resolve_workspace_allowlist(ctx.workspace_allowlist)
+        if allowed is not None:
+            result = [ws for ws in result if _workspace_in_allowlist(ws, allowed)]
         return [ws.model_dump(by_alias=True, mode="json") for ws in result]
 
     @mcp.tool(name="get_workspace")
     async def get_workspace(workspace: str) -> dict[str, Any]:
         """Return details for a single workspace (name or GUID)."""
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id = await ctx.resolver.workspace_id(workspace)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug("get_workspace ws=%s", ws_id)
             result = await workspaces.get(ctx.http, ws_id)
         except FabricError as exc:
@@ -122,11 +122,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
                 return an error.  See the Fabric documentation for the full
                 list of supported collations.
         """
-        assert_workspace_allowed(workspace)
         ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             ws_id = await ctx.resolver.workspace_id(workspace)
-            assert_workspace_allowed(workspace, str(ws_id))
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
             _log.debug("set_workspace_collation ws=%s collation=%r", ws_id, collation)
             await workspaces.set_collation(ctx.http, ws_id, collation)
         except ValueError as exc:

--- a/tests/unit/cli/commands/test_config.py
+++ b/tests/unit/cli/commands/test_config.py
@@ -713,3 +713,107 @@ class TestConfigShowAuthMode:
         assert result.exit_code == 0
         data = json.loads(result.output)
         assert data["defaults"]["auth_mode"] is None
+
+
+# ---------------------------------------------------------------------------
+# config set / unset / show for mcp workspace_allowlist
+# ---------------------------------------------------------------------------
+
+
+class TestConfigSetMcpWorkspaceAllowlist:
+    def test_set_workspace_allowlist_exits_zero(self, runner: CliRunner, config_env: Path) -> None:
+        _ = config_env
+        result = runner.invoke(
+            cli, ["config", "set", "mcp", "workspace-allowlist", "Sales WS,Finance WS"]
+        )
+        assert result.exit_code == 0
+
+    def test_set_workspace_allowlist_writes_list(self, runner: CliRunner, config_env: Path) -> None:
+        _ = config_env
+        runner.invoke(cli, ["config", "set", "mcp", "workspace-allowlist", "Sales WS,Finance WS"])
+        cfg = load_config(default_path())
+        assert cfg.mcp.workspace_allowlist == ["Sales WS", "Finance WS"]
+
+    def test_set_workspace_allowlist_trims_whitespace(
+        self, runner: CliRunner, config_env: Path
+    ) -> None:
+        _ = config_env
+        runner.invoke(
+            cli, ["config", "set", "mcp", "workspace-allowlist", "  Sales WS , Finance WS  "]
+        )
+        cfg = load_config(default_path())
+        assert cfg.mcp.workspace_allowlist == ["Sales WS", "Finance WS"]
+
+    def test_set_workspace_allowlist_single_entry(
+        self, runner: CliRunner, config_env: Path
+    ) -> None:
+        _ = config_env
+        runner.invoke(cli, ["config", "set", "mcp", "workspace-allowlist", "prod"])
+        cfg = load_config(default_path())
+        assert cfg.mcp.workspace_allowlist == ["prod"]
+
+    def test_set_workspace_allowlist_preserves_other_keys(
+        self, runner: CliRunner, config_env: Path
+    ) -> None:
+        _ = config_env
+        runner.invoke(cli, ["config", "set", "workspace", "MyWS"])
+        runner.invoke(cli, ["config", "set", "mcp", "workspace-allowlist", "prod,staging"])
+        cfg = load_config(default_path())
+        assert cfg.mcp.workspace_allowlist == ["prod", "staging"]
+        assert cfg.defaults.workspace == "MyWS"  # preserved
+
+
+class TestConfigUnsetMcpWorkspaceAllowlist:
+    def test_unset_workspace_allowlist_exits_zero(
+        self, runner: CliRunner, config_env: Path
+    ) -> None:
+        _ = config_env
+        runner.invoke(cli, ["config", "set", "mcp", "workspace-allowlist", "prod"])
+        result = runner.invoke(cli, ["config", "unset", "mcp", "workspace-allowlist"])
+        assert result.exit_code == 0
+
+    def test_unset_workspace_allowlist_clears_key(
+        self, runner: CliRunner, config_env: Path
+    ) -> None:
+        _ = config_env
+        runner.invoke(cli, ["config", "set", "mcp", "workspace-allowlist", "prod"])
+        runner.invoke(cli, ["config", "unset", "mcp", "workspace-allowlist"])
+        cfg = load_config(default_path())
+        assert cfg.mcp.workspace_allowlist is None
+
+    def test_unset_workspace_allowlist_preserves_other_keys(
+        self, runner: CliRunner, config_env: Path
+    ) -> None:
+        _ = config_env
+        runner.invoke(cli, ["config", "set", "workspace", "MyWS"])
+        runner.invoke(cli, ["config", "set", "mcp", "workspace-allowlist", "prod"])
+        runner.invoke(cli, ["config", "unset", "mcp", "workspace-allowlist"])
+        cfg = load_config(default_path())
+        assert cfg.mcp.workspace_allowlist is None
+        assert cfg.defaults.workspace == "MyWS"  # preserved
+
+
+class TestConfigShowMcpWorkspaceAllowlist:
+    def test_show_includes_mcp_section(self, runner: CliRunner, config_env: Path) -> None:
+        _ = config_env
+        result = runner.invoke(cli, ["--json", "config", "show"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "mcp" in data
+
+    def test_show_workspace_allowlist_when_set(self, runner: CliRunner, config_env: Path) -> None:
+        _ = config_env
+        runner.invoke(cli, ["config", "set", "mcp", "workspace-allowlist", "Sales WS,Finance WS"])
+        result = runner.invoke(cli, ["--json", "config", "show"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["mcp"]["workspace_allowlist"] == ["Sales WS", "Finance WS"]
+
+    def test_show_workspace_allowlist_null_when_not_set(
+        self, runner: CliRunner, config_env: Path
+    ) -> None:
+        _ = config_env
+        result = runner.invoke(cli, ["--json", "config", "show"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["mcp"]["workspace_allowlist"] is None

--- a/tests/unit/cli/commands/test_config.py
+++ b/tests/unit/cli/commands/test_config.py
@@ -817,3 +817,36 @@ class TestConfigShowMcpWorkspaceAllowlist:
         assert result.exit_code == 0
         data = json.loads(result.output)
         assert data["mcp"]["workspace_allowlist"] is None
+
+
+class TestConfigSetMcpWorkspaceAllowlistValidation:
+    """set mcp workspace-allowlist rejects empty / whitespace-only input."""
+
+    def test_empty_string_rejected(self, runner: CliRunner, config_env: Path) -> None:
+        _ = config_env
+        result = runner.invoke(cli, ["config", "set", "mcp", "workspace-allowlist", ""])
+        assert result.exit_code != 0
+
+    def test_whitespace_string_rejected(self, runner: CliRunner, config_env: Path) -> None:
+        _ = config_env
+        result = runner.invoke(cli, ["config", "set", "mcp", "workspace-allowlist", "   "])
+        assert result.exit_code != 0
+
+    def test_comma_only_rejected(self, runner: CliRunner, config_env: Path) -> None:
+        """A value that is all commas has no non-empty entries after splitting."""
+        _ = config_env
+        result = runner.invoke(cli, ["config", "set", "mcp", "workspace-allowlist", ",,,"])
+        assert result.exit_code != 0
+
+    def test_empty_string_error_mentions_unset(self, runner: CliRunner, config_env: Path) -> None:
+        """Error message points operator toward fdw config unset."""
+        _ = config_env
+        result = runner.invoke(cli, ["config", "set", "mcp", "workspace-allowlist", ""])
+        assert "unset" in result.output.lower()
+
+    def test_empty_string_does_not_write_config(self, runner: CliRunner, config_env: Path) -> None:
+        """A rejected empty call must not modify config.toml."""
+        _ = config_env
+        runner.invoke(cli, ["config", "set", "mcp", "workspace-allowlist", ""])
+        cfg = load_config(default_path())
+        assert cfg.mcp.workspace_allowlist is None

--- a/tests/unit/mcp/test_security.py
+++ b/tests/unit/mcp/test_security.py
@@ -420,6 +420,211 @@ class TestAssertWorkspaceAllowed:
 
 
 # ---------------------------------------------------------------------------
+# 4b. resolve_workspace_allowlist — 3-layer precedence
+# ---------------------------------------------------------------------------
+
+
+class TestResolveWorkspaceAllowlist:
+    """3-layer resolution: env > config > no restriction."""
+
+    def test_no_restriction_when_both_absent(self) -> None:
+        """Unset env AND unset config → None (no restriction)."""
+        from fabric_dw.mcp._guards import resolve_workspace_allowlist  # noqa: PLC0415
+
+        env_without_workspaces = {
+            k: v for k, v in os.environ.items() if k != "FABRIC_MCP_WORKSPACES"
+        }
+        with patch.dict(os.environ, env_without_workspaces, clear=True):
+            assert resolve_workspace_allowlist(None) is None
+
+    def test_env_wins_over_config(self) -> None:
+        """Non-empty env var takes precedence over config."""
+        from fabric_dw.mcp._guards import resolve_workspace_allowlist  # noqa: PLC0415
+
+        with patch.dict(os.environ, {"FABRIC_MCP_WORKSPACES": "env-ws"}):
+            result = resolve_workspace_allowlist(["config-ws"])
+        assert result == frozenset({"env-ws"})
+
+    def test_config_used_when_env_absent(self) -> None:
+        """When env is absent, config layer provides the allowlist."""
+        from fabric_dw.mcp._guards import resolve_workspace_allowlist  # noqa: PLC0415
+
+        env_without_workspaces = {
+            k: v for k, v in os.environ.items() if k != "FABRIC_MCP_WORKSPACES"
+        }
+        with patch.dict(os.environ, env_without_workspaces, clear=True):
+            result = resolve_workspace_allowlist(["Sales WS", "Finance WS"])
+        assert result == frozenset({"sales ws", "finance ws"})
+
+    def test_empty_env_falls_through_to_config(self) -> None:
+        """Empty FABRIC_MCP_WORKSPACES= falls through to config layer."""
+        from fabric_dw.mcp._guards import resolve_workspace_allowlist  # noqa: PLC0415
+
+        with patch.dict(os.environ, {"FABRIC_MCP_WORKSPACES": ""}):
+            result = resolve_workspace_allowlist(["config-ws"])
+        assert result == frozenset({"config-ws"})
+
+    def test_whitespace_only_env_falls_through_to_config(self) -> None:
+        """Whitespace-only env value falls through to config, not no-restriction."""
+        from fabric_dw.mcp._guards import resolve_workspace_allowlist  # noqa: PLC0415
+
+        with patch.dict(os.environ, {"FABRIC_MCP_WORKSPACES": "   "}):
+            result = resolve_workspace_allowlist(["config-ws"])
+        assert result == frozenset({"config-ws"})
+
+    def test_comma_only_env_falls_through_to_config(self) -> None:
+        """Comma-only env value falls through to config."""
+        from fabric_dw.mcp._guards import resolve_workspace_allowlist  # noqa: PLC0415
+
+        with patch.dict(os.environ, {"FABRIC_MCP_WORKSPACES": " , , "}):
+            result = resolve_workspace_allowlist(["config-ws"])
+        assert result == frozenset({"config-ws"})
+
+    def test_empty_config_list_means_no_restriction(self) -> None:
+        """Empty TOML array [] is treated as absent — no restriction, NOT block-all."""
+        from fabric_dw.mcp._guards import resolve_workspace_allowlist  # noqa: PLC0415
+
+        env_without_workspaces = {
+            k: v for k, v in os.environ.items() if k != "FABRIC_MCP_WORKSPACES"
+        }
+        with patch.dict(os.environ, env_without_workspaces, clear=True):
+            assert resolve_workspace_allowlist([]) is None
+
+    def test_empty_env_and_empty_config_means_no_restriction(self) -> None:
+        """Both empty env and empty config → no restriction."""
+        from fabric_dw.mcp._guards import resolve_workspace_allowlist  # noqa: PLC0415
+
+        with patch.dict(os.environ, {"FABRIC_MCP_WORKSPACES": ""}):
+            assert resolve_workspace_allowlist([]) is None
+
+    def test_non_empty_allowlist_restricts(self) -> None:
+        """Non-empty allowlist returns a frozenset of lower-cased entries."""
+        from fabric_dw.mcp._guards import resolve_workspace_allowlist  # noqa: PLC0415
+
+        with patch.dict(os.environ, {"FABRIC_MCP_WORKSPACES": "  Sales WS , Finance WS  "}):
+            result = resolve_workspace_allowlist(None)
+        assert result == frozenset({"sales ws", "finance ws"})
+
+    def test_config_entries_trimmed_and_lowercased(self) -> None:
+        """Config entries are trimmed and lowercased before comparison."""
+        from fabric_dw.mcp._guards import resolve_workspace_allowlist  # noqa: PLC0415
+
+        env_without_workspaces = {
+            k: v for k, v in os.environ.items() if k != "FABRIC_MCP_WORKSPACES"
+        }
+        with patch.dict(os.environ, env_without_workspaces, clear=True):
+            result = resolve_workspace_allowlist(["  PROD  ", " Staging "])
+        assert result == frozenset({"prod", "staging"})
+
+
+class TestWorkspaceAllowlistActive:
+    """workspace_allowlist_active mirrors resolve_workspace_allowlist semantics."""
+
+    def test_false_when_no_restriction(self) -> None:
+        from fabric_dw.mcp._guards import workspace_allowlist_active  # noqa: PLC0415
+
+        env_without_workspaces = {
+            k: v for k, v in os.environ.items() if k != "FABRIC_MCP_WORKSPACES"
+        }
+        with patch.dict(os.environ, env_without_workspaces, clear=True):
+            assert workspace_allowlist_active(None) is False
+
+    def test_true_when_env_set(self) -> None:
+        from fabric_dw.mcp._guards import workspace_allowlist_active  # noqa: PLC0415
+
+        with patch.dict(os.environ, {"FABRIC_MCP_WORKSPACES": "prod"}):
+            assert workspace_allowlist_active(None) is True
+
+    def test_true_when_config_set(self) -> None:
+        from fabric_dw.mcp._guards import workspace_allowlist_active  # noqa: PLC0415
+
+        env_without_workspaces = {
+            k: v for k, v in os.environ.items() if k != "FABRIC_MCP_WORKSPACES"
+        }
+        with patch.dict(os.environ, env_without_workspaces, clear=True):
+            assert workspace_allowlist_active(["prod"]) is True
+
+    def test_false_when_empty_env_and_no_config(self) -> None:
+        from fabric_dw.mcp._guards import workspace_allowlist_active  # noqa: PLC0415
+
+        with patch.dict(os.environ, {"FABRIC_MCP_WORKSPACES": ""}):
+            assert workspace_allowlist_active(None) is False
+
+    def test_false_when_empty_config_list(self) -> None:
+        from fabric_dw.mcp._guards import workspace_allowlist_active  # noqa: PLC0415
+
+        env_without_workspaces = {
+            k: v for k, v in os.environ.items() if k != "FABRIC_MCP_WORKSPACES"
+        }
+        with patch.dict(os.environ, env_without_workspaces, clear=True):
+            assert workspace_allowlist_active([]) is False
+
+
+class TestAssertWorkspaceAllowedConfigLayer:
+    """assert_workspace_allowed 3-layer semantics."""
+
+    def test_config_layer_blocks_unlisted(self) -> None:
+        """Config-only allowlist blocks workspaces not in the list."""
+        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+        from fabric_dw.mcp._guards import assert_workspace_allowed  # noqa: PLC0415
+
+        env_without_workspaces = {
+            k: v for k, v in os.environ.items() if k != "FABRIC_MCP_WORKSPACES"
+        }
+        with (
+            patch.dict(os.environ, env_without_workspaces, clear=True),
+            pytest.raises(ToolError, match="allowlist"),
+        ):
+            assert_workspace_allowed("dev", config_allowlist=["prod", "staging"])
+
+    def test_config_layer_allows_listed(self) -> None:
+        """Config-only allowlist permits workspaces in the list."""
+        from fabric_dw.mcp._guards import assert_workspace_allowed  # noqa: PLC0415
+
+        env_without_workspaces = {
+            k: v for k, v in os.environ.items() if k != "FABRIC_MCP_WORKSPACES"
+        }
+        with patch.dict(os.environ, env_without_workspaces, clear=True):
+            assert_workspace_allowed("prod", config_allowlist=["prod", "staging"])
+
+    def test_env_overrides_config(self) -> None:
+        """Env allowlist overrides config; workspace in config but not env is blocked."""
+        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+        from fabric_dw.mcp._guards import assert_workspace_allowed  # noqa: PLC0415
+
+        with (
+            patch.dict(os.environ, {"FABRIC_MCP_WORKSPACES": "env-ws"}),
+            pytest.raises(ToolError, match="allowlist"),
+        ):
+            # "config-ws" is in the config layer but not the env layer — env wins
+            assert_workspace_allowed("config-ws", config_allowlist=["config-ws"])
+
+    def test_no_restriction_when_both_absent(self) -> None:
+        """No env, no config → all workspaces allowed."""
+        from fabric_dw.mcp._guards import assert_workspace_allowed  # noqa: PLC0415
+
+        env_without_workspaces = {
+            k: v for k, v in os.environ.items() if k != "FABRIC_MCP_WORKSPACES"
+        }
+        with patch.dict(os.environ, env_without_workspaces, clear=True):
+            assert_workspace_allowed("any-ws", config_allowlist=None)
+
+    def test_empty_env_falls_through_config_blocks(self) -> None:
+        """Empty env falls through to config; config restriction is applied."""
+        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+        from fabric_dw.mcp._guards import assert_workspace_allowed  # noqa: PLC0415
+
+        with (
+            patch.dict(os.environ, {"FABRIC_MCP_WORKSPACES": ""}),
+            pytest.raises(ToolError, match="allowlist"),
+        ):
+            assert_workspace_allowed("dev", config_allowlist=["prod"])
+
+
+# ---------------------------------------------------------------------------
 # 5. execute_sql max_rows truncation
 # ---------------------------------------------------------------------------
 
@@ -642,9 +847,21 @@ async def test_get_workspace_blocked_by_workspace_allowlist() -> None:
     """get_workspace raises ToolError when workspace not in FABRIC_MCP_WORKSPACES."""
     from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
 
+    from fabric_dw import auth as _auth  # noqa: PLC0415
+    from fabric_dw.mcp._context import ServerContext  # noqa: PLC0415
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
+    mock_resolver = AsyncMock()
+    mock_resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    ctx = ServerContext(
+        http=AsyncMock(),
+        cache=MagicMock(),
+        resolver=mock_resolver,
+        auth_mode=_auth.CredentialMode.DEFAULT,
+    )
+
     with (
+        patch("fabric_dw.mcp._context._SERVER_CTX", ctx),
         patch.dict(os.environ, {"FABRIC_MCP_WORKSPACES": "allowed-ws"}),
         pytest.raises(ToolError, match="allowlist"),
     ):
@@ -658,9 +875,19 @@ async def test_list_warehouses_all_workspaces_blocked_when_allowlist_set() -> No
     """list_warehouses(all_workspaces=True) raises ToolError when FABRIC_MCP_WORKSPACES is set."""
     from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
 
+    from fabric_dw import auth as _auth  # noqa: PLC0415
+    from fabric_dw.mcp._context import ServerContext  # noqa: PLC0415
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
+    ctx = ServerContext(
+        http=AsyncMock(),
+        cache=MagicMock(),
+        resolver=AsyncMock(),
+        auth_mode=_auth.CredentialMode.DEFAULT,
+    )
+
     with (
+        patch("fabric_dw.mcp._context._SERVER_CTX", ctx),
         patch.dict(os.environ, {"FABRIC_MCP_WORKSPACES": "prod"}),
         pytest.raises(ToolError, match="all_workspaces"),
     ):
@@ -674,9 +901,19 @@ async def test_list_sql_endpoints_all_workspaces_blocked_when_allowlist_set() ->
     """list_sql_endpoints(all_workspaces=True) raises ToolError when allowlist is set."""
     from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
 
+    from fabric_dw import auth as _auth  # noqa: PLC0415
+    from fabric_dw.mcp._context import ServerContext  # noqa: PLC0415
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
+    ctx = ServerContext(
+        http=AsyncMock(),
+        cache=MagicMock(),
+        resolver=AsyncMock(),
+        auth_mode=_auth.CredentialMode.DEFAULT,
+    )
+
     with (
+        patch("fabric_dw.mcp._context._SERVER_CTX", ctx),
         patch.dict(os.environ, {"FABRIC_MCP_WORKSPACES": "prod"}),
         pytest.raises(ToolError, match="all_workspaces"),
     ):

--- a/tests/unit/mcp/test_security.py
+++ b/tests/unit/mcp/test_security.py
@@ -14,6 +14,7 @@ Coverage
 from __future__ import annotations
 
 import os
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import UUID
 
@@ -1276,3 +1277,85 @@ def test_assert_workspace_allowed_still_blocks_name_when_allowlist_has_names() -
         pytest.raises(ToolError, match="allowlist"),
     ):
         assert_workspace_allowed("forbidden-workspace")  # pre-resolve, name-only allowlist
+
+
+# ---------------------------------------------------------------------------
+# FIX 1(a): build_context wiring — workspace_allowlist propagated to ServerContext
+# ---------------------------------------------------------------------------
+
+
+def test_build_context_propagates_workspace_allowlist(tmp_path: Path) -> None:
+    """build_context passes cfg.mcp.workspace_allowlist into ServerContext."""
+    from fabric_dw.config import McpConfig, UserConfig, save_config  # noqa: PLC0415
+    from fabric_dw.mcp._context import build_context  # noqa: PLC0415
+
+    cfg_file = tmp_path / "config.toml"
+    save_config(
+        UserConfig(mcp=McpConfig(workspace_allowlist=["Sales WS", "Finance WS"])),
+        cfg_file,
+    )
+
+    env_without_workspaces = {k: v for k, v in os.environ.items() if k != "FABRIC_MCP_WORKSPACES"}
+    with patch.dict(os.environ, env_without_workspaces, clear=True):
+        ctx = build_context(config_path=cfg_file)
+
+    assert ctx.workspace_allowlist == ["Sales WS", "Finance WS"]
+
+
+def test_build_context_workspace_allowlist_none_when_absent(tmp_path: Path) -> None:
+    """build_context sets workspace_allowlist=None when the key is absent from config."""
+    from fabric_dw.config import UserConfig, save_config  # noqa: PLC0415
+    from fabric_dw.mcp._context import build_context  # noqa: PLC0415
+
+    cfg_file = tmp_path / "config.toml"
+    save_config(UserConfig(), cfg_file)
+
+    env_without_workspaces = {k: v for k, v in os.environ.items() if k != "FABRIC_MCP_WORKSPACES"}
+    with patch.dict(os.environ, env_without_workspaces, clear=True):
+        ctx = build_context(config_path=cfg_file)
+
+    assert ctx.workspace_allowlist is None
+
+
+# ---------------------------------------------------------------------------
+# FIX 1(b): tool-level test — config layer blocks when env is UNSET
+# ---------------------------------------------------------------------------
+
+
+async def test_get_workspace_blocked_by_config_allowlist_env_unset() -> None:
+    """get_workspace blocks a workspace via config layer when FABRIC_MCP_WORKSPACES is unset.
+
+    This test proves that:
+    1.  The tool reads ctx.workspace_allowlist from ServerContext.
+    2.  When FABRIC_MCP_WORKSPACES is absent, the config layer still restricts access.
+    """
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw import auth as _auth  # noqa: PLC0415
+    from fabric_dw.cache import LookupCache  # noqa: PLC0415
+    from fabric_dw.mcp._context import ServerContext  # noqa: PLC0415
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+    from fabric_dw.resolver import Resolver  # noqa: PLC0415
+
+    mock_http = AsyncMock()
+    mock_cache = LookupCache()
+    mock_resolver = AsyncMock(spec=Resolver)
+
+    ctx = ServerContext(
+        http=mock_http,
+        cache=mock_cache,
+        resolver=mock_resolver,
+        auth_mode=_auth.CredentialMode.DEFAULT,
+        workspace_allowlist=["allowed-ws"],
+    )
+
+    env_without_workspaces = {k: v for k, v in os.environ.items() if k != "FABRIC_MCP_WORKSPACES"}
+    with (
+        patch("fabric_dw.mcp._context._SERVER_CTX", ctx),
+        patch.dict(os.environ, env_without_workspaces, clear=True),
+        pytest.raises(ToolError, match="allowlist"),
+    ):
+        await mcp._tool_manager.call_tool(
+            "get_workspace",
+            {"workspace": "forbidden-ws"},
+        )

--- a/tests/unit/mcp/test_server.py
+++ b/tests/unit/mcp/test_server.py
@@ -1727,7 +1727,7 @@ async def test_rename_table_workspace_allowlist_blocks(mock_ctx, ctx_patch) -> N
     with (
         ctx_patch,
         patch.dict(os.environ, {"FABRIC_MCP_WORKSPACES": "other-workspace"}),
-        pytest.raises(ToolError, match="FABRIC_MCP_WORKSPACES"),
+        pytest.raises(ToolError, match="allowlist"),
     ):
         await mcp._tool_manager.call_tool(
             "rename_table",

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1268,3 +1268,83 @@ def test_valid_auth_modes_mirrors_credential_mode_enum() -> None:
     instead of silently rejecting/accepting the wrong modes at runtime.
     """
     assert frozenset(m.value for m in CredentialMode) == VALID_AUTH_MODES
+
+
+# ---------------------------------------------------------------------------
+# set_config mcp.workspace_allowlist — CSV parse, round-trip, unset
+# ---------------------------------------------------------------------------
+
+
+def test_set_config_mcp_workspace_allowlist_csv_parses(tmp_path: Path) -> None:
+    """CSV value is split, trimmed, and stored as a list."""
+    path = tmp_path / "config.toml"
+    set_config("mcp", "workspace_allowlist", "Sales WS, Finance WS", path)
+    loaded = load_config(path)
+    assert loaded.mcp.workspace_allowlist == ["Sales WS", "Finance WS"]
+
+
+def test_set_config_mcp_workspace_allowlist_single_entry(tmp_path: Path) -> None:
+    """A single workspace name without commas is stored as a one-element list."""
+    path = tmp_path / "config.toml"
+    set_config("mcp", "workspace_allowlist", "prod", path)
+    loaded = load_config(path)
+    assert loaded.mcp.workspace_allowlist == ["prod"]
+
+
+def test_set_config_mcp_workspace_allowlist_none_clears(tmp_path: Path) -> None:
+    """set_config(..., None) removes the key and section when it was the only field."""
+    path = tmp_path / "config.toml"
+    set_config("mcp", "workspace_allowlist", "prod", path)
+    assert load_config(path).mcp.workspace_allowlist == ["prod"]
+    set_config("mcp", "workspace_allowlist", None, path)
+    loaded = load_config(path)
+    assert loaded.mcp.workspace_allowlist is None
+
+
+def test_set_config_mcp_workspace_allowlist_trims_entries(tmp_path: Path) -> None:
+    """Whitespace around individual entries is stripped."""
+    path = tmp_path / "config.toml"
+    set_config("mcp", "workspace_allowlist", "  Sales WS  ,  Finance WS  ", path)
+    loaded = load_config(path)
+    assert loaded.mcp.workspace_allowlist == ["Sales WS", "Finance WS"]
+
+
+def test_set_config_mcp_workspace_allowlist_empty_entries_skipped(tmp_path: Path) -> None:
+    """Comma-only or whitespace-only entries are not stored."""
+    path = tmp_path / "config.toml"
+    set_config("mcp", "workspace_allowlist", "prod,,staging,  ", path)
+    loaded = load_config(path)
+    assert loaded.mcp.workspace_allowlist == ["prod", "staging"]
+
+
+def test_set_config_mcp_workspace_allowlist_all_empty_clears(tmp_path: Path) -> None:
+    """A value of only commas/whitespace results in no allowlist (no restriction)."""
+    path = tmp_path / "config.toml"
+    set_config("mcp", "workspace_allowlist", " , , ", path)
+    loaded = load_config(path)
+    assert loaded.mcp.workspace_allowlist is None
+
+
+def test_set_config_mcp_workspace_allowlist_preserves_other_sections(tmp_path: Path) -> None:
+    """Writing mcp.workspace_allowlist does not disturb unrelated sections."""
+    path = tmp_path / "config.toml"
+    save_config(
+        UserConfig(
+            defaults=Defaults(workspace="WS"),
+            telemetry=TelemetryConfig(disabled=True),
+        ),
+        path,
+    )
+    set_config("mcp", "workspace_allowlist", "prod", path)
+    loaded = load_config(path)
+    assert loaded.mcp.workspace_allowlist == ["prod"]
+    assert loaded.defaults.workspace == "WS"
+    assert loaded.telemetry.disabled is True
+
+
+def test_set_config_mcp_workspace_allowlist_round_trip(tmp_path: Path) -> None:
+    """Full CSV round-trip: set → save → load preserves list."""
+    path = tmp_path / "config.toml"
+    set_config("mcp", "workspace_allowlist", "Sales WS,Finance WS,HR WS", path)
+    loaded = load_config(path)
+    assert loaded.mcp.workspace_allowlist == ["Sales WS", "Finance WS", "HR WS"]


### PR DESCRIPTION
## Summary

- Adds `[mcp] workspace_allowlist` to `config.toml` as the config-file layer of the workspace allowlist (env CSV > config TOML array > no restriction)
- Empty/whitespace env `FABRIC_MCP_WORKSPACES=` falls through to config; empty TOML array `[]` falls through to no restriction — neither silently blocks all workspaces
- CLI: `fdw config set mcp workspace-allowlist <ws1,ws2>` and `fdw config unset mcp workspace-allowlist`; `config show` now includes the `[mcp]` section
- All 17 MCP tool files updated to pass `config_allowlist=ctx.workspace_allowlist` to guard functions; `ServerContext` carries the config value from `build_context`
- Docs: config page (new MCP workspace allowlist section) + install page (3-layer resolution + empty-value semantics)
- 39 new unit tests covering all acceptance criteria

## Test plan

- [ ] `uv run ruff format --check .` — passes
- [ ] `uv run ruff check .` — passes
- [ ] `uv run ty check src tests` — passes
- [ ] `uv run pytest tests/unit -q` — 4536 passed, 0 failed
- [ ] Unset env AND unset config → no restriction (all workspaces allowed)
- [ ] Non-empty env → restricts to those workspaces (env wins over config)
- [ ] Non-empty config, env absent → restricts to config workspaces
- [ ] `FABRIC_MCP_WORKSPACES=` (empty) → falls through to config, then no restriction
- [ ] `workspace_allowlist = []` (empty TOML array) → no restriction
- [ ] `fdw config set mcp workspace-allowlist "A,B"` → stores `["A", "B"]`
- [ ] `fdw config unset mcp workspace-allowlist` → clears the key
- [ ] `fdw config show` includes `mcp.workspace_allowlist`

Closes #692

🤖 Generated with [Claude Code](https://claude.com/claude-code)