### PR TITLE
docs: replace middot separators with slashes (#781)

### DIFF
--- a/docs/commands/audit.md
+++ b/docs/commands/audit.md
@@ -6,13 +6,13 @@ title: Audit
 
 Manage SQL audit settings for Microsoft Fabric Data Warehouses and SQL Analytics Endpoints.
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 ## CLI
 
 ### audit add-group
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Add a single audit action group without overwriting the others. Idempotent - if the group is already present the command succeeds without modifying the configuration. Auditing must already be enabled.
 
@@ -30,7 +30,7 @@ fdw -w MyWorkspace audit add-group SalesWH BATCH_COMPLETED_GROUP
 
 ### audit disable
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Disable SQL auditing on a warehouse or SQL Analytics Endpoint.
 
@@ -48,7 +48,7 @@ fdw -w MyWorkspace audit disable SalesWH
 
 ### audit enable
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Enable SQL auditing on a warehouse or SQL Analytics Endpoint.
 
@@ -77,7 +77,7 @@ fdw -w MyWorkspace audit enable --unlimited SalesWH
 
 ### audit get
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Get the current audit settings for a warehouse or SQL Analytics Endpoint.
 
@@ -101,7 +101,7 @@ actionGroups     BATCH_COMPLETED_GROUP
 
 ### audit remove-group
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Remove a single audit action group without overwriting the others. Idempotent - if the group is not present the command succeeds without modifying the configuration. Auditing must already be enabled.
 
@@ -119,7 +119,7 @@ fdw -w MyWorkspace audit remove-group SalesWH BATCH_COMPLETED_GROUP
 
 ### audit set-groups
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Set the audit action groups for a warehouse or SQL Analytics Endpoint. Pass `--group` / `-g` once per action group. This replaces the existing list of groups.
 
@@ -144,7 +144,7 @@ fdw -w MyWorkspace audit set-groups \
 
 ### audit set-retention
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Update the audit log retention period without changing the audit enabled/disabled state. Audit must already be enabled; if it is disabled, run `audit enable` first.
 
@@ -168,7 +168,7 @@ fdw -w MyWorkspace audit set-retention --days 90 SalesWH
 
 ### add_audit_group
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Add a single audit action group without overwriting the others. Idempotent - if the group is already present the current settings are returned unchanged. Auditing must already be enabled.
 
@@ -182,7 +182,7 @@ Add a single audit action group without overwriting the others. Idempotent - if 
 
 ### disable_audit
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Disable SQL auditing on a warehouse or SQL analytics endpoint.
 
@@ -195,7 +195,7 @@ Disable SQL auditing on a warehouse or SQL analytics endpoint.
 
 ### enable_audit
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Enable SQL auditing on a warehouse or SQL analytics endpoint.
 
@@ -209,7 +209,7 @@ Enable SQL auditing on a warehouse or SQL analytics endpoint.
 
 ### get_audit_settings
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Fetch the current SQL audit settings for a warehouse or SQL analytics endpoint.
 
@@ -222,7 +222,7 @@ Fetch the current SQL audit settings for a warehouse or SQL analytics endpoint.
 
 ### remove_audit_group
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Remove a single audit action group without overwriting the others. Idempotent - if the group is not present the current settings are returned unchanged. Auditing must already be enabled.
 
@@ -236,7 +236,7 @@ Remove a single audit action group without overwriting the others. Idempotent - 
 
 ### set_audit_action_groups
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Replace the audited action groups for a warehouse or SQL analytics endpoint. This overwrites the existing list of groups.
 
@@ -250,7 +250,7 @@ Replace the audited action groups for a warehouse or SQL analytics endpoint. Thi
 
 ### set_audit_retention
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Update the audit log retention period without changing the audit enabled/disabled state. Audit must already be enabled; if it is disabled, enable it first with `enable_audit`.
 

--- a/docs/commands/functions.md
+++ b/docs/commands/functions.md
@@ -6,13 +6,13 @@ title: Functions
 
 Manage T-SQL user-defined functions on Microsoft Fabric Data Warehouses and SQL Analytics Endpoints.
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 ## CLI
 
 ### functions create
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Create a new T-SQL user-defined function.
 
@@ -40,7 +40,7 @@ fdw -w MyWorkspace functions create SalesWH \
 
 ### functions drop
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Drop a T-SQL user-defined function. You will be asked to confirm unless `--yes` is passed.
 
@@ -62,7 +62,7 @@ fdw -w MyWorkspace --yes functions drop SalesWH dbo.fn_clean_input
 
 ### functions get
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Get the full definition of a single T-SQL user-defined function, including its parameter list.
 
@@ -82,7 +82,7 @@ fdw -w MyWorkspace functions get SalesWH dbo.fn_clean_input
 
 ### functions list
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 List T-SQL user-defined functions on a warehouse or SQL Analytics Endpoint. Pass `--schema` to filter by schema, or `--kind` to filter by function kind.
 
@@ -111,7 +111,7 @@ fdw -w MyWorkspace functions list SalesWH --schema dbo --kind scalar
 
 ### functions rename
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Rename a T-SQL user-defined function via `EXEC sp_rename`. The new name must be a bare (unqualified) identifier - `sp_rename` cannot move a function to a different schema. You will be asked to confirm unless `--yes` is passed.
 
@@ -134,7 +134,7 @@ fdw -w MyWorkspace --yes functions rename SalesWH dbo.fn_clean_input \
 
 ### functions update
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Redefine an existing T-SQL user-defined function via `CREATE OR ALTER FUNCTION`.
 
@@ -168,7 +168,7 @@ fdw -w MyWorkspace functions update SalesWH dbo.fn_clean_input \
 
 ### create_function
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Create a new T-SQL user-defined function.
 
@@ -187,7 +187,7 @@ Create a new T-SQL user-defined function.
 
 ### drop_function
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Drop a T-SQL user-defined function.
 
@@ -202,7 +202,7 @@ Drop a T-SQL user-defined function.
 
 ### get_function
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Fetch the full definition of a single T-SQL user-defined function, including its parameter list.
 
@@ -216,7 +216,7 @@ Fetch the full definition of a single T-SQL user-defined function, including its
 
 ### list_functions
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 List T-SQL user-defined functions on a warehouse or SQL Analytics Endpoint, optionally filtered by schema or kind.
 
@@ -231,7 +231,7 @@ List T-SQL user-defined functions on a warehouse or SQL Analytics Endpoint, opti
 
 ### rename_function
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Rename a T-SQL user-defined function via `sp_rename`. The new name must be a bare (unqualified) identifier - `sp_rename` cannot move a function across schemas.
 
@@ -246,7 +246,7 @@ Rename a T-SQL user-defined function via `sp_rename`. The new name must be a bar
 
 ### update_function
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Redefine a T-SQL user-defined function via `CREATE OR ALTER FUNCTION`.
 

--- a/docs/commands/procedures.md
+++ b/docs/commands/procedures.md
@@ -6,13 +6,13 @@ title: Stored procedures
 
 Manage stored procedures on Microsoft Fabric Data Warehouses and SQL Analytics Endpoints.
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 ## CLI
 
 ### procedures create
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Create a new stored procedure.
 
@@ -40,7 +40,7 @@ fdw -w MyWorkspace procedures create SalesWH \
 
 ### procedures drop
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Drop a stored procedure. You will be asked to confirm unless `--yes` is passed.
 
@@ -58,7 +58,7 @@ fdw -w MyWorkspace --yes procedures drop SalesWH dbo.usp_archive_orders
 
 ### procedures get
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Get the full definition of a single stored procedure.
 
@@ -78,7 +78,7 @@ fdw -w MyWorkspace procedures get SalesWH dbo.usp_load_sales
 
 ### procedures list
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 List stored procedures on a warehouse or SQL Analytics Endpoint. Pass `--schema` to filter to a single schema.
 
@@ -106,7 +106,7 @@ fdw -w MyWorkspace procedures list SalesWH --schema dbo
 
 ### procedures update
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Redefine an existing stored procedure via `CREATE OR ALTER PROCEDURE`.
 
@@ -136,7 +136,7 @@ fdw -w MyWorkspace procedures update SalesWH dbo.usp_archive_orders \
 
 ### create_procedure
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Create a new stored procedure.
 
@@ -155,7 +155,7 @@ Create a new stored procedure.
 
 ### drop_procedure
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Drop a stored procedure.
 
@@ -169,7 +169,7 @@ Drop a stored procedure.
 
 ### get_procedure
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Fetch the full definition of a single stored procedure.
 
@@ -183,7 +183,7 @@ Fetch the full definition of a single stored procedure.
 
 ### list_procedures
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 List stored procedures on a warehouse or SQL Analytics Endpoint, optionally filtered to a single schema.
 
@@ -197,7 +197,7 @@ List stored procedures on a warehouse or SQL Analytics Endpoint, optionally filt
 
 ### update_procedure
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Redefine a stored procedure via `CREATE OR ALTER PROCEDURE`.
 

--- a/docs/commands/queries.md
+++ b/docs/commands/queries.md
@@ -6,13 +6,13 @@ title: Queries
 
 Inspect and manage running queries on Microsoft Fabric Data Warehouses and SQL Analytics Endpoints.
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 ## CLI
 
 ### queries connections
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 List all active SQL connections on a warehouse or SQL Analytics Endpoint. This queries `sys.dm_exec_connections` and shows lower-level connection info (including idle connections) that is not visible in `queries running`.
 
@@ -37,7 +37,7 @@ fdw -w MyWorkspace queries connections SalesWH
 
 ### queries frequent
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 List frequently-run queries from `queryinsights.frequently_run_queries`.
 
@@ -65,7 +65,7 @@ fdw -w MyWorkspace queries frequent SalesWH --ago 1h
 
 ### queries history
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 List completed SQL requests from `queryinsights.exec_requests_history`. Supports optional time-range filtering with `--since` and `--until` (ISO-8601 strings). The `--limit` option caps the number of rows returned (default: 100, max: 10 000).
 
@@ -93,7 +93,7 @@ fdw -w MyWorkspace queries history SalesWH --ago 1h
 
 ### queries kill
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Kill a specific session on a warehouse or SQL Analytics Endpoint. You will be asked to confirm unless `--yes` is passed.
 
@@ -111,7 +111,7 @@ fdw -w MyWorkspace --yes queries kill SalesWH 42
 
 ### queries long-running
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 List long-running queries from `queryinsights.long_running_queries`.
 
@@ -139,7 +139,7 @@ fdw -w MyWorkspace queries long-running SalesWH --ago 2d
 
 ### queries running
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 List all currently running queries on a warehouse or SQL Analytics Endpoint.
 
@@ -163,7 +163,7 @@ fdw -w MyWorkspace queries running SalesWH
 
 ### queries sessions
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 List completed sessions from `queryinsights.exec_sessions_history`.
 
@@ -195,7 +195,7 @@ The following four tools query the `queryinsights` schema DMVs via TDS. They sha
 
 ### kill_session
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Terminate a session on a warehouse.
 
@@ -209,7 +209,7 @@ Terminate a session on a warehouse.
 
 ### list_connections
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Return all active SQL connections on a warehouse or SQL Analytics Endpoint. Queries `sys.dm_exec_connections`, which includes idle connections not visible via `list_running_queries`.
 
@@ -222,7 +222,7 @@ Return all active SQL connections on a warehouse or SQL Analytics Endpoint. Quer
 
 ### list_frequent_queries
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Return frequently-run queries from `queryinsights.frequently_run_queries`.
 
@@ -238,7 +238,7 @@ Return frequently-run queries from `queryinsights.frequently_run_queries`.
 
 ### list_long_running_queries
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Return long-running queries from `queryinsights.long_running_queries`.
 
@@ -254,7 +254,7 @@ Return long-running queries from `queryinsights.long_running_queries`.
 
 ### list_request_history
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Return completed SQL requests from `queryinsights.exec_requests_history`.
 
@@ -270,7 +270,7 @@ Return completed SQL requests from `queryinsights.exec_requests_history`.
 
 ### list_running_queries
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Return all currently-executing queries on a warehouse.
 
@@ -283,7 +283,7 @@ Return all currently-executing queries on a warehouse.
 
 ### list_session_history
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Return completed sessions from `queryinsights.exec_sessions_history`.
 

--- a/docs/commands/schemas.md
+++ b/docs/commands/schemas.md
@@ -6,7 +6,7 @@ title: Schemas
 
 Manage SQL schemas on Microsoft Fabric Data Warehouses and SQL Analytics Endpoints.
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 !!! note "SQL Analytics Endpoints"
 
@@ -16,7 +16,7 @@ Manage SQL schemas on Microsoft Fabric Data Warehouses and SQL Analytics Endpoin
 
 ### schemas create
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Create a new SQL schema on a warehouse.
 
@@ -34,7 +34,7 @@ fdw -w MyWorkspace schemas create SalesWH reporting
 
 ### schemas delete
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Drop a schema from a warehouse. You will be asked to confirm unless `--yes` is passed.
 
@@ -62,7 +62,7 @@ fdw -w MyWorkspace --yes schemas delete SalesWH staging --cascade
 
 ### schemas list
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 List all user-defined schemas on a warehouse or SQL Analytics Endpoint. System schemas are excluded.
 
@@ -90,7 +90,7 @@ fdw -w MyWorkspace schemas list SalesWH
 
 ### create_schema
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Create a new SQL schema on a Fabric Data Warehouse or SQL Analytics Endpoint.
 
@@ -104,7 +104,7 @@ Create a new SQL schema on a Fabric Data Warehouse or SQL Analytics Endpoint.
 
 ### delete_schema
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Drop a SQL schema from a Fabric Data Warehouse or SQL Analytics Endpoint.
 
@@ -123,7 +123,7 @@ Drop a SQL schema from a Fabric Data Warehouse or SQL Analytics Endpoint.
 
 ### list_schemas
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 List user-defined SQL schemas on a warehouse or SQL Analytics Endpoint. System schemas are excluded automatically.
 

--- a/docs/commands/settings.md
+++ b/docs/commands/settings.md
@@ -65,7 +65,7 @@ fdw -w MyWorkspace --json settings retention MyWarehouse --days 7
 
 ### settings show
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Display all server-side database settings for an item in a single table.
 
@@ -84,7 +84,7 @@ fdw -w MyWorkspace --json settings show MyWarehouse
 
 ### get_warehouse_settings
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 **Guards:** `assert_workspace_allowed`
 

--- a/docs/commands/sql-pools.md
+++ b/docs/commands/sql-pools.md
@@ -122,7 +122,7 @@ fdw -w MyWorkspace sql-pools get
 
 ### sql-pools insights
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 List SQL pool insight events from `queryinsights.sql_pool_insights`. Supports optional time-range filtering with `--since` and `--until` (ISO-8601 strings). The `--limit` option caps the number of rows returned (default: 100, max: 10 000).
 
@@ -325,7 +325,7 @@ Fetch the full SQL Pools configuration (enabled flag + pool list) for a workspac
 
 ### list_sql_pool_insights
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Return SQL pool insight events from `queryinsights.sql_pool_insights`.
 

--- a/docs/commands/sql.md
+++ b/docs/commands/sql.md
@@ -6,7 +6,7 @@ title: Running SQL
 
 SQL execution and query-plan capture against a Fabric Data Warehouse or SQL Analytics Endpoint.
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 ## CLI
 
@@ -197,7 +197,7 @@ Each operator appears as a node labelled with its physical op name (and logical 
 
 ### execute_sql
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Execute an arbitrary SQL statement or batch against a warehouse or SQL Analytics Endpoint.
 
@@ -219,7 +219,7 @@ Multi-statement batches are supported; only the **last** result set is returned.
 
 ### get_query_plan
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Capture the **estimated** SHOWPLAN_XML execution plan for a SQL query without executing it.
 

--- a/docs/commands/statistics.md
+++ b/docs/commands/statistics.md
@@ -6,7 +6,7 @@ title: Statistics
 
 Manage user-defined statistics on Fabric Data Warehouses and read their details on SQL Analytics Endpoints.
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 !!! note
 
@@ -44,7 +44,7 @@ fdw [-w WORKSPACE] statistics delete [ITEM] QUALIFIED_TABLE STAT_NAME
 
 ### statistics list
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 List statistics on an item.
 
@@ -61,7 +61,7 @@ fdw [-w WORKSPACE] statistics list [ITEM] [OPTIONS]
 
 ### statistics show
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Show details of a named statistic using `DBCC SHOW_STATISTICS`. Returns the stat header, density vector, and histogram steps.
 
@@ -143,7 +143,7 @@ Drop a statistic via `DROP STATISTICS`. **Destructive and irreversible.** Requir
 
 ### list_statistics
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 **Guards:** `assert_workspace_allowed`
 
@@ -164,7 +164,7 @@ List statistics on a warehouse or SQL Analytics Endpoint.
 
 ### show_statistics
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 **Guards:** `assert_workspace_allowed`
 

--- a/docs/commands/tables.md
+++ b/docs/commands/tables.md
@@ -6,7 +6,7 @@ title: Tables
 
 Manage SQL tables on Microsoft Fabric Data Warehouses and SQL Analytics Endpoints. Commands and tools cover listing, counting, reading, creating (including CTAS, empty DDL from schema inference, and zero-copy clone), deleting, clearing, renaming, and loading data via `COPY INTO` from local files or remote URLs.
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 ## CLI
 
@@ -30,7 +30,7 @@ fdw -w MyWorkspace --yes tables clear SalesWH dbo.staging_load
 
 ### tables columns
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 List the columns of a table, including name, formatted data type, nullability, ordinal position, collation, identity, and computed flags.
 
@@ -170,7 +170,7 @@ fdw -w MyWorkspace tables clone SalesWH \
 
 ### tables count
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Return the total row count of a table using `SELECT COUNT_BIG(*)`.
 
@@ -343,7 +343,7 @@ fdw -w MyWorkspace --json tables health-check MySqlEndpoint dbo.FactSales
 
 ### tables list
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 List all tables on a warehouse or SQL Analytics Endpoint. Pass `--schema` to filter to a single schema.
 
@@ -479,7 +479,7 @@ fdw -w MyWorkspace tables load SalesWH dbo.events \
 
 ### tables read
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Read up to `--count` rows from a table and emit them as JSON (default), CSV, or Parquet.
 
@@ -570,7 +570,7 @@ Create a zero-copy clone of a table using `CREATE TABLE … AS CLONE OF …`. On
 
 ### get_table_columns
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Return column metadata for a SQL table via `sys.columns`. Works on both Fabric Data Warehouses and SQL Analytics Endpoints.
 
@@ -594,7 +594,7 @@ Results are ordered by ordinal position. Raises a `ToolError` if the table does 
 
 ### count_table_rows
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Return the total row count of a table via `SELECT COUNT_BIG(*)`.
 
@@ -760,7 +760,7 @@ Load data from a remote URL into an existing Data Warehouse table with control o
 
 ### list_tables
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 List SQL tables on a warehouse or SQL Analytics Endpoint.
 
@@ -812,7 +812,7 @@ Load data into a Data Warehouse table via `COPY INTO` from a remote URL. For One
 
 ### read_table
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Return up to `count` rows from a table as JSON-serialisable columns and rows.
 

--- a/docs/commands/views.md
+++ b/docs/commands/views.md
@@ -6,13 +6,13 @@ title: Views
 
 Manage SQL views on Microsoft Fabric Data Warehouses and SQL Analytics Endpoints.
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 ## CLI
 
 ### views columns
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 List the columns of a view, including name, formatted data type, nullability, ordinal position, collation, identity, and computed flags.
 
@@ -39,7 +39,7 @@ fdw -w MyWorkspace views columns SalesWH dbo.vw_sales
 
 ### views count
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Return the total row count of a view using `SELECT COUNT_BIG(*)`.
 
@@ -61,7 +61,7 @@ fdw -w MyWorkspace --json views count SalesWH dbo.vw_sales
 
 ### views create
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Create a new SQL view.
 
@@ -89,7 +89,7 @@ fdw -w MyWorkspace views create SalesWH \
 
 ### views drop
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Drop a SQL view. You will be asked to confirm unless `--yes` is passed.
 
@@ -107,7 +107,7 @@ fdw -w MyWorkspace --yes views drop SalesWH dbo.vw_recent
 
 ### views get
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Get the full definition of a single view.
 
@@ -136,7 +136,7 @@ definition     SELECT id, amount FROM dbo.sales
 
 ### views list
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 List all views on a warehouse or SQL Analytics Endpoint. Pass `--schema` to filter to a single schema.
 
@@ -165,7 +165,7 @@ fdw -w MyWorkspace views list SalesWH --schema dbo
 
 ### views read
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Read up to `--count` rows from a view and emit them as JSON (default), CSV, or Parquet.
 
@@ -198,7 +198,7 @@ fdw -w MyWorkspace views read SalesWH dbo.vw_sales --count 5
 
 ### views rename
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Rename a SQL view via `sp_rename`. The new name must be an unqualified (bare) identifier - `sp_rename` cannot move a view to a different schema.
 
@@ -222,7 +222,7 @@ fdw -w MyWorkspace views rename SalesWH dbo.vw_recent --new-name vw_revenue
 
 ### views update
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Redefine an existing view using `CREATE OR ALTER VIEW`.
 
@@ -252,7 +252,7 @@ fdw -w MyWorkspace views update SalesWH dbo.vw_recent \
 
 ### count_view_rows
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Return the total row count of a view via `SELECT COUNT_BIG(*)`.
 
@@ -266,7 +266,7 @@ Return the total row count of a view via `SELECT COUNT_BIG(*)`.
 
 ### create_view
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Create a new SQL view.
 
@@ -281,7 +281,7 @@ Create a new SQL view.
 
 ### drop_view
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Drop a SQL view.
 
@@ -295,7 +295,7 @@ Drop a SQL view.
 
 ### get_view
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Fetch the full definition of a single SQL view.
 
@@ -309,7 +309,7 @@ Fetch the full definition of a single SQL view.
 
 ### get_view_columns
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Return column metadata for a SQL view via `sys.columns`. Works on both Fabric Data Warehouses and SQL Analytics Endpoints.
 
@@ -333,7 +333,7 @@ Results are ordered by ordinal position. Raises a `ToolError` if the view does n
 
 ### list_views
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 List SQL views on a warehouse or SQL Analytics Endpoint, optionally filtered to a single schema.
 
@@ -347,7 +347,7 @@ List SQL views on a warehouse or SQL Analytics Endpoint, optionally filtered to 
 
 ### read_view
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Return up to `count` rows from a view as JSON-serialisable columns and rows.
 
@@ -362,7 +362,7 @@ Return up to `count` rows from a view as JSON-serialisable columns and rows.
 
 ### rename_view
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Rename a SQL view via `sp_rename`. Works on both Data Warehouses and SQL Analytics Endpoints. The new name must be a bare (unqualified) identifier - `sp_rename` cannot move a view across schemas.
 
@@ -377,7 +377,7 @@ Rename a SQL view via `sp_rename`. Works on both Data Warehouses and SQL Analyti
 
 ### update_view
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Redefine an existing SQL view using `CREATE OR ALTER VIEW`.
 

--- a/docs/commands/warehouses.md
+++ b/docs/commands/warehouses.md
@@ -6,7 +6,7 @@ title: Warehouses
 
 Manage Microsoft Fabric Data Warehouses and SQL Analytics Endpoints.
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 ## CLI
 
@@ -77,7 +77,7 @@ description    Main sales warehouse
 
 ### warehouses list
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 List all Data Warehouses and SQL Analytics Endpoints in a workspace. Pass `-A` / `--all-workspaces` to aggregate across every visible workspace. `-w` / `--workspace` and `--all-workspaces` are mutually exclusive.
 
@@ -114,7 +114,7 @@ fdw warehouses list --all-workspaces
 
 ### warehouses permissions
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 List all principals (users, groups, service principals) with access to a warehouse, including their effective permissions. Requires **Fabric Administrator** role.
 
@@ -230,7 +230,7 @@ Return details for a single Data Warehouse. Uses the warehouse-scoped REST path 
 
 ### get_warehouse_permissions
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 Return all principals (users, groups, service principals) with access to a Warehouse, including their effective permissions.
 
@@ -247,7 +247,7 @@ Return all principals (users, groups, service principals) with access to a Wareh
 
 ### list_warehouses
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 List all warehouses and SQL analytics endpoints in a workspace, or across all visible workspaces.
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -15,7 +15,7 @@ Fabric has two SQL-surface item kinds:
 
 Each command below is labelled with one of:
 
-- **`Targets: Data Warehouse · SQL Analytics Endpoint`**: the command works on both item kinds.
+- **`Targets: Data Warehouse / SQL Analytics Endpoint`**: the command works on both item kinds.
 - **`Targets: Data Warehouse only`**: the command is blocked on SQL Analytics Endpoints (either by an explicit client-side guard in the source code, because it requires write/DDL capability that endpoints do not have, or because it calls warehouse-scoped REST API paths that are not available for SQL Analytics Endpoints).
 - **`Targets: SQL Analytics Endpoint`**: the command operates on SQL Analytics Endpoints specifically (not on Data Warehouses).
 - **`Targets: Workspace (not item-specific)`**: the command operates at the workspace level and does not target a specific DW or SQL Analytics Endpoint item.

--- a/docs/guides/query-performance.md
+++ b/docs/guides/query-performance.md
@@ -6,7 +6,7 @@ title: Query performance
 
 A task-oriented walkthrough for using `fabric-dw` (binary alias **`fdw`**) to find and fix slow queries on a Microsoft Fabric Data Warehouse or SQL Analytics Endpoint. It threads a single loop (**investigate → diagnose → improve → verify**) across the `queries`, `sql`, `statistics`, `sql-pools`, and `settings` command groups, and grounds each step in Microsoft Learn guidance.
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 !!! tip "Driving `fabric-dw` from an AI assistant?"
 
@@ -333,8 +333,8 @@ The mutating MCP tools (`create_statistics`, `update_statistics`, `delete_statis
 
 ## See also
 
-- [Queries](../commands/queries.md) · [Running SQL](../commands/sql.md) · [Statistics](../commands/statistics.md) · [Settings](../commands/settings.md) · [SQL Pools](../commands/sql-pools.md)
+- [Queries](../commands/queries.md) / [Running SQL](../commands/sql.md) / [Statistics](../commands/statistics.md) / [Settings](../commands/settings.md) / [SQL Pools](../commands/sql-pools.md)
 - [Agent Skills](../skills.md) - `query-optimizer` (single-query automation of this loop) and `warehouse-performance` (warehouse-wide).
-- [Performance guidelines for Fabric Data Warehouse](https://learn.microsoft.com/fabric/data-warehouse/guidelines-warehouse-performance?WT.mc_id=MVP_310840) · [Query insights](https://learn.microsoft.com/fabric/data-warehouse/query-insights?WT.mc_id=MVP_310840) · [Monitoring overview](https://learn.microsoft.com/fabric/data-warehouse/monitoring-overview?WT.mc_id=MVP_310840)
+- [Performance guidelines for Fabric Data Warehouse](https://learn.microsoft.com/fabric/data-warehouse/guidelines-warehouse-performance?WT.mc_id=MVP_310840) / [Query insights](https://learn.microsoft.com/fabric/data-warehouse/query-insights?WT.mc_id=MVP_310840) / [Monitoring overview](https://learn.microsoft.com/fabric/data-warehouse/monitoring-overview?WT.mc_id=MVP_310840)
 </content>
 </invoke>

--- a/docs/guides/tables-and-views.md
+++ b/docs/guides/tables-and-views.md
@@ -50,7 +50,7 @@ The rest of this guide assumes these defaults are set, so the examples omit `-w 
 
 Schemas are the namespace for your tables and views. `dbo` always exists; create custom schemas to group related objects.
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint
+**Targets:** Data Warehouse / SQL Analytics Endpoint
 
 ```shell
 # Create the schema (warehouse positional kept - schema NAME follows)
@@ -70,7 +70,7 @@ fdw schemas list
 
 `tables create` is a single command with mutually-exclusive source modes (validated client-side before any DDL runs). All of them are **Data Warehouse only**: tables can't be created on a SQL Analytics Endpoint.
 
-**Targets:** Data Warehouse only · **MCP:** `create_table` (CTAS), `create_empty_table` (explicit columns)
+**Targets:** Data Warehouse only / **MCP:** `create_table` (CTAS), `create_empty_table` (explicit columns)
 
 ### Empty table from explicit columns
 
@@ -168,7 +168,7 @@ fdw tables create \
 
 ### Inspect what you built
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint · **MCP:** `get_table_columns`, `count_table_rows`, `list_tables`
+**Targets:** Data Warehouse / SQL Analytics Endpoint / **MCP:** `get_table_columns`, `count_table_rows`, `list_tables`
 
 ```shell
 # Column metadata (name, type, nullability, ordinal, collation, identity/computed)
@@ -195,7 +195,7 @@ fdw tables load SalesWH sales.orders --file ./data/orders.parquet
 
 Views give consumers a stable, named query. Unlike tables, **views are creatable on both a Data Warehouse and a SQL Analytics Endpoint**: there's no Warehouse-only guard.
 
-**Targets:** Data Warehouse · SQL Analytics Endpoint · **MCP:** `create_view`, `update_view`, `get_view`, `get_view_columns`, `rename_view`, `list_views`
+**Targets:** Data Warehouse / SQL Analytics Endpoint / **MCP:** `create_view`, `update_view`, `get_view`, `get_view_columns`, `rename_view`, `list_views`
 
 ### Create from a versioned `.sql` file
 
@@ -241,7 +241,7 @@ fdw views update SalesWH sales.vw_orders_by_month \
 
 After you load data, give the query optimizer the statistics it needs. `fabric-dw` manages **single-column** statistics (a Fabric limitation - multi-column statistics aren't supported), and you must pass an explicit `--name` (Fabric requires an explicit statistic name - there is no auto-generated default).
 
-**Targets:** Data Warehouse only (create/update/delete) · Data Warehouse · SQL Analytics Endpoint (list/show) · **MCP:** `create_statistics`, `update_statistics`, `list_statistics`, `show_statistics`
+**Targets:** Data Warehouse only (create/update/delete) / Data Warehouse / SQL Analytics Endpoint (list/show) / **MCP:** `create_statistics`, `update_statistics`, `list_statistics`, `show_statistics`
 
 ```shell
 # Create a single-column statistic
@@ -274,7 +274,7 @@ fdw --yes tables cluster-by SalesWH sales.orders
 fdw tables cluster-columns SalesWH sales.orders
 ```
 
-**Targets:** Data Warehouse only · **MCP:** `set_cluster_columns` (destructive - copies the full table), `get_cluster_columns`.
+**Targets:** Data Warehouse only / **MCP:** `set_cluster_columns` (destructive - copies the full table), `get_cluster_columns`.
 
 !!! tip "Diagnosing slow queries"
 

--- a/docs/guides/warehouse-performance.md
+++ b/docs/guides/warehouse-performance.md
@@ -394,7 +394,7 @@ For a real capacity decision you have two levers, only one of which `fabric-dw` 
 
 | Lever | Tool support |
 | --- | --- |
-| **Move the workspace to another capacity** (load-balance across capacities) | [`fdw workspaces assign-capacity <workspace> --capacity-id <uuid>`](../commands/workspaces.md#workspaces-assign-capacity) · MCP `assign_workspace_to_capacity` |
+| **Move the workspace to another capacity** (load-balance across capacities) | [`fdw workspaces assign-capacity <workspace> --capacity-id <uuid>`](../commands/workspaces.md#workspaces-assign-capacity) / MCP `assign_workspace_to_capacity` |
 | **Resize the capacity SKU** (e.g. F64 → F128) | **Out of CLI scope**: a capacity-admin action in the Fabric/Azure portal |
 
 ```shell
@@ -473,6 +473,6 @@ of scope:
 - [`warehouse-performance` Agent Skill](../skills.md#warehouse-performance) - the AI-assistant
   automation of this workflow.
 - [`query-optimizer` Agent Skill](../skills.md#query-optimizer) - single-query tuning.
-- Command pages: [Queries](../commands/queries.md) · [SQL Pools](../commands/sql-pools.md) ·
-  [Settings](../commands/settings.md) · [Statistics](../commands/statistics.md) ·
-  [Warehouses](../commands/warehouses.md) · [Workspaces](../commands/workspaces.md)
+- Command pages: [Queries](../commands/queries.md) / [SQL Pools](../commands/sql-pools.md) /
+  [Settings](../commands/settings.md) / [Statistics](../commands/statistics.md) /
+  [Warehouses](../commands/warehouses.md) / [Workspaces](../commands/workspaces.md)


### PR DESCRIPTION
## Summary

Sweeps all prose-separator middot characters (U+00B7) from docs/ and replaces them with space-slash-space (` / `), matching the project style convention.

- **120 lines** changed across **16 files** (all under `docs/`)
- Files: `docs/commands/audit.md`, `functions.md`, `procedures.md`, `queries.md`, `schemas.md`, `settings.md`, `sql-pools.md`, `sql.md`, `statistics.md`, `tables.md`, `views.md`, `warehouses.md`, `docs/guides/query-performance.md`, `tables-and-views.md`, `warehouse-performance.md`, `docs/concepts.md`
- Pattern: every ` · ` (space-middot-space) prose separator, including multi-middot lines like `Data Warehouse / SQL Analytics Endpoint / **MCP:** ...` and link lists like `[Queries](...) / [SQL Pools](...) / ...`
- `docs/concepts.md:18` was also updated: the inline code span illustrates the label format, so it must match the real command pages after their separator changed to ` / `

Zero middots remain across all tracked files. No em-dashes were introduced. En-dash numeric ranges were untouched (none were in scope). No comma substitutions were needed.

Closes #781