### PR TITLE
fix(security): catch raw driver exceptions at MCP tool boundary

### DIFF
--- a/src/fabric_dw/mcp/tools/queries.py
+++ b/src/fabric_dw/mcp/tools/queries.py
@@ -6,13 +6,13 @@ import logging
 from typing import Annotated, Any
 
 from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from fabric_dw.exceptions import FabricError
 from fabric_dw.mcp._context import get_context
 from fabric_dw.mcp._guards import assert_workspace_allowed, assert_writes_allowed
 from fabric_dw.mcp._helpers import (
-    fabric_err,
     make_sql_target,
     parse_iso8601,
     resolve_item,
@@ -47,8 +47,17 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             _log.debug("list_running_queries ws=%s item=%s", ws_id, entry.id)
             target = make_sql_target(ws_id, entry, item)
             result = await queries.list_running(target, mode=ctx.auth_mode)
-        except FabricError as exc:
-            raise fabric_err(exc) from exc
+        except (ValueError, FabricError) as exc:
+            raise tool_err(exc) from exc
+        except Exception as exc:
+            if isinstance(exc, ToolError):
+                raise
+            _log.debug(
+                "list_running_queries: unhandled driver exception (suppressed)", exc_info=True
+            )
+            raise ToolError(
+                "Listing running queries failed due to a driver or network error."
+            ) from exc
         return [q.model_dump(by_alias=True, mode="json") for q in result]
 
     @mcp.tool(name="list_connections")
@@ -69,8 +78,13 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             _log.debug("list_connections ws=%s item=%s", ws_id, entry.id)
             target = make_sql_target(ws_id, entry, item)
             result = await queries.list_connections(target, mode=ctx.auth_mode)
-        except FabricError as exc:
-            raise fabric_err(exc) from exc
+        except (ValueError, FabricError) as exc:
+            raise tool_err(exc) from exc
+        except Exception as exc:
+            if isinstance(exc, ToolError):
+                raise
+            _log.debug("list_connections: unhandled driver exception (suppressed)", exc_info=True)
+            raise ToolError("Listing connections failed due to a driver or network error.") from exc
         return [c.model_dump(by_alias=True, mode="json") for c in result]
 
     @mcp.tool(name="kill_session")
@@ -132,8 +146,17 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             result = await _qi_svc.list_request_history(
                 target, limit=limit, since=since_dt, until=until_dt, mode=ctx.auth_mode
             )
-        except FabricError as exc:
-            raise fabric_err(exc) from exc
+        except (ValueError, FabricError) as exc:
+            raise tool_err(exc) from exc
+        except Exception as exc:
+            if isinstance(exc, ToolError):
+                raise
+            _log.debug(
+                "list_request_history: unhandled driver exception (suppressed)", exc_info=True
+            )
+            raise ToolError(
+                "Request history query failed due to a driver or network error."
+            ) from exc
         return [q.model_dump(by_alias=True, mode="json") for q in result]
 
     @mcp.tool(name="list_session_history")
@@ -167,8 +190,17 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             result = await _qi_svc.list_session_history(
                 target, limit=limit, since=since_dt, until=until_dt, mode=ctx.auth_mode
             )
-        except FabricError as exc:
-            raise fabric_err(exc) from exc
+        except (ValueError, FabricError) as exc:
+            raise tool_err(exc) from exc
+        except Exception as exc:
+            if isinstance(exc, ToolError):
+                raise
+            _log.debug(
+                "list_session_history: unhandled driver exception (suppressed)", exc_info=True
+            )
+            raise ToolError(
+                "Session history query failed due to a driver or network error."
+            ) from exc
         return [q.model_dump(by_alias=True, mode="json") for q in result]
 
     @mcp.tool(name="list_frequent_queries")
@@ -202,8 +234,17 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             result = await _qi_svc.list_frequent_queries(
                 target, limit=limit, since=since_dt, until=until_dt, mode=ctx.auth_mode
             )
-        except FabricError as exc:
-            raise fabric_err(exc) from exc
+        except (ValueError, FabricError) as exc:
+            raise tool_err(exc) from exc
+        except Exception as exc:
+            if isinstance(exc, ToolError):
+                raise
+            _log.debug(
+                "list_frequent_queries: unhandled driver exception (suppressed)", exc_info=True
+            )
+            raise ToolError(
+                "Frequent queries lookup failed due to a driver or network error."
+            ) from exc
         return [q.model_dump(by_alias=True, mode="json") for q in result]
 
     @mcp.tool(name="list_long_running_queries")
@@ -237,6 +278,15 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             result = await _qi_svc.list_long_running_queries(
                 target, limit=limit, since=since_dt, until=until_dt, mode=ctx.auth_mode
             )
-        except FabricError as exc:
-            raise fabric_err(exc) from exc
+        except (ValueError, FabricError) as exc:
+            raise tool_err(exc) from exc
+        except Exception as exc:
+            if isinstance(exc, ToolError):
+                raise
+            _log.debug(
+                "list_long_running_queries: unhandled driver exception (suppressed)", exc_info=True
+            )
+            raise ToolError(
+                "Long-running queries lookup failed due to a driver or network error."
+            ) from exc
         return [q.model_dump(by_alias=True, mode="json") for q in result]

--- a/src/fabric_dw/mcp/tools/queries.py
+++ b/src/fabric_dw/mcp/tools/queries.py
@@ -113,6 +113,11 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             await queries.kill(target, session_id, mode=ctx.auth_mode)
         except (ValueError, FabricError) as exc:
             raise tool_err(exc) from exc
+        except Exception as exc:
+            if isinstance(exc, ToolError):
+                raise
+            _log.debug("kill_session: unhandled driver exception (suppressed)", exc_info=True)
+            raise ToolError("Session kill failed due to a driver or network error.") from exc
         return {"killed": True, "session_id": session_id}
 
     @mcp.tool(name="list_request_history")

--- a/src/fabric_dw/mcp/tools/snapshots.py
+++ b/src/fabric_dw/mcp/tools/snapshots.py
@@ -6,6 +6,7 @@ import logging
 from typing import Any
 
 from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp.exceptions import ToolError
 
 from fabric_dw.exceptions import FabricError
 from fabric_dw.mcp._context import get_context
@@ -161,8 +162,19 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             applied_dt = await snapshots.roll_timestamp(
                 target, snapshot_name, parsed_dt, mode=ctx.auth_mode
             )
-        except FabricError as exc:
-            raise fabric_err(exc) from exc
+        except (ValueError, FabricError) as exc:
+            raise tool_err(exc) from exc
+        except Exception as exc:
+            if isinstance(exc, ToolError):
+                raise
+            # roll_timestamp uses run_statements which documents bare re-raise for
+            # unclassified driver errors — catch here at the MCP trust boundary.
+            _log.debug(
+                "roll_snapshot_timestamp: unhandled driver exception (suppressed)", exc_info=True
+            )
+            raise ToolError(
+                "Snapshot timestamp roll failed due to a driver or network error."
+            ) from exc
         return {
             "rolled": True,
             "snapshot_name": snapshot_name,

--- a/src/fabric_dw/mcp/tools/sql_exec.py
+++ b/src/fabric_dw/mcp/tools/sql_exec.py
@@ -7,6 +7,7 @@ import logging
 from typing import Annotated, Any, Literal, assert_never
 
 from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from fabric_dw.cli._plan_mermaid import render_plan_mermaid
@@ -15,7 +16,7 @@ from fabric_dw.cli._plan_render import operator_to_dict
 from fabric_dw.exceptions import FabricError
 from fabric_dw.mcp._context import get_context
 from fabric_dw.mcp._guards import assert_readonly_sql, assert_workspace_allowed, env_flag
-from fabric_dw.mcp._helpers import fabric_err, make_sql_target, resolve_item
+from fabric_dw.mcp._helpers import make_sql_target, resolve_item, tool_err
 from fabric_dw.services import sql_exec as _sql_exec_svc
 
 __all__ = ["register"]
@@ -81,8 +82,19 @@ def register(mcp: FastMCP) -> None:
             result = await _sql_exec_svc.execute(
                 target, query, mode=ctx.auth_mode, row_limit=max_rows
             )
-        except FabricError as exc:
-            raise fabric_err(exc) from exc
+        except (ValueError, FabricError) as exc:
+            raise tool_err(exc) from exc
+        except Exception as exc:
+            # Re-raise ToolError instances unchanged — they are already structured
+            # (e.g. from make_sql_target when the item has no connection string).
+            if isinstance(exc, ToolError):
+                raise
+            # The service execute() re-raises unmapped driver errors unchanged
+            # (documented bare `raise`). These can contain internal connection
+            # detail, ODBC state, or query text — they must not reach the MCP
+            # client. Convert to a generic safe message here at the trust boundary.
+            _log.debug("execute_sql: unhandled driver exception (suppressed)", exc_info=True)
+            raise ToolError("SQL execution failed due to a driver or network error.") from exc
         # The service fetches max_rows+1 rows so we can detect truncation without
         # pulling the entire result set over the wire.  Slice back to max_rows here.
         truncated = len(result.rows) > max_rows
@@ -158,8 +170,18 @@ def register(mcp: FastMCP) -> None:
             _log.debug("get_query_plan ws=%s item=%s format=%s", ws_id, entry.id, format)
             target = make_sql_target(ws_id, entry, item)
             plan_xml = await _sql_exec_svc.get_plan(target, query, mode=ctx.auth_mode)
-        except FabricError as exc:
-            raise fabric_err(exc) from exc
+        except (ValueError, FabricError) as exc:
+            raise tool_err(exc) from exc
+        except Exception as exc:
+            if isinstance(exc, ToolError):
+                raise
+            # The service get_plan() re-raises unmapped driver errors unchanged
+            # (documented bare `raise`). These can contain internal connection
+            # detail or ODBC state — they must not reach the MCP client.
+            _log.debug("get_query_plan: unhandled driver exception (suppressed)", exc_info=True)
+            raise ToolError(
+                "Query plan retrieval failed due to a driver or network error."
+            ) from exc
 
         if format == "xml":
             return {"format": "xml", "plan_xml": plan_xml}

--- a/tests/unit/mcp/tools/test_queries.py
+++ b/tests/unit/mcp/tools/test_queries.py
@@ -1021,3 +1021,75 @@ async def test_list_long_running_queries_workspace_not_allowed(ctx_patch) -> Non
             "list_long_running_queries",
             {"workspace": _WS_NAME, "item": _WH_NAME},
         )
+
+
+# ---------------------------------------------------------------------------
+# Security: raw driver exceptions must not escape the MCP boundary
+# ---------------------------------------------------------------------------
+# Tools in queries.py call SQL-based services via run_query, which documents
+# "Exception: Any other driver error is propagated unchanged" for unclassified
+# driver exceptions. The tool boundary must catch and sanitise these before
+# they reach the MCP client.
+
+
+class _FakeDriverError(Exception):
+    """Simulated raw driver exception (not FabricError, not ValueError)."""
+
+    _INTERNAL_DETAIL = "ODBC 17: TDS protocol error; host=wh.fabric.microsoft.com; state=08S01"
+
+
+_RAW_DRIVER_EXC = _FakeDriverError(_FakeDriverError._INTERNAL_DETAIL)
+
+
+async def test_list_running_queries_raw_driver_exc_raises_tool_error(mock_ctx, ctx_patch) -> None:
+    """A raw driver exception from list_running is converted to ToolError."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.queries.list_running",
+            new=AsyncMock(side_effect=_RAW_DRIVER_EXC),
+        ),
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "list_running_queries",
+            {"workspace": _WS_NAME, "item": _WH_NAME},
+        )
+
+    assert _FakeDriverError._INTERNAL_DETAIL not in str(exc_info.value), (
+        "raw driver exception detail must not appear in the ToolError message"
+    )
+
+
+async def test_list_connections_raw_driver_exc_raises_tool_error(mock_ctx, ctx_patch) -> None:
+    """A raw driver exception from list_connections is converted to ToolError."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.queries.list_connections",
+            new=AsyncMock(side_effect=_RAW_DRIVER_EXC),
+        ),
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "list_connections",
+            {"workspace": _WS_NAME, "item": _WH_NAME},
+        )
+
+    assert _FakeDriverError._INTERNAL_DETAIL not in str(exc_info.value), (
+        "raw driver exception detail must not appear in the ToolError message"
+    )

--- a/tests/unit/mcp/tools/test_queries.py
+++ b/tests/unit/mcp/tools/test_queries.py
@@ -1093,3 +1093,30 @@ async def test_list_connections_raw_driver_exc_raises_tool_error(mock_ctx, ctx_p
     assert _FakeDriverError._INTERNAL_DETAIL not in str(exc_info.value), (
         "raw driver exception detail must not appear in the ToolError message"
     )
+
+
+async def test_kill_session_raw_driver_exc_raises_tool_error(mock_ctx, ctx_patch) -> None:
+    """A raw driver exception from queries.kill is converted to ToolError without leaking."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.queries.kill",
+            new=AsyncMock(side_effect=_RAW_DRIVER_EXC),
+        ),
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "kill_session",
+            {"workspace": _WS_NAME, "item": _WH_NAME, "session_id": 42},
+        )
+
+    assert _FakeDriverError._INTERNAL_DETAIL not in str(exc_info.value), (
+        "raw driver exception detail must not appear in the ToolError message"
+    )

--- a/tests/unit/mcp/tools/test_sql_exec.py
+++ b/tests/unit/mcp/tools/test_sql_exec.py
@@ -1,15 +1,19 @@
-"""Unit tests for the MCP sql_exec tool wrappers — get_query_plan format param.
+"""Unit tests for the MCP sql_exec tool wrappers.
 
 Target: src/fabric_dw/mcp/tools/sql_exec.py
-Goal:   Cover all four format values, invalid-format error, and back-compat assertion.
+Goals:
+  - Cover all four format values, invalid-format error, and back-compat assertion
+    for get_query_plan.
+  - Verify that raw driver exceptions (non-FabricError) raised by the service are
+    converted to structured ToolError at the MCP boundary and do NOT leak the raw
+    exception message or query text (security: information-disclosure at MCP boundary).
 
 Strategy
 --------
 - All calls routed via ``mcp._tool_manager.call_tool``.
 - ``ServerContext`` injected by patching ``fabric_dw.mcp._context._SERVER_CTX``
   with the shared ``mock_ctx`` fixture.
-- ``fabric_dw.services.sql_exec.get_plan`` is mocked to return a known SHOWPLAN_XML
-  string (reused from tests/unit/cli/test_plan_parse.py fixture).
+- ``fabric_dw.services.sql_exec.get_plan`` / ``.execute`` are mocked per-test.
 """
 
 from __future__ import annotations
@@ -287,3 +291,135 @@ async def test_get_query_plan_invalid_format_raises_tool_error(mock_ctx, ctx_pat
             "get_query_plan",
             {"workspace": WS_NAME, "item": WH_NAME, "query": "SELECT 1", "format": "svg"},
         )
+
+
+# ---------------------------------------------------------------------------
+# Security: raw driver exceptions must not escape the MCP boundary
+# ---------------------------------------------------------------------------
+
+
+# A fake driver exception type that is NOT a subclass of FabricError or ValueError.
+# This simulates the bare `raise` in services/sql_exec.py execute() / get_plan()
+# for unmapped driver errors that carry no ddbc_error attribute (e.g. cursor-state
+# errors, network failures, TLS errors).
+class _FakeDriverError(Exception):
+    """Simulated raw driver exception (not FabricError, not ValueError)."""
+
+    # Intentionally contains connection detail to verify it does not leak to the MCP client.
+    _INTERNAL_DETAIL = (
+        "ODBC Driver 17: [08S01] connection reset by peer;"
+        " host=wh.fabric.microsoft.com; token=Bearer eyJ..."
+    )
+
+
+_RAW_DRIVER_EXC = _FakeDriverError(_FakeDriverError._INTERNAL_DETAIL)
+# A query string used to verify the tool does not echo query text into ToolError messages.
+_SENSITIVE_QUERY = "SELECT col FROM dbo.Payments WHERE user_id = 42"
+
+
+async def test_execute_sql_raw_driver_exc_raises_tool_error(mock_ctx, ctx_patch) -> None:
+    """A raw driver exception from execute() is converted to ToolError at the tool boundary."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.sql_exec.execute",
+            new=AsyncMock(side_effect=_RAW_DRIVER_EXC),
+        ),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "execute_sql",
+            {"workspace": WS_NAME, "item": WH_NAME, "query": _SENSITIVE_QUERY},
+        )
+
+
+async def test_execute_sql_raw_driver_exc_does_not_leak_internal_detail(
+    mock_ctx, ctx_patch
+) -> None:
+    """ToolError message from a raw driver exception must not contain the raw exception text."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.sql_exec.execute",
+            new=AsyncMock(side_effect=_RAW_DRIVER_EXC),
+        ),
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "execute_sql",
+            {"workspace": WS_NAME, "item": WH_NAME, "query": _SENSITIVE_QUERY},
+        )
+
+    err_msg = str(exc_info.value)
+    assert _FakeDriverError._INTERNAL_DETAIL not in err_msg, (
+        "raw driver exception detail must not appear in the ToolError message"
+    )
+    assert _SENSITIVE_QUERY not in err_msg, "query text must not appear in the ToolError message"
+
+
+async def test_get_query_plan_raw_driver_exc_raises_tool_error(mock_ctx, ctx_patch) -> None:
+    """A raw driver exception from get_plan() is converted to ToolError at the tool boundary."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.sql_exec.get_plan",
+            new=AsyncMock(side_effect=_RAW_DRIVER_EXC),
+        ),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "get_query_plan",
+            {"workspace": WS_NAME, "item": WH_NAME, "query": _SENSITIVE_QUERY},
+        )
+
+
+async def test_get_query_plan_raw_driver_exc_does_not_leak_internal_detail(
+    mock_ctx, ctx_patch
+) -> None:
+    """ToolError message from a raw driver exception must not contain the raw exception text."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.sql_exec.get_plan",
+            new=AsyncMock(side_effect=_RAW_DRIVER_EXC),
+        ),
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "get_query_plan",
+            {"workspace": WS_NAME, "item": WH_NAME, "query": _SENSITIVE_QUERY},
+        )
+
+    err_msg = str(exc_info.value)
+    assert _FakeDriverError._INTERNAL_DETAIL not in err_msg, (
+        "raw driver exception detail must not appear in the ToolError message"
+    )
+    assert _SENSITIVE_QUERY not in err_msg, "query text must not appear in the ToolError message"


### PR DESCRIPTION
## Summary

- `execute_sql` and `get_query_plan` caught only `FabricError`, letting bare-raised driver exceptions (documented in `services/sql_exec.py::execute()` and `get_plan()`) escape to the MCP client with internal ODBC state, connection identifiers, and query text intact.
- Added a final `except Exception` guard at the MCP trust boundary in `execute_sql`, `get_query_plan`, and all SQL-based tools in `queries.py` and `roll_snapshot_timestamp` in `snapshots.py`.
- Existing `ToolError` instances (e.g. from `make_sql_target`) are re-raised unchanged; only unstructured exceptions are converted to a generic safe message.
- The service-layer bare-raise behavior is NOT changed; the CLI may rely on raw exceptions.

## Audit scope (narrowed to tools calling SQL-backed services)

Files changed (5, within the 6-file cap):
- `src/fabric_dw/mcp/tools/sql_exec.py` - primary fix: `execute_sql`, `get_query_plan`
- `src/fabric_dw/mcp/tools/queries.py` - all 6 SQL-backed query listing tools
- `src/fabric_dw/mcp/tools/snapshots.py` - `roll_snapshot_timestamp` (uses `run_statements`)
- `tests/unit/mcp/tools/test_sql_exec.py` - new TDD tests for raw exception handling
- `tests/unit/mcp/tools/test_queries.py` - new TDD tests for `list_running_queries` and `list_connections`

Remaining narrow `except FabricError` catches in HTTP-only tools (`list_restore_points`, `get_restore_point`, `list_snapshots`, warehouse/workspace/SQL endpoint tools) are NOT affected: those services wrap all HTTP errors as `FabricError` subtypes and never propagate raw driver exceptions. They can be standardized for consistency in a follow-up.

## Test plan

- [x] New tests simulate a raw (non-FabricError) driver exception being raised by the service and assert the tool raises `ToolError`
- [x] New tests assert the `ToolError` message does not contain the raw exception text or query text
- [x] Existing FabricError-path tests still pass (5010 unit tests pass)
- [x] `ruff check` and `ruff format` clean
- [x] `ty check` clean

Closes #799

🤖 Generated with [Claude Code](https://claude.com/claude-code)