### PR TITLE
feat(statistics): visualise SHOW_STATISTICS histogram with inline terminal bars

### DIFF
--- a/src/fabric_dw/cli/_render.py
+++ b/src/fabric_dw/cli/_render.py
@@ -814,14 +814,18 @@ def _render_histogram_table(
     column's own maximum across all steps.  On narrow terminals (when the
     bar budget yields zero cells) the bar columns are omitted but the five
     data columns always render.  Unlike the generic wide-table fallback the
-    histogram is never transposed to a vertical layout — per-step comparison
+    histogram is never transposed to a vertical layout; per-step comparison
     requires a horizontal view, so bar columns are simply dropped instead.
 
     Args:
         steps: Histogram steps from :class:`~fabric_dw.models.StatisticDetails`.
         console: The Rich console to print to.
     """
-    # Per-column maxima — None and non-finite treated as 0.
+    if not steps:
+        console.print("[bold]Histogram[/bold]: [dim]no steps[/dim]")
+        return
+
+    # Per-column maxima; None and non-finite treated as 0.
     eq_max = 0.0
     range_max = 0.0
     for step in steps:
@@ -835,7 +839,11 @@ def _render_histogram_table(
     #   - the minimum content widths of the 5 data column headers,
     #   - the header widths of the 2 bar columns,
     #   - the Rich border overhead for 7 columns (3 * 7 + 1).
-    data_min = sum(min(len(h), _KEY_MAX_WIDTH) for h in _HISTOGRAM_DATA_HEADERS)
+    # Only RANGE_HI_KEY has max_width=_KEY_MAX_WIDTH on its column definition;
+    # the remaining four columns grow to their full header-text width.
+    data_min = min(len(_HISTOGRAM_DATA_HEADERS[0]), _KEY_MAX_WIDTH) + sum(
+        len(h) for h in _HISTOGRAM_DATA_HEADERS[1:]
+    )
     bar_headers_min = len(_EQ_BAR_HEADER) + len(_RANGE_BAR_HEADER)
     budget = console.width - data_min - bar_headers_min - (3 * 7 + 1)
     bar_max_cells = max(0, min(20, budget // 2))

--- a/src/fabric_dw/cli/_render.py
+++ b/src/fabric_dw/cli/_render.py
@@ -13,7 +13,7 @@ from rich.markup import escape as _escape_markup
 from rich.panel import Panel
 from rich.table import Table
 
-from fabric_dw.models import ItemAccess, TableSyncStatus
+from fabric_dw.models import ItemAccess, StatisticDetails, StatisticHistogramStep, TableSyncStatus
 
 __all__ = [
     "confirm",
@@ -21,6 +21,7 @@ __all__ = [
     "render_permissions_table",
     "render_refresh_table",
     "render_result_rows",
+    "render_statistic_details",
     "sanitise_json",
 ]
 
@@ -737,6 +738,186 @@ def render_result_rows(
         title=table_title,
         prune_null_columns=prune_null_columns,
     )
+
+
+# ---------------------------------------------------------------------------
+# Histogram bar rendering
+# ---------------------------------------------------------------------------
+
+#: Unicode block characters for sub-character bar precision.
+#: Index 0 is a plain space (never accessed via ``_BLOCKS[0]``; the caller
+#: uses ``""`` for an empty partial), 1-7 are 1/8-through-7/8 blocks,
+#: and 8 is the full block (also used directly as ``"█"`` in ``_make_bar``).
+_BLOCKS = " ▏▎▍▌▋▊▉█"
+
+#: Maximum character width for the RANGE_HI_KEY column.
+_KEY_MAX_WIDTH = 16
+
+#: Column headers for the five histogram data columns.
+_HISTOGRAM_DATA_HEADERS = (
+    "RANGE_HI_KEY",
+    "RANGE_ROWS",
+    "EQ_ROWS",
+    "DISTINCT_RANGE_ROWS",
+    "AVG_RANGE_ROWS",
+)
+
+#: Header text for the EQ_ROWS bar column.
+_EQ_BAR_HEADER = "EQ bar"
+
+#: Header text for the RANGE_ROWS bar column.
+_RANGE_BAR_HEADER = "Range bar"
+
+
+def _make_bar(value: float | None, max_value: float, max_cells: int) -> str:
+    """Return a Unicode block-character bar string.
+
+    Returns ``""`` (no bar) when any of these conditions holds:
+
+    * ``value`` is ``None``, negative, zero, or non-finite.
+    * ``max_value`` is ``<= 0`` or non-finite.
+    * ``max_cells`` is ``<= 0``.
+
+    Args:
+        value: The numeric value to represent.
+        max_value: The scale ceiling (must be positive and finite).
+        max_cells: Maximum character cells available for the bar.
+
+    Returns:
+        A string built from ``█`` and partial-block characters (``▏▎▍▌▋▊▉``),
+        or ``""`` for an empty/invalid bar.
+    """
+    if value is None or max_cells <= 0:
+        return ""
+    if not math.isfinite(value) or not math.isfinite(max_value) or max_value <= 0:
+        return ""
+    clamped = max(0.0, value)
+    if clamped == 0.0:
+        return ""
+    total_eighths = round((clamped / max_value) * max_cells * 8)
+    total_eighths = max(0, min(total_eighths, max_cells * 8))
+    if total_eighths == 0:
+        return ""
+    full = total_eighths // 8
+    partial = total_eighths % 8
+    return "█" * full + (_BLOCKS[partial] if partial else "")
+
+
+def _render_histogram_table(
+    steps: list[StatisticHistogramStep],
+    *,
+    console: Console,
+) -> None:
+    """Render histogram steps as a Rich table with optional bar columns.
+
+    Bars for EQ_ROWS and RANGE_ROWS are scaled independently to each
+    column's own maximum across all steps.  On narrow terminals (when the
+    bar budget yields zero cells) the bar columns are omitted but the five
+    data columns always render.  Unlike the generic wide-table fallback the
+    histogram is never transposed to a vertical layout — per-step comparison
+    requires a horizontal view, so bar columns are simply dropped instead.
+
+    Args:
+        steps: Histogram steps from :class:`~fabric_dw.models.StatisticDetails`.
+        console: The Rich console to print to.
+    """
+    # Per-column maxima — None and non-finite treated as 0.
+    eq_max = 0.0
+    range_max = 0.0
+    for step in steps:
+        if step.eq_rows is not None and math.isfinite(step.eq_rows):
+            eq_max = max(eq_max, step.eq_rows)
+        if step.range_rows is not None and math.isfinite(step.range_rows):
+            range_max = max(range_max, step.range_rows)
+
+    # Budget: characters available for bar content, shared equally between
+    # the two bar columns.  The formula subtracts:
+    #   - the minimum content widths of the 5 data column headers,
+    #   - the header widths of the 2 bar columns,
+    #   - the Rich border overhead for 7 columns (3 * 7 + 1).
+    data_min = sum(min(len(h), _KEY_MAX_WIDTH) for h in _HISTOGRAM_DATA_HEADERS)
+    bar_headers_min = len(_EQ_BAR_HEADER) + len(_RANGE_BAR_HEADER)
+    budget = console.width - data_min - bar_headers_min - (3 * 7 + 1)
+    bar_max_cells = max(0, min(20, budget // 2))
+    show_bars = bar_max_cells > 0
+
+    table = Table(show_header=True, header_style="bold", title="Histogram")
+    table.add_column("RANGE_HI_KEY", max_width=_KEY_MAX_WIDTH)
+    table.add_column("RANGE_ROWS", justify="right")
+    table.add_column("EQ_ROWS", justify="right")
+    table.add_column("DISTINCT_RANGE_ROWS", justify="right")
+    table.add_column("AVG_RANGE_ROWS", justify="right")
+    if show_bars:
+        table.add_column(_EQ_BAR_HEADER)
+        table.add_column(_RANGE_BAR_HEADER)
+
+    for step in steps:
+        key_cell = (
+            _escape_markup(step.range_hi_key)
+            if step.range_hi_key is not None
+            else "[dim]NULL[/dim]"
+        )
+        row: list[str] = [
+            key_cell,
+            _cell(step.range_rows),
+            _cell(step.eq_rows),
+            _cell(step.distinct_range_rows),
+            _cell(step.avg_range_rows),
+        ]
+        if show_bars:
+            eq_bar = _make_bar(step.eq_rows, eq_max, bar_max_cells)
+            range_bar = _make_bar(step.range_rows, range_max, bar_max_cells)
+            row.append(f"[cyan]{eq_bar}[/cyan]" if eq_bar else "")
+            row.append(f"[green]{range_bar}[/green]" if range_bar else "")
+        table.add_row(*row)
+
+    console.print(table)
+
+
+def render_statistic_details(
+    details: StatisticDetails,
+    *,
+    json_output: bool,
+    console: Console | None = None,
+) -> None:
+    """Render a :class:`~fabric_dw.models.StatisticDetails` result.
+
+    In JSON mode the output is byte-for-byte identical to calling
+    ``render(details.model_dump(by_alias=True, mode="json"), json_output=True)``.
+    In terminal mode the stat header (when present) is rendered as a panel,
+    the density vector (when non-empty) as a table, and the histogram always
+    as a Rich table with optional block-character bar columns.
+
+    Args:
+        details: The statistic details to render.
+        json_output: When ``True`` emit indented JSON; when ``False`` use
+            Rich for human-friendly output.
+        console: Optional Rich Console instance.  Ignored when
+            ``json_output=True``.
+    """
+    if json_output:
+        render(details.model_dump(by_alias=True, mode="json"), json_output=True)
+        return
+
+    con = console if console is not None else _DEFAULT_CONSOLE
+
+    if details.stat_header is not None:
+        _render_panel(
+            details.stat_header.model_dump(by_alias=True, mode="json"),
+            console=con,
+            title="Stat Header",
+        )
+
+    if details.density_vector:
+        _render_table(
+            [row.model_dump(by_alias=True, mode="json") for row in details.density_vector],
+            console=con,
+            title="Density Vector",
+            drop_columns=None,
+            prune_null_columns=False,
+        )
+
+    _render_histogram_table(details.histogram, console=con)
 
 
 def confirm(message: str, *, yes: bool) -> bool:

--- a/src/fabric_dw/cli/commands/statistics.py
+++ b/src/fabric_dw/cli/commands/statistics.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import click
 
 from fabric_dw.cli._context import CliContext
-from fabric_dw.cli._render import render
+from fabric_dw.cli._render import render, render_statistic_details
 from fabric_dw.cli.commands._utils import (
     build_http_client,
     build_sql_target,
@@ -117,7 +117,7 @@ async def show_cmd(
                 histogram_only=histogram_only,
                 mode=ctx.auth,
             )
-            render(details.model_dump(by_alias=True, mode="json"), json_output=ctx.json_output)
+            render_statistic_details(details, json_output=ctx.json_output)
     except (ValueError, FabricError) as exc:
         raise click.ClickException(str(exc)) from exc
 

--- a/tests/unit/cli/commands/test_statistics.py
+++ b/tests/unit/cli/commands/test_statistics.py
@@ -15,7 +15,7 @@ from click.testing import CliRunner
 from fabric_dw.cache import ItemEntry
 from fabric_dw.cli._main import cli
 from fabric_dw.exceptions import ItemKindError, NotFoundError
-from fabric_dw.models import Statistic, StatisticDetails, WarehouseKind
+from fabric_dw.models import Statistic, StatisticDetails, StatisticHistogramStep, WarehouseKind
 from fabric_dw.sql import SqlTarget
 
 WS_GUID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
@@ -85,7 +85,22 @@ def _make_statistic_details() -> StatisticDetails:
     return StatisticDetails(
         stat_header=None,
         density_vector=[],
-        histogram=[],
+        histogram=[
+            StatisticHistogramStep(
+                range_hi_key="100",
+                range_rows=50.0,
+                eq_rows=10.0,
+                distinct_range_rows=5.0,
+                avg_range_rows=10.0,
+            ),
+            StatisticHistogramStep(
+                range_hi_key="200",
+                range_rows=100.0,
+                eq_rows=20.0,
+                distinct_range_rows=10.0,
+                avg_range_rows=10.0,
+            ),
+        ],
     )
 
 
@@ -259,6 +274,104 @@ class TestStatisticsShow:
             ["-w", WS_GUID, "statistics", "show", WH_GUID, "nodot", "stat"],
         )
         assert result.exit_code != 0
+
+    def test_show_json_output_is_valid_json(self, runner: CliRunner) -> None:
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.statistics.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.statistics.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.statistics.show_statistics",
+                new=AsyncMock(return_value=_make_statistic_details()),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--json",
+                    "-w",
+                    WS_GUID,
+                    "statistics",
+                    "show",
+                    WH_GUID,
+                    "dbo.sales",
+                    "stat_sales_id",
+                ],
+            )
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert "histogram" in parsed
+        assert isinstance(parsed["histogram"], list)
+        assert len(parsed["histogram"]) == 2
+
+    def test_show_json_structure_unchanged(self, runner: CliRunner) -> None:
+        """JSON output from show must be byte-identical to model_dump serialization."""
+        mock_http = AsyncMock()
+        details = _make_statistic_details()
+        expected = json.loads(
+            json.dumps(details.model_dump(by_alias=True, mode="json"), indent=2, default=str)
+        )
+        with (
+            patch(
+                "fabric_dw.cli.commands.statistics.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.statistics.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.statistics.show_statistics",
+                new=AsyncMock(return_value=details),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--json",
+                    "-w",
+                    WS_GUID,
+                    "statistics",
+                    "show",
+                    WH_GUID,
+                    "dbo.sales",
+                    "stat_sales_id",
+                ],
+            )
+        assert result.exit_code == 0
+        actual = json.loads(result.output)
+        assert actual == expected
+
+    def test_show_non_json_contains_histogram_headers(self, runner: CliRunner) -> None:
+        """Non-JSON output must include histogram column headers."""
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.statistics.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.statistics.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.statistics.show_statistics",
+                new=AsyncMock(return_value=_make_statistic_details()),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                ["-w", WS_GUID, "statistics", "show", WH_GUID, "dbo.sales", "stat_sales_id"],
+            )
+        assert result.exit_code == 0
+        assert "RANGE_HI_KEY" in result.output
+        assert "EQ_ROWS" in result.output
 
 
 # ===========================================================================

--- a/tests/unit/cli/test_render.py
+++ b/tests/unit/cli/test_render.py
@@ -1867,7 +1867,7 @@ class TestMakeBar:
 
     def test_small_value_rounds_to_one_eighth(self) -> None:
         # Very small non-zero value should either return "" (rounds to 0)
-        # or a partial block — crucially, never crash.
+        # or a partial block; crucially, never crash.
         bar = _make_bar(0.001, 1000.0, 10)
         # Rounds to 0 eighths → empty bar
         assert bar == ""
@@ -1992,14 +1992,38 @@ class TestRenderStatisticDetails:
         assert "EQ_ROWS" in output
 
     # ------------------------------------------------------------------
+    # Bar visibility threshold: pins the exact width where bars appear
+    # ------------------------------------------------------------------
+
+    def test_bar_columns_absent_at_width_100(self) -> None:
+        """At width 100 the budget is < 2 so bar columns must not appear."""
+        sio = StringIO()
+        con = Console(file=sio, width=100, highlight=False, no_color=True)
+        render_statistic_details(_make_details(), json_output=False, console=con)
+        output = sio.getvalue()
+        assert "EQ bar" not in output
+        assert "Range bar" not in output
+
+    def test_bar_columns_present_at_width_101(self) -> None:
+        """At width 101 the budget reaches 2, giving 1 bar cell each side."""
+        sio = StringIO()
+        con = Console(file=sio, width=101, highlight=False, no_color=True)
+        render_statistic_details(_make_details(), json_output=False, console=con)
+        output = sio.getvalue()
+        assert "EQ bar" in output
+        assert "Range bar" in output
+
+    # ------------------------------------------------------------------
     # All-zero and all-None columns: no block chars
     # ------------------------------------------------------------------
 
     def test_all_zero_eq_rows_no_block_char_in_eq_column(self) -> None:
+        # Both eq_rows and range_rows are zero so no bar chars appear anywhere.
+        # This directly asserts that an all-zero column never produces a block char.
         steps = [
             StatisticHistogramStep(
                 range_hi_key="100",
-                range_rows=50.0,
+                range_rows=0.0,
                 eq_rows=0.0,
                 distinct_range_rows=None,
                 avg_range_rows=None,
@@ -2008,9 +2032,8 @@ class TestRenderStatisticDetails:
         con, sio = _make_wide_console()
         render_statistic_details(_make_details(steps=steps), json_output=False, console=con)
         output = sio.getvalue()
-        # Range bar should have a block char; EQ bar should be empty (no blocks)
-        # We can't easily assert per-column, but we CAN assert no crash
         assert "RANGE_HI_KEY" in output
+        assert "█" not in output
 
     def test_all_none_eq_rows_no_crash(self) -> None:
         steps = [
@@ -2035,7 +2058,8 @@ class TestRenderStatisticDetails:
         con, sio = _make_wide_console()
         render_statistic_details(_make_details(steps=[]), json_output=False, console=con)
         output = sio.getvalue()
-        assert output is not None
+        # No crash; a short "no steps" notice is printed instead of an empty table.
+        assert "no steps" in output
 
     # ------------------------------------------------------------------
     # stat_header and density_vector
@@ -2084,6 +2108,23 @@ class TestRenderStatisticDetails:
         render_statistic_details(_make_details(steps=steps), json_output=False, console=con)
         output = sio.getvalue()
         assert "NULL" in output
+
+    def test_range_hi_key_markup_brackets_rendered_verbatim(self) -> None:
+        """Rich markup in range_hi_key must be escaped, not interpreted."""
+        steps = [
+            StatisticHistogramStep(
+                range_hi_key="[red]x[/red]",
+                range_rows=10.0,
+                eq_rows=5.0,
+                distinct_range_rows=2.0,
+                avg_range_rows=5.0,
+            ),
+        ]
+        con, sio = _make_wide_console()
+        render_statistic_details(_make_details(steps=steps), json_output=False, console=con)
+        output = sio.getvalue()
+        # The brackets must appear as literal characters, not trigger a red colour span.
+        assert "[red]x[/red]" in output
 
     # ------------------------------------------------------------------
     # histogram-only (--histogram flag): no header or density sections

--- a/tests/unit/cli/test_render.py
+++ b/tests/unit/cli/test_render.py
@@ -14,16 +14,22 @@ from fabric_dw.cli._render import (
     _cell,
     _format_nested,
     _is_guid_column,
+    _make_bar,
     confirm,
     render,
     render_permissions_table,
     render_refresh_table,
+    render_statistic_details,
     sanitise_json,
 )
 from fabric_dw.models import (
     ItemAccess,
     ItemAccessDetail,
     ItemAccessPrincipal,
+    StatisticDensityRow,
+    StatisticDetails,
+    StatisticHeaderRow,
+    StatisticHistogramStep,
     TableSyncError,
     TableSyncStatus,
 )
@@ -1796,3 +1802,339 @@ class TestNestedPanelRendering:
         # No line should be non-empty but consist only of whitespace
         blank_indent_lines = [line for line in lines if line and not line.strip()]
         assert blank_indent_lines == [], f"Blank indent lines found: {blank_indent_lines!r}"
+
+
+# ===========================================================================
+# _make_bar unit tests
+# ===========================================================================
+
+
+class TestMakeBar:
+    """Unit tests for the _make_bar helper."""
+
+    def test_none_value_returns_empty(self) -> None:
+        assert _make_bar(None, 100.0, 10) == ""
+
+    def test_zero_value_returns_empty(self) -> None:
+        assert _make_bar(0.0, 100.0, 10) == ""
+
+    def test_negative_value_returns_empty(self) -> None:
+        assert _make_bar(-5.0, 100.0, 10) == ""
+
+    def test_zero_max_value_returns_empty(self) -> None:
+        assert _make_bar(50.0, 0.0, 10) == ""
+
+    def test_negative_max_value_returns_empty(self) -> None:
+        assert _make_bar(50.0, -10.0, 10) == ""
+
+    def test_zero_max_cells_returns_empty(self) -> None:
+        assert _make_bar(50.0, 100.0, 0) == ""
+
+    def test_negative_max_cells_returns_empty(self) -> None:
+        assert _make_bar(50.0, 100.0, -1) == ""
+
+    def test_nan_value_returns_empty(self) -> None:
+
+        assert _make_bar(float("nan"), 100.0, 10) == ""
+
+    def test_inf_value_returns_empty(self) -> None:
+        assert _make_bar(float("inf"), 100.0, 10) == ""
+
+    def test_nan_max_value_returns_empty(self) -> None:
+
+        assert _make_bar(50.0, float("nan"), 10) == ""
+
+    def test_inf_max_value_returns_empty(self) -> None:
+        assert _make_bar(50.0, float("inf"), 10) == ""
+
+    def test_full_value_fills_all_cells(self) -> None:
+        bar = _make_bar(100.0, 100.0, 10)
+        assert bar == "█" * 10
+
+    def test_half_value_fills_half_cells(self) -> None:
+        bar = _make_bar(50.0, 100.0, 10)
+        assert bar == "█" * 5
+
+    def test_one_eighth_produces_partial_block(self) -> None:
+        # 1/8 of 1 cell = 1/8 block character ▏
+        bar = _make_bar(1.0, 8.0, 1)
+        assert bar == "▏"
+
+    def test_bar_length_never_exceeds_max_cells(self) -> None:
+        # value > max_value is clamped to max_cells full blocks
+        bar = _make_bar(200.0, 100.0, 5)
+        assert len(bar) <= 5
+
+    def test_small_value_rounds_to_one_eighth(self) -> None:
+        # Very small non-zero value should either return "" (rounds to 0)
+        # or a partial block — crucially, never crash.
+        bar = _make_bar(0.001, 1000.0, 10)
+        # Rounds to 0 eighths → empty bar
+        assert bar == ""
+
+    def test_bar_contains_only_block_chars(self) -> None:
+        bar = _make_bar(75.0, 100.0, 8)
+        block_chars = set("█▏▎▍▌▋▊▉")
+        assert all(c in block_chars for c in bar)
+
+
+# ===========================================================================
+# render_statistic_details integration tests
+# ===========================================================================
+
+
+def _make_wide_console() -> tuple[Console, StringIO]:
+    """Return a (Console, StringIO) pair at width=160 (bars always visible)."""
+    sio = StringIO()
+    con = Console(file=sio, width=160, highlight=False, no_color=True)
+    return con, sio
+
+
+def _make_narrow_console() -> tuple[Console, StringIO]:
+    """Return a (Console, StringIO) pair at width=70 (bars always omitted)."""
+    sio = StringIO()
+    con = Console(file=sio, width=70, highlight=False, no_color=True)
+    return con, sio
+
+
+def _make_details(
+    *,
+    steps: list[StatisticHistogramStep] | None = None,
+    with_header: bool = False,
+    with_density: bool = False,
+) -> StatisticDetails:
+    """Build a minimal StatisticDetails for testing."""
+    if steps is None:
+        steps = [
+            StatisticHistogramStep(
+                range_hi_key="100",
+                range_rows=50.0,
+                eq_rows=10.0,
+                distinct_range_rows=5.0,
+                avg_range_rows=10.0,
+            ),
+            StatisticHistogramStep(
+                range_hi_key="200",
+                range_rows=100.0,
+                eq_rows=20.0,
+                distinct_range_rows=10.0,
+                avg_range_rows=10.0,
+            ),
+        ]
+    header = (
+        StatisticHeaderRow(
+            name="stat_sales_id",
+            updated=None,
+            rows=1000,
+            rows_sampled=1000,
+            steps=2,
+            density=0.001,
+            average_key_length=4.0,
+            string_index="NO",
+            filter_expression=None,
+            unfiltered_rows=None,
+        )
+        if with_header
+        else None
+    )
+    density = (
+        [StatisticDensityRow(all_density=0.001, average_length=4.0, columns="id")]
+        if with_density
+        else []
+    )
+    return StatisticDetails(stat_header=header, density_vector=density, histogram=steps)
+
+
+class TestRenderStatisticDetails:
+    """Integration tests for render_statistic_details."""
+
+    # ------------------------------------------------------------------
+    # Wide terminal: bar columns present
+    # ------------------------------------------------------------------
+
+    def test_wide_terminal_shows_histogram_column_headers(self) -> None:
+        con, sio = _make_wide_console()
+        render_statistic_details(_make_details(), json_output=False, console=con)
+        output = sio.getvalue()
+        assert "RANGE_HI_KEY" in output
+        assert "EQ_ROWS" in output
+        assert "RANGE_ROWS" in output
+
+    def test_wide_terminal_shows_bar_columns(self) -> None:
+        con, sio = _make_wide_console()
+        render_statistic_details(_make_details(), json_output=False, console=con)
+        output = sio.getvalue()
+        assert "EQ bar" in output
+        assert "Range bar" in output
+
+    def test_wide_terminal_bars_contain_block_char(self) -> None:
+        con, sio = _make_wide_console()
+        render_statistic_details(_make_details(), json_output=False, console=con)
+        output = sio.getvalue()
+        assert "█" in output
+
+    # ------------------------------------------------------------------
+    # Narrow terminal: bar columns omitted, data still rendered
+    # ------------------------------------------------------------------
+
+    def test_narrow_terminal_no_bar_columns(self) -> None:
+        con, sio = _make_narrow_console()
+        render_statistic_details(_make_details(), json_output=False, console=con)
+        output = sio.getvalue()
+        assert "EQ bar" not in output
+        assert "Range bar" not in output
+
+    def test_narrow_terminal_data_columns_still_present(self) -> None:
+        con, sio = _make_narrow_console()
+        render_statistic_details(_make_details(), json_output=False, console=con)
+        output = sio.getvalue()
+        assert "RANGE_HI_KEY" in output
+        assert "EQ_ROWS" in output
+
+    # ------------------------------------------------------------------
+    # All-zero and all-None columns: no block chars
+    # ------------------------------------------------------------------
+
+    def test_all_zero_eq_rows_no_block_char_in_eq_column(self) -> None:
+        steps = [
+            StatisticHistogramStep(
+                range_hi_key="100",
+                range_rows=50.0,
+                eq_rows=0.0,
+                distinct_range_rows=None,
+                avg_range_rows=None,
+            ),
+        ]
+        con, sio = _make_wide_console()
+        render_statistic_details(_make_details(steps=steps), json_output=False, console=con)
+        output = sio.getvalue()
+        # Range bar should have a block char; EQ bar should be empty (no blocks)
+        # We can't easily assert per-column, but we CAN assert no crash
+        assert "RANGE_HI_KEY" in output
+
+    def test_all_none_eq_rows_no_crash(self) -> None:
+        steps = [
+            StatisticHistogramStep(
+                range_hi_key="100",
+                range_rows=None,
+                eq_rows=None,
+                distinct_range_rows=None,
+                avg_range_rows=None,
+            ),
+        ]
+        con, sio = _make_wide_console()
+        render_statistic_details(_make_details(steps=steps), json_output=False, console=con)
+        output = sio.getvalue()
+        assert "RANGE_HI_KEY" in output
+
+    # ------------------------------------------------------------------
+    # Empty histogram
+    # ------------------------------------------------------------------
+
+    def test_empty_histogram_renders_without_error(self) -> None:
+        con, sio = _make_wide_console()
+        render_statistic_details(_make_details(steps=[]), json_output=False, console=con)
+        output = sio.getvalue()
+        assert output is not None
+
+    # ------------------------------------------------------------------
+    # stat_header and density_vector
+    # ------------------------------------------------------------------
+
+    def test_stat_header_panel_shown_when_present(self) -> None:
+        con, sio = _make_wide_console()
+        render_statistic_details(_make_details(with_header=True), json_output=False, console=con)
+        output = sio.getvalue()
+        assert "Stat Header" in output
+        assert "stat_sales_id" in output
+
+    def test_stat_header_absent_when_none(self) -> None:
+        con, sio = _make_wide_console()
+        render_statistic_details(_make_details(with_header=False), json_output=False, console=con)
+        output = sio.getvalue()
+        assert "Stat Header" not in output
+
+    def test_density_vector_shown_when_non_empty(self) -> None:
+        con, sio = _make_wide_console()
+        render_statistic_details(_make_details(with_density=True), json_output=False, console=con)
+        output = sio.getvalue()
+        assert "Density Vector" in output
+
+    def test_density_vector_absent_when_empty(self) -> None:
+        con, sio = _make_wide_console()
+        render_statistic_details(_make_details(with_density=False), json_output=False, console=con)
+        output = sio.getvalue()
+        assert "Density Vector" not in output
+
+    # ------------------------------------------------------------------
+    # None range_hi_key renders as NULL
+    # ------------------------------------------------------------------
+
+    def test_none_range_hi_key_renders_null(self) -> None:
+        steps = [
+            StatisticHistogramStep(
+                range_hi_key=None,
+                range_rows=10.0,
+                eq_rows=5.0,
+                distinct_range_rows=2.0,
+                avg_range_rows=5.0,
+            ),
+        ]
+        con, sio = _make_wide_console()
+        render_statistic_details(_make_details(steps=steps), json_output=False, console=con)
+        output = sio.getvalue()
+        assert "NULL" in output
+
+    # ------------------------------------------------------------------
+    # histogram-only (--histogram flag): no header or density sections
+    # ------------------------------------------------------------------
+
+    def test_histogram_only_no_header_no_density(self) -> None:
+        """When stat_header is None and density_vector is empty, only histogram renders."""
+        details = StatisticDetails(
+            stat_header=None,
+            density_vector=[],
+            histogram=[
+                StatisticHistogramStep(
+                    range_hi_key="50",
+                    range_rows=25.0,
+                    eq_rows=5.0,
+                    distinct_range_rows=3.0,
+                    avg_range_rows=8.0,
+                ),
+            ],
+        )
+        con, sio = _make_wide_console()
+        render_statistic_details(details, json_output=False, console=con)
+        output = sio.getvalue()
+        assert "Stat Header" not in output
+        assert "Density Vector" not in output
+        assert "RANGE_HI_KEY" in output
+
+    # ------------------------------------------------------------------
+    # JSON regression: byte-for-byte identical to raw render() call
+    # ------------------------------------------------------------------
+
+    def test_json_output_identical_to_raw_render(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """JSON branch must produce output character-for-character identical to
+        render(details.model_dump(by_alias=True, mode=\"json\"), json_output=True)."""
+        details = _make_details(with_header=True, with_density=True)
+        dumped = details.model_dump(by_alias=True, mode="json")
+
+        # Capture render_statistic_details output
+        render_statistic_details(details, json_output=True)
+        captured_new = capsys.readouterr().out
+
+        # Capture raw render() output with identical serialization
+        render(dumped, json_output=True)
+        captured_old = capsys.readouterr().out
+
+        assert captured_new == captured_old
+
+    def test_json_output_is_valid_json(self, capsys: pytest.CaptureFixture[str]) -> None:
+        details = _make_details(with_header=True, with_density=True)
+        render_statistic_details(details, json_output=True)
+        captured = capsys.readouterr()
+        parsed = json.loads(captured.out)
+        assert "histogram" in parsed
+        assert isinstance(parsed["histogram"], list)


### PR DESCRIPTION
## Summary

- Adds horizontal Unicode block-character bar columns to `statistics show` non-JSON output, scaled independently per column (EQ_ROWS in cyan, RANGE_ROWS in green).
- On narrow terminals the bar columns are silently dropped; the five data columns (RANGE_HI_KEY, RANGE_ROWS, EQ_ROWS, DISTINCT_RANGE_ROWS, AVG_RANGE_ROWS) always render.
- JSON and MCP tool output are byte-for-byte unchanged (regression-tested).
- No new dependencies; uses `rich` (already a dependency) and Unicode block characters (U+2588 family) for sub-character resolution.

## Changes

- `src/fabric_dw/cli/_render.py`: new `_make_bar`, `_render_histogram_table`, `render_statistic_details` functions; `_BLOCKS` constant.
- `src/fabric_dw/cli/commands/statistics.py`: `show_cmd` calls `render_statistic_details` instead of the generic `render`.
- Tests: `_make_bar` edge cases (None, zero, negative, non-finite, clamping, partial blocks), renderer integration at wide and narrow widths, JSON regression test, and command-level tests.

## Test plan

- [x] `uv run ruff check src tests` - passes
- [x] `uv run ruff format --check .` - passes
- [x] `uv run ty check src tests` - no new errors (pre-existing warnings only)
- [x] `uv run pytest tests/unit/cli -q` - 1350 passed

Closes #908

🤖 Generated with [Claude Code](https://claude.com/claude-code)