### PR TITLE
docs(config): document the telemetry opt-out knob on the config page

### DIFF
--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -154,14 +154,13 @@ fdw config unset sql-pool
 
 ## Telemetry
 
-`fabric-dw` collects **anonymous, opt-out** usage telemetry — it is **on by default**. Any of the following disables it. Resolution order (highest priority first):
+`fabric-dw` collects **anonymous, opt-out** usage telemetry — it is **on by default**. Any of the following independently disables it — no events are emitted and the SDK is never imported:
 
-| Layer | Mechanism | Description |
+| Mechanism | Type | Effect |
 |---|---|---|
-| 1 | `FABRIC_DW_TELEMETRY_OPT_OUT` env var | Any truthy value (not in `""`, `0`, `false`, `no`, `off`, case-insensitive) disables telemetry. |
-| 2 | `DO_NOT_TRACK` env var | The [consoledonottrack.com](https://consoledonottrack.com/) standard. Any truthy value (same rules as above) disables telemetry. |
-| 3 | `[telemetry] disabled` in `config.toml` | Stored with `fdw config set telemetry disabled true`. |
-| 4 | Built-in default | Telemetry **enabled**. |
+| `FABRIC_DW_TELEMETRY_OPT_OUT` | env var | Any truthy value (not in `""`, `0`, `false`, `no`, `off`, case-insensitive) disables telemetry. |
+| `DO_NOT_TRACK` | env var | The [consoledonottrack.com](https://consoledonottrack.com/) standard. Any truthy value (same rules as above) disables telemetry. |
+| `[telemetry] disabled = true` in `config.toml` | config key | Set with `fdw config set telemetry disabled true`. |
 
 To opt out via the config file:
 

--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -152,6 +152,37 @@ fdw config set sql-pool true
 fdw config unset sql-pool
 ```
 
+## Telemetry
+
+`fabric-dw` collects **anonymous, opt-out** usage telemetry — it is **on by default**. Any of the following disables it. Resolution order (highest priority first):
+
+| Layer | Mechanism | Description |
+|---|---|---|
+| 1 | `FABRIC_DW_TELEMETRY_OPT_OUT` env var | Any truthy value (not in `""`, `0`, `false`, `no`, `off`, case-insensitive) disables telemetry. |
+| 2 | `DO_NOT_TRACK` env var | The [consoledonottrack.com](https://consoledonottrack.com/) standard. Any truthy value (same rules as above) disables telemetry. |
+| 3 | `[telemetry] disabled` in `config.toml` | Stored with `fdw config set telemetry disabled true`. |
+| 4 | Built-in default | Telemetry **enabled**. |
+
+To opt out via the config file:
+
+```shell
+fdw config set telemetry disabled true
+```
+
+To re-enable telemetry:
+
+```shell
+fdw config set telemetry disabled false
+```
+
+To revert to the built-in default:
+
+```shell
+fdw config unset telemetry disabled
+```
+
+See [Telemetry](../telemetry.md) for the full list of collected fields and lifecycle events.
+
 ## Credential mode
 
 Both the `fdw` CLI and the MCP server (`fdw mcp`) resolve the credential mode from the same


### PR DESCRIPTION
## Summary

- Adds a dedicated `## Telemetry` section to `docs/commands/config.md`
- Documents all three opt-out mechanisms in a resolution-order table: `FABRIC_DW_TELEMETRY_OPT_OUT` env var, `DO_NOT_TRACK` env var (consoledonottrack.com standard), and the `[telemetry] disabled` config key
- States the on-by-default behaviour and includes `fdw config set/unset telemetry disabled` examples
- Links to the Telemetry detail page (`../telemetry.md`) for the full list of collected fields and lifecycle events
- Section placement: after `## SQL connection pooling`, before `## Credential mode`, consistent with the neighbouring section style

## Test plan

- [x] Docs build passes (`zensical build` — no issues found)
- [x] Relative link `../telemetry.md` resolves to the existing `docs/telemetry.md`
- [x] Opt-out logic verified against `src/fabric_dw/telemetry.py` (`telemetry_enabled()`) and `src/fabric_dw/config.py`

Closes #704