### PR TITLE
fix(warehouses): treat any 2xx create as success, never re-POST

### DIFF
--- a/src/fabric_dw/services/warehouses.py
+++ b/src/fabric_dw/services/warehouses.py
@@ -9,7 +9,7 @@ from uuid import UUID
 
 from fabric_dw.cache import ItemEntry, LookupCache
 from fabric_dw.exceptions import FabricServerError, NotFoundError, PermissionDeniedError
-from fabric_dw.http_client import FabricHttpClient, HttpBase
+from fabric_dw.http_client import FabricHttpClient, HttpBase, _parse_json_body
 from fabric_dw.models import Warehouse, WarehouseKind
 from fabric_dw.services._helpers import compact, scan_all_workspaces
 from fabric_dw.services._lro import extract_operation_id, resolve_lro_item_id
@@ -18,6 +18,11 @@ from fabric_dw.services.workspaces import SUPPORTED_COLLATIONS
 from fabric_dw.services.workspaces import list_all as _list_all_workspaces
 
 _logger = logging.getLogger("fabric_dw.warehouses")
+
+# Backoff schedule (seconds) for the GET-by-name retry after an empty 2xx create response.
+# Two retries (after the initial attempt) tolerate brief eventual-consistency lag without
+# adding the old retry loop's ~26 s worst-case delay for truly empty responses.
+_GET_BY_NAME_BACKOFF = (2, 6)
 
 
 async def _post_create(
@@ -45,11 +50,13 @@ async def _post_create(
         return location, None
 
     # Fabric occasionally returns 201 with the new warehouse directly in the body.
-    resp_body = resp.json()
-    resp_id = resp_body.get("id")
-    resp_name = resp_body.get("displayName") or resp_body.get("name")
-    if resp_id and resp_name:
-        return None, resp_body
+    # Use _parse_json_body to handle truly empty or non-JSON bodies without crashing.
+    resp_body = _parse_json_body(resp)
+    if resp_body is not None:
+        resp_id = resp_body.get("id")
+        resp_name = resp_body.get("displayName") or resp_body.get("name")
+        if resp_id and resp_name:
+            return None, resp_body
 
     # 2xx + no Location + no usable body: object is assumed created (2xx = success).
     # Do NOT re-POST — that risks a duplicate.  The caller resolves via a read instead.
@@ -266,11 +273,29 @@ async def create(
 
     if location is None:
         # 2xx with no Location and no usable body: object is assumed created.
-        # Resolve via an idempotent name-existence GET, never a re-POST.
-        all_warehouses = await list_warehouses(http, workspace_id, warehouses_only=True)
-        found = next((wh for wh in all_warehouses if wh.name == name), None)
-        if found is not None:
-            return found
+        # Resolve via bounded GET-by-name retries — never a re-POST.
+        # Short backoff tolerates brief eventual-consistency lag after the create.
+        found_id: UUID | None = None
+        for attempt, backoff in enumerate([None, *_GET_BY_NAME_BACKOFF], start=0):
+            if backoff is not None:
+                _logger.debug(
+                    "create warehouse: GET-by-name attempt %d/%d — waiting %ss for propagation",
+                    attempt + 1,
+                    len(_GET_BY_NAME_BACKOFF) + 1,
+                    backoff,
+                )
+                await asyncio.sleep(backoff)
+            all_warehouses = await list_warehouses(http, workspace_id, warehouses_only=True)
+            match = next((wh for wh in all_warehouses if wh.name == name), None)
+            if match is not None:
+                found_id = match.id
+                break
+
+        if found_id is not None:
+            # Follow up with a GET to return a fully-populated Warehouse (list payload
+            # omits fields such as connectionString that get_warehouse returns).
+            return await get_warehouse(http, workspace_id, found_id)
+
         msg = (
             f"create warehouse '{name}': 2xx response with no Location and no usable body; "
             f"warehouse is assumed created (issue #861) but could not be confirmed by name "

--- a/src/fabric_dw/services/warehouses.py
+++ b/src/fabric_dw/services/warehouses.py
@@ -19,62 +19,45 @@ from fabric_dw.services.workspaces import list_all as _list_all_workspaces
 
 _logger = logging.getLogger("fabric_dw.warehouses")
 
-# Backoff schedule for transient empty-2xx responses (seconds).
-_EMPTY_2XX_BACKOFF = (2, 6, 18)
 
-
-async def _post_create_with_retry(
+async def _post_create(
     http: FabricHttpClient,
     workspace_id: UUID,
     body: dict[str, object],
 ) -> tuple[str | None, dict[str, object] | None]:
-    """POST the create-warehouse request, retrying on transient empty-2xx responses.
+    """POST the create-warehouse request once.
 
-    Returns either the ``Location`` header string (LRO path) or the warehouse
-    body dict (synchronous 201 path), or raises :class:`FabricServerError` if
-    all retries are exhausted.
+    A 2xx response always means the object was created.  This function never
+    re-POSTs; re-posting on a 2xx risks creating a duplicate warehouse.
 
     Returns:
-        ``(location, None)`` when a ``Location`` header is present, or
-        ``(None, body_dict)`` when a 201 with a usable body is returned.
-
-    Raises:
-        FabricServerError: If all attempts return 2xx with no Location and no
-            usable body (transient data-plane not ready, issue #204).
+        ``(location, None)`` when a ``Location`` header is present (LRO path),
+        ``(None, body_dict)`` when a usable body is returned (synchronous path),
+        or ``(None, None)`` when the 2xx carries no Location and no usable body
+        (object assumed created; caller must resolve via idempotent read).
     """
-    for attempt, backoff in enumerate([None, *_EMPTY_2XX_BACKOFF], start=0):
-        if backoff is not None:
-            _logger.warning(
-                "create warehouse: 2xx response had no Location header and no usable body "
-                "(retry %d/3) — waiting %ss before retry (see issue #204)",
-                attempt,
-                backoff,
-            )
-            await asyncio.sleep(backoff)
-
-        resp = await http.request(
-            "POST", HttpBase.FABRIC, f"/workspaces/{workspace_id}/warehouses", json=body
-        )
-
-        location = resp.headers.get("Location")
-        if location is not None:
-            return location, None
-
-        # Fabric occasionally returns 201 with the new warehouse directly in the body.
-        resp_body = resp.json()
-        resp_id = resp_body.get("id")
-        resp_name = resp_body.get("displayName") or resp_body.get("name")
-        if resp_id and resp_name:
-            return None, resp_body
-
-        # 2xx + no Location + no usable body: transient Fabric data-plane not ready.
-
-    msg = (
-        "create warehouse: Fabric returned 2xx with no Location header and no usable body "
-        "after 4 attempts. The capacity data plane may not be ready yet. "
-        "See issue #204 for tracking frequency."
+    resp = await http.request(
+        "POST", HttpBase.FABRIC, f"/workspaces/{workspace_id}/warehouses", json=body
     )
-    raise FabricServerError(msg)
+
+    location = resp.headers.get("Location")
+    if location is not None:
+        return location, None
+
+    # Fabric occasionally returns 201 with the new warehouse directly in the body.
+    resp_body = resp.json()
+    resp_id = resp_body.get("id")
+    resp_name = resp_body.get("displayName") or resp_body.get("name")
+    if resp_id and resp_name:
+        return None, resp_body
+
+    # 2xx + no Location + no usable body: object is assumed created (2xx = success).
+    # Do NOT re-POST — that risks a duplicate.  The caller resolves via a read instead.
+    _logger.warning(
+        "create warehouse: 2xx response with no Location header and no usable body; "
+        "warehouse assumed created — will resolve via GET by name (see issue #861)"
+    )
+    return None, None
 
 
 def _resolve_warehouse_id_from_lro(lro_result: dict[str, object]) -> UUID | None:
@@ -272,9 +255,8 @@ async def create(
         body["creationPayload"] = {"collationType": collation}
 
     # Use the type-specific endpoint (POST /workspaces/{id}/warehouses).
-    # Any 4xx is raised by the HTTP client as BadRequestError before reaching here,
-    # so the only non-202/201 responses that arrive are genuine 2xx with missing data.
-    location, resp_body = await _post_create_with_retry(http, workspace_id, body)
+    # Any 4xx is raised by the HTTP client as BadRequestError before reaching here.
+    location, resp_body = await _post_create(http, workspace_id, body)
 
     if resp_body is not None:
         # 201 synchronous path: body contains the new warehouse (without connectionString).
@@ -282,18 +264,26 @@ async def create(
         new_id = UUID(str(resp_body["id"]))
         return await get_warehouse(http, workspace_id, new_id)
 
+    if location is None:
+        # 2xx with no Location and no usable body: object is assumed created.
+        # Resolve via an idempotent name-existence GET, never a re-POST.
+        all_warehouses = await list_warehouses(http, workspace_id, warehouses_only=True)
+        found = next((wh for wh in all_warehouses if wh.name == name), None)
+        if found is not None:
+            return found
+        msg = (
+            f"create warehouse '{name}': 2xx response with no Location and no usable body; "
+            f"warehouse is assumed created (issue #861) but could not be confirmed by name "
+            f"in workspace {workspace_id}. Use list_warehouses to locate it."
+        )
+        raise FabricServerError(msg)
+
     # 202 LRO path: poll until complete, then resolve the new warehouse ID.
     # Per the Fabric LRO contract, the operation status body is NOT guaranteed to
     # include ``resourceLocation``.  We try it first for backward compatibility, and
     # fall back to the shared resolve_lro_item_id helper (Path B: GET /result) when
     # it is absent.  The helper also handles the transient 404 race on the /result
     # endpoint with a bounded retry.
-    # location is non-None here because _post_create_with_retry only returns (None, body)
-    # for the synchronous 201 path (handled above) or (location_str, None) for LRO.
-    if location is None:
-        raise RuntimeError(
-            "LRO location is unexpectedly None; internal error in _post_create_with_retry"
-        )
     lro_result = await http.poll_operation(location)
     new_id = _resolve_warehouse_id_from_lro(lro_result)
     if new_id is None:

--- a/tests/unit/services/test_warehouses.py
+++ b/tests/unit/services/test_warehouses.py
@@ -454,10 +454,12 @@ async def test_create_empty_2xx_yields_exactly_one_post_and_success() -> None:
     """Regression test for issue #861: empty 2xx must yield exactly ONE POST and a success result.
 
     A 2xx response means the warehouse was created.  The old code re-posted on an empty
-    2xx, risking duplicates.  The new code issues one POST, then resolves via GET by name.
+    2xx, risking duplicates.  The new code issues one POST, resolves via GET by name, then
+    does a follow-up GET by ID to return a fully-populated Warehouse.
     """
     wh_list = json.loads(WAREHOUSE_LIST_PAYLOAD)
     wh_list.pop("continuationUri", None)  # single-page response
+    wh_payload = json.loads(WAREHOUSE_GET_PAYLOAD)
 
     with respx.mock:
         post_route = respx.post(_WAREHOUSES_URL).mock(
@@ -465,6 +467,8 @@ async def test_create_empty_2xx_yields_exactly_one_post_and_success() -> None:
         )
         # GET by name: list_warehouses returns "SalesWarehouse" so the create can resolve it.
         respx.get(_WAREHOUSES_URL).mock(return_value=httpx.Response(200, json=wh_list))
+        # Follow-up GET by ID to return the fully-populated Warehouse (with connectionString).
+        respx.get(_WAREHOUSE_URL).mock(return_value=httpx.Response(200, json=wh_payload))
 
         client = await _make_client()
         async with client:
@@ -475,28 +479,99 @@ async def test_create_empty_2xx_yields_exactly_one_post_and_success() -> None:
     assert isinstance(result, Warehouse)
     assert result.name == "SalesWarehouse"
     assert result.kind == WarehouseKind.WAREHOUSE
+    # Fully populated: connection_string comes from the follow-up GET, not the list payload.
+    assert result.connection_string == "saleswarehouse.datawarehouse.fabric.microsoft.com"
+
+
+async def test_create_truly_empty_body_does_not_crash_and_resolves_by_name() -> None:
+    """create must not crash when the 2xx response has a genuinely empty body (zero bytes).
+
+    A truly empty body causes resp.json() to raise JSONDecodeError.  The fix uses
+    _parse_json_body() which returns None for such bodies, so the GET-by-name recovery
+    path is taken instead of crashing.
+    """
+    wh_list = json.loads(WAREHOUSE_LIST_PAYLOAD)
+    wh_list.pop("continuationUri", None)
+    wh_payload = json.loads(WAREHOUSE_GET_PAYLOAD)
+
+    with respx.mock:
+        post_route = respx.post(_WAREHOUSES_URL).mock(
+            # content=b"" produces a genuinely empty body — resp.json() would raise here.
+            return_value=httpx.Response(202, content=b"")
+        )
+        respx.get(_WAREHOUSES_URL).mock(return_value=httpx.Response(200, json=wh_list))
+        respx.get(_WAREHOUSE_URL).mock(return_value=httpx.Response(200, json=wh_payload))
+
+        client = await _make_client()
+        async with client:
+            result = await warehouses.create(client, _WORKSPACE_ID, "SalesWarehouse")
+
+    assert post_route.call_count == 1
+    assert isinstance(result, Warehouse)
+    assert result.name == "SalesWarehouse"
+    assert result.connection_string == "saleswarehouse.datawarehouse.fabric.microsoft.com"
+
+
+async def test_create_empty_2xx_get_by_name_retries_on_propagation_lag() -> None:
+    """create must retry GET-by-name when the warehouse is not yet visible after the create.
+
+    Mocks the list returning empty on the first call, then the warehouse on the second.
+    Asserts exactly 1 POST and 2 list calls (initial + 1 retry), with sleep between them.
+    """
+    wh_list = json.loads(WAREHOUSE_LIST_PAYLOAD)
+    wh_list.pop("continuationUri", None)
+    wh_payload = json.loads(WAREHOUSE_GET_PAYLOAD)
+    list_call_count = 0
+
+    def list_side_effect(_request: httpx.Request) -> httpx.Response:
+        nonlocal list_call_count
+        list_call_count += 1
+        if list_call_count == 1:
+            return httpx.Response(200, json={"value": []})  # not yet visible
+        return httpx.Response(200, json=wh_list)  # visible on retry
+
+    with respx.mock:
+        post_route = respx.post(_WAREHOUSES_URL).mock(return_value=httpx.Response(202, json={}))
+        respx.get(_WAREHOUSES_URL).mock(side_effect=list_side_effect)
+        respx.get(_WAREHOUSE_URL).mock(return_value=httpx.Response(200, json=wh_payload))
+
+        client = await _make_client()
+        async with client:
+            with patch("fabric_dw.services.warehouses.asyncio.sleep") as mock_sleep:
+                result = await warehouses.create(client, _WORKSPACE_ID, "SalesWarehouse")
+
+    assert post_route.call_count == 1  # never re-POSTs
+    assert list_call_count == 2  # initial + 1 retry
+    mock_sleep.assert_called_once()  # slept once between the two list calls
+    assert isinstance(result, Warehouse)
+    assert result.connection_string == "saleswarehouse.datawarehouse.fabric.microsoft.com"
 
 
 async def test_create_empty_2xx_get_by_name_not_found_raises_fabric_server_error() -> None:
     """create must raise FabricServerError when the 2xx body is empty and GET by name finds nothing.
 
-    This is the last-resort path: the warehouse is assumed created but cannot be confirmed.
-    Exactly ONE POST must be issued (no retry), then the error is raised.
+    This is the last-resort path: the warehouse is assumed created but cannot be confirmed
+    even after all GET-by-name retries.  Exactly ONE POST must be issued.
     """
     with respx.mock:
         post_route = respx.post(_WAREHOUSES_URL).mock(
             return_value=httpx.Response(202, json={})  # no Location header, empty body
         )
-        # list_warehouses returns an empty value list — warehouse not visible yet.
-        respx.get(_WAREHOUSES_URL).mock(return_value=httpx.Response(200, json={"value": []}))
+        # list_warehouses always returns an empty value list — warehouse never becomes visible.
+        list_route = respx.get(_WAREHOUSES_URL).mock(
+            return_value=httpx.Response(200, json={"value": []})
+        )
 
         client = await _make_client()
         async with client:
-            with pytest.raises(FabricServerError, match="861"):
-                await warehouses.create(client, _WORKSPACE_ID, "SalesWarehouse")
+            with patch("fabric_dw.services.warehouses.asyncio.sleep"):
+                with pytest.raises(FabricServerError, match="861"):
+                    await warehouses.create(client, _WORKSPACE_ID, "SalesWarehouse")
 
-    # Exactly one POST — no retry.
+    # Exactly one POST — no duplicate create.
     assert post_route.call_count == 1
+    # All GET-by-name attempts were made (initial + len(_GET_BY_NAME_BACKOFF) retries).
+    assert list_route.call_count == 3
 
 
 async def test_create_4xx_is_not_retried() -> None:

--- a/tests/unit/services/test_warehouses.py
+++ b/tests/unit/services/test_warehouses.py
@@ -450,65 +450,53 @@ async def test_create_no_location_header_but_body_present_returns_warehouse() ->
     assert result.connection_string == "saleswarehouse.datawarehouse.fabric.microsoft.com"
 
 
-async def test_create_no_location_header_and_empty_body_raises_fabric_server_error() -> None:
-    """create must raise FabricServerError (after exhausting retries) when body is always empty.
+async def test_create_empty_2xx_yields_exactly_one_post_and_success() -> None:
+    """Regression test for issue #861: empty 2xx must yield exactly ONE POST and a success result.
 
-    This test mocks 4 consecutive empty-2xx responses (> max 3 retries) and verifies
-    that FabricServerError is raised with a reference to issue #204.
+    A 2xx response means the warehouse was created.  The old code re-posted on an empty
+    2xx, risking duplicates.  The new code issues one POST, then resolves via GET by name.
+    """
+    wh_list = json.loads(WAREHOUSE_LIST_PAYLOAD)
+    wh_list.pop("continuationUri", None)  # single-page response
+
+    with respx.mock:
+        post_route = respx.post(_WAREHOUSES_URL).mock(
+            return_value=httpx.Response(202, json={})  # no Location header, empty body
+        )
+        # GET by name: list_warehouses returns "SalesWarehouse" so the create can resolve it.
+        respx.get(_WAREHOUSES_URL).mock(return_value=httpx.Response(200, json=wh_list))
+
+        client = await _make_client()
+        async with client:
+            result = await warehouses.create(client, _WORKSPACE_ID, "SalesWarehouse")
+
+    # Exactly one POST — no duplicate create.
+    assert post_route.call_count == 1
+    assert isinstance(result, Warehouse)
+    assert result.name == "SalesWarehouse"
+    assert result.kind == WarehouseKind.WAREHOUSE
+
+
+async def test_create_empty_2xx_get_by_name_not_found_raises_fabric_server_error() -> None:
+    """create must raise FabricServerError when the 2xx body is empty and GET by name finds nothing.
+
+    This is the last-resort path: the warehouse is assumed created but cannot be confirmed.
+    Exactly ONE POST must be issued (no retry), then the error is raised.
     """
     with respx.mock:
         post_route = respx.post(_WAREHOUSES_URL).mock(
-            return_value=httpx.Response(202, json={})  # no Location header, empty body, always
+            return_value=httpx.Response(202, json={})  # no Location header, empty body
         )
+        # list_warehouses returns an empty value list — warehouse not visible yet.
+        respx.get(_WAREHOUSES_URL).mock(return_value=httpx.Response(200, json={"value": []}))
 
         client = await _make_client()
         async with client:
-            with patch("fabric_dw.services.warehouses.asyncio.sleep") as mock_sleep:
-                with pytest.raises(FabricServerError, match="204"):
-                    await warehouses.create(client, _WORKSPACE_ID, "SalesWarehouse")
-        mock_sleep.assert_called()  # retries must have slept
+            with pytest.raises(FabricServerError, match="861"):
+                await warehouses.create(client, _WORKSPACE_ID, "SalesWarehouse")
 
-    # 1 original + 3 retries = 4 total POST calls
-    assert post_route.call_count == 4
-
-
-async def test_create_empty_2xx_retries_then_succeeds() -> None:
-    """create must retry up to 3 times on 2xx + no Location + no usable body, then succeed.
-
-    Mocks 3 consecutive empty-2xx responses followed by a normal 202+Location response.
-    Verifies 4 total POST attempts and that the returned Warehouse is fully populated.
-    """
-    op_succeeded = json.loads(WAREHOUSE_OPERATION_SUCCEEDED_PAYLOAD)
-    wh_payload = json.loads(WAREHOUSE_GET_PAYLOAD)
-    new_wh_id = UUID("d4e5f6a7-b8c9-0123-def0-123456789abc")
-    new_wh_url = f"{_WAREHOUSES_URL}/{new_wh_id}"
-
-    call_count = 0
-
-    def post_side_effect(_request: httpx.Request) -> httpx.Response:
-        nonlocal call_count
-        call_count += 1
-        if call_count <= 3:
-            # Empty-2xx: no Location header, no usable body
-            return httpx.Response(202, json={})
-        # 4th attempt: normal LRO response
-        return httpx.Response(202, json={}, headers={"Location": _OPERATION_URL})
-
-    with respx.mock:
-        respx.post(_WAREHOUSES_URL).mock(side_effect=post_side_effect)
-        respx.get(_OPERATION_URL).mock(return_value=httpx.Response(200, json=op_succeeded))
-        respx.get(new_wh_url).mock(return_value=httpx.Response(200, json=wh_payload))
-
-        client = await _make_client()
-        async with client:
-            with patch("fabric_dw.services.warehouses.asyncio.sleep") as mock_sleep:
-                result = await warehouses.create(client, _WORKSPACE_ID, "SalesWarehouse")
-        mock_sleep.assert_called()  # retries must have slept
-
-    assert isinstance(result, Warehouse)
-    assert result.id == new_wh_id
-    assert result.kind == WarehouseKind.WAREHOUSE
-    assert call_count == 4  # 3 empty retries + 1 successful
+    # Exactly one POST — no retry.
+    assert post_route.call_count == 1
 
 
 async def test_create_4xx_is_not_retried() -> None:


### PR DESCRIPTION
## Summary

- Replace `_post_create_with_retry` (retry loop) with `_post_create` (single attempt): a 2xx response means the warehouse was created, so no second POST is ever issued.
- On a 2xx with no `Location` header and no usable body, resolve the created warehouse via an idempotent `list_warehouses` GET filtered by name, instead of re-posting.
- If even the name lookup fails, raise `FabricServerError` with a clear message - never duplicate the POST.
- Existing paths unchanged: 202 + `Location` (LRO poll) and 201 with body (synchronous) both continue to work exactly as before.

## Test plan

- [x] Regression test: `test_create_empty_2xx_yields_exactly_one_post_and_success` asserts exactly one POST is issued and a success `Warehouse` result is returned when the POST returns an empty 2xx and `list_warehouses` can find the warehouse by name.
- [x] Replaced `test_create_no_location_header_and_empty_body_raises_fabric_server_error` and `test_create_empty_2xx_retries_then_succeeds` with tests matching the new single-attempt behavior.
- [x] All 5036 unit tests pass; ruff lint and format clean.

Closes #861

🤖 Generated with [Claude Code](https://claude.com/claude-code)