### PR TITLE
fix(tables): normalise point-in-time to UTC in clone_table

### DIFF
--- a/src/fabric_dw/services/tables.py
+++ b/src/fabric_dw/services/tables.py
@@ -42,7 +42,7 @@ from fabric_dw.auth import CredentialMode
 from fabric_dw.exceptions import FabricError, ItemKindError, NotFoundError
 from fabric_dw.identifiers import parse_qualified_name, quote_identifier, validate_identifier
 from fabric_dw.models import ColumnSpec, Table, WarehouseKind
-from fabric_dw.services._helpers import reject_non_select
+from fabric_dw.services._helpers import coerce_to_utc, reject_non_select
 from fabric_dw.sql import SqlTarget, run_query, run_statements
 from fabric_dw.types import arrow_type_to_tsql, validate_tsql_type
 
@@ -1273,15 +1273,19 @@ async def clone_table(
 
     ddl = f"CREATE TABLE {new_q} AS CLONE OF {src_q}"
     if at is not None:
+        # Normalise to UTC first so the AT literal is always in UTC regardless
+        # of whether the caller passes a naive (assumed UTC per coerce_to_utc
+        # convention) or a tz-aware non-UTC datetime.
+        at = coerce_to_utc(at)
         # Format the datetime as a millisecond-precision UTC literal.
         # The AT clause does not support bound parameters in T-SQL DDL, so we
         # embed a fixed-format literal derived from the already-validated datetime
-        # object — never an arbitrary user string.
+        # object -- never an arbitrary user string.
         #
         # Round to the nearest millisecond (half-to-even via Python round())
-        # rather than truncating, so that e.g. 123_750 µs → 124 ms instead
+        # rather than truncating, so that e.g. 123_750 us -> 124 ms instead
         # of silently shifting the point-in-time 0.75 ms earlier.
-        # round() can return 1000 for microsecond values ≥ 999_500 µs;
+        # round() can return 1000 for microsecond values >= 999_500 us;
         # use timedelta to roll the carry into the seconds field correctly.
         at_rounded = at.replace(microsecond=0) + timedelta(
             milliseconds=round(at.microsecond / 1000)

--- a/tests/unit/services/test_tables.py
+++ b/tests/unit/services/test_tables.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 import time
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta, timezone
 from pathlib import Path
 from typing import ClassVar
 from unittest.mock import MagicMock, patch
@@ -1025,6 +1025,26 @@ class TestCloneTable:
         cursor = ddl_conn.cursor.return_value
         call_sql: str = cursor.execute.call_args[0][0]
         # Naive datetime with same wall-clock value as UTC - literal must match
+        assert "AT '2024-05-20T14:00:00.000'" in call_sql
+
+    async def test_at_clause_non_utc_aware_datetime_normalised_to_utc(self) -> None:
+        """Non-UTC tz-aware at is converted to UTC before building the AT literal (#850).
+
+        A UTC+2 datetime at 16:00 must produce the UTC-equivalent 14:00 literal,
+        not the raw wall-clock value.  Without coerce_to_utc this would silently
+        embed the wrong hour.
+        """
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_TABLE_ROW_1], _LIST_COLS)
+        tz_plus2 = timezone(timedelta(hours=2))
+        # 2024-05-20 16:00:00+02:00 == 2024-05-20 14:00:00 UTC
+        non_utc_dt = datetime(2024, 5, 20, 16, 0, 0, tzinfo=tz_plus2)
+        mock_oc = patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn])
+        with mock_oc:
+            await tables.clone_table(target, "dbo.source_tbl", "dbo.sales", at=non_utc_dt)
+        cursor = ddl_conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
         assert "AT '2024-05-20T14:00:00.000'" in call_sql
 
     async def test_rejects_sql_endpoint(self) -> None:


### PR DESCRIPTION
## Summary

- `clone_table` in `services/tables.py` was formatting the `at` datetime via `strftime` on the raw value, dropping tzinfo. A tz-aware non-UTC argument would produce the wrong AT literal (wrong hour embedded in DDL).
- Fix: apply `coerce_to_utc(at)` before rounding and formatting, matching the pattern used by `roll_timestamp` in `snapshots.py`.
- Naive datetimes continue to be treated as UTC per the existing `coerce_to_utc` convention. Existing UTC-normalising callers are unaffected.

## Tests added

- `test_at_clause_non_utc_aware_datetime_normalised_to_utc`: passes a UTC+2 aware datetime and asserts the AT literal contains the UTC-equivalent hour (14:00, not 16:00).
- The existing `test_at_clause_naive_datetime_treated_as_utc` (regression guard from #774) continues to pass.

## Test plan

- [x] `uv run pytest tests/unit/services/test_tables.py::TestCloneTable` - 25 passed
- [x] `uv run pytest tests/unit/` - 5037 passed
- [x] `uv run ruff check` and `ruff format --check` - clean

Closes #850

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>