### PR TITLE
docs(audit): document GET-lag eventual-consistency tension in audit-write functions

### DIFF
--- a/src/fabric_dw/cli/commands/audit.py
+++ b/src/fabric_dw/cli/commands/audit.py
@@ -67,6 +67,10 @@ async def enable_cmd(
     """Enable SQL auditing on ITEM (warehouse or SQL analytics endpoint).
 
     Omitting both --retention-days and --unlimited defaults to unlimited retention.
+
+    NOTE: Each audit write reads current settings via an eventually-consistent GET
+    that lags PATCHes by minutes. Two rapid writes may silently revert the first.
+    Space audit writes at least a few minutes apart.
     """
     if retention_days is not None and unlimited:
         raise click.UsageError("--retention-days and --unlimited are mutually exclusive.")
@@ -98,7 +102,12 @@ async def enable_cmd(
 @click.pass_obj
 @coro
 async def disable_cmd(ctx: CliContext, item: str | None) -> None:
-    """Disable SQL auditing on ITEM (warehouse or SQL analytics endpoint)."""
+    """Disable SQL auditing on ITEM (warehouse or SQL analytics endpoint).
+
+    NOTE: Each audit write reads current settings via an eventually-consistent GET
+    that lags PATCHes by minutes. Two rapid writes may silently revert the first.
+    Space audit writes at least a few minutes apart.
+    """
     ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     try:
@@ -136,6 +145,10 @@ async def set_retention_cmd(
 
     Audit must already be enabled; if disabled, enable it first with
     ``audit enable``.  This command does NOT change the audit state.
+
+    NOTE: Each audit write reads current settings via an eventually-consistent GET
+    that lags PATCHes by minutes. Two rapid writes may silently revert the first.
+    Space audit writes at least a few minutes apart.
     """
     ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
@@ -165,6 +178,10 @@ async def set_groups_cmd(ctx: CliContext, item: str | None, groups: tuple[str, .
 
     Pass --group for each action group name, e.g.
     --group BATCH_COMPLETED_GROUP --group SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP.
+
+    NOTE: Each audit write reads current settings via an eventually-consistent GET
+    that lags PATCHes by minutes. Two rapid writes may silently revert the first.
+    Space audit writes at least a few minutes apart.
     """
     ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
@@ -187,8 +204,12 @@ async def set_groups_cmd(ctx: CliContext, item: str | None, groups: tuple[str, .
 async def add_group_cmd(ctx: CliContext, item: str | None, group: str) -> None:
     """Add GROUP to the audit action groups for ITEM (warehouse or SQL analytics endpoint).
 
-    Idempotent — if GROUP is already present the command succeeds without
+    Idempotent -- if GROUP is already present the command succeeds without
     modifying the configuration.  Auditing must already be enabled.
+
+    NOTE: Each audit write reads current settings via an eventually-consistent GET
+    that lags PATCHes by minutes. Two rapid writes may silently revert the first.
+    Space audit writes at least a few minutes apart.
     """
     ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
@@ -209,8 +230,12 @@ async def add_group_cmd(ctx: CliContext, item: str | None, group: str) -> None:
 async def remove_group_cmd(ctx: CliContext, item: str | None, group: str) -> None:
     """Remove GROUP from the audit action groups for ITEM (warehouse or SQL analytics endpoint).
 
-    Idempotent — if GROUP is not present the command succeeds without
+    Idempotent -- if GROUP is not present the command succeeds without
     modifying the configuration.  Auditing must already be enabled.
+
+    NOTE: Each audit write reads current settings via an eventually-consistent GET
+    that lags PATCHes by minutes. Two rapid writes may silently revert the first.
+    Space audit writes at least a few minutes apart.
     """
     ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)

--- a/src/fabric_dw/cli/commands/audit.py
+++ b/src/fabric_dw/cli/commands/audit.py
@@ -68,9 +68,10 @@ async def enable_cmd(
 
     Omitting both --retention-days and --unlimited defaults to unlimited retention.
 
-    NOTE: Each audit write reads current settings via an eventually-consistent GET
-    that lags PATCHes by minutes. Two rapid writes may silently revert the first.
-    Space audit writes at least a few minutes apart.
+    NOTE: The pre-flight GET used to round-trip the existing action-group list
+    lags PATCHes by minutes; if the action-group list was changed within that
+    window, this call may silently revert it. Space audit writes at least a few
+    minutes apart.
     """
     if retention_days is not None and unlimited:
         raise click.UsageError("--retention-days and --unlimited are mutually exclusive.")
@@ -146,9 +147,10 @@ async def set_retention_cmd(
     Audit must already be enabled; if disabled, enable it first with
     ``audit enable``.  This command does NOT change the audit state.
 
-    NOTE: Each audit write reads current settings via an eventually-consistent GET
-    that lags PATCHes by minutes. Two rapid writes may silently revert the first.
-    Space audit writes at least a few minutes apart.
+    NOTE: The pre-flight GET used to round-trip the existing action-group list
+    lags PATCHes by minutes; if the action-group list was changed within that
+    window, this call may silently revert it. Space audit writes at least a few
+    minutes apart.
     """
     ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)

--- a/src/fabric_dw/mcp/tools/audit.py
+++ b/src/fabric_dw/mcp/tools/audit.py
@@ -51,6 +51,11 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
     ) -> dict[str, Any]:
         """Enable SQL auditing on a warehouse or SQL analytics endpoint.
 
+        CAUTION: Each audit write reads current settings via an eventually-consistent
+        GET that may lag a recent PATCH by several minutes. Two audit writes issued
+        within that window can cause the second to silently revert the first.
+        Space audit writes at least a few minutes apart.
+
         Args:
             workspace: Workspace name or GUID.
             warehouse: Warehouse or SQL analytics endpoint name or GUID.
@@ -82,6 +87,11 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
     async def disable_audit(workspace: str, warehouse: str) -> dict[str, Any]:
         """Disable SQL auditing on a warehouse or SQL analytics endpoint.
 
+        CAUTION: Each audit write reads current settings via an eventually-consistent
+        GET that may lag a recent PATCH by several minutes. Two audit writes issued
+        within that window can cause the second to silently revert the first.
+        Space audit writes at least a few minutes apart.
+
         Args:
             workspace: Workspace name or GUID.
             warehouse: Warehouse or SQL analytics endpoint name or GUID.
@@ -105,6 +115,12 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         workspace: str, warehouse: str, action_groups: list[str]
     ) -> dict[str, Any]:
         """Replace the audited action groups for a warehouse or SQL analytics endpoint.
+
+        CAUTION: Each audit write reads current settings via an eventually-consistent
+        GET that may lag a recent PATCH by several minutes. The retention period
+        read from that GET is round-tripped; if retention was changed within the lag
+        window, this call may silently revert it. Space audit writes at least a few
+        minutes apart.
 
         Args:
             workspace: Workspace name or GUID.
@@ -137,10 +153,15 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
     async def add_audit_group(workspace: str, warehouse: str, group: str) -> dict[str, Any]:
         """Add a single audit action group without overwriting the others.
 
-        Idempotent — if *group* is already present the current settings are
+        Idempotent -- if the group is already present the current settings are
         returned unchanged.  Auditing must already be enabled.
 
         CAUTION: changes take effect immediately on the live audit policy.
+
+        CAUTION: Each audit write reads current settings via an eventually-consistent
+        GET that may lag a recent PATCH by several minutes. Two audit writes issued
+        within that window can cause the second to silently revert the first.
+        Space audit writes at least a few minutes apart.
 
         Args:
             workspace: Workspace name or GUID.
@@ -167,10 +188,15 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
     async def remove_audit_group(workspace: str, warehouse: str, group: str) -> dict[str, Any]:
         """Remove a single audit action group without overwriting the others.
 
-        Idempotent — if *group* is not present the current settings are returned
+        Idempotent -- if the group is not present the current settings are returned
         unchanged.  Auditing must already be enabled.
 
         CAUTION: changes take effect immediately on the live audit policy.
+
+        CAUTION: Each audit write reads current settings via an eventually-consistent
+        GET that may lag a recent PATCH by several minutes. Two audit writes issued
+        within that window can cause the second to silently revert the first.
+        Space audit writes at least a few minutes apart.
 
         Args:
             workspace: Workspace name or GUID.
@@ -206,6 +232,11 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         """Update the audit log retention period without changing the audit enabled/disabled state.
 
         Audit must already be enabled; if disabled, enable it first with ``enable_audit``.
+
+        CAUTION: Each audit write reads current settings via an eventually-consistent
+        GET that may lag a recent PATCH by several minutes. Two audit writes issued
+        within that window can cause the second to silently revert the first.
+        Space audit writes at least a few minutes apart.
 
         Args:
             workspace: Workspace name or GUID.

--- a/src/fabric_dw/mcp/tools/audit.py
+++ b/src/fabric_dw/mcp/tools/audit.py
@@ -51,10 +51,10 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
     ) -> dict[str, Any]:
         """Enable SQL auditing on a warehouse or SQL analytics endpoint.
 
-        CAUTION: Each audit write reads current settings via an eventually-consistent
-        GET that may lag a recent PATCH by several minutes. Two audit writes issued
-        within that window can cause the second to silently revert the first.
-        Space audit writes at least a few minutes apart.
+        CAUTION: The pre-flight GET used to round-trip the existing action-group
+        list is eventually consistent and may lag a recent PATCH by several minutes.
+        If the action-group list was changed within that window, this call may
+        silently revert it. Space audit writes at least a few minutes apart.
 
         Args:
             workspace: Workspace name or GUID.
@@ -233,10 +233,10 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
 
         Audit must already be enabled; if disabled, enable it first with ``enable_audit``.
 
-        CAUTION: Each audit write reads current settings via an eventually-consistent
-        GET that may lag a recent PATCH by several minutes. Two audit writes issued
-        within that window can cause the second to silently revert the first.
-        Space audit writes at least a few minutes apart.
+        CAUTION: The pre-flight GET used to round-trip the existing action-group
+        list is eventually consistent and may lag a recent PATCH by several minutes.
+        If the action-group list was changed within that window, this call may
+        silently revert it. Space audit writes at least a few minutes apart.
 
         Args:
             workspace: Workspace name or GUID.

--- a/src/fabric_dw/services/audit.py
+++ b/src/fabric_dw/services/audit.py
@@ -179,6 +179,12 @@ async def enable(
         ETags or ``If-Match`` on the ``/settings/sqlAudit`` endpoint.  Under
         concurrent modification the last writer wins silently.
 
+        The pre-flight GET is eventually consistent and may lag a recent PATCH
+        by several minutes.  If another audit write was issued within that lag
+        window, this call re-asserts the stale ``auditActionsAndGroups`` value
+        from the GET and silently reverts the earlier change.  Space audit
+        writes at least a few minutes apart to avoid this.
+
     Args:
         http: Authenticated Fabric HTTP client.
         workspace_id: GUID of the Fabric workspace.
@@ -195,7 +201,7 @@ async def enable(
     Raises:
         ValueError: If *retention_days* is negative.
         PermissionDeniedError: If the caller lacks the required permission (HTTP 403).
-        NotFoundError: If the item does not exist (HTTP 404) — raised by the
+        NotFoundError: If the item does not exist (HTTP 404) -- raised by the
             pre-flight GET or the final re-fetch.
     """
     if retention_days < 0:
@@ -244,6 +250,13 @@ async def disable(
         optimistic concurrency control.  The Fabric REST API does not expose
         ETags or ``If-Match`` on the ``/settings/sqlAudit`` endpoint.  Under
         concurrent modification the last writer wins silently.
+
+        The pre-flight GET is eventually consistent and may lag a recent PATCH
+        by several minutes.  If another audit write was issued within that lag
+        window, this call re-asserts stale ``retentionDays`` and/or
+        ``auditActionsAndGroups`` values from the GET and silently reverts the
+        earlier change.  Space audit writes at least a few minutes apart to
+        avoid this.
 
     Args:
         http: Authenticated Fabric HTTP client.
@@ -306,6 +319,18 @@ async def set_retention(
     The Fabric REST API does not document an upper bound for ``retentionDays``.
     Only the lower bound (>= 1) is enforced here; the API will reject any value
     it considers out of range and surface an appropriate error.
+
+    Note:
+        This function performs a read-modify-write (GET then PATCH) without
+        optimistic concurrency control.  The Fabric REST API does not expose
+        ETags or ``If-Match`` on the ``/settings/sqlAudit`` endpoint.  Under
+        concurrent modification the last writer wins silently.
+
+        The pre-flight GET is eventually consistent and may lag a recent PATCH
+        by several minutes.  If another audit write was issued within that lag
+        window, this call re-asserts a stale ``auditActionsAndGroups`` value
+        from the GET and silently reverts the earlier change.  Space audit
+        writes at least a few minutes apart to avoid this.
 
     Args:
         http: Authenticated Fabric HTTP client.
@@ -396,6 +421,13 @@ async def set_action_groups(
                 updating groups is desired, pass ``ensure_enabled=False`` to
                 preserve the current audit state.
 
+    Note:
+        The pre-flight GET used to obtain ``retentionDays`` is eventually
+        consistent and may lag a recent PATCH by several minutes.  If another
+        audit write changed the retention period within that window, this call
+        re-asserts the stale value and silently reverts it.  Space audit writes
+        at least a few minutes apart to avoid this.
+
     Returns:
         The authoritative :class:`~fabric_dw.models.AuditSettings` after the
         PATCH, constructed locally from the pre-PATCH settings and the supplied
@@ -476,6 +508,12 @@ async def add_action_group(
         ETags or ``If-Match`` on the ``/settings/sqlAudit`` endpoint.  Under
         concurrent modification the last writer wins silently.
 
+        The pre-flight GET is eventually consistent and may lag a recent PATCH
+        by several minutes.  If another audit write was issued within that lag
+        window, this call re-asserts stale ``retentionDays`` and/or existing
+        action-group values from the GET and silently reverts the earlier
+        change.  Space audit writes at least a few minutes apart to avoid this.
+
     Args:
         http: Authenticated Fabric HTTP client.
         workspace_id: GUID of the Fabric workspace.
@@ -554,6 +592,12 @@ async def remove_action_group(
         optimistic concurrency control.  The Fabric REST API does not expose
         ETags or ``If-Match`` on the ``/settings/sqlAudit`` endpoint.  Under
         concurrent modification the last writer wins silently.
+
+        The pre-flight GET is eventually consistent and may lag a recent PATCH
+        by several minutes.  If another audit write was issued within that lag
+        window, this call re-asserts stale ``retentionDays`` and/or existing
+        action-group values from the GET and silently reverts the earlier
+        change.  Space audit writes at least a few minutes apart to avoid this.
 
     The authoritative post-PATCH state is returned immediately after the PATCH
     succeeds, constructed locally from the pre-PATCH settings and the computed

--- a/src/fabric_dw/services/audit.py
+++ b/src/fabric_dw/services/audit.py
@@ -422,6 +422,11 @@ async def set_action_groups(
                 preserve the current audit state.
 
     Note:
+        This function performs a read-modify-write (GET then PATCH) without
+        optimistic concurrency control.  The Fabric REST API does not expose
+        ETags or ``If-Match`` on the ``/settings/sqlAudit`` endpoint.  Under
+        concurrent modification the last writer wins silently.
+
         The pre-flight GET used to obtain ``retentionDays`` is eventually
         consistent and may lag a recent PATCH by several minutes.  If another
         audit write changed the retention period within that window, this call


### PR DESCRIPTION
## Summary

- Extended the existing TOCTOU / last-writer-wins `Note:` in all six audit-write functions (`enable`, `disable`, `set_retention`, `set_action_groups`, `add_action_group`, `remove_action_group`) to explicitly name the GET-lag dimension: the pre-flight GET is eventually consistent and may lag a recent PATCH by several minutes, so two audit writes within that window can cause the second to re-assert stale field values and silently revert the earlier change.
- Added a matching `CAUTION:` paragraph to each write tool's MCP tool description.
- Added a matching `NOTE:` paragraph to each write command's CLI help text.
- No functional behaviour change; no tests added or modified.

## Evaluate-only assessment (criteria 2 and 3 from issue #786)

**Criterion 2 - soft warning in tool result:** Surfacing a runtime warning in every write result would be noisy for callers who already know about the lag (e.g., they are the only writer). The documentation added here already makes the risk visible at the tool-description / help level. A warning in the result would require detecting "was there a recent PATCH?" which the stateless server cannot do. Recommendation: defer.

**Criterion 3 - `known_state` / explicit-full-settings passthrough:** This would let a caller pass the full desired settings directly, bypassing the pre-flight GET entirely. The design is clean in principle but adds API surface (new optional parameters on all six functions plus all six tools and CLI commands), and the stateless server has no way to validate that the supplied state is actually authoritative. The main benefit accrues only to callers who already issued the prior write themselves and retained the response. Recommendation: defer; the documentation note already tells callers to space writes apart, which is the low-effort mitigation.

Closes #786