### PR TITLE
fix(mcp): run KILL in autocommit so kill_session works (#776)

### DIFF
--- a/src/fabric_dw/services/queries.py
+++ b/src/fabric_dw/services/queries.py
@@ -151,10 +151,9 @@ async def kill(
     safe_id = int(session_id)
     kill_sql = f"KILL {safe_id}"
 
-    def _run() -> None:
-        # T-SQL forbids KILL inside a user transaction.  Pass autocommit=True
-        # so the ODBC driver opens the connection without BEGIN TRANSACTION,
-        # which is required for KILL to succeed on Fabric DW.
-        run_query(target, kill_sql, mode=mode, fetch="none", autocommit=True)
-
-    await asyncio.to_thread(_run)
+    # T-SQL forbids KILL inside a user transaction.  Pass autocommit=True so
+    # the ODBC driver opens the connection without BEGIN TRANSACTION, which is
+    # required for KILL to succeed on Fabric DW.
+    await asyncio.to_thread(
+        run_query, target, kill_sql, mode=mode, fetch="none", autocommit=True
+    )

--- a/src/fabric_dw/services/queries.py
+++ b/src/fabric_dw/services/queries.py
@@ -154,6 +154,4 @@ async def kill(
     # T-SQL forbids KILL inside a user transaction.  Pass autocommit=True so
     # the ODBC driver opens the connection without BEGIN TRANSACTION, which is
     # required for KILL to succeed on Fabric DW.
-    await asyncio.to_thread(
-        run_query, target, kill_sql, mode=mode, fetch="none", autocommit=True
-    )
+    await asyncio.to_thread(run_query, target, kill_sql, mode=mode, fetch="none", autocommit=True)

--- a/src/fabric_dw/services/queries.py
+++ b/src/fabric_dw/services/queries.py
@@ -152,6 +152,9 @@ async def kill(
     kill_sql = f"KILL {safe_id}"
 
     def _run() -> None:
-        run_query(target, kill_sql, mode=mode, commit=True, fetch="none")
+        # T-SQL forbids KILL inside a user transaction.  Pass autocommit=True
+        # so the ODBC driver opens the connection without BEGIN TRANSACTION,
+        # which is required for KILL to succeed on Fabric DW.
+        run_query(target, kill_sql, mode=mode, fetch="none", autocommit=True)
 
     await asyncio.to_thread(_run)

--- a/tests/unit/services/test_queries.py
+++ b/tests/unit/services/test_queries.py
@@ -247,16 +247,23 @@ async def test_kill_uses_autocommit_mode() -> None:
 
 
 async def test_kill_does_not_commit_manually_in_autocommit_mode() -> None:
-    """With autocommit, the driver handles commit; run_query must not call conn.commit()."""
+    """With autocommit, the driver handles commit; run_query must not call conn.commit().
+
+    Also asserts that open_connection was opened with autocommit=True, which is
+    the actual guard: without it, this test would pass even if autocommit=True
+    were accidentally dropped (because commit defaults to False in run_query).
+    """
     target = _make_target()
     conn = MagicMock()
     cursor = MagicMock()
     conn.cursor.return_value = cursor
 
-    with patch("fabric_dw.sql.open_connection", return_value=conn):
+    with patch("fabric_dw.sql.open_connection", return_value=conn) as mock_open:
         await queries.kill(target, 42)
 
     conn.commit.assert_not_called()
+    mock_open.assert_called_once()
+    assert mock_open.call_args.kwargs.get("autocommit") is True
 
 
 async def test_kill_closes_connection_after_success() -> None:

--- a/tests/unit/services/test_queries.py
+++ b/tests/unit/services/test_queries.py
@@ -229,8 +229,25 @@ async def test_kill_issues_kill_statement() -> None:
     assert call_sql.strip() == "KILL 42"
 
 
-async def test_kill_commits_after_execute() -> None:
-    """run_query with commit=True issues commit via the shared execution path."""
+async def test_kill_uses_autocommit_mode() -> None:
+    """KILL must be issued in autocommit mode, not inside a user transaction.
+
+    T-SQL forbids KILL inside an explicit transaction.  run_query must be
+    called with autocommit=True so the ODBC driver does not wrap the KILL
+    in BEGIN TRANSACTION / COMMIT.
+    """
+    target = _make_target()
+
+    with patch("fabric_dw.services.queries.run_query") as mock_run_query:
+        mock_run_query.return_value = ([], [])
+        await queries.kill(target, 42)
+
+    call_kwargs = mock_run_query.call_args
+    assert call_kwargs.kwargs.get("autocommit") is True
+
+
+async def test_kill_does_not_commit_manually_in_autocommit_mode() -> None:
+    """With autocommit, the driver handles commit; run_query must not call conn.commit()."""
     target = _make_target()
     conn = MagicMock()
     cursor = MagicMock()
@@ -239,7 +256,7 @@ async def test_kill_commits_after_execute() -> None:
     with patch("fabric_dw.sql.open_connection", return_value=conn):
         await queries.kill(target, 42)
 
-    conn.commit.assert_called_once()
+    conn.commit.assert_not_called()
 
 
 async def test_kill_closes_connection_after_success() -> None:
@@ -372,8 +389,8 @@ async def test_kill_uses_run_query_not_direct_connection() -> None:
     sql_arg: str = call_kwargs.args[1]
     assert "KILL" in sql_arg
     assert "99" in sql_arg
-    # Verify commit=True and fetch="none" are set
-    assert call_kwargs.kwargs.get("commit") is True
+    # Verify autocommit=True (KILL is forbidden inside a user transaction) and fetch="none"
+    assert call_kwargs.kwargs.get("autocommit") is True
     assert call_kwargs.kwargs.get("fetch") == "none"
 
 


### PR DESCRIPTION
## Root cause

`kill()` called `run_query()` with `commit=True` but without `autocommit=True`.
The ODBC driver therefore opened a regular connection and wrapped the `KILL`
statement in `BEGIN TRANSACTION / COMMIT`. T-SQL forbids `KILL` inside a user
transaction, so every call to `kill_session` failed immediately with:

> KILL command cannot be used inside user transactions.

The target session was never actually killed.

## Fix

Pass `autocommit=True` to `run_query()` (and drop `commit=True`, which is
ignored when `autocommit=True` per the existing docstring). This causes the
ODBC driver to open the connection without wrapping statements in an explicit
transaction, matching the same pattern already used for `ALTER DATABASE`-style
DDL elsewhere in the codebase. Autocommit connections are never pooled.

Changed files:
- `src/fabric_dw/services/queries.py`: one-line change in `kill()`
- `tests/unit/services/test_queries.py`: new `test_kill_uses_autocommit_mode`
  (TDD: fails before fix, passes after), new
  `test_kill_does_not_commit_manually_in_autocommit_mode`, and updated
  `test_kill_uses_run_query_not_direct_connection` to assert `autocommit=True`
  instead of `commit=True`.

## Test plan

- [x] `uv run pytest tests/unit/services/test_queries.py -k kill` -- 15 passed
- [x] `uv run pytest tests/unit/` -- 4906 passed
- [x] `uv run ruff check src tests` -- clean (pre-existing error in auto-generated
  `_version.py`, which is gitignored and not checked by CI)
- [x] `uv run ty check src/fabric_dw/services/queries.py tests/unit/services/test_queries.py` -- All checks passed

Closes #776

🤖 Generated with [Claude Code](https://claude.com/claude-code)