### PR TITLE
refactor(config): rename connection-pooling knob sql_pool to conn_pooling

### DIFF
--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -135,21 +135,21 @@ Connection pooling reuses open TDS connections across queries to avoid the TCP+T
 
 | Knob | Env var | Config key | Built-in default |
 |---|---|---|---|
-| Connection pooling enabled | `FABRIC_SQL_POOL` | `sql_pool` | true |
+| Connection pooling enabled | `FABRIC_CONN_POOLING` | `conn_pooling` | true |
 
 Pooling is enabled by default. Disable it only when diagnosing connection issues or when running in an environment where persistent connections are not supported.
 
 To disable connection pooling:
 
 ```shell
-fdw config set sql-pool false
+fdw config set conn-pooling false
 ```
 
 To re-enable pooling (or to revert to the built-in default):
 
 ```shell
-fdw config set sql-pool true
-fdw config unset sql-pool
+fdw config set conn-pooling true
+fdw config unset conn-pooling
 ```
 
 ## Credential mode
@@ -207,7 +207,7 @@ fdw config clear
 
 ### config set
 
-Set a default value. Accepts `workspace`, `warehouse`, `max-429-retries`, `retry-deadline`, `sql-retry-deadline`, `sql-retry-executes`, `sql-pool`, or `auth-mode` as a flat key, or the nested sub-commands `telemetry disabled`, `logging level`, and `mcp workspace-allowlist` for section-scoped knobs.
+Set a default value. Accepts `workspace`, `warehouse`, `max-429-retries`, `retry-deadline`, `sql-retry-deadline`, `sql-retry-executes`, `conn-pooling`, or `auth-mode` as a flat key, or the nested sub-commands `telemetry disabled`, `logging level`, and `mcp workspace-allowlist` for section-scoped knobs.
 
 **Synopsis**
 
@@ -218,7 +218,7 @@ fdw config set max-429-retries N
 fdw config set retry-deadline SECONDS
 fdw config set sql-retry-deadline SECONDS
 fdw config set sql-retry-executes true|false
-fdw config set sql-pool true|false
+fdw config set conn-pooling true|false
 fdw config set auth-mode MODE
 fdw config set telemetry disabled true|false
 fdw config set logging level LEVEL
@@ -234,7 +234,7 @@ fdw config set max-429-retries 20
 fdw config set retry-deadline 600
 fdw config set sql-retry-deadline 300
 fdw config set sql-retry-executes true
-fdw config set sql-pool false
+fdw config set conn-pooling false
 fdw config set auth-mode interactive
 fdw config set telemetry disabled true
 fdw config set logging level DEBUG
@@ -269,7 +269,7 @@ warehouse  MyWarehouse
 
 ### config unset
 
-Clear a single default value. Accepts `workspace`, `warehouse`, `max-429-retries`, `retry-deadline`, `sql-retry-deadline`, `sql-retry-executes`, `sql-pool`, or `auth-mode` as a flat key, or the nested sub-commands `telemetry disabled`, `logging level`, and `mcp workspace-allowlist` for section-scoped knobs.
+Clear a single default value. Accepts `workspace`, `warehouse`, `max-429-retries`, `retry-deadline`, `sql-retry-deadline`, `sql-retry-executes`, `conn-pooling`, or `auth-mode` as a flat key, or the nested sub-commands `telemetry disabled`, `logging level`, and `mcp workspace-allowlist` for section-scoped knobs.
 
 **Synopsis**
 
@@ -280,7 +280,7 @@ fdw config unset max-429-retries
 fdw config unset retry-deadline
 fdw config unset sql-retry-deadline
 fdw config unset sql-retry-executes
-fdw config unset sql-pool
+fdw config unset conn-pooling
 fdw config unset auth-mode
 fdw config unset telemetry disabled
 fdw config unset logging level

--- a/src/fabric_dw/cli/commands/config.py
+++ b/src/fabric_dw/cli/commands/config.py
@@ -12,7 +12,7 @@ config set max-429-retries           — persist the max consecutive 429 retry c
 config set retry-deadline            — persist the combined 429+5xx wall-clock deadline
 config set sql-retry-deadline        — persist the SQL/TDS connect+execute retry budget
 config set sql-retry-executes        — persist whether fetch="none" statements are retried
-config set sql-pool                  — persist whether SQL connection pooling is enabled
+config set conn-pooling              — persist whether SQL connection pooling is enabled
 config set auth-mode                 — persist the MCP server credential mode
 config set telemetry disabled        — opt in/out of telemetry via config
 config set logging level             — set the MCP server log level
@@ -23,7 +23,7 @@ config unset max-429-retries         — clear the max consecutive 429 retry cou
 config unset retry-deadline          — clear the HTTP deadline default
 config unset sql-retry-deadline      — clear the SQL retry deadline default
 config unset sql-retry-executes      — clear the SQL execute-retry flag
-config unset sql-pool                — clear the SQL pool flag
+config unset conn-pooling            — clear the conn_pooling flag
 config unset auth-mode               — clear the credential mode (revert to built-in default)
 config unset telemetry disabled      — clear the telemetry opt-out (revert to default-on)
 config unset logging level           — clear the logging level (revert to built-in INFO)
@@ -69,7 +69,7 @@ def show_cmd(ctx: CliContext) -> None:
             "retry_deadline_s": cfg.defaults.retry_deadline_s,
             "sql_retry_deadline_s": cfg.defaults.sql_retry_deadline_s,
             "sql_retry_executes": cfg.defaults.sql_retry_executes,
-            "sql_pool": cfg.defaults.sql_pool,
+            "conn_pooling": cfg.defaults.conn_pooling,
             "auth_mode": cfg.defaults.auth_mode,
         },
         "telemetry": {
@@ -149,9 +149,9 @@ def set_sql_retry_executes_cmd(value: str) -> None:
     click.echo(f"Default sql_retry_executes set to {value.lower()}.")
 
 
-@set_group.command("sql-pool")
+@set_group.command("conn-pooling")
 @click.argument("value", type=click.Choice(["true", "false"], case_sensitive=False))
-def set_sql_pool_cmd(value: str) -> None:
+def set_conn_pooling_cmd(value: str) -> None:
     """Enable or disable SQL connection pooling.
 
     When set to false, every query opens a fresh TDS connection and closes it
@@ -159,8 +159,8 @@ def set_sql_pool_cmd(value: str) -> None:
     issues or when running in an environment where persistent connections are
     not supported.
     """
-    set_default("sql_pool", value.lower())
-    click.echo(f"Default sql_pool set to {value.lower()}.")
+    set_default("conn_pooling", value.lower())
+    click.echo(f"Default conn_pooling set to {value.lower()}.")
 
 
 _AUTH_MODE_CHOICES = click.Choice(sorted(VALID_AUTH_MODES), case_sensitive=False)
@@ -313,11 +313,11 @@ def unset_sql_retry_executes_cmd() -> None:
     click.echo("Default sql_retry_executes cleared.")
 
 
-@unset_group.command("sql-pool")
-def unset_sql_pool_cmd() -> None:
-    """Clear the sql_pool default (revert to built-in true)."""
-    set_default("sql_pool", None)
-    click.echo("Default sql_pool cleared.")
+@unset_group.command("conn-pooling")
+def unset_conn_pooling_cmd() -> None:
+    """Clear the conn_pooling default (revert to built-in true)."""
+    set_default("conn_pooling", None)
+    click.echo("Default conn_pooling cleared.")
 
 
 @unset_group.command("auth-mode")

--- a/src/fabric_dw/config.py
+++ b/src/fabric_dw/config.py
@@ -111,7 +111,7 @@ class Defaults:
     retry_deadline_s: int | None = None
     sql_retry_deadline_s: int | None = None
     sql_retry_executes: bool | None = None
-    sql_pool: bool | None = None
+    conn_pooling: bool | None = None
     auth_mode: str | None = None
 
 
@@ -197,7 +197,7 @@ def _parse_defaults_section(data: dict[str, object]) -> Defaults:
     raw_deadline = raw.get("retry_deadline_s")
     raw_sql_deadline = raw.get("sql_retry_deadline_s")
     raw_sql_executes = raw.get("sql_retry_executes")
-    raw_sql_pool = raw.get("sql_pool")
+    raw_conn_pooling = raw.get("conn_pooling")
     raw_auth_mode = raw.get("auth_mode")
     auth_mode: str | None = None
     if isinstance(raw_auth_mode, str):
@@ -222,7 +222,7 @@ def _parse_defaults_section(data: dict[str, object]) -> Defaults:
         if isinstance(raw_sql_deadline, (int, float)) and math.isfinite(raw_sql_deadline)
         else None,
         sql_retry_executes=raw_sql_executes if isinstance(raw_sql_executes, bool) else None,
-        sql_pool=raw_sql_pool if isinstance(raw_sql_pool, bool) else None,
+        conn_pooling=raw_conn_pooling if isinstance(raw_conn_pooling, bool) else None,
         auth_mode=auth_mode,
     )
 
@@ -394,8 +394,8 @@ def _defaults_to_dict(d: Defaults) -> dict[str, object]:
         out["sql_retry_deadline_s"] = d.sql_retry_deadline_s
     if d.sql_retry_executes is not None:
         out["sql_retry_executes"] = d.sql_retry_executes
-    if d.sql_pool is not None:
-        out["sql_pool"] = d.sql_pool
+    if d.conn_pooling is not None:
+        out["conn_pooling"] = d.conn_pooling
     if d.auth_mode is not None:
         out["auth_mode"] = d.auth_mode
     return out
@@ -518,7 +518,7 @@ def _coerce_defaults_key(key: str, value: str | None) -> tuple[int | None, bool 
                 ) from exc
             if coerced_int < _MIN_RETRY_DEADLINE_S:
                 raise ValueError(f"{key} must be >= {_MIN_RETRY_DEADLINE_S}, got {coerced_int}")
-        elif key in {"sql_retry_executes", "sql_pool"}:
+        elif key in {"sql_retry_executes", "conn_pooling"}:
             if value.lower() in {"true", "1", "yes", "on"}:
                 coerced_bool = True
             elif value.lower() in {"false", "0", "no", "off"}:
@@ -572,7 +572,7 @@ def _make_defaults_setter(
             sql_retry_executes=coerced_bool
             if key == "sql_retry_executes"
             else current.defaults.sql_retry_executes,
-            sql_pool=coerced_bool if key == "sql_pool" else current.defaults.sql_pool,
+            conn_pooling=coerced_bool if key == "conn_pooling" else current.defaults.conn_pooling,
             auth_mode=auth_mode_value,
         )
         return UserConfig(
@@ -705,7 +705,7 @@ _SET_CONFIG_DISPATCH: dict[
     ("defaults", "retry_deadline_s"): _make_defaults_setter("retry_deadline_s"),
     ("defaults", "sql_retry_deadline_s"): _make_defaults_setter("sql_retry_deadline_s"),
     ("defaults", "sql_retry_executes"): _make_defaults_setter("sql_retry_executes"),
-    ("defaults", "sql_pool"): _make_defaults_setter("sql_pool"),
+    ("defaults", "conn_pooling"): _make_defaults_setter("conn_pooling"),
     ("defaults", "auth_mode"): _make_defaults_setter("auth_mode"),
     ("telemetry", "disabled"): _set_telemetry_disabled,
     ("mcp", "workspace_allowlist"): _set_mcp_workspace_allowlist,
@@ -783,7 +783,7 @@ def set_default(key: str, value: str | None, path: Path | None = None) -> None:
     Args:
         key: One of ``"workspace"``, ``"warehouse"``, ``"max_429_retries"``,
              ``"retry_deadline_s"``, ``"sql_retry_deadline_s"``,
-             ``"sql_retry_executes"``, or ``"sql_pool"``.
+             ``"sql_retry_executes"``, or ``"conn_pooling"``.
         value: The new value (as a string for numeric keys it is coerced), or
                *None* to clear (unset) the key.
         path: Optional override for the config file path.
@@ -803,7 +803,7 @@ def set_default(key: str, value: str | None, path: Path | None = None) -> None:
         "retry_deadline_s",
         "sql_retry_deadline_s",
         "sql_retry_executes",
-        "sql_pool",
+        "conn_pooling",
         "auth_mode",
     }
     if key not in allowed:

--- a/src/fabric_dw/sql.py
+++ b/src/fabric_dw/sql.py
@@ -26,13 +26,13 @@ module-level constants:
 ``POOL_MAX_IDLE``       — maximum idle connections per key (default 4).
 ``POOL_MAX_IDLE_SECS``  — maximum idle age in seconds before eviction (default 300).
 
-Disable pooling by setting the environment variable ``FABRIC_SQL_POOL``
+Disable pooling by setting the environment variable ``FABRIC_CONN_POOLING``
 to a falsy value (``"0"``, ``"false"``, ``"no"``, or ``"off"``) before
 process startup, or at runtime by assigning the same value and then calling
 :func:`reset_pool` to drain existing connections.  Pooling can also be
-disabled via ``config.toml`` ``[defaults] sql_pool = false`` (resolution
+disabled via ``config.toml`` ``[defaults] conn_pooling = false`` (resolution
 order: env var > config > built-in default on).  An empty or whitespace-only
-``FABRIC_SQL_POOL`` is treated as absent and falls through to the config/default
+``FABRIC_CONN_POOLING`` is treated as absent and falls through to the config/default
 layer.  When disabled every ``open_connection`` call opens a fresh physical
 connection and ``.close()`` physically closes it.
 
@@ -563,9 +563,9 @@ def _set_key(connection_string: str, key: str, value: str) -> str:
 # ---------------------------------------------------------------------------
 
 # Pool configuration constants — override at module level before first use.
-# Pooling is controlled by _pool_enabled() which resolves: env var FABRIC_SQL_POOL
+# Pooling is controlled by _pool_enabled() which resolves: env var FABRIC_CONN_POOLING
 # (falsy: "0"/"false"/"no"/"off"; empty/whitespace → absent) > config.toml
-# [defaults].sql_pool > built-in default on.
+# [defaults].conn_pooling > built-in default on.
 POOL_MAX_IDLE: int = 4
 """Maximum number of idle connections kept per ``(workspace_id, database, mode)`` key."""
 
@@ -587,19 +587,19 @@ def _pool_enabled() -> bool:
     """Return True when connection pooling is active.
 
     Resolution order (3-layer):
-    1. ``FABRIC_SQL_POOL`` env var — read at call-time so tests can toggle
+    1. ``FABRIC_CONN_POOLING`` env var — read at call-time so tests can toggle
        it without reimporting the module.  Only a non-empty, non-whitespace
        value is honoured; an empty or whitespace-only value (e.g. a Docker
-       ``ENV FABRIC_SQL_POOL=`` placeholder) is treated as absent and falls
+       ``ENV FABRIC_CONN_POOLING=`` placeholder) is treated as absent and falls
        through to the next layer.  Accepted disable values: ``"0"``,
        ``"false"``, ``"no"``, ``"off"`` (case-insensitive).  Any other
        non-empty string keeps pooling enabled.
-    2. ``config.toml`` ``[defaults].sql_pool`` — consulted via the existing
+    2. ``config.toml`` ``[defaults].conn_pooling`` — consulted via the existing
        memoised :func:`_load_sql_config` cache (never calls load_config()
        per call).
     3. Built-in default: ``True`` (pooling on).
     """
-    raw_env = os.environ.get("FABRIC_SQL_POOL")
+    raw_env = os.environ.get("FABRIC_CONN_POOLING")
     if raw_env is not None:
         stripped = raw_env.strip()
         if stripped:
@@ -607,7 +607,7 @@ def _pool_enabled() -> bool:
             return stripped.lower() not in _FALSY_STRINGS
         # Empty / whitespace-only — treat as absent; fall through to config/default.
 
-    cfg_val = _load_sql_config().defaults.sql_pool
+    cfg_val = _load_sql_config().defaults.conn_pooling
     if cfg_val is not None:
         return cfg_val
 
@@ -867,7 +867,7 @@ def open_connection(
     pattern works unchanged.
 
     When pooling is disabled (``_pool_enabled()`` returns ``False``, controlled
-    via the ``FABRIC_SQL_POOL`` env var, ``config.toml [defaults] sql_pool``,
+    via the ``FABRIC_CONN_POOLING`` env var, ``config.toml [defaults] conn_pooling``,
     or the built-in default on) every call opens a fresh physical connection
     and ``.close()`` physically closes it.
 

--- a/tests/unit/cli/commands/test_config.py
+++ b/tests/unit/cli/commands/test_config.py
@@ -549,78 +549,80 @@ class TestConfigTelemetryEndToEnd:
 
 
 # ---------------------------------------------------------------------------
-# config set/unset sql-pool
+# config set/unset conn-pooling
 # ---------------------------------------------------------------------------
 
 
-class TestConfigSetSqlPool:
-    def test_set_sql_pool_false_exits_zero(self, runner: CliRunner, config_env: Path) -> None:
+class TestConfigSetConnPooling:
+    def test_set_conn_pooling_false_exits_zero(self, runner: CliRunner, config_env: Path) -> None:
         _ = config_env
-        result = runner.invoke(cli, ["config", "set", "sql-pool", "false"])
+        result = runner.invoke(cli, ["config", "set", "conn-pooling", "false"])
         assert result.exit_code == 0
 
-    def test_set_sql_pool_false_writes_file(self, runner: CliRunner, config_env: Path) -> None:
+    def test_set_conn_pooling_false_writes_file(self, runner: CliRunner, config_env: Path) -> None:
         _ = config_env
-        runner.invoke(cli, ["config", "set", "sql-pool", "false"])
+        runner.invoke(cli, ["config", "set", "conn-pooling", "false"])
         cfg = load_config(default_path())
-        assert cfg.defaults.sql_pool is False
+        assert cfg.defaults.conn_pooling is False
 
-    def test_set_sql_pool_true_writes_file(self, runner: CliRunner, config_env: Path) -> None:
+    def test_set_conn_pooling_true_writes_file(self, runner: CliRunner, config_env: Path) -> None:
         _ = config_env
-        runner.invoke(cli, ["config", "set", "sql-pool", "true"])
+        runner.invoke(cli, ["config", "set", "conn-pooling", "true"])
         cfg = load_config(default_path())
-        assert cfg.defaults.sql_pool is True
+        assert cfg.defaults.conn_pooling is True
 
-    def test_set_sql_pool_case_insensitive(self, runner: CliRunner, config_env: Path) -> None:
+    def test_set_conn_pooling_case_insensitive(self, runner: CliRunner, config_env: Path) -> None:
         _ = config_env
-        result = runner.invoke(cli, ["config", "set", "sql-pool", "False"])
+        result = runner.invoke(cli, ["config", "set", "conn-pooling", "False"])
         assert result.exit_code == 0
         cfg = load_config(default_path())
-        assert cfg.defaults.sql_pool is False
+        assert cfg.defaults.conn_pooling is False
 
-    def test_set_sql_pool_preserves_other_keys(self, runner: CliRunner, config_env: Path) -> None:
+    def test_set_conn_pooling_preserves_other_keys(
+        self, runner: CliRunner, config_env: Path
+    ) -> None:
         _ = config_env
         runner.invoke(cli, ["config", "set", "workspace", "MyWS"])
         runner.invoke(cli, ["config", "set", "sql-retry-executes", "true"])
-        runner.invoke(cli, ["config", "set", "sql-pool", "false"])
+        runner.invoke(cli, ["config", "set", "conn-pooling", "false"])
         cfg = load_config(default_path())
-        assert cfg.defaults.sql_pool is False
+        assert cfg.defaults.conn_pooling is False
         assert cfg.defaults.workspace == "MyWS"
         assert cfg.defaults.sql_retry_executes is True  # preserved
 
 
-class TestConfigUnsetSqlPool:
-    def test_unset_sql_pool_exits_zero(self, runner: CliRunner, config_env: Path) -> None:
+class TestConfigUnsetConnPooling:
+    def test_unset_conn_pooling_exits_zero(self, runner: CliRunner, config_env: Path) -> None:
         _ = config_env
-        runner.invoke(cli, ["config", "set", "sql-pool", "false"])
-        result = runner.invoke(cli, ["config", "unset", "sql-pool"])
+        runner.invoke(cli, ["config", "set", "conn-pooling", "false"])
+        result = runner.invoke(cli, ["config", "unset", "conn-pooling"])
         assert result.exit_code == 0
 
-    def test_unset_sql_pool_clears_key(self, runner: CliRunner, config_env: Path) -> None:
+    def test_unset_conn_pooling_clears_key(self, runner: CliRunner, config_env: Path) -> None:
         _ = config_env
-        runner.invoke(cli, ["config", "set", "sql-pool", "false"])
+        runner.invoke(cli, ["config", "set", "conn-pooling", "false"])
         runner.invoke(cli, ["config", "set", "sql-retry-executes", "true"])
-        runner.invoke(cli, ["config", "unset", "sql-pool"])
+        runner.invoke(cli, ["config", "unset", "conn-pooling"])
         cfg = load_config(default_path())
-        assert cfg.defaults.sql_pool is None
+        assert cfg.defaults.conn_pooling is None
         assert cfg.defaults.sql_retry_executes is True  # preserved
 
 
-class TestConfigShowSqlPool:
-    def test_show_includes_sql_pool_field(self, runner: CliRunner, config_env: Path) -> None:
+class TestConfigShowConnPooling:
+    def test_show_includes_conn_pooling_field(self, runner: CliRunner, config_env: Path) -> None:
         _ = config_env
-        runner.invoke(cli, ["config", "set", "sql-pool", "false"])
+        runner.invoke(cli, ["config", "set", "conn-pooling", "false"])
         result = runner.invoke(cli, ["--json", "config", "show"])
         assert result.exit_code == 0
         data = json.loads(result.output)
-        assert data["defaults"]["sql_pool"] is False
+        assert data["defaults"]["conn_pooling"] is False
 
-    def test_show_null_when_sql_pool_not_set(self, runner: CliRunner, config_env: Path) -> None:
+    def test_show_null_when_conn_pooling_not_set(self, runner: CliRunner, config_env: Path) -> None:
         _ = config_env
         result = runner.invoke(cli, ["--json", "config", "show"])
         assert result.exit_code == 0
         data = json.loads(result.output)
-        assert data["defaults"]["sql_pool"] is None
+        assert data["defaults"]["conn_pooling"] is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/services/test_sql_exec.py
+++ b/tests/unit/services/test_sql_exec.py
@@ -653,7 +653,7 @@ class TestExecuteLoginRetry:
     @pytest.fixture(autouse=True)
     def _setup(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Disable pooling and replace time.sleep so retries are instant."""
-        monkeypatch.setenv("FABRIC_SQL_POOL", "0")
+        monkeypatch.setenv("FABRIC_CONN_POOLING", "0")
         _sql_module.reset_pool()
         # Default: real monotonic clock (deadline never fires in fast tests).
         monkeypatch.setattr(_sql_module, "time", _make_fake_time())

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1083,98 +1083,98 @@ def test_load_config_invalid_logging_level_valid_level_preserved(tmp_path: Path)
 
 
 # ---------------------------------------------------------------------------
-# sql_pool — round-trip and set_default coercion
+# conn_pooling — round-trip and set_default coercion
 # ---------------------------------------------------------------------------
 
 
-def test_round_trip_sql_pool_true(tmp_path: Path) -> None:
-    """sql_pool=True is saved and loaded as a bool."""
+def test_round_trip_conn_pooling_true(tmp_path: Path) -> None:
+    """conn_pooling=True is saved and loaded as a bool."""
     path = tmp_path / "config.toml"
-    cfg = UserConfig(defaults=Defaults(sql_pool=True))
+    cfg = UserConfig(defaults=Defaults(conn_pooling=True))
     save_config(cfg, path)
     loaded = load_config(path)
-    assert loaded.defaults.sql_pool is True
+    assert loaded.defaults.conn_pooling is True
 
 
-def test_round_trip_sql_pool_false(tmp_path: Path) -> None:
-    """sql_pool=False is saved and loaded as a bool."""
+def test_round_trip_conn_pooling_false(tmp_path: Path) -> None:
+    """conn_pooling=False is saved and loaded as a bool."""
     path = tmp_path / "config.toml"
-    cfg = UserConfig(defaults=Defaults(sql_pool=False))
+    cfg = UserConfig(defaults=Defaults(conn_pooling=False))
     save_config(cfg, path)
     loaded = load_config(path)
-    assert loaded.defaults.sql_pool is False
+    assert loaded.defaults.conn_pooling is False
 
 
-def test_round_trip_sql_pool_none(tmp_path: Path) -> None:
-    """sql_pool=None is not written to the file."""
+def test_round_trip_conn_pooling_none(tmp_path: Path) -> None:
+    """conn_pooling=None is not written to the file."""
     path = tmp_path / "config.toml"
-    cfg = UserConfig(defaults=Defaults(workspace="WS", sql_pool=None))
+    cfg = UserConfig(defaults=Defaults(workspace="WS", conn_pooling=None))
     save_config(cfg, path)
     content = path.read_text(encoding="utf-8")
-    assert "sql_pool" not in content
+    assert "conn_pooling" not in content
     loaded = load_config(path)
-    assert loaded.defaults.sql_pool is None
+    assert loaded.defaults.conn_pooling is None
     assert loaded.defaults.workspace == "WS"
 
 
-def test_set_default_sql_pool_true_persists(tmp_path: Path) -> None:
-    """set_default('sql_pool', 'true') stores True."""
+def test_set_default_conn_pooling_true_persists(tmp_path: Path) -> None:
+    """set_default('conn_pooling', 'true') stores True."""
     path = tmp_path / "config.toml"
-    set_default("sql_pool", "true", path)
+    set_default("conn_pooling", "true", path)
     loaded = load_config(path)
-    assert loaded.defaults.sql_pool is True
+    assert loaded.defaults.conn_pooling is True
 
 
-def test_set_default_sql_pool_false_persists(tmp_path: Path) -> None:
-    """set_default('sql_pool', 'false') stores False."""
+def test_set_default_conn_pooling_false_persists(tmp_path: Path) -> None:
+    """set_default('conn_pooling', 'false') stores False."""
     path = tmp_path / "config.toml"
-    set_default("sql_pool", "false", path)
+    set_default("conn_pooling", "false", path)
     loaded = load_config(path)
-    assert loaded.defaults.sql_pool is False
+    assert loaded.defaults.conn_pooling is False
 
 
-def test_set_default_sql_pool_none_clears(tmp_path: Path) -> None:
-    """set_default('sql_pool', None) clears the key."""
+def test_set_default_conn_pooling_none_clears(tmp_path: Path) -> None:
+    """set_default('conn_pooling', None) clears the key."""
     path = tmp_path / "config.toml"
-    save_config(UserConfig(defaults=Defaults(sql_pool=False, sql_retry_executes=True)), path)
-    set_default("sql_pool", None, path)
+    save_config(UserConfig(defaults=Defaults(conn_pooling=False, sql_retry_executes=True)), path)
+    set_default("conn_pooling", None, path)
     loaded = load_config(path)
-    assert loaded.defaults.sql_pool is None
+    assert loaded.defaults.conn_pooling is None
     assert loaded.defaults.sql_retry_executes is True  # preserved
 
 
-def test_set_default_sql_pool_garbage_raises(tmp_path: Path) -> None:
-    """An unrecognised value for sql_pool raises ValueError."""
+def test_set_default_conn_pooling_garbage_raises(tmp_path: Path) -> None:
+    """An unrecognised value for conn_pooling raises ValueError."""
     path = tmp_path / "config.toml"
-    with pytest.raises(ValueError, match="sql_pool"):
-        set_default("sql_pool", "maybe", path)
+    with pytest.raises(ValueError, match="conn_pooling"):
+        set_default("conn_pooling", "maybe", path)
 
 
 @pytest.mark.parametrize("truthy", ["true", "True", "TRUE", "1", "yes", "on"])
-def test_set_default_sql_pool_truthy_variants(tmp_path: Path, truthy: str) -> None:
-    """All truthy string variants are accepted for sql_pool."""
+def test_set_default_conn_pooling_truthy_variants(tmp_path: Path, truthy: str) -> None:
+    """All truthy string variants are accepted for conn_pooling."""
     path = tmp_path / "config.toml"
-    set_default("sql_pool", truthy, path)
+    set_default("conn_pooling", truthy, path)
     loaded = load_config(path)
-    assert loaded.defaults.sql_pool is True
+    assert loaded.defaults.conn_pooling is True
 
 
 @pytest.mark.parametrize("falsy", ["false", "False", "FALSE", "0", "no", "off"])
-def test_set_default_sql_pool_falsy_variants(tmp_path: Path, falsy: str) -> None:
-    """All falsy string variants are accepted for sql_pool."""
+def test_set_default_conn_pooling_falsy_variants(tmp_path: Path, falsy: str) -> None:
+    """All falsy string variants are accepted for conn_pooling."""
     path = tmp_path / "config.toml"
-    set_default("sql_pool", falsy, path)
+    set_default("conn_pooling", falsy, path)
     loaded = load_config(path)
-    assert loaded.defaults.sql_pool is False
+    assert loaded.defaults.conn_pooling is False
 
 
-def test_set_default_sql_pool_preserves_other_keys(tmp_path: Path) -> None:
-    """set_default('sql_pool', ...) does not clear unrelated keys."""
+def test_set_default_conn_pooling_preserves_other_keys(tmp_path: Path) -> None:
+    """set_default('conn_pooling', ...) does not clear unrelated keys."""
     path = tmp_path / "config.toml"
     save_config(UserConfig(defaults=Defaults(workspace="WS", sql_retry_executes=True)), path)
-    set_default("sql_pool", "false", path)
+    set_default("conn_pooling", "false", path)
     loaded = load_config(path)
-    assert loaded.defaults.sql_pool is False
+    assert loaded.defaults.conn_pooling is False
     assert loaded.defaults.workspace == "WS"
     assert loaded.defaults.sql_retry_executes is True
 
@@ -1286,13 +1286,15 @@ def test_load_config_auth_mode_valid_normalised(tmp_path: Path) -> None:
 def test_set_default_auth_mode_preserves_other_keys(tmp_path: Path) -> None:
     """set_default('auth_mode', ...) does not clear unrelated keys."""
     path = tmp_path / "config.toml"
-    save_config(UserConfig(defaults=Defaults(workspace="WS", warehouse="WH", sql_pool=True)), path)
+    save_config(
+        UserConfig(defaults=Defaults(workspace="WS", warehouse="WH", conn_pooling=True)), path
+    )
     set_default("auth_mode", "interactive", path)
     loaded = load_config(path)
     assert loaded.defaults.auth_mode == "interactive"
     assert loaded.defaults.workspace == "WS"
     assert loaded.defaults.warehouse == "WH"
-    assert loaded.defaults.sql_pool is True
+    assert loaded.defaults.conn_pooling is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_sql.py
+++ b/tests/unit/test_sql.py
@@ -76,7 +76,7 @@ def _patch_mssql(monkeypatch: pytest.MonkeyPatch, mock_mssql: MagicMock) -> None
 @pytest.fixture(autouse=True)
 def _disable_pool_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
     """Disable the connection pool for all tests unless they opt in."""
-    monkeypatch.setenv("FABRIC_SQL_POOL", "0")
+    monkeypatch.setenv("FABRIC_CONN_POOLING", "0")
     reset_pool()
 
 
@@ -676,7 +676,7 @@ class TestConnectionPool:
     @pytest.fixture(autouse=True)
     def _enable_pool(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Enable the pool for all tests in this class and drain it after."""
-        monkeypatch.setenv("FABRIC_SQL_POOL", "1")
+        monkeypatch.setenv("FABRIC_CONN_POOLING", "1")
         reset_pool()
 
     def test_pool_reuse_same_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -808,8 +808,8 @@ class TestConnectionPool:
         assert mock_mssql.connect.call_count == 2
 
     def test_pool_disabled_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """FABRIC_SQL_POOL=0 disables the pool — every call opens+closes."""
-        monkeypatch.setenv("FABRIC_SQL_POOL", "0")
+        """FABRIC_CONN_POOLING=0 disables the pool — every call opens+closes."""
+        monkeypatch.setenv("FABRIC_CONN_POOLING", "0")
 
         mock_mssql, mock_conn, _ = _make_mock_mssql()
         _patch_mssql(monkeypatch, mock_mssql)
@@ -1671,7 +1671,7 @@ class TestOpenConnectionOidcTokenInjection:
         _patch_mssql(monkeypatch, mock_mssql)
 
         # Enable the pool for this test.
-        monkeypatch.setenv("FABRIC_SQL_POOL", "1")
+        monkeypatch.setenv("FABRIC_CONN_POOLING", "1")
         reset_pool()
 
         # Track how many times the token stub is invoked.
@@ -1816,7 +1816,7 @@ class TestPoolCheckinEvictsStale:
 
     @pytest.fixture(autouse=True)
     def _enable_pool(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("FABRIC_SQL_POOL", "1")
+        monkeypatch.setenv("FABRIC_CONN_POOLING", "1")
         reset_pool()
 
     def test_stale_bottom_layer_evicted_on_checkin(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1965,7 +1965,7 @@ class TestD23PoolRollbackOnReturn:
 
     @pytest.fixture(autouse=True)
     def _enable_pool(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("FABRIC_SQL_POOL", "1")
+        monkeypatch.setenv("FABRIC_CONN_POOLING", "1")
         reset_pool()
 
     def test_rollback_called_before_checkin(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -3014,79 +3014,79 @@ class TestPoolEnabledConfig:
     """_pool_enabled follows the 3-layer rule: env > config > built-in True.
 
     Note: the module-level ``_disable_pool_by_default`` autouse fixture sets
-    ``FABRIC_SQL_POOL=0`` for every test in this module.  Tests that need to
+    ``FABRIC_CONN_POOLING=0`` for every test in this module.  Tests that need to
     remove the env var entirely (to test config or default fall-through) call
-    ``monkeypatch.delenv("FABRIC_SQL_POOL", raising=False)`` to undo it.
+    ``monkeypatch.delenv("FABRIC_CONN_POOLING", raising=False)`` to undo it.
     """
 
     def test_env_zero_disables_pool(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """FABRIC_SQL_POOL=0 disables pooling even when config says True."""
-        monkeypatch.setenv("FABRIC_SQL_POOL", "0")
-        cfg = UserConfig(defaults=Defaults(sql_pool=True))
+        """FABRIC_CONN_POOLING=0 disables pooling even when config says True."""
+        monkeypatch.setenv("FABRIC_CONN_POOLING", "0")
+        cfg = UserConfig(defaults=Defaults(conn_pooling=True))
         _sql_module._sql_config_cache = cfg
         assert _sql_module._pool_enabled() is False
 
     def test_env_one_enables_pool(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """FABRIC_SQL_POOL=1 enables pooling even when config says False."""
-        monkeypatch.setenv("FABRIC_SQL_POOL", "1")
-        cfg = UserConfig(defaults=Defaults(sql_pool=False))
+        """FABRIC_CONN_POOLING=1 enables pooling even when config says False."""
+        monkeypatch.setenv("FABRIC_CONN_POOLING", "1")
+        cfg = UserConfig(defaults=Defaults(conn_pooling=False))
         _sql_module._sql_config_cache = cfg
         assert _sql_module._pool_enabled() is True
 
     def test_env_false_string_disables_pool(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """FABRIC_SQL_POOL=false (string) disables pooling."""
-        monkeypatch.setenv("FABRIC_SQL_POOL", "false")
+        """FABRIC_CONN_POOLING=false (string) disables pooling."""
+        monkeypatch.setenv("FABRIC_CONN_POOLING", "false")
         assert _sql_module._pool_enabled() is False
 
     def test_env_off_string_disables_pool(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """FABRIC_SQL_POOL=off (string) disables pooling."""
-        monkeypatch.setenv("FABRIC_SQL_POOL", "off")
+        """FABRIC_CONN_POOLING=off (string) disables pooling."""
+        monkeypatch.setenv("FABRIC_CONN_POOLING", "off")
         assert _sql_module._pool_enabled() is False
 
     def test_env_no_string_disables_pool(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """FABRIC_SQL_POOL=no (string) disables pooling."""
-        monkeypatch.setenv("FABRIC_SQL_POOL", "no")
+        """FABRIC_CONN_POOLING=no (string) disables pooling."""
+        monkeypatch.setenv("FABRIC_CONN_POOLING", "no")
         assert _sql_module._pool_enabled() is False
 
     def test_env_empty_string_falls_through_to_default_on(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """FABRIC_SQL_POOL='' (empty string) is treated as absent — pooling stays ON.
+        """FABRIC_CONN_POOLING='' (empty string) is treated as absent — pooling stays ON.
 
-        An empty placeholder (e.g. Docker ``ENV FABRIC_SQL_POOL=``) must not
+        An empty placeholder (e.g. Docker ``ENV FABRIC_CONN_POOLING=``) must not
         silently disable pooling.  Only a non-empty falsy value disables it.
         """
-        monkeypatch.setenv("FABRIC_SQL_POOL", "")
+        monkeypatch.setenv("FABRIC_CONN_POOLING", "")
         assert _sql_module._pool_enabled() is True
 
     def test_env_whitespace_only_falls_through_to_default_on(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """FABRIC_SQL_POOL='  ' (whitespace only) is treated as absent — pooling stays ON."""
-        monkeypatch.setenv("FABRIC_SQL_POOL", "   ")
+        """FABRIC_CONN_POOLING='  ' (whitespace only) is treated as absent — pooling stays ON."""
+        monkeypatch.setenv("FABRIC_CONN_POOLING", "   ")
         assert _sql_module._pool_enabled() is True
 
     def test_env_true_string_enables_pool(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """FABRIC_SQL_POOL=true enables pooling."""
-        monkeypatch.setenv("FABRIC_SQL_POOL", "true")
+        """FABRIC_CONN_POOLING=true enables pooling."""
+        monkeypatch.setenv("FABRIC_CONN_POOLING", "true")
         assert _sql_module._pool_enabled() is True
 
     def test_env_any_non_falsy_string_enables_pool(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Any non-falsy FABRIC_SQL_POOL value enables pooling."""
-        monkeypatch.setenv("FABRIC_SQL_POOL", "yes")
+        """Any non-falsy FABRIC_CONN_POOLING value enables pooling."""
+        monkeypatch.setenv("FABRIC_CONN_POOLING", "yes")
         assert _sql_module._pool_enabled() is True
 
     def test_config_false_disables_pool(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Config sql_pool=False disables pooling when env var is absent."""
-        monkeypatch.delenv("FABRIC_SQL_POOL", raising=False)
-        cfg = UserConfig(defaults=Defaults(sql_pool=False))
+        """Config conn_pooling=False disables pooling when env var is absent."""
+        monkeypatch.delenv("FABRIC_CONN_POOLING", raising=False)
+        cfg = UserConfig(defaults=Defaults(conn_pooling=False))
         _sql_module._sql_config_cache = cfg
         assert _sql_module._pool_enabled() is False
 
     def test_config_true_enables_pool(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Config sql_pool=True enables pooling when env var is absent."""
-        monkeypatch.delenv("FABRIC_SQL_POOL", raising=False)
-        cfg = UserConfig(defaults=Defaults(sql_pool=True))
+        """Config conn_pooling=True enables pooling when env var is absent."""
+        monkeypatch.delenv("FABRIC_CONN_POOLING", raising=False)
+        cfg = UserConfig(defaults=Defaults(conn_pooling=True))
         _sql_module._sql_config_cache = cfg
         assert _sql_module._pool_enabled() is True
 
@@ -3094,20 +3094,20 @@ class TestPoolEnabledConfig:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """When neither env var nor config is set, pooling is enabled (default True)."""
-        monkeypatch.delenv("FABRIC_SQL_POOL", raising=False)
+        monkeypatch.delenv("FABRIC_CONN_POOLING", raising=False)
         # _isolate_sql_config autouse fixture already cleared the cache.
         assert _sql_module._pool_enabled() is True
 
     def test_config_none_falls_back_to_true(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Config sql_pool=None (unset) falls through to the built-in True default."""
-        monkeypatch.delenv("FABRIC_SQL_POOL", raising=False)
-        cfg = UserConfig(defaults=Defaults(sql_pool=None))
+        """Config conn_pooling=None (unset) falls through to the built-in True default."""
+        monkeypatch.delenv("FABRIC_CONN_POOLING", raising=False)
+        cfg = UserConfig(defaults=Defaults(conn_pooling=None))
         _sql_module._sql_config_cache = cfg
         assert _sql_module._pool_enabled() is True
 
     def test_env_wins_over_config_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """FABRIC_SQL_POOL=1 wins over config sql_pool=False."""
-        monkeypatch.setenv("FABRIC_SQL_POOL", "1")
-        cfg = UserConfig(defaults=Defaults(sql_pool=False))
+        """FABRIC_CONN_POOLING=1 wins over config conn_pooling=False."""
+        monkeypatch.setenv("FABRIC_CONN_POOLING", "1")
+        cfg = UserConfig(defaults=Defaults(conn_pooling=False))
         _sql_module._sql_config_cache = cfg
         assert _sql_module._pool_enabled() is True


### PR DESCRIPTION
## Summary

Renames the connection-pooling configuration knob from `sql_pool` / `FABRIC_SQL_POOL` / `sql-pool` to `conn_pooling` / `FABRIC_CONN_POOLING` / `conn-pooling`. The old name was confusingly close to the unrelated Fabric **SQL Pools** feature.

Clean break — no backward-compat alias (maintainer-confirmed).

## Rename mapping

| From | To | Form |
|---|---|---|
| `sql_pool` | `conn_pooling` | config/TOML key + model field (snake_case) |
| `FABRIC_SQL_POOL` | `FABRIC_CONN_POOLING` | env var |
| `sql-pool` | `conn-pooling` | CLI subcommand name + docs flat-key (dash form) |
| `set_sql_pool_cmd` / `unset_sql_pool_cmd` | `set_conn_pooling_cmd` / `unset_conn_pooling_cmd` | CLI function names |

## Does NOT touch the Fabric SQL Pools feature

The following are entirely unrelated and are left exactly as-is:

- `src/fabric_dw/services/sql_pools.py`, `custom_sql_pools`, `custom_sql_pools_enabled`
- MCP tools `get_sql_pools_configuration`, `list_sql_pools`, `delete_sql_pool`, and the module `src/fabric_dw/mcp/tools/sql_pools.py`
- `src/fabric_dw/services/query_insights.py`: `sql_pool_insights`, `SQL_POOL_INSIGHTS_COLUMNS`, `list_sql_pool_insights`, `sql_pool_name`

## Acceptance criteria

- [x] `grep -rn 'sql_pool\b\|FABRIC_SQL_POOL\|sql-pool' src tests docs` returns only genuine Fabric SQL Pools feature symbols — no remaining connection-pooling knob references under the old names
- [x] `fdw config set conn-pooling false|true` and `fdw config unset conn-pooling` work; `config show` uses key `conn_pooling`
- [x] `FABRIC_CONN_POOLING` toggles pooling; `FABRIC_SQL_POOL` is no longer consulted anywhere
- [x] TOML `[defaults] conn_pooling = false` is honored
- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `ty check` passes
- [x] `pytest tests/unit` passes (4641 tests)

## Files changed

- `src/fabric_dw/config.py` — model field, parser, serializer, coercion set, dispatch table, docstrings
- `src/fabric_dw/sql.py` — env var reads, config read, docstrings/comments
- `src/fabric_dw/cli/commands/config.py` — command decorators, function names, echo strings, help text
- `docs/commands/config.md` — env var/key/commands in the SQL connection pooling section and synopsis
- `tests/unit/test_config.py`, `tests/unit/test_sql.py`, `tests/unit/services/test_sql_exec.py`, `tests/unit/cli/commands/test_config.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)