### PR TITLE
fix(sql): floor sql_retry_deadline_s from config.toml like the env var

### DIFF
--- a/src/fabric_dw/sql.py
+++ b/src/fabric_dw/sql.py
@@ -202,6 +202,25 @@ def _sql_config_cache_clear() -> None:
         _sql_config_cache = None
 
 
+def _validate_sql_retry_deadline_s(value: int, source: str) -> int | None:
+    """Return *value* when it meets the minimum, else log a warning and return None.
+
+    Args:
+        value:  Candidate deadline in seconds (already parsed to int).
+        source: Human-readable label for the origin (e.g. the env-var name or
+                ``"sql_retry_deadline_s (config.toml)"``), used in the warning.
+    """
+    if value >= _MIN_SQL_RETRY_DEADLINE_S:
+        return value
+    _log.warning(
+        "%s=%r must be >= %s; ignoring",
+        source,
+        value,
+        _MIN_SQL_RETRY_DEADLINE_S,
+    )
+    return None
+
+
 def _resolve_sql_retry_deadline_s() -> int:
     """Return the effective SQL retry deadline in seconds.
 
@@ -209,7 +228,8 @@ def _resolve_sql_retry_deadline_s() -> int:
     1. ``FABRIC_SQL_RETRY_TIMEOUT_S`` env var — must be an integer (or float-formatted
        integer like ``"120.0"``) >= 1.  Invalid values are ignored (warning logged)
        and fall through to next layer.
-    2. ``config.toml`` ``[defaults].sql_retry_deadline_s``.
+    2. ``config.toml`` ``[defaults].sql_retry_deadline_s`` — same >= 1 floor applies;
+       values below the minimum are ignored (warning logged) and fall through.
     3. Built-in fallback: :data:`_SQL_RETRY_DEADLINE_S_DEFAULT` (120 s).
     """
     raw_env = os.environ.get("FABRIC_SQL_RETRY_TIMEOUT_S")
@@ -219,17 +239,15 @@ def _resolve_sql_retry_deadline_s() -> int:
         except (ValueError, OverflowError):
             _log.warning("FABRIC_SQL_RETRY_TIMEOUT_S=%r is not a valid integer; ignoring", raw_env)
         else:
-            if v >= _MIN_SQL_RETRY_DEADLINE_S:
-                return v
-            _log.warning(
-                "FABRIC_SQL_RETRY_TIMEOUT_S=%r must be >= %s; ignoring",
-                raw_env,
-                _MIN_SQL_RETRY_DEADLINE_S,
-            )
+            result = _validate_sql_retry_deadline_s(v, "FABRIC_SQL_RETRY_TIMEOUT_S")
+            if result is not None:
+                return result
 
     cfg_val = _load_sql_config().defaults.sql_retry_deadline_s
     if cfg_val is not None:
-        return cfg_val
+        result = _validate_sql_retry_deadline_s(cfg_val, "sql_retry_deadline_s (config.toml)")
+        if result is not None:
+            return result
 
     return _SQL_RETRY_DEADLINE_S_DEFAULT
 

--- a/tests/unit/test_sql.py
+++ b/tests/unit/test_sql.py
@@ -2921,6 +2921,26 @@ class TestSqlRetryConfig:
         _sql_module._sql_config_cache = cfg
         assert _sql_module._resolve_sql_retry_deadline_s() == 88
 
+    def test_deadline_config_zero_floored_to_default(self) -> None:
+        """A config.toml sql_retry_deadline_s of 0 is rejected and falls through to default."""
+        cfg = UserConfig(defaults=Defaults(sql_retry_deadline_s=0))
+        _sql_module._sql_config_cache = cfg
+        assert _sql_module._resolve_sql_retry_deadline_s() == 120
+
+    def test_deadline_config_below_min_floored_to_default(self) -> None:
+        """A config.toml sql_retry_deadline_s below the minimum is rejected and falls through."""
+        cfg = UserConfig(defaults=Defaults(sql_retry_deadline_s=-5))
+        _sql_module._sql_config_cache = cfg
+        # -5 < _MIN_SQL_RETRY_DEADLINE_S, so the built-in default is used
+        assert _sql_module._resolve_sql_retry_deadline_s() == 120
+
+    def test_deadline_valid_config_value_returned(self) -> None:
+        """A config.toml sql_retry_deadline_s at or above the minimum is returned as-is."""
+        min_val = _sql_module._MIN_SQL_RETRY_DEADLINE_S
+        cfg = UserConfig(defaults=Defaults(sql_retry_deadline_s=min_val))
+        _sql_module._sql_config_cache = cfg
+        assert _sql_module._resolve_sql_retry_deadline_s() == min_val
+
     def test_executes_env_wins_over_config_and_default(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Summary

- `_resolve_sql_retry_deadline_s` honoured a `config.toml` value of `0` verbatim while the same value from `FABRIC_SQL_RETRY_TIMEOUT_S` was rejected with a warning and floored to the built-in default. This asymmetry could silently disable connect retries.
- Extracted a shared `_validate_sql_retry_deadline_s(value, source)` helper that applies the `_MIN_SQL_RETRY_DEADLINE_S` floor and warning to any candidate value.
- Both the env-var path and the config.toml path now call this helper, making their behaviour identical.

## Tests added

- `test_deadline_config_zero_floored_to_default` - config value 0 falls through to default
- `test_deadline_config_below_min_floored_to_default` - config value below minimum falls through to default
- `test_deadline_valid_config_value_returned` - config value at the minimum is returned unchanged

Closes #834