### PR TITLE
refactor(sql): extract connection prerequisites and config resolution into sql_pool

### DIFF
--- a/src/fabric_dw/sql.py
+++ b/src/fabric_dw/sql.py
@@ -44,32 +44,17 @@ connections are drained on server shutdown.
 from __future__ import annotations
 
 import contextlib
-import functools
-import importlib
 import logging
 import os
-import re
 import threading
 import time
-import types
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any, Literal, Protocol
 
 from fabric_dw.auth import CredentialMode, get_sql_token_struct
-
-# Re-export shims: bind function names in this module's namespace so that
-# `from fabric_dw.sql import map_driver_error` (and the other helpers listed in
-# __all__) keeps working, so that `patch("fabric_dw.sql.<function>")` patches
-# the binding used by the runner functions below, and so that test code that
-# references private helpers via `_sql_module._<name>` can still find them.
-# Note: the private error-classification CONSTANTS are intentionally not
-# re-exported here.  They have no external callers, are not referenced by bare
-# name anywhere in this module, and patching them via fabric_dw.sql.* would be
-# a silent no-op regardless - the functions in sql_errors.py read their own
-# module globals, not any binding in sql.py.
 from fabric_dw.sql_errors import (
-    _clean_driver_error_message,  # noqa: F401 (test shim: accessed as _sql_module._clean_driver_error_message)
+    _clean_driver_error_message,  # noqa: F401 (test shim: _sql_module._clean_driver_error_message)
     _is_connect_retryable,
     _wrap_unmapped_driver_error,
     is_auth_failed_message,
@@ -77,6 +62,43 @@ from fabric_dw.sql_errors import (
     is_transient_connection_error,
     map_driver_error,
 )
+from fabric_dw.sql_pool import (
+    _CONNECT_RETRY_TIMEOUT_S,  # noqa: F401 (backwards-compat alias; read by integration smoke)
+    _FALSY_STRINGS,
+    _MIN_SQL_RETRY_DEADLINE_S,  # noqa: F401 (test shim: _sql_module._MIN_SQL_RETRY_DEADLINE_S)
+    _SQL_RETRY_DEADLINE_S_DEFAULT,  # noqa: F401 (test shim: _sql_module._SQL_RETRY_DEADLINE_S_DEFAULT)
+    SQL_COPT_SS_ACCESS_TOKEN,
+    SQL_LOGIN_TIMEOUT_S,
+    SQL_QUERY_TIMEOUT_S,
+    _driver,  # noqa: F401 (test shim: _sql_module._driver)
+    _get_mssql,
+    _load_sql_config,
+    _mssql,  # noqa: F401 (test seam: tests retarget to fabric_dw.sql_pool._mssql)
+    _resolve_sql_retry_deadline_s,
+    _resolve_sql_retry_executes,
+    _sql_config_cache_clear,  # noqa: F401 (test hook: _sql_module._sql_config_cache_clear())
+    _validate_sql_retry_deadline_s,  # noqa: F401 (test shim: _sql_module._validate_sql_retry_deadline_s)
+    build_connection_string,
+)
+
+# Re-export shims rationale (two groups):
+#
+# sql_errors shims: bind function names in this module's namespace so that
+# `from fabric_dw.sql import map_driver_error` keeps working, so that
+# `patch("fabric_dw.sql.<function>")` patches the binding used by the runner
+# functions below, and so that test code that accesses private helpers via
+# `_sql_module._<name>` can still find them.  The private error-classification
+# CONSTANTS are intentionally not re-exported: they are not referenced by bare
+# name here, and patching them via fabric_dw.sql.* would be a silent no-op.
+#
+# sql_pool shims: all names that were defined here but now live in sql_pool.py.
+# Importing them preserves the public surface (`from fabric_dw.sql import
+# build_connection_string`), bare-name calls inside open_connection /
+# _pool_enabled / _with_connect_retry / run_query, and test accesses such as
+# `_sql_module._SQL_RETRY_DEADLINE_S_DEFAULT`.
+# _sql_config_cache and _sql_config_lock are intentionally NOT re-exported:
+# they are mutable state owned by sql_pool; tests that must inject a cached
+# config value target fabric_dw.sql_pool._sql_config_cache directly.
 
 _log = logging.getLogger(__name__)
 
@@ -126,30 +148,6 @@ __all__ = [
 # ``fdw config set sql-retry-deadline``.
 _EXECUTE_RETRY_DELAYS: tuple[float, ...] = (2.0, 5.0, 10.0)
 
-# ---------------------------------------------------------------------------
-# Connect-phase retry configuration
-# ---------------------------------------------------------------------------
-
-# Total wall-clock budget (seconds) for the connect-phase retry loop inside
-# _with_connect_retry.  The loop keeps retrying while _is_connect_retryable
-# returns True and the elapsed time is less than this budget.
-#
-# The built-in default is 120 s, which covers the observed Fabric warehouse
-# warm-up window (~60-90 s) with comfortable margin.  It is configurable via
-# the FABRIC_SQL_RETRY_TIMEOUT_S env var or ``fdw config set sql-retry-deadline``.
-#
-# **Trade-off**: a genuinely-wrong credential will now hang up to ~120 s
-# before the AuthError is surfaced to the caller — because the retry loop
-# cannot distinguish "wrong credential" from "warehouse still warming up".
-# This latency is accepted: the warm-up case is far more common in production.
-_SQL_RETRY_DEADLINE_S_DEFAULT: int = 120
-_MIN_SQL_RETRY_DEADLINE_S: int = 1  # minimum accepted value for env / config
-
-# Backwards-compatible alias used by integration tests and the smoke-timeout invariant test.
-# The old name was _CONNECT_RETRY_TIMEOUT_S; it was renamed to _SQL_RETRY_DEADLINE_S_DEFAULT
-# when the value became configurable.  Remove after all callsites are updated.
-_CONNECT_RETRY_TIMEOUT_S: int = _SQL_RETRY_DEADLINE_S_DEFAULT
-
 # Backoff delays for the connect-phase retry loop.  The delay before attempt
 # N+1 is _CONNECT_RETRY_DELAYS[min(N, len-1)], so the sequence is:
 #   attempt 1 → fails → sleep 5 s → attempt 2
@@ -157,188 +155,6 @@ _CONNECT_RETRY_TIMEOUT_S: int = _SQL_RETRY_DEADLINE_S_DEFAULT
 #   attempt 3 → fails → sleep 15 s → attempt 4
 #   attempt 4+ → fails → sleep 15 s → attempt 5 … (capped at 15 s)
 _CONNECT_RETRY_DELAYS: tuple[float, ...] = (5.0, 10.0, 15.0)
-
-# ---------------------------------------------------------------------------
-# Timeout configuration
-# ---------------------------------------------------------------------------
-
-# Login / connection timeout (seconds) passed as the ``timeout`` keyword
-# argument to ``mssql_python.connect()``.  The driver default is 0 (no
-# timeout), which is too permissive for a freshly-warming Fabric warehouse.
-SQL_LOGIN_TIMEOUT_S: int = 60
-
-# Query / command timeout (seconds) applied to every cursor via the
-# ``Connection.timeout`` property setter after a fresh connection is opened.
-# A generous value prevents long-running administrative queries from being
-# cancelled prematurely.
-SQL_QUERY_TIMEOUT_S: int = 300
-
-# ---------------------------------------------------------------------------
-# SQL retry config resolution — 3-layer precedence
-# ---------------------------------------------------------------------------
-# Both knobs resolve at call-time via the 3-layer rule:
-#   env var (highest) > config.toml [defaults] > built-in fallback
-#
-# A module-level cache avoids re-reading the config file on every query.
-# The cache is protected by a threading.Lock (threading is already imported).
-# _sql_config_cache_clear() is a test-only hook to reset the cache between
-# tests that mutate env vars or the config.
-
-from fabric_dw.config import UserConfig as _UserConfig  # noqa: E402
-
-_sql_config_cache: _UserConfig | None = None
-_sql_config_lock: threading.Lock = threading.Lock()
-
-
-def _load_sql_config() -> _UserConfig:
-    """Return a cached :class:`~fabric_dw.config.UserConfig`, loading on first call.
-
-    Uses a module-level cache so the config file is read at most once per
-    process.  Thread-safe via double-checked locking: the fast path (cache
-    already populated) avoids acquiring the lock entirely; the slow path
-    (first call) acquires the lock and re-checks before loading.  Safe
-    because ``_UserConfig`` is a frozen dataclass — once assigned the
-    reference is immutable and visible to all threads after the lock release.
-    """
-    global _sql_config_cache  # noqa: PLW0603
-    # Fast path: check without the lock (common case after first load).
-    if _sql_config_cache is not None:
-        return _sql_config_cache
-    with _sql_config_lock:
-        # Re-check inside the lock to handle a concurrent first-loader.
-        if _sql_config_cache is None:
-            from fabric_dw.config import load_config  # noqa: PLC0415
-
-            _sql_config_cache = load_config()
-        return _sql_config_cache
-
-
-def _sql_config_cache_clear() -> None:
-    """Reset the SQL config cache.  For use in tests only."""
-    global _sql_config_cache  # noqa: PLW0603
-    with _sql_config_lock:
-        _sql_config_cache = None
-
-
-def _validate_sql_retry_deadline_s(value: int, source: str) -> int | None:
-    """Return *value* when it meets the minimum, else log a warning and return None.
-
-    Args:
-        value:  Candidate deadline in seconds (already parsed to int).
-        source: Human-readable label for the origin (e.g. the env-var name or
-                ``"sql_retry_deadline_s (config.toml)"``), used in the warning.
-    """
-    if value >= _MIN_SQL_RETRY_DEADLINE_S:
-        return value
-    _log.warning(
-        "%s=%r must be >= %s; ignoring",
-        source,
-        value,
-        _MIN_SQL_RETRY_DEADLINE_S,
-    )
-    return None
-
-
-def _resolve_sql_retry_deadline_s() -> int:
-    """Return the effective SQL retry deadline in seconds.
-
-    Resolution order (3-layer):
-    1. ``FABRIC_SQL_RETRY_TIMEOUT_S`` env var — must be an integer (or float-formatted
-       integer like ``"120.0"``) >= 1.  Invalid values are ignored (warning logged)
-       and fall through to next layer.
-    2. ``config.toml`` ``[defaults].sql_retry_deadline_s`` — same >= 1 floor applies;
-       values below the minimum are ignored (warning logged) and fall through.
-    3. Built-in fallback: :data:`_SQL_RETRY_DEADLINE_S_DEFAULT` (120 s).
-    """
-    raw_env = os.environ.get("FABRIC_SQL_RETRY_TIMEOUT_S")
-    if raw_env is not None:
-        try:
-            v = int(float(raw_env))
-        except (ValueError, OverflowError):
-            _log.warning("FABRIC_SQL_RETRY_TIMEOUT_S=%r is not a valid integer; ignoring", raw_env)
-        else:
-            result = _validate_sql_retry_deadline_s(v, "FABRIC_SQL_RETRY_TIMEOUT_S")
-            if result is not None:
-                return result
-
-    cfg_val = _load_sql_config().defaults.sql_retry_deadline_s
-    if cfg_val is not None:
-        result = _validate_sql_retry_deadline_s(cfg_val, "sql_retry_deadline_s (config.toml)")
-        if result is not None:
-            return result
-
-    return _SQL_RETRY_DEADLINE_S_DEFAULT
-
-
-# Truthy/falsy string sets for _resolve_sql_retry_executes.
-# Kept inline to avoid importing telemetry's private helpers.
-_FALSY_STRINGS: frozenset[str] = frozenset({"", "0", "false", "no", "off"})
-
-
-def _resolve_sql_retry_executes() -> bool:
-    """Return True if execute-phase retry should be widened to include fetch="none".
-
-    Resolution order (3-layer):
-    1. ``FABRIC_SQL_RETRY_EXECUTES`` env var — falsy: ``{"","0","false","no","off"}``
-       (case-insensitive); anything else is truthy.
-    2. ``config.toml`` ``[defaults].sql_retry_executes``.
-    3. Built-in fallback: ``False`` (non-idempotent DML is not retried by default).
-    """
-    raw_env = os.environ.get("FABRIC_SQL_RETRY_EXECUTES")
-    if raw_env is not None:
-        return raw_env.lower() not in _FALSY_STRINGS
-
-    cfg_val = _load_sql_config().defaults.sql_retry_executes
-    if cfg_val is not None:
-        return cfg_val
-
-    return False
-
-
-# ---------------------------------------------------------------------------
-# Lazy driver import — @functools.cache avoids the module-level global and the
-# PLW0603 noqa suppression.
-# ---------------------------------------------------------------------------
-
-
-@functools.cache
-def _driver() -> types.ModuleType:
-    """Return the ``mssql_python`` module, importing it on first call.
-
-    The result is cached so the import happens at most once per process.
-    Tests can monkeypatch :func:`_get_mssql` instead (kept as alias below).
-    """
-    return importlib.import_module("mssql_python")
-
-
-# Legacy shim used by existing tests / callers that monkeypatch ``_mssql``.
-# We keep it so tests that do ``monkeypatch.setattr(_sql_module, "_mssql", ...)``
-# still work — they write to the module-level name which is checked first.
-_mssql: types.ModuleType | None = None
-
-
-def _get_mssql() -> types.ModuleType:
-    """Return the mssql_python module, preferring the monkeypatched stub.
-
-    Tests that use ``monkeypatch.setattr(_sql_module, "_mssql", mock)`` set
-    ``_mssql`` to a non-None value.  Production code (where ``_mssql`` is
-    ``None``) falls through to the cached :func:`_driver`.
-    """
-    return _mssql if _mssql is not None else _driver()
-
-
-# ODBC connection attribute number for injecting a pre-acquired SQL access token.
-# When set in attrs_before, the driver uses this token instead of its own
-# DefaultAzureCredential chain — critical for long-running CI jobs where the
-# mssql-python driver's own AzureCliCredential assertion expires after ~5 min.
-SQL_COPT_SS_ACCESS_TOKEN: int = 1256
-
-# Mapping from CredentialMode to the ActiveDirectory auth type suffix.
-_MODE_TO_AD_AUTH: dict[CredentialMode, str] = {
-    CredentialMode.DEFAULT: "ActiveDirectoryDefault",
-    CredentialMode.SERVICE_PRINCIPAL: "ActiveDirectoryServicePrincipal",
-    CredentialMode.INTERACTIVE: "ActiveDirectoryInteractive",
-}
 
 # ---------------------------------------------------------------------------
 # Minimal DB-API 2.0 Protocols (for type checking only)
@@ -487,26 +303,6 @@ def tenant_from_connection_string_host(host: object) -> str | None:
         return None
     else:
         return tenant_id
-
-
-# ---------------------------------------------------------------------------
-# Internal connection-string helpers
-# ---------------------------------------------------------------------------
-
-
-def _has_key(connection_string: str, key: str) -> bool:
-    """Return True if *key* is already present in the ODBC connection string."""
-    pattern = re.compile(r"(?:^|;)\s*" + re.escape(key) + r"\s*=", re.IGNORECASE)
-    return bool(pattern.search(connection_string))
-
-
-def _set_key(connection_string: str, key: str, value: str) -> str:
-    """Append *key=value* to *connection_string* if *key* is not already set."""
-    if _has_key(connection_string, key):
-        return connection_string
-    stripped = connection_string.rstrip().rstrip(";")
-    sep = ";" if stripped else ""
-    return f"{stripped}{sep}{key}={value}"
 
 
 # ---------------------------------------------------------------------------
@@ -762,45 +558,6 @@ def _make_pool_key(target: SqlTarget, mode: CredentialMode) -> _PoolKey:
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
-
-
-def build_connection_string(
-    target: SqlTarget,
-    *,
-    mode: CredentialMode = CredentialMode.DEFAULT,
-    use_access_token: bool = False,
-) -> str:
-    """Augment the API-provided connection string with auth, encryption and database settings.
-
-    The operation is idempotent: calling it twice with the same target and mode
-    returns the identical string.
-
-    Args:
-        target: The :class:`SqlTarget` whose ``connection_string`` and ``database``
-            are used as inputs.
-        mode: The credential mode, used to select the ActiveDirectory auth variant.
-            Ignored when ``use_access_token`` is ``True``.
-        use_access_token: When ``True``, omit the ``Authentication=`` key from the
-            connection string.  The caller is responsible for injecting a pre-acquired
-            token via ``attrs_before={SQL_COPT_SS_ACCESS_TOKEN: token_struct}``.
-
-    Returns:
-        The augmented ODBC connection string, ready to pass to the driver.
-    """
-    # The Fabric API returns the warehouse FQDN as a bare hostname with no
-    # "Server=" prefix.  The mssql_python driver requires a proper ODBC key=value
-    # format, so prepend "Server=" when the raw string has no Server key.
-    raw = target.connection_string
-    if not _has_key(raw, "Server"):
-        raw = f"Server={raw}"
-    # Only set the Authentication key when we are NOT injecting a pre-acquired token.
-    # With a token in attrs_before, the Authentication key must be absent — the driver
-    # uses whichever identity source is provided first and having both causes conflicts.
-    if not use_access_token:
-        raw = _set_key(raw, "Authentication", _MODE_TO_AD_AUTH[mode])
-    cs = _set_key(raw, "Encrypt", "yes")
-    cs = _set_key(cs, "TrustServerCertificate", "no")
-    return _set_key(cs, "Database", target.database)
 
 
 def open_connection(

--- a/src/fabric_dw/sql.py
+++ b/src/fabric_dw/sql.py
@@ -73,7 +73,10 @@ from fabric_dw.sql_pool import (
     _driver,  # noqa: F401 (test shim: _sql_module._driver)
     _get_mssql,
     _load_sql_config,
-    _mssql,  # noqa: F401 (test seam: tests retarget to fabric_dw.sql_pool._mssql)
+    # _mssql is the import-time value (None). Patching fabric_dw.sql._mssql is a
+    # silent no-op because _get_mssql() reads _mssql from sql_pool's own globals,
+    # not from sql.py's namespace.  Tests MUST patch fabric_dw.sql_pool._mssql.
+    _mssql,  # noqa: F401 (import-time snapshot; do NOT patch via fabric_dw.sql)
     _resolve_sql_retry_deadline_s,
     _resolve_sql_retry_executes,
     _sql_config_cache_clear,  # noqa: F401 (test hook: _sql_module._sql_config_cache_clear())

--- a/src/fabric_dw/sql_pool.py
+++ b/src/fabric_dw/sql_pool.py
@@ -1,0 +1,313 @@
+"""Connection prerequisites for Microsoft Fabric Data Warehouse SQL connections.
+
+This module holds the stateless helpers and config resolution that are shared
+by :mod:`fabric_dw.sql` (connection pool and query runner).  It has no
+module-global mutable state except the SQL config cache, which is lazily
+populated and protected by a threading lock.
+
+Import graph (no cycle):
+    sql_pool <- {fabric_dw.auth (CredentialMode),
+                 fabric_dw.config (UserConfig, load_config)}
+    sql      <- sql_pool, sql_errors, fabric_dw.auth (get_sql_token_struct)
+
+:class:`~fabric_dw.sql.SqlTarget` is only referenced under ``TYPE_CHECKING``
+in this module (safe because ``fabric_dw.sql`` has
+``from __future__ import annotations``).
+"""
+
+from __future__ import annotations
+
+import functools
+import importlib
+import logging
+import os
+import re
+import threading
+import types
+from typing import TYPE_CHECKING
+
+from fabric_dw.auth import CredentialMode
+from fabric_dw.config import UserConfig as _UserConfig
+
+if TYPE_CHECKING:
+    from fabric_dw.sql import SqlTarget
+
+_log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Timeout configuration
+# ---------------------------------------------------------------------------
+
+# Login / connection timeout (seconds) passed as the ``timeout`` keyword
+# argument to ``mssql_python.connect()``.  The driver default is 0 (no
+# timeout), which is too permissive for a freshly-warming Fabric warehouse.
+SQL_LOGIN_TIMEOUT_S: int = 60
+
+# Query / command timeout (seconds) applied to every cursor via the
+# ``Connection.timeout`` property setter after a fresh connection is opened.
+# A generous value prevents long-running administrative queries from being
+# cancelled prematurely.
+SQL_QUERY_TIMEOUT_S: int = 300
+
+# ---------------------------------------------------------------------------
+# Connect-phase retry configuration
+# ---------------------------------------------------------------------------
+
+# Total wall-clock budget (seconds) for the connect-phase retry loop inside
+# _with_connect_retry.  The loop keeps retrying while _is_connect_retryable
+# returns True and the elapsed time is less than this budget.
+#
+# The built-in default is 120 s, which covers the observed Fabric warehouse
+# warm-up window (~60-90 s) with comfortable margin.  It is configurable via
+# the FABRIC_SQL_RETRY_TIMEOUT_S env var or ``fdw config set sql-retry-deadline``.
+#
+# **Trade-off**: a genuinely-wrong credential will now hang up to ~120 s
+# before the AuthError is surfaced to the caller — because the retry loop
+# cannot distinguish "wrong credential" from "warehouse still warming up".
+# This latency is accepted: the warm-up case is far more common in production.
+_SQL_RETRY_DEADLINE_S_DEFAULT: int = 120
+_MIN_SQL_RETRY_DEADLINE_S: int = 1  # minimum accepted value for env / config
+
+# Backwards-compatible alias used by integration tests and the smoke-timeout invariant test.
+# The old name was _CONNECT_RETRY_TIMEOUT_S; it was renamed to _SQL_RETRY_DEADLINE_S_DEFAULT
+# when the value became configurable.  Remove after all callsites are updated.
+_CONNECT_RETRY_TIMEOUT_S: int = _SQL_RETRY_DEADLINE_S_DEFAULT
+
+# ---------------------------------------------------------------------------
+# SQL config cache — 3-layer config resolution
+# ---------------------------------------------------------------------------
+# Both knobs resolve at call-time via the 3-layer rule:
+#   env var (highest) > config.toml [defaults] > built-in fallback
+#
+# A module-level cache avoids re-reading the config file on every query.
+# The cache is protected by a threading.Lock.
+# _sql_config_cache_clear() is a test-only hook to reset the cache between
+# tests that mutate env vars or the config.
+
+_sql_config_cache: _UserConfig | None = None
+_sql_config_lock: threading.Lock = threading.Lock()
+
+# Truthy/falsy string sets for _resolve_sql_retry_executes and _pool_enabled.
+# Kept inline to avoid importing telemetry's private helpers.
+_FALSY_STRINGS: frozenset[str] = frozenset({"", "0", "false", "no", "off"})
+
+# ---------------------------------------------------------------------------
+# ODBC connection attribute constant
+# ---------------------------------------------------------------------------
+
+# ODBC connection attribute number for injecting a pre-acquired SQL access token.
+# When set in attrs_before, the driver uses this token instead of its own
+# DefaultAzureCredential chain — critical for long-running CI jobs where the
+# mssql-python driver's own AzureCliCredential assertion expires after ~5 min.
+SQL_COPT_SS_ACCESS_TOKEN: int = 1256
+
+# Mapping from CredentialMode to the ActiveDirectory auth type suffix.
+_MODE_TO_AD_AUTH: dict[CredentialMode, str] = {
+    CredentialMode.DEFAULT: "ActiveDirectoryDefault",
+    CredentialMode.SERVICE_PRINCIPAL: "ActiveDirectoryServicePrincipal",
+    CredentialMode.INTERACTIVE: "ActiveDirectoryInteractive",
+}
+
+# ---------------------------------------------------------------------------
+# Config cache helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_sql_config() -> _UserConfig:
+    """Return a cached :class:`~fabric_dw.config.UserConfig`, loading on first call.
+
+    Uses a module-level cache so the config file is read at most once per
+    process.  Thread-safe via double-checked locking: the fast path (cache
+    already populated) avoids acquiring the lock entirely; the slow path
+    (first call) acquires the lock and re-checks before loading.  Safe
+    because ``_UserConfig`` is a frozen dataclass — once assigned the
+    reference is immutable and visible to all threads after the lock release.
+    """
+    global _sql_config_cache  # noqa: PLW0603
+    # Fast path: check without the lock (common case after first load).
+    if _sql_config_cache is not None:
+        return _sql_config_cache
+    with _sql_config_lock:
+        # Re-check inside the lock to handle a concurrent first-loader.
+        if _sql_config_cache is None:
+            from fabric_dw.config import load_config  # noqa: PLC0415
+
+            _sql_config_cache = load_config()
+        return _sql_config_cache
+
+
+def _sql_config_cache_clear() -> None:
+    """Reset the SQL config cache.  For use in tests only."""
+    global _sql_config_cache  # noqa: PLW0603
+    with _sql_config_lock:
+        _sql_config_cache = None
+
+
+# ---------------------------------------------------------------------------
+# SQL retry config resolution
+# ---------------------------------------------------------------------------
+
+
+def _validate_sql_retry_deadline_s(value: int, source: str) -> int | None:
+    """Return *value* when it meets the minimum, else log a warning and return None.
+
+    Args:
+        value:  Candidate deadline in seconds (already parsed to int).
+        source: Human-readable label for the origin (e.g. the env-var name or
+                ``"sql_retry_deadline_s (config.toml)"``), used in the warning.
+    """
+    if value >= _MIN_SQL_RETRY_DEADLINE_S:
+        return value
+    _log.warning(
+        "%s=%r must be >= %s; ignoring",
+        source,
+        value,
+        _MIN_SQL_RETRY_DEADLINE_S,
+    )
+    return None
+
+
+def _resolve_sql_retry_deadline_s() -> int:
+    """Return the effective SQL retry deadline in seconds.
+
+    Resolution order (3-layer):
+    1. ``FABRIC_SQL_RETRY_TIMEOUT_S`` env var — must be an integer (or float-formatted
+       integer like ``"120.0"``) >= 1.  Invalid values are ignored (warning logged)
+       and fall through to next layer.
+    2. ``config.toml`` ``[defaults].sql_retry_deadline_s`` — same >= 1 floor applies;
+       values below the minimum are ignored (warning logged) and fall through.
+    3. Built-in fallback: :data:`_SQL_RETRY_DEADLINE_S_DEFAULT` (120 s).
+    """
+    raw_env = os.environ.get("FABRIC_SQL_RETRY_TIMEOUT_S")
+    if raw_env is not None:
+        try:
+            v = int(float(raw_env))
+        except (ValueError, OverflowError):
+            _log.warning("FABRIC_SQL_RETRY_TIMEOUT_S=%r is not a valid integer; ignoring", raw_env)
+        else:
+            result = _validate_sql_retry_deadline_s(v, "FABRIC_SQL_RETRY_TIMEOUT_S")
+            if result is not None:
+                return result
+
+    cfg_val = _load_sql_config().defaults.sql_retry_deadline_s
+    if cfg_val is not None:
+        result = _validate_sql_retry_deadline_s(cfg_val, "sql_retry_deadline_s (config.toml)")
+        if result is not None:
+            return result
+
+    return _SQL_RETRY_DEADLINE_S_DEFAULT
+
+
+def _resolve_sql_retry_executes() -> bool:
+    """Return True if execute-phase retry should be widened to include fetch="none".
+
+    Resolution order (3-layer):
+    1. ``FABRIC_SQL_RETRY_EXECUTES`` env var — falsy: ``{"","0","false","no","off"}``
+       (case-insensitive); anything else is truthy.
+    2. ``config.toml`` ``[defaults].sql_retry_executes``.
+    3. Built-in fallback: ``False`` (non-idempotent DML is not retried by default).
+    """
+    raw_env = os.environ.get("FABRIC_SQL_RETRY_EXECUTES")
+    if raw_env is not None:
+        return raw_env.lower() not in _FALSY_STRINGS
+
+    cfg_val = _load_sql_config().defaults.sql_retry_executes
+    if cfg_val is not None:
+        return cfg_val
+
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Lazy driver import
+# ---------------------------------------------------------------------------
+
+
+@functools.cache
+def _driver() -> types.ModuleType:
+    """Return the ``mssql_python`` module, importing it on first call.
+
+    The result is cached so the import happens at most once per process.
+    Tests can monkeypatch :func:`_get_mssql` instead (kept as alias below).
+    """
+    return importlib.import_module("mssql_python")
+
+
+# Legacy shim used by existing tests / callers that monkeypatch ``_mssql``.
+# We keep it so tests that do ``monkeypatch.setattr(_sql_pool_module, "_mssql", ...)``
+# still work — they write to the module-level name which is checked first.
+_mssql: types.ModuleType | None = None
+
+
+def _get_mssql() -> types.ModuleType:
+    """Return the mssql_python module, preferring the monkeypatched stub.
+
+    Tests that use ``monkeypatch.setattr(_sql_pool_module, "_mssql", mock)`` set
+    ``_mssql`` to a non-None value.  Production code (where ``_mssql`` is
+    ``None``) falls through to the cached :func:`_driver`.
+    """
+    return _mssql if _mssql is not None else _driver()
+
+
+# ---------------------------------------------------------------------------
+# Internal connection-string helpers
+# ---------------------------------------------------------------------------
+
+
+def _has_key(connection_string: str, key: str) -> bool:
+    """Return True if *key* is already present in the ODBC connection string."""
+    pattern = re.compile(r"(?:^|;)\s*" + re.escape(key) + r"\s*=", re.IGNORECASE)
+    return bool(pattern.search(connection_string))
+
+
+def _set_key(connection_string: str, key: str, value: str) -> str:
+    """Append *key=value* to *connection_string* if *key* is not already set."""
+    if _has_key(connection_string, key):
+        return connection_string
+    stripped = connection_string.rstrip().rstrip(";")
+    sep = ";" if stripped else ""
+    return f"{stripped}{sep}{key}={value}"
+
+
+# ---------------------------------------------------------------------------
+# Connection-string builder
+# ---------------------------------------------------------------------------
+
+
+def build_connection_string(
+    target: SqlTarget,
+    *,
+    mode: CredentialMode = CredentialMode.DEFAULT,
+    use_access_token: bool = False,
+) -> str:
+    """Augment the API-provided connection string with auth, encryption and database settings.
+
+    The operation is idempotent: calling it twice with the same target and mode
+    returns the identical string.
+
+    Args:
+        target: The :class:`SqlTarget` whose ``connection_string`` and ``database``
+            are used as inputs.
+        mode: The credential mode, used to select the ActiveDirectory auth variant.
+            Ignored when ``use_access_token`` is ``True``.
+        use_access_token: When ``True``, omit the ``Authentication=`` key from the
+            connection string.  The caller is responsible for injecting a pre-acquired
+            token via ``attrs_before={SQL_COPT_SS_ACCESS_TOKEN: token_struct}``.
+
+    Returns:
+        The augmented ODBC connection string, ready to pass to the driver.
+    """
+    # The Fabric API returns the warehouse FQDN as a bare hostname with no
+    # "Server=" prefix.  The mssql_python driver requires a proper ODBC key=value
+    # format, so prepend "Server=" when the raw string has no Server key.
+    raw = target.connection_string
+    if not _has_key(raw, "Server"):
+        raw = f"Server={raw}"
+    # Only set the Authentication key when we are NOT injecting a pre-acquired token.
+    # With a token in attrs_before, the Authentication key must be absent — the driver
+    # uses whichever identity source is provided first and having both causes conflicts.
+    if not use_access_token:
+        raw = _set_key(raw, "Authentication", _MODE_TO_AD_AUTH[mode])
+    cs = _set_key(raw, "Encrypt", "yes")
+    cs = _set_key(cs, "TrustServerCertificate", "no")
+    return _set_key(cs, "Database", target.database)

--- a/tests/unit/services/test_sql_exec.py
+++ b/tests/unit/services/test_sql_exec.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 import fabric_dw.sql as _sql_module
+import fabric_dw.sql_pool as _sql_pool_module
 from fabric_dw.exceptions import AuthError, FabricServerError, PermissionDeniedError
 from fabric_dw.models import SqlResult
 from fabric_dw.services import sql_exec
@@ -737,7 +738,7 @@ class TestExecuteLoginRetry:
 
         mock_mssql = MagicMock()
         mock_mssql.connect.side_effect = [auth_exc, auth_exc, good_conn]
-        monkeypatch.setattr(_sql_module, "_mssql", mock_mssql)
+        monkeypatch.setattr(_sql_pool_module, "_mssql", mock_mssql)
 
         result = await sql_exec.execute(_REAL_TARGET, "SELECT 1 AS n")
 
@@ -772,7 +773,7 @@ class TestExecuteLoginRetry:
 
         mock_mssql = MagicMock()
         mock_mssql.connect.side_effect = auth_exc
-        monkeypatch.setattr(_sql_module, "_mssql", mock_mssql)
+        monkeypatch.setattr(_sql_pool_module, "_mssql", mock_mssql)
 
         with pytest.raises(AuthError, match="authentication failed"):
             await sql_exec.execute(_REAL_TARGET, "SELECT 1")
@@ -795,7 +796,7 @@ class TestExecuteLoginRetry:
 
         mock_mssql = MagicMock()
         mock_mssql.connect.side_effect = non_retryable
-        monkeypatch.setattr(_sql_module, "_mssql", mock_mssql)
+        monkeypatch.setattr(_sql_pool_module, "_mssql", mock_mssql)
 
         with pytest.raises(Exception, match="unexpected driver"):
             await sql_exec.execute(_REAL_TARGET, "SELECT 1")
@@ -817,7 +818,7 @@ class TestExecuteLoginRetry:
 
         mock_mssql = MagicMock()
         mock_mssql.connect.return_value = good_conn
-        monkeypatch.setattr(_sql_module, "_mssql", mock_mssql)
+        monkeypatch.setattr(_sql_pool_module, "_mssql", mock_mssql)
 
         await sql_exec.execute(_REAL_TARGET, "SELECT 1 AS n")
 

--- a/tests/unit/test_sql.py
+++ b/tests/unit/test_sql.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock
 import pytest
 
 import fabric_dw.sql as _sql_module
+import fabric_dw.sql_pool as _sql_pool_module
 from fabric_dw.auth import CredentialMode
 from fabric_dw.config import Defaults, UserConfig
 from fabric_dw.exceptions import AuthError, FabricServerError, NotFoundError, PermissionDeniedError
@@ -57,8 +58,14 @@ def _make_mock_mssql() -> tuple[MagicMock, MagicMock, MagicMock]:
 
 
 def _patch_mssql(monkeypatch: pytest.MonkeyPatch, mock_mssql: MagicMock) -> None:
-    """Replace the _mssql attribute on sql module with the mock."""
-    monkeypatch.setattr(_sql_module, "_mssql", mock_mssql)
+    """Replace the _mssql attribute on sql_pool module with the mock.
+
+    _mssql is now defined in fabric_dw.sql_pool; _get_mssql() reads it from
+    sql_pool's globals.  Patching sql.py's re-export binding would be a no-op
+    because _get_mssql checks the sql_pool-module-level name, not the sql.py
+    binding.
+    """
+    monkeypatch.setattr(_sql_pool_module, "_mssql", mock_mssql)
 
 
 # ---------------------------------------------------------------------------
@@ -2653,7 +2660,7 @@ class TestFetchBeforeCommitOrdering:
         fake_conn = _CommitInvalidatingConnection(description, rows)
         mock_mssql = MagicMock()
         mock_mssql.connect.return_value = fake_conn
-        monkeypatch.setattr(_sql_module, "_mssql", mock_mssql)
+        monkeypatch.setattr(_sql_pool_module, "_mssql", mock_mssql)
         return fake_conn
 
     def test_fetch_all_commit_true_returns_rows(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -2779,7 +2786,7 @@ class TestFetchRowcountMode:
         fake_conn = _RowcountConnection(rowcount)
         mock_mssql = MagicMock()
         mock_mssql.connect.return_value = fake_conn
-        monkeypatch.setattr(_sql_module, "_mssql", mock_mssql)
+        monkeypatch.setattr(_sql_pool_module, "_mssql", mock_mssql)
         return fake_conn
 
     def test_rowcount_returns_count_tuple(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -2890,7 +2897,7 @@ class TestFetchAllDescriptionNoneGuard:
         fake_conn = _NoResultSetConnection()
         mock_mssql = MagicMock()
         mock_mssql.connect.return_value = fake_conn
-        monkeypatch.setattr(_sql_module, "_mssql", mock_mssql)
+        monkeypatch.setattr(_sql_pool_module, "_mssql", mock_mssql)
         return fake_conn
 
     def test_fetch_all_description_none_returns_empty(
@@ -2953,7 +2960,7 @@ class TestSqlRetryConfig:
     def test_deadline_config_wins_over_default(self) -> None:
         """Config sql_retry_deadline_s beats the built-in 120 default."""
         cfg = UserConfig(defaults=Defaults(sql_retry_deadline_s=250))
-        _sql_module._sql_config_cache = cfg
+        _sql_pool_module._sql_config_cache = cfg
         assert _sql_module._resolve_sql_retry_deadline_s() == 250
 
     def test_deadline_falls_back_to_default(self) -> None:
@@ -2984,19 +2991,19 @@ class TestSqlRetryConfig:
         """Invalid env var falls through to config value."""
         monkeypatch.setenv("FABRIC_SQL_RETRY_TIMEOUT_S", "bad")
         cfg = UserConfig(defaults=Defaults(sql_retry_deadline_s=88))
-        _sql_module._sql_config_cache = cfg
+        _sql_pool_module._sql_config_cache = cfg
         assert _sql_module._resolve_sql_retry_deadline_s() == 88
 
     def test_deadline_config_zero_floored_to_default(self) -> None:
         """A config.toml sql_retry_deadline_s of 0 is rejected and falls through to default."""
         cfg = UserConfig(defaults=Defaults(sql_retry_deadline_s=0))
-        _sql_module._sql_config_cache = cfg
+        _sql_pool_module._sql_config_cache = cfg
         assert _sql_module._resolve_sql_retry_deadline_s() == 120
 
     def test_deadline_config_below_min_floored_to_default(self) -> None:
         """A config.toml sql_retry_deadline_s below the minimum is rejected and falls through."""
         cfg = UserConfig(defaults=Defaults(sql_retry_deadline_s=-5))
-        _sql_module._sql_config_cache = cfg
+        _sql_pool_module._sql_config_cache = cfg
         # -5 < _MIN_SQL_RETRY_DEADLINE_S, so the built-in default is used
         assert _sql_module._resolve_sql_retry_deadline_s() == 120
 
@@ -3004,7 +3011,7 @@ class TestSqlRetryConfig:
         """A config.toml sql_retry_deadline_s at or above the minimum is returned as-is."""
         min_val = _sql_module._MIN_SQL_RETRY_DEADLINE_S
         cfg = UserConfig(defaults=Defaults(sql_retry_deadline_s=min_val))
-        _sql_module._sql_config_cache = cfg
+        _sql_pool_module._sql_config_cache = cfg
         assert _sql_module._resolve_sql_retry_deadline_s() == min_val
 
     def test_executes_env_wins_over_config_and_default(
@@ -3018,13 +3025,13 @@ class TestSqlRetryConfig:
         """FABRIC_SQL_RETRY_EXECUTES=false → False."""
         monkeypatch.setenv("FABRIC_SQL_RETRY_EXECUTES", "false")
         cfg = UserConfig(defaults=Defaults(sql_retry_executes=True))
-        _sql_module._sql_config_cache = cfg
+        _sql_pool_module._sql_config_cache = cfg
         assert _sql_module._resolve_sql_retry_executes() is False
 
     def test_executes_config_wins_over_default(self) -> None:
         """Config sql_retry_executes=True beats the built-in False default."""
         cfg = UserConfig(defaults=Defaults(sql_retry_executes=True))
-        _sql_module._sql_config_cache = cfg
+        _sql_pool_module._sql_config_cache = cfg
         assert _sql_module._resolve_sql_retry_executes() is True
 
     def test_executes_falls_back_to_false(self) -> None:
@@ -3130,14 +3137,14 @@ class TestPoolEnabledConfig:
         """FABRIC_CONN_POOLING=0 disables pooling even when config says True."""
         monkeypatch.setenv("FABRIC_CONN_POOLING", "0")
         cfg = UserConfig(defaults=Defaults(conn_pooling=True))
-        _sql_module._sql_config_cache = cfg
+        _sql_pool_module._sql_config_cache = cfg
         assert _sql_module._pool_enabled() is False
 
     def test_env_one_enables_pool(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """FABRIC_CONN_POOLING=1 enables pooling even when config says False."""
         monkeypatch.setenv("FABRIC_CONN_POOLING", "1")
         cfg = UserConfig(defaults=Defaults(conn_pooling=False))
-        _sql_module._sql_config_cache = cfg
+        _sql_pool_module._sql_config_cache = cfg
         assert _sql_module._pool_enabled() is True
 
     def test_env_false_string_disables_pool(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -3187,14 +3194,14 @@ class TestPoolEnabledConfig:
         """Config conn_pooling=False disables pooling when env var is absent."""
         monkeypatch.delenv("FABRIC_CONN_POOLING", raising=False)
         cfg = UserConfig(defaults=Defaults(conn_pooling=False))
-        _sql_module._sql_config_cache = cfg
+        _sql_pool_module._sql_config_cache = cfg
         assert _sql_module._pool_enabled() is False
 
     def test_config_true_enables_pool(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Config conn_pooling=True enables pooling when env var is absent."""
         monkeypatch.delenv("FABRIC_CONN_POOLING", raising=False)
         cfg = UserConfig(defaults=Defaults(conn_pooling=True))
-        _sql_module._sql_config_cache = cfg
+        _sql_pool_module._sql_config_cache = cfg
         assert _sql_module._pool_enabled() is True
 
     def test_falls_back_to_true_when_no_env_no_config(
@@ -3209,14 +3216,14 @@ class TestPoolEnabledConfig:
         """Config conn_pooling=None (unset) falls through to the built-in True default."""
         monkeypatch.delenv("FABRIC_CONN_POOLING", raising=False)
         cfg = UserConfig(defaults=Defaults(conn_pooling=None))
-        _sql_module._sql_config_cache = cfg
+        _sql_pool_module._sql_config_cache = cfg
         assert _sql_module._pool_enabled() is True
 
     def test_env_wins_over_config_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """FABRIC_CONN_POOLING=1 wins over config conn_pooling=False."""
         monkeypatch.setenv("FABRIC_CONN_POOLING", "1")
         cfg = UserConfig(defaults=Defaults(conn_pooling=False))
-        _sql_module._sql_config_cache = cfg
+        _sql_pool_module._sql_config_cache = cfg
         assert _sql_module._pool_enabled() is True
 
 


### PR DESCRIPTION
## Summary

- Creates `src/fabric_dw/sql_pool.py` as a new leaf module holding the stateless connection prerequisites that were previously in `sql.py`: the driver import machinery (`_driver`, `_mssql`, `_get_mssql`), connection-string helpers (`_has_key`, `_set_key`, `_MODE_TO_AD_AUTH`, `build_connection_string`), ODBC constants (`SQL_COPT_SS_ACCESS_TOKEN`, `SQL_LOGIN_TIMEOUT_S`, `SQL_QUERY_TIMEOUT_S`), and the full config-resolution layer (`_load_sql_config`, `_sql_config_cache`, `_sql_config_cache_clear`, `_resolve_sql_retry_deadline_s`, `_resolve_sql_retry_executes`, and related constants).
- The connection pool (`_pool`, `_PooledConnection`, `open_connection`, `reset_pool`) and query runner (`run_query`, `run_statements`, `_with_connect_retry`) remain in `sql.py` to be moved in PR D.
- Re-export shims in `sql.py` preserve the full public surface and all bare-name calls inside the code that stays, so no callers outside the module change.

## Import graph (no cycle)

```
sql_pool  <-  fabric_dw.auth (CredentialMode)
          <-  fabric_dw.config (UserConfig, load_config)
sql       <-  sql_pool, sql_errors, fabric_dw.auth (get_sql_token_struct)
```

`SqlTarget` is imported in `sql_pool` only under `TYPE_CHECKING` (safe because `sql.py` has `from __future__ import annotations`).

## Retargeted test patch sites

The following patch targets were changed because the relevant symbol is now defined in `sql_pool.py` and read by functions that also live there - patching the `sql.py` re-export binding would be a silent no-op:

| Old patch target | New patch target | Reason |
|---|---|---|
| `fabric_dw.sql._mssql` (3 direct `setattr` calls in `test_sql.py`, 4 in `test_sql_exec.py`, plus the `_patch_mssql` helper) | `fabric_dw.sql_pool._mssql` | `_get_mssql()` reads `_mssql` from `sql_pool`'s globals |
| `_sql_module._sql_config_cache = cfg` (13 assignments in `TestSqlRetryConfig` and `TestPoolEnabled`) | `_sql_pool_module._sql_config_cache = cfg` | `_resolve_sql_retry_deadline_s`, `_resolve_sql_retry_executes`, and `_pool_enabled` all call `_load_sql_config()` which reads from `sql_pool`'s `_sql_config_cache` |

All other test accesses (`_sql_module._SQL_RETRY_DEADLINE_S_DEFAULT`, `_resolve_sql_retry_*()`, `_sql_config_cache_clear()`, `_CONNECT_RETRY_TIMEOUT_S`, etc.) route through the shim re-exports and require no change.

The `conftest.py` autouse fixture (`_sql_module._sql_config_cache_clear()`) also continues to work without change: the shim in `sql.py` imports the same function object from `sql_pool`, so calling it via `_sql_module` still clears `sql_pool`'s real cache.

## Test results

- Full unit suite: 5123 passed, 0 failed
- `ruff check`: clean
- `ruff format --check`: clean
- `ty check`: clean
- No import cycle: `sql_pool` imports only `{fabric_dw.auth, fabric_dw.config}` at runtime

Part of #828

🤖 Generated with [Claude Code](https://claude.com/claude-code)