### PR TITLE
ci(publish): mark prerelease GitHub Releases for aN/bN/rcN/.dev tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -127,6 +127,19 @@ jobs:
             fi
           fi
 
+      - name: Determine prerelease flag
+        id: prerelease
+        if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
+        env:
+          EFFECTIVE_TAG: ${{ inputs.tag || github.ref_name }}
+        run: |
+          version="${EFFECTIVE_TAG#v}"
+          if echo "$version" | grep -qE '(a|b|rc)[0-9]*$|\.dev'; then
+            echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Create GitHub Release (tag only)
         if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
         uses: softprops/action-gh-release@v3
@@ -139,3 +152,4 @@ jobs:
           generate_release_notes: true
           name: ${{ inputs.tag || github.ref_name }}
           tag_name: ${{ inputs.tag || github.ref_name }}
+          prerelease: ${{ steps.prerelease.outputs.is_prerelease }}


### PR DESCRIPTION
## Summary

- Adds a **"Determine prerelease flag"** step (id: `prerelease`) before the "Create GitHub Release" step, gated with the same `if:` condition (`github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'`).
- The step strips the leading `v` from `${{ inputs.tag || github.ref_name }}` and checks against the existing regex `(a|b|rc)[0-9]*$|\.dev` (reused from the plugin.json version-check step at ~line 63).
- Writes `is_prerelease=true` or `is_prerelease=false` to `$GITHUB_OUTPUT`.
- Passes the result to `softprops/action-gh-release@v3` via `prerelease: ${{ steps.prerelease.outputs.is_prerelease }}`.

No other behavior changes: PyPI publish, SBOM generation, asset upload, and `generate_release_notes` are all untouched.

## Regex classification verification

| Version | Classification |
|---|---|
| `2026.6.0a0` | prerelease |
| `2026.6.0b0` | prerelease |
| `2026.6.0rc0` | prerelease |
| `2026.6.0rc0.dev5` | prerelease |
| `2026.6.0` | stable |
| `2026.6.10` | stable |

`actionlint` ran clean; YAML validated.

Closes #760