### PR TITLE
fix(sql-pools): read enabled flag without validating full pool schema

### DIFF
--- a/src/fabric_dw/cli/commands/sql_pools.py
+++ b/src/fabric_dw/cli/commands/sql_pools.py
@@ -101,9 +101,9 @@ async def status_cmd(ctx: CliContext) -> None:
     try:
         async with build_http_client(ctx) as http:
             ws_id = await resolve_workspace_id(http, ws)
-            config = await _svc.get_configuration(http, ws_id)
+            enabled = await _svc.get_status(http, ws_id)
             render(
-                {"customSQLPoolsEnabled": config.custom_sql_pools_enabled},
+                {"customSQLPoolsEnabled": enabled},
                 json_output=ctx.json_output,
             )
     except PermissionDeniedError as exc:

--- a/src/fabric_dw/mcp/tools/sql_pools.py
+++ b/src/fabric_dw/mcp/tools/sql_pools.py
@@ -52,10 +52,10 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
                 workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
             )
             _log.debug("get_sql_pools_status ws=%s", ws_id)
-            result = await sql_pools_svc.get_configuration(ctx.http, ws_id)
+            enabled = await sql_pools_svc.get_status(ctx.http, ws_id)
         except FabricError as exc:
             raise fabric_err(exc) from exc
-        return {"customSQLPoolsEnabled": result.custom_sql_pools_enabled}
+        return {"customSQLPoolsEnabled": enabled}
 
     @mcp.tool(name="list_sql_pools")
     async def list_sql_pools(workspace: str) -> list[dict[str, Any]]:

--- a/src/fabric_dw/services/sql_pools.py
+++ b/src/fabric_dw/services/sql_pools.py
@@ -45,6 +45,11 @@ __all__ = [
 # Wrapped in MappingProxyType to prevent accidental mutation by callers.
 _BETA_PARAMS: Mapping[str, str] = types.MappingProxyType({"beta": "True"})
 
+# The JSON key for the workspace-level enabled flag.  Must match the field alias
+# on SqlPoolsConfiguration.custom_sql_pools_enabled (Field(alias=...)) so that
+# get_status() and get_configuration() both refer to the same key.
+_STATUS_KEY = "customSQLPoolsEnabled"
+
 
 def _config_path(workspace_id: UUID) -> str:
     return f"/workspaces/{workspace_id}/warehouses/sqlPoolsConfiguration"
@@ -83,6 +88,12 @@ async def get_status(
     a pool field (renamed or added required attribute) therefore cannot crash
     a simple enabled/disabled status check.  See issue #905.
 
+    The flag read is intentionally strict: only a genuine JSON boolean is
+    accepted.  A missing key, a null value, or a non-boolean type (string,
+    integer) raises :class:`~fabric_dw.exceptions.FabricError` rather than
+    silently misreporting the state.  A non-JSON or empty response body is
+    treated the same way so that no raw exception ever escapes this function.
+
     Args:
         http: An authenticated :class:`~fabric_dw.http_client.FabricHttpClient`.
         workspace_id: The Fabric workspace UUID.
@@ -91,8 +102,9 @@ async def get_status(
         ``True`` if custom SQL pools are enabled, ``False`` otherwise.
 
     Raises:
-        FabricError: If the top-level ``customSQLPoolsEnabled`` key is absent
-            from the response (unexpected API response shape).
+        FabricError: If the response cannot be parsed as JSON, the
+            ``customSQLPoolsEnabled`` key is absent, the value is null, or the
+            value is not a real JSON boolean.
         PermissionDeniedError: If the caller does not have the workspace admin role
             (HTTP 403).
     """
@@ -102,15 +114,31 @@ async def get_status(
         _config_path(workspace_id),
         params=_BETA_PARAMS,
     )
-    data = resp.json()
     try:
-        return bool(data["customSQLPoolsEnabled"])
-    except (KeyError, TypeError) as exc:
+        data = resp.json()
+        value = data[_STATUS_KEY]
+    except (ValueError, KeyError, TypeError) as exc:
+        # ValueError covers JSONDecodeError (non-JSON or empty body).
+        # KeyError covers a missing top-level key.
+        # TypeError covers resp.json() returning a non-dict (e.g. a JSON array).
         msg = (
-            "Unexpected API response: 'customSQLPoolsEnabled' key is missing. "
-            "The Fabric SQL Pools beta API may have changed."
+            f"Unexpected API response: '{_STATUS_KEY}' key is missing or the response "
+            "body is not valid JSON.  The Fabric SQL Pools beta API may have changed."
         )
         raise FabricError(msg) from exc
+
+    if not isinstance(value, bool):
+        # A null, string, or numeric value would silently misreport the state
+        # via bool() coercion (null->False, "false"->True).  Reject these
+        # explicitly so schema drift produces a clear error rather than a
+        # wrong answer.
+        msg = (
+            f"Unexpected API response: '{_STATUS_KEY}' is {value!r} "
+            f"(expected a JSON boolean).  The Fabric SQL Pools beta API may have changed."
+        )
+        raise FabricError(msg)
+
+    return value
 
 
 async def get_configuration(

--- a/src/fabric_dw/services/sql_pools.py
+++ b/src/fabric_dw/services/sql_pools.py
@@ -25,7 +25,7 @@ import types
 from collections.abc import Mapping
 from uuid import UUID
 
-from fabric_dw.exceptions import AlreadyExistsError, BadRequestError, NotFoundError
+from fabric_dw.exceptions import AlreadyExistsError, BadRequestError, FabricError, NotFoundError
 from fabric_dw.http_client import FabricHttpClient, HttpBase
 from fabric_dw.models import SqlPool, SqlPoolsConfiguration
 
@@ -35,6 +35,7 @@ __all__ = [
     "disable",
     "enable",
     "get_configuration",
+    "get_status",
     "update_configuration",
     "update_pool",
 ]
@@ -69,6 +70,47 @@ def _rebuild_config(*, enabled: bool, pools: list[SqlPool]) -> SqlPoolsConfigura
             "customSQLPools": [p.model_dump(by_alias=True, mode="json") for p in pools],
         }
     )
+
+
+async def get_status(
+    http: FabricHttpClient,
+    workspace_id: UUID,
+) -> bool:
+    """Fetch only the ``customSQLPoolsEnabled`` flag for a workspace.
+
+    Unlike :func:`get_configuration`, this function does **not** validate or
+    deserialise the nested ``customSQLPools`` list.  Beta API schema drift in
+    a pool field (renamed or added required attribute) therefore cannot crash
+    a simple enabled/disabled status check.  See issue #905.
+
+    Args:
+        http: An authenticated :class:`~fabric_dw.http_client.FabricHttpClient`.
+        workspace_id: The Fabric workspace UUID.
+
+    Returns:
+        ``True`` if custom SQL pools are enabled, ``False`` otherwise.
+
+    Raises:
+        FabricError: If the top-level ``customSQLPoolsEnabled`` key is absent
+            from the response (unexpected API response shape).
+        PermissionDeniedError: If the caller does not have the workspace admin role
+            (HTTP 403).
+    """
+    resp = await http.request(
+        "GET",
+        HttpBase.FABRIC,
+        _config_path(workspace_id),
+        params=_BETA_PARAMS,
+    )
+    data = resp.json()
+    try:
+        return bool(data["customSQLPoolsEnabled"])
+    except (KeyError, TypeError) as exc:
+        msg = (
+            "Unexpected API response: 'customSQLPoolsEnabled' key is missing. "
+            "The Fabric SQL Pools beta API may have changed."
+        )
+        raise FabricError(msg) from exc
 
 
 async def get_configuration(

--- a/tests/unit/cli/commands/test_sql_pools.py
+++ b/tests/unit/cli/commands/test_sql_pools.py
@@ -102,8 +102,8 @@ class TestSqlPoolsStatus:
                 new=AsyncMock(return_value=WS_UUID),
             ),
             patch(
-                "fabric_dw.cli.commands.sql_pools._svc.get_configuration",
-                new=AsyncMock(return_value=_CONFIG),
+                "fabric_dw.cli.commands.sql_pools._svc.get_status",
+                new=AsyncMock(return_value=True),
             ),
         ):
             result = runner.invoke(cli, ["-w", WS_GUID, "--json", "sql-pools", "status"])
@@ -124,8 +124,8 @@ class TestSqlPoolsStatus:
                 new=AsyncMock(return_value=WS_UUID),
             ),
             patch(
-                "fabric_dw.cli.commands.sql_pools._svc.get_configuration",
-                new=AsyncMock(return_value=_CONFIG_DISABLED),
+                "fabric_dw.cli.commands.sql_pools._svc.get_status",
+                new=AsyncMock(return_value=False),
             ),
         ):
             result = runner.invoke(cli, ["-w", WS_GUID, "--json", "sql-pools", "status"])
@@ -145,7 +145,7 @@ class TestSqlPoolsStatus:
                 new=AsyncMock(return_value=WS_UUID),
             ),
             patch(
-                "fabric_dw.cli.commands.sql_pools._svc.get_configuration",
+                "fabric_dw.cli.commands.sql_pools._svc.get_status",
                 new=AsyncMock(side_effect=PermissionDeniedError("403")),
             ),
         ):
@@ -808,7 +808,7 @@ class TestSqlPoolsStatusFabricError:
                 new=AsyncMock(return_value=WS_UUID),
             ),
             patch(
-                "fabric_dw.cli.commands.sql_pools._svc.get_configuration",
+                "fabric_dw.cli.commands.sql_pools._svc.get_status",
                 new=AsyncMock(side_effect=FabricError("server error")),
             ),
         ):

--- a/tests/unit/mcp/tools/test_sql_pools.py
+++ b/tests/unit/mcp/tools/test_sql_pools.py
@@ -101,14 +101,13 @@ async def test_get_sql_pools_status_happy_path(mock_ctx, ctx_patch) -> None:
     """get_sql_pools_status returns only the enabled flag, not the pool list."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
-    config = _make_config()
     mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
 
     with (
         ctx_patch,
         patch(
-            "fabric_dw.services.sql_pools.get_configuration",
-            new=AsyncMock(return_value=config),
+            "fabric_dw.services.sql_pools.get_status",
+            new=AsyncMock(return_value=True),
         ),
     ):
         result = await mcp._tool_manager.call_tool(
@@ -123,14 +122,13 @@ async def test_get_sql_pools_status_disabled(mock_ctx, ctx_patch) -> None:
     """get_sql_pools_status returns False when custom pools are disabled."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
-    config = _make_config(enabled=False)
     mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
 
     with (
         ctx_patch,
         patch(
-            "fabric_dw.services.sql_pools.get_configuration",
-            new=AsyncMock(return_value=config),
+            "fabric_dw.services.sql_pools.get_status",
+            new=AsyncMock(return_value=False),
         ),
     ):
         result = await mcp._tool_manager.call_tool(
@@ -189,7 +187,7 @@ async def test_get_sql_pools_status_service_fabric_error(mock_ctx, ctx_patch) ->
     with (
         ctx_patch,
         patch(
-            "fabric_dw.services.sql_pools.get_configuration",
+            "fabric_dw.services.sql_pools.get_status",
             new=AsyncMock(side_effect=FabricError("api error")),
         ),
         pytest.raises(ToolError),
@@ -198,6 +196,45 @@ async def test_get_sql_pools_status_service_fabric_error(mock_ctx, ctx_patch) ->
             "get_sql_pools_status",
             {"workspace": _WS_NAME},
         )
+
+
+async def test_get_sql_pools_status_broken_pool_schema_does_not_crash(mock_ctx, ctx_patch) -> None:
+    """get_sql_pools_status still returns the flag when nested pool fields are missing.
+
+    This verifies the integration between get_status() and the MCP tool: even
+    if the beta API returns a pool list with missing required fields (which would
+    fail SqlPoolsConfiguration.model_validate), the status call must succeed.
+    get_status() reads only the top-level key, so get_sql_pools_status must not
+    raise ToolError in this scenario.  See issue #905.
+
+    The mock_ctx HTTP client is configured to return the broken payload directly,
+    bypassing the real network layer (respx cannot intercept mock objects).
+    """
+    from unittest.mock import MagicMock  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    broken_payload = {
+        "customSQLPoolsEnabled": True,
+        "customSQLPools": [
+            # 'name' and 'maxResourcePercentage' are intentionally absent.
+            {"isDefault": True, "optimizeForReads": False}
+        ],
+    }
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+
+    # Configure the mock HTTP client to return the broken payload.
+    mock_response = MagicMock()
+    mock_response.json.return_value = broken_payload
+    mock_ctx.http.request = AsyncMock(return_value=mock_response)
+
+    with ctx_patch:
+        result = await mcp._tool_manager.call_tool(
+            "get_sql_pools_status",
+            {"workspace": _WS_NAME},
+        )
+
+    assert result == {"customSQLPoolsEnabled": True}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/mcp/tools/test_sql_pools.py
+++ b/tests/unit/mcp/tools/test_sql_pools.py
@@ -235,6 +235,8 @@ async def test_get_sql_pools_status_broken_pool_schema_does_not_crash(mock_ctx, 
         )
 
     assert result == {"customSQLPoolsEnabled": True}
+    # Confirm the HTTP layer was actually invoked -- not just a mock shortcut.
+    mock_ctx.http.request.assert_called_once()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/services/test_sql_pools.py
+++ b/tests/unit/services/test_sql_pools.py
@@ -14,6 +14,7 @@ from pydantic import ValidationError
 from fabric_dw.exceptions import (
     AlreadyExistsError,
     BadRequestError,
+    FabricError,
     NotFoundError,
     PermissionDeniedError,
 )
@@ -174,13 +175,64 @@ async def test_get_status_ignores_broken_nested_pool_fields_when_disabled() -> N
 
 async def test_get_status_raises_fabric_error_when_flag_key_missing() -> None:
     """get_status raises FabricError when customSQLPoolsEnabled is absent."""
-    from fabric_dw.exceptions import FabricError  # noqa: PLC0415
-
     with respx.mock:
         respx.get(_CONFIG_URL).mock(return_value=httpx.Response(200, json={"customSQLPools": []}))
         client = await _make_client()
         async with client:
             with pytest.raises(FabricError, match="customSQLPoolsEnabled"):
+                await sql_pools.get_status(client, _WS_ID)
+
+
+async def test_get_status_raises_fabric_error_when_flag_is_null() -> None:
+    """get_status raises FabricError when customSQLPoolsEnabled is JSON null.
+
+    A null value must NOT silently coerce to False via bool(None); that would
+    misreport the actual state.  Pydantic rejects null on the bool field, so
+    get_status() must be equally strict.
+    """
+    with respx.mock:
+        # json= serialises None as JSON null.
+        respx.get(_CONFIG_URL).mock(
+            return_value=httpx.Response(
+                200, json={"customSQLPoolsEnabled": None, "customSQLPools": []}
+            )
+        )
+        client = await _make_client()
+        async with client:
+            with pytest.raises(FabricError, match="customSQLPoolsEnabled"):
+                await sql_pools.get_status(client, _WS_ID)
+
+
+async def test_get_status_raises_fabric_error_when_flag_is_string() -> None:
+    """get_status raises FabricError when customSQLPoolsEnabled is a string.
+
+    bool("false") is True, so naive coercion would silently misreport.
+    """
+    with respx.mock:
+        respx.get(_CONFIG_URL).mock(
+            return_value=httpx.Response(
+                200, json={"customSQLPoolsEnabled": "false", "customSQLPools": []}
+            )
+        )
+        client = await _make_client()
+        async with client:
+            with pytest.raises(FabricError, match="customSQLPoolsEnabled"):
+                await sql_pools.get_status(client, _WS_ID)
+
+
+async def test_get_status_raises_fabric_error_when_body_is_not_json() -> None:
+    """get_status raises FabricError instead of a raw JSONDecodeError.
+
+    A non-JSON response body (e.g. an HTML gateway error page) must not
+    produce a raw traceback at the CLI or MCP boundary.
+    """
+    with respx.mock:
+        respx.get(_CONFIG_URL).mock(
+            return_value=httpx.Response(200, content=b"<html>Bad Gateway</html>")
+        )
+        client = await _make_client()
+        async with client:
+            with pytest.raises(FabricError):
                 await sql_pools.get_status(client, _WS_ID)
 
 

--- a/tests/unit/services/test_sql_pools.py
+++ b/tests/unit/services/test_sql_pools.py
@@ -84,6 +84,117 @@ POOLS_EMPTY_PAYLOAD: dict[str, Any] = {
 
 
 # ---------------------------------------------------------------------------
+# get_status
+# ---------------------------------------------------------------------------
+
+# A response payload where a nested pool entry is missing required fields
+# ('name' and 'maxResourcePercentage').  model_validate on SqlPoolsConfiguration
+# would raise ValidationError here, but get_status must succeed regardless.
+POOLS_ENABLED_BROKEN_POOL_PAYLOAD: dict[str, object] = {
+    "customSQLPoolsEnabled": True,
+    "customSQLPools": [
+        {
+            # 'name' and 'maxResourcePercentage' are intentionally absent
+            # to simulate beta API schema drift.
+            "isDefault": True,
+            "optimizeForReads": False,
+        }
+    ],
+}
+
+POOLS_DISABLED_BROKEN_POOL_PAYLOAD: dict[str, object] = {
+    "customSQLPoolsEnabled": False,
+    "customSQLPools": [
+        {
+            # Same broken pool entry as above.
+            "isDefault": False,
+        }
+    ],
+}
+
+
+async def test_get_status_returns_true_when_enabled() -> None:
+    """get_status returns True when customSQLPoolsEnabled is true."""
+    with respx.mock:
+        route = respx.get(_CONFIG_URL).mock(
+            return_value=httpx.Response(200, json=POOLS_ENABLED_PAYLOAD)
+        )
+        client = await _make_client()
+        async with client:
+            result = await sql_pools.get_status(client, _WS_ID)
+
+    assert route.called
+    assert "beta=True" in str(route.calls[0].request.url)
+    assert result is True
+
+
+async def test_get_status_returns_false_when_disabled() -> None:
+    """get_status returns False when customSQLPoolsEnabled is false."""
+    with respx.mock:
+        respx.get(_CONFIG_URL).mock(return_value=httpx.Response(200, json=POOLS_DISABLED_PAYLOAD))
+        client = await _make_client()
+        async with client:
+            result = await sql_pools.get_status(client, _WS_ID)
+
+    assert result is False
+
+
+async def test_get_status_ignores_broken_nested_pool_fields_when_enabled() -> None:
+    """get_status does not raise ValidationError when nested pool fields are missing.
+
+    This is the key regression test for issue #905: if the beta API renames or
+    drops a required pool field, full SqlPoolsConfiguration.model_validate would
+    raise ValidationError.  get_status reads only the top-level flag and must
+    therefore succeed even when the pool list is malformed.
+    """
+    with respx.mock:
+        respx.get(_CONFIG_URL).mock(
+            return_value=httpx.Response(200, json=POOLS_ENABLED_BROKEN_POOL_PAYLOAD)
+        )
+        client = await _make_client()
+        async with client:
+            result = await sql_pools.get_status(client, _WS_ID)
+
+    # The flag is readable even though the nested pool entry is missing fields.
+    assert result is True
+
+
+async def test_get_status_ignores_broken_nested_pool_fields_when_disabled() -> None:
+    """get_status returns False and does not raise when pool entries are malformed."""
+    with respx.mock:
+        respx.get(_CONFIG_URL).mock(
+            return_value=httpx.Response(200, json=POOLS_DISABLED_BROKEN_POOL_PAYLOAD)
+        )
+        client = await _make_client()
+        async with client:
+            result = await sql_pools.get_status(client, _WS_ID)
+
+    assert result is False
+
+
+async def test_get_status_raises_fabric_error_when_flag_key_missing() -> None:
+    """get_status raises FabricError when customSQLPoolsEnabled is absent."""
+    from fabric_dw.exceptions import FabricError  # noqa: PLC0415
+
+    with respx.mock:
+        respx.get(_CONFIG_URL).mock(return_value=httpx.Response(200, json={"customSQLPools": []}))
+        client = await _make_client()
+        async with client:
+            with pytest.raises(FabricError, match="customSQLPoolsEnabled"):
+                await sql_pools.get_status(client, _WS_ID)
+
+
+async def test_get_status_403_raises_permission_denied() -> None:
+    """get_status propagates PermissionDeniedError on 403."""
+    with respx.mock:
+        respx.get(_CONFIG_URL).mock(return_value=httpx.Response(403, json={"error": "forbidden"}))
+        client = await _make_client()
+        async with client:
+            with pytest.raises(PermissionDeniedError):
+                await sql_pools.get_status(client, _WS_ID)
+
+
+# ---------------------------------------------------------------------------
 # get_configuration
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

`sql-pools status` (CLI) and `get_sql_pools_status` (MCP tool) called
`services.sql_pools.get_configuration()`, which runs
`SqlPoolsConfiguration.model_validate()` over the entire API response,
including the nested `customSQLPools` list. Each `SqlPool` has required
fields (`name`, `maxResourcePercentage`). If the Fabric beta API renames
or drops one of those fields, the status command raises `ValidationError`
even though the top-level `customSQLPoolsEnabled` flag is perfectly readable.

## Solution

Add `services.sql_pools.get_status(http, workspace_id) -> bool`: a thin
async function that makes the same GET request as `get_configuration` but
reads only the top-level `customSQLPoolsEnabled` key from the raw JSON dict.
It never touches the pool list and never calls `model_validate`.

Wire `status_cmd` (CLI) and `get_sql_pools_status` (MCP) to call
`get_status()` instead. All other operations that genuinely need the pool
list (`list`, `show`, `enable`, `disable`, `create`, `update`, `delete`)
continue to use `get_configuration()` with full validation unchanged.

## Tests added

- Service: `get_status()` returns correct bool for enabled/disabled responses.
- Service: `get_status()` succeeds when a nested pool entry is missing `name`
  and `maxResourcePercentage` (the key regression test for this issue).
- Service: `get_status()` raises `FabricError` when the top-level key is absent.
- Service: `get_status()` propagates `PermissionDeniedError` on 403.
- MCP: `get_sql_pools_status` succeeds against a broken-pool-schema HTTP
  response, configured via the mock HTTP client.
- All existing status tests updated to patch `get_status` instead of
  `get_configuration`.

## What is NOT changed

`get_configuration()` itself, `list_sql_pools`, `get_sql_pool`,
`enable_sql_pools`, `disable_sql_pools`, `create_sql_pool`, `update_sql_pool`,
`delete_sql_pool` - all unchanged.

Closes #905

🤖 Generated with [Claude Code](https://claude.com/claude-code)