### PR TITLE
fix(security): close read-only bypass via raw scan in assert_readonly_sql

### DIFF
--- a/src/fabric_dw/mcp/_guards.py
+++ b/src/fabric_dw/mcp/_guards.py
@@ -183,15 +183,6 @@ _BLOCK_COMMENT_RE = re.compile(r"/\*.*?\*/", re.DOTALL)
 # Line comment: -- to end of line.
 _LINE_COMMENT_RE = re.compile(r"--[^\n]*")
 
-# String literal: 'content' with '' as escape for single quote.
-_STRING_LITERAL_RE = re.compile(r"'(?:[^']|'')*'")
-
-# Bracket-quoted identifier: [name] with ]] as escape.
-_BRACKET_IDENT_RE = re.compile(r"\[(?:[^\]]|\]\])*\]")
-
-# Double-quoted identifier: "name" with "" as escape.
-_DQUOTE_IDENT_RE = re.compile(r'"(?:[^"]|"")*"')
-
 # Tokens that must never appear in a read-only statement (case-insensitive).
 _FORBIDDEN_TOKENS = frozenset(
     {
@@ -253,21 +244,21 @@ def _strip_block_comments(sql: str) -> str:
 
 
 def _sanitise(statement: str) -> str:
-    """Return a sanitised copy of *statement* suitable for token inspection.
+    """Return a comment-stripped copy of *statement* for token inspection.
 
     Steps (in order):
-    1. Iteratively strip block comments.
+    1. Iteratively strip block comments (space replacement, never empty string).
     2. Strip line comments (``--`` to EOL).
-    3. Replace string literals with ``''`` so semicolons/keywords inside
-       strings do not trigger false positives.
-    4. Replace bracket-quoted identifiers (``[delete]``) with ``[x]``.
-    5. Replace double-quoted identifiers with ``[x]``.
+
+    String literals and quoted identifiers are intentionally NOT masked.
+    All checks run on the raw comment-stripped text so that forbidden keywords
+    are physically present in the scanned text regardless of the context they
+    appear in.  This fails closed: a query that embeds a write keyword or a
+    semicolon inside a string literal or quoted identifier will be rejected.
+    Unset FABRIC_MCP_READONLY for such queries.
     """
     text = _strip_block_comments(statement)
-    text = _LINE_COMMENT_RE.sub(" ", text)
-    text = _STRING_LITERAL_RE.sub("''", text)
-    text = _BRACKET_IDENT_RE.sub("[x]", text)
-    return _DQUOTE_IDENT_RE.sub("[x]", text)
+    return _LINE_COMMENT_RE.sub(" ", text)
 
 
 def assert_readonly_sql(statement: str) -> None:
@@ -277,24 +268,30 @@ def assert_readonly_sql(statement: str) -> None:
 
     Design
     ------
-    The classifier is **conservative-by-design**: it rejects anything it cannot
-    prove is a plain read-only query, rather than trying to exhaustively parse
-    T-SQL.  Legitimate bracket-quoted identifiers that collide with forbidden
-    keywords (e.g. ``SELECT [delete] FROM t``) are preserved because bracketed
-    names are replaced with ``[x]`` before the token scan.
+    The classifier is **conservative-by-design** (fail-closed): it rejects
+    anything it cannot prove is a plain read-only query, rather than trying to
+    exhaustively parse T-SQL.  All checks run on the raw comment-stripped text,
+    so forbidden keywords are physically present in the scanned text regardless
+    of whether they appear inside a string literal, a bracket-quoted identifier,
+    or a double-quoted identifier.
+
+    This means read-only mode may also reject otherwise-harmless reads that
+    embed a write keyword or a ``;`` inside a string literal or quoted
+    identifier (e.g. ``SELECT * FROM cdc WHERE op='DELETE'``,
+    ``SELECT [delete] FROM t``).  This is by design.  Unset
+    ``FABRIC_MCP_READONLY`` to run such queries.
 
     Sanitisation pipeline
     ~~~~~~~~~~~~~~~~~~~~~
-    1. Iteratively strip block comments (non-greedy sub loop until stable).
-       Residual ``/*`` or ``*/`` → rejected ("unbalanced comment").
+    1. Iteratively strip block comments (non-greedy sub loop until stable,
+       replacing with a space so adjacent tokens cannot merge into a keyword).
+       Residual ``/*`` or ``*/`` after stabilisation → rejected.
     2. Strip ``--`` line comments.
-    3. Replace string literals ``'(?:[^']|'')*'`` → ``''`` (preserves
-       semicolons inside strings from triggering the multi-statement check).
-    4. Replace bracketed identifiers ``[…]`` → ``[x]``; double-quoted
-       identifiers ``"…"`` likewise.
 
-    Checks (all on the sanitised text)
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    String literals and quoted identifiers are NOT masked.
+
+    Checks (all on the comment-stripped raw text)
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     (a) First token must be ``SELECT`` or ``WITH``.
     (b) A ``;`` followed by any non-whitespace character is rejected as a
         multi-statement batch.
@@ -306,7 +303,7 @@ def assert_readonly_sql(statement: str) -> None:
         statement to be rejected — regardless of where it appears.  This
         catches ``WITH x AS (SELECT 1) DELETE …``, ``SELECT * INTO backup FROM
         t``, and newline-separated DoS/context-switch payloads such as
-        ``SELECT 1\nWAITFOR DELAY '99:0:0'`` or ``SELECT 1\nUSE master``.
+        ``SELECT 1\\nWAITFOR DELAY '99:0:0'`` or ``SELECT 1\\nUSE master``.
 
     Args:
         statement: The raw SQL string supplied by the caller.

--- a/tests/unit/mcp/test_security.py
+++ b/tests/unit/mcp/test_security.py
@@ -186,17 +186,35 @@ class TestAssertReadonlySql:
         with pytest.raises(ToolError):
             self._call("SELECT 1 */ DROP TABLE t")
 
-    def test_accepts_string_literal_with_semicolon(self) -> None:
-        """LOW: WHERE name = 'a;b' must NOT be rejected as multi-statement."""
-        self._call("SELECT id FROM t WHERE name = 'a;b'")
+    def test_rejects_semicolon_inside_string_literal_pre_fix(self) -> None:
+        """FLIPPED: WHERE name = 'a;b' is now REJECTED (fail-closed raw-scan policy).
+
+        Previously this was allowed because the string-literal masking hid the
+        semicolon.  After the fix, the raw text is scanned and the semicolon
+        trips the multi-statement guard.  Unset FABRIC_MCP_READONLY for such
+        queries.
+        """
+        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+        with pytest.raises(ToolError, match="multi-statement"):
+            self._call("SELECT id FROM t WHERE name = 'a;b'")
 
     def test_accepts_string_literal_with_escaped_quote(self) -> None:
-        """String literal with escaped single-quote must be accepted."""
+        """String literal with escaped single-quote and no forbidden keyword is accepted."""
         self._call("SELECT 'it''s' FROM t")
 
-    def test_accepts_bracketed_keyword_identifier(self) -> None:
-        """SELECT [delete] FROM t must be accepted (bracketed identifier, not keyword)."""
-        self._call("SELECT [delete] FROM t")
+    def test_rejects_bracketed_keyword_identifier(self) -> None:
+        """FLIPPED: SELECT [delete] FROM t is now REJECTED (fail-closed raw-scan policy).
+
+        Previously this was allowed because the bracket-identifier masking
+        replaced [delete] with [x] before the token scan.  After the fix, the
+        raw text is scanned and the token 'delete' is found inside the brackets.
+        Unset FABRIC_MCP_READONLY for such queries.
+        """
+        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+        with pytest.raises(ToolError):
+            self._call("SELECT [delete] FROM t")
 
     def test_accepts_with_cte_then_select(self) -> None:
         """WITH cte AS (SELECT 1) SELECT * FROM cte; is a valid read-only statement."""
@@ -286,6 +304,140 @@ class TestAssertReadonlySql:
 
         with pytest.raises(ToolError, match=r"multi-statement|non-SELECT"):
             self._call("SET NOCOUNT ON;\nSELECT 1")
+
+    # ------------------------------------------------------------------
+    # Fail-closed behavior: previously ALLOWED, now REJECTED
+    # ------------------------------------------------------------------
+
+    def test_rejects_forbidden_keyword_in_string_literal(self) -> None:
+        """SECURITY: a forbidden keyword inside a string literal must be rejected.
+
+        The raw-scan policy fails closed: read-only mode rejects queries that
+        embed a write keyword in a string literal.  Unset FABRIC_MCP_READONLY
+        to run such queries.
+        """
+        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+        with pytest.raises(ToolError):
+            self._call("SELECT * FROM cdc WHERE op='DELETE'")
+
+    def test_rejects_forbidden_keyword_as_bracket_identifier(self) -> None:
+        """SECURITY: a forbidden keyword used as a bracket-quoted identifier is rejected.
+
+        Raw-scan policy: the token scanner sees 'delete' from [delete] and blocks it.
+        """
+        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+        with pytest.raises(ToolError):
+            self._call("SELECT [delete] FROM t")
+
+    def test_rejects_forbidden_keyword_as_dquote_identifier(self) -> None:
+        """SECURITY: a forbidden keyword used as a double-quoted identifier is rejected."""
+        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+        with pytest.raises(ToolError):
+            self._call('SELECT "drop" FROM t')
+
+    def test_rejects_semicolon_inside_string_literal(self) -> None:
+        """SECURITY: a semicolon inside a string literal now trips the multi-statement guard.
+
+        Raw-scan policy: ';' in any context (including string literals) is rejected.
+        """
+        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+        with pytest.raises(ToolError, match="multi-statement"):
+            self._call("SELECT id FROM t WHERE name = 'a;b'")
+
+    # ------------------------------------------------------------------
+    # Bracket/double-quote identifier bypass regression tests (#788)
+    # ------------------------------------------------------------------
+
+    def test_rejects_bracket_quote_trick_delete(self) -> None:
+        """CRITICAL #788: bracket-identifier with embedded quote hides DELETE."""
+        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+        with pytest.raises(ToolError):
+            self._call("SELECT [a'];DELETE FROM t WHERE c='x'")
+
+    def test_rejects_bracket_quote_trick_drop(self) -> None:
+        """CRITICAL #788: bracket-identifier with embedded quote hides DROP."""
+        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+        with pytest.raises(ToolError):
+            self._call("SELECT [a'];DROP TABLE t WHERE c='x'")
+
+    def test_rejects_bracket_quote_trick_update(self) -> None:
+        """CRITICAL #788: bracket-identifier with embedded quote hides UPDATE."""
+        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+        with pytest.raises(ToolError):
+            self._call("SELECT [a'];UPDATE t SET x=1 WHERE c='x'")
+
+    def test_rejects_bracket_quote_trick_insert(self) -> None:
+        """CRITICAL #788: bracket-identifier with embedded quote hides INSERT."""
+        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+        with pytest.raises(ToolError):
+            self._call("SELECT [a'];INSERT INTO t VALUES (1) WHERE c='x'")
+
+    def test_rejects_bracket_quote_trick_merge(self) -> None:
+        """CRITICAL #788: bracket-identifier with embedded quote hides MERGE."""
+        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+        with pytest.raises(ToolError):
+            self._call("SELECT [a'];MERGE t USING s ON 1=0 WHERE c='x'")
+
+    def test_rejects_bracket_quote_trick_truncate(self) -> None:
+        """CRITICAL #788: bracket-identifier with embedded quote hides TRUNCATE."""
+        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+        with pytest.raises(ToolError):
+            self._call("SELECT [a'];TRUNCATE TABLE t WHERE c='x'")
+
+    def test_rejects_bracket_quote_trick_exec(self) -> None:
+        """CRITICAL #788: bracket-identifier with embedded quote hides EXEC."""
+        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+        with pytest.raises(ToolError):
+            self._call("SELECT [a'];EXEC sp_who WHERE c='x'")
+
+    def test_rejects_dquote_identifier_bypass(self) -> None:
+        """CRITICAL #788: double-quote identifier bypass hides DELETE."""
+        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+        with pytest.raises(ToolError):
+            self._call("SELECT \"a'\";DELETE FROM t WHERE c='x'")
+
+    def test_rejects_string_literal_hides_keyword(self) -> None:
+        """CRITICAL #788: string literal that previously hid a forbidden keyword."""
+        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+        with pytest.raises(ToolError):
+            self._call("SELECT * FROM t WHERE x='DROP TABLE t--'")
+
+    # ------------------------------------------------------------------
+    # Legitimate plain reads that must still PASS after fix
+    # ------------------------------------------------------------------
+
+    def test_accepts_plain_select_after_fix(self) -> None:
+        """Regression: basic SELECT must still be allowed."""
+        self._call("SELECT * FROM t")
+
+    def test_accepts_select_1_after_fix(self) -> None:
+        """Regression: bare SELECT 1 must still be allowed."""
+        self._call("select 1")
+
+    def test_accepts_with_cte_then_select_after_fix(self) -> None:
+        """Regression: CTE followed by SELECT must still be allowed."""
+        self._call("WITH cte AS (SELECT 1) SELECT * FROM cte")
+
+    def test_accepts_multiline_select_after_fix(self) -> None:
+        """Regression: multi-line SELECT must still be allowed."""
+        self._call("SELECT\n    id,\n    name\nFROM dbo.users\nWHERE active = 1")
+
+    def test_accepts_select_with_block_and_line_comments_after_fix(self) -> None:
+        """Regression: SELECT with both a block comment and a line comment must be allowed."""
+        self._call("/* admin */ SELECT id FROM t -- end")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This PR fixes a security vulnerability in `FABRIC_MCP_READONLY` mode where `execute_sql` could be bypassed via bracket-identifier quote confusion in `_sanitise()`.

- **Root cause:** `_sanitise()` masked string literals before bracket/double-quote identifiers, so a single quote inside a bracket identifier opened a phantom string literal that swallowed the `;` separator and the forbidden keyword. `SELECT [a'];DELETE FROM t WHERE c='x'` sanitised to `SELECT [a''x'` - the DELETE disappeared - so `assert_readonly_sql` returned ALLOW, but TDS ran the DELETE.
- **Fix:** Remove all string-literal, bracket-identifier, and double-quote-identifier masking from `_sanitise()`. All checks now run on the raw comment-stripped text so forbidden keywords are physically present regardless of context.
- **Intentional behavior change (fail-closed):** Read-only mode now rejects queries that embed a write keyword or a `;` inside a string literal or quoted identifier (e.g. `SELECT * FROM cdc WHERE op='DELETE'`, `SELECT [delete] FROM t`). This is by design. Unset `FABRIC_MCP_READONLY` for such queries.
- **Regression tests:** 12 new bypass-regression tests were written first (TDD), confirmed to fail before the fix, and pass after. Two previously-allowed tests are flipped to reflect the fail-closed policy.
- **Scope:** Only `_guards.py` (`_sanitise`, `assert_readonly_sql`, regex constants, docstrings) and the read-only guard unit tests.

Closes #788