### PR TITLE
fix(load): friendly error for missing target table on remote-URL load

### DIFF
--- a/src/fabric_dw/mcp/tools/load.py
+++ b/src/fabric_dw/mcp/tools/load.py
@@ -183,6 +183,23 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
                 # secret and identity are intentionally excluded from this log call
             )
             sql_target = make_sql_target(ws_id, entry, item)
+
+            # Pre-check: COPY INTO gives a raw "Invalid object name" error when the
+            # target table is absent. Raise a friendly message instead.
+            from mcp.server.fastmcp.exceptions import (  # noqa: PLC0415
+                ToolError as _ToolError,
+            )
+
+            from fabric_dw.services.load import table_exists  # noqa: PLC0415
+
+            if not await table_exists(sql_target, schema, table_name, mode=ctx.auth_mode):
+                raise _ToolError(
+                    f"Table [{schema}].[{table_name}] does not exist; "
+                    "remote-URL load cannot infer schema. "
+                    "Create the table first with create_empty_table or create_table, "
+                    "then retry."
+                )
+
             result = await copy_into_from_url(
                 sql_target,
                 schema,
@@ -439,8 +456,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
                         "to infer schema. Use the CLI "
                         "'tables load --file --create --if-exists replace' instead."
                     )
-                # "fail" or "append" on absent table: proceed; COPY INTO will raise a
-                # clear SQL error if the table truly does not exist.
+                if if_exists in ("fail", "append"):
+                    raise _ToolError(
+                        f"Table [{schema}].[{table_name}] does not exist; "
+                        "remote-URL load cannot infer schema. "
+                        "Create the table first with create_empty_table or create_table, "
+                        "then retry."
+                    )
 
             result = await copy_into_from_url(
                 sql_target,

--- a/src/fabric_dw/mcp/tools/load.py
+++ b/src/fabric_dw/mcp/tools/load.py
@@ -29,6 +29,16 @@ __all__ = ["register"]
 _log = logging.getLogger(__name__)
 
 
+def _absent_table_msg(schema: str, table: str) -> str:
+    """Return a friendly error message for a missing target table on remote-URL load."""
+    return (
+        f"Table [{schema}].[{table}] does not exist; "
+        "remote-URL load cannot infer schema. "
+        "Create the table first with create_empty_table or create_table, "
+        "then retry."
+    )
+
+
 def register(mcp: FastMCP) -> None:  # noqa: PLR0915
     """Register table-load tools against *mcp*."""
 
@@ -143,14 +153,14 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             max_errors: Maximum errors before aborting.
             rejected_row_location: URL for rejected-row output.
         """
+        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
         schema, table_name = parse_qualified_name(qualified_name, kind="table")
         ctx = get_context()
         assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
 
         # Validate file_type
         if file_type not in ("CSV", "PARQUET"):
-            from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
-
             raise ToolError(f"Unsupported file_type {file_type!r}; must be CSV or PARQUET")
 
         # Build CSV options.
@@ -184,21 +194,19 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             )
             sql_target = make_sql_target(ws_id, entry, item)
 
-            # Pre-check: COPY INTO gives a raw "Invalid object name" error when the
-            # target table is absent. Raise a friendly message instead.
-            from mcp.server.fastmcp.exceptions import (  # noqa: PLC0415
-                ToolError as _ToolError,
-            )
-
+            from fabric_dw.exceptions import ItemKindError  # noqa: PLC0415
+            from fabric_dw.models import WarehouseKind  # noqa: PLC0415
             from fabric_dw.services.load import table_exists  # noqa: PLC0415
 
+            # SQL Endpoint: COPY INTO is Warehouse-only (check before table_exists so the
+            # endpoint guard fires with the right message even when the table is absent).
+            if entry.kind == WarehouseKind.SQL_ENDPOINT:
+                raise ItemKindError("SQL Endpoints are read-only; COPY INTO not supported")
+
+            # Pre-check: COPY INTO gives a raw "Invalid object name" error when the
+            # target table is absent. Raise a friendly message instead.
             if not await table_exists(sql_target, schema, table_name, mode=ctx.auth_mode):
-                raise _ToolError(
-                    f"Table [{schema}].[{table_name}] does not exist; "
-                    "remote-URL load cannot infer schema. "
-                    "Create the table first with create_empty_table or create_table, "
-                    "then retry."
-                )
+                raise ToolError(_absent_table_msg(schema, table_name))
 
             result = await copy_into_from_url(
                 sql_target,
@@ -238,9 +246,9 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             IfExistsPolicy,
             Field(
                 description=(
-                    "What to do when the target table already exists. "
-                    "'fail': error (default). "
-                    "'append': load into existing table. "
+                    "What to do when the target table exists or is absent. "
+                    "'fail': error if the table already exists, or if it does not exist (default). "
+                    "'append': load into the existing table; error if the table is absent. "
                     "'truncate': TRUNCATE then load (destructive). "
                     "'replace': DROP + recreate from inferred schema, then load (destructive)."
                 ),
@@ -317,8 +325,11 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
 
         ``if_exists`` controls behaviour when the table already exists:
 
-        - ``"fail"`` (default): raise an error if the table already exists.
+        - ``"fail"`` (default): raise an error if the table already exists, or if it
+          does not exist (the table must be created first with create_empty_table or
+          create_table).
         - ``"append"``: load rows into the existing table without modification.
+          Raises an error if the table does not exist.
         - ``"truncate"``: TRUNCATE the existing table first, then load.
           Requires ``FABRIC_MCP_ALLOW_DESTRUCTIVE=1``.  Raises an error if the
           table does **not** exist.
@@ -441,28 +452,24 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
                         "'tables load --file --create --if-exists replace'."
                     )
                 # "append": do nothing — COPY INTO will add rows to the existing table.
+            # Table does not exist.
+            elif if_exists == "truncate":
+                raise _ToolError(
+                    f"Table [{schema}].[{table_name}] does not exist; "
+                    "nothing to truncate. Create the table first or use "
+                    "if_exists='fail' / 'append'."
+                )
+            elif if_exists == "replace":
+                raise _ToolError(
+                    f"Table [{schema}].[{table_name}] does not exist; "
+                    "if_exists='replace' for remote URLs requires downloading the file "
+                    "to infer schema. Use the CLI "
+                    "'tables load --file --create --if-exists replace' instead."
+                )
             else:
-                # Table does not exist.
-                if if_exists == "truncate":
-                    raise _ToolError(
-                        f"Table [{schema}].[{table_name}] does not exist; "
-                        "nothing to truncate. Create the table first or use "
-                        "if_exists='fail' / 'append'."
-                    )
-                if if_exists == "replace":
-                    raise _ToolError(
-                        f"Table [{schema}].[{table_name}] does not exist; "
-                        "if_exists='replace' for remote URLs requires downloading the file "
-                        "to infer schema. Use the CLI "
-                        "'tables load --file --create --if-exists replace' instead."
-                    )
-                if if_exists in ("fail", "append"):
-                    raise _ToolError(
-                        f"Table [{schema}].[{table_name}] does not exist; "
-                        "remote-URL load cannot infer schema. "
-                        "Create the table first with create_empty_table or create_table, "
-                        "then retry."
-                    )
+                # "fail", "append", or any future policy: table must exist first because
+                # remote-URL load cannot infer schema to auto-create it.
+                raise _ToolError(_absent_table_msg(schema, table_name))
 
             result = await copy_into_from_url(
                 sql_target,

--- a/tests/unit/mcp/tools/test_load.py
+++ b/tests/unit/mcp/tools/test_load.py
@@ -447,6 +447,45 @@ async def test_import_table_from_url_replace_absent_table_raises(
 
 
 # ---------------------------------------------------------------------------
+# load_table_from_url — SQL endpoint rejection fires before table-existence check
+# ---------------------------------------------------------------------------
+
+
+async def test_load_table_from_url_rejects_sql_endpoint(
+    mock_ctx, ctx_patch, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """load_table_from_url raises ToolError for SQL Analytics Endpoint items.
+
+    The endpoint guard must fire before the table-existence check so that
+    'SQL endpoint + absent table' yields the endpoint error, not 'table not found'.
+    """
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    monkeypatch.delenv("FABRIC_MCP_READONLY", raising=False)
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_sql_endpoint_entry())
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.load.table_exists",
+            new=AsyncMock(return_value=False),
+        ),
+        pytest.raises(ToolError, match="read-only"),
+    ):
+        await mcp._tool_manager.call_tool(
+            "load_table_from_url",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_name": "dbo.sales",
+                "url": "https://example.com/f.parquet",
+                "file_type": "PARQUET",
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
 # load_table_from_url — absent table raises friendly error
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/mcp/tools/test_load.py
+++ b/tests/unit/mcp/tools/test_load.py
@@ -187,14 +187,14 @@ async def test_import_table_from_url_fail_when_table_exists(
 
 
 # ---------------------------------------------------------------------------
-# import_table_from_url — happy path (append, table not exists)
+# import_table_from_url — absent table raises friendly error for fail/append
 # ---------------------------------------------------------------------------
 
 
-async def test_import_table_from_url_append_table_not_exists_happy_path(
+async def test_import_table_from_url_append_absent_table_raises(
     mock_ctx, ctx_patch, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """import_table_from_url with if_exists=append + no existing table succeeds."""
+    """import_table_from_url with if_exists=append raises ToolError when table does not exist."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
     monkeypatch.delenv("FABRIC_MCP_READONLY", raising=False)
@@ -207,6 +207,75 @@ async def test_import_table_from_url_append_table_not_exists_happy_path(
         patch(
             "fabric_dw.services.load.table_exists",
             new=AsyncMock(return_value=False),
+        ),
+        pytest.raises(ToolError, match="does not exist"),
+    ):
+        await mcp._tool_manager.call_tool(
+            "import_table_from_url",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_name": "dbo.sales",
+                "url": "https://onelake.dfs.fabric.microsoft.com/ws/lh/Files/f.parquet",
+                "file_type": "PARQUET",
+                "if_exists": "append",
+            },
+        )
+
+
+async def test_import_table_from_url_fail_absent_table_raises(
+    mock_ctx, ctx_patch, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """import_table_from_url with if_exists=fail raises ToolError when table does not exist."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    monkeypatch.delenv("FABRIC_MCP_READONLY", raising=False)
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.load.table_exists",
+            new=AsyncMock(return_value=False),
+        ),
+        pytest.raises(ToolError, match="does not exist"),
+    ):
+        await mcp._tool_manager.call_tool(
+            "import_table_from_url",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_name": "dbo.sales",
+                "url": "https://example.com/f.parquet",
+                "file_type": "PARQUET",
+                "if_exists": "fail",
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# import_table_from_url — happy path (append, table exists)
+# ---------------------------------------------------------------------------
+
+
+async def test_import_table_from_url_append_table_exists_happy_path(
+    mock_ctx, ctx_patch, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """import_table_from_url with if_exists=append + existing table loads successfully."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    monkeypatch.delenv("FABRIC_MCP_READONLY", raising=False)
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.load.table_exists",
+            new=AsyncMock(return_value=True),
         ),
         patch(
             "fabric_dw.mcp.tools.load.copy_into_from_url",
@@ -375,3 +444,81 @@ async def test_import_table_from_url_replace_absent_table_raises(
                 "if_exists": "replace",
             },
         )
+
+
+# ---------------------------------------------------------------------------
+# load_table_from_url — absent table raises friendly error
+# ---------------------------------------------------------------------------
+
+
+async def test_load_table_from_url_absent_table_raises(
+    mock_ctx, ctx_patch, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """load_table_from_url raises ToolError when the target table does not exist."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    monkeypatch.delenv("FABRIC_MCP_READONLY", raising=False)
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.load.table_exists",
+            new=AsyncMock(return_value=False),
+        ),
+        pytest.raises(ToolError, match="does not exist"),
+    ):
+        await mcp._tool_manager.call_tool(
+            "load_table_from_url",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_name": "dbo.sales",
+                "url": "https://onelake.dfs.fabric.microsoft.com/ws/lh/Files/f.parquet",
+                "file_type": "PARQUET",
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# load_table_from_url — happy path (table exists)
+# ---------------------------------------------------------------------------
+
+
+async def test_load_table_from_url_table_exists_happy_path(
+    mock_ctx, ctx_patch, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """load_table_from_url loads rows when the target table already exists."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    monkeypatch.delenv("FABRIC_MCP_READONLY", raising=False)
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.load.table_exists",
+            new=AsyncMock(return_value=True),
+        ),
+        patch(
+            "fabric_dw.mcp.tools.load.copy_into_from_url",
+            new=AsyncMock(return_value=_make_result()),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "load_table_from_url",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_name": "dbo.sales",
+                "url": "https://onelake.dfs.fabric.microsoft.com/ws/lh/Files/f.parquet",
+                "file_type": "PARQUET",
+            },
+        )
+
+    assert result["rows_loaded"] == 3
+    assert result["target"] == "dbo.sales"


### PR DESCRIPTION
## Summary

- `import_table_from_url` with `if_exists="fail"` or `"append"` now raises a clear actionable error when the target table does not exist, instead of letting `COPY INTO` surface a raw "Invalid object name" message.
- `load_table_from_url` (append-only) receives the same pre-check.
- Both use the existing `table_exists` helper and match the message style already in place for `if_exists="truncate"` and `"replace"`.
- Existing-table behavior is unchanged: `fail` still rejects, `append`/`truncate` still load as before.

## Test plan

- [x] New unit tests: `import_table_from_url` with `fail`+absent and `append`+absent both raise `ToolError` matching "does not exist".
- [x] New unit tests: `load_table_from_url` with absent table raises `ToolError`; with existing table loads successfully.
- [x] Existing test for `append`+existing table updated to confirm behavior unchanged.
- [x] `uv run pytest tests/unit -q -k load` - 237 passed, 0 failed.
- [x] `uv run ruff check src tests` - no new errors (pre-existing `RUF022` in `_version.py` on base branch is unchanged).
- [x] `uv run ruff format --check .` - all formatted.
- [x] `uv run ty check src tests` - all checks passed.

Closes #773

🤖 Generated with [Claude Code](https://claude.com/claude-code)