### PR TITLE
fix(mcp): accept naive datetimes as UTC consistently across snapshot tools (#774)

### DIFF
--- a/src/fabric_dw/mcp/tools/snapshots.py
+++ b/src/fabric_dw/mcp/tools/snapshots.py
@@ -62,6 +62,7 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             name: Display name for the new snapshot.
             description: Optional description.
             snapshot_dt: Optional ISO-8601 datetime string for the snapshot point-in-time.
+                Naive datetimes (no timezone offset) are interpreted as UTC.
         """
         ctx = get_context()
         assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
@@ -143,6 +144,7 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             warehouse: Parent warehouse name or GUID (used for the SQL connection).
             snapshot_name: The snapshot database name to roll.
             new_dt: Optional ISO-8601 datetime string; defaults to CURRENT_TIMESTAMP.
+                Naive datetimes (no timezone offset) are interpreted as UTC.
         """
         ctx = get_context()
         assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)

--- a/src/fabric_dw/services/_helpers.py
+++ b/src/fabric_dw/services/_helpers.py
@@ -5,16 +5,48 @@ from __future__ import annotations
 import logging
 import re
 from collections.abc import Callable, Coroutine, Mapping, Sequence
+from datetime import UTC, datetime
 from typing import Protocol, TypeVar
 from uuid import UUID
 
 from fabric_dw.services.capacities import ACTIVE_STATE
 
-__all__ = ["compact", "normalize_object_definition", "reject_non_select", "scan_all_workspaces"]
+__all__ = [
+    "coerce_to_utc",
+    "compact",
+    "normalize_object_definition",
+    "reject_non_select",
+    "scan_all_workspaces",
+]
 
 _log = logging.getLogger(__name__)
 
 _T = TypeVar("_T")
+
+
+# ---------------------------------------------------------------------------
+# Datetime coercion
+# ---------------------------------------------------------------------------
+
+
+def coerce_to_utc(dt: datetime) -> datetime:
+    """Return *dt* as a UTC-aware datetime.
+
+    Naive datetimes (no tzinfo) are assumed to be UTC and returned with
+    ``tzinfo=UTC``.  Already-aware datetimes are converted to UTC.
+
+    Use this at service-layer boundaries where callers may pass either a naive
+    or tz-aware datetime; the convention is that naive means UTC.
+
+    Args:
+        dt: A :class:`~datetime.datetime` object, naive or tz-aware.
+
+    Returns:
+        A UTC-aware :class:`~datetime.datetime`.
+    """
+    if dt.tzinfo is None or dt.tzinfo.utcoffset(dt) is None:
+        return dt.replace(tzinfo=UTC)
+    return dt.astimezone(UTC)
 
 
 class _HasNameAndId(Protocol):

--- a/src/fabric_dw/services/snapshots.py
+++ b/src/fabric_dw/services/snapshots.py
@@ -439,9 +439,10 @@ async def roll_timestamp(
         if rows:
             raw = rows[0][0]
             if isinstance(raw, datetime):
-                return raw
-            # Some driver versions return a string — parse it.
-            return datetime.fromisoformat(str(raw))
+                # Driver may return a naive datetime; coerce to UTC.
+                return coerce_to_utc(raw)
+            # Some driver versions return a string — parse it, then coerce.
+            return coerce_to_utc(datetime.fromisoformat(str(raw)))
         return datetime.now(tz=UTC)
 
     return await asyncio.to_thread(_fetch_ts)

--- a/src/fabric_dw/services/snapshots.py
+++ b/src/fabric_dw/services/snapshots.py
@@ -12,7 +12,7 @@ from fabric_dw.cache import ItemEntry, LookupCache
 from fabric_dw.exceptions import FabricError
 from fabric_dw.http_client import FabricHttpClient, HttpBase
 from fabric_dw.models import WarehouseKind, WarehouseSnapshot, WarehouseSnapshotApiPayload, as_props
-from fabric_dw.services._helpers import compact
+from fabric_dw.services._helpers import coerce_to_utc, compact
 from fabric_dw.services._lro import LRO_DETAIL_WAIT_S, LRO_MAX_DETAIL_RETRIES, resolve_lro_item_id
 from fabric_dw.sql import SqlTarget, is_snapshot_not_ready_error, run_query, run_statements
 
@@ -121,7 +121,8 @@ async def create(
         name: Display name for the new snapshot (non-empty trimmed string).
         description: Optional description for the snapshot.
         snapshot_dt: Optional point-in-time datetime for the snapshot. If
-            ``None``, the service captures the current state.
+            ``None``, the service captures the current state. Naive datetimes
+            (no tzinfo) are treated as UTC.
 
     Returns:
         The newly-created :class:`~fabric_dw.models.WarehouseSnapshot`.
@@ -137,11 +138,8 @@ async def create(
         "parentWarehouseId": str(parent_warehouse_id),
     }
     if snapshot_dt is not None:
-        # Always emit UTC; convert aware datetimes, reject naive ones.
-        if snapshot_dt.tzinfo is None or snapshot_dt.tzinfo.utcoffset(snapshot_dt) is None:
-            msg = "snapshot_dt must be a timezone-aware datetime"
-            raise ValueError(msg)
-        snapshot_dt_utc = snapshot_dt.astimezone(UTC)
+        # Always emit UTC; naive datetimes are treated as UTC.
+        snapshot_dt_utc = coerce_to_utc(snapshot_dt)
         creation_payload["snapshotDateTime"] = snapshot_dt_utc.strftime("%Y-%m-%dT%H:%M:%SZ")
 
     body: dict[str, object] = {
@@ -343,9 +341,10 @@ async def roll_timestamp(
             warehouse (the snapshot lives in the same SQL endpoint).
         snapshot_name: The name of the snapshot database. Must not contain
             ``]``, ``;``, ``\\``, ``'``, ``"``, ``--``, or newlines.
-        new_dt: If supplied, the snapshot is rolled to this UTC datetime,
-            formatted as ``YYYY-MM-DDTHH:MM:SS.SS``. If ``None``, the
-            snapshot rolls forward to ``CURRENT_TIMESTAMP``.
+        new_dt: If supplied, the snapshot is rolled to this datetime,
+            formatted as ``YYYY-MM-DDTHH:MM:SS.SS`` (UTC). If ``None``, the
+            snapshot rolls forward to ``CURRENT_TIMESTAMP``. Naive datetimes
+            (no tzinfo) are treated as UTC.
         mode: The credential mode for Entra authentication.
 
     Returns:
@@ -360,14 +359,12 @@ async def roll_timestamp(
     """
     _validate_snapshot_name(snapshot_name, param="snapshot_name")
 
+    new_dt_utc: datetime | None = None
     if new_dt is None:
         alter_sql = f"ALTER DATABASE [{snapshot_name}] SET TIMESTAMP = CURRENT_TIMESTAMP;"
     else:
-        # Enforce UTC-aware datetimes; reject naive datetimes to avoid silent tz errors.
-        if new_dt.tzinfo is None or new_dt.tzinfo.utcoffset(new_dt) is None:
-            msg = "new_dt must be a timezone-aware datetime (e.g. datetime(..., tzinfo=UTC))"
-            raise ValueError(msg)
-        new_dt_utc = new_dt.astimezone(UTC)
+        # Naive datetimes are treated as UTC.
+        new_dt_utc = coerce_to_utc(new_dt)
         formatted = new_dt_utc.strftime("%Y-%m-%dT%H:%M:%S.00")
         alter_sql = f"ALTER DATABASE [{snapshot_name}] SET TIMESTAMP = '{formatted}';"
 
@@ -429,8 +426,8 @@ async def roll_timestamp(
     # When new_dt was supplied the applied timestamp equals new_dt (the ALTER
     # SET a deterministic value).  When new_dt is None the server applied
     # CURRENT_TIMESTAMP, which is only knowable by querying it back.
-    if new_dt is not None:
-        return new_dt
+    if new_dt_utc is not None:
+        return new_dt_utc
 
     def _fetch_ts() -> datetime:
         _, rows = run_query(

--- a/tests/unit/services/test_helpers.py
+++ b/tests/unit/services/test_helpers.py
@@ -2,9 +2,54 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta, timezone
+
 import pytest
 
-from fabric_dw.services._helpers import compact, normalize_object_definition, reject_non_select
+from fabric_dw.services._helpers import (
+    coerce_to_utc,
+    compact,
+    normalize_object_definition,
+    reject_non_select,
+)
+
+# ---------------------------------------------------------------------------
+# coerce_to_utc
+# ---------------------------------------------------------------------------
+
+
+def test_coerce_to_utc_naive_becomes_utc() -> None:
+    """coerce_to_utc treats a naive datetime as UTC."""
+    naive = datetime(2026, 3, 1, 12, 0, 0)  # noqa: DTZ001
+    result = coerce_to_utc(naive)
+    assert result.tzinfo is UTC
+    assert result == datetime(2026, 3, 1, 12, 0, 0, tzinfo=UTC)
+
+
+def test_coerce_to_utc_utc_aware_is_unchanged() -> None:
+    """coerce_to_utc returns a UTC-aware datetime unchanged."""
+    utc_dt = datetime(2026, 3, 1, 12, 0, 0, tzinfo=UTC)
+    result = coerce_to_utc(utc_dt)
+    assert result == utc_dt
+    assert result.tzinfo is UTC
+
+
+def test_coerce_to_utc_non_utc_aware_is_converted() -> None:
+    """coerce_to_utc converts a non-UTC tz-aware datetime to UTC."""
+    plus2 = timezone(timedelta(hours=2))
+    aware = datetime(2026, 3, 1, 14, 0, 0, tzinfo=plus2)  # 14:00+02:00 = 12:00 UTC
+    result = coerce_to_utc(aware)
+    assert result.tzinfo is UTC
+    assert result == datetime(2026, 3, 1, 12, 0, 0, tzinfo=UTC)
+
+
+def test_coerce_to_utc_preserves_sub_second_precision() -> None:
+    """coerce_to_utc preserves microseconds when coercing a naive datetime."""
+    naive = datetime(2026, 3, 1, 12, 0, 0, 123456)  # noqa: DTZ001
+    result = coerce_to_utc(naive)
+    assert result.microsecond == 123456
+    assert result.tzinfo is UTC
+
 
 # ---------------------------------------------------------------------------
 # compact

--- a/tests/unit/services/test_snapshots.py
+++ b/tests/unit/services/test_snapshots.py
@@ -353,7 +353,11 @@ async def test_create_naive_snapshot_dt_treated_as_utc() -> None:
 
 @respx.mock
 async def test_create_aware_non_utc_snapshot_dt_normalized_to_utc() -> None:
-    """create normalizes a tz-aware non-UTC snapshot_dt to UTC before emitting."""
+    """create normalizes a tz-aware non-UTC snapshot_dt to UTC before emitting.
+
+    This exercises the pre-existing aware-datetime conversion path (present before #774).
+    The naive-datetime test immediately above is the actual #774 regression guard.
+    """
     from datetime import timedelta, timezone  # noqa: PLC0415
 
     plus2 = timezone(timedelta(hours=2))
@@ -763,7 +767,11 @@ async def test_roll_timestamp_naive_new_dt_treated_as_utc() -> None:
 
 
 async def test_roll_timestamp_aware_non_utc_new_dt_normalized_to_utc() -> None:
-    """roll_timestamp normalizes a tz-aware non-UTC new_dt to UTC."""
+    """roll_timestamp normalizes a tz-aware non-UTC new_dt to UTC.
+
+    This exercises the pre-existing aware-datetime conversion path (present before #774).
+    The naive-datetime test immediately above is the actual #774 regression guard.
+    """
     from datetime import timedelta, timezone  # noqa: PLC0415
 
     target = _make_sql_target()

--- a/tests/unit/services/test_snapshots.py
+++ b/tests/unit/services/test_snapshots.py
@@ -321,6 +321,64 @@ async def test_create_posts_correct_body_with_snapshot_dt() -> None:
     assert body["creationPayload"]["snapshotDateTime"] == "2024-03-15T08:00:00Z"
 
 
+# ---------------------------------------------------------------------------
+# create - naive datetime handling (regression guard for #774)
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+async def test_create_naive_snapshot_dt_treated_as_utc() -> None:
+    """create accepts a naive snapshot_dt and treats it as UTC (no ValueError)."""
+    naive_dt = datetime(2026, 3, 1, 12, 0, 0)  # noqa: DTZ001 - intentionally naive
+    captured: list[Any] = []
+
+    def _capture(request: Any) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(202, headers={"Location": _LRO_LOCATION})
+
+    respx.post(_ITEMS_URL).mock(side_effect=_capture)
+    respx.get(_TYPED_SNAP_URL).mock(
+        return_value=httpx.Response(200, json=WAREHOUSE_SNAPSHOT_TYPED_PAYLOAD)
+    )
+
+    async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
+        with patch.object(http, "poll_operation", new_callable=AsyncMock) as mock_poll:
+            mock_poll.return_value = {"status": "Succeeded", "resourceId": str(_SNAP_ID)}
+            await snapshots.create(http, _WS_ID, _PARENT_WH_ID, "MySnap", snapshot_dt=naive_dt)
+
+    body = _json.loads(captured[0].content)
+    # naive 2026-03-01T12:00:00 is treated as UTC and emitted with Z suffix
+    assert body["creationPayload"]["snapshotDateTime"] == "2026-03-01T12:00:00Z"
+
+
+@respx.mock
+async def test_create_aware_non_utc_snapshot_dt_normalized_to_utc() -> None:
+    """create normalizes a tz-aware non-UTC snapshot_dt to UTC before emitting."""
+    from datetime import timedelta, timezone  # noqa: PLC0415
+
+    plus2 = timezone(timedelta(hours=2))
+    aware_dt = datetime(2026, 3, 1, 14, 0, 0, tzinfo=plus2)  # 14:00+02:00 = 12:00 UTC
+    captured: list[Any] = []
+
+    def _capture(request: Any) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(202, headers={"Location": _LRO_LOCATION})
+
+    respx.post(_ITEMS_URL).mock(side_effect=_capture)
+    respx.get(_TYPED_SNAP_URL).mock(
+        return_value=httpx.Response(200, json=WAREHOUSE_SNAPSHOT_TYPED_PAYLOAD)
+    )
+
+    async with FabricHttpClient(credential=_make_credential(), rps=100) as http:
+        with patch.object(http, "poll_operation", new_callable=AsyncMock) as mock_poll:
+            mock_poll.return_value = {"status": "Succeeded", "resourceId": str(_SNAP_ID)}
+            await snapshots.create(http, _WS_ID, _PARENT_WH_ID, "MySnap", snapshot_dt=aware_dt)
+
+    body = _json.loads(captured[0].content)
+    # 14:00+02:00 is normalized to 12:00 UTC
+    assert body["creationPayload"]["snapshotDateTime"] == "2026-03-01T12:00:00Z"
+
+
 @respx.mock
 async def test_create_polls_lro_and_fetches_result() -> None:
     """create should call poll_operation with the Location header URL."""
@@ -680,6 +738,47 @@ async def test_roll_timestamp_with_new_dt_formats_correctly() -> None:
     executed_sql = cursor.execute.call_args_list[0][0][0]
     assert "ALTER DATABASE [MySnapshot] SET TIMESTAMP = '2024-03-15T08:30:45.00';" in executed_sql
     assert "SET IMPLICIT_TRANSACTIONS" not in executed_sql
+
+
+# ---------------------------------------------------------------------------
+# roll_timestamp - naive datetime handling (regression guard for #774)
+# ---------------------------------------------------------------------------
+
+
+async def test_roll_timestamp_naive_new_dt_treated_as_utc() -> None:
+    """roll_timestamp accepts a naive new_dt and treats it as UTC (no ValueError)."""
+    target = _make_sql_target()
+    conn = _make_mock_conn()
+    naive_dt = datetime(2024, 3, 15, 8, 30, 45)  # noqa: DTZ001 - intentionally naive
+
+    with patch("fabric_dw.sql.open_connection", return_value=conn):
+        result = await snapshots.roll_timestamp(target, "MySnapshot", new_dt=naive_dt)
+
+    cursor = conn.cursor.return_value
+    sql = cursor.execute.call_args_list[0][0][0]
+    # naive datetime formatted the same way as a UTC-aware datetime
+    assert "ALTER DATABASE [MySnapshot] SET TIMESTAMP = '2024-03-15T08:30:45.00';" in sql
+    # The returned datetime is UTC-aware (naive coerced to UTC)
+    assert result == naive_dt.replace(tzinfo=UTC)
+
+
+async def test_roll_timestamp_aware_non_utc_new_dt_normalized_to_utc() -> None:
+    """roll_timestamp normalizes a tz-aware non-UTC new_dt to UTC."""
+    from datetime import timedelta, timezone  # noqa: PLC0415
+
+    target = _make_sql_target()
+    conn = _make_mock_conn()
+    plus2 = timezone(timedelta(hours=2))
+    aware_dt = datetime(2024, 3, 15, 10, 30, 45, tzinfo=plus2)  # 10:30+02:00 = 08:30 UTC
+
+    with patch("fabric_dw.sql.open_connection", return_value=conn):
+        result = await snapshots.roll_timestamp(target, "MySnapshot", new_dt=aware_dt)
+
+    cursor = conn.cursor.return_value
+    sql = cursor.execute.call_args_list[0][0][0]
+    # 10:30+02:00 is normalized to 08:30 UTC
+    assert "ALTER DATABASE [MySnapshot] SET TIMESTAMP = '2024-03-15T08:30:45.00';" in sql
+    assert result == datetime(2024, 3, 15, 8, 30, 45, tzinfo=UTC)
 
 
 async def test_roll_timestamp_name_injection_bracket() -> None:

--- a/tests/unit/services/test_tables.py
+++ b/tests/unit/services/test_tables.py
@@ -1013,6 +1013,20 @@ class TestCloneTable:
             "clone DDL with AT must not pass commit=True (autocommit handles it)"
         )
 
+    async def test_at_clause_naive_datetime_treated_as_utc(self) -> None:
+        """Regression guard (#774): naive at datetime is accepted and formatted as UTC."""
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_TABLE_ROW_1], _LIST_COLS)
+        naive_dt = datetime(2024, 5, 20, 14, 0, 0)  # noqa: DTZ001 - intentionally naive
+        mock_oc = patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn])
+        with mock_oc:
+            await tables.clone_table(target, "dbo.source_tbl", "dbo.sales", at=naive_dt)
+        cursor = ddl_conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        # Naive datetime with same wall-clock value as UTC - literal must match
+        assert "AT '2024-05-20T14:00:00.000'" in call_sql
+
     async def test_rejects_sql_endpoint(self) -> None:
         target = _make_target()
         with pytest.raises(ItemKindError, match="read-only"):

--- a/tests/unit/test_services_w_series.py
+++ b/tests/unit/test_services_w_series.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import base64
 from datetime import UTC, date, datetime, time, timedelta, timezone
 from decimal import Decimal
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import UUID
 
 import pytest
@@ -22,6 +22,7 @@ import pytest
 from fabric_dw.exceptions import ItemKindError
 from fabric_dw.models import CreationModeType, RestorePoint, WarehouseKind
 from fabric_dw.services import snapshots as _snapshots_mod
+from fabric_dw.services._helpers import coerce_to_utc
 from fabric_dw.services.ownership import takeover
 from fabric_dw.services.snapshots import create as _snap_create
 from fabric_dw.services.snapshots import rename as _snap_rename
@@ -105,28 +106,34 @@ class TestSerializeValue:
 
 
 def _tz_format(new_dt: datetime) -> str:
-    """Mirror the tz-conversion logic in roll_timestamp for isolated testing."""
-    if new_dt.tzinfo is None or new_dt.tzinfo.utcoffset(new_dt) is None:
-        msg = "new_dt must be a timezone-aware datetime"
-        raise ValueError(msg)
-    new_dt_utc = new_dt.astimezone(UTC)
+    """Mirror the tz-conversion logic in roll_timestamp for isolated testing.
+
+    Naive datetimes are treated as UTC (fix #774).
+    """
+    new_dt_utc = coerce_to_utc(new_dt)
     return new_dt_utc.strftime("%Y-%m-%dT%H:%M:%S.00")
 
 
 class TestRollTimestampTimezone:
-    """roll_timestamp must enforce tz-aware datetimes and format in UTC."""
+    """roll_timestamp treats naive datetimes as UTC and formats in UTC (fix #774)."""
 
     @pytest.mark.asyncio
-    async def test_naive_dt_raises_via_service(self) -> None:
-        """A naive datetime must raise ValueError via roll_timestamp before any DB call."""
+    async def test_naive_dt_accepted_via_service(self) -> None:
+        """A naive datetime is accepted by roll_timestamp and treated as UTC (fix #774)."""
         naive_dt = datetime(2024, 6, 1, 12, 0, 0)  # noqa: DTZ001
-        with pytest.raises(ValueError, match="timezone-aware"):
-            await _snapshots_mod.roll_timestamp(MagicMock(), "snap1", naive_dt)
+        conn = MagicMock()
+        cursor = MagicMock()
+        conn.cursor.return_value = cursor
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            result = await _snapshots_mod.roll_timestamp(MagicMock(), "snap1", naive_dt)
+        # Naive datetime treated as UTC - returned as UTC-aware
+        assert result == naive_dt.replace(tzinfo=UTC)
 
-    def test_naive_raises_from_format_helper(self) -> None:
+    def test_naive_formats_as_utc_from_helper(self) -> None:
+        """Naive datetime passed to format helper is treated as UTC (fix #774)."""
         naive = datetime(2024, 1, 1, 0, 0, 0)  # noqa: DTZ001
-        with pytest.raises(ValueError, match="timezone-aware"):
-            _tz_format(naive)
+        result = _tz_format(naive)
+        assert result == "2024-01-01T00:00:00.00"
 
     def test_utc_aware_formats_correctly(self) -> None:
         dt = datetime(2024, 6, 1, 12, 30, 45, tzinfo=UTC)
@@ -286,12 +293,16 @@ class TestSnapshotsCreateLocationGuard:
             )
 
     @pytest.mark.asyncio
-    async def test_naive_snapshot_dt_raises(self) -> None:
-        """A naive snapshot_dt must raise ValueError before any HTTP call (W01)."""
-        http = MagicMock()
-        http.request = AsyncMock()
+    async def test_naive_snapshot_dt_treated_as_utc(self) -> None:
+        """A naive snapshot_dt is accepted and treated as UTC - no longer raises (fix #774)."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 202
+        mock_resp.headers = {}
 
-        with pytest.raises(ValueError, match="timezone-aware"):
+        http = MagicMock()
+        http.request = AsyncMock(return_value=mock_resp)
+
+        with pytest.raises(ValueError, match="Location header is missing"):
             await _snap_create(
                 http,
                 UUID("aaaaaaaa-0000-0000-0000-000000000000"),
@@ -300,7 +311,12 @@ class TestSnapshotsCreateLocationGuard:
                 snapshot_dt=datetime(2024, 1, 1, 12, 0, 0),  # naive  # noqa: DTZ001
             )
 
-        http.request.assert_not_called()
+        # HTTP request must have been made (naive dt is no longer rejected)
+        http.request.assert_called_once()
+        body = http.request.call_args.kwargs.get("json", {})
+        # Naive 2024-01-01T12:00:00 treated as UTC - emitted with Z suffix
+        snap_dt = body.get("creationPayload", {}).get("snapshotDateTime", "")
+        assert snap_dt == "2024-01-01T12:00:00Z"
 
     @pytest.mark.asyncio
     async def test_aware_snapshot_dt_converted_to_utc(self) -> None:


### PR DESCRIPTION
## Summary

Snapshot tools (`create_snapshot`, `roll_snapshot_timestamp`) rejected naive (tz-unaware) datetime strings with a `ValueError` while all other datetime params (`clone_table` AT clause, etc.) silently accepted them as UTC. This made the same naive string like `2026-01-01T12:00:00` work for `clone_table` but fail for `create_snapshot`.

- Add `coerce_to_utc()` helper in `services/_helpers.py` that treats naive datetimes as UTC and normalizes tz-aware datetimes to UTC.
- Wire `coerce_to_utc()` into `services/snapshots.py` `create()` and `roll_timestamp()` replacing the rejection logic.
- Update docstrings on `snapshot_dt` and `new_dt` params to document that naive datetimes are interpreted as UTC.
- Update two tests in `test_services_w_series.py` that documented the old rejection behavior.
- Add new TDD tests for naive and non-UTC aware datetimes in `create()`, `roll_timestamp()`, and `coerce_to_utc()` directly. Add a regression guard for `clone_table` to confirm lenient behavior is preserved.

## Files changed

- `src/fabric_dw/services/_helpers.py` - new `coerce_to_utc()` helper
- `src/fabric_dw/services/snapshots.py` - use `coerce_to_utc()` instead of rejection
- `src/fabric_dw/mcp/tools/snapshots.py` - updated docstrings
- `tests/unit/services/test_helpers.py` - tests for `coerce_to_utc()`
- `tests/unit/services/test_snapshots.py` - new naive datetime acceptance tests
- `tests/unit/services/test_tables.py` - regression guard for `clone_table`
- `tests/unit/test_services_w_series.py` - updated to reflect new behavior

## Test plan

- [x] `uv run ruff check src tests` passes
- [x] `uv run ruff format --check .` passes
- [x] `uv run ty check src tests` passes
- [x] `uv run pytest tests/unit/` passes (4914 tests, 0 failures)
- [x] New tests cover: naive datetime accepted in `create()`, `roll_timestamp()`, non-UTC aware datetime normalized to UTC, `coerce_to_utc()` helper directly, `clone_table` regression guard

Closes #774

Generated with [Claude Code](https://claude.com/claude-code)