### PR TITLE
fix(cli): accept -w/--auth/retry global options after the subcommand

### DIFF
--- a/src/fabric_dw/cli/_main.py
+++ b/src/fabric_dw/cli/_main.py
@@ -76,25 +76,38 @@ _HELP_MAX_WIDTH = max(80, min(shutil.get_terminal_size(fallback=(120, 24)).colum
 # Global-options injection
 # ---------------------------------------------------------------------------
 # These option definitions are injected into every leaf command and sub-group
-# so that --json, -y/--yes, and -v/--verbose work regardless of whether they
-# appear before or after the subcommand on the command line.
+# so that all global options work regardless of whether they appear before or
+# after the subcommand on the command line.
 #
-# --auth is intentionally excluded: it is consumed in the root group callback
-# before any subcommand runs, so positional placement there is load-bearing.
+# Collision handling: if a leaf command already declares a flag with the same
+# name (e.g. "--auth" in "dbt init" which has its own dbt-specific auth mode),
+# injection for that flag is silently skipped on that command.  The pre-
+# subcommand form of the global option is unaffected; only the trailing form
+# is unavailable for that specific command.
 #
-# Design note — expose_value=False for all commands (groups and leaves):
+# Known collision: "dbt init --auth" is dbt's own auth-mode selector
+# (destination: dbt_auth_override).  The global "--auth" is therefore not
+# injected into "dbt init"; users who need to set the global auth mode for
+# that command must use the pre-subcommand form: "fabric-dw --auth <mode>
+# dbt init ...".
+#
+# Design note -- expose_value=False for all commands (groups and leaves):
 #   All injected options use expose_value=False so Click parses the option but
 #   does NOT pass it as a keyword argument to any command callback.  Instead,
-#   an option callback (see _make_meta_callback) stores the value in ctx.meta
-#   when the flag is set.  Before the command body runs, _apply_meta_global_params
-#   reads ctx.meta and OR-merges the stored flags into ctx.obj (the shared
-#   CliContext).  This uniform approach avoids having to distinguish between
-#   group callbacks and leaf-command callbacks.
+#   an option callback (see _make_meta_callback / _make_meta_value_callback)
+#   stores the value in ctx.meta when the flag is set.  Before the command body
+#   runs, _apply_meta_global_params reads ctx.meta and merges the stored values
+#   into ctx.obj (the shared CliContext).  This uniform approach avoids having
+#   to distinguish between group callbacks and leaf-command callbacks.
 # ---------------------------------------------------------------------------
 
 _META_KEY_JSON = "fabric_dw_global_json_output"
 _META_KEY_YES = "fabric_dw_global_yes"
 _META_KEY_VERBOSE = "fabric_dw_global_verbose"
+_META_KEY_WORKSPACE = "fabric_dw_global_workspace"
+_META_KEY_AUTH = "fabric_dw_global_auth_mode"
+_META_KEY_MAX_429_RETRIES = "fabric_dw_global_max_429_retries"
+_META_KEY_RETRY_DEADLINE = "fabric_dw_global_retry_deadline"
 
 
 def _make_meta_callback(meta_key: str) -> Any:  # noqa: ANN401
@@ -108,14 +121,29 @@ def _make_meta_callback(meta_key: str) -> Any:  # noqa: ANN401
     return _cb
 
 
+def _make_meta_value_callback(meta_key: str) -> Any:  # noqa: ANN401
+    """Return an option callback that stores a non-None value in ``ctx.meta``."""
+
+    def _cb(ctx: click.Context, _param: click.Parameter, value: Any) -> Any:  # noqa: ANN401
+        if value is not None:
+            ctx.meta[meta_key] = value
+        return value
+
+    return _cb
+
+
 def _inject_global_options(cmd: click.Command) -> None:
-    """Add the three global options to *cmd*, skipping any that already exist.
+    """Add all global options to *cmd*, skipping any that already exist.
 
     All injected options use ``expose_value=False`` so they are never passed
     as keyword arguments to the command's own callback (which may not declare
     them).  Instead, an option callback stores the value in ``ctx.meta`` so
     the ``_wrapped_invoke`` can read it and fold it into the shared
     :class:`CliContext` before the command body runs.
+
+    Collision policy: if a command already declares an option with the same
+    flag string (e.g. ``--auth`` on ``dbt init``), that option is skipped for
+    that command.  See the module-level comment for details.
     """
     existing_names: set[str] = set()
     existing_dests: set[str] = set()
@@ -125,8 +153,8 @@ def _inject_global_options(cmd: click.Command) -> None:
         if param.name is not None:
             existing_dests.add(param.name)
 
-    # Tuples of (opts, dest, meta_key, help_text).
-    _specs: list[tuple[list[str], str, str, str]] = [
+    # Boolean flag specs: (opts, dest, meta_key, help_text).
+    _flag_specs: list[tuple[list[str], str, str, str]] = [
         (
             ["--json", "json_output"],
             "json_output",
@@ -137,7 +165,7 @@ def _inject_global_options(cmd: click.Command) -> None:
         (["--verbose", "-v", "verbose"], "verbose", _META_KEY_VERBOSE, "Enable debug logging."),
     ]
 
-    for opts, dest, meta_key, help_text in _specs:
+    for opts, dest, meta_key, help_text in _flag_specs:
         # Skip if any declared option string already exists on this command.
         if existing_names.intersection(opts):
             continue
@@ -160,19 +188,90 @@ def _inject_global_options(cmd: click.Command) -> None:
         # include the Click destination name (e.g. "json_output").
         existing_names.update(option.opts)
 
+    # Value option specs: (opts, dest, meta_key, param_type, metavar, help_text).
+    # Each is skipped if a flag with the same name already exists on the command
+    # (collision policy -- see module-level comment).
+    _value_specs: list[tuple[list[str], str, str, Any, str | None, str]] = [
+        (
+            ["-w", "--workspace", "workspace"],
+            "workspace",
+            _META_KEY_WORKSPACE,
+            str,
+            "NAME|GUID",
+            "Target workspace (name or GUID). Falls back to the configured default.",
+        ),
+        (
+            ["--auth", "auth_mode"],
+            "auth_mode",
+            _META_KEY_AUTH,
+            click.Choice([m.value for m in CredentialMode], case_sensitive=False),
+            None,
+            (
+                "Authentication mode (default: 'default', or as configured by "
+                "FABRIC_AUTH / config file [defaults] auth_mode)."
+            ),
+        ),
+        (
+            ["--max-429-retries", "max_429_retries"],
+            "max_429_retries",
+            _META_KEY_MAX_429_RETRIES,
+            click.IntRange(min=1),
+            "N",
+            (
+                "Maximum consecutive 429 responses before raising RateLimitedError "
+                "(default: 10, or as configured by FABRIC_DW_MAX_429_RETRIES / config file)."
+            ),
+        ),
+        (
+            ["--retry-deadline", "retry_deadline"],
+            "retry_deadline",
+            _META_KEY_RETRY_DEADLINE,
+            click.IntRange(min=1),
+            "SECONDS",
+            (
+                "Combined wall-clock deadline in seconds for the 429-loop and 5xx-retry "
+                "budget (default: 300, or as configured by FABRIC_DW_RETRY_DEADLINE_S / "
+                "config file)."
+            ),
+        ),
+    ]
+
+    for opts, dest, meta_key, param_type, metavar, help_text in _value_specs:
+        if existing_names.intersection(opts):
+            continue
+        if dest in existing_dests:
+            continue
+
+        option = click.Option(
+            opts,
+            type=param_type,
+            default=None,
+            expose_value=False,
+            callback=_make_meta_value_callback(meta_key),
+            metavar=metavar,
+            help=help_text,
+        )
+        cmd.params.append(option)
+        existing_dests.add(dest)
+        existing_names.update(option.opts)
+
 
 def _apply_meta_global_params(ctx: click.Context) -> None:
-    """Apply global flags stored in ``ctx.meta`` to the shared :class:`CliContext`.
+    """Apply global options stored in ``ctx.meta`` to the shared :class:`CliContext`.
 
-    The option callbacks (set up via :func:`_inject_global_options`) store flag
-    values in ``ctx.meta`` when the flag is set.  This function merges those
+    The option callbacks (set up via :func:`_inject_global_options`) store
+    values in ``ctx.meta`` when the option is set.  This function merges those
     stored values into ``ctx.obj`` (the shared :class:`CliContext`) before the
     command body runs.
 
-    Merge semantics (OR-merge — the most-permissive position wins):
-    - ``json_output`` → ``ctx.obj.json_output = True``
-    - ``yes``         → ``ctx.obj.yes = True``
-    - ``verbose``     → re-applies ``setup_logging(DEBUG)``
+    Merge semantics:
+    - ``json_output``     → ``ctx.obj.json_output = True`` (OR-merge)
+    - ``yes``             → ``ctx.obj.yes = True`` (OR-merge)
+    - ``verbose``         → re-applies ``setup_logging(DEBUG)`` (OR-merge)
+    - ``workspace``       → ``ctx.obj.workspace`` (trailing value wins over None)
+    - ``auth_mode``       → re-resolves and updates ``ctx.obj.auth``
+    - ``max_429_retries`` → ``ctx.obj.max_429_retries`` (trailing value wins over None)
+    - ``retry_deadline``  → ``ctx.obj.retry_deadline_s`` (trailing value wins over None)
     """
     obj: CliContext | None = ctx.obj
     if obj is None:
@@ -183,6 +282,23 @@ def _apply_meta_global_params(ctx: click.Context) -> None:
         obj.yes = True
     if ctx.meta.get(_META_KEY_VERBOSE):
         setup_logging(logging.DEBUG)
+    if (ws := ctx.meta.get(_META_KEY_WORKSPACE)) is not None:
+        obj.workspace = ws
+    if (auth_val := ctx.meta.get(_META_KEY_AUTH)) is not None:
+        cfg = load_config()
+        try:
+            resolved = resolve_auth_mode(
+                cli_value=auth_val,
+                config_value=cfg.defaults.auth_mode,
+                valid_modes=VALID_AUTH_MODES,
+            )
+            obj.auth = CredentialMode(resolved)
+        except ValueError as exc:
+            raise click.UsageError(str(exc)) from exc
+    if (retries := ctx.meta.get(_META_KEY_MAX_429_RETRIES)) is not None:
+        obj.max_429_retries = retries
+    if (deadline := ctx.meta.get(_META_KEY_RETRY_DEADLINE)) is not None:
+        obj.retry_deadline_s = deadline
 
 
 def _patch_command_for_global_options(cmd: click.Command) -> None:

--- a/tests/unit/test_global_options_anywhere.py
+++ b/tests/unit/test_global_options_anywhere.py
@@ -1,4 +1,4 @@
-"""Tests for global options (--json, -y/--yes, -v/--verbose) accepted after subcommand.
+"""Tests for global options accepted after the subcommand.
 
 Covers:
 - Before-position (existing behaviour, regression test)
@@ -6,10 +6,12 @@ Covers:
 - After/with a sub-group
 - Help still renders global flags in command help
 - -h / --help still work
+- Collision: dbt init --auth is dbt's own option (global injection skipped)
 """
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -17,6 +19,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from click.testing import CliRunner
 
+from fabric_dw.auth import CredentialMode
+from fabric_dw.cli._context import CliContext
 from fabric_dw.cli._main import cli
 
 
@@ -252,12 +256,24 @@ class TestHelpOutput:
         assert result.exit_code == 0, result.output
         assert "Usage:" in result.output
 
-    def test_auth_not_in_leaf_help(self, runner: CliRunner) -> None:
-        """--auth is intentionally NOT injected into leaf commands."""
+    def test_auth_in_leaf_help(self, runner: CliRunner) -> None:
+        """--auth is injected into leaf commands that do not already declare it."""
         result = runner.invoke(cli, ["workspaces", "list", "--help"])
         assert result.exit_code == 0, result.output
-        # --auth only appears at the root level; not injected into leaves
-        assert "--auth" not in result.output
+        assert "--auth" in result.output
+
+    def test_workspace_flag_in_leaf_help(self, runner: CliRunner) -> None:
+        """-w / --workspace appears in leaf command help."""
+        result = runner.invoke(cli, ["workspaces", "list", "--help"])
+        assert result.exit_code == 0, result.output
+        assert "--workspace" in result.output
+
+    def test_retry_flags_in_leaf_help(self, runner: CliRunner) -> None:
+        """--max-429-retries and --retry-deadline appear in leaf command help."""
+        result = runner.invoke(cli, ["workspaces", "list", "--help"])
+        assert result.exit_code == 0, result.output
+        assert "--max-429-retries" in result.output
+        assert "--retry-deadline" in result.output
 
 
 # ---------------------------------------------------------------------------
@@ -283,3 +299,262 @@ class TestIdempotency:
         assert result.exit_code == 0, result.output
         parsed = json.loads(result.output)
         assert isinstance(parsed, list)
+
+
+# ---------------------------------------------------------------------------
+# -w / --workspace: BEFORE (regression) and AFTER the leaf command
+# ---------------------------------------------------------------------------
+
+
+class TestWorkspaceFlag:
+    """-w / --workspace can appear before or after the subcommand."""
+
+    @pytest.fixture(autouse=True)
+    def _mock_warehouses_list(self) -> object:
+        """Patch the service layer so warehouses list runs without live HTTP."""
+        with (
+            patch(
+                "fabric_dw.cli.commands.warehouses.build_http_client",
+            ) as mock_http_cm,
+            patch(
+                "fabric_dw.cli.commands.warehouses.make_resolver",
+            ) as mock_make_resolver,
+            patch(
+                "fabric_dw.cli.commands.warehouses._warehouses_svc.list_warehouses",
+                new=AsyncMock(return_value=[]),
+            ),
+        ):
+            mock_http = AsyncMock()
+            mock_http_cm.return_value.__aenter__ = AsyncMock(return_value=mock_http)
+            mock_http_cm.return_value.__aexit__ = AsyncMock(return_value=None)
+            mock_resolver = MagicMock()
+            mock_resolver.workspace_id = AsyncMock(return_value="fake-ws-uuid")
+            mock_make_resolver.return_value = (mock_resolver, MagicMock())
+            yield
+
+    def test_workspace_before_subcommand(self, runner: CliRunner) -> None:
+        """-w BEFORE the subcommand sets the workspace (regression)."""
+        result = runner.invoke(cli, ["-w", "myws", "warehouses", "list"], catch_exceptions=False)
+        assert result.exit_code == 0, result.output
+
+    def test_workspace_short_after_leaf(self, runner: CliRunner) -> None:
+        """-w AFTER the leaf command sets ctx.obj.workspace identically.
+
+        warehouses list calls resolve_workspace(ctx), which raises UsageError
+        if ctx.workspace is None and no default is configured.  Passing -w in
+        trailing position must set ctx.obj.workspace so the command succeeds.
+        """
+        captured: dict[str, str | None] = {}
+
+        def _capture_resolve_workspace(ctx: CliContext) -> str:
+            captured["workspace"] = ctx.workspace
+            return "fake-ws-name"
+
+        with patch(
+            "fabric_dw.cli.commands.warehouses.resolve_workspace",
+            side_effect=_capture_resolve_workspace,
+        ):
+            result = runner.invoke(
+                cli, ["warehouses", "list", "-w", "myws"], catch_exceptions=False
+            )
+        assert result.exit_code == 0, result.output
+        assert captured["workspace"] == "myws"
+
+    def test_workspace_long_after_leaf(self, runner: CliRunner) -> None:
+        """--workspace AFTER the leaf command resolves identically to the before form."""
+        captured: dict[str, str | None] = {}
+
+        def _capture_resolve_workspace(ctx: CliContext) -> str:
+            captured["workspace"] = ctx.workspace
+            return "fake-ws-name"
+
+        with patch(
+            "fabric_dw.cli.commands.warehouses.resolve_workspace",
+            side_effect=_capture_resolve_workspace,
+        ):
+            result = runner.invoke(
+                cli, ["warehouses", "list", "--workspace", "myws"], catch_exceptions=False
+            )
+        assert result.exit_code == 0, result.output
+        assert captured["workspace"] == "myws"
+
+    def test_workspace_both_positions(self, runner: CliRunner) -> None:
+        """-w before AND after the subcommand does not cause a parse error."""
+        with patch(
+            "fabric_dw.cli.commands.warehouses.resolve_workspace",
+            return_value="fake-ws-name",
+        ):
+            result = runner.invoke(
+                cli,
+                ["-w", "first", "warehouses", "list", "-w", "second"],
+                catch_exceptions=False,
+            )
+        # Trailing value wins over the root-level value (last-writer semantics).
+        assert result.exit_code == 0, result.output
+
+
+# ---------------------------------------------------------------------------
+# --auth: BEFORE (regression) and AFTER the leaf command
+# ---------------------------------------------------------------------------
+
+
+class TestAuthFlag:
+    """--auth can appear before or after the subcommand (except on dbt init)."""
+
+    @pytest.fixture(autouse=True)
+    def _mock_list(self) -> object:
+        mock_ws = MagicMock()
+        mock_ws.model_dump.return_value = {"id": "ws-1", "displayName": "Test"}
+        with patch(
+            "fabric_dw.cli.commands.workspaces._workspaces_svc.list_all",
+            new=AsyncMock(return_value=[mock_ws]),
+        ):
+            yield
+
+    def test_auth_before_subcommand(self, runner: CliRunner) -> None:
+        """--auth BEFORE the subcommand resolves the auth mode (regression)."""
+        result = runner.invoke(
+            cli, ["--auth", "default", "workspaces", "list"], catch_exceptions=False
+        )
+        assert result.exit_code == 0, result.output
+
+    def test_auth_after_leaf_command(self, runner: CliRunner) -> None:
+        """--auth AFTER the leaf command sets ctx.obj.auth identically.
+
+        The resolved CredentialMode must match what the before-position form
+        produces.
+        """
+        ctx_holder: list[CliContext] = []
+
+        @contextlib.asynccontextmanager
+        async def _fake_build_http_client(ctx: CliContext) -> object:  # type: ignore[misc]
+            ctx_holder.append(ctx)
+            yield AsyncMock()
+
+        with patch(
+            "fabric_dw.cli.commands.workspaces.build_http_client",
+            side_effect=_fake_build_http_client,
+        ):
+            result = runner.invoke(
+                cli, ["workspaces", "list", "--auth", "default"], catch_exceptions=False
+            )
+
+        assert result.exit_code == 0, result.output
+        assert len(ctx_holder) == 1
+        assert ctx_holder[0].auth == CredentialMode.DEFAULT
+
+    def test_auth_invalid_value_after_leaf(self, runner: CliRunner) -> None:
+        """--auth with an invalid value after the subcommand yields a usage error."""
+        result = runner.invoke(cli, ["workspaces", "list", "--auth", "notamode"])
+        # Click rejects invalid Choice values with exit code 2.
+        assert result.exit_code == 2, result.output
+
+
+# ---------------------------------------------------------------------------
+# --max-429-retries / --retry-deadline: BEFORE (regression) and AFTER
+# ---------------------------------------------------------------------------
+
+
+class TestRetryOptionsFlag:
+    """--max-429-retries and --retry-deadline can appear after the subcommand."""
+
+    @pytest.fixture(autouse=True)
+    def _mock_list(self) -> object:
+        mock_ws = MagicMock()
+        mock_ws.model_dump.return_value = {"id": "ws-1", "displayName": "Test"}
+        with patch(
+            "fabric_dw.cli.commands.workspaces._workspaces_svc.list_all",
+            new=AsyncMock(return_value=[mock_ws]),
+        ):
+            yield
+
+    @staticmethod
+    def _make_capturing_http(ctx_holder: list[CliContext]) -> object:
+        """Return an async-context-manager factory that records the CliContext."""
+
+        @contextlib.asynccontextmanager
+        async def _fake(ctx: CliContext) -> object:  # type: ignore[misc]
+            ctx_holder.append(ctx)
+            yield AsyncMock()
+
+        return _fake
+
+    def test_max_429_retries_before_subcommand(self, runner: CliRunner) -> None:
+        """--max-429-retries BEFORE the subcommand sets the retry count (regression)."""
+        result = runner.invoke(
+            cli, ["--max-429-retries", "3", "workspaces", "list"], catch_exceptions=False
+        )
+        assert result.exit_code == 0, result.output
+
+    def test_max_429_retries_after_leaf(self, runner: CliRunner) -> None:
+        """--max-429-retries AFTER the leaf command sets ctx.obj.max_429_retries."""
+        ctx_holder: list[CliContext] = []
+        with patch(
+            "fabric_dw.cli.commands.workspaces.build_http_client",
+            side_effect=self._make_capturing_http(ctx_holder),
+        ):
+            result = runner.invoke(
+                cli, ["workspaces", "list", "--max-429-retries", "7"], catch_exceptions=False
+            )
+        assert result.exit_code == 0, result.output
+        assert len(ctx_holder) == 1
+        assert ctx_holder[0].max_429_retries == 7
+
+    def test_retry_deadline_before_subcommand(self, runner: CliRunner) -> None:
+        """--retry-deadline BEFORE the subcommand sets the deadline (regression)."""
+        result = runner.invoke(
+            cli, ["--retry-deadline", "60", "workspaces", "list"], catch_exceptions=False
+        )
+        assert result.exit_code == 0, result.output
+
+    def test_retry_deadline_after_leaf(self, runner: CliRunner) -> None:
+        """--retry-deadline AFTER the leaf command sets ctx.obj.retry_deadline_s."""
+        ctx_holder: list[CliContext] = []
+        with patch(
+            "fabric_dw.cli.commands.workspaces.build_http_client",
+            side_effect=self._make_capturing_http(ctx_holder),
+        ):
+            result = runner.invoke(
+                cli, ["workspaces", "list", "--retry-deadline", "120"], catch_exceptions=False
+            )
+        assert result.exit_code == 0, result.output
+        assert len(ctx_holder) == 1
+        assert ctx_holder[0].retry_deadline_s == 120
+
+
+# ---------------------------------------------------------------------------
+# Collision: dbt init --auth is dbt's own option, not the global auth flag
+# ---------------------------------------------------------------------------
+
+
+class TestDbtAuthCollision:
+    """The global --auth is not injected into dbt init (collision with dbt's own --auth).
+
+    dbt init declares "--auth" with destination "dbt_auth_override" (a dbt-
+    specific auth mode selector with a different Choice set).  The injection
+    logic skips "--auth" for that command.  Users who need to set the global
+    auth mode for dbt commands must use the pre-subcommand position:
+    "fabric-dw --auth <mode> dbt init ...".
+    """
+
+    def test_dbt_auth_not_injected_as_global(self, runner: CliRunner) -> None:
+        """dbt init --help shows its own --auth only -- global injection is skipped.
+
+        The dbt-local --auth shows choices like [auto|cli|serviceprincipal|...].
+        If the global --auth were also injected, a second option block would
+        appear with the global CredentialMode choices.  Exactly one --auth
+        option block must appear in the output.
+        """
+        result = runner.invoke(cli, ["dbt", "init", "--help"])
+        assert result.exit_code == 0, result.output
+        # Count option-header occurrences: "--auth [" marks an option block line.
+        # The dbt help text also contains "--auth mode" in the description text,
+        # but that does not start a new option block and does not include "[".
+        assert result.output.count("--auth [") == 1
+
+    def test_global_auth_before_dbt_init(self, runner: CliRunner) -> None:
+        """The global --auth in pre-subcommand position still works for dbt init."""
+        # We only verify that Click does not reject the argument; we do not
+        # actually run the dbt scaffold (no mocks for the full dbt init flow).
+        result = runner.invoke(cli, ["--auth", "default", "dbt", "--help"])
+        assert result.exit_code == 0, result.output

--- a/tests/unit/test_global_options_anywhere.py
+++ b/tests/unit/test_global_options_anywhere.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import contextlib
 import json
 import logging
+from collections.abc import AsyncGenerator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -379,18 +380,25 @@ class TestWorkspaceFlag:
         assert captured["workspace"] == "myws"
 
     def test_workspace_both_positions(self, runner: CliRunner) -> None:
-        """-w before AND after the subcommand does not cause a parse error."""
+        """-w before AND after the subcommand: trailing value wins."""
+        captured: dict[str, str | None] = {}
+
+        def _capture_resolve_workspace(ctx: CliContext) -> str:
+            captured["workspace"] = ctx.workspace
+            return "fake-ws-name"
+
         with patch(
             "fabric_dw.cli.commands.warehouses.resolve_workspace",
-            return_value="fake-ws-name",
+            side_effect=_capture_resolve_workspace,
         ):
             result = runner.invoke(
                 cli,
                 ["-w", "first", "warehouses", "list", "-w", "second"],
                 catch_exceptions=False,
             )
-        # Trailing value wins over the root-level value (last-writer semantics).
         assert result.exit_code == 0, result.output
+        # The trailing -w value overwrites the root-level one in ctx.obj.
+        assert captured["workspace"] == "second"
 
 
 # ---------------------------------------------------------------------------
@@ -427,7 +435,7 @@ class TestAuthFlag:
         ctx_holder: list[CliContext] = []
 
         @contextlib.asynccontextmanager
-        async def _fake_build_http_client(ctx: CliContext) -> object:  # type: ignore[misc]
+        async def _fake_build_http_client(ctx: CliContext) -> AsyncGenerator[AsyncMock, None]:
             ctx_holder.append(ctx)
             yield AsyncMock()
 
@@ -468,17 +476,6 @@ class TestRetryOptionsFlag:
         ):
             yield
 
-    @staticmethod
-    def _make_capturing_http(ctx_holder: list[CliContext]) -> object:
-        """Return an async-context-manager factory that records the CliContext."""
-
-        @contextlib.asynccontextmanager
-        async def _fake(ctx: CliContext) -> object:  # type: ignore[misc]
-            ctx_holder.append(ctx)
-            yield AsyncMock()
-
-        return _fake
-
     def test_max_429_retries_before_subcommand(self, runner: CliRunner) -> None:
         """--max-429-retries BEFORE the subcommand sets the retry count (regression)."""
         result = runner.invoke(
@@ -489,9 +486,15 @@ class TestRetryOptionsFlag:
     def test_max_429_retries_after_leaf(self, runner: CliRunner) -> None:
         """--max-429-retries AFTER the leaf command sets ctx.obj.max_429_retries."""
         ctx_holder: list[CliContext] = []
+
+        @contextlib.asynccontextmanager
+        async def _fake_http(ctx: CliContext) -> AsyncGenerator[AsyncMock, None]:
+            ctx_holder.append(ctx)
+            yield AsyncMock()
+
         with patch(
             "fabric_dw.cli.commands.workspaces.build_http_client",
-            side_effect=self._make_capturing_http(ctx_holder),
+            side_effect=_fake_http,
         ):
             result = runner.invoke(
                 cli, ["workspaces", "list", "--max-429-retries", "7"], catch_exceptions=False
@@ -510,9 +513,15 @@ class TestRetryOptionsFlag:
     def test_retry_deadline_after_leaf(self, runner: CliRunner) -> None:
         """--retry-deadline AFTER the leaf command sets ctx.obj.retry_deadline_s."""
         ctx_holder: list[CliContext] = []
+
+        @contextlib.asynccontextmanager
+        async def _fake_http(ctx: CliContext) -> AsyncGenerator[AsyncMock, None]:
+            ctx_holder.append(ctx)
+            yield AsyncMock()
+
         with patch(
             "fabric_dw.cli.commands.workspaces.build_http_client",
-            side_effect=self._make_capturing_http(ctx_holder),
+            side_effect=_fake_http,
         ):
             result = runner.invoke(
                 cli, ["workspaces", "list", "--retry-deadline", "120"], catch_exceptions=False


### PR DESCRIPTION
## Summary

- Inject `-w`/`--workspace`, `--auth`, `--max-429-retries`, and `--retry-deadline` into every leaf command via the existing `_inject_global_options` plumbing, using a new `_make_meta_value_callback` for non-boolean options.
- Extend `_apply_meta_global_params` to write the trailing values back into `ctx.obj` (the shared `CliContext`) before the command body runs, with last-writer semantics for value options.
- Audit and document option-name collisions across all subcommand declarations.

## Collision found and resolved

`dbt init` declares `--auth` with destination `dbt_auth_override` and a dbt-specific `Choice` set (`auto|cli|serviceprincipal|interactive|sp`). The injection skip logic detects the name clash and leaves the dbt-local option intact. The global `--auth` is not injected into `dbt init`; users who need to set the global auth mode for that command must use the pre-subcommand position: `fabric-dw --auth <mode> dbt init ...`.

No other collision was found across all subcommand option declarations.

## Test plan

- `TestWorkspaceFlag`: trailing `-w`/`--workspace` accepted, `ctx.obj.workspace` captured and verified identical to before-position form.
- `TestAuthFlag`: trailing `--auth default` sets `ctx.obj.auth == CredentialMode.DEFAULT`; invalid value yields exit 2.
- `TestRetryOptionsFlag`: trailing `--max-429-retries 7` and `--retry-deadline 120` set the matching `ctx.obj` fields.
- `TestDbtAuthCollision`: exactly one `--auth [` option block in `dbt init --help`; pre-subcommand `--auth` still accepted.
- All 5020 existing unit tests pass; linting clean.

Closes #829