### PR TITLE
fix(audit): preserve retentionDays and auditActionsAndGroups in all PATCH calls

### DIFF
--- a/src/fabric_dw/services/audit.py
+++ b/src/fabric_dw/services/audit.py
@@ -429,16 +429,14 @@ async def set_action_groups(
     # warehouses, since PATCH with state=Enabled is idempotent and always works.
     # retentionDays is always round-tripped: omitting it from a partial PATCH causes
     # the Fabric API to silently reset it to its default value (data-loss bug).
+    # state is always "Enabled" on both paths: ensure_enabled=True forces it explicitly;
+    # ensure_enabled=False reaches here only after _require_enabled() confirmed state is
+    # "Enabled" (it raises ValueError for "Disabled").
     patch_body: dict[str, object] = {
+        "state": "Enabled",
         "auditActionsAndGroups": action_groups,
         "retentionDays": current.retention_days,
     }
-    if ensure_enabled:
-        patch_body["state"] = "Enabled"
-    else:
-        # Round-trip the current state so the Fabric API does not reset it to
-        # its default.  _require_enabled already confirmed state is "Enabled".
-        patch_body["state"] = current.state
 
     await http.request(
         "PATCH",
@@ -449,8 +447,7 @@ async def set_action_groups(
     # Return the authoritative post-PATCH state constructed locally.
     # Do NOT poll GET: the GET endpoint lags the PATCH by minutes; the PATCH
     # itself is the authoritative source of truth.
-    new_state = "Enabled" if ensure_enabled else current.state
-    return current.model_copy(update={"action_groups": list(action_groups), "state": new_state})
+    return current.model_copy(update={"action_groups": list(action_groups), "state": "Enabled"})
 
 
 async def add_action_group(

--- a/src/fabric_dw/services/audit.py
+++ b/src/fabric_dw/services/audit.py
@@ -232,6 +232,19 @@ async def disable(
 ) -> AuditSettings:
     """Disable SQL auditing on a Data Warehouse or SQL Analytics Endpoint.
 
+    Performs a pre-flight ``GET /settings/sqlAudit`` to read the current
+    ``retentionDays`` and ``auditActionsAndGroups`` before sending the PATCH.
+    The Fabric API resets any field omitted from a partial PATCH to its default
+    value, so both fields are always round-tripped alongside ``state=Disabled``.
+    This preserves the configured retention period and action-group list so a
+    subsequent re-enable restores them rather than wiping the prior configuration.
+
+    Note:
+        This function performs a read-modify-write (GET then PATCH) without
+        optimistic concurrency control.  The Fabric REST API does not expose
+        ETags or ``If-Match`` on the ``/settings/sqlAudit`` endpoint.  Under
+        concurrent modification the last writer wins silently.
+
     Args:
         http: Authenticated Fabric HTTP client.
         workspace_id: GUID of the Fabric workspace.
@@ -245,9 +258,24 @@ async def disable(
 
     Raises:
         PermissionDeniedError: If the caller lacks the required permission (HTTP 403).
+        NotFoundError: If the item does not exist (HTTP 404) -- raised by the
+            pre-flight GET or the final re-fetch.
     """
     path = _audit_path(workspace_id, item_id, kind)
-    await http.request("PATCH", HttpBase.FABRIC, path, json={"state": "Disabled"})
+    # Pre-flight GET to preserve retentionDays and auditActionsAndGroups in the
+    # PATCH body.  Omitting either field causes the Fabric API to silently reset
+    # it to its default value, wiping custom retention and group configuration.
+    current = await get_settings(http, workspace_id, item_id, kind)
+    await http.request(
+        "PATCH",
+        HttpBase.FABRIC,
+        path,
+        json={
+            "state": "Disabled",
+            "retentionDays": current.retention_days,
+            "auditActionsAndGroups": current.action_groups,
+        },
+    )
     # PATCH returns empty/partial body on this endpoint; re-fetch required.
     return await get_settings(http, workspace_id, item_id, kind)
 
@@ -399,9 +427,18 @@ async def set_action_groups(
     # alongside ``state`` and ``retentionDays``.  Using PATCH to set the action groups
     # avoids the EntityNotFound (404) that the POST method returns on freshly-created
     # warehouses, since PATCH with state=Enabled is idempotent and always works.
-    patch_body: dict[str, object] = {"auditActionsAndGroups": action_groups}
+    # retentionDays is always round-tripped: omitting it from a partial PATCH causes
+    # the Fabric API to silently reset it to its default value (data-loss bug).
+    patch_body: dict[str, object] = {
+        "auditActionsAndGroups": action_groups,
+        "retentionDays": current.retention_days,
+    }
     if ensure_enabled:
         patch_body["state"] = "Enabled"
+    else:
+        # Round-trip the current state so the Fabric API does not reset it to
+        # its default.  _require_enabled already confirmed state is "Enabled".
+        patch_body["state"] = current.state
 
     await http.request(
         "PATCH",
@@ -476,11 +513,18 @@ async def add_action_group(
 
     new_groups = [*current.action_groups, group]
     path = _audit_path(workspace_id, item_id, kind)
+    # Round-trip state and retentionDays alongside the updated group list.
+    # Omitting either field from a partial PATCH causes the Fabric API to
+    # silently reset it to its default value (data-loss bug).
     await http.request(
         "PATCH",
         HttpBase.FABRIC,
         path,
-        json={"auditActionsAndGroups": new_groups},
+        json={
+            "state": current.state,
+            "retentionDays": current.retention_days,
+            "auditActionsAndGroups": new_groups,
+        },
     )
     # Return the authoritative post-PATCH state constructed locally.
     # Do NOT poll GET: the GET endpoint lags the PATCH by minutes; the PATCH
@@ -551,11 +595,18 @@ async def remove_action_group(
 
     new_groups = [g for g in current.action_groups if g != group]
     path = _audit_path(workspace_id, item_id, kind)
+    # Round-trip state and retentionDays alongside the updated group list.
+    # Omitting either field from a partial PATCH causes the Fabric API to
+    # silently reset it to its default value (data-loss bug).
     await http.request(
         "PATCH",
         HttpBase.FABRIC,
         path,
-        json={"auditActionsAndGroups": new_groups},
+        json={
+            "state": current.state,
+            "retentionDays": current.retention_days,
+            "auditActionsAndGroups": new_groups,
+        },
     )
     # Return the authoritative post-PATCH state constructed locally.
     # Do NOT poll GET: the GET endpoint lags the PATCH by minutes; the PATCH

--- a/tests/unit/cli/commands/test_audit_respx.py
+++ b/tests/unit/cli/commands/test_audit_respx.py
@@ -205,8 +205,13 @@ class TestAuditDisableRespx:
         assert len(captured_bodies) == 1
         body = captured_bodies[0]
         assert body.get("state") == "Disabled", f"Expected state=Disabled in body: {body}"
-        # Must NOT include retentionDays for a plain disable
-        assert "retentionDays" not in body, f"disable body must not include retentionDays: {body}"
+        # Regression guard (#780): disable must preserve retentionDays and
+        # auditActionsAndGroups in the PATCH body so the Fabric API does not silently
+        # reset them to defaults.
+        assert "retentionDays" in body, f"disable body must include retentionDays: {body}"
+        assert "auditActionsAndGroups" in body, (
+            f"disable body must include auditActionsAndGroups: {body}"
+        )
 
     def test_disable_uses_correct_http_method(self, runner: CliRunner, cache_env: Path) -> None:
         """The audit disable request must use PATCH, not POST or PUT."""
@@ -457,3 +462,147 @@ class TestAuditRemoveGroupRespx:
 
         assert result.exit_code == 0, result.output
         assert audit_patch.called
+
+    def test_remove_group_body_preserves_retention_days(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """PATCH body from remove-group must include retentionDays so it is not silently reset.
+
+        Regression guard for #780: the old code omitted retentionDays, causing the
+        Fabric API to reset it to its default value on every remove-group call.
+        """
+        _ = cache_env
+        captured_bodies: list[dict[str, object]] = []
+
+        def _capture_patch(request: httpx.Request) -> httpx.Response:
+            captured_bodies.append(json.loads(request.content))
+            return httpx.Response(204)
+
+        existing_groups: list[str] = _AUDIT_SETTINGS_ENABLED["auditActionsAndGroups"]  # type: ignore[assignment]
+        group_to_remove = existing_groups[0]
+
+        with respx.mock(assert_all_called=False) as mock_router:
+            _setup_resolver_mocks(mock_router)
+            mock_router.get(_AUDIT_URL).mock(
+                return_value=httpx.Response(200, json=_AUDIT_SETTINGS_ENABLED)
+            )
+            mock_router.patch(_AUDIT_URL).mock(side_effect=_capture_patch)
+
+            with patch(
+                "fabric_dw.cli.commands.audit.build_http_client",
+                new=_real_http_client_cm,
+            ):
+                result = runner.invoke(
+                    cli,
+                    ["-w", WS_GUID, "--json", "audit", "remove-group", WH_GUID, group_to_remove],
+                )
+
+        assert result.exit_code == 0, result.output
+        assert len(captured_bodies) == 1
+        body = captured_bodies[0]
+        assert "retentionDays" in body, (
+            f"retentionDays must be preserved in remove-group PATCH body: {body}"
+        )
+        assert body["retentionDays"] == _AUDIT_SETTINGS_ENABLED["retentionDays"], (
+            f"retentionDays must match pre-flight GET value: {body}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Regression tests — #780: partial-PATCH data-loss on add-group and disable
+# ---------------------------------------------------------------------------
+
+
+class TestAuditAddGroupRetentionPreservation:
+    """Regression tests: add-group PATCH must not silently reset retentionDays."""
+
+    def test_add_group_body_preserves_retention_days(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """PATCH body from add-group must include retentionDays so it is not silently reset.
+
+        Regression guard for #780: the old code omitted retentionDays, causing the
+        Fabric API to reset it to its default value on every add-group call.
+        """
+        _ = cache_env
+        captured_bodies: list[dict[str, object]] = []
+
+        def _capture_patch(request: httpx.Request) -> httpx.Response:
+            captured_bodies.append(json.loads(request.content))
+            return httpx.Response(204)
+
+        new_group = "FAILED_DATABASE_AUTHENTICATION_GROUP"
+
+        with respx.mock(assert_all_called=False) as mock_router:
+            _setup_resolver_mocks(mock_router)
+            mock_router.get(_AUDIT_URL).mock(
+                return_value=httpx.Response(200, json=_AUDIT_SETTINGS_ENABLED)
+            )
+            mock_router.patch(_AUDIT_URL).mock(side_effect=_capture_patch)
+
+            with patch(
+                "fabric_dw.cli.commands.audit.build_http_client",
+                new=_real_http_client_cm,
+            ):
+                result = runner.invoke(
+                    cli,
+                    ["-w", WS_GUID, "--json", "audit", "add-group", WH_GUID, new_group],
+                )
+
+        assert result.exit_code == 0, result.output
+        assert len(captured_bodies) == 1
+        body = captured_bodies[0]
+        assert "retentionDays" in body, (
+            f"retentionDays must be preserved in add-group PATCH body: {body}"
+        )
+        assert body["retentionDays"] == _AUDIT_SETTINGS_ENABLED["retentionDays"], (
+            f"retentionDays must match pre-flight GET value: {body}"
+        )
+
+
+class TestAuditDisableRetentionPreservation:
+    """Regression tests: disable PATCH must not silently reset retentionDays or groups."""
+
+    def test_disable_body_preserves_retention_and_groups(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """PATCH body from disable must include retentionDays and auditActionsAndGroups.
+
+        Regression guard for #780: the old code sent only state=Disabled, causing the
+        Fabric API to reset retentionDays and auditActionsAndGroups to defaults on disable.
+        """
+        _ = cache_env
+        captured_bodies: list[dict[str, object]] = []
+
+        def _capture_patch(request: httpx.Request) -> httpx.Response:
+            captured_bodies.append(json.loads(request.content))
+            return httpx.Response(204)
+
+        with respx.mock(assert_all_called=False) as mock_router:
+            _setup_resolver_mocks(mock_router)
+            # Single mock handles both the pre-flight GET and the re-fetch GET.
+            mock_router.get(_AUDIT_URL).mock(
+                return_value=httpx.Response(200, json=_AUDIT_SETTINGS_ENABLED)
+            )
+            mock_router.patch(_AUDIT_URL).mock(side_effect=_capture_patch)
+
+            with patch(
+                "fabric_dw.cli.commands.audit.build_http_client",
+                new=_real_http_client_cm,
+            ):
+                result = runner.invoke(
+                    cli,
+                    ["-w", WS_GUID, "--yes", "--json", "audit", "disable", WH_GUID],
+                )
+
+        assert result.exit_code == 0, result.output
+        assert len(captured_bodies) == 1
+        body = captured_bodies[0]
+        assert body.get("state") == "Disabled"
+        assert "retentionDays" in body, (
+            f"retentionDays must be preserved in disable PATCH body: {body}"
+        )
+        existing_groups: list[str] = _AUDIT_SETTINGS_ENABLED["auditActionsAndGroups"]  # type: ignore[assignment]
+        assert body.get("auditActionsAndGroups") == existing_groups, (
+            f"auditActionsAndGroups must be preserved in disable PATCH body: {body}"
+        )

--- a/tests/unit/cli/commands/test_audit_respx.py
+++ b/tests/unit/cli/commands/test_audit_respx.py
@@ -599,8 +599,10 @@ class TestAuditDisableRetentionPreservation:
         assert len(captured_bodies) == 1
         body = captured_bodies[0]
         assert body.get("state") == "Disabled"
-        assert "retentionDays" in body, (
-            f"retentionDays must be preserved in disable PATCH body: {body}"
+        # Check the VALUE, not just presence: an impl sending retentionDays=0 would
+        # pass a presence-only check while the GET mock returns retentionDays=30.
+        assert body.get("retentionDays") == _AUDIT_SETTINGS_ENABLED["retentionDays"], (
+            f"retentionDays must match the pre-flight GET value in disable PATCH body: {body}"
         )
         existing_groups: list[str] = _AUDIT_SETTINGS_ENABLED["auditActionsAndGroups"]  # type: ignore[assignment]
         assert body.get("auditActionsAndGroups") == existing_groups, (

--- a/tests/unit/services/test_audit.py
+++ b/tests/unit/services/test_audit.py
@@ -242,12 +242,27 @@ async def test_disable_patches_with_disabled_state() -> None:
     auditActionsAndGroups from that GET must appear in the PATCH body so the
     Fabric API does not silently reset them to defaults.  Two GETs are issued:
     one pre-flight and one re-fetch after PATCH.
+
+    Non-default values (retentionDays=90, one custom group) are used so that
+    a buggy implementation that hardcodes zeros/empty would fail the value assertions.
     """
+    # Non-default pre-PATCH state: currently Enabled with custom retention + groups.
+    _pre_patch = {
+        "state": "Enabled",
+        "retentionDays": 90,
+        "auditActionsAndGroups": ["BATCH_COMPLETED_GROUP"],
+    }
+    # Post-PATCH re-fetch returns the same retention/groups with state flipped.
+    _post_patch = {**_pre_patch, "state": "Disabled"}
+
     with respx.mock:
         patch_route = respx.patch(_AUDIT_URL).mock(return_value=httpx.Response(200, json={}))
-        # Single mock handles both the pre-flight GET and the re-fetch GET.
+        # Two GETs: pre-flight reads current state, re-fetch reads post-PATCH state.
         get_route = respx.get(_AUDIT_URL).mock(
-            return_value=httpx.Response(200, json=AUDIT_SETTINGS_DISABLED_PAYLOAD)
+            side_effect=[
+                httpx.Response(200, json=_pre_patch),  # pre-flight GET
+                httpx.Response(200, json=_post_patch),  # re-fetch after PATCH
+            ]
         )
         client = await _make_client()
         async with client:
@@ -257,13 +272,15 @@ async def test_disable_patches_with_disabled_state() -> None:
     sent_body = json.loads(patch_route.calls[0].request.content)
     # Regression guard: retentionDays and auditActionsAndGroups must be preserved
     # (sourced from the pre-flight GET) so the Fabric API does not reset them.
+    # Non-default values prove the pre-flight GET is actually used.
     assert sent_body == {
         "state": "Disabled",
-        "retentionDays": AUDIT_SETTINGS_DISABLED_PAYLOAD["retentionDays"],
-        "auditActionsAndGroups": AUDIT_SETTINGS_DISABLED_PAYLOAD["auditActionsAndGroups"],
+        "retentionDays": 90,
+        "auditActionsAndGroups": ["BATCH_COMPLETED_GROUP"],
     }
 
-    assert get_route.call_count >= 1
+    # Two GETs must be issued: one pre-flight + one re-fetch after PATCH.
+    assert get_route.call_count == 2
     assert isinstance(result, AuditSettings)
     assert result.state == "Disabled"
 
@@ -1007,13 +1024,25 @@ async def test_endpoint_disable_uses_sql_endpoints_collection() -> None:
     """disable with SQL_ENDPOINT kind must PATCH /sqlEndpoints/{id}/settings/sqlAudit.
 
     Also verifies that the PATCH body preserves retentionDays and auditActionsAndGroups
-    sourced from the pre-flight GET (fix for #780).
+    sourced from the pre-flight GET (fix for #780).  Non-default values are used so a
+    buggy impl that hardcodes zeros/empty fails the value assertions.
     """
+    # Non-default pre-PATCH state: currently Enabled with custom retention + groups.
+    _ep_pre_patch = {
+        "state": "Enabled",
+        "retentionDays": 42,
+        "auditActionsAndGroups": ["BATCH_COMPLETED_GROUP"],
+    }
+    _ep_post_patch = {**_ep_pre_patch, "state": "Disabled"}
+
     with respx.mock:
         patch_route = respx.patch(_EP_AUDIT_URL).mock(return_value=httpx.Response(200, json={}))
-        # Single mock handles both the pre-flight GET and the re-fetch GET.
-        respx.get(_EP_AUDIT_URL).mock(
-            return_value=httpx.Response(200, json=AUDIT_SETTINGS_DISABLED_PAYLOAD)
+        # Two GETs: pre-flight reads current state, re-fetch reads post-PATCH state.
+        get_route = respx.get(_EP_AUDIT_URL).mock(
+            side_effect=[
+                httpx.Response(200, json=_ep_pre_patch),  # pre-flight GET
+                httpx.Response(200, json=_ep_post_patch),  # re-fetch after PATCH
+            ]
         )
         client = await _make_client()
         async with client:
@@ -1021,11 +1050,15 @@ async def test_endpoint_disable_uses_sql_endpoints_collection() -> None:
 
     assert patch_route.called
     sent_body = json.loads(patch_route.calls[0].request.content)
+    # Non-default values prove the pre-flight GET is actually used and the correct
+    # URL segment (/sqlEndpoints/) is used for both GET and PATCH.
     assert sent_body == {
         "state": "Disabled",
-        "retentionDays": AUDIT_SETTINGS_DISABLED_PAYLOAD["retentionDays"],
-        "auditActionsAndGroups": AUDIT_SETTINGS_DISABLED_PAYLOAD["auditActionsAndGroups"],
+        "retentionDays": 42,
+        "auditActionsAndGroups": ["BATCH_COMPLETED_GROUP"],
     }
+    # Two GETs must be issued: one pre-flight + one re-fetch after PATCH.
+    assert get_route.call_count == 2
     assert isinstance(result, AuditSettings)
     assert result.state == "Disabled"
 

--- a/tests/unit/services/test_audit.py
+++ b/tests/unit/services/test_audit.py
@@ -236,9 +236,16 @@ async def test_enable_get_403_raises_permission_denied() -> None:
 
 
 async def test_disable_patches_with_disabled_state() -> None:
-    """disable should PATCH with state=Disabled, then GET and return fresh state."""
+    """disable should PATCH with state=Disabled (preserving retentionDays and groups), then GET.
+
+    The pre-flight GET returns the current settings; both retentionDays and
+    auditActionsAndGroups from that GET must appear in the PATCH body so the
+    Fabric API does not silently reset them to defaults.  Two GETs are issued:
+    one pre-flight and one re-fetch after PATCH.
+    """
     with respx.mock:
         patch_route = respx.patch(_AUDIT_URL).mock(return_value=httpx.Response(200, json={}))
+        # Single mock handles both the pre-flight GET and the re-fetch GET.
         get_route = respx.get(_AUDIT_URL).mock(
             return_value=httpx.Response(200, json=AUDIT_SETTINGS_DISABLED_PAYLOAD)
         )
@@ -248,21 +255,49 @@ async def test_disable_patches_with_disabled_state() -> None:
 
     assert patch_route.called
     sent_body = json.loads(patch_route.calls[0].request.content)
-    assert sent_body == {"state": "Disabled"}
+    # Regression guard: retentionDays and auditActionsAndGroups must be preserved
+    # (sourced from the pre-flight GET) so the Fabric API does not reset them.
+    assert sent_body == {
+        "state": "Disabled",
+        "retentionDays": AUDIT_SETTINGS_DISABLED_PAYLOAD["retentionDays"],
+        "auditActionsAndGroups": AUDIT_SETTINGS_DISABLED_PAYLOAD["auditActionsAndGroups"],
+    }
 
-    assert get_route.called
+    assert get_route.call_count >= 1
     assert isinstance(result, AuditSettings)
     assert result.state == "Disabled"
 
 
 async def test_disable_403_raises_permission_denied() -> None:
-    """disable should propagate PermissionDeniedError on 403 from PATCH."""
+    """disable should propagate PermissionDeniedError on 403 from PATCH.
+
+    disable performs a pre-flight GET (which succeeds here) before sending the
+    PATCH that returns 403.
+    """
     with respx.mock:
+        respx.get(_AUDIT_URL).mock(return_value=httpx.Response(200, json=AUDIT_SETTINGS_PAYLOAD))
         respx.patch(_AUDIT_URL).mock(return_value=httpx.Response(403, json={"error": "forbidden"}))
         client = await _make_client()
         async with client:
             with pytest.raises(PermissionDeniedError):
                 await audit.disable(client, _WS_ID, _WH_ID)
+
+
+async def test_disable_get_403_raises_permission_denied() -> None:
+    """disable should propagate PermissionDeniedError on 403 from the pre-flight GET.
+
+    The pre-flight GET added by this fix is a new 403 surface.  This test
+    confirms the error propagates before the PATCH is ever attempted.
+    """
+    with respx.mock:
+        respx.get(_AUDIT_URL).mock(return_value=httpx.Response(403, json={"error": "forbidden"}))
+        patch_route = respx.patch(_AUDIT_URL).mock(return_value=httpx.Response(200, json={}))
+        client = await _make_client()
+        async with client:
+            with pytest.raises(PermissionDeniedError):
+                await audit.disable(client, _WS_ID, _WH_ID)
+
+    assert not patch_route.called
 
 
 # ---------------------------------------------------------------------------
@@ -271,8 +306,12 @@ async def test_disable_403_raises_permission_denied() -> None:
 
 
 async def test_set_action_groups_patches_with_enabled_state_and_groups() -> None:
-    """set_action_groups should GET current state, PATCH with state=Enabled + auditActionsAndGroups,
+    """set_action_groups should GET current state, PATCH with state, retentionDays, and groups,
     then return authoritative constructed state (no re-GET after PATCH).
+
+    Regression guard: retentionDays must be included in the PATCH body alongside
+    state=Enabled and auditActionsAndGroups so the Fabric API does not silently
+    reset retentionDays to its default value (fix for #780).
     """
     groups = ["BATCH_COMPLETED_GROUP", "FAILED_DATABASE_AUTHENTICATION_GROUP"]
     current_payload = AUDIT_SETTINGS_PAYLOAD.copy()
@@ -288,7 +327,11 @@ async def test_set_action_groups_patches_with_enabled_state_and_groups() -> None
 
     assert patch_route.called
     sent_body = json.loads(patch_route.calls[0].request.content)
-    assert sent_body == {"state": "Enabled", "auditActionsAndGroups": groups}
+    assert sent_body == {
+        "state": "Enabled",
+        "retentionDays": current_payload["retentionDays"],
+        "auditActionsAndGroups": groups,
+    }
 
     # Exactly one GET (pre-flight) — no re-GET after PATCH.
     assert get_route.call_count == 1
@@ -415,13 +458,19 @@ async def test_set_action_groups_works_on_fresh_warehouse() -> None:
     assert result.action_groups == groups
 
 
-async def test_set_action_groups_ensure_enabled_false_omits_state() -> None:
-    """set_action_groups with ensure_enabled=False should NOT include state=Enabled in the PATCH.
+async def test_set_action_groups_ensure_enabled_false_preserves_current_state() -> None:
+    """set_action_groups with ensure_enabled=False round-trips the current state in the PATCH.
 
-    The returned state reflects the current state (from the pre-flight GET), not Enabled.
+    The Fabric API resets any omitted field to its default value, so state must
+    be included even when ensure_enabled=False.  The current state (from the
+    pre-flight GET) is used so the effective audit state is not changed.
+    retentionDays is also round-tripped to prevent it from being silently reset.
+
+    Regression guard for #780: the old code omitted state on the ensure_enabled=False
+    path, which caused the Fabric API to reset state to its default (Disabled).
     """
     groups = ["BATCH_COMPLETED_GROUP"]
-    current_payload = AUDIT_SETTINGS_PAYLOAD.copy()  # state == "Enabled"
+    current_payload = AUDIT_SETTINGS_PAYLOAD.copy()  # state == "Enabled", retentionDays == 30
 
     with respx.mock:
         get_route = respx.get(_AUDIT_URL).mock(
@@ -436,7 +485,9 @@ async def test_set_action_groups_ensure_enabled_false_omits_state() -> None:
 
     assert patch_route.called
     sent_body = json.loads(patch_route.calls[0].request.content)
-    assert "state" not in sent_body
+    # state and retentionDays must be round-tripped to prevent Fabric API resets.
+    assert sent_body.get("state") == current_payload["state"]
+    assert sent_body.get("retentionDays") == current_payload["retentionDays"]
     assert sent_body["auditActionsAndGroups"] == groups
     # Exactly one GET (pre-flight) — no re-GET after PATCH.
     assert get_route.call_count == 1
@@ -953,9 +1004,14 @@ async def test_endpoint_enable_uses_sql_endpoints_collection() -> None:
 
 
 async def test_endpoint_disable_uses_sql_endpoints_collection() -> None:
-    """disable with SQL_ENDPOINT kind must PATCH /sqlEndpoints/{id}/settings/sqlAudit."""
+    """disable with SQL_ENDPOINT kind must PATCH /sqlEndpoints/{id}/settings/sqlAudit.
+
+    Also verifies that the PATCH body preserves retentionDays and auditActionsAndGroups
+    sourced from the pre-flight GET (fix for #780).
+    """
     with respx.mock:
         patch_route = respx.patch(_EP_AUDIT_URL).mock(return_value=httpx.Response(200, json={}))
+        # Single mock handles both the pre-flight GET and the re-fetch GET.
         respx.get(_EP_AUDIT_URL).mock(
             return_value=httpx.Response(200, json=AUDIT_SETTINGS_DISABLED_PAYLOAD)
         )
@@ -965,7 +1021,11 @@ async def test_endpoint_disable_uses_sql_endpoints_collection() -> None:
 
     assert patch_route.called
     sent_body = json.loads(patch_route.calls[0].request.content)
-    assert sent_body == {"state": "Disabled"}
+    assert sent_body == {
+        "state": "Disabled",
+        "retentionDays": AUDIT_SETTINGS_DISABLED_PAYLOAD["retentionDays"],
+        "auditActionsAndGroups": AUDIT_SETTINGS_DISABLED_PAYLOAD["auditActionsAndGroups"],
+    }
     assert isinstance(result, AuditSettings)
     assert result.state == "Disabled"
 
@@ -1133,3 +1193,118 @@ async def test_set_action_groups_snapshot_raises_value_error() -> None:
                 await audit.set_action_groups(
                     client, _WS_ID, _WH_ID, ["BATCH_COMPLETED_GROUP"], WarehouseKind.SNAPSHOT
                 )
+
+
+# ---------------------------------------------------------------------------
+# Regression tests — #780: partial-PATCH data-loss on group/disable mutations
+# ---------------------------------------------------------------------------
+
+
+async def test_add_action_group_preserves_state_and_retention_in_patch_body() -> None:
+    """add_action_group PATCH body must include state and retentionDays alongside the group list.
+
+    Regression guard for #780: the old code omitted state and retentionDays, causing the
+    Fabric API to silently reset both fields to their defaults whenever a group was added.
+    """
+    new_group = "FAILED_DATABASE_AUTHENTICATION_GROUP"
+    existing = AUDIT_SETTINGS_PAYLOAD.copy()  # state=Enabled, retentionDays=30
+
+    with respx.mock:
+        respx.get(_AUDIT_URL).mock(return_value=httpx.Response(200, json=existing))
+        patch_route = respx.patch(_AUDIT_URL).mock(return_value=httpx.Response(200, json={}))
+        client = await _make_client()
+        async with client:
+            await audit.add_action_group(client, _WS_ID, _WH_ID, new_group)
+
+    assert patch_route.called
+    sent_body = json.loads(patch_route.calls[0].request.content)
+    # Primary assertion: state and retentionDays must be round-tripped.
+    assert sent_body.get("state") == existing["state"], (
+        f"state must be preserved in PATCH body, got: {sent_body}"
+    )
+    assert sent_body.get("retentionDays") == existing["retentionDays"], (
+        f"retentionDays must be preserved in PATCH body, got: {sent_body}"
+    )
+    assert new_group in sent_body.get("auditActionsAndGroups", [])
+
+
+async def test_remove_action_group_preserves_state_and_retention_in_patch_body() -> None:
+    """remove_action_group PATCH body must include state and retentionDays alongside the group list.
+
+    Regression guard for #780: the old code omitted state and retentionDays, causing the
+    Fabric API to silently reset both fields to their defaults whenever a group was removed.
+    """
+    group_to_remove = "SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP"
+    existing = AUDIT_SETTINGS_PAYLOAD.copy()  # state=Enabled, retentionDays=30
+
+    with respx.mock:
+        respx.get(_AUDIT_URL).mock(return_value=httpx.Response(200, json=existing))
+        patch_route = respx.patch(_AUDIT_URL).mock(return_value=httpx.Response(200, json={}))
+        client = await _make_client()
+        async with client:
+            await audit.remove_action_group(client, _WS_ID, _WH_ID, group_to_remove)
+
+    assert patch_route.called
+    sent_body = json.loads(patch_route.calls[0].request.content)
+    # Primary assertion: state and retentionDays must be round-tripped.
+    assert sent_body.get("state") == existing["state"], (
+        f"state must be preserved in PATCH body, got: {sent_body}"
+    )
+    assert sent_body.get("retentionDays") == existing["retentionDays"], (
+        f"retentionDays must be preserved in PATCH body, got: {sent_body}"
+    )
+    assert group_to_remove not in sent_body.get("auditActionsAndGroups", [])
+
+
+async def test_set_action_groups_preserves_retention_in_patch_body() -> None:
+    """set_action_groups PATCH body must include retentionDays so it is not silently reset.
+
+    Regression guard for #780: the old code omitted retentionDays from the PATCH body,
+    causing the Fabric API to reset it to its default value on every set-groups call.
+    """
+    groups = ["BATCH_COMPLETED_GROUP"]
+    existing = AUDIT_SETTINGS_PAYLOAD.copy()  # retentionDays=30
+
+    with respx.mock:
+        respx.get(_AUDIT_URL).mock(return_value=httpx.Response(200, json=existing))
+        patch_route = respx.patch(_AUDIT_URL).mock(return_value=httpx.Response(200, json={}))
+        client = await _make_client()
+        async with client:
+            await audit.set_action_groups(client, _WS_ID, _WH_ID, groups)
+
+    assert patch_route.called
+    sent_body = json.loads(patch_route.calls[0].request.content)
+    assert sent_body.get("retentionDays") == existing["retentionDays"], (
+        f"retentionDays must be preserved in PATCH body, got: {sent_body}"
+    )
+
+
+async def test_disable_preserves_retention_and_groups_in_patch_body() -> None:
+    """disable PATCH body must include retentionDays and auditActionsAndGroups.
+
+    Regression guard for #780: the old code sent only state=Disabled, causing the
+    Fabric API to silently reset retentionDays and auditActionsAndGroups to their
+    defaults whenever auditing was disabled.  A subsequent re-enable would then
+    start with blank retention and no custom action groups.
+    """
+    existing = AUDIT_SETTINGS_PAYLOAD.copy()  # state=Enabled, retentionDays=30, groups=[...]
+
+    with respx.mock:
+        # Single mock handles both the pre-flight GET and the re-fetch GET.
+        respx.get(_AUDIT_URL).mock(return_value=httpx.Response(200, json=existing))
+        patch_route = respx.patch(_AUDIT_URL).mock(return_value=httpx.Response(200, json={}))
+        client = await _make_client()
+        async with client:
+            await audit.disable(client, _WS_ID, _WH_ID)
+
+    assert patch_route.called
+    sent_body = json.loads(patch_route.calls[0].request.content)
+    assert sent_body.get("state") == "Disabled"
+    # Primary assertions: retentionDays and groups must be round-tripped from the
+    # pre-flight GET so the Fabric API does not silently reset them.
+    assert sent_body.get("retentionDays") == existing["retentionDays"], (
+        f"retentionDays must be preserved on disable, got: {sent_body}"
+    )
+    assert sent_body.get("auditActionsAndGroups") == existing["auditActionsAndGroups"], (
+        f"auditActionsAndGroups must be preserved on disable, got: {sent_body}"
+    )


### PR DESCRIPTION
## Summary

- `disable()` sent only `{"state":"Disabled"}`, causing the Fabric API to silently reset `retentionDays` and `auditActionsAndGroups` on every disable call.
- `add_action_group()` and `remove_action_group()` sent only `{"auditActionsAndGroups":[...]}`, silently resetting `retentionDays` and `state`.
- `set_action_groups()` omitted `retentionDays` from all PATCH bodies (and omitted `state` on the `ensure_enabled=False` path).

Fix: `disable()` now performs a pre-flight GET and round-trips all three fields (`state`, `retentionDays`, `auditActionsAndGroups`) in its PATCH body. The same three fields are now always included in `add_action_group`, `remove_action_group`, and `set_action_groups` PATCH bodies. This mirrors the pattern applied to `enable()` and `set_retention()` in #767.

Regression tests added to `tests/unit/services/test_audit.py` and `tests/unit/cli/commands/test_audit_respx.py` asserting each PATCH body carries the preserved fields. Existing tests whose assertions described the old buggy behaviour are updated accordingly.

Closes #780