### PR TITLE
docs: remove em-dashes and tidy prose across docs, README, and skills

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@
 
 - [ ] All gates pass locally (`just check`)
 - [ ] Unit tests pass (`just test`)
-- [ ] Integration tests pass where applicable (`just integration` — requires `az login` and the `integration` label on the PR)
+- [ ] Integration tests pass where applicable (`just integration`, requires `az login` and the `integration` label on the PR)
 - [ ] Manual testing steps (if any):
 
 ## Linked issue

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for your interest in contributing to `fabric-dw-mcp-cli`!
 
 ## Dev Setup
 
-> **Recommended:** open the repo in [GitHub Codespaces](https://codespaces.new/sdebruyn/fabric-dw-mcp-cli) or VS Code with the Remote-Containers extension — the devcontainer handles all of steps 1–2 automatically.
+> **Recommended:** open the repo in [GitHub Codespaces](https://codespaces.new/sdebruyn/fabric-dw-mcp-cli) or VS Code with the Remote-Containers extension. The devcontainer handles all of steps 1–2 automatically.
 
 1. **Install dependencies**
 
@@ -25,7 +25,7 @@ Thank you for your interest in contributing to `fabric-dw-mcp-cli`!
 - Branch off `main` for every change.
 - Use descriptive branch names, e.g. `feat/add-table-command` or `fix/connection-timeout`.
 - Open a pull request back to `main`.
-- PR titles must follow [Conventional Commits](#conventional-commits) — they become the squash-merge commit message.
+- PR titles must follow [Conventional Commits](#conventional-commits); they become the squash-merge commit message.
 - All PRs are squash-merged.
 
 ## Conventional Commits
@@ -94,7 +94,7 @@ Any unit test that accidentally reaches a real HTTP client will fail loudly.
   patch `build_http_client` / `open_connection` at the service boundary.
 - Unix-domain sockets (AF_UNIX) are permitted because asyncio's event loop requires
   them internally; they cannot reach the internet.
-- Integration tests (`tests/integration/`) are exempt — they legitimately call
+- Integration tests (`tests/integration/`) are exempt; they legitimately call
   real Fabric APIs and are not subject to this fixture.
 
 ### Integration tests
@@ -105,7 +105,7 @@ Requires a valid `az login` session and a reachable Fabric workspace.
 just integration
 ```
 
-**Integration test policy:** the integration suite is **label-gated** — it only runs in CI when the `integration` label is applied to a PR. This is intentional: the integration tests hit real Fabric APIs and consume capacity. Maintainers apply the label when a PR touches API-touching behaviour. The integration suite is _not_ a required status check; it is a maintainer-controlled gate.
+**Integration test policy:** the integration suite is **label-gated**: it only runs in CI when the `integration` label is applied to a PR. This is intentional: the integration tests hit real Fabric APIs and consume capacity. Maintainers apply the label when a PR touches API-touching behaviour. The integration suite is _not_ a required status check; it is a maintainer-controlled gate.
 
 ### Security audit
 
@@ -123,9 +123,9 @@ just build
 
 The plugin version (`plugin.json`) is single-sourced from stable git tags. The flow:
 
-1. **Bump** — run `just release X.Y.Z` (e.g. `just release 2026.7.0`) to write the stable calver into `plugin.json`. The version must follow `YYYY.M.N` (year `20xx`, month `1–12` with no leading zero, patch `0` or a positive integer without a leading zero). Open a release-prep PR and merge it.
-2. **Tag** — after the bump PR is merged, run `just tag X.Y.Z` **from a clean, up-to-date local `main`**. This reads the committed `plugin.json` (not the working tree) and verifies the version matches before creating and pushing the annotated tag.
-3. **Publish** — the `Publish` CI workflow fires on the tag push. It enforces the same version match (failing fast before the build if they disagree), then ships the package to PyPI and creates a GitHub Release.
+1. **Bump**: run `just release X.Y.Z` (e.g. `just release 2026.7.0`) to write the stable calver into `plugin.json`. The version must follow `YYYY.M.N` (year `20xx`, month `1–12` with no leading zero, patch `0` or a positive integer without a leading zero). Open a release-prep PR and merge it.
+2. **Tag**: after the bump PR is merged, run `just tag X.Y.Z` **from a clean, up-to-date local `main`**. This reads the committed `plugin.json` (not the working tree) and verifies the version matches before creating and pushing the annotated tag.
+3. **Publish**: the `Publish` CI workflow fires on the tag push. It enforces the same version match (failing fast before the build if they disagree), then ships the package to PyPI and creates a GitHub Release.
 
 `just release` and `just tag` both reject out-of-range or leading-zero months/patches and any prerelease suffix (`aN`/`bN`/`rcN`/`.devN`). Prerelease builds (`.devN` suffix derived by hatch-vcs from commits since the last tag) are published automatically on every push to `main`; `plugin.json` always reflects the latest stable release only.
 

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ Python CLI and MCP server for administering Microsoft Fabric Data Warehouses and
 
 `fabric-dw` provides two interfaces for managing Microsoft Fabric Data Warehouses and SQL Analytics Endpoints:
 
-- **CLI** — a command-line tool for common DW administration tasks.
-- **MCP server** — a [Model Context Protocol](https://modelcontextprotocol.io) server that exposes DW operations as tools for AI assistants.
+- **CLI**: a command-line tool for common DW administration tasks.
+- **MCP server**: a [Model Context Protocol](https://modelcontextprotocol.io) server that exposes DW operations as tools for AI assistants.
 
-Authentication is configured via the `FABRIC_AUTH` environment variable. The default (`FABRIC_AUTH=default`) uses [`azure-identity` `DefaultAzureCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.defaultazurecredential?WT.mc_id=MVP_310840), which walks environment variables, Workload/Managed Identity, Azure CLI, Azure Developer CLI, Azure PowerShell, and interactive browser in order — any of these will satisfy it. See the [Authentication](https://fdw.debruyn.dev/authentication/) docs for the full chain, all supported sources, and debugging tips.
+Authentication is configured via the `FABRIC_AUTH` environment variable. The default (`FABRIC_AUTH=default`) uses [`azure-identity` `DefaultAzureCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.defaultazurecredential?WT.mc_id=MVP_310840), which walks environment variables, Workload/Managed Identity, Azure CLI, Azure Developer CLI, Azure PowerShell, and interactive browser in order. Any of these will satisfy it. See the [Authentication](https://fdw.debruyn.dev/authentication/) docs for the full chain, all supported sources, and debugging tips.
 
 ## Installation
 
@@ -32,7 +32,7 @@ pip install fabric-dw
 uvx fabric-dw --help
 ```
 
-After installation, the `fdw` command is a short alias for `fabric-dw` — both invoke the same entry point.
+After installation, the `fdw` command is a short alias for `fabric-dw`; both invoke the same entry point.
 
 ## Quick Start
 
@@ -86,7 +86,7 @@ The Docker image's default `ENTRYPOINT` is the **MCP server** (`fabric-dw-mcp`).
 ```bash
 docker pull ghcr.io/sdebruyn/fabric-dw:latest
 
-# Run the MCP server (default entrypoint — connect via stdio from your MCP client):
+# Run the MCP server (default entrypoint, connect via stdio from your MCP client):
 docker run --rm -i \
   -e AZURE_CLIENT_ID=… \
   -e AZURE_TENANT_ID=… \
@@ -125,11 +125,11 @@ The MCP server can be started in HTTP mode for remote clients:
 fabric-dw-mcp --transport http [--host 127.0.0.1] [--port 8000]
 ```
 
-Binding to non-loopback addresses requires `FABRIC_MCP_ALLOW_REMOTE=1`. The HTTP transport has **no built-in authentication or TLS** — always front it with an authenticating reverse proxy.
+Binding to non-loopback addresses requires `FABRIC_MCP_ALLOW_REMOTE=1`. The HTTP transport has **no built-in authentication or TLS**. Always front it with an authenticating reverse proxy.
 
 ## Develop in a container
 
-Open the repo in [GitHub Codespaces](https://github.com/codespaces) or VS Code's Remote-Containers extension — the devcontainer pre-installs Python 3.13, uv, Azure CLI, and the GitHub CLI.
+Open the repo in [GitHub Codespaces](https://github.com/codespaces) or VS Code's Remote-Containers extension. The devcontainer pre-installs Python 3.13, uv, Azure CLI, and the GitHub CLI.
 
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/sdebruyn/fabric-dw-mcp-cli)
 
@@ -145,7 +145,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for dev setup, branch flow, and how to ru
 
 ## Security
 
-Please report vulnerabilities privately — see [SECURITY.md](SECURITY.md).
+Please report vulnerabilities privately. See [SECURITY.md](SECURITY.md).
 
 ## Code of Conduct
 
@@ -153,4 +153,4 @@ This project follows the [Contributor Covenant 2.1](CODE_OF_CONDUCT.md).
 
 ## License
 
-[MIT](LICENSE) — Copyright (c) 2026 Sam Debruyn
+[MIT](LICENSE). Copyright (c) 2026 Sam Debruyn

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 We use [GitHub Private Vulnerability Reporting](https://docs.github.com/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability?WT.mc_id=MVP_310840) for security disclosures.
 
-**To report a vulnerability**: [open a private advisory](https://github.com/sdebruyn/fabric-dw-mcp-cli/security/advisories/new). GitHub will deliver it directly and privately to the maintainers — no public issue or email needed.
+**To report a vulnerability**: [open a private advisory](https://github.com/sdebruyn/fabric-dw-mcp-cli/security/advisories/new). GitHub will deliver it directly and privately to the maintainers. No public issue or email needed.
 
 We aim to acknowledge reports within **5 business days** and to publish a fix or advisory within **90 days** of confirmation.
 
@@ -24,7 +24,7 @@ The interactive browser sign-in path (and the fallback interactive browser step 
 
 This application requests delegated (user-context) permissions for the following scope:
 
-- `https://analysis.windows.net/powerbi/api/.default` — Power BI / Fabric REST API
+- `https://analysis.windows.net/powerbi/api/.default`: Power BI / Fabric REST API
 
 > **Note**: The `SQL_SCOPE` constant (`https://database.windows.net/.default`) is defined in `auth.py` for future use when direct Fabric SQL Analytics Endpoint connections are implemented, but it is not yet requested at runtime.
 
@@ -32,7 +32,7 @@ This application requests delegated (user-context) permissions for the following
 
 Because the app is **multi-tenant and shared across all users of this tool**:
 
-1. **Upstream-app trust**: your tenant admin must consent to the app (or the user must do per-user consent if your tenant policy allows it). The audit trail in your Azure AD / Entra audit log will show the *upstream app ID* (`f666e5ee-...`), not a tenant-specific registration — this reduces per-tenant audit granularity.
+1. **Upstream-app trust**: your tenant admin must consent to the app (or the user must do per-user consent if your tenant policy allows it). The audit trail in your Azure AD / Entra audit log will show the *upstream app ID* (`f666e5ee-...`), not a tenant-specific registration. This reduces per-tenant audit granularity.
 2. **Supply-chain risk**: if the shared application is compromised, suspended, or deleted by Microsoft, all users on the default flow will be impacted without a per-tenant fallback.
 3. **No tenant-specific conditional-access policies**: because the app is not registered in your tenant, you cannot target it with tenant-specific conditional-access rules.
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -20,8 +20,6 @@ fdw -w "Sales Workspace" warehouses list
 
 If neither of those works for you, read on for the alternatives.
 
----
-
 `fabric-dw` selects a credential source via a 3-layer resolution stack:
 
 | Layer | Mechanism | Description |
@@ -40,8 +38,6 @@ Valid values: `default`, `interactive`, `sp` (case-insensitive).
 
 !!! note "Empty-value semantics"
     An empty or whitespace-only `FABRIC_AUTH` (e.g. `FABRIC_AUTH=`) is treated as absent and falls through to `config.toml` / the built-in default. An unrecognised non-empty value (e.g. `FABRIC_AUTH=typo`) raises a configuration error immediately at server start so the credential is never silently wrong.
-
----
 
 ## Interactive browser sign-in (zero setup)
 
@@ -89,8 +85,6 @@ Then grant the same delegated permissions as the shared app:
 !!! note "Tenant pinning"
     When `FABRIC_INTERACTIVE_TENANT_ID` is set, `FABRIC_AUTH=interactive` passes it as `tenant_id` to [`InteractiveBrowserCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.interactivebrowsercredential?WT.mc_id=MVP_310840) and the default-mode browser fallback also receives it as `interactive_browser_tenant_id`. Useful when your tenant policy requires a specific tenant context at sign-in time.
 
----
-
 ## `FABRIC_AUTH=default`: DefaultAzureCredential chain
 
 When `FABRIC_AUTH` is `default` (or unset), the package delegates to [`azure-identity`'s `DefaultAzureCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.defaultazurecredential?WT.mc_id=MVP_310840). It walks the following sources **in order** and stops at the first one that returns a usable token:
@@ -104,8 +98,6 @@ When `FABRIC_AUTH` is `default` (or unset), the package delegates to [`azure-ide
 7. **Azure PowerShell**: token from `Connect-AzAccount` - see [`AzurePowerShellCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.azurepowershellcredential?WT.mc_id=MVP_310840)
 8. **Interactive browser**: falls back to browser sign-in using the [shared app](#interactive-browser-sign-in-zero-setup) (or your override via `FABRIC_INTERACTIVE_CLIENT_ID`) - see [`InteractiveBrowserCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.interactivebrowsercredential?WT.mc_id=MVP_310840)
 
----
-
 ## `FABRIC_AUTH=sp`: Service principal
 
 Set the following environment variables:
@@ -117,8 +109,6 @@ Set the following environment variables:
 | `AZURE_CLIENT_SECRET` | A client secret for the app |
 
 The package uses [`ClientSecretCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.clientsecretcredential?WT.mc_id=MVP_310840) with these values. The shared `fabric-dw` app is **not** used in SP mode - you must supply your own app registration and secret.
-
----
 
 ## Environment variable reference
 
@@ -144,8 +134,6 @@ the CLI, an explicit `--auth` flag on the command line takes the highest priorit
 ```shell
 fdw --auth sp warehouses list   # override: use service-principal for this invocation
 ```
-
----
 
 ## Debugging
 

--- a/docs/commands/audit.md
+++ b/docs/commands/audit.md
@@ -8,8 +8,6 @@ Manage SQL audit settings for Microsoft Fabric Data Warehouses and SQL Analytics
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
 
----
-
 ## CLI
 
 ### audit add-group
@@ -30,8 +28,6 @@ fdw [-w WORKSPACE] audit add-group [WAREHOUSE] GROUP
 fdw -w MyWorkspace audit add-group SalesWH BATCH_COMPLETED_GROUP
 ```
 
----
-
 ### audit disable
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
@@ -49,8 +45,6 @@ fdw [-w WORKSPACE] audit disable [WAREHOUSE]
 ```shell
 fdw -w MyWorkspace audit disable SalesWH
 ```
-
----
 
 ### audit enable
 
@@ -81,8 +75,6 @@ fdw -w MyWorkspace audit enable --retention-days 90 SalesWH
 fdw -w MyWorkspace audit enable --unlimited SalesWH
 ```
 
----
-
 ### audit get
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
@@ -107,8 +99,6 @@ retentionDays    7
 actionGroups     BATCH_COMPLETED_GROUP
 ```
 
----
-
 ### audit remove-group
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
@@ -126,8 +116,6 @@ fdw [-w WORKSPACE] audit remove-group [WAREHOUSE] GROUP
 ```shell
 fdw -w MyWorkspace audit remove-group SalesWH BATCH_COMPLETED_GROUP
 ```
-
----
 
 ### audit set-groups
 
@@ -154,8 +142,6 @@ fdw -w MyWorkspace audit set-groups \
   SalesWH
 ```
 
----
-
 ### audit set-retention
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
@@ -178,8 +164,6 @@ fdw [-w WORKSPACE] audit set-retention --days INTEGER [WAREHOUSE]
 fdw -w MyWorkspace audit set-retention --days 90 SalesWH
 ```
 
----
-
 ## MCP tools
 
 ### add_audit_group
@@ -196,8 +180,6 @@ Add a single audit action group without overwriting the others. Idempotent - if 
 
 **Returns:** `AuditSettings`: the updated audit settings.
 
----
-
 ### disable_audit
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
@@ -210,8 +192,6 @@ Disable SQL auditing on a warehouse or SQL analytics endpoint.
 - `warehouse` (`str`): warehouse or SQL analytics endpoint name or GUID.
 
 **Returns:** `AuditSettings`: the updated audit settings.
-
----
 
 ### enable_audit
 
@@ -227,8 +207,6 @@ Enable SQL auditing on a warehouse or SQL analytics endpoint.
 
 **Returns:** `AuditSettings`: the updated audit settings.
 
----
-
 ### get_audit_settings
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
@@ -241,8 +219,6 @@ Fetch the current SQL audit settings for a warehouse or SQL analytics endpoint.
 - `warehouse` (`str`): warehouse or SQL analytics endpoint name or GUID.
 
 **Returns:** `AuditSettings`: object with `state` (`Enabled` or `Disabled`), `retentionDays`, and `auditActionsAndGroups`.
-
----
 
 ### remove_audit_group
 
@@ -258,8 +234,6 @@ Remove a single audit action group without overwriting the others. Idempotent - 
 
 **Returns:** `AuditSettings`: the updated audit settings.
 
----
-
 ### set_audit_action_groups
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
@@ -273,8 +247,6 @@ Replace the audited action groups for a warehouse or SQL analytics endpoint. Thi
 - `action_groups` (`list[str]`): list of audit action group names (e.g. `["BATCH_COMPLETED_GROUP"]`).
 
 **Returns:** `AuditSettings`: the updated audit settings.
-
----
 
 ### set_audit_retention
 

--- a/docs/commands/cache.md
+++ b/docs/commands/cache.md
@@ -8,8 +8,6 @@ Manage the local name-to-UUID lookup cache. `fabric-dw` caches workspace and ite
 
 **Targets:** Workspace (not item-specific)
 
----
-
 ## CLI
 
 ### cache clear
@@ -33,8 +31,6 @@ fdw cache clear
 ```
 Cache cleared.
 ```
-
----
 
 ## MCP tools
 

--- a/docs/commands/completion.md
+++ b/docs/commands/completion.md
@@ -8,8 +8,6 @@ Manage shell completion scripts. See [Shell Completion](../completion.md) for fu
 
 **Targets:** Workspace (not item-specific)
 
----
-
 ## CLI
 
 ### completion install

--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -219,8 +219,6 @@ fdw --auth sp warehouses list
 
 See [Authentication](../authentication.md) for the full list of valid modes and their requirements.
 
----
-
 ## CLI
 
 ### config clear
@@ -232,8 +230,6 @@ Wipe **all** configuration defaults.
 ```
 fdw config clear
 ```
-
----
 
 ### config set
 
@@ -271,8 +267,6 @@ fdw config set logging level DEBUG
 fdw config set mcp workspace-allowlist "Sales WS,Finance WS"
 ```
 
----
-
 ### config show
 
 Print the current defaults.
@@ -294,8 +288,6 @@ fdw config show
 workspace  MyWorkspace
 warehouse  MyWarehouse
 ```
-
----
 
 ### config unset
 

--- a/docs/commands/dbt.md
+++ b/docs/commands/dbt.md
@@ -10,8 +10,6 @@ No dbt installation is required to run these commands - `fabric-dw` generates al
 
 **Targets:** Data Warehouse
 
----
-
 ## CLI
 
 ### dbt init
@@ -90,8 +88,6 @@ fdw -w MyWorkspace dbt init SalesWH ./sales_dbt --force
 ├── macros/
 └── analyses/
 ```
-
----
 
 ## MCP tools
 

--- a/docs/commands/functions.md
+++ b/docs/commands/functions.md
@@ -8,8 +8,6 @@ Manage T-SQL user-defined functions on Microsoft Fabric Data Warehouses and SQL 
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
 
----
-
 ## CLI
 
 ### functions create
@@ -40,8 +38,6 @@ fdw -w MyWorkspace functions create SalesWH \
   --body "(@input NVARCHAR(100)) RETURNS NVARCHAR(100) AS BEGIN RETURN LTRIM(RTRIM(@input)) END"
 ```
 
----
-
 ### functions drop
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
@@ -64,8 +60,6 @@ fdw [-w WORKSPACE] functions drop [OPTIONS] [ITEM] QUALIFIED_NAME
 fdw -w MyWorkspace --yes functions drop SalesWH dbo.fn_clean_input
 ```
 
----
-
 ### functions get
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
@@ -85,8 +79,6 @@ fdw [-w WORKSPACE] functions get [ITEM] QUALIFIED_NAME
 ```shell
 fdw -w MyWorkspace functions get SalesWH dbo.fn_clean_input
 ```
-
----
 
 ### functions list
 
@@ -117,8 +109,6 @@ fdw -w MyWorkspace functions list SalesWH --schema dbo --kind scalar
  dbo          fn_clean_input  scalar  True           2026-06-01T08:00:00Z  2026-06-10T12:00:00Z
 ```
 
----
-
 ### functions rename
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
@@ -141,8 +131,6 @@ fdw [-w WORKSPACE] functions rename [OPTIONS] [ITEM] QUALIFIED_NAME
 fdw -w MyWorkspace --yes functions rename SalesWH dbo.fn_clean_input \
   --new-name fn_sanitize_input
 ```
-
----
 
 ### functions update
 
@@ -176,8 +164,6 @@ fdw -w MyWorkspace functions update SalesWH dbo.fn_clean_input \
   --from-file ./fns/fn_clean_input_v2.sql
 ```
 
----
-
 ## MCP tools
 
 ### create_function
@@ -199,8 +185,6 @@ Create a new T-SQL user-defined function.
 
 **Returns:** `FunctionDetails`: the newly-created function object.
 
----
-
 ### drop_function
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
@@ -216,8 +200,6 @@ Drop a T-SQL user-defined function.
 
 **Returns:** `{ "dropped": true }`: confirmation.
 
----
-
 ### get_function
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
@@ -231,8 +213,6 @@ Fetch the full definition of a single T-SQL user-defined function, including its
 - `qualified_name` (`str`): dot-separated qualified function name, e.g. `dbo.fn_clean_input`.
 
 **Returns:** `FunctionDetails`: single function object with `definition` (from `sys.sql_modules`) and `parameters` (from `sys.parameters`).
-
----
 
 ### list_functions
 
@@ -249,8 +229,6 @@ List T-SQL user-defined functions on a warehouse or SQL Analytics Endpoint, opti
 
 **Returns:** `list[Function]`: array of function objects, each with `schema_name`, `name`, `qualified_name`, `kind`, `is_inlineable`, `created`, and `modified`.
 
----
-
 ### rename_function
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
@@ -265,8 +243,6 @@ Rename a T-SQL user-defined function via `sp_rename`. The new name must be a bar
 - `new_name` (`str`): new bare function name (no schema prefix), e.g. `fn_sanitize_input`.
 
 **Returns:** `FunctionDetails`: the renamed function record.
-
----
 
 ### update_function
 

--- a/docs/commands/procedures.md
+++ b/docs/commands/procedures.md
@@ -8,8 +8,6 @@ Manage stored procedures on Microsoft Fabric Data Warehouses and SQL Analytics E
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
 
----
-
 ## CLI
 
 ### procedures create
@@ -40,8 +38,6 @@ fdw -w MyWorkspace procedures create SalesWH \
   --body "BEGIN INSERT INTO dbo.archive SELECT * FROM dbo.orders; END"
 ```
 
----
-
 ### procedures drop
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
@@ -59,8 +55,6 @@ fdw [-w WORKSPACE] procedures drop [ITEM] QUALIFIED_NAME
 ```shell
 fdw -w MyWorkspace --yes procedures drop SalesWH dbo.usp_archive_orders
 ```
-
----
 
 ### procedures get
 
@@ -81,8 +75,6 @@ fdw [-w WORKSPACE] procedures get [ITEM] QUALIFIED_NAME
 ```shell
 fdw -w MyWorkspace procedures get SalesWH dbo.usp_load_sales
 ```
-
----
 
 ### procedures list
 
@@ -112,8 +104,6 @@ fdw -w MyWorkspace procedures list SalesWH --schema dbo
  dbo          usp_load_sales  2026-01-10T08:00:00Z  2026-06-01T12:00:00Z
 ```
 
----
-
 ### procedures update
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
@@ -142,8 +132,6 @@ fdw -w MyWorkspace procedures update SalesWH dbo.usp_archive_orders \
   --from-file ./procs/usp_archive_orders_v2.sql
 ```
 
----
-
 ## MCP tools
 
 ### create_procedure
@@ -165,8 +153,6 @@ Create a new stored procedure.
 
 **Returns:** `StoredProcedure`: the newly-created procedure object.
 
----
-
 ### drop_procedure
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
@@ -180,8 +166,6 @@ Drop a stored procedure.
 - `qualified_name` (`str`): dot-separated qualified procedure name, e.g. `dbo.usp_load`.
 
 **Returns:** `{ "dropped": true }`: confirmation.
-
----
 
 ### get_procedure
 
@@ -197,8 +181,6 @@ Fetch the full definition of a single stored procedure.
 
 **Returns:** `StoredProcedure`: single procedure object with `definition` populated from `sys.sql_modules`.
 
----
-
 ### list_procedures
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
@@ -212,8 +194,6 @@ List stored procedures on a warehouse or SQL Analytics Endpoint, optionally filt
 - `schema` (`str | null`, optional): when provided, only procedures in this schema are returned.
 
 **Returns:** `list[StoredProcedure]`: array of procedure objects, each with `schema_name`, `name`, `qualified_name`, `created`, and `modified`.
-
----
 
 ### update_procedure
 

--- a/docs/commands/queries.md
+++ b/docs/commands/queries.md
@@ -8,8 +8,6 @@ Inspect and manage running queries on Microsoft Fabric Data Warehouses and SQL A
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
 
----
-
 ## CLI
 
 ### queries connections
@@ -36,8 +34,6 @@ fdw -w MyWorkspace queries connections SalesWH
  10          2026-06-08T10:00:00Z  192.168.1.100       NTLM         TRUE            TCP            10
  20          2026-06-08T10:01:00Z  192.168.1.101       KERBEROS     FALSE           TCP            20
 ```
-
----
 
 ### queries frequent
 
@@ -67,8 +63,6 @@ fdw -w MyWorkspace queries frequent SalesWH --limit 20
 fdw -w MyWorkspace queries frequent SalesWH --ago 1h
 ```
 
----
-
 ### queries history
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
@@ -97,8 +91,6 @@ fdw -w MyWorkspace queries history SalesWH --limit 50 --since 2026-06-01T00:00:0
 fdw -w MyWorkspace queries history SalesWH --ago 1h
 ```
 
----
-
 ### queries kill
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
@@ -116,8 +108,6 @@ fdw [-w WORKSPACE] queries kill [WAREHOUSE] SESSION_ID
 ```shell
 fdw -w MyWorkspace --yes queries kill SalesWH 42
 ```
-
----
 
 ### queries long-running
 
@@ -147,8 +137,6 @@ fdw -w MyWorkspace queries long-running SalesWH
 fdw -w MyWorkspace queries long-running SalesWH --ago 2d
 ```
 
----
-
 ### queries running
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
@@ -172,8 +160,6 @@ fdw -w MyWorkspace queries running SalesWH
  ----------- ----------- --------------------- -------------------------
  42          user@co.io  2026-06-08T10:01:00Z  SELECT * FROM sales ...
 ```
-
----
 
 ### queries sessions
 
@@ -203,8 +189,6 @@ fdw -w MyWorkspace queries sessions SalesWH
 fdw -w MyWorkspace queries sessions SalesWH --ago 90m
 ```
 
----
-
 ## MCP tools
 
 The following four tools query the `queryinsights` schema DMVs via TDS. They share the same parameter shape - `workspace`, `warehouse`, optional `limit`, optional `since`, and optional `until`.
@@ -223,8 +207,6 @@ Terminate a session on a warehouse.
 
 **Returns:** `{ "killed": true, "session_id": int }`: confirmation with the terminated session ID.
 
----
-
 ### list_connections
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
@@ -237,8 +219,6 @@ Return all active SQL connections on a warehouse or SQL Analytics Endpoint. Quer
 - `warehouse` (`str`): warehouse name or GUID.
 
 **Returns:** `list[Connection]`: array of connection objects, each with `session_id`, `connect_time`, `client_net_address`, `auth_scheme`, `encrypt_option`, and `net_transport`.
-
----
 
 ### list_frequent_queries
 
@@ -256,8 +236,6 @@ Return frequently-run queries from `queryinsights.frequently_run_queries`.
 
 **Returns:** `list[dict]`: array of frequently-run query row objects. Elapsed-time fields (e.g. `avg_total_elapsed_time_ms`, `min_run_total_elapsed_time_ms`, `max_run_total_elapsed_time_ms`, `last_run_total_elapsed_time_ms`) are JSON `number` (float); count fields remain `integer`.
 
----
-
 ### list_long_running_queries
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
@@ -273,8 +251,6 @@ Return long-running queries from `queryinsights.long_running_queries`.
 - `until` (`str | null`, optional): ISO-8601 upper bound on `last_run_start_time`.
 
 **Returns:** `list[dict]`: array of long-running query row objects. `median_total_elapsed_time_ms` and `last_run_total_elapsed_time_ms` are JSON `number` (float); `number_of_runs` remains `integer`.
-
----
 
 ### list_request_history
 
@@ -292,8 +268,6 @@ Return completed SQL requests from `queryinsights.exec_requests_history`.
 
 **Returns:** `list[dict]`: array of request-history row objects. Elapsed-time and CPU-time fields (e.g. `total_elapsed_time_ms`, `allocated_cpu_time_ms`) are JSON `number` (float) because Fabric returns fractional millisecond values.
 
----
-
 ### list_running_queries
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
@@ -306,8 +280,6 @@ Return all currently-executing queries on a warehouse.
 - `warehouse` (`str`): warehouse name or GUID.
 
 **Returns:** `list[RunningQuery]`: array of query objects, each with `session_id`, `request_id`, `status`, `start_time`, `total_elapsed_time` (ms), `login_name`, `command`, and `query_text`.
-
----
 
 ### list_session_history
 

--- a/docs/commands/restore-points.md
+++ b/docs/commands/restore-points.md
@@ -10,8 +10,6 @@ A restore point captures the state of a warehouse at a point in time. User-defin
 
 **Targets:** Data Warehouse only
 
----
-
 ## CLI
 
 ### restore-points create
@@ -39,8 +37,6 @@ fdw -w MyWorkspace restore-points create SalesWH \
   --description "Pre-migration checkpoint"
 ```
 
----
-
 ### restore-points delete
 
 **Targets:** Data Warehouse only
@@ -59,8 +55,6 @@ fdw [-w WORKSPACE] restore-points delete WAREHOUSE RESTORE_POINT_ID
 fdw -w MyWorkspace --yes restore-points delete SalesWH 1726617378000
 ```
 
----
-
 ### restore-points get
 
 **Targets:** Data Warehouse only
@@ -78,8 +72,6 @@ fdw [-w WORKSPACE] restore-points get WAREHOUSE RESTORE_POINT_ID
 ```shell
 fdw -w MyWorkspace restore-points get SalesWH 1726617378000
 ```
-
----
 
 ### restore-points list
 
@@ -105,8 +97,6 @@ fdw -w MyWorkspace restore-points list SalesWH
  1726617378000   Before migration   UserDefined    2024-10-18T22:17:09Z
 ```
 
----
-
 ### restore-points rename
 
 **Targets:** Data Warehouse only
@@ -129,8 +119,6 @@ fdw [-w WORKSPACE] restore-points rename [OPTIONS] WAREHOUSE RESTORE_POINT_ID NE
 fdw -w MyWorkspace restore-points rename SalesWH 1726617378000 "Post-migration backup"
 ```
 
----
-
 ### restore-points restore
 
 **Targets:** Data Warehouse only
@@ -149,8 +137,6 @@ fdw [-w WORKSPACE] restore-points restore WAREHOUSE RESTORE_POINT_ID
 fdw -w MyWorkspace --yes restore-points restore SalesWH 1726617378000
 ```
 
----
-
 ## MCP tools
 
 ### create_restore_point
@@ -168,8 +154,6 @@ Create a restore point for a warehouse at the current timestamp.
 
 **Returns:** `RestorePoint`: the newly-created restore point object.
 
----
-
 ### delete_restore_point
 
 **Targets:** Data Warehouse only
@@ -183,8 +167,6 @@ Delete a user-defined restore point. System-created restore points cannot be del
 - `restore_point_id` (`str`): the restore point ID string.
 
 **Returns:** `{ "deleted": true, "restore_point_id": str }`: confirmation.
-
----
 
 ### get_restore_point
 
@@ -200,8 +182,6 @@ Return a single restore point by ID.
 
 **Returns:** `RestorePoint`: the restore point object.
 
----
-
 ### list_restore_points
 
 **Targets:** Data Warehouse only
@@ -214,8 +194,6 @@ Return all restore points for a warehouse.
 - `warehouse` (`str`): warehouse name or GUID.
 
 **Returns:** `list[RestorePoint]`: array of restore point objects.
-
----
 
 ### restore_warehouse_in_place
 
@@ -230,8 +208,6 @@ Restore a warehouse in-place to a restore point. **This is a destructive, long-r
 - `restore_point_id` (`str`): the restore point ID string to restore to.
 
 **Returns:** `{ "restored": true, "restore_point_id": str }`: confirmation.
-
----
 
 ### update_restore_point
 

--- a/docs/commands/schemas.md
+++ b/docs/commands/schemas.md
@@ -12,8 +12,6 @@ Manage SQL schemas on Microsoft Fabric Data Warehouses and SQL Analytics Endpoin
 
     `schemas list`, `schemas create`, and `schemas delete` (CLI) and `list_schemas`, `create_schema`, and `delete_schema` (MCP) all work on both Fabric Data Warehouses and SQL Analytics Endpoints. When `schemas delete --cascade` (CLI) or `delete_schema` with `cascade=True` (MCP) is used on a SQL Analytics Endpoint, views, stored procedures, and functions in the schema are dropped, but tables are **not** dropped (because `DROP TABLE` is a Warehouse-only operation on Fabric). If the schema contains tables, the final `DROP SCHEMA` will be rejected by the engine; remove the tables manually first or omit `--cascade` and drop the schema only after it is empty.
 
----
-
 ## CLI
 
 ### schemas create
@@ -33,8 +31,6 @@ fdw [-w WORKSPACE] schemas create [OPTIONS] [WAREHOUSE] NAME
 ```shell
 fdw -w MyWorkspace schemas create SalesWH reporting
 ```
-
----
 
 ### schemas delete
 
@@ -64,8 +60,6 @@ fdw -w MyWorkspace --yes schemas delete SalesWH staging
 fdw -w MyWorkspace --yes schemas delete SalesWH staging --cascade
 ```
 
----
-
 ### schemas list
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
@@ -92,8 +86,6 @@ fdw -w MyWorkspace schemas list SalesWH
  staging  7
 ```
 
----
-
 ## MCP tools
 
 ### create_schema
@@ -109,8 +101,6 @@ Create a new SQL schema on a Fabric Data Warehouse or SQL Analytics Endpoint.
 - `name` (`str`): the schema name; must be a valid SQL identifier.
 
 **Returns:** `Schema`: the newly-created schema record with `name` and `principal_id`.
-
----
 
 ### delete_schema
 
@@ -130,8 +120,6 @@ Drop a SQL schema from a Fabric Data Warehouse or SQL Analytics Endpoint.
 - `cascade` (`bool`, default `False`): when `True`, drop all tables, views, functions, and stored procedures in the schema first.
 
 **Returns:** `{ "deleted": true }`: confirmation.
-
----
 
 ### list_schemas
 

--- a/docs/commands/settings.md
+++ b/docs/commands/settings.md
@@ -16,8 +16,6 @@ The workspace is resolved from the global `-w/--workspace` option, the `FABRIC_D
 
 **Targets:** Data Warehouse
 
----
-
 ## CLI
 
 ### settings result-set-caching
@@ -42,8 +40,6 @@ fdw -w MyWorkspace settings result-set-caching MyWarehouse off
 fdw -w MyWorkspace --json settings result-set-caching MyWarehouse on
 ```
 
----
-
 ### settings retention
 
 **Targets:** Data Warehouse
@@ -67,8 +63,6 @@ fdw -w MyWorkspace settings retention MyWarehouse --days 30
 fdw -w MyWorkspace --json settings retention MyWarehouse --days 7
 ```
 
----
-
 ### settings show
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
@@ -85,8 +79,6 @@ fdw -w <workspace> settings show [ITEM]
 fdw -w MyWorkspace settings show MyWarehouse
 fdw -w MyWorkspace --json settings show MyWarehouse
 ```
-
----
 
 ## MCP tools
 
@@ -107,8 +99,6 @@ Return the current server-side database settings for a warehouse. Reads `result_
 
 **Returns:** `WarehouseSettings`: `{ database, result_set_caching, time_travel_retention_days, time_travel_retention_cutoff_date }`.
 
----
-
 ### set_result_set_caching
 
 **Targets:** Data Warehouse
@@ -126,8 +116,6 @@ Enable or disable result-set caching on a warehouse. Executes `ALTER DATABASE CU
 | `enabled` | `bool` | `true` to enable result-set caching, `false` to disable it. |
 
 **Returns:** `WarehouseSettings`: the effective settings after the change.
-
----
 
 ### set_time_travel_retention
 

--- a/docs/commands/snapshots.md
+++ b/docs/commands/snapshots.md
@@ -8,8 +8,6 @@ Manage Microsoft Fabric Data Warehouse snapshots.
 
 **Targets:** Data Warehouse only
 
----
-
 ## CLI
 
 ### snapshots create
@@ -36,8 +34,6 @@ fdw -w MyWorkspace snapshots create SalesWH snap-2026-06-08 \
   --snapshot-dt 2026-06-08T00:00:00Z
 ```
 
----
-
 ### snapshots delete
 
 **Targets:** Data Warehouse only
@@ -55,8 +51,6 @@ fdw [-w WORKSPACE] snapshots delete SNAPSHOT
 ```shell
 fdw -w MyWorkspace --yes snapshots delete snap-old
 ```
-
----
 
 ### snapshots list
 
@@ -82,8 +76,6 @@ fdw -w MyWorkspace snapshots list SalesWH
  snap-2026-06-01  d1e2...      2026-06-01T00:00:00Z
 ```
 
----
-
 ### snapshots rename
 
 **Targets:** Data Warehouse only
@@ -105,8 +97,6 @@ fdw [-w WORKSPACE] snapshots rename [OPTIONS] SNAPSHOT NEW_NAME
 ```shell
 fdw -w MyWorkspace snapshots rename snap-2026-06-01 snap-june-2026
 ```
-
----
 
 ### snapshots roll
 
@@ -131,8 +121,6 @@ fdw -w MyWorkspace snapshots roll SalesWH snap-june-2026 \
   --at 2026-06-08T12:00:00Z
 ```
 
----
-
 ## MCP tools
 
 ### create_snapshot
@@ -151,8 +139,6 @@ Create a new warehouse snapshot.
 
 **Returns:** `WarehouseSnapshot`: the newly-created snapshot object.
 
----
-
 ### delete_snapshot
 
 **Targets:** Data Warehouse only
@@ -166,8 +152,6 @@ Delete a warehouse snapshot.
 
 **Returns:** `{ "deleted": true, "snapshot_id": str }`: confirmation with the snapshot GUID.
 
----
-
 ### list_snapshots
 
 **Targets:** Data Warehouse only
@@ -180,8 +164,6 @@ Return all snapshots belonging to a warehouse.
 - `warehouse` (`str`): warehouse name or GUID.
 
 **Returns:** `list[WarehouseSnapshot]`: array of snapshot objects, each with `id`, `displayName`, `parentWarehouseId`, and `snapshotDateTime`.
-
----
 
 ### rename_snapshot
 
@@ -197,8 +179,6 @@ Rename a warehouse snapshot and optionally update its description.
 - `description` (`str | null`, optional): new description; omit to leave unchanged.
 
 **Returns:** `WarehouseSnapshot`: the updated snapshot object.
-
----
 
 ### roll_snapshot_timestamp
 

--- a/docs/commands/sql-endpoints.md
+++ b/docs/commands/sql-endpoints.md
@@ -8,8 +8,6 @@ Manage Microsoft Fabric SQL Analytics Endpoints.
 
 **Targets:** SQL Analytics Endpoint
 
----
-
 ## CLI
 
 ### sql-endpoints get
@@ -29,8 +27,6 @@ fdw [-w WORKSPACE] sql-endpoints get ENDPOINT
 ```shell
 fdw -w MyWorkspace sql-endpoints get MyLakehouseEP
 ```
-
----
 
 ### sql-endpoints list
 
@@ -67,8 +63,6 @@ fdw sql-endpoints list --all-workspaces
  MyLakehouseEP      f9e1...
 ```
 
----
-
 ### sql-endpoints permissions
 
 **Targets:** SQL Analytics Endpoint
@@ -101,8 +95,6 @@ fdw -w MyWorkspace --json sql-endpoints permissions MyLakehouseEP
  Alice           alice@contoso.com        User    Read, Write
  DataPipeline    00000000-0000-...        ServicePrincipal  Read
 ```
-
----
 
 ### sql-endpoints refresh
 
@@ -137,8 +129,6 @@ fdw -w MyWorkspace sql-endpoints refresh --recreate-tables MyLakehouseEP
 fdw -w MyWorkspace --json sql-endpoints refresh MyLakehouseEP
 ```
 
----
-
 ## MCP tools
 
 ### get_sql_endpoint
@@ -153,8 +143,6 @@ Return details for a single SQL analytics endpoint.
 - `endpoint` (`str`): endpoint name or GUID.
 
 **Returns:** `Warehouse`: single SQL analytics endpoint object.
-
----
 
 ### get_sql_endpoint_permissions
 
@@ -173,8 +161,6 @@ Return all principals (users, groups, service principals) with access to a SQL A
 
 **Returns:** `list[ItemAccess]`: array of access records, each with `principal` (containing `id`, `displayName`, `type`, and type-specific fields such as `userPrincipalName` or `aadAppId`) and `itemAccessDetails` (containing `type`, `permissions`, and `additionalPermissions`).
 
----
-
 ### list_sql_endpoints
 
 **Targets:** SQL Analytics Endpoint
@@ -187,8 +173,6 @@ List all SQL analytics endpoints in a workspace, or across all visible workspace
 - `all_workspaces` (`bool`, default `false`): when `true`, aggregate results across every workspace the caller can see.
 
 **Returns:** `list[Warehouse]`: array of SQL analytics endpoint objects (same fields as Warehouse, `kind` is always `SQLEndpoint`).
-
----
 
 ### refresh_sql_endpoint_metadata
 

--- a/docs/commands/sql-pools.md
+++ b/docs/commands/sql-pools.md
@@ -8,8 +8,6 @@ Manage custom SQL Pools at the workspace level with sub-resource commands that m
 
 **Targets:** Workspace (not item-specific)
 
----
-
 ## CLI
 
 ### sql-pools create
@@ -45,8 +43,6 @@ fdw -w MyWorkspace sql-pools create \
   --classifier-value "Load"
 ```
 
----
-
 ### sql-pools delete
 
 **Targets:** Workspace (not item-specific)
@@ -70,8 +66,6 @@ fdw [-w WORKSPACE] sql-pools delete [OPTIONS]
 fdw -w MyWorkspace --yes sql-pools delete --name ETL
 ```
 
----
-
 ### sql-pools disable
 
 **Targets:** Workspace (not item-specific)
@@ -89,8 +83,6 @@ fdw [-w WORKSPACE] sql-pools disable
 ```shell
 fdw -w MyWorkspace sql-pools disable
 ```
-
----
 
 ### sql-pools enable
 
@@ -110,8 +102,6 @@ fdw [-w WORKSPACE] sql-pools enable
 fdw -w MyWorkspace sql-pools enable
 ```
 
----
-
 ### sql-pools get
 
 **Targets:** Workspace (not item-specific)
@@ -129,8 +119,6 @@ fdw [-w WORKSPACE] sql-pools get
 ```shell
 fdw -w MyWorkspace sql-pools get
 ```
-
----
 
 ### sql-pools insights
 
@@ -157,8 +145,6 @@ fdw [-w WORKSPACE] sql-pools insights [OPTIONS] [WAREHOUSE]
 fdw -w MyWorkspace sql-pools insights SalesWH
 fdw -w MyWorkspace sql-pools insights SalesWH --ago 1h
 ```
-
----
 
 ### sql-pools list
 
@@ -204,8 +190,6 @@ about there being no custom pools:
 }
 ```
 
----
-
 ### sql-pools show
 
 **Targets:** Workspace (not item-specific)
@@ -227,8 +211,6 @@ fdw [-w WORKSPACE] sql-pools show --name POOL
 ```shell
 fdw -w MyWorkspace sql-pools show --name ETL
 ```
-
----
 
 ### sql-pools update
 
@@ -257,8 +239,6 @@ fdw [-w WORKSPACE] sql-pools update [OPTIONS]
 fdw -w MyWorkspace sql-pools update --name ETL --max-percent 40
 ```
 
----
-
 ## MCP tools
 
 All callers must hold the **workspace admin role**.
@@ -281,8 +261,6 @@ Add a new SQL pool to a workspace.
 
 **Returns:** `SqlPool`: the newly-created pool object.
 
----
-
 ### delete_sql_pool
 
 **Targets:** Workspace (not item-specific)
@@ -296,8 +274,6 @@ Delete an SQL pool from a workspace.
 
 **Returns:** `{ "deleted": true, "pool_name": str }`: confirmation.
 
----
-
 ### disable_sql_pools
 
 **Targets:** Workspace (not item-specific)
@@ -310,8 +286,6 @@ Disable custom SQL Pools for a workspace, preserving the pool configuration. Re-
 
 **Returns:** `SqlPoolsConfiguration`: the updated configuration.
 
----
-
 ### enable_sql_pools
 
 **Targets:** Workspace (not item-specific)
@@ -323,8 +297,6 @@ Enable custom SQL Pools for a workspace without modifying pool definitions.
 - `workspace` (`str`): workspace name or GUID.
 
 **Returns:** `SqlPoolsConfiguration`: the updated configuration.
-
----
 
 ### get_sql_pool
 
@@ -339,8 +311,6 @@ Return details for a single SQL pool by name.
 
 **Returns:** `SqlPool`: single pool object (fields as above).
 
----
-
 ### get_sql_pools_configuration
 
 **Targets:** Workspace (not item-specific)
@@ -352,8 +322,6 @@ Fetch the full SQL Pools configuration (enabled flag + pool list) for a workspac
 - `workspace` (`str`): workspace name or GUID.
 
 **Returns:** `SqlPoolsConfiguration`: object with `customSQLPoolsEnabled` (bool) and `customSQLPools` (list of pool objects, each with `name`, `maxResourcePercentage`, `isDefault`, `optimizeForReads`, and optional `classifier`).
-
----
 
 ### list_sql_pool_insights
 
@@ -371,8 +339,6 @@ Return SQL pool insight events from `queryinsights.sql_pool_insights`.
 
 **Returns:** `list[dict]`: array of SQL pool insight row objects.
 
----
-
 ### list_sql_pools
 
 **Targets:** Workspace (not item-specific)
@@ -384,8 +350,6 @@ Return the list of SQL pools for a workspace.
 - `workspace` (`str`): workspace name or GUID.
 
 **Returns:** `list[SqlPool]`: array of pool objects, each with `name`, `isDefault`, `maxResourcePercentage`, `optimizeForReads`, and optional `classifier`.
-
----
 
 ### update_sql_pool
 

--- a/docs/commands/sql.md
+++ b/docs/commands/sql.md
@@ -8,8 +8,6 @@ SQL execution and query-plan capture against a Fabric Data Warehouse or SQL Anal
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
 
----
-
 ## CLI
 
 ### sql exec
@@ -46,8 +44,6 @@ fdw -w MyWorkspace --json sql exec SalesWH -f ./queries/report.sql
 ```json
 {"columns": ["id", "name"], "rows": [[1, "Alice"], [2, "Bob"]], "rowcount": 2}
 ```
-
----
 
 ### sql plan
 
@@ -140,8 +136,6 @@ Unknown operators degrade gracefully; the library renders what it knows and skip
 
 **Attribution:** The vendored assets (JS and CSS) are from [html-query-plan 2.6.1](https://github.com/JustinPealing/html-query-plan) by Justin Pealing, released under the MIT licence.  A copy of the licence is included in `src/fabric_dw/assets/html_query_plan/LICENSE.txt`.
 
----
-
 ##### svg
 
 `--format svg` renders the execution plan to an **SVG image** by piping the generated DOT through the system `dot` binary (`dot -Tsvg`).
@@ -153,8 +147,6 @@ Unknown operators degrade gracefully; the library renders what it knows and skip
     When the `dot` binary is not found, the command exits with a clear error and an install hint rather than crashing.
 
 A `.svg` extension is recommended for the `-o`/`--output` file.  SVG can be opened directly in any web browser or vector graphics editor.
-
----
 
 ##### dot
 
@@ -179,8 +171,6 @@ digraph stmt0 {
 }
 ```
 
----
-
 ##### mermaid
 
 `--format mermaid` renders the execution plan as a [Mermaid](https://mermaid.js.org/) `flowchart TD` diagram (plain text, no extra dependencies).
@@ -202,8 +192,6 @@ Each operator appears as a node labelled with its physical op name (and logical 
       S0N0 --> S0N2
   ```
   ````
-
----
 
 ## MCP tools
 
@@ -228,8 +216,6 @@ Multi-statement batches are supported; only the **last** result set is returned.
 - `query` (`str`): SQL statement or batch to execute.
 
 **Returns:** `{ "columns": list[str], "rows": list[list[Any]], "rowcount": int }`: `rowcount` is `-1` when the driver does not report a count.
-
----
 
 ### get_query_plan
 

--- a/docs/commands/statistics.md
+++ b/docs/commands/statistics.md
@@ -12,8 +12,6 @@ Manage user-defined statistics on Fabric Data Warehouses and read their details 
 
     Only **single-column, histogram-based** statistics can be created or updated (Fabric limitation). Multi-column statistics are not supported.
 
----
-
 ## CLI
 
 ### statistics create
@@ -34,8 +32,6 @@ fdw [-w WORKSPACE] statistics create [ITEM] --table schema.table --column COL --
 | `--fullscan` | Use `WITH FULLSCAN` (default). Mutually exclusive with `--sample-percent`. | on |
 | `--sample-percent N` | Sample `N`% of the table (1–100). Overrides `--fullscan`. | - |
 
----
-
 ### statistics delete
 
 **Targets:** Data Warehouse only
@@ -45,8 +41,6 @@ Drop a statistic via `DROP STATISTICS`. Prompts for confirmation unless `--yes` 
 ```
 fdw [-w WORKSPACE] statistics delete [ITEM] QUALIFIED_TABLE STAT_NAME
 ```
-
----
 
 ### statistics list
 
@@ -65,8 +59,6 @@ fdw [-w WORKSPACE] statistics list [ITEM] [OPTIONS]
 | `--user-only` | Only show user-created statistics. | off |
 | `--auto-only` | Only show auto-created statistics. | off |
 
----
-
 ### statistics show
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
@@ -83,8 +75,6 @@ fdw [-w WORKSPACE] statistics show [ITEM] QUALIFIED_TABLE STAT_NAME [OPTIONS]
 | --- | --- | --- |
 | `--histogram` | Show only the histogram steps (skip header and density vector). | off |
 
----
-
 ### statistics update
 
 **Targets:** Data Warehouse only
@@ -99,8 +89,6 @@ fdw [-w WORKSPACE] statistics update [ITEM] QUALIFIED_TABLE STAT_NAME [OPTIONS]
 | --- | --- | --- |
 | `--fullscan` | Use `WITH FULLSCAN` (default). | on |
 | `--sample-percent N` | Sample `N`% of the table (1–100). Overrides `--fullscan`. | - |
-
----
 
 ## MCP tools
 
@@ -134,8 +122,6 @@ Create a single-column statistic on a table. Only single-column statistics are s
 
 **Returns:** `Statistic`: the newly-created statistic.
 
----
-
 ### delete_statistics
 
 **Targets:** Data Warehouse only
@@ -154,8 +140,6 @@ Drop a statistic via `DROP STATISTICS`. **Destructive and irreversible.** Requir
 | `stat_name` | `str` | Name of the statistic to drop. |
 
 **Returns:** `{ "dropped": true }`: confirmation.
-
----
 
 ### list_statistics
 
@@ -178,8 +162,6 @@ List statistics on a warehouse or SQL Analytics Endpoint.
 
 **Returns:** `list[dict]`: array of `Statistic` objects.
 
----
-
 ### show_statistics
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
@@ -199,8 +181,6 @@ Show details of a statistic using `DBCC SHOW_STATISTICS`. Returns the stat heade
 | `histogram_only` | `bool` | When `true`, return only the histogram steps. |
 
 **Returns:** `StatisticDetails`: `{ stat_header, density_vector, histogram }`.
-
----
 
 ### update_statistics
 

--- a/docs/commands/tables.md
+++ b/docs/commands/tables.md
@@ -8,8 +8,6 @@ Manage SQL tables on Microsoft Fabric Data Warehouses and SQL Analytics Endpoint
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
 
----
-
 ## CLI
 
 ### tables clear
@@ -29,8 +27,6 @@ fdw [-w WORKSPACE] tables clear [OPTIONS] [WAREHOUSE] QUALIFIED_NAME
 ```shell
 fdw -w MyWorkspace --yes tables clear SalesWH dbo.staging_load
 ```
-
----
 
 ### tables columns
 
@@ -60,8 +56,6 @@ fdw -w MyWorkspace tables columns SalesWH dbo.Sales
  3        label   NVARCHAR(100) True      False        False        Latin1_General_CI_AS
 ```
 
----
-
 ### tables clear
 
 **Targets:** Data Warehouse only
@@ -79,8 +73,6 @@ fdw [-w WORKSPACE] tables clear [OPTIONS] [WAREHOUSE] QUALIFIED_NAME
 ```shell
 fdw -w MyWorkspace --yes tables clear SalesWH dbo.staging_load
 ```
-
----
 
 ### tables cluster-by
 
@@ -118,8 +110,6 @@ fdw -w MyWorkspace --yes tables cluster-by SalesWH dbo.orders \
 fdw -w MyWorkspace --yes tables cluster-by SalesWH dbo.orders
 ```
 
----
-
 ### tables cluster-columns
 
 **Targets:** Data Warehouse only
@@ -144,9 +134,6 @@ fdw -w MyWorkspace --json tables cluster-columns SalesWH dbo.orders
   {"column_name": "country", "clustering_ordinal": 2}
 ]
 ```
-
----
-
 
 ### tables clone
 
@@ -181,8 +168,6 @@ fdw -w MyWorkspace tables clone SalesWH \
   --at 2024-05-20T14:00:00
 ```
 
----
-
 ### tables count
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
@@ -204,8 +189,6 @@ fdw -w MyWorkspace --json tables count SalesWH dbo.orders
 ```json
 {"schema": "dbo", "name": "orders", "row_count": 999999}
 ```
-
----
 
 ### tables create
 
@@ -319,8 +302,6 @@ fdw -w MyWorkspace tables create SalesWH \
   --cluster-by CustomerID --cluster-by SaleDate
 ```
 
----
-
 ### tables delete
 
 **Targets:** Data Warehouse only
@@ -338,8 +319,6 @@ fdw [-w WORKSPACE] tables delete [OPTIONS] [WAREHOUSE] QUALIFIED_NAME
 ```shell
 fdw -w MyWorkspace --yes tables delete SalesWH dbo.orders_2026
 ```
-
----
 
 ### tables health-check
 
@@ -361,8 +340,6 @@ fdw [-w WORKSPACE] tables health-check [ENDPOINT] QUALIFIED_NAME
 fdw -w MyWorkspace tables health-check MySqlEndpoint dbo.FactSales
 fdw -w MyWorkspace --json tables health-check MySqlEndpoint dbo.FactSales
 ```
-
----
 
 ### tables list
 
@@ -392,8 +369,6 @@ fdw -w MyWorkspace tables list SalesWH --schema dbo
  dbo          customers 2026-01-10T08:00:00Z  2026-06-01T12:00:00Z
  dbo          orders    2026-02-01T09:00:00Z  2026-05-15T14:00:00Z
 ```
-
----
 
 ### tables load
 
@@ -502,8 +477,6 @@ fdw -w MyWorkspace tables load SalesWH dbo.events \
     --format csv --credential-type sas --secret "?sv=2021&..."
 ```
 
----
-
 ### tables read
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
@@ -537,8 +510,6 @@ fdw -w MyWorkspace tables read SalesWH dbo.orders --count 5
 ]
 ```
 
----
-
 ### tables rename
 
 **Targets:** Data Warehouse only
@@ -563,8 +534,6 @@ fdw [-w WORKSPACE] tables rename [OPTIONS] [ITEM] QUALIFIED_NAME
 fdw -w MyWorkspace tables rename SalesWH dbo.orders_2025 --new-name orders_archive_2025
 ```
 
----
-
 ## MCP tools
 
 ### clear_table
@@ -583,8 +552,6 @@ Truncate a SQL table (remove all rows, preserve structure).
 
 **Returns:** `{ "truncated": true }`: confirmation.
 
----
-
 ### clone_table
 
 **Targets:** Data Warehouse only
@@ -600,8 +567,6 @@ Create a zero-copy clone of a table using `CREATE TABLE … AS CLONE OF …`. On
 - `at` (`str | null`, optional): ISO-8601 UTC timestamp for a point-in-time clone (e.g. `2024-05-20T14:00:00`). Must be within the data-retention window. When omitted, the clone reflects the current state of the source table.
 
 **Returns:** `Table`: the newly-created cloned table record.
-
----
 
 ### get_table_columns
 
@@ -627,8 +592,6 @@ Return column metadata for a SQL table via `sys.columns`. Works on both Fabric D
 
 Results are ordered by ordinal position. Raises a `ToolError` if the table does not exist.
 
----
-
 ### count_table_rows
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
@@ -642,8 +605,6 @@ Return the total row count of a table via `SELECT COUNT_BIG(*)`.
 - `qualified_name` (`str`): dot-separated table name, e.g. `dbo.sales`.
 
 **Returns:** `{ "schema": str, "name": str, "row_count": int }`: the schema name, table name, and total row count.
-
----
 
 ### create_empty_table
 
@@ -681,8 +642,6 @@ Server-side file access is unreliable in MCP deployments, so CSV/Parquet schema 
 }
 ```
 
----
-
 ### create_table
 
 **Targets:** Data Warehouse only
@@ -703,8 +662,6 @@ When `cluster_by` is supplied the DDL becomes `CREATE TABLE … WITH (CLUSTER BY
 
 **Returns:** `Table`: the newly-created table record.
 
----
-
 ### delete_table
 
 **Targets:** Data Warehouse only
@@ -721,8 +678,6 @@ Drop a SQL table.
 
 **Returns:** `{ "dropped": true }`: confirmation.
 
----
-
 ### get_cluster_columns
 
 **Targets:** Data Warehouse only
@@ -736,8 +691,6 @@ Return the data-clustering columns of a table, ordered by clustering ordinal. Re
 - `qualified_name` (`str`): dot-separated table name, e.g. `dbo.sales`.
 
 **Returns:** `list[{ "column_name": str, "clustering_ordinal": int }]`: ordered by ascending `clustering_ordinal`.
-
----
 
 ### get_table_health_metrics
 
@@ -756,8 +709,6 @@ The proc is Generally Available (announced at Build 2026) but its output column 
 - `qualified_name` (`str`): dot-separated table name, e.g. `dbo.FactSales`.
 
 **Returns:** `{ "columns": list[str], "rows": list[list] }`: column names and rows passed through verbatim from the proc.
-
----
 
 ### import_table_from_url
 
@@ -807,8 +758,6 @@ Load data from a remote URL into an existing Data Warehouse table with control o
 
 **Returns:** `CopyIntoResult`: `{ "rows_loaded": int, "rows_rejected": int, "target": "schema.table" }`.
 
----
-
 ### list_tables
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
@@ -822,8 +771,6 @@ List SQL tables on a warehouse or SQL Analytics Endpoint.
 - `schema` (`str | null`, optional): when provided, only tables in this schema are returned.
 
 **Returns:** `list[Table]`: each with `schema_name`, `name`, `qualified_name`, `created`, `modified`.
-
----
 
 ### load_table_from_url
 
@@ -863,8 +810,6 @@ Load data into a Data Warehouse table via `COPY INTO` from a remote URL. For One
 
 **Returns:** `CopyIntoResult`: `{ "rows_loaded": int, "rows_rejected": int, "target": "schema.table" }`.
 
----
-
 ### read_table
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
@@ -880,8 +825,6 @@ Return up to `count` rows from a table as JSON-serialisable columns and rows.
 
 **Returns:** `{ "columns": list[str], "rows": list[list] }`: column names and row arrays.
 
----
-
 ### rename_table
 
 **Targets:** Data Warehouse only
@@ -896,8 +839,6 @@ Rename a SQL table via `sp_rename`. Only supported on Fabric Data Warehouses (SQ
 - `new_name` (`str`): new bare table name (no schema prefix), e.g. `sales_v2`.
 
 **Returns:** `Table`: the updated table record.
-
----
 
 ### set_cluster_columns
 

--- a/docs/commands/views.md
+++ b/docs/commands/views.md
@@ -8,8 +8,6 @@ Manage SQL views on Microsoft Fabric Data Warehouses and SQL Analytics Endpoints
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
 
----
-
 ## CLI
 
 ### views columns
@@ -39,8 +37,6 @@ fdw -w MyWorkspace views columns SalesWH dbo.vw_sales
  2        amount  DECIMAL(18,2) True      False        False
 ```
 
----
-
 ### views count
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
@@ -62,8 +58,6 @@ fdw -w MyWorkspace --json views count SalesWH dbo.vw_sales
 ```json
 {"schema": "dbo", "name": "vw_sales", "row_count": 12345}
 ```
-
----
 
 ### views create
 
@@ -93,8 +87,6 @@ fdw -w MyWorkspace views create SalesWH \
   --select "SELECT id, amount FROM dbo.sales WHERE sale_date >= '2026-01-01'"
 ```
 
----
-
 ### views drop
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
@@ -112,8 +104,6 @@ fdw [-w WORKSPACE] views drop [WAREHOUSE] QUALIFIED_NAME
 ```shell
 fdw -w MyWorkspace --yes views drop SalesWH dbo.vw_recent
 ```
-
----
 
 ### views get
 
@@ -144,8 +134,6 @@ modified       2026-06-01T12:00:00Z
 definition     SELECT id, amount FROM dbo.sales
 ```
 
----
-
 ### views list
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
@@ -174,8 +162,6 @@ fdw -w MyWorkspace views list SalesWH --schema dbo
  dbo          vw_sales     2026-01-10T08:00:00Z  2026-06-01T12:00:00Z
  dbo          vw_monthly   2026-02-01T09:00:00Z  2026-05-15T14:00:00Z
 ```
-
----
 
 ### views read
 
@@ -210,8 +196,6 @@ fdw -w MyWorkspace views read SalesWH dbo.vw_sales --count 5
 ]
 ```
 
----
-
 ### views rename
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
@@ -235,8 +219,6 @@ fdw [-w WORKSPACE] views rename [OPTIONS] [WAREHOUSE] QUALIFIED_NAME
 ```shell
 fdw -w MyWorkspace views rename SalesWH dbo.vw_recent --new-name vw_revenue
 ```
-
----
 
 ### views update
 
@@ -266,8 +248,6 @@ fdw -w MyWorkspace views update SalesWH dbo.vw_recent \
   --select "SELECT id, amount, region FROM dbo.sales WHERE sale_date >= '2026-01-01'"
 ```
 
----
-
 ## MCP tools
 
 ### count_view_rows
@@ -284,8 +264,6 @@ Return the total row count of a view via `SELECT COUNT_BIG(*)`.
 
 **Returns:** `{ "schema": str, "name": str, "row_count": int }`: the schema name, view name, and total row count.
 
----
-
 ### create_view
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
@@ -301,8 +279,6 @@ Create a new SQL view.
 
 **Returns:** `View`: the newly-created view object (fetched after DDL, includes `definition`).
 
----
-
 ### drop_view
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
@@ -317,8 +293,6 @@ Drop a SQL view.
 
 **Returns:** `{ "dropped": true }`: confirmation.
 
----
-
 ### get_view
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
@@ -332,8 +306,6 @@ Fetch the full definition of a single SQL view.
 - `qualified_name` (`str`): dot-separated schema and view name, e.g. `dbo.vw_sales`.
 
 **Returns:** `View`: single view object with `definition` populated from `sys.sql_modules`.
-
----
 
 ### get_view_columns
 
@@ -359,8 +331,6 @@ Return column metadata for a SQL view via `sys.columns`. Works on both Fabric Da
 
 Results are ordered by ordinal position. Raises a `ToolError` if the view does not exist.
 
----
-
 ### list_views
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
@@ -374,8 +344,6 @@ List SQL views on a warehouse or SQL Analytics Endpoint, optionally filtered to 
 - `schema` (`str | null`, optional): when provided, only views in this schema are returned; must be a valid SQL identifier.
 
 **Returns:** `list[View]`: array of view objects, each with `schema_name`, `name`, `qualified_name`, `created`, `modified`, and `definition` (always `null` for list results).
-
----
 
 ### read_view
 
@@ -392,8 +360,6 @@ Return up to `count` rows from a view as JSON-serialisable columns and rows.
 
 **Returns:** `{ "columns": list[str], "rows": list[list] }`: column names and row arrays.
 
----
-
 ### rename_view
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
@@ -408,8 +374,6 @@ Rename a SQL view via `sp_rename`. Works on both Data Warehouses and SQL Analyti
 - `new_name` (`str`): new bare view name (no schema prefix), e.g. `vw_revenue`.
 
 **Returns:** `View`: the updated view object (fetched after rename, includes `definition`).
-
----
 
 ### update_view
 

--- a/docs/commands/warehouses.md
+++ b/docs/commands/warehouses.md
@@ -8,8 +8,6 @@ Manage Microsoft Fabric Data Warehouses and SQL Analytics Endpoints.
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
 
----
-
 ## CLI
 
 ### warehouses create
@@ -35,8 +33,6 @@ fdw [-w WORKSPACE] warehouses create [OPTIONS] NAME
 fdw -w MyWorkspace warehouses create NewWH --description "Staging warehouse"
 ```
 
----
-
 ### warehouses delete
 
 **Targets:** Data Warehouse only
@@ -54,8 +50,6 @@ fdw [-w WORKSPACE] warehouses delete [WAREHOUSE]
 ```shell
 fdw -w MyWorkspace --yes warehouses delete OldWH
 ```
-
----
 
 ### warehouses get
 
@@ -80,8 +74,6 @@ id             7c3f...
 displayName    SalesWH
 description    Main sales warehouse
 ```
-
----
 
 ### warehouses list
 
@@ -120,8 +112,6 @@ fdw warehouses list --all-workspaces
  OtherWS        AnalyticsWH    1a2b...
 ```
 
----
-
 ### warehouses permissions
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
@@ -155,8 +145,6 @@ fdw -w MyWorkspace --json warehouses permissions SalesWH
  DataPipeline    00000000-0000-...        ServicePrincipal  Read
 ```
 
----
-
 ### warehouses rename
 
 **Targets:** Data Warehouse only
@@ -179,8 +167,6 @@ fdw [-w WORKSPACE] warehouses rename [OPTIONS] [WAREHOUSE] NEW_NAME
 fdw -w MyWorkspace warehouses rename SalesWH SalesWH_v2 --description "Renamed"
 ```
 
----
-
 ### warehouses takeover
 
 **Targets:** Data Warehouse only
@@ -199,8 +185,6 @@ fdw [-w WORKSPACE] warehouses takeover [WAREHOUSE]
 fdw -w MyWorkspace warehouses takeover SalesWH
 ```
 
----
-
 ## MCP tools
 
 ### create_warehouse
@@ -218,8 +202,6 @@ Create a new Warehouse in a workspace.
 
 **Returns:** `Warehouse`: the newly-created warehouse object.
 
----
-
 ### delete_warehouse
 
 **Targets:** Data Warehouse only
@@ -233,8 +215,6 @@ Delete a Warehouse.
 
 **Returns:** `{ "deleted": true, "warehouse_id": str }`: confirmation with the warehouse GUID.
 
----
-
 ### get_warehouse
 
 **Targets:** Data Warehouse only
@@ -247,8 +227,6 @@ Return details for a single Data Warehouse. Uses the warehouse-scoped REST path 
 - `warehouse` (`str`): warehouse name or GUID.
 
 **Returns:** `Warehouse`: single warehouse object (fields as above).
-
----
 
 ### get_warehouse_permissions
 
@@ -267,8 +245,6 @@ Return all principals (users, groups, service principals) with access to a Wareh
 
 **Returns:** `list[ItemAccess]`: array of access records, each with `principal` (containing `id`, `displayName`, `type`, and type-specific fields such as `userPrincipalName` or `aadAppId`) and `itemAccessDetails` (containing `type`, `permissions`, and `additionalPermissions`).
 
----
-
 ### list_warehouses
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
@@ -281,8 +257,6 @@ List all warehouses and SQL analytics endpoints in a workspace, or across all vi
 - `all_workspaces` (`bool`, default `false`): when `true`, aggregate results across every workspace the caller can see.
 
 **Returns:** `list[Warehouse]`: array of warehouse objects, each with `id`, `displayName`, `description`, `workspaceId`, `kind` (`Warehouse` or `SQLEndpoint`), `connectionString`, `defaultCollation`, and `createdDate`.
-
----
 
 ### rename_warehouse
 
@@ -298,8 +272,6 @@ Rename a Warehouse and optionally update its description.
 - `description` (`str | null`, optional): new description; omit to leave unchanged.
 
 **Returns:** `Warehouse`: the updated warehouse object.
-
----
 
 ### takeover_warehouse
 

--- a/docs/commands/workspaces.md
+++ b/docs/commands/workspaces.md
@@ -12,8 +12,6 @@ Manage Microsoft Fabric workspaces - list all workspaces the authenticated princ
 
     The `workspaces` CLI group is exempt from the global `-w/--workspace` option. Pass the workspace name or GUID as a positional argument to `workspaces get` and `workspaces set-collation` instead.
 
----
-
 ## CLI
 
 ### workspaces assign-capacity
@@ -41,8 +39,6 @@ fdw workspaces assign-capacity [WORKSPACE] --capacity-id <UUID>
 ```shell
 fdw workspaces assign-capacity MyWorkspace --capacity-id ab12cd34-ef56-7890-abcd-ef1234567890
 ```
-
----
 
 ### workspaces get
 
@@ -73,8 +69,6 @@ capacityId                        ab12cd34-...
 defaultDataWarehouseCollation     Latin1_General_100_CI_AS_KS_WS_SC_UTF8
 ```
 
----
-
 ### workspaces list
 
 **Targets:** Workspace (not item-specific)
@@ -98,8 +92,6 @@ fdw workspaces list
  ------------------------------------ ---------------- ------------------------------------
  3f2a1c5d-...                          MyWorkspace       ab12cd34-...
 ```
-
----
 
 ### workspaces list-capacities
 
@@ -125,8 +117,6 @@ fdw workspaces list-capacities
  ab12cd34-...                          MyCapacity     F64   West Europe   Active
 ```
 
----
-
 ### workspaces set-collation
 
 **Targets:** Workspace (not item-specific)
@@ -149,8 +139,6 @@ fdw workspaces set-collation [WORKSPACE] COLLATION
 fdw workspaces set-collation MyWorkspace Latin1_General_100_CI_AS_KS_WS_SC_UTF8
 ```
 
----
-
 ## MCP tools
 
 ### assign_workspace_to_capacity
@@ -166,8 +154,6 @@ Assign a workspace to a Fabric capacity. This is a mutating operation and is blo
 
 **Returns:** `{ "workspace_id": str, "capacity_id": str }`: the workspace GUID and the capacity GUID.
 
----
-
 ### get_workspace
 
 **Targets:** Workspace (not item-specific)
@@ -180,8 +166,6 @@ Return details for a single workspace.
 
 **Returns:** `Workspace`: single workspace object (fields as above).
 
----
-
 ### list_capacities
 
 **Targets:** Workspace (not item-specific)
@@ -192,8 +176,6 @@ List all Fabric capacities the authenticated principal has access to. Requires t
 
 **Returns:** `list[Capacity]`: array of capacity objects, each with `id`, `displayName`, `sku`, `region`, and `state`.
 
----
-
 ### list_workspaces
 
 **Targets:** Workspace (not item-specific)
@@ -203,8 +185,6 @@ List all Fabric workspaces the authenticated principal has access to.
 **Parameters:** None
 
 **Returns:** `list[Workspace]`: array of workspace objects, each with `id`, `displayName`, `description`, `capacityId`, and `defaultDatasetStorageFormat`.
-
----
 
 ### set_workspace_collation
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -6,8 +6,6 @@ title: Concepts
 
 The sections below describe cross-cutting concepts that apply to all `fdw`/`fabric-dw` commands: how the CLI distinguishes between item kinds, which global flags are available on every invocation, and how the target workspace is resolved.
 
----
-
 ## Item targets: Data Warehouse vs SQL Analytics Endpoint
 
 Fabric has two SQL-surface item kinds:
@@ -21,8 +19,6 @@ Each command below is labelled with one of:
 - **`Targets: Data Warehouse only`**: the command is blocked on SQL Analytics Endpoints (either by an explicit client-side guard in the source code, because it requires write/DDL capability that endpoints do not have, or because it calls warehouse-scoped REST API paths that are not available for SQL Analytics Endpoints).
 - **`Targets: SQL Analytics Endpoint`**: the command operates on SQL Analytics Endpoints specifically (not on Data Warehouses).
 - **`Targets: Workspace (not item-specific)`**: the command operates at the workspace level and does not target a specific DW or SQL Analytics Endpoint item.
-
----
 
 ## Global options
 
@@ -39,8 +35,6 @@ These options are placed immediately after `fabric-dw` (or `fdw`), before the co
 
 The `--auth` flag and the `FABRIC_AUTH` environment variable accept the same three values. See [Authentication](install.md#authentication) for the full credential chain.
 
----
-
 ## Selecting a workspace
 
 Every command that operates on a workspace (everything except `workspaces list` and `cache clear`) resolves the target workspace from the following sources, in priority order:
@@ -55,8 +49,6 @@ The `workspaces` command group is an exception: `workspaces get` and `workspaces
 !!! note "-A / --all-workspaces interaction"
 
     Passing `-A` on the two list commands that support it (`warehouses list`, `sql-endpoints list`) explicitly scans every visible workspace. This flag is mutually exclusive with `-w` (an explicit `-w` conflicts with scanning all workspaces), but it does **not** conflict with a configured default workspace or `FABRIC_DW_DEFAULT_WORKSPACE`: the configured default is silently ignored when `-A` is used.
-
----
 
 ## Name-or-GUID resolution
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -4,7 +4,7 @@ title: Concepts
 
 # Concepts
 
-The sections below describe cross-cutting concepts that apply to all `fdw`/`fabric-dw` commands: how the CLI distinguishes between item kinds, which global flags are available on every invocation, and how the target workspace is resolved. Understanding these concepts first makes the rest of the documentation easier to follow.
+The sections below describe cross-cutting concepts that apply to all `fdw`/`fabric-dw` commands: how the CLI distinguishes between item kinds, which global flags are available on every invocation, and how the target workspace is resolved.
 
 ---
 

--- a/docs/guides/dbt-setup.md
+++ b/docs/guides/dbt-setup.md
@@ -17,8 +17,6 @@ Microsoft's own [tutorial](https://learn.microsoft.com/fabric/data-warehouse/tut
 
     Everything below is the **human, copy-pasteable narrative** for someone driving `fabric-dw` from a terminal. If you drive an AI assistant (Claude) against the [MCP server](../install.md#mcp), the shipped [`dbt-setup` Agent Skill](../skills.md#dbt-setup) automates the same provision → scaffold → sources → verify flow through the MCP tools. The CLI commands here and the skill are two front-ends to the same logic - pick whichever fits your workflow.
 
----
-
 ## Prerequisites
 
 - A Fabric **workspace** on an active capacity (Trial, Premium, or Fabric capacity).
@@ -33,8 +31,6 @@ Microsoft's own [tutorial](https://learn.microsoft.com/fabric/data-warehouse/tut
 !!! note "Entra ID only - no SQL authentication"
 
     dbt-fabric authenticates with **Microsoft Entra ID** identities (users, service principals); SQL username/password authentication is **not supported**. See [Connect using dbt](https://learn.microsoft.com/fabric/data-warehouse/how-to-connect?WT.mc_id=MVP_310840#connect-using-dbt). `fabric-dw` uses the same Entra-based credential chain, so once you can run `fdw` you have everything dbt needs.
-
----
 
 ## Step 1 - Sign in
 
@@ -64,8 +60,6 @@ Microsoft recommends interactive (`CLI`) auth for working on a warehouse by hand
 
 See the [Authentication reference](../authentication.md) for the full credential chain and every environment variable.
 
----
-
 ## Set your defaults
 
 Once you are signed in, store the workspace so you do not repeat it on every command:
@@ -76,8 +70,6 @@ fdw config set warehouse SalesWH        # optional - once the warehouse exists (
 ```
 
 The rest of this guide assumes the workspace default is set, so the examples omit `-w "Sales Workspace"`. Any command still accepts an explicit `-w`/`--workspace NAME|GUID` to override it. The warehouse default fills optional `[ITEM]` positionals once the warehouse has been provisioned; commands here that take a required name (`warehouses create NAME`, `dbt init … FOLDER`, `sql-endpoints get ENDPOINT`) still spell out the warehouse. See [Configuration & defaults](../commands/config.md).
-
----
 
 ## Step 2 - Provision the warehouse
 
@@ -98,8 +90,6 @@ If a service principal or team needs access (for example, the identity that will
 
     The MCP tool [`create_warehouse`](../commands/warehouses.md#create_warehouse) provisions the warehouse from an AI client with the same polling behaviour.
 
----
-
 ## Step 3 - Scaffold the dbt project
 
 [`fdw dbt init`](../commands/dbt.md#dbt-init) creates the whole project directory pre-wired to the warehouse. `ITEM` (the warehouse name or GUID) is optional if you set a default warehouse; `FOLDER` is the target directory.
@@ -118,8 +108,6 @@ You do **not** hand-author `profiles.yml`. `fdw dbt init` resolves the warehouse
 - **`database`**: the warehouse display name (Fabric uses the item name as the Initial Catalog). For `SalesWH`, the database is simply `SalesWH`.
 
 The `authentication` value is mapped from your sign-in mode (`default` → `auto`, `interactive` → `CLI`, `sp` → `ServicePrincipal`). With `--auth sp`, secrets are emitted as Jinja2 `env_var()` placeholders - never literal secrets - so the file is safe to commit. The full option list (`--schema`, `--target`, `--threads`, `--profiles-dir`, `--auth`, …), the exact generated `profiles.yml`, and the auth mapping live in the [dbt command reference](../commands/dbt.md#dbt-init); the credential chain is in the [Authentication reference](../authentication.md).
-
----
 
 ## Step 4 - Provision all your dbt sources
 
@@ -187,8 +175,6 @@ from {{ source('sales', 'customer') }}
 
 Because every schema and table is already declared in `_sources.yml`, `source()` resolves immediately and `dbt run` / `dbt test` can build on top of the real warehouse objects without any manual source authoring.
 
----
-
 ## Step 5 - Verify
 
 Install the dbt dependencies in a **separate environment** (the scaffolded `requirements.txt` pins `dbt-core` and `dbt-fabric`), then verify the connection and build the sample model:
@@ -220,8 +206,6 @@ fdw tables list SalesWH
 
     The SQL group is `fdw sql exec` / `fdw sql plan`. There is no `fdw sql query` command.
 
----
-
 ## Doing it from an AI assistant
 
 If you drive an AI client over the [MCP server](../install.md#mcp), the same scaffold is available as the [`generate_dbt_profile`](../commands/dbt.md#generate_dbt_profile) tool. Unlike the CLI, it does **not** write files - the MCP server cannot touch the caller's filesystem, so it returns each file's contents as a string:
@@ -233,8 +217,6 @@ If you drive an AI client over the [MCP server](../install.md#mcp), the same sca
 - `gitignore`
 
 The AI agent writes those strings to disk itself. The shipped [`dbt-setup` Agent Skill](../skills.md#dbt-setup) orchestrates the whole flow - it resolves the warehouse with `get_warehouse`, confirms connectivity with `list_schemas` / `list_tables`, calls `generate_dbt_profile` with `with_sources=True` to provision the sources, writes the files, and tells you to run `pip install -r requirements.txt`, `dbt debug`, and `dbt run`. In short: **the guide is the CLI narrative; the skill is the assistant-driven equivalent.**
-
----
 
 ## Next steps & references
 

--- a/docs/guides/ingesting-data.md
+++ b/docs/guides/ingesting-data.md
@@ -18,7 +18,7 @@ Use this guide when you have a target **Data Warehouse** and want to load file-b
 
     `COPY INTO` and table DDL (create / load / clear / statistics writes) are **Data Warehouse only**. SQL Analytics Endpoints are read-only here - listing, counting, and reading tables work, but you cannot create or load into them. If your `[ITEM]` is a SQL Analytics Endpoint the engine (or this tool) will reject the write.
 
-Fabric offers several ingestion mechanisms. `COPY INTO`: what this tool uses - is Microsoft's recommended high-throughput, code-rich path for getting files into a warehouse. For scheduled low-code ingestion use **pipelines**, for code-free transforms use **dataflows**, and for in-warehouse moves use T-SQL (`INSERT … SELECT`, `SELECT INTO`, `CTAS`). See [Ingest data into a Fabric warehouse](https://learn.microsoft.com/fabric/data-warehouse/ingest-data?WT.mc_id=MVP_310840) for the full picture.
+Fabric offers several ingestion mechanisms. `COPY INTO`, what this tool uses, is Microsoft's recommended high-throughput, code-rich path for getting files into a warehouse. For scheduled low-code ingestion use **pipelines**, for code-free transforms use **dataflows**, and for in-warehouse moves use T-SQL (`INSERT … SELECT`, `SELECT INTO`, `CTAS`). See [Ingest data into a Fabric warehouse](https://learn.microsoft.com/fabric/data-warehouse/ingest-data?WT.mc_id=MVP_310840) for the full picture.
 
 ---
 

--- a/docs/guides/ingesting-data.md
+++ b/docs/guides/ingesting-data.md
@@ -8,8 +8,6 @@ This guide walks through getting file-based data - CSV, Parquet, or JSON - into 
 
 It is task-oriented. For the full option reference of each command and tool, see the per-domain pages it links to: [Tables](../commands/tables.md), [Schemas](../commands/schemas.md), [Statistics](../commands/statistics.md), [Running SQL](../commands/sql.md), and the [MCP server](../install.md#mcp).
 
----
-
 ## When to use this guide
 
 Use this guide when you have a target **Data Warehouse** and want to load file-based data into one of its tables.
@@ -19,8 +17,6 @@ Use this guide when you have a target **Data Warehouse** and want to load file-b
     `COPY INTO` and table DDL (create / load / clear / statistics writes) are **Data Warehouse only**. SQL Analytics Endpoints are read-only here - listing, counting, and reading tables work, but you cannot create or load into them. If your `[ITEM]` is a SQL Analytics Endpoint the engine (or this tool) will reject the write.
 
 Fabric offers several ingestion mechanisms. `COPY INTO`, what this tool uses, is Microsoft's recommended high-throughput, code-rich path for getting files into a warehouse. For scheduled low-code ingestion use **pipelines**, for code-free transforms use **dataflows**, and for in-warehouse moves use T-SQL (`INSERT … SELECT`, `SELECT INTO`, `CTAS`). See [Ingest data into a Fabric warehouse](https://learn.microsoft.com/fabric/data-warehouse/ingest-data?WT.mc_id=MVP_310840) for the full picture.
-
----
 
 ## Prerequisites
 
@@ -38,8 +34,6 @@ Fabric offers several ingestion mechanisms. `COPY INTO`, what this tool uses, is
     ```
 
     not `<command> <workspace> <item> …`. Once the [defaults](#set-your-defaults) are set, both `-w <workspace>` and the optional `[ITEM]` positional can be omitted (the examples below do).
-
----
 
 ## Decide your path
 
@@ -63,8 +57,6 @@ Two decisions shape the whole workflow:
 
     The MCP tools (`load_table_from_url`, `import_table_from_url`) are **remote-URL only**, and `create_empty_table` does not infer a schema from files. Local-file staging and file-based schema inference are **CLI-only**. From an AI assistant, either point at a remote/OneLake URL or run the local-file load from the CLI. See [Same workflow from MCP](#same-workflow-from-mcp-or-an-ai-assistant) below.
 
----
-
 ## Set your defaults
 
 Store the workspace and warehouse once so you do not repeat them on every command:
@@ -75,8 +67,6 @@ fdw config set warehouse SalesWH
 ```
 
 The rest of this guide assumes these defaults are set, so the examples omit `-w MyWorkspace` and drop the warehouse positional where it is optional. Any command still accepts an explicit `-w`/`--workspace` or a positional `[ITEM]` to override them. Commands that take a trailing required argument (such as `tables load … QUALIFIED_NAME`) keep the warehouse positional so the remaining arguments stay unambiguous. See [Configuration & defaults](../commands/config.md).
-
----
 
 ## Step 1 - (optional) create the schema
 
@@ -93,8 +83,6 @@ If your destination schema does not exist yet, create it. `dbo` always exists, s
     Call `create_schema` with `workspace`, `item`, and `name`. `list_schemas` enumerates existing schemas; `delete_schema` is destructive and gated (see [statistics & destructive gating](#destructive-operations)).
 
 See [Schemas](../commands/schemas.md) for the full reference.
-
----
 
 ## Step 2 - create the destination table
 
@@ -148,8 +136,6 @@ Skip this step if you plan to auto-create with `tables load --create` (see [Step
 !!! tip "Prefer Parquet over CSV"
 
     Parquet is columnar, compressed, and supports column/row skipping, so it is faster for repeated reads and gives exact types on ingestion (CSV requires inference). Whatever method you use, the Parquet files Fabric writes are V-Order optimized - don't disable V-Order. See the [warehouse performance guidance](https://learn.microsoft.com/fabric/data-warehouse/guidelines-warehouse-performance?WT.mc_id=MVP_310840#data-ingestion-and-preparation-into-a-warehouse).
-
----
 
 ## Step 3 - load the data
 
@@ -255,8 +241,6 @@ fdw tables load SalesWH dbo.sales --file data.parquet --create \
 
 CSV tuning (`--header / --no-header`, `--delimiter`, `--encoding`, `--field-quote`, `--row-terminator`) and error handling (`--max-errors`, `--rejected-row-location`) are documented in full on the [tables load](../commands/tables.md#tables-load) reference.
 
----
-
 ## Step 4 - verify the load
 
 `tables load` reports `rows_loaded`, `rows_rejected`, and the target.
@@ -289,8 +273,6 @@ Confirm the data landed:
 
 See [Tables](../commands/tables.md) for the full reference.
 
----
-
 ## Step 5 - refresh statistics after the load
 
 Statistics are **not** updated automatically after a load. Create or update single-column histogram statistics on the columns your queries filter and join on so the optimizer has fresh cardinality estimates.
@@ -318,8 +300,6 @@ Statistics are **not** updated automatically after a load. Create or update sing
     `create_statistics`, `update_statistics`, `list_statistics`, and `show_statistics` mirror the CLI. `delete_statistics` is destructive and gated.
 
 See [Statistics](../commands/statistics.md) for the full reference and [Update statistics after a load](https://learn.microsoft.com/fabric/data-warehouse/statistics?WT.mc_id=MVP_310840) on Microsoft Learn.
-
----
 
 ## Same workflow from MCP (or an AI assistant)
 
@@ -354,8 +334,6 @@ The same end-to-end flow is available to an AI assistant through the MCP server,
 
 Destructive `if_exists` policies (and `delete_schema` / `delete_statistics`) require the server to run with `FABRIC_MCP_ALLOW_DESTRUCTIVE=1`: see the [MCP security environment variables](../install.md#security-environment-variables).
 
----
-
 ## Best practices
 
 These recommendations come from Microsoft Learn. Where they describe pre-staging many files, note that `fabric-dw` stages one local file at a time - that parallel-file guidance applies when you pre-stage files yourself and load them with `--url`, not as a feature of this tool.
@@ -368,8 +346,6 @@ These recommendations come from Microsoft Learn. Where they describe pre-staging
 - **Prefer Parquet over CSV** for repeated reads - columnar, compressed, with column/row skipping. See [warehouse performance guidance](https://learn.microsoft.com/fabric/data-warehouse/guidelines-warehouse-performance?WT.mc_id=MVP_310840#data-ingestion-and-preparation-into-a-warehouse).
 - **Create the table before `COPY INTO`, and use `FIRSTROW=2` to skip a CSV header.** See [ingest with COPY](https://learn.microsoft.com/fabric/data-warehouse/ingest-data-copy?WT.mc_id=MVP_310840) and [ingest data into a table](https://learn.microsoft.com/fabric/data-warehouse/ingest-data-into-table?WT.mc_id=MVP_310840).
 - **Update statistics after a load**: they are not refreshed automatically. Create/update single-column histogram stats, and inspect them with `DBCC SHOW_STATISTICS` (`statistics show`). See [tables & statistics](https://learn.microsoft.com/fabric/data-warehouse/tables?WT.mc_id=MVP_310840#statistics) and [statistics](https://learn.microsoft.com/fabric/data-warehouse/statistics?WT.mc_id=MVP_310840).
-
----
 
 ## Troubleshooting
 

--- a/docs/guides/query-performance.md
+++ b/docs/guides/query-performance.md
@@ -12,8 +12,6 @@ A task-oriented walkthrough for using `fabric-dw` (binary alias **`fdw`**) to fi
 
     The [`query-optimizer`](../skills.md#query-optimizer) Agent Skill automates exactly this single-query workflow - capture the plan, pull history, audit statistics, inspect clustering, then propose or apply fixes. This page is the human-facing version of the same loop, followed by hand at the terminal. For the **warehouse-wide** angle (hotspots across every query, SQL-pool pressure, caching health) see the [`warehouse-performance`](../skills.md#warehouse-performance) skill and its companion [Warehouse performance guide](warehouse-performance.md).
 
----
-
 ## Overview & when to use this guide
 
 Reach for this guide when a query, report, or dashboard is slow and you want a repeatable method to find out *why* and make it faster. The loop is:
@@ -31,8 +29,6 @@ Every command works both from the CLI and from the MCP server; the MCP tool that
 
 Throughout, the workspace comes from the global `-w`/`--workspace` option (or `FABRIC_DW_DEFAULT_WORKSPACE`, or the configured default; see [Selecting a workspace](../concepts.md#selecting-a-workspace)). The warehouse or endpoint is an **optional positional** `[WAREHOUSE]`/`[ITEM]` that falls back to the configured default - there is no positional `<workspace>` argument.
 
----
-
 ## Prerequisites & permissions
 
 | You want to… | You need |
@@ -48,8 +44,6 @@ The `queryinsights` views are documented in [Query insights in Fabric Data Wareh
 
     The `queryinsights.*` views are **not populated immediately** on a brand-new warehouse and completed queries lag behind real time. If a view comes back empty on a fresh item, give it time and re-run. See [Caveats & limits](#caveats-limits).
 
----
-
 ## Set your defaults
 
 Store the workspace and warehouse once so you do not repeat them on every command:
@@ -60,8 +54,6 @@ fdw config set warehouse SalesWH
 ```
 
 The rest of this guide assumes these defaults are set, so the examples omit `-w MyWorkspace` and the warehouse positional. Any command still accepts an explicit `-w`/`--workspace` or a positional `[WAREHOUSE]`/`[ITEM]` to override them. See [Configuration & defaults](../commands/config.md).
-
----
 
 ## Step 1 - Investigate live activity
 
@@ -79,8 +71,6 @@ fdw queries connections
 
 If a live query is clearly runaway and you have Admin rights, jump straight to [Step 9 - Mitigate runaway queries](#step-9-mitigate-runaway-queries). Otherwise, move on to the history views to build a picture over time.
 
----
-
 ## Step 2 - Review query history
 
 Live DMVs only show the present moment. To see what *happened*, read the per-request and per-session history from Query Insights.
@@ -96,8 +86,6 @@ fdw queries sessions --since 2026-06-01T00:00:00 --until 2026-06-08T00:00:00
 Both commands accept `--limit` (1–10 000, default 100), `--since`, and `--until` (ISO-8601). `queries history` (MCP [`list_request_history`](../commands/queries.md#list_request_history)) is the raw per-request feed - one row per execution - carrying the columns you will lean on for diagnosis: `total_elapsed_time_ms`, `data_scanned_remote_storage_mb`, `data_scanned_memory_mb`, `data_scanned_disk_mb`, `result_cache_hit`, `query_hash`, and `label`. `queries sessions` (MCP [`list_session_history`](../commands/queries.md#list_session_history)) rolls the same activity up per session.
 
 These are the **raw** insight views. Step 3 uses the **aggregated** views that rank queries server-side. The distinction matters - see [aggregated vs raw views](https://learn.microsoft.com/fabric/data-warehouse/guidelines-warehouse-performance?WT.mc_id=MVP_310840#query-metadata-views).
-
----
 
 ## Step 3 - Find the worst offenders
 
@@ -121,8 +109,6 @@ fdw sql-pools insights
 Microsoft Learn shows how to combine these views to find top consumers - top CPU via `allocated_cpu_time_ms`, most-data-scanned via `data_scanned_remote_storage_mb`, and frequent/long-running by command substring: see the [Query insights examples](https://learn.microsoft.com/fabric/data-warehouse/query-insights?WT.mc_id=MVP_310840#examples) and the [performance guidelines](https://learn.microsoft.com/fabric/data-warehouse/guidelines-warehouse-performance?WT.mc_id=MVP_310840#query-performance).
 
 Pick one query from the top of these lists and carry it through the rest of the loop.
-
----
 
 ## Step 4 - Capture & read the execution plan
 
@@ -158,8 +144,6 @@ Representation (`--raw`/`--xml`, root `--json`, `--format mermaid|dot|svg|html`)
 
 Microsoft recommends reading `SHOWPLAN_XML` to understand a query and reserving query hints (e.g. `OPTION (FORCE DISTRIBUTED PLAN)`) as a last resort. Clustering inspection (`get_cluster_columns` / `set_cluster_columns`) is a deeper-dive lever beyond this guide's scope - the [`query-optimizer`](../skills.md#query-optimizer) skill handles it, and the cluster columns concept is covered in the [performance guidelines](https://learn.microsoft.com/fabric/data-warehouse/guidelines-warehouse-performance?WT.mc_id=MVP_310840#query-performance).
 
----
-
 ## Step 5 - Diagnose root cause from history columns
 
 Cross-reference the plan with the numbers from `queries history`. The key columns:
@@ -186,8 +170,6 @@ fdw sql exec -q "SELECT TOP 20 submit_time, total_elapsed_time_ms, data_scanned_
 ```
 
 Using a **query label** to track and compare one query across executions is a first-class Microsoft pattern - see [Query labeling](https://learn.microsoft.com/fabric/data-warehouse/query-label?WT.mc_id=MVP_310840).
-
----
 
 ## Step 6 - Check & fix statistics
 
@@ -220,8 +202,6 @@ These map to MCP [`create_statistics`](../commands/statistics.md#create_statisti
 
 Microsoft recommends creating/updating single-column histogram statistics **during maintenance windows**, so user `SELECT`s do not pay for synchronous auto-stats creation, focusing on columns used in `GROUP BY` / `ORDER BY` / `WHERE` / `JOIN`, and refreshing after big data changes. See [Statistics in Fabric Data Warehouse](https://learn.microsoft.com/fabric/data-warehouse/statistics?WT.mc_id=MVP_310840).
 
----
-
 ## Step 7 - Improve the query
 
 With statistics healthy, turn to the query text itself. Common, high-leverage rewrites:
@@ -235,8 +215,6 @@ Re-run the improved query through `sql exec` with a label (and any hint):
 ```shell
 fdw sql exec -q "SELECT s.id, s.amount FROM dbo.Sales s JOIN dbo.Customer c ON s.cust_id = c.id WHERE c.region = 'EU' OPTION (LABEL='sales-eu-report')"
 ```
-
----
 
 ## Step 8 - Verify the improvement
 
@@ -265,8 +243,6 @@ Confirm the fix actually helped, on the **warm** path.
 
 A `result_cache_hit = true` in `queries history` on the second and later runs confirms the cache is doing its job.
 
----
-
 ## Step 9 - Mitigate runaway queries
 
 When a live query is clearly out of control and you have Admin rights, terminate its session. `KILL` is **Admin-only** and **destructive**: `queries kill` prompts unless `-y` is passed.
@@ -280,8 +256,6 @@ fdw --yes queries kill SalesWH 42
 ```
 
 `queries kill` maps to MCP [`kill_session`](../commands/queries.md#kill_session), which is write-gated. Identifying and killing a long-running query via DMVs is the documented incident path - see [Monitor using DMVs](https://learn.microsoft.com/fabric/data-warehouse/monitor-using-dmv?WT.mc_id=MVP_310840).
-
----
 
 ## Worked example - end to end
 
@@ -316,8 +290,6 @@ fdw sql exec -q "SELECT TOP 10 submit_time, total_elapsed_time_ms, data_scanned_
 
 Median elapsed time on the warm runs drops once the statistic gives the optimizer an accurate estimate and the implicit conversion is gone. Because the report runs identically every night, enabling `settings result-set-caching SalesWH on` lets unchanged re-runs return instantly.
 
----
-
 ## MCP equivalents
 
 The same loop, driven by an AI assistant. Every step above maps to one MCP tool - the [`query-optimizer`](../skills.md#query-optimizer) skill chains exactly these.
@@ -344,8 +316,6 @@ The same loop, driven by an AI assistant. Every step above maps to one MCP tool 
 
 The mutating MCP tools (`create_statistics`, `update_statistics`, `delete_statistics`, `set_result_set_caching`, `kill_session`) are gated behind the server's write-guard (`FABRIC_MCP_ALLOW_WRITES` / `FABRIC_MCP_ALLOW_DESTRUCTIVE`) and do **not** raise a user dialog, so an AI assistant must confirm with you before calling them.
 
----
-
 ## Caveats & limits
 
 - **Query Insights lag.** Completed queries do not appear in `queryinsights.*` instantly, and the views are empty for a period on a new warehouse. Re-run if a view comes back empty.
@@ -360,8 +330,6 @@ The mutating MCP tools (`create_statistics`, `update_statistics`, `delete_statis
 - **Result-set cache cooldown has no API** ([#595](https://github.com/sdebruyn/fabric-dw-mcp-cli/issues/595)). This is distinct from the result-set-caching toggle and from the local lookup cache.
 - **Statement-type SQL-pool routing does not exist** ([#596](https://github.com/sdebruyn/fabric-dw-mcp-cli/issues/596)). The only routing key is the application-name classifier; do not imply statement-type routing.
 - **Data clustering** (`get_cluster_columns` / `set_cluster_columns`) is a deeper-dive topic handled by the [`query-optimizer`](../skills.md#query-optimizer) skill rather than expanded here.
-
----
 
 ## See also
 

--- a/docs/guides/query-performance.md
+++ b/docs/guides/query-performance.md
@@ -4,7 +4,7 @@ title: Query performance
 
 # Investigating and improving query performance
 
-A task-oriented walkthrough for using `fabric-dw` (binary alias **`fdw`**) to find and fix slow queries on a Microsoft Fabric Data Warehouse or SQL Analytics Endpoint. It threads a single loop - **investigate → diagnose → improve → verify**: across the `queries`, `sql`, `statistics`, `sql-pools`, and `settings` command groups, and grounds each step in Microsoft Learn guidance.
+A task-oriented walkthrough for using `fabric-dw` (binary alias **`fdw`**) to find and fix slow queries on a Microsoft Fabric Data Warehouse or SQL Analytics Endpoint. It threads a single loop (**investigate → diagnose → improve → verify**) across the `queries`, `sql`, `statistics`, `sql-pools`, and `settings` command groups, and grounds each step in Microsoft Learn guidance.
 
 **Targets:** Data Warehouse · SQL Analytics Endpoint
 
@@ -126,7 +126,7 @@ Pick one query from the top of these lists and carry it through the rest of the 
 
 ## Step 4 - Capture & read the execution plan
 
-With a specific slow query in hand, capture its **estimated** execution plan. `sql plan` (MCP [`get_query_plan`](../commands/sql.md#get_query_plan)) retrieves the estimated `SHOWPLAN_XML` **without executing the query**: so it is safe to plan even DDL/DML text, and reading it costs nothing.
+With a specific slow query in hand, capture its **estimated** execution plan. `sql plan` (MCP [`get_query_plan`](../commands/sql.md#get_query_plan)) retrieves the estimated `SHOWPLAN_XML` **without executing the query**, so it is safe to plan even DDL/DML text, and reading it costs nothing.
 
 ```shell
 # Default: a colour-coded Rich operator tree in the terminal
@@ -175,7 +175,7 @@ Cross-reference the plan with the numbers from `queries history`. The key column
 
 !!! tip "Don't judge a query by its first run"
 
-    A **non-zero `data_scanned_remote_storage_mb`** means the data was fetched from OneLake - a cold start. The first run after a cache eviction is *not* representative; **subsequent runs are**. Always discard the cold-start run before drawing conclusions. - [Query performance guidelines](https://learn.microsoft.com/fabric/data-warehouse/guidelines-warehouse-performance?WT.mc_id=MVP_310840#query-performance)
+    A **non-zero `data_scanned_remote_storage_mb`** means the data was fetched from OneLake - a cold start. The first run after a cache eviction is *not* representative; **subsequent runs are**. Always discard the cold-start run before drawing conclusions. See the [Query performance guidelines](https://learn.microsoft.com/fabric/data-warehouse/guidelines-warehouse-performance?WT.mc_id=MVP_310840#query-performance).
 
 Caching in Fabric is **automatic and not user-clearable**: the in-memory and disk caches are transparent, which is why you interpret cache columns rather than manage them. See [Caching in Fabric Data Warehouse](https://learn.microsoft.com/fabric/data-warehouse/caching?WT.mc_id=MVP_310840).
 
@@ -218,7 +218,7 @@ fdw statistics delete SalesWH dbo.Customer stat_customer_region
 
 These map to MCP [`create_statistics`](../commands/statistics.md#create_statistics), [`update_statistics`](../commands/statistics.md#update_statistics), and [`delete_statistics`](../commands/statistics.md#delete_statistics). All three are **mutating** MCP tools gated behind the write-guard (`delete_statistics` is additionally destructive-gated via `FABRIC_MCP_ALLOW_DESTRUCTIVE`); they do **not** pop a confirmation dialog, so an AI assistant must ask before calling them.
 
-Microsoft recommends creating/updating single-column histogram statistics **during maintenance windows**: so user `SELECT`s do not pay for synchronous auto-stats creation - focusing on columns used in `GROUP BY` / `ORDER BY` / `WHERE` / `JOIN`, and refreshing after big data changes. See [Statistics in Fabric Data Warehouse](https://learn.microsoft.com/fabric/data-warehouse/statistics?WT.mc_id=MVP_310840).
+Microsoft recommends creating/updating single-column histogram statistics **during maintenance windows**, so user `SELECT`s do not pay for synchronous auto-stats creation, focusing on columns used in `GROUP BY` / `ORDER BY` / `WHERE` / `JOIN`, and refreshing after big data changes. See [Statistics in Fabric Data Warehouse](https://learn.microsoft.com/fabric/data-warehouse/statistics?WT.mc_id=MVP_310840).
 
 ---
 
@@ -226,8 +226,8 @@ Microsoft recommends creating/updating single-column histogram statistics **duri
 
 With statistics healthy, turn to the query text itself. Common, high-leverage rewrites:
 
-- **Return less data**: avoid `SELECT *`, project only the columns you need, and apply `WHERE` filters *before* joins. Filtering on a low-cardinality column early shrinks everything downstream. - [Query performance guidelines](https://learn.microsoft.com/fabric/data-warehouse/guidelines-warehouse-performance?WT.mc_id=MVP_310840#query-performance)
-- **Match data types in comparisons**: eliminate the `CONVERT_IMPLICIT` you spotted in Step 4 by comparing like types, and use the smallest sufficient string lengths. - [Data type optimization](https://learn.microsoft.com/fabric/data-warehouse/guidelines-warehouse-performance?WT.mc_id=MVP_310840#data-type-optimization)
+- **Return less data**: avoid `SELECT *`, project only the columns you need, and apply `WHERE` filters *before* joins. Filtering on a low-cardinality column early shrinks everything downstream. See the [Query performance guidelines](https://learn.microsoft.com/fabric/data-warehouse/guidelines-warehouse-performance?WT.mc_id=MVP_310840#query-performance).
+- **Match data types in comparisons**: eliminate the `CONVERT_IMPLICIT` you spotted in Step 4 by comparing like types, and use the smallest sufficient string lengths. See [Data type optimization](https://learn.microsoft.com/fabric/data-warehouse/guidelines-warehouse-performance?WT.mc_id=MVP_310840#data-type-optimization).
 - **Tag the query with a label** so you can find every run of the improved version in `queries history`, and apply hints only as a last resort.
 
 Re-run the improved query through `sql exec` with a label (and any hint):

--- a/docs/guides/tables-and-views.md
+++ b/docs/guides/tables-and-views.md
@@ -8,8 +8,6 @@ This guide walks through building out a schema model on a Microsoft Fabric Data 
 
 The flat per-command references stay the source of truth for every flag and parameter: [Schemas](../commands/schemas.md), [Tables](../commands/tables.md), [Views](../commands/views.md), and [Statistics](../commands/statistics.md). This guide ties them together as a single narrative.
 
----
-
 ## What you'll build
 
 A small star-schema-style model in one warehouse:
@@ -27,8 +25,6 @@ You'll then maintain and iterate on the model - clone, rename, re-cluster, clear
 - **CLI** (`fdw …`) is the full surface. File-based schema inference (`--from-parquet` / `--from-csv` / `--from-json`), `tables load`, and `if-exists replace` are **CLI-only** because they need reliable local file access.
 - **MCP tools** mirror the CLI for everything that doesn't depend on server-side file access, so an AI assistant can author and inspect the same objects. Where an MCP equivalent exists it's named in each step; where it doesn't (notably `tables load`), the gap is called out.
 
----
-
 ## Prerequisites
 
 - `fabric-dw` [installed](../install.md) and [authenticated](../authentication.md) (the Azure credential chain - Azure CLI, managed identity, service principal, and more).
@@ -38,8 +34,6 @@ You'll then maintain and iterate on the model - clone, rename, re-cluster, clear
 !!! warning "Data Warehouse vs SQL Analytics Endpoint"
 
     A **SQL Analytics Endpoint** (the read query surface over a Lakehouse) cannot create, alter, or drop **tables**: that's a Warehouse-only capability. On a SQL Analytics Endpoint you can still create **views**, list/read/inspect everything, and manage schemas. The capability split is spelled out under [The SQL Analytics Endpoint read-only guard](#the-sql-analytics-endpoint-read-only-guard); each step below marks its **Targets**.
-
----
 
 ## Set your defaults
 
@@ -51,8 +45,6 @@ fdw config set warehouse SalesWH
 ```
 
 The rest of this guide assumes these defaults are set, so the examples omit `-w MyWorkspace` and drop the warehouse positional where it is optional. Any command still accepts an explicit `-w`/`--workspace` or a positional `[WAREHOUSE]`/`[ITEM]` to override them. Commands that take a trailing required argument (such as `tables clear … QUALIFIED_NAME` or `schemas create … NAME`) keep the warehouse positional so the remaining arguments stay unambiguous. See [Configuration & defaults](../commands/config.md).
-
----
 
 ## Step 1 - Create a schema
 
@@ -73,8 +65,6 @@ fdw schemas list
 !!! note "Schema names are case-sensitive"
 
     Fabric warehouses use a fixed, case-sensitive default collation (`Latin1_General_100_BIN2_UTF8`), and **schema names are case-sensitive**. `Sales` and `sales` are different schemas. See [Limitations & gotchas](#fixed-case-sensitive-collation) before you settle on a naming convention - collation can't be changed after the warehouse is created.
-
----
 
 ## Step 2 - Create tables
 
@@ -191,8 +181,6 @@ fdw --json tables count SalesWH sales.orders
 fdw tables list --schema sales
 ```
 
----
-
 ## Step 3 - Populate the tables
 
 Loading data is its own topic. The bridge from "empty table" to "populated table" is **`tables load`**, which issues `COPY INTO` from a local file or a remote URL (and can auto-create the table from the source schema with `--create`):
@@ -202,8 +190,6 @@ fdw tables load SalesWH sales.orders --file ./data/orders.parquet
 ```
 
 **Targets:** Data Warehouse only. There is **no MCP `load` tool for local files**; the MCP server exposes `load_table_from_url` / `import_table_from_url` for remote URLs only (local staging needs reliable file access). For the full loading surface - `--create`, `--if-exists`, credentials for secured external URLs, CSV options - see the [`tables load`](../commands/tables.md#tables-load) reference rather than this guide.
-
----
 
 ## Step 4 - Create views
 
@@ -251,8 +237,6 @@ fdw views update SalesWH sales.vw_orders_by_month \
 
     Views, stored procedures, and table-valued/scalar functions are the object kinds you *can* create on a SQL Analytics Endpoint. `fabric-dw` ships read-only [`procedures`](../commands/procedures.md) (`list_procedures`, `get_procedure`) and [`functions`](../commands/functions.md) (`list_functions`, `get_function`) groups for inspecting the procs and functions that sit alongside your views.
 
----
-
 ## Step 5 - Help the optimizer
 
 After you load data, give the query optimizer the statistics it needs. `fabric-dw` manages **single-column** statistics (a Fabric limitation - multi-column statistics aren't supported), and you must pass an explicit `--name` (Fabric requires an explicit statistic name - there is no auto-generated default).
@@ -295,8 +279,6 @@ fdw tables cluster-columns SalesWH sales.orders
 !!! tip "Diagnosing slow queries"
 
     The [Agent Skills](../skills.md) page documents `/query-optimizer` (clustering and missing/stale statistics for a single query) and `/warehouse-performance` (warehouse-wide statistics health). They pick up where this authoring workflow leaves off.
-
----
 
 ## Step 6 - Maintain & iterate
 
@@ -343,8 +325,6 @@ fdw --yes schemas delete SalesWH sales --cascade
 
 **MCP equivalents:** `clone_table`, `rename_table` / `rename_view`, `clear_table`, `get_table_health_metrics`, `drop_view`, `delete_table`, `delete_schema(..., cascade=True)`.
 
----
-
 ### Destructive operations and the `--yes` flag
 
 These commands prompt for confirmation before they run; pass `--yes` / `-y` to skip the prompt in scripts (at your own risk):
@@ -363,8 +343,6 @@ A SQL Analytics Endpoint can't mutate tables. The following raise an error when 
 Everything else works on both item kinds: every `list` / `read` / `columns` / `count` / `get` operation, `schemas create` / `delete`, and **all** `views` mutations (`create` / `update` / `rename` / `drop`). The one inverse is **`tables health-check`**, which is **SQL-Analytics-Endpoint-only** and rejected on a Data Warehouse.
 
 `--json` output and name-or-GUID resolution apply uniformly across every command group.
-
----
 
 ## Limitations & gotchas
 
@@ -403,8 +381,6 @@ Table and schema names **can't contain `/` or `\`, and can't end with a `.`**. S
 ### Table design
 
 For the schema model itself, follow the [dimensional-modeling](https://learn.microsoft.com/fabric/data-warehouse/dimensional-modeling-overview?WT.mc_id=MVP_310840#star-schema-design) and [table design](https://learn.microsoft.com/fabric/data-warehouse/tables?WT.mc_id=MVP_310840) guidance: fact / dimension / integration table categories, surrogate keys, types matched to semantics (`date` / `datetime2`, integer types for whole numbers, the smallest viable `decimal` precision - see [data-type optimization](https://learn.microsoft.com/fabric/data-warehouse/guidelines-warehouse-performance?WT.mc_id=MVP_310840#data-type-optimization)), and [statistics](https://learn.microsoft.com/fabric/data-warehouse/statistics?WT.mc_id=MVP_310840) refreshed after loads. The canonical DDL references are [CREATE TABLE](https://learn.microsoft.com/fabric/data-warehouse/create-table?WT.mc_id=MVP_310840) and [CREATE TABLE AS SELECT](https://learn.microsoft.com/sql/t-sql/statements/create-table-azure-sql-data-warehouse?view=fabric&WT.mc_id=MVP_310840).
-
----
 
 ## The same workflow via MCP
 

--- a/docs/guides/warehouse-performance.md
+++ b/docs/guides/warehouse-performance.md
@@ -23,8 +23,6 @@ Every command appears in **both** its CLI form (`fdw …`) and its MCP tool name
 this workflow by hand or through an AI assistant. CLI subcommand names and MCP tool names mostly
 match; where they diverge (the `queries` group), both are given.
 
----
-
 ## Relationship to the `warehouse-performance` Agent Skill
 
 `fabric-dw` ships a [`warehouse-performance` Agent Skill](../skills.md#warehouse-performance)
@@ -44,8 +42,6 @@ The guide and the skill are **complementary, not duplicates**:
 
 If you have an MCP-connected assistant configured, you can let the skill drive the steps below for
 you. Either way, the underlying commands and their guarantees are identical.
-
----
 
 ## How Fabric Warehouse compute actually works
 
@@ -95,8 +91,6 @@ This keeps ingestion from starving interactive reads (and vice-versa) by default
 this baseline with **custom SQL pools**: covered in [Step 3](#step-3-tune-apply-the-right-lever).
 See [Workload management - compute pool isolation](https://learn.microsoft.com/fabric/data-warehouse/workload-management?WT.mc_id=MVP_310840#compute-pool-isolation).
 
----
-
 ## When to use this guide
 
 Reach for this playbook when you see warehouse-wide symptoms, not a single slow query:
@@ -108,8 +102,6 @@ Reach for this playbook when you see warehouse-wide symptoms, not a single slow 
 
 If instead a *specific* query regressed, start with the [`query-optimizer` skill](../skills.md#query-optimizer).
 
----
-
 ## Set your defaults
 
 Store the workspace and warehouse once so you do not repeat them on every command:
@@ -120,8 +112,6 @@ fdw config set warehouse SalesWH
 ```
 
 The rest of this guide assumes these defaults are set, so the examples omit `-w MyWorkspace` and drop the warehouse positional where it is optional. Any command still accepts an explicit `-w`/`--workspace` or a positional `[WAREHOUSE]`/`[ITEM]` to override them. Commands that take a trailing required argument (such as `queries kill … SESSION_ID` or `settings result-set-caching … on|off`) keep the warehouse positional so the remaining arguments stay unambiguous. The workspace-wide commands (`warehouses list`, `workspaces list-capacities`) take no per-warehouse target. See [Configuration & defaults](../commands/config.md).
-
----
 
 ## Step 1 - Monitor: is there a problem, and where?
 
@@ -200,8 +190,6 @@ fdw workspaces list-capacities
 
 `fabric-dw` also reads `GET /v1/capacities` internally so that an all-workspaces scan
 (`warehouses list -A`) automatically skips paused/inactive capacities.
-
----
 
 ## Step 2 - Diagnose: what is consuming compute, and why?
 
@@ -284,8 +272,6 @@ fdw statistics show SalesWH dbo.sales _stat_order_date --histogram   # warehouse
 See [Statistics in Fabric Data Warehouse](https://learn.microsoft.com/fabric/data-warehouse/statistics?WT.mc_id=MVP_310840)
 for when automatic statistics suffice and when to create/update manually, and the umbrella
 [Performance guidelines](https://learn.microsoft.com/fabric/data-warehouse/guidelines-warehouse-performance?WT.mc_id=MVP_310840).
-
----
 
 ## Step 3 - Tune: apply the right lever
 
@@ -392,8 +378,6 @@ If a single runaway session is blocking everything else, terminate it.
 fdw --yes queries kill SalesWH 42   # warehouse positional kept - SESSION_ID follows
 ```
 
----
-
 ## Step 4 - Decide whether to scale
 
 If the cost drivers are genuinely justified work - not a tuning problem - and you are still
@@ -432,8 +416,6 @@ for right-sizing and load-balancing guidance.
     work but is not itself a diagnosis tool. Enable auditing for accountability, not to find slow
     queries.
 
----
-
 ## Worked example
 
 A copy-pasteable session that walks the whole loop on a warehouse that "feels slow". Or let the
@@ -469,8 +451,6 @@ Only if throttling persists after re-measuring should you consider
 [Step 4](#step-4-decide-whether-to-scale) - reassigning the workspace to another capacity, or
 escalating a SKU resize to a capacity admin.
 
----
-
 ## Limits of this tool
 
 `fabric-dw` covers the *read* and most of the *tune* levers, but a few things are deliberately out
@@ -487,8 +467,6 @@ of scope:
   ([#596](https://github.com/sdebruyn/fabric-dw-mcp-cli/issues/596)).
 - **No cache-cooldown control** for result-set caching
   ([#595](https://github.com/sdebruyn/fabric-dw-mcp-cli/issues/595)).
-
----
 
 ## See also
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -419,6 +419,4 @@ After configuring your client, restart it and ask the assistant to list its avai
 
 For a more complete reference of error messages and resolutions, see the [Troubleshooting](troubleshooting.md) page.
 
----
-
 See also the [Authentication](authentication.md) page for the full credential chain and the [Troubleshooting](troubleshooting.md) page for common failure modes such as expired tokens and 403 permission errors.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -6,8 +6,6 @@ title: Troubleshooting
 
 This page collects failure modes that real users have encountered, with the exact error message and the resolution.
 
----
-
 ## `az login` expired / no token
 
 **Error you see:**
@@ -40,8 +38,6 @@ Then retry your `fabric-dw` command. The credential chain picks up the refreshed
 
 Or use any other source listed in [Authentication](authentication.md). Set `AZURE_LOG_LEVEL=debug` to see which source the chain tried.
 
----
-
 ## 403 PermissionDenied on a workspace call
 
 **Error you see:**
@@ -59,8 +55,6 @@ fabric_dw.exceptions.PermissionDenied: permission was denied on the object ...
 **What happened:** Your account does not have the required role in the Fabric workspace. Workspace-level REST calls require at least the **Contributor** role; some write operations require **Member** or **Admin**.
 
 **Resolution:** Ask the workspace owner to grant you Contributor (or Member) access in the Fabric portal under **Workspace settings → People and groups**.
-
----
 
 ## Capacity paused - cryptic 5xx or 404 errors
 
@@ -87,8 +81,6 @@ az resource show \
 ```
 
 Alternatively, resume from the [Fabric portal](https://app.fabric.microsoft.com) under **Capacity settings**.
-
----
 
 ## mssql-python "authentication failed"
 
@@ -135,8 +127,6 @@ Re-authenticate via whichever credential source your chain ended up using:
 
 After re-authenticating, retry your command. `FabricSqlClient` opens a fresh connection and picks up the new token automatically. Set `AZURE_LOG_LEVEL=debug` if you are unsure which credential source the chain selected.
 
----
-
 ## 429 RateLimitedError
 
 **Error you see:**
@@ -155,8 +145,6 @@ fabric_dw.exceptions.RateLimitedError: Received 429 10 consecutive times for htt
 
 The client automatically retries on each 429 and waits exactly as long as the server requests, so transient throttling is usually transparent.
 
----
-
 ## Restore points not appearing
 
 **Symptom:** `fdw snapshots list` returns an empty list, or user-defined restore points that you created are not visible.
@@ -171,8 +159,6 @@ The client automatically retries on each 429 and waits exactly as long as the se
 1. Confirm the capacity is Active (see [Capacity paused](#capacity-paused-cryptic-5xx-or-404-errors) above).
 2. Create a new user-defined restore point while the capacity is Active.
 3. If you expected a system restore point from a period when the capacity was paused, that point does not exist - it was not created.
-
----
 
 ## MCP server doesn't show tools
 

--- a/skills/dbt-setup/SKILL.md
+++ b/skills/dbt-setup/SKILL.md
@@ -18,26 +18,26 @@ Generates a complete dbt-fabric project scaffold using the fabric-dw MCP tools a
 
 Gather these from the user (via `$ARGUMENTS` or natural language) before starting:
 
-- **workspace** — workspace name or GUID
-- **warehouse** — Fabric Data Warehouse name or GUID
-- **project_name** — desired dbt project name (default: warehouse name, lowercased, spaces replaced with underscores)
-- **schema** — default dbt schema (default: `dbo`)
-- **authentication** — `default` (DefaultAzureCredential), `sp` (service principal), or `interactive` (default: `default`)
-- **with_sources** — whether to generate a column-rich `_sources.yml` (default: `true`, recommended)
+- **workspace**: workspace name or GUID
+- **warehouse**: Fabric Data Warehouse name or GUID
+- **project_name**: desired dbt project name (default: warehouse name, lowercased, spaces replaced with underscores)
+- **schema**: default dbt schema (default: `dbo`)
+- **authentication**: `default` (DefaultAzureCredential), `sp` (service principal), or `interactive` (default: `default`)
+- **with_sources**: whether to generate a column-rich `_sources.yml` (default: `true`, recommended)
 
 ## Workflow
 
-### Step 1 — Resolve the warehouse connection
+### Step 1 - Resolve the warehouse connection
 
 Call `get_warehouse` with the workspace and warehouse name. This returns the warehouse metadata including the connection string used in the dbt profile.
 
-### Step 2 — Confirm connectivity and list objects
+### Step 2 - Confirm connectivity and list objects
 
 Call `list_schemas` and `list_tables` to confirm that the warehouse is reachable and to identify the schemas and tables that will appear as dbt sources.
 
 Show the user a summary: number of schemas found, number of tables found.
 
-### Step 3 — Generate the dbt scaffold
+### Step 3 - Generate the dbt scaffold
 
 Call `generate_dbt_profile` with:
 
@@ -46,7 +46,7 @@ Call `generate_dbt_profile` with:
 
 When `with_sources=true`, the tool performs a bulk column fetch and emits a `models/staging/_sources.yml` that already includes each table's `columns:` block with `name` and formatted `data_type` for every column. This output is ready for dbt [contract enforcement](https://docs.getdbt.com/docs/collaborate/govern/model-contracts) and column-level documentation without any manual assembly.
 
-### Step 4 — Write files to the local filesystem
+### Step 4 - Write files to the local filesystem
 
 Write all file contents returned by `generate_dbt_profile` to the user's working directory. The expected set of files:
 
@@ -60,7 +60,7 @@ Write all file contents returned by `generate_dbt_profile` to the user's working
 
 Before writing, check whether any of these files already exist and confirm with the user before overwriting.
 
-### Step 5 — Provide next steps
+### Step 5 - Provide next steps
 
 After writing the files, give the user the following instructions:
 
@@ -77,12 +77,12 @@ dbt run
 
 Also remind the user to:
 
-1. Review `profiles.yml` and fill in any `{{ env_var(...) }}` placeholders (service-principal credentials are never written as literals — they are templated).
+1. Review `profiles.yml` and fill in any `{{ env_var(...) }}` placeholders (service-principal credentials are never written as literals; they are templated).
 2. Check that environment variables (`AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`) are set before running `dbt debug` if using service-principal auth.
 
 ## Guardrails
 
 - **Service-principal auth**: when `authentication=sp`, the generated `profiles.yml` uses `{{ env_var(...) }}` placeholders for tenant ID, client ID, and client secret. Never write literal credential values. Remind the user that these must be set in environment before committing `profiles.yml` to version control.
 - **Overwrite protection**: if any target file already exists, list them and ask the user to confirm before overwriting.
-- **Fabric auth only**: dbt-fabric requires Entra (Azure AD) authentication. Warn the user if they ask about username/password auth — it is not supported by the dbt-fabric adapter.
-- **Column inspection**: `get_table_columns` and `get_view_columns` are available for ad-hoc schema inspection (e.g., if the user wants to review a specific table before deciding which columns to expose), but explicit calls to those tools are not required — column data is built into `generate_dbt_profile` with `with_sources=true`.
+- **Fabric auth only**: dbt-fabric requires Entra (Azure AD) authentication. Warn the user if they ask about username/password auth. It is not supported by the dbt-fabric adapter.
+- **Column inspection**: `get_table_columns` and `get_view_columns` are available for ad-hoc schema inspection (e.g., if the user wants to review a specific table before deciding which columns to expose), but explicit calls to those tools are not required; column data is built into `generate_dbt_profile` with `with_sources=true`.

--- a/skills/query-optimizer/SKILL.md
+++ b/skills/query-optimizer/SKILL.md
@@ -19,15 +19,15 @@ Analyzes and optimizes a query on a Fabric Data Warehouse using the fabric-dw MC
 
 Gather these from the user (via `$ARGUMENTS` or natural language) before starting:
 
-- **workspace** — workspace name or GUID
-- **warehouse** — warehouse name or GUID (must be a Fabric Data Warehouse, not a SQL Analytics Endpoint, for clustering steps)
-- **query** — the SQL query text to analyze (or a historical query ID / text snippet to look up)
+- **workspace**: workspace name or GUID
+- **warehouse**: warehouse name or GUID (must be a Fabric Data Warehouse, not a SQL Analytics Endpoint, for clustering steps)
+- **query**: the SQL query text to analyze (or a historical query ID / text snippet to look up)
 
 If the warehouse is a SQL Analytics Endpoint, skip steps 8, 9, 11 (clustering), and 13 (`set_cluster_columns`).
 
 ## Workflow
 
-### Step 1 — Capture the estimated execution plan
+### Step 1 - Capture the estimated execution plan
 
 Call `get_query_plan` with the query text. This returns a SHOWPLAN_XML document without executing the query.
 
@@ -40,7 +40,7 @@ fdw sql plan <workspace>/<warehouse> -q "<query>" --format svg -o plan.svg   # r
 
 Note: `--format html` requires `-o/--output`; it writes a file and does not open the browser automatically.
 
-### Step 2 — Parse the plan XML
+### Step 2 - Parse the plan XML
 
 Analyze the returned SHOWPLAN_XML for:
 
@@ -50,35 +50,35 @@ Analyze the returned SHOWPLAN_XML for:
 - **Data skew warnings** or large estimated vs. actual row count mismatches (if available)
 - **Type mismatch conversions**: e.g. `CONVERT_IMPLICIT` on a column used in a predicate
 
-### Step 3 — Pull recent history
+### Step 3 - Pull recent history
 
 Use `list_request_history` (filter by SQL text substring if supported) and `list_long_running_queries` to see whether this query pattern has a history of slow executions. Note elapsed time and status.
 
-### Step 4 — List statistics on referenced tables
+### Step 4 - List statistics on referenced tables
 
 For every table referenced in the query, call `list_statistics` to enumerate existing statistics objects. Note which columns lack statistics.
 
-### Step 5 — Inspect histogram for stale or missing stats
+### Step 5 - Inspect histogram for stale or missing stats
 
-For any statistic that appears potentially stale or absent, call `show_statistics` to examine its header (last_updated timestamp, row count, rows sampled) and histogram. Flag statistics whose sample rate or update date suggests staleness — this is heuristic; flag rather than assert.
+For any statistic that appears potentially stale or absent, call `show_statistics` to examine its header (last_updated timestamp, row count, rows sampled) and histogram. Flag statistics whose sample rate or update date suggests staleness. This is heuristic; flag rather than assert.
 
-### Step 6 — Fetch column metadata
+### Step 6 - Fetch column metadata
 
 For each table referenced in the query, call `get_table_columns` to retrieve: column name, formatted data type (e.g. `VARCHAR(50)`, `DECIMAL(18,2)`), nullable flag, identity flag, computed flag.
 
-### Step 7 — Refine plan analysis with column metadata
+### Step 7 - Refine plan analysis with column metadata
 
 Use column types and nullable flags to identify:
 
-- **Implicit type conversions**: e.g. a VARCHAR predicate applied to an NVARCHAR column — causes CONVERT_IMPLICIT, preventing index use
-- **Non-nullable columns used in outer joins** — potential over-broad join semantics
-- **Computed columns that block predicate pushdown** — the optimizer cannot always push a predicate through a computed expression
+- **Implicit type conversions**: e.g. a VARCHAR predicate applied to an NVARCHAR column, which causes CONVERT_IMPLICIT, preventing index use
+- **Non-nullable columns used in outer joins**: potential over-broad join semantics
+- **Computed columns that block predicate pushdown**: the optimizer cannot always push a predicate through a computed expression
 
-### Step 8 — Inspect current clustering columns (DW only)
+### Step 8 - Inspect current clustering columns (DW only)
 
 Call `get_cluster_columns` for each table (skip for SQL Analytics Endpoints). Returns the ordered list of CLUSTER BY columns, or an empty list if no clustering is defined.
 
-### Step 9 — Analyze clustering fit
+### Step 9 - Analyze clustering fit
 
 Compare current clustering columns (and their data types from step 6) against the WHERE predicates, JOIN keys, and aggregation patterns in the query plan. A good clustering candidate:
 
@@ -89,17 +89,17 @@ Compare current clustering columns (and their data types from step 6) against th
 
 Note whether a table lacks clustering entirely but would benefit from it.
 
-### Step 10 — Present findings
+### Step 10 - Present findings
 
 Summarize all findings in a structured report:
 
-1. **Expensive operators** — operator name, estimated subtree cost, row estimates
-2. **Missing or stale statistics** — table, column(s), issue description
-3. **Type-mismatch anti-patterns** — column, expected type vs. predicate type
-4. **Non-SARGable predicates** — expression and rewrite suggestion
-5. **Clustering assessment** — current columns vs. recommended columns per table
+1. **Expensive operators**: operator name, estimated subtree cost, row estimates
+2. **Missing or stale statistics**: table, column(s), issue description
+3. **Type-mismatch anti-patterns**: column, expected type vs. predicate type
+4. **Non-SARGable predicates**: expression and rewrite suggestion
+5. **Clustering assessment**: current columns vs. recommended columns per table
 
-### Step 11 — Propose optimizations
+### Step 11 - Propose optimizations
 
 For each finding, propose a concrete action:
 
@@ -107,21 +107,21 @@ For each finding, propose a concrete action:
 - **Query rewrite**: explicit CAST to avoid CONVERT_IMPLICIT, predicate restructuring for SARGability
 - **Clustering**: recommend clustering column(s) with rationale from column metadata
 
-### Step 12 — Apply statistics changes (optional — ask the user first)
+### Step 12 - Apply statistics changes (optional - ask the user first)
 
-> **Before calling any statistics tool, ask the user explicitly:** "Should I apply the statistics changes now?" The MCP server enforces its own write-guard (controlled by `FABRIC_MCP_ALLOW_WRITES` / `FABRIC_MCP_ALLOW_DESTRUCTIVE` server config), but it does not pop a user dialog — the agent must ask before proceeding.
+> **Before calling any statistics tool, ask the user explicitly:** "Should I apply the statistics changes now?" The MCP server enforces its own write-guard (controlled by `FABRIC_MCP_ALLOW_WRITES` / `FABRIC_MCP_ALLOW_DESTRUCTIVE` server config), but it does not pop a user dialog. The agent must ask before proceeding.
 
 If the user confirms, apply statistics changes using `create_statistics` (for absent stats) or `update_statistics` (for stale stats). For large tables, prefer `update_statistics` with a SAMPLE percentage rather than FULLSCAN to limit execution time.
 
-### Step 13 — Re-cluster the table (optional — ask the user first, destructive)
+### Step 13 - Re-cluster the table (optional - ask the user first, destructive)
 
-> **Before calling `set_cluster_columns`, ask the user explicitly and surface the following:** "`set_cluster_columns` performs a full transactional CTAS-swap — a complete physical copy of the table. This may take significant time on large tables, the table will be briefly unavailable during the swap, and dependent views or stored procedures may need refreshing afterwards. Should I proceed?" Only call the tool after the user explicitly acknowledges and approves.
+> **Before calling `set_cluster_columns`, ask the user explicitly and surface the following:** "`set_cluster_columns` performs a full transactional CTAS-swap, a complete physical copy of the table. This may take significant time on large tables, the table will be briefly unavailable during the swap, and dependent views or stored procedures may need refreshing afterwards. Should I proceed?" Only call the tool after the user explicitly acknowledges and approves.
 
 If the user confirms and acknowledges, call `set_cluster_columns` with the recommended clustering columns.
 
 ## Guardrails
 
-- Steps 12 and 13 are opt-in: the agent must ask the user for explicit confirmation before calling any write or destructive tool. The tools enforce a server-side write/destructive guard, but they do not prompt the user — that is the agent's responsibility.
-- Steps 8, 9, 11, and 13 apply only to Fabric Data Warehouses — skip them for SQL Analytics Endpoints
+- Steps 12 and 13 are opt-in: the agent must ask the user for explicit confirmation before calling any write or destructive tool. The tools enforce a server-side write/destructive guard, but they do not prompt the user. That is the agent's responsibility.
+- Steps 8, 9, 11, and 13 apply only to Fabric Data Warehouses; skip them for SQL Analytics Endpoints
 - Stale-statistics detection is heuristic; always frame it as a flag, not a certainty
-- Do not run the original query against the warehouse during analysis — `get_query_plan` obtains the plan without execution
+- Do not run the original query against the warehouse during analysis; `get_query_plan` obtains the plan without execution

--- a/skills/warehouse-performance/SKILL.md
+++ b/skills/warehouse-performance/SKILL.md
@@ -21,21 +21,21 @@ Investigates the performance of an entire Fabric Data Warehouse using the fabric
 
 Gather these from the user (via `$ARGUMENTS` or natural language) before starting:
 
-- **workspace** — workspace name or GUID
-- **warehouse** — warehouse name or GUID. May be a Fabric Data Warehouse (DWH) or a SQL Analytics Endpoint; some steps are DWH-only (noted per step)
-- **window** *(optional)* — a time range for the query-hotspot views (`--since` / `--until`, ISO-8601)
+- **workspace**: workspace name or GUID
+- **warehouse**: warehouse name or GUID. May be a Fabric Data Warehouse (DWH) or a SQL Analytics Endpoint; some steps are DWH-only (noted per step)
+- **window** *(optional)*: a time range for the query-hotspot views (`--since` / `--until`, ISO-8601)
 
 The CLI binary is `fdw` (also installed as `fabric-dw`). All MCP tool names below are exposed by the fabric-dw MCP server.
 
-Read-only steps (1–4 reads) are safe to run unprompted. Every mutating action (step 3 toggle, step 4 create/update/delete/enable/disable) is gated behind explicit user confirmation — see **Guardrails**.
+Read-only steps (1–4 reads) are safe to run unprompted. Every mutating action (step 3 toggle, step 4 create/update/delete/enable/disable) is gated behind explicit user confirmation; see **Guardrails**.
 
 ## When NOT to use this skill
 
-If the user wants to diagnose or rewrite ONE specific query — execution plan, statistics on that query's tables, or clustering — hand off to **`/query-optimizer`**. This skill stops at warehouse-wide hotspots and emits each query's `query_hash` so the user can feed a specific query to `query-optimizer`.
+If the user wants to diagnose or rewrite ONE specific query (execution plan, statistics on that query's tables, or clustering), hand off to **`/query-optimizer`**. This skill stops at warehouse-wide hotspots and emits each query's `query_hash` so the user can feed a specific query to `query-optimizer`.
 
 ## Workflow
 
-### Step 1 — Find query hotspots (DWH + SQL Analytics Endpoint)
+### Step 1 - Find query hotspots (DWH + SQL Analytics Endpoint)
 
 Identify the warehouse's most expensive and most frequent workloads. These views read Query Insights and work on both DWH and SQL Analytics Endpoints.
 
@@ -47,9 +47,9 @@ fdw sql-pools insights    <workspace>/<warehouse>             # resource-pressur
 
 MCP equivalents: `list_long_running_queries`, `list_frequent_queries`, `list_sql_pool_insights`.
 
-- There is **no `--order-by` flag** — each view is ordered server-side (`long-running` by median total elapsed time DESC; `frequent` by number of runs DESC). "Top N" is simply `--limit N` on the already-sorted view. `--limit` defaults to `100` and is capped at `10000`.
+- There is **no `--order-by` flag**: each view is ordered server-side (`long-running` by median total elapsed time DESC; `frequent` by number of runs DESC). "Top N" is simply `--limit N` on the already-sorted view. `--limit` defaults to `100` and is capped at `10000`.
 - `--since` / `--until` (ISO-8601) optionally bound the time window.
-- Each row carries a **`query_hash`** — record it for the synthesis report so the user can hand a specific query to `/query-optimizer`.
+- Each row carries a **`query_hash`**; record it for the synthesis report so the user can hand a specific query to `/query-optimizer`.
 
 Optional drill-down once a suspect appears:
 
@@ -60,9 +60,9 @@ fdw queries sessions <workspace>/<warehouse> --limit 50   # session history, ser
 
 MCP equivalents: `list_request_history`, `list_session_history`.
 
-**Graceful degradation:** if a Query Insights view returns empty, is unavailable, or fails with permission denied, note it (Query Insights needs **Contributor or higher** on the workspace) and continue with the remaining steps — do **not** abort the whole investigation.
+**Graceful degradation:** if a Query Insights view returns empty, is unavailable, or fails with permission denied, note it (Query Insights needs **Contributor or higher** on the workspace) and continue with the remaining steps. Do **not** abort the whole investigation.
 
-### Step 2 — Audit statistics health (read both; DDL is DWH-only)
+### Step 2 - Audit statistics health (read both; DDL is DWH-only)
 
 Missing or stale statistics are a common cause of poor plan choices across many queries. Reading statistics works on both DWH and SQL Analytics Endpoints; only the DDL fixes (create/update/delete) require a DWH.
 
@@ -73,10 +73,10 @@ fdw statistics show <workspace>/<warehouse> <schema.table> <stat_name> --histogr
 
 MCP equivalents: `list_statistics`, `show_statistics`.
 
-- Flag columns that lack statistics, and statistics whose last-updated date / sample rate suggests staleness. This is a **heuristic — flag it, never assert** that a statistic is definitely stale.
+- Flag columns that lack statistics, and statistics whose last-updated date / sample rate suggests staleness. This is a **heuristic; flag it, never assert** that a statistic is definitely stale.
 - Fabric supports **single-column statistics only**. Defer the actual `create_statistics` / `update_statistics` (DWH-only DDL) to `query-optimizer` for a specific query, or surface them as recommendations here for the user to confirm (see **Guardrails**).
 
-### Step 3 — Check result-set caching (read both; toggle DWH-only)
+### Step 3 - Check result-set caching (read both; toggle DWH-only)
 
 Result-set caching can cut elapsed time for repeated identical queries.
 
@@ -95,11 +95,11 @@ fdw settings result-set-caching <workspace>/<warehouse> on    # ALTER DATABASE .
 MCP equivalent: `set_result_set_caching`. SQL Analytics Endpoints are **rejected with an error** for this toggle.
 
 > **Do not confuse three distinct things:**
-> 1. **Result-set caching** — `settings result-set-caching` / `set_result_set_caching` (this step).
-> 2. **The local name→UUID lookup cache** — `fdw cache clear` / `clear_cache`. This only erases cached workspace/item name-to-UUID mappings on the client; it has **nothing** to do with query result caching. Never suggest `cache clear` to influence query performance.
-> 3. **Cache cooldown** — see the observe-only gap below.
+> 1. **Result-set caching**: `settings result-set-caching` / `set_result_set_caching` (this step).
+> 2. **The local name→UUID lookup cache**: `fdw cache clear` / `clear_cache`. This only erases cached workspace/item name-to-UUID mappings on the client; it has **nothing** to do with query result caching. Never suggest `cache clear` to influence query performance.
+> 3. **Cache cooldown**: see the observe-only gap below.
 
-### Step 4 — Review and tune SQL pool configuration (workspace-scoped, beta/preview, admin)
+### Step 4 - Review and tune SQL pool configuration (workspace-scoped, beta/preview, admin)
 
 > **SQL Pools is a beta / preview feature.** It is **workspace-scoped** (configuration applies to the workspace, not a single warehouse) and requires the **workspace admin** role. The underlying API may change before general availability. State this to the user once, up front.
 
@@ -113,12 +113,12 @@ fdw sql-pools show <workspace> --name <pool>   # one pool's detail
 
 MCP equivalents: `get_sql_pools_configuration`, `list_sql_pools`, `get_sql_pool`.
 
-When no custom pools exist, `list` shows the **default autonomous 50/50 split** — one pool at 50% `maxResourcePercentage` for SELECT (read/analytics) and one at 50% for non-SELECT (DML/DDL/ETL/ingestion). Treat this as the baseline.
+When no custom pools exist, `list` shows the **default autonomous 50/50 split**: one pool at 50% `maxResourcePercentage` for SELECT (read/analytics) and one at 50% for non-SELECT (DML/DDL/ETL/ingestion). Treat this as the baseline.
 
-If step 1's `sql-pools insights` shows resource pressure concentrated on one workload type, the actionable levers are (all **mutating** — confirm first, see **Guardrails**):
+If step 1's `sql-pools insights` shows resource pressure concentrated on one workload type, the actionable levers are (all **mutating**; confirm first, see **Guardrails**):
 
 ```bash
-# Carve out a read-optimized pool routed by application name (the only routing key available — see gaps below)
+# Carve out a read-optimized pool routed by application name (the only routing key available, see gaps below)
 fdw sql-pools create <workspace> --name reads-pool --max-percent 60 --optimize-for-reads \
   --classifier-type "Application Name" --classifier-value "PowerBI" --classifier-value "dbt"
 
@@ -132,15 +132,15 @@ MCP equivalents: `create_sql_pool`, `update_sql_pool`, `delete_sql_pool`, `enabl
 
 Tuning levers: `--max-percent` (the pool's `maxResourcePercentage`, 1–100), `--optimize-for-reads/--no-optimize-for-reads`, and the **application-name classifier** (`--classifier-type "Application Name"` with one or more repeatable `--classifier-value`).
 
-### Step 5 — Synthesize a prioritized report
+### Step 5 - Synthesize a prioritized report
 
 Pull the steps together into a single report the user can act on:
 
-1. **Top cost drivers** — from `long-running` and `frequent`, with each query's `query_hash`. Point the user to `/query-optimizer <workspace>/<warehouse>` (plus the query text) for per-query diagnosis.
-2. **Resource-pressure events** — what `sql-pools insights` surfaced, and which workload (SELECT vs non-SELECT) is under pressure.
-3. **Statistics health** — tables/columns flagged as missing or likely-stale (heuristic).
-4. **Caching recommendation** — whether result-set caching is on, and whether the frequent-query pattern justifies enabling it (DWH-only).
-5. **SQL pool tuning suggestions** — concrete `create`/`update` levers vs. the 50/50 baseline (beta, workspace admin).
+1. **Top cost drivers**: from `long-running` and `frequent`, with each query's `query_hash`. Point the user to `/query-optimizer <workspace>/<warehouse>` (plus the query text) for per-query diagnosis.
+2. **Resource-pressure events**: what `sql-pools insights` surfaced, and which workload (SELECT vs non-SELECT) is under pressure.
+3. **Statistics health**: tables/columns flagged as missing or likely-stale (heuristic).
+4. **Caching recommendation**: whether result-set caching is on, and whether the frequent-query pattern justifies enabling it (DWH-only).
+5. **SQL pool tuning suggestions**: concrete `create`/`update` levers vs. the 50/50 baseline (beta, workspace admin).
 
 List every proposed mutating action explicitly and ask the user which (if any) to apply before touching anything.
 
@@ -148,15 +148,15 @@ List every proposed mutating action explicitly and ask the user which (if any) t
 
 There is no API for the following. Document them honestly; never present them as available capabilities.
 
-- **Statement-type routing** — there is **no API** to route a SQL pool by statement type (e.g. "send all SELECTs here"). The **only** routing key is the application-name classifier shown in step 4. Recommend application-name classifiers; do **not** claim statement-type routing exists. Tracked in issue **#596**.
-- **Cache cooldown** — there is **no `ALTER DATABASE` / REST option** to configure a result-set cache cooldown. Do not invent a command for it. This is distinct from the result-set caching toggle (step 3) and from the local lookup cache (`cache clear`). Tracked in issue **#595**.
+- **Statement-type routing**: there is **no API** to route a SQL pool by statement type (e.g. "send all SELECTs here"). The **only** routing key is the application-name classifier shown in step 4. Recommend application-name classifiers; do **not** claim statement-type routing exists. Tracked in issue **#596**.
+- **Cache cooldown**: there is **no `ALTER DATABASE` / REST option** to configure a result-set cache cooldown. Do not invent a command for it. This is distinct from the result-set caching toggle (step 3) and from the local lookup cache (`cache clear`). Tracked in issue **#595**.
 
 ## Guardrails
 
-- **Reads are free; writes require explicit confirmation.** Steps 1–4's *read* commands (`queries *`, `sql-pools insights/get/list/show`, `statistics list/show`, `settings show`) are safe to run unprompted. Every *mutating* action — `settings result-set-caching` (toggle), statistics DDL (`create`/`update`/`delete`), and `sql-pools create/update/delete/enable/disable` — must be confirmed by the user first. The MCP server enforces its own write-guard (`FABRIC_MCP_ALLOW_WRITES` / `FABRIC_MCP_ALLOW_DESTRUCTIVE`), but it does **not** pop a user dialog — asking is the agent's responsibility. List the exact action and ask before proceeding.
-- **DWH vs SQL Analytics Endpoint.** `queries *`, `statistics list`/`show`, `settings show`, and the `sql-pools` reads work on both. The **result-set-caching toggle** and **statistics DDL** are **DWH-only** — SQL Analytics Endpoints are rejected with an error; surface that as a limitation rather than retrying.
-- **SQL Pools is beta/preview, workspace-scoped, and requires workspace admin** — state this before recommending any `sql-pools` change, and note the API may change before GA.
-- **Graceful degradation.** If Query Insights views are unavailable or permission-denied (needs Contributor+), note it and continue — do not abort the investigation.
+- **Reads are free; writes require explicit confirmation.** Steps 1–4's *read* commands (`queries *`, `sql-pools insights/get/list/show`, `statistics list/show`, `settings show`) are safe to run unprompted. Every *mutating* action must be confirmed by the user first: `settings result-set-caching` (toggle), statistics DDL (`create`/`update`/`delete`), and `sql-pools create/update/delete/enable/disable`. The MCP server enforces its own write-guard (`FABRIC_MCP_ALLOW_WRITES` / `FABRIC_MCP_ALLOW_DESTRUCTIVE`), but it does **not** pop a user dialog. Asking is the agent's responsibility. List the exact action and ask before proceeding.
+- **DWH vs SQL Analytics Endpoint.** `queries *`, `statistics list`/`show`, `settings show`, and the `sql-pools` reads work on both. The **result-set-caching toggle** and **statistics DDL** are **DWH-only**: SQL Analytics Endpoints are rejected with an error; surface that as a limitation rather than retrying.
+- **SQL Pools is beta/preview, workspace-scoped, and requires workspace admin**: state this before recommending any `sql-pools` change, and note the API may change before GA.
+- **Graceful degradation.** If Query Insights views are unavailable or permission-denied (needs Contributor+), note it and continue. Do not abort the investigation.
 - **Heuristics stay heuristics.** Frame missing/stale statistics and pressure interpretations as flags to investigate, not certainties.
-- **Don't confuse the caches.** Result-set caching, the local name→UUID lookup cache (`cache clear`), and cache cooldown (#595) are three different things — keep them distinct in every recommendation.
+- **Don't confuse the caches.** Result-set caching, the local name→UUID lookup cache (`cache clear`), and cache cooldown (#595) are three different things; keep them distinct in every recommendation.
 - **Hand single queries to `/query-optimizer`.** This skill diagnoses warehouse-wide; per-query plan/statistics/clustering analysis belongs to `query-optimizer`.

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -2,7 +2,7 @@
 
 This document describes the fixture rule that governs which SQL target(s) each
 integration test must run against.  **Violations of this rule mean silent
-coverage drift** — a dual-target operation can break on SQL Analytics Endpoints
+coverage drift**. A dual-target operation can break on SQL Analytics Endpoints
 without any failing CI test.  A unit-level meta-guard
 (`tests/unit/test_dual_target_coverage.py`) enforces the rule automatically.
 
@@ -11,9 +11,9 @@ without any failing CI test.  A unit-level meta-guard
 The single source of truth for whether an operation is DWH-only or dual-target
 is the **service guard** `_assert_not_sql_endpoint(kind)` in the service layer:
 
-- **DWH-only** — the service calls `_assert_not_sql_endpoint`; the operation is
+- **DWH-only**: the service calls `_assert_not_sql_endpoint`; the operation is
   rejected on SQL Analytics Endpoints at the service layer.
-- **Dual-target** — no such guard; the operation works on both Fabric Data
+- **Dual-target**: no such guard; the operation works on both Fabric Data
   Warehouses and SQL Analytics Endpoints.
 
 ## Fixture rule
@@ -28,9 +28,9 @@ is the **service guard** `_assert_not_sql_endpoint(kind)` in the service layer:
 
 ### Dual-target read tests (`read_target`)
 
-Any test that only **reads** data — `list_*`, `get_*`, `count_*`, `execute_sql`,
+Any test that only **reads** data (`list_*`, `get_*`, `count_*`, `execute_sql`,
 `get_query_plan`, query-insights views, audit settings read, statistics read,
-`generate_dbt_profile`, column metadata — must use `read_target`.  This fixture
+`generate_dbt_profile`, column metadata) must use `read_target`.  This fixture
 is parametrized over `["warehouse", "sql_endpoint"]` so the test body runs once
 per target automatically.
 
@@ -53,10 +53,10 @@ dual-target, so teardown works identically on both targets.
 
 ### DWH-only tests (`warehouse_schema` / `shared_warehouse`)
 
-Base-table data writes — `create_table`, `create_empty_table`, `create_table_from_parquet`,
+Base-table data writes (`create_table`, `create_empty_table`, `create_table_from_parquet`,
 `create_table_from_csv`, `clone_table`, `delete_table`, `clear_table`, `rename_table`,
 `set_cluster_columns`, `copy_into_from_url`, `import_table_from_url`, `load_local_file`,
-`create_statistics`, `update_statistics`, `drop_statistics` — are rejected by the service
+`create_statistics`, `update_statistics`, `drop_statistics`) are rejected by the service
 layer on SQL Analytics Endpoints.  Their tests use `warehouse_schema` (for per-test
 schema isolation) or `shared_warehouse` directly and do NOT need `read_target` or
 `mutable_schema_target`.
@@ -87,12 +87,12 @@ pytest -m "integration and sql_endpoint" -n0 -v tests/integration/
 `request.getfixturevalue("shared_sql_endpoint")` only on the `sql_endpoint`
 leg.  This prevents pytest from provisioning the SQL analytics endpoint
 (~6 min: Lakehouse create + poll + seed) during local runs or during the
-`[warehouse]` leg — provisioning is paid only when the endpoint leg actually
+`[warehouse]` leg. Provisioning is paid only when the endpoint leg actually
 runs.
 
 `read_target` is a sync fixture, so its `getfixturevalue` runs outside any
 event loop.  `mutable_schema_target` is async, so it **must not** call
-`getfixturevalue` on the async `shared_sql_endpoint` itself — doing so makes
+`getfixturevalue` on the async `shared_sql_endpoint` itself. Doing so makes
 pytest-asyncio call `runner.run()` nested inside the running loop and raises
 `RuntimeError: Runner.run() cannot be called from a running event loop`.
 Instead, the parametrisation and the lazy resolution live on a **sync**


### PR DESCRIPTION
## Summary

A documentation unslop pass, in three independent and individually reviewable commits.

1. **Remove em-dashes and tidy prose** (`9f345dc`). #772 stripped em-dashes from `docs/` but left them in `README.md`, `CONTRIBUTING.md`, `SECURITY.md`, the PR template, and the three `SKILL.md` files. This brings those in line with the no-em-dash convention using ordinary punctuation rather than spaced hyphens: a colon for label lists, a comma/period/semicolon in prose, and a hyphen only in step headings to match the existing `docs/` style. Numeric en-dash ranges (`1-10000`, `F2-F2048`) and flow arrows are left as they are. It also repairs a few mid-sentence artifacts the mechanical #772 pass left in `docs/`, where a closing dash had become a stray colon or a trailing ` - [link]` citation (in `query-performance.md` and `ingesting-data.md`), and drops one empty meta-sentence in `concepts.md`.

2. **Drop horizontal-rule dividers between sections** (`a88a880`). Every section in the `docs/` pages was preceded by a `---` thematic break. The docs theme renders that as an `<hr>` immediately above each heading, which is redundant with the heading and reads as generated markdown. This removes 285 of them and lets the headings do the separating. Front-matter, code fences, and table separators are untouched, and there are no wording changes. Kept in its own commit so it can be dropped if you would rather keep the rules.

3. **Remove em-dashes from the integration-test README** (`e697f09`). The same cleanup applied to `tests/integration/README.md`.

## What this deliberately leaves alone

- The `- **flag**: description` definition-list pattern throughout the command reference. In CLI reference docs that is the correct idiom, not a tell, and rewriting roughly 600 of them into prose would only hurt the reference.
- En-dash numeric ranges and the flow arrows, which are correct as written.
- The destructive-operation warning markers in the table-load docs, which are a deliberate safety signal.

## Test plan

- Docs only, no code changes.
- Verified that no em-dashes remain in tracked markdown, that front-matter and fenced code blocks are intact, and that no setext heading underlines were removed by the divider pass.