### PR TITLE
fix(cache): run blocking file-lock I/O off the event loop

### DIFF
--- a/src/fabric_dw/cache.py
+++ b/src/fabric_dw/cache.py
@@ -28,6 +28,7 @@ string form is lower-case hex with hyphens).
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import json
 import logging
@@ -429,3 +430,39 @@ class LookupCache:
             data = self._read()
             data[scope] = {}
             self._write(data)
+
+    # ------------------------------------------------------------------
+    # Async wrappers (off-loop dispatch via asyncio.to_thread)
+    # ------------------------------------------------------------------
+    # The sync public methods above acquire a FileLock (timeout=5 s) and do
+    # blocking file I/O.  Calling them directly from a coroutine on the shared
+    # MCP event loop can freeze the loop for up to 5 s when a concurrent
+    # process holds the OS lock.  The wrappers below push every blocking
+    # operation into a worker thread so the event loop stays responsive.
+    #
+    # The sync internals (locking, atomic replace, freshness checks) are
+    # unchanged; only the call path from async callers changes.
+
+    async def async_get_workspace(self, name: str) -> WorkspaceEntry | None:
+        """Run :meth:`get_workspace` off the event loop via asyncio.to_thread."""
+        return await asyncio.to_thread(self.get_workspace, name)
+
+    async def async_put_workspace(self, name: str, workspace_id: UUID) -> None:
+        """Run :meth:`put_workspace` off the event loop via asyncio.to_thread."""
+        await asyncio.to_thread(self.put_workspace, name, workspace_id)
+
+    async def async_get_item(self, workspace_id: UUID, name: str) -> ItemEntry | None:
+        """Run :meth:`get_item` off the event loop via asyncio.to_thread."""
+        return await asyncio.to_thread(self.get_item, workspace_id, name)
+
+    async def async_put_items(
+        self,
+        workspace_id: UUID,
+        entries: Iterable[tuple[str, ItemEntry]],
+    ) -> None:
+        """Run :meth:`put_items` off the event loop via asyncio.to_thread.
+
+        Pass a list (not a lazy generator) when possible; the iterable is
+        consumed inside the worker thread, not on the calling coroutine.
+        """
+        await asyncio.to_thread(self.put_items, workspace_id, entries)

--- a/src/fabric_dw/cache.py
+++ b/src/fabric_dw/cache.py
@@ -462,7 +462,23 @@ class LookupCache:
     ) -> None:
         """Run :meth:`put_items` off the event loop via asyncio.to_thread.
 
-        Pass a list (not a lazy generator) when possible; the iterable is
-        consumed inside the worker thread, not on the calling coroutine.
+        The *entries* iterable is materialised into a list on the calling
+        coroutine before the worker thread is entered.  This prevents a lazy
+        generator from being consumed inside the thread (where the generator
+        would have been created on a different thread than the one iterating it,
+        which is unsafe for most non-thread-safe generators).
         """
-        await asyncio.to_thread(self.put_items, workspace_id, entries)
+        items = list(entries)
+        await asyncio.to_thread(self.put_items, workspace_id, items)
+
+    async def async_counts(self) -> tuple[int, int]:
+        """Run :meth:`counts` off the event loop via asyncio.to_thread."""
+        return await asyncio.to_thread(self.counts)
+
+    async def async_clear(self) -> None:
+        """Run :meth:`clear` off the event loop via asyncio.to_thread."""
+        await asyncio.to_thread(self.clear)
+
+    async def async_clear_scope(self, scope: str) -> None:
+        """Run :meth:`clear_scope` off the event loop via asyncio.to_thread."""
+        await asyncio.to_thread(self.clear_scope, scope)

--- a/src/fabric_dw/mcp/tools/cache.py
+++ b/src/fabric_dw/mcp/tools/cache.py
@@ -39,17 +39,18 @@ def register(mcp: FastMCP) -> None:
         ctx = get_context()
         cache = ctx.cache
 
-        # Read current counts via the public API before clearing.
-        ws_count, items_count = cache.counts()
+        # Read current counts via the async public API before clearing so the
+        # FileLock acquisition runs off the event loop.
+        ws_count, items_count = await cache.async_counts()
 
         if scope == "workspaces":
-            cache.clear_scope("workspaces")
+            await cache.async_clear_scope("workspaces")
             items_count = 0  # items not touched
         elif scope == "items":
-            cache.clear_scope("items")
+            await cache.async_clear_scope("items")
             ws_count = 0  # workspaces not touched
         else:  # "all"
-            cache.clear()
+            await cache.async_clear()
 
         _log.info(
             "clear_cache complete: scope=%r ws=%d items=%d",

--- a/src/fabric_dw/resolver.py
+++ b/src/fabric_dw/resolver.py
@@ -145,7 +145,7 @@ class Resolver:
             return UUID(value)
 
         # 2. Cache hit
-        cached = self._cache.get_workspace(value)
+        cached = await self._cache.async_get_workspace(value)
         if cached is not None:
             return cached.id
 
@@ -167,7 +167,7 @@ class Resolver:
             raise FabricError(f"workspace name {value!r} is ambiguous: ids = {ids}")
 
         ws_id = UUID(str(results[0]["id"]))
-        self._cache.put_workspace(value, ws_id)
+        await self._cache.async_put_workspace(value, ws_id)
         return ws_id
 
     # ------------------------------------------------------------------
@@ -198,13 +198,13 @@ class Resolver:
         # 1. GUID fast-path: check cache first, then fetch detail
         if GUID_RE.match(value):
             item_uuid = UUID(value)
-            cached_item = self._cache.get_item(ws_id, value)
+            cached_item = await self._cache.async_get_item(ws_id, value)
             if cached_item is not None:
                 return cached_item
             return await self._fetch_item_detail(ws_id, item_uuid)
 
         # 2. Cache hit
-        cached_item = self._cache.get_item(ws_id, value)
+        cached_item = await self._cache.async_get_item(ws_id, value)
         if cached_item is not None:
             return cached_item
 
@@ -335,7 +335,7 @@ class Resolver:
         should_cache = not (kind == WarehouseKind.SQL_ENDPOINT and conn is None)
         if should_cache:
             # Store under display name and GUID string in a single lock+read+write cycle
-            self._cache.put_items(
+            await self._cache.async_put_items(
                 workspace_id,
                 [
                     (display_name, entry),

--- a/tests/unit/mcp/test_server.py
+++ b/tests/unit/mcp/test_server.py
@@ -322,16 +322,19 @@ async def test_list_workspaces_happy_path(ctx_patch) -> None:
 
 
 async def test_clear_cache_side_effect(mock_ctx, ctx_patch) -> None:
-    """clear_cache(scope='all') must call LookupCache.clear()."""
+    """clear_cache(scope='all') must call LookupCache.async_clear() off the loop."""
+    from unittest.mock import AsyncMock  # noqa: PLC0415
+
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
-    mock_ctx.cache.counts.return_value = (2, 3)
+    mock_ctx.cache.async_counts = AsyncMock(return_value=(2, 3))
+    mock_ctx.cache.async_clear = AsyncMock()
 
     with ctx_patch:
         result = await mcp._tool_manager.call_tool("clear_cache", {})
 
-    mock_ctx.cache.counts.assert_called_once()
-    mock_ctx.cache.clear.assert_called_once()
+    mock_ctx.cache.async_counts.assert_called_once()
+    mock_ctx.cache.async_clear.assert_called_once()
     assert result["scope"] == "all"
     assert result["workspaces_cleared"] == 2
     assert result["items_cleared"] == 3
@@ -339,18 +342,21 @@ async def test_clear_cache_side_effect(mock_ctx, ctx_patch) -> None:
 
 
 async def test_clear_cache_scope_workspaces(mock_ctx, ctx_patch) -> None:
-    """clear_cache(scope='workspaces') must NOT call full clear()."""
+    """clear_cache(scope='workspaces') must NOT call async_clear()."""
+    from unittest.mock import AsyncMock  # noqa: PLC0415
+
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
-    # Configure the public counts() API to return (1 workspace, 0 item buckets).
-    mock_ctx.cache.counts.return_value = (1, 0)
+    mock_ctx.cache.async_counts = AsyncMock(return_value=(1, 0))
+    mock_ctx.cache.async_clear_scope = AsyncMock()
+    mock_ctx.cache.async_clear = AsyncMock()
 
     with ctx_patch:
         result = await mcp._tool_manager.call_tool("clear_cache", {"scope": "workspaces"})
 
-    mock_ctx.cache.counts.assert_called_once()
-    mock_ctx.cache.clear_scope.assert_called_once_with("workspaces")
-    mock_ctx.cache.clear.assert_not_called()
+    mock_ctx.cache.async_counts.assert_called_once()
+    mock_ctx.cache.async_clear_scope.assert_called_once_with("workspaces")
+    mock_ctx.cache.async_clear.assert_not_called()
     assert result["scope"] == "workspaces"
     assert result["workspaces_cleared"] == 1
     assert result["items_cleared"] == 0
@@ -358,18 +364,21 @@ async def test_clear_cache_scope_workspaces(mock_ctx, ctx_patch) -> None:
 
 
 async def test_clear_cache_scope_items(mock_ctx, ctx_patch) -> None:
-    """clear_cache(scope='items') must NOT call full clear()."""
+    """clear_cache(scope='items') must NOT call async_clear()."""
+    from unittest.mock import AsyncMock  # noqa: PLC0415
+
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
-    # Configure the public counts() API to return (0 workspaces, 1 item bucket).
-    mock_ctx.cache.counts.return_value = (0, 1)
+    mock_ctx.cache.async_counts = AsyncMock(return_value=(0, 1))
+    mock_ctx.cache.async_clear_scope = AsyncMock()
+    mock_ctx.cache.async_clear = AsyncMock()
 
     with ctx_patch:
         result = await mcp._tool_manager.call_tool("clear_cache", {"scope": "items"})
 
-    mock_ctx.cache.counts.assert_called_once()
-    mock_ctx.cache.clear_scope.assert_called_once_with("items")
-    mock_ctx.cache.clear.assert_not_called()
+    mock_ctx.cache.async_counts.assert_called_once()
+    mock_ctx.cache.async_clear_scope.assert_called_once_with("items")
+    mock_ctx.cache.async_clear.assert_not_called()
     assert result["scope"] == "items"
     assert result["workspaces_cleared"] == 0
     assert result["items_cleared"] == 1

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -862,42 +862,151 @@ def test_clear_scope_invalid_raises_value_error(tmp_path: Path) -> None:
 
 
 async def test_async_get_workspace_dispatches_via_to_thread(tmp_path: Path) -> None:
-    """async_get_workspace must run through asyncio.to_thread, not on the event loop."""
+    """async_get_workspace must dispatch get_workspace through asyncio.to_thread."""
     cache = _make_cache(tmp_path)
     with patch("asyncio.to_thread", wraps=asyncio.to_thread) as mock_thread:
         result = await cache.async_get_workspace("NonExistent")
     mock_thread.assert_called_once()
+    # Verify the correct underlying callable was dispatched.
+    assert mock_thread.call_args[0][0] == cache.get_workspace
     assert result is None
 
 
 async def test_async_put_workspace_dispatches_via_to_thread(tmp_path: Path) -> None:
-    """async_put_workspace must run through asyncio.to_thread, not on the event loop."""
+    """async_put_workspace must dispatch put_workspace through asyncio.to_thread."""
     cache = _make_cache(tmp_path)
     with patch("asyncio.to_thread", wraps=asyncio.to_thread) as mock_thread:
         await cache.async_put_workspace("ws", WS_ID)
     mock_thread.assert_called_once()
-    # Verify the write actually happened (sync read works after async write)
+    assert mock_thread.call_args[0][0] == cache.put_workspace
+    # Verify the write actually happened (sync read works after async write).
     assert cache.get_workspace("ws") is not None
 
 
 async def test_async_get_item_dispatches_via_to_thread(tmp_path: Path) -> None:
-    """async_get_item must run through asyncio.to_thread, not on the event loop."""
+    """async_get_item must dispatch get_item through asyncio.to_thread."""
     cache = _make_cache(tmp_path)
     with patch("asyncio.to_thread", wraps=asyncio.to_thread) as mock_thread:
         result = await cache.async_get_item(WS_ID, "NonExistent")
     mock_thread.assert_called_once()
+    assert mock_thread.call_args[0][0] == cache.get_item
     assert result is None
 
 
 async def test_async_put_items_dispatches_via_to_thread(tmp_path: Path) -> None:
-    """async_put_items must run through asyncio.to_thread, not on the event loop."""
+    """async_put_items must dispatch put_items through asyncio.to_thread."""
     cache = _make_cache(tmp_path)
     entry = _make_item_entry()
     with patch("asyncio.to_thread", wraps=asyncio.to_thread) as mock_thread:
         await cache.async_put_items(WS_ID, [("wh", entry)])
     mock_thread.assert_called_once()
-    # Verify the write actually happened (sync read works after async write)
+    assert mock_thread.call_args[0][0] == cache.put_items
+    # Verify the write actually happened (sync read works after async write).
     assert cache.get_item(WS_ID, "wh") is not None
+
+
+async def test_async_put_items_materialises_iterable_before_thread(tmp_path: Path) -> None:
+    """async_put_items must materialise the entries iterable before entering the thread.
+
+    A lazy generator must not be consumed inside the worker thread; it is
+    materialised to a list on the calling coroutine so that the generator's
+    iterator is driven on the correct thread.
+    """
+    cache = _make_cache(tmp_path)
+    entry = _make_item_entry()
+
+    consumed: list[bool] = []
+
+    def _gen() -> Any:
+        consumed.append(True)
+        yield "wh", entry
+
+    with patch("asyncio.to_thread", wraps=asyncio.to_thread) as mock_thread:
+        await cache.async_put_items(WS_ID, _gen())
+
+    # The iterable was consumed (materialised) before to_thread was entered.
+    assert consumed == [True]
+    # The second positional arg (items) passed to to_thread must be a list.
+    items_arg = mock_thread.call_args[0][2]
+    assert isinstance(items_arg, list)
+
+
+async def test_async_counts_dispatches_via_to_thread(tmp_path: Path) -> None:
+    """async_counts must dispatch counts through asyncio.to_thread."""
+    cache = _make_cache(tmp_path)
+    cache.put_workspace("ws", WS_ID)
+    with patch("asyncio.to_thread", wraps=asyncio.to_thread) as mock_thread:
+        ws_count, items_count = await cache.async_counts()
+    mock_thread.assert_called_once()
+    assert mock_thread.call_args[0][0] == cache.counts
+    assert ws_count == 1
+    assert items_count == 0
+
+
+async def test_async_clear_dispatches_via_to_thread(tmp_path: Path) -> None:
+    """async_clear must dispatch clear through asyncio.to_thread."""
+    cache = _make_cache(tmp_path)
+    cache.put_workspace("ws", WS_ID)
+    with patch("asyncio.to_thread", wraps=asyncio.to_thread) as mock_thread:
+        await cache.async_clear()
+    mock_thread.assert_called_once()
+    assert mock_thread.call_args[0][0] == cache.clear
+    assert cache.get_workspace("ws") is None
+
+
+async def test_async_clear_scope_dispatches_via_to_thread(tmp_path: Path) -> None:
+    """async_clear_scope must dispatch clear_scope through asyncio.to_thread."""
+    cache = _make_cache(tmp_path)
+    cache.put_workspace("ws", WS_ID)
+    cache.put_item(WS_ID, "wh", _make_item_entry())
+    with patch("asyncio.to_thread", wraps=asyncio.to_thread) as mock_thread:
+        await cache.async_clear_scope("workspaces")
+    mock_thread.assert_called_once()
+    assert mock_thread.call_args[0][0] == cache.clear_scope
+    # Only workspaces cleared; items intact.
+    assert cache.get_workspace("ws") is None
+    assert cache.get_item(WS_ID, "wh") is not None
+
+
+async def test_async_counts_returns_correct_values(tmp_path: Path) -> None:
+    """async_counts returns the same (ws_count, items_count) as the sync counts()."""
+    cache = _make_cache(tmp_path)
+    cache.put_workspace("ws1", WS_ID)
+    cache.put_workspace("ws2", WS_ID_2)
+    cache.put_item(WS_ID, "wh", _make_item_entry())
+    ws_count, items_count = await cache.async_counts()
+    assert ws_count == 2
+    assert items_count == 1
+
+
+async def test_async_clear_empties_cache(tmp_path: Path) -> None:
+    """async_clear erases all entries (same semantics as sync clear())."""
+    cache = _make_cache(tmp_path)
+    cache.put_workspace("ws", WS_ID)
+    cache.put_item(WS_ID, "wh", _make_item_entry())
+    await cache.async_clear()
+    assert cache.get_workspace("ws") is None
+    assert cache.get_item(WS_ID, "wh") is None
+
+
+async def test_async_clear_scope_workspaces_leaves_items(tmp_path: Path) -> None:
+    """async_clear_scope('workspaces') removes only workspace entries."""
+    cache = _make_cache(tmp_path)
+    cache.put_workspace("ws", WS_ID)
+    cache.put_item(WS_ID, "wh", _make_item_entry())
+    await cache.async_clear_scope("workspaces")
+    assert cache.get_workspace("ws") is None
+    assert cache.get_item(WS_ID, "wh") is not None
+
+
+async def test_async_clear_scope_items_leaves_workspaces(tmp_path: Path) -> None:
+    """async_clear_scope('items') removes only item entries."""
+    cache = _make_cache(tmp_path)
+    cache.put_workspace("ws", WS_ID)
+    cache.put_item(WS_ID, "wh", _make_item_entry())
+    await cache.async_clear_scope("items")
+    assert cache.get_workspace("ws") is not None
+    assert cache.get_item(WS_ID, "wh") is None
 
 
 async def test_async_get_workspace_returns_stored_entry(tmp_path: Path) -> None:

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import threading
@@ -853,3 +854,113 @@ def test_clear_scope_invalid_raises_value_error(tmp_path: Path) -> None:
     cache = _make_cache(tmp_path)
     with pytest.raises(ValueError, match="scope must be"):
         cache.clear_scope("all")
+
+
+# ---------------------------------------------------------------------------
+# Async wrappers: off-loop dispatch and preserved sync behaviour
+# ---------------------------------------------------------------------------
+
+
+async def test_async_get_workspace_dispatches_via_to_thread(tmp_path: Path) -> None:
+    """async_get_workspace must run through asyncio.to_thread, not on the event loop."""
+    cache = _make_cache(tmp_path)
+    with patch("asyncio.to_thread", wraps=asyncio.to_thread) as mock_thread:
+        result = await cache.async_get_workspace("NonExistent")
+    mock_thread.assert_called_once()
+    assert result is None
+
+
+async def test_async_put_workspace_dispatches_via_to_thread(tmp_path: Path) -> None:
+    """async_put_workspace must run through asyncio.to_thread, not on the event loop."""
+    cache = _make_cache(tmp_path)
+    with patch("asyncio.to_thread", wraps=asyncio.to_thread) as mock_thread:
+        await cache.async_put_workspace("ws", WS_ID)
+    mock_thread.assert_called_once()
+    # Verify the write actually happened (sync read works after async write)
+    assert cache.get_workspace("ws") is not None
+
+
+async def test_async_get_item_dispatches_via_to_thread(tmp_path: Path) -> None:
+    """async_get_item must run through asyncio.to_thread, not on the event loop."""
+    cache = _make_cache(tmp_path)
+    with patch("asyncio.to_thread", wraps=asyncio.to_thread) as mock_thread:
+        result = await cache.async_get_item(WS_ID, "NonExistent")
+    mock_thread.assert_called_once()
+    assert result is None
+
+
+async def test_async_put_items_dispatches_via_to_thread(tmp_path: Path) -> None:
+    """async_put_items must run through asyncio.to_thread, not on the event loop."""
+    cache = _make_cache(tmp_path)
+    entry = _make_item_entry()
+    with patch("asyncio.to_thread", wraps=asyncio.to_thread) as mock_thread:
+        await cache.async_put_items(WS_ID, [("wh", entry)])
+    mock_thread.assert_called_once()
+    # Verify the write actually happened (sync read works after async write)
+    assert cache.get_item(WS_ID, "wh") is not None
+
+
+async def test_async_get_workspace_returns_stored_entry(tmp_path: Path) -> None:
+    """async_get_workspace returns the entry written by the sync put_workspace."""
+    cache = _make_cache(tmp_path)
+    cache.put_workspace("MyWorkspace", WS_ID)
+    result = await cache.async_get_workspace("MyWorkspace")
+    assert result is not None
+    assert result.id == WS_ID
+
+
+async def test_async_put_workspace_readable_by_sync_get(tmp_path: Path) -> None:
+    """Entries written via async_put_workspace are readable by the sync get_workspace."""
+    cache = _make_cache(tmp_path)
+    await cache.async_put_workspace("MyWorkspace", WS_ID)
+    result = cache.get_workspace("MyWorkspace")
+    assert result is not None
+    assert result.id == WS_ID
+
+
+async def test_async_get_item_returns_stored_entry(tmp_path: Path) -> None:
+    """async_get_item returns the entry written by the sync put_item."""
+    cache = _make_cache(tmp_path)
+    entry = _make_item_entry()
+    cache.put_item(WS_ID, "wh", entry)
+    result = await cache.async_get_item(WS_ID, "wh")
+    assert result is not None
+    assert result.id == ITEM_ID
+    assert result.kind == WarehouseKind.WAREHOUSE
+
+
+async def test_async_put_items_readable_by_sync_get(tmp_path: Path) -> None:
+    """Entries written via async_put_items are readable by the sync get_item."""
+    cache = _make_cache(tmp_path)
+    entry = _make_item_entry()
+    await cache.async_put_items(WS_ID, [("wh", entry), (str(ITEM_ID), entry)])
+    assert cache.get_item(WS_ID, "wh") is not None
+    assert cache.get_item(WS_ID, str(ITEM_ID)) is not None
+
+
+async def test_async_get_workspace_miss_returns_none(tmp_path: Path) -> None:
+    """async_get_workspace returns None for a missing entry (same as sync get_workspace)."""
+    cache = _make_cache(tmp_path)
+    assert await cache.async_get_workspace("NonExistent") is None
+
+
+async def test_async_get_item_miss_returns_none(tmp_path: Path) -> None:
+    """async_get_item returns None for a missing entry (same as sync get_item)."""
+    cache = _make_cache(tmp_path)
+    assert await cache.async_get_item(WS_ID, "NonExistent") is None
+
+
+async def test_async_get_workspace_case_insensitive(tmp_path: Path) -> None:
+    """async_get_workspace inherits the case-insensitive lookup from get_workspace."""
+    cache = _make_cache(tmp_path)
+    cache.put_workspace("MyWorkspace", WS_ID)
+    assert await cache.async_get_workspace("MYWORKSPACE") is not None
+    assert await cache.async_get_workspace("myworkspace") is not None
+
+
+async def test_async_get_item_case_insensitive(tmp_path: Path) -> None:
+    """async_get_item inherits the case-insensitive lookup from get_item."""
+    cache = _make_cache(tmp_path)
+    cache.put_item(WS_ID, "SalesWarehouse", _make_item_entry())
+    assert await cache.async_get_item(WS_ID, "SALESWAREHOUSE") is not None
+    assert await cache.async_get_item(WS_ID, "saleswarehouse") is not None


### PR DESCRIPTION
## Summary

- `LookupCache` acquires a `FileLock` (timeout=5 s) and does synchronous file I/O in `get_workspace`, `put_workspace`, `get_item`, and `put_items`. Calling these directly from a coroutine on the shared MCP event loop can freeze the entire loop for up to 5 s when a concurrent process holds the OS lock.
- Add `async_get_workspace`, `async_put_workspace`, `async_get_item`, and `async_put_items` to `LookupCache`; each delegates to the corresponding sync method via `asyncio.to_thread` so all blocking I/O runs in a worker thread.
- Update all five call sites in `Resolver.workspace_id` and `Resolver._fetch_item_detail` to `await` the async wrappers. The sync cache internals (locking, atomic replace, freshness, schema validation) are unchanged.

## Test plan

- [ ] `tests/unit/test_cache.py` - four new `test_async_*_dispatches_via_to_thread` tests confirm each wrapper goes through `asyncio.to_thread` (not directly on the loop); eight new behaviour tests confirm round-trips, case-insensitivity, and miss-returns-None are preserved via the async interface.
- [ ] `tests/unit/test_resolver.py` - all existing resolver tests pass unchanged; the `test_fetch_item_detail_uses_put_items` spy still works because `async_put_items` routes through the patched `put_items`.
- [ ] `uv run pytest tests/unit/test_cache.py tests/unit/test_resolver.py` - 108 passed.
- [ ] `uv run ruff check` and `ruff format --check` - clean.

Closes #881

🤖 Generated with [Claude Code](https://claude.com/claude-code)