### PR TITLE
refactor(cli): public truncate entry point, share credential cleanup

### DIFF
--- a/src/fabric_dw/cli/commands/tables.py
+++ b/src/fabric_dw/cli/commands/tables.py
@@ -1119,6 +1119,25 @@ async def load_cmd(  # noqa: PLR0912, PLR0915
         raise click.ClickException(str(exc)) from exc
 
 
+async def _close_credential(credential: object) -> None:
+    """Close an azure.identity-style async credential, suppressing teardown errors.
+
+    Many azure.identity.aio credential objects hold an aiohttp.ClientSession
+    internally.  Calling close() and awaiting the result releases that session;
+    without this call the session leaks and emits an 'Unclosed client session'
+    ResourceWarning.  Errors during teardown are suppressed — a failed close
+    must not shadow the original exception from the load path.
+    """
+    _close = getattr(credential, "close", None)
+    if callable(_close):
+        try:
+            _close_result = _close()
+            if asyncio.iscoroutine(_close_result):
+                await _close_result
+        except Exception:  # noqa: S110
+            pass
+
+
 async def _load_cmd_local(
     ctx: CliContext,
     http: FabricHttpClient,
@@ -1148,7 +1167,7 @@ async def _load_cmd_local(
     guard), so it never reaches this helper.
     """
     from fabric_dw import auth as _auth  # noqa: PLC0415
-    from fabric_dw.services.load import FileFormat, _truncate_table_sql  # noqa: PLC0415
+    from fabric_dw.services.load import FileFormat  # noqa: PLC0415
 
     local = Path(file_path)
     if not local.exists():
@@ -1177,7 +1196,9 @@ async def _load_cmd_local(
     # Note: "replace" always requires --create (enforced earlier) so only
     # "truncate" can arrive here.
     if if_exists == "truncate":
-        await _truncate_table_sql(sql_target, schema, table_name, mode=ctx.auth)
+        await _tables_svc.clear_table(
+            sql_target, schema, table_name, kind=entry.kind, mode=ctx.auth
+        )
 
     credential = _auth.get_credential(ctx.auth)
     try:
@@ -1199,18 +1220,7 @@ async def _load_cmd_local(
             mode=ctx.auth,
         )
     finally:
-        # Close the storage-scope credential to release its internal aiohttp
-        # session (azure.identity.aio credentials hold one).  Mirror the same
-        # robust pattern used in FabricHttpClient.__aexit__: call close(),
-        # await if it returns a coroutine, suppress any teardown error.
-        _close = getattr(credential, "close", None)
-        if callable(_close):
-            try:
-                _close_result = _close()
-                if asyncio.iscoroutine(_close_result):
-                    await _close_result
-            except Exception:  # noqa: S110
-                pass
+        await _close_credential(credential)
 
 
 async def _load_cmd_create_and_load(
@@ -1295,18 +1305,7 @@ async def _load_cmd_create_and_load(
             cluster_by=cluster_by,
         )
     finally:
-        # Close the storage-scope credential to release its internal aiohttp
-        # session (azure.identity.aio credentials hold one).  Same pattern as
-        # _load_cmd_local — without this close() call the session leaks and
-        # emits an 'Unclosed client session' ResourceWarning on every load.
-        _close = getattr(credential, "close", None)
-        if callable(_close):
-            try:
-                _close_result = _close()
-                if asyncio.iscoroutine(_close_result):
-                    await _close_result
-            except Exception:  # noqa: S110
-                pass
+        await _close_credential(credential)
 
 
 async def _load_cmd_url(

--- a/tests/unit/cli/commands/test_tables.py
+++ b/tests/unit/cli/commands/test_tables.py
@@ -2168,7 +2168,7 @@ class TestLoadCreateAndLoad:
                 return_value="csv",
             ),
             patch(
-                "fabric_dw.services.load._truncate_table_sql",
+                "fabric_dw.services.tables.clear_table",
                 new=AsyncMock(),
             ) as mock_trunc,
         ):
@@ -2471,6 +2471,60 @@ class TestLoadCmdCreateAndLoadStorageCredential:
             )
 
         close_spy.assert_awaited_once()
+
+
+# ===========================================================================
+# _close_credential — shared credential teardown helper (#824)
+# ===========================================================================
+
+
+class TestCloseCredential:
+    """Verify the shared _close_credential helper correctly tears down credentials."""
+
+    @pytest.mark.asyncio
+    async def test_awaits_async_close(self) -> None:
+        """_close_credential awaits a coroutine returned by close()."""
+        from fabric_dw.cli.commands.tables import _close_credential  # noqa: PLC0415
+
+        close_spy = AsyncMock()
+        mock_cred = MagicMock()
+        mock_cred.close = close_spy
+
+        await _close_credential(mock_cred)
+
+        close_spy.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_calls_sync_close(self) -> None:
+        """_close_credential calls a synchronous close() without error."""
+        from fabric_dw.cli.commands.tables import _close_credential  # noqa: PLC0415
+
+        close_spy = MagicMock(return_value=None)  # sync: returns None, not a coroutine
+        mock_cred = MagicMock()
+        mock_cred.close = close_spy
+
+        await _close_credential(mock_cred)
+
+        close_spy.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_suppresses_teardown_error(self) -> None:
+        """_close_credential swallows exceptions from close() so they do not shadow load errors."""
+        from fabric_dw.cli.commands.tables import _close_credential  # noqa: PLC0415
+
+        mock_cred = MagicMock()
+        mock_cred.close = MagicMock(side_effect=RuntimeError("teardown boom"))
+
+        # Must not raise.
+        await _close_credential(mock_cred)
+
+    @pytest.mark.asyncio
+    async def test_noop_when_close_absent(self) -> None:
+        """_close_credential is a no-op when the credential has no close() method."""
+        from fabric_dw.cli.commands.tables import _close_credential  # noqa: PLC0415
+
+        # A plain object with no close attribute.
+        await _close_credential(object())
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

- Replace the private `_truncate_table_sql` import in `_load_cmd_local` with a call to the public `services.tables.clear_table`, so the CLI no longer imports private service symbols for the truncate path.
- Factor the duplicated credential open/close teardown block (previously copy-pasted in both `_load_cmd_local` and `_load_cmd_create_and_load`) into a single `_close_credential` helper used by both callers.
- Add `TestCloseCredential` covering async close, sync close, teardown-error suppression, and the no-op path for credentials without `close()`.

## Test plan

- [x] `TestLoadCreateAndLoad::test_if_exists_truncate_without_create_invokes_truncate` updated to patch `services.tables.clear_table` (was patching the removed private symbol) and still passes.
- [x] `TestLoadCmdLocalStorageCredential` and `TestLoadCmdCreateAndLoadStorageCredential` (existing credential lifecycle tests) still pass unchanged.
- [x] `TestCloseCredential` (new) passes for all four cases.
- [x] Full `tests/unit/cli/commands/test_tables.py`, `tests/unit/services/test_tables.py`, `tests/unit/services/test_create_and_load.py` suite: 358 passed.
- [x] `ruff check` and `ruff format --check` clean on changed files.

Closes #824

🤖 Generated with [Claude Code](https://claude.com/claude-code)