### PR TITLE
refactor(resolver): remove negative cache, keep only positive cache

### DIFF
--- a/src/fabric_dw/mcp/tools/cache.py
+++ b/src/fabric_dw/mcp/tools/cache.py
@@ -28,19 +28,16 @@ def register(mcp: FastMCP) -> None:
 
                 - ``"workspaces"`` — clear only workspace name→UUID entries.
                 - ``"items"`` — clear only item (warehouse/endpoint) entries.
-                - ``"all"`` (default) — clear everything, including the
-                  in-memory negative cache on the resolver.
+                - ``"all"`` (default) — clear all entries.
 
         Returns:
             A dict with keys ``scope`` (the value used), ``workspaces_cleared``
-            (number of workspace entries removed), ``items_cleared`` (number
-            of item workspace buckets removed), and ``negative_cache_cleared``
-            (``True`` when the resolver's negative cache was also wiped).
+            (number of workspace entries removed), and ``items_cleared`` (number
+            of item workspace buckets removed).
         """
         _log.info("clear_cache called with scope=%r", scope)
         ctx = get_context()
         cache = ctx.cache
-        negative_cache_cleared = False
 
         # Read current counts via the public API before clearing.
         ws_count, items_count = cache.counts()
@@ -53,19 +50,15 @@ def register(mcp: FastMCP) -> None:
             ws_count = 0  # workspaces not touched
         else:  # "all"
             cache.clear()
-            ctx.resolver.clear_negative_cache()
-            negative_cache_cleared = True
 
         _log.info(
-            "clear_cache complete: scope=%r ws=%d items=%d neg=%s",
+            "clear_cache complete: scope=%r ws=%d items=%d",
             scope,
             ws_count,
             items_count,
-            negative_cache_cleared,
         )
         return {
             "scope": scope,
             "workspaces_cleared": ws_count,
             "items_cleared": items_count,
-            "negative_cache_cleared": negative_cache_cleared,
         }

--- a/src/fabric_dw/mcp/tools/functions.py
+++ b/src/fabric_dw/mcp/tools/functions.py
@@ -144,7 +144,6 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             )
         except (ValueError, FabricError) as exc:
             raise tool_err(exc) from exc
-        ctx.resolver.clear_negative_cache()
         return result.model_dump(mode="json")
 
     @mutating_tool(mcp, "update_function")
@@ -183,7 +182,6 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             )
         except (ValueError, FabricError) as exc:
             raise tool_err(exc) from exc
-        ctx.resolver.clear_negative_cache()
         return result.model_dump(mode="json")
 
     @mutating_tool(mcp, "drop_function", destructive=True)
@@ -262,5 +260,4 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             )
         except (ValueError, FabricError) as exc:
             raise tool_err(exc) from exc
-        ctx.resolver.clear_negative_cache()
         return result.model_dump(mode="json")

--- a/src/fabric_dw/mcp/tools/procedures.py
+++ b/src/fabric_dw/mcp/tools/procedures.py
@@ -121,7 +121,6 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             )
         except (ValueError, FabricError) as exc:
             raise tool_err(exc) from exc
-        ctx.resolver.clear_negative_cache()
         return result.model_dump(mode="json")
 
     @mutating_tool(mcp, "update_procedure")

--- a/src/fabric_dw/mcp/tools/snapshots.py
+++ b/src/fabric_dw/mcp/tools/snapshots.py
@@ -83,7 +83,6 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             )
         except (ValueError, FabricError) as exc:
             raise tool_err(exc) from exc
-        ctx.resolver.clear_negative_cache()
         return result.model_dump(by_alias=True, mode="json")
 
     @mutating_tool(mcp, "rename_snapshot")
@@ -111,7 +110,6 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             )
         except (ValueError, FabricError) as exc:
             raise tool_err(exc) from exc
-        ctx.resolver.clear_negative_cache()
         return result.model_dump(by_alias=True, mode="json")
 
     @mutating_tool(mcp, "delete_snapshot", destructive=True)

--- a/src/fabric_dw/mcp/tools/sql_pools.py
+++ b/src/fabric_dw/mcp/tools/sql_pools.py
@@ -161,7 +161,6 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
                 f"pool {name!r} was not found in the API response after creation; "
                 "the pool may have been created but is not yet visible (eventual consistency)"
             )
-        ctx.resolver.clear_negative_cache()
         return created.model_dump(by_alias=True, mode="json")
 
     @mutating_tool(mcp, "update_sql_pool")

--- a/src/fabric_dw/mcp/tools/tables.py
+++ b/src/fabric_dw/mcp/tools/tables.py
@@ -286,7 +286,6 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             )
         except (ValueError, FabricError) as exc:
             raise tool_err(exc) from exc
-        ctx.resolver.clear_negative_cache()
         return result.model_dump(mode="json")
 
     @mutating_tool(mcp, "delete_table", destructive=True)
@@ -418,7 +417,6 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             )
         except (TypeError, ValueError, FabricError) as exc:
             raise tool_err(exc) from exc
-        ctx.resolver.clear_negative_cache()
         return result.model_dump(mode="json")
 
     @mutating_tool(mcp, "clone_table")
@@ -481,7 +479,6 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             )
         except (ValueError, FabricError) as exc:
             raise tool_err(exc) from exc
-        ctx.resolver.clear_negative_cache()
         return result.model_dump(mode="json")
 
     @mcp.tool(name="get_table_health_metrics")
@@ -574,7 +571,6 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             )
         except (ValueError, FabricError) as exc:
             raise tool_err(exc) from exc
-        ctx.resolver.clear_negative_cache()
         return result.model_dump(mode="json")
 
     @mutating_tool(mcp, "set_cluster_columns", destructive=True)
@@ -638,5 +634,4 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             )
         except (ValueError, FabricError) as exc:
             raise tool_err(exc) from exc
-        ctx.resolver.clear_negative_cache()
         return result.model_dump(mode="json")

--- a/src/fabric_dw/mcp/tools/views.py
+++ b/src/fabric_dw/mcp/tools/views.py
@@ -229,7 +229,6 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             )
         except (ValueError, FabricError) as exc:
             raise tool_err(exc) from exc
-        ctx.resolver.clear_negative_cache()
         return result.model_dump(mode="json")
 
     @mutating_tool(mcp, "update_view")
@@ -262,7 +261,6 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             )
         except (ValueError, FabricError) as exc:
             raise tool_err(exc) from exc
-        ctx.resolver.clear_negative_cache()
         return result.model_dump(mode="json")
 
     @mutating_tool(mcp, "drop_view", destructive=True)
@@ -287,7 +285,6 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             await views_svc.drop_view(target, schema, view_name, mode=ctx.auth_mode)
         except (ValueError, FabricError) as exc:
             raise tool_err(exc) from exc
-        ctx.resolver.clear_negative_cache()
         return {"dropped": True}
 
     @mutating_tool(mcp, "rename_view")
@@ -330,5 +327,4 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             )
         except (ValueError, FabricError) as exc:
             raise tool_err(exc) from exc
-        ctx.resolver.clear_negative_cache()
         return result.model_dump(mode="json")

--- a/src/fabric_dw/mcp/tools/warehouses.py
+++ b/src/fabric_dw/mcp/tools/warehouses.py
@@ -125,7 +125,6 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             )
         except (ValueError, FabricError) as exc:
             raise tool_err(exc) from exc
-        ctx.resolver.clear_negative_cache()
         return result.model_dump(by_alias=True, mode="json")
 
     @mutating_tool(mcp, "rename_warehouse")
@@ -149,7 +148,6 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             )
         except (ValueError, FabricError) as exc:
             raise tool_err(exc) from exc
-        ctx.resolver.clear_negative_cache()
         return result.model_dump(by_alias=True, mode="json")
 
     @mutating_tool(mcp, "delete_warehouse", destructive=True)

--- a/src/fabric_dw/resolver.py
+++ b/src/fabric_dw/resolver.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 import logging
 import re
-import time
 from datetime import UTC, datetime
 from typing import Any, NamedTuple
 from uuid import UUID
@@ -42,16 +41,6 @@ GUID_RE = re.compile(
 # Fabric display names are well below this limit; rejecting oversized inputs
 # defends against injection attempts and avoids unexpected server errors.
 _ODATA_MAX_LEN = 256
-
-# How long (in seconds) a negative-cache entry is considered valid.
-# Kept in-memory only — persisting "not found" results across restarts would
-# suppress retries even when the resource reappears after a short outage.
-#
-# This TTL is intentionally short (5 s): the negative cache exists only to
-# suppress rapid repeated misses (typo retry loops, burst lookups within a
-# single user gesture).  A longer window would mask newly created resources
-# from the MCP singleton, which outlives any single command invocation.
-_NEGATIVE_TTL = 5.0
 
 
 class ItemTypeInfo(NamedTuple):
@@ -121,76 +110,14 @@ def _connection_string_from_detail(payload: dict[str, Any], kind: WarehouseKind)
 class Resolver:
     """Resolves workspace / item names or GUIDs to UUIDs and ItemEntry objects.
 
-    In addition to the persistent filesystem cache (``LookupCache``), each
-    ``Resolver`` instance keeps an **in-memory** negative cache.  When a
-    workspace or item lookup raises ``NotFoundError``, the failed key is recorded
-    with a monotonic timestamp; subsequent lookups within ``_NEGATIVE_TTL``
-    seconds re-raise ``NotFoundError`` without hitting the API.
-
-    The negative cache is intentionally *not* persisted.  "Not found" is a
-    transient condition (the resource may be created moments later), and
-    persisting it across process restarts would suppress retries even after
-    the resource appears.  An in-memory TTL of ``_NEGATIVE_TTL`` seconds
-    provides adequate 429-protection without that risk.
+    Uses the persistent filesystem cache (``LookupCache``) for positive results.
+    A lookup of a genuinely-missing item hits the API each time, which keeps
+    the resolver simple and avoids masking newly created resources.
     """
 
     def __init__(self, http: FabricHttpClient, cache: LookupCache) -> None:
         self._http = http
         self._cache = cache
-        # Negative cache: maps (scope, key) → monotonic timestamp of the failure.
-        # scope is "workspace" or a workspace UUID string (for items).
-        self._negative: dict[tuple[str, str], float] = {}
-
-    def _negative_check(self, scope: str, key: str) -> None:
-        """Raise NotFoundError immediately if *key* is in the negative cache and still fresh.
-
-        *key* is normalised to lower-case so that negative-cache lookups are
-        case-insensitive and consistent with the positive :class:`LookupCache`
-        which stores all names as lower-case.
-        """
-        normalised = key.strip().lower()
-        ts = self._negative.get((scope, normalised))
-        if ts is not None:
-            age = time.monotonic() - ts
-            if age < _NEGATIVE_TTL:
-                raise NotFoundError(f"{scope}/{normalised!r} not found")
-            # Entry has expired; prune it now to keep the dict bounded.
-            del self._negative[(scope, normalised)]
-
-    def _negative_record(self, scope: str, key: str) -> None:
-        """Record a not-found result in the negative cache.
-
-        *key* is normalised to lower-case (consistent with positive cache).
-        """
-        self._negative[(scope, key.strip().lower())] = time.monotonic()
-
-    def _negative_clear(self, scope: str, key: str) -> None:
-        """Remove a negative-cache entry after a successful put.
-
-        *key* is normalised to lower-case (consistent with positive cache).
-        """
-        self._negative.pop((scope, key.strip().lower()), None)
-
-    def _negative_clear_scope(self, scope: str) -> None:
-        """Remove all negative-cache entries whose first element equals *scope*.
-
-        Used after a successful item detail fetch to ensure that newly created
-        (or just-discovered) items become immediately resolvable within the
-        ``_NEGATIVE_TTL`` window.
-        """
-        stale = [k for k in self._negative if k[0] == scope]
-        for k in stale:
-            del self._negative[k]
-
-    def clear_negative_cache(self) -> None:
-        """Clear the entire in-memory negative cache.
-
-        Cheap O(1) operation that discards all recorded "not found" results.
-        Mutating frontends (MCP create / rename tools) call this after a
-        successful write so that subsequent lookups for the new name succeed
-        immediately rather than waiting for ``_NEGATIVE_TTL`` seconds to elapse.
-        """
-        self._negative.clear()
 
     # ------------------------------------------------------------------
     # workspace_id
@@ -217,15 +144,12 @@ class Resolver:
         if GUID_RE.match(value):
             return UUID(value)
 
-        # 2. Negative cache hit — avoid re-hitting the API for known-missing names
-        self._negative_check("workspace", value)
-
-        # 3. Cache hit
+        # 2. Cache hit
         cached = self._cache.get_workspace(value)
         if cached is not None:
             return cached.id
 
-        # 4. Power BI OData filter — escape single quotes per OData spec
+        # 3. Power BI OData filter — escape single quotes per OData spec
         resp = await self._http.request(
             "GET",
             HttpBase.POWERBI,
@@ -236,7 +160,6 @@ class Resolver:
         results: list[dict[str, Any]] = body.get("value", [])
 
         if not results:
-            self._negative_record("workspace", value)
             raise NotFoundError(f"workspace {value!r} not found")
 
         if len(results) > 1:
@@ -245,7 +168,6 @@ class Resolver:
 
         ws_id = UUID(str(results[0]["id"]))
         self._cache.put_workspace(value, ws_id)
-        self._negative_clear("workspace", value)
         return ws_id
 
     # ------------------------------------------------------------------
@@ -272,7 +194,6 @@ class Resolver:
         """
         value = value.strip()
         ws_id = await self.workspace_id(workspace)
-        ws_key = str(ws_id)
 
         # 1. GUID fast-path: check cache first, then fetch detail
         if GUID_RE.match(value):
@@ -280,24 +201,14 @@ class Resolver:
             cached_item = self._cache.get_item(ws_id, value)
             if cached_item is not None:
                 return cached_item
-            self._negative_check(ws_key, value)
-            try:
-                result = await self._fetch_item_detail(ws_id, item_uuid)
-            except NotFoundError:
-                self._negative_record(ws_key, value)
-                raise
-            self._negative_clear(ws_key, value)
-            return result
+            return await self._fetch_item_detail(ws_id, item_uuid)
 
-        # 2. Negative cache hit
-        self._negative_check(ws_key, value)
-
-        # 3. Cache hit
+        # 2. Cache hit
         cached_item = self._cache.get_item(ws_id, value)
         if cached_item is not None:
             return cached_item
 
-        # 4. Page through /v1/workspaces/{ws}/items, filter by kind + name.
+        # 3. Page through /v1/workspaces/{ws}/items, filter by kind + name.
         # Pass ``type`` parameter when a single item type is known so the
         # server returns fewer items (Fabric items API supports this filter).
         # Reject unknown item_type values immediately (D22) rather than
@@ -321,15 +232,8 @@ class Resolver:
             # Found a name match — fetch full detail to get connection_string.
             # Break out of pagination immediately; no need to fetch remaining pages.
             item_id = UUID(str(raw_item["id"]))
-            try:
-                result = await self._fetch_item_detail(ws_id, item_id)
-            except NotFoundError:
-                self._negative_record(ws_key, value)
-                raise
-            self._negative_clear(ws_key, value)
-            return result
+            return await self._fetch_item_detail(ws_id, item_id)
 
-        self._negative_record(ws_key, value)
         raise NotFoundError(f"item {value!r} not found in workspace {ws_id}")
 
     async def _fetch_item_detail(self, workspace_id: UUID, item_id: UUID) -> ItemEntry:
@@ -438,8 +342,4 @@ class Resolver:
                     (str(item_id), entry),
                 ],
             )
-            # Clear-on-put: drop all negative entries for this workspace scope so
-            # that a freshly created item becomes immediately resolvable even within
-            # the _NEGATIVE_TTL window (defence-in-depth against create→resolve race).
-            self._negative_clear_scope(str(workspace_id))
         return entry

--- a/tests/unit/mcp/conftest.py
+++ b/tests/unit/mcp/conftest.py
@@ -104,9 +104,6 @@ def mock_ctx() -> ServerContext:
     # Sensible defaults so tests that don't care about internals still work.
     mock_resolver.workspace_id = AsyncMock(return_value=WS_ID)
     mock_resolver.item = AsyncMock(return_value=make_item_entry())
-    # clear_negative_cache is a synchronous method on the real Resolver.
-    mock_resolver.clear_negative_cache = MagicMock()
-
     return ServerContext(
         http=mock_http,
         cache=mock_cache,

--- a/tests/unit/mcp/test_contract.py
+++ b/tests/unit/mcp/test_contract.py
@@ -76,8 +76,6 @@ def contract_ctx():
     mock_resolver = AsyncMock()
     mock_resolver.workspace_id = AsyncMock(return_value=WS_ID)
     mock_resolver.item = AsyncMock(return_value=make_item_entry())
-    mock_resolver.clear_negative_cache = MagicMock()
-
     return ServerContext(
         http=mock_http,
         cache=mock_cache,

--- a/tests/unit/mcp/test_security.py
+++ b/tests/unit/mcp/test_security.py
@@ -1240,8 +1240,6 @@ async def test_drop_view_allowed_with_destructive_flag() -> None:
     mock_resolver = AsyncMock()
     mock_resolver.workspace_id = AsyncMock(return_value=_WS_ID)
     mock_resolver.item = AsyncMock(return_value=entry)
-    mock_resolver.clear_negative_cache = MagicMock()
-
     ctx = ServerContext(
         http=AsyncMock(),
         cache=MagicMock(),

--- a/tests/unit/mcp/test_server.py
+++ b/tests/unit/mcp/test_server.py
@@ -322,7 +322,7 @@ async def test_list_workspaces_happy_path(ctx_patch) -> None:
 
 
 async def test_clear_cache_side_effect(mock_ctx, ctx_patch) -> None:
-    """clear_cache(scope='all') must call LookupCache.clear() and clear_negative_cache."""
+    """clear_cache(scope='all') must call LookupCache.clear()."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
     mock_ctx.cache.counts.return_value = (2, 3)
@@ -332,15 +332,14 @@ async def test_clear_cache_side_effect(mock_ctx, ctx_patch) -> None:
 
     mock_ctx.cache.counts.assert_called_once()
     mock_ctx.cache.clear.assert_called_once()
-    mock_ctx.resolver.clear_negative_cache.assert_called_once()
     assert result["scope"] == "all"
     assert result["workspaces_cleared"] == 2
     assert result["items_cleared"] == 3
-    assert result["negative_cache_cleared"] is True
+    assert "negative_cache_cleared" not in result
 
 
 async def test_clear_cache_scope_workspaces(mock_ctx, ctx_patch) -> None:
-    """clear_cache(scope='workspaces') must NOT call full clear() or clear_negative_cache."""
+    """clear_cache(scope='workspaces') must NOT call full clear()."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
     # Configure the public counts() API to return (1 workspace, 0 item buckets).
@@ -352,15 +351,14 @@ async def test_clear_cache_scope_workspaces(mock_ctx, ctx_patch) -> None:
     mock_ctx.cache.counts.assert_called_once()
     mock_ctx.cache.clear_scope.assert_called_once_with("workspaces")
     mock_ctx.cache.clear.assert_not_called()
-    mock_ctx.resolver.clear_negative_cache.assert_not_called()
     assert result["scope"] == "workspaces"
     assert result["workspaces_cleared"] == 1
     assert result["items_cleared"] == 0
-    assert result["negative_cache_cleared"] is False
+    assert "negative_cache_cleared" not in result
 
 
 async def test_clear_cache_scope_items(mock_ctx, ctx_patch) -> None:
-    """clear_cache(scope='items') must NOT call full clear() or clear_negative_cache."""
+    """clear_cache(scope='items') must NOT call full clear()."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
     # Configure the public counts() API to return (0 workspaces, 1 item bucket).
@@ -372,11 +370,10 @@ async def test_clear_cache_scope_items(mock_ctx, ctx_patch) -> None:
     mock_ctx.cache.counts.assert_called_once()
     mock_ctx.cache.clear_scope.assert_called_once_with("items")
     mock_ctx.cache.clear.assert_not_called()
-    mock_ctx.resolver.clear_negative_cache.assert_not_called()
     assert result["scope"] == "items"
     assert result["workspaces_cleared"] == 0
     assert result["items_cleared"] == 1
-    assert result["negative_cache_cleared"] is False
+    assert "negative_cache_cleared" not in result
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/mcp/tools/test_functions.py
+++ b/tests/unit/mcp/tools/test_functions.py
@@ -298,31 +298,6 @@ async def test_create_function_on_sql_endpoint_succeeds(mock_ctx, ctx_patch) -> 
     assert isinstance(result, dict)
 
 
-async def test_create_function_clears_negative_cache(mock_ctx, ctx_patch) -> None:
-    """create_function calls clear_negative_cache after creation."""
-    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
-
-    fn = _make_fn_details()
-    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
-    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
-
-    with (
-        ctx_patch,
-        patch("fabric_dw.services.functions.create_function", new=AsyncMock(return_value=fn)),
-    ):
-        await mcp._tool_manager.call_tool(
-            "create_function",
-            {
-                "workspace": WS_NAME,
-                "item": WH_NAME,
-                "qualified_name": "dbo.fn_clean",
-                "body": "...",
-            },
-        )
-
-    mock_ctx.resolver.clear_negative_cache.assert_called_once()
-
-
 # ---------------------------------------------------------------------------
 # update_function — mutating tool
 # ---------------------------------------------------------------------------
@@ -484,31 +459,6 @@ async def test_rename_function_not_found_raises(mock_ctx, ctx_patch) -> None:
                 "new_name": "fn_whatever",
             },
         )
-
-
-async def test_rename_function_clears_negative_cache(mock_ctx, ctx_patch) -> None:
-    """rename_function calls clear_negative_cache after rename."""
-    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
-
-    fn = _make_fn_details(name="fn_sanitize")
-    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
-    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
-
-    with (
-        ctx_patch,
-        patch("fabric_dw.services.functions.rename_function", new=AsyncMock(return_value=fn)),
-    ):
-        await mcp._tool_manager.call_tool(
-            "rename_function",
-            {
-                "workspace": WS_NAME,
-                "item": WH_NAME,
-                "qualified_name": "dbo.fn_clean",
-                "new_name": "fn_sanitize",
-            },
-        )
-
-    mock_ctx.resolver.clear_negative_cache.assert_called_once()
 
 
 async def test_rename_function_invalid_qualified_name_raises(ctx_patch) -> None:

--- a/tests/unit/mcp/tools/test_snapshots.py
+++ b/tests/unit/mcp/tools/test_snapshots.py
@@ -298,30 +298,6 @@ async def test_create_snapshot_value_error_becomes_tool_error(mock_ctx, ctx_patc
     assert "non-empty" in str(exc_info.value).lower()
 
 
-async def test_create_snapshot_clears_negative_cache(mock_ctx, ctx_patch) -> None:
-    """create_snapshot calls resolver.clear_negative_cache() after success."""
-    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
-
-    snap = _make_snapshot()
-    item = make_item_entry()
-    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
-    mock_ctx.resolver.item = AsyncMock(return_value=item)
-
-    with (
-        ctx_patch,
-        patch(
-            "fabric_dw.services.snapshots.create",
-            new=AsyncMock(return_value=snap),
-        ),
-    ):
-        await mcp._tool_manager.call_tool(
-            "create_snapshot",
-            {"workspace": WS_NAME, "warehouse": WH_NAME, "name": _SNAP_NAME},
-        )
-
-    mock_ctx.resolver.clear_negative_cache.assert_called_once()
-
-
 async def test_create_snapshot_workspace_guard(ctx_patch) -> None:
     """create_snapshot raises ToolError when workspace is not in the allowlist."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
@@ -430,30 +406,6 @@ async def test_rename_snapshot_value_error_becomes_tool_error(mock_ctx, ctx_patc
         )
 
     assert "non-empty" in str(exc_info.value).lower()
-
-
-async def test_rename_snapshot_clears_negative_cache(mock_ctx, ctx_patch) -> None:
-    """rename_snapshot calls resolver.clear_negative_cache() after success."""
-    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
-
-    snap = _make_snapshot(name="snap-renamed")
-    item = make_item_entry()
-    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
-    mock_ctx.resolver.item = AsyncMock(return_value=item)
-
-    with (
-        ctx_patch,
-        patch(
-            "fabric_dw.services.snapshots.rename",
-            new=AsyncMock(return_value=snap),
-        ),
-    ):
-        await mcp._tool_manager.call_tool(
-            "rename_snapshot",
-            {"workspace": WS_NAME, "snapshot": _SNAP_NAME, "new_name": "snap-renamed"},
-        )
-
-    mock_ctx.resolver.clear_negative_cache.assert_called_once()
 
 
 async def test_rename_snapshot_workspace_guard(ctx_patch) -> None:

--- a/tests/unit/mcp/tools/test_sql_pools.py
+++ b/tests/unit/mcp/tools/test_sql_pools.py
@@ -371,7 +371,6 @@ async def test_create_sql_pool_happy_path(mock_ctx, ctx_patch) -> None:
     assert isinstance(result, dict)
     assert result["name"] == "new-pool"
     assert result["maxResourcePercentage"] == 20
-    mock_ctx.resolver.clear_negative_cache.assert_called_once()
 
 
 async def test_create_sql_pool_with_classifier(mock_ctx, ctx_patch) -> None:

--- a/tests/unit/mcp/tools/test_tool_quality.py
+++ b/tests/unit/mcp/tools/test_tool_quality.py
@@ -11,7 +11,6 @@ Coverage
 7. Int param bounds — FastMCP rejects out-of-range values.
 8. ``next()`` fallback in create_sql_pool / update_sql_pool.
 9. ``clear_cache`` scope + stats.
-10. ``clear_negative_cache`` called after mutating tool (create_warehouse).
 """
 
 from __future__ import annotations
@@ -70,7 +69,6 @@ def _make_ctx() -> ServerContext:
     mock_resolver = AsyncMock()
     mock_resolver.workspace_id = AsyncMock(return_value=_WS_ID)
     mock_resolver.item = AsyncMock(return_value=_make_entry())
-    mock_resolver.clear_negative_cache = MagicMock()
     return ServerContext(
         http=mock_http,
         cache=mock_cache,
@@ -453,7 +451,6 @@ def _make_ctx_with_real_cache(tmp_path: Any) -> ServerContext:
     mock_resolver = AsyncMock()
     mock_resolver.workspace_id = AsyncMock(return_value=_WS_ID)
     mock_resolver.item = AsyncMock(return_value=_make_entry())
-    mock_resolver.clear_negative_cache = MagicMock()
     return ServerContext(
         http=mock_http,
         cache=real_cache,
@@ -463,7 +460,7 @@ def _make_ctx_with_real_cache(tmp_path: Any) -> ServerContext:
 
 
 async def test_clear_cache_all_returns_stats(tmp_path: Any) -> None:
-    """clear_cache(scope='all') reports 0 counts on an empty cache and calls resolver.clear."""
+    """clear_cache(scope='all') reports 0 counts on an empty cache."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
     ctx = _make_ctx_with_real_cache(tmp_path)
@@ -474,12 +471,7 @@ async def test_clear_cache_all_returns_stats(tmp_path: Any) -> None:
     assert result["scope"] == "all"
     assert result["workspaces_cleared"] == 0
     assert result["items_cleared"] == 0
-    assert result["negative_cache_cleared"] is True
-    # ctx.resolver is an AsyncMock; cast to Any so static checkers don't flag
-    # the assertion methods that are only available on Mock objects.
-    from typing import cast as _cast  # noqa: PLC0415
-
-    _cast(Any, ctx.resolver).clear_negative_cache.assert_called_once()
+    assert "negative_cache_cleared" not in result
 
 
 async def test_clear_cache_workspaces_scope(tmp_path: Any) -> None:
@@ -497,7 +489,6 @@ async def test_clear_cache_workspaces_scope(tmp_path: Any) -> None:
 
     mock_http = AsyncMock()
     mock_resolver = AsyncMock()
-    mock_resolver.clear_negative_cache = MagicMock()
     ctx = ServerContext(
         http=mock_http,
         cache=real_cache,
@@ -511,8 +502,7 @@ async def test_clear_cache_workspaces_scope(tmp_path: Any) -> None:
     assert result["scope"] == "workspaces"
     assert result["workspaces_cleared"] == 2
     assert result["items_cleared"] == 0
-    assert result["negative_cache_cleared"] is False
-    mock_resolver.clear_negative_cache.assert_not_called()
+    assert "negative_cache_cleared" not in result
 
     # Verify the workspace entries are actually gone.
     assert real_cache.get_workspace("ws1") is None
@@ -544,7 +534,6 @@ async def test_clear_cache_items_scope(tmp_path: Any) -> None:
 
     mock_http = AsyncMock()
     mock_resolver = AsyncMock()
-    mock_resolver.clear_negative_cache = MagicMock()
     ctx = ServerContext(
         http=mock_http,
         cache=real_cache,
@@ -558,108 +547,11 @@ async def test_clear_cache_items_scope(tmp_path: Any) -> None:
     assert result["scope"] == "items"
     assert result["workspaces_cleared"] == 0
     assert result["items_cleared"] == 2
-    assert result["negative_cache_cleared"] is False
-    mock_resolver.clear_negative_cache.assert_not_called()
+    assert "negative_cache_cleared" not in result
 
     # Verify the item entries are actually gone.
     assert real_cache.get_item(ws_a, "item-x") is None
     assert real_cache.get_item(ws_b, "item-y") is None
-
-
-# ---------------------------------------------------------------------------
-# 10. clear_negative_cache called after successful create (create_warehouse)
-# ---------------------------------------------------------------------------
-
-
-async def test_create_warehouse_clears_negative_cache() -> None:
-    """create_warehouse must call resolver.clear_negative_cache() on success."""
-    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
-    from fabric_dw.models import Warehouse, WarehouseKind  # noqa: PLC0415
-
-    ctx = _make_ctx()
-    wh = Warehouse.model_validate(
-        {
-            "id": str(_WH_ID),
-            "displayName": "new-wh",
-            "workspaceId": str(_WS_ID),
-            "kind": WarehouseKind.WAREHOUSE,
-            "connectionString": _CONN_STRING,
-        }
-    )
-    with (
-        patch("fabric_dw.services.warehouses.create", new=AsyncMock(return_value=wh)),
-        patch("fabric_dw.mcp._context._SERVER_CTX", ctx),
-        patch.dict("os.environ", {}, clear=False),
-    ):
-        result = await mcp._tool_manager.call_tool(
-            "create_warehouse",
-            {"workspace": _WS_NAME, "name": "new-wh"},
-        )
-
-    from typing import cast as _cast  # noqa: PLC0415
-
-    resolver_mock: Any = _cast(Any, ctx.resolver)
-    assert result["displayName"] == "new-wh"
-    resolver_mock.clear_negative_cache.assert_called_once()
-
-
-async def test_create_table_clears_negative_cache() -> None:
-    """create_table must call resolver.clear_negative_cache() on success."""
-    from typing import cast as _cast  # noqa: PLC0415
-
-    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
-
-    ctx = _make_ctx()
-    resolver_mock: Any = _cast(Any, ctx.resolver)
-    # Simulate what tables_svc.create_table returns (a Pydantic model with model_dump)
-    mock_table = MagicMock()
-    mock_table.model_dump.return_value = {"schema": "dbo", "name": "new_table"}
-
-    with (
-        patch("fabric_dw.services.tables.create_table", new=AsyncMock(return_value=mock_table)),
-        patch("fabric_dw.mcp._context._SERVER_CTX", ctx),
-        patch.dict("os.environ", {}, clear=False),
-    ):
-        await mcp._tool_manager.call_tool(
-            "create_table",
-            {
-                "workspace": _WS_NAME,
-                "item": _WH_NAME,
-                "qualified_name": "dbo.new_table",
-                "select_body": "SELECT 1 AS id",
-            },
-        )
-
-    resolver_mock.clear_negative_cache.assert_called_once()
-
-
-async def test_create_view_clears_negative_cache() -> None:
-    """create_view must call resolver.clear_negative_cache() on success."""
-    from typing import cast as _cast  # noqa: PLC0415
-
-    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
-
-    ctx = _make_ctx()
-    resolver_mock: Any = _cast(Any, ctx.resolver)
-    mock_view = MagicMock()
-    mock_view.model_dump.return_value = {"schema": "dbo", "name": "new_view"}
-
-    with (
-        patch("fabric_dw.services.views.create_view", new=AsyncMock(return_value=mock_view)),
-        patch("fabric_dw.mcp._context._SERVER_CTX", ctx),
-        patch.dict("os.environ", {}, clear=False),
-    ):
-        await mcp._tool_manager.call_tool(
-            "create_view",
-            {
-                "workspace": _WS_NAME,
-                "item": _WH_NAME,
-                "qualified_name": "dbo.new_view",
-                "select_body": "SELECT 1 AS id",
-            },
-        )
-
-    resolver_mock.clear_negative_cache.assert_called_once()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/mcp/tools/test_views.py
+++ b/tests/unit/mcp/tools/test_views.py
@@ -456,31 +456,6 @@ async def test_create_view_happy_path(mock_ctx, ctx_patch) -> None:
     assert result["name"] == "vw_sales"
 
 
-async def test_create_view_clears_negative_cache(mock_ctx, ctx_patch) -> None:
-    """create_view must call resolver.clear_negative_cache() after success."""
-    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
-
-    view = _make_view()
-    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
-    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
-
-    with (
-        ctx_patch,
-        patch("fabric_dw.services.views.create_view", new=AsyncMock(return_value=view)),
-    ):
-        await mcp._tool_manager.call_tool(
-            "create_view",
-            {
-                "workspace": WS_NAME,
-                "item": WH_NAME,
-                "qualified_name": "dbo.vw_sales",
-                "select_body": "SELECT 1 AS col",
-            },
-        )
-
-    mock_ctx.resolver.clear_negative_cache.assert_called_once()
-
-
 # ---------------------------------------------------------------------------
 # create_view — error / guard paths
 # ---------------------------------------------------------------------------
@@ -981,85 +956,6 @@ async def test_rename_view_value_error_becomes_tool_error(mock_ctx, ctx_patch) -
                 "new_name": "vw_revenue",
             },
         )
-
-
-# ---------------------------------------------------------------------------
-# M09 — negative cache cleared on view mutations
-# ---------------------------------------------------------------------------
-
-
-async def test_update_view_clears_negative_cache(mock_ctx, ctx_patch) -> None:
-    """update_view must call resolver.clear_negative_cache() after success (M09)."""
-    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
-
-    view = _make_view()
-    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
-    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
-
-    with (
-        ctx_patch,
-        patch("fabric_dw.services.views.update_view", new=AsyncMock(return_value=view)),
-    ):
-        await mcp._tool_manager.call_tool(
-            "update_view",
-            {
-                "workspace": WS_NAME,
-                "item": WH_NAME,
-                "qualified_name": "dbo.vw_sales",
-                "select_body": "SELECT 2 AS col",
-            },
-        )
-
-    mock_ctx.resolver.clear_negative_cache.assert_called_once()
-
-
-async def test_drop_view_clears_negative_cache(mock_ctx, ctx_patch) -> None:
-    """drop_view must call resolver.clear_negative_cache() after success (M09)."""
-    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
-
-    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
-    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
-
-    with (
-        ctx_patch,
-        patch.dict(os.environ, {"FABRIC_MCP_ALLOW_DESTRUCTIVE": "1"}),
-        patch("fabric_dw.services.views.drop_view", new=AsyncMock(return_value=None)),
-    ):
-        await mcp._tool_manager.call_tool(
-            "drop_view",
-            {
-                "workspace": WS_NAME,
-                "item": WH_NAME,
-                "qualified_name": "dbo.vw_sales",
-            },
-        )
-
-    mock_ctx.resolver.clear_negative_cache.assert_called_once()
-
-
-async def test_rename_view_clears_negative_cache(mock_ctx, ctx_patch) -> None:
-    """rename_view must call resolver.clear_negative_cache() after success (M09)."""
-    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
-
-    view = _make_view()
-    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
-    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
-
-    with (
-        ctx_patch,
-        patch("fabric_dw.services.views.rename_view", new=AsyncMock(return_value=view)),
-    ):
-        await mcp._tool_manager.call_tool(
-            "rename_view",
-            {
-                "workspace": WS_NAME,
-                "item": WH_NAME,
-                "qualified_name": "dbo.vw_sales",
-                "new_name": "vw_revenue",
-            },
-        )
-
-    mock_ctx.resolver.clear_negative_cache.assert_called_once()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/mcp/tools/test_warehouses.py
+++ b/tests/unit/mcp/tools/test_warehouses.py
@@ -276,7 +276,6 @@ async def test_create_warehouse_happy_path(mock_ctx, ctx_patch) -> None:
 
     assert isinstance(result, dict)
     assert result["id"] == str(WH_ID)
-    mock_ctx.resolver.clear_negative_cache.assert_called_once()
 
 
 async def test_create_warehouse_value_error_becomes_tool_error(mock_ctx, ctx_patch) -> None:
@@ -364,7 +363,6 @@ async def test_rename_warehouse_happy_path(mock_ctx, ctx_patch) -> None:
 
     assert isinstance(result, dict)
     assert result["id"] == str(WH_ID)
-    mock_ctx.resolver.clear_negative_cache.assert_called_once()
 
 
 async def test_rename_warehouse_fabric_error_becomes_tool_error(mock_ctx, ctx_patch) -> None:

--- a/tests/unit/test_resolver.py
+++ b/tests/unit/test_resolver.py
@@ -591,8 +591,6 @@ async def test_item_miss_then_found_resolves(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-
-
 def test_odata_escape_rejects_oversized_value() -> None:
     """_odata_escape must raise FabricError for values exceeding _ODATA_MAX_LEN."""
     ok_value = "A" * 256  # exactly at the limit
@@ -958,5 +956,3 @@ async def test_item_sql_endpoint_unresolved_conn_not_cached_and_retries(
     assert second.connection_string == "mysqlep.datawarehouse.fabric.microsoft.com"
     # The /sqlEndpoints resource was fetched twice — no stale cache short-circuit.
     assert sql_ep_calls["n"] == 2
-
-

--- a/tests/unit/test_resolver.py
+++ b/tests/unit/test_resolver.py
@@ -20,7 +20,6 @@ from fabric_dw.models import WarehouseKind
 from fabric_dw.resolver import (
     _ITEM_TYPE_INFO,
     _ITEM_TYPES,
-    _NEGATIVE_TTL,
     ItemTypeInfo,
     Resolver,
     _odata_escape,
@@ -537,12 +536,12 @@ async def test_item_guid_unknown_type_raises_fabric_error(tmp_path: Path) -> Non
 
 
 # ---------------------------------------------------------------------------
-# Negative cache: repeated NotFoundError avoids API call
+# Miss-then-create: a NotFoundError followed by a successful lookup resolves correctly
 # ---------------------------------------------------------------------------
 
 
-async def test_workspace_negative_cache_avoids_second_api_call(tmp_path: Path) -> None:
-    """Second lookup of a missing workspace must not hit the API (negative cache)."""
+async def test_workspace_miss_then_found_resolves(tmp_path: Path) -> None:
+    """A workspace absent on the first call must resolve on a subsequent call once created."""
     resolver, client, _ = _make_resolver(tmp_path)
     with respx.mock:
         route = respx.get(_PBI_GROUPS_URL).mock(
@@ -551,70 +550,47 @@ async def test_workspace_negative_cache_avoids_second_api_call(tmp_path: Path) -
         async with client:
             with pytest.raises(NotFoundError):
                 await resolver.workspace_id("GhostWorkspace")
-            # Second call: negative cache should fire before the HTTP route
-            with pytest.raises(NotFoundError):
-                await resolver.workspace_id("GhostWorkspace")
-    # The real API should only have been called once
-    assert route.call_count == 1, "negative cache must suppress the second API call"
-
-
-async def test_workspace_negative_cache_clears_on_success(tmp_path: Path) -> None:
-    """After a successful lookup the negative cache entry must be cleared.
-
-    This test verifies that when workspace_id() finds the workspace via the API
-    (positive result), it calls _negative_clear() and removes any stale negative
-    entry for that key — WITHOUT relying on manual cache manipulation.
-    """
-    resolver, client, _ = _make_resolver(tmp_path)
-    with respx.mock:
-        # First call: not found → recorded in negative cache
-        route = respx.get(_PBI_GROUPS_URL).mock(
-            return_value=httpx.Response(200, json=_pbi_empty_response())
-        )
-        async with client:
-            with pytest.raises(NotFoundError):
-                await resolver.workspace_id("GhostWorkspace")
-
-        # Verify the entry was recorded
-        assert ("workspace", "ghostworkspace") in resolver._negative
-
-        # Now the workspace "appears" — but the negative TTL (5s) is still active,
-        # so we back-date the negative entry timestamp to simulate TTL expiry.
-        resolver._negative[("workspace", "ghostworkspace")] = time.monotonic() - 10.0
-
-        route.side_effect = None  # type: ignore[attr-defined]
+        # Simulate the workspace being created; next call must hit the API and succeed.
         route.mock(
             return_value=httpx.Response(200, json=_pbi_group_response(WS_GUID, "GhostWorkspace"))
         )
         async with client:
             result = await resolver.workspace_id("GhostWorkspace")
-
-    # Successful lookup must have cleared the negative entry
-    assert ("workspace", "ghostworkspace") not in resolver._negative
     assert result == WS_UUID
+    # The API was called twice: once for the miss, once for the subsequent hit.
+    assert route.call_count == 2
 
 
-async def test_item_negative_cache_avoids_second_api_call(tmp_path: Path) -> None:
-    """Second lookup of a missing item must not page through items again."""
+async def test_item_miss_then_found_resolves(tmp_path: Path) -> None:
+    """An item that is absent on the first call must resolve on a subsequent call once created."""
     resolver, client, _ = _make_resolver(tmp_path)
-    # Items list returns nothing matching the name
-    list_payload = _items_list_payload(_warehouse_list_item(ITEM_GUID, "OtherWarehouse"))
+    list_payload_empty = _items_list_payload(_warehouse_list_item(ITEM_GUID, "OtherWarehouse"))
+    list_payload_found = _items_list_payload(_warehouse_list_item(ITEM_GUID, "GhostItem"))
+    generic_payload = _warehouse_detail_payload(ITEM_GUID, WS_GUID, "GhostItem")
+    specific_payload = _warehouse_detail_payload(ITEM_GUID, WS_GUID, "GhostItem")
     with respx.mock:
-        route = respx.get(_FABRIC_ITEMS_URL).mock(
-            return_value=httpx.Response(200, json=list_payload)
+        list_route = respx.get(_FABRIC_ITEMS_URL).mock(
+            return_value=httpx.Response(200, json=list_payload_empty)
         )
+        respx.get(_FABRIC_ITEM_URL).mock(return_value=httpx.Response(200, json=generic_payload))
+        respx.get(
+            f"https://api.fabric.microsoft.com/v1/workspaces/{WS_GUID}/warehouses/{ITEM_GUID}"
+        ).mock(return_value=httpx.Response(200, json=specific_payload))
         async with client:
             with pytest.raises(NotFoundError):
                 await resolver.item(WS_GUID, "GhostItem")
-            # Second call: negative cache should fire before hitting the list endpoint
-            with pytest.raises(NotFoundError):
-                await resolver.item(WS_GUID, "GhostItem")
-    assert route.call_count == 1, "negative cache must suppress the second items-list call"
+        # Simulate the item being created; next call must hit the API and succeed.
+        list_route.mock(return_value=httpx.Response(200, json=list_payload_found))
+        async with client:
+            result = await resolver.item(WS_GUID, "GhostItem")
+    assert result.id == ITEM_UUID
 
 
 # ---------------------------------------------------------------------------
 # _odata_escape: length guard
 # ---------------------------------------------------------------------------
+
+
 
 
 def test_odata_escape_rejects_oversized_value() -> None:
@@ -717,80 +693,6 @@ async def test_fetch_item_detail_uses_put_items(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Negative cache: TTL constant, expired-entry pruning, clear-on-put
-# ---------------------------------------------------------------------------
-
-
-def test_negative_ttl_is_five_seconds() -> None:
-    """_NEGATIVE_TTL must be 5 seconds (not 60) to avoid masking newly created items."""
-    assert _NEGATIVE_TTL == 5.0, (
-        f"_NEGATIVE_TTL should be 5.0 s but is {_NEGATIVE_TTL}; "
-        "a longer window masks newly created resources in the MCP singleton"
-    )
-
-
-async def test_negative_cache_expired_entry_pruned_on_check(tmp_path: Path) -> None:
-    """_negative_check must prune expired entries to keep the dict bounded."""
-    resolver, client, _ = _make_resolver(tmp_path)
-    # Manually insert an expired negative entry
-    resolver._negative[("workspace", "ghost")] = time.monotonic() - (_NEGATIVE_TTL + 1)
-    with respx.mock:
-        respx.get(_PBI_GROUPS_URL).mock(
-            return_value=httpx.Response(200, json=_pbi_group_response(WS_GUID, "ghost"))
-        )
-        async with client:
-            # Should NOT raise NotFoundError (entry is expired), and must prune it
-            result = await resolver.workspace_id("ghost")
-    assert result == WS_UUID
-    # Expired entry must have been pruned
-    assert ("workspace", "ghost") not in resolver._negative
-
-
-async def test_clear_negative_cache_empties_all_entries(tmp_path: Path) -> None:
-    """clear_negative_cache() must discard all in-memory negative entries."""
-    resolver, client, _ = _make_resolver(tmp_path)
-    with respx.mock:
-        respx.get(_PBI_GROUPS_URL).mock(
-            return_value=httpx.Response(200, json=_pbi_empty_response())
-        )
-        async with client:
-            with pytest.raises(NotFoundError):
-                await resolver.workspace_id("Ghost1")
-            with pytest.raises(NotFoundError):
-                await resolver.workspace_id("Ghost2")
-    assert len(resolver._negative) == 2
-    resolver.clear_negative_cache()
-    assert len(resolver._negative) == 0
-
-
-async def test_item_fetch_clears_workspace_negative_entries(tmp_path: Path) -> None:
-    """After _fetch_item_detail succeeds, negative entries for that workspace are cleared."""
-    resolver, client, _ = _make_resolver(tmp_path)
-    # Pre-seed negative cache entries for the workspace scope
-    ws_key = str(WS_UUID)
-    resolver._negative[(ws_key, "saleswarehouse")] = time.monotonic()
-    resolver._negative[(ws_key, "otherwarehouse")] = time.monotonic()
-    # An unrelated workspace entry must not be touched
-    resolver._negative[("otherws", "something")] = time.monotonic()
-
-    generic_payload = _warehouse_detail_payload(ITEM_GUID, WS_GUID, "SalesWarehouse")
-    specific_payload = _warehouse_detail_payload(ITEM_GUID, WS_GUID, "SalesWarehouse")
-    with respx.mock:
-        respx.get(_FABRIC_ITEM_URL).mock(return_value=httpx.Response(200, json=generic_payload))
-        respx.get(
-            f"https://api.fabric.microsoft.com/v1/workspaces/{WS_GUID}/warehouses/{ITEM_GUID}"
-        ).mock(return_value=httpx.Response(200, json=specific_payload))
-        async with client:
-            await resolver.item(WS_GUID, ITEM_GUID)
-
-    # Workspace-scoped negative entries must have been cleared
-    assert (ws_key, "saleswarehouse") not in resolver._negative
-    assert (ws_key, "otherwarehouse") not in resolver._negative
-    # Unrelated workspace entries must be untouched
-    assert ("otherws", "something") in resolver._negative
-
-
-# ---------------------------------------------------------------------------
 # _ITEM_TYPE_INFO consolidation
 # ---------------------------------------------------------------------------
 
@@ -842,84 +744,6 @@ class TestD22InvalidItemType:
 
         # The HTTP layer must NOT have been called -- error raised before pagination.
         mock_http.iter_paginated.assert_not_called()
-
-
-# ---------------------------------------------------------------------------
-# D13 — negative cache casing consistency
-# ---------------------------------------------------------------------------
-
-
-def test_negative_cache_normalises_keys_to_lowercase(tmp_path: Path) -> None:
-    """Negative-cache helpers must normalise keys to lower-case (D13).
-
-    _negative_record, _negative_check, and _negative_clear must all use the
-    same lower-cased key so that lookups are case-insensitive and consistent
-    with the positive LookupCache (which also stores names lower-cased).
-    """
-    from fabric_dw.cache import LookupCache  # noqa: PLC0415
-
-    cache = LookupCache(path=tmp_path / "dummy.json")
-    mock_http = MagicMock()
-    resolver = Resolver(http=mock_http, cache=cache)
-
-    # Record under mixed case
-    resolver._negative_record("workspace", "MyWorkspace")
-    # The internal key must be lower-cased regardless of input casing
-    assert ("workspace", "myworkspace") in resolver._negative
-
-    # Check must recognise it under different casing
-    with pytest.raises(NotFoundError):
-        resolver._negative_check("workspace", "MYWORKSPACE")
-
-    # Clear must also normalise
-    resolver._negative_clear("workspace", "MYWORKSPACE")
-    assert ("workspace", "myworkspace") not in resolver._negative
-
-
-def test_negative_cache_strips_whitespace(tmp_path: Path) -> None:
-    """Negative-cache helpers must strip leading/trailing whitespace from keys."""
-    from fabric_dw.cache import LookupCache  # noqa: PLC0415
-
-    cache = LookupCache(path=tmp_path / "dummy.json")
-    mock_http = MagicMock()
-    resolver = Resolver(http=mock_http, cache=cache)
-
-    resolver._negative_record("workspace", "  My WS  ")
-    assert ("workspace", "my ws") in resolver._negative
-
-    with pytest.raises(NotFoundError):
-        resolver._negative_check("workspace", "  My WS  ")
-
-    resolver._negative_clear("workspace", "  My WS  ")
-    assert ("workspace", "my ws") not in resolver._negative
-
-
-# ---------------------------------------------------------------------------
-# D12 — _negative_clear_scope
-# ---------------------------------------------------------------------------
-
-
-def test_negative_clear_scope_removes_matching_scope_only(tmp_path: Path) -> None:
-    """_negative_clear_scope must remove all entries for the given scope and leave others."""
-    from fabric_dw.cache import LookupCache  # noqa: PLC0415
-
-    cache = LookupCache(path=tmp_path / "dummy.json")
-    mock_http = MagicMock()
-    resolver = Resolver(http=mock_http, cache=cache)
-
-    ws_id = "ws-uuid-1234"
-    other_ws_id = "ws-other-5678"
-
-    resolver._negative[(ws_id, "item_a")] = time.monotonic()
-    resolver._negative[(ws_id, "item_b")] = time.monotonic()
-    resolver._negative[(other_ws_id, "item_c")] = time.monotonic()
-
-    resolver._negative_clear_scope(ws_id)
-
-    assert (ws_id, "item_a") not in resolver._negative
-    assert (ws_id, "item_b") not in resolver._negative
-    # Entries from a different scope must be preserved
-    assert (other_ws_id, "item_c") in resolver._negative
 
 
 # ---------------------------------------------------------------------------
@@ -1136,74 +960,3 @@ async def test_item_sql_endpoint_unresolved_conn_not_cached_and_retries(
     assert sql_ep_calls["n"] == 2
 
 
-# ---------------------------------------------------------------------------
-# D13 cross-layer parity — positive cache hit is not blocked by negative cache
-# ---------------------------------------------------------------------------
-
-
-async def test_positive_cache_hit_not_blocked_by_negative_cache_same_mixed_case(
-    tmp_path: Path,
-) -> None:
-    """A positive-cache hit must win over a stale negative entry for the same name.
-
-    Scenario (D13 parity):
-    1. Record a negative entry under mixed case ``'MYWS'``.
-    2. Put the same workspace into the *positive* LookupCache under the same
-       name (simulating a successful resolution that now populates the cache).
-    3. After clearing the stale negative entry (as a mutating tool would), assert
-       that ``workspace_id('myws')`` returns the cached UUID without an HTTP call.
-    4. Verify parity: recording a negative entry under any casing of the same
-       name uses the same normalised key, so negative and positive caches never
-       disagree on which key represents the workspace name.
-
-    This test exercises the public resolver API only (not internal helpers) and
-    confirms that both layers normalise case identically, closing the gap
-    identified in the D13 review comment.
-    """
-    from uuid import UUID  # noqa: PLC0415
-
-    from fabric_dw.cache import LookupCache  # noqa: PLC0415
-    from fabric_dw.exceptions import NotFoundError  # noqa: PLC0415
-
-    ws_uuid = UUID("aaaabbbb-cccc-dddd-eeee-ffff00001111")
-
-    cache = LookupCache(path=tmp_path / "ws_cache.json")
-    mock_http = MagicMock()
-    resolver = Resolver(http=mock_http, cache=cache)
-
-    # Step 1: record a negative entry under mixed case.
-    resolver._negative_record("workspace", "MYWS")
-    # Confirm it is recorded (normalised to lowercase).
-    assert ("workspace", "myws") in resolver._negative
-
-    # Step 2: put the workspace into the positive cache under the same
-    # (mixed-case) name — put_workspace normalises to lowercase internally.
-    cache.put_workspace("MYWS", ws_uuid)
-
-    # Step 3: clear the stale negative entry (as a successful mutating call
-    # would do via clear_negative_cache), then verify the positive cache wins.
-    # The lookup order in workspace_id is:
-    #   1. GUID fast-path
-    #   2. _negative_check  ← would raise if still set
-    #   3. cache.get_workspace  ← positive hit
-    resolver._negative_clear("workspace", "MYWS")
-    assert ("workspace", "myws") not in resolver._negative
-
-    # Positive-cache hit — no HTTP call expected.
-    result = await resolver.workspace_id("myws")
-    assert result == ws_uuid
-    mock_http.request.assert_not_called()
-
-    # Step 4: Verify parity: recording a negative entry under a *different*
-    # casing of the same name uses the same normalised key.  Both caches agree
-    # on the key, so there is no scenario where one accepts a name the other
-    # rejects due to different normalisation.
-    resolver._negative_record("workspace", "MyWS")  # mixed case, same key after normalise
-    assert ("workspace", "myws") in resolver._negative
-
-    # Now workspace_id hits the negative cache (step 2) before the positive
-    # cache (step 3), raising NotFoundError.  This demonstrates that both
-    # layers share the same normalised key — whichever casing was stored, the
-    # lookup is consistent.
-    with pytest.raises(NotFoundError):
-        await resolver.workspace_id("MYWS")


### PR DESCRIPTION
## Summary

- Remove the in-memory negative cache from `Resolver` entirely: the `_negative` store, `_NEGATIVE_TTL` constant, and all five negative-cache methods (`_negative_check`, `_negative_record`, `_negative_clear`, `_negative_clear_scope`, `clear_negative_cache`)
- Fix the ordering bug on the name path where a stale negative entry shadowed a now-valid item for up to 5s; resolution now uses only the positive cache plus a live lookup
- Remove all `clear_negative_cache()` calls from MCP mutating tools (warehouses, snapshots, sql_pools, tables, views, functions, procedures) and from the `clear_cache` tool response
- Remove negative-cache unit tests; add miss-then-create tests confirming that a name absent on the first call resolves correctly on the next call once the resource is created

## Test plan

- All 4985 unit tests pass locally
- New tests `test_workspace_miss_then_found_resolves` and `test_item_miss_then_found_resolves` cover the acceptance criterion that a prior miss does not block a subsequent successful resolution
- Ruff check passes on all modified files

Closes #838

Generated with [Claude Code](https://claude.ai/code)