### PR TITLE
fix(sql): set the SQL connection Application Name to fdw.debruyn.dev

### DIFF
--- a/src/fabric_dw/sql.py
+++ b/src/fabric_dw/sql.py
@@ -800,7 +800,8 @@ def build_connection_string(
         raw = _set_key(raw, "Authentication", _MODE_TO_AD_AUTH[mode])
     cs = _set_key(raw, "Encrypt", "yes")
     cs = _set_key(cs, "TrustServerCertificate", "no")
-    return _set_key(cs, "Database", target.database)
+    cs = _set_key(cs, "Database", target.database)
+    return _set_key(cs, "APP", "fdw.debruyn.dev")
 
 
 def open_connection(

--- a/tests/unit/test_sql.py
+++ b/tests/unit/test_sql.py
@@ -208,6 +208,28 @@ class TestBuildConnectionString:
         result = build_connection_string(target)
         assert result.count("Server=") == 1
 
+    def test_adds_app_name(self) -> None:
+        result = build_connection_string(_make_target())
+        assert "APP=fdw.debruyn.dev" in result
+        assert ";;" not in result
+
+    def test_app_name_not_duplicated_when_already_present(self) -> None:
+        target = _make_target(connection_string="Server=srv;APP=fdw.debruyn.dev")
+        result = build_connection_string(target)
+        assert result.count("APP=") == 1
+
+    def test_app_name_idempotent(self) -> None:
+        target = _make_target()
+        first = build_connection_string(target)
+        target2 = SqlTarget(
+            workspace_id=target.workspace_id,
+            database=target.database,
+            connection_string=first,
+        )
+        second = build_connection_string(target2)
+        assert first == second
+        assert first.count("APP=") == 1
+
 
 # ---------------------------------------------------------------------------
 # open_connection — sync, caller closes


### PR DESCRIPTION
## Summary

- Adds `APP=fdw.debruyn.dev` to `build_connection_string` in `src/fabric_dw/sql.py` using the existing `_set_key` helper, alongside the already-set `Encrypt`, `TrustServerCertificate`, and `Database` keys.
- The ODBC keyword `APP` maps directly to `program_name` in `sys.dm_exec_sessions`, so connections opened by this tool will now show `fdw.debruyn.dev` instead of the `MSSQL-Python` driver default.
- `build_connection_string` remains idempotent: `_set_key` skips the key when it is already present.
- No configuration knob added - a single fixed value is intentional.

## Test plan

- [ ] `tests/unit/test_sql.py::TestBuildConnectionString::test_adds_app_name` - asserts `APP=fdw.debruyn.dev` in the output
- [ ] `tests/unit/test_sql.py::TestBuildConnectionString::test_app_name_not_duplicated_when_already_present` - asserts `APP=` appears exactly once when already in the base string
- [ ] `tests/unit/test_sql.py::TestBuildConnectionString::test_app_name_idempotent` - asserts calling twice yields the same string with exactly one `APP=`
- [ ] All 17 existing `TestBuildConnectionString` tests still pass
- [ ] `ruff check`, `ruff format --check`, and `ty check` all clean

Closes #892

🤖 Generated with [Claude Code](https://claude.com/claude-code)