### PR TITLE
fix(dbt): route scaffold names through safe_dump and escape Jinja

### DIFF
--- a/src/fabric_dw/services/dbt_scaffold.py
+++ b/src/fabric_dw/services/dbt_scaffold.py
@@ -229,8 +229,22 @@ def render_profiles_yml(cfg: DbtScaffoldConfig) -> str:
     return yaml.safe_dump(doc, default_flow_style=False, allow_unicode=True, sort_keys=False)
 
 
+def _escape_jinja_str(value: str) -> str:
+    """Escape *value* for embedding inside a single-quoted Jinja string literal.
+
+    Replaces backslashes and single quotes so that the value cannot break out
+    of the surrounding ``'...'`` Jinja string.
+    """
+    return value.replace("\\", "\\\\").replace("'", "\\'")
+
+
 def render_dbt_project_yml(cfg: DbtScaffoldConfig) -> str:
     """Render the ``dbt_project.yml`` content for the given config.
+
+    Uses :func:`yaml.safe_dump` to serialise the document so that any
+    special characters in ``project_name`` or ``profile_name`` (colons,
+    hashes, newlines, etc.) are automatically quoted and cannot inject
+    top-level YAML keys.
 
     Args:
         cfg: The scaffold configuration.
@@ -238,23 +252,24 @@ def render_dbt_project_yml(cfg: DbtScaffoldConfig) -> str:
     Returns:
         The ``dbt_project.yml`` content as a YAML string.
     """
-    return (
-        f"name: {cfg.project_name}\n"
-        "version: '1.0.0'\n"
-        "config-version: 2\n"
-        f"profile: {cfg.profile_name}\n"
-        "\n"
-        "model-paths: ['models']\n"
-        "analysis-paths: ['analyses']\n"
-        "test-paths: ['tests']\n"
-        "seed-paths: ['seeds']\n"
-        "macro-paths: ['macros']\n"
-        "snapshot-paths: ['snapshots']\n"
-        "\n"
-        "models:\n"
-        f"  {cfg.project_name}:\n"
-        "    +materialized: table\n"
-    )
+    doc: dict[str, object] = {
+        "name": cfg.project_name,
+        "version": "1.0.0",
+        "config-version": 2,
+        "profile": cfg.profile_name,
+        "model-paths": ["models"],
+        "analysis-paths": ["analyses"],
+        "test-paths": ["tests"],
+        "seed-paths": ["seeds"],
+        "macro-paths": ["macros"],
+        "snapshot-paths": ["snapshots"],
+        "models": {
+            cfg.project_name: {
+                "+materialized": "table",
+            }
+        },
+    }
+    return yaml.safe_dump(doc, default_flow_style=False, allow_unicode=True, sort_keys=False)
 
 
 def render_sources_yml(
@@ -284,7 +299,9 @@ def render_sources_yml(
                 {
                     "name": "placeholder",
                     "description": "Replace with your source definitions.",
-                    "database": "{{ env_var('DBT_DATABASE', '" + cfg.database + "') }}",
+                    "database": (
+                        "{{ env_var('DBT_DATABASE', '" + _escape_jinja_str(cfg.database) + "') }}"
+                    ),
                     "schema": "dbo",
                     "tables": [],
                 }

--- a/tests/unit/services/test_dbt_scaffold.py
+++ b/tests/unit/services/test_dbt_scaffold.py
@@ -272,6 +272,28 @@ class TestRenderDbtProjectYml:
         content = render_dbt_project_yml(cfg)
         assert "version:" in content
 
+    def test_malicious_profile_name_does_not_inject_yaml_key(self) -> None:
+        """A --profile value with YAML metacharacters must not inject a top-level key."""
+        malicious = "evil:\n  injected: true\nname"
+        cfg = _make_cfg(profile_name=malicious)
+        content = render_dbt_project_yml(cfg)
+        parsed = yaml.safe_load(content)
+        assert isinstance(parsed, dict)
+        # The injected stanza must not appear at the top level.
+        assert "injected" not in parsed
+        # The profile value must round-trip exactly.
+        assert parsed["profile"] == malicious
+
+    def test_malicious_project_name_does_not_inject_yaml_key(self) -> None:
+        """A project name with YAML metacharacters and a newline must not inject a top-level key."""
+        malicious = "evil:\n  injected: true\nproject"
+        cfg = _make_cfg(project_name=malicious, profile_name="ok_profile")
+        content = render_dbt_project_yml(cfg)
+        parsed = yaml.safe_load(content)
+        assert isinstance(parsed, dict)
+        assert "injected" not in parsed
+        assert parsed["name"] == malicious
+
 
 # ---------------------------------------------------------------------------
 # render_sources_yml
@@ -443,6 +465,28 @@ class TestRenderSourcesYml:
         content = render_sources_yml(cfg)
         parsed = yaml.safe_load(content)
         assert isinstance(parsed, dict)
+
+    def test_database_with_single_quote_in_placeholder_is_valid_yaml(self) -> None:
+        """A database name containing ' must not corrupt the Jinja env_var default."""
+        cfg = _make_cfg(database="O'Brien DW", with_sources=False)
+        content = render_sources_yml(cfg)
+        # Must produce valid YAML.
+        parsed = yaml.safe_load(content)
+        assert isinstance(parsed, dict)
+        # The database field must start with the env_var Jinja call.
+        db_field: str = parsed["sources"][0]["database"]
+        assert db_field.startswith("{{ env_var(")
+        # The escaped single quote must be present, preserving the database name.
+        assert r"O\'Brien DW" in db_field
+
+    def test_database_with_single_quote_in_placeholder_round_trips_name(self) -> None:
+        """The env_var default in the placeholder must embed the exact escaped database name."""
+        cfg = _make_cfg(database="O'Brien DW", with_sources=False)
+        content = render_sources_yml(cfg)
+        parsed = yaml.safe_load(content)
+        db_field: str = parsed["sources"][0]["database"]
+        # The field value (after YAML parse) must be the properly-escaped Jinja call.
+        assert db_field == r"{{ env_var('DBT_DATABASE', 'O\'Brien DW') }}"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `render_dbt_project_yml` used raw f-strings for `profile_name` and `project_name`, allowing YAML metacharacters (colons, newlines) to inject top-level keys into `dbt_project.yml`. Replaced with `yaml.safe_dump` on a dict, matching the pattern used by `render_profiles_yml` and `render_sources_yml`.
- `render_sources_yml` embedded `cfg.database` directly into a Jinja `env_var('DBT_DATABASE', '<db>')` string literal. A database name containing `'` would break out of the Jinja string. Added `_escape_jinja_str` helper (escapes `\` then `'`) and applied it to the embedded value.
- Added four regression tests: two for YAML injection via malicious `profile_name`/`project_name`, two for the single-quote Jinja corruption.

## Test plan

- All 86 unit tests in `tests/unit/services/test_dbt_scaffold.py` pass, including the four new regression tests.
- Full unit suite (5024 tests) passes.
- `ruff check` and `ruff format --check` both clean.

Closes #847