### PR TITLE
fix(cli): do not prune all-NULL columns from raw sql exec output

### DIFF
--- a/src/fabric_dw/cli/_render.py
+++ b/src/fabric_dw/cli/_render.py
@@ -96,6 +96,7 @@ def render(
     console: Console | None = None,
     table_title: str | None = None,
     drop_columns: tuple[str, ...] | list[str] | None = None,
+    prune_null_columns: bool = False,
 ) -> None:
     """Print *data* to stdout using JSON or Rich formatting.
 
@@ -116,6 +117,14 @@ def render(
             workspace-id column when every row shares the same workspace).
             Ignored when *json_output=True* (machine-readable output is never
             pruned) and when *data* is not a list.
+        prune_null_columns: When *True*, columns whose value is ``None`` in
+            every row are omitted from the rendered table.  Defaults to
+            *False* so that raw query results (e.g. ``sql exec``) always show
+            every column the query returned, including all-``NULL`` ones.
+            Set to *True* for metadata renders (list commands) where optional
+            model fields that happen to be unpopulated in a given response
+            should be hidden to reduce visual clutter.
+            Ignored when *json_output=True*.
     """
     if json_output:
         click.echo(_json.dumps(data, indent=2, default=str))
@@ -124,7 +133,13 @@ def render(
     con = console if console is not None else _DEFAULT_CONSOLE
 
     if isinstance(data, list):
-        _render_table(data, console=con, title=table_title, drop_columns=drop_columns)
+        _render_table(
+            data,
+            console=con,
+            title=table_title,
+            drop_columns=drop_columns,
+            prune_null_columns=prune_null_columns,
+        )
     elif isinstance(data, dict):
         _render_panel({str(k): v for k, v in data.items()}, console=con, title=table_title)
     else:
@@ -260,6 +275,7 @@ def _render_table(
     console: Console,
     title: str | None,
     drop_columns: tuple[str, ...] | list[str] | None = None,
+    prune_null_columns: bool = False,
 ) -> None:
     """Render a list of dicts as a Rich Table (or vertical fallback).
 
@@ -271,18 +287,27 @@ def _render_table(
     normally keep the horizontal layout and the existing GUID-column width
     behaviour from PR #743.  See :func:`_table_fits` for the exact criterion.
 
-    Columns whose value is ``None`` in **every** row are omitted from the
-    output — they only clutter list views (e.g. ``definition`` for
-    ``procedures list``).  A column that is non-null in at least one row is
-    kept, and any null cells in that column still render as ``[dim]NULL[/dim]``.
+    When *prune_null_columns* is *True*, columns whose value is ``None`` in
+    every row are omitted from the output.  This is appropriate for metadata
+    list views (e.g. ``procedures list``) where optional model fields that are
+    unpopulated in a given response only add visual clutter.  A column that is
+    non-null in at least one row is always kept, and any null cells in that
+    column still render as ``[dim]NULL[/dim]``.
+
+    When *prune_null_columns* is *False* (the default), every column that
+    appears in the data is rendered, including all-``NULL`` ones.  Raw query
+    results (``sql exec``) must use this default so that the user sees every
+    column their query selected.
 
     Args:
         rows: The list of rows (dicts or scalars) to render.
         console: The Rich console to print to.
         title: Optional table title.
-        drop_columns: Optional column names to explicitly omit, in addition to
-            the automatic all-null pruning.  Used by callers to hide a column
-            that is redundant in a given context (e.g. a shared workspace id).
+        drop_columns: Optional column names to explicitly omit.  Used by callers
+            to hide a column that is redundant in a given context (e.g. a
+            shared workspace id).
+        prune_null_columns: When *True*, drop columns whose value is ``None``
+            in every row before rendering.  Defaults to *False*.
     """
     dropped: frozenset[str] = frozenset(drop_columns or ())
 
@@ -309,10 +334,15 @@ def _render_table(
         else:
             norm_rows.append(row)
 
-    # Drop columns where every dict-row's value is None (or the key is absent).
+    # Optionally drop columns where every dict-row's value is None (or absent).
     # Non-dict rows (scalars) are never counted as "having" any column value, so
     # a column is only kept if at least one dict-row provides a non-None value.
-    all_null = {col for col in columns if _column_is_all_null(col, norm_rows)}
+    # Pruning is opt-in: raw query results must show every column they returned.
+    all_null: set[str] = (
+        {col for col in columns if _column_is_all_null(col, norm_rows)}
+        if prune_null_columns
+        else set()
+    )
     visible_columns = [col for col in columns if col not in all_null and col not in dropped]
 
     # Wide-table fallback: when the estimated minimum width for all visible

--- a/src/fabric_dw/cli/commands/functions.py
+++ b/src/fabric_dw/cli/commands/functions.py
@@ -68,6 +68,7 @@ async def list_cmd(
                 [f.model_dump(by_alias=True, mode="json") for f in items],
                 json_output=ctx.json_output,
                 table_title="Functions",
+                prune_null_columns=True,
             )
     except (ValueError, FabricError) as exc:
         raise click.ClickException(str(exc)) from exc

--- a/src/fabric_dw/cli/commands/procedures.py
+++ b/src/fabric_dw/cli/commands/procedures.py
@@ -42,6 +42,7 @@ async def list_cmd(ctx: CliContext, item: str | None, schema: str | None) -> Non
                 [p.model_dump(by_alias=True, mode="json") for p in items],
                 json_output=ctx.json_output,
                 table_title="Stored Procedures",
+                prune_null_columns=True,
             )
     except (ValueError, FabricError) as exc:
         raise click.ClickException(str(exc)) from exc

--- a/src/fabric_dw/cli/commands/queries.py
+++ b/src/fabric_dw/cli/commands/queries.py
@@ -46,6 +46,7 @@ async def running_cmd(ctx: CliContext, item: str | None) -> None:
                 [q.model_dump(by_alias=True, mode="json") for q in items],
                 json_output=ctx.json_output,
                 table_title="Running Queries",
+                prune_null_columns=True,
             )
     except (ValueError, FabricError) as exc:
         raise click.ClickException(str(exc)) from exc
@@ -67,6 +68,7 @@ async def connections_cmd(ctx: CliContext, item: str | None) -> None:
                 [c.model_dump(by_alias=True, mode="json") for c in items],
                 json_output=ctx.json_output,
                 table_title="SQL Connections",
+                prune_null_columns=True,
             )
     except (ValueError, FabricError) as exc:
         raise click.ClickException(str(exc)) from exc
@@ -135,6 +137,7 @@ async def history_cmd(
                 [q.model_dump(by_alias=True, mode="json") for q in items],
                 json_output=ctx.json_output,
                 table_title="Request History",
+                prune_null_columns=True,
             )
     except (ValueError, FabricError) as exc:
         raise click.ClickException(str(exc)) from exc
@@ -176,6 +179,7 @@ async def sessions_cmd(
                 [q.model_dump(by_alias=True, mode="json") for q in items],
                 json_output=ctx.json_output,
                 table_title="Session History",
+                prune_null_columns=True,
             )
     except (ValueError, FabricError) as exc:
         raise click.ClickException(str(exc)) from exc
@@ -217,6 +221,7 @@ async def frequent_cmd(
                 [q.model_dump(by_alias=True, mode="json") for q in items],
                 json_output=ctx.json_output,
                 table_title="Frequently Run Queries",
+                prune_null_columns=True,
             )
     except (ValueError, FabricError) as exc:
         raise click.ClickException(str(exc)) from exc
@@ -258,6 +263,7 @@ async def long_running_cmd(
                 [q.model_dump(by_alias=True, mode="json") for q in items],
                 json_output=ctx.json_output,
                 table_title="Long Running Queries",
+                prune_null_columns=True,
             )
     except (ValueError, FabricError) as exc:
         raise click.ClickException(str(exc)) from exc

--- a/src/fabric_dw/cli/commands/restore_points.py
+++ b/src/fabric_dw/cli/commands/restore_points.py
@@ -40,6 +40,7 @@ async def list_cmd(ctx: CliContext, item: str | None) -> None:
                 [rp.model_dump(by_alias=True, mode="json") for rp in items],
                 json_output=ctx.json_output,
                 table_title="Restore Points",
+                prune_null_columns=True,
             )
     except (ValueError, FabricError) as exc:
         raise click.ClickException(str(exc)) from exc

--- a/src/fabric_dw/cli/commands/schemas.py
+++ b/src/fabric_dw/cli/commands/schemas.py
@@ -39,6 +39,7 @@ async def list_cmd(ctx: CliContext, item: str | None) -> None:
                 [s.model_dump(by_alias=True, mode="json") for s in items],
                 json_output=ctx.json_output,
                 table_title="Schemas",
+                prune_null_columns=True,
             )
     except (ValueError, FabricError) as exc:
         raise click.ClickException(str(exc)) from exc

--- a/src/fabric_dw/cli/commands/snapshots.py
+++ b/src/fabric_dw/cli/commands/snapshots.py
@@ -44,6 +44,7 @@ async def list_cmd(ctx: CliContext, item: str | None) -> None:
                 [s.model_dump(by_alias=True, mode="json") for s in items],
                 json_output=ctx.json_output,
                 table_title="Snapshots",
+                prune_null_columns=True,
             )
     except (ValueError, FabricError) as exc:
         raise click.ClickException(str(exc)) from exc

--- a/src/fabric_dw/cli/commands/sql_endpoints.py
+++ b/src/fabric_dw/cli/commands/sql_endpoints.py
@@ -132,6 +132,7 @@ async def list_cmd(ctx: CliContext, all_workspaces: bool) -> None:
                 rows,
                 json_output=ctx.json_output,
                 table_title="SQL Analytics Endpoints",
+                prune_null_columns=True,
             )
     except FabricError as exc:
         raise click.ClickException(str(exc)) from exc

--- a/src/fabric_dw/cli/commands/sql_pools.py
+++ b/src/fabric_dw/cli/commands/sql_pools.py
@@ -156,7 +156,7 @@ async def list_cmd(ctx: CliContext) -> None:
             _print_default_workload_note()
         return
 
-    render(pools, json_output=ctx.json_output)
+    render(pools, json_output=ctx.json_output, prune_null_columns=True)
 
 
 # ---------------------------------------------------------------------------
@@ -461,6 +461,7 @@ async def insights_cmd(
                 [q.model_dump(by_alias=True, mode="json") for q in items],
                 json_output=ctx.json_output,
                 table_title="SQL Pool Insights",
+                prune_null_columns=True,
             )
     except FabricError as exc:
         raise click.ClickException(str(exc)) from exc

--- a/src/fabric_dw/cli/commands/statistics.py
+++ b/src/fabric_dw/cli/commands/statistics.py
@@ -73,6 +73,7 @@ async def list_cmd(
                 [s.model_dump(by_alias=True, mode="json") for s in items],
                 json_output=ctx.json_output,
                 table_title="Statistics",
+                prune_null_columns=True,
             )
     except (ValueError, FabricError) as exc:
         raise click.ClickException(str(exc)) from exc

--- a/src/fabric_dw/cli/commands/tables.py
+++ b/src/fabric_dw/cli/commands/tables.py
@@ -66,6 +66,7 @@ async def list_cmd(ctx: CliContext, item: str | None, schema: str | None) -> Non
                 [t.model_dump(by_alias=True, mode="json") for t in items],
                 json_output=ctx.json_output,
                 table_title="Tables",
+                prune_null_columns=True,
             )
     except (ValueError, FabricError) as exc:
         raise click.ClickException(str(exc)) from exc
@@ -176,6 +177,7 @@ async def columns_cmd(
                 cols,
                 json_output=ctx.json_output,
                 table_title="Columns",
+                prune_null_columns=True,
             )
     except (ValueError, FabricError) as exc:
         raise click.ClickException(str(exc)) from exc
@@ -241,6 +243,7 @@ async def health_check_cmd(
                 [dict(zip(columns, row, strict=True)) for row in rows],
                 json_output=ctx.json_output,
                 table_title="Table Health Metrics",
+                prune_null_columns=True,
             )
     except (ValueError, FabricError) as exc:
         raise click.ClickException(str(exc)) from exc
@@ -672,6 +675,7 @@ async def cluster_columns_cmd(
                 rows,
                 json_output=ctx.json_output,
                 table_title="Cluster Columns",
+                prune_null_columns=True,
             )
     except (ValueError, FabricError) as exc:
         raise click.ClickException(str(exc)) from exc

--- a/src/fabric_dw/cli/commands/views.py
+++ b/src/fabric_dw/cli/commands/views.py
@@ -46,6 +46,7 @@ async def list_cmd(ctx: CliContext, item: str | None, schema: str | None) -> Non
                 [v.model_dump(by_alias=True, mode="json") for v in items],
                 json_output=ctx.json_output,
                 table_title="Views",
+                prune_null_columns=True,
             )
     except (ValueError, FabricError) as exc:
         raise click.ClickException(str(exc)) from exc
@@ -122,6 +123,7 @@ async def columns_cmd(
                 cols,
                 json_output=ctx.json_output,
                 table_title="Columns",
+                prune_null_columns=True,
             )
     except (ValueError, FabricError) as exc:
         raise click.ClickException(str(exc)) from exc

--- a/src/fabric_dw/cli/commands/warehouses.py
+++ b/src/fabric_dw/cli/commands/warehouses.py
@@ -97,6 +97,7 @@ async def list_cmd(
                 json_output=ctx.json_output,
                 table_title="Warehouses",
                 drop_columns=drop_columns,
+                prune_null_columns=True,
             )
     except (ValueError, FabricError) as exc:
         raise click.ClickException(str(exc)) from exc

--- a/src/fabric_dw/cli/commands/workspaces.py
+++ b/src/fabric_dw/cli/commands/workspaces.py
@@ -37,6 +37,7 @@ async def list_capacities_cmd(ctx: CliContext) -> None:
                 [c.model_dump(by_alias=True, mode="json") for c in items],
                 json_output=ctx.json_output,
                 table_title="Capacities",
+                prune_null_columns=True,
             )
     except FabricError as exc:
         raise click.ClickException(str(exc)) from exc
@@ -54,6 +55,7 @@ async def list_cmd(ctx: CliContext) -> None:
                 [w.model_dump(by_alias=True, mode="json") for w in items],
                 json_output=ctx.json_output,
                 table_title="Workspaces",
+                prune_null_columns=True,
             )
     except FabricError as exc:
         raise click.ClickException(str(exc)) from exc

--- a/tests/unit/cli/test_render.py
+++ b/tests/unit/cli/test_render.py
@@ -349,6 +349,7 @@ class TestWideTableVerticalFallback:
         *,
         table_title: str | None = None,
         drop_columns: tuple[str, ...] | None = None,
+        prune_null_columns: bool = False,
     ) -> str:
         sio = StringIO()
         console = Console(file=sio, width=width, highlight=False, no_color=True)
@@ -358,6 +359,7 @@ class TestWideTableVerticalFallback:
             console=console,
             table_title=table_title,
             drop_columns=drop_columns,
+            prune_null_columns=prune_null_columns,
         )
         return sio.getvalue()
 
@@ -447,11 +449,11 @@ class TestWideTableVerticalFallback:
         """All non-null field names appear in the vertical layout at width=80.
 
         With the header-based threshold, the 11 visible columns (blocking_session_id
-        is all-null and pruned) have headers averaging ~10 chars, which far exceeds
-        80 columns, triggering the vertical fallback.
+        is all-null and pruned when prune_null_columns=True) have headers averaging
+        ~10 chars, which far exceeds 80 columns, triggering the vertical fallback.
         """
-        output = self._render_at_width(_QUERIES_ROWS, width=80)
-        # blocking_session_id is all-null → pruned; check the non-null columns only
+        output = self._render_at_width(_QUERIES_ROWS, width=80, prune_null_columns=True)
+        # blocking_session_id is all-null and pruned; check the non-null columns only
         visible_cols = [c for c in _QUERIES_ROWS[0] if c != "blocking_session_id"]
         for col in visible_cols:
             assert col in output, f"Field '{col}' missing from vertical output"
@@ -651,12 +653,18 @@ class TestSparseRowRendering:
 
 
 class TestOmitAllNullColumns:
-    """_render_table omits columns that are None in every row (human table only)."""
+    """_render_table omits columns that are None in every row when prune_null_columns=True."""
 
     def _render_to_string(self, data: object, table_title: str | None = None) -> str:
         sio = StringIO()
         console = Console(file=sio, width=200, highlight=False, no_color=True)
-        render(data, json_output=False, console=console, table_title=table_title)
+        render(
+            data,
+            json_output=False,
+            console=console,
+            table_title=table_title,
+            prune_null_columns=True,
+        )
         return sio.getvalue()
 
     # ------------------------------------------------------------------
@@ -763,6 +771,58 @@ class TestOmitAllNullColumns:
         output = self._render_to_string(data)
         assert "name" in output
         assert "definition" not in output
+
+
+class TestRawSqlNullColumns:
+    """Raw sql exec results must show every column, including all-NULL ones.
+
+    The prune_null_columns flag defaults to False so that raw query output
+    (sql exec) never silently hides a column the user asked for.
+    """
+
+    def _render_to_string(self, data: object) -> str:
+        sio = StringIO()
+        console = Console(file=sio, width=200, highlight=False, no_color=True)
+        # prune_null_columns defaults to False - raw SQL callers do not set it
+        render(data, json_output=False, console=console)
+        return sio.getvalue()
+
+    def test_all_null_column_present_when_pruning_disabled(self) -> None:
+        """A column that is NULL in every row must appear when prune_null_columns=False."""
+        data = [
+            {"a": None, "b": 5},
+            {"a": None, "b": 10},
+        ]
+        output = self._render_to_string(data)
+        assert "a" in output
+        assert "b" in output
+
+    def test_all_null_column_header_shown(self) -> None:
+        """SELECT NULL AS a, 5 AS b: column header 'a' must be visible."""
+        data = [{"a": None, "b": 5}]
+        output = self._render_to_string(data)
+        assert "a" in output
+
+    def test_all_null_cell_renders_as_null(self) -> None:
+        """The all-NULL column's cell must render as NULL, not disappear."""
+        data = [{"a": None, "b": 5}]
+        output = self._render_to_string(data)
+        assert "NULL" in output
+
+    def test_single_row_all_null_result_shows_column(self) -> None:
+        """A single-row result where every column is NULL still shows the header."""
+        data = [{"x": None}]
+        output = self._render_to_string(data)
+        assert "x" in output
+
+    def test_prune_false_is_default(self) -> None:
+        """Passing prune_null_columns=False explicitly has the same effect as omitting it."""
+        data = [{"col": None}]
+        sio = StringIO()
+        console = Console(file=sio, width=200, highlight=False, no_color=True)
+        render(data, json_output=False, console=console, prune_null_columns=False)
+        output = sio.getvalue()
+        assert "col" in output
 
 
 class TestDropColumns:
@@ -1191,10 +1251,17 @@ class TestGuidColumnWidthInNarrowConsole:
         *,
         width: int = 50,
         table_title: str | None = None,
+        prune_null_columns: bool = False,
     ) -> str:
         sio = StringIO()
         console = Console(file=sio, width=width, highlight=False, no_color=True)
-        render(data, json_output=False, console=console, table_title=table_title)
+        render(
+            data,
+            json_output=False,
+            console=console,
+            table_title=table_title,
+            prune_null_columns=prune_null_columns,
+        )
         return sio.getvalue()
 
     def test_guid_survives_narrow_console(self) -> None:
@@ -1242,13 +1309,20 @@ class TestGuidColumnWidthInNarrowConsole:
         # is truncated — the point is we don't crash and the output is produced.
         assert "short-non-guid" in output
 
-    def test_all_none_guid_col_stays_normal(self) -> None:
-        """A column that is all-None is dropped entirely (existing behaviour)."""
+    def test_all_none_guid_col_dropped_when_pruning_enabled(self) -> None:
+        """An all-None column is dropped when prune_null_columns=True."""
         data: list[dict[str, object]] = [{"id": None, "displayName": "Alice"}]
-        output = self._render_narrow(data, width=50)
-        # Column "id" is all-null → dropped; "displayName" remains
+        output = self._render_narrow(data, width=50, prune_null_columns=True)
+        # Column "id" is all-null and pruned; "displayName" remains
         assert "Alice" in output
         assert "id" not in output
+
+    def test_all_none_guid_col_visible_when_pruning_disabled(self) -> None:
+        """An all-None column is kept when prune_null_columns=False (the default)."""
+        data: list[dict[str, object]] = [{"id": None, "displayName": "Alice"}]
+        output = self._render_narrow(data, width=50, prune_null_columns=False)
+        assert "Alice" in output
+        assert "id" in output
 
     def test_guid_column_with_some_nulls_survives(self) -> None:
         """A partially-null GUID column still gets full width."""
@@ -1421,13 +1495,14 @@ class TestMultiGuidColumnWidthStarvation:
     # ------------------------------------------------------------------
 
     def test_all_null_guid_column_still_pruned_in_multi_guid_table(self) -> None:
-        """An all-null GUID column is pruned even when other GUID columns are present.
+        """An all-null GUID column is pruned when prune_null_columns=True.
 
         This test exercises the primary/secondary-GUID code path: ``id`` is the
         primary GUID (non-null), ``workspaceId`` is a secondary non-null GUID, and
-        ``capacityId`` is all-null and must be dropped.  After pruning, the table
-        has two live GUID columns (primary + secondary) plus ``displayName``; the
-        fix must ensure ``displayName`` is NOT starved to zero width at 80 cols.
+        ``capacityId`` is all-null and must be dropped when pruning is enabled.
+        After pruning, the table has two live GUID columns (primary + secondary)
+        plus ``displayName``; the fix must ensure ``displayName`` is NOT starved
+        to zero width at 80 cols.
         """
         data: list[dict[str, object]] = [
             {
@@ -1445,7 +1520,7 @@ class TestMultiGuidColumnWidthStarvation:
         ]
         sio = StringIO()
         console = Console(file=sio, width=80, highlight=False, no_color=True)
-        render(data, json_output=False, console=console)
+        render(data, json_output=False, console=console, prune_null_columns=True)
         output = sio.getvalue()
         # All-null column pruned
         assert "capacityId" not in output


### PR DESCRIPTION
## Summary

- Add a `prune_null_columns: bool = False` flag to `render()` and `_render_table()` in `_render.py`.
- All-NULL column pruning only runs when the flag is `True`. The raw `sql exec` path does not set it, so `SELECT NULL AS a, 5 AS b` now correctly shows both columns.
- Every metadata list command (warehouses, tables, views, procedures, queries, schemas, snapshots, statistics, functions, workspaces, sql-pools, restore-points, sql-endpoints) opts in via `prune_null_columns=True`, preserving the existing behaviour for optional model fields.

## Test plan

- New `TestRawSqlNullColumns` class verifies that all-NULL columns are visible when `prune_null_columns` is omitted (the raw-query case).
- Existing `TestOmitAllNullColumns` tests updated to pass `prune_null_columns=True`, confirming metadata renders still prune.
- `TestGuidColumnWidthInNarrowConsole` and `TestWideTableVerticalFallback` updated to pass the flag explicitly where pruning is expected.
- All 5011 unit tests pass; ruff and ty are clean.

Closes #832