### PR TITLE
refactor(sql): move connection pool and open_connection into sql_pool

### DIFF
--- a/src/fabric_dw/sql.py
+++ b/src/fabric_dw/sql.py
@@ -43,16 +43,13 @@ connections are drained on server shutdown.
 
 from __future__ import annotations
 
-import contextlib
 import logging
-import os
-import threading
 import time
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any, Literal, Protocol
 
-from fabric_dw.auth import CredentialMode, get_sql_token_struct
+from fabric_dw.auth import CredentialMode
 from fabric_dw.sql_errors import (
     _clean_driver_error_message,  # noqa: F401 (test shim: _sql_module._clean_driver_error_message)
     _is_connect_retryable,
@@ -64,24 +61,49 @@ from fabric_dw.sql_errors import (
 )
 from fabric_dw.sql_pool import (
     _CONNECT_RETRY_TIMEOUT_S,  # noqa: F401 (backwards-compat alias; read by integration smoke)
-    _FALSY_STRINGS,
+    _FALSY_STRINGS,  # noqa: F401 (backwards-compat alias)
     _MIN_SQL_RETRY_DEADLINE_S,  # noqa: F401 (test shim: _sql_module._MIN_SQL_RETRY_DEADLINE_S)
     _SQL_RETRY_DEADLINE_S_DEFAULT,  # noqa: F401 (test shim: _sql_module._SQL_RETRY_DEADLINE_S_DEFAULT)
+    POOL_MAX_IDLE,
+    # POOL_MAX_IDLE is read from sql_pool.py's globals by _pool_checkout/_pool_checkin.
+    # Tests that SET POOL_MAX_IDLE to change pool capacity MUST target
+    # fabric_dw.sql_pool.POOL_MAX_IDLE — setting fabric_dw.sql.POOL_MAX_IDLE is a
+    # silent no-op for those callers.
+    POOL_MAX_IDLE_SECS,
     SQL_COPT_SS_ACCESS_TOKEN,
     SQL_LOGIN_TIMEOUT_S,
     SQL_QUERY_TIMEOUT_S,
     _driver,  # noqa: F401 (test shim: _sql_module._driver)
-    _get_mssql,
-    _load_sql_config,
+    _get_mssql,  # noqa: F401 (test shim)
+    _is_alive,  # noqa: F401 (backwards-compat alias)
+    _load_sql_config,  # noqa: F401 (test shim)
+    _make_pool_key,  # noqa: F401 (backwards-compat alias)
     # _mssql is the import-time value (None). Patching fabric_dw.sql._mssql is a
     # silent no-op because _get_mssql() reads _mssql from sql_pool's own globals,
     # not from sql.py's namespace.  Tests MUST patch fabric_dw.sql_pool._mssql.
     _mssql,  # noqa: F401 (import-time snapshot; do NOT patch via fabric_dw.sql)
+    _pool,  # noqa: F401 (test access: from fabric_dw.sql import _pool; same object as sql_pool._pool)
+    _pool_checkin,  # noqa: F401 (backwards-compat alias)
+    _pool_checkout,  # noqa: F401 (backwards-compat alias)
+    # _pool_enabled is called by bare name via _PooledConnection.close() and
+    # open_connection — both live in sql_pool.py.  Patching fabric_dw.sql._pool_enabled
+    # is a silent no-op for those callers.  Tests that call _pool_enabled() directly
+    # via _sql_module._pool_enabled() call the function (which executes in sql_pool
+    # context) and get the correct result — the function reference is the same object.
+    _pool_enabled,  # noqa: F401 (test access via _sql_module._pool_enabled())
+    _pool_lock,  # noqa: F401 (test access: from fabric_dw.sql import _pool_lock; same object)
+    # _pool_time is called by bare name inside _pool_checkout/_pool_checkin, both in
+    # sql_pool.py.  Tests that patch _pool_time MUST target fabric_dw.sql_pool._pool_time
+    # — patching fabric_dw.sql._pool_time is a silent no-op for those callers.
+    _pool_time,  # noqa: F401 (import-time snapshot; do NOT patch via fabric_dw.sql)
+    _PooledConnection,
     _resolve_sql_retry_deadline_s,
     _resolve_sql_retry_executes,
     _sql_config_cache_clear,  # noqa: F401 (test hook: _sql_module._sql_config_cache_clear())
     _validate_sql_retry_deadline_s,  # noqa: F401 (test shim: _sql_module._validate_sql_retry_deadline_s)
     build_connection_string,
+    open_connection,
+    reset_pool,
 )
 
 # Re-export shims rationale (two groups):
@@ -96,9 +118,15 @@ from fabric_dw.sql_pool import (
 #
 # sql_pool shims: all names that were defined here but now live in sql_pool.py.
 # Importing them preserves the public surface (`from fabric_dw.sql import
-# build_connection_string`), bare-name calls inside open_connection /
-# _pool_enabled / _with_connect_retry / run_query, and test accesses such as
+# build_connection_string`), bare-name calls inside _with_connect_retry /
+# run_query / run_statements, and test accesses such as
 # `_sql_module._SQL_RETRY_DEADLINE_S_DEFAULT`.
+#
+# IMPORTANT — silent no-ops (do NOT patch via fabric_dw.sql):
+#   _mssql        — tests MUST patch fabric_dw.sql_pool._mssql
+#   _pool_time    — tests MUST patch fabric_dw.sql_pool._pool_time
+#   POOL_MAX_IDLE — tests that SET this MUST target fabric_dw.sql_pool.POOL_MAX_IDLE
+#
 # _sql_config_cache and _sql_config_lock are intentionally NOT re-exported:
 # they are mutable state owned by sql_pool; tests that must inject a cached
 # config value target fabric_dw.sql_pool._sql_config_cache directly.
@@ -306,357 +334,6 @@ def tenant_from_connection_string_host(host: object) -> str | None:
         return None
     else:
         return tenant_id
-
-
-# ---------------------------------------------------------------------------
-# Connection pool
-# ---------------------------------------------------------------------------
-
-# Pool configuration constants — override at module level before first use.
-# Pooling is controlled by _pool_enabled() which resolves: env var FABRIC_CONN_POOLING
-# (falsy: "0"/"false"/"no"/"off"; empty/whitespace → absent) > config.toml
-# [defaults].conn_pooling > built-in default on.
-POOL_MAX_IDLE: int = 4
-"""Maximum number of idle connections kept per ``(workspace_id, database, mode)`` key."""
-
-POOL_MAX_IDLE_SECS: float = 300.0
-"""Maximum age (seconds) of an idle connection before eviction on next checkout."""
-
-# Pool key type: (workspace_id, database, mode_value)
-_PoolKey = tuple[str, str, str]
-
-# Each slot stores (underlying_connection, last_used_monotonic_timestamp).
-_PoolSlot = tuple[Any, float]
-
-# The pool: key -> LIFO stack of idle slots (top = last element).
-_pool: dict[_PoolKey, list[_PoolSlot]] = {}
-_pool_lock = threading.Lock()
-
-
-def _pool_enabled() -> bool:
-    """Return True when connection pooling is active.
-
-    Resolution order (3-layer):
-    1. ``FABRIC_CONN_POOLING`` env var — read at call-time so tests can toggle
-       it without reimporting the module.  Only a non-empty, non-whitespace
-       value is honoured; an empty or whitespace-only value (e.g. a Docker
-       ``ENV FABRIC_CONN_POOLING=`` placeholder) is treated as absent and falls
-       through to the next layer.  Accepted disable values: ``"0"``,
-       ``"false"``, ``"no"``, ``"off"`` (case-insensitive).  Any other
-       non-empty string keeps pooling enabled.
-    2. ``config.toml`` ``[defaults].conn_pooling`` — consulted via the existing
-       memoised :func:`_load_sql_config` cache (never calls load_config()
-       per call).
-    3. Built-in default: ``True`` (pooling on).
-    """
-    raw_env = os.environ.get("FABRIC_CONN_POOLING")
-    if raw_env is not None:
-        stripped = raw_env.strip()
-        if stripped:
-            # Non-empty value — honour it (falsy set disables, anything else enables).
-            return stripped.lower() not in _FALSY_STRINGS
-        # Empty / whitespace-only — treat as absent; fall through to config/default.
-
-    cfg_val = _load_sql_config().defaults.conn_pooling
-    if cfg_val is not None:
-        return cfg_val
-
-    return True
-
-
-def _pool_time() -> float:
-    """Return the current monotonic clock value.
-
-    Isolated so tests can monkeypatch it to inject a deterministic clock
-    without affecting ``time.monotonic`` globally.
-    """
-    return time.monotonic()
-
-
-def _is_alive(conn: Any) -> bool:  # noqa: ANN401
-    """Return True if *conn* appears usable.
-
-    Checks the ``closed`` attribute when it is an ``int`` or ``bool`` (the
-    DB-API convention: 0 = open).  Ignores the attribute when it is not a
-    plain numeric value so that mock objects without an explicit ``closed``
-    attribute are treated as alive.
-    """
-    closed = getattr(conn, "closed", None)
-    # Only trust closed when it is a real int/bool; ignore Mock objects, etc.
-    if not isinstance(closed, (int, bool)):
-        return True
-    return not bool(closed)
-
-
-def reset_pool() -> None:
-    """Drain and physically close every pooled connection.
-
-    Call this on graceful shutdown (e.g. from the MCP server lifespan teardown,
-    a CLI ``finally`` block, or a pytest fixture teardown).  Safe to call
-    multiple times and from any thread.
-    """
-    with _pool_lock:
-        to_close: list[Any] = []
-        for slots in _pool.values():
-            while slots:
-                conn, _ts = slots.pop()
-                to_close.append(conn)
-        _pool.clear()
-    # Close outside the lock so slow I/O does not block other threads.
-    for conn in to_close:
-        with contextlib.suppress(Exception):
-            conn.close()
-
-
-def _pool_checkout(key: _PoolKey) -> Any | None:  # noqa: ANN401
-    """Pop and return a live, non-expired connection from the pool, or ``None``.
-
-    Expired or dead connections are discarded (physically closed) during the
-    search.  The pop is from the end of the list (LIFO - most recently used).
-    """
-    now = _pool_time()
-    deadline = POOL_MAX_IDLE_SECS
-    to_discard: list[Any] = []
-    result: Any = None
-
-    with _pool_lock:
-        slots = _pool.get(key)
-        if not slots:
-            return None
-        # Pop from the top (LIFO) until we find a usable slot.
-        while slots:
-            conn, last_used = slots.pop()
-            if now - last_used > deadline or not _is_alive(conn):
-                to_discard.append(conn)
-                continue
-            result = conn
-            break
-
-    # Close discarded connections outside the lock (may be slow I/O).
-    for dead in to_discard:
-        with contextlib.suppress(Exception):
-            dead.close()
-
-    return result
-
-
-def _pool_checkin(key: _PoolKey, conn: Any) -> None:  # noqa: ANN401
-    """Return *conn* to the pool if there is room, else physically close it.
-
-    Also evicts expired or dead connections from the entire slot list on
-    every checkin (D06 fix) so stale bottom-layer connections do not linger
-    indefinitely even when only the top of the LIFO stack is ever reused.
-    """
-    now = _pool_time()
-    deadline = POOL_MAX_IDLE_SECS
-    to_close: list[Any] = []
-
-    with _pool_lock:
-        slots = _pool.setdefault(key, [])
-        # Sweep the whole list for expired / dead entries before deciding
-        # whether to add the incoming connection.  Iterate in reverse to
-        # pop-in-place safely; build a new list to avoid O(n²) pops.
-        live: list[_PoolSlot] = []
-        for slot_conn, last_used in slots:
-            if now - last_used > deadline or not _is_alive(slot_conn):
-                to_close.append(slot_conn)
-            else:
-                live.append((slot_conn, last_used))
-        slots[:] = live
-
-        if len(slots) >= POOL_MAX_IDLE:
-            to_close.append(conn)
-        else:
-            slots.append((conn, now))
-
-    for dead in to_close:
-        with contextlib.suppress(Exception):
-            dead.close()
-
-
-# ---------------------------------------------------------------------------
-# Pooled connection wrapper
-# ---------------------------------------------------------------------------
-
-
-class _PooledConnection:
-    """Thin wrapper that intercepts ``.close()`` to return the connection to the pool.
-
-    When ``.close()`` is called:
-    - If ``_discard`` is ``True`` (set after a failed query), the underlying
-      connection is physically closed and NOT returned to the pool.
-    - If pooling is disabled (``_pool_enabled()`` returns ``False``), the
-      underlying connection is physically closed.
-    - Otherwise the underlying connection is returned to the pool for reuse.
-
-    All other method calls are forwarded verbatim to the underlying connection,
-    so callers need not change any code.
-    """
-
-    def __init__(self, underlying: Any, key: _PoolKey) -> None:  # noqa: ANN401
-        self._underlying = underlying
-        self._key = key
-        # Set to True after an exception during execute so that the connection
-        # is NOT returned to the pool (unknown transaction state).
-        self._discard: bool = False
-        # Guard against double-close (e.g. explicit close in retry path + outer
-        # finally).  Once True, subsequent close() calls are no-ops.
-        self._closed: bool = False
-
-    # ------------------------------------------------------------------ #
-    # Forward _Connection protocol methods to the underlying object.      #
-    # ------------------------------------------------------------------ #
-
-    def cursor(self) -> Any:  # noqa: ANN401
-        return self._underlying.cursor()
-
-    def commit(self) -> None:
-        self._underlying.commit()
-
-    def rollback(self) -> None:
-        self._underlying.rollback()
-
-    def mark_discard(self) -> None:
-        """Mark this connection for physical close instead of pool return.
-
-        Call after any error that leaves the connection in an unknown state
-        (e.g. mid-execute failure, open transaction with unknown content).
-        Once marked, ``.close()`` physically closes the underlying socket and
-        does NOT return it to the pool.
-        """
-        self._discard = True
-
-    def close(self) -> None:
-        """Return to pool or physically close, depending on state and config.
-
-        Idempotent: a second call is a no-op.  This prevents the underlying TDS
-        socket from receiving ``close()`` twice when the execute-retry path
-        calls ``conn.close()`` explicitly and the outer ``finally`` also closes.
-
-        Before returning to the pool, any open implicit transaction is rolled
-        back so the next caller starts with a clean transaction state.
-        """
-        if self._closed:
-            return
-        self._closed = True
-        if self._discard or not _pool_enabled():
-            self._underlying.close()
-        else:
-            # Roll back any open implicit transaction before pool return so
-            # the next lender starts with a clean state (D23).
-            with contextlib.suppress(Exception):
-                self._underlying.rollback()
-            _pool_checkin(self._key, self._underlying)
-
-    # Convenience accessor used by pool-specific tests.
-    @property
-    def _raw(self) -> Any:  # noqa: ANN401
-        return self._underlying
-
-
-def _make_pool_key(target: SqlTarget, mode: CredentialMode) -> _PoolKey:
-    return (target.workspace_id, target.database, mode.value)
-
-
-# ---------------------------------------------------------------------------
-# Public API
-# ---------------------------------------------------------------------------
-
-
-def open_connection(
-    target: SqlTarget,
-    *,
-    mode: CredentialMode = CredentialMode.DEFAULT,
-    autocommit: bool = False,
-) -> _Connection:
-    """Return a connection to the target warehouse, reusing a pooled one when available.
-
-    The returned object satisfies the :class:`_Connection` protocol.  Its
-    ``.close()`` method returns the connection to the pool (when pooling is
-    enabled and the connection is healthy) rather than physically closing the
-    socket.  Callers do **not** need to change - the ``contextlib.closing``
-    pattern works unchanged.
-
-    When pooling is disabled (``_pool_enabled()`` returns ``False``, controlled
-    via the ``FABRIC_CONN_POOLING`` env var, ``config.toml [defaults] conn_pooling``,
-    or the built-in default on) every call opens a fresh physical connection
-    and ``.close()`` physically closes it.
-
-    When ``autocommit=True``, the ODBC driver does **not** wrap each statement
-    in an explicit ``BEGIN TRANSACTION`` / ``COMMIT`` pair.  This is required
-    for DDL statements that SQL Server disallows inside a transaction (e.g.
-    ``ALTER DATABASE``).  Autocommit connections are **never** pooled — they
-    are always opened fresh and physically closed on ``.close()``.
-
-    This function is intentionally synchronous.  Callers that need to keep the
-    event loop free should wrap the entire sync block in ``asyncio.to_thread``.
-
-    Args:
-        target: The :class:`SqlTarget` identifying the warehouse.
-        mode: The credential mode for Entra authentication.
-        autocommit: When ``True``, open the connection with ODBC-level
-            autocommit enabled.  Defaults to ``False``.  Autocommit connections
-            bypass the pool entirely.
-
-    Returns:
-        A :class:`_PooledConnection` wrapping a DB-API 2.0 connection from
-        the ``mssql_python`` driver.
-    """
-    # Autocommit connections bypass the pool entirely to avoid cross-contaminating
-    # a pooled autocommit=False connection with autocommit=True semantics or vice
-    # versa.  They are always opened fresh and physically closed after use.
-    if autocommit:
-        # Acquire a token struct when running under GitHub OIDC.  This bypasses the
-        # mssql-python driver's own DefaultAzureCredential chain (which uses
-        # AzureCliCredential whose GitHub OIDC assertion expires after ~5 min) in
-        # favour of our self-refreshing credential whose _fetch_github_oidc_jwt
-        # always obtains a fresh assertion.
-        token_struct = get_sql_token_struct(mode)
-        use_token = token_struct is not None
-        cs = build_connection_string(target, mode=mode, use_access_token=use_token)
-        attrs: dict[int, bytes] | None = (
-            {SQL_COPT_SS_ACCESS_TOKEN: token_struct} if use_token else None
-        )
-        raw_conn: Any = _get_mssql().connect(
-            cs, autocommit=True, attrs_before=attrs, timeout=SQL_LOGIN_TIMEOUT_S
-        )
-        # Sets query timeout on all *future* cursors (Connection.timeout.setter stores
-        # the value; each cursor.__init__ reads it via _set_timeout()).  Safe here
-        # because every cursor in this codebase is acquired after open_connection()
-        # returns — no caller holds a cursor across connection open.
-        raw_conn.timeout = SQL_QUERY_TIMEOUT_S
-        # Wrap in _PooledConnection with a sentinel key; mark_discard() ensures
-        # .close() physically closes the connection rather than pooling it.
-        key = _make_pool_key(target, mode)
-        wrapped = _PooledConnection(raw_conn, key)
-        wrapped.mark_discard()
-        return wrapped
-
-    key = _make_pool_key(target, mode)
-
-    if _pool_enabled():
-        cached = _pool_checkout(key)
-        if cached is not None:
-            # Pool HIT — return the cached connection without acquiring a token.
-            # Checked-out connections are already authenticated; acquiring a token
-            # here would invoke credential.get_token() (holding azure-identity's
-            # token-cache lock) and then discard the result — pure waste.
-            return _PooledConnection(cached, key)
-
-    # Pool MISS (or pooling disabled) — open a new physical connection.
-    # Only now do we acquire the OIDC token struct, so the credential is never
-    # consulted on pool-hit paths.
-    token_struct = get_sql_token_struct(mode)
-    use_token = token_struct is not None
-    cs = build_connection_string(target, mode=mode, use_access_token=use_token)
-    attrs = {SQL_COPT_SS_ACCESS_TOKEN: token_struct} if use_token else None
-    raw_conn = _get_mssql().connect(cs, attrs_before=attrs, timeout=SQL_LOGIN_TIMEOUT_S)
-    # Sets query timeout on all *future* cursors (Connection.timeout.setter stores
-    # the value; each cursor.__init__ reads it via _set_timeout()).  Safe here
-    # because every cursor in this codebase is acquired after open_connection()
-    # returns — no caller holds a cursor across connection open.
-    raw_conn.timeout = SQL_QUERY_TIMEOUT_S
-    return _PooledConnection(raw_conn, key)
 
 
 # ---------------------------------------------------------------------------

--- a/src/fabric_dw/sql_pool.py
+++ b/src/fabric_dw/sql_pool.py
@@ -11,7 +11,9 @@ Module-global mutable state:
 Import graph (no cycle):
     sql_pool <- {fabric_dw.auth (CredentialMode, get_sql_token_struct),
                  fabric_dw.config (UserConfig, load_config)}
-    sql      <- sql_pool, sql_errors, fabric_dw.auth (get_sql_token_struct)
+    sql      <- sql_pool, sql_errors
+    (sql no longer imports fabric_dw.auth directly; get_sql_token_struct lives
+    in sql_pool alongside open_connection which calls it)
 
 :class:`~fabric_dw.sql.SqlTarget` is only referenced under ``TYPE_CHECKING``
 in this module (safe because ``fabric_dw.sql`` has

--- a/src/fabric_dw/sql_pool.py
+++ b/src/fabric_dw/sql_pool.py
@@ -1,12 +1,15 @@
-"""Connection prerequisites for Microsoft Fabric Data Warehouse SQL connections.
+"""Connection pool and prerequisites for Microsoft Fabric Data Warehouse SQL connections.
 
-This module holds the stateless helpers and config resolution that are shared
-by :mod:`fabric_dw.sql` (connection pool and query runner).  It has no
-module-global mutable state except the SQL config cache, which is lazily
-populated and protected by a threading lock.
+This module holds the stateless helpers, config resolution, connection pool
+implementation, and ``open_connection`` that are shared by or exposed via
+:mod:`fabric_dw.sql` (query runner, ``SqlTarget``).
+
+Module-global mutable state:
+- ``_sql_config_cache`` — SQL config cache; thread-safe, cleared by ``_sql_config_cache_clear()``.
+- ``_pool`` / ``_pool_lock`` — per-key LIFO connection pool; thread-safe.
 
 Import graph (no cycle):
-    sql_pool <- {fabric_dw.auth (CredentialMode),
+    sql_pool <- {fabric_dw.auth (CredentialMode, get_sql_token_struct),
                  fabric_dw.config (UserConfig, load_config)}
     sql      <- sql_pool, sql_errors, fabric_dw.auth (get_sql_token_struct)
 
@@ -17,16 +20,18 @@ in this module (safe because ``fabric_dw.sql`` has
 
 from __future__ import annotations
 
+import contextlib
 import functools
 import importlib
 import logging
 import os
 import re
 import threading
+import time
 import types
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
-from fabric_dw.auth import CredentialMode
+from fabric_dw.auth import CredentialMode, get_sql_token_struct
 from fabric_dw.config import UserConfig as _UserConfig
 
 if TYPE_CHECKING:
@@ -311,3 +316,354 @@ def build_connection_string(
     cs = _set_key(raw, "Encrypt", "yes")
     cs = _set_key(cs, "TrustServerCertificate", "no")
     return _set_key(cs, "Database", target.database)
+
+
+# ---------------------------------------------------------------------------
+# Connection pool
+# ---------------------------------------------------------------------------
+
+# Pool configuration constants — override at module level before first use.
+# Pooling is controlled by _pool_enabled() which resolves: env var FABRIC_CONN_POOLING
+# (falsy: "0"/"false"/"no"/"off"; empty/whitespace → absent) > config.toml
+# [defaults].conn_pooling > built-in default on.
+POOL_MAX_IDLE: int = 4
+"""Maximum number of idle connections kept per ``(workspace_id, database, mode)`` key."""
+
+POOL_MAX_IDLE_SECS: float = 300.0
+"""Maximum age (seconds) of an idle connection before eviction on next checkout."""
+
+# Pool key type: (workspace_id, database, mode_value)
+_PoolKey = tuple[str, str, str]
+
+# Each slot stores (underlying_connection, last_used_monotonic_timestamp).
+_PoolSlot = tuple[Any, float]
+
+# The pool: key -> LIFO stack of idle slots (top = last element).
+_pool: dict[_PoolKey, list[_PoolSlot]] = {}
+_pool_lock = threading.Lock()
+
+
+def _pool_enabled() -> bool:
+    """Return True when connection pooling is active.
+
+    Resolution order (3-layer):
+    1. ``FABRIC_CONN_POOLING`` env var — read at call-time so tests can toggle
+       it without reimporting the module.  Only a non-empty, non-whitespace
+       value is honoured; an empty or whitespace-only value (e.g. a Docker
+       ``ENV FABRIC_CONN_POOLING=`` placeholder) is treated as absent and falls
+       through to the next layer.  Accepted disable values: ``"0"``,
+       ``"false"``, ``"no"``, ``"off"`` (case-insensitive).  Any other
+       non-empty string keeps pooling enabled.
+    2. ``config.toml`` ``[defaults].conn_pooling`` — consulted via the existing
+       memoised :func:`_load_sql_config` cache (never calls load_config()
+       per call).
+    3. Built-in default: ``True`` (pooling on).
+    """
+    raw_env = os.environ.get("FABRIC_CONN_POOLING")
+    if raw_env is not None:
+        stripped = raw_env.strip()
+        if stripped:
+            # Non-empty value — honour it (falsy set disables, anything else enables).
+            return stripped.lower() not in _FALSY_STRINGS
+        # Empty / whitespace-only — treat as absent; fall through to config/default.
+
+    cfg_val = _load_sql_config().defaults.conn_pooling
+    if cfg_val is not None:
+        return cfg_val
+
+    return True
+
+
+def _pool_time() -> float:
+    """Return the current monotonic clock value.
+
+    Isolated so tests can monkeypatch it to inject a deterministic clock
+    without affecting ``time.monotonic`` globally.
+    """
+    return time.monotonic()
+
+
+def _is_alive(conn: Any) -> bool:  # noqa: ANN401
+    """Return True if *conn* appears usable.
+
+    Checks the ``closed`` attribute when it is an ``int`` or ``bool`` (the
+    DB-API convention: 0 = open).  Ignores the attribute when it is not a
+    plain numeric value so that mock objects without an explicit ``closed``
+    attribute are treated as alive.
+    """
+    closed = getattr(conn, "closed", None)
+    # Only trust closed when it is a real int/bool; ignore Mock objects, etc.
+    if not isinstance(closed, (int, bool)):
+        return True
+    return not bool(closed)
+
+
+def reset_pool() -> None:
+    """Drain and physically close every pooled connection.
+
+    Call this on graceful shutdown (e.g. from the MCP server lifespan teardown,
+    a CLI ``finally`` block, or a pytest fixture teardown).  Safe to call
+    multiple times and from any thread.
+    """
+    with _pool_lock:
+        to_close: list[Any] = []
+        for slots in _pool.values():
+            while slots:
+                conn, _ts = slots.pop()
+                to_close.append(conn)
+        _pool.clear()
+    # Close outside the lock so slow I/O does not block other threads.
+    for conn in to_close:
+        with contextlib.suppress(Exception):
+            conn.close()
+
+
+def _pool_checkout(key: _PoolKey) -> Any | None:  # noqa: ANN401
+    """Pop and return a live, non-expired connection from the pool, or ``None``.
+
+    Expired or dead connections are discarded (physically closed) during the
+    search.  The pop is from the end of the list (LIFO - most recently used).
+    """
+    now = _pool_time()
+    deadline = POOL_MAX_IDLE_SECS
+    to_discard: list[Any] = []
+    result: Any = None
+
+    with _pool_lock:
+        slots = _pool.get(key)
+        if not slots:
+            return None
+        # Pop from the top (LIFO) until we find a usable slot.
+        while slots:
+            conn, last_used = slots.pop()
+            if now - last_used > deadline or not _is_alive(conn):
+                to_discard.append(conn)
+                continue
+            result = conn
+            break
+
+    # Close discarded connections outside the lock (may be slow I/O).
+    for dead in to_discard:
+        with contextlib.suppress(Exception):
+            dead.close()
+
+    return result
+
+
+def _pool_checkin(key: _PoolKey, conn: Any) -> None:  # noqa: ANN401
+    """Return *conn* to the pool if there is room, else physically close it.
+
+    Also evicts expired or dead connections from the entire slot list on
+    every checkin (D06 fix) so stale bottom-layer connections do not linger
+    indefinitely even when only the top of the LIFO stack is ever reused.
+    """
+    now = _pool_time()
+    deadline = POOL_MAX_IDLE_SECS
+    to_close: list[Any] = []
+
+    with _pool_lock:
+        slots = _pool.setdefault(key, [])
+        # Sweep the whole list for expired / dead entries before deciding
+        # whether to add the incoming connection.  Iterate in reverse to
+        # pop-in-place safely; build a new list to avoid O(n²) pops.
+        live: list[_PoolSlot] = []
+        for slot_conn, last_used in slots:
+            if now - last_used > deadline or not _is_alive(slot_conn):
+                to_close.append(slot_conn)
+            else:
+                live.append((slot_conn, last_used))
+        slots[:] = live
+
+        if len(slots) >= POOL_MAX_IDLE:
+            to_close.append(conn)
+        else:
+            slots.append((conn, now))
+
+    for dead in to_close:
+        with contextlib.suppress(Exception):
+            dead.close()
+
+
+# ---------------------------------------------------------------------------
+# Pooled connection wrapper
+# ---------------------------------------------------------------------------
+
+
+class _PooledConnection:
+    """Thin wrapper that intercepts ``.close()`` to return the connection to the pool.
+
+    When ``.close()`` is called:
+    - If ``_discard`` is ``True`` (set after a failed query), the underlying
+      connection is physically closed and NOT returned to the pool.
+    - If pooling is disabled (``_pool_enabled()`` returns ``False``), the
+      underlying connection is physically closed.
+    - Otherwise the underlying connection is returned to the pool for reuse.
+
+    All other method calls are forwarded verbatim to the underlying connection,
+    so callers need not change any code.
+    """
+
+    def __init__(self, underlying: Any, key: _PoolKey) -> None:  # noqa: ANN401
+        self._underlying = underlying
+        self._key = key
+        # Set to True after an exception during execute so that the connection
+        # is NOT returned to the pool (unknown transaction state).
+        self._discard: bool = False
+        # Guard against double-close (e.g. explicit close in retry path + outer
+        # finally).  Once True, subsequent close() calls are no-ops.
+        self._closed: bool = False
+
+    # ------------------------------------------------------------------ #
+    # Forward _Connection protocol methods to the underlying object.      #
+    # ------------------------------------------------------------------ #
+
+    def cursor(self) -> Any:  # noqa: ANN401
+        return self._underlying.cursor()
+
+    def commit(self) -> None:
+        self._underlying.commit()
+
+    def rollback(self) -> None:
+        self._underlying.rollback()
+
+    def mark_discard(self) -> None:
+        """Mark this connection for physical close instead of pool return.
+
+        Call after any error that leaves the connection in an unknown state
+        (e.g. mid-execute failure, open transaction with unknown content).
+        Once marked, ``.close()`` physically closes the underlying socket and
+        does NOT return it to the pool.
+        """
+        self._discard = True
+
+    def close(self) -> None:
+        """Return to pool or physically close, depending on state and config.
+
+        Idempotent: a second call is a no-op.  This prevents the underlying TDS
+        socket from receiving ``close()`` twice when the execute-retry path
+        calls ``conn.close()`` explicitly and the outer ``finally`` also closes.
+
+        Before returning to the pool, any open implicit transaction is rolled
+        back so the next caller starts with a clean transaction state.
+        """
+        if self._closed:
+            return
+        self._closed = True
+        if self._discard or not _pool_enabled():
+            self._underlying.close()
+        else:
+            # Roll back any open implicit transaction before pool return so
+            # the next lender starts with a clean state (D23).
+            with contextlib.suppress(Exception):
+                self._underlying.rollback()
+            _pool_checkin(self._key, self._underlying)
+
+    # Convenience accessor used by pool-specific tests.
+    @property
+    def _raw(self) -> Any:  # noqa: ANN401
+        return self._underlying
+
+
+def _make_pool_key(target: SqlTarget, mode: CredentialMode) -> _PoolKey:
+    return (target.workspace_id, target.database, mode.value)
+
+
+# ---------------------------------------------------------------------------
+# open_connection
+# ---------------------------------------------------------------------------
+
+
+def open_connection(
+    target: SqlTarget,
+    *,
+    mode: CredentialMode = CredentialMode.DEFAULT,
+    autocommit: bool = False,
+) -> _PooledConnection:
+    """Return a connection to the target warehouse, reusing a pooled one when available.
+
+    The returned object satisfies the :class:`~fabric_dw.sql._Connection` protocol.
+    Its ``.close()`` method returns the connection to the pool (when pooling is
+    enabled and the connection is healthy) rather than physically closing the
+    socket.  Callers do **not** need to change — the ``contextlib.closing``
+    pattern works unchanged.
+
+    When pooling is disabled (``_pool_enabled()`` returns ``False``, controlled
+    via the ``FABRIC_CONN_POOLING`` env var, ``config.toml [defaults] conn_pooling``,
+    or the built-in default on) every call opens a fresh physical connection
+    and ``.close()`` physically closes it.
+
+    When ``autocommit=True``, the ODBC driver does **not** wrap each statement
+    in an explicit ``BEGIN TRANSACTION`` / ``COMMIT`` pair.  This is required
+    for DDL statements that SQL Server disallows inside a transaction (e.g.
+    ``ALTER DATABASE``).  Autocommit connections are **never** pooled — they
+    are always opened fresh and physically closed on ``.close()``.
+
+    This function is intentionally synchronous.  Callers that need to keep the
+    event loop free should wrap the entire sync block in ``asyncio.to_thread``.
+
+    Args:
+        target: The :class:`~fabric_dw.sql.SqlTarget` identifying the warehouse.
+        mode: The credential mode for Entra authentication.
+        autocommit: When ``True``, open the connection with ODBC-level
+            autocommit enabled.  Defaults to ``False``.  Autocommit connections
+            bypass the pool entirely.
+
+    Returns:
+        A :class:`_PooledConnection` wrapping a DB-API 2.0 connection from
+        the ``mssql_python`` driver.
+    """
+    # Autocommit connections bypass the pool entirely to avoid cross-contaminating
+    # a pooled autocommit=False connection with autocommit=True semantics or vice
+    # versa.  They are always opened fresh and physically closed after use.
+    if autocommit:
+        # Acquire a token struct when running under GitHub OIDC.  This bypasses the
+        # mssql-python driver's own DefaultAzureCredential chain (which uses
+        # AzureCliCredential whose GitHub OIDC assertion expires after ~5 min) in
+        # favour of our self-refreshing credential whose _fetch_github_oidc_jwt
+        # always obtains a fresh assertion.
+        token_struct = get_sql_token_struct(mode)
+        use_token = token_struct is not None
+        cs = build_connection_string(target, mode=mode, use_access_token=use_token)
+        attrs: dict[int, bytes] | None = (
+            {SQL_COPT_SS_ACCESS_TOKEN: token_struct} if use_token else None
+        )
+        raw_conn: Any = _get_mssql().connect(
+            cs, autocommit=True, attrs_before=attrs, timeout=SQL_LOGIN_TIMEOUT_S
+        )
+        # Sets query timeout on all *future* cursors (Connection.timeout.setter stores
+        # the value; each cursor.__init__ reads it via _set_timeout()).  Safe here
+        # because every cursor in this codebase is acquired after open_connection()
+        # returns — no caller holds a cursor across connection open.
+        raw_conn.timeout = SQL_QUERY_TIMEOUT_S
+        # Wrap in _PooledConnection with a sentinel key; mark_discard() ensures
+        # .close() physically closes the connection rather than pooling it.
+        key = _make_pool_key(target, mode)
+        wrapped = _PooledConnection(raw_conn, key)
+        wrapped.mark_discard()
+        return wrapped
+
+    key = _make_pool_key(target, mode)
+
+    if _pool_enabled():
+        cached = _pool_checkout(key)
+        if cached is not None:
+            # Pool HIT — return the cached connection without acquiring a token.
+            # Checked-out connections are already authenticated; acquiring a token
+            # here would invoke credential.get_token() (holding azure-identity's
+            # token-cache lock) and then discard the result — pure waste.
+            return _PooledConnection(cached, key)
+
+    # Pool MISS (or pooling disabled) — open a new physical connection.
+    # Only now do we acquire the OIDC token struct, so the credential is never
+    # consulted on pool-hit paths.
+    token_struct = get_sql_token_struct(mode)
+    use_token = token_struct is not None
+    cs = build_connection_string(target, mode=mode, use_access_token=use_token)
+    attrs = {SQL_COPT_SS_ACCESS_TOKEN: token_struct} if use_token else None
+    raw_conn = _get_mssql().connect(cs, attrs_before=attrs, timeout=SQL_LOGIN_TIMEOUT_S)
+    # Sets query timeout on all *future* cursors (Connection.timeout.setter stores
+    # the value; each cursor.__init__ reads it via _set_timeout()).  Safe here
+    # because every cursor in this codebase is acquired after open_connection()
+    # returns — no caller holds a cursor across connection open.
+    raw_conn.timeout = SQL_QUERY_TIMEOUT_S
+    return _PooledConnection(raw_conn, key)

--- a/tests/unit/test_sql.py
+++ b/tests/unit/test_sql.py
@@ -841,7 +841,9 @@ class TestConnectionPool:
         def _fake_time() -> float:
             return next(fake_times)
 
-        monkeypatch.setattr(sql_mod, "_pool_time", _fake_time)
+        # _pool_time is called by bare name inside _pool_checkout/_pool_checkin,
+        # both of which live in sql_pool.py.  Must patch sql_pool's own binding.
+        monkeypatch.setattr(_sql_pool_module, "_pool_time", _fake_time)
 
         # Put the first conn into the pool (checkin stores t=0.0).
         conn1 = open_connection(_make_target())
@@ -941,10 +943,10 @@ class TestConnectionPool:
 
     def test_max_idle_cap_per_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Pool never grows beyond POOL_MAX_IDLE per key; excess are physically closed."""
-        import fabric_dw.sql as sql_mod  # noqa: PLC0415
-
-        original_max = sql_mod.POOL_MAX_IDLE
-        sql_mod.POOL_MAX_IDLE = 2
+        # POOL_MAX_IDLE is read from sql_pool.py's globals by _pool_checkin.
+        # Must target sql_pool's own binding, not the re-export shim in sql.py.
+        original_max = _sql_pool_module.POOL_MAX_IDLE
+        _sql_pool_module.POOL_MAX_IDLE = 2
         try:
             mock_mssql, _, _ = _make_mock_mssql()
             conns = [MagicMock() for _ in range(4)]
@@ -967,7 +969,7 @@ class TestConnectionPool:
             closed_count = sum(1 for c in conns if c.close.called)
             assert closed_count == 2
         finally:
-            sql_mod.POOL_MAX_IDLE = original_max
+            _sql_pool_module.POOL_MAX_IDLE = original_max
 
     def test_run_statements_checks_out_once_checks_in_once(
         self, monkeypatch: pytest.MonkeyPatch
@@ -1651,8 +1653,9 @@ class TestOpenConnectionOidcTokenInjection:
     """Tests for OIDC token injection in open_connection.
 
     The mssql_python driver is never imported: _mssql is monkeypatched with a
-    MagicMock.  get_sql_token_struct is patched at the fabric_dw.sql module level
-    so that the mock controls the OIDC environment independently of env-vars.
+    MagicMock.  get_sql_token_struct is patched at the fabric_dw.sql_pool module
+    level (where open_connection lives) so that the mock controls the OIDC
+    environment independently of env-vars.
     """
 
     def test_non_oidc_connect_called_without_attrs_before(
@@ -1663,7 +1666,7 @@ class TestOpenConnectionOidcTokenInjection:
         mock_mssql, _, _ = _make_mock_mssql()
         _patch_mssql(monkeypatch, mock_mssql)
         # Simulate non-OIDC: get_sql_token_struct returns None.
-        monkeypatch.setattr(_sql_module, "get_sql_token_struct", lambda *_a, **_kw: None)
+        monkeypatch.setattr(_sql_pool_module, "get_sql_token_struct", lambda *_a, **_kw: None)
 
         from fabric_dw.sql import open_connection  # noqa: PLC0415
 
@@ -1691,7 +1694,9 @@ class TestOpenConnectionOidcTokenInjection:
         token_bytes = known_token.encode("UTF-16-LE")
         fake_struct = struct.pack(f"<I{len(token_bytes)}s", len(token_bytes), token_bytes)
 
-        monkeypatch.setattr(_sql_module, "get_sql_token_struct", lambda *_a, **_kw: fake_struct)
+        monkeypatch.setattr(
+            _sql_pool_module, "get_sql_token_struct", lambda *_a, **_kw: fake_struct
+        )
 
         from fabric_dw.sql import SQL_COPT_SS_ACCESS_TOKEN, open_connection  # noqa: PLC0415
 
@@ -1714,7 +1719,9 @@ class TestOpenConnectionOidcTokenInjection:
 
         token_bytes = b"fake"
         fake_struct = struct.pack(f"<I{len(token_bytes)}s", len(token_bytes), token_bytes)
-        monkeypatch.setattr(_sql_module, "get_sql_token_struct", lambda *_a, **_kw: fake_struct)
+        monkeypatch.setattr(
+            _sql_pool_module, "get_sql_token_struct", lambda *_a, **_kw: fake_struct
+        )
 
         from fabric_dw.sql import open_connection  # noqa: PLC0415
 
@@ -1734,7 +1741,9 @@ class TestOpenConnectionOidcTokenInjection:
 
         token_bytes = b"tok"
         fake_struct = struct.pack(f"<I{len(token_bytes)}s", len(token_bytes), token_bytes)
-        monkeypatch.setattr(_sql_module, "get_sql_token_struct", lambda *_a, **_kw: fake_struct)
+        monkeypatch.setattr(
+            _sql_pool_module, "get_sql_token_struct", lambda *_a, **_kw: fake_struct
+        )
 
         from fabric_dw.sql import SQL_COPT_SS_ACCESS_TOKEN, open_connection  # noqa: PLC0415
 
@@ -1779,7 +1788,7 @@ class TestOpenConnectionOidcTokenInjection:
             token_call_count += 1
             return fake_struct
 
-        monkeypatch.setattr(_sql_module, "get_sql_token_struct", _counting_token_stub)
+        monkeypatch.setattr(_sql_pool_module, "get_sql_token_struct", _counting_token_stub)
 
         from fabric_dw.sql import open_connection  # noqa: PLC0415
 
@@ -1939,7 +1948,9 @@ class TestPoolCheckinEvictsStale:
         #   checkin conn_b (now):    t=idle_limit+5.0
         #     -> age of conn_a = idle_limit+5.0 > idle_limit => evict
         fake_times = iter([1.0, 2.0, 0.0, idle_limit + 5.0])
-        monkeypatch.setattr(sql_mod, "_pool_time", lambda: next(fake_times))
+        # _pool_time is called by bare name inside _pool_checkin, which lives in
+        # sql_pool.py.  Must patch sql_pool's own binding, not the shim in sql.py.
+        monkeypatch.setattr(_sql_pool_module, "_pool_time", lambda: next(fake_times))
 
         target = _make_target()
         wrap_a = open_connection(target)
@@ -2229,7 +2240,7 @@ class TestOpenConnectionTimeoutAPI:
         mock_mssql, _, _ = _make_mock_mssql()
         _patch_mssql(monkeypatch, mock_mssql)
         # No OIDC token — straightforward path.
-        monkeypatch.setattr(_sql_module, "get_sql_token_struct", lambda *_a, **_kw: None)
+        monkeypatch.setattr(_sql_pool_module, "get_sql_token_struct", lambda *_a, **_kw: None)
 
         from fabric_dw.sql import open_connection  # noqa: PLC0415
 
@@ -2246,7 +2257,7 @@ class TestOpenConnectionTimeoutAPI:
 
         mock_mssql, mock_conn, _ = _make_mock_mssql()
         _patch_mssql(monkeypatch, mock_mssql)
-        monkeypatch.setattr(_sql_module, "get_sql_token_struct", lambda *_a, **_kw: None)
+        monkeypatch.setattr(_sql_pool_module, "get_sql_token_struct", lambda *_a, **_kw: None)
 
         from fabric_dw.sql import open_connection  # noqa: PLC0415
 


### PR DESCRIPTION
## What moves

All connection pool machinery is extracted from `sql.py` into `sql_pool.py`:

- Pool constants: `POOL_MAX_IDLE`, `POOL_MAX_IDLE_SECS`
- Pool state: `_pool`, `_pool_lock`, `_PoolKey`, `_PoolSlot`
- Pool functions: `_pool_enabled`, `_pool_time`, `_is_alive`, `reset_pool`, `_pool_checkout`, `_pool_checkin`
- Pool wrapper class: `_PooledConnection`
- Pool key helper: `_make_pool_key`
- Connection factory: `open_connection` (imports `get_sql_token_struct` from `fabric_dw.auth`)

`sql.py` becomes a thin runner layer containing only `SqlTarget`, protocol classes, the retry helpers (`_with_connect_retry`, `_EXECUTE_RETRY_DELAYS`, `_CONNECT_RETRY_DELAYS`), `_log_sql_execute`, `run_query`, and `run_statements`.

## Re-export shims

`sql.py` imports every moved name from `sql_pool` so the public surface is unchanged. Names that are read by `sql.py`'s own code by bare name (`open_connection` in `_with_connect_retry`, `_PooledConnection` in `run_query`/`run_statements`) resolve through the shim binding correctly.

## Retargeted patch sites

The same foot-gun as PR C applies: bare-name calls inside a function resolve against the module where the function is defined, not where it was imported. Three categories needed retargeting:

- `get_sql_token_struct` (7 sites in `TestOpenConnectionOidcTokenInjection` and `TestOpenConnectionTimeoutAPI`): `open_connection` (now in `sql_pool.py`) calls it by bare name from `sql_pool`'s globals. Patches retargeted from `fabric_dw.sql` to `fabric_dw.sql_pool`.
- `_pool_time` (2 sites in `TestPoolBehaviourIdleEviction`, `TestPoolCheckinEvictsStale`): called by bare name inside `_pool_checkout`/`_pool_checkin`, both now in `sql_pool.py`. Patches retargeted to `fabric_dw.sql_pool._pool_time`.
- `POOL_MAX_IDLE` set (2 sites in `TestPoolBehaviourMaxIdle`): read from `sql_pool.py`'s globals by `_pool_checkin`. Assignments retargeted to `_sql_pool_module.POOL_MAX_IDLE`.

Patches that stay on `fabric_dw.sql.*` and remain valid:
- `fabric_dw.sql.open_connection` — `_with_connect_retry` (stays in `sql.py`) calls `open_connection` by bare name, resolving `sql.py`'s shim binding; patching the shim intercepts the call.
- `_pool_enabled()` calls via `_sql_module._pool_enabled()` — returns the same function object; executes in `sql_pool` context regardless.
- `from fabric_dw.sql import _pool, _pool_lock` — shims give the same dict/Lock object references.

Part of #828