### PR TITLE
fix(cli): reject non-finite floats in --json output

### DIFF
--- a/src/fabric_dw/cli/_render.py
+++ b/src/fabric_dw/cli/_render.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json as _json
+import math
 import re
 from collections.abc import Sequence
 
@@ -19,7 +20,40 @@ __all__ = [
     "render",
     "render_permissions_table",
     "render_refresh_table",
+    "sanitise_json",
 ]
+
+
+# ---------------------------------------------------------------------------
+# JSON sanitisation
+# ---------------------------------------------------------------------------
+
+
+def sanitise_json(obj: object) -> object:
+    """Recursively replace non-finite floats with ``None`` for strict JSON.
+
+    ``json.dumps`` with the default ``allow_nan=True`` emits the non-standard
+    tokens ``Infinity``, ``-Infinity``, and ``NaN``, which strict JSON parsers
+    reject.  This function walks the value tree and coerces any non-finite
+    ``float`` to ``None`` (serialised as JSON ``null``) so the payload is
+    always RFC 8259 compliant before being passed to ``json.dumps``.
+
+    Handles ``dict``, ``list``, and scalar types.  All other types are returned
+    unchanged for the ``default`` fallback in ``json.dumps`` to handle.
+
+    Args:
+        obj: The value to sanitise (can be any JSON-representable Python value).
+
+    Returns:
+        A new value with non-finite floats replaced by ``None``.
+    """
+    if isinstance(obj, float):
+        return None if not math.isfinite(obj) else obj
+    if isinstance(obj, dict):
+        return {k: sanitise_json(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [sanitise_json(item) for item in obj]
+    return obj
 
 
 # ---------------------------------------------------------------------------
@@ -118,7 +152,7 @@ def render(
             pruned) and when *data* is not a list.
     """
     if json_output:
-        click.echo(_json.dumps(data, indent=2, default=str))
+        click.echo(_json.dumps(sanitise_json(data), indent=2, default=str, allow_nan=False))
         return
 
     con = console if console is not None else _DEFAULT_CONSOLE

--- a/src/fabric_dw/cli/commands/sql.py
+++ b/src/fabric_dw/cli/commands/sql.py
@@ -19,7 +19,7 @@ from fabric_dw.cli._plan_mermaid import render_plan_mermaid
 from fabric_dw.cli._plan_parse import parse_showplan
 from fabric_dw.cli._plan_render import operator_to_dict, render_plan_tree
 from fabric_dw.cli._plan_svg import render_plan_svg
-from fabric_dw.cli._render import render
+from fabric_dw.cli._render import render, sanitise_json
 from fabric_dw.cli.commands._utils import (
     build_http_client,
     build_sql_target,
@@ -238,7 +238,7 @@ def _output_plan(
         # Global --json: parsed operator tree as JSON; -o writes to file.
         operators = parse_showplan(plan_xml)
         payload = [operator_to_dict(op) for op in operators]
-        json_text = _json.dumps(payload, indent=2)
+        json_text = _json.dumps(sanitise_json(payload), indent=2, allow_nan=False)
         _write_or_echo(json_text, output_path, "Execution plan JSON written to {path}")
     elif output_format == "mermaid":
         # --format mermaid: Mermaid flowchart diagram; -o writes to file.

--- a/tests/unit/cli/commands/test_sql.py
+++ b/tests/unit/cli/commands/test_sql.py
@@ -1221,3 +1221,90 @@ class TestSqlPlanFormatHtml:
                 ],
             )
         assert result.exit_code != 0
+
+
+# Plan XML whose EstimateRows="1e400" parses to float('inf') via float().
+_NONFINITE_PLAN_XML = (
+    f'<ShowPlanXML xmlns="{_NS}" Version="1.6" Build="16.0.0.0">'
+    f"<BatchSequence><Batch><Statements>"
+    f'<StmtSimple StatementText="SELECT 1">'
+    f"<QueryPlan>"
+    f'<RelOp NodeId="0" PhysicalOp="Table Scan" LogicalOp="Table Scan"'
+    f' EstimateRows="1e400" EstimatedTotalSubtreeCost="0.5" Parallel="0">'
+    f"<TableScan />"
+    f"</RelOp>"
+    f"</QueryPlan>"
+    f"</StmtSimple>"
+    f"</Statements></Batch></BatchSequence>"
+    f"</ShowPlanXML>"
+)
+
+
+class TestSqlJsonNonFinite:
+    """--json output must never contain non-standard Infinity / NaN tokens."""
+
+    def test_exec_json_non_finite_float_emits_null(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """sql exec --json coerces a non-finite float row value to null."""
+        _ = cache_env
+        mock_http = AsyncMock()
+        non_finite_result = SqlResult(
+            columns=["value"],
+            rows=[[float("inf")]],
+            rowcount=1,
+        )
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.sql_exec.execute",
+                new=AsyncMock(return_value=non_finite_result),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                ["-w", WS_GUID, "--json", "sql", "exec", WH_GUID, "-q", "SELECT 1e400"],
+            )
+        assert result.exit_code == 0
+        # Must be strict JSON (json.loads raises on Infinity / NaN tokens).
+        parsed = json.loads(result.output)
+        # The non-finite float must become null.
+        assert parsed["rows"][0][0] is None
+
+    def test_plan_json_non_finite_estimate_rows_emits_null(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """sql plan --json coerces a non-finite estimateRows to null."""
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.sql_exec.get_plan",
+                new=AsyncMock(return_value=_NONFINITE_PLAN_XML),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                ["-w", WS_GUID, "--json", "sql", "plan", WH_GUID, "-q", "SELECT 1"],
+            )
+        assert result.exit_code == 0
+        # Must be strict JSON (json.loads raises on Infinity / NaN tokens).
+        parsed = json.loads(result.output)
+        assert isinstance(parsed, list)
+        # The operator with EstimateRows="1e400" must have estimateRows=null.
+        assert parsed[0]["estimateRows"] is None

--- a/tests/unit/cli/test_render.py
+++ b/tests/unit/cli/test_render.py
@@ -17,6 +17,7 @@ from fabric_dw.cli._render import (
     render,
     render_permissions_table,
     render_refresh_table,
+    sanitise_json,
 )
 from fabric_dw.models import (
     ItemAccess,
@@ -1533,3 +1534,75 @@ class TestWarehousesAllShapeWidthStarvation:
         assert "displayName" in output
         assert "kind" in output
         assert "id" in output
+
+
+class TestSanitiseJson:
+    """Unit tests for the sanitise_json helper."""
+
+    def test_finite_float_unchanged(self) -> None:
+        assert sanitise_json(1.5) == 1.5
+
+    def test_positive_infinity_becomes_none(self) -> None:
+        assert sanitise_json(float("inf")) is None
+
+    def test_negative_infinity_becomes_none(self) -> None:
+        assert sanitise_json(float("-inf")) is None
+
+    def test_nan_becomes_none(self) -> None:
+        assert sanitise_json(float("nan")) is None
+
+    def test_non_float_scalars_unchanged(self) -> None:
+        assert sanitise_json(42) == 42
+        assert sanitise_json("hello") == "hello"
+        assert sanitise_json(None) is None
+        assert sanitise_json(True) is True  # noqa: FBT003
+
+    def test_dict_with_non_finite_value_coerced(self) -> None:
+        result = sanitise_json({"a": float("inf"), "b": 1.0})
+        assert result == {"a": None, "b": 1.0}
+
+    def test_list_with_non_finite_value_coerced(self) -> None:
+        result = sanitise_json([float("nan"), 2.0, float("-inf")])
+        assert result == [None, 2.0, None]
+
+    def test_nested_structure_coerced(self) -> None:
+        data = {"rows": [{"cost": float("inf"), "label": "x"}], "total": float("nan")}
+        result = sanitise_json(data)
+        assert result == {"rows": [{"cost": None, "label": "x"}], "total": None}
+
+    def test_no_copy_when_no_non_finite(self) -> None:
+        """Finite-only data roundtrips without mutation."""
+        data = {"a": 1.0, "b": [2.5, 3.0]}
+        result = sanitise_json(data)
+        assert result == data
+
+
+class TestRenderJsonNonFinite:
+    """render(data, json_output=True) must emit strict JSON even for non-finite floats."""
+
+    def test_infinity_in_dict_emits_null(self, capsys: pytest.CaptureFixture[str]) -> None:
+        render({"cost": float("inf")}, json_output=True)
+        captured = capsys.readouterr()
+        parsed = json.loads(captured.out)
+        assert parsed["cost"] is None
+
+    def test_nan_in_dict_emits_null(self, capsys: pytest.CaptureFixture[str]) -> None:
+        render({"value": float("nan")}, json_output=True)
+        captured = capsys.readouterr()
+        parsed = json.loads(captured.out)
+        assert parsed["value"] is None
+
+    def test_negative_infinity_in_list_emits_null(self, capsys: pytest.CaptureFixture[str]) -> None:
+        render([float("-inf"), 1.0], json_output=True)
+        captured = capsys.readouterr()
+        parsed = json.loads(captured.out)
+        assert parsed[0] is None
+        assert parsed[1] == 1.0
+
+    def test_output_is_strict_json_parseable(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """json.loads must succeed: no Infinity / NaN tokens in the output."""
+        render({"a": float("inf"), "b": float("nan"), "c": 2.5}, json_output=True)
+        captured = capsys.readouterr()
+        # json.loads raises if the output is not strict JSON
+        parsed = json.loads(captured.out)
+        assert parsed["c"] == 2.5


### PR DESCRIPTION
## Summary

- Add `sanitise_json()` helper to `_render.py` that recursively replaces non-finite floats (`Infinity`, `-Infinity`, `NaN`) with `None` before serialisation.
- Apply it in `render()` (covers `sql exec --json`) and in `_output_plan()` in `sql.py` (covers `sql plan --json`), both coupled with `allow_nan=False`.
- Coerces values such as `EstimateRows="1e400"` (parsed by `_plan_parse.py` via `float()` to `float('inf')`) to JSON `null`.
- Adds 15 new unit tests: `TestSanitiseJson`, `TestRenderJsonNonFinite`, and `TestSqlJsonNonFinite`.

## Test plan

- [ ] `uv run pytest tests/unit/cli/test_render.py::TestSanitiseJson` - 9 tests for the helper.
- [ ] `uv run pytest tests/unit/cli/test_render.py::TestRenderJsonNonFinite` - 4 tests for `render()` with non-finite floats.
- [ ] `uv run pytest tests/unit/cli/commands/test_sql.py::TestSqlJsonNonFinite` - 2 end-to-end CLI tests for `sql exec --json` and `sql plan --json` with non-finite floats.
- [ ] Full unit suite stays green: `uv run pytest tests/unit/`.

Closes #831

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>