### PR TITLE
fix(security): fully-raw scan closes string-aware comment bypass

### DIFF
--- a/src/fabric_dw/mcp/_guards.py
+++ b/src/fabric_dw/mcp/_guards.py
@@ -177,12 +177,6 @@ def workspace_allowlist_active(config_allowlist: Sequence[str] | None = None) ->
 # SQL classifier
 # ---------------------------------------------------------------------------
 
-# Single block-comment pass (non-greedy, no nesting).
-_BLOCK_COMMENT_RE = re.compile(r"/\*.*?\*/", re.DOTALL)
-
-# Line comment: -- to end of line.
-_LINE_COMMENT_RE = re.compile(r"--[^\n]*")
-
 # Tokens that must never appear in a read-only statement (case-insensitive).
 _FORBIDDEN_TOKENS = frozenset(
     {
@@ -228,82 +222,48 @@ _ALLOWED_FIRST_TOKENS = frozenset({"SELECT", "WITH"})
 _TOKEN_RE = re.compile(r"\w+")
 
 
-def _strip_block_comments(sql: str) -> str:
-    """Iteratively remove C-style block comments until the text is stable.
-
-    Nested or malformed comments such as ``/* /* */ payload */`` are handled
-    by repeating the substitution until no further change occurs.  Any residual
-    ``/*`` or ``*/`` after stabilisation indicates unbalanced delimiters and
-    causes the caller to reject the statement.
-    """
-    prev = None
-    while prev != sql:
-        prev = sql
-        sql = _BLOCK_COMMENT_RE.sub(" ", sql)
-    return sql
-
-
-def _sanitise(statement: str) -> str:
-    """Return a comment-stripped copy of *statement* for token inspection.
-
-    Steps (in order):
-    1. Iteratively strip block comments (space replacement, never empty string).
-    2. Strip line comments (``--`` to EOL).
-
-    String literals and quoted identifiers are intentionally NOT masked.
-    All checks run on the raw comment-stripped text so that forbidden keywords
-    are physically present in the scanned text regardless of the context they
-    appear in.  This fails closed: a query that embeds a write keyword or a
-    semicolon inside a string literal or quoted identifier will be rejected.
-    Unset FABRIC_MCP_READONLY for such queries.
-    """
-    text = _strip_block_comments(statement)
-    return _LINE_COMMENT_RE.sub(" ", text)
-
-
 def assert_readonly_sql(statement: str) -> None:
     """Raise :class:`ToolError` when *statement* is not allowed in read-only mode.
 
     Called only when ``FABRIC_MCP_READONLY`` is truthy.
 
-    Design
-    ------
-    The classifier is **conservative-by-design** (fail-closed): it rejects
-    anything it cannot prove is a plain read-only query, rather than trying to
-    exhaustively parse T-SQL.  All checks run on the raw comment-stripped text,
-    so forbidden keywords are physically present in the scanned text regardless
-    of whether they appear inside a string literal, a bracket-quoted identifier,
-    or a double-quoted identifier.
+    Design: fully-raw, fail-closed scan
+    ------------------------------------
+    All checks run on the COMPLETELY RAW ``statement`` text (after stripping
+    leading and trailing whitespace only).  No comment stripping, no string-
+    literal masking, no SQL parsing.  Because comment delimiters and string
+    quotes are never touched, a forbidden keyword or a semicolon-separated
+    rider is always physically present in the scanned text and is always
+    caught -- regardless of how it is wrapped in comments or string literals.
 
-    This means read-only mode may also reject otherwise-harmless reads that
-    embed a write keyword or a ``;`` inside a string literal or quoted
-    identifier (e.g. ``SELECT * FROM cdc WHERE op='DELETE'``,
-    ``SELECT [delete] FROM t``).  This is by design.  Unset
-    ``FABRIC_MCP_READONLY`` to run such queries.
+    This is fail-closed by design and deliberately accepts certain false
+    positives.  The following otherwise-harmless queries are REJECTED and
+    require unsetting ``FABRIC_MCP_READONLY`` to run:
 
-    Sanitisation pipeline
-    ~~~~~~~~~~~~~~~~~~~~~
-    1. Iteratively strip block comments (non-greedy sub loop until stable,
-       replacing with a space so adjacent tokens cannot merge into a keyword).
-       Residual ``/*`` or ``*/`` after stabilisation → rejected.
-    2. Strip ``--`` line comments.
+    - A leading comment before SELECT (``-- comment\\nSELECT ...`` or
+      ``/* comment */ SELECT ...``): the first raw word token is a word
+      from the comment body, not SELECT or WITH, so the non-SELECT gate fires.
+    - A forbidden keyword inside a block comment or a string literal
+      (``SELECT * FROM cdc WHERE op='DELETE'``, ``SELECT [delete] FROM t``):
+      the token scanner sees the keyword regardless of context.
+    - A semicolon inside a string literal
+      (``SELECT id FROM t WHERE name = 'a;b'``): the multi-statement check
+      triggers on the bare semicolon character.
 
-    String literals and quoted identifiers are NOT masked.
+    These false positives are accepted by design.  Unset ``FABRIC_MCP_READONLY``
+    for such queries.
 
-    Checks (all on the comment-stripped raw text)
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    (a) First token must be ``SELECT`` or ``WITH``.
-    (b) A ``;`` followed by any non-whitespace character is rejected as a
+    Checks (all on the raw text, in order)
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    (a) A ``;`` followed by any non-whitespace character is rejected as a
         multi-statement batch.
-    (c) Any word token (case-insensitive) that matches a forbidden keyword
+    (b) First ``\\w+`` token must be ``SELECT`` or ``WITH``.
+    (c) Any ``\\w+`` token (case-insensitive) that matches a forbidden keyword
         (INSERT, UPDATE, DELETE, MERGE, INTO, EXEC, EXECUTE, DROP, ALTER,
         CREATE, TRUNCATE, GRANT, REVOKE, DENY, KILL, BACKUP, RESTORE,
         OPENROWSET, OPENQUERY, WRITETEXT, UPDATETEXT, SP_EXECUTESQL,
         XP_CMDSHELL, WAITFOR, USE, SHUTDOWN, RECONFIGURE, DBCC) causes the
-        statement to be rejected — regardless of where it appears.  This
-        catches ``WITH x AS (SELECT 1) DELETE …``, ``SELECT * INTO backup FROM
-        t``, and newline-separated DoS/context-switch payloads such as
-        ``SELECT 1\\nWAITFOR DELAY '99:0:0'`` or ``SELECT 1\\nUSE master``.
+        statement to be rejected regardless of where it appears.
 
     Args:
         statement: The raw SQL string supplied by the caller.
@@ -311,30 +271,23 @@ def assert_readonly_sql(statement: str) -> None:
     Raises:
         ToolError: When the statement does not pass all read-only checks.
     """
-    sanitised = _sanitise(statement)
+    statement = statement.strip()
 
-    # Reject unbalanced block-comment delimiters left after stripping.
-    if "/*" in sanitised or "*/" in sanitised:
-        raise ToolError(
-            "read-only mode (FABRIC_MCP_READONLY) blocks statements with unbalanced block comments"
-        )
-
-    sanitised = sanitised.strip()
-
-    # Reject multi-statement batches: a ';' followed by non-whitespace.
-    if re.search(r";\s*\S", sanitised):
+    # (a) Reject multi-statement batches: a ';' followed by non-whitespace.
+    if re.search(r";\s*\S", statement):
         raise ToolError("read-only mode (FABRIC_MCP_READONLY) blocks multi-statement batches")
 
-    tokens = _TOKEN_RE.findall(sanitised)
+    tokens = _TOKEN_RE.findall(statement)
     first_token = tokens[0].upper() if tokens else ""
 
+    # (b) First token must be SELECT or WITH.
     if first_token not in _ALLOWED_FIRST_TOKENS:
         raise ToolError(
             f"read-only mode (FABRIC_MCP_READONLY) blocks non-SELECT statements "
             f"(got {first_token!r})"
         )
 
-    # Scan every token for forbidden keywords.
+    # (c) Scan every token for forbidden keywords.
     for tok in tokens:
         if tok.upper() in _FORBIDDEN_TOKENS:
             raise ToolError(

--- a/tests/unit/mcp/test_security.py
+++ b/tests/unit/mcp/test_security.py
@@ -59,11 +59,28 @@ class TestAssertReadonlySql:
     def test_accepts_with_cte(self) -> None:
         self._call("WITH cte AS (SELECT 1) SELECT * FROM cte")
 
-    def test_accepts_select_after_line_comment(self) -> None:
-        self._call("-- get rows\nSELECT id FROM dbo.t")
+    def test_rejects_select_after_line_comment(self) -> None:
+        """FLIPPED (Option A): a leading '--' comment makes the first token 'get', not SELECT.
 
-    def test_accepts_select_after_block_comment(self) -> None:
-        self._call("/* admin query */ SELECT id FROM dbo.t")
+        The fully-raw scan has no comment-stripping step, so a statement that
+        begins with a line comment is rejected because its first word token is
+        not SELECT or WITH.  Unset FABRIC_MCP_READONLY for such queries.
+        """
+        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+        with pytest.raises(ToolError, match="non-SELECT"):
+            self._call("-- get rows\nSELECT id FROM dbo.t")
+
+    def test_rejects_select_after_block_comment(self) -> None:
+        """FLIPPED (Option A): a leading block comment makes the first token 'admin', not SELECT.
+
+        No comment stripping means the raw first word is from the comment body.
+        Unset FABRIC_MCP_READONLY for such queries.
+        """
+        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+        with pytest.raises(ToolError, match="non-SELECT"):
+            self._call("/* admin query */ SELECT id FROM dbo.t")
 
     def test_accepts_select_with_trailing_semicolon(self) -> None:
         """A single trailing ';' is OK (optional terminator)."""
@@ -416,6 +433,48 @@ class TestAssertReadonlySql:
             self._call("SELECT * FROM t WHERE x='DROP TABLE t--'")
 
     # ------------------------------------------------------------------
+    # #797 bypass regression tests -- string-aware comment delimiter bypass
+    # ------------------------------------------------------------------
+
+    def test_rejects_string_line_comment_hides_delete(self) -> None:
+        """CRITICAL #797: string literal containing '--' hides a ';DELETE' rider.
+
+        The old _sanitise stripped '--';DELETE FROM t as a line comment starting
+        at the '--' inside the string, removing the semicolon-separated DML.
+        The fully-raw scan catches the semicolon immediately.
+        """
+        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+        with pytest.raises(ToolError, match="multi-statement"):
+            self._call("SELECT '--';DELETE FROM t")
+
+    def test_rejects_string_block_comment_hides_drop(self) -> None:
+        """CRITICAL #797: string literals forming fake block-comment delimiters hide DROP.
+
+        SELECT '/*' AS a;DROP TABLE t;SELECT '*/' AS b -- the old iterative
+        block-comment stripper consumed '/*' ... '*/' spanning the DML payload.
+        The fully-raw scan catches the first semicolon.
+        """
+        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+        with pytest.raises(ToolError, match="multi-statement"):
+            self._call("SELECT '/*' AS a;DROP TABLE t;SELECT '*/' AS b")
+
+    def test_rejects_string_block_comment_hides_update(self) -> None:
+        """CRITICAL #797: fake block-comment delimiters in strings hide UPDATE."""
+        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+        with pytest.raises(ToolError, match="multi-statement"):
+            self._call("SELECT '/*' AS a;UPDATE t SET x=1;SELECT '*/' AS b")
+
+    def test_rejects_string_block_comment_hides_insert(self) -> None:
+        """CRITICAL #797: fake block-comment delimiters in strings hide INSERT."""
+        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+        with pytest.raises(ToolError, match="multi-statement"):
+            self._call("SELECT '/*' x;INSERT INTO t VALUES(1);SELECT '*/' y")
+
+    # ------------------------------------------------------------------
     # Legitimate plain reads that must still PASS after fix
     # ------------------------------------------------------------------
 
@@ -435,9 +494,18 @@ class TestAssertReadonlySql:
         """Regression: multi-line SELECT must still be allowed."""
         self._call("SELECT\n    id,\n    name\nFROM dbo.users\nWHERE active = 1")
 
-    def test_accepts_select_with_block_and_line_comments_after_fix(self) -> None:
-        """Regression: SELECT with both a block comment and a line comment must be allowed."""
-        self._call("/* admin */ SELECT id FROM t -- end")
+    def test_rejects_select_with_leading_block_comment_after_fix(self) -> None:
+        """FLIPPED (Option A): a leading block comment causes rejection.
+
+        '/* admin */ SELECT id FROM t -- end' has 'admin' as its first raw
+        token, which is not SELECT or WITH.  Rejected by the non-SELECT gate.
+        Trailing '-- end' contains no forbidden keyword so that part would pass,
+        but the leading comment fails first.  Unset FABRIC_MCP_READONLY to run.
+        """
+        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+        with pytest.raises(ToolError, match="non-SELECT"):
+            self._call("/* admin */ SELECT id FROM t -- end")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This PR supersedes the incomplete fix from #789. That fix removed string-literal
and identifier masking and switched to scanning the comment-stripped text, but the
comment-stripping itself was not string-literal-aware. The iterative block-comment
regex could be made to consume `'/*'` ... `'*/'` spans across a DML payload, and
the line-comment regex erased everything after a `--` inside a quoted string
(including a semicolon-separated rider). The result: four confirmed bypasses that
returned ALLOW and executed the write.

This PR implements **Option A: fully-raw, fail-closed scan**. The comment-stripping
machinery (`_sanitise`, `_strip_block_comments`, `_BLOCK_COMMENT_RE`,
`_LINE_COMMENT_RE`) is removed entirely. All three checks run on the completely
raw statement text (leading/trailing whitespace stripped only). Because no
delimiters are touched, a forbidden keyword or semicolon-separated rider is always
physically present and always caught.

**Accepted false positives (by design, documented in the docstring):**
- A leading `--` or `/* */` comment before SELECT: rejected because the first
  raw word token is a comment word, not SELECT or WITH.
- A forbidden keyword inside any comment or string literal: rejected.
- A semicolon inside a string literal: trips the multi-statement check.

Unset `FABRIC_MCP_READONLY` for such queries.

## Verified bypasses: fail-before / pass-after

| Payload | Before | After |
|---|---|---|
| `SELECT '--';DELETE FROM t` | ALLOW | BLOCK (multi-statement) |
| `SELECT '/*' AS a;DROP TABLE t;SELECT '*/' AS b` | ALLOW | BLOCK (multi-statement) |
| `SELECT '/*' AS a;UPDATE t SET x=1;SELECT '*/' AS b` | ALLOW | BLOCK (multi-statement) |
| `SELECT '/*' x;INSERT INTO t VALUES(1);SELECT '*/' y` | ALLOW | BLOCK (multi-statement) |

## Test plan

- [x] 4 new regression tests for the #797 bypass payloads (fail-before / pass-after confirmed)
- [x] 3 existing tests for leading-comment-before-SELECT flipped from ALLOW to REJECT
- [x] All 60 `TestAssertReadonlySql` tests pass
- [x] Full unit suite (5008 tests) green
- [x] `ruff check`, `ruff format --check`, `ty check` all clean

Closes #797

🤖 Generated with [Claude Code](https://claude.com/claude-code)