### PR TITLE
fix(mcp): canonicalize GUID/name matching for the workspace allowlist

### DIFF
--- a/src/fabric_dw/mcp/_guards.py
+++ b/src/fabric_dw/mcp/_guards.py
@@ -86,6 +86,22 @@ def env_flag(name: str) -> bool:
 _env_flag = env_flag
 
 
+def _canonicalize_entry(entry: str) -> str:
+    """Return a canonical form of a workspace allowlist entry.
+
+    GUID-shaped entries (braced, unhyphenated, ``urn:uuid:``, or canonical) are
+    normalised to RFC-4122 lower-cased hyphenated form via :func:`uuid.UUID`.
+    Non-GUID strings are lower-cased and trimmed as before.
+
+    This prevents wrongful denials when a hand-edited ``config.toml`` entry uses
+    a non-canonical GUID form such as ``{a1b2c3d4-...}`` or a 32-hex string.
+    """
+    stripped = entry.strip()
+    if _looks_like_uuid(stripped):
+        return str(_uuid_mod.UUID(stripped))
+    return stripped.lower()
+
+
 def resolve_workspace_allowlist(
     config_allowlist: Sequence[str] | None = None,
 ) -> frozenset[str] | None:
@@ -105,13 +121,17 @@ def resolve_workspace_allowlist(
        list.
     3. Built-in default: ``None`` — no restriction, all workspaces allowed.
 
+    GUID-shaped entries are canonicalised to RFC-4122 lower-cased hyphenated
+    form so that ``{guid}``, ``urn:uuid:guid``, or unhyphenated 32-hex entries
+    reliably match the resolved workspace ID returned by the Fabric API.
+
     Args:
         config_allowlist: The ``McpConfig.workspace_allowlist`` value loaded
             from ``config.toml``.  Pass ``None`` when no config is available
             or when the key is absent.
 
     Returns:
-        A non-empty :class:`frozenset` of lower-cased, trimmed workspace
+        A non-empty :class:`frozenset` of canonicalised, trimmed workspace
         names / GUIDs when a restriction is in effect, or ``None`` when
         every workspace is allowed.
     """
@@ -119,7 +139,7 @@ def resolve_workspace_allowlist(
     raw_env = os.environ.get("FABRIC_MCP_WORKSPACES", "").strip()
     if raw_env:
         env_entries = frozenset(
-            entry.strip().lower() for entry in raw_env.split(",") if entry.strip()
+            _canonicalize_entry(entry) for entry in raw_env.split(",") if entry.strip()
         )
         if env_entries:
             return env_entries
@@ -127,7 +147,7 @@ def resolve_workspace_allowlist(
     # Layer 2: config.toml
     if config_allowlist is not None:
         config_entries = frozenset(
-            entry.strip().lower() for entry in config_allowlist if entry.strip()
+            _canonicalize_entry(entry) for entry in config_allowlist if entry.strip()
         )
         if config_entries:
             return config_entries
@@ -427,15 +447,22 @@ def assert_workspace_allowed(
     if allowed is None:
         return  # no restriction — every workspace is allowed
 
-    candidates = {workspace_arg.strip().lower()}
+    # Build the candidate set using the same canonicalisation applied to the
+    # allowlist entries so that non-canonical GUID forms match correctly.
+    candidates = {_canonicalize_entry(workspace_arg)}
     if resolved_id is not None:
-        candidates.add(resolved_id.strip().lower())
+        candidates.add(_canonicalize_entry(resolved_id))
     else:
-        # Pre-resolve: if *all* allowlist entries are GUIDs and the raw arg is
-        # not itself a GUID, we cannot determine validity yet — defer to the
-        # post-resolve call rather than falsely rejecting a valid name.
-        all_guids = all(_looks_like_uuid(entry) for entry in allowed)
-        if all_guids and not _looks_like_uuid(workspace_arg.strip()):
+        # Pre-resolve: when the raw arg is a name (not a GUID) and the
+        # allowlist contains at least one GUID-shaped entry, we cannot
+        # determine whether this name resolves to a listed GUID.  Defer to
+        # the post-resolve call to prevent false denials.  This covers both
+        # the all-GUIDs case and the mixed (names + GUIDs) case.
+        # If the allowlist has no GUID entries at all, a name can be
+        # matched (or rejected) immediately by name comparison.
+        arg_is_name = not _looks_like_uuid(workspace_arg.strip())
+        allowlist_has_guids = any(_looks_like_uuid(e) for e in allowed)
+        if arg_is_name and allowlist_has_guids:
             return  # cannot decide pre-resolve; post-resolve call will gate
 
     if candidates.isdisjoint(allowed):

--- a/tests/unit/mcp/test_security.py
+++ b/tests/unit/mcp/test_security.py
@@ -1359,3 +1359,195 @@ async def test_get_workspace_blocked_by_config_allowlist_env_unset() -> None:
             "get_workspace",
             {"workspace": "forbidden-ws"},
         )
+
+
+# ---------------------------------------------------------------------------
+# #697 — GUID canonicalization + mixed name/GUID allowlist fixes
+# ---------------------------------------------------------------------------
+
+# Canonical form of the test GUID used across these tests.
+_CANONICAL_GUID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+
+
+class TestGuidCanonicalization:
+    """Trap 1: non-canonical GUID allowlist entries must match the canonical resolved GUID."""
+
+    def test_braced_guid_entry_matches_canonical_resolved_id(self) -> None:
+        """A braced {guid} allowlist entry must match the canonical hyphenated resolved GUID."""
+        from fabric_dw.mcp._guards import assert_workspace_allowed  # noqa: PLC0415
+
+        braced = "{" + _CANONICAL_GUID + "}"
+        env_without_workspaces = {
+            k: v for k, v in os.environ.items() if k != "FABRIC_MCP_WORKSPACES"
+        }
+        with patch.dict(os.environ, env_without_workspaces, clear=True):
+            # Must not raise: braced entry should match canonical resolved_id
+            assert_workspace_allowed(
+                _CANONICAL_GUID,
+                resolved_id=_CANONICAL_GUID,
+                config_allowlist=[braced],
+            )
+
+    def test_unhyphenated_guid_entry_matches_canonical_resolved_id(self) -> None:
+        """A 32-hex unhyphenated GUID allowlist entry must match the canonical resolved GUID."""
+        from fabric_dw.mcp._guards import assert_workspace_allowed  # noqa: PLC0415
+
+        unhyphenated = _CANONICAL_GUID.replace("-", "")
+        env_without_workspaces = {
+            k: v for k, v in os.environ.items() if k != "FABRIC_MCP_WORKSPACES"
+        }
+        with patch.dict(os.environ, env_without_workspaces, clear=True):
+            assert_workspace_allowed(
+                _CANONICAL_GUID,
+                resolved_id=_CANONICAL_GUID,
+                config_allowlist=[unhyphenated],
+            )
+
+    def test_urn_uuid_entry_matches_canonical_resolved_id(self) -> None:
+        """A urn:uuid:<guid> allowlist entry must match the canonical resolved GUID."""
+        from fabric_dw.mcp._guards import assert_workspace_allowed  # noqa: PLC0415
+
+        urn = "urn:uuid:" + _CANONICAL_GUID
+        env_without_workspaces = {
+            k: v for k, v in os.environ.items() if k != "FABRIC_MCP_WORKSPACES"
+        }
+        with patch.dict(os.environ, env_without_workspaces, clear=True):
+            assert_workspace_allowed(
+                _CANONICAL_GUID,
+                resolved_id=_CANONICAL_GUID,
+                config_allowlist=[urn],
+            )
+
+    def test_non_listed_workspace_still_blocked_with_non_canonical_entry(self) -> None:
+        """A workspace not on the allowlist is still denied even when the entry is non-canonical."""
+        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+        from fabric_dw.mcp._guards import assert_workspace_allowed  # noqa: PLC0415
+
+        other_guid = "00000000-0000-0000-0000-000000000099"
+        braced = "{" + _CANONICAL_GUID + "}"
+        env_without_workspaces = {
+            k: v for k, v in os.environ.items() if k != "FABRIC_MCP_WORKSPACES"
+        }
+        with (
+            patch.dict(os.environ, env_without_workspaces, clear=True),
+            pytest.raises(ToolError, match="allowlist"),
+        ):
+            assert_workspace_allowed(
+                other_guid,
+                resolved_id=other_guid,
+                config_allowlist=[braced],
+            )
+
+    def test_resolve_workspace_allowlist_canonicalizes_braced_guid(self) -> None:
+        """resolve_workspace_allowlist stores braced GUIDs in canonical form."""
+        from fabric_dw.mcp._guards import resolve_workspace_allowlist  # noqa: PLC0415
+
+        braced = "{" + _CANONICAL_GUID + "}"
+        env_without_workspaces = {
+            k: v for k, v in os.environ.items() if k != "FABRIC_MCP_WORKSPACES"
+        }
+        with patch.dict(os.environ, env_without_workspaces, clear=True):
+            result = resolve_workspace_allowlist([braced])
+        assert result == frozenset({_CANONICAL_GUID})
+
+    def test_resolve_workspace_allowlist_canonicalizes_unhyphenated_guid(self) -> None:
+        """resolve_workspace_allowlist stores 32-hex GUIDs in canonical form."""
+        from fabric_dw.mcp._guards import resolve_workspace_allowlist  # noqa: PLC0415
+
+        unhyphenated = _CANONICAL_GUID.replace("-", "")
+        env_without_workspaces = {
+            k: v for k, v in os.environ.items() if k != "FABRIC_MCP_WORKSPACES"
+        }
+        with patch.dict(os.environ, env_without_workspaces, clear=True):
+            result = resolve_workspace_allowlist([unhyphenated])
+        assert result == frozenset({_CANONICAL_GUID})
+
+
+class TestMixedNameGuidAllowlist:
+    """Trap 2: a name addressed against a mixed name+GUID allowlist must defer to post-resolve."""
+
+    def test_name_defers_to_post_resolve_with_mixed_allowlist(self) -> None:
+        """Pre-resolve name call must NOT raise when allowlist is a mix of GUIDs and names.
+
+        The name 'sales' can't be matched pre-resolve against the GUID entry;
+        the guard must defer to the post-resolve call.
+        """
+        from fabric_dw.mcp._guards import assert_workspace_allowed  # noqa: PLC0415
+
+        env_without_workspaces = {
+            k: v for k, v in os.environ.items() if k != "FABRIC_MCP_WORKSPACES"
+        }
+        with patch.dict(os.environ, env_without_workspaces, clear=True):
+            # Pre-resolve call with a name against a mixed allowlist — must NOT raise
+            assert_workspace_allowed(
+                "sales",
+                resolved_id=None,
+                config_allowlist=[_CANONICAL_GUID, "finance"],
+            )
+
+    def test_post_resolve_matches_guid_in_mixed_allowlist(self) -> None:
+        """Post-resolve call succeeds when the resolved GUID is in a mixed allowlist."""
+        from fabric_dw.mcp._guards import assert_workspace_allowed  # noqa: PLC0415
+
+        env_without_workspaces = {
+            k: v for k, v in os.environ.items() if k != "FABRIC_MCP_WORKSPACES"
+        }
+        with patch.dict(os.environ, env_without_workspaces, clear=True):
+            # 'sales' resolves to _CANONICAL_GUID which IS in the allowlist
+            assert_workspace_allowed(
+                "sales",
+                resolved_id=_CANONICAL_GUID,
+                config_allowlist=[_CANONICAL_GUID, "finance"],
+            )
+
+    def test_post_resolve_blocks_when_guid_not_in_mixed_allowlist(self) -> None:
+        """Post-resolve call blocks when the resolved GUID is NOT in a mixed allowlist."""
+        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+        from fabric_dw.mcp._guards import assert_workspace_allowed  # noqa: PLC0415
+
+        other_guid = "00000000-0000-0000-0000-000000000099"
+        env_without_workspaces = {
+            k: v for k, v in os.environ.items() if k != "FABRIC_MCP_WORKSPACES"
+        }
+        with (
+            patch.dict(os.environ, env_without_workspaces, clear=True),
+            pytest.raises(ToolError, match="allowlist"),
+        ):
+            # 'evil-ws' resolves to other_guid which is NOT in the allowlist
+            assert_workspace_allowed(
+                "evil-ws",
+                resolved_id=other_guid,
+                config_allowlist=[_CANONICAL_GUID, "finance"],
+            )
+
+    def test_name_in_mixed_allowlist_matches_directly(self) -> None:
+        """A name that IS in the mixed allowlist matches at the post-resolve call."""
+        from fabric_dw.mcp._guards import assert_workspace_allowed  # noqa: PLC0415
+
+        env_without_workspaces = {
+            k: v for k, v in os.environ.items() if k != "FABRIC_MCP_WORKSPACES"
+        }
+        with patch.dict(os.environ, env_without_workspaces, clear=True):
+            # 'finance' is explicitly in the allowlist by name
+            assert_workspace_allowed(
+                "finance",
+                resolved_id=None,
+                config_allowlist=[_CANONICAL_GUID, "finance"],
+            )
+
+    def test_guid_arg_against_mixed_allowlist_is_not_deferred(self) -> None:
+        """A GUID workspace_arg does NOT defer pre-resolve; it is checked immediately."""
+        from fabric_dw.mcp._guards import assert_workspace_allowed  # noqa: PLC0415
+
+        env_without_workspaces = {
+            k: v for k, v in os.environ.items() if k != "FABRIC_MCP_WORKSPACES"
+        }
+        with patch.dict(os.environ, env_without_workspaces, clear=True):
+            # Canonical GUID arg against matching allowlist — must succeed pre-resolve
+            assert_workspace_allowed(
+                _CANONICAL_GUID,
+                resolved_id=None,
+                config_allowlist=[_CANONICAL_GUID, "finance"],
+            )


### PR DESCRIPTION
## Summary

Fixes two wrongful-denial traps in `_guards.py` that the new hand-editable `[mcp] workspace_allowlist` config layer makes more likely to hit in practice.

**Trap 1 — non-canonical GUID entries never match (braced / unhyphenated / urn:uuid: forms)**

`_looks_like_uuid` accepted `{...}`, 32-hex, and `urn:uuid:` forms, so such entries passed the type check but raw lowercased-string set membership never matched the canonical hyphenated resolved ID from the Fabric API. Introduced `_canonicalize_entry()` that calls `str(uuid.UUID(e))` to normalise GUID-shaped strings to RFC-4122 lower-cased hyphenated form, applied both when building the allowlist frozenset and when building the candidate set inside `assert_workspace_allowed`.

**Trap 2 — mixed name+GUID allowlist defeats the pre-resolve deferral**

The deferral that prevents false denials was gated on `all_guids` (ALL entries are GUIDs). With a mixed `["<guid>", "finance"]` allowlist `all_guids` was `False`, so a name-addressed workspace was rejected at the pre-resolve call before the authoritative post-resolve GUID match could run. Changed the condition to `arg_is_name AND any entry in allowlist is a GUID` — both the all-GUIDs and mixed cases now defer correctly.

## Security properties

- **Fail-closed**: no access is widened. Non-listed workspaces are still denied in every path. A negative test explicitly verifies this.
- The deferral is only triggered when the raw arg is a name (not a GUID-shaped string) and the allowlist contains at least one GUID entry — the minimum needed to prevent the wrongful denial.

## Test plan

- `TestGuidCanonicalization` — braced, unhyphenated, and `urn:uuid:` allowlist entries each match the canonical resolved GUID; non-listed workspace still blocked (negative test); `resolve_workspace_allowlist` stores canonical form.
- `TestMixedNameGuidAllowlist` — name defers pre-resolve when allowlist has GUID entries; post-resolve matches the GUID; post-resolve blocks an unlisted workspace; name in mixed allowlist matches directly; GUID arg is not deferred.
- All 736 existing unit tests remain green.

Closes #697