### PR TITLE
test(telemetry): harden install-method cache test and remove inert ignores

### DIFF
--- a/src/fabric_dw/telemetry.py
+++ b/src/fabric_dw/telemetry.py
@@ -172,6 +172,14 @@ def _config_dir() -> Path:
     return base / "fabric-dw"
 
 
+# ---------------------------------------------------------------------------
+# Config-disabled cache (#844)
+# ---------------------------------------------------------------------------
+
+# Computed once per process; None means not yet read from disk.
+_config_disabled_cache: bool | None = None
+
+
 def _is_disabled_by_config() -> bool:
     """Return True when the config file contains a truthy ``[telemetry] disabled``.
 
@@ -290,13 +298,6 @@ _install_id_cache: str | None = None
 
 # Computed once per process; None means not yet detected.
 _install_method_cache: str | None = None
-
-# ---------------------------------------------------------------------------
-# Config-disabled cache (#844)
-# ---------------------------------------------------------------------------
-
-# Computed once per process; None means not yet read from disk.
-_config_disabled_cache: bool | None = None
 
 # ---------------------------------------------------------------------------
 # Tenant-ID persistence (#652)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -180,7 +180,7 @@ def _reset_telemetry_module_globals(
     # original module object (the same one that file-level imports in other test
     # modules have bound to).
     if _orig_telemetry_module is None:
-        _orig_telemetry_module = sys.modules.get("fabric_dw.telemetry")  # type: ignore[assignment]
+        _orig_telemetry_module = sys.modules.get("fabric_dw.telemetry")
 
     is_self_managed = (
         request.path is not None and request.path.name in _TELEMETRY_SELF_MANAGED_MODULES

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -1417,7 +1417,14 @@ def test_install_method_cached_across_envelope_calls(
     fake_dist = MagicMock()
     fake_dist.read_text.return_value = None  # no direct_url.json present
 
-    with patch.object(_meta, "distribution", return_value=fake_dist) as mock_dist:
+    # Patch sys.executable to a neutral path so the pipx detection branch
+    # ("pipx" in sys.executable) cannot short-circuit before reaching the
+    # importlib.metadata branch — otherwise the test fails on a pipx-installed
+    # interpreter where sys.executable contains "pipx".
+    with (
+        patch.object(mod.sys, "executable", "/usr/bin/python3"),
+        patch.object(_meta, "distribution", return_value=fake_dist) as mock_dist,
+    ):
         for _ in range(3):
             mod._build_envelope()  # type: ignore[attr-defined]
 
@@ -1449,10 +1456,15 @@ def test_config_disabled_cached_across_telemetry_enabled_calls(
     original_read_text = Path.read_text
 
     def counting_read_text(
-        self: Path, encoding: str | None = None, errors: str | None = None
+        self: Path,
+        encoding: str | None = None,
+        errors: str | None = None,
+        newline: str | None = None,
     ) -> str:
         if self.name == "config.toml":
             read_calls.append(1)
+        if sys.version_info >= (3, 13):
+            return original_read_text(self, encoding=encoding, errors=errors, newline=newline)
         return original_read_text(self, encoding=encoding, errors=errors)
 
     with patch.object(Path, "read_text", counting_read_text):
@@ -1489,12 +1501,19 @@ def test_config_disabled_transient_error_not_cached(
     original_read_text = Path.read_text
     call_count = 0
 
-    def flaky_read_text(self: Path, encoding: str | None = None, errors: str | None = None) -> str:
+    def flaky_read_text(
+        self: Path,
+        encoding: str | None = None,
+        errors: str | None = None,
+        newline: str | None = None,
+    ) -> str:
         nonlocal call_count
         if self.name == "config.toml":
             call_count += 1
             if call_count == 1:
                 raise OSError("simulated transient read failure")
+        if sys.version_info >= (3, 13):
+            return original_read_text(self, encoding=encoding, errors=errors, newline=newline)
         return original_read_text(self, encoding=encoding, errors=errors)
 
     with patch.object(Path, "read_text", flaky_read_text):


### PR DESCRIPTION
## Summary

- Patches `mod.sys.executable` to a neutral path in `test_install_method_cached_across_envelope_calls` so the pipx detection branch cannot short-circuit on a pipx-installed runner (where `sys.executable` contains `"pipx"`), which caused `call_count` to be 0 and the assertion to fail.
- Adds the Python 3.13 `newline` parameter to `counting_read_text` and `flaky_read_text` test proxies; forwards it conditionally on `sys.version_info >= (3, 13)` for compatibility with Python 3.11 and later.
- Moves `_config_disabled_cache` declaration to immediately before `_is_disabled_by_config()`, mirroring the `_install_method_cache` placement next to `_detect_install_method()`. Pure layout move, no behaviour change.
- Removes the inert `# type: ignore[assignment]` on the `_orig_telemetry_module` assignment in `tests/conftest.py`; the underlying type is correct and ty does not honour mypy-style ignore codes.

## Test plan

- `ruff check`, `ruff format --check`, and `ty check` all clean on the changed files.
- All 163 telemetry unit tests pass (`tests/unit/test_telemetry.py`).
- TDD simulation confirmed: without the `sys.executable` patch, `mock_dist.call_count` is 0 on a pipx-style runner (assertion would fail); with the patch it is 1 (assertion passes).

Closes #887

🤖 Generated with [Claude Code](https://claude.com/claude-code)