### PR TITLE
refactor(logging): remove unused _SENTINEL dead code

### DIFF
--- a/src/fabric_dw/logging.py
+++ b/src/fabric_dw/logging.py
@@ -17,8 +17,6 @@ __all__ = [
     "setup_logging",
 ]
 
-_SENTINEL = object()
-
 # Build the set of "standard" LogRecord attribute names by inspecting a fresh
 # instance, then add the keys that are added during formatting.
 _STANDARD_LOGRECORD_ATTRS: frozenset[str] = frozenset(


### PR DESCRIPTION
## Summary
Removes the unused `_SENTINEL = object()` definition from `src/fabric_dw/logging.py:20`. The variable was never referenced anywhere in src or tests.

## Testing
- All CI gates pass: ruff check, ruff format, py type check, pytest (4986 tests)

Closes #792