### PR TITLE
fix(render): wide-table vertical fallback + markup escape hardening

### DIFF
--- a/src/fabric_dw/cli/_render.py
+++ b/src/fabric_dw/cli/_render.py
@@ -8,6 +8,7 @@ from collections.abc import Sequence
 
 import click
 from rich.console import Console
+from rich.markup import escape as _escape_markup
 from rich.panel import Panel
 from rich.table import Table
 
@@ -130,12 +131,16 @@ def _cell(value: object) -> str:
     spurious ``.0`` suffix (e.g. ``"1500"``), matching the appearance of the
     underlying integer.  Fractional floats (e.g. ``1234.5``) are rendered
     as-is via ``str()``.
+
+    All data-derived string values are escaped with :func:`rich.markup.escape`
+    so that bracket characters (``[``, ``]``) in the data are rendered
+    verbatim and never interpreted as Rich markup tags.
     """
     if value is None:
         return "[dim]NULL[/dim]"
     if isinstance(value, float) and value.is_integer():
-        return str(int(value))
-    return str(value)
+        return _escape_markup(str(int(value)))
+    return _escape_markup(str(value))
 
 
 def _column_is_all_null(col: str, norm_rows: list[dict[str, object] | object]) -> bool:
@@ -176,14 +181,15 @@ def _add_columns(
     """
     primary_guid_assigned = False
     for col in visible_columns:
+        escaped_col = _escape_markup(col)
         if _is_guid_column(col, norm_rows):
             if not primary_guid_assigned:
-                table.add_column(col, no_wrap=True, min_width=_GUID_WIDTH)
+                table.add_column(escaped_col, no_wrap=True, min_width=_GUID_WIDTH)
                 primary_guid_assigned = True
             else:
-                table.add_column(col)
+                table.add_column(escaped_col)
         else:
-            table.add_column(col)
+            table.add_column(escaped_col)
 
 
 def _render_table(

--- a/src/fabric_dw/cli/_render.py
+++ b/src/fabric_dw/cli/_render.py
@@ -36,6 +36,11 @@ _GUID_RE: re.Pattern[str] = re.compile(
 #: Fixed width for GUID columns — a GUID is exactly 36 characters.
 _GUID_WIDTH = 36
 
+#: Minimum usable character width per column before the table is considered
+#: un-fittable and the vertical fallback is triggered.  A column squeezed to
+#: fewer characters than this cannot show meaningful content.
+_MIN_COLUMN_WIDTH = 4
+
 
 def _is_guid_column(col: str, norm_rows: list[dict[str, object] | object]) -> bool:
     """Return *True* when *col* is a GUID column.
@@ -172,6 +177,10 @@ def _add_columns(
     width on a narrow terminal (e.g. the 80-col default for piped/non-TTY
     output).
 
+    Column names are escaped with :func:`rich.markup.escape` so that bracket
+    characters (e.g. ``FileRowCount[avg]``) are rendered verbatim instead of
+    being silently stripped as markup tags.
+
     .. note::
         "First" is determined by insertion order of *visible_columns*, which
         mirrors API-response field order.  All current Fabric API models place
@@ -192,6 +201,27 @@ def _add_columns(
             table.add_column(escaped_col)
 
 
+def _table_fits(visible_columns: list[str], console_width: int) -> bool:
+    """Return *True* when *visible_columns* can fit legibly in *console_width*.
+
+    The heuristic: each column needs at least ``_MIN_COLUMN_WIDTH`` characters
+    of usable space.  The table borders add 1 char per column separator plus 2
+    for the outer frame.  When a GUID column is present it requires its full
+    ``_GUID_WIDTH`` chars (``no_wrap``), which is added to the minimum instead.
+
+    This is intentionally conservative — the fallback is only triggered when
+    the table would genuinely become unreadable (headers squeezed to 1-2
+    chars), not for mild wrapping or truncation.
+    """
+    if not visible_columns:
+        return True
+    # Border overhead: 1 separator between each column + 2 outer chars
+    border_chars = len(visible_columns) + 1
+    # Sum of minimum widths: _MIN_COLUMN_WIDTH per column
+    min_content = _MIN_COLUMN_WIDTH * len(visible_columns)
+    return border_chars + min_content <= console_width
+
+
 def _render_table(
     rows: Sequence[object],
     *,
@@ -199,7 +229,15 @@ def _render_table(
     title: str | None,
     drop_columns: tuple[str, ...] | list[str] | None = None,
 ) -> None:
-    """Render a list of dicts as a Rich Table.
+    """Render a list of dicts as a Rich Table (or vertical fallback).
+
+    When the number of visible columns would squeeze each header below
+    ``_MIN_COLUMN_WIDTH`` characters at the current console width, the
+    renderer switches to a vertical, record-oriented layout — one panel per
+    row listing ``key: value`` pairs.  This keeps wide-schema tables (e.g.
+    ``tables health-check`` with ~16 metrics) fully legible on an 80-column
+    terminal.  Tables that fit normally keep the horizontal layout and the
+    existing GUID-column width behaviour from PR #743.
 
     Columns whose value is ``None`` in **every** row are omitted from the
     output — they only clutter list views (e.g. ``definition`` for
@@ -215,9 +253,9 @@ def _render_table(
             that is redundant in a given context (e.g. a shared workspace id).
     """
     dropped: frozenset[str] = frozenset(drop_columns or ())
-    table = Table(title=title, show_header=True, header_style="bold")
 
     if not rows:
+        table = Table(title=title, show_header=True, header_style="bold")
         console.print(table)
         return
 
@@ -243,6 +281,14 @@ def _render_table(
     all_null = {col for col in columns if _column_is_all_null(col, norm_rows)}
     visible_columns = [col for col in columns if col not in all_null and col not in dropped]
 
+    # Wide-table fallback: when columns would be squeezed below _MIN_COLUMN_WIDTH
+    # characters each, switch to a vertical key: value layout per row so that
+    # every field name and value is fully readable.
+    if not _table_fits(visible_columns, console.width):
+        _render_vertical(norm_rows, visible_columns, console=console, title=title)
+        return
+
+    table = Table(title=title, show_header=True, header_style="bold")
     _add_columns(table, visible_columns, norm_rows)
 
     for row in norm_rows:
@@ -254,9 +300,37 @@ def _render_table(
     console.print(table)
 
 
+def _render_vertical(
+    norm_rows: list[dict[str, object] | object],
+    visible_columns: list[str],
+    *,
+    console: Console,
+    title: str | None,
+) -> None:
+    """Render *norm_rows* as a sequence of vertical key: value panels.
+
+    Used as a fallback when the horizontal table would be too wide for the
+    console.  Each dict row is rendered as a ``_render_panel``-style block;
+    scalar rows are printed as plain text.  The overall title is printed once
+    before the first row.
+    """
+    if title:
+        console.print(f"[bold]{_escape_markup(title)}[/bold]")
+
+    for i, row in enumerate(norm_rows):
+        if i > 0:
+            # Light separator between rows
+            console.rule(style="dim")
+        if isinstance(row, dict):
+            panel_data = {col: row.get(col) for col in visible_columns}
+            _render_panel(panel_data, console=console, title=None)
+        else:
+            console.print(_cell(row))
+
+
 def _render_panel(data: dict[str, object], *, console: Console, title: str | None) -> None:
     """Render a single dict as a Rich Panel with key: value lines."""
-    lines = "\n".join(f"[bold]{k}[/bold]: {_cell(v)}" for k, v in data.items())
+    lines = "\n".join(f"[bold]{_escape_markup(k)}[/bold]: {_cell(v)}" for k, v in data.items())
     panel = Panel(lines, title=title)
     console.print(panel)
 
@@ -297,11 +371,13 @@ def render_permissions_table(
 
     for entry in accesses:
         p = entry.principal
-        display = p.display_name or ""
-        identity = p.user_principal_name or (str(p.aad_app_id) if p.aad_app_id else "")
-        ptype = p.type
-        perms = ", ".join(entry.item_access_details.permissions)
-        additional = ", ".join(entry.item_access_details.additional_permissions)
+        display = _escape_markup(p.display_name or "")
+        identity = _escape_markup(
+            p.user_principal_name or (str(p.aad_app_id) if p.aad_app_id else "")
+        )
+        ptype = _escape_markup(p.type)
+        perms = _escape_markup(", ".join(entry.item_access_details.permissions))
+        additional = _escape_markup(", ".join(entry.item_access_details.additional_permissions))
         table.add_row(display, identity, ptype, perms, additional)
 
     con.print(table)
@@ -319,9 +395,9 @@ def render_refresh_table(
     table.add_column("Error", max_width=ERROR_MAX_LEN)
 
     for s in statuses:
-        status_text = s.status
+        status_text = _escape_markup(s.status)
         style = STATUS_STYLES.get(s.status, "")
-        end_dt = s.end_date_time.isoformat() if s.end_date_time else ""
+        end_dt = _escape_markup(s.end_date_time.isoformat() if s.end_date_time else "")
 
         error_text = ""
         if s.error:
@@ -330,10 +406,10 @@ def render_refresh_table(
                 parts.append(s.error.error_code)
             if s.error.message:
                 parts.append(s.error.message)
-            error_text = ": ".join(parts)
+            error_text = _escape_markup(": ".join(parts))
 
         table.add_row(
-            s.table_name,
+            _escape_markup(s.table_name),
             f"[{style}]{status_text}[/{style}]" if style else status_text,
             end_dt,
             error_text,

--- a/src/fabric_dw/cli/_render.py
+++ b/src/fabric_dw/cli/_render.py
@@ -36,10 +36,15 @@ _GUID_RE: re.Pattern[str] = re.compile(
 #: Fixed width for GUID columns — a GUID is exactly 36 characters.
 _GUID_WIDTH = 36
 
-#: Minimum usable character width per column before the table is considered
-#: un-fittable and the vertical fallback is triggered.  A column squeezed to
-#: fewer characters than this cannot show meaningful content.
-_MIN_COLUMN_WIDTH = 4
+#: Estimated width for secondary (non-primary) GUID columns in the fit
+#: heuristic.  Secondary GUIDs are allowed to truncate (no forced min_width),
+#: but they still occupy at least this many chars in practice before wrapping.
+_GUID_SECONDARY_WIDTH = 10
+
+#: Cap applied to non-GUID header names when estimating required table width.
+#: Headers longer than this are assumed to truncate gracefully (Rich ellipsis)
+#: rather than needing their full length to be legible.
+_HEADER_MAX_WIDTH = 24
 
 
 def _is_guid_column(col: str, norm_rows: list[dict[str, object] | object]) -> bool:
@@ -201,25 +206,55 @@ def _add_columns(
             table.add_column(escaped_col)
 
 
-def _table_fits(visible_columns: list[str], console_width: int) -> bool:
+def _table_fits(
+    visible_columns: list[str],
+    norm_rows: list[dict[str, object] | object],
+    console_width: int,
+) -> bool:
     """Return *True* when *visible_columns* can fit legibly in *console_width*.
 
-    The heuristic: each column needs at least ``_MIN_COLUMN_WIDTH`` characters
-    of usable space.  The table borders add 1 char per column separator plus 2
-    for the outer frame.  When a GUID column is present it requires its full
-    ``_GUID_WIDTH`` chars (``no_wrap``), which is added to the minimum instead.
+    The heuristic mirrors what :func:`_add_columns` actually does at render time:
 
-    This is intentionally conservative — the fallback is only triggered when
-    the table would genuinely become unreadable (headers squeezed to 1-2
-    chars), not for mild wrapping or truncation.
+    * The **primary GUID column** (first column whose every non-null value is a
+      canonical GUID) needs its full ``_GUID_WIDTH`` (36) chars — it is rendered
+      ``no_wrap`` so it is never truncated.
+    * **Secondary GUID columns** are given a floor of ``_GUID_SECONDARY_WIDTH``
+      (10) chars — they can truncate, but they still consume visible space.
+    * **Non-GUID columns** need ``min(len(header), _HEADER_MAX_WIDTH)`` chars —
+      a 20-char header like ``PotentialAnomalyType`` needs its full length to be
+      readable; a very long header (>24) is assumed to truncate gracefully.
+    * **Rich border overhead**: 2 chars padding per column (1 space each side)
+      plus 1 separator char between each pair of columns (``len(cols) - 1``)
+      plus 2 outer border chars.  Total: ``3 * len(cols) + 1``.
+
+    Calibration examples at ``console_width = 80``:
+    * #743 shape — ``id``(GUID/36) + ``workspaceId``(GUID/10) +
+      ``displayName``(11) + ``kind``(4) + borders ≈ 36+10+11+4 + 3*4+1 = 74 ≤ 80
+      → **horizontal** ✓
+    * 12-col queries shape — headers avg ~10 chars → 12*10 + 3*12+1 = 157 > 80
+      → **vertical** ✓
+    * 16-col health-check shape — headers avg ~15 chars → 16*15 + 3*16+1 = 289 > 80
+      → **vertical** ✓
     """
     if not visible_columns:
         return True
-    # Border overhead: 1 separator between each column + 2 outer chars
-    border_chars = len(visible_columns) + 1
-    # Sum of minimum widths: _MIN_COLUMN_WIDTH per column
-    min_content = _MIN_COLUMN_WIDTH * len(visible_columns)
-    return border_chars + min_content <= console_width
+
+    primary_guid_assigned = False
+    content_width = 0
+    for col in visible_columns:
+        if _is_guid_column(col, norm_rows):
+            if not primary_guid_assigned:
+                content_width += _GUID_WIDTH
+                primary_guid_assigned = True
+            else:
+                content_width += _GUID_SECONDARY_WIDTH
+        else:
+            content_width += min(len(col), _HEADER_MAX_WIDTH)
+
+    # Rich border: 1 left-padding + 1 right-padding per column + 1 separator
+    # between each adjacent pair + 2 outer frame chars → 3 * N + 1.
+    border_chars = 3 * len(visible_columns) + 1
+    return content_width + border_chars <= console_width
 
 
 def _render_table(
@@ -231,13 +266,13 @@ def _render_table(
 ) -> None:
     """Render a list of dicts as a Rich Table (or vertical fallback).
 
-    When the number of visible columns would squeeze each header below
-    ``_MIN_COLUMN_WIDTH`` characters at the current console width, the
-    renderer switches to a vertical, record-oriented layout — one panel per
-    row listing ``key: value`` pairs.  This keeps wide-schema tables (e.g.
-    ``tables health-check`` with ~16 metrics) fully legible on an 80-column
-    terminal.  Tables that fit normally keep the horizontal layout and the
-    existing GUID-column width behaviour from PR #743.
+    When the estimated minimum width required to show all visible column headers
+    legibly exceeds the current console width, the renderer switches to a
+    vertical, record-oriented layout — one panel per row listing ``key: value``
+    pairs.  This keeps wide-schema tables (e.g. ``tables health-check`` with
+    ~16 metrics) fully legible on an 80-column terminal.  Tables that fit
+    normally keep the horizontal layout and the existing GUID-column width
+    behaviour from PR #743.  See :func:`_table_fits` for the exact criterion.
 
     Columns whose value is ``None`` in **every** row are omitted from the
     output — they only clutter list views (e.g. ``definition`` for
@@ -281,10 +316,10 @@ def _render_table(
     all_null = {col for col in columns if _column_is_all_null(col, norm_rows)}
     visible_columns = [col for col in columns if col not in all_null and col not in dropped]
 
-    # Wide-table fallback: when columns would be squeezed below _MIN_COLUMN_WIDTH
-    # characters each, switch to a vertical key: value layout per row so that
-    # every field name and value is fully readable.
-    if not _table_fits(visible_columns, console.width):
+    # Wide-table fallback: when the estimated minimum width for all visible
+    # columns exceeds the console width, switch to a vertical key: value layout
+    # per row so that every field name and value is fully readable.
+    if not _table_fits(visible_columns, norm_rows, console.width):
         _render_vertical(norm_rows, visible_columns, console=console, title=title)
         return
 

--- a/src/fabric_dw/cli/_render.py
+++ b/src/fabric_dw/cli/_render.py
@@ -287,7 +287,11 @@ def _render_table(
     dropped: frozenset[str] = frozenset(drop_columns or ())
 
     if not rows:
-        table = Table(title=title, show_header=True, header_style="bold")
+        table = Table(
+            title=_escape_markup(title) if title else title,
+            show_header=True,
+            header_style="bold",
+        )
         console.print(table)
         return
 
@@ -320,7 +324,11 @@ def _render_table(
         _render_vertical(norm_rows, visible_columns, console=console, title=title)
         return
 
-    table = Table(title=title, show_header=True, header_style="bold")
+    table = Table(
+        title=_escape_markup(title) if title else title,
+        show_header=True,
+        header_style="bold",
+    )
     _add_columns(table, visible_columns, norm_rows)
 
     for row in norm_rows:

--- a/src/fabric_dw/cli/_render.py
+++ b/src/fabric_dw/cli/_render.py
@@ -196,12 +196,9 @@ def _add_columns(
     primary_guid_assigned = False
     for col in visible_columns:
         escaped_col = _escape_markup(col)
-        if _is_guid_column(col, norm_rows):
-            if not primary_guid_assigned:
-                table.add_column(escaped_col, no_wrap=True, min_width=_GUID_WIDTH)
-                primary_guid_assigned = True
-            else:
-                table.add_column(escaped_col)
+        if _is_guid_column(col, norm_rows) and not primary_guid_assigned:
+            table.add_column(escaped_col, no_wrap=True, min_width=_GUID_WIDTH)
+            primary_guid_assigned = True
         else:
             table.add_column(escaped_col)
 

--- a/tests/unit/cli/test_render.py
+++ b/tests/unit/cli/test_render.py
@@ -150,6 +150,78 @@ class TestCellHelper:
         assert _cell(0.0) == "0"
 
 
+class TestRichMarkupEscape:
+    """Column names and cell values containing Rich markup characters render verbatim.
+
+    ``sp_get_table_health_metrics`` returns column names such as
+    ``FileRowCount[0]`` and ``FileRowCount[1,10)`` that include bracket
+    characters.  Rich interprets ``[...]`` as markup tags, so without escaping
+    those names are stripped and the column headers appear blank.
+
+    Regression tests for issue #745.
+    """
+
+    def _render_to_string(self, data: object, *, width: int = 200) -> str:
+        sio = StringIO()
+        console = Console(file=sio, width=width, highlight=False, no_color=True)
+        render(data, json_output=False, console=console, table_title="Table Health Metrics")
+        return sio.getvalue()
+
+    # ------------------------------------------------------------------
+    # 1. Column names with brackets render verbatim (the core issue #745 bug)
+    # ------------------------------------------------------------------
+
+    def test_bracket_column_name_renders_verbatim(self) -> None:
+        """Column headers containing ``[0]`` must appear in the output, not be stripped."""
+        data = [
+            {
+                "FileRowCount[0]": 0,
+                "FileRowCount[1,10)": 0,
+                "PhysicalRowCount": 1000000,
+            }
+        ]
+        output = self._render_to_string(data)
+        assert "FileRowCount[0]" in output
+        assert "FileRowCount[1,10)" in output
+
+    def test_plain_column_name_still_renders(self) -> None:
+        """Non-bracket column names must continue to render correctly after the fix."""
+        data = [{"PhysicalRowCount": 1000000, "FileRowCount[0]": 0}]
+        output = self._render_to_string(data)
+        assert "PhysicalRowCount" in output
+
+    # ------------------------------------------------------------------
+    # 2. Cell values with brackets render verbatim
+    # ------------------------------------------------------------------
+
+    def test_bracket_cell_value_renders_verbatim(self) -> None:
+        """A string cell value like ``[redacted]`` must appear verbatim, not stripped."""
+        data = [{"label": "[redacted]", "count": 5}]
+        output = self._render_to_string(data)
+        assert "[redacted]" in output
+
+    # ------------------------------------------------------------------
+    # 3. Intentional NULL styling is preserved (no double-escape)
+    # ------------------------------------------------------------------
+
+    def test_null_cell_still_renders_as_dim_null(self) -> None:
+        """Escaping data strings must not break the intentional ``[dim]NULL[/dim]`` styling.
+
+        A ``None`` value in a kept column must still render as the visible text
+        ``NULL`` (styled dim) — not as the literal tag string ``[dim]NULL[/dim]``.
+        Two rows are used so the column is not all-null and is therefore kept.
+        """
+        data = [
+            {"FileRowCount[0]": None, "PhysicalRowCount": 1000000},
+            {"FileRowCount[0]": 42, "PhysicalRowCount": 2000000},
+        ]
+        output = self._render_to_string(data)
+        # The visible rendered text "NULL" must appear (dim styling applied by Rich)
+        assert "NULL" in output
+        # The raw tag must NOT appear literally (that would mean escaping went wrong)
+        assert "[dim]NULL[/dim]" not in output
+
+
 class TestNullRendering:
     """NULL values in table and panel output are rendered as dim 'NULL', not 'None'."""
 

--- a/tests/unit/cli/test_render.py
+++ b/tests/unit/cli/test_render.py
@@ -374,11 +374,19 @@ class TestWideTableVerticalFallback:
             assert col in output, f"Field '{col}' missing from vertical output"
 
     def test_health_check_vertical_at_width_80_shows_bracketed_field_names(self) -> None:
-        """Bracketed column names like ``FileRowCount[1,10)`` appear verbatim at width=80."""
+        """Alpha-bracket column names appear verbatim in the vertical fallback at width=80.
+
+        ``FileRowCount[ten_thousand_plus]`` has alpha-prefixed bracket content —
+        Rich strips ``[ten_thousand_plus]`` as a (failed) markup tag on unpatched code,
+        making this a genuine guard for the ``_escape_markup`` call on column names.
+        ``FileRowCount[1,10)`` is digit-prefixed and also checked for completeness.
+        """
         output = self._render_at_width(
             [_HEALTH_CHECK_ROW], width=80, table_title="Table Health Metrics"
         )
-        assert "FileRowCount[0]" in output
+        # Alpha-bracket — stripped by unpatched Rich, so this guards the escape fix
+        assert "FileRowCount[ten_thousand_plus]" in output
+        # Also present for completeness (digit-bracket, not stripped by Rich)
         assert "FileRowCount[1,10)" in output
 
     def test_health_check_vertical_at_width_80_shows_title(self) -> None:
@@ -394,6 +402,24 @@ class TestWideTableVerticalFallback:
             [_HEALTH_CHECK_ROW], width=80, table_title="Table Health Metrics"
         )
         assert "┃┃┃" not in output
+
+    def test_bracket_title_renders_verbatim_in_vertical_fallback(self) -> None:
+        """A table title containing brackets appears verbatim in the vertical fallback.
+
+        Rich parses ``Table(title=...)`` as markup.  Without ``_escape_markup`` a
+        title like ``Stats [2024]`` would render as ``Stats`` with ``[2024]`` dropped.
+        """
+        output = self._render_at_width([_HEALTH_CHECK_ROW], width=80, table_title="Stats [2024]")
+        assert "Stats [2024]" in output
+
+    def test_bracket_title_renders_verbatim_in_horizontal_table(self) -> None:
+        """A table title containing brackets appears verbatim in the horizontal layout.
+
+        Uses a 2-column table that fits at width=200 to stay in the horizontal path.
+        """
+        data = [{"id": "1", "name": "foo"}]
+        output = self._render_at_width(data, width=200, table_title="Stats [2024]")
+        assert "Stats [2024]" in output
 
     # ------------------------------------------------------------------
     # 2. 10-col and 14-col health-check shapes → vertical at width=80

--- a/tests/unit/cli/test_render.py
+++ b/tests/unit/cli/test_render.py
@@ -334,14 +334,12 @@ _QUERIES_ROWS: list[dict[str, object]] = [
 class TestWideTableVerticalFallback:
     """Wide-schema tables fall back to a vertical layout when they cannot fit horizontally.
 
-    When a table has so many columns that each one would be squeezed below
-    ``_MIN_COLUMN_WIDTH`` characters at the current console width, the renderer
-    switches to a vertical, record-oriented layout.  This is the real fix for
-    issue #745: the health-check table with ~16 columns cannot fit in 80 columns
-    and so all headers were collapsed to 1-2 characters and appeared blank.
-
-    Tables that DO fit at the given console width keep the normal horizontal layout
-    (including the GUID-column no_wrap behaviour from PR #743).
+    The fallback criterion is header-legibility based: ``_table_fits`` estimates
+    the minimum width needed to show each column header (GUID columns get their
+    fixed width; non-GUID columns get ``min(len(header), _HEADER_MAX_WIDTH)``
+    chars) and triggers vertical rendering when that estimate exceeds the console
+    width.  This correctly catches 10-, 12-, 14-, and 16-column shapes at width=80
+    while leaving the #743 GUID-heavy shape (2 GUIDs + displayName + kind) horizontal.
     """
 
     def _render_at_width(
@@ -391,44 +389,82 @@ class TestWideTableVerticalFallback:
         assert "Table Health Metrics" in output
 
     def test_health_check_no_truncated_header_artifacts(self) -> None:
-        """At width=80 the vertical output must NOT contain the truncation artifact
-        of narrow horizontal tables (three consecutive column separators)."""
+        """At width=80 the vertical output must NOT contain the three-separator artifact."""
         output = self._render_at_width(
             [_HEALTH_CHECK_ROW], width=80, table_title="Table Health Metrics"
         )
         assert "┃┃┃" not in output
 
     # ------------------------------------------------------------------
-    # 2. Wide queries shape (~12 cols, multiple rows) at a narrow width → vertical
-    #
-    #    The ``blocking_session_id`` column is all-null and is pruned, leaving 11
-    #    visible columns.  11 x 4 min-width + 12 border chars = 56 total, so
-    #    width=50 reliably triggers the vertical fallback for this shape.
+    # 2. 10-col and 14-col health-check shapes → vertical at width=80
     # ------------------------------------------------------------------
 
-    def test_queries_vertical_at_narrow_width_shows_all_field_names(self) -> None:
-        """All non-null field names appear in the vertical layout for a multi-row wide table."""
-        output = self._render_at_width(_QUERIES_ROWS, width=50)
+    def test_10col_health_check_vertical_at_width_80(self) -> None:
+        """A 10-column health-check subset goes vertical at width=80."""
+        data = [dict(list(_HEALTH_CHECK_ROW.items())[:10])]
+        output = self._render_at_width(data, width=80, table_title="Health Check")
+        for col in data[0]:
+            assert col in output, f"Field '{col}' missing from 10-col vertical output"
+
+    def test_14col_health_check_vertical_at_width_80(self) -> None:
+        """A 14-column health-check subset goes vertical at width=80."""
+        data = [dict(list(_HEALTH_CHECK_ROW.items())[:14])]
+        output = self._render_at_width(data, width=80, table_title="Health Check")
+        for col in data[0]:
+            assert col in output, f"Field '{col}' missing from 14-col vertical output"
+
+    # ------------------------------------------------------------------
+    # 3. 12-col queries shape at width=80 → vertical (issue #749)
+    # ------------------------------------------------------------------
+
+    def test_queries_vertical_at_width_80_shows_all_field_names(self) -> None:
+        """All non-null field names appear in the vertical layout at width=80.
+
+        With the header-based threshold, the 11 visible columns (blocking_session_id
+        is all-null and pruned) have headers averaging ~10 chars, which far exceeds
+        80 columns, triggering the vertical fallback.
+        """
+        output = self._render_at_width(_QUERIES_ROWS, width=80)
         # blocking_session_id is all-null → pruned; check the non-null columns only
         visible_cols = [c for c in _QUERIES_ROWS[0] if c != "blocking_session_id"]
         for col in visible_cols:
             assert col in output, f"Field '{col}' missing from vertical output"
 
-    def test_queries_vertical_at_narrow_width_shows_values(self) -> None:
-        """Cell values appear in the vertical output at a narrow console width."""
-        output = self._render_at_width(_QUERIES_ROWS, width=50)
+    def test_queries_vertical_at_width_80_shows_values(self) -> None:
+        """Cell values from multiple rows appear in the vertical output at width=80."""
+        output = self._render_at_width(_QUERIES_ROWS, width=80)
         assert "abc123" in output
         assert "user@example.com" in output
 
     # ------------------------------------------------------------------
-    # 3. Normal (fits) tables keep horizontal layout — no regression
+    # 4. #743 shape stays horizontal — regression guard
+    # ------------------------------------------------------------------
+
+    def test_guid_shape_stays_horizontal_at_width_80(self) -> None:
+        """The #743 GUID-heavy shape (2 GUIDs + displayName + kind) stays horizontal.
+
+        Estimated fit: primary GUID (36) + secondary GUID (10) + displayName (11)
+        + kind (4) + borders (3*4+1=13) = 74 <= 80, so the horizontal layout is kept.
+        """
+        guid1 = "eb85cc99-5ad8-4f89-85b8-2a46eaa410d6"
+        guid2 = "4c18bf4e-86dd-47da-8602-87184ff16c13"
+        data = [
+            {"id": guid1, "displayName": "My Workspace", "workspaceId": guid2, "kind": "Warehouse"}
+        ]
+        output = self._render_at_width(data, width=80)
+        # Horizontal table uses box-drawing column separators
+        assert "┃" in output or "│" in output
+        # Primary GUID must appear in full (no_wrap)
+        assert guid1 in output
+
+    # ------------------------------------------------------------------
+    # 5. Small (fits) tables keep horizontal layout — regression guard
     # ------------------------------------------------------------------
 
     def test_small_table_stays_horizontal(self) -> None:
         """A 2-column table at width=80 stays horizontal (no panel-style output)."""
         data = [{"id": "1", "name": "foo"}, {"id": "2", "name": "bar"}]
         output = self._render_at_width(data, width=80)
-        # Horizontal table has column separator characters
         assert "┃" in output or "│" in output
 
     def test_small_table_headers_present(self) -> None:
@@ -439,7 +475,7 @@ class TestWideTableVerticalFallback:
         assert "name" in output
 
     # ------------------------------------------------------------------
-    # 4. Existing multi-GUID width tests are unaffected (PR #743 regression guard)
+    # 6. Existing multi-GUID width tests are unaffected (PR #743 regression guard)
     # ------------------------------------------------------------------
 
     def test_two_guid_columns_still_work_at_width_120(self) -> None:

--- a/tests/unit/cli/test_render.py
+++ b/tests/unit/cli/test_render.py
@@ -153,10 +153,9 @@ class TestCellHelper:
 class TestRichMarkupEscape:
     """Column names and cell values containing Rich markup characters render verbatim.
 
-    ``sp_get_table_health_metrics`` returns column names such as
-    ``FileRowCount[0]`` and ``FileRowCount[1,10)`` that include bracket
-    characters.  Rich interprets ``[...]`` as markup tags, so without escaping
-    those names are stripped and the column headers appear blank.
+    Rich interprets ``[<alpha>...]`` sequences as markup tags and strips them.
+    Column names like ``FileRowCount[avg]`` or ``Status[current]`` (alpha-prefixed
+    bracket content) are silently stripped without escaping — leaving blank headers.
 
     Regression tests for issue #745.
     """
@@ -168,30 +167,36 @@ class TestRichMarkupEscape:
         return sio.getvalue()
 
     # ------------------------------------------------------------------
-    # 1. Column names with brackets render verbatim (the core issue #745 bug)
+    # 1. Column names with alpha-prefixed brackets ARE stripped by Rich without escaping
     # ------------------------------------------------------------------
 
-    def test_bracket_column_name_renders_verbatim(self) -> None:
-        """Column headers containing ``[0]`` must appear in the output, not be stripped."""
+    def test_alpha_bracket_column_name_renders_verbatim(self) -> None:
+        """Column headers like ``FileRowCount[avg]`` must appear verbatim, not stripped.
+
+        Rich treats ``[avg]`` as a (failed) markup tag and strips it, leaving
+        ``FileRowCount`` without the bracket suffix — or an empty string if the
+        whole name is ``[something]``.  Without ``_escape_markup`` the bracket
+        content disappears silently.
+        """
         data = [
             {
-                "FileRowCount[0]": 0,
-                "FileRowCount[1,10)": 0,
+                "FileRowCount[avg]": 0,
+                "Status[current]": "ok",
                 "PhysicalRowCount": 1000000,
             }
         ]
         output = self._render_to_string(data)
-        assert "FileRowCount[0]" in output
-        assert "FileRowCount[1,10)" in output
+        assert "FileRowCount[avg]" in output
+        assert "Status[current]" in output
 
     def test_plain_column_name_still_renders(self) -> None:
         """Non-bracket column names must continue to render correctly after the fix."""
-        data = [{"PhysicalRowCount": 1000000, "FileRowCount[0]": 0}]
+        data = [{"PhysicalRowCount": 1000000, "FileRowCount[avg]": 0}]
         output = self._render_to_string(data)
         assert "PhysicalRowCount" in output
 
     # ------------------------------------------------------------------
-    # 2. Cell values with brackets render verbatim
+    # 2. Cell values with alpha-bracketed content render verbatim
     # ------------------------------------------------------------------
 
     def test_bracket_cell_value_renders_verbatim(self) -> None:
@@ -212,14 +217,239 @@ class TestRichMarkupEscape:
         Two rows are used so the column is not all-null and is therefore kept.
         """
         data = [
-            {"FileRowCount[0]": None, "PhysicalRowCount": 1000000},
-            {"FileRowCount[0]": 42, "PhysicalRowCount": 2000000},
+            {"FileRowCount[avg]": None, "PhysicalRowCount": 1000000},
+            {"FileRowCount[avg]": 42, "PhysicalRowCount": 2000000},
         ]
         output = self._render_to_string(data)
         # The visible rendered text "NULL" must appear (dim styling applied by Rich)
         assert "NULL" in output
         # The raw tag must NOT appear literally (that would mean escaping went wrong)
         assert "[dim]NULL[/dim]" not in output
+
+    # ------------------------------------------------------------------
+    # 4. render_permissions_table escapes data-derived values
+    # ------------------------------------------------------------------
+
+    def test_permissions_table_escapes_group_name_in_display(self) -> None:
+        """A principal display name containing brackets must appear verbatim."""
+        principal = ItemAccessPrincipal.model_validate(
+            {
+                "id": "12345678-1234-5678-1234-567812345678",
+                "displayName": "[sg-devs]",
+                "type": "Group",
+                "userDetails": {"userPrincipalName": ""},
+            }
+        )
+        detail = ItemAccessDetail.model_validate(
+            {"permissions": ["Read"], "additionalPermissions": []}
+        )
+        access = ItemAccess.model_validate(
+            {
+                "principal": principal.model_dump(by_alias=True, mode="json"),
+                "itemAccessDetails": detail.model_dump(by_alias=True, mode="json"),
+            }
+        )
+        sio = StringIO()
+        console = Console(file=sio, width=200, highlight=False, no_color=True)
+        render_permissions_table([access], title="Test", console=console)
+        output = sio.getvalue()
+        assert "[sg-devs]" in output
+
+    def test_refresh_table_escapes_table_name(self) -> None:
+        """A table name containing brackets must appear verbatim in the refresh table."""
+        s = TableSyncStatus.model_validate(
+            {
+                "tableName": "dbo.[weird table]",
+                "status": "Success",
+                "endDateTime": None,
+                "error": None,
+            }
+        )
+        sio = StringIO()
+        console = Console(file=sio, width=200, highlight=False, no_color=True)
+        render_refresh_table([s], console=console)
+        output = sio.getvalue()
+        assert "dbo.[weird table]" in output
+
+
+# ---------------------------------------------------------------------------
+# Wide-table vertical fallback (issue #745 / #749)
+# ---------------------------------------------------------------------------
+
+#: Simulated health-check row (~16 columns) — the real sp_get_table_health_metrics
+#: shape that triggered #745.  Width-starvation at 80 cols, not markup, was the
+#: cause of all-blank headers in practice.
+_HEALTH_CHECK_ROW: dict[str, object] = {
+    "PotentialAnomalyType": 0,
+    "PhysicalRowCount": 1000000,
+    "FileRowCount[0]": 0,
+    "FileRowCount[1,10)": 0,
+    "FileRowCount[10,100)": 5,
+    "FileRowCount[100,1000)": 12,
+    "FileRowCount[1000,10000)": 40,
+    "FileRowCount[ten_thousand_plus]": 0,
+    "DeletedRowCount": 3,
+    "TotalFileCount": 57,
+    "ActiveFileCount": 57,
+    "InactiveFileCount": 0,
+    "CompressedFileSize": 4096000,
+    "UncompressedFileSize": 8192000,
+    "TableName": "dbo.taxi_trips",
+    "SchemaName": "dbo",
+}
+
+#: Simulated queries/sessions shape (~12 columns).
+_QUERIES_ROWS: list[dict[str, object]] = [
+    {
+        "session_id": "abc123",
+        "login_name": "user@example.com",
+        "status": "running",
+        "command": "SELECT",
+        "start_time": "2026-06-25T10:00:00",
+        "cpu_time": 1200,
+        "total_elapsed_time": 1500,
+        "reads": 9000,
+        "writes": 0,
+        "logical_reads": 18000,
+        "blocking_session_id": None,
+        "wait_type": "ASYNC_NETWORK_IO",
+    },
+    {
+        "session_id": "def456",
+        "login_name": "svc@example.com",
+        "status": "sleeping",
+        "command": "AWAITING COMMAND",
+        "start_time": "2026-06-25T09:55:00",
+        "cpu_time": 0,
+        "total_elapsed_time": 300000,
+        "reads": 0,
+        "writes": 0,
+        "logical_reads": 0,
+        "blocking_session_id": None,
+        "wait_type": None,
+    },
+]
+
+
+class TestWideTableVerticalFallback:
+    """Wide-schema tables fall back to a vertical layout when they cannot fit horizontally.
+
+    When a table has so many columns that each one would be squeezed below
+    ``_MIN_COLUMN_WIDTH`` characters at the current console width, the renderer
+    switches to a vertical, record-oriented layout.  This is the real fix for
+    issue #745: the health-check table with ~16 columns cannot fit in 80 columns
+    and so all headers were collapsed to 1-2 characters and appeared blank.
+
+    Tables that DO fit at the given console width keep the normal horizontal layout
+    (including the GUID-column no_wrap behaviour from PR #743).
+    """
+
+    def _render_at_width(
+        self,
+        data: object,
+        width: int,
+        *,
+        table_title: str | None = None,
+        drop_columns: tuple[str, ...] | None = None,
+    ) -> str:
+        sio = StringIO()
+        console = Console(file=sio, width=width, highlight=False, no_color=True)
+        render(
+            data,
+            json_output=False,
+            console=console,
+            table_title=table_title,
+            drop_columns=drop_columns,
+        )
+        return sio.getvalue()
+
+    # ------------------------------------------------------------------
+    # 1. Health-check shape (~16 cols, 1 row) at width=80 → vertical
+    # ------------------------------------------------------------------
+
+    def test_health_check_vertical_at_width_80_shows_all_field_names(self) -> None:
+        """All ~16 field names appear in full in the vertical layout at width=80."""
+        output = self._render_at_width(
+            [_HEALTH_CHECK_ROW], width=80, table_title="Table Health Metrics"
+        )
+        for col in _HEALTH_CHECK_ROW:
+            assert col in output, f"Field '{col}' missing from vertical output"
+
+    def test_health_check_vertical_at_width_80_shows_bracketed_field_names(self) -> None:
+        """Bracketed column names like ``FileRowCount[1,10)`` appear verbatim at width=80."""
+        output = self._render_at_width(
+            [_HEALTH_CHECK_ROW], width=80, table_title="Table Health Metrics"
+        )
+        assert "FileRowCount[0]" in output
+        assert "FileRowCount[1,10)" in output
+
+    def test_health_check_vertical_at_width_80_shows_title(self) -> None:
+        """The table title is printed in the vertical fallback output."""
+        output = self._render_at_width(
+            [_HEALTH_CHECK_ROW], width=80, table_title="Table Health Metrics"
+        )
+        assert "Table Health Metrics" in output
+
+    def test_health_check_no_truncated_header_artifacts(self) -> None:
+        """At width=80 the vertical output must NOT contain the truncation artifact
+        of narrow horizontal tables (three consecutive column separators)."""
+        output = self._render_at_width(
+            [_HEALTH_CHECK_ROW], width=80, table_title="Table Health Metrics"
+        )
+        assert "┃┃┃" not in output
+
+    # ------------------------------------------------------------------
+    # 2. Wide queries shape (~12 cols, multiple rows) at a narrow width → vertical
+    #
+    #    The ``blocking_session_id`` column is all-null and is pruned, leaving 11
+    #    visible columns.  11 x 4 min-width + 12 border chars = 56 total, so
+    #    width=50 reliably triggers the vertical fallback for this shape.
+    # ------------------------------------------------------------------
+
+    def test_queries_vertical_at_narrow_width_shows_all_field_names(self) -> None:
+        """All non-null field names appear in the vertical layout for a multi-row wide table."""
+        output = self._render_at_width(_QUERIES_ROWS, width=50)
+        # blocking_session_id is all-null → pruned; check the non-null columns only
+        visible_cols = [c for c in _QUERIES_ROWS[0] if c != "blocking_session_id"]
+        for col in visible_cols:
+            assert col in output, f"Field '{col}' missing from vertical output"
+
+    def test_queries_vertical_at_narrow_width_shows_values(self) -> None:
+        """Cell values appear in the vertical output at a narrow console width."""
+        output = self._render_at_width(_QUERIES_ROWS, width=50)
+        assert "abc123" in output
+        assert "user@example.com" in output
+
+    # ------------------------------------------------------------------
+    # 3. Normal (fits) tables keep horizontal layout — no regression
+    # ------------------------------------------------------------------
+
+    def test_small_table_stays_horizontal(self) -> None:
+        """A 2-column table at width=80 stays horizontal (no panel-style output)."""
+        data = [{"id": "1", "name": "foo"}, {"id": "2", "name": "bar"}]
+        output = self._render_at_width(data, width=80)
+        # Horizontal table has column separator characters
+        assert "┃" in output or "│" in output
+
+    def test_small_table_headers_present(self) -> None:
+        """Column headers appear in the horizontal layout for small tables."""
+        data = [{"id": "1", "name": "foo"}]
+        output = self._render_at_width(data, width=120)
+        assert "id" in output
+        assert "name" in output
+
+    # ------------------------------------------------------------------
+    # 4. Existing multi-GUID width tests are unaffected (PR #743 regression guard)
+    # ------------------------------------------------------------------
+
+    def test_two_guid_columns_still_work_at_width_120(self) -> None:
+        """Two-GUID-column table renders correctly at width=120 (horizontal layout)."""
+        guid1 = "eb85cc99-5ad8-4f89-85b8-2a46eaa410d6"
+        guid2 = "4c18bf4e-86dd-47da-8602-87184ff16c13"
+        data = [{"id": guid1, "displayName": "Adventure Works Finance", "capacityId": guid2}]
+        output = self._render_at_width(data, width=120)
+        assert guid1 in output
+        assert "displayName" in output
 
 
 class TestNullRendering:


### PR DESCRIPTION
## Summary

The actual cause of issue #745 (all health-check column headers blank) was **column-count width starvation**, not markup stripping: `sp_get_table_health_metrics` returns ~16 columns which, at an 80-column terminal, squeeze each header to 1–2 characters (appearing blank). The same root cause affected any wide-schema query (issue #749).

This PR addresses both issues plus hardens the renderer against Rich markup injection in data-derived strings:

- **Wide-table vertical fallback** (`_render_table`): when the visible columns cannot each receive at least `_MIN_COLUMN_WIDTH` (4) characters at the current console width, the renderer switches to a vertical, record-oriented layout — one Rich Panel per row listing all `key: value` pairs fully readable. Tables that fit normally keep the horizontal layout, preserving the GUID `no_wrap` behaviour from PR #743.
- **Rich markup escape hardening** (defensive hardening): `_cell()`, `_add_columns()`, `_render_panel()`, `render_permissions_table()`, and `render_refresh_table()` now apply `rich.markup.escape()` to all data-derived strings so that alpha-bracketed column names like `FileRowCount[avg]` or group names like `[sg-devs]` render verbatim.
- **Non-vacuous markup test**: replaced digit-prefixed bracket fixtures (`FileRowCount[0]`, which Rich does NOT treat as markup) with alpha-prefixed ones (`FileRowCount[avg]`, `Status[current]`) that ARE stripped without escaping — making the test discriminate correctly.

## Before / After

**Before** — all ~16 headers blank (starvation at 80 cols):

```
              Table Health Metrics
┏━┳━┳━┳━┳━┳━┳━┳━┳━┳━┳━┳━┳━┳━┳━┳━┳━┳━┳━━┳━┳━━┳━┳━━┳━┳━━┳━┳━━┳━┳━━┳━┳━━┳━┳━━┳━┳━━┓
┃ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┃  ┃ ┃  ┃ ┃  ┃ ┃  ┃ ┃  ┃ ┃  ┃ ┃  ┃ ┃  ┃ ┃  ┃
```

**After** — vertical fallback shows every field in full:

```
Table Health Metrics
╭───────────────────────────────────╮
│ PotentialAnomalyType: 0           │
│ PhysicalRowCount: 1000000         │
│ FileRowCount[0]: 0                │
│ FileRowCount[1,10): 0             │
│ ...                               │
╰───────────────────────────────────╯
```

## Test plan

- [x] `TestWideTableVerticalFallback.test_health_check_vertical_at_width_80_shows_all_field_names` — all ~16 field names present in vertical output at width=80.
- [x] `TestWideTableVerticalFallback.test_health_check_vertical_at_width_80_shows_bracketed_field_names` — `FileRowCount[0]` and `FileRowCount[1,10)` appear verbatim.
- [x] `TestWideTableVerticalFallback.test_queries_vertical_at_narrow_width_shows_all_field_names` — multi-row wide table renders vertically at narrow width.
- [x] `TestWideTableVerticalFallback.test_small_table_stays_horizontal` — a 2-column table at width=80 keeps the horizontal layout (no regression).
- [x] `TestWideTableVerticalFallback.test_two_guid_columns_still_work_at_width_120` — PR #743 multi-GUID behaviour unaffected.
- [x] `TestRichMarkupEscape.test_alpha_bracket_column_name_renders_verbatim` — `FileRowCount[avg]` and `Status[current]` appear verbatim (was vacuous before, now discriminates).
- [x] `TestRichMarkupEscape.test_permissions_table_escapes_group_name_in_display` — `[sg-devs]` display name renders verbatim.
- [x] `TestRichMarkupEscape.test_refresh_table_escapes_table_name` — bracketed table name renders verbatim.
- [x] 1212 unit tests in `tests/unit/cli/` pass — no regression.
- [x] `ruff check`, `ruff format --check`, `ty check` all clean on changed files.

Closes #745
Closes #749