### PR TITLE
chore(mcp): add project .mcp.json running the server via uvx@latest

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "fabric-dw": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": [
+        "--from",
+        "fabric-dw@latest",
+        "fabric-dw-mcp"
+      ],
+      "env": {}
+    }
+  }
+}


### PR DESCRIPTION
Register the `fabric-dw` MCP server at project scope via `.mcp.json` so MCP clients always launch the latest published release:

```
uvx --from fabric-dw@latest fabric-dw-mcp
```

Verified locally that the command resolves the package from PyPI and starts the MCP entry point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)