### PR TITLE
fix(snapshots): roll_snapshot_timestamp returns applied UTC value, normalises naive input

### DIFF
--- a/src/fabric_dw/mcp/tools/snapshots.py
+++ b/src/fabric_dw/mcp/tools/snapshots.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import UTC, datetime
 from typing import Any
 
 from mcp.server.fastmcp import FastMCP
@@ -147,7 +148,20 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         """
         ctx = get_context()
         assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
-        parsed_dt = parse_iso8601(new_dt, "new_dt")
+        parsed_dt_raw = parse_iso8601(new_dt, "new_dt")
+        # Normalise to UTC before passing to the service (mirrors clone_table).
+        # Naive datetimes (no tzinfo) are treated as UTC; offset-aware datetimes
+        # are converted.  This keeps the MCP boundary consistent and avoids
+        # surfacing a raw ValueError from the service layer on naive input.
+        parsed_dt: datetime | None = (
+            None
+            if parsed_dt_raw is None
+            else (
+                parsed_dt_raw.replace(tzinfo=UTC)
+                if parsed_dt_raw.tzinfo is None
+                else parsed_dt_raw.astimezone(UTC)
+            )
+        )
         try:
             ws_id, item = await resolve_item(ctx.resolver, workspace, warehouse)
             assert_workspace_allowed(

--- a/src/fabric_dw/services/snapshots.py
+++ b/src/fabric_dw/services/snapshots.py
@@ -349,9 +349,12 @@ async def roll_timestamp(
 
     Returns:
         The datetime that was actually applied to the snapshot.  When
-        *new_dt* is supplied this equals the normalised *new_dt*; when
-        *new_dt* is ``None`` (reset to ``CURRENT_TIMESTAMP``) this is the
-        server-side timestamp queried back immediately after the ALTER.
+        *new_dt* is supplied this is the UTC-normalised, whole-second-truncated
+        value that was written to the ``SET TIMESTAMP`` literal (sub-second
+        precision is dropped because the literal uses the fixed suffix
+        ``.00``); when *new_dt* is ``None`` (reset to ``CURRENT_TIMESTAMP``)
+        this is the server-side timestamp queried back immediately after the
+        ALTER.
 
     Raises:
         ValueError: If *snapshot_name* contains any forbidden character.
@@ -423,11 +426,15 @@ async def roll_timestamp(
         else:
             break  # ALTER succeeded — proceed to fetch the applied timestamp.
 
-    # When new_dt was supplied the applied timestamp equals new_dt (the ALTER
-    # SET a deterministic value).  When new_dt is None the server applied
-    # CURRENT_TIMESTAMP, which is only knowable by querying it back.
+    # When new_dt was supplied the applied timestamp is new_dt normalised to
+    # UTC and truncated to whole-second precision (the SET TIMESTAMP literal
+    # uses the fixed suffix ".00", so any sub-second component is dropped).
+    # Return exactly that value so callers see the datetime the database
+    # received, not the original un-truncated input.
+    # When new_dt is None the server applied CURRENT_TIMESTAMP, which is only
+    # knowable by querying it back.
     if new_dt_utc is not None:
-        return new_dt_utc
+        return new_dt_utc.replace(microsecond=0)
 
     def _fetch_ts() -> datetime:
         _, rows = run_query(

--- a/tests/unit/mcp/tools/test_snapshots.py
+++ b/tests/unit/mcp/tools/test_snapshots.py
@@ -666,6 +666,82 @@ async def test_roll_snapshot_timestamp_fabric_error_becomes_tool_error(mock_ctx,
         )
 
 
+async def test_roll_snapshot_timestamp_naive_input_normalised_to_utc(mock_ctx, ctx_patch) -> None:
+    """roll_snapshot_timestamp normalises a naive datetime string to UTC before the service.
+
+    A naive ISO-8601 input (no timezone offset) must be treated as UTC at the
+    MCP boundary so the service receives a UTC-aware datetime, matching the
+    behaviour of clone_table.
+    """
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+    _applied = datetime(2024, 5, 20, 14, 0, 0, tzinfo=UTC)
+    mock_roll = AsyncMock(return_value=_applied)
+
+    with (
+        ctx_patch,
+        patch("fabric_dw.services.snapshots.roll_timestamp", new=mock_roll),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "roll_snapshot_timestamp",
+            {
+                "workspace": WS_NAME,
+                "warehouse": WH_NAME,
+                "snapshot_name": _SNAP_NAME,
+                "new_dt": "2024-05-20T14:00:00",  # naive, no offset
+            },
+        )
+
+    mock_roll.assert_called_once()
+    _args, _kwargs = mock_roll.call_args
+    passed_dt: datetime = _args[2]
+    # The service must receive a UTC-aware datetime, not a naive one.
+    assert passed_dt.tzinfo is not None
+    assert passed_dt == datetime(2024, 5, 20, 14, 0, 0, tzinfo=UTC)
+    assert result["applied_dt"] == _applied.isoformat()
+
+
+async def test_roll_snapshot_timestamp_non_utc_aware_input_converted_to_utc(
+    mock_ctx, ctx_patch
+) -> None:
+    """roll_snapshot_timestamp converts an offset-aware non-UTC datetime to UTC.
+
+    An ISO-8601 string with a non-UTC offset (e.g. +02:00) must be converted
+    to the equivalent UTC datetime before the service is called.
+    """
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+    # 16:00+02:00 equals 14:00 UTC
+    _applied = datetime(2024, 5, 20, 14, 0, 0, tzinfo=UTC)
+    mock_roll = AsyncMock(return_value=_applied)
+
+    with (
+        ctx_patch,
+        patch("fabric_dw.services.snapshots.roll_timestamp", new=mock_roll),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "roll_snapshot_timestamp",
+            {
+                "workspace": WS_NAME,
+                "warehouse": WH_NAME,
+                "snapshot_name": _SNAP_NAME,
+                "new_dt": "2024-05-20T16:00:00+02:00",
+            },
+        )
+
+    mock_roll.assert_called_once()
+    _args, _kwargs = mock_roll.call_args
+    passed_dt: datetime = _args[2]
+    assert passed_dt == datetime(2024, 5, 20, 14, 0, 0, tzinfo=UTC)
+    assert result["applied_dt"] == _applied.isoformat()
+
+
 async def test_roll_snapshot_timestamp_workspace_guard(ctx_patch) -> None:
     """roll_snapshot_timestamp raises ToolError when workspace is not in the allowlist."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415

--- a/tests/unit/services/test_snapshots.py
+++ b/tests/unit/services/test_snapshots.py
@@ -789,6 +789,29 @@ async def test_roll_timestamp_aware_non_utc_new_dt_normalized_to_utc() -> None:
     assert result == datetime(2024, 3, 15, 8, 30, 45, tzinfo=UTC)
 
 
+async def test_roll_timestamp_returns_truncated_utc() -> None:
+    """roll_timestamp returns the UTC, whole-second-truncated value written to SET TIMESTAMP.
+
+    The SET TIMESTAMP literal uses the fixed suffix ".00", so any sub-second
+    component of new_dt is dropped.  The returned datetime must reflect what
+    the database actually received, not the original un-truncated input.
+    """
+    target = _make_sql_target()
+    conn = _make_mock_conn()
+    # Supply a datetime with microseconds; the SQL literal will strip them.
+    new_dt = datetime(2024, 3, 15, 8, 30, 45, 123456, tzinfo=UTC)
+
+    with patch("fabric_dw.sql.open_connection", return_value=conn):
+        result = await snapshots.roll_timestamp(target, "MySnapshot", new_dt=new_dt)
+
+    cursor = conn.cursor.return_value
+    sql = cursor.execute.call_args_list[0][0][0]
+    assert "ALTER DATABASE [MySnapshot] SET TIMESTAMP = '2024-03-15T08:30:45.00';" in sql
+    # The returned value must match what was written: microsecond zeroed out.
+    assert result == datetime(2024, 3, 15, 8, 30, 45, tzinfo=UTC)
+    assert result.microsecond == 0
+
+
 async def test_roll_timestamp_name_injection_bracket() -> None:
     """snapshot_name containing ] should raise ValueError."""
     target = _make_sql_target()


### PR DESCRIPTION
## Summary

- `roll_timestamp` (service) was returning the un-truncated `new_dt_utc` even though the `SET TIMESTAMP` literal always uses the fixed suffix `.00`, dropping sub-second precision. The `applied_dt` reported to callers therefore did not match what the database received. Fix: return `new_dt_utc.replace(microsecond=0)` and update the docstring to match the real return contract.
- The MCP tool `roll_snapshot_timestamp` was passing the output of `parse_iso8601` directly to the service without UTC normalisation, unlike `clone_table`. A naive input (no timezone offset) would reach the service layer without `tzinfo`, which is inconsistent with the established MCP boundary convention. Fix: mirror the `clone_table` pattern - naive datetimes get `tzinfo=UTC`, offset-aware datetimes are converted with `.astimezone(UTC)`.
- New tests: `test_roll_timestamp_returns_truncated_utc` (service - verifies `microsecond=0` in return value), `test_roll_snapshot_timestamp_naive_input_normalised_to_utc` and `test_roll_snapshot_timestamp_non_utc_aware_input_converted_to_utc` (MCP tool - verify UTC normalisation at the boundary).

Closes #864