### PR TITLE
fix(sql): wrap unmapped driver SQL errors as FabricServerError

### DIFF
--- a/src/fabric_dw/services/load.py
+++ b/src/fabric_dw/services/load.py
@@ -772,23 +772,23 @@ async def copy_into_from_url(
         _mode = mode if isinstance(mode, CredentialMode) else CredentialMode.DEFAULT
         try:
             _cols, rows = run_query(target, sql, mode=_mode, commit=True, fetch="rowcount")
+        except FabricServerError as exc:
+            # run_query now wraps unmapped driver SQL errors (e.g. a column-type
+            # mismatch in the COPY INTO target) as FabricServerError.  Re-raise
+            # with the COPY INTO context prepended so the user knows which table
+            # failed, while the cleaned SQL Server message is preserved.
+            safe_msg = f"COPY INTO [{schema}].[{table}] failed: {exc}"
+            raise FabricServerError(safe_msg, is_retriable=False) from exc
         except FabricError:
-            # Already a mapped high-level error — re-raise as-is; it does not
-            # contain the raw SQL statement text.
+            # Other already-mapped high-level errors (NotFoundError,
+            # PermissionDeniedError, AuthError) are re-raised as-is; they carry
+            # their own actionable messages and do not contain SQL statement text.
             raise
         except Exception as exc:
-            # Raw driver errors (e.g. pyodbc.Error) can include the full SQL
-            # statement text in str(exc), which may contain embedded secrets.
-            # run_query already calls map_driver_error and re-raises mapped
-            # errors as FabricError subclasses; those are caught by the
-            # `except FabricError: raise` guard above.  Any exception that
-            # reaches here is therefore guaranteed to be unmapped.
-            #
-            # Surface the server-side error detail (ddbc_error) which contains
-            # the SQL Server error message but NOT the raw SQL statement text.
-            # This gives the user actionable feedback (e.g. "Column 'x' does
-            # not exist") without leaking the COPY INTO statement that may
-            # embed credential values.
+            # Truly unmapped exceptions that carry no ddbc_error attribute (e.g.
+            # network errors whose str() may embed the raw SQL statement with
+            # embedded secrets).  Surface only the safe ddbc_detail when present,
+            # otherwise suppress the detail entirely to protect credentials.
             ddbc_detail = getattr(exc, "ddbc_error", None)
             _logger.debug(
                 "copy_into_from_url: driver error executing COPY INTO (schema=%s table=%s): %s",

--- a/src/fabric_dw/services/sql_exec.py
+++ b/src/fabric_dw/services/sql_exec.py
@@ -187,6 +187,9 @@ async def execute(
         PermissionDeniedError: If the driver raises a SQL permission-denial error.
             The exception message contains a hint pointing to the
             documentation for the required permissions.
+        FabricServerError: If the driver raises an unmapped SQL error (e.g.
+            invalid column name, syntax error) that carries a ``ddbc_error``
+            attribute.  The message is cleaned of driver-noise prefixes.
         Exception: Any other driver error is propagated unchanged.
     """
 
@@ -206,6 +209,11 @@ async def execute(
                                 hint=_SQL_EXEC_PERMISSION_HINT,
                             ) from exc
                         raise mapped from exc
+                    # Wrap unmapped driver SQL errors (e.g. invalid column, syntax
+                    # error) as FabricServerError so callers catch FabricError.
+                    wrapped = sql._wrap_unmapped_driver_error(exc)
+                    if wrapped:
+                        raise wrapped from exc
                     raise
 
                 # Capture result sets in order, keeping only the last one that has
@@ -328,6 +336,10 @@ async def get_plan(
                                     hint=_SQL_EXEC_PERMISSION_HINT,
                                 ) from exc
                             raise mapped from exc
+                        # Wrap unmapped driver SQL errors so callers catch FabricError.
+                        wrapped = sql._wrap_unmapped_driver_error(exc)
+                        if wrapped:
+                            raise wrapped from exc
                     raise
                 finally:
                     # Always attempt to restore SHOWPLAN_XML to OFF before the

--- a/src/fabric_dw/sql.py
+++ b/src/fabric_dw/sql.py
@@ -57,7 +57,7 @@ from dataclasses import dataclass
 from typing import Any, Literal, Protocol
 
 from fabric_dw.auth import CredentialMode, get_sql_token_struct
-from fabric_dw.exceptions import AuthError, NotFoundError, PermissionDeniedError
+from fabric_dw.exceptions import AuthError, FabricServerError, NotFoundError, PermissionDeniedError
 
 _log = logging.getLogger(__name__)
 
@@ -1005,6 +1005,69 @@ def map_driver_error(exc: BaseException) -> Exception | None:
     return None
 
 
+# Pattern that matches the driver noise prefix produced by mssql_python.
+# Format: Driver Error: <short category>; DDBC Error: <sql server message>
+# We strip everything up to and including the DDBC Error label so callers
+# see only the meaningful SQL Server portion.
+_DRIVER_NOISE_RE = re.compile(
+    r"^Driver Error:[^;]*;\s*DDBC Error:\s*",
+    re.IGNORECASE,
+)
+
+
+def _clean_driver_error_message(msg: str) -> str:
+    """Strip the mssql_python driver-noise prefix from *msg*.
+
+    The driver wraps SQL Server errors with a prefix of the form::
+
+        Driver Error: <short category>; DDBC Error: <SQL Server message>
+
+    This helper returns the SQL Server message only.  If the prefix is not
+    present the original *msg* is returned unchanged.
+
+    Args:
+        msg: The stringified driver exception message.
+
+    Returns:
+        The cleaned message, with driver-noise prefix removed when present.
+    """
+    return _DRIVER_NOISE_RE.sub("", msg, count=1)
+
+
+def _wrap_unmapped_driver_error(exc: BaseException) -> FabricServerError | None:
+    """Wrap a driver SQL error that was not classified by :func:`map_driver_error`.
+
+    When the driver attaches a ``ddbc_error`` attribute to an exception it
+    signals a genuine SQL Server error (e.g. "Invalid column name", syntax
+    errors, constraint violations).  These are distinct from internal
+    cursor-state errors (which carry no ``ddbc_error``) and from transient
+    network errors.
+
+    A ``ddbc_error`` present on an unclassified exception means
+    :func:`map_driver_error` recognised no specific category (not a
+    permission/auth/not-found error).  We surface it as a
+    :class:`~fabric_dw.exceptions.FabricServerError` with a cleaned message
+    so the CLI can catch it via ``except (ValueError, FabricError)`` and print
+    a friendly error instead of a raw traceback.
+
+    Args:
+        exc: The raw exception raised by the driver.
+
+    Returns:
+        A :class:`~fabric_dw.exceptions.FabricServerError` when *exc* carries
+        a ``ddbc_error`` attribute (unmapped driver SQL error), otherwise
+        ``None`` (not a driver SQL error — let the caller re-raise as-is).
+    """
+    ddbc_error = getattr(exc, "ddbc_error", None)
+    if not ddbc_error:
+        return None
+    # Prefer ddbc_error as the message source: it contains the SQL Server-level
+    # text without the leading driver-noise prefix.  Fall back to the cleaned
+    # full exception string when ddbc_error is present but empty.
+    cleaned = str(ddbc_error).strip() or _clean_driver_error_message(str(exc))
+    return FabricServerError(cleaned)
+
+
 def is_transient_connection_error(exc: BaseException) -> bool:
     """Return True when *exc* represents a retryable TDS connection-level drop.
 
@@ -1297,6 +1360,10 @@ def run_query(  # noqa: PLR0913, PLR0915
         AuthError: If the driver reports an authentication failure.
         NotFoundError: If the driver reports a missing-object error (SQL Server
             error 208, invalid object name / base table or view not found).
+        FabricServerError: If the driver reports an unmapped SQL error (e.g.
+            "Invalid column name") that carries a ``ddbc_error`` attribute.
+            The message is cleaned of driver-noise prefixes so the user sees
+            the SQL Server-level message directly.
         Exception: Any other driver error is propagated unchanged.
     """
     # Whether execute-phase transient errors are safe to retry.
@@ -1396,6 +1463,13 @@ def run_query(  # noqa: PLR0913, PLR0915
             # not be re-executed (D10 retry boundary).
             if not (execute_retry_allowed and is_transient_connection_error(exc)):
                 conn.close()
+                # Wrap unmapped driver SQL errors (e.g. "Invalid column name")
+                # as FabricServerError so the CLI catches them cleanly.
+                # Internal cursor-state errors and network errors carry no
+                # ddbc_error and pass through unwrapped.
+                wrapped = _wrap_unmapped_driver_error(exc)
+                if wrapped:
+                    raise wrapped from exc
                 raise
             # Set the deadline on the first execute-phase transient failure.
             if execute_deadline is None:
@@ -1488,6 +1562,9 @@ def run_statements(
     Raises:
         PermissionDeniedError: If the driver reports a permission error on any statement.
         AuthError: If the driver reports an authentication failure.
+        FabricServerError: If the driver reports an unmapped SQL error that
+            carries a ``ddbc_error`` attribute (e.g. syntax errors, invalid
+            column names).  The message is cleaned of driver-noise prefixes.
         Exception: Any other driver error is propagated unchanged.
     """
     conn, _attempt, _max, _ = _with_connect_retry(target, mode, autocommit)
@@ -1505,6 +1582,11 @@ def run_statements(
                 mapped = map_driver_error(exc)
                 if mapped:
                     raise mapped from exc
+                # Wrap unmapped driver SQL errors as FabricServerError so CLI
+                # callers see a clean message rather than a raw traceback.
+                wrapped = _wrap_unmapped_driver_error(exc)
+                if wrapped:
+                    raise wrapped from exc
                 raise
         # All statements executed — commit once if deferred.
         if not autocommit and not commit_per_statement:

--- a/src/fabric_dw/sql.py
+++ b/src/fabric_dw/sql.py
@@ -1061,11 +1061,10 @@ def _wrap_unmapped_driver_error(exc: BaseException) -> FabricServerError | None:
     ddbc_error = getattr(exc, "ddbc_error", None)
     if not ddbc_error:
         return None
-    # Prefer ddbc_error as the message source: it contains the SQL Server-level
-    # text without the leading driver-noise prefix.  Fall back to the cleaned
-    # full exception string when ddbc_error is present but empty.
-    cleaned = str(ddbc_error).strip() or _clean_driver_error_message(str(exc))
-    return FabricServerError(cleaned)
+    # ddbc_error contains the SQL Server-level message without driver-noise prefix.
+    # The `if not ddbc_error` guard above already handles the empty/falsy case, so
+    # str(ddbc_error) is always non-empty here.
+    return FabricServerError(str(ddbc_error).strip(), is_retriable=False)
 
 
 def is_transient_connection_error(exc: BaseException) -> bool:

--- a/tests/unit/services/test_functions.py
+++ b/tests/unit/services/test_functions.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from fabric_dw.exceptions import AuthError, NotFoundError, PermissionDeniedError
+from fabric_dw.exceptions import AuthError, FabricServerError, NotFoundError, PermissionDeniedError
 from fabric_dw.models import Function, FunctionDetails, FunctionKind, FunctionParameter
 from fabric_dw.services import functions
 from fabric_dw.services.functions import validate_identifier, validate_kind
@@ -582,6 +582,38 @@ class TestUpdateFunction:
             await functions.update_function(target, "dbo", "fn_clean", "...")
 
         ddl_conn.commit.assert_called_once()
+
+    async def test_invalid_column_raises_fabric_server_error(self) -> None:
+        """#747: a driver SQL error (invalid column) on update_function raises FabricServerError.
+
+        The mssql_python driver raises a ProgrammingError with a ``ddbc_error``
+        attribute when the server rejects the DDL.  run_query must wrap it as
+        FabricServerError so the CLI catches it cleanly.
+        """
+        target = _make_target()
+        conn = MagicMock()
+        cursor = MagicMock()
+
+        class _InvalidColumnError(Exception):
+            ddbc_error = "[Microsoft][SQL Server]Invalid column name 'amount'."
+
+            def __str__(self) -> str:
+                return (
+                    "Driver Error: Column not found; DDBC Error: "
+                    "[Microsoft][SQL Server]Invalid column name 'amount'."
+                )
+
+        cursor.execute.side_effect = _InvalidColumnError()
+        conn.cursor.return_value = cursor
+
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(FabricServerError) as exc_info,
+        ):
+            await functions.update_function(target, "dbo", "fn_bad", "RETURN amount FROM t")
+
+        assert "Invalid column name 'amount'" in str(exc_info.value)
+        assert "Driver Error:" not in str(exc_info.value)
 
 
 # ===========================================================================

--- a/tests/unit/services/test_load.py
+++ b/tests/unit/services/test_load.py
@@ -12,7 +12,7 @@ import pytest
 import respx
 from azure.core.credentials_async import AsyncTokenCredential
 
-from fabric_dw.exceptions import FabricError, ItemKindError
+from fabric_dw.exceptions import FabricError, FabricServerError, ItemKindError
 from fabric_dw.models import CopyIntoResult, WarehouseKind
 from fabric_dw.services.load import (
     _DFS_API_VERSION,
@@ -2138,7 +2138,7 @@ class TestCopyIntoFromUrlRejectedRowValidation:
         mock_rq.assert_not_called()
 
     async def test_fabric_error_reraised_as_is(self) -> None:
-        """FabricError from run_query must be re-raised as-is (not wrapped)."""
+        """Non-FabricServerError FabricError from run_query must be re-raised as-is."""
         from fabric_dw.sql import SqlTarget  # noqa: PLC0415
 
         target = SqlTarget(
@@ -2159,6 +2159,41 @@ class TestCopyIntoFromUrlRejectedRowValidation:
             )
 
         assert exc_info.value is orig_error
+
+    async def test_fabric_server_error_gets_copy_into_framing(self) -> None:
+        """#747: FabricServerError from run_query gets COPY INTO framing prepended.
+
+        With the #747 fix, run_query wraps unmapped driver SQL errors as
+        FabricServerError.  copy_into_from_url must intercept these and
+        prepend 'COPY INTO [schema].[table] failed:' context so users see
+        which table failed, while retaining the cleaned SQL Server message.
+        """
+        from fabric_dw.sql import SqlTarget  # noqa: PLC0415
+
+        target = SqlTarget(
+            workspace_id="ws-id", database="db", connection_string="server=x;database=y"
+        )
+        # Simulate what run_query now raises for an unmapped driver SQL error.
+        driver_error = FabricServerError(
+            "[Microsoft][SQL Server]Column 'amount' cannot be converted to 'int'.",
+            is_retriable=False,
+        )
+
+        with (
+            patch("fabric_dw.services.load.run_query", side_effect=driver_error),
+            pytest.raises(FabricServerError) as exc_info,
+        ):
+            await copy_into_from_url(
+                target,
+                "dbo",
+                "sales",
+                "https://example.com/f.parquet",
+                file_type="PARQUET",
+            )
+
+        msg = str(exc_info.value)
+        assert "COPY INTO [dbo].[sales] failed:" in msg
+        assert "Column 'amount' cannot be converted to 'int'" in msg
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/services/test_sql_exec.py
+++ b/tests/unit/services/test_sql_exec.py
@@ -12,7 +12,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 import fabric_dw.sql as _sql_module
-from fabric_dw.exceptions import AuthError, PermissionDeniedError
+from fabric_dw.exceptions import AuthError, FabricServerError, PermissionDeniedError
 from fabric_dw.models import SqlResult
 from fabric_dw.services import sql_exec
 from fabric_dw.sql import SqlTarget
@@ -209,8 +209,8 @@ async def test_execute_non_binary_column_name_unchanged() -> None:
 # ---------------------------------------------------------------------------
 
 
-async def test_execute_syntax_error_propagates() -> None:
-    """Non-mapped driver errors are raised as-is."""
+async def test_execute_non_driver_error_propagates() -> None:
+    """Errors without a ddbc_error attribute (not driver SQL errors) are raised as-is."""
     target = _make_target()
     conn = MagicMock()
     cursor = MagicMock()
@@ -1254,3 +1254,75 @@ async def test_get_plan_iter_only_row_with_none_skipped() -> None:
         result = await sql_exec.get_plan(target, "SELECT 1")
 
     assert result == _PLAN_XML
+
+
+# ---------------------------------------------------------------------------
+# execute / get_plan — unmapped driver SQL error wrapping (#747)
+# ---------------------------------------------------------------------------
+
+
+class _SqlExecDriverError(Exception):
+    """Minimal stand-in for mssql_python driver exception with ddbc_error."""
+
+    def __init__(self, msg: str, ddbc_error: str) -> None:
+        super().__init__(msg)
+        self.ddbc_error = ddbc_error
+
+
+async def test_execute_invalid_column_raises_fabric_server_error() -> None:
+    """#747: execute() wraps unmapped driver SQL errors as FabricServerError.
+
+    When the driver rejects a statement due to an invalid column name the
+    exception carries a ddbc_error attribute.  execute() must surface this
+    as FabricServerError so MCP callers catch it via FabricError instead of
+    seeing a raw traceback.
+    """
+    target = _make_target()
+    conn = MagicMock()
+    cursor = MagicMock()
+    cursor.execute.side_effect = _SqlExecDriverError(
+        "Driver Error: Column not found; DDBC Error: [SQL Server]Invalid column name 'x'.",
+        "[Microsoft][SQL Server]Invalid column name 'x'.",
+    )
+    conn.cursor.return_value = cursor
+
+    with _patch_connect(conn), pytest.raises(FabricServerError) as exc_info:
+        await sql_exec.execute(target, "SELECT x FROM t")
+
+    assert "Invalid column name 'x'" in str(exc_info.value)
+    assert "Driver Error:" not in str(exc_info.value)
+
+
+async def test_execute_driver_error_without_ddbc_propagates_unchanged() -> None:
+    """An exception with no ddbc_error attribute is not wrapped by execute()."""
+    target = _make_target()
+    conn = MagicMock()
+    cursor = MagicMock()
+    cursor.execute.side_effect = Exception("something unexpected")
+    conn.cursor.return_value = cursor
+
+    with _patch_connect(conn), pytest.raises(Exception, match="something unexpected") as exc_info:
+        await sql_exec.execute(target, "SELECT 1")
+
+    assert not isinstance(exc_info.value, FabricServerError)
+
+
+async def test_get_plan_invalid_column_raises_fabric_server_error() -> None:
+    """#747: get_plan() wraps unmapped driver SQL errors as FabricServerError."""
+    target = _make_target()
+    conn = MagicMock()
+    cursor = MagicMock()
+    # Simulate driver raising on the plan-capture execute call.
+    cursor.execute.side_effect = _SqlExecDriverError(
+        "Driver Error: Column not found; DDBC Error: [SQL Server]Invalid column name 'y'.",
+        "[Microsoft][SQL Server]Invalid column name 'y'.",
+    )
+    conn.cursor.return_value = cursor
+
+    with (
+        patch("fabric_dw.sql._with_connect_retry", return_value=(conn, 0, 1, None)),
+        pytest.raises(FabricServerError) as exc_info,
+    ):
+        await sql_exec.get_plan(target, "SELECT y FROM t")
+
+    assert "Invalid column name 'y'" in str(exc_info.value)

--- a/tests/unit/services/test_views.py
+++ b/tests/unit/services/test_views.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from fabric_dw.exceptions import AuthError, NotFoundError, PermissionDeniedError
+from fabric_dw.exceptions import AuthError, FabricServerError, NotFoundError, PermissionDeniedError
 from fabric_dw.models import View
 from fabric_dw.services import views
 from fabric_dw.services._helpers import normalize_object_definition as _normalize_definition
@@ -821,6 +821,41 @@ class TestUpdateView:
                 "WITH cte AS (SELECT id FROM dbo.src) SELECT * FROM cte",
             )
         assert isinstance(result, View)
+
+    async def test_invalid_column_raises_fabric_server_error(self) -> None:
+        """#747: a driver SQL error (invalid column) must raise FabricServerError, not traceback.
+
+        When the server rejects the CREATE OR ALTER VIEW DDL due to an invalid
+        column reference, the mssql_python driver raises a ProgrammingError
+        carrying a ``ddbc_error`` attribute.  run_query must wrap it as a
+        FabricServerError so the CLI's ``except (ValueError, FabricError)``
+        handler catches it and prints a clean error message instead of a raw
+        Python traceback.
+        """
+        target = _make_target()
+        conn = MagicMock()
+        cursor = MagicMock()
+
+        class _InvalidColumnError(Exception):
+            ddbc_error = "[Microsoft][SQL Server]Invalid column name 'amount'."
+
+            def __str__(self) -> str:
+                return (
+                    "Driver Error: Column not found; DDBC Error: "
+                    "[Microsoft][SQL Server]Invalid column name 'amount'."
+                )
+
+        cursor.execute.side_effect = _InvalidColumnError()
+        conn.cursor.return_value = cursor
+
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(FabricServerError) as exc_info,
+        ):
+            await views.update_view(target, "dbo", "vw_sales", "SELECT id, amount FROM t")
+
+        assert "Invalid column name 'amount'" in str(exc_info.value)
+        assert "Driver Error:" not in str(exc_info.value)
 
 
 # ===========================================================================

--- a/tests/unit/test_sql.py
+++ b/tests/unit/test_sql.py
@@ -3337,19 +3337,20 @@ class TestWrapUnmappedDriverError:
         exc = Exception("connection timed out")
         assert self._wrap(exc) is None
 
-    def test_not_found_208_not_double_wrapped(self) -> None:
-        """Error 208 is already handled by map_driver_error; _wrap returns None
-        only when called in isolation, but in run_query map_driver_error fires first."""
-        # _wrap_unmapped_driver_error itself does not know about error numbers —
-        # it wraps any exception that carries ddbc_error.  The test here verifies
-        # that the wrapper is transparent: the result is FabricServerError (not
-        # NotFoundError), and the caller (run_query) always calls map_driver_error
-        # first so NotFoundError is raised before _wrap is consulted.
+    def test_not_found_208_wraps_as_fabric_server_error_in_isolation(self) -> None:
+        """_wrap_unmapped_driver_error wraps error-208 as FabricServerError when called alone.
+
+        _wrap_unmapped_driver_error does not know about error numbers — it wraps
+        any exception that carries a ddbc_error attribute.  In run_query the
+        callers invoke map_driver_error FIRST (which returns NotFoundError for 208),
+        so _wrap_unmapped_driver_error is never reached for known error numbers.
+        When called in isolation the wrapper returns FabricServerError; the
+        prioritisation is enforced by the call order in run_query, not by _wrap.
+        """
         exc = self._make_driver_exc_with_ddbc(
             "Invalid object name 'dbo.x'",
             "Error: 208 Invalid object name 'dbo.x'",
         )
-        # _wrap_unmapped_driver_error itself wraps it; map_driver_error takes priority in run_query.
         result = self._wrap(exc)
         assert isinstance(result, FabricServerError)
 

--- a/tests/unit/test_sql.py
+++ b/tests/unit/test_sql.py
@@ -11,7 +11,7 @@ import pytest
 import fabric_dw.sql as _sql_module
 from fabric_dw.auth import CredentialMode
 from fabric_dw.config import Defaults, UserConfig
-from fabric_dw.exceptions import AuthError, NotFoundError, PermissionDeniedError
+from fabric_dw.exceptions import AuthError, FabricServerError, NotFoundError, PermissionDeniedError
 from fabric_dw.sql import (
     SqlTarget,
     build_connection_string,
@@ -3244,3 +3244,219 @@ class TestRunQueryRowNormalisation:
         dicts = [dict(zip(cols, r, strict=True)) for r in rows]
         assert dicts[0] == {"session_id": "sess-1", "connection_id": "conn-1"}
         assert dicts[1] == {"session_id": "sess-2", "connection_id": "conn-2"}
+
+
+# ---------------------------------------------------------------------------
+# _clean_driver_error_message — noise-stripping helper
+# ---------------------------------------------------------------------------
+
+
+class TestCleanDriverErrorMessage:
+    """Tests for _clean_driver_error_message (private helper, accessed via module)."""
+
+    def _clean(self, msg: str) -> str:
+        return _sql_module._clean_driver_error_message(msg)  # type: ignore[attr-defined]
+
+    def test_strips_driver_noise_prefix(self) -> None:
+        """The driver-noise prefix is removed, leaving only the SQL Server message."""
+        raw = (
+            "Driver Error: Column not found; DDBC Error: "
+            "[Microsoft][SQL Server]Invalid column name 'amount'."
+        )
+        assert self._clean(raw) == "[Microsoft][SQL Server]Invalid column name 'amount'."
+
+    def test_case_insensitive_prefix_match(self) -> None:
+        """Prefix matching is case-insensitive."""
+        raw = "driver error: something; ddbc error: [SQL Server]Bad stuff."
+        assert self._clean(raw) == "[SQL Server]Bad stuff."
+
+    def test_no_prefix_returns_original(self) -> None:
+        """A message without the prefix is returned unchanged."""
+        raw = "[Microsoft][SQL Server]Invalid column name 'amount'."
+        assert self._clean(raw) == raw
+
+    def test_empty_string_returns_empty(self) -> None:
+        assert self._clean("") == ""
+
+    def test_multiple_semicolons_only_strips_first_segment(self) -> None:
+        """Only the first 'Driver Error: ...; DDBC Error:' segment is stripped."""
+        raw = "Driver Error: Col not found; DDBC Error: [SQL Server]Err; extra stuff."
+        assert self._clean(raw) == "[SQL Server]Err; extra stuff."
+
+
+# ---------------------------------------------------------------------------
+# _wrap_unmapped_driver_error — FabricServerError wrapper
+# ---------------------------------------------------------------------------
+
+
+class _DriverExcWithDdbcError(Exception):
+    """Minimal stand-in for a driver exception with a ddbc_error attribute."""
+
+    def __init__(self, msg: str, ddbc_error: str) -> None:
+        super().__init__(msg)
+        self.ddbc_error = ddbc_error
+
+
+class TestWrapUnmappedDriverError:
+    """Tests for _wrap_unmapped_driver_error (private helper, accessed via module)."""
+
+    def _wrap(self, exc: BaseException) -> FabricServerError | None:
+        return _sql_module._wrap_unmapped_driver_error(exc)  # type: ignore[attr-defined]
+
+    def _make_driver_exc_with_ddbc(self, msg: str, ddbc_error: str) -> _DriverExcWithDdbcError:
+        return _DriverExcWithDdbcError(msg, ddbc_error)
+
+    def test_returns_fabric_server_error_for_ddbc_error(self) -> None:
+        """An exception with ddbc_error is wrapped in FabricServerError."""
+        exc = self._make_driver_exc_with_ddbc(
+            "Driver Error: Column not found; DDBC Error: [SQL Server]Invalid column name 'amount'.",
+            "[Microsoft][SQL Server]Invalid column name 'amount'.",
+        )
+        result = self._wrap(exc)
+        assert isinstance(result, FabricServerError)
+
+    def test_message_uses_ddbc_error_content(self) -> None:
+        """The wrapped message comes from ddbc_error, not the noisy full string."""
+        exc = self._make_driver_exc_with_ddbc(
+            "Driver Error: Column not found; DDBC Error: [SQL Server]Invalid column name 'amount'.",
+            "[Microsoft][SQL Server]Invalid column name 'amount'.",
+        )
+        result = self._wrap(exc)
+        assert result is not None
+        assert "Invalid column name 'amount'" in str(result)
+        assert "Driver Error:" not in str(result)
+        assert "DDBC Error:" not in str(result)
+
+    def test_returns_none_for_exception_without_ddbc_error(self) -> None:
+        """An exception without ddbc_error (e.g. network/cursor error) returns None."""
+        exc = Exception("Invalid cursor state")
+        assert self._wrap(exc) is None
+
+    def test_returns_none_for_plain_exception(self) -> None:
+        """A plain Exception with no ddbc_error attribute returns None."""
+        exc = Exception("connection timed out")
+        assert self._wrap(exc) is None
+
+    def test_not_found_208_not_double_wrapped(self) -> None:
+        """Error 208 is already handled by map_driver_error; _wrap returns None
+        only when called in isolation, but in run_query map_driver_error fires first."""
+        # _wrap_unmapped_driver_error itself does not know about error numbers —
+        # it wraps any exception that carries ddbc_error.  The test here verifies
+        # that the wrapper is transparent: the result is FabricServerError (not
+        # NotFoundError), and the caller (run_query) always calls map_driver_error
+        # first so NotFoundError is raised before _wrap is consulted.
+        exc = self._make_driver_exc_with_ddbc(
+            "Invalid object name 'dbo.x'",
+            "Error: 208 Invalid object name 'dbo.x'",
+        )
+        # _wrap_unmapped_driver_error itself wraps it; map_driver_error takes priority in run_query.
+        result = self._wrap(exc)
+        assert isinstance(result, FabricServerError)
+
+
+# ---------------------------------------------------------------------------
+# run_query — unmapped driver SQL error wrapping (#747)
+# ---------------------------------------------------------------------------
+
+
+class _DriverSqlExecError(Exception):
+    """Minimal stand-in for mssql_python.exceptions.ProgrammingError with ddbc_error."""
+
+    def __init__(self, msg: str, ddbc_error: str) -> None:
+        super().__init__(msg)
+        self.ddbc_error = ddbc_error
+
+
+class TestRunQueryUnmappedDriverError:
+    """run_query must surface unmapped driver SQL errors as FabricServerError."""
+
+    @staticmethod
+    def _make_driver_execute_exc(msg: str, ddbc_error: str) -> _DriverSqlExecError:
+        """Return a driver-like exception with ddbc_error attribute."""
+        return _DriverSqlExecError(msg, ddbc_error)
+
+    def test_invalid_column_raises_fabric_server_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A driver ProgrammingError with ddbc_error raises FabricServerError, not a raw error."""
+        mock_mssql, _, mock_cursor = _make_mock_mssql()
+        exc = self._make_driver_execute_exc(
+            "Driver Error: Column not found; DDBC Error: [SQL Server]Invalid column name 'amount'.",
+            "[Microsoft][SQL Server]Invalid column name 'amount'.",
+        )
+        mock_cursor.execute.side_effect = exc
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        with pytest.raises(FabricServerError) as exc_info:
+            run_query(_make_target(), "CREATE OR ALTER VIEW [dbo].[v] AS SELECT amount FROM t")
+
+        assert "Invalid column name 'amount'" in str(exc_info.value)
+
+    def test_invalid_column_message_no_driver_noise(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The FabricServerError message must not contain the driver-noise prefix."""
+        mock_mssql, _, mock_cursor = _make_mock_mssql()
+        exc = self._make_driver_execute_exc(
+            "Driver Error: Column not found; DDBC Error: [SQL Server]Invalid column name 'x'.",
+            "[Microsoft][SQL Server]Invalid column name 'x'.",
+        )
+        mock_cursor.execute.side_effect = exc
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        with pytest.raises(FabricServerError) as exc_info:
+            run_query(_make_target(), "SELECT x FROM t", fetch="none")
+
+        msg = str(exc_info.value)
+        assert "Driver Error:" not in msg
+        assert "DDBC Error:" not in msg
+
+    def test_fetch_none_invalid_column_raises_fabric_server_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """fetch='none' DDL path also wraps unmapped driver SQL errors."""
+        mock_mssql, _, mock_cursor = _make_mock_mssql()
+        exc = self._make_driver_execute_exc(
+            "Driver Error: Column not found; DDBC Error: [SQL Server]Invalid column name 'amount'.",
+            "[Microsoft][SQL Server]Invalid column name 'amount'.",
+        )
+        mock_cursor.execute.side_effect = exc
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        with pytest.raises(FabricServerError):
+            run_query(
+                _make_target(),
+                "CREATE OR ALTER VIEW [dbo].[v] AS SELECT amount FROM t",
+                fetch="none",
+                commit=True,
+            )
+
+    def test_already_mapped_not_found_still_raises_not_found(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Error 208 (NotFoundError) is mapped before the FabricServerError fallback."""
+        mock_mssql, _, mock_cursor = _make_mock_mssql()
+
+        class _Err208Error(Exception):
+            ddbc_error = "Error: 208 Invalid object name 'dbo.missing'"
+
+            def __str__(self) -> str:
+                return "Invalid object name 'dbo.missing'"
+
+        mock_cursor.execute.side_effect = _Err208Error()
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        with pytest.raises(NotFoundError):
+            run_query(_make_target(), "SELECT * FROM [dbo].[missing]")
+
+    def test_exception_without_ddbc_error_not_wrapped(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An exception with no ddbc_error (e.g. cursor state error) propagates unchanged."""
+        mock_mssql, _, mock_cursor = _make_mock_mssql()
+        mock_cursor.execute.side_effect = Exception("Invalid cursor state")
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        with pytest.raises(Exception, match="Invalid cursor state") as exc_info:
+            run_query(_make_target(), "SELECT 1")
+
+        # Must NOT be wrapped as FabricServerError.
+        assert not isinstance(exc_info.value, FabricServerError)


### PR DESCRIPTION
## Summary

- Unmapped driver SQL errors (e.g. `Invalid column name`) were re-raised as raw `mssql_python.ProgrammingError`, escaping the `except (ValueError, FabricError)` guard at the CLI boundary and producing a Python traceback instead of a clean error message.
- Added `_wrap_unmapped_driver_error()` in `sql.py` that detects driver SQL errors via the presence of a `ddbc_error` attribute and wraps them as `FabricServerError` with the SQL Server message cleaned of the `Driver Error: ...; DDBC Error:` noise prefix.
- `run_query` and `run_statements` now call this wrapper after `map_driver_error` returns `None`, before re-raising — covering all callers (views update, functions update, procedures, and any future DDL/DML path) without per-command changes.

Internal cursor-state errors (`Invalid cursor state`) and network errors carry no `ddbc_error` and pass through unwrapped, so the retry logic and description guard remain unaffected.

## Test plan

- [x] New `TestCleanDriverErrorMessage` tests verify the noise-stripping helper
- [x] New `TestWrapUnmappedDriverError` tests verify the wrapping logic and None-passthrough
- [x] New `TestRunQueryUnmappedDriverError` tests verify end-to-end `run_query` behaviour for `fetch="all"`, `fetch="none"`, and the existing-mapped-error (NotFoundError 208) path
- [x] New `test_invalid_column_raises_fabric_server_error` in `TestUpdateView` and `TestUpdateFunction` verifying the service layer raises `FabricServerError` instead of a raw traceback
- [x] `uv run pytest tests/unit/ -q` — 4809 passed, 0 failed
- [x] `uv run ruff check src tests` — clean (pre-existing `_version.py` RUF022 unrelated to this change)
- [x] `uv run ruff format --check .` — clean
- [x] `uv run ty check src tests` — All checks passed

Closes #747

🤖 Generated with [Claude Code](https://claude.com/claude-code)