### PR TITLE
fix(load): omit MAXERRORS for Parquet COPY INTO, warn when ignored

### DIFF
--- a/src/fabric_dw/services/load.py
+++ b/src/fabric_dw/services/load.py
@@ -348,7 +348,9 @@ def _build_copy_into_sql(
         if cred:
             with_parts.append(cred)
 
-    if max_errors is not None:
+    # MAXERRORS is only valid for CSV; Fabric rejects it for PARQUET with
+    # "Option 'MAXERRORS' is not supported for specified format 'PARQUET'".
+    if max_errors is not None and file_type == "CSV":
         with_parts.append(f"MAXERRORS = {int(max_errors)}")
 
     if rejected_row_location is not None:
@@ -933,6 +935,14 @@ async def load_local_file(  # noqa: PLR0912, PLR0915
         file_type = "PARQUET"
     else:
         file_type = "CSV"
+
+    # MAXERRORS is not supported for PARQUET COPY INTO; warn and ignore.
+    if max_errors is not None and file_type == "PARQUET":
+        _logger.warning(
+            "load_local_file: --max-errors is not supported for Parquet COPY INTO "
+            "(Fabric rejects MAXERRORS for FILE_TYPE='PARQUET'); ignoring max_errors=%d",
+            max_errors,
+        )
 
     # A1: normalise the destination filename — decode percent-encoded characters
     # (e.g. %2F / %5C that could be interpreted as path separators) and strip

--- a/src/fabric_dw/services/load.py
+++ b/src/fabric_dw/services/load.py
@@ -727,7 +727,10 @@ async def copy_into_from_url(
         secret: Secret value (SAS token / client secret / account key).
         identity: Identity for managed-identity or service-principal credentials.
         csv_options: Optional CSV loading options.
-        max_errors: Maximum errors before abort.
+        max_errors: Maximum errors before abort.  Only valid for ``FILE_TYPE='CSV'``;
+            Fabric rejects ``MAXERRORS`` for Parquet.  When *file_type* is
+            ``'PARQUET'`` and *max_errors* is not ``None``, a warning is emitted
+            and the value is cleared before building the SQL statement.
         rejected_row_location: URL for rejected row output.
         kind: Warehouse item kind.  SQL Endpoint items are rejected.
         mode: Credential mode for SQL authentication.
@@ -747,6 +750,18 @@ async def copy_into_from_url(
     _validate_https_url(url, "url")
     if rejected_row_location is not None:
         _validate_https_url(rejected_row_location, "rejected_row_location")
+
+    # MAXERRORS is only valid for CSV; Fabric rejects it for PARQUET with
+    # "Option 'MAXERRORS' is not supported for specified format 'PARQUET'".
+    # Clear the value here (defence-in-depth alongside the gate in
+    # _build_copy_into_sql) so every caller — local-file and URL — is covered.
+    if max_errors is not None and file_type == "PARQUET":
+        _logger.warning(
+            "copy_into_from_url: --max-errors is not supported for Parquet COPY INTO "
+            "(Fabric rejects MAXERRORS for FILE_TYPE='PARQUET'); ignoring max_errors=%d",
+            max_errors,
+        )
+        max_errors = None
 
     sql = _build_copy_into_sql(
         schema,
@@ -935,14 +950,6 @@ async def load_local_file(  # noqa: PLR0912, PLR0915
         file_type = "PARQUET"
     else:
         file_type = "CSV"
-
-    # MAXERRORS is not supported for PARQUET COPY INTO; warn and ignore.
-    if max_errors is not None and file_type == "PARQUET":
-        _logger.warning(
-            "load_local_file: --max-errors is not supported for Parquet COPY INTO "
-            "(Fabric rejects MAXERRORS for FILE_TYPE='PARQUET'); ignoring max_errors=%d",
-            max_errors,
-        )
 
     # A1: normalise the destination filename — decode percent-encoded characters
     # (e.g. %2F / %5C that could be interpreted as path separators) and strip

--- a/tests/unit/services/test_load.py
+++ b/tests/unit/services/test_load.py
@@ -139,11 +139,26 @@ class TestBuildCopyIntoSql:
         )
         assert "CREDENTIAL = (IDENTITY = 'Storage Account Key', SECRET = 'base64key==')" in sql
 
-    def test_max_errors_option(self) -> None:
+    def test_max_errors_csv(self) -> None:
+        """MAXERRORS must appear in the SQL for CSV loads."""
         sql = _build_copy_into_sql(
-            "dbo", "t", "https://example.com/f.parquet", "PARQUET", max_errors=10
+            "dbo", "t", "https://example.com/f.csv", "CSV", max_errors=5
         )
-        assert "MAXERRORS = 10" in sql
+        assert "MAXERRORS = 5" in sql
+
+    def test_max_errors_parquet_omitted(self) -> None:
+        """MAXERRORS must NOT appear when FILE_TYPE is PARQUET (Fabric rejects it)."""
+        sql = _build_copy_into_sql(
+            "dbo", "t", "https://example.com/f.parquet", "PARQUET", max_errors=0
+        )
+        assert "MAXERRORS" not in sql
+
+    def test_max_errors_parquet_none_unaffected(self) -> None:
+        """No MAXERRORS in PARQUET SQL when max_errors is None."""
+        sql = _build_copy_into_sql(
+            "dbo", "t", "https://example.com/f.parquet", "PARQUET", max_errors=None
+        )
+        assert "MAXERRORS" not in sql
 
     def test_rejected_row_location(self) -> None:
         sql = _build_copy_into_sql(
@@ -817,6 +832,153 @@ class TestTempFileCleanup:
         assert not converted_paths[0].exists(), (
             f"Temp Parquet file was not cleaned up: {converted_paths[0]}"
         )
+
+
+# ---------------------------------------------------------------------------
+# max_errors warning for Parquet/JSON-converted loads (#744)
+# ---------------------------------------------------------------------------
+
+
+class TestMaxErrorsParquetWarning:
+    async def test_json_load_with_max_errors_emits_warning(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """When format=json (converted to Parquet) and max_errors is set,
+        a WARNING must be emitted and the load must succeed (not raise)."""
+        json_file = tmp_path / "data.json"
+        json_file.write_text('{"id": 1}\n', encoding="utf-8")
+
+        from fabric_dw.sql import SqlTarget  # noqa: PLC0415
+
+        target = SqlTarget(
+            workspace_id="ws-id", database="db", connection_string="server=x;database=y"
+        )
+        ws_id = uuid.UUID("a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+        mock_http = AsyncMock()
+        mock_credential = AsyncMock()
+
+        with (
+            caplog.at_level(logging.WARNING, logger="fabric_dw"),
+            patch("fabric_dw.services.load.create_staging_lakehouse", return_value="lh-id"),
+            patch("fabric_dw.services.load.onelake_upload_file", return_value=None),
+            patch(
+                "fabric_dw.services.load.copy_into_from_url",
+                return_value=CopyIntoResult(rows_loaded=1, rows_rejected=0, target="dbo.t"),
+            ),
+            patch("fabric_dw.services.load.delete_lakehouse"),
+        ):
+            result = await load_local_file(
+                mock_http,
+                mock_credential,
+                ws_id,
+                target,
+                "dbo",
+                "t",
+                json_file,
+                file_format="json",
+                max_errors=0,
+            )
+
+        # Load must succeed.
+        assert result.rows_loaded == 1
+
+        # A WARNING must have been logged mentioning max-errors and Parquet.
+        warning_messages = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+        assert any(
+            "max-errors" in msg.lower() or "max_errors" in msg.lower() for msg in warning_messages
+        ), f"Expected a warning about max_errors/max-errors; got: {warning_messages}"
+        assert any(
+            "parquet" in msg.lower() for msg in warning_messages
+        ), f"Expected warning to mention 'parquet'; got: {warning_messages}"
+
+    async def test_parquet_load_with_max_errors_emits_warning(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """When format=parquet and max_errors is set, a WARNING must be emitted."""
+        parquet_file = tmp_path / "data.parquet"
+        parquet_file.write_bytes(b"PAR1")  # minimal placeholder
+
+        from fabric_dw.sql import SqlTarget  # noqa: PLC0415
+
+        target = SqlTarget(
+            workspace_id="ws-id", database="db", connection_string="server=x;database=y"
+        )
+        ws_id = uuid.UUID("a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+        mock_http = AsyncMock()
+        mock_credential = AsyncMock()
+
+        with (
+            caplog.at_level(logging.WARNING, logger="fabric_dw"),
+            patch("fabric_dw.services.load.create_staging_lakehouse", return_value="lh-id"),
+            patch("fabric_dw.services.load.onelake_upload_file", return_value=None),
+            patch(
+                "fabric_dw.services.load.copy_into_from_url",
+                return_value=CopyIntoResult(rows_loaded=3, rows_rejected=0, target="dbo.t"),
+            ),
+            patch("fabric_dw.services.load.delete_lakehouse"),
+        ):
+            result = await load_local_file(
+                mock_http,
+                mock_credential,
+                ws_id,
+                target,
+                "dbo",
+                "t",
+                parquet_file,
+                file_format="parquet",
+                max_errors=5,
+            )
+
+        assert result.rows_loaded == 3
+
+        warning_messages = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+        assert any(
+            "max-errors" in msg.lower() or "max_errors" in msg.lower() for msg in warning_messages
+        ), f"Expected a warning about max_errors/max-errors; got: {warning_messages}"
+
+    async def test_csv_load_with_max_errors_no_warning(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """CSV loads with max_errors must NOT emit a warning (MAXERRORS is valid for CSV)."""
+        csv_file = tmp_path / "data.csv"
+        csv_file.write_text("id\n1\n", encoding="utf-8")
+
+        from fabric_dw.sql import SqlTarget  # noqa: PLC0415
+
+        target = SqlTarget(
+            workspace_id="ws-id", database="db", connection_string="server=x;database=y"
+        )
+        ws_id = uuid.UUID("a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+        mock_http = AsyncMock()
+        mock_credential = AsyncMock()
+
+        with (
+            caplog.at_level(logging.WARNING, logger="fabric_dw"),
+            patch("fabric_dw.services.load.create_staging_lakehouse", return_value="lh-id"),
+            patch("fabric_dw.services.load.onelake_upload_file", return_value=None),
+            patch(
+                "fabric_dw.services.load.copy_into_from_url",
+                return_value=CopyIntoResult(rows_loaded=1, rows_rejected=0, target="dbo.t"),
+            ),
+            patch("fabric_dw.services.load.delete_lakehouse"),
+        ):
+            await load_local_file(
+                mock_http,
+                mock_credential,
+                ws_id,
+                target,
+                "dbo",
+                "t",
+                csv_file,
+                file_format="csv",
+                max_errors=10,
+            )
+
+        # No warning expected for CSV + max_errors.
+        warning_messages = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+        assert not any(
+            "max-errors" in msg.lower() or "max_errors" in msg.lower() for msg in warning_messages
+        ), f"Unexpected warning for CSV max_errors; got: {warning_messages}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/services/test_load.py
+++ b/tests/unit/services/test_load.py
@@ -141,9 +141,7 @@ class TestBuildCopyIntoSql:
 
     def test_max_errors_csv(self) -> None:
         """MAXERRORS must appear in the SQL for CSV loads."""
-        sql = _build_copy_into_sql(
-            "dbo", "t", "https://example.com/f.csv", "CSV", max_errors=5
-        )
+        sql = _build_copy_into_sql("dbo", "t", "https://example.com/f.csv", "CSV", max_errors=5)
         assert "MAXERRORS = 5" in sql
 
     def test_max_errors_parquet_omitted(self) -> None:
@@ -840,11 +838,77 @@ class TestTempFileCleanup:
 
 
 class TestMaxErrorsParquetWarning:
+    async def test_copy_into_from_url_parquet_with_max_errors_emits_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """copy_into_from_url with FILE_TYPE=PARQUET and max_errors must emit a WARNING
+        and succeed — the common choke point covering local-file AND URL callers."""
+        from fabric_dw.sql import SqlTarget  # noqa: PLC0415
+
+        target = SqlTarget(
+            workspace_id="ws-id", database="db", connection_string="server=x;database=y"
+        )
+
+        with (
+            caplog.at_level(logging.WARNING, logger="fabric_dw"),
+            patch("fabric_dw.services.load.run_query") as mock_run,
+        ):
+            mock_run.return_value = ([], [(2,)])
+            result = await copy_into_from_url(
+                target,
+                "dbo",
+                "t",
+                "https://onelake.dfs.fabric.microsoft.com/ws/lh/Files/f.parquet",
+                file_type="PARQUET",
+                max_errors=0,
+            )
+
+        assert result.rows_loaded == 2
+
+        # A WARNING must have been logged mentioning max-errors and Parquet.
+        warning_messages = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+        assert any(
+            "max-errors" in msg.lower() or "max_errors" in msg.lower() for msg in warning_messages
+        ), f"Expected a warning about max_errors/max-errors; got: {warning_messages}"
+        assert any("parquet" in msg.lower() for msg in warning_messages), (
+            f"Expected warning to mention 'parquet'; got: {warning_messages}"
+        )
+
+    async def test_copy_into_from_url_csv_with_max_errors_no_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """copy_into_from_url with FILE_TYPE=CSV and max_errors must NOT emit a warning."""
+        from fabric_dw.sql import SqlTarget  # noqa: PLC0415
+
+        target = SqlTarget(
+            workspace_id="ws-id", database="db", connection_string="server=x;database=y"
+        )
+
+        with (
+            caplog.at_level(logging.WARNING, logger="fabric_dw"),
+            patch("fabric_dw.services.load.run_query") as mock_run,
+        ):
+            mock_run.return_value = ([], [(1,)])
+            await copy_into_from_url(
+                target,
+                "dbo",
+                "t",
+                "https://example.com/f.csv",
+                file_type="CSV",
+                max_errors=10,
+            )
+
+        # No warning expected for CSV + max_errors.
+        warning_messages = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+        assert not any(
+            "max-errors" in msg.lower() or "max_errors" in msg.lower() for msg in warning_messages
+        ), f"Unexpected warning for CSV max_errors; got: {warning_messages}"
+
     async def test_json_load_with_max_errors_emits_warning(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """When format=json (converted to Parquet) and max_errors is set,
-        a WARNING must be emitted and the load must succeed (not raise)."""
+        """When format=json (converted to Parquet) and max_errors is set, a WARNING
+        must be emitted (via copy_into_from_url) and the load must succeed."""
         json_file = tmp_path / "data.json"
         json_file.write_text('{"id": 1}\n', encoding="utf-8")
 
@@ -861,10 +925,9 @@ class TestMaxErrorsParquetWarning:
             caplog.at_level(logging.WARNING, logger="fabric_dw"),
             patch("fabric_dw.services.load.create_staging_lakehouse", return_value="lh-id"),
             patch("fabric_dw.services.load.onelake_upload_file", return_value=None),
-            patch(
-                "fabric_dw.services.load.copy_into_from_url",
-                return_value=CopyIntoResult(rows_loaded=1, rows_rejected=0, target="dbo.t"),
-            ),
+            # Patch run_query (not copy_into_from_url) so the real copy_into_from_url
+            # runs and the warning is emitted at the common choke point.
+            patch("fabric_dw.services.load.run_query", return_value=([], [(1,)])),
             patch("fabric_dw.services.load.delete_lakehouse"),
         ):
             result = await load_local_file(
@@ -887,9 +950,9 @@ class TestMaxErrorsParquetWarning:
         assert any(
             "max-errors" in msg.lower() or "max_errors" in msg.lower() for msg in warning_messages
         ), f"Expected a warning about max_errors/max-errors; got: {warning_messages}"
-        assert any(
-            "parquet" in msg.lower() for msg in warning_messages
-        ), f"Expected warning to mention 'parquet'; got: {warning_messages}"
+        assert any("parquet" in msg.lower() for msg in warning_messages), (
+            f"Expected warning to mention 'parquet'; got: {warning_messages}"
+        )
 
     async def test_parquet_load_with_max_errors_emits_warning(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture
@@ -911,10 +974,7 @@ class TestMaxErrorsParquetWarning:
             caplog.at_level(logging.WARNING, logger="fabric_dw"),
             patch("fabric_dw.services.load.create_staging_lakehouse", return_value="lh-id"),
             patch("fabric_dw.services.load.onelake_upload_file", return_value=None),
-            patch(
-                "fabric_dw.services.load.copy_into_from_url",
-                return_value=CopyIntoResult(rows_loaded=3, rows_rejected=0, target="dbo.t"),
-            ),
+            patch("fabric_dw.services.load.run_query", return_value=([], [(3,)])),
             patch("fabric_dw.services.load.delete_lakehouse"),
         ):
             result = await load_local_file(


### PR DESCRIPTION
## Summary

- Gates the `MAXERRORS` WITH clause in `_build_copy_into_sql` on `file_type == "CSV"`, mirroring the existing CSV-specific options gate — Parquet COPY INTO statements no longer include `MAXERRORS`.
- Emits a `WARNING` log in `load_local_file` when `max_errors` is provided but the effective file type is `PARQUET` (both native Parquet and JSON-converted loads), so the caller understands the option is ignored rather than silently failing.
- Updates the pre-existing `test_max_errors_option` test (which incorrectly asserted MAXERRORS appeared for PARQUET) and adds three new unit tests covering the Parquet-omit, CSV-kept, and warning-emitted scenarios.

## Root cause

When `--format json` is used, the file is converted to Parquet client-side before upload. The `max_errors` value was then forwarded unchanged to `_build_copy_into_sql`, which appended `MAXERRORS = N` unconditionally. Fabric rejects this with:

```
Option 'MAXERRORS' is not supported for specified format 'PARQUET'
```

## Test plan

- [x] `_build_copy_into_sql(..., file_type="PARQUET", max_errors=0)` → no `MAXERRORS` in SQL
- [x] `_build_copy_into_sql(..., file_type="CSV", max_errors=5)` → `MAXERRORS = 5` still present
- [x] `_build_copy_into_sql(..., file_type="PARQUET", max_errors=None)` → unaffected
- [x] `load_local_file` with `file_format="json"` and `max_errors=0` → WARNING logged, load succeeds
- [x] `load_local_file` with `file_format="parquet"` and `max_errors=5` → WARNING logged
- [x] `load_local_file` with `file_format="csv"` and `max_errors=10` → no spurious warning
- [x] All 135 existing unit tests pass

Closes #744

🤖 Generated with [Claude Code](https://claude.com/claude-code)