### PR TITLE
fix(models): make ExecRequestHistory.row_count optional

### DIFF
--- a/src/fabric_dw/models.py
+++ b/src/fabric_dw/models.py
@@ -357,7 +357,7 @@ class ExecRequestHistory(_FabricBase):
     is_distributed: int | None = None
     statement_type: str | None = None
     login_name: str | None = None
-    row_count: int
+    row_count: int | None = None
     status: str | None = None
     program_name: str | None = None
     query_hash: str | None = None

--- a/tests/unit/services/test_query_insights.py
+++ b/tests/unit/services/test_query_insights.py
@@ -98,6 +98,21 @@ async def test_list_request_history_parses_fields() -> None:
     assert row.total_elapsed_time_ms == 1500
 
 
+async def test_list_request_history_null_row_count_batch() -> None:
+    """A batch containing a NULL row_count row (DDL/failed/cancelled) must
+    return all rows without raising ValidationError."""
+    # Build a second row identical to _REQ_HIST_ROW but with row_count=None.
+    # The column list keeps the same order; row_count is at index 9.
+    null_row_count_row = _REQ_HIST_ROW[:9] + (None,) + _REQ_HIST_ROW[10:]
+    target = _make_target()
+    conn = _make_conn([_REQ_HIST_ROW, null_row_count_row], _REQ_HIST_COLS)
+    with patch("fabric_dw.sql.open_connection", return_value=conn):
+        result = await query_insights.list_request_history(target)
+    assert len(result) == 2
+    assert result[0].row_count == 100
+    assert result[1].row_count is None
+
+
 async def test_list_request_history_sql_references_exec_requests_history() -> None:
     target = _make_target()
     conn = _make_conn([], _REQ_HIST_COLS)

--- a/tests/unit/services/test_query_insights.py
+++ b/tests/unit/services/test_query_insights.py
@@ -103,7 +103,7 @@ async def test_list_request_history_null_row_count_batch() -> None:
     return all rows without raising ValidationError."""
     # Build a second row identical to _REQ_HIST_ROW but with row_count=None.
     # The column list keeps the same order; row_count is at index 9.
-    null_row_count_row = _REQ_HIST_ROW[:9] + (None,) + _REQ_HIST_ROW[10:]
+    null_row_count_row = (*_REQ_HIST_ROW[:9], None, *_REQ_HIST_ROW[10:])
     target = _make_target()
     conn = _make_conn([_REQ_HIST_ROW, null_row_count_row], _REQ_HIST_COLS)
     with patch("fabric_dw.sql.open_connection", return_value=conn):

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -954,9 +954,7 @@ class TestSqlResult:
 class TestExecRequestHistoryFieldParsing:
     """ExecRequestHistory is a 1-to-1 DMV projection — test required vs optional fields."""
 
-    _MINIMAL: ClassVar[dict] = {
-        "row_count": 0,
-    }
+    _MINIMAL: ClassVar[dict] = {}
 
     _FULL: ClassVar[dict] = {
         "distributed_statement_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
@@ -989,7 +987,7 @@ class TestExecRequestHistoryFieldParsing:
 
     def test_minimal_parses(self) -> None:
         obj = ExecRequestHistory.model_validate(self._MINIMAL)
-        assert obj.row_count == 0
+        assert obj.row_count is None
         assert obj.distributed_statement_id is None
         assert obj.session_id is None
 
@@ -999,6 +997,13 @@ class TestExecRequestHistoryFieldParsing:
         assert obj.row_count == 100
         assert obj.database_name == "SalesDB"
         assert obj.statement_type == "SELECT"
+
+    def test_null_row_count_parses(self) -> None:
+        """A row with row_count=NULL (DDL/failed/cancelled) must deserialize without error."""
+        payload = {**self._FULL, "row_count": None}
+        obj = ExecRequestHistory.model_validate(payload)
+        assert obj.row_count is None
+        assert obj.database_name == "SalesDB"
 
     def test_uuid_fields_parsed(self) -> None:
         obj = ExecRequestHistory.model_validate(self._FULL)


### PR DESCRIPTION
## Summary

- `ExecRequestHistory.row_count` was typed as required `int`, but `queryinsights.exec_requests_history` returns `NULL` for DDL, failed, and cancelled statements.
- A single NULL row triggered `ValidationError` in `_list_insights`, causing `list_request_history` to return zero rows instead of the full history.
- Change `row_count` to `int | None = None`, consistent with all sibling columns.

## Changes

- `src/fabric_dw/models.py`: `row_count: int` -> `row_count: int | None = None`
- `tests/unit/test_models.py`: update `_MINIMAL` fixture and assertions; add `test_null_row_count_parses`
- `tests/unit/services/test_query_insights.py`: add `test_list_request_history_null_row_count_batch` verifying a mixed batch returns all rows

## Test plan

- [ ] `pytest tests/unit/test_models.py::TestExecRequestHistoryFieldParsing` - 8 tests pass including new null case
- [ ] `pytest tests/unit/services/test_query_insights.py::test_list_request_history_null_row_count_batch` - new batch test passes
- [ ] Full unit test suite green

Closes #862

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>