### PR TITLE
docs: remove em-dashes from documentation

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -6,7 +6,7 @@ title: Authentication
 
 ## TL;DR
 
-If you are already signed in via [Azure CLI](https://learn.microsoft.com/cli/azure/reference-index?view=azure-cli-latest&WT.mc_id=MVP_310840#az-login) or [Azure PowerShell](https://learn.microsoft.com/powershell/module/az.accounts/connect-azaccount?WT.mc_id=MVP_310840), you don't need to configure anything — `fabric-dw` picks up your session automatically.
+If you are already signed in via [Azure CLI](https://learn.microsoft.com/cli/azure/reference-index?view=azure-cli-latest&WT.mc_id=MVP_310840#az-login) or [Azure PowerShell](https://learn.microsoft.com/powershell/module/az.accounts/connect-azaccount?WT.mc_id=MVP_310840), you don't need to configure anything - `fabric-dw` picks up your session automatically.
 
 ```bash
 az login          # or: az login --tenant <tenant-id>
@@ -34,9 +34,9 @@ Valid values: `default`, `interactive`, `sp` (case-insensitive).
 
 | Value | What it uses |
 | --- | --- |
-| `default` | [`azure-identity` `DefaultAzureCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.defaultazurecredential?WT.mc_id=MVP_310840) — see [credential chain](#fabric_authdefault-defaultazurecredential-chain) below |
-| `interactive` | Browser pop-up — see [interactive sign-in](#interactive-browser-sign-in-zero-setup) below |
-| `sp` | Service-principal — see [service principal](#fabric_authsp-service-principal) below |
+| `default` | [`azure-identity` `DefaultAzureCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.defaultazurecredential?WT.mc_id=MVP_310840) - see [credential chain](#fabric_authdefault-defaultazurecredential-chain) below |
+| `interactive` | Browser pop-up - see [interactive sign-in](#interactive-browser-sign-in-zero-setup) below |
+| `sp` | Service-principal - see [service principal](#fabric_authsp-service-principal) below |
 
 !!! note "Empty-value semantics"
     An empty or whitespace-only `FABRIC_AUTH` (e.g. `FABRIC_AUTH=`) is treated as absent and falls through to `config.toml` / the built-in default. An unrecognised non-empty value (e.g. `FABRIC_AUTH=typo`) raises a configuration error immediately at server start so the credential is never silently wrong.
@@ -45,7 +45,7 @@ Valid values: `default`, `interactive`, `sp` (case-insensitive).
 
 ## Interactive browser sign-in (zero setup)
 
-`FABRIC_AUTH=interactive` (and the default-mode browser fallback) uses a shared multi-tenant app — no registration needed:
+`FABRIC_AUTH=interactive` (and the default-mode browser fallback) uses a shared multi-tenant app - no registration needed:
 
 | | |
 | --- | --- |
@@ -56,8 +56,8 @@ Valid values: `default`, `interactive`, `sp` (case-insensitive).
 
 On first sign-in:
 
-- **Non-admin users** — the consent prompt asks for the delegated scopes the app needs (Workspace, Item, Tenant.Read, SQL user_impersonation). If your tenant policy requires admin consent for any of them, sign-in will fail until an admin grants it.
-- **Admins** — choose "Consent on behalf of your organization" once; subsequent sign-ins from anyone in the tenant just work.
+- **Non-admin users**: the consent prompt asks for the delegated scopes the app needs (Workspace, Item, Tenant.Read, SQL user_impersonation). If your tenant policy requires admin consent for any of them, sign-in will fail until an admin grants it.
+- **Admins**: choose "Consent on behalf of your organization" once; subsequent sign-ins from anyone in the tenant just work.
 
 Pre-consent admin URL:
 
@@ -91,22 +91,22 @@ Then grant the same delegated permissions as the shared app:
 
 ---
 
-## `FABRIC_AUTH=default` — DefaultAzureCredential chain
+## `FABRIC_AUTH=default`: DefaultAzureCredential chain
 
 When `FABRIC_AUTH` is `default` (or unset), the package delegates to [`azure-identity`'s `DefaultAzureCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.defaultazurecredential?WT.mc_id=MVP_310840). It walks the following sources **in order** and stops at the first one that returns a usable token:
 
-1. **Environment variables** — `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET` / `AZURE_CLIENT_CERTIFICATE_PATH`, `AZURE_TENANT_ID` — see [`EnvironmentCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.environmentcredential?WT.mc_id=MVP_310840)
-2. **Workload Identity** — injected in Kubernetes / AKS workloads — see [`WorkloadIdentityCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.workloadidentitycredential?WT.mc_id=MVP_310840)
-3. **Managed Identity** — Azure VMs, App Service, Container Apps, etc. — see [`ManagedIdentityCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.managedidentitycredential?WT.mc_id=MVP_310840)
-4. **Shared token cache** — the MSAL cache shared between Azure tools — see [`SharedTokenCacheCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.sharedtokencachecredential?WT.mc_id=MVP_310840)
-5. **Azure CLI** — token from `az login` — see [`AzureCliCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.azureclicredential?WT.mc_id=MVP_310840)
-6. **Azure Developer CLI** — token from `azd auth login` — see [`AzureDeveloperCliCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.azuredeveloperclicredential?WT.mc_id=MVP_310840)
-7. **Azure PowerShell** — token from `Connect-AzAccount` — see [`AzurePowerShellCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.azurepowershellcredential?WT.mc_id=MVP_310840)
-8. **Interactive browser** — falls back to browser sign-in using the [shared app](#interactive-browser-sign-in-zero-setup) (or your override via `FABRIC_INTERACTIVE_CLIENT_ID`) — see [`InteractiveBrowserCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.interactivebrowsercredential?WT.mc_id=MVP_310840)
+1. **Environment variables**: `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET` / `AZURE_CLIENT_CERTIFICATE_PATH`, `AZURE_TENANT_ID`: see [`EnvironmentCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.environmentcredential?WT.mc_id=MVP_310840)
+2. **Workload Identity**: injected in Kubernetes / AKS workloads - see [`WorkloadIdentityCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.workloadidentitycredential?WT.mc_id=MVP_310840)
+3. **Managed Identity**: Azure VMs, App Service, Container Apps, etc. - see [`ManagedIdentityCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.managedidentitycredential?WT.mc_id=MVP_310840)
+4. **Shared token cache**: the MSAL cache shared between Azure tools - see [`SharedTokenCacheCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.sharedtokencachecredential?WT.mc_id=MVP_310840)
+5. **Azure CLI**: token from `az login`: see [`AzureCliCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.azureclicredential?WT.mc_id=MVP_310840)
+6. **Azure Developer CLI**: token from `azd auth login`: see [`AzureDeveloperCliCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.azuredeveloperclicredential?WT.mc_id=MVP_310840)
+7. **Azure PowerShell**: token from `Connect-AzAccount`: see [`AzurePowerShellCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.azurepowershellcredential?WT.mc_id=MVP_310840)
+8. **Interactive browser**: falls back to browser sign-in using the [shared app](#interactive-browser-sign-in-zero-setup) (or your override via `FABRIC_INTERACTIVE_CLIENT_ID`): see [`InteractiveBrowserCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.interactivebrowsercredential?WT.mc_id=MVP_310840)
 
 ---
 
-## `FABRIC_AUTH=sp` — Service principal
+## `FABRIC_AUTH=sp`: Service principal
 
 Set the following environment variables:
 
@@ -116,7 +116,7 @@ Set the following environment variables:
 | `AZURE_CLIENT_ID` | Application (client) ID of your registered app |
 | `AZURE_CLIENT_SECRET` | A client secret for the app |
 
-The package uses [`ClientSecretCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.clientsecretcredential?WT.mc_id=MVP_310840) with these values. The shared `fabric-dw` app is **not** used in SP mode — you must supply your own app registration and secret.
+The package uses [`ClientSecretCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.clientsecretcredential?WT.mc_id=MVP_310840) with these values. The shared `fabric-dw` app is **not** used in SP mode - you must supply your own app registration and secret.
 
 ---
 
@@ -124,7 +124,7 @@ The package uses [`ClientSecretCredential`](https://learn.microsoft.com/python/a
 
 | Variable | Default | Description |
 | --- | --- | --- |
-| `FABRIC_AUTH` | _(unset — falls through to config / built-in default)_ | Credential mode: `default`, `interactive`, or `sp`. Empty/whitespace falls through; unrecognised non-empty value raises an error at startup. |
+| `FABRIC_AUTH` | _(unset - falls through to config / built-in default)_ | Credential mode: `default`, `interactive`, or `sp`. Empty/whitespace falls through; unrecognised non-empty value raises an error at startup. |
 | `FABRIC_INTERACTIVE_CLIENT_ID` | `f666e5ee-2149-4c6a-87eb-13c9e1fdc70d` | Override the shared app client ID for browser sign-in |
 | `FABRIC_INTERACTIVE_TENANT_ID` | _(unset)_ | Pin a specific Entra tenant for browser sign-in |
 | `AZURE_TENANT_ID` | _(unset)_ | Required for `FABRIC_AUTH=sp` |

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -95,14 +95,14 @@ Then grant the same delegated permissions as the shared app:
 
 When `FABRIC_AUTH` is `default` (or unset), the package delegates to [`azure-identity`'s `DefaultAzureCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.defaultazurecredential?WT.mc_id=MVP_310840). It walks the following sources **in order** and stops at the first one that returns a usable token:
 
-1. **Environment variables**: `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET` / `AZURE_CLIENT_CERTIFICATE_PATH`, `AZURE_TENANT_ID`: see [`EnvironmentCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.environmentcredential?WT.mc_id=MVP_310840)
+1. **Environment variables**: `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET` / `AZURE_CLIENT_CERTIFICATE_PATH`, `AZURE_TENANT_ID` - see [`EnvironmentCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.environmentcredential?WT.mc_id=MVP_310840)
 2. **Workload Identity**: injected in Kubernetes / AKS workloads - see [`WorkloadIdentityCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.workloadidentitycredential?WT.mc_id=MVP_310840)
 3. **Managed Identity**: Azure VMs, App Service, Container Apps, etc. - see [`ManagedIdentityCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.managedidentitycredential?WT.mc_id=MVP_310840)
 4. **Shared token cache**: the MSAL cache shared between Azure tools - see [`SharedTokenCacheCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.sharedtokencachecredential?WT.mc_id=MVP_310840)
-5. **Azure CLI**: token from `az login`: see [`AzureCliCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.azureclicredential?WT.mc_id=MVP_310840)
-6. **Azure Developer CLI**: token from `azd auth login`: see [`AzureDeveloperCliCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.azuredeveloperclicredential?WT.mc_id=MVP_310840)
-7. **Azure PowerShell**: token from `Connect-AzAccount`: see [`AzurePowerShellCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.azurepowershellcredential?WT.mc_id=MVP_310840)
-8. **Interactive browser**: falls back to browser sign-in using the [shared app](#interactive-browser-sign-in-zero-setup) (or your override via `FABRIC_INTERACTIVE_CLIENT_ID`): see [`InteractiveBrowserCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.interactivebrowsercredential?WT.mc_id=MVP_310840)
+5. **Azure CLI**: token from `az login` - see [`AzureCliCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.azureclicredential?WT.mc_id=MVP_310840)
+6. **Azure Developer CLI**: token from `azd auth login` - see [`AzureDeveloperCliCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.azuredeveloperclicredential?WT.mc_id=MVP_310840)
+7. **Azure PowerShell**: token from `Connect-AzAccount` - see [`AzurePowerShellCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.azurepowershellcredential?WT.mc_id=MVP_310840)
+8. **Interactive browser**: falls back to browser sign-in using the [shared app](#interactive-browser-sign-in-zero-setup) (or your override via `FABRIC_INTERACTIVE_CLIENT_ID`) - see [`InteractiveBrowserCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.interactivebrowsercredential?WT.mc_id=MVP_310840)
 
 ---
 

--- a/docs/commands/audit.md
+++ b/docs/commands/audit.md
@@ -16,7 +16,7 @@ Manage SQL audit settings for Microsoft Fabric Data Warehouses and SQL Analytics
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
 
-Add a single audit action group without overwriting the others. Idempotent — if the group is already present the command succeeds without modifying the configuration. Auditing must already be enabled.
+Add a single audit action group without overwriting the others. Idempotent - if the group is already present the command succeeds without modifying the configuration. Auditing must already be enabled.
 
 **Synopsis**
 
@@ -66,10 +66,10 @@ fdw [-w WORKSPACE] audit enable [OPTIONS] [WAREHOUSE]
 
 | Option | Description | Default |
 | --- | --- | --- |
-| `--retention-days INTEGER` | Audit log retention in days (>= 1). Mutually exclusive with `--unlimited`. | — |
+| `--retention-days INTEGER` | Audit log retention in days (>= 1). Mutually exclusive with `--unlimited`. | - |
 | `--unlimited` | Set unlimited audit log retention (service value 0). Mutually exclusive with `--retention-days`. | off |
 
-Omitting both `--retention-days` and `--unlimited` defaults to unlimited retention. Passing `0` for `--retention-days` is rejected — use `--unlimited` for no-limit retention.
+Omitting both `--retention-days` and `--unlimited` defaults to unlimited retention. Passing `0` for `--retention-days` is rejected - use `--unlimited` for no-limit retention.
 
 **Example**
 
@@ -113,7 +113,7 @@ actionGroups     BATCH_COMPLETED_GROUP
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
 
-Remove a single audit action group without overwriting the others. Idempotent — if the group is not present the command succeeds without modifying the configuration. Auditing must already be enabled.
+Remove a single audit action group without overwriting the others. Idempotent - if the group is not present the command succeeds without modifying the configuration. Auditing must already be enabled.
 
 **Synopsis**
 
@@ -186,15 +186,15 @@ fdw -w MyWorkspace audit set-retention --days 90 SalesWH
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
 
-Add a single audit action group without overwriting the others. Idempotent — if the group is already present the current settings are returned unchanged. Auditing must already be enabled.
+Add a single audit action group without overwriting the others. Idempotent - if the group is already present the current settings are returned unchanged. Auditing must already be enabled.
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `warehouse` (`str`) — warehouse or SQL analytics endpoint name or GUID.
-- `group` (`str`) — action group name (e.g. `"BATCH_COMPLETED_GROUP"`).
+- `workspace` (`str`): workspace name or GUID.
+- `warehouse` (`str`): warehouse or SQL analytics endpoint name or GUID.
+- `group` (`str`): action group name (e.g. `"BATCH_COMPLETED_GROUP"`).
 
-**Returns:** `AuditSettings` — the updated audit settings.
+**Returns:** `AuditSettings`: the updated audit settings.
 
 ---
 
@@ -206,10 +206,10 @@ Disable SQL auditing on a warehouse or SQL analytics endpoint.
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `warehouse` (`str`) — warehouse or SQL analytics endpoint name or GUID.
+- `workspace` (`str`): workspace name or GUID.
+- `warehouse` (`str`): warehouse or SQL analytics endpoint name or GUID.
 
-**Returns:** `AuditSettings` — the updated audit settings.
+**Returns:** `AuditSettings`: the updated audit settings.
 
 ---
 
@@ -221,11 +221,11 @@ Enable SQL auditing on a warehouse or SQL analytics endpoint.
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `warehouse` (`str`) — warehouse or SQL analytics endpoint name or GUID.
-- `retention_days` (`int`, default `0`) — audit log retention in days; `0` means unlimited.
+- `workspace` (`str`): workspace name or GUID.
+- `warehouse` (`str`): warehouse or SQL analytics endpoint name or GUID.
+- `retention_days` (`int`, default `0`): audit log retention in days; `0` means unlimited.
 
-**Returns:** `AuditSettings` — the updated audit settings.
+**Returns:** `AuditSettings`: the updated audit settings.
 
 ---
 
@@ -237,10 +237,10 @@ Fetch the current SQL audit settings for a warehouse or SQL analytics endpoint.
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `warehouse` (`str`) — warehouse or SQL analytics endpoint name or GUID.
+- `workspace` (`str`): workspace name or GUID.
+- `warehouse` (`str`): warehouse or SQL analytics endpoint name or GUID.
 
-**Returns:** `AuditSettings` — object with `state` (`Enabled` or `Disabled`), `retentionDays`, and `auditActionsAndGroups`.
+**Returns:** `AuditSettings`: object with `state` (`Enabled` or `Disabled`), `retentionDays`, and `auditActionsAndGroups`.
 
 ---
 
@@ -248,15 +248,15 @@ Fetch the current SQL audit settings for a warehouse or SQL analytics endpoint.
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
 
-Remove a single audit action group without overwriting the others. Idempotent — if the group is not present the current settings are returned unchanged. Auditing must already be enabled.
+Remove a single audit action group without overwriting the others. Idempotent - if the group is not present the current settings are returned unchanged. Auditing must already be enabled.
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `warehouse` (`str`) — warehouse or SQL analytics endpoint name or GUID.
-- `group` (`str`) — action group name (e.g. `"BATCH_COMPLETED_GROUP"`).
+- `workspace` (`str`): workspace name or GUID.
+- `warehouse` (`str`): warehouse or SQL analytics endpoint name or GUID.
+- `group` (`str`): action group name (e.g. `"BATCH_COMPLETED_GROUP"`).
 
-**Returns:** `AuditSettings` — the updated audit settings.
+**Returns:** `AuditSettings`: the updated audit settings.
 
 ---
 
@@ -268,11 +268,11 @@ Replace the audited action groups for a warehouse or SQL analytics endpoint. Thi
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `warehouse` (`str`) — warehouse or SQL analytics endpoint name or GUID.
-- `action_groups` (`list[str]`) — list of audit action group names (e.g. `["BATCH_COMPLETED_GROUP"]`).
+- `workspace` (`str`): workspace name or GUID.
+- `warehouse` (`str`): warehouse or SQL analytics endpoint name or GUID.
+- `action_groups` (`list[str]`): list of audit action group names (e.g. `["BATCH_COMPLETED_GROUP"]`).
 
-**Returns:** `AuditSettings` — the updated audit settings.
+**Returns:** `AuditSettings`: the updated audit settings.
 
 ---
 
@@ -284,8 +284,8 @@ Update the audit log retention period without changing the audit enabled/disable
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `warehouse` (`str`) — warehouse or SQL analytics endpoint name or GUID.
-- `days` (`int`) — retention period in days (1–3650; 3650 ≈ 10 years).
+- `workspace` (`str`): workspace name or GUID.
+- `warehouse` (`str`): warehouse or SQL analytics endpoint name or GUID.
+- `days` (`int`): retention period in days (1–3650; 3650 ≈ 10 years).
 
-**Returns:** `AuditSettings` — the updated audit settings.
+**Returns:** `AuditSettings`: the updated audit settings.

--- a/docs/commands/cache.md
+++ b/docs/commands/cache.md
@@ -46,4 +46,4 @@ Erase all cached workspace and item name-to-UUID mappings.
 
 **Parameters:** None
 
-**Returns:** `{ "cleared": true }` — confirmation.
+**Returns:** `{ "cleared": true }`: confirmation.

--- a/docs/commands/completion.md
+++ b/docs/commands/completion.md
@@ -44,4 +44,4 @@ fdw completion install zsh
 fdw completion install bash --print
 ```
 
-For AI-assistant (MCP) usage there is no shell completion — see [MCP server](../install.md#mcp) instead.
+For AI-assistant (MCP) usage there is no shell completion - see [MCP server](../install.md#mcp) instead.

--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -85,9 +85,9 @@ The MCP server workspace allowlist restricts which workspaces the server may ope
 
 | Layer | Mechanism | Description |
 |---|---|---|
-| 1 | `FABRIC_MCP_WORKSPACES` env var | Comma-separated workspace names or GUIDs. An empty or whitespace-only value (including `FABRIC_MCP_WORKSPACES=`) is treated as **absent** and falls through to the next layer — it does **not** block all workspaces. |
-| 2 | `[mcp] workspace_allowlist` in `config.toml` | Stored with `fdw config set mcp workspace-allowlist`. An empty TOML array `[]` is treated as absent (no restriction) — consistent with the unset case. |
-| 3 | Built-in default | No restriction — all workspaces allowed. |
+| 1 | `FABRIC_MCP_WORKSPACES` env var | Comma-separated workspace names or GUIDs. An empty or whitespace-only value (including `FABRIC_MCP_WORKSPACES=`) is treated as **absent** and falls through to the next layer - it does **not** block all workspaces. |
+| 2 | `[mcp] workspace_allowlist` in `config.toml` | Stored with `fdw config set mcp workspace-allowlist`. An empty TOML array `[]` is treated as absent (no restriction) - consistent with the unset case. |
+| 3 | Built-in default | No restriction - all workspaces allowed. |
 
 Matching is case-insensitive and whitespace-trimmed. Both workspace names and GUIDs are accepted.
 
@@ -154,7 +154,7 @@ fdw config unset conn-pooling
 
 ## Telemetry
 
-`fabric-dw` collects **anonymous, opt-out** usage telemetry — it is **on by default**. Any of the following independently disables it — no events are emitted and the SDK is never imported:
+`fabric-dw` collects **anonymous, opt-out** usage telemetry - it is **on by default**. Any of the following independently disables it - no events are emitted and the SDK is never imported:
 
 | Mechanism | Type | Effect |
 |---|---|---|
@@ -286,7 +286,7 @@ fdw config show
 **Example**
 
 ```shell
-# Example — show current config
+# Example - show current config
 fdw config show
 ```
 

--- a/docs/commands/dbt.md
+++ b/docs/commands/dbt.md
@@ -6,7 +6,7 @@ title: dbt
 
 Scaffold a [dbt](https://docs.getdbt.com/) project pre-wired to a Microsoft Fabric Data Warehouse using the [dbt-fabric](https://docs.getdbt.com/docs/core/connect-data-platform/fabric-setup) adapter.
 
-No dbt installation is required to run these commands — `fabric-dw` generates all project files itself. A `requirements.txt` inside the scaffolded project lists the required pip packages (`dbt-core`, `dbt-fabric`) so you can install them in a separate environment when you are ready to run dbt.
+No dbt installation is required to run these commands - `fabric-dw` generates all project files itself. A `requirements.txt` inside the scaffolded project lists the required pip packages (`dbt-core`, `dbt-fabric`) so you can install them in a separate environment when you are ready to run dbt.
 
 **Targets:** Data Warehouse
 
@@ -54,7 +54,7 @@ fdw [-w WORKSPACE] dbt init [OPTIONS] [ITEM] FOLDER
 **Examples**
 
 ```shell
-# Minimal — uses configured default workspace and warehouse
+# Minimal - uses configured default workspace and warehouse
 fdw dbt init SalesWH ./my_dbt_project
 
 # Explicit workspace via -w
@@ -109,20 +109,20 @@ Return the contents of all files needed to bootstrap a dbt project that connects
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `item` (`str`) — Data Warehouse name or GUID.
-- `project_name` (`str`, optional) — dbt project name. Defaults to the warehouse display name (sanitised to lowercase + underscores).
-- `profile_name` (`str`, optional) — dbt profile name. Defaults to the project name.
-- `schema` (`str`, default `"dbo"`) — default target schema for dbt models.
-- `target` (`str`, default `"dev"`) — dbt target name.
-- `threads` (`int`, default `4`) — number of dbt threads (1–64).
-- `authentication` (`str`, optional) — authentication method (`"auto"`, `"CLI"`, `"ServicePrincipal"`). Defaults to the MCP server's active credential mode.
-- `with_sources` (`bool`, default `False`) — when `True`, introspect the live warehouse and include all schemas/tables in the returned `sources_yml`.
+- `workspace` (`str`): workspace name or GUID.
+- `item` (`str`): Data Warehouse name or GUID.
+- `project_name` (`str`, optional): dbt project name. Defaults to the warehouse display name (sanitised to lowercase + underscores).
+- `profile_name` (`str`, optional): dbt profile name. Defaults to the project name.
+- `schema` (`str`, default `"dbo"`): default target schema for dbt models.
+- `target` (`str`, default `"dev"`): dbt target name.
+- `threads` (`int`, default `4`): number of dbt threads (1–64).
+- `authentication` (`str`, optional): authentication method (`"auto"`, `"CLI"`, `"ServicePrincipal"`). Defaults to the MCP server's active credential mode.
+- `with_sources` (`bool`, default `False`): when `True`, introspect the live warehouse and include all schemas/tables in the returned `sources_yml`.
 
 **Returns:** object with:
 
-- `profiles_yml` (`str`) — contents for `profiles.yml` (write next to `dbt_project.yml` or into `~/.dbt/profiles.yml`).
-- `dbt_project_yml` (`str`) — contents for `dbt_project.yml`.
-- `sources_yml` (`str`) — contents for `models/staging/_sources.yml` (placeholder or real entries when `with_sources=True`).
-- `requirements_txt` (`str`) — pip requirements listing `dbt-core` and `dbt-fabric`.
-- `gitignore` (`str`) — contents for `.gitignore`, pre-configured for dbt projects.
+- `profiles_yml` (`str`): contents for `profiles.yml` (write next to `dbt_project.yml` or into `~/.dbt/profiles.yml`).
+- `dbt_project_yml` (`str`): contents for `dbt_project.yml`.
+- `sources_yml` (`str`): contents for `models/staging/_sources.yml` (placeholder or real entries when `with_sources=True`).
+- `requirements_txt` (`str`): pip requirements listing `dbt-core` and `dbt-fabric`.
+- `gitignore` (`str`): contents for `.gitignore`, pre-configured for dbt projects.

--- a/docs/commands/functions.md
+++ b/docs/commands/functions.md
@@ -123,7 +123,7 @@ fdw -w MyWorkspace functions list SalesWH --schema dbo --kind scalar
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
 
-Rename a T-SQL user-defined function via `EXEC sp_rename`. The new name must be a bare (unqualified) identifier — `sp_rename` cannot move a function to a different schema. You will be asked to confirm unless `--yes` is passed.
+Rename a T-SQL user-defined function via `EXEC sp_rename`. The new name must be a bare (unqualified) identifier - `sp_rename` cannot move a function to a different schema. You will be asked to confirm unless `--yes` is passed.
 
 **Synopsis**
 
@@ -192,12 +192,12 @@ Create a new T-SQL user-defined function.
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `item` (`str`) — warehouse or SQL Analytics Endpoint name or GUID.
-- `qualified_name` (`str`) — dot-separated qualified function name, e.g. `dbo.fn_clean_input`.
-- `body` (`str`) — the function body (parameter list, RETURNS clause, and implementation).
+- `workspace` (`str`): workspace name or GUID.
+- `item` (`str`): warehouse or SQL Analytics Endpoint name or GUID.
+- `qualified_name` (`str`): dot-separated qualified function name, e.g. `dbo.fn_clean_input`.
+- `body` (`str`): the function body (parameter list, RETURNS clause, and implementation).
 
-**Returns:** `FunctionDetails` — the newly-created function object.
+**Returns:** `FunctionDetails`: the newly-created function object.
 
 ---
 
@@ -209,12 +209,12 @@ Drop a T-SQL user-defined function.
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `item` (`str`) — warehouse or SQL Analytics Endpoint name or GUID.
-- `qualified_name` (`str`) — dot-separated qualified function name, e.g. `dbo.fn_clean_input`.
-- `if_exists` (`bool`, optional) — when `true`, emits `DROP FUNCTION IF EXISTS` (no-op when function does not exist). Defaults to `false`.
+- `workspace` (`str`): workspace name or GUID.
+- `item` (`str`): warehouse or SQL Analytics Endpoint name or GUID.
+- `qualified_name` (`str`): dot-separated qualified function name, e.g. `dbo.fn_clean_input`.
+- `if_exists` (`bool`, optional): when `true`, emits `DROP FUNCTION IF EXISTS` (no-op when function does not exist). Defaults to `false`.
 
-**Returns:** `{ "dropped": true }` — confirmation.
+**Returns:** `{ "dropped": true }`: confirmation.
 
 ---
 
@@ -226,11 +226,11 @@ Fetch the full definition of a single T-SQL user-defined function, including its
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `item` (`str`) — warehouse or SQL Analytics Endpoint name or GUID.
-- `qualified_name` (`str`) — dot-separated qualified function name, e.g. `dbo.fn_clean_input`.
+- `workspace` (`str`): workspace name or GUID.
+- `item` (`str`): warehouse or SQL Analytics Endpoint name or GUID.
+- `qualified_name` (`str`): dot-separated qualified function name, e.g. `dbo.fn_clean_input`.
 
-**Returns:** `FunctionDetails` — single function object with `definition` (from `sys.sql_modules`) and `parameters` (from `sys.parameters`).
+**Returns:** `FunctionDetails`: single function object with `definition` (from `sys.sql_modules`) and `parameters` (from `sys.parameters`).
 
 ---
 
@@ -242,12 +242,12 @@ List T-SQL user-defined functions on a warehouse or SQL Analytics Endpoint, opti
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `item` (`str`) — warehouse or SQL Analytics Endpoint name or GUID.
-- `schema` (`str | null`, optional) — when provided, only functions in this schema are returned.
-- `kind` (`str`, optional) — filter by function kind: `"scalar"` (FN only), `"inline-tvf"` (IF only), or `"all"` (FN + IF + TF, the default).
+- `workspace` (`str`): workspace name or GUID.
+- `item` (`str`): warehouse or SQL Analytics Endpoint name or GUID.
+- `schema` (`str | null`, optional): when provided, only functions in this schema are returned.
+- `kind` (`str`, optional): filter by function kind: `"scalar"` (FN only), `"inline-tvf"` (IF only), or `"all"` (FN + IF + TF, the default).
 
-**Returns:** `list[Function]` — array of function objects, each with `schema_name`, `name`, `qualified_name`, `kind`, `is_inlineable`, `created`, and `modified`.
+**Returns:** `list[Function]`: array of function objects, each with `schema_name`, `name`, `qualified_name`, `kind`, `is_inlineable`, `created`, and `modified`.
 
 ---
 
@@ -255,16 +255,16 @@ List T-SQL user-defined functions on a warehouse or SQL Analytics Endpoint, opti
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
 
-Rename a T-SQL user-defined function via `sp_rename`. The new name must be a bare (unqualified) identifier — `sp_rename` cannot move a function across schemas.
+Rename a T-SQL user-defined function via `sp_rename`. The new name must be a bare (unqualified) identifier - `sp_rename` cannot move a function across schemas.
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `item` (`str`) — warehouse or SQL Analytics Endpoint name or GUID.
-- `qualified_name` (`str`) — current dot-separated qualified function name, e.g. `dbo.fn_clean_input`.
-- `new_name` (`str`) — new bare function name (no schema prefix), e.g. `fn_sanitize_input`.
+- `workspace` (`str`): workspace name or GUID.
+- `item` (`str`): warehouse or SQL Analytics Endpoint name or GUID.
+- `qualified_name` (`str`): current dot-separated qualified function name, e.g. `dbo.fn_clean_input`.
+- `new_name` (`str`): new bare function name (no schema prefix), e.g. `fn_sanitize_input`.
 
-**Returns:** `FunctionDetails` — the renamed function record.
+**Returns:** `FunctionDetails`: the renamed function record.
 
 ---
 
@@ -284,9 +284,9 @@ Redefine a T-SQL user-defined function via `CREATE OR ALTER FUNCTION`.
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `item` (`str`) — warehouse or SQL Analytics Endpoint name or GUID.
-- `qualified_name` (`str`) — dot-separated qualified function name, e.g. `dbo.fn_clean_input`.
-- `body` (`str`) — the new function body (parameter list, RETURNS clause, and implementation).
+- `workspace` (`str`): workspace name or GUID.
+- `item` (`str`): warehouse or SQL Analytics Endpoint name or GUID.
+- `qualified_name` (`str`): dot-separated qualified function name, e.g. `dbo.fn_clean_input`.
+- `body` (`str`): the new function body (parameter list, RETURNS clause, and implementation).
 
-**Returns:** `FunctionDetails` — the updated function object.
+**Returns:** `FunctionDetails`: the updated function object.

--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -4,29 +4,29 @@ title: Commands
 
 # Commands
 
-`fabric-dw` exposes every operation as both a CLI command and an MCP tool. The two surfaces share the same authentication, connection, and business logic — a fix or new feature lands in both at once.
+`fabric-dw` exposes every operation as both a CLI command and an MCP tool. The two surfaces share the same authentication, connection, and business logic - a fix or new feature lands in both at once.
 
 Each page below covers one command domain: CLI synopsis, options, and examples alongside the corresponding MCP tool parameters and return values.
 
 ## Domains
 
-- **[Audit](audit.md)** — Manage SQL audit settings for Data Warehouses and SQL Analytics Endpoints.
-- **[Cache](cache.md)** — Manage the local name-to-UUID lookup cache.
-- **[Completion](completion.md)** — Install and manage shell completion scripts.
-- **[Configuration & defaults](config.md)** — Store a default workspace and/or warehouse to avoid repeating them on every invocation.
-- **[dbt](dbt.md)** — Scaffold a dbt project pre-wired to a Fabric Data Warehouse.
-- **[Functions](functions.md)** — Manage T-SQL user-defined functions.
-- **[Queries](queries.md)** — Inspect and manage running queries.
-- **[Restore Points](restore-points.md)** — Create, list, rename, and delete warehouse restore points.
-- **[Running SQL](sql.md)** — Execute SQL statements and capture estimated execution plans.
-- **[Schemas](schemas.md)** — Manage SQL schemas.
-- **[Settings](settings.md)** — Manage server-side database settings.
-- **[Snapshots](snapshots.md)** — Manage Data Warehouse snapshots.
-- **[SQL Analytics Endpoints](sql-endpoints.md)** — Manage SQL Analytics Endpoints.
-- **[SQL Pools](sql-pools.md)** — Manage custom SQL Pools at the workspace level.
-- **[Statistics](statistics.md)** — Manage user-defined statistics.
-- **[Stored procedures](procedures.md)** — Manage stored procedures.
-- **[Tables](tables.md)** — Manage SQL tables, including CTAS, clone, load, and clustering.
-- **[Views](views.md)** — Manage SQL views.
-- **[Warehouses](warehouses.md)** — Manage Data Warehouses and SQL Analytics Endpoints.
-- **[Workspaces](workspaces.md)** — List, inspect, and manage workspaces — capacity assignment, collation, and more.
+- **[Audit](audit.md)**: Manage SQL audit settings for Data Warehouses and SQL Analytics Endpoints.
+- **[Cache](cache.md)**: Manage the local name-to-UUID lookup cache.
+- **[Completion](completion.md)**: Install and manage shell completion scripts.
+- **[Configuration & defaults](config.md)**: Store a default workspace and/or warehouse to avoid repeating them on every invocation.
+- **[dbt](dbt.md)**: Scaffold a dbt project pre-wired to a Fabric Data Warehouse.
+- **[Functions](functions.md)**: Manage T-SQL user-defined functions.
+- **[Queries](queries.md)**: Inspect and manage running queries.
+- **[Restore Points](restore-points.md)**: Create, list, rename, and delete warehouse restore points.
+- **[Running SQL](sql.md)**: Execute SQL statements and capture estimated execution plans.
+- **[Schemas](schemas.md)**: Manage SQL schemas.
+- **[Settings](settings.md)**: Manage server-side database settings.
+- **[Snapshots](snapshots.md)**: Manage Data Warehouse snapshots.
+- **[SQL Analytics Endpoints](sql-endpoints.md)**: Manage SQL Analytics Endpoints.
+- **[SQL Pools](sql-pools.md)**: Manage custom SQL Pools at the workspace level.
+- **[Statistics](statistics.md)**: Manage user-defined statistics.
+- **[Stored procedures](procedures.md)**: Manage stored procedures.
+- **[Tables](tables.md)**: Manage SQL tables, including CTAS, clone, load, and clustering.
+- **[Views](views.md)**: Manage SQL views.
+- **[Warehouses](warehouses.md)**: Manage Data Warehouses and SQL Analytics Endpoints.
+- **[Workspaces](workspaces.md)**: List, inspect, and manage workspaces - capacity assignment, collation, and more.

--- a/docs/commands/procedures.md
+++ b/docs/commands/procedures.md
@@ -158,12 +158,12 @@ Create a new stored procedure.
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `item` (`str`) — warehouse or SQL analytics endpoint name or GUID.
-- `qualified_name` (`str`) — dot-separated qualified procedure name, e.g. `dbo.usp_load`.
-- `body` (`str`) — the procedure body (the `AS …` section).
+- `workspace` (`str`): workspace name or GUID.
+- `item` (`str`): warehouse or SQL analytics endpoint name or GUID.
+- `qualified_name` (`str`): dot-separated qualified procedure name, e.g. `dbo.usp_load`.
+- `body` (`str`): the procedure body (the `AS …` section).
 
-**Returns:** `StoredProcedure` — the newly-created procedure object.
+**Returns:** `StoredProcedure`: the newly-created procedure object.
 
 ---
 
@@ -175,11 +175,11 @@ Drop a stored procedure.
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `item` (`str`) — warehouse or SQL analytics endpoint name or GUID.
-- `qualified_name` (`str`) — dot-separated qualified procedure name, e.g. `dbo.usp_load`.
+- `workspace` (`str`): workspace name or GUID.
+- `item` (`str`): warehouse or SQL analytics endpoint name or GUID.
+- `qualified_name` (`str`): dot-separated qualified procedure name, e.g. `dbo.usp_load`.
 
-**Returns:** `{ "dropped": true }` — confirmation.
+**Returns:** `{ "dropped": true }`: confirmation.
 
 ---
 
@@ -191,11 +191,11 @@ Fetch the full definition of a single stored procedure.
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `item` (`str`) — warehouse or SQL analytics endpoint name or GUID.
-- `qualified_name` (`str`) — dot-separated qualified procedure name, e.g. `dbo.usp_load`.
+- `workspace` (`str`): workspace name or GUID.
+- `item` (`str`): warehouse or SQL analytics endpoint name or GUID.
+- `qualified_name` (`str`): dot-separated qualified procedure name, e.g. `dbo.usp_load`.
 
-**Returns:** `StoredProcedure` — single procedure object with `definition` populated from `sys.sql_modules`.
+**Returns:** `StoredProcedure`: single procedure object with `definition` populated from `sys.sql_modules`.
 
 ---
 
@@ -207,11 +207,11 @@ List stored procedures on a warehouse or SQL Analytics Endpoint, optionally filt
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `item` (`str`) — warehouse or SQL analytics endpoint name or GUID.
-- `schema` (`str | null`, optional) — when provided, only procedures in this schema are returned.
+- `workspace` (`str`): workspace name or GUID.
+- `item` (`str`): warehouse or SQL analytics endpoint name or GUID.
+- `schema` (`str | null`, optional): when provided, only procedures in this schema are returned.
 
-**Returns:** `list[StoredProcedure]` — array of procedure objects, each with `schema_name`, `name`, `qualified_name`, `created`, and `modified`.
+**Returns:** `list[StoredProcedure]`: array of procedure objects, each with `schema_name`, `name`, `qualified_name`, `created`, and `modified`.
 
 ---
 
@@ -227,9 +227,9 @@ Redefine a stored procedure via `CREATE OR ALTER PROCEDURE`.
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `item` (`str`) — warehouse or SQL analytics endpoint name or GUID.
-- `qualified_name` (`str`) — dot-separated qualified procedure name, e.g. `dbo.usp_load`.
-- `body` (`str`) — the new procedure body (the `AS …` section).
+- `workspace` (`str`): workspace name or GUID.
+- `item` (`str`): warehouse or SQL analytics endpoint name or GUID.
+- `qualified_name` (`str`): dot-separated qualified procedure name, e.g. `dbo.usp_load`.
+- `body` (`str`): the new procedure body (the `AS …` section).
 
-**Returns:** `StoredProcedure` — the updated procedure object.
+**Returns:** `StoredProcedure`: the updated procedure object.

--- a/docs/commands/queries.md
+++ b/docs/commands/queries.md
@@ -56,9 +56,9 @@ fdw [-w WORKSPACE] queries frequent [OPTIONS] [WAREHOUSE]
 | Option | Description | Default |
 | --- | --- | --- |
 | `--limit INTEGER` | Maximum rows to return (1–10 000). | `100` |
-| `--since ISO8601` | Return rows with last_run_start_time >= this value. Mutually exclusive with `--ago`. | — |
-| `--until ISO8601` | Return rows with last_run_start_time <= this value. | — |
-| `--ago DURATION` | Relative alternative to `--since`: rows newer than now minus this duration (e.g. `1h`, `90m`, `3600s`, `2d`). Mutually exclusive with `--since`. | — |
+| `--since ISO8601` | Return rows with last_run_start_time >= this value. Mutually exclusive with `--ago`. | - |
+| `--until ISO8601` | Return rows with last_run_start_time <= this value. | - |
+| `--ago DURATION` | Relative alternative to `--since`: rows newer than now minus this duration (e.g. `1h`, `90m`, `3600s`, `2d`). Mutually exclusive with `--since`. | - |
 
 **Example**
 
@@ -86,9 +86,9 @@ fdw [-w WORKSPACE] queries history [OPTIONS] [WAREHOUSE]
 | Option | Description | Default |
 | --- | --- | --- |
 | `--limit INTEGER` | Maximum rows to return (1–10 000). | `100` |
-| `--since ISO8601` | Return rows with timestamp >= this value. Mutually exclusive with `--ago`. | — |
-| `--until ISO8601` | Return rows with timestamp <= this value. | — |
-| `--ago DURATION` | Relative alternative to `--since`: rows newer than now minus this duration (e.g. `1h`, `90m`, `3600s`, `2d`). Mutually exclusive with `--since`. | — |
+| `--since ISO8601` | Return rows with timestamp >= this value. Mutually exclusive with `--ago`. | - |
+| `--until ISO8601` | Return rows with timestamp <= this value. | - |
+| `--ago DURATION` | Relative alternative to `--since`: rows newer than now minus this duration (e.g. `1h`, `90m`, `3600s`, `2d`). Mutually exclusive with `--since`. | - |
 
 **Example**
 
@@ -136,9 +136,9 @@ fdw [-w WORKSPACE] queries long-running [OPTIONS] [WAREHOUSE]
 | Option | Description | Default |
 | --- | --- | --- |
 | `--limit INTEGER` | Maximum rows to return (1–10 000). | `100` |
-| `--since ISO8601` | Return rows with last_run_start_time >= this value. Mutually exclusive with `--ago`. | — |
-| `--until ISO8601` | Return rows with last_run_start_time <= this value. | — |
-| `--ago DURATION` | Relative alternative to `--since`: rows newer than now minus this duration (e.g. `1h`, `90m`, `3600s`, `2d`). Mutually exclusive with `--since`. | — |
+| `--since ISO8601` | Return rows with last_run_start_time >= this value. Mutually exclusive with `--ago`. | - |
+| `--until ISO8601` | Return rows with last_run_start_time <= this value. | - |
+| `--ago DURATION` | Relative alternative to `--since`: rows newer than now minus this duration (e.g. `1h`, `90m`, `3600s`, `2d`). Mutually exclusive with `--since`. | - |
 
 **Example**
 
@@ -192,9 +192,9 @@ fdw [-w WORKSPACE] queries sessions [OPTIONS] [WAREHOUSE]
 | Option | Description | Default |
 | --- | --- | --- |
 | `--limit INTEGER` | Maximum rows to return (1–10 000). | `100` |
-| `--since ISO8601` | Return rows with session_start_time >= this value. Mutually exclusive with `--ago`. | — |
-| `--until ISO8601` | Return rows with session_start_time <= this value. | — |
-| `--ago DURATION` | Relative alternative to `--since`: rows newer than now minus this duration (e.g. `1h`, `90m`, `3600s`, `2d`). Mutually exclusive with `--since`. | — |
+| `--since ISO8601` | Return rows with session_start_time >= this value. Mutually exclusive with `--ago`. | - |
+| `--until ISO8601` | Return rows with session_start_time <= this value. | - |
+| `--ago DURATION` | Relative alternative to `--since`: rows newer than now minus this duration (e.g. `1h`, `90m`, `3600s`, `2d`). Mutually exclusive with `--since`. | - |
 
 **Example**
 
@@ -207,7 +207,7 @@ fdw -w MyWorkspace queries sessions SalesWH --ago 90m
 
 ## MCP tools
 
-The following four tools query the `queryinsights` schema DMVs via TDS. They share the same parameter shape — `workspace`, `warehouse`, optional `limit`, optional `since`, and optional `until`.
+The following four tools query the `queryinsights` schema DMVs via TDS. They share the same parameter shape - `workspace`, `warehouse`, optional `limit`, optional `since`, and optional `until`.
 
 ### kill_session
 
@@ -217,11 +217,11 @@ Terminate a session on a warehouse.
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `warehouse` (`str`) — warehouse name or GUID.
-- `session_id` (`int`) — the session ID to terminate.
+- `workspace` (`str`): workspace name or GUID.
+- `warehouse` (`str`): warehouse name or GUID.
+- `session_id` (`int`): the session ID to terminate.
 
-**Returns:** `{ "killed": true, "session_id": int }` — confirmation with the terminated session ID.
+**Returns:** `{ "killed": true, "session_id": int }`: confirmation with the terminated session ID.
 
 ---
 
@@ -233,10 +233,10 @@ Return all active SQL connections on a warehouse or SQL Analytics Endpoint. Quer
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `warehouse` (`str`) — warehouse name or GUID.
+- `workspace` (`str`): workspace name or GUID.
+- `warehouse` (`str`): warehouse name or GUID.
 
-**Returns:** `list[Connection]` — array of connection objects, each with `session_id`, `connect_time`, `client_net_address`, `auth_scheme`, `encrypt_option`, and `net_transport`.
+**Returns:** `list[Connection]`: array of connection objects, each with `session_id`, `connect_time`, `client_net_address`, `auth_scheme`, `encrypt_option`, and `net_transport`.
 
 ---
 
@@ -248,13 +248,13 @@ Return frequently-run queries from `queryinsights.frequently_run_queries`.
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `warehouse` (`str`) — warehouse or SQL Analytics Endpoint name or GUID.
-- `limit` (`int`, default `100`) — maximum rows to return (1–10 000).
-- `since` (`str | null`, optional) — ISO-8601 lower bound on `last_run_start_time`.
-- `until` (`str | null`, optional) — ISO-8601 upper bound on `last_run_start_time`.
+- `workspace` (`str`): workspace name or GUID.
+- `warehouse` (`str`): warehouse or SQL Analytics Endpoint name or GUID.
+- `limit` (`int`, default `100`): maximum rows to return (1–10 000).
+- `since` (`str | null`, optional): ISO-8601 lower bound on `last_run_start_time`.
+- `until` (`str | null`, optional): ISO-8601 upper bound on `last_run_start_time`.
 
-**Returns:** `list[dict]` — array of frequently-run query row objects. Elapsed-time fields (e.g. `avg_total_elapsed_time_ms`, `min_run_total_elapsed_time_ms`, `max_run_total_elapsed_time_ms`, `last_run_total_elapsed_time_ms`) are JSON `number` (float); count fields remain `integer`.
+**Returns:** `list[dict]`: array of frequently-run query row objects. Elapsed-time fields (e.g. `avg_total_elapsed_time_ms`, `min_run_total_elapsed_time_ms`, `max_run_total_elapsed_time_ms`, `last_run_total_elapsed_time_ms`) are JSON `number` (float); count fields remain `integer`.
 
 ---
 
@@ -266,13 +266,13 @@ Return long-running queries from `queryinsights.long_running_queries`.
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `warehouse` (`str`) — warehouse or SQL Analytics Endpoint name or GUID.
-- `limit` (`int`, default `100`) — maximum rows to return (1–10 000).
-- `since` (`str | null`, optional) — ISO-8601 lower bound on `last_run_start_time`.
-- `until` (`str | null`, optional) — ISO-8601 upper bound on `last_run_start_time`.
+- `workspace` (`str`): workspace name or GUID.
+- `warehouse` (`str`): warehouse or SQL Analytics Endpoint name or GUID.
+- `limit` (`int`, default `100`): maximum rows to return (1–10 000).
+- `since` (`str | null`, optional): ISO-8601 lower bound on `last_run_start_time`.
+- `until` (`str | null`, optional): ISO-8601 upper bound on `last_run_start_time`.
 
-**Returns:** `list[dict]` — array of long-running query row objects. `median_total_elapsed_time_ms` and `last_run_total_elapsed_time_ms` are JSON `number` (float); `number_of_runs` remains `integer`.
+**Returns:** `list[dict]`: array of long-running query row objects. `median_total_elapsed_time_ms` and `last_run_total_elapsed_time_ms` are JSON `number` (float); `number_of_runs` remains `integer`.
 
 ---
 
@@ -284,13 +284,13 @@ Return completed SQL requests from `queryinsights.exec_requests_history`.
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `warehouse` (`str`) — warehouse or SQL Analytics Endpoint name or GUID.
-- `limit` (`int`, default `100`) — maximum rows to return (1–10 000).
-- `since` (`str | null`, optional) — ISO-8601 lower bound on `submit_time`.
-- `until` (`str | null`, optional) — ISO-8601 upper bound on `submit_time`.
+- `workspace` (`str`): workspace name or GUID.
+- `warehouse` (`str`): warehouse or SQL Analytics Endpoint name or GUID.
+- `limit` (`int`, default `100`): maximum rows to return (1–10 000).
+- `since` (`str | null`, optional): ISO-8601 lower bound on `submit_time`.
+- `until` (`str | null`, optional): ISO-8601 upper bound on `submit_time`.
 
-**Returns:** `list[dict]` — array of request-history row objects. Elapsed-time and CPU-time fields (e.g. `total_elapsed_time_ms`, `allocated_cpu_time_ms`) are JSON `number` (float) because Fabric returns fractional millisecond values.
+**Returns:** `list[dict]`: array of request-history row objects. Elapsed-time and CPU-time fields (e.g. `total_elapsed_time_ms`, `allocated_cpu_time_ms`) are JSON `number` (float) because Fabric returns fractional millisecond values.
 
 ---
 
@@ -302,10 +302,10 @@ Return all currently-executing queries on a warehouse.
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `warehouse` (`str`) — warehouse name or GUID.
+- `workspace` (`str`): workspace name or GUID.
+- `warehouse` (`str`): warehouse name or GUID.
 
-**Returns:** `list[RunningQuery]` — array of query objects, each with `session_id`, `request_id`, `status`, `start_time`, `total_elapsed_time` (ms), `login_name`, `command`, and `query_text`.
+**Returns:** `list[RunningQuery]`: array of query objects, each with `session_id`, `request_id`, `status`, `start_time`, `total_elapsed_time` (ms), `login_name`, `command`, and `query_text`.
 
 ---
 
@@ -317,10 +317,10 @@ Return completed sessions from `queryinsights.exec_sessions_history`.
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `warehouse` (`str`) — warehouse or SQL Analytics Endpoint name or GUID.
-- `limit` (`int`, default `100`) — maximum rows to return (1–10 000).
-- `since` (`str | null`, optional) — ISO-8601 lower bound on `session_start_time`.
-- `until` (`str | null`, optional) — ISO-8601 upper bound on `session_start_time`.
+- `workspace` (`str`): workspace name or GUID.
+- `warehouse` (`str`): warehouse or SQL Analytics Endpoint name or GUID.
+- `limit` (`int`, default `100`): maximum rows to return (1–10 000).
+- `since` (`str | null`, optional): ISO-8601 lower bound on `session_start_time`.
+- `until` (`str | null`, optional): ISO-8601 upper bound on `session_start_time`.
 
-**Returns:** `list[dict]` — array of session-history row objects. `total_query_elapsed_time_ms` is JSON `number` (float) because Fabric returns fractional millisecond values.
+**Returns:** `list[dict]`: array of session-history row objects. `total_query_elapsed_time_ms` is JSON `number` (float) because Fabric returns fractional millisecond values.

--- a/docs/commands/restore-points.md
+++ b/docs/commands/restore-points.md
@@ -135,7 +135,7 @@ fdw -w MyWorkspace restore-points rename SalesWH 1726617378000 "Post-migration b
 
 **Targets:** Data Warehouse only
 
-Restore a warehouse in-place to a restore point. **This is a destructive operation** — the warehouse will be unavailable for approximately 10 minutes. You will be asked to confirm unless `--yes` is passed.
+Restore a warehouse in-place to a restore point. **This is a destructive operation**: the warehouse will be unavailable for approximately 10 minutes. You will be asked to confirm unless `--yes` is passed.
 
 **Synopsis**
 
@@ -161,12 +161,12 @@ Create a restore point for a warehouse at the current timestamp.
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `warehouse` (`str`) — warehouse name or GUID.
-- `name` (`str | null`, optional) — display name (max 128 chars).
-- `description` (`str | null`, optional) — description (max 512 chars).
+- `workspace` (`str`): workspace name or GUID.
+- `warehouse` (`str`): warehouse name or GUID.
+- `name` (`str | null`, optional): display name (max 128 chars).
+- `description` (`str | null`, optional): description (max 512 chars).
 
-**Returns:** `RestorePoint` — the newly-created restore point object.
+**Returns:** `RestorePoint`: the newly-created restore point object.
 
 ---
 
@@ -178,11 +178,11 @@ Delete a user-defined restore point. System-created restore points cannot be del
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `warehouse` (`str`) — warehouse name or GUID.
-- `restore_point_id` (`str`) — the restore point ID string.
+- `workspace` (`str`): workspace name or GUID.
+- `warehouse` (`str`): warehouse name or GUID.
+- `restore_point_id` (`str`): the restore point ID string.
 
-**Returns:** `{ "deleted": true, "restore_point_id": str }` — confirmation.
+**Returns:** `{ "deleted": true, "restore_point_id": str }`: confirmation.
 
 ---
 
@@ -194,11 +194,11 @@ Return a single restore point by ID.
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `warehouse` (`str`) — warehouse name or GUID.
-- `restore_point_id` (`str`) — the restore point ID string (e.g. `"1726617378000"`).
+- `workspace` (`str`): workspace name or GUID.
+- `warehouse` (`str`): warehouse name or GUID.
+- `restore_point_id` (`str`): the restore point ID string (e.g. `"1726617378000"`).
 
-**Returns:** `RestorePoint` — the restore point object.
+**Returns:** `RestorePoint`: the restore point object.
 
 ---
 
@@ -210,10 +210,10 @@ Return all restore points for a warehouse.
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `warehouse` (`str`) — warehouse name or GUID.
+- `workspace` (`str`): workspace name or GUID.
+- `warehouse` (`str`): warehouse name or GUID.
 
-**Returns:** `list[RestorePoint]` — array of restore point objects.
+**Returns:** `list[RestorePoint]`: array of restore point objects.
 
 ---
 
@@ -221,15 +221,15 @@ Return all restore points for a warehouse.
 
 **Targets:** Data Warehouse only
 
-Restore a warehouse in-place to a restore point. **This is a destructive, long-running operation** — the warehouse will be unavailable for approximately 10 minutes while the restore completes.
+Restore a warehouse in-place to a restore point. **This is a destructive, long-running operation**: the warehouse will be unavailable for approximately 10 minutes while the restore completes.
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `warehouse` (`str`) — warehouse name or GUID.
-- `restore_point_id` (`str`) — the restore point ID string to restore to.
+- `workspace` (`str`): workspace name or GUID.
+- `warehouse` (`str`): warehouse name or GUID.
+- `restore_point_id` (`str`): the restore point ID string to restore to.
 
-**Returns:** `{ "restored": true, "restore_point_id": str }` — confirmation.
+**Returns:** `{ "restored": true, "restore_point_id": str }`: confirmation.
 
 ---
 
@@ -241,10 +241,10 @@ Rename and/or update the description of a restore point. At least one of `name` 
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `warehouse` (`str`) — warehouse name or GUID.
-- `restore_point_id` (`str`) — the restore point ID string.
-- `name` (`str | null`, optional) — new display name (max 128 chars).
-- `description` (`str | null`, optional) — new description (max 512 chars).
+- `workspace` (`str`): workspace name or GUID.
+- `warehouse` (`str`): warehouse name or GUID.
+- `restore_point_id` (`str`): the restore point ID string.
+- `name` (`str | null`, optional): new display name (max 128 chars).
+- `description` (`str | null`, optional): new description (max 512 chars).
 
-**Returns:** `RestorePoint` — the updated restore point object.
+**Returns:** `RestorePoint`: the updated restore point object.

--- a/docs/commands/schemas.md
+++ b/docs/commands/schemas.md
@@ -104,11 +104,11 @@ Create a new SQL schema on a Fabric Data Warehouse or SQL Analytics Endpoint.
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `item` (`str`) — warehouse or SQL analytics endpoint name or GUID.
-- `name` (`str`) — the schema name; must be a valid SQL identifier.
+- `workspace` (`str`): workspace name or GUID.
+- `item` (`str`): warehouse or SQL analytics endpoint name or GUID.
+- `name` (`str`): the schema name; must be a valid SQL identifier.
 
-**Returns:** `Schema` — the newly-created schema record with `name` and `principal_id`.
+**Returns:** `Schema`: the newly-created schema record with `name` and `principal_id`.
 
 ---
 
@@ -124,12 +124,12 @@ Drop a SQL schema from a Fabric Data Warehouse or SQL Analytics Endpoint.
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `item` (`str`) — warehouse or SQL analytics endpoint name or GUID.
-- `name` (`str`) — the schema name to drop.
-- `cascade` (`bool`, default `False`) — when `True`, drop all tables, views, functions, and stored procedures in the schema first.
+- `workspace` (`str`): workspace name or GUID.
+- `item` (`str`): warehouse or SQL analytics endpoint name or GUID.
+- `name` (`str`): the schema name to drop.
+- `cascade` (`bool`, default `False`): when `True`, drop all tables, views, functions, and stored procedures in the schema first.
 
-**Returns:** `{ "deleted": true }` — confirmation.
+**Returns:** `{ "deleted": true }`: confirmation.
 
 ---
 
@@ -141,7 +141,7 @@ List user-defined SQL schemas on a warehouse or SQL Analytics Endpoint. System s
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `item` (`str`) — warehouse or SQL Analytics Endpoint name or GUID.
+- `workspace` (`str`): workspace name or GUID.
+- `item` (`str`): warehouse or SQL Analytics Endpoint name or GUID.
 
-**Returns:** `list[Schema]` — array of schema objects, each with `name` and `principal_id`.
+**Returns:** `list[Schema]`: array of schema objects, each with `name` and `principal_id`.

--- a/docs/commands/settings.md
+++ b/docs/commands/settings.md
@@ -10,7 +10,7 @@ Manage **server-side** database settings on a Fabric Data Warehouse or SQL Analy
 
     `settings` manages server-side warehouse/database configuration. For client-side CLI defaults (workspace, warehouse) use [`fdw config`](config.md) instead.
 
-`show` works on both Data Warehouses and SQL Analytics Endpoints. `result-set-caching` and `retention` issue `ALTER DATABASE CURRENT SET …`, which is **not supported on SQL Analytics Endpoints** — running either command against one returns a clean error.
+`show` works on both Data Warehouses and SQL Analytics Endpoints. `result-set-caching` and `retention` issue `ALTER DATABASE CURRENT SET …`, which is **not supported on SQL Analytics Endpoints**: running either command against one returns a clean error.
 
 The workspace is resolved from the global `-w/--workspace` option, the `FABRIC_DW_DEFAULT_WORKSPACE` environment variable, or the client-side config default. `ITEM` may be a display name or GUID.
 
@@ -58,7 +58,7 @@ fdw -w <workspace> settings retention [ITEM] --days DAYS
 
 | Option | Description | Default |
 | --- | --- | --- |
-| `--days N` | Retention period in days (1-120, required). | — |
+| `--days N` | Retention period in days (1-120, required). | - |
 
 **Example:**
 
@@ -105,7 +105,7 @@ Return the current server-side database settings for a warehouse. Reads `result_
 | `workspace` | `str` | Workspace name or GUID. |
 | `item` | `str` | Warehouse or SQL Analytics Endpoint name or GUID. |
 
-**Returns:** `WarehouseSettings` — `{ database, result_set_caching, time_travel_retention_days, time_travel_retention_cutoff_date }`.
+**Returns:** `WarehouseSettings`: `{ database, result_set_caching, time_travel_retention_days, time_travel_retention_cutoff_date }`.
 
 ---
 
@@ -125,7 +125,7 @@ Enable or disable result-set caching on a warehouse. Executes `ALTER DATABASE CU
 | `item` | `str` | Warehouse or SQL Analytics Endpoint name or GUID. |
 | `enabled` | `bool` | `true` to enable result-set caching, `false` to disable it. |
 
-**Returns:** `WarehouseSettings` — the effective settings after the change.
+**Returns:** `WarehouseSettings`: the effective settings after the change.
 
 ---
 
@@ -145,4 +145,4 @@ Set the time-travel retention period on a warehouse. Executes `ALTER DATABASE CU
 | `item` | `str` | Warehouse or SQL Analytics Endpoint name or GUID. |
 | `days` | `int` | Retention period in days. Must be in the range 1–120 (inclusive). |
 
-**Returns:** `WarehouseSettings` — the effective settings after the change.
+**Returns:** `WarehouseSettings`: the effective settings after the change.

--- a/docs/commands/snapshots.md
+++ b/docs/commands/snapshots.md
@@ -143,13 +143,13 @@ Create a new warehouse snapshot.
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `warehouse` (`str`) — warehouse name or GUID.
-- `name` (`str`) — display name for the new snapshot.
-- `description` (`str | null`, optional) — optional description.
-- `snapshot_dt` (`str | null`, optional) — ISO-8601 datetime string for the snapshot point-in-time; defaults to the current timestamp when omitted.
+- `workspace` (`str`): workspace name or GUID.
+- `warehouse` (`str`): warehouse name or GUID.
+- `name` (`str`): display name for the new snapshot.
+- `description` (`str | null`, optional): optional description.
+- `snapshot_dt` (`str | null`, optional): ISO-8601 datetime string for the snapshot point-in-time; defaults to the current timestamp when omitted.
 
-**Returns:** `WarehouseSnapshot` — the newly-created snapshot object.
+**Returns:** `WarehouseSnapshot`: the newly-created snapshot object.
 
 ---
 
@@ -161,10 +161,10 @@ Delete a warehouse snapshot.
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `snapshot` (`str`) — snapshot name or GUID.
+- `workspace` (`str`): workspace name or GUID.
+- `snapshot` (`str`): snapshot name or GUID.
 
-**Returns:** `{ "deleted": true, "snapshot_id": str }` — confirmation with the snapshot GUID.
+**Returns:** `{ "deleted": true, "snapshot_id": str }`: confirmation with the snapshot GUID.
 
 ---
 
@@ -176,10 +176,10 @@ Return all snapshots belonging to a warehouse.
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `warehouse` (`str`) — warehouse name or GUID.
+- `workspace` (`str`): workspace name or GUID.
+- `warehouse` (`str`): warehouse name or GUID.
 
-**Returns:** `list[WarehouseSnapshot]` — array of snapshot objects, each with `id`, `displayName`, `parentWarehouseId`, and `snapshotDateTime`.
+**Returns:** `list[WarehouseSnapshot]`: array of snapshot objects, each with `id`, `displayName`, `parentWarehouseId`, and `snapshotDateTime`.
 
 ---
 
@@ -191,12 +191,12 @@ Rename a warehouse snapshot and optionally update its description.
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `snapshot` (`str`) — snapshot name or GUID.
-- `new_name` (`str`) — new display name.
-- `description` (`str | null`, optional) — new description; omit to leave unchanged.
+- `workspace` (`str`): workspace name or GUID.
+- `snapshot` (`str`): snapshot name or GUID.
+- `new_name` (`str`): new display name.
+- `description` (`str | null`, optional): new description; omit to leave unchanged.
 
-**Returns:** `WarehouseSnapshot` — the updated snapshot object.
+**Returns:** `WarehouseSnapshot`: the updated snapshot object.
 
 ---
 
@@ -208,9 +208,9 @@ Roll a snapshot's timestamp forward, or reset it to the current time.
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `warehouse` (`str`) — parent warehouse name or GUID (used for the SQL connection).
-- `snapshot_name` (`str`) — the snapshot database name to roll.
-- `new_dt` (`str | null`, optional) — target ISO-8601 datetime string; defaults to `CURRENT_TIMESTAMP` when omitted.
+- `workspace` (`str`): workspace name or GUID.
+- `warehouse` (`str`): parent warehouse name or GUID (used for the SQL connection).
+- `snapshot_name` (`str`): the snapshot database name to roll.
+- `new_dt` (`str | null`, optional): target ISO-8601 datetime string; defaults to `CURRENT_TIMESTAMP` when omitted.
 
-**Returns:** `{ "rolled": true, "snapshot_name": str, "new_dt": str | null }` — confirmation with the snapshot name and the target datetime.
+**Returns:** `{ "rolled": true, "snapshot_name": str, "new_dt": str | null }`: confirmation with the snapshot name and the target datetime.

--- a/docs/commands/sql-endpoints.md
+++ b/docs/commands/sql-endpoints.md
@@ -122,12 +122,12 @@ fdw [-w WORKSPACE] sql-endpoints refresh [--recreate-tables] ENDPOINT
 
 | Flag | Description |
 |------|-------------|
-| `--recreate-tables` | Drop and recreate all tables during the refresh. Use to resolve inconsistencies or force a clean rebuild. **Destructive** — use with caution. |
+| `--recreate-tables` | Drop and recreate all tables during the refresh. Use to resolve inconsistencies or force a clean rebuild. **Destructive**: use with caution. |
 
 **Example**
 
 ```shell
-# Standard refresh — shows a per-table Rich table
+# Standard refresh - shows a per-table Rich table
 fdw -w MyWorkspace sql-endpoints refresh MyLakehouseEP
 
 # Force a full table recreate
@@ -149,10 +149,10 @@ Return details for a single SQL analytics endpoint.
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `endpoint` (`str`) — endpoint name or GUID.
+- `workspace` (`str`): workspace name or GUID.
+- `endpoint` (`str`): endpoint name or GUID.
 
-**Returns:** `Warehouse` — single SQL analytics endpoint object.
+**Returns:** `Warehouse`: single SQL analytics endpoint object.
 
 ---
 
@@ -168,10 +168,10 @@ Return all principals (users, groups, service principals) with access to a SQL A
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `sql_endpoint` (`str`) — SQL analytics endpoint name or GUID.
+- `workspace` (`str`): workspace name or GUID.
+- `sql_endpoint` (`str`): SQL analytics endpoint name or GUID.
 
-**Returns:** `list[ItemAccess]` — array of access records, each with `principal` (containing `id`, `displayName`, `type`, and type-specific fields such as `userPrincipalName` or `aadAppId`) and `itemAccessDetails` (containing `type`, `permissions`, and `additionalPermissions`).
+**Returns:** `list[ItemAccess]`: array of access records, each with `principal` (containing `id`, `displayName`, `type`, and type-specific fields such as `userPrincipalName` or `aadAppId`) and `itemAccessDetails` (containing `type`, `permissions`, and `additionalPermissions`).
 
 ---
 
@@ -183,10 +183,10 @@ List all SQL analytics endpoints in a workspace, or across all visible workspace
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID; required when `all_workspaces` is `false`; ignored when `true`.
-- `all_workspaces` (`bool`, default `false`) — when `true`, aggregate results across every workspace the caller can see.
+- `workspace` (`str`): workspace name or GUID; required when `all_workspaces` is `false`; ignored when `true`.
+- `all_workspaces` (`bool`, default `false`): when `true`, aggregate results across every workspace the caller can see.
 
-**Returns:** `list[Warehouse]` — array of SQL analytics endpoint objects (same fields as Warehouse, `kind` is always `SQLEndpoint`).
+**Returns:** `list[Warehouse]`: array of SQL analytics endpoint objects (same fields as Warehouse, `kind` is always `SQLEndpoint`).
 
 ---
 
@@ -198,8 +198,8 @@ Refresh metadata for a SQL analytics endpoint by syncing from the underlying Lak
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `endpoint` (`str`) — endpoint name or GUID.
-- `recreate_tables` (`bool`, default `False`) — drop and recreate all tables during the refresh. Use to resolve inconsistencies or force a clean rebuild. DESTRUCTIVE — use with caution.
+- `workspace` (`str`): workspace name or GUID.
+- `endpoint` (`str`): endpoint name or GUID.
+- `recreate_tables` (`bool`, default `False`): drop and recreate all tables during the refresh. Use to resolve inconsistencies or force a clean rebuild. DESTRUCTIVE - use with caution.
 
-**Returns:** `list[TableSyncStatus]` — array of per-table sync results, each with `tableName`, `status`, `startDateTime`, `endDateTime`, `lastSuccessfulSyncDateTime`, and `error`.
+**Returns:** `list[TableSyncStatus]`: array of per-table sync results, each with `tableName`, `status`, `startDateTime`, `endDateTime`, `lastSuccessfulSyncDateTime`, and `error`.

--- a/docs/commands/sql-pools.md
+++ b/docs/commands/sql-pools.md
@@ -147,9 +147,9 @@ fdw [-w WORKSPACE] sql-pools insights [OPTIONS] [WAREHOUSE]
 | Option | Description | Default |
 | --- | --- | --- |
 | `--limit INTEGER` | Maximum rows to return (1–10 000). | `100` |
-| `--since ISO8601` | Return rows with timestamp >= this value. Mutually exclusive with `--ago`. | — |
-| `--until ISO8601` | Return rows with timestamp <= this value. | — |
-| `--ago DURATION` | Relative alternative to `--since`: rows newer than now minus this duration (e.g. `1h`, `90m`, `3600s`, `2d`). Mutually exclusive with `--since`. | — |
+| `--since ISO8601` | Return rows with timestamp >= this value. Mutually exclusive with `--ago`. | - |
+| `--until ISO8601` | Return rows with timestamp <= this value. | - |
+| `--ago DURATION` | Relative alternative to `--since`: rows newer than now minus this duration (e.g. `1h`, `90m`, `3600s`, `2d`). Mutually exclusive with `--since`. | - |
 
 **Example**
 
@@ -271,15 +271,15 @@ Add a new SQL pool to a workspace.
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `name` (`str`) — pool name (must be unique within the workspace).
-- `max_percent` (`int`) — max resource percentage (1–100).
-- `is_default` (`bool`, default `false`) — whether this is the default pool.
-- `optimize_for_reads` (`bool`, default `true`) — enable read optimisation.
-- `classifier_type` (`str | null`, optional) — classifier type (e.g. `"Application Name"`).
-- `classifier_values` (`list[str] | null`, optional) — classifier value list.
+- `workspace` (`str`): workspace name or GUID.
+- `name` (`str`): pool name (must be unique within the workspace).
+- `max_percent` (`int`): max resource percentage (1–100).
+- `is_default` (`bool`, default `false`): whether this is the default pool.
+- `optimize_for_reads` (`bool`, default `true`): enable read optimisation.
+- `classifier_type` (`str | null`, optional): classifier type (e.g. `"Application Name"`).
+- `classifier_values` (`list[str] | null`, optional): classifier value list.
 
-**Returns:** `SqlPool` — the newly-created pool object.
+**Returns:** `SqlPool`: the newly-created pool object.
 
 ---
 
@@ -291,10 +291,10 @@ Delete an SQL pool from a workspace.
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `pool_name` (`str`) — name of the pool to delete.
+- `workspace` (`str`): workspace name or GUID.
+- `pool_name` (`str`): name of the pool to delete.
 
-**Returns:** `{ "deleted": true, "pool_name": str }` — confirmation.
+**Returns:** `{ "deleted": true, "pool_name": str }`: confirmation.
 
 ---
 
@@ -306,9 +306,9 @@ Disable custom SQL Pools for a workspace, preserving the pool configuration. Re-
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
+- `workspace` (`str`): workspace name or GUID.
 
-**Returns:** `SqlPoolsConfiguration` — the updated configuration.
+**Returns:** `SqlPoolsConfiguration`: the updated configuration.
 
 ---
 
@@ -320,9 +320,9 @@ Enable custom SQL Pools for a workspace without modifying pool definitions.
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
+- `workspace` (`str`): workspace name or GUID.
 
-**Returns:** `SqlPoolsConfiguration` — the updated configuration.
+**Returns:** `SqlPoolsConfiguration`: the updated configuration.
 
 ---
 
@@ -334,10 +334,10 @@ Return details for a single SQL pool by name.
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `pool_name` (`str`) — pool name.
+- `workspace` (`str`): workspace name or GUID.
+- `pool_name` (`str`): pool name.
 
-**Returns:** `SqlPool` — single pool object (fields as above).
+**Returns:** `SqlPool`: single pool object (fields as above).
 
 ---
 
@@ -349,9 +349,9 @@ Fetch the full SQL Pools configuration (enabled flag + pool list) for a workspac
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
+- `workspace` (`str`): workspace name or GUID.
 
-**Returns:** `SqlPoolsConfiguration` — object with `customSQLPoolsEnabled` (bool) and `customSQLPools` (list of pool objects, each with `name`, `maxResourcePercentage`, `isDefault`, `optimizeForReads`, and optional `classifier`).
+**Returns:** `SqlPoolsConfiguration`: object with `customSQLPoolsEnabled` (bool) and `customSQLPools` (list of pool objects, each with `name`, `maxResourcePercentage`, `isDefault`, `optimizeForReads`, and optional `classifier`).
 
 ---
 
@@ -363,13 +363,13 @@ Return SQL pool insight events from `queryinsights.sql_pool_insights`.
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `warehouse` (`str`) — warehouse or SQL Analytics Endpoint name or GUID.
-- `limit` (`int`, default `100`) — maximum rows to return (1–10 000).
-- `since` (`str | null`, optional) — ISO-8601 lower bound on `timestamp`.
-- `until` (`str | null`, optional) — ISO-8601 upper bound on `timestamp`.
+- `workspace` (`str`): workspace name or GUID.
+- `warehouse` (`str`): warehouse or SQL Analytics Endpoint name or GUID.
+- `limit` (`int`, default `100`): maximum rows to return (1–10 000).
+- `since` (`str | null`, optional): ISO-8601 lower bound on `timestamp`.
+- `until` (`str | null`, optional): ISO-8601 upper bound on `timestamp`.
 
-**Returns:** `list[dict]` — array of SQL pool insight row objects.
+**Returns:** `list[dict]`: array of SQL pool insight row objects.
 
 ---
 
@@ -381,9 +381,9 @@ Return the list of SQL pools for a workspace.
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
+- `workspace` (`str`): workspace name or GUID.
 
-**Returns:** `list[SqlPool]` — array of pool objects, each with `name`, `isDefault`, `maxResourcePercentage`, `optimizeForReads`, and optional `classifier`.
+**Returns:** `list[SqlPool]`: array of pool objects, each with `name`, `isDefault`, `maxResourcePercentage`, `optimizeForReads`, and optional `classifier`.
 
 ---
 
@@ -395,12 +395,12 @@ Update an existing SQL pool.  Only the parameters you supply are changed; all ot
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `name` (`str`) — name of the pool to update.
-- `max_percent` (`int | null`, optional) — new max resource percentage.
-- `is_default` (`bool | null`, optional) — set or clear the default flag.
-- `optimize_for_reads` (`bool | null`, optional) — enable or disable read optimisation.
-- `classifier_type` (`str | null`, optional) — new classifier type.
-- `classifier_values` (`list[str] | null`, optional) — new classifier value list (replaces all existing values).
+- `workspace` (`str`): workspace name or GUID.
+- `name` (`str`): name of the pool to update.
+- `max_percent` (`int | null`, optional): new max resource percentage.
+- `is_default` (`bool | null`, optional): set or clear the default flag.
+- `optimize_for_reads` (`bool | null`, optional): enable or disable read optimisation.
+- `classifier_type` (`str | null`, optional): new classifier type.
+- `classifier_values` (`list[str] | null`, optional): new classifier value list (replaces all existing values).
 
-**Returns:** `SqlPool` — the updated pool object.
+**Returns:** `SqlPool`: the updated pool object.

--- a/docs/commands/sql.md
+++ b/docs/commands/sql.md
@@ -51,7 +51,7 @@ fdw -w MyWorkspace --json sql exec SalesWH -f ./queries/report.sql
 
 ### sql plan
 
-Capture the **estimated** SHOWPLAN_XML execution plan for a SQL statement without executing it. The query is **not** run — only the plan is returned. This means DDL/DML query text is safe to plan without modifying any data.
+Capture the **estimated** SHOWPLAN_XML execution plan for a SQL statement without executing it. The query is **not** run - only the plan is returned. This means DDL/DML query text is safe to plan without modifying any data.
 
 By default the plan is rendered as a **Rich terminal tree**: each operator is shown with its physical/logical op name, estimated row count, cost percentage (colour-coded), and badges for parallel execution or warnings. For multi-statement batches, one tree is printed per statement.
 
@@ -73,7 +73,7 @@ fdw [-w WORKSPACE] sql plan [OPTIONS] [ITEM]
 
 Pass the root `--json` flag to emit the parsed operator tree as machine-readable JSON instead of the Rich tree.
 
-**Representation vs. destination** — these two axes are orthogonal:
+**Representation vs. destination**: these two axes are orthogonal:
 
 | | no `-o` | `-o FILE` |
 | --- | --- | --- |
@@ -148,7 +148,7 @@ Unknown operators degrade gracefully; the library renders what it knows and skip
 
 !!! note "System dependency"
 
-    This format requires [Graphviz](https://graphviz.org/download/) to be installed on your system — it is **not** a Python package.  Install it via your package manager (e.g. `brew install graphviz` on macOS, `apt install graphviz` on Debian/Ubuntu) or download it from [graphviz.org](https://graphviz.org/download/).
+    This format requires [Graphviz](https://graphviz.org/download/) to be installed on your system - it is **not** a Python package.  Install it via your package manager (e.g. `brew install graphviz` on macOS, `apt install graphviz` on Debian/Ubuntu) or download it from [graphviz.org](https://graphviz.org/download/).
 
     When the `dot` binary is not found, the command exits with a clear error and an install hint rather than crashing.
 
@@ -223,11 +223,11 @@ Multi-statement batches are supported; only the **last** result set is returned.
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `item` (`str`) — warehouse or SQL Analytics Endpoint name or GUID.
-- `query` (`str`) — SQL statement or batch to execute.
+- `workspace` (`str`): workspace name or GUID.
+- `item` (`str`): warehouse or SQL Analytics Endpoint name or GUID.
+- `query` (`str`): SQL statement or batch to execute.
 
-**Returns:** `{ "columns": list[str], "rows": list[list[Any]], "rowcount": int }` — `rowcount` is `-1` when the driver does not report a count.
+**Returns:** `{ "columns": list[str], "rows": list[list[Any]], "rowcount": int }`: `rowcount` is `-1` when the driver does not report a count.
 
 ---
 
@@ -237,22 +237,22 @@ Multi-statement batches are supported; only the **last** result set is returned.
 
 Capture the **estimated** SHOWPLAN_XML execution plan for a SQL query without executing it.
 
-This tool does **not** execute the query — it only retrieves the estimated plan. Because no data is modified, this tool is permitted even when `FABRIC_MCP_READONLY=1`. DDL/DML query text is safe to plan without modifying any data.
+This tool does **not** execute the query - it only retrieves the estimated plan. Because no data is modified, this tool is permitted even when `FABRIC_MCP_READONLY=1`. DDL/DML query text is safe to plan without modifying any data.
 
 The plan XML uses the standard namespace `http://schemas.microsoft.com/sqlserver/2004/07/showplan` and can be opened in SSMS or Azure Data Studio.
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `item` (`str`) — warehouse or SQL Analytics Endpoint name or GUID.
-- `query` (`str`) — SQL statement to generate an estimated execution plan for.
-- `format` (`"xml" | "tree" | "json" | "mermaid"`, default `"xml"`) — output format. See [Format options](#format-options) below.
+- `workspace` (`str`): workspace name or GUID.
+- `item` (`str`): warehouse or SQL Analytics Endpoint name or GUID.
+- `query` (`str`): SQL statement to generate an estimated execution plan for.
+- `format` (`"xml" | "tree" | "json" | "mermaid"`, default `"xml"`): output format. See [Format options](#format-options) below.
 
 #### Format options
 
 | `format` | Return key | Value type | Description |
 | --- | --- | --- | --- |
-| `"xml"` *(default)* | `plan_xml` | `str` | Raw SHOWPLAN_XML string. Backwards-compatible — existing callers relying on `{"plan_xml": str}` continue to work unchanged. |
+| `"xml"` *(default)* | `plan_xml` | `str` | Raw SHOWPLAN_XML string. Backwards-compatible - existing callers relying on `{"plan_xml": str}` continue to work unchanged. |
 | `"tree"` | `plan` | `list[dict]` | Native nested list of dicts, one entry per statement. Best for agent reasoning over the plan structure. |
 | `"json"` | `plan_json` | `str` | Same tree as `"tree"`, serialised to an indented JSON string. Ready to write out or pass through as compact text. |
 | `"mermaid"` | `mermaid` | `str` | Mermaid `flowchart TD` diagram. Paste into [mermaid.live](https://mermaid.live) or embed in GitHub Markdown. |

--- a/docs/commands/statistics.md
+++ b/docs/commands/statistics.md
@@ -28,11 +28,11 @@ fdw [-w WORKSPACE] statistics create [ITEM] --table schema.table --column COL --
 
 | Option | Description | Default |
 | --- | --- | --- |
-| `--table schema.table` | Qualified table name (required). | — |
-| `--column COL` | Column name to build the statistic on (required). Single column only. | — |
-| `--name NAME` | Statistic name (required). | — |
+| `--table schema.table` | Qualified table name (required). | - |
+| `--column COL` | Column name to build the statistic on (required). Single column only. | - |
+| `--name NAME` | Statistic name (required). | - |
 | `--fullscan` | Use `WITH FULLSCAN` (default). Mutually exclusive with `--sample-percent`. | on |
-| `--sample-percent N` | Sample `N`% of the table (1–100). Overrides `--fullscan`. | — |
+| `--sample-percent N` | Sample `N`% of the table (1–100). Overrides `--fullscan`. | - |
 
 ---
 
@@ -98,7 +98,7 @@ fdw [-w WORKSPACE] statistics update [ITEM] QUALIFIED_TABLE STAT_NAME [OPTIONS]
 | Option | Description | Default |
 | --- | --- | --- |
 | `--fullscan` | Use `WITH FULLSCAN` (default). | on |
-| `--sample-percent N` | Sample `N`% of the table (1–100). Overrides `--fullscan`. | — |
+| `--sample-percent N` | Sample `N`% of the table (1–100). Overrides `--fullscan`. | - |
 
 ---
 
@@ -132,7 +132,7 @@ Create a single-column statistic on a table. Only single-column statistics are s
 | `fullscan` | `bool` | Use `WITH FULLSCAN` (default `true`). |
 | `sample_percent` | `int \| None` | Sample percentage (1–100). Overrides `fullscan`. |
 
-**Returns:** `Statistic` — the newly-created statistic.
+**Returns:** `Statistic`: the newly-created statistic.
 
 ---
 
@@ -153,7 +153,7 @@ Drop a statistic via `DROP STATISTICS`. **Destructive and irreversible.** Requir
 | `qualified_table` | `str` | Qualified table name, e.g. `dbo.sales`. |
 | `stat_name` | `str` | Name of the statistic to drop. |
 
-**Returns:** `{ "dropped": true }` — confirmation.
+**Returns:** `{ "dropped": true }`: confirmation.
 
 ---
 
@@ -176,7 +176,7 @@ List statistics on a warehouse or SQL Analytics Endpoint.
 | `user_only` | `bool` | Only return user-created statistics. |
 | `auto_only` | `bool` | Only return auto-created statistics. |
 
-**Returns:** `list[dict]` — array of `Statistic` objects.
+**Returns:** `list[dict]`: array of `Statistic` objects.
 
 ---
 
@@ -198,7 +198,7 @@ Show details of a statistic using `DBCC SHOW_STATISTICS`. Returns the stat heade
 | `stat_name` | `str` | Name of the statistic to show. |
 | `histogram_only` | `bool` | When `true`, return only the histogram steps. |
 
-**Returns:** `StatisticDetails` — `{ stat_header, density_vector, histogram }`.
+**Returns:** `StatisticDetails`: `{ stat_header, density_vector, histogram }`.
 
 ---
 
@@ -221,4 +221,4 @@ Update an existing statistic via `UPDATE STATISTICS`. SQL Analytics Endpoints ar
 | `fullscan` | `bool` | Use `WITH FULLSCAN` (default `true`). |
 | `sample_percent` | `int \| None` | Sample percentage (1–100). Overrides `fullscan`. |
 
-**Returns:** `{ "updated": true }` — confirmation.
+**Returns:** `{ "updated": true }`: confirmation.

--- a/docs/commands/tables.md
+++ b/docs/commands/tables.md
@@ -94,7 +94,7 @@ Change (or remove) the data-clustering columns of an existing table via a transa
 
     Dependent views and stored procedures that reference this table by name are **NOT** automatically updated by `sp_rename` and may need refreshing after the swap.
 
-The operation is atomic: all three steps run inside a single transaction. Any failure rolls back automatically — no orphan temp table is left behind.
+The operation is atomic: all three steps run inside a single transaction. Any failure rolls back automatically - no orphan temp table is left behind.
 
 **Synopsis**
 
@@ -213,8 +213,8 @@ fdw -w MyWorkspace --json tables count SalesWH dbo.orders
 
 Create a new table on a Fabric Data Warehouse. Two modes are available:
 
-- **CTAS** (`CREATE TABLE … AS SELECT`) — supply `--select` or `--from-file`. The body must start with `SELECT` (leading block/line comments are allowed).
-- **Empty DDL** (`CREATE TABLE … (col TYPE, …)`) — supply exactly one of `--from-parquet`, `--from-csv`, `--from-json`, or one-or-more `--column`. The schema is derived (Parquet/CSV/JSON inference) or listed explicitly; no data is ever read or inserted — this scaffolds the table structure only. To load data afterwards, use [`tables load`](#tables-load).
+- **CTAS** (`CREATE TABLE … AS SELECT`): supply `--select` or `--from-file`. The body must start with `SELECT` (leading block/line comments are allowed).
+- **Empty DDL** (`CREATE TABLE … (col TYPE, …)`): supply exactly one of `--from-parquet`, `--from-csv`, `--from-json`, or one-or-more `--column`. The schema is derived (Parquet/CSV/JSON inference) or listed explicitly; no data is ever read or inserted - this scaffolds the table structure only. To load data afterwards, use [`tables load`](#tables-load).
 
 **Synopsis**
 
@@ -238,9 +238,9 @@ Exactly one of `--select` or `--from-file` must be provided for the CTAS path. C
 | Option | Description |
 | --- | --- |
 | `--name SCHEMA.TABLE` | **Required.** Qualified table name. |
-| `--from-parquet PATH` | Derive schema from a Parquet file (reads footer only — no data loaded). |
+| `--from-parquet PATH` | Derive schema from a Parquet file (reads footer only - no data loaded). |
 | `--from-csv PATH` | Derive schema from a CSV header + bounded sample (no data loaded). |
-| `--from-json PATH` | Derive schema from JSON **data** — a JSONL file or a JSON file containing an array of objects; types are inferred from a bounded sample (no data loaded). JSONL streams; a JSON array is fully loaded into memory — for very large data prefer JSONL. |
+| `--from-json PATH` | Derive schema from JSON **data**: a JSONL file or a JSON file containing an array of objects; types are inferred from a bounded sample (no data loaded). JSONL streams; a JSON array is fully loaded into memory - for very large data prefer JSONL. |
 | `--column NAME:TYPE[:null\|notnull]` | Inline column definition (repeatable). |
 | `--cluster-by COL` | Column name for `CLUSTER BY` (repeatable, up to 4). Each name must appear in the table schema. |
 | `--all-varchar` | (CSV/JSON) Force all columns to `VARCHAR`; skip type inference. |
@@ -267,7 +267,7 @@ Exactly one of `--select` or `--from-file` must be provided for the CTAS path. C
 | `timestamp*` | `DATETIME2(7)` |
 | `string`, `large_string` | `VARCHAR(n)` |
 | `binary`, `large_binary` | `VARBINARY(n)` |
-| nested / list / struct | CSV/JSON: falls back to `VARCHAR(n)` with a warning (or use `--all-varchar`). Parquet: **Error** — define the column explicitly with `--column` instead. |
+| nested / list / struct | CSV/JSON: falls back to `VARCHAR(n)` with a warning (or use `--all-varchar`). Parquet: **Error**: define the column explicitly with `--column` instead. |
 
 **Examples**
 
@@ -294,12 +294,12 @@ fdw -w MyWorkspace tables create SalesWH \
   --column "event_type:VARCHAR(100)" \
   --column "occurred_at:DATETIME2(7)"
 
-# Empty table from JSON data — JSONL (schema inferred from the data)
+# Empty table from JSON data - JSONL (schema inferred from the data)
 fdw -w MyWorkspace tables create SalesWH \
   --name staging.events \
   --from-json ./data/events.jsonl
 
-# Empty table from JSON data — a JSON array of objects
+# Empty table from JSON data - a JSON array of objects
 fdw -w MyWorkspace tables create SalesWH \
   --name dbo.audit_log \
   --from-json ./data/audit_log.json --varchar-length 500
@@ -347,7 +347,7 @@ fdw -w MyWorkspace --yes tables delete SalesWH dbo.orders_2026
 
 Run `sp_get_table_health_metrics` against a single table to surface Delta/Parquet layout issues (small files, fragmentation, excessive deletes/updates, delayed checkpoints) and decide whether maintenance is needed.
 
-The proc is Generally Available (announced at Build 2026) but Microsoft Learn has no dedicated reference page yet. Output columns are passed through verbatim — the exact column names and types are determined by the proc and may change across Fabric releases.
+The proc is Generally Available (announced at Build 2026) but Microsoft Learn has no dedicated reference page yet. Output columns are passed through verbatim - the exact column names and types are determined by the proc and may change across Fabric releases.
 
 **Synopsis**
 
@@ -405,7 +405,7 @@ Load data into a warehouse table via `COPY INTO` from either a local file or a r
 
 **Remote URL** (`--url`): `COPY INTO` is issued directly from the given URL. For OneLake or same-tenant URLs no credential is needed. For secured external URLs (Azure Blob Storage, ADLS Gen2) supply `--credential-type` and `--secret`/`--identity` as appropriate.
 
-**Auto-create (create-and-load)** — Pass `--create` to auto-create the target table from the source schema before loading (local files only; requires `pyarrow`). The schema is inferred from the source:
+**Auto-create (create-and-load)**: Pass `--create` to auto-create the target table from the source schema before loading (local files only; requires `pyarrow`). The schema is inferred from the source:
 
 - **Parquet**: exact types are read from the Parquet footer (no row data is read).
 - **CSV**: the header row and up to `--sample-rows` rows are read for type inference. Use `--all-varchar` to skip inference and force every column to `VARCHAR`.
@@ -415,7 +415,7 @@ Use `--if-exists` to control behaviour when the table already exists:
 
 | `--if-exists` value | Table exists | Table absent |
 | --- | --- | --- |
-| `fail` (default with `--create`) | Error — table already exists | Create + load |
+| `fail` (default with `--create`) | Error - table already exists | Create + load |
 | `append` | Skip create, `COPY INTO` existing | Create + load |
 | `truncate` ⚠️ **DESTRUCTIVE** | `TRUNCATE` existing table, then load | Create + load |
 | `replace` ⚠️ **DESTRUCTIVE** | `DROP` + recreate from inferred schema, then load | Create + load |
@@ -438,28 +438,28 @@ fdw [-w WORKSPACE] tables load [OPTIONS] [ITEM] QUALIFIED_NAME
 
 | Option | Default | Description |
 | --- | --- | --- |
-| `--file PATH` | — | Local file path (CSV, Parquet, or JSON). |
-| `--url TEXT` | — | Remote URL (OneLake DFS or external Azure Blob). |
+| `--file PATH` | - | Local file path (CSV, Parquet, or JSON). |
+| `--url TEXT` | - | Remote URL (OneLake DFS or external Azure Blob). |
 | `--format [csv\|parquet\|json]` | auto-detect | File format. For `--url`, only `csv` and `parquet` are supported. |
 | `--header/--no-header` | `--header` | Whether the CSV file contains a header row. |
 | `--delimiter TEXT` | `,` | CSV column delimiter. |
-| `--encoding TEXT` | — | CSV encoding (e.g. `UTF8`, `UTF8BOM`). |
-| `--field-quote TEXT` | — | CSV field-quote character. |
-| `--row-terminator TEXT` | — | CSV row terminator (e.g. `\n`, `\r\n`). |
+| `--encoding TEXT` | - | CSV encoding (e.g. `UTF8`, `UTF8BOM`). |
+| `--field-quote TEXT` | - | CSV field-quote character. |
+| `--row-terminator TEXT` | - | CSV row terminator (e.g. `\n`, `\r\n`). |
 | `--credential-type [none\|sas\|managed-identity\|service-principal\|account-key]` | `none` | Credential type for secured external URLs. |
-| `--secret TEXT` | — | Credential secret (SAS token / client secret / account key). Never echoed. |
-| `--identity TEXT` | — | Identity for `managed-identity` or `service-principal`. |
+| `--secret TEXT` | - | Credential secret (SAS token / client secret / account key). Never echoed. |
+| `--identity TEXT` | - | Identity for `managed-identity` or `service-principal`. |
 | `--staging-lakehouse TEXT` | auto-generated | Name for the temporary staging Lakehouse (local path only). |
 | `--keep-staging` | off | Keep the staging Lakehouse after load (for debugging). |
-| `--max-errors INT` | — | Maximum errors before aborting. |
-| `--rejected-row-location TEXT` | — | URL to write rejected rows to. |
+| `--max-errors INT` | - | Maximum errors before aborting. |
+| `--rejected-row-location TEXT` | - | URL to write rejected rows to. |
 | `--create` | off | Auto-create the target table from the source schema (local files only). |
 | `--if-exists [fail\|append\|truncate\|replace]` | `fail` (with `--create`) | What to do when the target table already exists. `truncate` and `replace` are destructive and require confirmation. |
 | `--all-varchar` | off | (CSV, `--create`) Force all columns to `VARCHAR`; skip type inference. |
 | `--varchar-length INT` | `8000` | (`--create`) Default VARCHAR/VARBINARY length for inferred columns. |
 | `--sample-rows INT` | `1000` | (CSV, `--create`) Maximum rows to sample for type inference. |
 | `--cleanup-on-failure` | off | Drop the table if WE created it and the load fails. Never drops a pre-existing table. |
-| `--cluster-by COL` | — | (`--create`) Column name for `CLUSTER BY` (repeatable, up to 4). Each name must appear in the inferred schema. |
+| `--cluster-by COL` | - | (`--create`) Column name for `CLUSTER BY` (repeatable, up to 4). Each name must appear in the inferred schema. |
 
 **Examples**
 
@@ -543,7 +543,7 @@ fdw -w MyWorkspace tables read SalesWH dbo.orders --count 5
 
 **Targets:** Data Warehouse only
 
-Rename a table via `sp_rename`. The new name must be an unqualified (bare) identifier — `sp_rename` cannot move a table to a different schema.
+Rename a table via `sp_rename`. The new name must be an unqualified (bare) identifier - `sp_rename` cannot move a table to a different schema.
 
 **Synopsis**
 
@@ -577,11 +577,11 @@ Truncate a SQL table (remove all rows, preserve structure).
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `item` (`str`) — warehouse or SQL analytics endpoint name or GUID.
-- `qualified_name` (`str`) — dot-separated table name, e.g. `dbo.sales`.
+- `workspace` (`str`): workspace name or GUID.
+- `item` (`str`): warehouse or SQL analytics endpoint name or GUID.
+- `qualified_name` (`str`): dot-separated table name, e.g. `dbo.sales`.
 
-**Returns:** `{ "truncated": true }` — confirmation.
+**Returns:** `{ "truncated": true }`: confirmation.
 
 ---
 
@@ -593,13 +593,13 @@ Create a zero-copy clone of a table using `CREATE TABLE … AS CLONE OF …`. On
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `item` (`str`) — warehouse name or GUID.
-- `source` (`str`) — qualified source table name, e.g. `dbo.sales`.
-- `new_table` (`str`) — qualified name for the new cloned table, e.g. `dbo.sales_clone`.
-- `at` (`str | null`, optional) — ISO-8601 UTC timestamp for a point-in-time clone (e.g. `2024-05-20T14:00:00`). Must be within the data-retention window. When omitted, the clone reflects the current state of the source table.
+- `workspace` (`str`): workspace name or GUID.
+- `item` (`str`): warehouse name or GUID.
+- `source` (`str`): qualified source table name, e.g. `dbo.sales`.
+- `new_table` (`str`): qualified name for the new cloned table, e.g. `dbo.sales_clone`.
+- `at` (`str | null`, optional): ISO-8601 UTC timestamp for a point-in-time clone (e.g. `2024-05-20T14:00:00`). Must be within the data-retention window. When omitted, the clone reflects the current state of the source table.
 
-**Returns:** `Table` — the newly-created cloned table record.
+**Returns:** `Table`: the newly-created cloned table record.
 
 ---
 
@@ -611,19 +611,19 @@ Return column metadata for a SQL table via `sys.columns`. Works on both Fabric D
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `item` (`str`) — warehouse or SQL analytics endpoint name or GUID.
-- `qualified_name` (`str`) — dot-separated table name, e.g. `dbo.Sales`.
+- `workspace` (`str`): workspace name or GUID.
+- `item` (`str`): warehouse or SQL analytics endpoint name or GUID.
+- `qualified_name` (`str`): dot-separated table name, e.g. `dbo.Sales`.
 
-**Returns:** `list[dict]` — one dict per column, each containing:
+**Returns:** `list[dict]`: one dict per column, each containing:
 
-- `ordinal` (`int`) — 1-based column position (`column_id`).
-- `name` (`str`) — column name.
-- `data_type` (`str`) — formatted T-SQL type string, e.g. `INT`, `VARCHAR(50)`, `NVARCHAR(MAX)`, `DECIMAL(18,2)`, `DATETIME2(7)`.
-- `nullable` (`bool`) — whether the column allows `NULL`.
-- `collation_name` (`str | null`) — collation name, if applicable.
-- `is_identity` (`bool`) — whether the column is an identity column.
-- `is_computed` (`bool`) — whether the column is a computed column.
+- `ordinal` (`int`): 1-based column position (`column_id`).
+- `name` (`str`): column name.
+- `data_type` (`str`): formatted T-SQL type string, e.g. `INT`, `VARCHAR(50)`, `NVARCHAR(MAX)`, `DECIMAL(18,2)`, `DATETIME2(7)`.
+- `nullable` (`bool`): whether the column allows `NULL`.
+- `collation_name` (`str | null`): collation name, if applicable.
+- `is_identity` (`bool`): whether the column is an identity column.
+- `is_computed` (`bool`): whether the column is a computed column.
 
 Results are ordered by ordinal position. Raises a `ToolError` if the table does not exist.
 
@@ -637,11 +637,11 @@ Return the total row count of a table via `SELECT COUNT_BIG(*)`.
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `item` (`str`) — warehouse or SQL analytics endpoint name or GUID.
-- `qualified_name` (`str`) — dot-separated table name, e.g. `dbo.sales`.
+- `workspace` (`str`): workspace name or GUID.
+- `item` (`str`): warehouse or SQL analytics endpoint name or GUID.
+- `qualified_name` (`str`): dot-separated table name, e.g. `dbo.sales`.
 
-**Returns:** `{ "schema": str, "name": str, "row_count": int }` — the schema name, table name, and total row count.
+**Returns:** `{ "schema": str, "name": str, "row_count": int }`: the schema name, table name, and total row count.
 
 ---
 
@@ -649,22 +649,22 @@ Return the total row count of a table via `SELECT COUNT_BIG(*)`.
 
 **Targets:** Data Warehouse only
 
-Create an empty SQL table from an explicit column specification (DDL only — no data is ever read or inserted). This scaffolds the table structure so that data can be loaded separately.
+Create an empty SQL table from an explicit column specification (DDL only - no data is ever read or inserted). This scaffolds the table structure so that data can be loaded separately.
 
 Server-side file access is unreliable in MCP deployments, so CSV/Parquet schema inference is not available via this tool. Use `fdw tables create --from-parquet` or `--from-csv` (CLI) for file-based schema inference.
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `item` (`str`) — warehouse name or GUID. SQL Analytics Endpoints are rejected.
-- `qualified_name` (`str`) — dot-separated table name, e.g. `dbo.sales`.
-- `columns` (`list[object]`) — non-empty list of column definitions, each an object with:
-  - `name` (`str`) — column identifier (must be a valid SQL identifier).
-  - `sql_type` (`str`) — Fabric-DW-supported T-SQL type, e.g. `"INT"`, `"VARCHAR(255)"`, `"DECIMAL(18,2)"`.
-  - `nullable` (`bool`, optional, default `true`) — whether the column allows `NULL`.
-- `cluster_by` (`list[str]`, optional) — column names for the `CLUSTER BY` clause (up to 4). Each name must appear in `columns`.
+- `workspace` (`str`): workspace name or GUID.
+- `item` (`str`): warehouse name or GUID. SQL Analytics Endpoints are rejected.
+- `qualified_name` (`str`): dot-separated table name, e.g. `dbo.sales`.
+- `columns` (`list[object]`): non-empty list of column definitions, each an object with:
+  - `name` (`str`): column identifier (must be a valid SQL identifier).
+  - `sql_type` (`str`): Fabric-DW-supported T-SQL type, e.g. `"INT"`, `"VARCHAR(255)"`, `"DECIMAL(18,2)"`.
+  - `nullable` (`bool`, optional, default `true`): whether the column allows `NULL`.
+- `cluster_by` (`list[str]`, optional): column names for the `CLUSTER BY` clause (up to 4). Each name must appear in `columns`.
 
-**Returns:** `Table` — the newly-created table record.
+**Returns:** `Table`: the newly-created table record.
 
 **Example call:**
 
@@ -695,13 +695,13 @@ When `cluster_by` is supplied the DDL becomes `CREATE TABLE … WITH (CLUSTER BY
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `item` (`str`) — warehouse or SQL analytics endpoint name or GUID.
-- `qualified_name` (`str`) — dot-separated table name, e.g. `dbo.sales`.
-- `select_body` (`str`) — the SELECT statement for the CTAS source.
-- `cluster_by` (`list[str]`, optional) — column names for the `CLUSTER BY` clause (up to 4). Column existence is not validated on the CTAS path.
+- `workspace` (`str`): workspace name or GUID.
+- `item` (`str`): warehouse or SQL analytics endpoint name or GUID.
+- `qualified_name` (`str`): dot-separated table name, e.g. `dbo.sales`.
+- `select_body` (`str`): the SELECT statement for the CTAS source.
+- `cluster_by` (`list[str]`, optional): column names for the `CLUSTER BY` clause (up to 4). Column existence is not validated on the CTAS path.
 
-**Returns:** `Table` — the newly-created table record.
+**Returns:** `Table`: the newly-created table record.
 
 ---
 
@@ -715,11 +715,11 @@ Drop a SQL table.
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `item` (`str`) — warehouse or SQL analytics endpoint name or GUID.
-- `qualified_name` (`str`) — dot-separated table name, e.g. `dbo.sales`.
+- `workspace` (`str`): workspace name or GUID.
+- `item` (`str`): warehouse or SQL analytics endpoint name or GUID.
+- `qualified_name` (`str`): dot-separated table name, e.g. `dbo.sales`.
 
-**Returns:** `{ "dropped": true }` — confirmation.
+**Returns:** `{ "dropped": true }`: confirmation.
 
 ---
 
@@ -731,11 +731,11 @@ Return the data-clustering columns of a table, ordered by clustering ordinal. Re
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `item` (`str`) — warehouse name or GUID. SQL Analytics Endpoints are rejected.
-- `qualified_name` (`str`) — dot-separated table name, e.g. `dbo.sales`.
+- `workspace` (`str`): workspace name or GUID.
+- `item` (`str`): warehouse name or GUID. SQL Analytics Endpoints are rejected.
+- `qualified_name` (`str`): dot-separated table name, e.g. `dbo.sales`.
 
-**Returns:** `list[{ "column_name": str, "clustering_ordinal": int }]` — ordered by ascending `clustering_ordinal`.
+**Returns:** `list[{ "column_name": str, "clustering_ordinal": int }]`: ordered by ascending `clustering_ordinal`.
 
 ---
 
@@ -745,17 +745,17 @@ Return the data-clustering columns of a table, ordered by clustering ordinal. Re
 
 Return health metrics for a table via `sp_get_table_health_metrics`. Only supported on SQL Analytics Endpoints (not Data Warehouses).
 
-The proc surfaces Delta/Parquet layout issues such as small files, fragmentation, excessive deletes/updates, and delayed checkpoints — useful for deciding whether table maintenance is needed.
+The proc surfaces Delta/Parquet layout issues such as small files, fragmentation, excessive deletes/updates, and delayed checkpoints - useful for deciding whether table maintenance is needed.
 
 The proc is Generally Available (announced at Build 2026) but its output column schema is not yet documented by Microsoft. Columns and rows are passed through verbatim.
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `item` (`str`) — SQL Analytics Endpoint name or GUID. Data Warehouses are rejected with a `ToolError`.
-- `qualified_name` (`str`) — dot-separated table name, e.g. `dbo.FactSales`.
+- `workspace` (`str`): workspace name or GUID.
+- `item` (`str`): SQL Analytics Endpoint name or GUID. Data Warehouses are rejected with a `ToolError`.
+- `qualified_name` (`str`): dot-separated table name, e.g. `dbo.FactSales`.
 
-**Returns:** `{ "columns": list[str], "rows": list[list] }` — column names and rows passed through verbatim from the proc.
+**Returns:** `{ "columns": list[str], "rows": list[list] }`: column names and rows passed through verbatim from the proc.
 
 ---
 
@@ -781,31 +781,31 @@ Load data from a remote URL into an existing Data Warehouse table with control o
 
 | Value | Table exists | Table absent |
 | --- | --- | --- |
-| `"fail"` (default) | Error — table already exists | Load normally |
+| `"fail"` (default) | Error - table already exists | Load normally |
 | `"append"` | Load into existing table | Load normally |
 | `"truncate"` ⚠️ | `TRUNCATE` existing table, then load | Load normally |
-| `"replace"` ⚠️ | Not supported for remote URLs — use CLI | Load normally |
+| `"replace"` ⚠️ | Not supported for remote URLs - use CLI | Load normally |
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `item` (`str`) — warehouse name or GUID. SQL Analytics Endpoints are rejected.
-- `qualified_name` (`str`) — dot-separated qualified table name, e.g. `dbo.sales`.
-- `url` (`str`) — source URL (OneLake DFS URL or external Azure Blob URL).
-- `file_type` (`"CSV" | "PARQUET"`) — file type to load. JSON is not supported for remote URLs.
-- `if_exists` (`"fail" | "append" | "truncate" | "replace"`, default `"fail"`) — what to do when the target table already exists.
-- `credential_type` (`"none" | "sas" | "managed-identity" | "service-principal" | "account-key"`, default `"none"`) — credential type for secured external URLs.
-- `secret` (`str | null`, optional) — credential secret (SAS token, client secret, or account key). Never logged.
-- `identity` (`str | null`, optional) — identity for `managed-identity` or `service-principal`.
-- `delimiter` (`str | null`, optional) — CSV column delimiter (e.g. `,`, `\t`).
-- `has_header` (`bool`, default `true`) — when `true`, the first CSV row is a header and is skipped.
-- `encoding` (`str | null`, optional) — CSV encoding (e.g. `UTF8`, `UTF8BOM`).
-- `field_quote` (`str | null`, optional) — CSV field-quote character.
-- `row_terminator` (`str | null`, optional) — CSV row terminator (e.g. `\n`, `\r\n`).
-- `max_errors` (`int | null`, optional) — maximum errors before aborting.
-- `rejected_row_location` (`str | null`, optional) — URL to write rejected rows to.
+- `workspace` (`str`): workspace name or GUID.
+- `item` (`str`): warehouse name or GUID. SQL Analytics Endpoints are rejected.
+- `qualified_name` (`str`): dot-separated qualified table name, e.g. `dbo.sales`.
+- `url` (`str`): source URL (OneLake DFS URL or external Azure Blob URL).
+- `file_type` (`"CSV" | "PARQUET"`): file type to load. JSON is not supported for remote URLs.
+- `if_exists` (`"fail" | "append" | "truncate" | "replace"`, default `"fail"`): what to do when the target table already exists.
+- `credential_type` (`"none" | "sas" | "managed-identity" | "service-principal" | "account-key"`, default `"none"`): credential type for secured external URLs.
+- `secret` (`str | null`, optional): credential secret (SAS token, client secret, or account key). Never logged.
+- `identity` (`str | null`, optional): identity for `managed-identity` or `service-principal`.
+- `delimiter` (`str | null`, optional): CSV column delimiter (e.g. `,`, `\t`).
+- `has_header` (`bool`, default `true`): when `true`, the first CSV row is a header and is skipped.
+- `encoding` (`str | null`, optional): CSV encoding (e.g. `UTF8`, `UTF8BOM`).
+- `field_quote` (`str | null`, optional): CSV field-quote character.
+- `row_terminator` (`str | null`, optional): CSV row terminator (e.g. `\n`, `\r\n`).
+- `max_errors` (`int | null`, optional): maximum errors before aborting.
+- `rejected_row_location` (`str | null`, optional): URL to write rejected rows to.
 
-**Returns:** `CopyIntoResult` — `{ "rows_loaded": int, "rows_rejected": int, "target": "schema.table" }`.
+**Returns:** `CopyIntoResult`: `{ "rows_loaded": int, "rows_rejected": int, "target": "schema.table" }`.
 
 ---
 
@@ -817,11 +817,11 @@ List SQL tables on a warehouse or SQL Analytics Endpoint.
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `item` (`str`) — warehouse or SQL analytics endpoint name or GUID.
-- `schema` (`str | null`, optional) — when provided, only tables in this schema are returned.
+- `workspace` (`str`): workspace name or GUID.
+- `item` (`str`): warehouse or SQL analytics endpoint name or GUID.
+- `schema` (`str | null`, optional): when provided, only tables in this schema are returned.
 
-**Returns:** `list[Table]` — each with `schema_name`, `name`, `qualified_name`, `created`, `modified`.
+**Returns:** `list[Table]`: each with `schema_name`, `name`, `qualified_name`, `created`, `modified`.
 
 ---
 
@@ -845,23 +845,23 @@ Load data into a Data Warehouse table via `COPY INTO` from a remote URL. For One
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `item` (`str`) — warehouse name or GUID. SQL Analytics Endpoints are rejected.
-- `qualified_name` (`str`) — dot-separated qualified table name, e.g. `dbo.sales`.
-- `url` (`str`) — source URL (OneLake DFS URL or external Azure Blob URL).
-- `file_type` (`"CSV" | "PARQUET"`) — file type to load.
-- `credential_type` (`"none" | "sas" | "managed-identity" | "service-principal" | "account-key"`, default `"none"`) — credential type for secured external URLs.
-- `secret` (`str | null`, optional) — credential secret (SAS token, client secret, or account key). Never logged.
-- `identity` (`str | null`, optional) — identity for `managed-identity` or `service-principal`.
-- `delimiter` (`str | null`, optional) — CSV column delimiter (e.g. `,`, `\t`).
-- `has_header` (`bool`, default `true`) — when `true`, the first CSV row is a header and is skipped.
-- `encoding` (`str | null`, optional) — CSV encoding (e.g. `UTF8`, `UTF8BOM`).
-- `field_quote` (`str | null`, optional) — CSV field-quote character.
-- `row_terminator` (`str | null`, optional) — CSV row terminator (e.g. `\n`, `\r\n`).
-- `max_errors` (`int | null`, optional) — maximum errors before aborting.
-- `rejected_row_location` (`str | null`, optional) — URL to write rejected rows to.
+- `workspace` (`str`): workspace name or GUID.
+- `item` (`str`): warehouse name or GUID. SQL Analytics Endpoints are rejected.
+- `qualified_name` (`str`): dot-separated qualified table name, e.g. `dbo.sales`.
+- `url` (`str`): source URL (OneLake DFS URL or external Azure Blob URL).
+- `file_type` (`"CSV" | "PARQUET"`): file type to load.
+- `credential_type` (`"none" | "sas" | "managed-identity" | "service-principal" | "account-key"`, default `"none"`): credential type for secured external URLs.
+- `secret` (`str | null`, optional): credential secret (SAS token, client secret, or account key). Never logged.
+- `identity` (`str | null`, optional): identity for `managed-identity` or `service-principal`.
+- `delimiter` (`str | null`, optional): CSV column delimiter (e.g. `,`, `\t`).
+- `has_header` (`bool`, default `true`): when `true`, the first CSV row is a header and is skipped.
+- `encoding` (`str | null`, optional): CSV encoding (e.g. `UTF8`, `UTF8BOM`).
+- `field_quote` (`str | null`, optional): CSV field-quote character.
+- `row_terminator` (`str | null`, optional): CSV row terminator (e.g. `\n`, `\r\n`).
+- `max_errors` (`int | null`, optional): maximum errors before aborting.
+- `rejected_row_location` (`str | null`, optional): URL to write rejected rows to.
 
-**Returns:** `CopyIntoResult` — `{ "rows_loaded": int, "rows_rejected": int, "target": "schema.table" }`.
+**Returns:** `CopyIntoResult`: `{ "rows_loaded": int, "rows_rejected": int, "target": "schema.table" }`.
 
 ---
 
@@ -873,12 +873,12 @@ Return up to `count` rows from a table as JSON-serialisable columns and rows.
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `item` (`str`) — warehouse or SQL analytics endpoint name or GUID.
-- `qualified_name` (`str`) — dot-separated table name, e.g. `dbo.sales`.
-- `count` (`int`, default `10`) — maximum rows to return.
+- `workspace` (`str`): workspace name or GUID.
+- `item` (`str`): warehouse or SQL analytics endpoint name or GUID.
+- `qualified_name` (`str`): dot-separated table name, e.g. `dbo.sales`.
+- `count` (`int`, default `10`): maximum rows to return.
 
-**Returns:** `{ "columns": list[str], "rows": list[list] }` — column names and row arrays.
+**Returns:** `{ "columns": list[str], "rows": list[list] }`: column names and row arrays.
 
 ---
 
@@ -886,16 +886,16 @@ Return up to `count` rows from a table as JSON-serialisable columns and rows.
 
 **Targets:** Data Warehouse only
 
-Rename a SQL table via `sp_rename`. Only supported on Fabric Data Warehouses (SQL Analytics Endpoints are rejected). The new name must be a bare (unqualified) identifier — `sp_rename` cannot move a table to a different schema.
+Rename a SQL table via `sp_rename`. Only supported on Fabric Data Warehouses (SQL Analytics Endpoints are rejected). The new name must be a bare (unqualified) identifier - `sp_rename` cannot move a table to a different schema.
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `item` (`str`) — warehouse name or GUID.
-- `qualified_name` (`str`) — current dot-separated qualified table name, e.g. `dbo.sales`.
-- `new_name` (`str`) — new bare table name (no schema prefix), e.g. `sales_v2`.
+- `workspace` (`str`): workspace name or GUID.
+- `item` (`str`): warehouse name or GUID.
+- `qualified_name` (`str`): current dot-separated qualified table name, e.g. `dbo.sales`.
+- `new_name` (`str`): new bare table name (no schema prefix), e.g. `sales_v2`.
 
-**Returns:** `Table` — the updated table record.
+**Returns:** `Table`: the updated table record.
 
 ---
 
@@ -909,13 +909,13 @@ Change (or remove) the data-clustering columns of an existing table via a transa
 
 **CAUTION:** Dependent views and stored procedures that reference this table by name are **NOT** automatically updated by `sp_rename` and may need refreshing after the swap.
 
-The operation is atomic: CTAS + DROP + sp_rename all run in one transaction. Any failure rolls back automatically — no orphan temp table is left behind.
+The operation is atomic: CTAS + DROP + sp_rename all run in one transaction. Any failure rolls back automatically - no orphan temp table is left behind.
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `item` (`str`) — warehouse name or GUID. SQL Analytics Endpoints are rejected.
-- `qualified_name` (`str`) — dot-separated qualified table name, e.g. `dbo.sales`.
-- `cluster_by` (`list[str] | null`, optional) — new column names for the `CLUSTER BY` clause (up to 4). Pass `null` or an empty list to remove clustering (rebuilds table without `CLUSTER BY`).
+- `workspace` (`str`): workspace name or GUID.
+- `item` (`str`): warehouse name or GUID. SQL Analytics Endpoints are rejected.
+- `qualified_name` (`str`): dot-separated qualified table name, e.g. `dbo.sales`.
+- `cluster_by` (`list[str] | null`, optional): new column names for the `CLUSTER BY` clause (up to 4). Pass `null` or an empty list to remove clustering (rebuilds table without `CLUSTER BY`).
 
-**Returns:** `Table` — the re-clustered table record.
+**Returns:** `Table`: the re-clustered table record.

--- a/docs/commands/views.md
+++ b/docs/commands/views.md
@@ -216,7 +216,7 @@ fdw -w MyWorkspace views read SalesWH dbo.vw_sales --count 5
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
 
-Rename a SQL view via `sp_rename`. The new name must be an unqualified (bare) identifier — `sp_rename` cannot move a view to a different schema.
+Rename a SQL view via `sp_rename`. The new name must be an unqualified (bare) identifier - `sp_rename` cannot move a view to a different schema.
 
 **Synopsis**
 
@@ -278,11 +278,11 @@ Return the total row count of a view via `SELECT COUNT_BIG(*)`.
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `item` (`str`) — warehouse or SQL analytics endpoint name or GUID.
-- `qualified_name` (`str`) — dot-separated schema and view name, e.g. `dbo.vw_sales`.
+- `workspace` (`str`): workspace name or GUID.
+- `item` (`str`): warehouse or SQL analytics endpoint name or GUID.
+- `qualified_name` (`str`): dot-separated schema and view name, e.g. `dbo.vw_sales`.
 
-**Returns:** `{ "schema": str, "name": str, "row_count": int }` — the schema name, view name, and total row count.
+**Returns:** `{ "schema": str, "name": str, "row_count": int }`: the schema name, view name, and total row count.
 
 ---
 
@@ -294,12 +294,12 @@ Create a new SQL view.
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `item` (`str`) — warehouse or SQL analytics endpoint name or GUID.
-- `qualified_name` (`str`) — dot-separated schema and view name, e.g. `dbo.vw_sales`.
-- `select_body` (`str`) — the SELECT statement that forms the view body; executed verbatim as DDL.
+- `workspace` (`str`): workspace name or GUID.
+- `item` (`str`): warehouse or SQL analytics endpoint name or GUID.
+- `qualified_name` (`str`): dot-separated schema and view name, e.g. `dbo.vw_sales`.
+- `select_body` (`str`): the SELECT statement that forms the view body; executed verbatim as DDL.
 
-**Returns:** `View` — the newly-created view object (fetched after DDL, includes `definition`).
+**Returns:** `View`: the newly-created view object (fetched after DDL, includes `definition`).
 
 ---
 
@@ -311,11 +311,11 @@ Drop a SQL view.
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `item` (`str`) — warehouse or SQL analytics endpoint name or GUID.
-- `qualified_name` (`str`) — dot-separated schema and view name, e.g. `dbo.vw_sales`.
+- `workspace` (`str`): workspace name or GUID.
+- `item` (`str`): warehouse or SQL analytics endpoint name or GUID.
+- `qualified_name` (`str`): dot-separated schema and view name, e.g. `dbo.vw_sales`.
 
-**Returns:** `{ "dropped": true }` — confirmation.
+**Returns:** `{ "dropped": true }`: confirmation.
 
 ---
 
@@ -327,11 +327,11 @@ Fetch the full definition of a single SQL view.
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `item` (`str`) — warehouse or SQL analytics endpoint name or GUID.
-- `qualified_name` (`str`) — dot-separated schema and view name, e.g. `dbo.vw_sales`.
+- `workspace` (`str`): workspace name or GUID.
+- `item` (`str`): warehouse or SQL analytics endpoint name or GUID.
+- `qualified_name` (`str`): dot-separated schema and view name, e.g. `dbo.vw_sales`.
 
-**Returns:** `View` — single view object with `definition` populated from `sys.sql_modules`.
+**Returns:** `View`: single view object with `definition` populated from `sys.sql_modules`.
 
 ---
 
@@ -343,19 +343,19 @@ Return column metadata for a SQL view via `sys.columns`. Works on both Fabric Da
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `item` (`str`) — warehouse or SQL analytics endpoint name or GUID.
-- `qualified_name` (`str`) — dot-separated view name, e.g. `dbo.vw_sales`.
+- `workspace` (`str`): workspace name or GUID.
+- `item` (`str`): warehouse or SQL analytics endpoint name or GUID.
+- `qualified_name` (`str`): dot-separated view name, e.g. `dbo.vw_sales`.
 
-**Returns:** `list[dict]` — one dict per column, each containing:
+**Returns:** `list[dict]`: one dict per column, each containing:
 
-- `ordinal` (`int`) — 1-based column position (`column_id`).
-- `name` (`str`) — column name.
-- `data_type` (`str`) — formatted T-SQL type string, e.g. `INT`, `NVARCHAR(MAX)`, `DECIMAL(18,2)`.
-- `nullable` (`bool`) — whether the column allows `NULL`.
-- `collation_name` (`str | null`) — collation name, if applicable.
-- `is_identity` (`bool`) — whether the column is an identity column.
-- `is_computed` (`bool`) — whether the column is a computed column.
+- `ordinal` (`int`): 1-based column position (`column_id`).
+- `name` (`str`): column name.
+- `data_type` (`str`): formatted T-SQL type string, e.g. `INT`, `NVARCHAR(MAX)`, `DECIMAL(18,2)`.
+- `nullable` (`bool`): whether the column allows `NULL`.
+- `collation_name` (`str | null`): collation name, if applicable.
+- `is_identity` (`bool`): whether the column is an identity column.
+- `is_computed` (`bool`): whether the column is a computed column.
 
 Results are ordered by ordinal position. Raises a `ToolError` if the view does not exist.
 
@@ -369,11 +369,11 @@ List SQL views on a warehouse or SQL Analytics Endpoint, optionally filtered to 
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `item` (`str`) — warehouse or SQL analytics endpoint name or GUID.
-- `schema` (`str | null`, optional) — when provided, only views in this schema are returned; must be a valid SQL identifier.
+- `workspace` (`str`): workspace name or GUID.
+- `item` (`str`): warehouse or SQL analytics endpoint name or GUID.
+- `schema` (`str | null`, optional): when provided, only views in this schema are returned; must be a valid SQL identifier.
 
-**Returns:** `list[View]` — array of view objects, each with `schema_name`, `name`, `qualified_name`, `created`, `modified`, and `definition` (always `null` for list results).
+**Returns:** `list[View]`: array of view objects, each with `schema_name`, `name`, `qualified_name`, `created`, `modified`, and `definition` (always `null` for list results).
 
 ---
 
@@ -385,12 +385,12 @@ Return up to `count` rows from a view as JSON-serialisable columns and rows.
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `item` (`str`) — warehouse or SQL analytics endpoint name or GUID.
-- `qualified_name` (`str`) — dot-separated schema and view name, e.g. `dbo.vw_sales`.
-- `count` (`int`, default `10`) — maximum rows to return.
+- `workspace` (`str`): workspace name or GUID.
+- `item` (`str`): warehouse or SQL analytics endpoint name or GUID.
+- `qualified_name` (`str`): dot-separated schema and view name, e.g. `dbo.vw_sales`.
+- `count` (`int`, default `10`): maximum rows to return.
 
-**Returns:** `{ "columns": list[str], "rows": list[list] }` — column names and row arrays.
+**Returns:** `{ "columns": list[str], "rows": list[list] }`: column names and row arrays.
 
 ---
 
@@ -398,16 +398,16 @@ Return up to `count` rows from a view as JSON-serialisable columns and rows.
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
 
-Rename a SQL view via `sp_rename`. Works on both Data Warehouses and SQL Analytics Endpoints. The new name must be a bare (unqualified) identifier — `sp_rename` cannot move a view across schemas.
+Rename a SQL view via `sp_rename`. Works on both Data Warehouses and SQL Analytics Endpoints. The new name must be a bare (unqualified) identifier - `sp_rename` cannot move a view across schemas.
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `item` (`str`) — warehouse or SQL analytics endpoint name or GUID.
-- `qualified_name` (`str`) — current dot-separated qualified view name, e.g. `dbo.vw_sales`.
-- `new_name` (`str`) — new bare view name (no schema prefix), e.g. `vw_revenue`.
+- `workspace` (`str`): workspace name or GUID.
+- `item` (`str`): warehouse or SQL analytics endpoint name or GUID.
+- `qualified_name` (`str`): current dot-separated qualified view name, e.g. `dbo.vw_sales`.
+- `new_name` (`str`): new bare view name (no schema prefix), e.g. `vw_revenue`.
 
-**Returns:** `View` — the updated view object (fetched after rename, includes `definition`).
+**Returns:** `View`: the updated view object (fetched after rename, includes `definition`).
 
 ---
 
@@ -419,9 +419,9 @@ Redefine an existing SQL view using `CREATE OR ALTER VIEW`.
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `item` (`str`) — warehouse or SQL analytics endpoint name or GUID.
-- `qualified_name` (`str`) — dot-separated schema and view name, e.g. `dbo.vw_sales`.
-- `select_body` (`str`) — the new SELECT statement; executed verbatim as DDL.
+- `workspace` (`str`): workspace name or GUID.
+- `item` (`str`): warehouse or SQL analytics endpoint name or GUID.
+- `qualified_name` (`str`): dot-separated schema and view name, e.g. `dbo.vw_sales`.
+- `select_body` (`str`): the new SELECT statement; executed verbatim as DDL.
 
-**Returns:** `View` — the updated view object (fetched after DDL, includes `definition`).
+**Returns:** `View`: the updated view object (fetched after DDL, includes `definition`).

--- a/docs/commands/warehouses.md
+++ b/docs/commands/warehouses.md
@@ -211,12 +211,12 @@ Create a new Warehouse in a workspace.
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `name` (`str`) — display name for the new warehouse.
-- `collation` (`str | null`, optional) — default collation for the new warehouse.
-- `description` (`str | null`, optional) — description for the new warehouse.
+- `workspace` (`str`): workspace name or GUID.
+- `name` (`str`): display name for the new warehouse.
+- `collation` (`str | null`, optional): default collation for the new warehouse.
+- `description` (`str | null`, optional): description for the new warehouse.
 
-**Returns:** `Warehouse` — the newly-created warehouse object.
+**Returns:** `Warehouse`: the newly-created warehouse object.
 
 ---
 
@@ -228,10 +228,10 @@ Delete a Warehouse.
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `warehouse` (`str`) — warehouse name or GUID.
+- `workspace` (`str`): workspace name or GUID.
+- `warehouse` (`str`): warehouse name or GUID.
 
-**Returns:** `{ "deleted": true, "warehouse_id": str }` — confirmation with the warehouse GUID.
+**Returns:** `{ "deleted": true, "warehouse_id": str }`: confirmation with the warehouse GUID.
 
 ---
 
@@ -243,10 +243,10 @@ Return details for a single Data Warehouse. Uses the warehouse-scoped REST path 
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `warehouse` (`str`) — warehouse name or GUID.
+- `workspace` (`str`): workspace name or GUID.
+- `warehouse` (`str`): warehouse name or GUID.
 
-**Returns:** `Warehouse` — single warehouse object (fields as above).
+**Returns:** `Warehouse`: single warehouse object (fields as above).
 
 ---
 
@@ -262,10 +262,10 @@ Return all principals (users, groups, service principals) with access to a Wareh
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `warehouse` (`str`) — warehouse name or GUID.
+- `workspace` (`str`): workspace name or GUID.
+- `warehouse` (`str`): warehouse name or GUID.
 
-**Returns:** `list[ItemAccess]` — array of access records, each with `principal` (containing `id`, `displayName`, `type`, and type-specific fields such as `userPrincipalName` or `aadAppId`) and `itemAccessDetails` (containing `type`, `permissions`, and `additionalPermissions`).
+**Returns:** `list[ItemAccess]`: array of access records, each with `principal` (containing `id`, `displayName`, `type`, and type-specific fields such as `userPrincipalName` or `aadAppId`) and `itemAccessDetails` (containing `type`, `permissions`, and `additionalPermissions`).
 
 ---
 
@@ -277,10 +277,10 @@ List all warehouses and SQL analytics endpoints in a workspace, or across all vi
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID; required when `all_workspaces` is `false`; ignored when `true`.
-- `all_workspaces` (`bool`, default `false`) — when `true`, aggregate results across every workspace the caller can see.
+- `workspace` (`str`): workspace name or GUID; required when `all_workspaces` is `false`; ignored when `true`.
+- `all_workspaces` (`bool`, default `false`): when `true`, aggregate results across every workspace the caller can see.
 
-**Returns:** `list[Warehouse]` — array of warehouse objects, each with `id`, `displayName`, `description`, `workspaceId`, `kind` (`Warehouse` or `SQLEndpoint`), `connectionString`, `defaultCollation`, and `createdDate`.
+**Returns:** `list[Warehouse]`: array of warehouse objects, each with `id`, `displayName`, `description`, `workspaceId`, `kind` (`Warehouse` or `SQLEndpoint`), `connectionString`, `defaultCollation`, and `createdDate`.
 
 ---
 
@@ -292,12 +292,12 @@ Rename a Warehouse and optionally update its description.
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `warehouse` (`str`) — warehouse name or GUID.
-- `new_name` (`str`) — new display name.
-- `description` (`str | null`, optional) — new description; omit to leave unchanged.
+- `workspace` (`str`): workspace name or GUID.
+- `warehouse` (`str`): warehouse name or GUID.
+- `new_name` (`str`): new display name.
+- `description` (`str | null`, optional): new description; omit to leave unchanged.
 
-**Returns:** `Warehouse` — the updated warehouse object.
+**Returns:** `Warehouse`: the updated warehouse object.
 
 ---
 
@@ -309,7 +309,7 @@ Take ownership of a Warehouse. Not supported for SQL analytics endpoints.
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `warehouse` (`str`) — warehouse name or GUID.
+- `workspace` (`str`): workspace name or GUID.
+- `warehouse` (`str`): warehouse name or GUID.
 
-**Returns:** `{ "taken_over": true, "warehouse_id": str }` — confirmation with the warehouse GUID.
+**Returns:** `{ "taken_over": true, "warehouse_id": str }`: confirmation with the warehouse GUID.

--- a/docs/commands/workspaces.md
+++ b/docs/commands/workspaces.md
@@ -4,7 +4,7 @@ title: Workspaces
 
 # Workspaces
 
-Manage Microsoft Fabric workspaces — list all workspaces the authenticated principal can see, inspect a single workspace's details (including its default Data Warehouse collation), and update that collation. All workspace commands operate at the workspace level and do not target a specific Data Warehouse or SQL Analytics Endpoint item.
+Manage Microsoft Fabric workspaces - list all workspaces the authenticated principal can see, inspect a single workspace's details (including its default Data Warehouse collation), and update that collation. All workspace commands operate at the workspace level and do not target a specific Data Warehouse or SQL Analytics Endpoint item.
 
 **Targets:** Workspace (not item-specific)
 
@@ -34,7 +34,7 @@ fdw workspaces assign-capacity [WORKSPACE] --capacity-id <UUID>
 
 **Options**
 
-- `--capacity-id` (`UUID`, required) — UUID of the capacity to assign the workspace to.
+- `--capacity-id` (`UUID`, required): UUID of the capacity to assign the workspace to.
 
 **Example**
 
@@ -161,10 +161,10 @@ Assign a workspace to a Fabric capacity. This is a mutating operation and is blo
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `capacity_id` (`str`) — UUID of the capacity to assign the workspace to.
+- `workspace` (`str`): workspace name or GUID.
+- `capacity_id` (`str`): UUID of the capacity to assign the workspace to.
 
-**Returns:** `{ "workspace_id": str, "capacity_id": str }` — the workspace GUID and the capacity GUID.
+**Returns:** `{ "workspace_id": str, "capacity_id": str }`: the workspace GUID and the capacity GUID.
 
 ---
 
@@ -176,9 +176,9 @@ Return details for a single workspace.
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
+- `workspace` (`str`): workspace name or GUID.
 
-**Returns:** `Workspace` — single workspace object (fields as above).
+**Returns:** `Workspace`: single workspace object (fields as above).
 
 ---
 
@@ -190,7 +190,7 @@ List all Fabric capacities the authenticated principal has access to. Requires t
 
 **Parameters:** None
 
-**Returns:** `list[Capacity]` — array of capacity objects, each with `id`, `displayName`, `sku`, `region`, and `state`.
+**Returns:** `list[Capacity]`: array of capacity objects, each with `id`, `displayName`, `sku`, `region`, and `state`.
 
 ---
 
@@ -202,7 +202,7 @@ List all Fabric workspaces the authenticated principal has access to.
 
 **Parameters:** None
 
-**Returns:** `list[Workspace]` — array of workspace objects, each with `id`, `displayName`, `description`, `capacityId`, and `defaultDatasetStorageFormat`.
+**Returns:** `list[Workspace]`: array of workspace objects, each with `id`, `displayName`, `description`, `capacityId`, and `defaultDatasetStorageFormat`.
 
 ---
 
@@ -214,7 +214,7 @@ Set the default Data Warehouse collation for a workspace.
 
 **Parameters:**
 
-- `workspace` (`str`) — workspace name or GUID.
-- `collation` (`str`) — collation name (must be a supported Fabric collation).
+- `workspace` (`str`): workspace name or GUID.
+- `collation` (`str`): collation name (must be a supported Fabric collation).
 
-**Returns:** `{ "workspace_id": str, "collation": str }` — the workspace GUID and the newly-set collation.
+**Returns:** `{ "workspace_id": str, "collation": str }`: the workspace GUID and the newly-set collation.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -12,15 +12,15 @@ The sections below describe cross-cutting concepts that apply to all `fdw`/`fabr
 
 Fabric has two SQL-surface item kinds:
 
-- **Data Warehouse** — read-write, supports full DDL (CREATE/DROP/TRUNCATE TABLE, CREATE/DROP SCHEMA, CREATE/ALTER VIEW, etc.).
-- **SQL Analytics Endpoint** — read-only SQL surface auto-generated over a Lakehouse. DDL and mutating operations are not supported; only read/query operations are allowed.
+- **Data Warehouse**: read-write, supports full DDL (CREATE/DROP/TRUNCATE TABLE, CREATE/DROP SCHEMA, CREATE/ALTER VIEW, etc.).
+- **SQL Analytics Endpoint**: read-only SQL surface auto-generated over a Lakehouse. DDL and mutating operations are not supported; only read/query operations are allowed.
 
 Each command below is labelled with one of:
 
-- **`Targets: Data Warehouse · SQL Analytics Endpoint`** — the command works on both item kinds.
-- **`Targets: Data Warehouse only`** — the command is blocked on SQL Analytics Endpoints (either by an explicit client-side guard in the source code, because it requires write/DDL capability that endpoints do not have, or because it calls warehouse-scoped REST API paths that are not available for SQL Analytics Endpoints).
-- **`Targets: SQL Analytics Endpoint`** — the command operates on SQL Analytics Endpoints specifically (not on Data Warehouses).
-- **`Targets: Workspace (not item-specific)`** — the command operates at the workspace level and does not target a specific DW or SQL Analytics Endpoint item.
+- **`Targets: Data Warehouse · SQL Analytics Endpoint`**: the command works on both item kinds.
+- **`Targets: Data Warehouse only`**: the command is blocked on SQL Analytics Endpoints (either by an explicit client-side guard in the source code, because it requires write/DDL capability that endpoints do not have, or because it calls warehouse-scoped REST API paths that are not available for SQL Analytics Endpoints).
+- **`Targets: SQL Analytics Endpoint`**: the command operates on SQL Analytics Endpoints specifically (not on Data Warehouses).
+- **`Targets: Workspace (not item-specific)`**: the command operates at the workspace level and does not target a specific DW or SQL Analytics Endpoint item.
 
 ---
 
@@ -30,8 +30,8 @@ These options are placed immediately after `fabric-dw` (or `fdw`), before the co
 
 | Flag | Description | Default |
 | --- | --- | --- |
-| `-V` / `--version` | Print the installed `fabric-dw` version and exit. | — |
-| `-w` / `--workspace TEXT` | Target workspace (name or GUID). Overrides the `FABRIC_DW_DEFAULT_WORKSPACE` environment variable and the configured default. See [Selecting a workspace](#selecting-a-workspace). | — |
+| `-V` / `--version` | Print the installed `fabric-dw` version and exit. | - |
+| `-w` / `--workspace TEXT` | Target workspace (name or GUID). Overrides the `FABRIC_DW_DEFAULT_WORKSPACE` environment variable and the configured default. See [Selecting a workspace](#selecting-a-workspace). | - |
 | `--json` | Emit machine-readable JSON instead of Rich tables. | off |
 | `--auth {default\|sp\|interactive}` | Override `FABRIC_AUTH` for this invocation. | `default` |
 | `-y` / `--yes` | Skip confirmation prompts on destructive commands. | off |
@@ -45,20 +45,20 @@ The `--auth` flag and the `FABRIC_AUTH` environment variable accept the same thr
 
 Every command that operates on a workspace (everything except `workspaces list` and `cache clear`) resolves the target workspace from the following sources, in priority order:
 
-1. **`-w` / `--workspace` flag** — explicit value passed on the root command, e.g. `fdw -w MyWorkspace warehouses list`.
-2. **`FABRIC_DW_DEFAULT_WORKSPACE` environment variable** — if the flag is absent, the CLI reads this variable.
-3. **Configured default** — set with `fdw config set workspace VALUE`; used when neither the flag nor the environment variable is present.
-4. **Error** — if none of the above is set, the CLI prints a helpful message suggesting you set one of the above.
+1. **`-w` / `--workspace` flag**: explicit value passed on the root command, e.g. `fdw -w MyWorkspace warehouses list`.
+2. **`FABRIC_DW_DEFAULT_WORKSPACE` environment variable**: if the flag is absent, the CLI reads this variable.
+3. **Configured default**: set with `fdw config set workspace VALUE`; used when neither the flag nor the environment variable is present.
+4. **Error**: if none of the above is set, the CLI prints a helpful message suggesting you set one of the above.
 
 The `workspaces` command group is an exception: `workspaces get` and `workspaces set-collation` take the workspace as an explicit positional argument (not via `-w`), and `workspaces list` takes no workspace at all.
 
 !!! note "-A / --all-workspaces interaction"
 
-    Passing `-A` on the two list commands that support it (`warehouses list`, `sql-endpoints list`) explicitly scans every visible workspace. This flag is mutually exclusive with `-w` (an explicit `-w` conflicts with scanning all workspaces), but it does **not** conflict with a configured default workspace or `FABRIC_DW_DEFAULT_WORKSPACE` — the configured default is silently ignored when `-A` is used.
+    Passing `-A` on the two list commands that support it (`warehouses list`, `sql-endpoints list`) explicitly scans every visible workspace. This flag is mutually exclusive with `-w` (an explicit `-w` conflicts with scanning all workspaces), but it does **not** conflict with a configured default workspace or `FABRIC_DW_DEFAULT_WORKSPACE`: the configured default is silently ignored when `-A` is used.
 
 ---
 
 ## Name-or-GUID resolution
 
 !!! note "Name-or-GUID resolution"
-    All `workspace`, `warehouse`, `endpoint`, and `snapshot` parameters — on both `fdw`/`fabric-dw` commands and the MCP tools — accept either the item's display name or its GUID. The resolver translates names to GUIDs automatically and caches the mapping locally. Use `fdw cache clear` (CLI) or the `clear_cache` MCP tool to force a fresh lookup after renaming items outside this tool.
+    All `workspace`, `warehouse`, `endpoint`, and `snapshot` parameters - on both `fdw`/`fabric-dw` commands and the MCP tools - accept either the item's display name or its GUID. The resolver translates names to GUIDs automatically and caches the mapping locally. Use `fdw cache clear` (CLI) or the `clear_cache` MCP tool to force a fresh lookup after renaming items outside this tool.

--- a/docs/guides/dbt-setup.md
+++ b/docs/guides/dbt-setup.md
@@ -108,7 +108,7 @@ If a service principal or team needs access (for example, the identity that will
 fdw dbt init SalesWH ./sales_dbt
 ```
 
-This writes `dbt_project.yml`, `profiles.yml`, `requirements.txt`, `.gitignore`, the standard dbt directories, a sample model, a `README.md`, and a `models/staging/_sources.yml` (a placeholder, or **real source definitions** with `--with-sources`: see [Step 4](#step-4-provision-all-your-dbt-sources)). If `git` is on your PATH and the folder is not already a repository, `git init` runs automatically. No dbt installation is required to scaffold - `fabric-dw` writes every file itself.
+This writes `dbt_project.yml`, `profiles.yml`, `requirements.txt`, `.gitignore`, the standard dbt directories, a sample model, a `README.md`, and a `models/staging/_sources.yml` (a placeholder, or **real source definitions** with `--with-sources` - see [Step 4](#step-4-provision-all-your-dbt-sources)). If `git` is on your PATH and the folder is not already a repository, `git init` runs automatically. No dbt installation is required to scaffold - `fabric-dw` writes every file itself.
 
 ### The connection is configured for you
 

--- a/docs/guides/dbt-setup.md
+++ b/docs/guides/dbt-setup.md
@@ -4,45 +4,45 @@ title: dbt setup
 
 # Set up a dbt environment
 
-This guide walks an analytics engineer end-to-end through standing up a working [dbt](https://docs.getdbt.com/) environment on a Microsoft Fabric Data Warehouse with `fabric-dw`. The headline feature is `fdw dbt init --with-sources`: it **introspects the live warehouse and writes a complete `models/staging/_sources.yml`** — one dbt `source:` per schema, listing every table (with column names and types) — so you never hand-author source definitions:
+This guide walks an analytics engineer end-to-end through standing up a working [dbt](https://docs.getdbt.com/) environment on a Microsoft Fabric Data Warehouse with `fabric-dw`. The headline feature is `fdw dbt init --with-sources`: it **introspects the live warehouse and writes a complete `models/staging/_sources.yml`**: one dbt `source:` per schema, listing every table (with column names and types) - so you never hand-author source definitions:
 
 1. **Provision** a new Warehouse.
 2. **Scaffold** a dbt project for the [dbt-fabric](https://docs.getdbt.com/docs/core/connect-data-platform/fabric-setup) adapter, with the connection details (host + database) filled in automatically.
-3. **Provision all your dbt sources** — `--with-sources` generates `_sources.yml` from the warehouse's real schemas and tables.
+3. **Provision all your dbt sources**: `--with-sources` generates `_sources.yml` from the warehouse's real schemas and tables.
 4. **Verify** the connection with `dbt debug` and build a model with `dbt run`.
 
 Microsoft's own [tutorial](https://learn.microsoft.com/fabric/data-warehouse/tutorial-setup-dbt?WT.mc_id=MVP_310840) requires you to find the SQL analytics endpoint in the portal, hand-author `profiles.yml`, and write every source definition yourself. `fabric-dw` automates all of that, so this guide closes the gap between Microsoft's manual portal steps and a fully scriptable path.
 
 !!! tip "Using an AI assistant? The `dbt-setup` skill does all of this for you"
 
-    Everything below is the **human, copy-pasteable narrative** for someone driving `fabric-dw` from a terminal. If you drive an AI assistant (Claude) against the [MCP server](../install.md#mcp), the shipped [`dbt-setup` Agent Skill](../skills.md#dbt-setup) automates the same provision → scaffold → sources → verify flow through the MCP tools. The CLI commands here and the skill are two front-ends to the same logic — pick whichever fits your workflow.
+    Everything below is the **human, copy-pasteable narrative** for someone driving `fabric-dw` from a terminal. If you drive an AI assistant (Claude) against the [MCP server](../install.md#mcp), the shipped [`dbt-setup` Agent Skill](../skills.md#dbt-setup) automates the same provision → scaffold → sources → verify flow through the MCP tools. The CLI commands here and the skill are two front-ends to the same logic - pick whichever fits your workflow.
 
 ---
 
 ## Prerequisites
 
 - A Fabric **workspace** on an active capacity (Trial, Premium, or Fabric capacity).
-- **Python 3.11+** — needed both by `fabric-dw` and by dbt itself.
-- **Microsoft ODBC Driver 18 for SQL Server** — required by the dbt-fabric adapter (it connects over [TDS via `pyodbc`](https://learn.microsoft.com/fabric/data-warehouse/how-to-connect?WT.mc_id=MVP_310840#connect-using-dbt)):
+- **Python 3.11+**: needed both by `fabric-dw` and by dbt itself.
+- **Microsoft ODBC Driver 18 for SQL Server**: required by the dbt-fabric adapter (it connects over [TDS via `pyodbc`](https://learn.microsoft.com/fabric/data-warehouse/how-to-connect?WT.mc_id=MVP_310840#connect-using-dbt)):
     - Windows: [download from Microsoft](https://learn.microsoft.com/sql/connect/odbc/download-odbc-driver-for-sql-server?WT.mc_id=MVP_310840)
     - macOS: `brew install microsoft/mssql-release/msodbcsql18`
     - Linux: [install instructions](https://learn.microsoft.com/sql/connect/odbc/linux-mac/installing-the-microsoft-odbc-driver-for-sql-server?WT.mc_id=MVP_310840)
-- **`fabric-dw` installed** — see [Install](../install.md).
-- A signed-in identity — `az login`, or service-principal environment variables (see the next step).
+- **`fabric-dw` installed**: see [Install](../install.md).
+- A signed-in identity - `az login`, or service-principal environment variables (see the next step).
 
-!!! note "Entra ID only — no SQL authentication"
+!!! note "Entra ID only - no SQL authentication"
 
     dbt-fabric authenticates with **Microsoft Entra ID** identities (users, service principals); SQL username/password authentication is **not supported**. See [Connect using dbt](https://learn.microsoft.com/fabric/data-warehouse/how-to-connect?WT.mc_id=MVP_310840#connect-using-dbt). `fabric-dw` uses the same Entra-based credential chain, so once you can run `fdw` you have everything dbt needs.
 
 ---
 
-## Step 1 — Sign in
+## Step 1 - Sign in
 
 `fabric-dw` selects how it authenticates via the global `--auth` option (it is **not** controlled by an environment variable):
 
 | `--auth` value | What it uses |
 | --- | --- |
-| `default` (default) | `azure-identity`'s `DefaultAzureCredential` chain — Azure CLI, Managed Identity, environment variables, browser fallback. |
+| `default` (default) | `azure-identity`'s `DefaultAzureCredential` chain - Azure CLI, Managed Identity, environment variables, browser fallback. |
 | `interactive` | A browser pop-up sign-in. |
 | `sp` | A service principal, read from `AZURE_TENANT_ID` / `AZURE_CLIENT_ID` / `AZURE_CLIENT_SECRET`. |
 
@@ -60,7 +60,7 @@ export AZURE_CLIENT_ID=<your-client-id>
 export AZURE_CLIENT_SECRET=<your-client-secret>
 ```
 
-Microsoft recommends interactive (`CLI`) auth for working on a warehouse by hand, and service principals for automation — see the [tutorial's considerations](https://learn.microsoft.com/fabric/data-warehouse/tutorial-setup-dbt?WT.mc_id=MVP_310840#considerations). The mode you choose here is also what the scaffolder maps into the dbt profile in [Step 3](#step-3-scaffold-the-dbt-project).
+Microsoft recommends interactive (`CLI`) auth for working on a warehouse by hand, and service principals for automation - see the [tutorial's considerations](https://learn.microsoft.com/fabric/data-warehouse/tutorial-setup-dbt?WT.mc_id=MVP_310840#considerations). The mode you choose here is also what the scaffolder maps into the dbt profile in [Step 3](#step-3-scaffold-the-dbt-project).
 
 See the [Authentication reference](../authentication.md) for the full credential chain and every environment variable.
 
@@ -72,14 +72,14 @@ Once you are signed in, store the workspace so you do not repeat it on every com
 
 ```shell
 fdw config set workspace "Sales Workspace"
-fdw config set warehouse SalesWH        # optional — once the warehouse exists (Step 2)
+fdw config set warehouse SalesWH        # optional - once the warehouse exists (Step 2)
 ```
 
 The rest of this guide assumes the workspace default is set, so the examples omit `-w "Sales Workspace"`. Any command still accepts an explicit `-w`/`--workspace NAME|GUID` to override it. The warehouse default fills optional `[ITEM]` positionals once the warehouse has been provisioned; commands here that take a required name (`warehouses create NAME`, `dbt init … FOLDER`, `sql-endpoints get ENDPOINT`) still spell out the warehouse. See [Configuration & defaults](../commands/config.md).
 
 ---
 
-## Step 2 — Provision the warehouse
+## Step 2 - Provision the warehouse
 
 Create a new warehouse with [`fdw warehouses create`](../commands/warehouses.md#warehouses-create). `NAME` is positional; the workspace comes from the global `-w` option.
 
@@ -87,12 +87,12 @@ Create a new warehouse with [`fdw warehouses create`](../commands/warehouses.md#
 fdw warehouses create SalesWH --description "dbt target warehouse"
 ```
 
-`fabric-dw` issues the create request, **polls the create operation to completion**, and re-reads the warehouse so the returned object is fully populated — when the command returns, the warehouse is ready to connect to.
+`fabric-dw` issues the create request, **polls the create operation to completion**, and re-reads the warehouse so the returned object is fully populated - when the command returns, the warehouse is ready to connect to.
 
 If a service principal or team needs access (for example, the identity that will run dbt in CI), grant it now:
 
-- [`fdw warehouses takeover`](../commands/warehouses.md#warehouses-takeover) — take ownership of the warehouse.
-- [`fdw warehouses permissions`](../commands/warehouses.md#warehouses-permissions) — list principals and their effective permissions (requires the **Fabric Administrator** role).
+- [`fdw warehouses takeover`](../commands/warehouses.md#warehouses-takeover) - take ownership of the warehouse.
+- [`fdw warehouses permissions`](../commands/warehouses.md#warehouses-permissions) - list principals and their effective permissions (requires the **Fabric Administrator** role).
 
 !!! tip "AI-assistant equivalent"
 
@@ -100,7 +100,7 @@ If a service principal or team needs access (for example, the identity that will
 
 ---
 
-## Step 3 — Scaffold the dbt project
+## Step 3 - Scaffold the dbt project
 
 [`fdw dbt init`](../commands/dbt.md#dbt-init) creates the whole project directory pre-wired to the warehouse. `ITEM` (the warehouse name or GUID) is optional if you set a default warehouse; `FOLDER` is the target directory.
 
@@ -108,22 +108,22 @@ If a service principal or team needs access (for example, the identity that will
 fdw dbt init SalesWH ./sales_dbt
 ```
 
-This writes `dbt_project.yml`, `profiles.yml`, `requirements.txt`, `.gitignore`, the standard dbt directories, a sample model, a `README.md`, and a `models/staging/_sources.yml` (a placeholder, or **real source definitions** with `--with-sources` — see [Step 4](#step-4-provision-all-your-dbt-sources)). If `git` is on your PATH and the folder is not already a repository, `git init` runs automatically. No dbt installation is required to scaffold — `fabric-dw` writes every file itself.
+This writes `dbt_project.yml`, `profiles.yml`, `requirements.txt`, `.gitignore`, the standard dbt directories, a sample model, a `README.md`, and a `models/staging/_sources.yml` (a placeholder, or **real source definitions** with `--with-sources`: see [Step 4](#step-4-provision-all-your-dbt-sources)). If `git` is on your PATH and the folder is not already a repository, `git init` runs automatically. No dbt installation is required to scaffold - `fabric-dw` writes every file itself.
 
 ### The connection is configured for you
 
 You do **not** hand-author `profiles.yml`. `fdw dbt init` resolves the warehouse's SQL analytics endpoint itself and fills in the two values dbt needs:
 
-- **`host`** — the SQL analytics endpoint TDS server (`<guid>.datawarehouse.fabric.microsoft.com`), polled until the connection string is ready (the endpoint is eventually consistent right after `create`).
-- **`database`** — the warehouse display name (Fabric uses the item name as the Initial Catalog). For `SalesWH`, the database is simply `SalesWH`.
+- **`host`**: the SQL analytics endpoint TDS server (`<guid>.datawarehouse.fabric.microsoft.com`), polled until the connection string is ready (the endpoint is eventually consistent right after `create`).
+- **`database`**: the warehouse display name (Fabric uses the item name as the Initial Catalog). For `SalesWH`, the database is simply `SalesWH`.
 
-The `authentication` value is mapped from your sign-in mode (`default` → `auto`, `interactive` → `CLI`, `sp` → `ServicePrincipal`). With `--auth sp`, secrets are emitted as Jinja2 `env_var()` placeholders — never literal secrets — so the file is safe to commit. The full option list (`--schema`, `--target`, `--threads`, `--profiles-dir`, `--auth`, …), the exact generated `profiles.yml`, and the auth mapping live in the [dbt command reference](../commands/dbt.md#dbt-init); the credential chain is in the [Authentication reference](../authentication.md).
+The `authentication` value is mapped from your sign-in mode (`default` → `auto`, `interactive` → `CLI`, `sp` → `ServicePrincipal`). With `--auth sp`, secrets are emitted as Jinja2 `env_var()` placeholders - never literal secrets - so the file is safe to commit. The full option list (`--schema`, `--target`, `--threads`, `--profiles-dir`, `--auth`, …), the exact generated `profiles.yml`, and the auth mapping live in the [dbt command reference](../commands/dbt.md#dbt-init); the credential chain is in the [Authentication reference](../authentication.md).
 
 ---
 
-## Step 4 — Provision all your dbt sources
+## Step 4 - Provision all your dbt sources
 
-This is the part you would otherwise do by hand. Add `--with-sources` and `fdw dbt init` **introspects the live warehouse** and writes a complete `models/staging/_sources.yml` — so you never type out a source definition:
+This is the part you would otherwise do by hand. Add `--with-sources` and `fdw dbt init` **introspects the live warehouse** and writes a complete `models/staging/_sources.yml`: so you never type out a source definition:
 
 ```shell
 fdw dbt init SalesWH ./sales_dbt --with-sources
@@ -161,7 +161,7 @@ sources:
       - name: my_first_model
 ```
 
-Without `--with-sources`, the placeholder looks like this — replace it with your own definitions:
+Without `--with-sources`, the placeholder looks like this - replace it with your own definitions:
 
 ```yaml
 version: 2
@@ -175,7 +175,7 @@ sources:
 
 ### Reference the sources from your models
 
-dbt models read from these sources with the [`source()`](https://docs.getdbt.com/reference/dbt-jinja-functions/source) function — `{{ source('<schema>', '<table>') }}`, where the first argument is the `source:` name (the schema) and the second is the table:
+dbt models read from these sources with the [`source()`](https://docs.getdbt.com/reference/dbt-jinja-functions/source) function - `{{ source('<schema>', '<table>') }}`, where the first argument is the `source:` name (the schema) and the second is the table:
 
 ```sql
 -- models/staging/stg_customers.sql
@@ -189,7 +189,7 @@ Because every schema and table is already declared in `_sources.yml`, `source()`
 
 ---
 
-## Step 5 — Verify
+## Step 5 - Verify
 
 Install the dbt dependencies in a **separate environment** (the scaffolded `requirements.txt` pins `dbt-core` and `dbt-fabric`), then verify the connection and build the sample model:
 
@@ -209,7 +209,7 @@ A passing `dbt debug` confirms the host, database, ODBC driver, and authenticati
 You can cross-check from `fabric-dw` itself that the model landed:
 
 ```shell
-# Confirm the warehouse answers SQL (warehouse positional spelled out — the warehouse default is optional in this guide)
+# Confirm the warehouse answers SQL (warehouse positional spelled out - the warehouse default is optional in this guide)
 fdw sql exec SalesWH -q "select 1"
 
 # List the tables/views the run produced
@@ -224,28 +224,28 @@ fdw tables list SalesWH
 
 ## Doing it from an AI assistant
 
-If you drive an AI client over the [MCP server](../install.md#mcp), the same scaffold is available as the [`generate_dbt_profile`](../commands/dbt.md#generate_dbt_profile) tool. Unlike the CLI, it does **not** write files — the MCP server cannot touch the caller's filesystem, so it returns each file's contents as a string:
+If you drive an AI client over the [MCP server](../install.md#mcp), the same scaffold is available as the [`generate_dbt_profile`](../commands/dbt.md#generate_dbt_profile) tool. Unlike the CLI, it does **not** write files - the MCP server cannot touch the caller's filesystem, so it returns each file's contents as a string:
 
 - `profiles_yml`
 - `dbt_project_yml`
-- `sources_yml` — the same `models/staging/_sources.yml` content as the CLI: **real source definitions for every schema and table when called with `with_sources=True`**, otherwise the placeholder.
+- `sources_yml`: the same `models/staging/_sources.yml` content as the CLI: **real source definitions for every schema and table when called with `with_sources=True`**, otherwise the placeholder.
 - `requirements_txt`
 - `gitignore`
 
-The AI agent writes those strings to disk itself. The shipped [`dbt-setup` Agent Skill](../skills.md#dbt-setup) orchestrates the whole flow — it resolves the warehouse with `get_warehouse`, confirms connectivity with `list_schemas` / `list_tables`, calls `generate_dbt_profile` with `with_sources=True` to provision the sources, writes the files, and tells you to run `pip install -r requirements.txt`, `dbt debug`, and `dbt run`. In short: **the guide is the CLI narrative; the skill is the assistant-driven equivalent.**
+The AI agent writes those strings to disk itself. The shipped [`dbt-setup` Agent Skill](../skills.md#dbt-setup) orchestrates the whole flow - it resolves the warehouse with `get_warehouse`, confirms connectivity with `list_schemas` / `list_tables`, calls `generate_dbt_profile` with `with_sources=True` to provision the sources, writes the files, and tells you to run `pip install -r requirements.txt`, `dbt debug`, and `dbt run`. In short: **the guide is the CLI narrative; the skill is the assistant-driven equivalent.**
 
 ---
 
 ## Next steps & references
 
-- [dbt command reference](../commands/dbt.md) — every `fdw dbt init` option and the `generate_dbt_profile` MCP tool.
-- [Authentication reference](../authentication.md) — the full credential chain and environment variables.
-- [MCP server install](../install.md#mcp) — configure the MCP server in your AI client.
-- [Agent Skills](../skills.md) — including the [`dbt-setup` skill](../skills.md#dbt-setup) that automates this guide.
-- [Set up dbt for Fabric Data Warehouse](https://learn.microsoft.com/fabric/data-warehouse/tutorial-setup-dbt?WT.mc_id=MVP_310840) — Microsoft's canonical tutorial.
-- [Microsoft Entra authentication for the warehouse](https://learn.microsoft.com/fabric/data-warehouse/entra-id-authentication?WT.mc_id=MVP_310840) — Entra modes and the `<guid>.datawarehouse.fabric.microsoft.com` server format.
-- [Warehouse connectivity](https://learn.microsoft.com/fabric/data-warehouse/connectivity?WT.mc_id=MVP_310840) — TDS on port 1433 and the connection-string semantics.
-- [Create a warehouse](https://learn.microsoft.com/fabric/data-warehouse/create-warehouse?WT.mc_id=MVP_310840) — portal/REST context for what `warehouses create` automates.
+- [dbt command reference](../commands/dbt.md) - every `fdw dbt init` option and the `generate_dbt_profile` MCP tool.
+- [Authentication reference](../authentication.md) - the full credential chain and environment variables.
+- [MCP server install](../install.md#mcp) - configure the MCP server in your AI client.
+- [Agent Skills](../skills.md) - including the [`dbt-setup` skill](../skills.md#dbt-setup) that automates this guide.
+- [Set up dbt for Fabric Data Warehouse](https://learn.microsoft.com/fabric/data-warehouse/tutorial-setup-dbt?WT.mc_id=MVP_310840) - Microsoft's canonical tutorial.
+- [Microsoft Entra authentication for the warehouse](https://learn.microsoft.com/fabric/data-warehouse/entra-id-authentication?WT.mc_id=MVP_310840) - Entra modes and the `<guid>.datawarehouse.fabric.microsoft.com` server format.
+- [Warehouse connectivity](https://learn.microsoft.com/fabric/data-warehouse/connectivity?WT.mc_id=MVP_310840) - TDS on port 1433 and the connection-string semantics.
+- [Create a warehouse](https://learn.microsoft.com/fabric/data-warehouse/create-warehouse?WT.mc_id=MVP_310840) - portal/REST context for what `warehouses create` automates.
 - [dbt-fabric adapter setup](https://docs.getdbt.com/docs/core/connect-data-platform/fabric-setup) and [resource configs](https://docs.getdbt.com/reference/resource-configs/fabric-configs).
 </content>
 </invoke>

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -8,8 +8,8 @@ Task-oriented walkthroughs that thread several `fabric-dw` commands and MCP tool
 
 ## Available guides
 
-- **[dbt setup](dbt-setup.md)** — Stand up a working dbt environment on a Fabric Data Warehouse: provision, scaffold the `dbt-fabric` project, generate `_sources.yml` from the live warehouse, and verify with `dbt debug`/`dbt run`.
-- **[Ingesting data](ingesting-data.md)** — Get CSV, Parquet, or JSON files into a warehouse table end to end: create the schema and table, stage and load via `COPY INTO`, verify, and refresh statistics.
-- **[Query performance](query-performance.md)** — Find and fix slow queries with an investigate → diagnose → improve → verify loop across the `queries`, `sql`, `statistics`, `sql-pools`, and `settings` groups.
-- **[Tables & views](tables-and-views.md)** — Build out a schema model from an empty schema through populated tables to reporting views, with the statistics that keep the optimizer honest.
-- **[Warehouse performance](warehouse-performance.md)** — A monitor → diagnose → tune/scale playbook at the warehouse and capacity level for when the warehouse feels slow or throttled.
+- **[dbt setup](dbt-setup.md)**: Stand up a working dbt environment on a Fabric Data Warehouse: provision, scaffold the `dbt-fabric` project, generate `_sources.yml` from the live warehouse, and verify with `dbt debug`/`dbt run`.
+- **[Ingesting data](ingesting-data.md)**: Get CSV, Parquet, or JSON files into a warehouse table end to end: create the schema and table, stage and load via `COPY INTO`, verify, and refresh statistics.
+- **[Query performance](query-performance.md)**: Find and fix slow queries with an investigate → diagnose → improve → verify loop across the `queries`, `sql`, `statistics`, `sql-pools`, and `settings` groups.
+- **[Tables & views](tables-and-views.md)**: Build out a schema model from an empty schema through populated tables to reporting views, with the statistics that keep the optimizer honest.
+- **[Warehouse performance](warehouse-performance.md)**: A monitor → diagnose → tune/scale playbook at the warehouse and capacity level for when the warehouse feels slow or throttled.

--- a/docs/guides/ingesting-data.md
+++ b/docs/guides/ingesting-data.md
@@ -4,7 +4,7 @@ title: Ingesting data
 
 # Ingesting data
 
-This guide walks through getting file-based data — CSV, Parquet, or JSON — into a Microsoft Fabric Data Warehouse table with `fabric-dw`, end to end: create the schema, create the destination table, stage and load the data via `COPY INTO`, verify the result, and refresh statistics. It covers both the CLI (`fdw …`) and the MCP server (for AI assistants).
+This guide walks through getting file-based data - CSV, Parquet, or JSON - into a Microsoft Fabric Data Warehouse table with `fabric-dw`, end to end: create the schema, create the destination table, stage and load the data via `COPY INTO`, verify the result, and refresh statistics. It covers both the CLI (`fdw …`) and the MCP server (for AI assistants).
 
 It is task-oriented. For the full option reference of each command and tool, see the per-domain pages it links to: [Tables](../commands/tables.md), [Schemas](../commands/schemas.md), [Statistics](../commands/statistics.md), [Running SQL](../commands/sql.md), and the [MCP server](../install.md#mcp).
 
@@ -16,15 +16,15 @@ Use this guide when you have a target **Data Warehouse** and want to load file-b
 
 !!! warning "SQL Analytics Endpoints are read-only"
 
-    `COPY INTO` and table DDL (create / load / clear / statistics writes) are **Data Warehouse only**. SQL Analytics Endpoints are read-only here — listing, counting, and reading tables work, but you cannot create or load into them. If your `[ITEM]` is a SQL Analytics Endpoint the engine (or this tool) will reject the write.
+    `COPY INTO` and table DDL (create / load / clear / statistics writes) are **Data Warehouse only**. SQL Analytics Endpoints are read-only here - listing, counting, and reading tables work, but you cannot create or load into them. If your `[ITEM]` is a SQL Analytics Endpoint the engine (or this tool) will reject the write.
 
-Fabric offers several ingestion mechanisms. `COPY INTO` — what this tool uses — is Microsoft's recommended high-throughput, code-rich path for getting files into a warehouse. For scheduled low-code ingestion use **pipelines**, for code-free transforms use **dataflows**, and for in-warehouse moves use T-SQL (`INSERT … SELECT`, `SELECT INTO`, `CTAS`). See [Ingest data into a Fabric warehouse](https://learn.microsoft.com/fabric/data-warehouse/ingest-data?WT.mc_id=MVP_310840) for the full picture.
+Fabric offers several ingestion mechanisms. `COPY INTO`: what this tool uses - is Microsoft's recommended high-throughput, code-rich path for getting files into a warehouse. For scheduled low-code ingestion use **pipelines**, for code-free transforms use **dataflows**, and for in-warehouse moves use T-SQL (`INSERT … SELECT`, `SELECT INTO`, `CTAS`). See [Ingest data into a Fabric warehouse](https://learn.microsoft.com/fabric/data-warehouse/ingest-data?WT.mc_id=MVP_310840) for the full picture.
 
 ---
 
 ## Prerequisites
 
-- `fabric-dw` installed — see [Install](../install.md).
+- `fabric-dw` installed - see [Install](../install.md).
 - A working Azure credential. `fabric-dw` uses the Azure credential chain (Azure CLI, Managed Identity, service principal, environment variables). See [Authentication](../authentication.md).
 - A target **Data Warehouse** in a Fabric workspace you can write to.
 - `pyarrow` installed for the local-file, JSON, and schema-inference paths (local staging converts JSON to Parquet and infers schemas client-side). The remote-URL path does not need it.
@@ -78,7 +78,7 @@ The rest of this guide assumes these defaults are set, so the examples omit `-w 
 
 ---
 
-## Step 1 — (optional) create the schema
+## Step 1 - (optional) create the schema
 
 If your destination schema does not exist yet, create it. `dbo` always exists, so this step is only needed for custom schemas such as `staging` or `reporting`.
 
@@ -96,14 +96,14 @@ See [Schemas](../commands/schemas.md) for the full reference.
 
 ---
 
-## Step 2 — create the destination table
+## Step 2 - create the destination table
 
-Skip this step if you plan to auto-create with `tables load --create` (see [Step 3](#step-3-load-the-data)). Otherwise create the table first — `COPY INTO` requires the destination table to already exist.
+Skip this step if you plan to auto-create with `tables load --create` (see [Step 3](#step-3-load-the-data)). Otherwise create the table first - `COPY INTO` requires the destination table to already exist.
 
 `tables create` (Data Warehouse only) has two modes:
 
-- **Empty DDL** — scaffold the structure only; no data is read or inserted. Supply one of `--from-parquet`, `--from-csv`, `--from-json`, or `--column`.
-- **CTAS** (`CREATE TABLE … AS SELECT`) — populate the table from a query. Supply `--select` or `--from-file`.
+- **Empty DDL**: scaffold the structure only; no data is read or inserted. Supply one of `--from-parquet`, `--from-csv`, `--from-json`, or `--column`.
+- **CTAS** (`CREATE TABLE … AS SELECT`): populate the table from a query. Supply `--select` or `--from-file`.
 
 === "CLI"
 
@@ -130,34 +130,34 @@ Skip this step if you plan to auto-create with `tables load --create` (see [Step
       --name dbo.audit_log \
       --from-json ./data/audit_log.jsonl --varchar-length 500
 
-    # CTAS — populate from a query
+    # CTAS - populate from a query
     fdw tables create \
       --name dbo.orders_2026 \
       --select "SELECT * FROM dbo.orders WHERE YEAR(sale_date) = 2026"
     ```
 
-    `--from-parquet`, `--from-csv`, `--from-json`, and `--column` are **mutually exclusive** — pick exactly one column source. `--from-json` infers the schema from a JSONL file or a JSON array of records (no rows are loaded into the table; use `tables load --format json` to load data afterwards). Add `--cluster-by COL` (repeatable, up to 4) to any create mode. See [tables create](../commands/tables.md#tables-create) for the full option table and the Arrow → T-SQL type mapping.
+    `--from-parquet`, `--from-csv`, `--from-json`, and `--column` are **mutually exclusive**: pick exactly one column source. `--from-json` infers the schema from a JSONL file or a JSON array of records (no rows are loaded into the table; use `tables load --format json` to load data afterwards). Add `--cluster-by COL` (repeatable, up to 4) to any create mode. See [tables create](../commands/tables.md#tables-create) for the full option table and the Arrow → T-SQL type mapping.
 
 === "MCP"
 
-    - **`create_empty_table`** — explicit column list only: `columns: [{name, sql_type, nullable?}]`, optional `cluster_by`. Server-side file inference is intentionally **not** exposed; for file-based inference use the CLI `tables create --from-parquet` / `--from-csv` / `--from-json`.
-    - **`create_table`** — CTAS: takes a `select_body`, optional `cluster_by`.
+    - **`create_empty_table`**: explicit column list only: `columns: [{name, sql_type, nullable?}]`, optional `cluster_by`. Server-side file inference is intentionally **not** exposed; for file-based inference use the CLI `tables create --from-parquet` / `--from-csv` / `--from-json`.
+    - **`create_table`**: CTAS: takes a `select_body`, optional `cluster_by`.
 
     See [create_empty_table](../commands/tables.md#create_empty_table) and [create_table](../commands/tables.md#create_table).
 
 !!! tip "Prefer Parquet over CSV"
 
-    Parquet is columnar, compressed, and supports column/row skipping, so it is faster for repeated reads and gives exact types on ingestion (CSV requires inference). Whatever method you use, the Parquet files Fabric writes are V-Order optimized — don't disable V-Order. See the [warehouse performance guidance](https://learn.microsoft.com/fabric/data-warehouse/guidelines-warehouse-performance?WT.mc_id=MVP_310840#data-ingestion-and-preparation-into-a-warehouse).
+    Parquet is columnar, compressed, and supports column/row skipping, so it is faster for repeated reads and gives exact types on ingestion (CSV requires inference). Whatever method you use, the Parquet files Fabric writes are V-Order optimized - don't disable V-Order. See the [warehouse performance guidance](https://learn.microsoft.com/fabric/data-warehouse/guidelines-warehouse-performance?WT.mc_id=MVP_310840#data-ingestion-and-preparation-into-a-warehouse).
 
 ---
 
-## Step 3 — load the data
+## Step 3 - load the data
 
 `tables load` (Data Warehouse only) runs `COPY INTO`. Supply **exactly one** of `--file` (local) or `--url` (remote).
 
 ### Local file (`--file`)
 
-A local file is staged to a **temporary staging Lakehouse** in OneLake, loaded with `COPY INTO` under your own Microsoft Entra identity, and the staging Lakehouse is then deleted automatically — even if the load fails.
+A local file is staged to a **temporary staging Lakehouse** in OneLake, loaded with `COPY INTO` under your own Microsoft Entra identity, and the staging Lakehouse is then deleted automatically - even if the load fails.
 
 ```mermaid
 flowchart LR
@@ -192,13 +192,13 @@ fdw tables load SalesWH dbo.products --file products.json
 
 ### Remote URL (`--url`)
 
-`COPY INTO` runs directly against the URL — no staging Lakehouse is created. The URL must be **HTTPS** (link-local / instance-metadata hosts are rejected to prevent SSRF). Only **CSV and Parquet** are supported; JSON remote URLs are rejected — download the file and use `--file` instead.
+`COPY INTO` runs directly against the URL - no staging Lakehouse is created. The URL must be **HTTPS** (link-local / instance-metadata hosts are rejected to prevent SSRF). Only **CSV and Parquet** are supported; JSON remote URLs are rejected - download the file and use `--file` instead.
 
 For OneLake or same-tenant URLs no credential is needed (`COPY INTO` runs under your Entra identity). For secured external sources supply `--credential-type` and the matching secret/identity:
 
 | `--credential-type` | Provide |
 | --- | --- |
-| `none` (default) | Nothing — uses your Entra identity. |
+| `none` (default) | Nothing - uses your Entra identity. |
 | `sas` | `--secret <SAS token>` |
 | `account-key` | `--secret <account key>` |
 | `managed-identity` | `--identity <identity>` |
@@ -222,11 +222,11 @@ fdw tables load SalesWH dbo.events \
 
 ### Combined create-and-load (`--create`)
 
-Pass `--create` (local files only; requires `pyarrow`) to infer the schema from the source and create the table before loading — no separate Step 2. Parquet types come from the footer; CSV types come from the header plus up to `--sample-rows` sampled rows (use `--all-varchar` to skip inference). Control the behaviour when the table already exists with `--if-exists`:
+Pass `--create` (local files only; requires `pyarrow`) to infer the schema from the source and create the table before loading - no separate Step 2. Parquet types come from the footer; CSV types come from the header plus up to `--sample-rows` sampled rows (use `--all-varchar` to skip inference). Control the behaviour when the table already exists with `--if-exists`:
 
 | `--if-exists` | Table exists | Table absent |
 | --- | --- | --- |
-| `fail` (default with `--create`) | Error — table already exists | Create + load |
+| `fail` (default with `--create`) | Error - table already exists | Create + load |
 | `append` | Skip create, `COPY INTO` into existing | Create + load |
 | `truncate` ⚠️ **DESTRUCTIVE** | `TRUNCATE`, then load | Create + load |
 | `replace` ⚠️ **DESTRUCTIVE** | `DROP` + recreate from inferred schema, then load | Create + load |
@@ -235,7 +235,7 @@ Pass `--create` (local files only; requires `pyarrow`) to infer the schema from 
 
 !!! warning "Create + load is not atomic"
 
-    `CREATE TABLE` and `COPY INTO` are separate statements; a failure between them can leave an empty table. Add `--cleanup-on-failure` to drop the table **only if this call created it** and the load then fails — a pre-existing table is never dropped.
+    `CREATE TABLE` and `COPY INTO` are separate statements; a failure between them can leave an empty table. Add `--cleanup-on-failure` to drop the table **only if this call created it** and the load then fails - a pre-existing table is never dropped.
 
 ```shell
 # Auto-create from a Parquet schema, then load
@@ -257,7 +257,7 @@ CSV tuning (`--header / --no-header`, `--delimiter`, `--encoding`, `--field-quot
 
 ---
 
-## Step 4 — verify the load
+## Step 4 - verify the load
 
 `tables load` reports `rows_loaded`, `rows_rejected`, and the target.
 
@@ -270,7 +270,7 @@ Confirm the data landed:
 === "CLI"
 
     ```shell
-    # Row count (warehouse positional kept — table name follows)
+    # Row count (warehouse positional kept - table name follows)
     fdw tables count SalesWH dbo.sales
 
     # Sample some rows
@@ -291,7 +291,7 @@ See [Tables](../commands/tables.md) for the full reference.
 
 ---
 
-## Step 5 — refresh statistics after the load
+## Step 5 - refresh statistics after the load
 
 Statistics are **not** updated automatically after a load. Create or update single-column histogram statistics on the columns your queries filter and join on so the optimizer has fresh cardinality estimates.
 
@@ -306,7 +306,7 @@ Statistics are **not** updated automatically after a load. Create or update sing
     fdw statistics create \
       --table dbo.sales --column SaleDate --name stat_sales_saledate
 
-    # Update an existing statistic after a subsequent load (warehouse positional kept — names follow)
+    # Update an existing statistic after a subsequent load (warehouse positional kept - names follow)
     fdw statistics update SalesWH dbo.sales stat_sales_saledate
 
     # Inspect a statistic (header, density vector, histogram)
@@ -350,33 +350,33 @@ The same end-to-end flow is available to an AI assistant through the MCP server,
 | `fail` (default) | Error if the table already exists. |
 | `append` | Load into the existing table. |
 | `truncate` ⚠️ | `TRUNCATE`, then load. Requires `FABRIC_MCP_ALLOW_DESTRUCTIVE=1`. |
-| `replace` ⚠️ | **Not supported for remote URLs** — it cannot infer the schema without downloading. Use the CLI `tables load --file --create --if-exists replace`. |
+| `replace` ⚠️ | **Not supported for remote URLs**: it cannot infer the schema without downloading. Use the CLI `tables load --file --create --if-exists replace`. |
 
-Destructive `if_exists` policies (and `delete_schema` / `delete_statistics`) require the server to run with `FABRIC_MCP_ALLOW_DESTRUCTIVE=1` — see the [MCP security environment variables](../install.md#security-environment-variables).
+Destructive `if_exists` policies (and `delete_schema` / `delete_statistics`) require the server to run with `FABRIC_MCP_ALLOW_DESTRUCTIVE=1`: see the [MCP security environment variables](../install.md#security-environment-variables).
 
 ---
 
 ## Best practices
 
-These recommendations come from Microsoft Learn. Where they describe pre-staging many files, note that `fabric-dw` stages one local file at a time — that parallel-file guidance applies when you pre-stage files yourself and load them with `--url`, not as a feature of this tool.
+These recommendations come from Microsoft Learn. Where they describe pre-staging many files, note that `fabric-dw` stages one local file at a time - that parallel-file guidance applies when you pre-stage files yourself and load them with `--url`, not as a feature of this tool.
 
 - **Prefer `COPY INTO` for high-throughput ingestion.** It is Microsoft's recommended code-rich path into a Fabric warehouse and supports Azure storage accounts and OneLake folders. CSV, JSONL, and Parquet are supported; sources are ADLS Gen2 and Azure Blob Storage. See [Ingest data](https://learn.microsoft.com/fabric/data-warehouse/ingest-data?WT.mc_id=MVP_310840).
 - **Size your files for throughput.** Aim for files between **100 MB and 1 GB** (at least 100 MB), use many files, and run multiple `COPY INTO` statements in parallel into different tables for large volumes. See [data ingestion and preparation guidance](https://learn.microsoft.com/fabric/data-warehouse/guidelines-warehouse-performance?WT.mc_id=MVP_310840#data-ingestion-and-preparation-into-a-warehouse).
-- **Keep external files at least 4 MB and split large compressed CSVs.** Prefer **ADLS Gen2 over Blob Storage**, and avoid singleton `INSERT`s — batch with `CTAS` / `INSERT … SELECT` and group changes in explicit transactions. See [best practices](https://learn.microsoft.com/fabric/data-warehouse/ingest-data?WT.mc_id=MVP_310840#best-practices).
-- **Default authentication uses your Entra identity.** If no credential is supplied, `COPY INTO` runs under the executing user's Microsoft Entra ID — exactly what the local-staging path does (it loads under your identity with no `CREDENTIAL`). See [best practices](https://learn.microsoft.com/fabric/data-warehouse/ingest-data?WT.mc_id=MVP_310840#best-practices).
+- **Keep external files at least 4 MB and split large compressed CSVs.** Prefer **ADLS Gen2 over Blob Storage**, and avoid singleton `INSERT`s - batch with `CTAS` / `INSERT … SELECT` and group changes in explicit transactions. See [best practices](https://learn.microsoft.com/fabric/data-warehouse/ingest-data?WT.mc_id=MVP_310840#best-practices).
+- **Default authentication uses your Entra identity.** If no credential is supplied, `COPY INTO` runs under the executing user's Microsoft Entra ID - exactly what the local-staging path does (it loads under your identity with no `CREDENTIAL`). See [best practices](https://learn.microsoft.com/fabric/data-warehouse/ingest-data?WT.mc_id=MVP_310840#best-practices).
 - **Don't disable V-Order.** Regardless of ingestion method the produced Parquet files are V-Order optimized. See [best practices](https://learn.microsoft.com/fabric/data-warehouse/ingest-data?WT.mc_id=MVP_310840#best-practices).
-- **Prefer Parquet over CSV** for repeated reads — columnar, compressed, with column/row skipping. See [warehouse performance guidance](https://learn.microsoft.com/fabric/data-warehouse/guidelines-warehouse-performance?WT.mc_id=MVP_310840#data-ingestion-and-preparation-into-a-warehouse).
+- **Prefer Parquet over CSV** for repeated reads - columnar, compressed, with column/row skipping. See [warehouse performance guidance](https://learn.microsoft.com/fabric/data-warehouse/guidelines-warehouse-performance?WT.mc_id=MVP_310840#data-ingestion-and-preparation-into-a-warehouse).
 - **Create the table before `COPY INTO`, and use `FIRSTROW=2` to skip a CSV header.** See [ingest with COPY](https://learn.microsoft.com/fabric/data-warehouse/ingest-data-copy?WT.mc_id=MVP_310840) and [ingest data into a table](https://learn.microsoft.com/fabric/data-warehouse/ingest-data-into-table?WT.mc_id=MVP_310840).
-- **Update statistics after a load** — they are not refreshed automatically. Create/update single-column histogram stats, and inspect them with `DBCC SHOW_STATISTICS` (`statistics show`). See [tables & statistics](https://learn.microsoft.com/fabric/data-warehouse/tables?WT.mc_id=MVP_310840#statistics) and [statistics](https://learn.microsoft.com/fabric/data-warehouse/statistics?WT.mc_id=MVP_310840).
+- **Update statistics after a load**: they are not refreshed automatically. Create/update single-column histogram stats, and inspect them with `DBCC SHOW_STATISTICS` (`statistics show`). See [tables & statistics](https://learn.microsoft.com/fabric/data-warehouse/tables?WT.mc_id=MVP_310840#statistics) and [statistics](https://learn.microsoft.com/fabric/data-warehouse/statistics?WT.mc_id=MVP_310840).
 
 ---
 
 ## Troubleshooting
 
-- **`COPY INTO` / DDL rejected** — confirm the `[ITEM]` is a Data Warehouse, not a SQL Analytics Endpoint (which is read-only). See [Concepts](../concepts.md).
-- **Local JSON load fails** — install `pyarrow` (JSON is converted to Parquet before staging). Remote JSON URLs are unsupported by design.
-- **Local file rejected as too large** — files over 2 GiB cannot be staged; upload to OneLake / external storage and load with `--url`.
-- **Remote URL rejected** — the URL must be HTTPS; link-local and instance-metadata hosts are blocked.
-- **Auth / connection errors** — see [Authentication](../authentication.md) and [Troubleshooting](../troubleshooting.md).
+- **`COPY INTO` / DDL rejected**: confirm the `[ITEM]` is a Data Warehouse, not a SQL Analytics Endpoint (which is read-only). See [Concepts](../concepts.md).
+- **Local JSON load fails**: install `pyarrow` (JSON is converted to Parquet before staging). Remote JSON URLs are unsupported by design.
+- **Local file rejected as too large**: files over 2 GiB cannot be staged; upload to OneLake / external storage and load with `--url`.
+- **Remote URL rejected**: the URL must be HTTPS; link-local and instance-metadata hosts are blocked.
+- **Auth / connection errors**: see [Authentication](../authentication.md) and [Troubleshooting](../troubleshooting.md).
 
 For the full T-SQL `COPY INTO` syntax and options, see the [COPY INTO (Transact-SQL) reference](https://learn.microsoft.com/sql/t-sql/statements/copy-into-transact-sql?view=fabric&WT.mc_id=MVP_310840). For creating tables (CREATE TABLE vs CTAS, naming rules), see [Create tables](https://learn.microsoft.com/fabric/data-warehouse/create-table?WT.mc_id=MVP_310840) and [Tables in the warehouse](https://learn.microsoft.com/fabric/data-warehouse/tables?WT.mc_id=MVP_310840).

--- a/docs/guides/query-performance.md
+++ b/docs/guides/query-performance.md
@@ -4,13 +4,13 @@ title: Query performance
 
 # Investigating and improving query performance
 
-A task-oriented walkthrough for using `fabric-dw` (binary alias **`fdw`**) to find and fix slow queries on a Microsoft Fabric Data Warehouse or SQL Analytics Endpoint. It threads a single loop — **investigate → diagnose → improve → verify** — across the `queries`, `sql`, `statistics`, `sql-pools`, and `settings` command groups, and grounds each step in Microsoft Learn guidance.
+A task-oriented walkthrough for using `fabric-dw` (binary alias **`fdw`**) to find and fix slow queries on a Microsoft Fabric Data Warehouse or SQL Analytics Endpoint. It threads a single loop - **investigate → diagnose → improve → verify**: across the `queries`, `sql`, `statistics`, `sql-pools`, and `settings` command groups, and grounds each step in Microsoft Learn guidance.
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
 
 !!! tip "Driving `fabric-dw` from an AI assistant?"
 
-    The [`query-optimizer`](../skills.md#query-optimizer) Agent Skill automates exactly this single-query workflow — capture the plan, pull history, audit statistics, inspect clustering, then propose or apply fixes. This page is the human-facing version of the same loop, followed by hand at the terminal. For the **warehouse-wide** angle (hotspots across every query, SQL-pool pressure, caching health) see the [`warehouse-performance`](../skills.md#warehouse-performance) skill and its companion [Warehouse performance guide](warehouse-performance.md).
+    The [`query-optimizer`](../skills.md#query-optimizer) Agent Skill automates exactly this single-query workflow - capture the plan, pull history, audit statistics, inspect clustering, then propose or apply fixes. This page is the human-facing version of the same loop, followed by hand at the terminal. For the **warehouse-wide** angle (hotspots across every query, SQL-pool pressure, caching health) see the [`warehouse-performance`](../skills.md#warehouse-performance) skill and its companion [Warehouse performance guide](warehouse-performance.md).
 
 ---
 
@@ -18,18 +18,18 @@ A task-oriented walkthrough for using `fabric-dw` (binary alias **`fdw`**) to fi
 
 Reach for this guide when a query, report, or dashboard is slow and you want a repeatable method to find out *why* and make it faster. The loop is:
 
-1. **Investigate** — see what is running now and what ran recently (`queries running`, `queries connections`, `queries history`, `queries sessions`).
-2. **Diagnose** — rank the worst offenders and read the root cause (`queries long-running`, `queries frequent`, `sql-pools insights`, `sql plan`, `statistics list`/`show`).
-3. **Improve** — apply a fix (refresh statistics, rewrite the query, toggle result-set caching, tune SQL pools).
-4. **Verify** — re-run and compare in `queries history` using a query label, ignoring the cold-start first run.
+1. **Investigate**: see what is running now and what ran recently (`queries running`, `queries connections`, `queries history`, `queries sessions`).
+2. **Diagnose**: rank the worst offenders and read the root cause (`queries long-running`, `queries frequent`, `sql-pools insights`, `sql plan`, `statistics list`/`show`).
+3. **Improve**: apply a fix (refresh statistics, rewrite the query, toggle result-set caching, tune SQL pools).
+4. **Verify**: re-run and compare in `queries history` using a query label, ignoring the cold-start first run.
 
 Every command works both from the CLI and from the MCP server; the MCP tool that backs each command is listed alongside it, and the full mapping is collected in [MCP equivalents](#mcp-equivalents) at the end.
 
 !!! note "Name-or-GUID resolution"
 
-    All `workspace`, `warehouse`, and `endpoint`/`item` arguments accept either the display name or the GUID — the resolver translates and caches the mapping locally. See [Name-or-GUID resolution](../concepts.md#name-or-guid-resolution). `fdw cache clear` (MCP `clear_cache`) only flushes that local name→GUID lookup cache; it is **unrelated** to query or result-set caching.
+    All `workspace`, `warehouse`, and `endpoint`/`item` arguments accept either the display name or the GUID - the resolver translates and caches the mapping locally. See [Name-or-GUID resolution](../concepts.md#name-or-guid-resolution). `fdw cache clear` (MCP `clear_cache`) only flushes that local name→GUID lookup cache; it is **unrelated** to query or result-set caching.
 
-Throughout, the workspace comes from the global `-w`/`--workspace` option (or `FABRIC_DW_DEFAULT_WORKSPACE`, or the configured default; see [Selecting a workspace](../concepts.md#selecting-a-workspace)). The warehouse or endpoint is an **optional positional** `[WAREHOUSE]`/`[ITEM]` that falls back to the configured default — there is no positional `<workspace>` argument.
+Throughout, the workspace comes from the global `-w`/`--workspace` option (or `FABRIC_DW_DEFAULT_WORKSPACE`, or the configured default; see [Selecting a workspace](../concepts.md#selecting-a-workspace)). The warehouse or endpoint is an **optional positional** `[WAREHOUSE]`/`[ITEM]` that falls back to the configured default - there is no positional `<workspace>` argument.
 
 ---
 
@@ -63,25 +63,25 @@ The rest of this guide assumes these defaults are set, so the examples omit `-w 
 
 ---
 
-## Step 1 — Investigate live activity
+## Step 1 - Investigate live activity
 
 Start with what is happening **right now**.
 
 ```shell
-# Queries executing this instant (live DMVs — Admin)
+# Queries executing this instant (live DMVs - Admin)
 fdw queries running
 
 # Active SQL connections/sessions, including idle ones not shown above
 fdw queries connections
 ```
 
-`queries running` (MCP [`list_running_queries`](../commands/queries.md#list_running_queries)) returns each in-flight query with its `session_id`, `start_time`, `total_elapsed_time`, `login_name`, and `query_text` — enough to spot a single session that is dominating the warehouse. `queries connections` (MCP [`list_connections`](../commands/queries.md#list_connections)) reads `sys.dm_exec_connections` and surfaces lower-level connection detail (including idle connections) that the running view omits.
+`queries running` (MCP [`list_running_queries`](../commands/queries.md#list_running_queries)) returns each in-flight query with its `session_id`, `start_time`, `total_elapsed_time`, `login_name`, and `query_text`: enough to spot a single session that is dominating the warehouse. `queries connections` (MCP [`list_connections`](../commands/queries.md#list_connections)) reads `sys.dm_exec_connections` and surfaces lower-level connection detail (including idle connections) that the running view omits.
 
-If a live query is clearly runaway and you have Admin rights, jump straight to [Step 9 — Mitigate runaway queries](#step-9-mitigate-runaway-queries). Otherwise, move on to the history views to build a picture over time.
+If a live query is clearly runaway and you have Admin rights, jump straight to [Step 9 - Mitigate runaway queries](#step-9-mitigate-runaway-queries). Otherwise, move on to the history views to build a picture over time.
 
 ---
 
-## Step 2 — Review query history
+## Step 2 - Review query history
 
 Live DMVs only show the present moment. To see what *happened*, read the per-request and per-session history from Query Insights.
 
@@ -93,13 +93,13 @@ fdw queries history --limit 50 --since 2026-06-01T00:00:00
 fdw queries sessions --since 2026-06-01T00:00:00 --until 2026-06-08T00:00:00
 ```
 
-Both commands accept `--limit` (1–10 000, default 100), `--since`, and `--until` (ISO-8601). `queries history` (MCP [`list_request_history`](../commands/queries.md#list_request_history)) is the raw per-request feed — one row per execution — carrying the columns you will lean on for diagnosis: `total_elapsed_time_ms`, `data_scanned_remote_storage_mb`, `data_scanned_memory_mb`, `data_scanned_disk_mb`, `result_cache_hit`, `query_hash`, and `label`. `queries sessions` (MCP [`list_session_history`](../commands/queries.md#list_session_history)) rolls the same activity up per session.
+Both commands accept `--limit` (1–10 000, default 100), `--since`, and `--until` (ISO-8601). `queries history` (MCP [`list_request_history`](../commands/queries.md#list_request_history)) is the raw per-request feed - one row per execution - carrying the columns you will lean on for diagnosis: `total_elapsed_time_ms`, `data_scanned_remote_storage_mb`, `data_scanned_memory_mb`, `data_scanned_disk_mb`, `result_cache_hit`, `query_hash`, and `label`. `queries sessions` (MCP [`list_session_history`](../commands/queries.md#list_session_history)) rolls the same activity up per session.
 
-These are the **raw** insight views. Step 3 uses the **aggregated** views that rank queries server-side. The distinction matters — see [aggregated vs raw views](https://learn.microsoft.com/fabric/data-warehouse/guidelines-warehouse-performance?WT.mc_id=MVP_310840#query-metadata-views).
+These are the **raw** insight views. Step 3 uses the **aggregated** views that rank queries server-side. The distinction matters - see [aggregated vs raw views](https://learn.microsoft.com/fabric/data-warehouse/guidelines-warehouse-performance?WT.mc_id=MVP_310840#query-metadata-views).
 
 ---
 
-## Step 3 — Find the worst offenders
+## Step 3 - Find the worst offenders
 
 Rather than eyeballing raw history, let Fabric rank the queries for you.
 
@@ -116,17 +116,17 @@ fdw sql-pools insights
 
 - `queries long-running` (MCP [`list_long_running_queries`](../commands/queries.md#list_long_running_queries)) reads `queryinsights.long_running_queries`, ordered server-side by `median_total_elapsed_time_ms` DESC. "Top N" is simply `--limit N`.
 - `queries frequent` (MCP [`list_frequent_queries`](../commands/queries.md#list_frequent_queries)) reads `queryinsights.frequently_run_queries`, ordered by run count DESC. A query that is individually fast but runs thousands of times can be a bigger cost driver than a single slow report.
-- `sql-pools insights` (MCP [`list_sql_pool_insights`](../commands/sql-pools.md#list_sql_pool_insights)) reads `queryinsights.sql_pool_insights` for capacity-pressure and read-optimization events. Treat persistent pressure here as a signal that the worst offenders are competing for compute — the [`warehouse-performance`](../skills.md#warehouse-performance) skill covers SQL-pool tuning in depth.
+- `sql-pools insights` (MCP [`list_sql_pool_insights`](../commands/sql-pools.md#list_sql_pool_insights)) reads `queryinsights.sql_pool_insights` for capacity-pressure and read-optimization events. Treat persistent pressure here as a signal that the worst offenders are competing for compute - the [`warehouse-performance`](../skills.md#warehouse-performance) skill covers SQL-pool tuning in depth.
 
-Microsoft Learn shows how to combine these views to find top consumers — top CPU via `allocated_cpu_time_ms`, most-data-scanned via `data_scanned_remote_storage_mb`, and frequent/long-running by command substring: see the [Query insights examples](https://learn.microsoft.com/fabric/data-warehouse/query-insights?WT.mc_id=MVP_310840#examples) and the [performance guidelines](https://learn.microsoft.com/fabric/data-warehouse/guidelines-warehouse-performance?WT.mc_id=MVP_310840#query-performance).
+Microsoft Learn shows how to combine these views to find top consumers - top CPU via `allocated_cpu_time_ms`, most-data-scanned via `data_scanned_remote_storage_mb`, and frequent/long-running by command substring: see the [Query insights examples](https://learn.microsoft.com/fabric/data-warehouse/query-insights?WT.mc_id=MVP_310840#examples) and the [performance guidelines](https://learn.microsoft.com/fabric/data-warehouse/guidelines-warehouse-performance?WT.mc_id=MVP_310840#query-performance).
 
 Pick one query from the top of these lists and carry it through the rest of the loop.
 
 ---
 
-## Step 4 — Capture & read the execution plan
+## Step 4 - Capture & read the execution plan
 
-With a specific slow query in hand, capture its **estimated** execution plan. `sql plan` (MCP [`get_query_plan`](../commands/sql.md#get_query_plan)) retrieves the estimated `SHOWPLAN_XML` **without executing the query** — so it is safe to plan even DDL/DML text, and reading it costs nothing.
+With a specific slow query in hand, capture its **estimated** execution plan. `sql plan` (MCP [`get_query_plan`](../commands/sql.md#get_query_plan)) retrieves the estimated `SHOWPLAN_XML` **without executing the query**: so it is safe to plan even DDL/DML text, and reading it costs nothing.
 
 ```shell
 # Default: a colour-coded Rich operator tree in the terminal
@@ -147,20 +147,20 @@ fdw sql plan -q "..." --format svg  -o plan.svg  # requires Graphviz
 fdw sql plan -q "..." --format html -o plan.html # self-contained, offline-viewable
 ```
 
-Representation (`--raw`/`--xml`, root `--json`, `--format mermaid|dot|svg|html`) and destination (`-o FILE`) are orthogonal — see [`sql plan`](../commands/sql.md#sql-plan) for the full matrix. Via MCP, `get_query_plan` takes a `format` parameter (`xml` | `tree` | `json` | `mermaid`); the artifact formats **SVG, HTML, and DOT are CLI-only** because the MCP server never writes files.
+Representation (`--raw`/`--xml`, root `--json`, `--format mermaid|dot|svg|html`) and destination (`-o FILE`) are orthogonal - see [`sql plan`](../commands/sql.md#sql-plan) for the full matrix. Via MCP, `get_query_plan` takes a `format` parameter (`xml` | `tree` | `json` | `mermaid`); the artifact formats **SVG, HTML, and DOT are CLI-only** because the MCP server never writes files.
 
 **What to look for in the plan:**
 
-- **Costly operators** — a high-percentage **Hash Join**, **Sort**, or **Spool** is where the time goes.
-- **`CONVERT_IMPLICIT` in a predicate** — a type mismatch between a column and a literal/parameter, which forces a conversion and can defeat a clean scan. Fix it with [data-type parity](https://learn.microsoft.com/fabric/data-warehouse/guidelines-warehouse-performance?WT.mc_id=MVP_310840#data-type-optimization) in Step 7.
-- **Large estimated row counts** — wildly off estimates usually mean missing or stale statistics; chase that in Step 6.
-- **"Non-scalable operation" warnings** — flagged in the plan per the [performance guidelines](https://learn.microsoft.com/fabric/data-warehouse/guidelines-warehouse-performance?WT.mc_id=MVP_310840#query-performance).
+- **Costly operators**: a high-percentage **Hash Join**, **Sort**, or **Spool** is where the time goes.
+- **`CONVERT_IMPLICIT` in a predicate**: a type mismatch between a column and a literal/parameter, which forces a conversion and can defeat a clean scan. Fix it with [data-type parity](https://learn.microsoft.com/fabric/data-warehouse/guidelines-warehouse-performance?WT.mc_id=MVP_310840#data-type-optimization) in Step 7.
+- **Large estimated row counts**: wildly off estimates usually mean missing or stale statistics; chase that in Step 6.
+- **"Non-scalable operation" warnings**: flagged in the plan per the [performance guidelines](https://learn.microsoft.com/fabric/data-warehouse/guidelines-warehouse-performance?WT.mc_id=MVP_310840#query-performance).
 
-Microsoft recommends reading `SHOWPLAN_XML` to understand a query and reserving query hints (e.g. `OPTION (FORCE DISTRIBUTED PLAN)`) as a last resort. Clustering inspection (`get_cluster_columns` / `set_cluster_columns`) is a deeper-dive lever beyond this guide's scope — the [`query-optimizer`](../skills.md#query-optimizer) skill handles it, and the cluster columns concept is covered in the [performance guidelines](https://learn.microsoft.com/fabric/data-warehouse/guidelines-warehouse-performance?WT.mc_id=MVP_310840#query-performance).
+Microsoft recommends reading `SHOWPLAN_XML` to understand a query and reserving query hints (e.g. `OPTION (FORCE DISTRIBUTED PLAN)`) as a last resort. Clustering inspection (`get_cluster_columns` / `set_cluster_columns`) is a deeper-dive lever beyond this guide's scope - the [`query-optimizer`](../skills.md#query-optimizer) skill handles it, and the cluster columns concept is covered in the [performance guidelines](https://learn.microsoft.com/fabric/data-warehouse/guidelines-warehouse-performance?WT.mc_id=MVP_310840#query-performance).
 
 ---
 
-## Step 5 — Diagnose root cause from history columns
+## Step 5 - Diagnose root cause from history columns
 
 Cross-reference the plan with the numbers from `queries history`. The key columns:
 
@@ -168,16 +168,16 @@ Cross-reference the plan with the numbers from `queries history`. The key column
 | --- | --- |
 | `total_elapsed_time_ms` | Wall-clock duration of the request. |
 | `data_scanned_remote_storage_mb` | Data pulled from OneLake. **Non-zero ⇒ cold start** (first run after the data left cache). |
-| `data_scanned_memory_mb` / `data_scanned_disk_mb` | Data served from the in-memory / local disk cache — the warm path. |
+| `data_scanned_memory_mb` / `data_scanned_disk_mb` | Data served from the in-memory / local disk cache - the warm path. |
 | `result_cache_hit` | Whether the result was served from the result-set cache (no compute at all). |
-| `query_hash` | Stable fingerprint of the query shape — use it to find every execution of "the same query". |
-| `label` | Your own tag from `OPTION (LABEL='...')` — use it to track one specific query over time. |
+| `query_hash` | Stable fingerprint of the query shape - use it to find every execution of "the same query". |
+| `label` | Your own tag from `OPTION (LABEL='...')`: use it to track one specific query over time. |
 
 !!! tip "Don't judge a query by its first run"
 
-    A **non-zero `data_scanned_remote_storage_mb`** means the data was fetched from OneLake — a cold start. The first run after a cache eviction is *not* representative; **subsequent runs are**. Always discard the cold-start run before drawing conclusions. — [Query performance guidelines](https://learn.microsoft.com/fabric/data-warehouse/guidelines-warehouse-performance?WT.mc_id=MVP_310840#query-performance)
+    A **non-zero `data_scanned_remote_storage_mb`** means the data was fetched from OneLake - a cold start. The first run after a cache eviction is *not* representative; **subsequent runs are**. Always discard the cold-start run before drawing conclusions. - [Query performance guidelines](https://learn.microsoft.com/fabric/data-warehouse/guidelines-warehouse-performance?WT.mc_id=MVP_310840#query-performance)
 
-Caching in Fabric is **automatic and not user-clearable** — the in-memory and disk caches are transparent, which is why you interpret cache columns rather than manage them. See [Caching in Fabric Data Warehouse](https://learn.microsoft.com/fabric/data-warehouse/caching?WT.mc_id=MVP_310840).
+Caching in Fabric is **automatic and not user-clearable**: the in-memory and disk caches are transparent, which is why you interpret cache columns rather than manage them. See [Caching in Fabric Data Warehouse](https://learn.microsoft.com/fabric/data-warehouse/caching?WT.mc_id=MVP_310840).
 
 To drill into a specific shape, run ad-hoc T-SQL with `sql exec` (MCP [`execute_sql`](../commands/sql.md#execute_sql)) and filter `exec_requests_history` by `query_hash` or `label`:
 
@@ -185,11 +185,11 @@ To drill into a specific shape, run ad-hoc T-SQL with `sql exec` (MCP [`execute_
 fdw sql exec -q "SELECT TOP 20 submit_time, total_elapsed_time_ms, data_scanned_remote_storage_mb, result_cache_hit FROM queryinsights.exec_requests_history WHERE label = 'sales-eu-report' ORDER BY submit_time DESC"
 ```
 
-Using a **query label** to track and compare one query across executions is a first-class Microsoft pattern — see [Query labeling](https://learn.microsoft.com/fabric/data-warehouse/query-label?WT.mc_id=MVP_310840).
+Using a **query label** to track and compare one query across executions is a first-class Microsoft pattern - see [Query labeling](https://learn.microsoft.com/fabric/data-warehouse/query-label?WT.mc_id=MVP_310840).
 
 ---
 
-## Step 6 — Check & fix statistics
+## Step 6 - Check & fix statistics
 
 Bad row estimates in the plan (Step 4) almost always trace back to missing or stale statistics. Accurate statistics are **critical** to good plans.
 
@@ -197,19 +197,19 @@ Bad row estimates in the plan (Step 4) almost always trace back to missing or st
 # List statistics on the referenced tables (spot missing ones)
 fdw statistics list --schema dbo --table Customer
 
-# Inspect a statistic's histogram and staleness (warehouse positional kept — names follow)
+# Inspect a statistic's histogram and staleness (warehouse positional kept - names follow)
 fdw statistics show SalesWH dbo.Customer _WA_Sys_00000003_12345678 --histogram
 ```
 
-`statistics list` (MCP [`list_statistics`](../commands/statistics.md#list_statistics)) shows both user-created and Fabric's automatic `_WA_Sys_*` statistics; `statistics show` (MCP [`show_statistics`](../commands/statistics.md#show_statistics)) runs `DBCC SHOW_STATISTICS` to return the header, density vector, and histogram so you can judge staleness. Verifying the auto-created stats and inspecting them via `DBCC SHOW_STATISTICS` is the documented diagnostic — see [Automatic statistics at query time](https://learn.microsoft.com/fabric/data-warehouse/statistics?WT.mc_id=MVP_310840#automatic-statistics-at-query).
+`statistics list` (MCP [`list_statistics`](../commands/statistics.md#list_statistics)) shows both user-created and Fabric's automatic `_WA_Sys_*` statistics; `statistics show` (MCP [`show_statistics`](../commands/statistics.md#show_statistics)) runs `DBCC SHOW_STATISTICS` to return the header, density vector, and histogram so you can judge staleness. Verifying the auto-created stats and inspecting them via `DBCC SHOW_STATISTICS` is the documented diagnostic - see [Automatic statistics at query time](https://learn.microsoft.com/fabric/data-warehouse/statistics?WT.mc_id=MVP_310840#automatic-statistics-at-query).
 
-When a column in a `GROUP BY` / `ORDER BY` / `WHERE` / `JOIN` lacks a good statistic, create or refresh one. **DDL targets a Data Warehouse only — these commands are rejected on SQL Analytics Endpoints**, and Fabric supports **single-column** statistics only.
+When a column in a `GROUP BY` / `ORDER BY` / `WHERE` / `JOIN` lacks a good statistic, create or refresh one. **DDL targets a Data Warehouse only - these commands are rejected on SQL Analytics Endpoints**, and Fabric supports **single-column** statistics only.
 
 ```shell
 # Create a single-column histogram statistic (--name is required)
 fdw statistics create --table dbo.Customer --column region --name stat_customer_region --fullscan
 
-# Refresh after a large data change (warehouse positional kept — table/stat names follow)
+# Refresh after a large data change (warehouse positional kept - table/stat names follow)
 fdw statistics update SalesWH dbo.Customer stat_customer_region --fullscan
 
 # Drop a redundant user statistic (prompts unless -y; warehouse positional kept)
@@ -218,16 +218,16 @@ fdw statistics delete SalesWH dbo.Customer stat_customer_region
 
 These map to MCP [`create_statistics`](../commands/statistics.md#create_statistics), [`update_statistics`](../commands/statistics.md#update_statistics), and [`delete_statistics`](../commands/statistics.md#delete_statistics). All three are **mutating** MCP tools gated behind the write-guard (`delete_statistics` is additionally destructive-gated via `FABRIC_MCP_ALLOW_DESTRUCTIVE`); they do **not** pop a confirmation dialog, so an AI assistant must ask before calling them.
 
-Microsoft recommends creating/updating single-column histogram statistics **during maintenance windows** — so user `SELECT`s do not pay for synchronous auto-stats creation — focusing on columns used in `GROUP BY` / `ORDER BY` / `WHERE` / `JOIN`, and refreshing after big data changes. See [Statistics in Fabric Data Warehouse](https://learn.microsoft.com/fabric/data-warehouse/statistics?WT.mc_id=MVP_310840).
+Microsoft recommends creating/updating single-column histogram statistics **during maintenance windows**: so user `SELECT`s do not pay for synchronous auto-stats creation - focusing on columns used in `GROUP BY` / `ORDER BY` / `WHERE` / `JOIN`, and refreshing after big data changes. See [Statistics in Fabric Data Warehouse](https://learn.microsoft.com/fabric/data-warehouse/statistics?WT.mc_id=MVP_310840).
 
 ---
 
-## Step 7 — Improve the query
+## Step 7 - Improve the query
 
 With statistics healthy, turn to the query text itself. Common, high-leverage rewrites:
 
-- **Return less data** — avoid `SELECT *`, project only the columns you need, and apply `WHERE` filters *before* joins. Filtering on a low-cardinality column early shrinks everything downstream. — [Query performance guidelines](https://learn.microsoft.com/fabric/data-warehouse/guidelines-warehouse-performance?WT.mc_id=MVP_310840#query-performance)
-- **Match data types in comparisons** — eliminate the `CONVERT_IMPLICIT` you spotted in Step 4 by comparing like types, and use the smallest sufficient string lengths. — [Data type optimization](https://learn.microsoft.com/fabric/data-warehouse/guidelines-warehouse-performance?WT.mc_id=MVP_310840#data-type-optimization)
+- **Return less data**: avoid `SELECT *`, project only the columns you need, and apply `WHERE` filters *before* joins. Filtering on a low-cardinality column early shrinks everything downstream. - [Query performance guidelines](https://learn.microsoft.com/fabric/data-warehouse/guidelines-warehouse-performance?WT.mc_id=MVP_310840#query-performance)
+- **Match data types in comparisons**: eliminate the `CONVERT_IMPLICIT` you spotted in Step 4 by comparing like types, and use the smallest sufficient string lengths. - [Data type optimization](https://learn.microsoft.com/fabric/data-warehouse/guidelines-warehouse-performance?WT.mc_id=MVP_310840#data-type-optimization)
 - **Tag the query with a label** so you can find every run of the improved version in `queries history`, and apply hints only as a last resort.
 
 Re-run the improved query through `sql exec` with a label (and any hint):
@@ -238,11 +238,11 @@ fdw sql exec -q "SELECT s.id, s.amount FROM dbo.Sales s JOIN dbo.Customer c ON s
 
 ---
 
-## Step 8 — Verify the improvement
+## Step 8 - Verify the improvement
 
 Confirm the fix actually helped, on the **warm** path.
 
-1. Run the labelled query **twice** — the first run may be a cold start (non-zero `data_scanned_remote_storage_mb`); ignore it.
+1. Run the labelled query **twice**: the first run may be a cold start (non-zero `data_scanned_remote_storage_mb`); ignore it.
 2. Pull the history filtered by your label and compare `total_elapsed_time_ms` against the original:
 
    ```shell
@@ -261,55 +261,55 @@ Confirm the fix actually helped, on the **warm** path.
 
 !!! note "Result-set caching in Fabric is ON by default"
 
-    Unlike the Synapse model (OFF by default), **Fabric Data Warehouse enables result-set caching ON by default** per item. A single query can still opt out with `OPTION (USE HINT('DISABLE_RESULT_SET_CACHE'))`. The toggle is **DW-only** — SQL Analytics Endpoints are rejected. See [Result set caching](https://learn.microsoft.com/fabric/data-warehouse/result-set-caching?WT.mc_id=MVP_310840).
+    Unlike the Synapse model (OFF by default), **Fabric Data Warehouse enables result-set caching ON by default** per item. A single query can still opt out with `OPTION (USE HINT('DISABLE_RESULT_SET_CACHE'))`. The toggle is **DW-only**: SQL Analytics Endpoints are rejected. See [Result set caching](https://learn.microsoft.com/fabric/data-warehouse/result-set-caching?WT.mc_id=MVP_310840).
 
 A `result_cache_hit = true` in `queries history` on the second and later runs confirms the cache is doing its job.
 
 ---
 
-## Step 9 — Mitigate runaway queries
+## Step 9 - Mitigate runaway queries
 
-When a live query is clearly out of control and you have Admin rights, terminate its session. `KILL` is **Admin-only** and **destructive** — `queries kill` prompts unless `-y` is passed.
+When a live query is clearly out of control and you have Admin rights, terminate its session. `KILL` is **Admin-only** and **destructive**: `queries kill` prompts unless `-y` is passed.
 
 ```shell
 # Find the runaway session
 fdw queries running
 
-# Terminate it (prompts unless -y; warehouse positional kept — SESSION_ID follows)
+# Terminate it (prompts unless -y; warehouse positional kept - SESSION_ID follows)
 fdw --yes queries kill SalesWH 42
 ```
 
-`queries kill` maps to MCP [`kill_session`](../commands/queries.md#kill_session), which is write-gated. Identifying and killing a long-running query via DMVs is the documented incident path — see [Monitor using DMVs](https://learn.microsoft.com/fabric/data-warehouse/monitor-using-dmv?WT.mc_id=MVP_310840).
+`queries kill` maps to MCP [`kill_session`](../commands/queries.md#kill_session), which is write-gated. Identifying and killing a long-running query via DMVs is the documented incident path - see [Monitor using DMVs](https://learn.microsoft.com/fabric/data-warehouse/monitor-using-dmv?WT.mc_id=MVP_310840).
 
 ---
 
-## Worked example — end to end
+## Worked example - end to end
 
 A nightly EU sales report is slow. The full loop:
 
 ```shell
-# 1. INVESTIGATE — confirm it is not a one-off live spike
+# 1. INVESTIGATE - confirm it is not a one-off live spike
 fdw queries running
 
-# 2. DIAGNOSE — it tops the long-running list
+# 2. DIAGNOSE - it tops the long-running list
 fdw queries long-running --limit 10
 
-# 3. CAPTURE THE PLAN — a Hash Join with a huge estimated row count on Customer,
+# 3. CAPTURE THE PLAN - a Hash Join with a huge estimated row count on Customer,
 #    plus CONVERT_IMPLICIT on c.region
 fdw sql plan -q "SELECT * FROM dbo.Sales s JOIN dbo.Customer c ON s.cust_id = c.id WHERE c.region = N'EU'"
 
-# 4. READ HISTORY — the slow runs all show non-zero data_scanned_remote_storage_mb
+# 4. READ HISTORY - the slow runs all show non-zero data_scanned_remote_storage_mb
 #    on the first execution only (cold start); warm runs are still slow
 fdw queries history --limit 20 --since 2026-06-01T00:00:00
 
-# 5. CHECK STATISTICS — no user statistic on Customer.region
+# 5. CHECK STATISTICS - no user statistic on Customer.region
 fdw statistics list --schema dbo --table Customer
 
-# 6. IMPROVE — create the missing statistic, and fix the type mismatch (region is varchar, not nvarchar)
+# 6. IMPROVE - create the missing statistic, and fix the type mismatch (region is varchar, not nvarchar)
 fdw statistics create --table dbo.Customer --column region --name stat_customer_region --fullscan
 fdw sql exec -q "SELECT s.id, s.amount FROM dbo.Sales s JOIN dbo.Customer c ON s.cust_id = c.id WHERE c.region = 'EU' OPTION (LABEL='sales-eu-report')"
 
-# 7. VERIFY — run twice (discard the cold-start run), then compare warm runs by label
+# 7. VERIFY - run twice (discard the cold-start run), then compare warm runs by label
 fdw sql exec -q "SELECT s.id, s.amount FROM dbo.Sales s JOIN dbo.Customer c ON s.cust_id = c.id WHERE c.region = 'EU' OPTION (LABEL='sales-eu-report')"
 fdw sql exec -q "SELECT TOP 10 submit_time, total_elapsed_time_ms, data_scanned_remote_storage_mb, result_cache_hit FROM queryinsights.exec_requests_history WHERE label = 'sales-eu-report' ORDER BY submit_time DESC"
 ```
@@ -320,7 +320,7 @@ Median elapsed time on the warm runs drops once the statistic gives the optimize
 
 ## MCP equivalents
 
-The same loop, driven by an AI assistant. Every step above maps to one MCP tool — the [`query-optimizer`](../skills.md#query-optimizer) skill chains exactly these.
+The same loop, driven by an AI assistant. Every step above maps to one MCP tool - the [`query-optimizer`](../skills.md#query-optimizer) skill chains exactly these.
 
 | Step | CLI | MCP tool |
 | --- | --- | --- |
@@ -355,7 +355,7 @@ The mutating MCP tools (`create_statistics`, `update_statistics`, `delete_statis
 - **Single-column statistics only.** Fabric supports single-column, histogram-based statistics; multi-column statistics are not available.
 - **`fdw cache clear` ≠ query caching.** It only clears the local name→GUID lookup cache; it has no effect on query, result-set, or cache-cooldown behaviour.
 
-### Gaps (no command exists — do not invent one)
+### Gaps (no command exists - do not invent one)
 
 - **Result-set cache cooldown has no API** ([#595](https://github.com/sdebruyn/fabric-dw-mcp-cli/issues/595)). This is distinct from the result-set-caching toggle and from the local lookup cache.
 - **Statement-type SQL-pool routing does not exist** ([#596](https://github.com/sdebruyn/fabric-dw-mcp-cli/issues/596)). The only routing key is the application-name classifier; do not imply statement-type routing.
@@ -366,7 +366,7 @@ The mutating MCP tools (`create_statistics`, `update_statistics`, `delete_statis
 ## See also
 
 - [Queries](../commands/queries.md) · [Running SQL](../commands/sql.md) · [Statistics](../commands/statistics.md) · [Settings](../commands/settings.md) · [SQL Pools](../commands/sql-pools.md)
-- [Agent Skills](../skills.md) — `query-optimizer` (single-query automation of this loop) and `warehouse-performance` (warehouse-wide).
+- [Agent Skills](../skills.md) - `query-optimizer` (single-query automation of this loop) and `warehouse-performance` (warehouse-wide).
 - [Performance guidelines for Fabric Data Warehouse](https://learn.microsoft.com/fabric/data-warehouse/guidelines-warehouse-performance?WT.mc_id=MVP_310840) · [Query insights](https://learn.microsoft.com/fabric/data-warehouse/query-insights?WT.mc_id=MVP_310840) · [Monitoring overview](https://learn.microsoft.com/fabric/data-warehouse/monitoring-overview?WT.mc_id=MVP_310840)
 </content>
 </invoke>

--- a/docs/guides/tables-and-views.md
+++ b/docs/guides/tables-and-views.md
@@ -4,7 +4,7 @@ title: Tables & views
 
 # Creating & managing tables and views
 
-This guide walks through building out a schema model on a Microsoft Fabric Data Warehouse with `fabric-dw` — from an empty schema, through populated tables, to reporting views and the statistics that keep the optimizer honest. Every step shows a runnable CLI example (`fdw …`) and names the equivalent MCP tool, so the same workflow applies whether you drive it from a terminal or from an AI assistant wired to the [MCP server](../install.md#mcp).
+This guide walks through building out a schema model on a Microsoft Fabric Data Warehouse with `fabric-dw`: from an empty schema, through populated tables, to reporting views and the statistics that keep the optimizer honest. Every step shows a runnable CLI example (`fdw …`) and names the equivalent MCP tool, so the same workflow applies whether you drive it from a terminal or from an AI assistant wired to the [MCP server](../install.md#mcp).
 
 The flat per-command references stay the source of truth for every flag and parameter: [Schemas](../commands/schemas.md), [Tables](../commands/tables.md), [Views](../commands/views.md), and [Statistics](../commands/statistics.md). This guide ties them together as a single narrative.
 
@@ -20,9 +20,9 @@ A small star-schema-style model in one warehouse:
 - a reporting view (`sales.vw_orders_by_month`) kept under version control as a `.sql` file,
 - single-column statistics so the optimizer can plan joins and filters.
 
-You'll then maintain and iterate on the model — clone, rename, re-cluster, clear, and finally tear it down.
+You'll then maintain and iterate on the model - clone, rename, re-cluster, clear, and finally tear it down.
 
-### CLI vs MCP — when to use which
+### CLI vs MCP - when to use which
 
 - **CLI** (`fdw …`) is the full surface. File-based schema inference (`--from-parquet` / `--from-csv` / `--from-json`), `tables load`, and `if-exists replace` are **CLI-only** because they need reliable local file access.
 - **MCP tools** mirror the CLI for everything that doesn't depend on server-side file access, so an AI assistant can author and inspect the same objects. Where an MCP equivalent exists it's named in each step; where it doesn't (notably `tables load`), the gap is called out.
@@ -31,13 +31,13 @@ You'll then maintain and iterate on the model — clone, rename, re-cluster, cle
 
 ## Prerequisites
 
-- `fabric-dw` [installed](../install.md) and [authenticated](../authentication.md) (the Azure credential chain — Azure CLI, managed identity, service principal, and more).
+- `fabric-dw` [installed](../install.md) and [authenticated](../authentication.md) (the Azure credential chain - Azure CLI, managed identity, service principal, and more).
 - A target warehouse you can write to. The examples use a workspace `MyWorkspace` and a warehouse `SalesWH`; substitute your own (both are resolvable by **name or GUID**, and both default from your [configuration](../commands/config.md), so `-w`/the item argument can be omitted once defaults are set).
 - For MCP usage, the [MCP server](../install.md#mcp) registered with your assistant. Mutating and destructive tools have their own opt-in guards (see [Destructive operations](#destructive-operations-and-the-yes-flag) below).
 
 !!! warning "Data Warehouse vs SQL Analytics Endpoint"
 
-    A **SQL Analytics Endpoint** (the read query surface over a Lakehouse) cannot create, alter, or drop **tables** — that's a Warehouse-only capability. On a SQL Analytics Endpoint you can still create **views**, list/read/inspect everything, and manage schemas. The capability split is spelled out under [The SQL Analytics Endpoint read-only guard](#the-sql-analytics-endpoint-read-only-guard); each step below marks its **Targets**.
+    A **SQL Analytics Endpoint** (the read query surface over a Lakehouse) cannot create, alter, or drop **tables**: that's a Warehouse-only capability. On a SQL Analytics Endpoint you can still create **views**, list/read/inspect everything, and manage schemas. The capability split is spelled out under [The SQL Analytics Endpoint read-only guard](#the-sql-analytics-endpoint-read-only-guard); each step below marks its **Targets**.
 
 ---
 
@@ -54,14 +54,14 @@ The rest of this guide assumes these defaults are set, so the examples omit `-w 
 
 ---
 
-## Step 1 — Create a schema
+## Step 1 - Create a schema
 
 Schemas are the namespace for your tables and views. `dbo` always exists; create custom schemas to group related objects.
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
 
 ```shell
-# Create the schema (warehouse positional kept — schema NAME follows)
+# Create the schema (warehouse positional kept - schema NAME follows)
 fdw schemas create SalesWH sales
 
 # Confirm it exists (system schemas like sys / INFORMATION_SCHEMA are excluded; dbo is shown)
@@ -72,13 +72,13 @@ fdw schemas list
 
 !!! note "Schema names are case-sensitive"
 
-    Fabric warehouses use a fixed, case-sensitive default collation (`Latin1_General_100_BIN2_UTF8`), and **schema names are case-sensitive**. `Sales` and `sales` are different schemas. See [Limitations & gotchas](#fixed-case-sensitive-collation) before you settle on a naming convention — collation can't be changed after the warehouse is created.
+    Fabric warehouses use a fixed, case-sensitive default collation (`Latin1_General_100_BIN2_UTF8`), and **schema names are case-sensitive**. `Sales` and `sales` are different schemas. See [Limitations & gotchas](#fixed-case-sensitive-collation) before you settle on a naming convention - collation can't be changed after the warehouse is created.
 
 ---
 
-## Step 2 — Create tables
+## Step 2 - Create tables
 
-`tables create` is a single command with mutually-exclusive source modes (validated client-side before any DDL runs). All of them are **Data Warehouse only** — tables can't be created on a SQL Analytics Endpoint.
+`tables create` is a single command with mutually-exclusive source modes (validated client-side before any DDL runs). All of them are **Data Warehouse only**: tables can't be created on a SQL Analytics Endpoint.
 
 **Targets:** Data Warehouse only · **MCP:** `create_table` (CTAS), `create_empty_table` (explicit columns)
 
@@ -95,7 +95,7 @@ fdw tables create \
   --column "signed_up:DATE"
 ```
 
-**MCP** (`create_empty_table`) takes an explicit `columns` list — each entry is `{name, sql_type, nullable?}`:
+**MCP** (`create_empty_table`) takes an explicit `columns` list - each entry is `{name, sql_type, nullable?}`:
 
 ```json
 {
@@ -113,11 +113,11 @@ fdw tables create \
 
 ### Infer a table from a data file (Parquet, CSV, or JSON)
 
-All three file-based flags — `--from-parquet`, `--from-csv`, and `--from-json` — do the same thing conceptually: read only the schema from a data file and scaffold an **empty** table (no rows are read or inserted). How much of the file each flag reads differs by format:
+All three file-based flags - `--from-parquet`, `--from-csv`, and `--from-json`: do the same thing conceptually: read only the schema from a data file and scaffold an **empty** table (no rows are read or inserted). How much of the file each flag reads differs by format:
 
-- **Parquet** — reads only the Parquet footer, which encodes exact column names and types; no row-group data is touched.
-- **CSV** — reads the header row plus a bounded sample of rows (controlled by `--sample-rows`) to infer types; accepts `--delimiter` and `--encoding` for non-default files.
-- **JSON** — reads a bounded sample of records from a JSONL file (one JSON object per line) or a JSON file containing an array of objects.
+- **Parquet**: reads only the Parquet footer, which encodes exact column names and types; no row-group data is touched.
+- **CSV**: reads the header row plus a bounded sample of rows (controlled by `--sample-rows`) to infer types; accepts `--delimiter` and `--encoding` for non-default files.
+- **JSON**: reads a bounded sample of records from a JSONL file (one JSON object per line) or a JSON file containing an array of objects.
 
 **Shared options** (available on all three paths unless noted):
 
@@ -129,7 +129,7 @@ All three file-based flags — `--from-parquet`, `--from-csv`, and `--from-json`
 | `--delimiter CHAR` | CSV only | Field delimiter (default `,`) |
 | `--encoding ENC` | CSV only | File encoding (default `utf-8`) |
 
-**Mutual exclusivity:** `--from-parquet`, `--from-csv`, `--from-json`, `--column`, and the CTAS flags `--select`/`--from-file` are all mutually exclusive — pick exactly one column source per `tables create` invocation.
+**Mutual exclusivity:** `--from-parquet`, `--from-csv`, `--from-json`, `--column`, and the CTAS flags `--select`/`--from-file` are all mutually exclusive - pick exactly one column source per `tables create` invocation.
 
 ```shell
 # From a Parquet footer (exact types, no sampling)
@@ -153,9 +153,9 @@ Once the table is created, load data into it with `tables load --format <parquet
 
 !!! note "File inference is CLI-only"
 
-    The MCP `create_empty_table` tool deliberately takes an explicit `columns` list and does **not** do Parquet/CSV/JSON inference — server-side file access is unreliable in MCP deployments. Use the CLI for file-based inference, or pass the resolved columns to `create_empty_table`.
+    The MCP `create_empty_table` tool deliberately takes an explicit `columns` list and does **not** do Parquet/CSV/JSON inference - server-side file access is unreliable in MCP deployments. Use the CLI for file-based inference, or pass the resolved columns to `create_empty_table`.
 
-### CTAS — create a table from a query
+### CTAS - create a table from a query
 
 `CREATE TABLE … AS SELECT` materialises a query result into a new table. Supply the SELECT inline with `--select`, or keep the body under version control and pass `--from-file body.sql`. The body is rejected client-side if its first non-comment keyword isn't `SELECT`.
 
@@ -193,7 +193,7 @@ fdw tables list --schema sales
 
 ---
 
-## Step 3 — Populate the tables
+## Step 3 - Populate the tables
 
 Loading data is its own topic. The bridge from "empty table" to "populated table" is **`tables load`**, which issues `COPY INTO` from a local file or a remote URL (and can auto-create the table from the source schema with `--create`):
 
@@ -201,13 +201,13 @@ Loading data is its own topic. The bridge from "empty table" to "populated table
 fdw tables load SalesWH sales.orders --file ./data/orders.parquet
 ```
 
-**Targets:** Data Warehouse only. There is **no MCP `load` tool for local files**; the MCP server exposes `load_table_from_url` / `import_table_from_url` for remote URLs only (local staging needs reliable file access). For the full loading surface — `--create`, `--if-exists`, credentials for secured external URLs, CSV options — see the [`tables load`](../commands/tables.md#tables-load) reference rather than this guide.
+**Targets:** Data Warehouse only. There is **no MCP `load` tool for local files**; the MCP server exposes `load_table_from_url` / `import_table_from_url` for remote URLs only (local staging needs reliable file access). For the full loading surface - `--create`, `--if-exists`, credentials for secured external URLs, CSV options - see the [`tables load`](../commands/tables.md#tables-load) reference rather than this guide.
 
 ---
 
-## Step 4 — Create views
+## Step 4 - Create views
 
-Views give consumers a stable, named query. Unlike tables, **views are creatable on both a Data Warehouse and a SQL Analytics Endpoint** — there's no Warehouse-only guard.
+Views give consumers a stable, named query. Unlike tables, **views are creatable on both a Data Warehouse and a SQL Analytics Endpoint**: there's no Warehouse-only guard.
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint · **MCP:** `create_view`, `update_view`, `get_view`, `get_view_columns`, `rename_view`, `list_views`
 
@@ -234,7 +234,7 @@ You can also create inline with `--select "<SELECT>"`. **MCP:** `create_view` (p
 ### Inspect and update a view
 
 ```shell
-# Full definition (from sys.sql_modules) — warehouse positional kept, view name follows
+# Full definition (from sys.sql_modules) - warehouse positional kept, view name follows
 fdw views get SalesWH sales.vw_orders_by_month
 
 # Column metadata
@@ -253,9 +253,9 @@ fdw views update SalesWH sales.vw_orders_by_month \
 
 ---
 
-## Step 5 — Help the optimizer
+## Step 5 - Help the optimizer
 
-After you load data, give the query optimizer the statistics it needs. `fabric-dw` manages **single-column** statistics (a Fabric limitation — multi-column statistics aren't supported), and you must pass an explicit `--name` (Fabric requires an explicit statistic name — there is no auto-generated default).
+After you load data, give the query optimizer the statistics it needs. `fabric-dw` manages **single-column** statistics (a Fabric limitation - multi-column statistics aren't supported), and you must pass an explicit `--name` (Fabric requires an explicit statistic name - there is no auto-generated default).
 
 **Targets:** Data Warehouse only (create/update/delete) · Data Warehouse · SQL Analytics Endpoint (list/show) · **MCP:** `create_statistics`, `update_statistics`, `list_statistics`, `show_statistics`
 
@@ -264,7 +264,7 @@ After you load data, give the query optimizer the statistics it needs. `fabric-d
 fdw statistics create \
   --table sales.orders --column region --name stat_orders_region
 
-# Refresh it after a load (warehouse positional kept — table/stat names follow)
+# Refresh it after a load (warehouse positional kept - table/stat names follow)
 fdw statistics update SalesWH sales.orders stat_orders_region
 
 # List / inspect
@@ -290,7 +290,7 @@ fdw --yes tables cluster-by SalesWH sales.orders
 fdw tables cluster-columns SalesWH sales.orders
 ```
 
-**Targets:** Data Warehouse only · **MCP:** `set_cluster_columns` (destructive — copies the full table), `get_cluster_columns`.
+**Targets:** Data Warehouse only · **MCP:** `set_cluster_columns` (destructive - copies the full table), `get_cluster_columns`.
 
 !!! tip "Diagnosing slow queries"
 
@@ -298,7 +298,7 @@ fdw tables cluster-columns SalesWH sales.orders
 
 ---
 
-## Step 6 — Maintain & iterate
+## Step 6 - Maintain & iterate
 
 **Clone** a table (zero-copy, near-instant, independent of the source). Add `--at` for a point-in-time clone within the warehouse's data-retention window:
 
@@ -312,20 +312,20 @@ fdw tables clone \
   --at 2026-05-20T14:00:00
 ```
 
-**Rename** a table or view (`sp_rename`; the new name must be **unqualified** — you can't move objects across schemas):
+**Rename** a table or view (`sp_rename`; the new name must be **unqualified**: you can't move objects across schemas):
 
 ```shell
 fdw tables rename SalesWH sales.orders_2025 --new-name orders_archive_2025
 fdw views rename SalesWH sales.vw_recent --new-name vw_revenue
 ```
 
-**Clear** a table (`TRUNCATE TABLE` — removes all rows, keeps the structure):
+**Clear** a table (`TRUNCATE TABLE`: removes all rows, keeps the structure):
 
 ```shell
 fdw --yes tables clear SalesWH staging.raw_products
 ```
 
-**Health-check** a table on a **SQL Analytics Endpoint** — this is the inverse of the usual guard: `tables health-check` runs `sp_get_table_health_metrics` (Delta/Parquet layout diagnostics) and is **rejected on a Data Warehouse**:
+**Health-check** a table on a **SQL Analytics Endpoint**: this is the inverse of the usual guard: `tables health-check` runs `sp_get_table_health_metrics` (Delta/Parquet layout diagnostics) and is **rejected on a Data Warehouse**:
 
 ```shell
 fdw tables health-check MySqlEndpoint dbo.FactSales
@@ -339,7 +339,7 @@ fdw --yes tables delete SalesWH sales.orders
 fdw --yes schemas delete SalesWH sales --cascade
 ```
 
-`schemas delete --cascade` first drops **all tables, views, functions, and stored procedures** in the schema. Without `--cascade`, the engine rejects `DROP SCHEMA` on a non-empty schema. On a SQL Analytics Endpoint, cascade can't drop tables (no `DROP TABLE` there), so a schema still holding tables won't drop — remove them from the warehouse first.
+`schemas delete --cascade` first drops **all tables, views, functions, and stored procedures** in the schema. Without `--cascade`, the engine rejects `DROP SCHEMA` on a non-empty schema. On a SQL Analytics Endpoint, cascade can't drop tables (no `DROP TABLE` there), so a schema still holding tables won't drop - remove them from the warehouse first.
 
 **MCP equivalents:** `clone_table`, `rename_table` / `rename_view`, `clear_table`, `get_table_health_metrics`, `drop_view`, `delete_table`, `delete_schema(..., cascade=True)`.
 
@@ -351,7 +351,7 @@ These commands prompt for confirmation before they run; pass `--yes` / `-y` to s
 
 `tables clear`, `tables delete`, `tables cluster-by`, `views drop`, `views update`, `schemas delete`, `statistics delete`, and `tables load --if-exists truncate|replace`.
 
-The matching MCP tools are marked `destructive=True`. An assistant must satisfy the server's destructive-operations guard before they execute — see the [MCP server install](../install.md#mcp) page.
+The matching MCP tools are marked `destructive=True`. An assistant must satisfy the server's destructive-operations guard before they execute - see the [MCP server install](../install.md#mcp) page.
 
 ### The SQL Analytics Endpoint read-only guard
 
@@ -372,7 +372,7 @@ Fabric's T-SQL surface differs from SQL Server. The points below most often trip
 
 ### Unsupported data types
 
-`tables create --column` accepts any type string you give it, but the **engine** rejects persisting columns whose type isn't supported for warehouse tables/views. Notably **unsupported**: `money` / `smallmoney`, `datetime` / `smalldatetime`, `datetimeoffset`, `nchar` / `nvarchar`, `text` / `ntext`, `image`, `tinyint`, `geography` / `geometry`, `json`, `xml`, CLR UDTs, and `Vector`. Use the documented alternatives instead — `decimal`, `datetime2`, `char` / `varchar`, `varbinary`, `smallint`, and so on. See [Data types in Fabric Data Warehouse](https://learn.microsoft.com/fabric/data-warehouse/data-types?WT.mc_id=MVP_310840#data-types-in-fabric-data-warehouse).
+`tables create --column` accepts any type string you give it, but the **engine** rejects persisting columns whose type isn't supported for warehouse tables/views. Notably **unsupported**: `money` / `smallmoney`, `datetime` / `smalldatetime`, `datetimeoffset`, `nchar` / `nvarchar`, `text` / `ntext`, `image`, `tinyint`, `geography` / `geometry`, `json`, `xml`, CLR UDTs, and `Vector`. Use the documented alternatives instead - `decimal`, `datetime2`, `char` / `varchar`, `varbinary`, `smallint`, and so on. See [Data types in Fabric Data Warehouse](https://learn.microsoft.com/fabric/data-warehouse/data-types?WT.mc_id=MVP_310840#data-types-in-fabric-data-warehouse).
 
 ### Constraints require `NOT ENFORCED`, and can't be inline
 
@@ -380,17 +380,17 @@ Fabric's T-SQL surface differs from SQL Server. The points below most often trip
 
 - `PRIMARY KEY` / `UNIQUE` are only allowed when both `NONCLUSTERED` **and** `NOT ENFORCED`; `FOREIGN KEY` only when `NOT ENFORCED`.
 - **No default constraints.**
-- Constraints **can't be declared inline** in `CREATE TABLE` — add them afterwards with `ALTER TABLE`.
+- Constraints **can't be declared inline** in `CREATE TABLE`: add them afterwards with `ALTER TABLE`.
 
-Because the keys are unenforced, the engine trusts them but doesn't validate them — don't treat an unenforced key as a guaranteed-unique JOIN candidate. See [Table constraints](https://learn.microsoft.com/fabric/data-warehouse/table-constraints?WT.mc_id=MVP_310840) and the [performance guidelines](https://learn.microsoft.com/fabric/data-warehouse/guidelines-warehouse-performance?WT.mc_id=MVP_310840#query-performance).
+Because the keys are unenforced, the engine trusts them but doesn't validate them - don't treat an unenforced key as a guaranteed-unique JOIN candidate. See [Table constraints](https://learn.microsoft.com/fabric/data-warehouse/table-constraints?WT.mc_id=MVP_310840) and the [performance guidelines](https://learn.microsoft.com/fabric/data-warehouse/guidelines-warehouse-performance?WT.mc_id=MVP_310840#query-performance).
 
 ### T-SQL surface area
 
-The Warehouse supports tables, views, procedures, and functions; `TRUNCATE TABLE`, `sp_rename`, CTAS, and a **limited** `ALTER TABLE` (add a nullable column, drop a column, add/drop `NOT ENFORCED` constraints) are supported. Creating, altering, or dropping **tables** and running **DML** are **not** supported on a Lakehouse SQL Analytics Endpoint — only views, table-valued functions, and stored procedures. This grounds the read-only-endpoint guard above. See [T-SQL surface area](https://learn.microsoft.com/fabric/data-warehouse/tsql-surface-area?WT.mc_id=MVP_310840#t-sql-surface-area).
+The Warehouse supports tables, views, procedures, and functions; `TRUNCATE TABLE`, `sp_rename`, CTAS, and a **limited** `ALTER TABLE` (add a nullable column, drop a column, add/drop `NOT ENFORCED` constraints) are supported. Creating, altering, or dropping **tables** and running **DML** are **not** supported on a Lakehouse SQL Analytics Endpoint - only views, table-valued functions, and stored procedures. This grounds the read-only-endpoint guard above. See [T-SQL surface area](https://learn.microsoft.com/fabric/data-warehouse/tsql-surface-area?WT.mc_id=MVP_310840#t-sql-surface-area).
 
 ### Fixed, case-sensitive collation
 
-A warehouse is created with the default `Latin1_General_100_BIN2_UTF8` collation (case-sensitive), and **collation can't be changed after creation**. This makes **schema and object names case-sensitive** — `sales.Orders` and `sales.orders` are different. Settle your naming convention up front. See [Collation in Fabric Data Warehouse](https://learn.microsoft.com/fabric/data-warehouse/collation?WT.mc_id=MVP_310840).
+A warehouse is created with the default `Latin1_General_100_BIN2_UTF8` collation (case-sensitive), and **collation can't be changed after creation**. This makes **schema and object names case-sensitive**: `sales.Orders` and `sales.orders` are different. Settle your naming convention up front. See [Collation in Fabric Data Warehouse](https://learn.microsoft.com/fabric/data-warehouse/collation?WT.mc_id=MVP_310840).
 
 ### Naming rules
 
@@ -402,7 +402,7 @@ Table and schema names **can't contain `/` or `\`, and can't end with a `.`**. S
 
 ### Table design
 
-For the schema model itself, follow the [dimensional-modeling](https://learn.microsoft.com/fabric/data-warehouse/dimensional-modeling-overview?WT.mc_id=MVP_310840#star-schema-design) and [table design](https://learn.microsoft.com/fabric/data-warehouse/tables?WT.mc_id=MVP_310840) guidance: fact / dimension / integration table categories, surrogate keys, types matched to semantics (`date` / `datetime2`, integer types for whole numbers, the smallest viable `decimal` precision — see [data-type optimization](https://learn.microsoft.com/fabric/data-warehouse/guidelines-warehouse-performance?WT.mc_id=MVP_310840#data-type-optimization)), and [statistics](https://learn.microsoft.com/fabric/data-warehouse/statistics?WT.mc_id=MVP_310840) refreshed after loads. The canonical DDL references are [CREATE TABLE](https://learn.microsoft.com/fabric/data-warehouse/create-table?WT.mc_id=MVP_310840) and [CREATE TABLE AS SELECT](https://learn.microsoft.com/sql/t-sql/statements/create-table-azure-sql-data-warehouse?view=fabric&WT.mc_id=MVP_310840).
+For the schema model itself, follow the [dimensional-modeling](https://learn.microsoft.com/fabric/data-warehouse/dimensional-modeling-overview?WT.mc_id=MVP_310840#star-schema-design) and [table design](https://learn.microsoft.com/fabric/data-warehouse/tables?WT.mc_id=MVP_310840) guidance: fact / dimension / integration table categories, surrogate keys, types matched to semantics (`date` / `datetime2`, integer types for whole numbers, the smallest viable `decimal` precision - see [data-type optimization](https://learn.microsoft.com/fabric/data-warehouse/guidelines-warehouse-performance?WT.mc_id=MVP_310840#data-type-optimization)), and [statistics](https://learn.microsoft.com/fabric/data-warehouse/statistics?WT.mc_id=MVP_310840) refreshed after loads. The canonical DDL references are [CREATE TABLE](https://learn.microsoft.com/fabric/data-warehouse/create-table?WT.mc_id=MVP_310840) and [CREATE TABLE AS SELECT](https://learn.microsoft.com/sql/t-sql/statements/create-table-azure-sql-data-warehouse?view=fabric&WT.mc_id=MVP_310840).
 
 ---
 

--- a/docs/guides/warehouse-performance.md
+++ b/docs/guides/warehouse-performance.md
@@ -5,8 +5,8 @@ title: Warehouse performance
 # Investigating & improving warehouse performance
 
 This guide is a repeatable **monitor → diagnose → tune/scale** playbook for answering
-*"the warehouse feels slow / we're being throttled — what now?"* using `fabric-dw`. It
-operates at the **warehouse / capacity (compute) level** — the whole-warehouse story — not
+*"the warehouse feels slow / we're being throttled - what now?"* using `fabric-dw`. It
+operates at the **warehouse / capacity (compute) level**: the whole-warehouse story - not
 the tuning of a single query.
 
 > **For single-query tuning** (execution plans, missing statistics on one query, clustering),
@@ -17,7 +17,7 @@ the tuning of a single query.
 **Audience.** Fabric workspace admins, data-platform / DWH operators, and SREs running Fabric
 Data Warehouses or SQL Analytics Endpoints from the CLI or via an MCP-connected assistant. It
 assumes you are comfortable with T-SQL and Fabric workspaces, but **not** with Fabric's internal
-compute model — that model is explained below, because it changes which lever is the right one.
+compute model - that model is explained below, because it changes which lever is the right one.
 
 Every command appears in **both** its CLI form (`fdw …`) and its MCP tool name, so you can drive
 this workflow by hand or through an AI assistant. CLI subcommand names and MCP tool names mostly
@@ -31,14 +31,14 @@ match; where they diverge (the `queries` group), both are given.
 (`/fabric-dw:warehouse-performance`) that automates **exactly** this monitor → diagnose → tune
 workflow: it surfaces long-running and frequent queries plus SQL pool insights, audits statistics
 health, checks result-set caching, reviews and tunes SQL pool configuration, and produces a
-prioritized findings report — with every mutating action gated on your confirmation.
+prioritized findings report - with every mutating action gated on your confirmation.
 
 The guide and the skill are **complementary, not duplicates**:
 
-- **This guide is the human narrative** — the *why*, and *how Fabric serverless compute works* —
+- **This guide is the human narrative**: the *why*, and *how Fabric serverless compute works* -
   for an operator driving `fabric-dw` (or any SQL/REST client) by hand and reasoning about whether
   the right lever is statistics, caching, workload isolation, or a capacity change.
-- **The skill is the AI-assistant automation** — the *do it for me* path: it runs the same read
+- **The skill is the AI-assistant automation**: the *do it for me* path: it runs the same read
   commands, synthesizes the report, and proposes the mutating actions for you to confirm via an
   MCP-connected assistant.
 
@@ -56,7 +56,7 @@ compute model is different from a provisioned MPP warehouse, and that difference
 
 A Fabric **Warehouse** and a **SQL Analytics Endpoint** share the same *serverless, autonomously
 scaling* distributed compute engine. Backend nodes are provisioned in seconds, scaling is an online
-operation, and **there is no compute to provision or resize** — scaling happens autonomously as the
+operation, and **there is no compute to provision or resize**: scaling happens autonomously as the
 workload demands it. You do not pick a node count or a "DWU" tier per warehouse.
 
 See [Workload management in Fabric Data Warehouse](https://learn.microsoft.com/fabric/data-warehouse/workload-management?WT.mc_id=MVP_310840).
@@ -66,11 +66,11 @@ See [Workload management in Fabric Data Warehouse](https://learn.microsoft.com/f
 Performance and cost headroom come from the **Fabric capacity SKU** the workspace runs on, measured
 in **Capacity Units (CU)**:
 
-- **Bursting** — a query can temporarily use *more* CU than the SKU baseline (up to 12× baseline)
+- **Bursting**: a query can temporarily use *more* CU than the SKU baseline (up to 12× baseline)
   so a single heavy operation finishes fast. The available burst is governed by a per-SKU scale
   factor (`CU / duration / Baseline CU`); F2–F2048 each have a guardrail.
   See [Burstable capacity](https://learn.microsoft.com/fabric/data-warehouse/burstable-capacity?WT.mc_id=MVP_310840).
-- **Smoothing** — CU accounting is *spread over time* (roughly 5 min for interactive queries,
+- **Smoothing**: CU accounting is *spread over time* (roughly 5 min for interactive queries,
   up to 24 h for background operations) rather than billed at the instant of execution. Smoothing
   does **not** change how long a query takes; it only spreads the *accounting* so short spikes don't
   immediately exhaust the capacity.
@@ -81,7 +81,7 @@ in **Capacity Units (CU)**:
 The practical consequence: when the warehouse "feels slow across the board" or you see
 `CapacityLimitExceeded` / *"query rejected due to current capacity constraints"*, the problem is
 usually **sustained CU demand exceeding the SKU** (a capacity decision) or **a few expensive queries
-consuming the shared engine** (a query/statistics/caching decision) — *not* an under-provisioned
+consuming the shared engine** (a query/statistics/caching decision) - *not* an under-provisioned
 warehouse you can resize.
 
 ### The default SELECT vs non-SELECT pool split
@@ -92,8 +92,8 @@ Even with no custom configuration, the engine isolates work into two pools, spli
 - a **`NON-SELECT`** pool for DML/DDL/ETL/ingestion statements.
 
 This keeps ingestion from starving interactive reads (and vice-versa) by default. You can change
-this baseline with **custom SQL pools** — covered in [Step 3](#step-3-tune-apply-the-right-lever).
-See [Workload management — compute pool isolation](https://learn.microsoft.com/fabric/data-warehouse/workload-management?WT.mc_id=MVP_310840#compute-pool-isolation).
+this baseline with **custom SQL pools**: covered in [Step 3](#step-3-tune-apply-the-right-lever).
+See [Workload management - compute pool isolation](https://learn.microsoft.com/fabric/data-warehouse/workload-management?WT.mc_id=MVP_310840#compute-pool-isolation).
 
 ---
 
@@ -123,13 +123,13 @@ The rest of this guide assumes these defaults are set, so the examples omit `-w 
 
 ---
 
-## Step 1 — Monitor: is there a problem, and where?
+## Step 1 - Monitor: is there a problem, and where?
 
 Establish what exists, what is running right now, and whether the capacity itself is the constraint.
 
 ### Inventory the warehouses
 
-Confirm which items exist and which kind each is (Data Warehouse vs SQL Analytics Endpoint — they
+Confirm which items exist and which kind each is (Data Warehouse vs SQL Analytics Endpoint - they
 behave differently for several tuning levers below).
 
 | Action | CLI | MCP tool |
@@ -164,7 +164,7 @@ fdw queries connections
 
 ### Read SQL pool pressure
 
-`sql-pools insights` reads `queryinsights.sql_pool_insights` — the warehouse's own resource-pressure
+`sql-pools insights` reads `queryinsights.sql_pool_insights`: the warehouse's own resource-pressure
 signal, including `is_pool_under_pressure` and `max_resource_percentage`. This is the single most
 direct *"is compute the bottleneck?"* read.
 
@@ -203,12 +203,12 @@ fdw workspaces list-capacities
 
 ---
 
-## Step 2 — Diagnose: what is consuming compute, and why?
+## Step 2 - Diagnose: what is consuming compute, and why?
 
 Once you know there's pressure, find the cost drivers. Fabric's **Query Insights** views retain
 about 30 days of history and aggregate repeated statements by `query_hash`. All of the commands
 below accept `--since` / `--until` / `--limit` to scope a window (`--limit` defaults to 100, capped
-at 10 000). There is **no `--order-by` flag** — each view is ordered server-side, so *"top N"* is
+at 10 000). There is **no `--order-by` flag**: each view is ordered server-side, so *"top N"* is
 simply `--limit N`.
 
 See [Query Insights](https://learn.microsoft.com/fabric/data-warehouse/query-insights?WT.mc_id=MVP_310840)
@@ -225,12 +225,12 @@ and [Monitor Fabric Data Warehouse](https://learn.microsoft.com/fabric/data-ware
 # Top 20 slowest queries over the last week
 fdw queries long-running --limit 20
 
-# Top 20 most-frequently-run queries — a cheap query run 100k times is also a cost driver
+# Top 20 most-frequently-run queries - a cheap query run 100k times is also a cost driver
 fdw queries frequent --limit 20
 ```
 
 A query that is individually fast but runs *constantly* can dominate CU usage just as much as one
-slow query — check both lists.
+slow query - check both lists.
 See the [`queryinsights.long_running_queries` column reference](https://learn.microsoft.com/sql/relational-databases/system-views/queryinsights-long-running-queries-transact-sql?view=fabric&WT.mc_id=MVP_310840).
 
 ### Drill into completed requests and sessions
@@ -278,7 +278,7 @@ warehouse-wide. Audit whether the optimizer has good statistics on hot columns. 
 
 ```shell
 fdw statistics list --table dbo.sales --user-only
-fdw statistics show SalesWH dbo.sales _stat_order_date --histogram   # warehouse positional kept — names follow
+fdw statistics show SalesWH dbo.sales _stat_order_date --histogram   # warehouse positional kept - names follow
 ```
 
 See [Statistics in Fabric Data Warehouse](https://learn.microsoft.com/fabric/data-warehouse/statistics?WT.mc_id=MVP_310840)
@@ -287,7 +287,7 @@ for when automatic statistics suffice and when to create/update manually, and th
 
 ---
 
-## Step 3 — Tune: apply the right lever
+## Step 3 - Tune: apply the right lever
 
 Now act on the diagnosis. Levers are ordered from *cheapest/safest* to *most structural*.
 
@@ -296,9 +296,9 @@ Now act on the diagnosis. Levers are ordered from *cheapest/safest* to *most str
     Every mutating MCP tool below is gated behind the server's write guard
     (`assert_writes_allowed`), and the destructive ones additionally behind `assert_destructive_allowed`
     (`FABRIC_MCP_ALLOW_DESTRUCTIVE=1`). In CLI, destructive commands prompt for confirmation unless
-    you pass `--yes`. None of these are read-only — treat them as changes.
+    you pass `--yes`. None of these are read-only - treat them as changes.
 
-### Result-set caching (Data Warehouse only — the fast win)
+### Result-set caching (Data Warehouse only - the fast win)
 
 If the diagnosis shows the same identical queries repeating with low `result_cache_hit`, enabling
 result-set caching can cut elapsed time for repeated identical queries dramatically.
@@ -310,11 +310,11 @@ result-set caching can cut elapsed time for repeated identical queries dramatica
 
 ```shell
 fdw settings show
-fdw settings result-set-caching SalesWH on   # warehouse positional kept — on|off follows
+fdw settings result-set-caching SalesWH on   # warehouse positional kept - on|off follows
 ```
 
 `settings result-set-caching` runs `ALTER DATABASE CURRENT SET RESULT_SET_CACHING { ON | OFF }`.
-The toggle is **Data-Warehouse-only** — SQL Analytics Endpoints are rejected with an error. (Note
+The toggle is **Data-Warehouse-only**: SQL Analytics Endpoints are rejected with an error. (Note
 that `settings show` itself works on both kinds; only the *toggle* is DW-only.)
 See [Result set caching in Fabric Data Warehouse](https://learn.microsoft.com/fabric/data-warehouse/result-set-caching?WT.mc_id=MVP_310840).
 
@@ -323,7 +323,7 @@ See [Result set caching in Fabric Data Warehouse](https://learn.microsoft.com/fa
     `settings retention --days N` (MCP `set_time_travel_retention`, also DW-only) lives in the same
     `settings` group but controls **time-travel retention**, not performance.
 
-### Statistics tuning (Data Warehouse only — DDL)
+### Statistics tuning (Data Warehouse only - DDL)
 
 If [Step 2](#check-statistics-health) found missing or stale statistics on hot columns, create or
 refresh them. Fabric supports **single-column, histogram-based** statistics only.
@@ -389,20 +389,20 @@ If a single runaway session is blocking everything else, terminate it.
 | Kill a session | [`fdw queries kill … <session_id>`](../commands/queries.md#queries-kill) | `kill_session` |
 
 ```shell
-fdw --yes queries kill SalesWH 42   # warehouse positional kept — SESSION_ID follows
+fdw --yes queries kill SalesWH 42   # warehouse positional kept - SESSION_ID follows
 ```
 
 ---
 
-## Step 4 — Decide whether to scale
+## Step 4 - Decide whether to scale
 
-If the cost drivers are genuinely justified work — not a tuning problem — and you are still
+If the cost drivers are genuinely justified work - not a tuning problem - and you are still
 throttled, the lever is the **capacity**, not the warehouse. Distinguish the two cases:
 
-- **A design / tuning problem** — a handful of queries dominate CU, statistics are stale, or one
+- **A design / tuning problem**: a handful of queries dominate CU, statistics are stale, or one
   workload is starving another. Fix it in [Step 2](#step-2-diagnose-what-is-consuming-compute-and-why) / [Step 3](#step-3-tune-apply-the-right-lever);
   scaling just pays more for the same waste.
-- **Sustained, legitimate demand exceeding the SKU** — throttling persists even after tuning, and
+- **Sustained, legitimate demand exceeding the SKU**: throttling persists even after tuning, and
   the [Capacity Metrics app](https://learn.microsoft.com/fabric/enterprise/metrics-app?WT.mc_id=MVP_310840)
   shows steady overage. This is a capacity decision.
 
@@ -411,7 +411,7 @@ For a real capacity decision you have two levers, only one of which `fabric-dw` 
 | Lever | Tool support |
 | --- | --- |
 | **Move the workspace to another capacity** (load-balance across capacities) | [`fdw workspaces assign-capacity <workspace> --capacity-id <uuid>`](../commands/workspaces.md#workspaces-assign-capacity) · MCP `assign_workspace_to_capacity` |
-| **Resize the capacity SKU** (e.g. F64 → F128) | **Out of CLI scope** — a capacity-admin action in the Fabric/Azure portal |
+| **Resize the capacity SKU** (e.g. F64 → F128) | **Out of CLI scope**: a capacity-admin action in the Fabric/Azure portal |
 
 ```shell
 # Spread load by moving a workspace onto a different (less-loaded) capacity
@@ -420,7 +420,7 @@ fdw workspaces assign-capacity MyWorkspace \
 ```
 
 `assign-capacity` **moves** the workspace; it does **not resize** a SKU. A SKU resize is a
-capacity-admin action — see
+capacity-admin action - see
 [Scale your Fabric capacity](https://learn.microsoft.com/fabric/enterprise/scale-capacity?WT.mc_id=MVP_310840)
 and [Evaluate and optimize your Fabric capacity](https://learn.microsoft.com/fabric/enterprise/optimize-capacity?WT.mc_id=MVP_310840)
 for right-sizing and load-balancing guidance.
@@ -440,19 +440,19 @@ A copy-pasteable session that walks the whole loop on a warehouse that "feels sl
 [`warehouse-performance` skill](../skills.md#warehouse-performance) drive these same steps for you.
 
 ```shell
-# 1. MONITOR — confirm the warehouse exists, check live load and pool pressure, check the SKU
+# 1. MONITOR - confirm the warehouse exists, check live load and pool pressure, check the SKU
 fdw warehouses get
 fdw queries running
 fdw sql-pools insights --since 2026-06-13T00:00:00
 fdw workspaces list-capacities
 
-# 2. DIAGNOSE — find the worst offenders and inspect their CPU / data-scanned / cache hits
+# 2. DIAGNOSE - find the worst offenders and inspect their CPU / data-scanned / cache hits
 fdw queries long-running --limit 20
 fdw queries frequent --limit 20
 fdw queries history --limit 50 --since 2026-06-13T00:00:00
 fdw statistics list --table dbo.sales --user-only
 
-# 3. TUNE — apply the cheapest effective lever(s) for what you found
+# 3. TUNE - apply the cheapest effective lever(s) for what you found
 fdw settings result-set-caching SalesWH on          # repeated identical queries (on|off follows, so warehouse positional kept)
 fdw statistics create \
   --table dbo.sales --column order_date --name _stat_order_date --fullscan   # stale/missing stats
@@ -460,13 +460,13 @@ fdw sql-pools create \
   --name ETL --max-percent 30 --no-optimize-for-reads \
   --classifier-type "Application Name" --classifier-value "ETL"     # ETL starving reads
 
-# 4. RE-MEASURE — confirm the change helped before reaching for a capacity change
+# 4. RE-MEASURE - confirm the change helped before reaching for a capacity change
 fdw queries long-running --limit 20
 fdw sql-pools insights --since 2026-06-13T00:00:00
 ```
 
 Only if throttling persists after re-measuring should you consider
-[Step 4](#step-4-decide-whether-to-scale) — reassigning the workspace to another capacity, or
+[Step 4](#step-4-decide-whether-to-scale) - reassigning the workspace to another capacity, or
 escalating a SKU resize to a capacity admin.
 
 ---
@@ -477,10 +477,10 @@ escalating a SKU resize to a capacity admin.
 of scope:
 
 - **No capacity SKU resize.** `fabric-dw` reads capacity state, lists capacities, and can reassign a
-  workspace to another capacity — but a SKU resize (e.g. F64 → F128) is a capacity-admin action in
+  workspace to another capacity - but a SKU resize (e.g. F64 → F128) is a capacity-admin action in
   the Fabric/Azure portal.
 - **No Capacity Metrics app.** For CU-usage and throttling trends over time, use the
-  [Capacity Metrics app](https://learn.microsoft.com/fabric/enterprise/metrics-app?WT.mc_id=MVP_310840) —
+  [Capacity Metrics app](https://learn.microsoft.com/fabric/enterprise/metrics-app?WT.mc_id=MVP_310840) -
   this tool does not replace it.
 - **Application-name classifier only.** The only SQL-pool routing key today is the application-name
   classifier; statement-type routing is observe-only with no API
@@ -492,9 +492,9 @@ of scope:
 
 ## See also
 
-- [`warehouse-performance` Agent Skill](../skills.md#warehouse-performance) — the AI-assistant
+- [`warehouse-performance` Agent Skill](../skills.md#warehouse-performance) - the AI-assistant
   automation of this workflow.
-- [`query-optimizer` Agent Skill](../skills.md#query-optimizer) — single-query tuning.
+- [`query-optimizer` Agent Skill](../skills.md#query-optimizer) - single-query tuning.
 - Command pages: [Queries](../commands/queries.md) · [SQL Pools](../commands/sql-pools.md) ·
   [Settings](../commands/settings.md) · [Statistics](../commands/statistics.md) ·
   [Warehouses](../commands/warehouses.md) · [Workspaces](../commands/workspaces.md)

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -56,8 +56,8 @@ Place each file at one of the Claude Code personal or project skill paths:
 
 | Path | Scope |
 | --- | --- |
-| `~/.claude/skills/<name>/SKILL.md` | Personal — applies to all projects |
-| `.claude/skills/<name>/SKILL.md` | Project-scoped — committed to repo |
+| `~/.claude/skills/<name>/SKILL.md` | Personal - applies to all projects |
+| `.claude/skills/<name>/SKILL.md` | Project-scoped - committed to repo |
 
 For example, to install `query-optimizer` at project scope:
 
@@ -88,7 +88,7 @@ fdw sql plan <warehouse> -q "<query>" --format html -o plan.html   # writes self
 fdw sql plan <workspace>/<warehouse> -q "<query>" --format svg -o plan.svg   # renders SVG via system dot binary (requires Graphviz)
 ```
 
-`--format html` requires `-o/--output` and writes a file — it does not open the browser automatically.
+`--format html` requires `-o/--output` and writes a file - it does not open the browser automatically.
 
 ### warehouse-performance
 
@@ -96,7 +96,7 @@ Runs a warehouse-wide performance investigation on a Fabric Data Warehouse (the 
 
 1. Finds query hotspots via `queries long-running` and `queries frequent` (server-ordered; "top N" is `--limit N`, no `--order-by`), plus resource-pressure events via `sql-pools insights`; drills down with `queries history` / `queries sessions` (MCP `list_long_running_queries`, `list_frequent_queries`, `list_sql_pool_insights`, `list_request_history`, `list_session_history`). Degrades gracefully when Query Insights is unavailable or permission-denied (needs Contributor+)
 2. Audits statistics health with `statistics list` and `statistics show --histogram`, flagging missing or likely-stale statistics as a heuristic (reads work on both surfaces; DDL is DWH-only)
-3. Checks result-set caching via `settings show`, and recommends `settings result-set-caching on` when frequent identical queries justify it (toggle is DWH-only and mutating — kept distinct from the local `cache clear` lookup cache and from cache cooldown)
+3. Checks result-set caching via `settings show`, and recommends `settings result-set-caching on` when frequent identical queries justify it (toggle is DWH-only and mutating - kept distinct from the local `cache clear` lookup cache and from cache cooldown)
 4. Reviews and tunes SQL pool configuration via `sql-pools get`/`list`/`show`, with actionable `create`/`update` levers (`--max-percent`, `--optimize-for-reads`, application-name classifier) against the default 50/50 baseline (workspace-scoped, workspace admin)
 5. Synthesizes a prioritized findings report with each cost driver's `query_hash` so a specific query can be handed to `query-optimizer`
 
@@ -104,10 +104,10 @@ Every mutating action (result-set-caching toggle, statistics DDL, `sql-pools cre
 
 ### dbt-setup
 
-Bootstraps a dbt-fabric project for a Fabric Data Warehouse. For the human, copy-pasteable CLI walkthrough of the same provision → inspect → scaffold → verify flow, see the [Set up a dbt environment](guides/dbt-setup.md) guide — this skill is the AI-assistant-driven equivalent.
+Bootstraps a dbt-fabric project for a Fabric Data Warehouse. For the human, copy-pasteable CLI walkthrough of the same provision → inspect → scaffold → verify flow, see the [Set up a dbt environment](guides/dbt-setup.md) guide - this skill is the AI-assistant-driven equivalent.
 
 1. Resolves the warehouse connection string via `get_warehouse`
 2. Lists schemas and tables with `list_schemas` and `list_tables` to confirm connectivity
-3. Generates all scaffold files with `generate_dbt_profile` using `with_sources=true` — the tool performs a bulk column fetch and emits a `models/staging/_sources.yml` with `columns:` blocks (name and formatted `data_type`) for every table, ready for dbt contract enforcement
+3. Generates all scaffold files with `generate_dbt_profile` using `with_sources=true`: the tool performs a bulk column fetch and emits a `models/staging/_sources.yml` with `columns:` blocks (name and formatted `data_type`) for every table, ready for dbt contract enforcement
 4. Writes `profiles.yml`, `dbt_project.yml`, `models/staging/_sources.yml`, `requirements.txt`, and `.gitignore` to disk; confirms before overwriting existing files
 5. Provides next steps: `pip install -r requirements.txt`, `dbt debug`, `dbt run`

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -15,7 +15,7 @@ Every telemetry event includes a shared envelope of anonymous fields:
 | `os` | Operating system (e.g. `linux`, `darwin`, `windows`). |
 | `arch` | CPU architecture (e.g. `arm64`, `x86_64`). |
 | `install_method` | Best-effort detection: `pip`, `uv`, `pipx`, or `source`. |
-| `surface` | `cli` or `mcp` — which interface was used. |
+| `surface` | `cli` or `mcp`: which interface was used. |
 | `auth_mode` | Categorical authentication mode: `service_principal`, `github_oidc`, `azure_cli`, `interactive`, or `managed_identity`. **Never credentials.** |
 | `tenant_id` | Your Azure (Entra) tenant ID. |
 
@@ -23,13 +23,13 @@ Every telemetry event includes a shared envelope of anonymous fields:
 
 | Event | When | Extra fields |
 |---|---|---|
-| `app_started` | Once per process | — (`auth_mode` omitted — see note below) |
-| `mcp_server_started` | When the MCP server boots | — (`auth_mode` omitted — see note below) |
+| `app_started` | Once per process | - (`auth_mode` omitted - see note below) |
+| `mcp_server_started` | When the MCP server boots | - (`auth_mode` omitted - see note below) |
 | `app_exited` | On process exit | `duration_ms`, `exit_status` (ok / user_error / api_error), `error_category` |
 
 > **Note on `auth_mode` in lifecycle-start events:** `app_started` and `mcp_server_started` fire at process start, before any token is acquired. Emitting `auth_mode` at that point would produce a possibly-wrong value derived from environment-variable heuristics (e.g. `interactive` for a plain `az login`). The accurate value is only available after the first token acquisition and is emitted on `command_invoked` and `app_exited`.
 
-### `command_invoked` — per-command usage
+### `command_invoked`: per-command usage
 
 One `command_invoked` event is emitted after every CLI command and every MCP tool call completes (success or failure).
 
@@ -63,8 +63,8 @@ One `command_invoked` event is emitted after every CLI command and every MCP too
 | `sql_pools` | `sql-pools` | `list_sql_pools`, `create_sql_pool`, `delete_sql_pool`, … |
 | `dbt` | `dbt` | `generate_dbt_profile` |
 | `cache` | `cache` | `clear_cache` |
-| `config` | `config` | — |
-| `completion` | `completion` | — |
+| `config` | `config` | - |
+| `completion` | `completion` | - |
 
 ### What is deliberately NOT collected
 
@@ -80,7 +80,7 @@ Events are sent to a private Azure Application Insights resource operated by the
 
 ## How to opt out
 
-Any of the following fully disables telemetry — no events are emitted and the SDK is never imported:
+Any of the following fully disables telemetry - no events are emitted and the SDK is never imported:
 
 | Method | How |
 |---|---|

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -22,7 +22,7 @@ or
 CredentialUnavailableError: Please run 'az login' to set up an account.
 ```
 
-**What happened:** `fabric-dw` authenticates through the [`DefaultAzureCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.defaultazurecredential?WT.mc_id=MVP_310840) chain (used by `FABRIC_AUTH=default`). The chain walks several sources — environment variables, Workload Identity, Managed Identity, shared token cache, Azure CLI, Azure Developer CLI, Azure PowerShell — and stops at the first that returns a token. The error above means every source was exhausted without finding one, which usually means the Azure CLI session has expired or you have not run `az login` yet. See [Authentication](install.md#authentication) for the full credential chain.
+**What happened:** `fabric-dw` authenticates through the [`DefaultAzureCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.defaultazurecredential?WT.mc_id=MVP_310840) chain (used by `FABRIC_AUTH=default`). The chain walks several sources - environment variables, Workload Identity, Managed Identity, shared token cache, Azure CLI, Azure Developer CLI, Azure PowerShell - and stops at the first that returns a token. The error above means every source was exhausted without finding one, which usually means the Azure CLI session has expired or you have not run `az login` yet. See [Authentication](install.md#authentication) for the full credential chain.
 
 **Resolution:**
 
@@ -62,7 +62,7 @@ fabric_dw.exceptions.PermissionDenied: permission was denied on the object ...
 
 ---
 
-## Capacity paused — cryptic 5xx or 404 errors
+## Capacity paused - cryptic 5xx or 404 errors
 
 **Symptoms:** Commands fail with `FabricServerError` (HTTP 5xx) or `NotFound` (HTTP 404) even though the workspace and warehouse clearly exist. The Fabric portal may show the capacity as **Paused**.
 
@@ -100,7 +100,7 @@ fabric_dw.exceptions.AuthError: authentication failed for server ...
 
 or a raw driver message containing `Login failed` or `28000`.
 
-**What happened:** The SQL driver is configured with `Authentication=ActiveDirectory{Default,ServicePrincipal,Interactive}` to match the `FABRIC_AUTH` mode you are using (see [`sql.py:_MODE_TO_AD_AUTH`](https://github.com/sdebruyn/fabric-dw-mcp-cli/blob/9a1436618112224b3e86085a9f2231b22e0c827b/src/fabric_dw/sql.py#L50)). In the default mode (`FABRIC_AUTH=default`) the driver runs its own [`ActiveDirectoryDefault`](https://learn.microsoft.com/sql/connect/odbc/using-azure-active-directory?WT.mc_id=MVP_310840) credential chain — environment variables → Managed Identity → Azure CLI → Visual Studio (Windows only) → Azure PowerShell → interactive browser — and is **not** limited to the Azure CLI cache. A token that was valid at connection-open time can still expire mid-session, causing the driver to fail on the next query. See [Authentication](authentication.md) for the full credential-chain reference.
+**What happened:** The SQL driver is configured with `Authentication=ActiveDirectory{Default,ServicePrincipal,Interactive}` to match the `FABRIC_AUTH` mode you are using (see [`sql.py:_MODE_TO_AD_AUTH`](https://github.com/sdebruyn/fabric-dw-mcp-cli/blob/9a1436618112224b3e86085a9f2231b22e0c827b/src/fabric_dw/sql.py#L50)). In the default mode (`FABRIC_AUTH=default`) the driver runs its own [`ActiveDirectoryDefault`](https://learn.microsoft.com/sql/connect/odbc/using-azure-active-directory?WT.mc_id=MVP_310840) credential chain - environment variables → Managed Identity → Azure CLI → Visual Studio (Windows only) → Azure PowerShell → interactive browser - and is **not** limited to the Azure CLI cache. A token that was valid at connection-open time can still expire mid-session, causing the driver to fail on the next query. See [Authentication](authentication.md) for the full credential-chain reference.
 
 **Resolution:**
 
@@ -125,13 +125,13 @@ Re-authenticate via whichever credential source your chain ended up using:
   Connect-AzAccount
   ```
 
-- **Service principal** (`FABRIC_AUTH=sp`) — `FABRIC_AUTH=sp` uses `ActiveDirectoryServicePrincipal` (`ClientSecretCredential`) and bypasses the `ActiveDirectoryDefault` chain described in "What happened" above. Rotate or re-export `AZURE_CLIENT_SECRET` and restart the process:
+- **Service principal** (`FABRIC_AUTH=sp`): `FABRIC_AUTH=sp` uses `ActiveDirectoryServicePrincipal` (`ClientSecretCredential`) and bypasses the `ActiveDirectoryDefault` chain described in "What happened" above. Rotate or re-export `AZURE_CLIENT_SECRET` and restart the process:
 
   ```bash
   export AZURE_CLIENT_SECRET="<new-secret>"
   ```
 
-- **Interactive browser** (`FABRIC_AUTH=interactive`) — re-run your `fabric-dw` command; a new browser sign-in prompt will appear.
+- **Interactive browser** (`FABRIC_AUTH=interactive`): re-run your `fabric-dw` command; a new browser sign-in prompt will appear.
 
 After re-authenticating, retry your command. `FabricSqlClient` opens a fresh connection and picks up the new token automatically. Set `AZURE_LOG_LEVEL=debug` if you are unsure which credential source the chain selected.
 
@@ -149,7 +149,7 @@ fabric_dw.exceptions.RateLimitedError: Received 429 10 consecutive times for htt
 
 **Resolution:**
 
-- If you hit this during a single command, simply retry — the capacity or the API may have been temporarily overloaded.
+- If you hit this during a single command, simply retry - the capacity or the API may have been temporarily overloaded.
 - If you are running `fabric-dw` commands in a loop or in parallel, reduce concurrency so that your effective request rate stays below the 2 RPS cap.
 - Wait a few minutes before retrying if the API continues to throttle.
 
@@ -170,7 +170,7 @@ The client automatically retries on each 429 and waits exactly as long as the se
 
 1. Confirm the capacity is Active (see [Capacity paused](#capacity-paused-cryptic-5xx-or-404-errors) above).
 2. Create a new user-defined restore point while the capacity is Active.
-3. If you expected a system restore point from a period when the capacity was paused, that point does not exist — it was not created.
+3. If you expected a system restore point from a period when the capacity was paused, that point does not exist - it was not created.
 
 ---
 
@@ -192,4 +192,4 @@ The client automatically retries on each 429 and waits exactly as long as the se
 
 3. **Restart the MCP client:** Most AI tools (Claude Desktop, Cursor, VS Code) cache the tool list at startup. After updating the config or reinstalling the package, fully quit and reopen the application.
 
-4. **Check the client logs:** Look for stderr output from the `fabric-dw-mcp` process in your AI tool's log folder — startup errors (missing env vars, import failures) are printed there.
+4. **Check the client logs:** Look for stderr output from the `fabric-dw-mcp` process in your AI tool's log folder - startup errors (missing env vars, import failures) are printed there.


### PR DESCRIPTION
## Summary

- Replace all em-dashes across 32 `docs/**/*.md` files with readable ASCII punctuation.
- Bold labels and type-annotated parameter docs use a colon (`:`); prose clause breaks and section headings use a spaced hyphen (` - `); standalone N/A table cells use a plain hyphen.
- Code block syntax is unchanged; shell comments inside fenced blocks are updated.
- `docs/install.md` and `docs/index.md` are intentionally excluded (those are covered by #768).

## Verification

`grep -rl "—" docs` returns no in-scope files after this change.

## Test plan

- [ ] Confirm `grep -rl "—" docs | grep -v docs/install.md | grep -v docs/index.md` is empty.
- [ ] Spot-check prose in `docs/concepts.md`, `docs/authentication.md`, and `docs/guides/warehouse-performance.md` for natural reading.
- [ ] MkDocs build passes in CI.

Closes #769

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>