### PR TITLE
ci: migrate codecov test-results upload to codecov-action report_type=test_results

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,10 +83,12 @@ jobs:
           flags: unit
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: unit
+          report_type: test_results
+          files: junit.xml
       # Upload coverage to GitHub Code Quality (public preview).
       # Only runs on Python 3.13 to avoid duplicate uploads across matrix entries.
       # Fork-PR guard: skip on PRs from forks (they lack write permissions).

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -259,10 +259,12 @@ jobs:
       - name: Upload test results to Codecov
         # !cancelled(): always upload test results so failures appear in Test Analytics
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: integration
+          report_type: test_results
+          files: junit.xml
 
       - name: Post-test full workspace wipe
         if: always()


### PR DESCRIPTION
## Summary

- Replaces the deprecated `codecov/test-results-action@v1` with `codecov/codecov-action@v7` (already in use for coverage uploads) in both `ci.yml` and `integration.yml`.
- Uses `report_type: test_results` and `files: junit.xml` to correctly upload JUnit XML test results to Codecov Test Analytics.
- Resolves both deprecation warnings emitted by GitHub Actions for the old action.

## Changes

- `.github/workflows/ci.yml` — test-results step now uses `codecov/codecov-action@v7` with `report_type: test_results`, `files: junit.xml`, `flags: unit`.
- `.github/workflows/integration.yml` — test-results step now uses `codecov/codecov-action@v7` with `report_type: test_results`, `files: junit.xml`, `flags: integration`. Existing explanatory comment preserved.

## Test plan

- [ ] Verify CI passes on this PR.
- [ ] Confirm no more deprecation warnings for `codecov/test-results-action` in CI logs.
- [ ] Confirm test results appear in Codecov Test Analytics dashboard.

Closes #735

🤖 Generated with [Claude Code](https://claude.com/claude-code)