### PR TITLE
refactor(auth): add from __future__ import annotations

### DIFF
--- a/src/fabric_dw/auth.py
+++ b/src/fabric_dw/auth.py
@@ -1,5 +1,7 @@
 """Azure credential chain with persistent token cache."""
 
+from __future__ import annotations
+
 import asyncio
 import logging
 import os
@@ -153,7 +155,7 @@ class SyncCredentialAdapter:
     async def close(self) -> None:
         await asyncio.to_thread(self._inner.close)
 
-    async def __aenter__(self) -> "SyncCredentialAdapter":
+    async def __aenter__(self) -> SyncCredentialAdapter:
         return self
 
     async def __aexit__(


### PR DESCRIPTION
## Summary

- Add `from __future__ import annotations` to `src/fabric_dw/auth.py`, consistent with every other non-trivial module in the package.
- Unquote the now-redundant hand-quoted forward reference on `__aenter__` (`-> "SyncCredentialAdapter"` becomes `-> SyncCredentialAdapter`).
- No behaviour change; ty and ruff both pass.

## Notes

The `integration` label was not applied - this is a pure annotation-import consistency fix with no logic change, so integration tests add no value here.

Closes #812

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>