### PR TITLE
refactor(load): remove client-side _validate_https_url

### DIFF
--- a/src/fabric_dw/services/load.py
+++ b/src/fabric_dw/services/load.py
@@ -119,19 +119,6 @@ _DFS_CREATE_RETRYABLE_STATUSES: frozenset[int] = frozenset({400, 408, 429, 500, 
 # SQL Endpoint rejection message.
 _SQL_ENDPOINT_READONLY_MSG = "SQL Endpoints are read-only; COPY INTO not supported"
 
-# ---------------------------------------------------------------------------
-# SSRF-prevention: blocked URL patterns for --url / rejected_row_location
-# ---------------------------------------------------------------------------
-
-#: Prefixes that are blocked to prevent SSRF to instance metadata / link-local endpoints.
-_BLOCKED_URL_PREFIXES: tuple[str, ...] = (
-    "http://169.254.",  # IMDS / link-local
-    "http://fd00:",  # IPv6 link-local (rare but possible)
-)
-
-#: Regex to detect link-local / IMDS hosts (IPv4 169.254.x.x and hostnames resolving to them).
-_METADATA_HOST_RE = re.compile(r"^(?:169\.254\.\d+\.\d+|metadata\.azure\.internal)$", re.IGNORECASE)
-
 #: Staging lakehouse name: same alphabet as SQL identifier but allow hyphens.
 _STAGING_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_\-]{0,127}$")
 
@@ -176,33 +163,6 @@ class CopyIntoCsvOptions:
 def _assert_not_sql_endpoint(kind: WarehouseKind) -> None:
     if kind == WarehouseKind.SQL_ENDPOINT:
         raise ItemKindError(_SQL_ENDPOINT_READONLY_MSG)
-
-
-def _validate_https_url(url: str, param_name: str = "url") -> None:
-    """Reject non-HTTPS URLs and known SSRF-prone endpoints.
-
-    Args:
-        url: The URL to validate.
-        param_name: The parameter name for use in error messages.
-
-    Raises:
-        ValueError: If the URL scheme is not ``https`` or the host is a
-            link-local / IMDS address that could enable SSRF.
-    """
-    parsed = urllib.parse.urlparse(url)
-    if parsed.scheme.lower() != "https":
-        msg = (
-            f"Invalid {param_name} scheme {parsed.scheme!r}: only HTTPS URLs are accepted. "
-            "Use https:// for all source and rejected-row URLs."
-        )
-        raise ValueError(msg)
-    host = parsed.hostname or ""
-    if _METADATA_HOST_RE.match(host):
-        msg = (
-            f"Invalid {param_name} host {host!r}: link-local and instance-metadata "
-            "endpoints are not permitted."
-        )
-        raise ValueError(msg)
 
 
 def _validate_staging_name(name: str) -> str:
@@ -747,9 +707,6 @@ async def copy_into_from_url(
     _assert_not_sql_endpoint(kind)
     validate_identifier(schema)
     validate_identifier(table)
-    _validate_https_url(url, "url")
-    if rejected_row_location is not None:
-        _validate_https_url(rejected_row_location, "rejected_row_location")
 
     # MAXERRORS is only valid for CSV; Fabric rejects it for PARQUET with
     # "Option 'MAXERRORS' is not supported for specified format 'PARQUET'".
@@ -848,7 +805,7 @@ async def copy_into_from_url(
 # ---------------------------------------------------------------------------
 
 
-async def load_local_file(  # noqa: PLR0912, PLR0915
+async def load_local_file(  # noqa: PLR0915
     http: FabricHttpClient,
     credential: AsyncTokenCredential,
     workspace_id: uuid.UUID,
@@ -913,10 +870,6 @@ async def load_local_file(  # noqa: PLR0912, PLR0915
     # A3: validate staging_lakehouse_name if explicitly provided.
     if staging_lakehouse_name is not None:
         _validate_staging_name(staging_lakehouse_name)
-
-    # A5: validate rejected_row_location URL scheme (no SSRF via rejected-row output).
-    if rejected_row_location is not None:
-        _validate_https_url(rejected_row_location, "rejected_row_location")
 
     if not local_path.exists():
         msg = f"Local file not found: {local_path}"

--- a/tests/unit/services/test_load.py
+++ b/tests/unit/services/test_load.py
@@ -25,7 +25,6 @@ from fabric_dw.services.load import (
     _log_dfs_error,
     _safe_dest_filename,
     _sq,
-    _validate_https_url,
     _validate_staging_name,
     copy_into_from_url,
     infer_file_format,
@@ -1168,77 +1167,6 @@ class TestStagingNameValidation:
 
 
 # ---------------------------------------------------------------------------
-# A5: URL scheme validation (SSRF prevention)
-# ---------------------------------------------------------------------------
-
-
-class TestUrlSchemeValidation:
-    def test_https_url_accepted(self) -> None:
-        _validate_https_url("https://sa.blob.core.windows.net/c/f.parquet", "url")  # no error
-
-    def test_http_url_rejected(self) -> None:
-        with pytest.raises(ValueError, match="only HTTPS"):
-            _validate_https_url("http://sa.blob.core.windows.net/c/f.parquet", "url")
-
-    def test_imds_link_local_rejected(self) -> None:
-        with pytest.raises(ValueError, match="link-local"):
-            _validate_https_url("https://169.254.169.254/metadata/instance", "url")
-
-    def test_metadata_azure_host_rejected(self) -> None:
-        with pytest.raises(ValueError, match="link-local"):
-            _validate_https_url("https://metadata.azure.internal/", "url")
-
-    def test_ftp_scheme_rejected(self) -> None:
-        with pytest.raises(ValueError, match="only HTTPS"):
-            _validate_https_url("ftp://example.com/file.parquet", "url")
-
-    async def test_http_url_rejected_in_copy_into_from_url(self) -> None:
-        """A5: copy_into_from_url must reject non-HTTPS source URLs."""
-        from fabric_dw.sql import SqlTarget  # noqa: PLC0415
-
-        target = SqlTarget(
-            workspace_id="ws-id", database="db", connection_string="server=x;database=y"
-        )
-        with pytest.raises(ValueError, match="only HTTPS"):
-            await copy_into_from_url(
-                target,
-                "dbo",
-                "t",
-                "http://sa.blob.core.windows.net/c/f.parquet",
-                file_type="PARQUET",
-            )
-
-    async def test_http_rejected_row_location_rejected_in_load_local_file(
-        self, tmp_path: Path
-    ) -> None:
-        """A5: load_local_file must reject non-HTTPS rejected_row_location."""
-        csv_file = tmp_path / "data.csv"
-        csv_file.write_text("id\n1\n", encoding="utf-8")
-
-        from fabric_dw.sql import SqlTarget  # noqa: PLC0415
-
-        target = SqlTarget(
-            workspace_id="ws-id", database="db", connection_string="server=x;database=y"
-        )
-        ws_id = uuid.UUID("a1b2c3d4-e5f6-7890-abcd-ef1234567890")
-        mock_http = AsyncMock()
-        mock_credential = AsyncMock()
-
-        with pytest.raises(ValueError, match="only HTTPS"):
-            await load_local_file(
-                mock_http,
-                mock_credential,
-                ws_id,
-                target,
-                "dbo",
-                "t",
-                csv_file,
-                file_format="csv",
-                rejected_row_location="http://example.com/rejected/",
-            )
-
-
-# ---------------------------------------------------------------------------
 # OneLake DFS upload: create → append → flush sequence
 # ---------------------------------------------------------------------------
 
@@ -2332,33 +2260,11 @@ class TestDeleteLakehouse:
 
 
 # ---------------------------------------------------------------------------
-# copy_into_from_url — rejected_row_location HTTPS validation
+# copy_into_from_url — error propagation
 # ---------------------------------------------------------------------------
 
 
 class TestCopyIntoFromUrlRejectedRowValidation:
-    async def test_http_rejected_row_location_raises(self) -> None:
-        """rejected_row_location with http:// must raise ValueError before executing SQL."""
-        from fabric_dw.sql import SqlTarget  # noqa: PLC0415
-
-        target = SqlTarget(
-            workspace_id="ws-id", database="db", connection_string="server=x;database=y"
-        )
-        with (
-            patch("fabric_dw.services.load.run_query") as mock_rq,
-            pytest.raises(ValueError, match="only HTTPS"),
-        ):
-            await copy_into_from_url(
-                target,
-                "dbo",
-                "t",
-                "https://example.com/f.parquet",
-                file_type="PARQUET",
-                rejected_row_location="http://example.com/rejected/",
-            )
-        # Validation fires before SQL execution — run_query must not be called.
-        mock_rq.assert_not_called()
-
     async def test_fabric_error_reraised_as_is(self) -> None:
         """Non-FabricServerError FabricError from run_query must be re-raised as-is."""
         from fabric_dw.sql import SqlTarget  # noqa: PLC0415


### PR DESCRIPTION
## Summary

- Removes `_validate_https_url`, `_METADATA_HOST_RE`, and `_BLOCKED_URL_PREFIXES` from `src/fabric_dw/services/load.py`.
- Removes all three call sites and their associated SSRF comments from `copy_into_from_url` and `load_local_file`.
- Removes the corresponding unit tests (`TestUrlSchemeValidation` and `test_http_rejected_row_location_raises`).

## Rationale

The `url` and `rejected_row_location` parameters are embedded as SQL string literals into `COPY INTO ... FROM '<url>'` and fetched server-side by the Fabric engine; the CLI never fetches these URLs. The https-only / IMDS guard therefore provides negligible real protection (Fabric already validates its own COPY INTO sources), and is over-engineering for a CLI. SQL-injection safety is unchanged: the URL is still single-quote-escaped via `_sq(url)`, identifiers remain bracket-quoted via `quote_identifier` / `validate_identifier`, and `_validate_staging_name` is untouched.

## Test plan

- `uv run ruff check src tests` - passed
- `uv run ruff format --check .` - passed
- `uv run ty check src tests` - passed
- `uv run pytest tests/unit` - 4978 passed, 0 failed

Closes #791