### PR TITLE
fix(http): gate 5xx retries on idempotent HTTP methods

### DIFF
--- a/src/fabric_dw/http_client.py
+++ b/src/fabric_dw/http_client.py
@@ -12,19 +12,22 @@ Provides:
 Retry arithmetic
 ~~~~~~~~~~~~~~~~
 Tenacity wraps ``_request_with_retry`` and retries on ``FabricServerError``
-(5xx) up to 3 attempts with exponential back-off.  Inside each attempt,
-``_do_request`` executes a 429-loop of up to ``max_429_retries`` iterations.
-Both mechanisms share a common wall-clock deadline (``_combined_deadline_s``
-seconds from the first attempt, default 300 s) so the combined worst-case
-latency is bounded even if the server returns large Retry-After values.
+(5xx) up to 3 attempts with exponential back-off, but ONLY for idempotent
+HTTP methods (GET, HEAD, OPTIONS).  POST, PATCH, and DELETE are not retried
+on 5xx because the server may have committed the request — re-sending risks a
+duplicate resource or a 409 Conflict.  Inside each attempt, ``_do_request``
+executes a 429-loop of up to ``max_429_retries`` iterations.  Both mechanisms
+share a common wall-clock deadline (``_combined_deadline_s`` seconds from the
+first attempt, default 300 s) so the combined worst-case latency is bounded
+even if the server returns large Retry-After values.
 
 Timeout retry safety
 ~~~~~~~~~~~~~~~~~~~~
 ``httpx.TimeoutException`` (including ``ReadTimeout``, ``ConnectTimeout``, etc.)
 is retried ONLY for idempotent HTTP methods (GET, HEAD, OPTIONS).  POST, PATCH,
-and DELETE are NOT retried on timeout because the server may have received and
-committed the request — re-sending a POST would duplicate the resource or cause
-a 409 Conflict.  LRO status polling (GET) is covered by the safe retry path.
+and DELETE are NOT retried on timeout for the same reason as 5xx: the server
+may have received and committed the request.  LRO status polling (GET) is
+covered by the safe retry path.
 
 Credential ownership
 ~~~~~~~~~~~~~~~~~~~~
@@ -202,19 +205,22 @@ def _make_should_retry(method: str) -> Callable[[BaseException], bool]:
     upper = method.upper()
 
     def _should_retry(exc: BaseException) -> bool:
-        """Retry on 5xx *or* on timeout for idempotent methods.
+        """Retry on 5xx or on timeout, but only for idempotent HTTP methods.
 
         - Retry :class:`~fabric_dw.exceptions.FabricServerError` (5xx) ONLY
-          when ``is_retriable`` is ``True`` (the default).  A Fabric error
-          envelope with ``"isRetriable": false`` (e.g. the ~22s
-          InternalServerError from a paused-capacity workspace) must NOT be
-          retried — fail fast, no 60-70s back-off waste.
+          when ``is_retriable`` is ``True`` AND the method is idempotent
+          (GET/HEAD/OPTIONS).  A Fabric error envelope with
+          ``"isRetriable": false`` (e.g. the ~22s InternalServerError from a
+          paused-capacity workspace) still fails fast regardless of method.
+          POST/PATCH/DELETE are not retried on 5xx: the server may have
+          already committed the request, so re-sending risks a duplicate
+          resource or a 409 Conflict.
         - Retry :class:`httpx.TimeoutException` ONLY for idempotent HTTP
           methods (GET, HEAD, OPTIONS).  POST/PATCH/DELETE are not retried
-          on timeout — the server may have already committed the request.
+          on timeout for the same reason.
         """
         if isinstance(exc, FabricServerError):
-            return exc.is_retriable
+            return exc.is_retriable and upper in _IDEMPOTENT_METHODS
         if isinstance(exc, httpx.TimeoutException):
             return upper in _IDEMPOTENT_METHODS
         return False
@@ -243,11 +249,14 @@ class FabricHttpClient:
     Retry arithmetic
     ~~~~~~~~~~~~~~~~
     Tenacity wraps ``_request_with_retry`` and retries on ``FabricServerError``
-    (5xx) up to 3 attempts.  Inside each tenacity attempt, ``_do_request`` runs
-    a 429-loop of up to ``max_429_retries`` iterations.  Both mechanisms share a
-    common wall-clock deadline (``combined_deadline_s`` seconds from the first
-    send, default 300 s) so the total latency is bounded even when the server
-    advertises large ``Retry-After`` values.
+    (5xx) up to 3 attempts, but ONLY for idempotent methods (GET/HEAD/OPTIONS).
+    POST, PATCH, and DELETE are not retried on 5xx: the server may have already
+    committed the request, and re-sending risks a duplicate resource or a 409.
+    Inside each tenacity attempt, ``_do_request`` runs a 429-loop of up to
+    ``max_429_retries`` iterations.  Both mechanisms share a common wall-clock
+    deadline (``combined_deadline_s`` seconds from the first send, default 300 s)
+    so the total latency is bounded even when the server advertises large
+    ``Retry-After`` values.
 
     Args:
         credential:             Azure credential used to fetch bearer tokens.

--- a/tests/unit/test_http_client.py
+++ b/tests/unit/test_http_client.py
@@ -1461,13 +1461,13 @@ def test_default_timeout_is_60_seconds() -> None:
     assert _DEFAULT_TIMEOUT == 60.0, f"Expected _DEFAULT_TIMEOUT == 60.0; got {_DEFAULT_TIMEOUT}"
 
 
-async def test_post_5xx_is_retried() -> None:
-    """POST on 5xx must still be retried (FabricServerError path in _should_retry).
+async def test_post_5xx_not_retried_method_gate() -> None:
+    """POST on 5xx must NOT be retried (method gate added in #801).
 
-    The switch from retry_if_exception_type(FabricServerError) to
-    retry_if_exception(_should_retry) keeps 5xx retry regardless of HTTP method.
-    This test guards against accidentally removing the isinstance(exc,
-    FabricServerError) branch from _should_retry.
+    5xx retries are gated on idempotent methods (GET/HEAD/OPTIONS) so that a
+    non-idempotent POST that returned a bare 500/503 is raised immediately.
+    Re-sending a POST that may have committed on the server risks creating a
+    duplicate resource or a 409 Conflict.
     """
     call_count = 0
 
@@ -1484,7 +1484,9 @@ async def test_post_5xx_is_retried() -> None:
             with pytest.raises(FabricServerError):
                 await client.request("POST", HttpBase.FABRIC, "/items", json={"x": 1})
 
-    assert call_count == 3, f"POST 5xx must be retried 3 times (tenacity budget); got {call_count}"
+    assert call_count == 1, (
+        f"POST 5xx must not be retried (non-idempotent); expected 1 call but got {call_count}"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -1896,3 +1898,142 @@ async def test_get_token_does_not_remap_non_auth_errors() -> None:
     async with client:
         with pytest.raises(RuntimeError, match="unexpected credential crash"):
             await client._get_token()  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# 5xx method gate: non-idempotent methods not retried on 5xx (#801)
+# ---------------------------------------------------------------------------
+
+
+async def test_post_bare_503_not_retried() -> None:
+    """A bare 503 (no envelope) on POST must NOT be retried (non-idempotent, #801).
+
+    Before the fix, FabricServerError retried regardless of HTTP method because
+    _make_should_retry had no method gate on the 5xx branch.  After the fix, 5xx
+    retries are gated on idempotent methods (GET/HEAD/OPTIONS) in the same way
+    timeouts are gated.
+
+    A POST that returns 503 without a Fabric error envelope (is_retriable defaults
+    to True) must be raised immediately with exactly one HTTP send.  Re-sending a
+    POST that already returned 503 risks creating a duplicate resource or a 409.
+    """
+    call_count = 0
+
+    def side_effect(_request: httpx.Request) -> httpx.Response:
+        nonlocal call_count
+        call_count += 1
+        return httpx.Response(503, json={"error": "service unavailable"})
+
+    with respx.mock(assert_all_called=False) as mock_router:
+        mock_router.post("https://api.fabric.microsoft.com/v1/items").mock(side_effect=side_effect)
+
+        client = await _get_client(rps=10)
+        async with client:
+            with pytest.raises(FabricServerError):
+                await client.request("POST", HttpBase.FABRIC, "/items", json={"x": 1})
+
+    assert call_count == 1, (
+        f"POST 503 must not be retried (non-idempotent); expected 1 call but got {call_count}"
+    )
+
+
+async def test_patch_bare_503_not_retried() -> None:
+    """A bare 503 on PATCH must NOT be retried (non-idempotent method, #801)."""
+    call_count = 0
+
+    def side_effect(_request: httpx.Request) -> httpx.Response:
+        nonlocal call_count
+        call_count += 1
+        return httpx.Response(503, json={"error": "service unavailable"})
+
+    with respx.mock(assert_all_called=False) as mock_router:
+        mock_router.patch("https://api.fabric.microsoft.com/v1/items/abc").mock(
+            side_effect=side_effect
+        )
+
+        client = await _get_client(rps=10)
+        async with client:
+            with pytest.raises(FabricServerError):
+                await client.request("PATCH", HttpBase.FABRIC, "/items/abc", json={"x": 1})
+
+    assert call_count == 1, (
+        f"PATCH 503 must not be retried (non-idempotent); expected 1 call but got {call_count}"
+    )
+
+
+async def test_delete_bare_503_not_retried() -> None:
+    """A bare 503 on DELETE must NOT be retried (non-idempotent method, #801)."""
+    call_count = 0
+
+    def side_effect(_request: httpx.Request) -> httpx.Response:
+        nonlocal call_count
+        call_count += 1
+        return httpx.Response(503, json={"error": "service unavailable"})
+
+    with respx.mock(assert_all_called=False) as mock_router:
+        mock_router.delete("https://api.fabric.microsoft.com/v1/items/abc").mock(
+            side_effect=side_effect
+        )
+
+        client = await _get_client(rps=10)
+        async with client:
+            with pytest.raises(FabricServerError):
+                await client.request("DELETE", HttpBase.FABRIC, "/items/abc")
+
+    assert call_count == 1, (
+        f"DELETE 503 must not be retried (non-idempotent); expected 1 call but got {call_count}"
+    )
+
+
+async def test_get_5xx_still_retried_after_method_gate() -> None:
+    """A 503 on GET must still be retried (idempotent method - existing behaviour, #801).
+
+    The method gate on 5xx retries must NOT block idempotent methods: GET is in
+    _IDEMPOTENT_METHODS so all three tenacity attempts must fire.
+    """
+    call_count = 0
+
+    def side_effect(_request: httpx.Request) -> httpx.Response:
+        nonlocal call_count
+        call_count += 1
+        return httpx.Response(503, json={"error": "service unavailable"})
+
+    with respx.mock(assert_all_called=False) as mock_router:
+        mock_router.get("https://api.fabric.microsoft.com/v1/items").mock(side_effect=side_effect)
+
+        client = await _get_client(rps=10)
+        async with client:
+            with pytest.raises(FabricServerError):
+                await client.request("GET", HttpBase.FABRIC, "/items")
+
+    assert call_count == 3, (
+        f"GET 503 must be retried up to 3 times (tenacity budget); got {call_count}"
+    )
+
+
+async def test_get_5xx_envelope_not_retriable_not_retried() -> None:
+    """GET with isRetriable: false in the envelope must NOT be retried (existing fail-fast, #801).
+
+    The is_retriable flag from the Fabric error envelope is preserved after adding
+    the method gate: both conditions (is_retriable AND idempotent method) must be
+    True for a retry to occur.  An envelope with isRetriable: false on any method
+    must still fail fast.
+    """
+    call_count = 0
+
+    def side_effect(_request: httpx.Request) -> httpx.Response:
+        nonlocal call_count
+        call_count += 1
+        return httpx.Response(503, json={"isRetriable": False, "error": "paused capacity"})
+
+    with respx.mock(assert_all_called=False) as mock_router:
+        mock_router.get("https://api.fabric.microsoft.com/v1/items").mock(side_effect=side_effect)
+
+        client = await _get_client(rps=10)
+        async with client:
+            with pytest.raises(FabricServerError):
+                await client.request("GET", HttpBase.FABRIC, "/items")
+
+    assert call_count == 1, (
+        f"GET 503 with isRetriable: false must not be retried; expected 1 call but got {call_count}"
+    )


### PR DESCRIPTION
## Summary

- `_make_should_retry` retried `FabricServerError` (5xx) for any HTTP method because the `FabricServerError` branch had no method gate, while the `TimeoutException` branch already refused POST/PATCH/DELETE.
- A non-idempotent POST/PATCH/DELETE that returned a bare 503 (no envelope, `is_retriable` defaults to True) was re-sent up to 3 times, risking duplicate resource creation or a 409 when the server had already committed.
- Fix: add `and upper in _IDEMPOTENT_METHODS` to the `FabricServerError` predicate in `_make_should_retry`, mirroring the existing timeout path. The `is_retriable` flag is preserved so envelope `isRetriable: false` still fails fast regardless of method.

## Changes

- `src/fabric_dw/http_client.py`: one-line predicate change in `_should_retry`, updated `_should_retry` docstring and both "Retry arithmetic" docstrings (module header + class) to document the method gate.
- `tests/unit/test_http_client.py`: regression tests added for bare 503 on POST/PATCH/DELETE (not retried), 503 on GET (retried - existing behaviour preserved), 503 with `isRetriable: false` on GET (not retried - fail-fast preserved). Updated `test_post_5xx_is_retried` (now `test_post_5xx_not_retried_method_gate`) to assert the correct post-fix behaviour.

## Test plan

- [x] New tests fail before the fix (POST/PATCH/DELETE bare 503: `call_count == 3`, expected 1)
- [x] New tests pass after the fix (5001 unit tests pass, 0 failures)
- [x] `ruff check` and `ruff format` pass
- [x] Existing timeout-gate tests (`test_post_timeout_is_not_retried`, `test_get_timeout_once_then_success_is_retried`) continue to pass

Closes #801

🤖 Generated with [Claude Code](https://claude.com/claude-code)