### PR TITLE
fix(load): make import_table_from_url truncate+load atomic

### DIFF
--- a/src/fabric_dw/mcp/tools/load.py
+++ b/src/fabric_dw/mcp/tools/load.py
@@ -330,9 +330,10 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
           create_table).
         - ``"append"``: load rows into the existing table without modification.
           Raises an error if the table does not exist.
-        - ``"truncate"``: TRUNCATE the existing table first, then load.
-          Requires ``FABRIC_MCP_ALLOW_DESTRUCTIVE=1``.  Raises an error if the
-          table does **not** exist.
+        - ``"truncate"``: TRUNCATE the existing table, then load, both inside a
+          single transaction so a failed load leaves the existing rows intact
+          (atomic replace).  Requires ``FABRIC_MCP_ALLOW_DESTRUCTIVE=1``.  Raises
+          an error if the table does **not** exist.
         - ``"replace"``: not supported for remote URLs (schema inference requires
           downloading the file).  Use ``"truncate"`` to keep the current schema,
           or download locally and use the CLI with ``--create --if-exists replace``.
@@ -422,7 +423,12 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
                 ToolError as _ToolError,
             )
 
-            from fabric_dw.services.load import table_exists, truncate_table  # noqa: PLC0415
+            from fabric_dw.services.load import table_exists  # noqa: PLC0415
+
+            # When truncate is requested, the TRUNCATE is deferred into the same
+            # transaction as the COPY INTO (see copy_into_from_url truncate_first)
+            # so a failed load leaves the existing rows intact (#863).
+            truncate_first = False
 
             exists = await table_exists(sql_target, schema, table_name, mode=ctx.auth_mode)
             if exists:
@@ -436,7 +442,7 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
                     from fabric_dw.mcp._guards import assert_destructive_allowed  # noqa: PLC0415
 
                     assert_destructive_allowed()
-                    await truncate_table(sql_target, schema, table_name, mode=ctx.auth_mode)
+                    truncate_first = True
                 elif if_exists == "replace":
                     # replace requires destructive flag even though it raises below —
                     # the intent is destructive regardless of the error.
@@ -485,6 +491,7 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
                 rejected_row_location=rejected_row_location,
                 kind=entry.kind,
                 mode=ctx.auth_mode,
+                truncate_first=truncate_first,
             )
         except (ValueError, FabricError) as exc:
             raise tool_err(exc) from exc

--- a/src/fabric_dw/services/load.py
+++ b/src/fabric_dw/services/load.py
@@ -50,7 +50,7 @@ from fabric_dw.exceptions import (
 from fabric_dw.http_client import FabricHttpClient, HttpBase
 from fabric_dw.identifiers import quote_identifier, validate_identifier
 from fabric_dw.models import CopyIntoResult, WarehouseKind
-from fabric_dw.sql import SqlTarget, run_query
+from fabric_dw.sql import SqlTarget, run_query, run_statements
 
 __all__ = [
     "CopyIntoCredentialType",
@@ -672,10 +672,21 @@ async def copy_into_from_url(
     rejected_row_location: str | None = None,
     kind: WarehouseKind = WarehouseKind.WAREHOUSE,
     mode: object = None,
+    truncate_first: bool = False,
 ) -> CopyIntoResult:
     """Run ``COPY INTO`` from *url* into ``[schema].[table]``.
 
     This is the remote-URL path; no local staging is performed.
+
+    Atomic truncate-and-load (#863)
+    -------------------------------
+    When *truncate_first* is ``True``, a ``TRUNCATE TABLE`` and the ``COPY INTO``
+    run inside a **single explicit transaction on one connection** (no commit
+    between them).  If the ``COPY INTO`` fails, the ``TRUNCATE`` is rolled back
+    and the table keeps its existing rows — there is no window in which the
+    table is left empty by a failed load.  Fabric Data Warehouse supports both
+    ``TRUNCATE TABLE`` and ``COPY INTO`` (a DML statement) inside an explicit
+    transaction; any statement failure rolls back the whole transaction.
 
     Args:
         target: SQL connection target (warehouse connection string).
@@ -694,6 +705,10 @@ async def copy_into_from_url(
         rejected_row_location: URL for rejected row output.
         kind: Warehouse item kind.  SQL Endpoint items are rejected.
         mode: Credential mode for SQL authentication.
+        truncate_first: When ``True``, ``TRUNCATE TABLE [schema].[table]`` runs in
+            the same transaction as the ``COPY INTO`` so a failed load rolls the
+            truncate back (atomic replace-the-rows semantics).  The caller is
+            responsible for any destructive-operation authorization gate.
 
     Returns:
         A :class:`~fabric_dw.models.CopyIntoResult`.
@@ -745,7 +760,26 @@ async def copy_into_from_url(
 
         _mode = mode if isinstance(mode, CredentialMode) else CredentialMode.DEFAULT
         try:
-            _cols, rows = run_query(target, sql, mode=_mode, commit=True, fetch="rowcount")
+            if truncate_first:
+                # Atomic replace (#863): TRUNCATE + COPY INTO in ONE transaction
+                # on ONE connection.  commit_per_statement=False defers the single
+                # commit until both statements succeed, so a COPY failure rolls
+                # back the TRUNCATE and the table keeps its existing rows.
+                truncate_sql = (
+                    f"TRUNCATE TABLE {quote_identifier(schema)}.{quote_identifier(table)}"
+                )
+                raw_rowcount = run_statements(
+                    target,
+                    [truncate_sql, sql],
+                    mode=_mode,
+                    commit_per_statement=False,
+                    fetch_last_rowcount=True,
+                )
+            else:
+                # mssql-python rowcount path: run_query(fetch="rowcount") returns
+                # ([], [(N,)]) where N is cursor.rowcount.
+                _cols, rows = run_query(target, sql, mode=_mode, commit=True, fetch="rowcount")
+                raw_rowcount = rows[0][0] if rows and rows[0] else None
         except FabricServerError as exc:
             # run_query now wraps unmapped driver SQL errors (e.g. a column-type
             # mismatch in the COPY INTO target) as FabricServerError.  Re-raise
@@ -781,14 +815,10 @@ async def copy_into_from_url(
                     f"{type(exc).__name__} (details suppressed to protect credentials)"
                 )
             raise FabricError(safe_msg) from exc
-        # rows[0][0] is cursor.rowcount from run_query fetch="rowcount".
+        # raw_rowcount is cursor.rowcount from the COPY INTO (rows loaded).
         # ODBC rowcount is -1 when the driver cannot determine the count;
-        # treat any negative value as 0.
-        rows_loaded = (
-            int(rows[0][0])
-            if rows and rows[0] and rows[0][0] is not None and rows[0][0] >= 0
-            else 0
-        )
+        # treat any negative or missing value as 0.
+        rows_loaded = int(raw_rowcount) if raw_rowcount is not None and raw_rowcount >= 0 else 0
         rows_rejected = 0
         return rows_loaded, rows_rejected
 

--- a/src/fabric_dw/sql.py
+++ b/src/fabric_dw/sql.py
@@ -1554,14 +1554,15 @@ def run_query(  # noqa: PLR0913, PLR0915
             return result
 
 
-def run_statements(
+def run_statements(  # noqa: PLR0913
     target: SqlTarget,
     statements: Sequence[str],
     *,
     mode: CredentialMode = CredentialMode.DEFAULT,
     autocommit: bool = False,
     commit_per_statement: bool = True,
-) -> None:
+    fetch_last_rowcount: bool = False,
+) -> int | None:
     """Execute multiple DDL/DML *statements* on a **single** connection.
 
     Opens ONE connection, executes each statement in sequence, then closes the
@@ -1605,6 +1606,17 @@ def run_statements(
             defer the commit until all statements have executed, giving
             all-or-nothing transaction semantics.  Ignored when
             ``autocommit=True``.
+        fetch_last_rowcount: When ``True``, read ``cursor.rowcount`` after each
+            statement and return the value recorded for the LAST statement
+            (e.g. the rows loaded by a trailing ``COPY INTO``).  The rowcount is
+            read immediately after ``execute`` and before any deferred commit,
+            matching the ``fetch="rowcount"`` behaviour of :func:`run_query`.
+            When ``False`` (default) the function returns ``None``.
+
+    Returns:
+        The ``cursor.rowcount`` of the last executed statement when
+        *fetch_last_rowcount* is ``True`` (``None`` if *statements* is empty),
+        otherwise ``None``.
 
     Raises:
         PermissionDeniedError: If the driver reports a permission error on any statement.
@@ -1617,11 +1629,17 @@ def run_statements(
     conn, _attempt, _max, _ = _with_connect_retry(target, mode, autocommit)
 
     cursor = conn.cursor()
+    last_rowcount: int | None = None
     try:
         for stmt in statements:
             try:
                 _log_sql_execute(stmt)
                 cursor.execute(stmt)
+                if fetch_last_rowcount:
+                    # Read rowcount BEFORE any deferred commit — committing first
+                    # can invalidate the cursor state on mssql-python.  Mirrors
+                    # run_query(fetch="rowcount").
+                    last_rowcount = cursor.rowcount
                 if not autocommit and commit_per_statement:
                     conn.commit()
             except Exception as exc:
@@ -1641,3 +1659,4 @@ def run_statements(
             conn.commit()
     finally:
         conn.close()
+    return last_rowcount

--- a/tests/unit/mcp/tools/test_load.py
+++ b/tests/unit/mcp/tools/test_load.py
@@ -306,7 +306,11 @@ async def test_import_table_from_url_append_table_exists_happy_path(
 async def test_import_table_from_url_truncate_with_flag_succeeds(
     mock_ctx, ctx_patch, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """import_table_from_url with if_exists=truncate + flag set → TRUNCATE + load."""
+    """import_table_from_url with if_exists=truncate + flag set → atomic TRUNCATE + load.
+
+    #863: the TRUNCATE is folded into the COPY INTO transaction (truncate_first=True)
+    rather than committed separately, so there is no destructive standalone truncate.
+    """
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
     monkeypatch.delenv("FABRIC_MCP_READONLY", raising=False)
@@ -328,7 +332,7 @@ async def test_import_table_from_url_truncate_with_flag_succeeds(
         patch(
             "fabric_dw.mcp.tools.load.copy_into_from_url",
             new=AsyncMock(return_value=_make_result()),
-        ),
+        ) as mock_copy,
     ):
         result = await mcp._tool_manager.call_tool(
             "import_table_from_url",
@@ -342,8 +346,62 @@ async def test_import_table_from_url_truncate_with_flag_succeeds(
             },
         )
 
-    mock_truncate.assert_called_once()
+    # No separate committed TRUNCATE — it is part of the atomic COPY transaction.
+    mock_truncate.assert_not_called()
+    assert mock_copy.call_args.kwargs["truncate_first"] is True
     assert result["rows_loaded"] == 3
+
+
+async def test_import_table_from_url_truncate_failed_copy_leaves_table_intact(
+    mock_ctx, ctx_patch, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#863: a failed COPY in truncate mode must not separately truncate the table.
+
+    The COPY runs with truncate_first=True, so the TRUNCATE shares the COPY's
+    transaction and rolls back on failure; truncate_table is never called and the
+    error surfaces to the caller.
+    """
+    from fabric_dw.exceptions import FabricError  # noqa: PLC0415
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    monkeypatch.delenv("FABRIC_MCP_READONLY", raising=False)
+    monkeypatch.setenv("FABRIC_MCP_ALLOW_DESTRUCTIVE", "1")
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.load.table_exists",
+            new=AsyncMock(return_value=True),
+        ),
+        patch(
+            "fabric_dw.services.load.truncate_table",
+            new=AsyncMock(),
+        ) as mock_truncate,
+        patch(
+            "fabric_dw.mcp.tools.load.copy_into_from_url",
+            new=AsyncMock(
+                side_effect=FabricError("COPY INTO [dbo].[sales] failed: schema mismatch")
+            ),
+        ) as mock_copy,
+        pytest.raises(ToolError, match="failed"),
+    ):
+        await mcp._tool_manager.call_tool(
+            "import_table_from_url",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_name": "dbo.sales",
+                "url": "https://onelake.dfs.fabric.microsoft.com/ws/lh/Files/f.parquet",
+                "file_type": "PARQUET",
+                "if_exists": "truncate",
+            },
+        )
+
+    mock_truncate.assert_not_called()
+    assert mock_copy.call_args.kwargs["truncate_first"] is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/services/test_load.py
+++ b/tests/unit/services/test_load.py
@@ -380,6 +380,93 @@ class TestCopyIntoFromUrl:
         assert result.rows_loaded == 0
         assert result.rows_rejected == 0
 
+    async def test_truncate_first_runs_truncate_and_copy_in_one_transaction(self) -> None:
+        """#863: truncate_first=True runs TRUNCATE + COPY INTO via a single
+        deferred-commit transaction (run_statements), not two committed calls.
+
+        The reported rows_loaded is the COPY INTO rowcount, and run_query is not
+        used at all for this path.
+        """
+        from fabric_dw.sql import SqlTarget  # noqa: PLC0415
+
+        target = SqlTarget(
+            workspace_id="ws-id", database="db", connection_string="server=x;database=y"
+        )
+
+        with (
+            patch("fabric_dw.services.load.run_statements") as mock_stmts,
+            patch("fabric_dw.services.load.run_query") as mock_query,
+        ):
+            mock_stmts.return_value = 42
+            result = await copy_into_from_url(
+                target,
+                "dbo",
+                "sales",
+                "https://example.com/f.parquet",
+                file_type="PARQUET",
+                truncate_first=True,
+            )
+
+        assert result.rows_loaded == 42
+        assert result.rows_rejected == 0
+        # run_query (separate commit per statement) must NOT be used here.
+        mock_query.assert_not_called()
+        # A single atomic batch: TRUNCATE then COPY INTO, deferred single commit.
+        mock_stmts.assert_called_once()
+        stmts = mock_stmts.call_args.args[1]
+        assert stmts[0] == "TRUNCATE TABLE [dbo].[sales]"
+        assert stmts[1].startswith("COPY INTO [dbo].[sales]")
+        assert mock_stmts.call_args.kwargs["commit_per_statement"] is False
+        assert mock_stmts.call_args.kwargs["fetch_last_rowcount"] is True
+
+    async def test_truncate_first_rowcount_none_treated_as_zero(self) -> None:
+        """run_statements returning None (driver could not report a count) → 0."""
+        from fabric_dw.sql import SqlTarget  # noqa: PLC0415
+
+        target = SqlTarget(
+            workspace_id="ws-id", database="db", connection_string="server=x;database=y"
+        )
+
+        with patch("fabric_dw.services.load.run_statements", return_value=None):
+            result = await copy_into_from_url(
+                target,
+                "dbo",
+                "sales",
+                "https://example.com/f.parquet",
+                file_type="PARQUET",
+                truncate_first=True,
+            )
+
+        assert result.rows_loaded == 0
+
+    async def test_truncate_first_copy_failure_propagates_without_separate_commit(self) -> None:
+        """#863: a failed COPY (run_statements raises) surfaces as a FabricError.
+
+        Because TRUNCATE and COPY INTO share one deferred-commit transaction, a
+        COPY failure rolls the TRUNCATE back — the table keeps its existing rows.
+        """
+        from fabric_dw.sql import SqlTarget  # noqa: PLC0415
+
+        target = SqlTarget(
+            workspace_id="ws-id", database="db", connection_string="server=x;database=y"
+        )
+
+        driver_exc = FabricServerError("Invalid column name 'foo'", is_retriable=False)
+        with (
+            patch("fabric_dw.services.load.run_statements", side_effect=driver_exc),
+            pytest.raises(FabricError) as exc_info,
+        ):
+            await copy_into_from_url(
+                target,
+                "dbo",
+                "sales",
+                "https://example.com/f.parquet",
+                file_type="PARQUET",
+                truncate_first=True,
+            )
+
+        assert "COPY INTO [dbo].[sales] failed" in str(exc_info.value)
+
     async def test_secret_not_logged(self, caplog: pytest.LogCaptureFixture) -> None:
         """Secret values must never appear in log output (happy path)."""
         from fabric_dw.sql import SqlTarget  # noqa: PLC0415

--- a/tests/unit/test_sql.py
+++ b/tests/unit/test_sql.py
@@ -685,6 +685,72 @@ class TestRunStatements:
         assert mock_mssql.connect.call_count == 1
         mock_conn.close.assert_called_once()
 
+    def test_returns_none_without_fetch_last_rowcount(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Default (fetch_last_rowcount=False) returns None."""
+        mock_mssql, _, _ = _make_mock_mssql()
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        assert run_statements(_make_target(), ["DROP TABLE [a]"]) is None
+
+    def test_fetch_last_rowcount_returns_last_statement_rowcount(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """fetch_last_rowcount=True returns cursor.rowcount of the LAST statement.
+
+        Models the atomic truncate-and-load (#863): TRUNCATE then COPY INTO in a
+        single deferred-commit transaction, where the reported row count is the
+        COPY INTO rowcount, not the TRUNCATE's.
+        """
+        mock_mssql, mock_conn, mock_cursor = _make_mock_mssql()
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        # TRUNCATE reports -1 (no rows), COPY INTO reports 7 rows loaded.
+        rowcounts = iter([-1, 7])
+
+        def _execute(_stmt: str) -> None:
+            mock_cursor.rowcount = next(rowcounts)
+
+        mock_cursor.execute.side_effect = _execute
+
+        result = run_statements(
+            _make_target(),
+            ["TRUNCATE TABLE [dbo].[t]", "COPY INTO [dbo].[t] FROM 'x' WITH (FILE_TYPE = 'CSV')"],
+            commit_per_statement=False,
+            fetch_last_rowcount=True,
+        )
+
+        assert result == 7
+        # One deferred commit for the whole transaction (not one per statement).
+        assert mock_conn.commit.call_count == 1
+
+    def test_deferred_transaction_not_committed_when_later_statement_fails(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """#863: with commit_per_statement=False a failing later statement must NOT
+        commit earlier ones — a failed COPY INTO must not commit the TRUNCATE."""
+
+        class _BoomError(Exception):
+            """Unmapped driver error (no ddbc_error) — re-raised as-is."""
+
+        mock_mssql, mock_conn, mock_cursor = _make_mock_mssql()
+        # TRUNCATE succeeds, COPY INTO fails.
+        mock_cursor.execute.side_effect = [None, _BoomError("copy failed")]
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        with pytest.raises(_BoomError):
+            run_statements(
+                _make_target(),
+                ["TRUNCATE TABLE [dbo].[t]", "COPY INTO [dbo].[t] FROM 'x'"],
+                commit_per_statement=False,
+            )
+
+        # No commit was issued: the transaction rolls back on connection close,
+        # so the TRUNCATE never persists.
+        mock_conn.commit.assert_not_called()
+        mock_conn.close.assert_called_once()
+
 
 # ---------------------------------------------------------------------------
 # Connection pool tests


### PR DESCRIPTION
## Problem (data loss, high)

With `if_exists="truncate"`, `import_table_from_url` ran `TRUNCATE TABLE` and `COPY INTO` as **two separate committed statements on two separate connections** (`truncate_table` then `copy_into_from_url`, each `run_query(..., commit=True)`). The `TRUNCATE` committed *before* `COPY` started, so a failed `COPY` (schema / delimiter / URL / auth error) left the table **empty** - data loss, with the destructive permission already consumed.

## Fix - approach 1 (preferred): single explicit transaction

`TRUNCATE TABLE` and `COPY INTO` now run inside **one explicit transaction on one connection** via `run_statements(..., commit_per_statement=False)`. The single commit is deferred until both statements succeed, so a `COPY` failure rolls the `TRUNCATE` back and the table keeps its existing rows. No staging table is needed.

- `copy_into_from_url` gains `truncate_first: bool`. When set, it builds `TRUNCATE TABLE [schema].[table]` and runs `[truncate, copy]` as a single deferred-commit transaction.
- `run_statements` gains an opt-in `fetch_last_rowcount` so the `COPY INTO` rows-loaded count is still reported (returns the last statement's `cursor.rowcount`, read before the deferred commit, mirroring `run_query(fetch="rowcount")`).
- The MCP tool's `truncate` branch keeps the `assert_destructive_allowed()` gate, then defers the `TRUNCATE` into the atomic `COPY` transaction instead of committing it separately.

`append` and `error`/`fail` modes are unchanged (they still use the single-statement `run_query` path). The local-file / `create_and_load` path is unchanged.

## Fabric Data Warehouse support evidence

Confirmed via Microsoft Learn that the single-transaction approach is supported on Fabric Warehouse:

- **TRUNCATE TABLE is explicitly supported inside an explicit transaction.** The [Transactions in Fabric Data Warehouse](https://learn.microsoft.com/fabric/data-warehouse/transactions#explicit-transactions) reference lists `TRUNCATE TABLE` among the statements supported inside `BEGIN TRAN ... COMMIT`.
- **COPY INTO is a DML statement that participates in transactions.** The same page's locking table classifies `COPY INTO` as DML taking an Intent Exclusive (`IX`) lock, alongside `INSERT`/`UPDATE`/`DELETE`/`MERGE`. The [ingest-data best practices](https://learn.microsoft.com/fabric/data-warehouse/ingest-data#best-practices) state: "Explicit transactions allow you to group multiple data changes together ... You also have the ability to roll back the transaction if any of the changes fail."
- **All-or-nothing guarantee:** "All operations within a single transaction are treated atomically, all succeeding or all failing. If any statement in the transaction fails, the entire transaction is rolled back."

So `TRUNCATE TABLE` + `COPY INTO` in one transaction is supported, and a `COPY` failure rolls the preceding `TRUNCATE` back. This is the simplest safe option, so the staging-then-swap fallback was not needed.

The single-connection / deferred-commit mechanism (`run_statements(autocommit=False, commit_per_statement=False)`) is already used and integration-tested elsewhere for atomic multi-statement transactions on Fabric (CTAS-swap re-cluster, cascade schema drop).

## Trade-off

For the `truncate` path, transient TDS drops *during* `COPY INTO` execute are no longer transparently retried (the whole transaction rolls back and the caller retries) - this is the cost of atomicity and is safer than a partial commit. Connect-phase retry (warehouse warm-up) is still preserved by `run_statements`.

## Tests

- `run_statements`: returns the last statement's rowcount with `fetch_last_rowcount=True`; a failing later statement under `commit_per_statement=False` issues **no commit** (the `TRUNCATE` never persists).
- `copy_into_from_url(truncate_first=True)`: runs `[TRUNCATE, COPY INTO]` via a single `run_statements` call (not `run_query`) with `commit_per_statement=False`; a failing `COPY` surfaces a `FabricError` with no separate commit.
- `import_table_from_url` truncate mode: passes `truncate_first=True` to `copy_into_from_url` and never calls a standalone `truncate_table`; a failed `COPY` leaves the table intact (no separate truncate) and surfaces the error.

## Out of scope

The CLI local-file path (`create_and_load` with `--if-exists truncate`) shares the same two-commit pattern but is not the subject of this issue (which is specifically about `import_table_from_url` / `truncate_table` + `copy_into_from_url`). It can be addressed as a follow-up; making it atomic requires uploading to staging first, then running `TRUNCATE` + `COPY INTO` together, to avoid holding a schema-modification lock open across the upload.

Closes #863