### PR TITLE
fix(telemetry): cache install-method and config detection per process

### DIFF
--- a/src/fabric_dw/telemetry.py
+++ b/src/fabric_dw/telemetry.py
@@ -190,8 +190,17 @@ def _is_disabled_by_config() -> bool:
     reads) keeps its lenient swallow-and-warn semantics; the opt-out
     decision is the sole caller that needs fail-closed behaviour.
 
-    The result is cached after the first read; config.toml does not change
-    within a process run so a one-time read is correct (#844).
+    The result is cached after the first SUCCESSFUL read; config.toml does
+    not change within a process run so a one-time read is correct (#844).
+    Transient failures (IO error, TOCTOU race between exists() and
+    read_text()) are NOT cached: the fail-closed value is returned for that
+    call only, and the next call retries from scratch so it can recover.
+
+    Concurrency note: two callers that race on the first read will both
+    compute the same value (config.toml is process-stable), and the last
+    write to ``_config_disabled_cache`` wins harmlessly.  A lock is not
+    needed because the values are always identical and the cached type is
+    ``bool``, which CPython assigns atomically on all supported platforms.
     """
     global _config_disabled_cache  # noqa: PLW0603
     if _config_disabled_cache is not None:
@@ -228,7 +237,11 @@ def _is_disabled_by_config() -> bool:
     except Exception:
         # Any read or parse failure when the file EXISTS is treated as
         # opt-out (fail-closed) to honour the user's declared intent.
-        _config_disabled_cache = True
+        # Do NOT cache this result: the error may be transient (IO error,
+        # TOCTOU race between exists() and read_text()).  Caching True here
+        # would permanently disable telemetry for the whole process after a
+        # single transient failure.  The next call will retry and can cache
+        # a successfully-computed result.
         return True
     else:
         _config_disabled_cache = disabled

--- a/src/fabric_dw/telemetry.py
+++ b/src/fabric_dw/telemetry.py
@@ -189,11 +189,19 @@ def _is_disabled_by_config() -> bool:
     :func:`~fabric_dw.config.load_config` path (used for all other config
     reads) keeps its lenient swallow-and-warn semantics; the opt-out
     decision is the sole caller that needs fail-closed behaviour.
+
+    The result is cached after the first read; config.toml does not change
+    within a process run so a one-time read is correct (#844).
     """
+    global _config_disabled_cache  # noqa: PLW0603
+    if _config_disabled_cache is not None:
+        return _config_disabled_cache
+
     import tomllib as _tomllib  # noqa: PLC0415
 
     config_file = _config_dir() / "config.toml"
     if not config_file.exists():
+        _config_disabled_cache = False
         return False
 
     # File exists — read it.  Fail CLOSED on any read/parse error so that
@@ -203,6 +211,7 @@ def _is_disabled_by_config() -> bool:
         data = _tomllib.loads(raw)
         telemetry_section = data.get("telemetry", {})
         if not isinstance(telemetry_section, dict):
+            _config_disabled_cache = False
             return False
         raw_disabled = telemetry_section.get("disabled")
         # Accept bool, int, and string — mirrors _parse_telemetry_section in
@@ -219,8 +228,10 @@ def _is_disabled_by_config() -> bool:
     except Exception:
         # Any read or parse failure when the file EXISTS is treated as
         # opt-out (fail-closed) to honour the user's declared intent.
+        _config_disabled_cache = True
         return True
     else:
+        _config_disabled_cache = disabled
         return disabled
 
 
@@ -259,6 +270,20 @@ def telemetry_enabled() -> bool:
 
 _INSTALL_ID_FILE = "install_id"
 _install_id_cache: str | None = None
+
+# ---------------------------------------------------------------------------
+# Install-method cache (#844)
+# ---------------------------------------------------------------------------
+
+# Computed once per process; None means not yet detected.
+_install_method_cache: str | None = None
+
+# ---------------------------------------------------------------------------
+# Config-disabled cache (#844)
+# ---------------------------------------------------------------------------
+
+# Computed once per process; None means not yet read from disk.
+_config_disabled_cache: bool | None = None
 
 # ---------------------------------------------------------------------------
 # Tenant-ID persistence (#652)
@@ -355,33 +380,35 @@ def _detect_install_method() -> str:
 
     Note: a plain ``.venv`` in ``sys.executable`` is NOT used to infer ``"uv"``
     because pip can also install into a ``.venv``; that would be a false positive.
+
+    The result is cached after the first detection; install method does not
+    change within a process run so a one-time detection is correct (#844).
     """
+    global _install_method_cache  # noqa: PLW0603
+    if _install_method_cache is not None:
+        return _install_method_cache
+
     # uv explicitly sets UV or UV_VIRTUAL_ENV in the runner environment.
     if os.environ.get("UV") or os.environ.get("UV_VIRTUAL_ENV"):
-        return "uv"
-
+        result = "uv"
     # pipx: either the dedicated env var or the executable lives inside a pipx dir.
-    if os.environ.get("PIPX_HOME"):
-        return "pipx"
-    executable = sys.executable or ""
-    if "pipx" in executable:
-        return "pipx"
+    elif os.environ.get("PIPX_HOME") or "pipx" in (sys.executable or ""):
+        result = "pipx"
+    else:
+        # Source / editable checkout: importlib.metadata won't find the package
+        # (no dist-info installed), or it will resolve with a direct_url that has
+        # "editable": true.  Default to "source" when the metadata check fails.
+        result = "source"
+        with contextlib.suppress(Exception):
+            import importlib.metadata  # noqa: PLC0415
 
-    # Source / editable checkout: importlib.metadata won't find the package
-    # (no dist-info installed), or it will resolve with a direct_url that has
-    # "editable": true.
-    with contextlib.suppress(Exception):
-        import importlib.metadata  # noqa: PLC0415
+            dist = importlib.metadata.distribution("fabric-dw")
+            # Check for an editable install via direct_url.json
+            direct_url = dist.read_text("direct_url.json")
+            result = "source" if (direct_url and '"editable": true' in direct_url) else "pip"
 
-        dist = importlib.metadata.distribution("fabric-dw")
-        # Check for an editable install via direct_url.json
-        direct_url = dist.read_text("direct_url.json")
-        if direct_url and '"editable": true' in direct_url:
-            return "source"
-        return "pip"
-
-    # importlib.metadata raised PackageNotFoundError → running from source tree.
-    return "source"
+    _install_method_cache = result
+    return result
 
 
 def _detect_auth_mode() -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,9 +32,19 @@ from __future__ import annotations
 
 import sys
 from collections.abc import Generator
+from types import ModuleType
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+# Capture the telemetry module at session start, before any _reload_telemetry()
+# calls can replace it in sys.modules.  Tests that import telemetry symbols at
+# file-load time (e.g. ``from fabric_dw.telemetry import telemetry_enabled`` in
+# test_config.py) hold a reference to *this* module object even after sys.modules
+# is replaced, so the per-test reset must also clear caches on this original object.
+# Import is deferred to avoid loading fabric_dw.telemetry before the test
+# collection phase — the reference is populated on first fixture call below.
+_orig_telemetry_module: ModuleType | None = None
 
 # All environment variables that can alter the MCP security/filter behaviour.
 _FABRIC_MCP_VARS = (
@@ -132,56 +142,84 @@ def _mock_configure_azure_monitor(
 def _reset_telemetry_module_globals(
     request: pytest.FixtureRequest,
 ) -> Generator[None, None, None]:
-    """Reset telemetry module globals before and after each self-managed test.
+    """Reset telemetry module globals before and after each test.
 
-    Applied only to ``test_telemetry.py`` and ``test_telemetry_commands.py``.
-    Without this fixture, a test that calls ``set_tenant_id("runtime-tenant-xyz")``
-    leaves ``_tenant_id_override`` set in the live module for subsequent tests in the
-    same process.  If those tests then trigger ``emit_event`` with a real SDK
-    initialisation, the dummy tenant bleeds into the exported envelope — which was
-    confirmed to reach the production App Insights resource.
+    Two tiers of reset are applied:
 
-    This fixture resets both:
-    - ``_tenant_id_override`` → ``None``
-    - ``_tenant_id_cache`` → the ``_UNSET`` sentinel (forces re-read from disk,
-      which is isolated by ``XDG_CONFIG_HOME``/``tmp_path`` in individual tests)
+    1. **All tests** — the per-process caches added in #844 (``_install_method_cache``
+       and ``_config_disabled_cache``) are always reset.  Any test that calls
+       ``telemetry_enabled()`` on the shared module instance can set these caches;
+       without a universal teardown they bleed into subsequent tests regardless of
+       which module file those tests live in.
 
-    Both resets are applied *before* and *after* each test (yield fixture), so state
+    2. **Self-managed telemetry modules only** (``test_telemetry.py``,
+       ``test_telemetry_commands.py``, ``test_app_exited_emission.py``) — the
+       heavier globals are also reset:
+
+       - ``_tenant_id_override`` → ``None``
+         (prevents ``set_tenant_id("runtime-tenant-xyz")`` from bleeding into
+         the next test's ``emit_event`` envelope and reaching production App Insights)
+       - ``_tenant_id_cache`` → ``_UNSET`` sentinel
+         (forces re-read from disk; the on-disk file is isolated per-test via
+         ``XDG_CONFIG_HOME``/``tmp_path``)
+       - ``_sdk_initialised``, ``_tracer``, ``_otel_logger`` → initial values
+         (prevents a test that calls ``_get_tracer()`` from leaving a live logger
+         object that causes subsequent tests to skip the SDK init path entirely)
+
+    All resets are applied *before* and *after* each test (yield fixture) so state
     never leaks from a previous test even if it raised.
 
-    Tests that manipulate these globals directly via ``mod._tenant_id_override = ...``
-    on a reloaded module are unaffected because ``_reload_telemetry()`` produces a
-    fresh module object with its own namespace.  This fixture guards the *shared*
-    module instance that lives in ``sys.modules["fabric_dw.telemetry"]``.
+    Tests that manipulate these globals via ``mod._foo = ...`` on a reloaded module
+    are unaffected because ``_reload_telemetry()`` produces a fresh module object
+    with its own namespace.  This fixture guards the *shared* module instance that
+    lives in ``sys.modules["fabric_dw.telemetry"]``.
     """
-    if request.path is None or request.path.name not in _TELEMETRY_SELF_MANAGED_MODULES:
-        yield
-        return
+    global _orig_telemetry_module  # noqa: PLW0603
+    # Capture the module reference on the very first fixture invocation.  At this
+    # point no _reload_telemetry() call has happened, so sys.modules holds the
+    # original module object (the same one that file-level imports in other test
+    # modules have bound to).
+    if _orig_telemetry_module is None:
+        _orig_telemetry_module = sys.modules.get("fabric_dw.telemetry")  # type: ignore[assignment]
+
+    is_self_managed = (
+        request.path is not None and request.path.name in _TELEMETRY_SELF_MANAGED_MODULES
+    )
 
     def _reset() -> None:
-        mod = sys.modules.get("fabric_dw.telemetry")
-        if mod is None:
-            return
-        # Mutate the module namespace dict directly to avoid both B010 (setattr
-        # with a constant name) and unresolved-attribute errors from ty on the
-        # opaque ModuleType.  vars() returns the live __dict__ so changes are
-        # immediately visible via the module object.
-        ns = vars(mod)
-        # Reset the runtime tenant override so a previous test's set_tenant_id()
-        # call cannot bleed into the next test's emit_event envelope.
-        ns["_tenant_id_override"] = None
-        # Reset the in-memory tenant cache to the _UNSET sentinel so that
-        # _get_cached_tenant_id() re-reads from disk on next access.  The on-disk
-        # file is isolated per-test via XDG_CONFIG_HOME / tmp_path.
-        # KeyError here means _UNSET was renamed in telemetry.py — update both files.
-        ns["_tenant_id_cache"] = ns["_UNSET"]
-        # Reset the SDK-init globals so each test starts with an uninitialised
-        # tracer/logger.  Without teardown a test that calls _get_tracer() leaves
-        # _sdk_initialised=True and a live logger object, causing subsequent tests
-        # that expect a clean SDK state to skip the init path entirely.
-        ns["_sdk_initialised"] = False
-        ns["_tracer"] = None
-        ns["_otel_logger"] = None
+        # Collect all distinct module objects that need their caches cleared.
+        # sys.modules may point to a reloaded module after _reload_telemetry();
+        # _orig_telemetry_module is the original object that file-level imports
+        # (e.g. test_config.py) continue to reference even after reloading.
+        seen: set[int] = set()
+        mods_to_clean: list[ModuleType] = []
+        for candidate in (sys.modules.get("fabric_dw.telemetry"), _orig_telemetry_module):
+            if candidate is not None and id(candidate) not in seen:
+                seen.add(id(candidate))
+                mods_to_clean.append(candidate)
+
+        for mod in mods_to_clean:
+            # Mutate the module namespace dict directly to avoid both B010 (setattr
+            # with a constant name) and unresolved-attribute errors from ty on the
+            # opaque ModuleType.  vars() returns the live __dict__ so changes are
+            # immediately visible via the module object.
+            ns = vars(mod)
+            # Per-process caches (#844): reset for every test because any test that
+            # calls telemetry_enabled() or _detect_install_method() on the live
+            # module — even via an import-time reference — can populate these.
+            # KeyError here means the variable was renamed in telemetry.py — update both files.
+            ns["_install_method_cache"] = None
+            ns["_config_disabled_cache"] = None
+            if not is_self_managed:
+                continue
+            # Heavier globals: only needed for tests that exercise the telemetry
+            # enabled-path directly (self-managed modules).
+            ns["_tenant_id_override"] = None
+            # KeyError here means _UNSET was renamed in telemetry.py — update both files.
+            ns["_tenant_id_cache"] = ns["_UNSET"]
+            ns["_sdk_initialised"] = False
+            ns["_tracer"] = None
+            ns["_otel_logger"] = None
 
     _reset()
     yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -207,7 +207,17 @@ def _reset_telemetry_module_globals(
             # Per-process caches (#844): reset for every test because any test that
             # calls telemetry_enabled() or _detect_install_method() on the live
             # module — even via an import-time reference — can populate these.
-            # KeyError here means the variable was renamed in telemetry.py — update both files.
+            # The asserts below verify the names still exist in the module so a
+            # rename in telemetry.py causes a loud failure here rather than a
+            # silent no-op that lets caches bleed between tests.
+            assert "_install_method_cache" in ns, (
+                "_install_method_cache not found in fabric_dw.telemetry — "
+                "update both telemetry.py and tests/conftest.py"
+            )
+            assert "_config_disabled_cache" in ns, (
+                "_config_disabled_cache not found in fabric_dw.telemetry — "
+                "update both telemetry.py and tests/conftest.py"
+            )
             ns["_install_method_cache"] = None
             ns["_config_disabled_cache"] = None
             if not is_self_managed:
@@ -215,7 +225,9 @@ def _reset_telemetry_module_globals(
             # Heavier globals: only needed for tests that exercise the telemetry
             # enabled-path directly (self-managed modules).
             ns["_tenant_id_override"] = None
-            # KeyError here means _UNSET was renamed in telemetry.py — update both files.
+            # _UNSET is a sentinel object; look it up by name to reset _tenant_id_cache.
+            # KeyError on ns["_UNSET"] (a dict lookup, not assignment) would mean
+            # _UNSET was renamed in telemetry.py — update both files if that happens.
             ns["_tenant_id_cache"] = ns["_UNSET"]
             ns["_sdk_initialised"] = False
             ns["_tracer"] = None

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -1448,10 +1448,12 @@ def test_config_disabled_cached_across_telemetry_enabled_calls(
     read_calls: list[int] = []
     original_read_text = Path.read_text
 
-    def counting_read_text(self: Path, **kwargs: object) -> str:
+    def counting_read_text(
+        self: Path, encoding: str | None = None, errors: str | None = None
+    ) -> str:
         if self.name == "config.toml":
             read_calls.append(1)
-        return original_read_text(self, **kwargs)  # type: ignore[arg-type]
+        return original_read_text(self, encoding=encoding, errors=errors)
 
     with patch.object(Path, "read_text", counting_read_text):
         for _ in range(3):

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -16,7 +16,7 @@ import uuid
 from collections.abc import Generator
 from pathlib import Path
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -1389,6 +1389,78 @@ def test_detect_install_method_no_false_uv_for_plain_venv(
 
     # Must NOT return "uv" just because the path contains ".venv"
     assert method != "uv", "Must not return 'uv' for a plain pip-in-venv interpreter"
+
+
+# ---------------------------------------------------------------------------
+# #844: per-process caching — detection/parse runs at most once
+# ---------------------------------------------------------------------------
+
+
+def test_install_method_cached_across_envelope_calls(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """importlib.metadata.distribution must be called at most once per process.
+
+    Subsequent _build_envelope() calls must reuse the cached install_method
+    value and never re-invoke the underlying importlib.metadata lookup (#844).
+    """
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    # Clear uv/pipx env vars so the importlib.metadata branch is exercised.
+    monkeypatch.delenv("UV", raising=False)
+    monkeypatch.delenv("UV_VIRTUAL_ENV", raising=False)
+    monkeypatch.delenv("PIPX_HOME", raising=False)
+
+    mod = _reload_telemetry()
+
+    import importlib.metadata as _meta  # noqa: PLC0415
+
+    fake_dist = MagicMock()
+    fake_dist.read_text.return_value = None  # no direct_url.json present
+
+    with patch.object(_meta, "distribution", return_value=fake_dist) as mock_dist:
+        for _ in range(3):
+            mod._build_envelope()  # type: ignore[attr-defined]
+
+    assert mock_dist.call_count == 1, (
+        "importlib.metadata.distribution must be called exactly once; "
+        "subsequent _build_envelope() calls must reuse the cached install_method"
+    )
+
+
+def test_config_disabled_cached_across_telemetry_enabled_calls(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """config.toml must be read at most once per process.
+
+    Subsequent telemetry_enabled() calls must reuse the cached disabled flag
+    and never re-read the config file (#844).
+    """
+    config_dir = tmp_path / "fabric-dw"
+    config_dir.mkdir()
+    config_file = config_dir / "config.toml"
+    config_file.write_text("[telemetry]\ndisabled = false\n", encoding="utf-8")
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+
+    mod = _reload_telemetry()
+
+    read_calls: list[int] = []
+    original_read_text = Path.read_text
+
+    def counting_read_text(self: Path, **kwargs: object) -> str:
+        if self.name == "config.toml":
+            read_calls.append(1)
+        return original_read_text(self, **kwargs)  # type: ignore[arg-type]
+
+    with patch.object(Path, "read_text", counting_read_text):
+        for _ in range(3):
+            mod.telemetry_enabled()  # type: ignore[attr-defined]
+
+    assert len(read_calls) == 1, (
+        "config.toml must be read exactly once; "
+        "subsequent telemetry_enabled() calls must reuse the cached result"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -1465,6 +1465,54 @@ def test_config_disabled_cached_across_telemetry_enabled_calls(
     )
 
 
+def test_config_disabled_transient_error_not_cached(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A transient read error on the first call must not permanently latch fail-closed.
+
+    If _is_disabled_by_config() raises on the first call (IO error, TOCTOU race
+    between exists() and read_text()), it must return the fail-closed value (True)
+    for that call only and leave _config_disabled_cache unset.  A subsequent call
+    that succeeds must return the real computed value and cache it (#844).
+    """
+    config_dir = tmp_path / "fabric-dw"
+    config_dir.mkdir()
+    config_file = config_dir / "config.toml"
+    # Config file has disabled = false so a successful read returns False (not disabled).
+    config_file.write_text("[telemetry]\ndisabled = false\n", encoding="utf-8")
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+
+    mod = _reload_telemetry()
+
+    original_read_text = Path.read_text
+    call_count = 0
+
+    def flaky_read_text(self: Path, encoding: str | None = None, errors: str | None = None) -> str:
+        nonlocal call_count
+        if self.name == "config.toml":
+            call_count += 1
+            if call_count == 1:
+                raise OSError("simulated transient read failure")
+        return original_read_text(self, encoding=encoding, errors=errors)
+
+    with patch.object(Path, "read_text", flaky_read_text):
+        # First call: transient error -> fail-closed (disabled), cache NOT set.
+        first_result = mod._is_disabled_by_config()  # type: ignore[attr-defined]
+        assert first_result is True, "transient error must return fail-closed (True)"
+        assert vars(mod)["_config_disabled_cache"] is None, (
+            "transient error must NOT populate the cache"
+        )
+
+        # Second call: read succeeds -> real computed value (file has disabled=false).
+        second_result = mod._is_disabled_by_config()  # type: ignore[attr-defined]
+        assert second_result is False, "successful retry must return the real value (False)"
+        assert vars(mod)["_config_disabled_cache"] is False, (
+            "successful read must populate the cache"
+        )
+
+
 # ---------------------------------------------------------------------------
 # A6: set_tenant_id wires to _tenant_id_override
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `_detect_install_method()` (importlib.metadata + read_text) and `_is_disabled_by_config()` (config.toml read + tomllib parse) ran on every emitted telemetry event. Under the MCP server this scales filesystem I/O linearly with tool-call volume.
- Both results are now cached in module-level sentinels (`_install_method_cache`, `_config_disabled_cache`) computed once and reused for the lifetime of the process.
- The two new caches are reset by the per-test cleanup fixture in `tests/conftest.py`. The fixture now resets them for all test modules and tracks the original module object (captured before any `_reload_telemetry()` call) so resets reach the correct namespace in every test ordering.
- Two new tests assert that the underlying `importlib.metadata.distribution` lookup and `config.toml` `read_text` each execute at most once across multiple `_build_envelope()` / `telemetry_enabled()` calls.

## Test plan

- [x] `test_install_method_cached_across_envelope_calls`: patches `importlib.metadata.distribution`, calls `_build_envelope()` three times, asserts `call_count == 1`
- [x] `test_config_disabled_cached_across_telemetry_enabled_calls`: patches `Path.read_text`, calls `telemetry_enabled()` three times, asserts config.toml read count == 1
- [x] Full unit test suite (5007 tests) green across multiple random orderings

Closes #844

🤖 Generated with [Claude Code](https://claude.com/claude-code)