### PR TITLE
fix(models): default null/empty collation to Latin1_General_100_BIN2_UTF8

### DIFF
--- a/src/fabric_dw/cli/_render.py
+++ b/src/fabric_dw/cli/_render.py
@@ -11,46 +11,14 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 
-from fabric_dw.models import FABRIC_DEFAULT_COLLATION, ItemAccess, TableSyncStatus
+from fabric_dw.models import ItemAccess, TableSyncStatus
 
 __all__ = [
     "confirm",
     "render",
     "render_permissions_table",
     "render_refresh_table",
-    "with_default_collation_for_display",
 ]
-
-#: API alias for the warehouse / SQL-endpoint collation field.
-_COLLATION_KEY = "defaultCollation"
-
-
-def with_default_collation_for_display(dump: dict[str, object]) -> dict[str, object]:
-    """Return a copy of a warehouse/SQL-endpoint dump with the collation filled in.
-
-    When the Fabric REST API returns ``null``/empty for ``defaultCollation``
-    (i.e. the item was created without an explicit collation), Fabric still
-    applies an effective default — :data:`~fabric_dw.models.FABRIC_DEFAULT_COLLATION`.
-    For **human** output we substitute that value, clearly marked as the default
-    (``"<value> (default)"``), instead of showing a misleading ``NULL``.
-
-    This helper is intended for the human/Rich rendering path **only**.  The
-    ``--json`` path must keep the raw API value (``None``) so machine consumers
-    are not fed a fabricated value; the ``(default)`` suffix would also break
-    callers that compare the string against a real collation name.
-
-    Args:
-        dump: A warehouse/SQL-endpoint dict (``model_dump(by_alias=True)``).
-
-    Returns:
-        A shallow copy of *dump*.  If ``defaultCollation`` is present and
-        null/empty, it is replaced with ``"<FABRIC_DEFAULT_COLLATION> (default)"``;
-        otherwise *dump* is returned unchanged (as a copy).
-    """
-    result = dict(dump)
-    if _COLLATION_KEY in result and not result.get(_COLLATION_KEY):
-        result[_COLLATION_KEY] = f"{FABRIC_DEFAULT_COLLATION} (default)"
-    return result
 
 
 # ---------------------------------------------------------------------------

--- a/src/fabric_dw/cli/commands/sql_endpoints.py
+++ b/src/fabric_dw/cli/commands/sql_endpoints.py
@@ -12,7 +12,6 @@ from fabric_dw.cli._render import (
     render,
     render_permissions_table,
     render_refresh_table,
-    with_default_collation_for_display,
 )
 from fabric_dw.cli.commands._utils import (
     build_http_client,
@@ -126,11 +125,9 @@ async def list_cmd(ctx: CliContext, all_workspaces: bool) -> None:
                 items = await _sql_endpoints_svc.list_endpoints(http, ws_id)
             rows = [ep.model_dump(by_alias=True, mode="json") for ep in items]
             # The --json path stays COMPLETE; only the human/table path drops the
-            # always-redundant columns (kind, and workspaceId when single-workspace)
-            # and substitutes Fabric's effective default collation for null values.
+            # always-redundant columns (kind, and workspaceId when single-workspace).
             if not ctx.json_output:
                 rows = _strip_table_keys(rows, all_workspaces=all_workspaces)
-                rows = [with_default_collation_for_display(r) for r in rows]
             render(
                 rows,
                 json_output=ctx.json_output,
@@ -156,10 +153,6 @@ async def get_cmd(ctx: CliContext, item: str | None) -> None:
             )
             obj = await _sql_endpoints_svc.get_endpoint(http, ws_id, entry.id)
             dump = obj.model_dump(by_alias=True, mode="json")
-            # Human output substitutes Fabric's effective default collation when
-            # the API returns null; --json keeps the raw API value.
-            if not ctx.json_output:
-                dump = with_default_collation_for_display(dump)
             render(dump, json_output=ctx.json_output)
     except FabricError as exc:
         raise click.ClickException(str(exc)) from exc

--- a/src/fabric_dw/cli/commands/warehouses.py
+++ b/src/fabric_dw/cli/commands/warehouses.py
@@ -8,7 +8,6 @@ from fabric_dw.cli._context import CliContext
 from fabric_dw.cli._render import (
     render,
     render_permissions_table,
-    with_default_collation_for_display,
 )
 from fabric_dw.cli.commands._utils import (
     build_http_client,
@@ -93,8 +92,6 @@ async def list_cmd(
             # --json is never pruned (render ignores drop_columns for JSON).
             drop_columns = None if all_workspaces else ("workspaceId",)
             rows = [w.model_dump(by_alias=True, mode="json") for w in items]
-            if not ctx.json_output:
-                rows = [with_default_collation_for_display(r) for r in rows]
             render(
                 rows,
                 json_output=ctx.json_output,
@@ -118,10 +115,6 @@ async def get_cmd(ctx: CliContext, warehouse: str | None) -> None:
             ws_id, entry = await resolve_item(http, ws, wh)
             obj = await _warehouses_svc.get_warehouse(http, ws_id, entry.id)
             dump = obj.model_dump(by_alias=True, mode="json")
-            # Human output substitutes Fabric's effective default collation when
-            # the API returns null; --json keeps the raw API value.
-            if not ctx.json_output:
-                dump = with_default_collation_for_display(dump)
             render(dump, json_output=ctx.json_output)
     except (ValueError, FabricError) as exc:
         raise click.ClickException(str(exc)) from exc
@@ -153,8 +146,6 @@ async def create_cmd(
                 description=description,
             )
             dump = obj.model_dump(by_alias=True, mode="json")
-            if not ctx.json_output:
-                dump = with_default_collation_for_display(dump)
             render(dump, json_output=ctx.json_output)
     except (ValueError, FabricError) as exc:
         raise click.ClickException(str(exc)) from exc
@@ -194,8 +185,6 @@ async def rename_cmd(
                 old_name=entry.display_name or None,
             )
             dump = obj.model_dump(by_alias=True, mode="json")
-            if not ctx.json_output:
-                dump = with_default_collation_for_display(dump)
             render(dump, json_output=ctx.json_output)
     except (ValueError, FabricError) as exc:
         raise click.ClickException(str(exc)) from exc

--- a/src/fabric_dw/models.py
+++ b/src/fabric_dw/models.py
@@ -53,6 +53,20 @@ class Capacity(_FabricBase):
     state: str
 
 
+#: The collation Fabric applies to a workspace / warehouse when no explicit collation is
+#: configured.  The Fabric REST API may return ``null``/empty for the collation fields
+#: (``defaultDataWarehouseCollation``, ``defaultCollation``) when the workspace or warehouse
+#: was created without an explicit setting, but Fabric still applies this case-sensitive (CS)
+#: collation as the effective default.
+#:
+#: Source (verified via Microsoft Learn):
+#:  - https://learn.microsoft.com/fabric/data-warehouse/collation
+#:    "New warehouses and all SQL analytics endpoints are configured based on the
+#:     workspace's Data Warehouse default collation setting, which by default is
+#:     the case-sensitive collation ``Latin1_General_100_BIN2_UTF8``."
+FABRIC_DEFAULT_COLLATION = "Latin1_General_100_BIN2_UTF8"
+
+
 class Workspace(_FabricBase):
     """A Microsoft Fabric workspace."""
 
@@ -64,7 +78,16 @@ class Workspace(_FabricBase):
         default=None, alias="defaultDatasetStorageFormat"
     )
     # Undocumented in WorkspaceInfo; the GET endpoint returns it in practice.
-    collation: str | None = Field(default=None, alias="defaultDataWarehouseCollation")
+    # The API may return null/empty; we coalesce to FABRIC_DEFAULT_COLLATION below.
+    collation: str = Field(default=FABRIC_DEFAULT_COLLATION, alias="defaultDataWarehouseCollation")
+
+    @field_validator("collation", mode="before")
+    @classmethod
+    def _coerce_collation(cls, v: object) -> str:
+        """Return the effective collation, defaulting to FABRIC_DEFAULT_COLLATION when absent."""
+        if not isinstance(v, str):
+            return FABRIC_DEFAULT_COLLATION
+        return v.strip() or FABRIC_DEFAULT_COLLATION
 
 
 class WarehouseKind(StrEnum):
@@ -88,21 +111,6 @@ class WarehouseKind(StrEnum):
         }[self]
 
 
-#: The collation Fabric applies to a warehouse / SQL analytics endpoint when no
-#: explicit collation is specified at creation time.  The Fabric REST API may
-#: return ``null``/empty for ``defaultCollation`` in that case, but Fabric still
-#: applies this case-sensitive (CS) collation as the effective default, derived
-#: from the workspace's Data Warehouse collation setting (whose own default is
-#: this value).
-#:
-#: Source (verified via Microsoft Learn):
-#:  - https://learn.microsoft.com/fabric/data-warehouse/collation
-#:    "New warehouses and all SQL analytics endpoints are configured based on the
-#:     workspace's Data Warehouse default collation setting, which by default is
-#:     the case-sensitive collation ``Latin1_General_100_BIN2_UTF8``."
-FABRIC_DEFAULT_COLLATION = "Latin1_General_100_BIN2_UTF8"
-
-
 class Warehouse(_FabricBase):
     """A Microsoft Fabric Data Warehouse or SQL analytics endpoint."""
 
@@ -112,8 +120,17 @@ class Warehouse(_FabricBase):
     workspace_id: UUID = Field(alias="workspaceId")
     kind: WarehouseKind
     connection_string: str | None = Field(default=None, alias="connectionString")
-    collation: str | None = Field(default=None, alias="defaultCollation")
+    # The API may return null/empty; we coalesce to FABRIC_DEFAULT_COLLATION below.
+    collation: str = Field(default=FABRIC_DEFAULT_COLLATION, alias="defaultCollation")
     created_date: datetime | None = Field(default=None, alias="createdDate")
+
+    @field_validator("collation", mode="before")
+    @classmethod
+    def _coerce_collation(cls, v: object) -> str:
+        """Return the effective collation, defaulting to FABRIC_DEFAULT_COLLATION when absent."""
+        if not isinstance(v, str):
+            return FABRIC_DEFAULT_COLLATION
+        return v.strip() or FABRIC_DEFAULT_COLLATION
 
     @model_validator(mode="before")
     @classmethod

--- a/src/fabric_dw/models.py
+++ b/src/fabric_dw/models.py
@@ -67,6 +67,22 @@ class Capacity(_FabricBase):
 FABRIC_DEFAULT_COLLATION = "Latin1_General_100_BIN2_UTF8"
 
 
+def _coerce_collation_str(v: object) -> str:
+    """Coerce a raw collation value to a non-empty string.
+
+    Maps ``None``, non-string values, empty strings, and whitespace-only
+    strings to :data:`FABRIC_DEFAULT_COLLATION`.  Any other non-empty string
+    is returned unchanged (stripped of surrounding whitespace).
+
+    Used as the shared implementation for the ``collation`` field validators
+    on :class:`Workspace` and :class:`Warehouse`.  Mirrors the :func:`_as_dict`
+    precedent of extracting common validator logic to a module-level helper.
+    """
+    if not isinstance(v, str):
+        return FABRIC_DEFAULT_COLLATION
+    return v.strip() or FABRIC_DEFAULT_COLLATION
+
+
 class Workspace(_FabricBase):
     """A Microsoft Fabric workspace."""
 
@@ -85,9 +101,7 @@ class Workspace(_FabricBase):
     @classmethod
     def _coerce_collation(cls, v: object) -> str:
         """Return the effective collation, defaulting to FABRIC_DEFAULT_COLLATION when absent."""
-        if not isinstance(v, str):
-            return FABRIC_DEFAULT_COLLATION
-        return v.strip() or FABRIC_DEFAULT_COLLATION
+        return _coerce_collation_str(v)
 
 
 class WarehouseKind(StrEnum):
@@ -128,9 +142,7 @@ class Warehouse(_FabricBase):
     @classmethod
     def _coerce_collation(cls, v: object) -> str:
         """Return the effective collation, defaulting to FABRIC_DEFAULT_COLLATION when absent."""
-        if not isinstance(v, str):
-            return FABRIC_DEFAULT_COLLATION
-        return v.strip() or FABRIC_DEFAULT_COLLATION
+        return _coerce_collation_str(v)
 
     @model_validator(mode="before")
     @classmethod

--- a/tests/unit/cli/commands/test_sql_endpoints.py
+++ b/tests/unit/cli/commands/test_sql_endpoints.py
@@ -363,7 +363,7 @@ class TestEndpointsGet:
     def test_get_human_output_shows_default_collation(
         self, runner: CliRunner, cache_env: Path
     ) -> None:
-        """SQL endpoints share the warehouse model: null collation → default '(default)'."""
+        """SQL endpoints share the warehouse model: null collation → effective default shown."""
         _ = cache_env
         mock_http = AsyncMock()
         mock_http.request = AsyncMock(return_value=_make_response(200, _ENDPOINT_JSON))
@@ -380,12 +380,11 @@ class TestEndpointsGet:
             result = runner.invoke(cli, ["-w", WS_GUID, "sql-endpoints", "get", EP_GUID])
         assert result.exit_code == 0, result.output
         assert FABRIC_DEFAULT_COLLATION in result.output
-        assert "(default)" in result.output
 
-    def test_get_json_output_keeps_raw_null_collation(
+    def test_get_json_output_coalesces_null_to_default_collation(
         self, runner: CliRunner, cache_env: Path
     ) -> None:
-        """--json must keep the raw API value (null) for SQL endpoints too."""
+        """--json surfaces the effective collation (null coalesced to default in the model)."""
         _ = cache_env
         mock_http = AsyncMock()
         mock_http.request = AsyncMock(return_value=_make_response(200, _ENDPOINT_JSON))
@@ -402,7 +401,7 @@ class TestEndpointsGet:
             result = runner.invoke(cli, ["--json", "-w", WS_GUID, "sql-endpoints", "get", EP_GUID])
         assert result.exit_code == 0, result.output
         parsed = json.loads(result.output)
-        assert parsed["defaultCollation"] is None
+        assert parsed["defaultCollation"] == FABRIC_DEFAULT_COLLATION
 
     def test_get_human_output_shows_explicit_collation_unchanged(
         self, runner: CliRunner, cache_env: Path

--- a/tests/unit/cli/commands/test_warehouses.py
+++ b/tests/unit/cli/commands/test_warehouses.py
@@ -450,18 +450,19 @@ class TestWarehousesGetCollationDefault:
     def test_human_output_shows_default_when_collation_null(
         self, runner: CliRunner, cache_env: Path
     ) -> None:
-        """Human output substitutes Fabric's default collation, marked '(default)'."""
+        """Human output shows the effective default collation when the API returns null."""
         _ = cache_env
         output = self._invoke(runner, self._NULL_COLLATION_PAYLOAD, json_flag=False)
         assert FABRIC_DEFAULT_COLLATION in output
-        assert f"{FABRIC_DEFAULT_COLLATION} (default)" in output
 
-    def test_json_output_keeps_raw_null_collation(self, runner: CliRunner, cache_env: Path) -> None:
-        """--json must keep the raw API value (null) — no fabricated default."""
+    def test_json_output_coalesces_null_to_default_collation(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """--json surfaces the effective collation (null coalesced to default in the model)."""
         _ = cache_env
         output = self._invoke(runner, self._NULL_COLLATION_PAYLOAD, json_flag=True)
         parsed = json.loads(output)
-        assert parsed["defaultCollation"] is None
+        assert parsed["defaultCollation"] == FABRIC_DEFAULT_COLLATION
 
     def test_human_output_shows_explicit_collation_unchanged(
         self, runner: CliRunner, cache_env: Path

--- a/tests/unit/cli/commands/test_warehouses.py
+++ b/tests/unit/cli/commands/test_warehouses.py
@@ -450,10 +450,16 @@ class TestWarehousesGetCollationDefault:
     def test_human_output_shows_default_when_collation_null(
         self, runner: CliRunner, cache_env: Path
     ) -> None:
-        """Human output shows the effective default collation when the API returns null."""
+        """Human output shows the effective default collation when the API returns null.
+
+        The ``(default)`` suffix is intentionally absent: the model now always
+        coalesces null/empty collation to FABRIC_DEFAULT_COLLATION, so the
+        rendered value is indistinguishable from an explicitly-set default.
+        """
         _ = cache_env
         output = self._invoke(runner, self._NULL_COLLATION_PAYLOAD, json_flag=False)
         assert FABRIC_DEFAULT_COLLATION in output
+        assert "(default)" not in output
 
     def test_json_output_coalesces_null_to_default_collation(
         self, runner: CliRunner, cache_env: Path

--- a/tests/unit/cli/commands/test_workspaces.py
+++ b/tests/unit/cli/commands/test_workspaces.py
@@ -14,6 +14,7 @@ from click.testing import CliRunner
 
 from fabric_dw.cli._main import cli
 from fabric_dw.exceptions import NotFoundError
+from fabric_dw.models import FABRIC_DEFAULT_COLLATION
 from tests.fixtures.api_payloads import WORKSPACE_GET_PAYLOAD
 
 WS_GUID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
@@ -130,7 +131,9 @@ class TestWorkspacesGet:
         parsed = json.loads(result.output)
         assert parsed["defaultDataWarehouseCollation"] == "Latin1_General_100_BIN2_UTF8"
 
-    def test_get_collation_null_in_json_output(self, runner: CliRunner, cache_env: Path) -> None:
+    def test_get_collation_null_coalesces_to_default_in_json_output(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
         _ = cache_env
         mock_http = AsyncMock()
         mock_http.request = AsyncMock(return_value=_make_response(200, WORKSPACE_GET_PAYLOAD))
@@ -141,7 +144,8 @@ class TestWorkspacesGet:
             result = runner.invoke(cli, ["--json", "workspaces", "get", WS_GUID])
         assert result.exit_code == 0
         parsed = json.loads(result.output)
-        assert parsed["defaultDataWarehouseCollation"] is None
+        # null/absent collation is coalesced to FABRIC_DEFAULT_COLLATION in the model
+        assert parsed["defaultDataWarehouseCollation"] == FABRIC_DEFAULT_COLLATION
 
     def test_get_shows_collation_in_table_output(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -10,6 +10,7 @@ import pytest
 from pydantic import ValidationError
 
 from fabric_dw.models import (
+    FABRIC_DEFAULT_COLLATION,
     AuditSettings,
     CreationModeType,
     ExecRequestHistory,
@@ -54,8 +55,11 @@ class TestWorkspace:
             "description",
             "capacityId",
             "defaultDatasetStorageFormat",
+            "defaultDataWarehouseCollation",
         }
         expected = {k: v for k, v in workspace_data.items() if k in modelled_keys and v is not None}
+        # collation is always populated (defaults to FABRIC_DEFAULT_COLLATION when absent)
+        expected.setdefault("defaultDataWarehouseCollation", FABRIC_DEFAULT_COLLATION)
         assert dumped == expected
 
     def test_round_trip_no_capacity(self) -> None:
@@ -1272,3 +1276,144 @@ class TestExecRequestHistoryFloatElapsedTime:
         obj = ExecRequestHistory.model_validate(payload)
         assert obj.allocated_cpu_time_ms == 99.5
         assert isinstance(obj.allocated_cpu_time_ms, float)
+
+
+# ---------------------------------------------------------------------------
+# Workspace.collation — null/empty coalesces to FABRIC_DEFAULT_COLLATION
+# ---------------------------------------------------------------------------
+
+_WS_BASE: dict = {
+    "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    "displayName": "MyWorkspace",
+    "capacityId": "b2c3d4e5-f6a7-8901-bcde-f01234567891",
+}
+
+_EXPLICIT_COLLATION = "Latin1_General_100_CI_AS_KS_WS_SC_UTF8"
+
+
+class TestWorkspaceCollationDefault:
+    """Workspace.collation coalesces missing/null/empty to FABRIC_DEFAULT_COLLATION."""
+
+    def test_missing_key_defaults_to_fabric_default(self) -> None:
+        obj = Workspace.model_validate(_WS_BASE)
+        assert obj.collation == FABRIC_DEFAULT_COLLATION
+
+    def test_explicit_null_defaults_to_fabric_default(self) -> None:
+        obj = Workspace.model_validate({**_WS_BASE, "defaultDataWarehouseCollation": None})
+        assert obj.collation == FABRIC_DEFAULT_COLLATION
+
+    def test_empty_string_defaults_to_fabric_default(self) -> None:
+        obj = Workspace.model_validate({**_WS_BASE, "defaultDataWarehouseCollation": ""})
+        assert obj.collation == FABRIC_DEFAULT_COLLATION
+
+    def test_whitespace_only_defaults_to_fabric_default(self) -> None:
+        obj = Workspace.model_validate({**_WS_BASE, "defaultDataWarehouseCollation": "   "})
+        assert obj.collation == FABRIC_DEFAULT_COLLATION
+
+    def test_explicit_collation_preserved(self) -> None:
+        obj = Workspace.model_validate(
+            {**_WS_BASE, "defaultDataWarehouseCollation": _EXPLICIT_COLLATION}
+        )
+        assert obj.collation == _EXPLICIT_COLLATION
+
+    def test_collation_is_never_none(self) -> None:
+        """collation must be a str on the read path — never None."""
+        obj = Workspace.model_validate(_WS_BASE)
+        assert obj.collation is not None
+        assert isinstance(obj.collation, str)
+
+
+# ---------------------------------------------------------------------------
+# Warehouse.collation — null/empty coalesces to FABRIC_DEFAULT_COLLATION
+# ---------------------------------------------------------------------------
+
+_WH_BASE: dict = {
+    "id": "c3d4e5f6-a7b8-9012-cdef-012345678901",
+    "displayName": "MySalesWarehouse",
+    "workspaceId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    "kind": WarehouseKind.WAREHOUSE,
+    "connectionString": "saleswarehouse.datawarehouse.fabric.microsoft.com",
+}
+
+_WH_API_BASE: dict = {
+    "id": "c3d4e5f6-a7b8-9012-cdef-012345678901",
+    "displayName": "MySalesWarehouse",
+    "workspaceId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    "properties": {
+        "connectionString": "saleswarehouse.datawarehouse.fabric.microsoft.com",
+        "createdDate": "2024-03-15T10:00:00Z",
+    },
+}
+
+
+class TestWarehouseCollationDefault:
+    """Warehouse.collation coalesces missing/null/empty to FABRIC_DEFAULT_COLLATION."""
+
+    # --- flat dict (already-processed / manual construction) path ---
+
+    def test_missing_key_flat_dict_defaults_to_fabric_default(self) -> None:
+        obj = Warehouse.model_validate(_WH_BASE)
+        assert obj.collation == FABRIC_DEFAULT_COLLATION
+
+    def test_explicit_null_flat_dict_defaults_to_fabric_default(self) -> None:
+        obj = Warehouse.model_validate({**_WH_BASE, "defaultCollation": None})
+        assert obj.collation == FABRIC_DEFAULT_COLLATION
+
+    def test_empty_string_flat_dict_defaults_to_fabric_default(self) -> None:
+        obj = Warehouse.model_validate({**_WH_BASE, "defaultCollation": ""})
+        assert obj.collation == FABRIC_DEFAULT_COLLATION
+
+    def test_whitespace_only_flat_dict_defaults_to_fabric_default(self) -> None:
+        obj = Warehouse.model_validate({**_WH_BASE, "defaultCollation": "   "})
+        assert obj.collation == FABRIC_DEFAULT_COLLATION
+
+    def test_explicit_collation_flat_dict_preserved(self) -> None:
+        obj = Warehouse.model_validate({**_WH_BASE, "defaultCollation": _EXPLICIT_COLLATION})
+        assert obj.collation == _EXPLICIT_COLLATION
+
+    # --- from_api / props construction path ---
+
+    def test_missing_collation_in_props_defaults_to_fabric_default(self) -> None:
+        obj = Warehouse.from_api(_WH_API_BASE, kind=WarehouseKind.WAREHOUSE)
+        assert obj.collation == FABRIC_DEFAULT_COLLATION
+
+    def test_null_collation_in_props_defaults_to_fabric_default(self) -> None:
+        payload = {
+            **_WH_API_BASE,
+            "properties": {**_WH_API_BASE["properties"], "defaultCollation": None},
+        }
+        obj = Warehouse.from_api(payload, kind=WarehouseKind.WAREHOUSE)
+        assert obj.collation == FABRIC_DEFAULT_COLLATION
+
+    def test_empty_collation_in_props_defaults_to_fabric_default(self) -> None:
+        payload = {
+            **_WH_API_BASE,
+            "properties": {**_WH_API_BASE["properties"], "defaultCollation": ""},
+        }
+        obj = Warehouse.from_api(payload, kind=WarehouseKind.WAREHOUSE)
+        assert obj.collation == FABRIC_DEFAULT_COLLATION
+
+    def test_whitespace_collation_in_props_defaults_to_fabric_default(self) -> None:
+        payload = {
+            **_WH_API_BASE,
+            "properties": {**_WH_API_BASE["properties"], "defaultCollation": "  "},
+        }
+        obj = Warehouse.from_api(payload, kind=WarehouseKind.WAREHOUSE)
+        assert obj.collation == FABRIC_DEFAULT_COLLATION
+
+    def test_explicit_collation_in_props_preserved(self) -> None:
+        payload = {
+            **_WH_API_BASE,
+            "properties": {
+                **_WH_API_BASE["properties"],
+                "defaultCollation": _EXPLICIT_COLLATION,
+            },
+        }
+        obj = Warehouse.from_api(payload, kind=WarehouseKind.WAREHOUSE)
+        assert obj.collation == _EXPLICIT_COLLATION
+
+    def test_collation_is_never_none(self) -> None:
+        """collation must be a str on the read path — never None."""
+        obj = Warehouse.model_validate(_WH_BASE)
+        assert obj.collation is not None
+        assert isinstance(obj.collation, str)


### PR DESCRIPTION
## Summary

- `Workspace.collation` and `Warehouse.collation` previously passed the raw Fabric REST API value through, which can be `null`/empty when a workspace or warehouse was created without an explicit collation setting.
- Add a `@field_validator("collation", mode="before")` on both models that coalesces `None`, empty string, and whitespace-only values to `FABRIC_DEFAULT_COLLATION` (`"Latin1_General_100_BIN2_UTF8"`).
- Move `FABRIC_DEFAULT_COLLATION` above `Workspace` so both classes can reference it. Tighten the field annotation to `str` (non-optional) since the read path now always populates the value.
- Update five existing tests that previously expected `null` to pass through on the JSON path; they now assert the effective collation is returned.
- Add 17 new focused unit tests in `tests/unit/test_models.py` covering both models across all coalescing cases (missing key, explicit null, empty string, whitespace-only) and the `Warehouse.from_api` / props construction path.

## Test plan

- [x] `uv run pytest tests/unit/test_models.py -q` — 162 tests pass (17 new)
- [x] `uv run pytest tests/unit -q` — 4658 tests pass
- [x] `uv run ruff check src tests` — no errors on changed files
- [x] `uv run ruff format --check .` — no formatting issues
- [x] `uv run ty check src tests` — no type errors

Closes #708

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>