### PR TITLE
docs: surface the documentation website in the README and PyPI page

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 <h1 align="center">fabric-dw</h1>
 
 <p align="center">
+  <a href="https://fdw.debruyn.dev"><img src="https://img.shields.io/badge/docs-fdw.debruyn.dev-blue" alt="Documentation"></a>
   <a href="https://github.com/sdebruyn/fabric-dw-mcp-cli/actions/workflows/ci.yml"><img src="https://github.com/sdebruyn/fabric-dw-mcp-cli/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://codecov.io/gh/sdebruyn/fabric-dw-mcp-cli"><img src="https://codecov.io/gh/sdebruyn/fabric-dw-mcp-cli/graph/badge.svg" alt="codecov"></a>
   <a href="https://pypi.org/project/fabric-dw/"><img src="https://img.shields.io/pypi/v/fabric-dw" alt="PyPI version"></a>
@@ -14,6 +15,8 @@
 </p>
 
 Python CLI and MCP server for administering Microsoft Fabric Data Warehouses and SQL Analytics Endpoints.
+
+**Full documentation: [fdw.debruyn.dev](https://fdw.debruyn.dev)**
 
 ## Description
 


### PR DESCRIPTION
## Summary

- Add a documentation badge (shields.io, `https://img.shields.io/badge/docs-fdw.debruyn.dev-blue`) as the first entry in the existing badge row, linking to `https://fdw.debruyn.dev`. Uses the same `<a><img></a>` pattern already used by all sibling badges so it renders correctly on both GitHub and the PyPI long-description page.
- Add a bold call-to-action line (`**Full documentation: [fdw.debruyn.dev](https://fdw.debruyn.dev)**`) immediately below the one-line tagline and above the Description section, so the docs URL is visible above the fold on both GitHub and PyPI.
- `pyproject.toml` `[project.urls]` already has `Documentation = https://fdw.debruyn.dev` in a prominent position; no changes needed there.

## Test plan

- [ ] Confirm the badge renders in the GitHub README preview (blue shield, links to https://fdw.debruyn.dev)
- [ ] Confirm the bold call-to-action line is visible above the fold on the GitHub README
- [ ] Confirm no em-dashes or middot characters were introduced
- [ ] Confirm CI passes (no Python files changed; ruff not applicable)

Closes #888

🤖 Generated with [Claude Code](https://claude.com/claude-code)