### PR TITLE
test(views): add regression tests for #746 bare-dot CREATE VIEW . AS form

### DIFF
--- a/tests/unit/services/test_functions.py
+++ b/tests/unit/services/test_functions.py
@@ -403,6 +403,28 @@ class TestGetFunction:
         assert "CREATE FUNCTION [dbo].[fn_clean]" in result.definition
         assert ". (" not in result.definition
 
+    async def test_get_function_regression_746_bare_dot_form(self) -> None:
+        """Regression #746: bare-dot 'CREATE FUNCTION . (...) ...' is fixed by get_function."""
+        raw_def = "CREATE FUNCTION . (@x INT) RETURNS INT AS BEGIN RETURN @x END"
+        row = (
+            "fdw_qa",
+            "fn_compute",
+            "FN",
+            "SQL_SCALAR_FUNCTION",
+            _NOW,
+            _LATER,
+            raw_def,
+            1,
+        )
+        target = _make_target()
+        conn_fn = _make_conn([row], _GET_COLS)
+        conn_params = _make_conn([], _PARAM_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[conn_fn, conn_params]):
+            result = await functions.get_function(target, "fdw_qa", "fn_compute")
+        assert result.definition is not None
+        assert "CREATE FUNCTION [fdw_qa].[fn_compute]" in result.definition
+        assert ". (" not in result.definition
+
     async def test_maps_permission_denied(self) -> None:
         target = _make_target()
         conn = MagicMock()
@@ -516,6 +538,36 @@ class TestCreateFunction:
             pytest.raises(PermissionDeniedError),
         ):
             await functions.create_function(target, "dbo", "fn_clean", "...")
+
+    async def test_create_function_regression_746_bare_dot_form(self) -> None:
+        """Regression #746: create_function returns a function whose definition is normalised.
+
+        Fabric stores 'CREATE FUNCTION . (...) ...' in sys.sql_modules after DDL;
+        the bare-dot header must be rewritten before the caller sees it.
+        """
+        body = "(@x INT) RETURNS INT AS BEGIN RETURN @x END"
+        raw_def = f"CREATE FUNCTION . {body}"
+        fetch_row = (
+            "fdw_qa",
+            "fn_compute",
+            "FN",
+            "SQL_SCALAR_FUNCTION",
+            _NOW,
+            _LATER,
+            raw_def,
+            1,
+        )
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        conn_fn = _make_conn([fetch_row], _GET_COLS)
+        conn_params = _make_conn([], _PARAM_COLS)
+
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, conn_fn, conn_params]):
+            result = await functions.create_function(target, "fdw_qa", "fn_compute", body)
+
+        assert result.definition is not None
+        assert "CREATE FUNCTION [fdw_qa].[fn_compute]" in result.definition
+        assert ". (" not in result.definition
 
 
 # ===========================================================================

--- a/tests/unit/services/test_helpers.py
+++ b/tests/unit/services/test_helpers.py
@@ -267,4 +267,23 @@ def test_normalize_regression_746_create_or_alter_bare_dot() -> None:
     """Regression #746: 'CREATE OR ALTER VIEW . AS' bare-dot form is also fixed."""
     raw = "CREATE OR ALTER VIEW . AS SELECT id, label FROM fdw_qa.t_ctas"
     result = normalize_object_definition(raw, "fdw_qa", "vw_dwh")
-    assert result == "CREATE OR ALTER VIEW [fdw_qa].[vw_dwh] AS SELECT id, label FROM fdw_qa.t_ctas"
+    expected = "CREATE OR ALTER VIEW [fdw_qa].[vw_dwh] AS SELECT id, label FROM fdw_qa.t_ctas"
+    assert result == expected
+
+
+def test_normalize_regression_746_procedure_bare_dot_form() -> None:
+    """Regression #746: bare-dot 'CREATE PROCEDURE . AS ...' is fixed for procedures."""
+    raw = "CREATE PROCEDURE . AS BEGIN SELECT id, label FROM fdw_qa.t_ctas END"
+    result = normalize_object_definition(raw, "fdw_qa", "usp_load")
+    expected = (
+        "CREATE PROCEDURE [fdw_qa].[usp_load] AS BEGIN SELECT id, label FROM fdw_qa.t_ctas END"
+    )
+    assert result == expected
+
+
+def test_normalize_regression_746_function_bare_dot_form() -> None:
+    """Regression #746: bare-dot 'CREATE FUNCTION . (...) ...' is fixed for functions."""
+    raw = "CREATE FUNCTION . (@x INT) RETURNS INT AS BEGIN RETURN @x END"
+    result = normalize_object_definition(raw, "fdw_qa", "fn_compute")
+    assert "CREATE FUNCTION [fdw_qa].[fn_compute]" in result
+    assert ". (" not in result

--- a/tests/unit/services/test_helpers.py
+++ b/tests/unit/services/test_helpers.py
@@ -242,3 +242,29 @@ def test_normalize_bracket_in_catalog_schema_escaped() -> None:
     result = normalize_object_definition("CREATE VIEW . AS SELECT 1", "sch]ema", "vw_ok")
     assert "[sch]]ema]" in result
     assert "[vw_ok]" in result
+
+
+# ---------------------------------------------------------------------------
+# Regression: #746 — bare-dot form "CREATE VIEW . AS" reported on live tenant
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_regression_746_exact_live_input() -> None:
+    """Regression #746: exact live-stored text 'CREATE VIEW . AS' is fixed.
+
+    Fabric's sys.sql_modules stores the definition with a bare dot between
+    CREATE VIEW and AS when the object was created without a fully-qualified
+    name in the DDL header (observed on fabric-dw 2026.6.0b1.dev15).
+    The helper must replace the bare dot schema/name slot with the catalog
+    values even when both parts are empty plain-form tokens (not bracket-quoted).
+    """
+    raw = "CREATE VIEW . AS SELECT id, label FROM fdw_qa.t_ctas"
+    result = normalize_object_definition(raw, "fdw_qa", "vw_dwh")
+    assert result == "CREATE VIEW [fdw_qa].[vw_dwh] AS SELECT id, label FROM fdw_qa.t_ctas"
+
+
+def test_normalize_regression_746_create_or_alter_bare_dot() -> None:
+    """Regression #746: 'CREATE OR ALTER VIEW . AS' bare-dot form is also fixed."""
+    raw = "CREATE OR ALTER VIEW . AS SELECT id, label FROM fdw_qa.t_ctas"
+    result = normalize_object_definition(raw, "fdw_qa", "vw_dwh")
+    assert result == "CREATE OR ALTER VIEW [fdw_qa].[vw_dwh] AS SELECT id, label FROM fdw_qa.t_ctas"

--- a/tests/unit/services/test_helpers.py
+++ b/tests/unit/services/test_helpers.py
@@ -287,3 +287,15 @@ def test_normalize_regression_746_function_bare_dot_form() -> None:
     result = normalize_object_definition(raw, "fdw_qa", "fn_compute")
     assert "CREATE FUNCTION [fdw_qa].[fn_compute]" in result
     assert ". (" not in result
+
+
+def test_normalize_regression_746_tester_captured_exact_raw() -> None:
+    """Regression #746: pinned to the EXACT raw string captured from the live tenant.
+
+    The tester ran ``sql exec`` against Fabric DW to read sys.sql_modules directly
+    (bypassing the normalizer) on build 2026.6.0b1.dev15 and observed this verbatim
+    string.  It must survive any future refactor of normalize_object_definition.
+    """
+    raw = "CREATE VIEW . AS SELECT 1 AS id"
+    result = normalize_object_definition(raw, "dbo", "vw_probe746")
+    assert result == "CREATE VIEW [dbo].[vw_probe746] AS SELECT 1 AS id"

--- a/tests/unit/services/test_procedures.py
+++ b/tests/unit/services/test_procedures.py
@@ -270,6 +270,19 @@ class TestGetProcedure:
         assert "CREATE PROCEDURE [dbo].[usp_load]" in result.definition
         assert ". AS" not in result.definition
 
+    async def test_get_procedure_regression_746_bare_dot_form(self) -> None:
+        """Regression #746: bare-dot 'CREATE PROCEDURE . AS ...' is fixed by get_procedure."""
+        raw_def = "CREATE PROCEDURE . AS BEGIN SELECT id, label FROM fdw_qa.t_ctas END"
+        row = ("fdw_qa", "usp_load", _NOW, _LATER, raw_def)
+        target = _make_target()
+        conn = _make_conn([row], _GET_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            result = await procedures.get_procedure(target, "fdw_qa", "usp_load")
+        expected = (
+            "CREATE PROCEDURE [fdw_qa].[usp_load] AS BEGIN SELECT id, label FROM fdw_qa.t_ctas END"
+        )
+        assert result.definition == expected
+
     async def test_maps_permission_denied(self) -> None:
         target = _make_target()
         conn = MagicMock()
@@ -374,6 +387,31 @@ class TestCreateProcedure:
             await procedures.create_procedure(
                 target, "dbo", "usp_ok] WITH EXECUTE AS OWNER--", "BEGIN END"
             )
+
+    async def test_create_procedure_regression_746_bare_dot_form(self) -> None:
+        """Regression #746: create_procedure returns a procedure whose definition is normalised.
+
+        Fabric stores 'CREATE PROCEDURE . AS ...' in sys.sql_modules after DDL;
+        the bare-dot header must be rewritten before the caller sees it.
+        """
+        raw_def = "CREATE PROCEDURE . AS BEGIN SELECT id, label FROM fdw_qa.t_ctas END"
+        fetch_row = ("fdw_qa", "usp_load", _NOW, _LATER, raw_def)
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([fetch_row], _GET_COLS)
+
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            result = await procedures.create_procedure(
+                target,
+                "fdw_qa",
+                "usp_load",
+                "BEGIN SELECT id, label FROM fdw_qa.t_ctas END",
+            )
+
+        expected = (
+            "CREATE PROCEDURE [fdw_qa].[usp_load] AS BEGIN SELECT id, label FROM fdw_qa.t_ctas END"
+        )
+        assert result.definition == expected
 
 
 # ===========================================================================

--- a/tests/unit/services/test_views.py
+++ b/tests/unit/services/test_views.py
@@ -586,6 +586,17 @@ class TestGetView:
         assert "CREATE VIEW [dbo].[vw_sales]" in result.definition
         assert ". AS" not in result.definition
 
+    async def test_get_view_regression_746_exact_live_input(self) -> None:
+        """Regression #746: bare-dot 'CREATE VIEW . AS SELECT ...' is fixed by get_view."""
+        raw_def = "CREATE VIEW . AS SELECT id, label FROM fdw_qa.t_ctas"
+        row = ("fdw_qa", "vw_dwh", _NOW, _LATER, raw_def)
+        target = _make_target()
+        conn = _make_conn([row], _GET_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            result = await views.get_view(target, "fdw_qa", "vw_dwh")
+        expected = "CREATE VIEW [fdw_qa].[vw_dwh] AS SELECT id, label FROM fdw_qa.t_ctas"
+        assert result.definition == expected
+
     async def test_maps_permission_denied(self) -> None:
         target = _make_target()
         conn = MagicMock()
@@ -727,6 +738,28 @@ class TestCreateView:
         assert result.definition is not None
         assert "CREATE VIEW [dbo].[vw_sales]" in result.definition
         assert ". AS" not in result.definition
+
+    async def test_create_view_regression_746_exact_live_input(self) -> None:
+        """Regression #746: create_view returns a view whose definition is fully normalised.
+
+        After CREATE VIEW DDL is issued, create_view reads the definition back via
+        get_view.  Fabric stores the bare-dot form 'CREATE VIEW . AS ...' in
+        sys.sql_modules; the helper must substitute the correct schema/name so the
+        returned View.definition contains '[fdw_qa].[vw_dwh]'.
+        """
+        raw_def = "CREATE VIEW . AS SELECT id, label FROM fdw_qa.t_ctas"
+        fetch_row = ("fdw_qa", "vw_dwh", _NOW, _LATER, raw_def)
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([fetch_row], _GET_COLS)
+
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            result = await views.create_view(
+                target, "fdw_qa", "vw_dwh", "SELECT id, label FROM fdw_qa.t_ctas"
+            )
+
+        expected = "CREATE VIEW [fdw_qa].[vw_dwh] AS SELECT id, label FROM fdw_qa.t_ctas"
+        assert result.definition == expected
 
 
 # ===========================================================================
@@ -1069,6 +1102,40 @@ class TestRenameView:
             result = await views.rename_view(target, "dbo.vw_sales", "vw_revenue")
 
         assert result.name == "vw_revenue"
+
+    async def test_rename_view_normalizes_empty_definition(self) -> None:
+        """rename_view must fix a Fabric-returned 'CREATE VIEW . AS ...' definition (issue #746).
+
+        After sp_rename succeeds, rename_view calls get_view which fetches the
+        definition from sys.sql_modules.  The bare-dot form must be normalised
+        before it reaches the caller.
+        """
+        broken_def = "CREATE VIEW . AS SELECT id, label FROM fdw_qa.t_ctas"
+        fetch_row = ("fdw_qa", "vw_dwh", _NOW, _LATER, broken_def)
+        target = _make_target()
+        rename_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([fetch_row], _GET_COLS)
+
+        with patch("fabric_dw.sql.open_connection", side_effect=[rename_conn, fetch_conn]):
+            result = await views.rename_view(target, "fdw_qa.vw_old", "vw_dwh")
+
+        assert result.definition is not None
+        assert "CREATE VIEW [fdw_qa].[vw_dwh]" in result.definition
+        assert ". AS" not in result.definition
+
+    async def test_rename_view_regression_746_exact_live_input(self) -> None:
+        """Regression #746: bare-dot 'CREATE VIEW . AS SELECT ...' is fixed after rename."""
+        raw_def = "CREATE VIEW . AS SELECT id, label FROM fdw_qa.t_ctas"
+        fetch_row = ("fdw_qa", "vw_dwh", _NOW, _LATER, raw_def)
+        target = _make_target()
+        rename_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([fetch_row], _GET_COLS)
+
+        with patch("fabric_dw.sql.open_connection", side_effect=[rename_conn, fetch_conn]):
+            result = await views.rename_view(target, "fdw_qa.vw_old", "vw_dwh")
+
+        expected = "CREATE VIEW [fdw_qa].[vw_dwh] AS SELECT id, label FROM fdw_qa.t_ctas"
+        assert result.definition == expected
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

- Adds explicit regression tests for the bare-dot `CREATE <TYPE> . AS ...` form across all three affected object types: **views, stored procedures, and user-defined functions**.
- Covers all code paths that read a definition from `sys.sql_modules`: `get_view`, `create_view`, `rename_view`, `get_procedure`, `create_procedure`, `get_function`, `create_function`.
- Adds helper-level regression tests in `test_helpers.py` for VIEW, PROCEDURE, and FUNCTION bare-dot forms.
- Includes a test pinned to the **exact raw string captured from the live Fabric tenant** by the tester (bypassing the normalizer via `sql exec` on build `2026.6.0b1.dev15`).

## Root cause

The `normalize_object_definition` helper already handles the bare-dot form correctly since PR #725 (commit `8d43d6d`). The regex matches the empty plain-form schema and name tokens (`CREATE VIEW . AS`, `CREATE PROCEDURE . AS`, `CREATE FUNCTION . (`) and substitutes the catalog values.

The tester confirmed the exact raw `sys.sql_modules` value Fabric stores is `CREATE VIEW . AS SELECT 1 AS id` (bare dot, no schema/name). Running `normalize_object_definition("CREATE VIEW . AS SELECT 1 AS id", "dbo", "vw_probe746")` on current main correctly returns `CREATE VIEW [dbo].[vw_probe746] AS SELECT 1 AS id`. The regression was observed on `fabric-dw 2026.6.0b1.dev15`, which lags the fix that landed in PR #725. No production code change is needed — what was missing were pinned regression tests locking in this behavior for all three object types.

## Files changed

| File | Added tests |
|------|-------------|
| `test_helpers.py` | 5 new: VIEW, PROCEDURE, FUNCTION bare-dot forms + `CREATE OR ALTER VIEW . AS` + **exact tester-captured raw string** |
| `test_views.py` | 4 new: `get_view`, `create_view`, `rename_view` normalisation, `rename_view` regression |
| `test_procedures.py` | 2 new: `get_procedure` and `create_procedure` bare-dot regression |
| `test_functions.py` | 2 new: `get_function` and `create_function` bare-dot regression |

## Test plan

- [x] Helper: bare-dot form for VIEW, PROCEDURE, FUNCTION — all normalised correctly
- [x] Helper: `CREATE OR ALTER VIEW . AS` variant
- [x] Helper: **pinned to exact tester-captured raw string** — `"CREATE VIEW . AS SELECT 1 AS id"` with `schema="dbo"`, `name="vw_probe746"`
- [x] `get_view` / `create_view` / `rename_view` — all normalise definition from sys.sql_modules
- [x] `get_procedure` / `create_procedure` — same for stored procedures
- [x] `get_function` / `create_function` — same for user-defined functions
- [x] All targeted tests pass; full test suite passes; ruff check + format + ty check clean

Closes #746

🤖 Generated with [Claude Code](https://claude.com/claude-code)