### PR TITLE
fix(cli): render duplicate result columns positionally

### DIFF
--- a/src/fabric_dw/cli/_render.py
+++ b/src/fabric_dw/cli/_render.py
@@ -20,6 +20,7 @@ __all__ = [
     "render",
     "render_permissions_table",
     "render_refresh_table",
+    "render_result_rows",
     "sanitise_json",
 ]
 
@@ -489,6 +490,165 @@ def render_refresh_table(
         )
 
     con.print(table)
+
+
+def _is_guid_column_values(values: list[object]) -> bool:
+    """Return *True* when all non-``None`` entries in *values* are GUIDs.
+
+    Used by :func:`_render_positional_table` to apply the same GUID-column
+    width heuristic as :func:`_is_guid_column`, but working directly on a
+    pre-collected list of values rather than through dict row lookups.
+    """
+    found = False
+    for val in values:
+        if val is None:
+            continue
+        found = True
+        if not _GUID_RE.fullmatch(str(val)):
+            return False
+    return found
+
+
+def _render_positional_vertical(
+    rows: Sequence[Sequence[object]],
+    columns: list[str],
+    visible: list[int],
+    *,
+    console: Console,
+    title: str | None,
+) -> None:
+    """Render *rows* as a sequence of vertical key-value panels, index-based.
+
+    Extracted from :func:`_render_positional_table` so that the parent
+    function stays within the branch-count budget.  Duplicate column names
+    are preserved because cell values are looked up by position, not by key.
+    """
+    if title:
+        console.print(f"[bold]{_escape_markup(title)}[/bold]")
+    for j, row in enumerate(rows):
+        if j > 0:
+            console.rule(style="dim")
+        lines = "\n".join(
+            f"[bold]{_escape_markup(columns[i])}[/bold]: {_cell(row[i] if i < len(row) else None)}"
+            for i in visible
+        )
+        console.print(Panel(lines))
+
+
+def _render_positional_table(
+    columns: list[str],
+    rows: Sequence[Sequence[object]],
+    *,
+    console: Console,
+    title: str | None,
+) -> None:
+    """Render *columns* and *rows* as a Rich table using positional access.
+
+    Unlike :func:`_render_table`, column headers come directly from *columns*
+    and cell values are accessed by index, so duplicate column names
+    (e.g. ``SELECT 1 AS id, 2 AS id``) each keep their own header and value
+    instead of being collapsed by dict keying.
+
+    All-null columns (every row has ``None`` at that position) are omitted.
+    The wide-table vertical fallback uses the same heuristic as
+    :func:`_render_table`.
+    """
+    if not rows:
+        if title:
+            console.print(f"[bold]{_escape_markup(title)}[/bold]")
+        console.print(Table(show_header=True, header_style="bold"))
+        return
+
+    n = len(columns)
+
+    # Pre-collect values per column position for GUID detection and null pruning.
+    col_values: list[list[object]] = [
+        [row[i] if i < len(row) else None for row in rows] for i in range(n)
+    ]
+
+    # Drop positions where every row has None.
+    all_null_idx: set[int] = {
+        i for i, vals in enumerate(col_values) if all(v is None for v in vals)
+    }
+    visible: list[int] = [i for i in range(n) if i not in all_null_idx]
+
+    # Estimate horizontal fit using the same heuristic as _table_fits().
+    primary_guid_assigned = False
+    content_width = 0
+    for i in visible:
+        if _is_guid_column_values(col_values[i]):
+            # Primary GUID gets full width; additional GUIDs get a smaller floor.
+            content_width += _GUID_WIDTH if not primary_guid_assigned else _GUID_SECONDARY_WIDTH
+            primary_guid_assigned = True
+        else:
+            content_width += min(len(columns[i]), _HEADER_MAX_WIDTH)
+    border_chars = 3 * len(visible) + 1
+
+    if content_width + border_chars > console.width:
+        _render_positional_vertical(rows, columns, visible, console=console, title=title)
+        return
+
+    if title:
+        console.print(f"[bold]{_escape_markup(title)}[/bold]")
+    table = Table(show_header=True, header_style="bold")
+
+    primary_guid_assigned = False
+    for i in visible:
+        escaped_col = _escape_markup(columns[i])
+        if _is_guid_column_values(col_values[i]) and not primary_guid_assigned:
+            table.add_column(escaped_col, no_wrap=True, min_width=_GUID_WIDTH)
+            primary_guid_assigned = True
+        else:
+            table.add_column(escaped_col)
+
+    for row in rows:
+        table.add_row(*[_cell(row[i] if i < len(row) else None) for i in visible])
+
+    console.print(table)
+
+
+def render_result_rows(
+    columns: list[str],
+    rows: Sequence[Sequence[object]],
+    *,
+    json_output: bool,
+    console: Console | None = None,
+    table_title: str | None = None,
+) -> None:
+    """Render SQL result columns and rows, preserving duplicate column names.
+
+    Unlike :func:`render`, this function takes *columns* and *rows*
+    separately and renders them positionally for the Rich table path, so
+    duplicate column names (e.g. ``SELECT 1 AS id, 2 AS id``) each keep
+    their own header and value.
+
+    For JSON output the rows are zipped into per-row dicts; duplicate column
+    names follow standard dict semantics (last value wins), which matches the
+    behaviour of the previous dict-based rendering.
+
+    Args:
+        columns: Ordered list of column names as returned by the query.
+        rows: Ordered list of rows; each row is a sequence of values aligned
+            positionally with *columns*.
+        json_output: When *True*, emit indented JSON.  When *False*, render a
+            Rich table via :func:`_render_positional_table`.
+        console: Optional Rich Console instance.  Ignored when
+            *json_output=True*.
+        table_title: Optional title shown above the Rich table.  Ignored when
+            *json_output=True*.
+    """
+    if json_output:
+        click.echo(
+            _json.dumps(
+                [dict(zip(columns, row, strict=False)) for row in rows],
+                indent=2,
+                default=str,
+            )
+        )
+        return
+
+    con = console if console is not None else _DEFAULT_CONSOLE
+    _render_positional_table(columns, list(rows), console=con, title=table_title)
 
 
 def confirm(message: str, *, yes: bool) -> bool:

--- a/src/fabric_dw/cli/commands/sql.py
+++ b/src/fabric_dw/cli/commands/sql.py
@@ -19,7 +19,7 @@ from fabric_dw.cli._plan_mermaid import render_plan_mermaid
 from fabric_dw.cli._plan_parse import parse_showplan
 from fabric_dw.cli._plan_render import operator_to_dict, render_plan_tree
 from fabric_dw.cli._plan_svg import render_plan_svg
-from fabric_dw.cli._render import render, sanitise_json
+from fabric_dw.cli._render import render, render_result_rows, sanitise_json
 from fabric_dw.cli.commands._utils import (
     build_http_client,
     build_sql_target,
@@ -86,8 +86,12 @@ async def sql_exec_cmd(
                     json_output=True,
                 )
             elif result.rows:
-                rows_as_dicts = [dict(zip(result.columns, row, strict=True)) for row in result.rows]
-                render(rows_as_dicts, json_output=False, table_title="SQL Result")
+                render_result_rows(
+                    result.columns,
+                    result.rows,
+                    json_output=False,
+                    table_title="SQL Result",
+                )
             else:
                 click.echo(f"Query executed successfully. rowcount={result.rowcount}")
     except (ValueError, FabricError) as exc:

--- a/src/fabric_dw/cli/commands/tables.py
+++ b/src/fabric_dw/cli/commands/tables.py
@@ -14,7 +14,7 @@ import click
 from fabric_dw.cache import ItemEntry
 from fabric_dw.cli._context import CliContext
 from fabric_dw.cli._main import _CLI_CONDITIONAL_DESTRUCTIVE_KEY
-from fabric_dw.cli._render import render
+from fabric_dw.cli._render import render, render_result_rows
 from fabric_dw.cli.commands._utils import (
     build_http_client,
     build_sql_target,
@@ -237,8 +237,9 @@ async def health_check_cmd(
             columns, rows = await _tables_svc.get_table_health_metrics(
                 target, schema, table_name, kind=entry.kind, mode=ctx.auth
             )
-            render(
-                [dict(zip(columns, row, strict=True)) for row in rows],
+            render_result_rows(
+                columns,
+                rows,
                 json_output=ctx.json_output,
                 table_title="Table Health Metrics",
             )

--- a/tests/unit/cli/commands/test_sql.py
+++ b/tests/unit/cli/commands/test_sql.py
@@ -66,6 +66,10 @@ def _make_empty_sql_result() -> SqlResult:
     return SqlResult(columns=[], rows=[], rowcount=3)
 
 
+def _make_duplicate_col_result() -> SqlResult:
+    return SqlResult(columns=["val", "val"], rows=[["alpha", "beta"]], rowcount=1)
+
+
 _PLAN_XML = (
     "<ShowPlanXML xmlns='http://schemas.microsoft.com/sqlserver/2004/07/showplan'>"
     "<Batch><Statements><StmtSimple /></Statements></Batch></ShowPlanXML>"
@@ -398,6 +402,71 @@ class TestSqlExecErrors:
                 ["-w", WS_GUID, "sql", "exec", WH_GUID, "-q", "SELECT 1"],
             )
         assert result.exit_code != 0
+
+
+class TestSqlExecDuplicateColumns:
+    """sql exec — duplicate column name handling (issue #833)."""
+
+    def test_duplicate_columns_renders_both_values(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """SELECT 1 AS val, 2 AS val must render both values, not collapse them.
+
+        With the old dict(zip(columns, row)) approach, the second value
+        overwrites the first, so only one value appears.  The positional
+        renderer must show both.
+        """
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.sql_exec.execute",
+                new=AsyncMock(return_value=_make_duplicate_col_result()),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                ["-w", WS_GUID, "sql", "exec", WH_GUID, "-q", "SELECT 1 AS val, 2 AS val"],
+            )
+        assert result.exit_code == 0
+        assert "alpha" in result.output, "first value must appear in table output"
+        assert "beta" in result.output, "second value must appear in table output"
+
+    def test_unique_columns_unaffected_by_positional_render(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """Unique-column results must still render correctly after the fix."""
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.sql_exec.execute",
+                new=AsyncMock(return_value=_make_sql_result()),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                ["-w", WS_GUID, "sql", "exec", WH_GUID, "-q", "SELECT id, name FROM t"],
+            )
+        assert result.exit_code == 0
+        assert "foo" in result.output
+        assert "bar" in result.output
 
 
 class TestSqlPlan:

--- a/tests/unit/cli/commands/test_tables.py
+++ b/tests/unit/cli/commands/test_tables.py
@@ -3096,3 +3096,71 @@ class TestTablesHealthCheck:
         assert result.exit_code == 0, result.output
         parsed = json.loads(result.output)
         assert parsed == []
+
+
+class TestTablesHealthCheckDuplicateColumns:
+    """tables health-check — duplicate column name handling (issue #833)."""
+
+    def test_health_check_duplicate_columns_renders_both_values(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """health-check with duplicate column names must render both values.
+
+        With the old dict(zip(columns, row)) approach the second value
+        overwrites the first; the positional renderer must show both.
+        """
+        _ = cache_env
+        mock_http = AsyncMock()
+        fake_cols = ["metric", "metric"]
+        fake_rows: list[tuple[object, ...]] = [("alpha", "beta")]
+        with (
+            patch(
+                "fabric_dw.cli.commands.tables.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.tables.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_sql_endpoint_entry())),
+            ),
+            patch(
+                "fabric_dw.services.tables.get_table_health_metrics",
+                new=AsyncMock(return_value=(fake_cols, fake_rows)),
+            ),
+        ):
+            result = runner.invoke(
+                cli, ["-w", WS_GUID, "tables", "health-check", SE_GUID, "dbo.FactSales"]
+            )
+        assert result.exit_code == 0, result.output
+        assert "alpha" in result.output, "first value must appear in table output"
+        assert "beta" in result.output, "second value must appear in table output"
+
+    def test_health_check_duplicate_columns_json_output(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """health-check with --json and duplicate column names must exit zero."""
+        _ = cache_env
+        mock_http = AsyncMock()
+        fake_cols = ["metric", "metric"]
+        fake_rows: list[tuple[object, ...]] = [("alpha", "beta")]
+        with (
+            patch(
+                "fabric_dw.cli.commands.tables.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.tables.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_sql_endpoint_entry())),
+            ),
+            patch(
+                "fabric_dw.services.tables.get_table_health_metrics",
+                new=AsyncMock(return_value=(fake_cols, fake_rows)),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                ["-w", WS_GUID, "--json", "tables", "health-check", SE_GUID, "dbo.FactSales"],
+            )
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.output)
+        assert isinstance(parsed, list)
+        assert len(parsed) == 1


### PR DESCRIPTION
## Summary

- `sql exec` and `tables health-check` built result rows via `dict(zip(columns, row))`, which collapses duplicate column names (e.g. `SELECT 1 AS id, 2 AS id`) so the first value is silently lost.
- Added `render_result_rows(columns, rows, ...)` in `cli/_render.py` that uses a new `_render_positional_table()` helper accessing cells by index, preserving every column header and value regardless of name collisions.
- Applied the fix to both affected call sites; JSON output and all existing rendering behaviour are unchanged.

## Test plan

- [x] `TestSqlExecDuplicateColumns::test_duplicate_columns_renders_both_values` - verifies both values appear when column names repeat
- [x] `TestSqlExecDuplicateColumns::test_unique_columns_unaffected_by_positional_render` - verifies existing unique-column output is unchanged
- [x] `TestTablesHealthCheckDuplicateColumns::test_health_check_duplicate_columns_renders_both_values` - same for the health-check path
- [x] `TestTablesHealthCheckDuplicateColumns::test_health_check_duplicate_columns_json_output` - JSON path exits zero with duplicate columns
- [x] Full unit suite (278 tests) passes with no regressions

Closes #833

Generated with [Claude Code](https://claude.com/claude-code)