### PR TITLE
fix(cli): pass explicit utf-8 encoding for shell-rc file IO

### DIFF
--- a/src/fabric_dw/cli/commands/completion.py
+++ b/src/fabric_dw/cli/commands/completion.py
@@ -93,7 +93,7 @@ def install(shell: str, print_only: bool) -> None:
         _append_idempotent(target, script)
     else:  # "write"
         target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_text(script)
+        target.write_text(script, encoding="utf-8")
         click.echo(f"Completion script written to {target}. Reload with: source {target}")
 
 
@@ -113,7 +113,7 @@ def _append_idempotent(path: Path, script: str) -> None:
     ``_SENTINEL_START`` and replace the block correctly.
     """
     block = f"\n{_SENTINEL_START}\n{script.strip()}\n{_SENTINEL_END}\n"
-    existing = path.read_text() if path.exists() else ""
+    existing = path.read_text(encoding="utf-8") if path.exists() else ""
 
     if _SENTINEL_START in existing:
         # Replace the existing managed block in-place.
@@ -123,9 +123,9 @@ def _append_idempotent(path: Path, script: str) -> None:
             existing,
             flags=re.DOTALL,
         )
-        path.write_text(new_content)
+        path.write_text(new_content, encoding="utf-8")
         click.echo(f"Completion script updated in {path}. Reload with: source {path}")
     else:
-        with path.open("a") as fh:
+        with path.open("a", encoding="utf-8") as fh:
             fh.write(block)
         click.echo(f"Completion script appended to {path}. Reload with: source {path}")

--- a/tests/unit/cli/commands/test_completion.py
+++ b/tests/unit/cli/commands/test_completion.py
@@ -191,6 +191,22 @@ class TestAppendIdempotent:
         assert "# new completion" in content
         assert "# old completion" not in content
 
+    def test_non_ascii_rc_content_round_trips_without_corruption(self, tmp_path: Path) -> None:
+        """Non-ASCII characters in an rc-file survive a read-then-append cycle intact."""
+        target = tmp_path / ".bashrc"
+        # Write a file with non-ASCII content using utf-8 so the test is
+        # independent of the locale default encoding.
+        non_ascii_line = "# Ångström, Ünit, 文字\n"  # Ångström, Ünit, 文字
+        target.write_text(non_ascii_line, encoding="utf-8")
+
+        script = "# completion script\n"
+        _append_idempotent(target, script)
+
+        content = target.read_text(encoding="utf-8")
+        # Original non-ASCII content must be intact after the append.
+        assert non_ascii_line.strip() in content
+        assert script.strip() in content
+
 
 class TestCompletionScript:
     """Unit tests for _completion_script helper."""


### PR DESCRIPTION
## Summary

- Add `encoding="utf-8"` to `read_text()`, `write_text()`, and `open(..., "a")` in `src/fabric_dw/cli/commands/completion.py` (lines 96, 116, 126, 129).
- Without an explicit encoding, Python uses the locale default, which causes `UnicodeDecodeError` or silent corruption on Windows when the rc-file contains non-ASCII characters.
- Add a unit test that writes non-ASCII content to a mock rc-file and verifies the read-then-append round-trip preserves it without corruption.

## Test plan

- [x] All 18 existing `tests/unit/cli/commands/test_completion.py` tests pass.
- [x] New test `test_non_ascii_rc_content_round_trips_without_corruption` passes.
- [ ] CI green.

Closes #823

🤖 Generated with [Claude Code](https://claude.com/claude-code)