### PR TITLE
fix(tables): normalize health-metric rows to real tuples

### DIFF
--- a/src/fabric_dw/services/tables.py
+++ b/src/fabric_dw/services/tables.py
@@ -1537,7 +1537,7 @@ async def get_table_health_metrics(
 
     def _run() -> tuple[list[str], list[tuple[object, ...]]]:
         cols, rows = run_query(target, sql, mode=mode)
-        return cols, list(rows)
+        return cols, [tuple(r) for r in rows]
 
     return await asyncio.to_thread(_run)
 

--- a/tests/unit/services/test_tables.py
+++ b/tests/unit/services/test_tables.py
@@ -2285,3 +2285,52 @@ class TestGetTableHealthMetrics:
                 "bad;table",
                 kind=WarehouseKind.SQL_ENDPOINT,
             )
+
+    async def test_rows_are_normalized_to_real_tuples(self) -> None:
+        """Driver Row-like objects (non-tuple sequences) are normalized to real tuples.
+
+        Monkeypatches ``run_query`` to yield a custom non-tuple sequence class
+        that mimics ``mssql_python.row.Row`` — iterable and indexable but NOT a
+        ``tuple`` subclass.  Asserts that every row in the result is a real
+        ``tuple`` and that values are preserved in order.
+        """
+
+        class _FakeRow:
+            """Tuple-like but not a tuple subclass, as mssql_python.row.Row."""
+
+            def __init__(self, *values: object) -> None:
+                self._values = values
+
+            def __iter__(self):  # type: ignore[override]
+                return iter(self._values)
+
+            def __len__(self) -> int:
+                return len(self._values)
+
+            def __getitem__(self, index: int) -> object:
+                return self._values[index]
+
+        fake_cols = ["col_x", "col_y", "col_z"]
+        fake_driver_rows = [
+            _FakeRow(1, "alpha", None),
+            _FakeRow(2, "beta", 3.14),
+        ]
+
+        target = _make_target()
+        with patch(
+            "fabric_dw.services.tables.run_query",
+            return_value=(fake_cols, fake_driver_rows),
+        ):
+            result_cols, result_rows = await tables.get_table_health_metrics(
+                target,
+                "dbo",
+                "FactSales",
+                kind=WarehouseKind.SQL_ENDPOINT,
+            )
+
+        assert result_cols == fake_cols
+        assert len(result_rows) == 2
+        for row in result_rows:
+            assert isinstance(row, tuple), f"each row must be a tuple, got {type(row)}: {row!r}"
+        assert result_rows[0] == (1, "alpha", None)
+        assert result_rows[1] == (2, "beta", 3.14)


### PR DESCRIPTION
## Summary

- `get_table_health_metrics._run()` returned driver `Row` objects verbatim from `run_query()`, violating the function's documented `-> tuple[list[str], list[tuple[object, ...]]]` contract
- Normalizes rows with `[tuple(r) for r in rows]` so every returned row is a real `tuple` regardless of what the underlying driver yields
- Adds a focused unit test that monkeypatches `run_query` to return a custom non-tuple sequence class (`_FakeRow`), confirming both type normalization and value preservation

## Test plan

- [x] `uv run ruff check src tests` — passes (pre-existing RUF022 in `_version.py` is unrelated)
- [x] `uv run ruff format --check .` — all 266 files already formatted
- [x] `uv run ty check src tests` — all checks passed
- [x] `uv run pytest tests/unit/services/test_tables.py -k TestGetTableHealthMetrics -v` — 9/9 passed, including new `test_rows_are_normalized_to_real_tuples`
- [x] `uv run pytest tests/unit -q` — 4642 passed
- [ ] Integration test (`test_get_table_health_metrics_on_sql_endpoint`) — unchanged; will pass on a live tenant

Closes #707

🤖 Generated with [Claude Code](https://claude.com/claude-code)