### PR TITLE
refactor: replace inert mypy-coded type: ignore with ty: ignore

### DIFF
--- a/src/fabric_dw/cli/_main.py
+++ b/src/fabric_dw/cli/_main.py
@@ -197,7 +197,7 @@ def _patch_command_for_global_options(cmd: click.Command) -> None:
     """
     if getattr(cmd, "_global_opts_patched", False):
         return
-    cmd._global_opts_patched = True  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+    cmd._global_opts_patched = True  # ty: ignore[unresolved-attribute]
 
     _inject_global_options(cmd)
 
@@ -207,10 +207,10 @@ def _patch_command_for_global_options(cmd: click.Command) -> None:
         _apply_meta_global_params(ctx)
         return original_invoke(ctx)
 
-    cmd.invoke = _wrapped_invoke  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
+    cmd.invoke = _wrapped_invoke  # ty: ignore[invalid-assignment]
 
     if isinstance(cmd, click.Group):
-        for sub in cmd.commands.values():  # type: ignore[attr-defined]
+        for sub in cmd.commands.values():
             _patch_command_for_global_options(sub)
 
 
@@ -430,10 +430,10 @@ def _patch_group_for_telemetry(group: click.Group) -> None:
     """
     if getattr(group, "_telemetry_patched", False):
         return
-    group._telemetry_patched = True  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+    group._telemetry_patched = True  # ty: ignore[unresolved-attribute]
 
     # Recursively patch any sub-groups already registered.
-    for sub_cmd in group.commands.values():  # type: ignore[attr-defined]
+    for sub_cmd in group.commands.values():
         if isinstance(sub_cmd, click.Group):
             _patch_group_for_telemetry(sub_cmd)
 
@@ -459,7 +459,7 @@ def _patch_group_for_telemetry(group: click.Group) -> None:
                 segs.append((depth, group_name, sub_name))
                 root_ctx.meta[_CLI_SEGMENTS_KEY] = segs
 
-    group.invoke = _patched_invoke  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
+    group.invoke = _patched_invoke  # ty: ignore[invalid-assignment]
 
 
 class _LazyGroup(_InstrumentedGroup):
@@ -476,7 +476,7 @@ class _LazyGroup(_InstrumentedGroup):
     in :meth:`get_command` after the lazy import.
     """
 
-    def list_commands(self, ctx: click.Context) -> list[str]:  # type: ignore[override]  # noqa: ARG002
+    def list_commands(self, ctx: click.Context) -> list[str]:  # noqa: ARG002
         """Return all registered command names in alphabetical order."""
         return sorted(_COMMAND_MAP)
 
@@ -514,12 +514,12 @@ class _LazyGroup(_InstrumentedGroup):
         # compute "Did you mean?" possibilities without triggering real imports.
         # We restore the empty dict immediately after resolution.
         dummy_cmds = {name: click.Command(name) for name in _COMMAND_MAP}
-        original_commands = self.commands  # type: ignore[attr-defined]
-        self.commands = dummy_cmds  # type: ignore[attr-defined]
+        original_commands = self.commands
+        self.commands = dummy_cmds
         try:
             return super().resolve_command(ctx, args)
         finally:
-            self.commands = original_commands  # type: ignore[attr-defined]
+            self.commands = original_commands
 
     def format_commands(self, ctx: click.Context, formatter: click.HelpFormatter) -> None:
         """Render the command list from :data:`_SHORT_HELP_MAP` without importing modules."""

--- a/src/fabric_dw/cli/commands/_utils.py
+++ b/src/fabric_dw/cli/commands/_utils.py
@@ -137,8 +137,8 @@ async def build_http_client(ctx: CliContext) -> AsyncIterator[FabricHttpClient]:
     # can apply its own built-in defaults for the rest.
     client = FabricHttpClient(
         credential,
-        **({"max_429_retries": retries} if retries is not None else {}),  # type: ignore[arg-type]
-        **({"combined_deadline_s": deadline} if deadline is not None else {}),  # type: ignore[arg-type]
+        **({"max_429_retries": retries} if retries is not None else {}),
+        **({"combined_deadline_s": deadline} if deadline is not None else {}),
     )
     async with client as http:
         yield http

--- a/src/fabric_dw/cli/commands/tables.py
+++ b/src/fabric_dw/cli/commands/tables.py
@@ -437,7 +437,7 @@ async def create_cmd(  # noqa: PLR0912, PLR0915
                     target,
                     schema,
                     table_name,
-                    Path(parquet_path),  # type: ignore[arg-type]
+                    Path(parquet_path),
                     cluster_by=cluster_by_list,
                     kind=entry.kind,
                     mode=ctx.auth,
@@ -449,7 +449,7 @@ async def create_cmd(  # noqa: PLR0912, PLR0915
                     target,
                     schema,
                     table_name,
-                    Path(csv_path),  # type: ignore[arg-type]
+                    Path(csv_path),
                     cluster_by=cluster_by_list,
                     kind=entry.kind,
                     mode=ctx.auth,
@@ -465,7 +465,7 @@ async def create_cmd(  # noqa: PLR0912, PLR0915
                     target,
                     schema,
                     table_name,
-                    Path(json_path),  # type: ignore[arg-type]
+                    Path(json_path),
                     cluster_by=cluster_by_list,
                     kind=entry.kind,
                     mode=ctx.auth,

--- a/src/fabric_dw/http_client.py
+++ b/src/fabric_dw/http_client.py
@@ -182,7 +182,7 @@ def _parse_json_body(resp: httpx.Response) -> dict[str, object] | None:
     try:
         parsed = resp.json()
         if isinstance(parsed, dict):
-            return parsed  # type: ignore[return-value]
+            return parsed
     except (ValueError, json.JSONDecodeError):
         pass
     return None

--- a/src/fabric_dw/mcp/_context.py
+++ b/src/fabric_dw/mcp/_context.py
@@ -179,8 +179,8 @@ def build_context(
 
     http = FabricHttpClient(
         credential=credential,
-        **({"max_429_retries": retries} if retries is not None else {}),  # type: ignore[arg-type]
-        **({"combined_deadline_s": deadline} if deadline is not None else {}),  # type: ignore[arg-type]
+        **({"max_429_retries": retries} if retries is not None else {}),
+        **({"combined_deadline_s": deadline} if deadline is not None else {}),
     )
     cache = LookupCache()
     resolver = Resolver(http=http, cache=cache)

--- a/src/fabric_dw/mcp/_helpers.py
+++ b/src/fabric_dw/mcp/_helpers.py
@@ -224,7 +224,7 @@ class InstrumentedFastMCP(FastMCP):
     ``@mcp.tool(name=...)`` calls automatically gain instrumentation.
     """
 
-    def tool(  # type: ignore[override]  # noqa: PLR0913
+    def tool(  # noqa: PLR0913
         self,
         name: str | None = None,
         title: str | None = None,

--- a/src/fabric_dw/mcp/tools/load.py
+++ b/src/fabric_dw/mcp/tools/load.py
@@ -214,7 +214,7 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
                 table_name,
                 url,
                 file_type=file_type,
-                credential_type=credential_type,  # type: ignore[arg-type]
+                credential_type=credential_type,
                 secret=secret,
                 identity=identity,
                 csv_options=csv_options,
@@ -477,7 +477,7 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
                 table_name,
                 url,
                 file_type=file_type,
-                credential_type=credential_type,  # type: ignore[arg-type]
+                credential_type=credential_type,
                 secret=secret,
                 identity=identity,
                 csv_options=csv_options,

--- a/src/fabric_dw/mcp/tools/tables.py
+++ b/src/fabric_dw/mcp/tools/tables.py
@@ -231,7 +231,7 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             )
         except (ValueError, FabricError) as exc:
             raise tool_err(exc) from exc
-        return result  # type: ignore[return-value]
+        return result
 
     @mutating_tool(mcp, "create_table")
     async def create_table(

--- a/src/fabric_dw/mcp/tools/views.py
+++ b/src/fabric_dw/mcp/tools/views.py
@@ -173,7 +173,7 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             )
         except (ValueError, FabricError) as exc:
             raise tool_err(exc) from exc
-        return result  # type: ignore[return-value]
+        return result
 
     @mcp.tool(name="get_view")
     async def get_view(workspace: str, item: str, qualified_name: str) -> dict[str, Any]:

--- a/src/fabric_dw/services/_helpers.py
+++ b/src/fabric_dw/services/_helpers.py
@@ -219,7 +219,7 @@ async def scan_all_workspaces(
     # not the total across all workspaces.
     fan_out_total = len(active_workspaces)
     raw = await bounded_gather(
-        [lambda ws=ws: fetch(ws) for ws in active_workspaces],  # type: ignore[misc]
+        [lambda ws=ws: fetch(ws) for ws in active_workspaces],
         return_exceptions=True,
     )
 
@@ -244,7 +244,7 @@ async def scan_all_workspaces(
         elif isinstance(result, BaseException):
             raise result
         else:
-            out.extend(result)  # type: ignore[arg-type]
+            out.extend(result)
 
     if access_skipped:
         logger.warning(

--- a/src/fabric_dw/services/columns.py
+++ b/src/fabric_dw/services/columns.py
@@ -211,12 +211,12 @@ async def get_object_columns(
         for row in rows:
             data = dict(zip(cols, row, strict=True))
             type_name = str(data["type_name"])
-            max_length = int(data["max_length"])  # type: ignore[arg-type]
-            precision = int(data["precision"])  # type: ignore[arg-type]
-            scale = int(data["scale"])  # type: ignore[arg-type]
+            max_length = int(data["max_length"])
+            precision = int(data["precision"])
+            scale = int(data["scale"])
             results.append(
                 {
-                    "ordinal": int(data["ordinal"]),  # type: ignore[arg-type]
+                    "ordinal": int(data["ordinal"]),
                     "name": str(data["name"]),
                     "data_type": format_data_type(type_name, max_length, precision, scale),
                     "nullable": bool(data["nullable"]),
@@ -319,11 +319,11 @@ async def get_columns_for_schemas(
             schema_name = str(data["schema_name"])
             object_name = str(data["object_name"])
             type_name = str(data["type_name"])
-            max_length = int(data["max_length"])  # type: ignore[arg-type]
-            precision = int(data["precision"])  # type: ignore[arg-type]
-            scale = int(data["scale"])  # type: ignore[arg-type]
+            max_length = int(data["max_length"])
+            precision = int(data["precision"])
+            scale = int(data["scale"])
             col_dict: dict[str, object] = {
-                "ordinal": int(data["ordinal"]),  # type: ignore[arg-type]
+                "ordinal": int(data["ordinal"]),
                 "name": str(data["name"]),
                 "data_type": format_data_type(type_name, max_length, precision, scale),
                 "nullable": bool(data["nullable"]),

--- a/src/fabric_dw/services/sql_endpoints.py
+++ b/src/fabric_dw/services/sql_endpoints.py
@@ -135,7 +135,7 @@ async def list_all_workspaces(http: FabricHttpClient) -> list[Warehouse]:
     )
     return await scan_all_workspaces(
         workspaces,
-        lambda ws: list_endpoints(http, ws.id),  # type: ignore[union-attr]  # mypy false-positive: Sequence[_HasNameIdAndCapacity] exposes id: UUID but mypy loses the concrete type through the Protocol abstraction
+        lambda ws: list_endpoints(http, ws.id),
         logger=_logger,
         skip_errors=(PermissionDeniedError, NotFoundError),
         capacity_states=capacity_states,
@@ -315,7 +315,7 @@ async def refresh_metadata(
             endpoint_id,
         )
         body: object = resp.json() if resp.content else {}
-        raw_value = body.get("value", []) if isinstance(body, dict) else []  # type: ignore[union-attr]
+        raw_value = body.get("value", []) if isinstance(body, dict) else []
 
     raw_items = raw_value if isinstance(raw_value, list) else []
     return [TableSyncStatus.model_validate(item) for item in raw_items]

--- a/src/fabric_dw/services/warehouses.py
+++ b/src/fabric_dw/services/warehouses.py
@@ -199,7 +199,7 @@ async def list_all_workspaces(
     )
     return await scan_all_workspaces(
         workspaces,
-        lambda ws: list_warehouses(http, ws.id, warehouses_only=warehouses_only),  # type: ignore[union-attr]  # mypy false-positive: Sequence[_HasNameIdAndCapacity] exposes id: UUID but mypy loses the concrete type through the Protocol abstraction
+        lambda ws: list_warehouses(http, ws.id, warehouses_only=warehouses_only),
         logger=_logger,
         skip_errors=(PermissionDeniedError, NotFoundError),
         capacity_states=capacity_states,

--- a/src/fabric_dw/telemetry.py
+++ b/src/fabric_dw/telemetry.py
@@ -986,7 +986,7 @@ def emit_event(
             merged["ai.operation.name"] = name
 
         record = LogRecord(  # ty: ignore[no-matching-overload]
-            attributes=merged,  # type: ignore[arg-type]
+            attributes=merged,
         )
 
         # getattr is intentional: `otel_logger` is typed as `object` to avoid

--- a/src/fabric_dw/types.py
+++ b/src/fabric_dw/types.py
@@ -110,7 +110,7 @@ def _arrow_primitive_to_tsql(  # noqa: PLR0911,PLR0912
         return "BIT"
     # Decimal
     if pa.types.is_decimal(at):
-        dec = at  # type: ignore[assignment]
+        dec = at
         if dec.precision > 38:  # noqa: PLR2004
             msg = (
                 f"Decimal type has precision {dec.precision}, which exceeds the Fabric DW "
@@ -127,7 +127,7 @@ def _arrow_primitive_to_tsql(  # noqa: PLR0911,PLR0912
         # Preserve timezone offset when the Arrow type carries timezone info.
         # DATETIMEOFFSET stores the UTC value plus the original UTC offset,
         # while DATETIME2 silently drops the offset.
-        ts = at  # type: ignore[assignment]
+        ts = at
         if ts.tz is not None:
             return "DATETIMEOFFSET(7)"
         return "DATETIME2(7)"
@@ -138,7 +138,7 @@ def _arrow_primitive_to_tsql(  # noqa: PLR0911,PLR0912
         return f"VARCHAR({varchar_length})"
     # UTF-8 view (Arrow 12+)
     try:
-        if pa.types.is_string_view(at):  # type: ignore[attr-defined]
+        if pa.types.is_string_view(at):
             return f"VARCHAR({varchar_length})"
     except AttributeError:  # pragma: no cover — older pyarrow
         pass
@@ -189,7 +189,7 @@ def arrow_type_to_tsql(
 
     # Dictionary (categorical) — expand to value type.
     if pa.types.is_dictionary(at):
-        dict_type = at  # type: ignore[assignment]
+        dict_type = at
         return arrow_type_to_tsql(dict_type.value_type, field_name, varchar_length=varchar_length)
 
     # Everything else (list, struct, map, union, fixed_size_list, …) is unsupported.


### PR DESCRIPTION
## Summary

- Removed all 41 occurrences of `# type: ignore[<mypy-code>]` in `src/` that ty (the configured type checker) does not honour.
- Verified empirically: stripping every bracketed mypy suppress left `ty check src` reporting zero errors, confirming all were inert.
- 4 sites that already carried a paired `# ty: ignore[<rule>]` had the mypy part stripped and the ty suppression retained (these do suppress real ty diagnostics).
- The remaining 37 sites had the comment deleted entirely - ty does not emit any diagnostic there.
- No runtime behaviour change.

**Breakdown: 4 replaced (mypy part stripped, ty part kept), 37 deleted.**

Closes #813

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>