### PR TITLE
feat(sql): log SQL statements at DEBUG with secret redaction

### DIFF
--- a/src/fabric_dw/logging.py
+++ b/src/fabric_dw/logging.py
@@ -1,17 +1,19 @@
 """Structured logging helpers for fabric_dw.
 
-Provides a JSON-emitting stdlib logging setup and a utility to redact
-sensitive values (Bearer tokens) from HTTP headers before logging.
+Provides a JSON-emitting stdlib logging setup and utilities to redact
+sensitive values (Bearer tokens, SQL secrets, SAS URLs) before logging.
 """
 
 from __future__ import annotations
 
 import json
 import logging
+import re
 import time
 
 __all__ = [
     "redact_auth_header",
+    "redact_sql",
     "setup_logging",
 ]
 
@@ -109,6 +111,58 @@ def setup_logging(level: int = logging.INFO) -> None:
     handler.setLevel(level)
     handler.setFormatter(_JsonFormatter())
     pkg_logger.addHandler(handler)
+
+
+# ---------------------------------------------------------------------------
+# SQL secret redaction
+# ---------------------------------------------------------------------------
+
+# Matches SECRET = '...' (case-insensitive).  The value may contain doubled
+# single-quotes (the _sq() escaping used by load.py), so we match a quoted
+# string that may contain '' (two consecutive single-quotes) inside.
+_RE_SQL_SECRET: re.Pattern[str] = re.compile(
+    r"(SECRET\s*=\s*')" r"(?:[^']|'')*" r"'",
+    re.IGNORECASE,
+)
+
+# Matches a https:// URL that contains a query string — replaces ?... with ?***.
+# Targets blob/dfs SAS URLs embedded in SQL (e.g. COPY INTO '...' FROM '...' …)
+# by stripping query-string parameters starting at '?'.
+_RE_SAS_URL: re.Pattern[str] = re.compile(
+    r"(https://[^\s'\"]*)\?[^\s'\"]*",
+    re.IGNORECASE,
+)
+
+
+def redact_sql(sql: str) -> str:
+    """Return *sql* with embedded secrets replaced by ``***``.
+
+    Two categories of secrets are redacted:
+
+    1. **SQL credential literals** — ``SECRET = '<value>'`` (case-insensitive).
+       The ``<value>`` is replaced with ``***``, giving ``SECRET = '***'``.
+       The ``_sq()`` helper in :mod:`fabric_dw.services.load` escapes
+       single-quotes by doubling them (``''``), so the regex handles values
+       that contain ``''`` inside the quoted string.
+
+    2. **SAS URL query strings** — any ``https://...?...`` URL embedded in the
+       SQL has the ``?<query-string>`` replaced with ``?***``.  This covers
+       ``sig=``, ``sv=``, and all other SAS parameters without having to
+       enumerate them individually.
+
+    The function is intentionally conservative (over-redacts rather than
+    leaks).  It must be applied to the SQL string before emitting any log
+    record so that no credential ever reaches a log sink.
+
+    Args:
+        sql: The raw SQL statement string.
+
+    Returns:
+        A copy of *sql* with secrets redacted.  The original string is not
+        mutated.
+    """
+    # Step 1: redact SECRET = '...' values; step 2: strip SAS query strings.
+    return _RE_SAS_URL.sub(r"\1?***", _RE_SQL_SECRET.sub(r"\g<1>***'", sql))
 
 
 _SENSITIVE_HEADERS: frozenset[str] = frozenset(

--- a/src/fabric_dw/logging.py
+++ b/src/fabric_dw/logging.py
@@ -125,11 +125,12 @@ _RE_SQL_SECRET: re.Pattern[str] = re.compile(
     re.IGNORECASE,
 )
 
-# Matches a https:// URL that contains a query string — replaces ?... with ?***.
-# Targets blob/dfs SAS URLs embedded in SQL (e.g. COPY INTO '...' FROM '...' …)
-# by stripping query-string parameters starting at '?'.
+# Matches any URL scheme that can carry SAS/query secrets and contains a query
+# string — replaces ?... with ?***.  Covers https://, http://, and Azure blob/
+# dfs/OneLake schemes (abfss://, abfs://, wasbs://, wasb://) that can also
+# appear inside SQL statements such as COPY INTO.
 _RE_SAS_URL: re.Pattern[str] = re.compile(
-    r"(https://[^\s'\"]*)\?[^\s'\"]*",
+    r"((?:https?|abfss?|wasbs?)://[^\s'\"]*)\?[^\s'\"]*",
     re.IGNORECASE,
 )
 
@@ -145,10 +146,12 @@ def redact_sql(sql: str) -> str:
        single-quotes by doubling them (``''``), so the regex handles values
        that contain ``''`` inside the quoted string.
 
-    2. **SAS URL query strings** — any ``https://...?...`` URL embedded in the
-       SQL has the ``?<query-string>`` replaced with ``?***``.  This covers
-       ``sig=``, ``sv=``, and all other SAS parameters without having to
-       enumerate them individually.
+    2. **SAS URL query strings** — any URL with a query string embedded in the
+       SQL has the ``?<query-string>`` replaced with ``?***``.  Covers
+       ``https://``, ``http://``, and Azure blob/dfs/OneLake schemes
+       (``abfss://``, ``abfs://``, ``wasbs://``, ``wasb://``).  This masks
+       ``sig=``, ``sv=``, and all other SAS parameters without enumerating
+       them individually.
 
     The function is intentionally conservative (over-redacts rather than
     leaks).  It must be applied to the SQL string before emitting any log

--- a/src/fabric_dw/sql.py
+++ b/src/fabric_dw/sql.py
@@ -1264,6 +1264,24 @@ def _with_connect_retry(
             return conn, attempt, attempt + 2, last_exc
 
 
+def _log_sql_execute(sql: str, *, param_count: int = 0) -> None:
+    """Emit a DEBUG record for an SQL statement about to be executed.
+
+    Guards the :func:`redact_sql` call and the log emission behind a single
+    :meth:`logging.Logger.isEnabledFor` check so there is zero overhead when
+    the ``fabric_dw.sql`` logger is not at DEBUG level.  Centralises the
+    redact-then-log idiom shared by :func:`run_query` and
+    :func:`run_statements` to prevent drift.
+
+    Args:
+        sql: The raw SQL statement (will be redacted before logging).
+        param_count: Number of bound parameters being passed (values are never
+            logged; only the count may appear in the log record).
+    """
+    if _log.isEnabledFor(logging.DEBUG):
+        _log.debug("sql execute", extra={"sql": redact_sql(sql), "param_count": param_count})
+
+
 def run_query(  # noqa: PLR0913, PLR0915
     target: SqlTarget,
     statement: str,
@@ -1387,20 +1405,14 @@ def run_query(  # noqa: PLR0913, PLR0915
         been committed server-side.
         """
         cur = c.cursor()
-        if _log.isEnabledFor(logging.DEBUG):
-            _log.debug(
-                "sql execute",
-                extra={
-                    "sql": redact_sql(statement),
-                    "param_count": len(params) if params else 0,
-                },
-            )
-        _t0 = time.monotonic() if _log.isEnabledFor(logging.DEBUG) else 0.0
+        _debug = _log.isEnabledFor(logging.DEBUG)
+        _log_sql_execute(statement, param_count=len(params) if params else 0)
+        _t0 = time.monotonic() if _debug else 0.0
         if params:
             cur.execute(statement, params)
         else:
             cur.execute(statement)
-        if _log.isEnabledFor(logging.DEBUG):
+        if _debug:
             _log.debug(
                 "sql execute -> done",
                 extra={
@@ -1590,8 +1602,7 @@ def run_statements(
     try:
         for stmt in statements:
             try:
-                if _log.isEnabledFor(logging.DEBUG):
-                    _log.debug("sql execute", extra={"sql": redact_sql(stmt)})
+                _log_sql_execute(stmt)
                 cursor.execute(stmt)
                 if not autocommit and commit_per_statement:
                     conn.commit()

--- a/src/fabric_dw/sql.py
+++ b/src/fabric_dw/sql.py
@@ -58,6 +58,7 @@ from typing import Any, Literal, Protocol
 
 from fabric_dw.auth import CredentialMode, get_sql_token_struct
 from fabric_dw.exceptions import AuthError, FabricServerError, NotFoundError, PermissionDeniedError
+from fabric_dw.logging import redact_sql
 
 _log = logging.getLogger(__name__)
 
@@ -1386,10 +1387,27 @@ def run_query(  # noqa: PLR0913, PLR0915
         been committed server-side.
         """
         cur = c.cursor()
+        if _log.isEnabledFor(logging.DEBUG):
+            _log.debug(
+                "sql execute",
+                extra={
+                    "sql": redact_sql(statement),
+                    "param_count": len(params) if params else 0,
+                },
+            )
+        _t0 = time.monotonic() if _log.isEnabledFor(logging.DEBUG) else 0.0
         if params:
             cur.execute(statement, params)
         else:
             cur.execute(statement)
+        if _log.isEnabledFor(logging.DEBUG):
+            _log.debug(
+                "sql execute -> done",
+                extra={
+                    "elapsed_ms": (time.monotonic() - _t0) * 1000,
+                    "rowcount": cur.rowcount,
+                },
+            )
 
         if fetch == "none":
             # No result set to read.  Return without committing — commit is
@@ -1572,6 +1590,8 @@ def run_statements(
     try:
         for stmt in statements:
             try:
+                if _log.isEnabledFor(logging.DEBUG):
+                    _log.debug("sql execute", extra={"sql": redact_sql(stmt)})
                 cursor.execute(stmt)
                 if not autocommit and commit_per_statement:
                     conn.commit()

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -283,3 +283,25 @@ class TestRedactSql:
         sql = "COPY INTO [t] FROM 'https://myaccount.blob.core.windows.net/c/f.parquet'"
         result = redact_sql(sql)
         assert result == sql
+
+    def test_abfss_url_query_string_redacted(self) -> None:
+        """abfss:// Azure Data Lake Storage URLs with query strings must be redacted."""
+        sql = (
+            "COPY INTO [t] FROM"
+            " 'abfss://container@account.dfs.core.windows.net/data.parquet"
+            "?sv=2024-01-01&sig=ABCSECRET&se=2025&sp=r'"
+        )
+        result = redact_sql(sql)
+        assert "ABCSECRET" not in result
+        assert "abfss://container@account.dfs.core.windows.net/data.parquet?***" in result
+
+    def test_wasbs_url_query_string_redacted(self) -> None:
+        """wasbs:// Azure Blob Storage URLs with query strings must be redacted."""
+        sql = (
+            "COPY INTO [t] FROM"
+            " 'wasbs://container@account.blob.core.windows.net/data.parquet"
+            "?sv=2024&sig=WASB_SECRET'"
+        )
+        result = redact_sql(sql)
+        assert "WASB_SECRET" not in result
+        assert "?***" in result

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import logging
 
-from fabric_dw.logging import _JsonFormatter, redact_auth_header, setup_logging
+from fabric_dw.logging import _JsonFormatter, redact_auth_header, redact_sql, setup_logging
 
 
 class TestSetupLogging:
@@ -205,3 +205,81 @@ class TestJsonFormatterExtraFields:
         record = self._make_record(extra={"request_id": "fabric-req-id-001"})
         parsed = json.loads(formatter.format(record))
         assert parsed.get("request_id") == "fabric-req-id-001"
+
+
+class TestRedactSql:
+    """Tests for redact_sql — SQL secret redaction helper."""
+
+    def test_secret_clause_value_is_replaced(self) -> None:
+        """SECRET = '<token>' must become SECRET = '***'."""
+        sql = (
+            "COPY INTO [dbo].[t] FROM 'https://x.blob.core.windows.net/c/f.parquet'"
+            " WITH (CREDENTIAL = (IDENTITY = 'Shared Access Signature',"
+            " SECRET = 'sv=2024&sig=ABC123xyz'))"
+        )
+        result = redact_sql(sql)
+        assert "ABC123xyz" not in result
+        assert "SECRET = '***'" in result
+
+    def test_secret_clause_case_insensitive(self) -> None:
+        """secret = and Secret = must also be redacted."""
+        sql = (
+            "COPY INTO [t] FROM 'x' WITH (CREDENTIAL = (IDENTITY = 'y', secret = 'mysecrettoken'))"
+        )
+        result = redact_sql(sql)
+        assert "mysecrettoken" not in result
+        assert "***" in result
+
+    def test_secret_with_doubled_quotes_redacted(self) -> None:
+        """Values that contain '' (doubled single-quote escaping via _sq) must be redacted."""
+        sql = (
+            "COPY INTO [t] FROM 'x'"
+            " WITH (CREDENTIAL = (IDENTITY = 'y', SECRET = 'token''with''quotes'))"
+        )
+        result = redact_sql(sql)
+        assert "token''with''quotes" not in result
+        assert "***" in result
+
+    def test_sas_url_query_string_redacted(self) -> None:
+        """https://... URLs with query strings must have ?... replaced with ?***."""
+        sql = (
+            "COPY INTO [t] FROM"
+            " 'https://myaccount.blob.core.windows.net/c/f.parquet"
+            "?sv=2024-01-01&sig=ABCSECRET&se=2025&sp=r'"
+        )
+        result = redact_sql(sql)
+        assert "ABCSECRET" not in result
+        assert "https://myaccount.blob.core.windows.net/c/f.parquet?***" in result
+
+    def test_copy_into_with_secret_and_sas_url_both_redacted(self) -> None:
+        """A realistic COPY INTO with both SECRET and a SAS URL must have both redacted."""
+        sql = (
+            "COPY INTO [dbo].[target] "
+            "FROM 'https://storage.dfs.core.windows.net/container/data.parquet"
+            "?sv=2022&sig=TOKEN&sp=r' "
+            "WITH (CREDENTIAL = (IDENTITY = 'Shared Access Signature',"
+            " SECRET = 'sv=2022&sig=TOKEN'))"
+        )
+        result = redact_sql(sql)
+        assert "TOKEN" not in result
+        assert "SECRET = '***'" in result
+        assert "?***" in result
+
+    def test_sql_without_secrets_unchanged(self) -> None:
+        """A plain SELECT without secrets is returned unchanged."""
+        sql = "SELECT TOP 10 * FROM [dbo].[mytable]"
+        result = redact_sql(sql)
+        assert result == sql
+
+    def test_original_string_not_mutated(self) -> None:
+        """redact_sql must not mutate the input string."""
+        sql = "COPY INTO [t] FROM 'x' WITH (CREDENTIAL = (IDENTITY = 'y', SECRET = 'tok'))"
+        original = sql
+        redact_sql(sql)
+        assert sql == original
+
+    def test_url_without_query_string_unchanged(self) -> None:
+        """An https:// URL without a query string must not be modified."""
+        sql = "COPY INTO [t] FROM 'https://myaccount.blob.core.windows.net/c/f.parquet'"
+        result = redact_sql(sql)
+        assert result == sql

--- a/tests/unit/test_sql.py
+++ b/tests/unit/test_sql.py
@@ -3461,3 +3461,127 @@ class TestRunQueryUnmappedDriverError:
 
         # Must NOT be wrapped as FabricServerError.
         assert not isinstance(exc_info.value, FabricServerError)
+
+
+# ---------------------------------------------------------------------------
+# SQL DEBUG logging
+# ---------------------------------------------------------------------------
+
+
+class TestSqlDebugLogging:
+    """DEBUG-level logging for executed SQL statements."""
+
+    def test_run_query_emits_debug_log_with_sql(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """run_query must emit a DEBUG record containing the SQL text when DEBUG is enabled."""
+        mock_mssql, _conn, _cursor = _make_mock_mssql()
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        with caplog.at_level("DEBUG", logger="fabric_dw.sql"):
+            run_query(_make_target(), "SELECT 1 AS n")
+
+        debug_records = [r for r in caplog.records if r.levelno == 10]  # logging.DEBUG == 10
+        sql_seen = any(
+            "SELECT 1 AS n" in r.getMessage() or getattr(r, "sql", None) == "SELECT 1 AS n"
+            for r in debug_records
+        )
+        assert sql_seen, (
+            f"Expected SQL in DEBUG records; got: {[r.getMessage() for r in debug_records]}"
+        )
+
+    def test_run_query_no_debug_log_when_level_is_info(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """run_query must NOT emit any record from fabric_dw.sql when DEBUG is disabled."""
+        mock_mssql, _conn, _cursor = _make_mock_mssql()
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        with caplog.at_level("INFO", logger="fabric_dw.sql"):
+            run_query(_make_target(), "SELECT 1 AS n")
+
+        sql_records = [r for r in caplog.records if r.name == "fabric_dw.sql"]
+        assert sql_records == [], (
+            f"Expected no fabric_dw.sql records at INFO level; got: {sql_records}"
+        )
+
+    def test_run_statements_emits_debug_log_per_statement(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """run_statements must emit a DEBUG record for each executed statement."""
+        mock_mssql, _conn, _cursor = _make_mock_mssql()
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        stmts = ["DROP TABLE [dbo].[t1]", "DROP VIEW [dbo].[v1]"]
+        with caplog.at_level("DEBUG", logger="fabric_dw.sql"):
+            run_statements(_make_target(), stmts)
+
+        debug_records = [r for r in caplog.records if r.levelno == 10 and r.name == "fabric_dw.sql"]
+        logged_sqls = [getattr(r, "sql", r.getMessage()) for r in debug_records]
+        assert any("DROP TABLE [dbo].[t1]" in s for s in logged_sqls), (
+            f"Expected first statement in DEBUG records; got: {logged_sqls}"
+        )
+        assert any("DROP VIEW [dbo].[v1]" in s for s in logged_sqls), (
+            f"Expected second statement in DEBUG records; got: {logged_sqls}"
+        )
+
+    def test_run_statements_no_debug_log_when_level_is_info(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """run_statements must NOT emit fabric_dw.sql records when DEBUG is disabled."""
+        mock_mssql, _conn, _cursor = _make_mock_mssql()
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        with caplog.at_level("INFO", logger="fabric_dw.sql"):
+            run_statements(_make_target(), ["DROP TABLE [dbo].[t]"])
+
+        sql_records = [r for r in caplog.records if r.name == "fabric_dw.sql"]
+        assert sql_records == [], (
+            f"Expected no fabric_dw.sql records at INFO level; got: {sql_records}"
+        )
+
+    def test_secret_not_logged_raw(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A COPY INTO with SECRET = '<token>' must not log the raw secret value."""
+        mock_mssql, _conn, _cursor = _make_mock_mssql()
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        raw_secret = "sv=2024&sig=TOPSECRETTOKEN"  # noqa: S105
+        copy_sql = (
+            f"COPY INTO [dbo].[t] FROM 'https://x.blob.core.windows.net/c/f.parquet' "
+            f"WITH (CREDENTIAL = (IDENTITY = 'Shared Access Signature', SECRET = '{raw_secret}'))"
+        )
+
+        with caplog.at_level("DEBUG", logger="fabric_dw.sql"):
+            run_query(_make_target(), copy_sql)
+
+        # The raw secret must NOT appear anywhere in any log record.
+        all_log_text = " ".join(
+            str(r.getMessage()) + str(getattr(r, "sql", "")) for r in caplog.records
+        )
+        assert "TOPSECRETTOKEN" not in all_log_text, (
+            "Raw secret token must not appear in any log record"
+        )
+        assert "***" in all_log_text, "Redacted placeholder '***' must appear in log records"
+
+    def test_bound_param_values_not_logged(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Bound parameter VALUES must not appear in logs — only the count may be logged."""
+        mock_mssql, _conn, _cursor = _make_mock_mssql()
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        sentinel_secret = "VERYSECRETPARAMVALUE"  # noqa: S105
+        sql = "SELECT * FROM [dbo].[t] WHERE col = ?"
+
+        with caplog.at_level("DEBUG", logger="fabric_dw.sql"):
+            run_query(_make_target(), sql, params=[sentinel_secret])
+
+        all_log_text = " ".join(
+            str(r.getMessage()) + str(getattr(r, "sql", "")) + str(getattr(r, "param_count", ""))
+            for r in caplog.records
+        )
+        assert sentinel_secret not in all_log_text, (
+            "Bound parameter value must not appear in any log record"
+        )


### PR DESCRIPTION
## Summary

- Adds `redact_sql()` to `src/fabric_dw/logging.py` (next to `redact_auth_header`): masks `SECRET = '...'` values (case-insensitive, handles `_sq` doubled-quote escaping) and strips SAS query-string parameters (`?sig=...`) from embedded HTTPS URLs.
- In `_execute_and_fetch`: emits a `"sql execute"` DEBUG record with redacted SQL and param count (guarded by `isEnabledFor(DEBUG)`), plus a completion record with `elapsed_ms` and `rowcount` mirroring the HTTP style.
- In `run_statements`: emits a `"sql execute"` DEBUG record per statement, also guarded. Zero overhead when not verbose.
- 14 new unit tests covering `redact_sql` and SQL DEBUG logging behaviour.

Example verbose output (with `-v`):
```json
{"level": "DEBUG", "name": "fabric_dw.sql", "msg": "sql execute", "sql": "COPY INTO [dbo].[t] FROM 'https://...?***' WITH (CREDENTIAL = (IDENTITY = 'Shared Access Signature', SECRET = '***'))", "param_count": 0, "time": "2026-06-24T10:00:00.000Z"}
{"level": "DEBUG", "name": "fabric_dw.sql", "msg": "sql execute -> done", "elapsed_ms": 142.3, "rowcount": 1, "time": "2026-06-24T10:00:00.142Z"}
```

Closes #754

## Test plan

- [x] `uv run pytest tests/unit/test_sql.py tests/unit/test_logging.py -q` — 234 passed
- [x] `uv run ruff check src tests` — no errors
- [x] `uv run ruff format --check .` — all formatted
- [x] `uv run ty check src tests` — all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)