### PR TITLE
refactor(services): consolidate _normalize_ts onto shared coerce_to_utc

### DIFF
--- a/src/fabric_dw/services/settings.py
+++ b/src/fabric_dw/services/settings.py
@@ -51,6 +51,7 @@ from typing import cast
 from fabric_dw.auth import CredentialMode
 from fabric_dw.exceptions import FabricError, ItemKindError
 from fabric_dw.models import WarehouseKind, WarehouseSettings
+from fabric_dw.services._helpers import coerce_to_utc
 from fabric_dw.sql import SqlTarget, run_query
 
 __all__ = [
@@ -125,29 +126,23 @@ _SET_RETENTION_SQL_TEMPLATE = "ALTER DATABASE CURRENT SET TIME_TRAVEL_RETENTION_
 # ---------------------------------------------------------------------------
 
 
-def _normalize_ts(ts: object) -> datetime | None:
-    """Normalise a ``sys.databases`` timestamp column to UTC-aware datetime or None."""
-    if ts is None:
-        return None
-    if isinstance(ts, datetime):
-        return ts.replace(tzinfo=UTC) if ts.tzinfo is None else ts.astimezone(UTC)
-    if isinstance(ts, _date):
-        # Bare date (not datetime) — promote to midnight UTC.
-        return datetime(ts.year, ts.month, ts.day, tzinfo=UTC)
-    return None
-
-
 def _row_to_settings(cols: list[str], row: tuple[object, ...]) -> WarehouseSettings:
     """Build a :class:`~fabric_dw.models.WarehouseSettings` from a column-name list and a row."""
     data = dict(zip(cols, row, strict=True))
     raw_days = data["time_travel_retention_period_days"]
+    raw_ts = data.get("time_travel_retention_cutoff_date")
+    if isinstance(raw_ts, datetime):
+        cutoff: datetime | None = coerce_to_utc(raw_ts)
+    elif isinstance(raw_ts, _date):
+        # Bare date (not datetime) — promote to midnight UTC.
+        cutoff = datetime(raw_ts.year, raw_ts.month, raw_ts.day, tzinfo=UTC)
+    else:
+        cutoff = None
     return WarehouseSettings(
         database=str(data["name"]),
         result_set_caching=bool(data["is_result_set_caching_on"]),
         time_travel_retention_days=int(cast("int", raw_days)) if raw_days is not None else None,
-        time_travel_retention_cutoff_date=_normalize_ts(
-            data.get("time_travel_retention_cutoff_date")
-        ),
+        time_travel_retention_cutoff_date=cutoff,
     )
 
 

--- a/src/fabric_dw/services/settings.py
+++ b/src/fabric_dw/services/settings.py
@@ -131,6 +131,7 @@ def _row_to_settings(cols: list[str], row: tuple[object, ...]) -> WarehouseSetti
     data = dict(zip(cols, row, strict=True))
     raw_days = data["time_travel_retention_period_days"]
     raw_ts = data.get("time_travel_retention_cutoff_date")
+    # datetime is a subclass of date; the datetime branch must come first.
     if isinstance(raw_ts, datetime):
         cutoff: datetime | None = coerce_to_utc(raw_ts)
     elif isinstance(raw_ts, _date):

--- a/src/fabric_dw/services/statistics.py
+++ b/src/fabric_dw/services/statistics.py
@@ -46,7 +46,7 @@ from __future__ import annotations
 
 import asyncio
 import time
-from datetime import UTC, datetime
+from datetime import datetime
 from typing import cast
 
 from fabric_dw.auth import CredentialMode
@@ -60,6 +60,7 @@ from fabric_dw.models import (
     StatisticHistogramStep,
     WarehouseKind,
 )
+from fabric_dw.services._helpers import coerce_to_utc
 from fabric_dw.sql import SqlTarget, run_query
 
 __all__ = [
@@ -190,15 +191,6 @@ WHERE s.name = ? AND t.name = ? AND st.name = ?;
 # ---------------------------------------------------------------------------
 
 
-def _normalize_ts(ts: object) -> datetime | None:
-    """Normalize a ``STATS_DATE`` value to UTC-aware datetime or None."""
-    if ts is None:
-        return None
-    if isinstance(ts, datetime):
-        return ts.replace(tzinfo=UTC) if ts.tzinfo is None else ts.astimezone(UTC)
-    return None
-
-
 def _coalesce(data: dict[str, object], *keys: str) -> object:
     """Return the value of the first key in *data* whose value is not ``None``.
 
@@ -228,13 +220,14 @@ def _row_to_statistic(cols: list[str], row: tuple[object, ...]) -> Statistic:
     data = dict(zip(cols, row, strict=True))
     schema_name = str(data["schema_name"])
     table_name = str(data["table_name"])
+    last_updated = data.get("last_updated")
     return Statistic(
         name=str(data["stat_name"]),
         qualified_table=f"{schema_name}.{table_name}",
         column=str(data["column_name"]),
         auto_created=bool(data["auto_created"]),
         user_created=bool(data["user_created"]),
-        last_updated=_normalize_ts(data.get("last_updated")),
+        last_updated=coerce_to_utc(last_updated) if isinstance(last_updated, datetime) else None,
         generation_method=(
             str(data["generation_method"]) if data.get("generation_method") is not None else None
         ),
@@ -252,9 +245,10 @@ def _row_to_header(cols: list[str], row: tuple[object, ...]) -> StatisticHeaderR
     data: dict[str, object] = {
         k.lower().replace(" ", "_"): v for k, v in zip(cols, row, strict=True)
     }
+    updated = data.get("updated")
     return StatisticHeaderRow(
         name=str(data.get("name") or ""),
-        updated=_normalize_ts(data.get("updated")),
+        updated=coerce_to_utc(updated) if isinstance(updated, datetime) else None,
         rows=cast("int | None", _coalesce(data, "rows")),
         rows_sampled=cast("int | None", _coalesce(data, "rows_sampled")),
         steps=cast("int | None", _coalesce(data, "steps")),

--- a/tests/unit/services/_helpers.py
+++ b/tests/unit/services/_helpers.py
@@ -18,6 +18,7 @@ centralising here ensures that improvements to the mock contract (e.g. adding
 from __future__ import annotations
 
 import time
+from datetime import tzinfo
 from unittest.mock import AsyncMock, MagicMock
 
 from azure.core.credentials import AccessToken
@@ -106,6 +107,23 @@ def _make_conn_for_ddl() -> MagicMock:
     compatibility with the modules that already import it by name.
     """
     return _make_no_result_conn(rowcount=0)
+
+
+class _NoOffsetTz(tzinfo):
+    """Quasi-naive tzinfo: tzinfo is set but utcoffset() returns None.
+
+    Used in tests to exercise the quasi-naive guard in coerce_to_utc, which
+    treats such datetimes the same as naive ones (i.e. stamps them as UTC).
+    """
+
+    def utcoffset(self, _dt: object) -> None:
+        return None
+
+    def tzname(self, _dt: object) -> str:
+        return "NoOffset"
+
+    def dst(self, _dt: object) -> None:
+        return None
 
 
 class _FakeRow:

--- a/tests/unit/services/test_settings.py
+++ b/tests/unit/services/test_settings.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import UTC, date, datetime, tzinfo
+from datetime import UTC, date, datetime
 from unittest.mock import patch
 
 import pytest
@@ -10,7 +10,7 @@ import pytest
 from fabric_dw.exceptions import FabricError, ItemKindError
 from fabric_dw.models import WarehouseKind, WarehouseSettings
 from fabric_dw.services import settings
-from tests.unit.services._helpers import _make_conn, _make_conn_for_ddl, _make_target
+from tests.unit.services._helpers import _make_conn, _make_conn_for_ddl, _make_target, _NoOffsetTz
 
 # ---------------------------------------------------------------------------
 # Fixture data
@@ -133,17 +133,6 @@ class TestGetSettings:
 
     async def test_quasi_naive_cutoff_treated_as_utc(self) -> None:
         """A quasi-naive cutoff (tzinfo present but utcoffset() returns None) is treated as UTC."""
-
-        class _NoOffsetTz(tzinfo):
-            def utcoffset(self, _dt: object) -> None:
-                return None
-
-            def tzname(self, _dt: object) -> str:
-                return "NoOffset"
-
-            def dst(self, _dt: object) -> None:
-                return None
-
         quasi_naive = datetime(2024, 6, 1, 12, 0, 0, tzinfo=_NoOffsetTz())
         row: tuple[object, ...] = ("SalesWarehouse", True, 7, quasi_naive)
         target = _make_target()

--- a/tests/unit/services/test_settings.py
+++ b/tests/unit/services/test_settings.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import UTC, date, datetime
+from datetime import UTC, date, datetime, tzinfo
 from unittest.mock import patch
 
 import pytest
@@ -130,6 +130,30 @@ class TestGetSettings:
         with patch("fabric_dw.sql.open_connection", return_value=conn):
             result = await settings.get_settings(target)
         assert result.time_travel_retention_cutoff_date == datetime(2024, 6, 1, tzinfo=UTC)
+
+    async def test_quasi_naive_cutoff_treated_as_utc(self) -> None:
+        """A quasi-naive cutoff (tzinfo present but utcoffset() returns None) is treated as UTC."""
+
+        class _NoOffsetTz(tzinfo):
+            def utcoffset(self, _dt: object) -> None:
+                return None
+
+            def tzname(self, _dt: object) -> str:
+                return "NoOffset"
+
+            def dst(self, _dt: object) -> None:
+                return None
+
+        quasi_naive = datetime(2024, 6, 1, 12, 0, 0, tzinfo=_NoOffsetTz())
+        row: tuple[object, ...] = ("SalesWarehouse", True, 7, quasi_naive)
+        target = _make_target()
+        conn = _make_conn([row], _SETTINGS_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            result = await settings.get_settings(target)
+        assert result.time_travel_retention_cutoff_date is not None
+        assert result.time_travel_retention_cutoff_date.tzinfo == UTC
+        cutoff = result.time_travel_retention_cutoff_date
+        assert cutoff == datetime(2024, 6, 1, 12, 0, 0, tzinfo=UTC)
 
 
 # ===========================================================================

--- a/tests/unit/services/test_statistics.py
+++ b/tests/unit/services/test_statistics.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime, tzinfo
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -10,7 +10,12 @@ import pytest
 from fabric_dw.exceptions import ItemKindError, NotFoundError, PermissionDeniedError
 from fabric_dw.models import Statistic, StatisticDetails, WarehouseKind
 from fabric_dw.services import statistics
-from tests.unit.services._helpers import _make_conn, _make_conn_for_ddl, _make_target
+from tests.unit.services._helpers import (
+    _make_conn,
+    _make_conn_for_ddl,
+    _make_target,
+    _NoOffsetTz,
+)
 
 # ---------------------------------------------------------------------------
 # Fixture data
@@ -229,17 +234,6 @@ class TestListStatistics:
 
     async def test_quasi_naive_last_updated_treated_as_utc(self) -> None:
         """Quasi-naive last_updated (tzinfo present but utcoffset() is None) is treated as UTC."""
-
-        class _NoOffsetTz(tzinfo):
-            def utcoffset(self, _dt: object) -> None:
-                return None
-
-            def tzname(self, _dt: object) -> str:
-                return "NoOffset"
-
-            def dst(self, _dt: object) -> None:
-                return None
-
         quasi_naive = datetime(2024, 6, 1, 12, 0, 0, tzinfo=_NoOffsetTz())
         row: tuple[object, ...] = (
             "stat_sales_id",
@@ -365,19 +359,36 @@ class TestShowStatistics:
                 f"{label}: bracket-quoted stat name found in SQL (regression): {call_sql!r}"
             )
 
+    async def test_naive_updated_converted_to_utc(self) -> None:
+        """A naive (tzinfo=None) STAT_HEADER Updated value is stamped as UTC."""
+        naive_dt = datetime(2024, 6, 1, 12, 0, 0)  # noqa: DTZ001
+        naive_header_row: tuple[object, ...] = (
+            "stat_sales_id",
+            naive_dt,
+            1000,
+            500,
+            10,
+            0.001,
+            4.0,
+            "NO",
+            None,
+            None,
+        )
+        target = _make_target()
+        header_conn = _make_conn([naive_header_row], _HEADER_COLS)
+        density_conn = _make_conn([_DENSITY_ROW], _DENSITY_COLS)
+        hist_conn = _make_conn([_HISTOGRAM_ROW], _HISTOGRAM_COLS)
+        with patch(
+            "fabric_dw.sql.open_connection",
+            side_effect=[header_conn, density_conn, hist_conn],
+        ):
+            result = await statistics.show_statistics(target, "dbo.sales", "stat_sales_id")
+        assert result.stat_header is not None
+        assert result.stat_header.updated is not None
+        assert result.stat_header.updated.tzinfo == UTC
+
     async def test_quasi_naive_updated_treated_as_utc(self) -> None:
         """Quasi-naive header Updated (tzinfo present but utcoffset() is None) is treated as UTC."""
-
-        class _NoOffsetTz(tzinfo):
-            def utcoffset(self, _dt: object) -> None:
-                return None
-
-            def tzname(self, _dt: object) -> str:
-                return "NoOffset"
-
-            def dst(self, _dt: object) -> None:
-                return None
-
         quasi_naive = datetime(2024, 6, 1, 12, 0, 0, tzinfo=_NoOffsetTz())
         quasi_header_row: tuple[object, ...] = (
             "stat_sales_id",

--- a/tests/unit/services/test_statistics.py
+++ b/tests/unit/services/test_statistics.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, tzinfo
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -227,6 +227,38 @@ class TestListStatistics:
         assert result[0].last_updated is not None
         assert result[0].last_updated.tzinfo is not None
 
+    async def test_quasi_naive_last_updated_treated_as_utc(self) -> None:
+        """Quasi-naive last_updated (tzinfo present but utcoffset() is None) is treated as UTC."""
+
+        class _NoOffsetTz(tzinfo):
+            def utcoffset(self, _dt: object) -> None:
+                return None
+
+            def tzname(self, _dt: object) -> str:
+                return "NoOffset"
+
+            def dst(self, _dt: object) -> None:
+                return None
+
+        quasi_naive = datetime(2024, 6, 1, 12, 0, 0, tzinfo=_NoOffsetTz())
+        row: tuple[object, ...] = (
+            "stat_sales_id",
+            "dbo",
+            "sales",
+            "id",
+            False,
+            True,
+            quasi_naive,
+            None,
+        )
+        target = _make_target()
+        conn = _make_conn([row], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            result = await statistics.list_statistics(target)
+        assert result[0].last_updated is not None
+        assert result[0].last_updated.tzinfo == UTC
+        assert result[0].last_updated == datetime(2024, 6, 1, 12, 0, 0, tzinfo=UTC)
+
 
 # ===========================================================================
 # show_statistics
@@ -332,6 +364,46 @@ class TestShowStatistics:
             assert "[stat_sales_id]" not in call_sql, (
                 f"{label}: bracket-quoted stat name found in SQL (regression): {call_sql!r}"
             )
+
+    async def test_quasi_naive_updated_treated_as_utc(self) -> None:
+        """Quasi-naive header Updated (tzinfo present but utcoffset() is None) is treated as UTC."""
+
+        class _NoOffsetTz(tzinfo):
+            def utcoffset(self, _dt: object) -> None:
+                return None
+
+            def tzname(self, _dt: object) -> str:
+                return "NoOffset"
+
+            def dst(self, _dt: object) -> None:
+                return None
+
+        quasi_naive = datetime(2024, 6, 1, 12, 0, 0, tzinfo=_NoOffsetTz())
+        quasi_header_row: tuple[object, ...] = (
+            "stat_sales_id",
+            quasi_naive,
+            1000,
+            500,
+            10,
+            0.001,
+            4.0,
+            "NO",
+            None,
+            None,
+        )
+        target = _make_target()
+        header_conn = _make_conn([quasi_header_row], _HEADER_COLS)
+        density_conn = _make_conn([_DENSITY_ROW], _DENSITY_COLS)
+        hist_conn = _make_conn([_HISTOGRAM_ROW], _HISTOGRAM_COLS)
+        with patch(
+            "fabric_dw.sql.open_connection",
+            side_effect=[header_conn, density_conn, hist_conn],
+        ):
+            result = await statistics.show_statistics(target, "dbo.sales", "stat_sales_id")
+        assert result.stat_header is not None
+        assert result.stat_header.updated is not None
+        assert result.stat_header.updated.tzinfo == UTC
+        assert result.stat_header.updated == datetime(2024, 6, 1, 12, 0, 0, tzinfo=UTC)
 
     async def test_raises_not_found_when_header_empty(self) -> None:
         target = _make_target()


### PR DESCRIPTION
## Summary

- Removes the private `_normalize_ts` helpers from `services/settings.py` and `services/statistics.py`, replacing all call sites with the canonical `coerce_to_utc` from `services/_helpers.py`.
- The quasi-naive guard (`tzinfo` present but `utcoffset()` returns `None`) is now applied consistently in both modules via `coerce_to_utc`.
- Adds unit tests covering the quasi-naive edge case for the settings cutoff date, the statistics `last_updated` field, and the DBCC header `updated` field.

Closes #782