### PR TITLE
fix(mcp): make workspace optional for all_workspaces aggregation (#763)

### DIFF
--- a/src/fabric_dw/mcp/tools/sql_endpoints.py
+++ b/src/fabric_dw/mcp/tools/sql_endpoints.py
@@ -29,13 +29,16 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
 
     @mcp.tool(name="list_sql_endpoints")
     async def list_sql_endpoints(
-        workspace: str,
+        workspace: str | None = None,
         all_workspaces: bool = False,  # noqa: FBT001, FBT002
     ) -> list[dict[str, Any]]:
         """List all SQL analytics endpoints in a workspace.
 
-        When *all_workspaces* is ``True``, ignore *workspace* and aggregate results
-        across every workspace the caller can see.
+        Args:
+            workspace: Workspace name or GUID.  Optional when *all_workspaces*
+                is ``True``; required otherwise.
+            all_workspaces: When ``True``, ignore *workspace* and aggregate
+                results across every workspace the caller can see.
         """
         ctx = get_context()
         if all_workspaces and workspace_allowlist_active(ctx.workspace_allowlist):
@@ -45,15 +48,20 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
                 "specify an individual workspace instead"
             )
         if not all_workspaces:
+            if not workspace:
+                raise ToolError("workspace is required unless all_workspaces=True")
             assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             if all_workspaces:
                 _log.debug("list_sql_endpoints all_workspaces=True")
                 result = await sql_endpoints.list_all_workspaces(ctx.http)
             else:
-                ws_id = await ctx.resolver.workspace_id(workspace)
+                # workspace is non-None/non-empty: guard above raised ToolError otherwise.
+                ws_id = await ctx.resolver.workspace_id(workspace)  # ty: ignore[invalid-argument-type]
                 assert_workspace_allowed(
-                    workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+                    workspace,  # ty: ignore[invalid-argument-type]
+                    str(ws_id),
+                    config_allowlist=ctx.workspace_allowlist,
                 )
                 _log.debug("list_sql_endpoints ws=%s", ws_id)
                 result = await sql_endpoints.list_endpoints(ctx.http, ws_id)

--- a/src/fabric_dw/mcp/tools/sql_endpoints.py
+++ b/src/fabric_dw/mcp/tools/sql_endpoints.py
@@ -48,7 +48,7 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
                 "specify an individual workspace instead"
             )
         if not all_workspaces:
-            if not workspace:
+            if not workspace or not workspace.strip():
                 raise ToolError("workspace is required unless all_workspaces=True")
             assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
@@ -56,10 +56,10 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
                 _log.debug("list_sql_endpoints all_workspaces=True")
                 result = await sql_endpoints.list_all_workspaces(ctx.http)
             else:
-                # workspace is non-None/non-empty: guard above raised ToolError otherwise.
-                ws_id = await ctx.resolver.workspace_id(workspace)  # ty: ignore[invalid-argument-type]
+                assert workspace is not None  # noqa: S101 — guard above raised ToolError otherwise
+                ws_id = await ctx.resolver.workspace_id(workspace)
                 assert_workspace_allowed(
-                    workspace,  # ty: ignore[invalid-argument-type]
+                    workspace,
                     str(ws_id),
                     config_allowlist=ctx.workspace_allowlist,
                 )

--- a/src/fabric_dw/mcp/tools/warehouses.py
+++ b/src/fabric_dw/mcp/tools/warehouses.py
@@ -29,13 +29,16 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
 
     @mcp.tool(name="list_warehouses")
     async def list_warehouses(
-        workspace: str,
+        workspace: str | None = None,
         all_workspaces: bool = False,  # noqa: FBT001, FBT002
     ) -> list[dict[str, Any]]:
         """List all warehouses and SQL analytics endpoints in a workspace.
 
-        When *all_workspaces* is ``True``, ignore *workspace* and aggregate results
-        across every workspace the caller can see.
+        Args:
+            workspace: Workspace name or GUID.  Optional when *all_workspaces*
+                is ``True``; required otherwise.
+            all_workspaces: When ``True``, ignore *workspace* and aggregate
+                results across every workspace the caller can see.
         """
         ctx = get_context()
         if all_workspaces and workspace_allowlist_active(ctx.workspace_allowlist):
@@ -45,15 +48,20 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
                 "specify an individual workspace instead"
             )
         if not all_workspaces:
+            if not workspace:
+                raise ToolError("workspace is required unless all_workspaces=True")
             assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
             if all_workspaces:
                 _log.debug("list_warehouses all_workspaces=True")
                 result = await warehouses.list_all_workspaces(ctx.http)
             else:
-                ws_id = await ctx.resolver.workspace_id(workspace)
+                # workspace is non-None/non-empty: guard above raised ToolError otherwise.
+                ws_id = await ctx.resolver.workspace_id(workspace)  # ty: ignore[invalid-argument-type]
                 assert_workspace_allowed(
-                    workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+                    workspace,  # ty: ignore[invalid-argument-type]
+                    str(ws_id),
+                    config_allowlist=ctx.workspace_allowlist,
                 )
                 _log.debug("list_warehouses ws=%s", ws_id)
                 result = await warehouses.list_warehouses(ctx.http, ws_id)

--- a/src/fabric_dw/mcp/tools/warehouses.py
+++ b/src/fabric_dw/mcp/tools/warehouses.py
@@ -48,7 +48,7 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
                 "specify an individual workspace instead"
             )
         if not all_workspaces:
-            if not workspace:
+            if not workspace or not workspace.strip():
                 raise ToolError("workspace is required unless all_workspaces=True")
             assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
@@ -56,10 +56,10 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
                 _log.debug("list_warehouses all_workspaces=True")
                 result = await warehouses.list_all_workspaces(ctx.http)
             else:
-                # workspace is non-None/non-empty: guard above raised ToolError otherwise.
-                ws_id = await ctx.resolver.workspace_id(workspace)  # ty: ignore[invalid-argument-type]
+                assert workspace is not None  # noqa: S101 — guard above raised ToolError otherwise
+                ws_id = await ctx.resolver.workspace_id(workspace)
                 assert_workspace_allowed(
-                    workspace,  # ty: ignore[invalid-argument-type]
+                    workspace,
                     str(ws_id),
                     config_allowlist=ctx.workspace_allowlist,
                 )

--- a/tests/unit/mcp/tools/test_sql_endpoints.py
+++ b/tests/unit/mcp/tools/test_sql_endpoints.py
@@ -16,6 +16,7 @@ from uuid import UUID
 import pytest
 from mcp.server.fastmcp.exceptions import ToolError
 
+from fabric_dw.exceptions import NotFoundError
 from fabric_dw.models import Warehouse, WarehouseKind
 from tests.unit.mcp.conftest import (
     WS_ID,
@@ -111,6 +112,28 @@ async def test_list_sql_endpoints_workspace_provided_succeeds(mock_ctx, ctx_patc
 
     assert isinstance(result, list)
     assert result[0]["id"] == str(_EP_ID)
+
+
+async def test_list_sql_endpoints_fabric_error_becomes_tool_error(mock_ctx, ctx_patch) -> None:
+    """list_sql_endpoints wraps FabricError into ToolError."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.sql_endpoints.list_endpoints",
+            new=AsyncMock(side_effect=NotFoundError("workspace not found")),
+        ),
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "list_sql_endpoints",
+            {"workspace": WS_NAME},
+        )
+
+    assert "NotFoundError" in str(exc_info.value) or "not found" in str(exc_info.value).lower()
 
 
 async def test_list_sql_endpoints_all_workspaces_with_allowlist_raises(ctx_patch) -> None:

--- a/tests/unit/mcp/tools/test_sql_endpoints.py
+++ b/tests/unit/mcp/tools/test_sql_endpoints.py
@@ -1,0 +1,130 @@
+"""Unit tests for fabric_dw.mcp.tools.sql_endpoints — list_sql_endpoints behaviour.
+
+Focuses on the optional-workspace fix introduced in #763:
+  - all_workspaces=True with no workspace arg → success (aggregation)
+  - all_workspaces=False with no workspace arg → clear ToolError
+  - workspace provided + all_workspaces=False → existing happy path
+  - all_workspaces=True with workspace allowlist configured → ToolError
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, patch
+from uuid import UUID
+
+import pytest
+from mcp.server.fastmcp.exceptions import ToolError
+
+from fabric_dw.models import Warehouse, WarehouseKind
+from tests.unit.mcp.conftest import (
+    WS_ID,
+    WS_NAME,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_EP_ID = UUID("f1e2d3c4-b5a6-7890-1234-567890abcdef")
+_EP_NAME = "my-sql-endpoint"
+
+
+def _make_sql_endpoint() -> Warehouse:
+    """Return a Warehouse model with SQL_ENDPOINT kind."""
+    return Warehouse.model_validate(
+        {
+            "id": str(_EP_ID),
+            "displayName": _EP_NAME,
+            "workspaceId": str(WS_ID),
+            "kind": WarehouseKind.SQL_ENDPOINT,
+            "connectionString": "ep.fabric.microsoft.com",
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# list_sql_endpoints — all_workspaces=True with no workspace (issue #763)
+# ---------------------------------------------------------------------------
+
+
+async def test_list_sql_endpoints_all_workspaces_true_no_workspace_succeeds(
+    ctx_patch,
+) -> None:
+    """all_workspaces=True with no workspace arg must aggregate without error."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    ep = _make_sql_endpoint()
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.sql_endpoints.list_all_workspaces",
+            new=AsyncMock(return_value=[ep]),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "list_sql_endpoints",
+            {"all_workspaces": True},
+        )
+
+    assert isinstance(result, list)
+    assert result[0]["id"] == str(_EP_ID)
+
+
+async def test_list_sql_endpoints_no_workspace_no_all_workspaces_raises_clear_error(
+    ctx_patch,
+) -> None:
+    """No workspace and all_workspaces=False must raise a clear ToolError."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "list_sql_endpoints",
+            {},
+        )
+
+    assert "workspace is required" in str(exc_info.value).lower()
+    assert "all_workspaces" in str(exc_info.value).lower()
+
+
+async def test_list_sql_endpoints_workspace_provided_succeeds(mock_ctx, ctx_patch) -> None:
+    """Existing behaviour: list_sql_endpoints with workspace and all_workspaces=False works."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    ep = _make_sql_endpoint()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.sql_endpoints.list_endpoints",
+            new=AsyncMock(return_value=[ep]),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "list_sql_endpoints",
+            {"workspace": WS_NAME},
+        )
+
+    assert isinstance(result, list)
+    assert result[0]["id"] == str(_EP_ID)
+
+
+async def test_list_sql_endpoints_all_workspaces_with_allowlist_raises(ctx_patch) -> None:
+    """all_workspaces=True must raise ToolError when FABRIC_MCP_WORKSPACES is configured."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_WORKSPACES": WS_NAME}),
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "list_sql_endpoints",
+            {"all_workspaces": True},
+        )
+
+    assert "FABRIC_MCP_WORKSPACES" in str(exc_info.value)

--- a/tests/unit/mcp/tools/test_warehouses.py
+++ b/tests/unit/mcp/tools/test_warehouses.py
@@ -110,6 +110,73 @@ async def test_list_warehouses_fabric_error_becomes_tool_error(mock_ctx, ctx_pat
     assert "NotFoundError" in str(exc_info.value) or "not found" in str(exc_info.value).lower()
 
 
+async def test_list_warehouses_all_workspaces_true_no_workspace_succeeds(
+    ctx_patch,
+) -> None:
+    """all_workspaces=True with no workspace arg must aggregate without error."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    wh = _make_warehouse()
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.warehouses.list_all_workspaces",
+            new=AsyncMock(return_value=[wh]),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "list_warehouses",
+            {"all_workspaces": True},
+        )
+
+    assert isinstance(result, list)
+    assert result[0]["id"] == str(WH_ID)
+
+
+async def test_list_warehouses_no_workspace_no_all_workspaces_raises_clear_error(
+    ctx_patch,
+) -> None:
+    """No workspace and all_workspaces=False must raise a clear ToolError."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "list_warehouses",
+            {},
+        )
+
+    assert "workspace is required" in str(exc_info.value).lower()
+    assert "all_workspaces" in str(exc_info.value).lower()
+
+
+async def test_list_warehouses_workspace_provided_all_workspaces_false_succeeds(
+    mock_ctx, ctx_patch
+) -> None:
+    """Existing behaviour: list_warehouses with workspace and all_workspaces=False works."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    wh = _make_warehouse()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.warehouses.list_warehouses",
+            new=AsyncMock(return_value=[wh]),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "list_warehouses",
+            {"workspace": WS_NAME},
+        )
+
+    assert isinstance(result, list)
+    assert result[0]["id"] == str(WH_ID)
+
+
 # ---------------------------------------------------------------------------
 # get_warehouse — happy path (lines 67-76)
 # ---------------------------------------------------------------------------

--- a/tests/unit/mcp/tools/test_warehouses.py
+++ b/tests/unit/mcp/tools/test_warehouses.py
@@ -82,7 +82,7 @@ async def test_list_warehouses_all_workspaces_with_allowlist_raises(ctx_patch) -
     ):
         await mcp._tool_manager.call_tool(
             "list_warehouses",
-            {"workspace": "", "all_workspaces": True},
+            {"all_workspaces": True},
         )
 
     assert "FABRIC_MCP_WORKSPACES" in str(exc_info.value)


### PR DESCRIPTION
## Summary

- `list_warehouses` and `list_sql_endpoints` declared `workspace` as a required parameter, causing an opaque Pydantic `Field required` validation error when callers passed `{"all_workspaces": true}` without a workspace argument.
- Changed the signature to `workspace: str | None = None` in both tools.
- Added an explicit `ToolError` guard before any use of `workspace`: raises `"workspace is required unless all_workspaces=True"` when `all_workspaces=False` and workspace is None or whitespace-only.
- Updated docstrings to state `workspace` is optional when `all_workspaces=True`, required otherwise.
- Used `assert workspace is not None  # noqa: S101` at the top of the else-branch in each tool to narrow the type for the type checker, matching the codebase convention.

**Other tools with `all_workspaces`:** No other MCP tools in the codebase have an `all_workspaces` parameter with a required `workspace` argument. The bug was limited to these two tools.

## Test plan

- [x] All gates pass locally (`uv run ruff check .`, `uv run ruff format --check .`, `uv run ty check src tests`)
- [x] Unit tests pass: 747 passed (includes new tests in `tests/unit/mcp/tools/test_warehouses.py` and new `tests/unit/mcp/tools/test_sql_endpoints.py`)
- [ ] Integration tests pass where applicable (`just integration` - requires `az login` and the `integration` label on the PR)
- Manual testing: calling `list_warehouses` / `list_sql_endpoints` with `{"all_workspaces": true}` and no `workspace` now returns results instead of raising a Pydantic validation error.

## Linked issue

Closes #763