### PR TITLE
fix(audit): set_audit_action_groups does not enable auditing

### DIFF
--- a/src/fabric_dw/mcp/tools/audit.py
+++ b/src/fabric_dw/mcp/tools/audit.py
@@ -116,6 +116,10 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
     ) -> dict[str, Any]:
         """Replace the audited action groups for a warehouse or SQL analytics endpoint.
 
+        Only replaces the action groups. Does not toggle the audit enabled or
+        disabled state; if auditing was Disabled before the call it remains Disabled
+        afterwards.
+
         CAUTION: Each audit write reads current settings via an eventually-consistent
         GET that may lag a recent PATCH by several minutes. The retention period
         read from that GET is round-tripped; if retention was changed within the lag
@@ -143,7 +147,7 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
                 action_groups,
             )
             result = await audit.set_action_groups(
-                ctx.http, ws_id, item.id, action_groups, item.kind
+                ctx.http, ws_id, item.id, action_groups, item.kind, ensure_enabled=False
             )
         except (ValueError, FabricError) as exc:
             raise tool_err(exc) from exc

--- a/src/fabric_dw/services/audit.py
+++ b/src/fabric_dw/services/audit.py
@@ -410,16 +410,10 @@ async def set_action_groups(
             that auditing is active after the call even if it was previously
             disabled — this is the typical "set groups and start auditing" path.
             When ``False``, only the action-group list is changed and the current
-            audit state is preserved; a :exc:`ValueError` is raised if the audit
-            is currently disabled (consistent with :func:`add_action_group` and
-            :func:`remove_action_group`).
-
-            Note:
-                This is an intentional design choice: ``set_action_groups``
-                doubles as "initialise auditing" (default) and "update groups
-                on a live audit" (``ensure_enabled=False``).  When only
-                updating groups is desired, pass ``ensure_enabled=False`` to
-                preserve the current audit state.
+            audit state (``Enabled`` or ``Disabled``) is round-tripped unchanged.
+            Use this path when replacing groups must not alter the audit on/off
+            state — for example, the MCP tool ``set_audit_action_groups`` which
+            advertises only group replacement.
 
     Note:
         This function performs a read-modify-write (GET then PATCH) without
@@ -443,8 +437,6 @@ async def set_action_groups(
 
     Raises:
         ValueError: If any name in *action_groups* does not match ``^[A-Z0-9_]+$``.
-        ValueError: If *ensure_enabled* is ``False`` and auditing is currently disabled
-            (``state == "Disabled"``).  Enable auditing first with :func:`enable`.
         PermissionDeniedError: If the caller lacks the required permission (HTTP 403).
     """
     for name in action_groups:
@@ -452,25 +444,21 @@ async def set_action_groups(
 
     # Pre-flight GET to obtain current settings so we can construct the
     # authoritative post-PATCH state without a stale re-fetch.
-    if not ensure_enabled:
-        # ensure_enabled=False: guard against writing to a disabled audit config.
-        current = await _require_enabled(http, workspace_id, item_id, kind)
-    else:
-        current = await get_settings(http, workspace_id, item_id, kind)
+    current = await get_settings(http, workspace_id, item_id, kind)
 
     path = _audit_path(workspace_id, item_id, kind)
 
-    # Fabric's PATCH /settings/sqlAudit accepts an ``auditActionsAndGroups`` field
-    # alongside ``state`` and ``retentionDays``.  Using PATCH to set the action groups
-    # avoids the EntityNotFound (404) that the POST method returns on freshly-created
-    # warehouses, since PATCH with state=Enabled is idempotent and always works.
-    # retentionDays is always round-tripped: omitting it from a partial PATCH causes
-    # the Fabric API to silently reset it to its default value (data-loss bug).
-    # state is always "Enabled" on both paths: ensure_enabled=True forces it explicitly;
-    # ensure_enabled=False reaches here only after _require_enabled() confirmed state is
-    # "Enabled" (it raises ValueError for "Disabled").
+    # Determine the state to write back.  When ensure_enabled=True (default),
+    # always activate auditing; this is the typical "set groups and start
+    # auditing" path.  When ensure_enabled=False, round-trip the current state
+    # unchanged so only the action-group list is replaced and the audit
+    # enabled/disabled state is left as-is — callers that must not silently
+    # enable a Disabled audit (e.g. the MCP tool) use this path.
+    # retentionDays is always round-tripped: omitting it from a partial PATCH
+    # causes the Fabric API to silently reset it to its default value (data-loss).
+    patch_state = "Enabled" if ensure_enabled else current.state
     patch_body: dict[str, object] = {
-        "state": "Enabled",
+        "state": patch_state,
         "auditActionsAndGroups": action_groups,
         "retentionDays": current.retention_days,
     }
@@ -484,7 +472,7 @@ async def set_action_groups(
     # Return the authoritative post-PATCH state constructed locally.
     # Do NOT poll GET: the GET endpoint lags the PATCH by minutes; the PATCH
     # itself is the authoritative source of truth.
-    return current.model_copy(update={"action_groups": list(action_groups), "state": "Enabled"})
+    return current.model_copy(update={"action_groups": list(action_groups), "state": patch_state})
 
 
 async def add_action_group(

--- a/tests/unit/mcp/tools/test_audit.py
+++ b/tests/unit/mcp/tools/test_audit.py
@@ -389,6 +389,90 @@ async def test_set_audit_action_groups_happy_path(mock_ctx, ctx_patch) -> None:
     mock_svc.assert_called_once()
 
 
+async def test_set_audit_action_groups_passes_ensure_enabled_false(mock_ctx, ctx_patch) -> None:
+    """set_audit_action_groups always passes ensure_enabled=False to the service.
+
+    Regression guard for #876: the tool must not silently enable auditing on a
+    Disabled warehouse, so it must call set_action_groups with ensure_enabled=False.
+    """
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    groups = ["BATCH_COMPLETED_GROUP"]
+    settings = _make_audit_settings(action_groups=groups)
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+    mock_svc = AsyncMock(return_value=settings)
+
+    with (
+        ctx_patch,
+        patch("fabric_dw.services.audit.set_action_groups", new=mock_svc),
+    ):
+        await mcp._tool_manager.call_tool(
+            "set_audit_action_groups",
+            {"workspace": WS_NAME, "warehouse": WH_NAME, "action_groups": groups},
+        )
+
+    _, kwargs = mock_svc.call_args
+    assert kwargs.get("ensure_enabled") is False
+
+
+async def test_set_audit_action_groups_disabled_warehouse_state_unchanged(
+    mock_ctx, ctx_patch
+) -> None:
+    """set_audit_action_groups on a Disabled warehouse returns Disabled state.
+
+    Regression guard for #876: the tool must not silently enable auditing.
+    When the service returns Disabled state (because ensure_enabled=False preserved
+    it), the tool must return that state to the caller unchanged.
+    """
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    groups = ["BATCH_COMPLETED_GROUP"]
+    settings = _make_audit_settings(state="Disabled", action_groups=groups)
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+
+    with (
+        ctx_patch,
+        patch("fabric_dw.services.audit.set_action_groups", new=AsyncMock(return_value=settings)),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "set_audit_action_groups",
+            {"workspace": WS_NAME, "warehouse": WH_NAME, "action_groups": groups},
+        )
+
+    assert result["state"] == "Disabled"
+    assert groups[0] in result["auditActionsAndGroups"]
+
+
+async def test_set_audit_action_groups_enabled_warehouse_state_unchanged(
+    mock_ctx, ctx_patch
+) -> None:
+    """set_audit_action_groups on an Enabled warehouse preserves Enabled state.
+
+    Companion to the Disabled case: replacing groups on an already-Enabled warehouse
+    must keep state=Enabled in the result.
+    """
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    groups = ["BATCH_COMPLETED_GROUP"]
+    settings = _make_audit_settings(state="Enabled", action_groups=groups)
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+
+    with (
+        ctx_patch,
+        patch("fabric_dw.services.audit.set_action_groups", new=AsyncMock(return_value=settings)),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "set_audit_action_groups",
+            {"workspace": WS_NAME, "warehouse": WH_NAME, "action_groups": groups},
+        )
+
+    assert result["state"] == "Enabled"
+    assert groups[0] in result["auditActionsAndGroups"]
+
+
 # ---------------------------------------------------------------------------
 # set_audit_action_groups — error / guard paths
 # ---------------------------------------------------------------------------

--- a/tests/unit/services/test_audit.py
+++ b/tests/unit/services/test_audit.py
@@ -420,28 +420,36 @@ async def test_set_action_groups_get_403_raises_permission_denied() -> None:
                 await audit.set_action_groups(client, _WS_ID, _WH_ID, ["BATCH_COMPLETED_GROUP"])
 
 
-async def test_set_action_groups_disabled_audit_raises_when_ensure_enabled_false() -> None:
-    """set_action_groups with ensure_enabled=False should raise ValueError when audit is Disabled.
+async def test_set_action_groups_ensure_enabled_false_disabled_preserves_disabled_state() -> None:
+    """set_action_groups with ensure_enabled=False preserves Disabled state in PATCH and return.
 
-    Consistent with add_action_group and remove_action_group which also raise
-    ValueError("audit is disabled; enable first") when the current state is Disabled.
-    When ensure_enabled=True (default) the function enables auditing, so the guard
-    only applies to the ensure_enabled=False path.
+    Regression guard for #876: the tool calls ensure_enabled=False so it must NOT
+    silently enable auditing on a Disabled warehouse.  The PATCH body must forward
+    state="Disabled" and the returned AuditSettings must also carry state="Disabled".
     """
+    groups = ["BATCH_COMPLETED_GROUP"]
+
     with respx.mock:
-        # Pre-flight GET returns disabled state; PATCH should never be reached.
-        respx.get(_AUDIT_URL).mock(
+        get_route = respx.get(_AUDIT_URL).mock(
             return_value=httpx.Response(200, json=AUDIT_SETTINGS_DISABLED_PAYLOAD)
         )
         patch_route = respx.patch(_AUDIT_URL).mock(return_value=httpx.Response(200, json={}))
         client = await _make_client()
         async with client:
-            with pytest.raises(ValueError, match="audit is disabled; enable first"):
-                await audit.set_action_groups(
-                    client, _WS_ID, _WH_ID, ["BATCH_COMPLETED_GROUP"], ensure_enabled=False
-                )
+            result = await audit.set_action_groups(
+                client, _WS_ID, _WH_ID, groups, ensure_enabled=False
+            )
 
-    assert not patch_route.called
+    assert get_route.call_count == 1
+    assert patch_route.called
+    sent_body = json.loads(patch_route.calls[0].request.content)
+    # state must be round-tripped as "Disabled" — must not silently enable auditing.
+    assert sent_body.get("state") == "Disabled"
+    assert sent_body["auditActionsAndGroups"] == groups
+    assert sent_body.get("retentionDays") == AUDIT_SETTINGS_DISABLED_PAYLOAD["retentionDays"]
+    assert isinstance(result, AuditSettings)
+    assert result.state == "Disabled"
+    assert result.action_groups == groups
 
 
 async def test_set_action_groups_works_on_fresh_warehouse() -> None:


### PR DESCRIPTION
## Summary

- `set_audit_action_groups` called the service without `ensure_enabled=False`, so the service default (`ensure_enabled=True`) caused a `state=Enabled` to always be included in the PATCH body. A warehouse with auditing intentionally Disabled was silently turned on whenever the tool replaced action groups.
- Fix: pass `ensure_enabled=False` from the tool. Update `set_action_groups` in the service layer to round-trip `current.state` when `ensure_enabled=False` instead of hardcoding `"Enabled"`. The service default (`ensure_enabled=True`) is unchanged for other callers.
- Update tool docstring to state the operation only replaces action groups and does not toggle audit state.

## Test plan

- [ ] Existing 117 unit tests pass (verified locally).
- [ ] New service test: Disabled warehouse with `ensure_enabled=False` issues a PATCH with `state="Disabled"` and returns `state="Disabled"`.
- [ ] New MCP tool tests: verify `ensure_enabled=False` is forwarded to the service; Disabled warehouse returns Disabled; Enabled warehouse returns Enabled.
- [ ] `ruff check` and `ruff format --check` pass on all changed files.

Closes #876

🤖 Generated with [Claude Code](https://claude.com/claude-code)