### PR TITLE
ci(docker): add :stable tag, keep :latest on all tags

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -39,7 +39,12 @@ jobs:
           VERSION=$(uv run python -c "import fabric_dw; print(fabric_dw.__version__)")
           echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
           if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
-            echo "tags=ghcr.io/sdebruyn/fabric-dw:${VERSION},ghcr.io/sdebruyn/fabric-dw:latest" >> "${GITHUB_OUTPUT}"
+            TAGS="ghcr.io/sdebruyn/fabric-dw:${VERSION},ghcr.io/sdebruyn/fabric-dw:latest"
+            version_str="${GITHUB_REF_NAME#v}"
+            if ! echo "$version_str" | grep -qE '(a|b|rc)[0-9]*$|\.dev'; then
+              TAGS="${TAGS},ghcr.io/sdebruyn/fabric-dw:stable"
+            fi
+            echo "tags=${TAGS}" >> "${GITHUB_OUTPUT}"
           else
             echo "tags=ghcr.io/sdebruyn/fabric-dw:${VERSION},ghcr.io/sdebruyn/fabric-dw:main" >> "${GITHUB_OUTPUT}"
           fi


### PR DESCRIPTION
## Summary

- On any `v*` tag push, `:VERSION` and `:latest` are always published (bleeding-edge channel, unchanged).
- `:stable` is now appended to the tag list only when the tag is NOT a prerelease.
- Main-branch pushes are unchanged (`:VERSION` + `:main`; no `:latest`, no `:stable`).

## Prerelease detection

Reuses the same `grep -qE '(a|b|rc)[0-9]*$|\.dev'` pattern from `.github/workflows/publish.yml` (lines 137-141), applied to the version string with the leading `v` stripped via `${GITHUB_REF_NAME#v}`. This ensures the two workflows cannot drift.

## Three-case walkthrough

| Push | `:VERSION` | `:latest` | `:stable` |
|------|-----------|----------|---------|
| `v2026.6.0rc1` (prerelease rc) | yes | yes | NO |
| `v2026.7.0` (clean calver) | yes | yes | YES |
| main branch push | yes (dev build) | no | no |

## Notes

No integration-test trigger label was found in the repo; `area:ci` is applied as the closest match.

Closes #809

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>