### PR TITLE
docs: add announcement blog post link to README and docs home

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Python CLI and MCP server for administering Microsoft Fabric Data Warehouses and
 
 **Full documentation: [fdw.debruyn.dev](https://fdw.debruyn.dev)**
 
+📣 **Just announced!** Read the story behind `fabric-dw` in the [announcement blog post](https://debruyn.dev/2026/introducing-the-fabric-data-warehouse-cli-and-mcp-server/).
+
 ## Description
 
 `fabric-dw` provides two interfaces for managing Microsoft Fabric Data Warehouses and SQL Analytics Endpoints:

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,9 @@ title: Home
 
 > Python CLI + MCP server for Microsoft Fabric Data Warehouse administration.
 
+!!! tip "Just announced"
+    Read the story behind `fabric-dw` in the [announcement blog post](https://debruyn.dev/2026/introducing-the-fabric-data-warehouse-cli-and-mcp-server/).
+
 `fabric-dw` is an open-source Python project that lets you administer Microsoft Fabric Data Warehouses and SQL Analytics Endpoints from the command line or from an AI assistant. It authenticates via the Azure credential chain, Azure CLI, Managed Identity, service principal, environment variables, and more, so it works in both local and automated environments without additional setup. See [Authentication](authentication.md) for the full chain.
 
 Both the CLI and the MCP server surfaces are built from a single Python package and share the same authentication, connection, and business logic layers. This means fixes and new features land in both interfaces simultaneously, and you only need to install one package regardless of how you plan to use it.


### PR DESCRIPTION
## Summary

- Adds a short `📣 Just announced!` callout in `README.md` (used as the PyPI long description via `pyproject.toml`) just below the full-documentation link.
- Adds a `!!! tip "Just announced"` Material admonition in `docs/index.md` just below the blockquote tagline.

Both point to the announcement blog post: <https://debruyn.dev/2026/introducing-the-fabric-data-warehouse-cli-and-mcp-server/>

> **Note:** the linked URL is currently staged and will go live when the announcement is published. Reviewers can expect a 404 until then - this is intentional.

No link-checker is configured in CI or pre-commit, so no ignore entry was needed.

Docs build (`uv run --only-group docs zensical build`) passes cleanly.

Closes #909

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>