### PR TITLE
refactor: idiom nits in cli/_context.py and config.py

### DIFF
--- a/src/fabric_dw/cli/_context.py
+++ b/src/fabric_dw/cli/_context.py
@@ -17,7 +17,7 @@ class CliContext:
 
     json_output: bool = False
     yes: bool = False
-    auth: CredentialMode = field(default_factory=lambda: CredentialMode.DEFAULT)
+    auth: CredentialMode = CredentialMode.DEFAULT
     workspace: str | None = None
     max_429_retries: int | None = None
     retry_deadline_s: int | None = None

--- a/src/fabric_dw/config.py
+++ b/src/fabric_dw/config.py
@@ -265,7 +265,7 @@ def _parse_mcp_section(data: dict[str, object]) -> McpConfig:
         raw = {}
     raw_allowlist = raw.get("workspace_allowlist")
     if isinstance(raw_allowlist, list) and all(isinstance(x, str) for x in raw_allowlist):
-        allowlist: list[str] | None = typing.cast(list[str], raw_allowlist)
+        allowlist: list[str] | None = typing.cast("list[str]", raw_allowlist)
     else:
         allowlist = None
     return McpConfig(workspace_allowlist=allowlist)


### PR DESCRIPTION
## Summary

- `cli/_context.py:20`: replace `field(default_factory=lambda: CredentialMode.DEFAULT)` with a plain default. Immutable enum members need no factory; behaviour is unchanged.
- `config.py:268`: switch `cast(list[str], ...)` to the string form `cast("list[str]", ...)` per codebase convention.

## Test plan

- [ ] ty passes
- [ ] ruff check and ruff format pass
- [ ] No behaviour change; existing tests cover both paths

Closes #808