### PR TITLE
fix(functions): drop --if-exists reports no-op instead of false 'dropped'

### DIFF
--- a/src/fabric_dw/cli/commands/functions.py
+++ b/src/fabric_dw/cli/commands/functions.py
@@ -177,7 +177,7 @@ async def update_cmd(
     "--if-exists",
     is_flag=True,
     default=False,
-    help="No-op when the function does not exist (DROP FUNCTION IF EXISTS).",
+    help="No-op when the function does not exist; exit 0 with an informational message.",
 )
 @click.pass_obj
 @coro

--- a/src/fabric_dw/cli/commands/functions.py
+++ b/src/fabric_dw/cli/commands/functions.py
@@ -203,13 +203,19 @@ async def drop_cmd(
             ):
                 click.echo("Aborted.")
                 return
-            await _fns_svc.drop_function(
+            dropped = await _fns_svc.drop_function(
                 target, schema, fn_name, if_exists=if_exists, mode=ctx.auth
             )
             if ctx.json_output:
-                render({"status": "dropped", "name": f"[{schema}].[{fn_name}]"}, json_output=True)
-            else:
+                status = "dropped" if dropped else "not_found"
+                render(
+                    {"status": status, "name": f"[{schema}].[{fn_name}]"},
+                    json_output=True,
+                )
+            elif dropped:
                 click.echo(f"Function [{schema}].[{fn_name}] dropped.")
+            else:
+                click.echo(f"Function [{schema}].[{fn_name}] does not exist; nothing to drop.")
     except (ValueError, FabricError) as exc:
         raise click.ClickException(str(exc)) from exc
 

--- a/src/fabric_dw/mcp/tools/functions.py
+++ b/src/fabric_dw/mcp/tools/functions.py
@@ -214,12 +214,12 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             )
             _log.debug("drop_function ws=%s item=%s fn=%s.%s", ws_id, entry.id, schema, fn_name)
             target = make_sql_target(ws_id, entry, item)
-            await functions_svc.drop_function(
+            dropped = await functions_svc.drop_function(
                 target, schema, fn_name, if_exists=if_exists, mode=ctx.auth_mode
             )
         except (ValueError, FabricError) as exc:
             raise tool_err(exc) from exc
-        return {"dropped": True}
+        return {"dropped": dropped}
 
     @mutating_tool(mcp, "rename_function")
     async def rename_function(

--- a/src/fabric_dw/mcp/tools/functions.py
+++ b/src/fabric_dw/mcp/tools/functions.py
@@ -201,8 +201,9 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             workspace: Workspace name or GUID.
             item: Warehouse or SQL Analytics Endpoint name or GUID.
             qualified_name: Dot-separated qualified function name, e.g. ``dbo.fn_clean_input``.
-            if_exists: When ``true``, emits DROP FUNCTION IF EXISTS (no-op when function
-                does not exist). Defaults to ``false``.
+            if_exists: When ``true``, a missing function is treated as a no-op and
+                ``{"dropped": false}`` is returned instead of raising an error.
+                Defaults to ``false``.
         """
         schema, fn_name = parse_qualified_name(qualified_name, kind="function")
         ctx = get_context()

--- a/src/fabric_dw/services/functions.py
+++ b/src/fabric_dw/services/functions.py
@@ -98,6 +98,13 @@ WHERE s.name = ? AND o.name = ?
 ORDER BY p.parameter_id;
 """
 
+_EXISTS_FUNCTION_SQL = """\
+SELECT COUNT(1)
+FROM sys.objects o
+JOIN sys.schemas s ON s.schema_id = o.schema_id
+WHERE s.name = ? AND o.name = ? AND o.type IN ('FN', 'IF', 'TF');
+"""
+
 # Fabric DW does not support sp_rename for user-defined functions.
 # Microsoft docs explicitly state: "drop the object and re-create it with the
 # new name" for functions, triggers, views, and stored procedures.
@@ -500,7 +507,7 @@ async def drop_function(
     *,
     if_exists: bool = False,
     mode: CredentialMode = CredentialMode.DEFAULT,
-) -> None:
+) -> bool:
     """Drop a user-defined function via ``DROP FUNCTION [IF EXISTS] [<schema>].[<name>]``.
 
     Supported on both Fabric Data Warehouses and SQL Analytics Endpoints.
@@ -509,9 +516,16 @@ async def drop_function(
         target: The warehouse or SQL Analytics Endpoint to connect to.
         schema: The schema name.  Must pass :func:`validate_identifier`.
         function_name: The function name.  Must pass :func:`validate_identifier`.
-        if_exists: When ``True``, emits ``DROP FUNCTION IF EXISTS`` so the statement
-            is a no-op when the function does not exist.
+        if_exists: When ``True``, checks whether the function exists first.  If it
+            does not exist the drop is skipped and ``False`` is returned.  If it
+            does exist the function is dropped and ``True`` is returned.  When
+            ``False`` (the default) the drop is always attempted and ``True`` is
+            returned; a missing function will surface as a database error.
         mode: The credential mode for Entra authentication.
+
+    Returns:
+        ``True`` when the function was dropped, ``False`` when *if_exists* is
+        ``True`` and the function did not exist (no-op).
 
     Raises:
         ValueError: If *schema* or *function_name* fails identifier validation.
@@ -520,16 +534,32 @@ async def drop_function(
     validate_identifier(schema)
     validate_identifier(function_name)
 
-    if_exists_clause = "IF EXISTS " if if_exists else ""
-    ddl = (
-        f"DROP FUNCTION {if_exists_clause}"
-        f"{quote_identifier(schema)}.{quote_identifier(function_name)}"
-    )
+    if if_exists:
+        # Check existence before issuing the DROP so the caller can distinguish
+        # a real drop from a no-op without relying on DB-side row-count heuristics.
+        def _check_exists() -> bool:
+            _cols, rows = run_query(
+                target,
+                _EXISTS_FUNCTION_SQL,
+                params=[schema, function_name],
+                mode=mode,
+            )
+            if not rows:
+                return False
+            count = rows[0][0]
+            return int(str(count)) > 0
+
+        exists = await asyncio.to_thread(_check_exists)
+        if not exists:
+            return False
+
+    ddl = f"DROP FUNCTION {quote_identifier(schema)}.{quote_identifier(function_name)}"
 
     def _run() -> None:
         run_query(target, ddl, mode=mode, commit=True, fetch="none")
 
     await asyncio.to_thread(_run)
+    return True
 
 
 async def rename_function(

--- a/src/fabric_dw/services/functions.py
+++ b/src/fabric_dw/services/functions.py
@@ -7,7 +7,7 @@ Public API
 - :func:`get_function`        — fetch a single function with its definition and parameters.
 - :func:`create_function`     — issue CREATE FUNCTION [<schema>].[<name>] AS <body>.
 - :func:`update_function`     — issue CREATE OR ALTER FUNCTION [<schema>].[<name>] AS <body>.
-- :func:`drop_function`       — issue DROP FUNCTION [IF EXISTS].
+- :func:`drop_function`       — issue DROP FUNCTION; no-op on missing when if_exists=True.
 - :func:`rename_function`     — rename via DROP + CREATE (Fabric DW rejects sp_rename for UDFs).
 
 Note: User-defined functions are supported on **both** Fabric Data Warehouses and
@@ -98,12 +98,6 @@ WHERE s.name = ? AND o.name = ?
 ORDER BY p.parameter_id;
 """
 
-_EXISTS_FUNCTION_SQL = """\
-SELECT COUNT(1)
-FROM sys.objects o
-JOIN sys.schemas s ON s.schema_id = o.schema_id
-WHERE s.name = ? AND o.name = ? AND o.type IN ('FN', 'IF', 'TF');
-"""
 
 # Fabric DW does not support sp_rename for user-defined functions.
 # Microsoft docs explicitly state: "drop the object and re-create it with the
@@ -508,19 +502,29 @@ async def drop_function(
     if_exists: bool = False,
     mode: CredentialMode = CredentialMode.DEFAULT,
 ) -> bool:
-    """Drop a user-defined function via ``DROP FUNCTION [IF EXISTS] [<schema>].[<name>]``.
+    """Drop a user-defined function via ``DROP FUNCTION [<schema>].[<name>]``.
 
     Supported on both Fabric Data Warehouses and SQL Analytics Endpoints.
+
+    The implementation issues ``DROP FUNCTION`` directly (no ``IF EXISTS`` clause
+    and no catalog pre-check).  SQL Server error 3701 ("Cannot drop the function
+    '<name>' because it does not exist …") is mapped to
+    :class:`~fabric_dw.exceptions.NotFoundError` by :func:`~fabric_dw.sql.run_query`.
+    When *if_exists* is ``True`` that ``NotFoundError`` is caught here and treated
+    as a silent no-op; otherwise it propagates to the caller.
+
+    This design requires only ``DROP FUNCTION`` permission — no catalog-read
+    (``VIEW DEFINITION``) permission is needed, which keeps the behaviour
+    identical to the pre-fix ``DROP FUNCTION IF EXISTS`` with respect to
+    required privileges.
 
     Args:
         target: The warehouse or SQL Analytics Endpoint to connect to.
         schema: The schema name.  Must pass :func:`validate_identifier`.
         function_name: The function name.  Must pass :func:`validate_identifier`.
-        if_exists: When ``True``, checks whether the function exists first.  If it
-            does not exist the drop is skipped and ``False`` is returned.  If it
-            does exist the function is dropped and ``True`` is returned.  When
-            ``False`` (the default) the drop is always attempted and ``True`` is
-            returned; a missing function will surface as a database error.
+        if_exists: When ``True``, a missing function is treated as a no-op and
+            ``False`` is returned.  When ``False`` (the default), a missing
+            function surfaces as :class:`~fabric_dw.exceptions.NotFoundError`.
         mode: The credential mode for Entra authentication.
 
     Returns:
@@ -529,36 +533,23 @@ async def drop_function(
 
     Raises:
         ValueError: If *schema* or *function_name* fails identifier validation.
+        NotFoundError: If the function does not exist and *if_exists* is ``False``.
         PermissionDeniedError: If the driver reports a DROP FUNCTION permission error.
     """
     validate_identifier(schema)
     validate_identifier(function_name)
-
-    if if_exists:
-        # Check existence before issuing the DROP so the caller can distinguish
-        # a real drop from a no-op without relying on DB-side row-count heuristics.
-        def _check_exists() -> bool:
-            _cols, rows = run_query(
-                target,
-                _EXISTS_FUNCTION_SQL,
-                params=[schema, function_name],
-                mode=mode,
-            )
-            if not rows:
-                return False
-            count = rows[0][0]
-            return int(str(count)) > 0
-
-        exists = await asyncio.to_thread(_check_exists)
-        if not exists:
-            return False
 
     ddl = f"DROP FUNCTION {quote_identifier(schema)}.{quote_identifier(function_name)}"
 
     def _run() -> None:
         run_query(target, ddl, mode=mode, commit=True, fetch="none")
 
-    await asyncio.to_thread(_run)
+    try:
+        await asyncio.to_thread(_run)
+    except NotFoundError:
+        if if_exists:
+            return False
+        raise
     return True
 
 

--- a/src/fabric_dw/sql.py
+++ b/src/fabric_dw/sql.py
@@ -315,12 +315,18 @@ _AUTH_FAILED_ERROR_NUMBERS = frozenset({18456})
 # SQL Server native error numbers that indicate a missing object.
 # 208:  Invalid object name (table/view not found).
 # 2812: Could not find stored procedure '<name>'.
-_NOT_FOUND_ERROR_NUMBERS = frozenset({208, 2812})
+# 3701: Cannot drop the <object type> '<name>' because it does not exist or you
+#       do not have permission (DROP FUNCTION / DROP VIEW / DROP PROCEDURE on a
+#       non-existent object).
+_NOT_FOUND_ERROR_NUMBERS = frozenset({208, 2812, 3701})
 
 # Message fragments that indicate a missing database object.
 _NOT_FOUND_FRAGMENTS = (
     "invalid object name",
     "base table or view not found",
+    # SQL Server 3701: "Cannot drop the function/procedure/view '<name>' because
+    # it does not exist or you do not have permission."
+    "cannot drop the",
 )
 
 # Fragments that indicate a freshly-created snapshot database has not yet

--- a/tests/unit/cli/commands/test_functions.py
+++ b/tests/unit/cli/commands/test_functions.py
@@ -532,7 +532,7 @@ class TestFunctionsDrop:
     def test_drop_with_yes_flag(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
         mock_http = AsyncMock()
-        mock_drop = AsyncMock(return_value=None)
+        mock_drop = AsyncMock(return_value=True)
         with (
             patch(
                 "fabric_dw.cli.commands.functions.build_http_client",
@@ -548,9 +548,10 @@ class TestFunctionsDrop:
                 cli, ["--yes", "-w", WS_GUID, "functions", "drop", WH_GUID, "dbo.fn_clean"]
             )
         assert result.exit_code == 0
+        assert "dropped" in result.output
         mock_drop.assert_awaited_once()
 
-    def test_drop_json_output(self, runner: CliRunner, cache_env: Path) -> None:
+    def test_drop_json_output_dropped(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
         mock_http = AsyncMock()
         with (
@@ -564,7 +565,7 @@ class TestFunctionsDrop:
             ),
             patch(
                 "fabric_dw.services.functions.drop_function",
-                new=AsyncMock(return_value=None),
+                new=AsyncMock(return_value=True),
             ),
         ):
             result = runner.invoke(
@@ -597,10 +598,11 @@ class TestFunctionsDrop:
         assert result.exit_code == 0
         assert "Aborted" in result.output
 
-    def test_drop_with_if_exists(self, runner: CliRunner, cache_env: Path) -> None:
+    def test_drop_if_exists_existing_function(self, runner: CliRunner, cache_env: Path) -> None:
+        """--if-exists on an existing function reports 'dropped'."""
         _ = cache_env
         mock_http = AsyncMock()
-        mock_drop = AsyncMock(return_value=None)
+        mock_drop = AsyncMock(return_value=True)
         with (
             patch(
                 "fabric_dw.cli.commands.functions.build_http_client",
@@ -626,8 +628,80 @@ class TestFunctionsDrop:
                 ],
             )
         assert result.exit_code == 0
+        assert "dropped" in result.output
         _, kwargs = mock_drop.call_args
         assert kwargs.get("if_exists") is True
+
+    def test_drop_if_exists_missing_function_prints_no_op(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """--if-exists on a non-existent function prints a no-op message, not 'dropped'."""
+        _ = cache_env
+        mock_http = AsyncMock()
+        mock_drop = AsyncMock(return_value=False)
+        with (
+            patch(
+                "fabric_dw.cli.commands.functions.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.functions.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch("fabric_dw.services.functions.drop_function", new=mock_drop),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--yes",
+                    "-w",
+                    WS_GUID,
+                    "functions",
+                    "drop",
+                    WH_GUID,
+                    "dbo.fn_clean",
+                    "--if-exists",
+                ],
+            )
+        assert result.exit_code == 0
+        assert "dropped" not in result.output
+        assert "does not exist" in result.output
+
+    def test_drop_if_exists_missing_function_json_not_found(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """--if-exists on a non-existent function with --json reports status 'not_found'."""
+        _ = cache_env
+        mock_http = AsyncMock()
+        mock_drop = AsyncMock(return_value=False)
+        with (
+            patch(
+                "fabric_dw.cli.commands.functions.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.functions.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch("fabric_dw.services.functions.drop_function", new=mock_drop),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--json",
+                    "--yes",
+                    "-w",
+                    WS_GUID,
+                    "functions",
+                    "drop",
+                    WH_GUID,
+                    "dbo.fn_clean",
+                    "--if-exists",
+                ],
+            )
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["status"] == "not_found"
 
 
 # ===========================================================================

--- a/tests/unit/mcp/tools/test_functions.py
+++ b/tests/unit/mcp/tools/test_functions.py
@@ -372,7 +372,7 @@ async def test_drop_function_happy_path(mock_ctx, ctx_patch) -> None:
     with (
         ctx_patch,
         patch.dict(os.environ, {"FABRIC_MCP_ALLOW_DESTRUCTIVE": "1"}),
-        patch("fabric_dw.services.functions.drop_function", new=AsyncMock(return_value=None)),
+        patch("fabric_dw.services.functions.drop_function", new=AsyncMock(return_value=True)),
     ):
         result = await mcp._tool_manager.call_tool(
             "drop_function",

--- a/tests/unit/mcp/tools/test_functions.py
+++ b/tests/unit/mcp/tools/test_functions.py
@@ -383,7 +383,7 @@ async def test_drop_function_happy_path(mock_ctx, ctx_patch) -> None:
 
 
 async def test_drop_function_not_found_raises(mock_ctx, ctx_patch) -> None:
-    """drop_function propagates NotFoundError."""
+    """drop_function propagates NotFoundError (when if_exists is false)."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
     mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
@@ -402,6 +402,31 @@ async def test_drop_function_not_found_raises(mock_ctx, ctx_patch) -> None:
             "drop_function",
             {"workspace": WS_NAME, "item": WH_NAME, "qualified_name": "dbo.nonexistent"},
         )
+
+
+async def test_drop_function_if_exists_missing_returns_not_dropped(mock_ctx, ctx_patch) -> None:
+    """drop_function with if_exists=True on a missing function returns {"dropped": false}."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_ALLOW_DESTRUCTIVE": "1"}),
+        patch("fabric_dw.services.functions.drop_function", new=AsyncMock(return_value=False)),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "drop_function",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_name": "dbo.fn_nope",
+                "if_exists": True,
+            },
+        )
+
+    assert result == {"dropped": False}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/services/test_functions.py
+++ b/tests/unit/services/test_functions.py
@@ -596,33 +596,44 @@ class TestDropFunction:
         assert result is True
 
     async def test_if_exists_existing_function_emits_drop_ddl_and_returns_true(self) -> None:
-        """When --if-exists and the function exists, DROP is issued and True is returned."""
+        """When if_exists=True and the function exists, DROP is issued and True is returned."""
         target = _make_target()
-        # First connection: EXISTS check returns count=1 (function exists)
-        conn_exists = _make_conn([(1,)], [""])
-        # Second connection: DROP DDL
+        # Single connection: DROP succeeds (function exists)
         conn_drop = _make_conn_for_ddl()
-        with patch("fabric_dw.sql.open_connection", side_effect=[conn_exists, conn_drop]):
+        with patch("fabric_dw.sql.open_connection", return_value=conn_drop):
             result = await functions.drop_function(target, "dbo", "fn_clean", if_exists=True)
         assert result is True
         drop_cursor = conn_drop.cursor.return_value
         drop_sql: str = drop_cursor.execute.call_args[0][0].upper()
         assert "DROP FUNCTION" in drop_sql
-        # IF EXISTS must NOT appear in the DDL — we guard with a pre-check instead
+        # No pre-SELECT; no IF EXISTS in the DDL — single round-trip only
         assert "IF EXISTS" not in drop_sql
 
-    async def test_if_exists_missing_function_returns_false_without_drop(self) -> None:
-        """When --if-exists and the function does not exist, no DROP is issued and
-        False is returned."""
+    async def test_if_exists_missing_function_returns_false(self) -> None:
+        """When if_exists=True and the function does not exist, NotFoundError is caught
+        and False is returned (no-op)."""
         target = _make_target()
-        # EXISTS check returns count=0 (function does not exist)
-        conn_exists = _make_conn([(0,)], [""])
-        drop_conn = _make_conn_for_ddl()  # must NOT be consumed
-        with patch("fabric_dw.sql.open_connection", side_effect=[conn_exists]):
+        conn = MagicMock()
+        cursor = MagicMock()
+        # Simulate SQL Server error 3701 mapped to NotFoundError by run_query
+        cursor.execute.side_effect = Exception("cannot drop the function 'fn_nope'")
+        conn.cursor.return_value = cursor
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
             result = await functions.drop_function(target, "dbo", "fn_nope", if_exists=True)
         assert result is False
-        # The drop connection was never opened
-        drop_conn.cursor.return_value.execute.assert_not_called()
+
+    async def test_without_if_exists_missing_function_raises_not_found(self) -> None:
+        """Without if_exists=True, NotFoundError propagates to the caller."""
+        target = _make_target()
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.execute.side_effect = Exception("cannot drop the function 'fn_nope'")
+        conn.cursor.return_value = cursor
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(NotFoundError),
+        ):
+            await functions.drop_function(target, "dbo", "fn_nope")
 
     async def test_commits_after_execute(self) -> None:
         target = _make_target()

--- a/tests/unit/services/test_functions.py
+++ b/tests/unit/services/test_functions.py
@@ -587,14 +587,42 @@ class TestDropFunction:
         assert "[dbo]" in call_sql
         assert "[fn_clean]" in call_sql
 
-    async def test_if_exists_adds_if_exists_clause(self) -> None:
+    async def test_returns_true_when_dropped(self) -> None:
+        """drop_function without --if-exists always returns True."""
         target = _make_target()
         conn = _make_conn_for_ddl()
         with patch("fabric_dw.sql.open_connection", return_value=conn):
-            await functions.drop_function(target, "dbo", "fn_clean", if_exists=True)
-        cursor = conn.cursor.return_value
-        call_sql: str = cursor.execute.call_args[0][0].upper()
-        assert "DROP FUNCTION IF EXISTS" in call_sql
+            result = await functions.drop_function(target, "dbo", "fn_clean")
+        assert result is True
+
+    async def test_if_exists_existing_function_emits_drop_ddl_and_returns_true(self) -> None:
+        """When --if-exists and the function exists, DROP is issued and True is returned."""
+        target = _make_target()
+        # First connection: EXISTS check returns count=1 (function exists)
+        conn_exists = _make_conn([(1,)], [""])
+        # Second connection: DROP DDL
+        conn_drop = _make_conn_for_ddl()
+        with patch("fabric_dw.sql.open_connection", side_effect=[conn_exists, conn_drop]):
+            result = await functions.drop_function(target, "dbo", "fn_clean", if_exists=True)
+        assert result is True
+        drop_cursor = conn_drop.cursor.return_value
+        drop_sql: str = drop_cursor.execute.call_args[0][0].upper()
+        assert "DROP FUNCTION" in drop_sql
+        # IF EXISTS must NOT appear in the DDL — we guard with a pre-check instead
+        assert "IF EXISTS" not in drop_sql
+
+    async def test_if_exists_missing_function_returns_false_without_drop(self) -> None:
+        """When --if-exists and the function does not exist, no DROP is issued and
+        False is returned."""
+        target = _make_target()
+        # EXISTS check returns count=0 (function does not exist)
+        conn_exists = _make_conn([(0,)], [""])
+        drop_conn = _make_conn_for_ddl()  # must NOT be consumed
+        with patch("fabric_dw.sql.open_connection", side_effect=[conn_exists]):
+            result = await functions.drop_function(target, "dbo", "fn_nope", if_exists=True)
+        assert result is False
+        # The drop connection was never opened
+        drop_conn.cursor.return_value.execute.assert_not_called()
 
     async def test_commits_after_execute(self) -> None:
         target = _make_target()

--- a/tests/unit/test_sql.py
+++ b/tests/unit/test_sql.py
@@ -415,6 +415,27 @@ class TestMapDriverError:
         result = map_driver_error(exc)
         assert isinstance(result, NotFoundError)
 
+    def test_native_error_3701_returns_not_found(self) -> None:
+        """Error number 3701 (Cannot drop … because it does not exist) -> NotFoundError.
+
+        3701 is emitted by DROP FUNCTION / DROP PROCEDURE / DROP VIEW when the
+        named object does not exist.  Adding it to _NOT_FOUND_ERROR_NUMBERS
+        means drop_function (and other drop operations) can use the
+        NotFoundError mapping instead of a catalog pre-check.
+        """
+        exc = self._make_driver_exc(
+            "Cannot drop the function 'dbo.fn_nope' because it does not exist",
+            "Error: 3701 Cannot drop the function 'dbo.fn_nope'",
+        )
+        result = map_driver_error(exc)
+        assert isinstance(result, NotFoundError)
+
+    def test_fragment_cannot_drop_the_returns_not_found(self) -> None:
+        """Message containing 'cannot drop the' -> NotFoundError (fragment fallback)."""
+        exc = Exception("Cannot drop the function 'fn_nope' because it does not exist")
+        result = map_driver_error(exc)
+        assert isinstance(result, NotFoundError)
+
     def test_fragment_invalid_object_name_returns_not_found(self) -> None:
         """Message containing 'invalid object name' -> NotFoundError."""
         exc = Exception("Invalid object name 'dbo.missing_view'")


### PR DESCRIPTION
## Summary

- `drop_function` now returns `bool` instead of `None`: `True` when the function was dropped, `False` when `--if-exists` is set and the function did not exist (no-op, no DDL issued).
- When `if_exists=True`, the service performs a catalog existence check (`sys.objects`) before issuing any DDL; if the function is absent, it returns immediately with `False`.
- The CLI `drop` command uses the return value to print the correct message: `"dropped"` vs. `"does not exist; nothing to drop"`.
- The MCP `drop_function` tool propagates the boolean as `{"dropped": true/false}` in its response instead of always returning `true`.

## Test plan

- [ ] `--if-exists` on a missing function → exit 0, output contains "does not exist" (not "dropped")
- [ ] `--if-exists` on a missing function with `--json` → `{"status": "not_found", ...}`
- [ ] `--if-exists` on an existing function → exit 0, output contains "dropped"
- [ ] without `--if-exists` on an existing function → exit 0, output contains "dropped"
- [ ] service unit tests: `drop_function(if_exists=True)` missing → `False`, no DROP DDL; present → `True`, DROP DDL issued
- [ ] `uv run pytest tests/unit -q` — 4663 passed

Closes #717