### PR TITLE
refactor(services/tables): converge return shapes on typed models

### DIFF
--- a/src/fabric_dw/cli/commands/tables.py
+++ b/src/fabric_dw/cli/commands/tables.py
@@ -112,10 +112,10 @@ async def read_cmd(
     try:
         async with build_http_client(ctx) as http:
             target, _entry = await build_sql_target(http, ws, wh)
-            columns, rows = await _tables_svc.read_table(
+            result = await _tables_svc.read_table(
                 target, schema, table_name, count=count, mode=ctx.auth
             )
-            arrow_table = columns_rows_to_arrow(columns, rows)
+            arrow_table = columns_rows_to_arrow(result.columns, result.rows)
             write_arrow(arrow_table, effective_fmt, output_path)
     except (ValueError, FabricError) as exc:
         raise click.ClickException(str(exc)) from exc
@@ -200,11 +200,9 @@ async def count_cmd(
     try:
         async with build_http_client(ctx) as http:
             target, _entry = await build_sql_target(http, ws, wh)
-            row_count = await _tables_svc.count_table_rows(
-                target, schema, table_name, mode=ctx.auth
-            )
+            result = await _tables_svc.count_table_rows(target, schema, table_name, mode=ctx.auth)
             render(
-                {"schema": schema, "name": table_name, "row_count": row_count},
+                result.model_dump(mode="json"),
                 json_output=ctx.json_output,
                 table_title="Row Count",
             )
@@ -236,12 +234,12 @@ async def health_check_cmd(
     try:
         async with build_http_client(ctx) as http:
             target, entry = await build_sql_target(http, ws, wh)
-            columns, rows = await _tables_svc.get_table_health_metrics(
+            result = await _tables_svc.get_table_health_metrics(
                 target, schema, table_name, kind=entry.kind, mode=ctx.auth
             )
             render_result_rows(
-                columns,
-                rows,
+                result.columns,
+                result.rows,
                 json_output=ctx.json_output,
                 table_title="Table Health Metrics",
                 prune_null_columns=True,
@@ -678,11 +676,11 @@ async def cluster_columns_cmd(
     try:
         async with build_http_client(ctx) as http:
             target, entry = await build_sql_target(http, ws, wh)
-            rows = await _tables_svc.get_cluster_columns(
+            result = await _tables_svc.get_cluster_columns(
                 target, schema, table_name, kind=entry.kind, mode=ctx.auth
             )
             render(
-                rows,
+                [c.model_dump(mode="json") for c in result],
                 json_output=ctx.json_output,
                 table_title="Cluster Columns",
                 prune_null_columns=True,

--- a/src/fabric_dw/mcp/tools/tables.py
+++ b/src/fabric_dw/mcp/tools/tables.py
@@ -109,14 +109,14 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
                 count,
             )
             target = make_sql_target(ws_id, entry, item)
-            columns, rows = await tables_svc.read_table(
+            result = await tables_svc.read_table(
                 target, schema, table_name, count=count, mode=ctx.auth_mode
             )
         except (ValueError, FabricError) as exc:
             raise tool_err(exc) from exc
         return {
-            "columns": columns,
-            "rows": safe_rows(rows),
+            "columns": result.columns,
+            "rows": safe_rows(result.rows),
         }
 
     @mcp.tool(name="count_table_rows")
@@ -150,12 +150,12 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
                 table_name,
             )
             target = make_sql_target(ws_id, entry, item)
-            row_count = await tables_svc.count_table_rows(
+            result = await tables_svc.count_table_rows(
                 target, schema, table_name, mode=ctx.auth_mode
             )
         except (ValueError, FabricError) as exc:
             raise tool_err(exc) from exc
-        return {"schema": schema, "name": table_name, "row_count": row_count}
+        return result.model_dump(mode="json")
 
     @mcp.tool(name="get_cluster_columns")
     async def get_cluster_columns(
@@ -189,11 +189,12 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
                 table_name,
             )
             target = make_sql_target(ws_id, entry, item)
-            return await tables_svc.get_cluster_columns(
+            result = await tables_svc.get_cluster_columns(
                 target, schema, table_name, kind=entry.kind, mode=ctx.auth_mode
             )
         except (ValueError, FabricError) as exc:
             raise tool_err(exc) from exc
+        return [c.model_dump(mode="json") for c in result]
 
     @mcp.tool(name="get_table_columns")
     async def get_table_columns(
@@ -527,14 +528,14 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
                 table_name,
             )
             target = make_sql_target(ws_id, entry, item)
-            columns, rows = await tables_svc.get_table_health_metrics(
+            result = await tables_svc.get_table_health_metrics(
                 target, schema, table_name, kind=entry.kind, mode=ctx.auth_mode
             )
         except (ValueError, FabricError) as exc:
             raise tool_err(exc) from exc
         return {
-            "columns": columns,
-            "rows": safe_rows(rows),
+            "columns": result.columns,
+            "rows": safe_rows(result.rows),
         }
 
     @mutating_tool(mcp, "rename_table")

--- a/src/fabric_dw/models.py
+++ b/src/fabric_dw/models.py
@@ -895,6 +895,54 @@ class ColumnSpec(_FabricBase):
     nullable: bool = True
 
 
+class ClusterColumn(_FabricBase):
+    """A data-clustering column on a Fabric Data Warehouse table.
+
+    Returned by :func:`~fabric_dw.services.tables.get_cluster_columns`.
+    The field names mirror the ``sys.index_columns`` query output so that
+    ``model_dump(mode="json")`` produces byte-identical output to the
+    previous ``{"column_name": ..., "clustering_ordinal": ...}`` dicts.
+    """
+
+    column_name: str
+    clustering_ordinal: int
+
+
+class TableRowCount(_FabricBase):
+    """Row-count result for a single table.
+
+    Field names mirror :class:`Table` (``schema_name`` / ``name``) so the
+    model is consistent with table-listing output.
+
+    Note: the ``schema_name`` field replaces the legacy ``schema`` key that
+    the MCP ``count_table_rows`` tool previously emitted.  Callers that used
+    ``result["schema"]`` must be updated to ``result["schema_name"]``.
+    """
+
+    schema_name: str
+    name: str
+    row_count: int
+
+
+class ResultSet(_FabricBase):
+    """Raw result set from a SQL query - columns and rows with native driver types.
+
+    Unlike :class:`SqlResult` (whose ``rows`` are JSON-pre-serialised scalars),
+    the rows here carry native Python driver types such as
+    :class:`~datetime.datetime`, :class:`~decimal.Decimal`, and :class:`bytes`
+    so that downstream consumers (Arrow materialisation, ``safe_rows``
+    serialisation) receive the original values without coercion.
+
+    Attributes:
+        columns: Ordered list of column name strings.
+        rows: Each element is one row of raw driver values.  Types are stored
+            by identity - pydantic does not coerce them.
+    """
+
+    columns: list[str] = Field(default_factory=list)
+    rows: list[tuple[object, ...]] = Field(default_factory=list)
+
+
 class CopyIntoResult(_FabricBase):
     """Result of a ``COPY INTO`` load operation.
 

--- a/src/fabric_dw/services/tables.py
+++ b/src/fabric_dw/services/tables.py
@@ -41,7 +41,14 @@ if TYPE_CHECKING:
 from fabric_dw.auth import CredentialMode
 from fabric_dw.exceptions import FabricError, ItemKindError, NotFoundError
 from fabric_dw.identifiers import parse_qualified_name, quote_identifier, validate_identifier
-from fabric_dw.models import ColumnSpec, Table, WarehouseKind
+from fabric_dw.models import (
+    ClusterColumn,
+    ColumnSpec,
+    ResultSet,
+    Table,
+    TableRowCount,
+    WarehouseKind,
+)
 from fabric_dw.services._helpers import _assert_not_sql_endpoint, coerce_to_utc, reject_non_select
 from fabric_dw.sql import SqlTarget, run_query, run_statements
 from fabric_dw.types import arrow_type_to_tsql, validate_tsql_type
@@ -231,11 +238,14 @@ async def read_table(
     *,
     count: int = 10,
     mode: CredentialMode = CredentialMode.DEFAULT,
-) -> tuple[list[str], list[tuple[object, ...]]]:
+) -> ResultSet:
     """Return up to *count* rows from *schema*.*table_name*.
 
-    The result is a ``(columns, rows)`` pair suitable for passing to
-    :mod:`fabric_dw.sql_io` for materialisation via Arrow.
+    The result is a :class:`~fabric_dw.models.ResultSet` with native driver
+    types preserved (``datetime``, ``Decimal``, ``bytes`` are NOT coerced).
+    Pass ``result.columns`` and ``result.rows`` to
+    :func:`~fabric_dw.sql_io.columns_rows_to_arrow` or
+    :func:`~fabric_dw.mcp._helpers.safe_rows` as needed.
 
     Args:
         target: The warehouse to query.
@@ -245,8 +255,7 @@ async def read_table(
         mode: The credential mode for Entra authentication.
 
     Returns:
-        A ``(columns, rows)`` tuple where *columns* is a list of column name
-        strings and *rows* is a list of row tuples.
+        A :class:`~fabric_dw.models.ResultSet` with ``columns`` and ``rows``.
 
     Raises:
         ValueError: If *schema* or *table_name* fails identifier validation.
@@ -262,12 +271,12 @@ async def read_table(
         table_q=quote_identifier(table_name),
     )
 
-    def _run() -> tuple[list[str], list[tuple[object, ...]]]:
+    def _run() -> ResultSet:
         cols, rows = run_query(target, read_sql, mode=mode)
         if not cols:
             msg = f"Table [{schema}].[{table_name}] not found"
             raise NotFoundError(msg)
-        return cols, list(rows)
+        return ResultSet(columns=cols, rows=list(rows))
 
     return await asyncio.to_thread(_run)
 
@@ -278,7 +287,7 @@ async def count_table_rows(
     table_name: str,
     *,
     mode: CredentialMode = CredentialMode.DEFAULT,
-) -> int:
+) -> TableRowCount:
     """Return the total row count of *schema*.*table_name* via ``COUNT_BIG(*)``.
 
     Uses ``COUNT_BIG(*)`` rather than ``COUNT(*)`` to avoid integer overflow on
@@ -291,7 +300,8 @@ async def count_table_rows(
         mode: The credential mode for Entra authentication.
 
     Returns:
-        The number of rows in the table as a Python :class:`int`.
+        A :class:`~fabric_dw.models.TableRowCount` with ``schema_name``,
+        ``name``, and ``row_count`` fields.
 
     Raises:
         ValueError: If *schema* or *table_name* fails identifier validation.
@@ -306,12 +316,12 @@ async def count_table_rows(
         table_q=quote_identifier(table_name),
     )
 
-    def _run() -> int:
+    def _run() -> TableRowCount:
         _cols, rows = run_query(target, count_sql, mode=mode)
         if not rows:
             msg = f"Table [{schema}].[{table_name}] not found"
             raise NotFoundError(msg)
-        return int(rows[0][0])
+        return TableRowCount(schema_name=schema, name=table_name, row_count=int(rows[0][0]))
 
     return await asyncio.to_thread(_run)
 
@@ -323,7 +333,7 @@ async def get_cluster_columns(
     *,
     kind: WarehouseKind = WarehouseKind.WAREHOUSE,
     mode: CredentialMode = CredentialMode.DEFAULT,
-) -> list[dict[str, object]]:
+) -> list[ClusterColumn]:
     """Return the data-clustering columns of *schema*.*table_name*, ordered by ordinal.
 
     Queries ``sys.index_columns`` filtered on ``data_clustering_ordinal > 0``.
@@ -338,8 +348,8 @@ async def get_cluster_columns(
         mode: The credential mode for Entra authentication.
 
     Returns:
-        A (possibly empty) list of ``{"column_name": str, "clustering_ordinal": int}``
-        dicts ordered by ascending *clustering_ordinal*.
+        A (possibly empty) list of :class:`~fabric_dw.models.ClusterColumn`
+        instances ordered by ascending ``clustering_ordinal``.
 
     Raises:
         ItemKindError: If *kind* is :attr:`~fabric_dw.models.WarehouseKind.SQL_ENDPOINT`.
@@ -353,14 +363,16 @@ async def get_cluster_columns(
     validate_identifier(schema)
     validate_identifier(table_name)
 
-    def _run() -> list[dict[str, object]]:
+    def _run() -> list[ClusterColumn]:
         _cols, rows = run_query(
             target,
             _CLUSTER_COLUMNS_SQL,
             params=[schema, table_name],
             mode=mode,
         )
-        return [{"column_name": str(row[0]), "clustering_ordinal": int(row[1])} for row in rows]
+        return [
+            ClusterColumn(column_name=str(row[0]), clustering_ordinal=int(row[1])) for row in rows
+        ]
 
     return await asyncio.to_thread(_run)
 
@@ -1497,7 +1509,7 @@ async def get_table_health_metrics(
     *,
     kind: WarehouseKind = WarehouseKind.WAREHOUSE,
     mode: CredentialMode = CredentialMode.DEFAULT,
-) -> tuple[list[str], list[tuple[object, ...]]]:
+) -> ResultSet:
     """Return health metrics for *schema*.*table_name* via ``sp_get_table_health_metrics``.
 
     Executes ``EXEC sp_get_table_health_metrics 'schema.table'`` against the
@@ -1521,9 +1533,8 @@ async def get_table_health_metrics(
         mode: The credential mode for Entra authentication.
 
     Returns:
-        A ``(columns, rows)`` tuple where *columns* is a list of column name
-        strings and *rows* is a list of row tuples.  The exact columns are
-        determined by the proc and are passed through verbatim.
+        A :class:`~fabric_dw.models.ResultSet` with ``columns`` and ``rows``.
+        The exact columns are determined by the proc and are passed through verbatim.
 
     Raises:
         ItemKindError: If *kind* is not
@@ -1545,9 +1556,9 @@ async def get_table_health_metrics(
     # expects a plain 'schema.table' string literal, not an ODBC-quoted name.
     sql = _SP_TABLE_HEALTH_METRICS_SQL.format(schema=schema, table=table_name)
 
-    def _run() -> tuple[list[str], list[tuple[object, ...]]]:
+    def _run() -> ResultSet:
         cols, rows = run_query(target, sql, mode=mode)
-        return cols, list(rows)
+        return ResultSet(columns=cols, rows=list(rows))
 
     return await asyncio.to_thread(_run)
 

--- a/tests/integration/test_services_tables.py
+++ b/tests/integration/test_services_tables.py
@@ -43,20 +43,20 @@ async def test_read_table_returns_seeded_rows(
     read_target: SqlTarget,
 ) -> None:
     """read_table against sample.colors must return the three seeded rows."""
-    cols, rows = await tables.read_table(read_target, SEED_SCHEMA_NAME, "colors", count=10)
-    assert "id" in cols
-    assert "name" in cols
+    result = await tables.read_table(read_target, SEED_SCHEMA_NAME, "colors", count=10)
+    assert "id" in result.columns
+    assert "name" in result.columns
     # Exactly three rows were seeded (red / green / blue).
-    assert len(rows) == 3
+    assert len(result.rows) == 3
 
 
 async def test_count_table_rows_on_seeded_table(
     read_target: SqlTarget,
 ) -> None:
     """count_table_rows on sample.colors must return 3 (the seeded row count)."""
-    count = await tables.count_table_rows(read_target, SEED_SCHEMA_NAME, "colors")
-    assert isinstance(count, int)
-    assert count == 3
+    result = await tables.count_table_rows(read_target, SEED_SCHEMA_NAME, "colors")
+    assert isinstance(result.row_count, int)
+    assert result.row_count == 3
 
 
 async def test_get_table_columns_on_seeded_table(
@@ -108,17 +108,17 @@ async def test_create_read_clear_delete_roundtrip(
         assert created.schema_name == schema
         assert created.name == table_name
 
-        cols, rows = await tables.read_table(sql_target, schema, table_name, count=5)
-        assert "id" in cols or len(cols) > 0
-        assert isinstance(rows, list)
+        read_result = await tables.read_table(sql_target, schema, table_name, count=5)
+        assert "id" in read_result.columns or len(read_result.columns) > 0
+        assert isinstance(read_result.rows, list)
 
         all_tables = await tables.list_tables(sql_target)
         names = {t.name for t in all_tables}
         assert table_name in names
 
         await tables.clear_table(sql_target, schema, table_name)
-        _, rows_after_clear = await tables.read_table(sql_target, schema, table_name, count=5)
-        assert rows_after_clear == []
+        after_clear = await tables.read_table(sql_target, schema, table_name, count=5)
+        assert after_clear.rows == []
 
     finally:
         with contextlib.suppress(Exception):
@@ -154,10 +154,10 @@ async def test_clone_table_creates_identical_rows(
         names = {t.name for t in all_tables}
         assert clone_name in names
 
-        src_cols, src_rows = await tables.read_table(sql_target, schema, source_name, count=100)
-        cln_cols, cln_rows = await tables.read_table(sql_target, schema, clone_name, count=100)
-        assert src_cols == cln_cols
-        assert cln_rows == src_rows
+        src_result = await tables.read_table(sql_target, schema, source_name, count=100)
+        cln_result = await tables.read_table(sql_target, schema, clone_name, count=100)
+        assert src_result.columns == cln_result.columns
+        assert cln_result.rows == src_result.rows
     finally:
         with contextlib.suppress(Exception):
             await tables.delete_table(sql_target, schema, source_name)
@@ -292,10 +292,10 @@ async def test_count_table_rows_returns_nonnegative_int(
 
     try:
         await tables.create_table(sql_target, schema, table_name, select_body)
-        count = await tables.count_table_rows(sql_target, schema, table_name)
-        assert isinstance(count, int)
-        assert count >= 0
-        assert count == 3
+        result = await tables.count_table_rows(sql_target, schema, table_name)
+        assert isinstance(result.row_count, int)
+        assert result.row_count >= 0
+        assert result.row_count == 3
     finally:
         with contextlib.suppress(Exception):
             await tables.delete_table(sql_target, schema, table_name)
@@ -364,7 +364,7 @@ async def test_get_table_health_metrics_on_sql_endpoint(
 
     sql_target = shared_sql_endpoint.sql_target
     try:
-        columns, rows = await tables.get_table_health_metrics(
+        metrics = await tables.get_table_health_metrics(
             sql_target,
             SEED_SCHEMA_NAME,
             "colors",
@@ -397,12 +397,14 @@ async def test_get_table_health_metrics_on_sql_endpoint(
 
     # The proc must return at least one column (output schema is undocumented
     # but the proc is GA and always yields a result set when available).
-    assert isinstance(columns, list), f"expected list of column names, got {type(columns)}"
-    assert columns, f"expected non-empty columns list, got {columns!r}"
-    for col in columns:
+    assert isinstance(metrics.columns, list), (
+        f"expected list of column names, got {type(metrics.columns)}"
+    )
+    assert metrics.columns, f"expected non-empty columns list, got {metrics.columns!r}"
+    for col in metrics.columns:
         assert isinstance(col, str), f"column name must be str, got {type(col)}: {col!r}"
 
     # rows is a list of tuples; may be empty for a freshly-seeded table.
-    assert isinstance(rows, list), f"expected list of row tuples, got {type(rows)}"
-    for row in rows:
+    assert isinstance(metrics.rows, list), f"expected list of row tuples, got {type(metrics.rows)}"
+    for row in metrics.rows:
         assert isinstance(row, tuple), f"each row must be a tuple, got {type(row)}: {row!r}"

--- a/tests/unit/cli/commands/test_tables.py
+++ b/tests/unit/cli/commands/test_tables.py
@@ -22,7 +22,7 @@ from fabric_dw.cli._context import CliContext
 from fabric_dw.cli._main import cli
 from fabric_dw.cli.commands.tables import _load_cmd_local, _parse_column_spec
 from fabric_dw.exceptions import FabricError, ItemKindError, NotFoundError, PermissionDeniedError
-from fabric_dw.models import CopyIntoResult, Table, WarehouseKind
+from fabric_dw.models import CopyIntoResult, ResultSet, Table, TableRowCount, WarehouseKind
 from fabric_dw.sql import SqlTarget
 
 SE_GUID = "bbbbbbbb-cccc-dddd-eeee-ffffffffffff"
@@ -193,7 +193,7 @@ class TestTablesRead:
             ),
             patch(
                 "fabric_dw.services.tables.read_table",
-                new=AsyncMock(return_value=(["id", "name"], [(1, "Alice")])),
+                new=AsyncMock(return_value=ResultSet(columns=["id", "name"], rows=[(1, "Alice")])),
             ),
         ):
             result = runner.invoke(cli, ["-w", WS_GUID, "tables", "read", WH_GUID, "dbo.sales"])
@@ -217,7 +217,7 @@ class TestTablesRead:
             ),
             patch(
                 "fabric_dw.services.tables.read_table",
-                new=AsyncMock(return_value=(["id"], [(42,)])),
+                new=AsyncMock(return_value=ResultSet(columns=["id"], rows=[(42,)])),
             ),
         ):
             result = runner.invoke(cli, ["-w", WS_GUID, "tables", "read", WH_GUID, "dbo.sales"])
@@ -254,7 +254,7 @@ class TestTablesRead:
             ),
             patch(
                 "fabric_dw.services.tables.read_table",
-                new=AsyncMock(return_value=(["id"], [(1,)])),
+                new=AsyncMock(return_value=ResultSet(columns=["id"], rows=[(1,)])),
             ),
         ):
             result = runner.invoke(
@@ -295,7 +295,7 @@ class TestTablesRead:
             ),
             patch(
                 "fabric_dw.services.tables.read_table",
-                new=AsyncMock(return_value=(["id"], [(1,)])),
+                new=AsyncMock(return_value=ResultSet(columns=["id"], rows=[(1,)])),
             ),
         ):
             result = runner.invoke(
@@ -369,7 +369,9 @@ class TestTablesCount:
             ),
             patch(
                 "fabric_dw.services.tables.count_table_rows",
-                new=AsyncMock(return_value=42),
+                new=AsyncMock(
+                    return_value=TableRowCount(schema_name="dbo", name="sales", row_count=42)
+                ),
             ),
         ):
             result = runner.invoke(cli, ["-w", WS_GUID, "tables", "count", WH_GUID, "dbo.sales"])
@@ -389,7 +391,9 @@ class TestTablesCount:
             ),
             patch(
                 "fabric_dw.services.tables.count_table_rows",
-                new=AsyncMock(return_value=99),
+                new=AsyncMock(
+                    return_value=TableRowCount(schema_name="dbo", name="sales", row_count=99)
+                ),
             ),
         ):
             result = runner.invoke(
@@ -397,7 +401,8 @@ class TestTablesCount:
             )
         assert result.exit_code == 0
         parsed = json.loads(result.output)
-        assert parsed["schema"] == "dbo"
+        # schema_name replaces the legacy "schema" key (deliberate behaviour change)
+        assert parsed["schema_name"] == "dbo"
         assert parsed["name"] == "sales"
         assert parsed["row_count"] == 99
 
@@ -3001,7 +3006,7 @@ class TestTablesHealthCheck:
             ),
             patch(
                 "fabric_dw.services.tables.get_table_health_metrics",
-                new=AsyncMock(return_value=(fake_cols, fake_rows)),
+                new=AsyncMock(return_value=ResultSet(columns=fake_cols, rows=fake_rows)),
             ),
         ):
             result = runner.invoke(
@@ -3026,7 +3031,7 @@ class TestTablesHealthCheck:
             ),
             patch(
                 "fabric_dw.services.tables.get_table_health_metrics",
-                new=AsyncMock(return_value=(fake_cols, fake_rows)),
+                new=AsyncMock(return_value=ResultSet(columns=fake_cols, rows=fake_rows)),
             ),
         ):
             result = runner.invoke(
@@ -3086,7 +3091,7 @@ class TestTablesHealthCheck:
             ),
             patch(
                 "fabric_dw.services.tables.get_table_health_metrics",
-                new=AsyncMock(return_value=([], [])),
+                new=AsyncMock(return_value=ResultSet(columns=[], rows=[])),
             ),
         ):
             result = runner.invoke(
@@ -3124,7 +3129,7 @@ class TestTablesHealthCheckDuplicateColumns:
             ),
             patch(
                 "fabric_dw.services.tables.get_table_health_metrics",
-                new=AsyncMock(return_value=(fake_cols, fake_rows)),
+                new=AsyncMock(return_value=ResultSet(columns=fake_cols, rows=fake_rows)),
             ),
         ):
             result = runner.invoke(
@@ -3153,7 +3158,7 @@ class TestTablesHealthCheckDuplicateColumns:
             ),
             patch(
                 "fabric_dw.services.tables.get_table_health_metrics",
-                new=AsyncMock(return_value=(fake_cols, fake_rows)),
+                new=AsyncMock(return_value=ResultSet(columns=fake_cols, rows=fake_rows)),
             ),
         ):
             result = runner.invoke(

--- a/tests/unit/mcp/tools/test_tables.py
+++ b/tests/unit/mcp/tools/test_tables.py
@@ -178,7 +178,7 @@ async def test_read_table_happy_path(mock_ctx, ctx_patch) -> None:
         patch(
             "fabric_dw.services.tables.read_table",
             new=AsyncMock(
-                return_value=ResultSet(columns=["id", "name"], rows=[[1, "foo"], [2, "bar"]])
+                return_value=ResultSet(columns=["id", "name"], rows=[(1, "foo"), (2, "bar")])
             ),
         ),
     ):
@@ -199,7 +199,7 @@ async def test_read_table_with_count(mock_ctx, ctx_patch) -> None:
     item = make_item_entry()
     mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
     mock_ctx.resolver.item = AsyncMock(return_value=item)
-    mock_read = AsyncMock(return_value=ResultSet(columns=["id"], rows=[[42]]))
+    mock_read = AsyncMock(return_value=ResultSet(columns=["id"], rows=[(42,)]))
 
     with (
         ctx_patch,

--- a/tests/unit/mcp/tools/test_tables.py
+++ b/tests/unit/mcp/tools/test_tables.py
@@ -23,7 +23,7 @@ import pytest
 from mcp.server.fastmcp.exceptions import ToolError
 
 from fabric_dw.exceptions import ItemKindError, NotFoundError
-from fabric_dw.models import Table, WarehouseKind
+from fabric_dw.models import ClusterColumn, ResultSet, Table, TableRowCount, WarehouseKind
 from tests.unit.mcp.conftest import (
     WH_NAME,
     WS_ID,
@@ -177,7 +177,9 @@ async def test_read_table_happy_path(mock_ctx, ctx_patch) -> None:
         ctx_patch,
         patch(
             "fabric_dw.services.tables.read_table",
-            new=AsyncMock(return_value=(["id", "name"], [[1, "foo"], [2, "bar"]])),
+            new=AsyncMock(
+                return_value=ResultSet(columns=["id", "name"], rows=[[1, "foo"], [2, "bar"]])
+            ),
         ),
     ):
         result = await mcp._tool_manager.call_tool(
@@ -197,7 +199,7 @@ async def test_read_table_with_count(mock_ctx, ctx_patch) -> None:
     item = make_item_entry()
     mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
     mock_ctx.resolver.item = AsyncMock(return_value=item)
-    mock_read = AsyncMock(return_value=(["id"], [[42]]))
+    mock_read = AsyncMock(return_value=ResultSet(columns=["id"], rows=[[42]]))
 
     with (
         ctx_patch,
@@ -589,7 +591,9 @@ async def test_count_table_rows_happy_path(mock_ctx, ctx_patch) -> None:
         ctx_patch,
         patch(
             "fabric_dw.services.tables.count_table_rows",
-            new=AsyncMock(return_value=42),
+            new=AsyncMock(
+                return_value=TableRowCount(schema_name="dbo", name="sales", row_count=42)
+            ),
         ),
     ):
         result = await mcp._tool_manager.call_tool(
@@ -598,7 +602,8 @@ async def test_count_table_rows_happy_path(mock_ctx, ctx_patch) -> None:
         )
 
     assert isinstance(result, dict)
-    assert result["schema"] == "dbo"
+    # schema_name replaces the legacy "schema" key (deliberate behaviour change)
+    assert result["schema_name"] == "dbo"
     assert result["name"] == "sales"
     assert result["row_count"] == 42
 
@@ -666,7 +671,12 @@ async def test_get_cluster_columns_happy_path(mock_ctx, ctx_patch) -> None:
     item = make_item_entry()
     mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
     mock_ctx.resolver.item = AsyncMock(return_value=item)
-    expected = [
+    # service now returns ClusterColumn instances; tool converts to dicts via model_dump
+    service_result = [
+        ClusterColumn(column_name="city", clustering_ordinal=1),
+        ClusterColumn(column_name="country", clustering_ordinal=2),
+    ]
+    expected_dicts = [
         {"column_name": "city", "clustering_ordinal": 1},
         {"column_name": "country", "clustering_ordinal": 2},
     ]
@@ -675,7 +685,7 @@ async def test_get_cluster_columns_happy_path(mock_ctx, ctx_patch) -> None:
         ctx_patch,
         patch(
             "fabric_dw.services.tables.get_cluster_columns",
-            new=AsyncMock(return_value=expected),
+            new=AsyncMock(return_value=service_result),
         ),
     ):
         result = await mcp._tool_manager.call_tool(
@@ -683,7 +693,7 @@ async def test_get_cluster_columns_happy_path(mock_ctx, ctx_patch) -> None:
             {"workspace": WS_NAME, "item": WH_NAME, "qualified_name": "dbo.sales"},
         )
 
-    assert result == expected
+    assert result == expected_dicts
 
 
 async def test_get_cluster_columns_empty_result(mock_ctx, ctx_patch) -> None:
@@ -889,7 +899,7 @@ async def test_get_table_health_metrics_is_not_mutating(
         ctx_patch,
         patch(
             "fabric_dw.services.tables.get_table_health_metrics",
-            new=AsyncMock(return_value=([], [])),
+            new=AsyncMock(return_value=ResultSet(columns=[], rows=[])),
         ),
     ):
         # Must NOT raise ToolError — read-only tools don't check writes_allowed.
@@ -909,7 +919,7 @@ async def test_get_table_health_metrics_happy_path(mock_ctx, ctx_patch) -> None:
 
     fake_cols = ["issue_type", "severity"]
     fake_rows: list[tuple[object, ...]] = [("small_files", "medium")]
-    mock_svc = AsyncMock(return_value=(fake_cols, fake_rows))
+    mock_svc = AsyncMock(return_value=ResultSet(columns=fake_cols, rows=fake_rows))
 
     with (
         ctx_patch,
@@ -931,7 +941,7 @@ async def test_get_table_health_metrics_forwards_qualified_name(mock_ctx, ctx_pa
 
     mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
     mock_ctx.resolver.item = AsyncMock(return_value=make_sql_endpoint_entry())
-    mock_svc = AsyncMock(return_value=([], []))
+    mock_svc = AsyncMock(return_value=ResultSet(columns=[], rows=[]))
 
     with (
         ctx_patch,

--- a/tests/unit/services/test_tables.py
+++ b/tests/unit/services/test_tables.py
@@ -20,7 +20,14 @@ from fabric_dw.exceptions import (
     NotFoundError,
     PermissionDeniedError,
 )
-from fabric_dw.models import ColumnSpec, Table, WarehouseKind
+from fabric_dw.models import (
+    ClusterColumn,
+    ColumnSpec,
+    ResultSet,
+    Table,
+    TableRowCount,
+    WarehouseKind,
+)
 from fabric_dw.services import tables
 from fabric_dw.services.tables import validate_identifier
 from tests.unit.services._helpers import (
@@ -380,15 +387,27 @@ class TestListTables:
 
 
 class TestReadTable:
-    async def test_returns_columns_and_rows(self) -> None:
+    async def test_returns_result_set(self) -> None:
         target = _make_target()
         cols = ["id", "name"]
         rows: list[tuple[object, ...]] = [(1, "Alice"), (2, "Bob")]
         conn = _make_conn(rows, cols)
         with patch("fabric_dw.sql.open_connection", return_value=conn):
-            result_cols, result_rows = await tables.read_table(target, "dbo", "sales")
-        assert result_cols == cols
-        assert list(result_rows) == rows
+            result = await tables.read_table(target, "dbo", "sales")
+        assert isinstance(result, ResultSet)
+        assert result.columns == cols
+        assert list(result.rows) == rows
+
+    async def test_returns_columns_and_rows(self) -> None:
+        """Accessor attributes on ResultSet match the raw query output."""
+        target = _make_target()
+        cols = ["id", "name"]
+        rows: list[tuple[object, ...]] = [(1, "Alice"), (2, "Bob")]
+        conn = _make_conn(rows, cols)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            result = await tables.read_table(target, "dbo", "sales")
+        assert result.columns == cols
+        assert list(result.rows) == rows
 
     async def test_sql_uses_select_top(self) -> None:
         target = _make_target()
@@ -460,19 +479,29 @@ class TestReadTable:
 
 
 class TestCountTableRows:
+    async def test_returns_table_row_count_model(self) -> None:
+        target = _make_target()
+        conn = _make_conn([(42,)], ["row_count"])
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            result = await tables.count_table_rows(target, "dbo", "sales")
+        assert isinstance(result, TableRowCount)
+        assert result.schema_name == "dbo"
+        assert result.name == "sales"
+        assert result.row_count == 42
+
     async def test_returns_row_count(self) -> None:
         target = _make_target()
         conn = _make_conn([(42,)], ["row_count"])
         with patch("fabric_dw.sql.open_connection", return_value=conn):
             result = await tables.count_table_rows(target, "dbo", "sales")
-        assert result == 42
+        assert result.row_count == 42
 
     async def test_returns_zero_for_empty_table(self) -> None:
         target = _make_target()
         conn = _make_conn([(0,)], ["row_count"])
         with patch("fabric_dw.sql.open_connection", return_value=conn):
             result = await tables.count_table_rows(target, "dbo", "sales")
-        assert result == 0
+        assert result.row_count == 0
 
     async def test_sql_uses_count_big(self) -> None:
         target = _make_target()
@@ -531,13 +560,29 @@ class TestCountTableRows:
 
 
 class TestGetClusterColumns:
-    async def test_returns_columns_ordered_by_ordinal(self) -> None:
+    async def test_returns_cluster_column_instances(self) -> None:
         target = _make_target()
         rows: list[tuple[object, ...]] = [("city", 1), ("country", 2)]
         conn = _make_conn(rows, ["column_name", "clustering_ordinal"])
         with patch("fabric_dw.sql.open_connection", return_value=conn):
             result = await tables.get_cluster_columns(target, "dbo", "sales")
-        assert result == [
+        assert len(result) == 2
+        assert isinstance(result[0], ClusterColumn)
+        assert result[0].column_name == "city"
+        assert result[0].clustering_ordinal == 1
+        assert isinstance(result[1], ClusterColumn)
+        assert result[1].column_name == "country"
+        assert result[1].clustering_ordinal == 2
+
+    async def test_returns_columns_ordered_by_ordinal(self) -> None:
+        """model_dump output matches the previous dict shape byte-for-byte."""
+        target = _make_target()
+        rows: list[tuple[object, ...]] = [("city", 1), ("country", 2)]
+        conn = _make_conn(rows, ["column_name", "clustering_ordinal"])
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            result = await tables.get_cluster_columns(target, "dbo", "sales")
+        dumped = [c.model_dump(mode="json") for c in result]
+        assert dumped == [
             {"column_name": "city", "clustering_ordinal": 1},
             {"column_name": "country", "clustering_ordinal": 2},
         ]
@@ -604,6 +649,113 @@ class TestGetClusterColumns:
             pytest.raises(PermissionDeniedError),
         ):
             await tables.get_cluster_columns(target, "dbo", "sales")
+
+
+# ===========================================================================
+# ResultSet native-type fidelity
+# ===========================================================================
+
+
+class TestResultSetNativeTypeFidelity:
+    """Verify that ResultSet stores native driver types without pydantic coercion.
+
+    The critical requirement: datetime, Decimal, and bytes values passed into
+    ResultSet must come out of .rows as the exact same Python objects (pydantic
+    must not coerce them to str or any other type).  Downstream consumers
+    (columns_rows_to_arrow, safe_rows) depend on receiving the raw driver types.
+    """
+
+    def test_datetime_preserved(self) -> None:
+        from datetime import UTC, datetime  # noqa: PLC0415
+
+        dt = datetime(2024, 6, 1, 12, 0, 0, tzinfo=UTC)
+        rs = ResultSet(columns=["ts"], rows=[(dt,)])
+        assert rs.rows[0][0] is dt
+        assert type(rs.rows[0][0]) is datetime  # type: ignore[comparison-overlap]
+
+    def test_decimal_preserved(self) -> None:
+        from decimal import Decimal  # noqa: PLC0415
+
+        dec = Decimal("3.14159")
+        rs = ResultSet(columns=["amount"], rows=[(dec,)])
+        assert rs.rows[0][0] is dec
+        assert type(rs.rows[0][0]) is Decimal  # type: ignore[comparison-overlap]
+
+    def test_bytes_preserved(self) -> None:
+        raw = b"\x00\x01\x02\xde\xad\xbe\xef"
+        rs = ResultSet(columns=["blob"], rows=[(raw,)])
+        assert rs.rows[0][0] is raw
+        assert type(rs.rows[0][0]) is bytes  # type: ignore[comparison-overlap]
+
+    def test_mixed_row_native_types_preserved(self) -> None:
+        """Round-trip a row with datetime + Decimal + bytes through ResultSet."""
+        from datetime import UTC, datetime  # noqa: PLC0415
+        from decimal import Decimal  # noqa: PLC0415
+
+        dt = datetime(2024, 1, 15, 8, 30, 0, tzinfo=UTC)
+        dec = Decimal("99.99")
+        raw = b"\xca\xfe\xba\xbe"
+        rs = ResultSet(
+            columns=["ts", "amount", "data__base64"],
+            rows=[(dt, dec, raw)],
+        )
+        row = rs.rows[0]
+        assert row[0] is dt
+        assert row[1] is dec
+        assert row[2] is raw
+
+    def test_round_trip_through_columns_rows_to_arrow(self) -> None:
+        """columns_rows_to_arrow must materialise Arrow columns with correct types."""
+        from datetime import UTC, datetime  # noqa: PLC0415
+        from decimal import Decimal  # noqa: PLC0415
+
+        import pyarrow as pa  # noqa: PLC0415
+
+        from fabric_dw.sql_io import columns_rows_to_arrow  # noqa: PLC0415
+
+        dt = datetime(2024, 6, 15, 10, 0, 0, tzinfo=UTC)
+        dec = Decimal("1.50")
+        raw = b"\xff\x00"
+        rs = ResultSet(
+            columns=["ts", "amount", "data__base64"],
+            rows=[(dt, dec, raw)],
+        )
+        arrow_table = columns_rows_to_arrow(rs.columns, rs.rows)  # type: ignore[arg-type]
+        # datetime column — Arrow must represent it as a temporal type, not string.
+        ts_col = arrow_table.column("ts")
+        assert pa.types.is_temporal(ts_col.type), f"expected temporal type, got {ts_col.type}"
+        # Decimal column — Arrow should produce a numeric type.
+        amount_col = arrow_table.column("amount")
+        assert (
+            pa.types.is_floating(amount_col.type)
+            or pa.types.is_decimal(amount_col.type)
+            or pa.types.is_large_string(amount_col.type)
+            or pa.types.is_string(amount_col.type)
+        ), f"unexpected Arrow type for Decimal: {amount_col.type}"
+        # bytes column — Arrow should produce a binary type or fall back to string.
+        blob_col = arrow_table.column("data__base64")
+        assert (
+            pa.types.is_binary(blob_col.type)
+            or pa.types.is_large_binary(blob_col.type)
+            or pa.types.is_string(blob_col.type)
+        ), f"unexpected Arrow type for bytes: {blob_col.type}"
+
+    def test_round_trip_through_safe_rows_base64(self) -> None:
+        """safe_rows must base64-encode bytes and leave datetime/Decimal as strings."""
+        import base64  # noqa: PLC0415
+        from decimal import Decimal  # noqa: PLC0415
+
+        from fabric_dw.mcp._helpers import safe_rows  # noqa: PLC0415
+
+        raw = b"\xde\xad\xbe\xef"
+        dec = Decimal("7.77")
+        rs = ResultSet(columns=["data__base64", "amount"], rows=[(raw, dec)])
+        serialised = safe_rows(rs.rows)  # type: ignore[arg-type]
+        row = serialised[0]
+        # bytes -> base64 string
+        assert row[0] == base64.b64encode(raw).decode("ascii")
+        # Decimal -> str (safe_rows delegates to json_safe which str()-ifies Decimals)
+        assert row[1] == str(dec)
 
 
 # ===========================================================================
@@ -2378,6 +2530,23 @@ class TestGetTableHealthMetrics:
         call_sql: str = cursor.execute.call_args[0][0]
         assert call_sql == "EXEC sp_get_table_health_metrics 'sales.Transactions'"
 
+    async def test_returns_result_set(self) -> None:
+        """Returns a ResultSet (generic passthrough); columns and rows are preserved."""
+        target = _make_target()
+        fake_cols = ["col_a", "col_b", "col_c"]
+        fake_rows: list[tuple[object, ...]] = [("v1", 42, True), ("v2", 0, False)]
+        conn = _make_conn(fake_rows, fake_cols)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            result = await tables.get_table_health_metrics(
+                target,
+                "dbo",
+                "FactSales",
+                kind=WarehouseKind.SQL_ENDPOINT,
+            )
+        assert isinstance(result, ResultSet)
+        assert result.columns == fake_cols
+        assert result.rows == fake_rows
+
     async def test_returns_columns_and_rows(self) -> None:
         """Columns and rows are returned as-is (generic passthrough)."""
         target = _make_target()
@@ -2385,27 +2554,27 @@ class TestGetTableHealthMetrics:
         fake_rows: list[tuple[object, ...]] = [("v1", 42, True), ("v2", 0, False)]
         conn = _make_conn(fake_rows, fake_cols)
         with patch("fabric_dw.sql.open_connection", return_value=conn):
-            result_cols, result_rows = await tables.get_table_health_metrics(
+            result = await tables.get_table_health_metrics(
                 target,
                 "dbo",
                 "FactSales",
                 kind=WarehouseKind.SQL_ENDPOINT,
             )
-        assert result_cols == fake_cols
-        assert result_rows == fake_rows
+        assert result.columns == fake_cols
+        assert result.rows == fake_rows
 
     async def test_returns_empty_rows_when_proc_returns_nothing(self) -> None:
         """An empty result set is valid (no rows, but columns may be present)."""
         target = _make_target()
         conn = _make_conn([], [])
         with patch("fabric_dw.sql.open_connection", return_value=conn):
-            _cols, rows = await tables.get_table_health_metrics(
+            result = await tables.get_table_health_metrics(
                 target,
                 "dbo",
                 "FactSales",
                 kind=WarehouseKind.SQL_ENDPOINT,
             )
-        assert rows == []
+        assert result.rows == []
 
     async def test_warehouse_kind_raises_item_kind_error(self) -> None:
         """Passing a Warehouse kind raises ItemKindError (inverse guard)."""
@@ -2483,19 +2652,19 @@ class TestGetTableHealthMetrics:
         target = _make_target()
         conn = _make_conn(fake_driver_rows, fake_cols)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
         with patch("fabric_dw.sql.open_connection", return_value=conn):
-            result_cols, result_rows = await tables.get_table_health_metrics(
+            result = await tables.get_table_health_metrics(
                 target,
                 "dbo",
                 "FactSales",
                 kind=WarehouseKind.SQL_ENDPOINT,
             )
 
-        assert result_cols == fake_cols
-        assert len(result_rows) == 2
-        for row in result_rows:
+        assert result.columns == fake_cols
+        assert len(result.rows) == 2
+        for row in result.rows:
             assert isinstance(row, tuple), f"each row must be a tuple, got {type(row)}: {row!r}"
-        assert result_rows[0] == (1, "alpha", None)
-        assert result_rows[1] == (2, "beta", 3.14)
+        assert result.rows[0] == (1, "alpha", None)
+        assert result.rows[1] == (2, "beta", 3.14)
 
 
 # ===========================================================================
@@ -2508,15 +2677,15 @@ class TestReadTableRowNormalisation:
     """Tests for :func:`tables.read_table` — ensures real tuples are returned (#718)."""
 
     async def test_returns_columns_and_rows(self) -> None:
-        """Basic smoke: columns and row values are returned correctly."""
+        """Basic smoke: columns and row values are returned correctly via ResultSet."""
         target = _make_target()
         cols = ["id", "name"]
         rows: list[tuple[object, ...]] = [(1, "Alice"), (2, "Bob")]
         conn = _make_conn(rows, cols)
         with patch("fabric_dw.sql.open_connection", return_value=conn):
-            result_cols, result_rows = await tables.read_table(target, "dbo", "my_table")
-        assert result_cols == cols
-        assert list(result_rows) == rows
+            result = await tables.read_table(target, "dbo", "my_table")
+        assert result.columns == cols
+        assert list(result.rows) == rows
 
     async def test_driver_row_objects_are_normalised_to_tuples(self) -> None:
         """Row objects (non-tuple) returned by the driver become real tuples.
@@ -2533,14 +2702,14 @@ class TestReadTableRowNormalisation:
         # run_query's central normalisation will convert them to real tuples.
         conn = _make_conn(fake_driver_rows, cols)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
         with patch("fabric_dw.sql.open_connection", return_value=conn):
-            result_cols, result_rows = await tables.read_table(target, "dbo", "my_table")
+            result = await tables.read_table(target, "dbo", "my_table")
 
-        assert result_cols == cols
-        assert len(result_rows) == 2
-        for row in result_rows:
+        assert result.columns == cols
+        assert len(result.rows) == 2
+        for row in result.rows:
             assert type(row) is tuple, f"expected tuple, got {type(row)}: {row!r}"
-        assert result_rows[0] == (1, "alpha", 3.14)
-        assert result_rows[1] == (2, "beta", None)
+        assert result.rows[0] == (1, "alpha", 3.14)
+        assert result.rows[1] == (2, "beta", None)
 
     async def test_raises_not_found_when_no_columns(self) -> None:
         """Empty column metadata raises NotFoundError (mirrors read_table contract)."""


### PR DESCRIPTION
## Summary

- Add three Pydantic models to `models.py`: `ClusterColumn`, `TableRowCount`, and `ResultSet`
- Update `get_cluster_columns`, `count_table_rows`, `read_table`, and `get_table_health_metrics` in `services/tables.py` to return the new typed models instead of bare tuples or ints
- Update all MCP tool callers in `mcp/tools/tables.py` to unpack results via model attributes and serialise with `model_dump(mode="json")`
- Update all CLI callers in `cli/commands/tables.py` to unpack results via model attributes
- Update all unit tests (`tests/unit/`) and integration tests (`tests/integration/`) to reflect the new return types

**Breaking change:** the `count_table_rows` output key `schema` is renamed to `schema_name` to match the model field name and avoid shadowing the Python built-in.

## Test plan

- All 398 unit tests pass (`tests/unit/services/test_tables.py`, `tests/unit/mcp/tools/test_tables.py`, `tests/unit/cli/commands/test_tables.py`)
- `ruff check` and `ruff format --check` pass on all modified files
- Integration tests updated to assert on the new model attributes (`result.row_count`, `result.columns`, `result.rows`)

Closes #827