### PR TITLE
refactor(config): make duration retry budgets int, not float

### DIFF
--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -28,13 +28,13 @@ The 429 retry budget (consecutive retries and combined wall-clock deadline) can 
 | Knob | CLI option | Env var | Config key | Built-in default |
 |---|---|---|---|---|
 | Max consecutive 429 retries | `--max-429-retries N` | `FABRIC_DW_MAX_429_RETRIES` | `max_429_retries` | 10 |
-| Combined deadline (s) | `--retry-deadline SECONDS` | `FABRIC_DW_RETRY_DEADLINE_S` | `retry_deadline_s` | 300.0 |
+| Combined deadline (s) | `--retry-deadline SECONDS` | `FABRIC_DW_RETRY_DEADLINE_S` | `retry_deadline_s` | 300 |
 
 To persist a higher retry budget for all invocations:
 
 ```shell
 fdw config set max-429-retries 20
-fdw config set retry-deadline 600.0
+fdw config set retry-deadline 600
 ```
 
 To revert to the built-in defaults:
@@ -50,7 +50,7 @@ The SQL/TDS connect-phase and execute-phase retry budget is a separate layer fro
 
 | Knob | Env var | Config key | Built-in default |
 |---|---|---|---|
-| Connect+execute deadline (s) | `FABRIC_SQL_RETRY_TIMEOUT_S` | `sql_retry_deadline_s` | 120.0 |
+| Connect+execute deadline (s) | `FABRIC_SQL_RETRY_TIMEOUT_S` | `sql_retry_deadline_s` | 120 |
 | Retry non-idempotent statements | `FABRIC_SQL_RETRY_EXECUTES` | `sql_retry_executes` | false |
 
 `sql_retry_deadline_s` sets the total wall-clock budget for both the connect-phase and execute-phase retry loops. The built-in 120 s covers the observed Fabric warehouse warm-up window (~60–90 s).
@@ -60,7 +60,7 @@ The SQL/TDS connect-phase and execute-phase retry budget is a separate layer fro
 To persist a longer SQL retry budget:
 
 ```shell
-fdw config set sql-retry-deadline 300.0
+fdw config set sql-retry-deadline 300
 ```
 
 To opt in to retrying non-idempotent statements:
@@ -231,8 +231,8 @@ fdw config set mcp workspace-allowlist WS1,WS2,...
 fdw config set workspace MyWorkspace
 fdw config set warehouse MyWarehouse
 fdw config set max-429-retries 20
-fdw config set retry-deadline 600.0
-fdw config set sql-retry-deadline 300.0
+fdw config set retry-deadline 600
+fdw config set sql-retry-deadline 300
 fdw config set sql-retry-executes true
 fdw config set sql-pool false
 fdw config set auth-mode interactive

--- a/src/fabric_dw/cli/_context.py
+++ b/src/fabric_dw/cli/_context.py
@@ -20,7 +20,7 @@ class CliContext:
     auth: CredentialMode = field(default_factory=lambda: CredentialMode.DEFAULT)
     workspace: str | None = None
     max_429_retries: int | None = None
-    retry_deadline_s: float | None = None
+    retry_deadline_s: int | None = None
     _config: UserConfig | None = field(default=None, repr=False, compare=False)
 
     @property

--- a/src/fabric_dw/cli/_main.py
+++ b/src/fabric_dw/cli/_main.py
@@ -605,12 +605,12 @@ class _LazyGroup(_InstrumentedGroup):
 @click.option(
     "--retry-deadline",
     "retry_deadline",
-    type=click.FloatRange(min=0.1),
+    type=click.IntRange(min=1),
     default=None,
     metavar="SECONDS",
     help=(
         "Combined wall-clock deadline in seconds for the 429-loop and 5xx-retry budget "
-        "(default: 300.0, or as configured by FABRIC_DW_RETRY_DEADLINE_S / config file)."
+        "(default: 300, or as configured by FABRIC_DW_RETRY_DEADLINE_S / config file)."
     ),
 )
 @click.pass_context
@@ -622,7 +622,7 @@ def cli(
     yes: bool,
     verbose: bool,
     max_429_retries: int | None,
-    retry_deadline: float | None,
+    retry_deadline: int | None,
 ) -> None:
     """Microsoft Fabric Data Warehouse CLI & MCP Server."""
     setup_logging(logging.DEBUG if verbose else logging.INFO)

--- a/src/fabric_dw/cli/commands/_utils.py
+++ b/src/fabric_dw/cli/commands/_utils.py
@@ -18,7 +18,7 @@ import click
 
 from fabric_dw import auth as _auth
 from fabric_dw.cache import ItemEntry, LookupCache
-from fabric_dw.config_resolve import resolve_float_knob, resolve_int_knob
+from fabric_dw.config_resolve import resolve_int_knob
 from fabric_dw.exceptions import ConfigError
 from fabric_dw.http_client import FabricHttpClient
 from fabric_dw.identifiers import parse_qualified_name as _parse_qn
@@ -69,8 +69,8 @@ def coro(f: Callable[_P, Coroutine[None, None, _R]]) -> Callable[_P, _R]:
 _logger_utils = logging.getLogger("fabric_dw.cli.utils")
 
 # Minimum accepted value for retry_deadline_s — enforced in both CLI
-# (click.FloatRange) and env-var / config-file fallback paths.
-_MIN_RETRY_DEADLINE_S: float = 0.1
+# (click.IntRange) and env-var / config-file fallback paths.
+_MIN_RETRY_DEADLINE_S: int = 1
 
 
 def _resolve_max_429_retries(ctx: CliContext) -> int | None:
@@ -89,14 +89,15 @@ def _resolve_max_429_retries(ctx: CliContext) -> int | None:
     )
 
 
-def _resolve_retry_deadline_s(ctx: CliContext) -> float | None:
+def _resolve_retry_deadline_s(ctx: CliContext) -> int | None:
     """Resolve effective retry_deadline_s with precedence CLI > env > config > None.
 
     Returns *None* when no source supplies a value, letting the HTTP client use
-    its own built-in default (300.0).  Malformed, non-finite, or out-of-range
-    env/config values are logged and skipped.
+    its own built-in default (300).  Malformed or out-of-range env/config values
+    are logged and skipped.  Float-formatted integers (e.g. ``"300.0"``) from env
+    vars are accepted via ``int(float(...))``.
     """
-    return resolve_float_knob(
+    return resolve_int_knob(
         cli_value=ctx.retry_deadline_s,
         env_key="FABRIC_DW_RETRY_DEADLINE_S",
         config_value=ctx.config.defaults.retry_deadline_s,
@@ -115,9 +116,8 @@ async def build_http_client(ctx: CliContext) -> AsyncIterator[FabricHttpClient]:
     The retry budget is resolved with precedence CLI option > env var
     (``FABRIC_DW_MAX_429_RETRIES`` / ``FABRIC_DW_RETRY_DEADLINE_S``) >
     config file (``[defaults] max_429_retries`` / ``retry_deadline_s``) >
-    built-in default (10 / 300.0).  Malformed, non-finite, or out-of-range
-    env/config values are logged and skipped; the next source in the chain is
-    tried.
+    built-in default (10 / 300).  Malformed or out-of-range env/config values
+    are logged and skipped; the next source in the chain is tried.
 
     Raises:
         click.UsageError: When ``get_credential`` raises :class:`~fabric_dw.exceptions.ConfigError`

--- a/src/fabric_dw/cli/commands/config.py
+++ b/src/fabric_dw/cli/commands/config.py
@@ -120,16 +120,16 @@ def set_max_429_retries_cmd(value: int) -> None:
 
 
 @set_group.command("retry-deadline")
-@click.argument("value", type=click.FloatRange(min=0.1))
-def set_retry_deadline_cmd(value: float) -> None:
+@click.argument("value", type=click.IntRange(min=1))
+def set_retry_deadline_cmd(value: int) -> None:
     """Set the combined 429+5xx retry wall-clock deadline in seconds."""
     set_default("retry_deadline_s", str(value))
     click.echo(f"Default retry_deadline_s set to {value}.")
 
 
 @set_group.command("sql-retry-deadline")
-@click.argument("value", type=click.FloatRange(min=0.1))
-def set_sql_retry_deadline_cmd(value: float) -> None:
+@click.argument("value", type=click.IntRange(min=1))
+def set_sql_retry_deadline_cmd(value: int) -> None:
     """Set the SQL/TDS connect+execute retry wall-clock budget in seconds."""
     set_default("sql_retry_deadline_s", str(value))
     click.echo(f"Default sql_retry_deadline_s set to {value}.")
@@ -294,14 +294,14 @@ def unset_max_429_retries_cmd() -> None:
 
 @unset_group.command("retry-deadline")
 def unset_retry_deadline_cmd() -> None:
-    """Clear the retry_deadline_s default (revert to built-in 300.0)."""
+    """Clear the retry_deadline_s default (revert to built-in 300)."""
     set_default("retry_deadline_s", None)
     click.echo("Default retry_deadline_s cleared.")
 
 
 @unset_group.command("sql-retry-deadline")
 def unset_sql_retry_deadline_cmd() -> None:
-    """Clear the sql_retry_deadline_s default (revert to built-in 120.0)."""
+    """Clear the sql_retry_deadline_s default (revert to built-in 120)."""
     set_default("sql_retry_deadline_s", None)
     click.echo("Default sql_retry_deadline_s cleared.")
 

--- a/src/fabric_dw/config.py
+++ b/src/fabric_dw/config.py
@@ -13,8 +13,8 @@ The TOML shape supports multiple named sections:
     workspace = "Sales Workspace"
     warehouse = "Sales-DW"
     max_429_retries = 10
-    retry_deadline_s = 300.0
-    sql_retry_deadline_s = 120.0
+    retry_deadline_s = 300
+    sql_retry_deadline_s = 120
     sql_retry_executes = false
     auth_mode = "default"
 
@@ -108,8 +108,8 @@ class Defaults:
     workspace: str | None = None
     warehouse: str | None = None
     max_429_retries: int | None = None
-    retry_deadline_s: float | None = None
-    sql_retry_deadline_s: float | None = None
+    retry_deadline_s: int | None = None
+    sql_retry_deadline_s: int | None = None
     sql_retry_executes: bool | None = None
     sql_pool: bool | None = None
     auth_mode: str | None = None
@@ -215,10 +215,10 @@ def _parse_defaults_section(data: dict[str, object]) -> Defaults:
         workspace=workspace if isinstance(workspace, str) else None,
         warehouse=warehouse if isinstance(warehouse, str) else None,
         max_429_retries=int(raw_retries) if isinstance(raw_retries, int) else None,
-        retry_deadline_s=float(raw_deadline)
+        retry_deadline_s=int(raw_deadline)
         if isinstance(raw_deadline, (int, float)) and math.isfinite(raw_deadline)
         else None,
-        sql_retry_deadline_s=float(raw_sql_deadline)
+        sql_retry_deadline_s=int(raw_sql_deadline)
         if isinstance(raw_sql_deadline, (int, float)) and math.isfinite(raw_sql_deadline)
         else None,
         sql_retry_executes=raw_sql_executes if isinstance(raw_sql_executes, bool) else None,
@@ -492,62 +492,32 @@ def _read_defaults_locked(resolved: Path) -> Defaults:
     return _read_all_sections_locked(resolved).defaults
 
 
-_MIN_RETRY_DEADLINE_S: float = 0.1
+_MIN_RETRY_DEADLINE_S: int = 1
 
 
-def _coerce_defaults_key(  # noqa: PLR0912
-    key: str, value: str | None
-) -> tuple[int | None, float | None, bool | None]:
+def _coerce_defaults_key(key: str, value: str | None) -> tuple[int | None, bool | None]:
     """Coerce and validate a numeric/boolean defaults key.
 
-    Returns ``(coerced_int, coerced_float, coerced_bool)`` — at most one will
-    be non-``None`` for typed keys; all three are ``None`` for string keys (no
-    coercion needed) or when *value* is ``None``.
+    Returns ``(coerced_int, coerced_bool)`` — at most one will be non-``None``
+    for typed keys; both are ``None`` for string keys (no coercion needed) or
+    when *value* is ``None``.
 
     Raises:
         ValueError: If the value is not coercible or is out of range.
     """
     coerced_int: int | None = None
-    coerced_float: float | None = None
     coerced_bool: bool | None = None
     if value is not None:
-        if key == "max_429_retries":
+        if key in {"max_429_retries", "retry_deadline_s", "sql_retry_deadline_s"}:
             try:
                 coerced_int = int(float(value))
             except (ValueError, OverflowError) as exc:
+                # Catches non-numeric strings, nan (ValueError), and inf (OverflowError).
                 raise ValueError(
-                    f"max_429_retries {value!r} cannot be converted to an integer: {exc}"
+                    f"{key} {value!r} cannot be converted to an integer: {exc}"
                 ) from exc
-            if coerced_int < 1:
-                raise ValueError(f"max_429_retries must be >= 1, got {coerced_int}")
-        elif key == "retry_deadline_s":
-            try:
-                coerced_float = float(value)
-            except (ValueError, OverflowError) as exc:
-                raise ValueError(
-                    f"retry_deadline_s {value!r} cannot be converted to a float: {exc}"
-                ) from exc
-            if not math.isfinite(coerced_float):
-                raise ValueError(f"retry_deadline_s must be a finite number, got {coerced_float!r}")
-            if coerced_float < _MIN_RETRY_DEADLINE_S:
-                raise ValueError(
-                    f"retry_deadline_s must be >= {_MIN_RETRY_DEADLINE_S}, got {coerced_float}"
-                )
-        elif key == "sql_retry_deadline_s":
-            try:
-                coerced_float = float(value)
-            except (ValueError, OverflowError) as exc:
-                raise ValueError(
-                    f"sql_retry_deadline_s {value!r} cannot be converted to a float: {exc}"
-                ) from exc
-            if not math.isfinite(coerced_float):
-                raise ValueError(
-                    f"sql_retry_deadline_s must be a finite number, got {coerced_float!r}"
-                )
-            if coerced_float < _MIN_RETRY_DEADLINE_S:
-                raise ValueError(
-                    f"sql_retry_deadline_s must be >= {_MIN_RETRY_DEADLINE_S}, got {coerced_float}"
-                )
+            if coerced_int < _MIN_RETRY_DEADLINE_S:
+                raise ValueError(f"{key} must be >= {_MIN_RETRY_DEADLINE_S}, got {coerced_int}")
         elif key in {"sql_retry_executes", "sql_pool"}:
             if value.lower() in {"true", "1", "yes", "on"}:
                 coerced_bool = True
@@ -563,7 +533,7 @@ def _coerce_defaults_key(  # noqa: PLR0912
                     f"auth_mode {value!r} is not a valid credential mode; "
                     f"must be one of {valid_sorted}"
                 )
-    return coerced_int, coerced_float, coerced_bool
+    return coerced_int, coerced_bool
 
 
 # ---------------------------------------------------------------------------
@@ -580,7 +550,7 @@ def _make_defaults_setter(
     """Return a UserConfig updater for the given defaults key."""
 
     def _set(current: UserConfig, value: str | None) -> UserConfig:
-        coerced_int, coerced_float, coerced_bool = _coerce_defaults_key(key, value)
+        coerced_int, coerced_bool = _coerce_defaults_key(key, value)
         # For auth_mode, normalise to lowercase when setting (None clears the key).
         auth_mode_value: str | None
         if key == "auth_mode":
@@ -593,10 +563,10 @@ def _make_defaults_setter(
             max_429_retries=coerced_int
             if key == "max_429_retries"
             else current.defaults.max_429_retries,
-            retry_deadline_s=coerced_float
+            retry_deadline_s=coerced_int
             if key == "retry_deadline_s"
             else current.defaults.retry_deadline_s,
-            sql_retry_deadline_s=coerced_float
+            sql_retry_deadline_s=coerced_int
             if key == "sql_retry_deadline_s"
             else current.defaults.sql_retry_deadline_s,
             sql_retry_executes=coerced_bool

--- a/src/fabric_dw/config_resolve.py
+++ b/src/fabric_dw/config_resolve.py
@@ -13,7 +13,6 @@ values and lets the caller convert to :class:`~fabric_dw.auth.CredentialMode`.
 from __future__ import annotations
 
 import logging
-import math
 import os
 from collections.abc import Mapping
 
@@ -21,7 +20,6 @@ _log = logging.getLogger(__name__)
 
 __all__ = [
     "resolve_auth_mode",
-    "resolve_float_knob",
     "resolve_int_knob",
 ]
 
@@ -71,65 +69,6 @@ def resolve_int_knob(  # noqa: PLR0913
         if config_value >= min_val:
             return config_value
         _log.warning("config %s=%r is less than %d; ignoring", knob_name, config_value, min_val)
-
-    return None
-
-
-def resolve_float_knob(  # noqa: PLR0913
-    *,
-    cli_value: float | None,
-    env_key: str,
-    env: Mapping[str, str] | None = None,
-    config_value: float | None,
-    min_val: float,
-    knob_name: str,
-) -> float | None:
-    """Resolve a float knob with precedence CLI > env > config > None.
-
-    Non-finite values (``inf``, ``nan``) from the env var are rejected with a
-    warning; values from the config file are assumed to have been validated at
-    write time.
-
-    Args:
-        cli_value: Value supplied by the CLI option (already validated).
-        env_key: The environment variable name to read.
-        env: Mapping to read env vars from; defaults to ``os.environ``.
-        config_value: Value from the config file (pre-parsed, may be ``None``).
-        min_val: Minimum accepted value; below-min env values are skipped.
-        knob_name: Human-readable name used in log warnings.
-
-    Returns:
-        The resolved float, or ``None`` when no source supplies a valid value
-        (caller should use the built-in default).
-    """
-    env_map = env if env is not None else os.environ
-
-    # 1. CLI option (already validated); guard against non-finite values
-    #    that slipped past click.FloatRange.
-    if cli_value is not None:
-        if math.isfinite(cli_value):
-            return cli_value
-        _log.warning("--%s %r is not finite; ignoring", knob_name, cli_value)
-
-    # 2. Environment variable
-    raw = env_map.get(env_key)
-    if raw is not None:
-        try:
-            v = float(raw)
-            if not math.isfinite(v):
-                _log.warning("%s=%r is not finite; ignoring", env_key, raw)
-            elif v >= min_val:
-                return v
-            else:
-                _log.warning("%s=%r is less than %s; ignoring", env_key, raw, min_val)
-        except ValueError:
-            _log.warning("%s=%r is not a valid float; ignoring", env_key, raw)
-
-    # 3. Config file (non-finite values were already rejected at load/set time)
-    if config_value is not None:
-        if config_value >= min_val:
-            return config_value
-        _log.warning("config %s=%r is less than %s; ignoring", knob_name, config_value, min_val)
 
     return None
 

--- a/src/fabric_dw/mcp/_context.py
+++ b/src/fabric_dw/mcp/_context.py
@@ -35,7 +35,7 @@ from typing import TYPE_CHECKING
 from fabric_dw import auth as _auth
 from fabric_dw.cache import LookupCache
 from fabric_dw.config import VALID_AUTH_MODES, load_config
-from fabric_dw.config_resolve import resolve_auth_mode, resolve_float_knob, resolve_int_knob
+from fabric_dw.config_resolve import resolve_auth_mode, resolve_int_knob
 from fabric_dw.exceptions import ConfigError
 from fabric_dw.http_client import FabricHttpClient
 from fabric_dw.resolver import Resolver
@@ -102,7 +102,7 @@ def get_context() -> ServerContext:
 
 _logger = logging.getLogger(__name__)
 
-_MIN_RETRY_DEADLINE_S: float = 0.1
+_MIN_RETRY_DEADLINE_S: int = 1
 
 
 def build_context(
@@ -112,8 +112,8 @@ def build_context(
     """Construct a fresh :class:`ServerContext` from the environment and config file.
 
     The 429 retry budget is resolved with precedence env > config > built-in
-    default (10 / 300.0) via the shared :func:`~fabric_dw.config_resolve.resolve_int_knob`
-    and :func:`~fabric_dw.config_resolve.resolve_float_knob` helpers.
+    default (10 / 300) via the shared :func:`~fabric_dw.config_resolve.resolve_int_knob`
+    helper.
 
     The credential mode is resolved with precedence:
 
@@ -168,7 +168,7 @@ def build_context(
         min_val=1,
         knob_name="max_429_retries",
     )
-    deadline = resolve_float_knob(
+    deadline = resolve_int_knob(
         cli_value=None,
         env_key="FABRIC_DW_RETRY_DEADLINE_S",
         env=env,

--- a/src/fabric_dw/sql.py
+++ b/src/fabric_dw/sql.py
@@ -1363,7 +1363,7 @@ def run_query(  # noqa: PLR0913, PLR0915
     execute_attempt = 1
     # deadline is set on the first execute-phase transient failure.  The total
     # wall-clock budget for execute-phase retries matches the connect-phase
-    # budget (sql_retry_deadline_s, default 120.0 s), resolved at call-time.
+    # budget (sql_retry_deadline_s, default 120 s), resolved at call-time.
     execute_deadline: float | None = None
 
     while True:

--- a/src/fabric_dw/sql.py
+++ b/src/fabric_dw/sql.py
@@ -47,7 +47,6 @@ import contextlib
 import functools
 import importlib
 import logging
-import math
 import os
 import re
 import threading
@@ -94,12 +93,12 @@ __all__ = [
 #
 # The loop retries up to len(_EXECUTE_RETRY_DELAYS) + 1 attempts total
 # (initial attempt + 3 retries = 4 attempts max) AND stops early if the
-# wall-clock deadline (sql_retry_deadline_s, default 120.0 s) is exceeded.
+# wall-clock deadline (sql_retry_deadline_s, default 120 s) is exceeded.
 # Both guards are applied so the worst-case bound is clearly bounded:
 #   worst case <= (len(_EXECUTE_RETRY_DELAYS) + 1) attempts
 #              x (effective deadline + SQL_QUERY_TIMEOUT_S)
 #
-# With the built-in default deadline (120.0 s):
+# With the built-in default deadline (120 s):
 #   = 4 x (120 s + 300 s) = ~1680 s (~28 minutes)
 # With FABRIC_SQL_RETRY_TIMEOUT_S=300 (integration CI):
 #   = 4 x (300 s + 300 s) = ~2400 s (~40 minutes)
@@ -116,7 +115,7 @@ _EXECUTE_RETRY_DELAYS: tuple[float, ...] = (2.0, 5.0, 10.0)
 # _with_connect_retry.  The loop keeps retrying while _is_connect_retryable
 # returns True and the elapsed time is less than this budget.
 #
-# The built-in default is 120.0 s, which covers the observed Fabric warehouse
+# The built-in default is 120 s, which covers the observed Fabric warehouse
 # warm-up window (~60-90 s) with comfortable margin.  It is configurable via
 # the FABRIC_SQL_RETRY_TIMEOUT_S env var or ``fdw config set sql-retry-deadline``.
 #
@@ -124,13 +123,13 @@ _EXECUTE_RETRY_DELAYS: tuple[float, ...] = (2.0, 5.0, 10.0)
 # before the AuthError is surfaced to the caller — because the retry loop
 # cannot distinguish "wrong credential" from "warehouse still warming up".
 # This latency is accepted: the warm-up case is far more common in production.
-_SQL_RETRY_DEADLINE_S_DEFAULT: float = 120.0
-_MIN_SQL_RETRY_DEADLINE_S: float = 0.1  # minimum accepted value for env / config
+_SQL_RETRY_DEADLINE_S_DEFAULT: int = 120
+_MIN_SQL_RETRY_DEADLINE_S: int = 1  # minimum accepted value for env / config
 
 # Backwards-compatible alias used by integration tests and the smoke-timeout invariant test.
 # The old name was _CONNECT_RETRY_TIMEOUT_S; it was renamed to _SQL_RETRY_DEADLINE_S_DEFAULT
 # when the value became configurable.  Remove after all callsites are updated.
-_CONNECT_RETRY_TIMEOUT_S: float = _SQL_RETRY_DEADLINE_S_DEFAULT
+_CONNECT_RETRY_TIMEOUT_S: int = _SQL_RETRY_DEADLINE_S_DEFAULT
 
 # Backoff delays for the connect-phase retry loop.  The delay before attempt
 # N+1 is _CONNECT_RETRY_DELAYS[min(N, len-1)], so the sequence is:
@@ -202,26 +201,27 @@ def _sql_config_cache_clear() -> None:
         _sql_config_cache = None
 
 
-def _resolve_sql_retry_deadline_s() -> float:
+def _resolve_sql_retry_deadline_s() -> int:
     """Return the effective SQL retry deadline in seconds.
 
     Resolution order (3-layer):
-    1. ``FABRIC_SQL_RETRY_TIMEOUT_S`` env var — must be a finite float >= 0.1.
-       Invalid values are ignored (warning logged) and fall through to next layer.
+    1. ``FABRIC_SQL_RETRY_TIMEOUT_S`` env var — must be an integer (or float-formatted
+       integer like ``"120.0"``) >= 1.  Invalid values are ignored (warning logged)
+       and fall through to next layer.
     2. ``config.toml`` ``[defaults].sql_retry_deadline_s``.
-    3. Built-in fallback: :data:`_SQL_RETRY_DEADLINE_S_DEFAULT` (120.0 s).
+    3. Built-in fallback: :data:`_SQL_RETRY_DEADLINE_S_DEFAULT` (120 s).
     """
     raw_env = os.environ.get("FABRIC_SQL_RETRY_TIMEOUT_S")
     if raw_env is not None:
         try:
-            v = float(raw_env)
+            v = int(float(raw_env))
         except (ValueError, OverflowError):
-            _log.warning("FABRIC_SQL_RETRY_TIMEOUT_S=%r is not a valid float; ignoring", raw_env)
+            _log.warning("FABRIC_SQL_RETRY_TIMEOUT_S=%r is not a valid integer; ignoring", raw_env)
         else:
-            if math.isfinite(v) and v >= _MIN_SQL_RETRY_DEADLINE_S:
+            if v >= _MIN_SQL_RETRY_DEADLINE_S:
                 return v
             _log.warning(
-                "FABRIC_SQL_RETRY_TIMEOUT_S=%r must be a finite number >= %s; ignoring",
+                "FABRIC_SQL_RETRY_TIMEOUT_S=%r must be >= %s; ignoring",
                 raw_env,
                 _MIN_SQL_RETRY_DEADLINE_S,
             )

--- a/tests/unit/cli/commands/test_config.py
+++ b/tests/unit/cli/commands/test_config.py
@@ -186,18 +186,18 @@ class TestConfigSetRetryBudget:
 
     def test_set_retry_deadline_exits_zero(self, runner: CliRunner, config_env: Path) -> None:
         _ = config_env
-        result = runner.invoke(cli, ["config", "set", "retry-deadline", "600.0"])
+        result = runner.invoke(cli, ["config", "set", "retry-deadline", "600"])
         assert result.exit_code == 0
 
     def test_set_retry_deadline_writes_file(self, runner: CliRunner, config_env: Path) -> None:
         _ = config_env
-        runner.invoke(cli, ["config", "set", "retry-deadline", "450.5"])
+        runner.invoke(cli, ["config", "set", "retry-deadline", "450"])
         cfg = load_config(default_path())
-        assert cfg.defaults.retry_deadline_s == 450.5
+        assert cfg.defaults.retry_deadline_s == 450
 
     def test_set_retry_deadline_invalid_rejected(self, runner: CliRunner, config_env: Path) -> None:
         _ = config_env
-        result = runner.invoke(cli, ["config", "set", "retry-deadline", "0.0"])
+        result = runner.invoke(cli, ["config", "set", "retry-deadline", "0"])
         assert result.exit_code != 0
 
     def test_set_retries_preserves_workspace(self, runner: CliRunner, config_env: Path) -> None:
@@ -219,16 +219,16 @@ class TestConfigUnsetRetryBudget:
     def test_unset_max_429_retries_clears_key(self, runner: CliRunner, config_env: Path) -> None:
         _ = config_env
         runner.invoke(cli, ["config", "set", "max-429-retries", "8"])
-        runner.invoke(cli, ["config", "set", "retry-deadline", "200.0"])
+        runner.invoke(cli, ["config", "set", "retry-deadline", "200"])
         runner.invoke(cli, ["config", "unset", "max-429-retries"])
         cfg = load_config(default_path())
         assert cfg.defaults.max_429_retries is None
-        assert cfg.defaults.retry_deadline_s == 200.0  # preserved
+        assert cfg.defaults.retry_deadline_s == 200  # preserved
 
     def test_unset_retry_deadline_clears_key(self, runner: CliRunner, config_env: Path) -> None:
         _ = config_env
         runner.invoke(cli, ["config", "set", "max-429-retries", "6"])
-        runner.invoke(cli, ["config", "set", "retry-deadline", "300.0"])
+        runner.invoke(cli, ["config", "set", "retry-deadline", "300"])
         runner.invoke(cli, ["config", "unset", "retry-deadline"])
         cfg = load_config(default_path())
         assert cfg.defaults.retry_deadline_s is None
@@ -239,12 +239,12 @@ class TestConfigShowRetryBudget:
     def test_show_includes_retry_budget_fields(self, runner: CliRunner, config_env: Path) -> None:
         _ = config_env
         runner.invoke(cli, ["config", "set", "max-429-retries", "10"])
-        runner.invoke(cli, ["config", "set", "retry-deadline", "300.0"])
+        runner.invoke(cli, ["config", "set", "retry-deadline", "300"])
         result = runner.invoke(cli, ["--json", "config", "show"])
         assert result.exit_code == 0
         data = json.loads(result.output)
         assert data["defaults"]["max_429_retries"] == 10
-        assert data["defaults"]["retry_deadline_s"] == 300.0
+        assert data["defaults"]["retry_deadline_s"] == 300
 
     def test_show_null_when_not_set(self, runner: CliRunner, config_env: Path) -> None:
         _ = config_env
@@ -263,20 +263,20 @@ class TestConfigShowRetryBudget:
 class TestConfigSetSqlRetry:
     def test_set_sql_retry_deadline_exits_zero(self, runner: CliRunner, config_env: Path) -> None:
         _ = config_env
-        result = runner.invoke(cli, ["config", "set", "sql-retry-deadline", "300.0"])
+        result = runner.invoke(cli, ["config", "set", "sql-retry-deadline", "300"])
         assert result.exit_code == 0
 
     def test_set_sql_retry_deadline_writes_file(self, runner: CliRunner, config_env: Path) -> None:
         _ = config_env
-        runner.invoke(cli, ["config", "set", "sql-retry-deadline", "250.5"])
+        runner.invoke(cli, ["config", "set", "sql-retry-deadline", "250"])
         cfg = load_config(default_path())
-        assert cfg.defaults.sql_retry_deadline_s == 250.5
+        assert cfg.defaults.sql_retry_deadline_s == 250
 
     def test_set_sql_retry_deadline_invalid_rejected(
         self, runner: CliRunner, config_env: Path
     ) -> None:
         _ = config_env
-        result = runner.invoke(cli, ["config", "set", "sql-retry-deadline", "0.0"])
+        result = runner.invoke(cli, ["config", "set", "sql-retry-deadline", "0"])
         assert result.exit_code != 0
 
     def test_set_sql_retry_deadline_preserves_workspace(
@@ -284,9 +284,9 @@ class TestConfigSetSqlRetry:
     ) -> None:
         _ = config_env
         runner.invoke(cli, ["config", "set", "workspace", "MyWS"])
-        runner.invoke(cli, ["config", "set", "sql-retry-deadline", "180.0"])
+        runner.invoke(cli, ["config", "set", "sql-retry-deadline", "180"])
         cfg = load_config(default_path())
-        assert cfg.defaults.sql_retry_deadline_s == 180.0
+        assert cfg.defaults.sql_retry_deadline_s == 180
         assert cfg.defaults.workspace == "MyWS"
 
     def test_set_sql_retry_executes_true_exits_zero(
@@ -346,23 +346,23 @@ class TestConfigUnsetSqlRetry:
 
     def test_unset_sql_retry_executes_clears_key(self, runner: CliRunner, config_env: Path) -> None:
         _ = config_env
-        runner.invoke(cli, ["config", "set", "sql-retry-deadline", "150.0"])
+        runner.invoke(cli, ["config", "set", "sql-retry-deadline", "150"])
         runner.invoke(cli, ["config", "set", "sql-retry-executes", "true"])
         runner.invoke(cli, ["config", "unset", "sql-retry-executes"])
         cfg = load_config(default_path())
         assert cfg.defaults.sql_retry_executes is None
-        assert cfg.defaults.sql_retry_deadline_s == 150.0  # preserved
+        assert cfg.defaults.sql_retry_deadline_s == 150  # preserved
 
 
 class TestConfigShowSqlRetry:
     def test_show_includes_sql_retry_fields(self, runner: CliRunner, config_env: Path) -> None:
         _ = config_env
-        runner.invoke(cli, ["config", "set", "sql-retry-deadline", "300.0"])
+        runner.invoke(cli, ["config", "set", "sql-retry-deadline", "300"])
         runner.invoke(cli, ["config", "set", "sql-retry-executes", "true"])
         result = runner.invoke(cli, ["--json", "config", "show"])
         assert result.exit_code == 0
         data = json.loads(result.output)
-        assert data["defaults"]["sql_retry_deadline_s"] == 300.0
+        assert data["defaults"]["sql_retry_deadline_s"] == 300
         assert data["defaults"]["sql_retry_executes"] is True
 
     def test_show_null_when_sql_retry_not_set(self, runner: CliRunner, config_env: Path) -> None:

--- a/tests/unit/cli/commands/test_utils.py
+++ b/tests/unit/cli/commands/test_utils.py
@@ -160,9 +160,9 @@ class TestBuildHttpClientCliPresentation:
 def _make_ctx_with_config(
     *,
     cli_retries: int | None = None,
-    cli_deadline: float | None = None,
+    cli_deadline: int | None = None,
     cfg_retries: int | None = None,
-    cfg_deadline: float | None = None,
+    cfg_deadline: int | None = None,
 ) -> CliContext:
     """Build a CliContext with the given CLI-option and config-file values."""
     defaults = Defaults(max_429_retries=cfg_retries, retry_deadline_s=cfg_deadline)
@@ -231,25 +231,25 @@ class TestResolveRetryDeadlineS:
     """Precedence: CLI > env > config > None."""
 
     def test_cli_wins_over_env_and_config(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("FABRIC_DW_RETRY_DEADLINE_S", "60.0")
-        ctx = _make_ctx_with_config(cli_deadline=500.0, cfg_deadline=120.0)
+        monkeypatch.setenv("FABRIC_DW_RETRY_DEADLINE_S", "60")
+        ctx = _make_ctx_with_config(cli_deadline=500, cfg_deadline=120)
         from fabric_dw.cli.commands._utils import _resolve_retry_deadline_s  # noqa: PLC0415
 
-        assert _resolve_retry_deadline_s(ctx) == 500.0
+        assert _resolve_retry_deadline_s(ctx) == 500
 
     def test_env_wins_over_config(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("FABRIC_DW_RETRY_DEADLINE_S", "250.0")
-        ctx = _make_ctx_with_config(cfg_deadline=120.0)
+        monkeypatch.setenv("FABRIC_DW_RETRY_DEADLINE_S", "250")
+        ctx = _make_ctx_with_config(cfg_deadline=120)
         from fabric_dw.cli.commands._utils import _resolve_retry_deadline_s  # noqa: PLC0415
 
-        assert _resolve_retry_deadline_s(ctx) == 250.0
+        assert _resolve_retry_deadline_s(ctx) == 250
 
     def test_config_wins_when_no_cli_no_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("FABRIC_DW_RETRY_DEADLINE_S", raising=False)
-        ctx = _make_ctx_with_config(cfg_deadline=180.0)
+        ctx = _make_ctx_with_config(cfg_deadline=180)
         from fabric_dw.cli.commands._utils import _resolve_retry_deadline_s  # noqa: PLC0415
 
-        assert _resolve_retry_deadline_s(ctx) == 180.0
+        assert _resolve_retry_deadline_s(ctx) == 180
 
     def test_all_absent_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("FABRIC_DW_RETRY_DEADLINE_S", raising=False)
@@ -259,34 +259,34 @@ class TestResolveRetryDeadlineS:
         assert _resolve_retry_deadline_s(ctx) is None
 
     def test_malformed_env_falls_through_to_config(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("FABRIC_DW_RETRY_DEADLINE_S", "not-a-float")
-        ctx = _make_ctx_with_config(cfg_deadline=240.0)
+        monkeypatch.setenv("FABRIC_DW_RETRY_DEADLINE_S", "not-an-int")
+        ctx = _make_ctx_with_config(cfg_deadline=240)
         from fabric_dw.cli.commands._utils import _resolve_retry_deadline_s  # noqa: PLC0415
 
-        assert _resolve_retry_deadline_s(ctx) == 240.0
+        assert _resolve_retry_deadline_s(ctx) == 240
 
     def test_below_min_env_falls_through_to_config(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("FABRIC_DW_RETRY_DEADLINE_S", "0.0")
-        ctx = _make_ctx_with_config(cfg_deadline=300.0)
+        monkeypatch.setenv("FABRIC_DW_RETRY_DEADLINE_S", "0")
+        ctx = _make_ctx_with_config(cfg_deadline=300)
         from fabric_dw.cli.commands._utils import _resolve_retry_deadline_s  # noqa: PLC0415
 
-        assert _resolve_retry_deadline_s(ctx) == 300.0
+        assert _resolve_retry_deadline_s(ctx) == 300
+
+    def test_float_formatted_int_env_accepted(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """FABRIC_DW_RETRY_DEADLINE_S='300.0' is accepted as 300 (Docker float-int)."""
+        monkeypatch.setenv("FABRIC_DW_RETRY_DEADLINE_S", "300.0")
+        ctx = _make_ctx_with_config()
+        from fabric_dw.cli.commands._utils import _resolve_retry_deadline_s  # noqa: PLC0415
+
+        assert _resolve_retry_deadline_s(ctx) == 300
 
     def test_inf_env_falls_through_to_config(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """inf in env var is rejected (non-finite); config value is used instead."""
+        """inf in env var is rejected (OverflowError); config value is used instead."""
         monkeypatch.setenv("FABRIC_DW_RETRY_DEADLINE_S", "inf")
-        ctx = _make_ctx_with_config(cfg_deadline=120.0)
+        ctx = _make_ctx_with_config(cfg_deadline=120)
         from fabric_dw.cli.commands._utils import _resolve_retry_deadline_s  # noqa: PLC0415
 
-        assert _resolve_retry_deadline_s(ctx) == 120.0
-
-    def test_inf_cli_option_ignored(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """inf passed as CLI value is also rejected; falls through to config."""
-        monkeypatch.delenv("FABRIC_DW_RETRY_DEADLINE_S", raising=False)
-        ctx = _make_ctx_with_config(cli_deadline=float("inf"), cfg_deadline=150.0)
-        from fabric_dw.cli.commands._utils import _resolve_retry_deadline_s  # noqa: PLC0415
-
-        assert _resolve_retry_deadline_s(ctx) == 150.0
+        assert _resolve_retry_deadline_s(ctx) == 120
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/mcp/test_context.py
+++ b/tests/unit/mcp/test_context.py
@@ -88,12 +88,12 @@ class TestBuildContext:
         assert kwargs.get("max_429_retries") == 15
 
     def test_retry_deadline_s_env_var_wired_to_client(self) -> None:
-        """FABRIC_DW_RETRY_DEADLINE_S must propagate to the HTTP client."""
+        """FABRIC_DW_RETRY_DEADLINE_S must propagate to the HTTP client as an int."""
         fake_http = MagicMock()
         with patch("fabric_dw.mcp._context.FabricHttpClient", return_value=fake_http) as mock_cls:
-            build_context(environ={"FABRIC_AUTH": "default", "FABRIC_DW_RETRY_DEADLINE_S": "600.0"})
+            build_context(environ={"FABRIC_AUTH": "default", "FABRIC_DW_RETRY_DEADLINE_S": "600"})
         _, kwargs = mock_cls.call_args
-        assert kwargs.get("combined_deadline_s") == 600.0
+        assert kwargs.get("combined_deadline_s") == 600
 
     def test_no_retry_env_vars_no_kwargs_passed(self) -> None:
         """When no retry env vars are set, the client receives no explicit retries/deadline."""
@@ -113,7 +113,7 @@ class TestBuildContext:
         assert "max_429_retries" not in kwargs
 
     def test_malformed_retry_deadline_env_var_ignored(self) -> None:
-        """A non-float FABRIC_DW_RETRY_DEADLINE_S must be ignored."""
+        """A non-integer FABRIC_DW_RETRY_DEADLINE_S must be ignored."""
         fake_http = MagicMock()
         with patch("fabric_dw.mcp._context.FabricHttpClient", return_value=fake_http) as mock_cls:
             build_context(environ={"FABRIC_AUTH": "default", "FABRIC_DW_RETRY_DEADLINE_S": "bad"})
@@ -121,12 +121,20 @@ class TestBuildContext:
         assert "combined_deadline_s" not in kwargs
 
     def test_inf_retry_deadline_env_var_ignored(self) -> None:
-        """A non-finite FABRIC_DW_RETRY_DEADLINE_S (inf) must be ignored."""
+        """A non-finite FABRIC_DW_RETRY_DEADLINE_S (inf) must be ignored (OverflowError)."""
         fake_http = MagicMock()
         with patch("fabric_dw.mcp._context.FabricHttpClient", return_value=fake_http) as mock_cls:
             build_context(environ={"FABRIC_AUTH": "default", "FABRIC_DW_RETRY_DEADLINE_S": "inf"})
         _, kwargs = mock_cls.call_args
         assert "combined_deadline_s" not in kwargs
+
+    def test_float_formatted_int_deadline_accepted(self) -> None:
+        """FABRIC_DW_RETRY_DEADLINE_S='300.0' is accepted as 300 (Docker float-int)."""
+        fake_http = MagicMock()
+        with patch("fabric_dw.mcp._context.FabricHttpClient", return_value=fake_http) as mock_cls:
+            build_context(environ={"FABRIC_AUTH": "default", "FABRIC_DW_RETRY_DEADLINE_S": "300.0"})
+        _, kwargs = mock_cls.call_args
+        assert kwargs.get("combined_deadline_s") == 300
 
     def test_float_formatted_int_retries_accepted(self) -> None:
         """FABRIC_DW_MAX_429_RETRIES='20.0' is accepted as 20 (Docker float-int)."""
@@ -295,14 +303,14 @@ class TestBuildContextConfigRead:
         assert kwargs.get("max_429_retries") == 7
 
     def test_config_retry_deadline_s_wired_to_client(self, tmp_path: Path) -> None:
-        """[defaults] retry_deadline_s from config propagates to the HTTP client."""
+        """[defaults] retry_deadline_s from config propagates to the HTTP client as int."""
         path = tmp_path / "config.toml"
-        save_config(UserConfig(defaults=Defaults(retry_deadline_s=120.0)), path)
+        save_config(UserConfig(defaults=Defaults(retry_deadline_s=120)), path)
         fake_http = MagicMock()
         with patch("fabric_dw.mcp._context.FabricHttpClient", return_value=fake_http) as mock_cls:
             build_context(environ={"FABRIC_AUTH": "default"}, config_path=path)
         _, kwargs = mock_cls.call_args
-        assert kwargs.get("combined_deadline_s") == 120.0
+        assert kwargs.get("combined_deadline_s") == 120
 
     def test_env_beats_config_for_retries(self, tmp_path: Path) -> None:
         """Env var takes precedence over config for max_429_retries."""
@@ -320,15 +328,15 @@ class TestBuildContextConfigRead:
     def test_env_beats_config_for_deadline(self, tmp_path: Path) -> None:
         """Env var takes precedence over config for retry_deadline_s."""
         path = tmp_path / "config.toml"
-        save_config(UserConfig(defaults=Defaults(retry_deadline_s=60.0)), path)
+        save_config(UserConfig(defaults=Defaults(retry_deadline_s=60)), path)
         fake_http = MagicMock()
         with patch("fabric_dw.mcp._context.FabricHttpClient", return_value=fake_http) as mock_cls:
             build_context(
-                environ={"FABRIC_AUTH": "default", "FABRIC_DW_RETRY_DEADLINE_S": "999.0"},
+                environ={"FABRIC_AUTH": "default", "FABRIC_DW_RETRY_DEADLINE_S": "999"},
                 config_path=path,
             )
         _, kwargs = mock_cls.call_args
-        assert kwargs.get("combined_deadline_s") == 999.0
+        assert kwargs.get("combined_deadline_s") == 999
 
     def test_config_path_none_uses_platform_default(self) -> None:
         """config_path=None is accepted and load_config is called without error."""

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -339,12 +339,13 @@ def test_round_trip_max_429_retries(tmp_path: Path) -> None:
 
 
 def test_round_trip_retry_deadline_s(tmp_path: Path) -> None:
-    """retry_deadline_s is saved and loaded as a float."""
+    """retry_deadline_s is saved and loaded as an int."""
     path = tmp_path / "config.toml"
-    cfg = UserConfig(defaults=Defaults(retry_deadline_s=600.0))
+    cfg = UserConfig(defaults=Defaults(retry_deadline_s=600))
     save_config(cfg, path)
     loaded = load_config(path)
-    assert loaded.defaults.retry_deadline_s == 600.0
+    assert loaded.defaults.retry_deadline_s == 600
+    assert isinstance(loaded.defaults.retry_deadline_s, int)
     assert loaded.defaults.max_429_retries is None
 
 
@@ -356,7 +357,7 @@ def test_round_trip_all_four_defaults(tmp_path: Path) -> None:
             workspace="SalesWS",
             warehouse="SalesDW",
             max_429_retries=7,
-            retry_deadline_s=180.0,
+            retry_deadline_s=180,
         )
     )
     save_config(cfg, path)
@@ -364,7 +365,7 @@ def test_round_trip_all_four_defaults(tmp_path: Path) -> None:
     assert loaded.defaults.workspace == "SalesWS"
     assert loaded.defaults.warehouse == "SalesDW"
     assert loaded.defaults.max_429_retries == 7
-    assert loaded.defaults.retry_deadline_s == 180.0
+    assert loaded.defaults.retry_deadline_s == 180
 
 
 def test_set_default_max_429_retries_persists(tmp_path: Path) -> None:
@@ -378,27 +379,37 @@ def test_set_default_max_429_retries_persists(tmp_path: Path) -> None:
 
 
 def test_set_default_retry_deadline_s_persists(tmp_path: Path) -> None:
-    """set_default('retry_deadline_s', '450.0') stores 450.0 as float."""
+    """set_default('retry_deadline_s', '450') stores 450 as int."""
     path = tmp_path / "config.toml"
-    set_default("retry_deadline_s", "450.0", path)
+    set_default("retry_deadline_s", "450", path)
     loaded = load_config(path)
-    assert loaded.defaults.retry_deadline_s == 450.0
+    assert loaded.defaults.retry_deadline_s == 450
+    assert isinstance(loaded.defaults.retry_deadline_s, int)
+
+
+def test_set_default_retry_deadline_s_float_formatted_int(tmp_path: Path) -> None:
+    """set_default('retry_deadline_s', '300.0') accepts float-formatted int."""
+    path = tmp_path / "config.toml"
+    set_default("retry_deadline_s", "300.0", path)
+    loaded = load_config(path)
+    assert loaded.defaults.retry_deadline_s == 300
+    assert isinstance(loaded.defaults.retry_deadline_s, int)
 
 
 def test_set_default_max_429_retries_none_clears(tmp_path: Path) -> None:
     """set_default('max_429_retries', None) clears the key."""
     path = tmp_path / "config.toml"
-    save_config(UserConfig(defaults=Defaults(max_429_retries=5, retry_deadline_s=120.0)), path)
+    save_config(UserConfig(defaults=Defaults(max_429_retries=5, retry_deadline_s=120)), path)
     set_default("max_429_retries", None, path)
     loaded = load_config(path)
     assert loaded.defaults.max_429_retries is None
-    assert loaded.defaults.retry_deadline_s == 120.0  # preserved
+    assert loaded.defaults.retry_deadline_s == 120  # preserved
 
 
 def test_set_default_retry_deadline_s_none_clears(tmp_path: Path) -> None:
     """set_default('retry_deadline_s', None) clears the key."""
     path = tmp_path / "config.toml"
-    save_config(UserConfig(defaults=Defaults(max_429_retries=8, retry_deadline_s=200.0)), path)
+    save_config(UserConfig(defaults=Defaults(max_429_retries=8, retry_deadline_s=200)), path)
     set_default("retry_deadline_s", None, path)
     loaded = load_config(path)
     assert loaded.defaults.retry_deadline_s is None
@@ -446,9 +457,9 @@ def test_set_default_read_error_does_not_clobber_existing_config(tmp_path: Path)
 
 @pytest.mark.parametrize("val", ["inf", "-inf", "nan"])
 def test_set_default_retry_deadline_s_non_finite_raises(tmp_path: Path, val: str) -> None:
-    """Non-finite values for retry_deadline_s must raise ValueError."""
+    """Non-finite values for retry_deadline_s must raise ValueError (cannot convert)."""
     path = tmp_path / "config.toml"
-    with pytest.raises(ValueError, match="finite"):
+    with pytest.raises(ValueError, match=r"cannot be converted|finite"):
         set_default("retry_deadline_s", val, path)
 
 
@@ -478,10 +489,10 @@ def test_set_default_max_429_retries_below_minimum_raises(tmp_path: Path) -> Non
 
 
 def test_set_default_retry_deadline_s_below_minimum_raises(tmp_path: Path) -> None:
-    """retry_deadline_s must be >= 0.1; 0.0 raises ValueError."""
+    """retry_deadline_s must be >= 1; 0 raises ValueError."""
     path = tmp_path / "config.toml"
-    with pytest.raises(ValueError, match=r">= 0\.1"):
-        set_default("retry_deadline_s", "0.0", path)
+    with pytest.raises(ValueError, match=r">= 1"):
+        set_default("retry_deadline_s", "0", path)
 
 
 # ---------------------------------------------------------------------------
@@ -490,12 +501,13 @@ def test_set_default_retry_deadline_s_below_minimum_raises(tmp_path: Path) -> No
 
 
 def test_round_trip_sql_retry_deadline_s(tmp_path: Path) -> None:
-    """sql_retry_deadline_s is saved and loaded as a float."""
+    """sql_retry_deadline_s is saved and loaded as an int."""
     path = tmp_path / "config.toml"
-    cfg = UserConfig(defaults=Defaults(sql_retry_deadline_s=300.0))
+    cfg = UserConfig(defaults=Defaults(sql_retry_deadline_s=300))
     save_config(cfg, path)
     loaded = load_config(path)
-    assert loaded.defaults.sql_retry_deadline_s == 300.0
+    assert loaded.defaults.sql_retry_deadline_s == 300
+    assert isinstance(loaded.defaults.sql_retry_deadline_s, int)
     assert loaded.defaults.sql_retry_executes is None
 
 
@@ -525,8 +537,8 @@ def test_round_trip_all_six_defaults(tmp_path: Path) -> None:
             workspace="SalesWS",
             warehouse="SalesDW",
             max_429_retries=7,
-            retry_deadline_s=180.0,
-            sql_retry_deadline_s=240.0,
+            retry_deadline_s=180,
+            sql_retry_deadline_s=240,
             sql_retry_executes=True,
         )
     )
@@ -535,26 +547,36 @@ def test_round_trip_all_six_defaults(tmp_path: Path) -> None:
     assert loaded.defaults.workspace == "SalesWS"
     assert loaded.defaults.warehouse == "SalesDW"
     assert loaded.defaults.max_429_retries == 7
-    assert loaded.defaults.retry_deadline_s == 180.0
-    assert loaded.defaults.sql_retry_deadline_s == 240.0
+    assert loaded.defaults.retry_deadline_s == 180
+    assert loaded.defaults.sql_retry_deadline_s == 240
     assert loaded.defaults.sql_retry_executes is True
 
 
 def test_set_default_sql_retry_deadline_s_persists(tmp_path: Path) -> None:
-    """set_default('sql_retry_deadline_s', '300.0') stores 300.0 and preserves other keys."""
+    """set_default('sql_retry_deadline_s', '300') stores 300 as int and preserves other keys."""
     path = tmp_path / "config.toml"
     save_config(UserConfig(defaults=Defaults(workspace="WS")), path)
+    set_default("sql_retry_deadline_s", "300", path)
+    loaded = load_config(path)
+    assert loaded.defaults.sql_retry_deadline_s == 300
+    assert isinstance(loaded.defaults.sql_retry_deadline_s, int)
+    assert loaded.defaults.workspace == "WS"  # preserved
+
+
+def test_set_default_sql_retry_deadline_s_float_formatted_int(tmp_path: Path) -> None:
+    """set_default('sql_retry_deadline_s', '300.0') accepts float-formatted int."""
+    path = tmp_path / "config.toml"
     set_default("sql_retry_deadline_s", "300.0", path)
     loaded = load_config(path)
-    assert loaded.defaults.sql_retry_deadline_s == 300.0
-    assert loaded.defaults.workspace == "WS"  # preserved
+    assert loaded.defaults.sql_retry_deadline_s == 300
+    assert isinstance(loaded.defaults.sql_retry_deadline_s, int)
 
 
 def test_set_default_sql_retry_deadline_s_none_clears(tmp_path: Path) -> None:
     """set_default('sql_retry_deadline_s', None) clears the key."""
     path = tmp_path / "config.toml"
     save_config(
-        UserConfig(defaults=Defaults(sql_retry_deadline_s=300.0, sql_retry_executes=True)), path
+        UserConfig(defaults=Defaults(sql_retry_deadline_s=300, sql_retry_executes=True)), path
     )
     set_default("sql_retry_deadline_s", None, path)
     loaded = load_config(path)
@@ -570,17 +592,17 @@ def test_set_default_sql_retry_deadline_s_bad_value_raises(tmp_path: Path) -> No
 
 
 def test_set_default_sql_retry_deadline_s_below_minimum_raises(tmp_path: Path) -> None:
-    """sql_retry_deadline_s must be >= 0.1; 0.0 raises ValueError."""
+    """sql_retry_deadline_s must be >= 1; 0 raises ValueError."""
     path = tmp_path / "config.toml"
-    with pytest.raises(ValueError, match=r">= 0\.1"):
-        set_default("sql_retry_deadline_s", "0.0", path)
+    with pytest.raises(ValueError, match=r">= 1"):
+        set_default("sql_retry_deadline_s", "0", path)
 
 
 @pytest.mark.parametrize("val", ["inf", "-inf", "nan"])
 def test_set_default_sql_retry_deadline_s_non_finite_raises(tmp_path: Path, val: str) -> None:
-    """Non-finite values for sql_retry_deadline_s must raise ValueError."""
+    """Non-finite values for sql_retry_deadline_s must raise ValueError (cannot convert)."""
     path = tmp_path / "config.toml"
-    with pytest.raises(ValueError, match="finite"):
+    with pytest.raises(ValueError, match=r"cannot be converted|finite"):
         set_default("sql_retry_deadline_s", val, path)
 
 
@@ -604,7 +626,7 @@ def test_set_default_sql_retry_executes_none_clears(tmp_path: Path) -> None:
     """set_default('sql_retry_executes', None) clears the key."""
     path = tmp_path / "config.toml"
     save_config(
-        UserConfig(defaults=Defaults(sql_retry_executes=True, sql_retry_deadline_s=120.0)), path
+        UserConfig(defaults=Defaults(sql_retry_executes=True, sql_retry_deadline_s=120)), path
     )
     set_default("sql_retry_executes", None, path)
     loaded = load_config(path)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -631,7 +631,7 @@ def test_set_default_sql_retry_executes_none_clears(tmp_path: Path) -> None:
     set_default("sql_retry_executes", None, path)
     loaded = load_config(path)
     assert loaded.defaults.sql_retry_executes is None
-    assert loaded.defaults.sql_retry_deadline_s == 120.0  # preserved
+    assert loaded.defaults.sql_retry_deadline_s == 120  # preserved
 
 
 def test_set_default_sql_retry_executes_garbage_raises(tmp_path: Path) -> None:
@@ -686,6 +686,25 @@ def test_old_style_user_config_equals_fully_defaulted() -> None:
     old_style = UserConfig(defaults=Defaults())
     new_style = UserConfig()
     assert old_style == new_style
+
+
+def test_load_config_toml_float_deadline_coerced_to_int(tmp_path: Path) -> None:
+    """TOML float literals for deadline knobs are coerced to int by load_config.
+
+    Existing config.toml files may contain ``retry_deadline_s = 300.0`` or
+    ``sql_retry_deadline_s = 120.0`` written before the float→int migration.
+    ``load_config`` must load them as ``int`` values, not floats.
+    """
+    path = tmp_path / "config.toml"
+    path.write_text(
+        "[defaults]\nretry_deadline_s = 300.0\nsql_retry_deadline_s = 120.0\n",
+        encoding="utf-8",
+    )
+    cfg = load_config(path)
+    assert cfg.defaults.retry_deadline_s == 300
+    assert isinstance(cfg.defaults.retry_deadline_s, int)
+    assert cfg.defaults.sql_retry_deadline_s == 120
+    assert isinstance(cfg.defaults.sql_retry_deadline_s, int)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_config_resolve.py
+++ b/tests/unit/test_config_resolve.py
@@ -2,11 +2,9 @@
 
 from __future__ import annotations
 
-import math
-
 import pytest
 
-from fabric_dw.config_resolve import resolve_auth_mode, resolve_float_knob, resolve_int_knob
+from fabric_dw.config_resolve import resolve_auth_mode, resolve_int_knob
 
 _VALID = frozenset({"default", "sp", "interactive"})
 
@@ -136,135 +134,6 @@ class TestResolveIntKnob:
             knob_name="test_knob",
         )
         assert result == 42
-
-
-# ---------------------------------------------------------------------------
-# resolve_float_knob
-# ---------------------------------------------------------------------------
-
-
-class TestResolveFloatKnob:
-    def test_cli_value_wins_over_env_and_config(self) -> None:
-        """CLI value takes precedence over env and config."""
-        result = resolve_float_knob(
-            cli_value=1.5,
-            env_key="SOME_ENV",
-            env={"SOME_ENV": "99.9"},
-            config_value=0.5,
-            min_val=0.1,
-            knob_name="test_knob",
-        )
-        assert result == 1.5
-
-    def test_env_wins_over_config(self) -> None:
-        """Env var takes precedence over config when cli_value is None."""
-        result = resolve_float_knob(
-            cli_value=None,
-            env_key="SOME_ENV",
-            env={"SOME_ENV": "300.0"},
-            config_value=0.5,
-            min_val=0.1,
-            knob_name="test_knob",
-        )
-        assert result == 300.0
-
-    def test_config_used_when_no_cli_no_env(self) -> None:
-        """Config value is used when neither CLI nor env are set."""
-        result = resolve_float_knob(
-            cli_value=None,
-            env_key="SOME_ENV",
-            env={},
-            config_value=45.0,
-            min_val=0.1,
-            knob_name="test_knob",
-        )
-        assert result == 45.0
-
-    def test_none_returned_when_no_source(self) -> None:
-        """Returns None when no source supplies a value."""
-        result = resolve_float_knob(
-            cli_value=None,
-            env_key="SOME_ENV",
-            env={},
-            config_value=None,
-            min_val=0.1,
-            knob_name="test_knob",
-        )
-        assert result is None
-
-    def test_bad_env_value_skipped_falls_to_config(self) -> None:
-        """Malformed env var is skipped; falls through to config."""
-        result = resolve_float_knob(
-            cli_value=None,
-            env_key="SOME_ENV",
-            env={"SOME_ENV": "not-a-float"},
-            config_value=5.0,
-            min_val=0.1,
-            knob_name="test_knob",
-        )
-        assert result == 5.0
-
-    def test_below_min_env_value_skipped_falls_to_config(self) -> None:
-        """Env var below min_val is skipped; falls through to config."""
-        result = resolve_float_knob(
-            cli_value=None,
-            env_key="SOME_ENV",
-            env={"SOME_ENV": "0.0"},
-            config_value=5.0,
-            min_val=0.1,
-            knob_name="test_knob",
-        )
-        assert result == 5.0
-
-    @pytest.mark.parametrize("val", ["inf", "-inf", "nan"])
-    def test_non_finite_env_value_skipped(self, val: str) -> None:
-        """Non-finite env var values are skipped; falls through to config."""
-        result = resolve_float_knob(
-            cli_value=None,
-            env_key="SOME_ENV",
-            env={"SOME_ENV": val},
-            config_value=3.0,
-            min_val=0.1,
-            knob_name="test_knob",
-        )
-        assert result == 3.0
-
-    def test_non_finite_cli_value_skipped(self) -> None:
-        """Non-finite CLI value is skipped; falls through to env/config."""
-        result = resolve_float_knob(
-            cli_value=math.inf,
-            env_key="SOME_ENV",
-            env={"SOME_ENV": "7.0"},
-            config_value=None,
-            min_val=0.1,
-            knob_name="test_knob",
-        )
-        assert result == 7.0
-
-    def test_below_min_config_skipped(self) -> None:
-        """Config value below min_val is skipped; returns None."""
-        result = resolve_float_knob(
-            cli_value=None,
-            env_key="SOME_ENV",
-            env={},
-            config_value=0.0,
-            min_val=0.1,
-            knob_name="test_knob",
-        )
-        assert result is None
-
-    def test_defaults_env_to_os_environ(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """When env=None, falls back to os.environ."""
-        monkeypatch.setenv("SOME_FLOAT_KEY", "1.23")
-        result = resolve_float_knob(
-            cli_value=None,
-            env_key="SOME_FLOAT_KEY",
-            env=None,
-            config_value=None,
-            min_val=0.1,
-            knob_name="test_knob",
-        )
-        assert result == pytest.approx(1.23)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_sql.py
+++ b/tests/unit/test_sql.py
@@ -2382,8 +2382,9 @@ class TestAuthFailedConnectRetry:
         assert mock_mssql.connect.call_count == 1
 
     def test_retry_policy_constants(self) -> None:
-        """Connect+execute-phase default deadline is 120 s; backoff arrays are set."""
-        assert _sql_module._SQL_RETRY_DEADLINE_S_DEFAULT == 120.0
+        """Connect+execute-phase default deadline is 120 s (int); backoff arrays are set."""
+        assert _sql_module._SQL_RETRY_DEADLINE_S_DEFAULT == 120
+        assert isinstance(_sql_module._SQL_RETRY_DEADLINE_S_DEFAULT, int)
         assert _sql_module._CONNECT_RETRY_DELAYS == (5.0, 10.0, 15.0)
         assert _sql_module._EXECUTE_RETRY_DELAYS == (2.0, 5.0, 10.0)
 
@@ -2852,41 +2853,52 @@ class TestSqlRetryConfig:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """FABRIC_SQL_RETRY_TIMEOUT_S takes precedence over config and built-in default."""
+        monkeypatch.setenv("FABRIC_SQL_RETRY_TIMEOUT_S", "999")
+        assert _sql_module._resolve_sql_retry_deadline_s() == 999
+
+    def test_deadline_float_formatted_int_env_accepted(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """FABRIC_SQL_RETRY_TIMEOUT_S='999.0' is accepted as 999 (Docker float-int)."""
         monkeypatch.setenv("FABRIC_SQL_RETRY_TIMEOUT_S", "999.0")
-        assert _sql_module._resolve_sql_retry_deadline_s() == 999.0
+        assert _sql_module._resolve_sql_retry_deadline_s() == 999
 
     def test_deadline_config_wins_over_default(self) -> None:
-        """Config sql_retry_deadline_s beats the built-in 120.0 default."""
-        cfg = UserConfig(defaults=Defaults(sql_retry_deadline_s=250.0))
+        """Config sql_retry_deadline_s beats the built-in 120 default."""
+        cfg = UserConfig(defaults=Defaults(sql_retry_deadline_s=250))
         _sql_module._sql_config_cache = cfg
-        assert _sql_module._resolve_sql_retry_deadline_s() == 250.0
+        assert _sql_module._resolve_sql_retry_deadline_s() == 250
 
     def test_deadline_falls_back_to_default(self) -> None:
-        """When no env var and no config value, the default 120.0 is returned."""
-        assert _sql_module._resolve_sql_retry_deadline_s() == 120.0
+        """When no env var and no config value, the default 120 is returned."""
+        assert _sql_module._resolve_sql_retry_deadline_s() == 120
+
+    def test_deadline_return_type_is_int(self) -> None:
+        """_resolve_sql_retry_deadline_s always returns an int."""
+        assert isinstance(_sql_module._resolve_sql_retry_deadline_s(), int)
 
     def test_deadline_invalid_env_falls_through_to_default(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """A non-numeric FABRIC_SQL_RETRY_TIMEOUT_S is ignored; default used instead."""
-        monkeypatch.setenv("FABRIC_SQL_RETRY_TIMEOUT_S", "not-a-float")
-        assert _sql_module._resolve_sql_retry_deadline_s() == 120.0
+        monkeypatch.setenv("FABRIC_SQL_RETRY_TIMEOUT_S", "not-an-int")
+        assert _sql_module._resolve_sql_retry_deadline_s() == 120
 
-    def test_deadline_negative_env_falls_through_to_default(
+    def test_deadline_below_min_env_falls_through_to_default(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """A value < 0.1 in FABRIC_SQL_RETRY_TIMEOUT_S is ignored; default used instead."""
-        monkeypatch.setenv("FABRIC_SQL_RETRY_TIMEOUT_S", "0.0")
-        assert _sql_module._resolve_sql_retry_deadline_s() == 120.0
+        """A value < 1 in FABRIC_SQL_RETRY_TIMEOUT_S is ignored; default used instead."""
+        monkeypatch.setenv("FABRIC_SQL_RETRY_TIMEOUT_S", "0")
+        assert _sql_module._resolve_sql_retry_deadline_s() == 120
 
     def test_deadline_invalid_env_falls_through_to_config(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Invalid env var falls through to config value."""
         monkeypatch.setenv("FABRIC_SQL_RETRY_TIMEOUT_S", "bad")
-        cfg = UserConfig(defaults=Defaults(sql_retry_deadline_s=88.0))
+        cfg = UserConfig(defaults=Defaults(sql_retry_deadline_s=88))
         _sql_module._sql_config_cache = cfg
-        assert _sql_module._resolve_sql_retry_deadline_s() == 88.0
+        assert _sql_module._resolve_sql_retry_deadline_s() == 88
 
     def test_executes_env_wins_over_config_and_default(
         self, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## Summary

- Convert `retry_deadline_s` and `sql_retry_deadline_s` from `float` to `int` end-to-end, mirroring the existing `max_429_retries` int-knob pattern
- Built-in defaults become `300` and `120` (ints); minimum enforced as `>= 1` (was `>= 0.1`)
- Existing `config.toml` files with `retry_deadline_s = 300.0` still load correctly via `int(float(...))`
- `resolve_float_knob` removed from `config_resolve.py` (and its `__all__` entry and tests) — no remaining callers after this change
- CLI options `--retry-deadline` and `config set retry-deadline` / `config set sql-retry-deadline` now accept integers only (`click.IntRange(min=1)`)

## Test plan

- [x] `uv run ruff check src tests` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run ty check src tests` — clean
- [x] `uv run pytest tests/unit -q` — 4640 passed, 3 deselected
- [x] New tests added for int round-trip, float-formatted-int acceptance, min enforcement, and resolver precedence for both knobs
- [x] Existing tests updated to use integer values throughout

Closes #702

🤖 Generated with [Claude Code](https://claude.com/claude-code)