### PR TITLE
feat(settings): enable/disable Delta Lake log publishing (DATA_LAKE_LOG_PUBLISHING)

### DIFF
--- a/docs/commands/settings.md
+++ b/docs/commands/settings.md
@@ -10,13 +10,35 @@ Manage **server-side** database settings on a Fabric Data Warehouse or SQL Analy
 
     `settings` manages server-side warehouse/database configuration. For client-side CLI defaults (workspace, warehouse) use [`fdw config`](config.md) instead.
 
-`show` works on both Data Warehouses and SQL Analytics Endpoints. `result-set-caching` and `retention` issue `ALTER DATABASE CURRENT SET …`, which is **not supported on SQL Analytics Endpoints**: running either command against one returns a clean error.
+`show` works on both Data Warehouses and SQL Analytics Endpoints. `result-set-caching`, `retention`, and `data-lake-log-publishing` issue `ALTER DATABASE CURRENT SET …`, which is **not supported on SQL Analytics Endpoints**: running any of them against an endpoint returns a clean error.
 
 The workspace is resolved from the global `-w/--workspace` option, the `FABRIC_DW_DEFAULT_WORKSPACE` environment variable, or the client-side config default. `ITEM` may be a display name or GUID.
 
 **Targets:** Data Warehouse
 
 ## CLI
+
+### settings data-lake-log-publishing
+
+**Targets:** Data Warehouse
+
+Enable or disable Delta Lake log publishing.
+
+Executes `ALTER DATABASE CURRENT SET DATA_LAKE_LOG_PUBLISHING = { AUTO | PAUSED }` on the target.
+
+```shell
+fdw -w <workspace> settings data-lake-log-publishing [ITEM] (on|off)
+```
+
+`STATE` is case-insensitive (`on`, `off`, `ON`, `OFF`). `on` maps to `= AUTO`; `off` maps to `= PAUSED`.
+
+**Example:**
+
+```shell
+fdw -w MyWorkspace settings data-lake-log-publishing MyWarehouse on
+fdw -w MyWorkspace settings data-lake-log-publishing MyWarehouse off
+fdw -w MyWorkspace --json settings data-lake-log-publishing MyWarehouse on
+```
 
 ### settings result-set-caching
 
@@ -88,7 +110,7 @@ fdw -w MyWorkspace --json settings show MyWarehouse
 
 **Guards:** `assert_workspace_allowed`
 
-Return the current server-side database settings for a warehouse. Reads `result_set_caching`, `time_travel_retention_days`, and `time_travel_retention_cutoff_date` from `sys.databases`.
+Return the current server-side database settings for a warehouse. Reads `result_set_caching`, `time_travel_retention_days`, `time_travel_retention_cutoff_date`, and `data_lake_log_publishing` from `sys.databases`.
 
 **Parameters:**
 
@@ -97,7 +119,25 @@ Return the current server-side database settings for a warehouse. Reads `result_
 | `workspace` | `str` | Workspace name or GUID. |
 | `item` | `str` | Warehouse or SQL Analytics Endpoint name or GUID. |
 
-**Returns:** `WarehouseSettings`: `{ database, result_set_caching, time_travel_retention_days, time_travel_retention_cutoff_date }`.
+**Returns:** `WarehouseSettings`: `{ database, result_set_caching, time_travel_retention_days, time_travel_retention_cutoff_date, data_lake_log_publishing }`.
+
+### set_data_lake_log_publishing
+
+**Targets:** Data Warehouse
+
+**Guards:** `assert_writes_allowed`, `assert_workspace_allowed`
+
+Enable or disable Delta Lake log publishing on a warehouse. Executes `ALTER DATABASE CURRENT SET DATA_LAKE_LOG_PUBLISHING = { AUTO | PAUSED }` and returns the effective settings after the change.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `workspace` | `str` | Workspace name or GUID. |
+| `item` | `str` | Warehouse name or GUID. SQL Analytics Endpoints are rejected. |
+| `enabled` | `bool` | `true` to enable Delta Lake log publishing (`= AUTO`), `false` to disable it (`= PAUSED`). |
+
+**Returns:** `WarehouseSettings`: the effective settings after the change.
 
 ### set_result_set_caching
 
@@ -131,6 +171,6 @@ Set the time-travel retention period on a warehouse. Executes `ALTER DATABASE CU
 | --- | --- | --- |
 | `workspace` | `str` | Workspace name or GUID. |
 | `item` | `str` | Warehouse or SQL Analytics Endpoint name or GUID. |
-| `days` | `int` | Retention period in days. Must be in the range 1–120 (inclusive). |
+| `days` | `int` | Retention period in days. Must be in the range 1-120 (inclusive). |
 
 **Returns:** `WarehouseSettings`: the effective settings after the change.

--- a/src/fabric_dw/cli/commands/settings.py
+++ b/src/fabric_dw/cli/commands/settings.py
@@ -27,12 +27,13 @@ def settings_group() -> None:
     """Manage server-side database settings on Fabric Data Warehouses.
 
     ``settings`` manages server-side warehouse/database configuration
-    (result-set caching, time-travel retention).  For client-side CLI
-    defaults (workspace, warehouse) use the ``config`` group instead.
+    (result-set caching, time-travel retention, Delta Lake log publishing).
+    For client-side CLI defaults (workspace, warehouse) use the ``config``
+    group instead.
 
     ``show`` works on both Data Warehouses and SQL Analytics Endpoints.
-    ``result-set-caching`` and ``retention`` are Data-Warehouse-only —
-    SQL Analytics Endpoints are rejected with an error.
+    ``result-set-caching``, ``retention``, and ``data-lake-log-publishing``
+    are Data-Warehouse-only — SQL Analytics Endpoints are rejected with an error.
     """
 
 
@@ -101,6 +102,48 @@ async def result_set_caching_cmd(
             else:
                 click.echo(
                     f"Result-set caching {'enabled' if enabled else 'disabled'} "
+                    f"on {result.database!r}."
+                )
+    except (ValueError, FabricError) as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@settings_group.command("data-lake-log-publishing")
+@click.argument("item", required=False, default=None)
+@click.argument("state", type=click.Choice(["on", "off"], case_sensitive=False))
+@click.pass_obj
+@coro
+async def data_lake_log_publishing_cmd(
+    ctx: CliContext,
+    item: str | None,
+    state: str,
+) -> None:
+    """Enable or disable Delta Lake log publishing on ITEM.
+
+    STATE must be ``on`` or ``off`` (case-insensitive).
+
+    Executes ``ALTER DATABASE CURRENT SET DATA_LAKE_LOG_PUBLISHING = { AUTO | PAUSED }``
+    on the target.  Only supported on Fabric Data Warehouses — SQL Analytics
+    Endpoints are rejected with an error.
+
+    ITEM may be a display name or GUID.  The workspace is resolved from
+    the global ``-w`` option, ``FABRIC_DW_DEFAULT_WORKSPACE`` env var, or
+    the client-side config default.
+    """
+    ws = resolve_workspace(ctx)
+    wh = resolve_warehouse_arg(ctx, item)
+    enabled = state.lower() == "on"
+    try:
+        async with build_http_client(ctx) as http:
+            target, entry = await build_sql_target(http, ws, wh)
+            result = await _settings_svc.set_data_lake_log_publishing(
+                target, enabled=enabled, kind=entry.kind, mode=ctx.auth
+            )
+            if ctx.json_output:
+                render(result.model_dump(by_alias=True, mode="json"), json_output=True)
+            else:
+                click.echo(
+                    f"Delta Lake log publishing {'enabled' if enabled else 'disabled'} "
                     f"on {result.database!r}."
                 )
     except (ValueError, FabricError) as exc:

--- a/src/fabric_dw/mcp/tools/settings.py
+++ b/src/fabric_dw/mcp/tools/settings.py
@@ -37,8 +37,9 @@ def register(mcp: FastMCP) -> None:
     ) -> dict[str, Any]:
         """Return the current server-side database settings for a warehouse.
 
-        Reads ``result_set_caching``, ``time_travel_retention_days``, and
-        ``time_travel_retention_cutoff_date`` from ``sys.databases``.
+        Reads ``result_set_caching``, ``time_travel_retention_days``,
+        ``time_travel_retention_cutoff_date``, and ``data_lake_log_publishing``
+        from ``sys.databases``.
 
         Both Data Warehouses and SQL Analytics Endpoints are supported.
 

--- a/src/fabric_dw/mcp/tools/settings.py
+++ b/src/fabric_dw/mcp/tools/settings.py
@@ -152,3 +152,47 @@ def register(mcp: FastMCP) -> None:
         except (ValueError, FabricError) as exc:
             raise tool_err(exc) from exc
         return result.model_dump(mode="json")
+
+    @mutating_tool(mcp, "set_data_lake_log_publishing")
+    async def set_data_lake_log_publishing(
+        workspace: str,
+        item: str,
+        enabled: bool,  # noqa: FBT001
+    ) -> dict[str, Any]:
+        """Enable or disable Delta Lake log publishing on a warehouse.
+
+        Executes ``ALTER DATABASE CURRENT SET DATA_LAKE_LOG_PUBLISHING = { AUTO | PAUSED }``
+        and returns the effective settings read back after the change.
+
+        Only supported on Fabric Data Warehouses (not SQL Analytics Endpoints).
+        SQL Analytics Endpoints are rejected with a ``ToolError``.
+
+        Args:
+            workspace: Workspace name or GUID.
+            item: Warehouse name or GUID.  SQL Analytics Endpoints are rejected.
+            enabled: ``True`` to enable Delta Lake log publishing (``= AUTO``),
+                ``False`` to disable it (``= PAUSED``).
+        """
+        ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
+        try:
+            ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
+            _log.debug(
+                "set_data_lake_log_publishing ws=%s item=%s enabled=%s",
+                ws_id,
+                entry.id,
+                enabled,
+            )
+            target = make_sql_target(ws_id, entry, item)
+            result = await settings_svc.set_data_lake_log_publishing(
+                target,
+                enabled=enabled,
+                kind=entry.kind,
+                mode=ctx.auth_mode,
+            )
+        except (ValueError, FabricError) as exc:
+            raise tool_err(exc) from exc
+        return result.model_dump(mode="json")

--- a/src/fabric_dw/models.py
+++ b/src/fabric_dw/models.py
@@ -649,8 +649,9 @@ class WarehouseSettings(_FabricBase):
     """Server-side database settings read from ``sys.databases``.
 
     Both Data Warehouses and SQL Analytics Endpoints expose these settings.
-    The two write operations (:func:`~fabric_dw.services.settings.set_result_set_caching`
-    and :func:`~fabric_dw.services.settings.set_time_travel_retention`) require
+    The write operations (:func:`~fabric_dw.services.settings.set_result_set_caching`,
+    :func:`~fabric_dw.services.settings.set_time_travel_retention`, and
+    :func:`~fabric_dw.services.settings.set_data_lake_log_publishing`) require
     a Data Warehouse (they execute ``ALTER DATABASE CURRENT SET …``).
 
     Attributes:
@@ -659,12 +660,16 @@ class WarehouseSettings(_FabricBase):
         time_travel_retention_days: Time-travel retention period in days.
         time_travel_retention_cutoff_date: The earliest date for which time-travel
             data is retained, or ``None`` when not applicable.
+        data_lake_log_publishing: Whether Delta Lake log publishing is enabled
+            (``True`` = ``AUTO``, ``False`` = ``PAUSED``).  ``None``/``NULL``
+            from the driver (e.g. on SQL Analytics Endpoints) maps to ``False``.
     """
 
     database: str
     result_set_caching: bool
     time_travel_retention_days: int | None
     time_travel_retention_cutoff_date: datetime | None
+    data_lake_log_publishing: bool
 
 
 # ---------------------------------------------------------------------------

--- a/src/fabric_dw/services/settings.py
+++ b/src/fabric_dw/services/settings.py
@@ -94,6 +94,12 @@ SELECT
 FROM sys.databases
 WHERE database_id = DB_ID();
 """
+# Dual-target note: sys.databases is readable on both Data Warehouses and SQL
+# Analytics Endpoints.  Warehouse-specific columns (time_travel_* and
+# data_lake_log_publishing_desc) are present in the view on both target types
+# but return NULL on SQL Analytics Endpoints — the same precedent as the existing
+# time_travel_retention_period_days column.  _row_to_settings handles NULL values
+# gracefully: time_travel_retention_days -> None, data_lake_log_publishing -> False.
 
 # ON/OFF are SQL keywords — embedded as a literal derived from a Python bool,
 # never from arbitrary user input.
@@ -128,8 +134,10 @@ def _row_to_settings(cols: list[str], row: tuple[object, ...]) -> WarehouseSetti
     else:
         cutoff = None
     # data_lake_log_publishing_desc may be NULL on SQL Analytics Endpoints; default to False.
+    # isinstance guard keeps the type narrowed to str before calling .upper(), so
+    # None (NULL) and any unexpected non-string value both map safely to False.
     raw_dllp = data.get("data_lake_log_publishing_desc")
-    data_lake_log_publishing = str(raw_dllp).upper() == "AUTO" if raw_dllp is not None else False
+    data_lake_log_publishing = isinstance(raw_dllp, str) and raw_dllp.upper() == "AUTO"
     return WarehouseSettings(
         database=str(data["name"]),
         result_set_caching=bool(data["is_result_set_caching_on"]),

--- a/src/fabric_dw/services/settings.py
+++ b/src/fabric_dw/services/settings.py
@@ -2,24 +2,27 @@
 
 Public API
 ----------
-- :func:`get_settings`              — read current settings from ``sys.databases``.
-- :func:`set_result_set_caching`    — toggle result-set caching via ``ALTER DATABASE``.
-- :func:`set_time_travel_retention` — set time-travel retention period via ``ALTER DATABASE``.
+- :func:`get_settings`                  — read current settings from ``sys.databases``.
+- :func:`set_result_set_caching`        — toggle result-set caching via ``ALTER DATABASE``.
+- :func:`set_time_travel_retention`     — set time-travel retention period via ``ALTER DATABASE``.
+- :func:`set_data_lake_log_publishing`  — toggle Delta Lake log publishing via ``ALTER DATABASE``.
 
 SQL-level safety
 ----------------
 ``ALTER DATABASE CURRENT SET …`` statements are DDL that **cannot** be bound via
-SQL parameters.  The two write functions therefore embed values as literals:
+SQL parameters.  The write functions therefore embed values as literals:
 
 - ``set_result_set_caching`` embeds ``ON`` or ``OFF`` — derived from a Python
   :class:`bool`, never from arbitrary user input.
 - ``set_time_travel_retention`` embeds an integer literal after range-validating
   the value as a Python :class:`int` (1-120).  Floats and strings are rejected
   before the literal is formed.
+- ``set_data_lake_log_publishing`` embeds ``AUTO`` or ``PAUSED`` — derived from
+  a Python :class:`bool`, never from arbitrary user input.
 
 Autocommit
 ----------
-Both ``ALTER DATABASE`` statements **must** run with ``autocommit=True``.
+All ``ALTER DATABASE`` statements **must** run with ``autocommit=True``.
 Using a regular (autocommit-off) connection raises:
 
     "ALTER DATABASE statement not allowed within multi-statement transaction."
@@ -32,11 +35,12 @@ SQL Analytics Endpoint note
 ``get_settings`` is dual-target — both Data Warehouses and SQL Analytics
 Endpoints respond to the ``sys.databases`` read query.
 
-The ``ALTER DATABASE`` write operations (``set_result_set_caching`` and
-``set_time_travel_retention``) are DWH-only.  SQL Analytics Endpoints are
-read-only at the SQL layer; ``ALTER DATABASE`` is silently rejected or
-produces unexpected results.  Both write functions guard against this via
-``_assert_not_sql_endpoint`` and accept a ``kind`` parameter (defaulting to
+The ``ALTER DATABASE`` write operations (``set_result_set_caching``,
+``set_time_travel_retention``, and ``set_data_lake_log_publishing``) are
+DWH-only.  SQL Analytics Endpoints are read-only at the SQL layer;
+``ALTER DATABASE`` is silently rejected or produces unexpected results.
+All write functions guard against this via ``_assert_not_sql_endpoint`` and
+accept a ``kind`` parameter (defaulting to
 :attr:`~fabric_dw.models.WarehouseKind.WAREHOUSE`) so that callers can pass
 the resolved item kind.
 """
@@ -58,6 +62,7 @@ __all__ = [
     "RETENTION_MAX",
     "RETENTION_MIN",
     "get_settings",
+    "set_data_lake_log_publishing",
     "set_result_set_caching",
     "set_time_travel_retention",
 ]
@@ -84,7 +89,8 @@ SELECT
     name,
     is_result_set_caching_on,
     time_travel_retention_period_days,
-    time_travel_retention_cutoff_date
+    time_travel_retention_cutoff_date,
+    data_lake_log_publishing_desc
 FROM sys.databases
 WHERE database_id = DB_ID();
 """
@@ -96,6 +102,11 @@ _SET_RSC_SQL_OFF = "ALTER DATABASE CURRENT SET RESULT_SET_CACHING OFF;"
 
 # <n> is an int literal (range-validated 1-120); not a SQL parameter.
 _SET_RETENTION_SQL_TEMPLATE = "ALTER DATABASE CURRENT SET TIME_TRAVEL_RETENTION_PERIOD = {n} DAYS;"
+
+# AUTO/PAUSED are SQL keywords — embedded as literals derived from a Python bool,
+# never from arbitrary user input.  The = sign is required (not a space-separated form).
+_SET_DLLP_SQL_AUTO = "ALTER DATABASE CURRENT SET DATA_LAKE_LOG_PUBLISHING = AUTO;"
+_SET_DLLP_SQL_PAUSED = "ALTER DATABASE CURRENT SET DATA_LAKE_LOG_PUBLISHING = PAUSED;"
 
 
 # ---------------------------------------------------------------------------
@@ -116,11 +127,15 @@ def _row_to_settings(cols: list[str], row: tuple[object, ...]) -> WarehouseSetti
         cutoff = datetime(raw_ts.year, raw_ts.month, raw_ts.day, tzinfo=UTC)
     else:
         cutoff = None
+    # data_lake_log_publishing_desc may be NULL on SQL Analytics Endpoints; default to False.
+    raw_dllp = data.get("data_lake_log_publishing_desc")
+    data_lake_log_publishing = str(raw_dllp).upper() == "AUTO" if raw_dllp is not None else False
     return WarehouseSettings(
         database=str(data["name"]),
         result_set_caching=bool(data["is_result_set_caching_on"]),
         time_travel_retention_days=int(cast("int", raw_days)) if raw_days is not None else None,
         time_travel_retention_cutoff_date=cutoff,
+        data_lake_log_publishing=data_lake_log_publishing,
     )
 
 
@@ -251,6 +266,50 @@ async def set_time_travel_retention(
         raise ValueError(msg)
 
     ddl = _SET_RETENTION_SQL_TEMPLATE.format(n=days_int)
+
+    def _run() -> None:
+        run_query(target, ddl, mode=mode, autocommit=True, fetch="none")
+
+    await asyncio.to_thread(_run)
+    return await get_settings(target, mode=mode)
+
+
+async def set_data_lake_log_publishing(
+    target: SqlTarget,
+    *,
+    enabled: bool,
+    kind: WarehouseKind = WarehouseKind.WAREHOUSE,
+    mode: CredentialMode = CredentialMode.DEFAULT,
+) -> WarehouseSettings:
+    """Enable or disable Delta Lake log publishing on *target*.
+
+    Executes ``ALTER DATABASE CURRENT SET DATA_LAKE_LOG_PUBLISHING = { AUTO | PAUSED }``
+    with autocommit (required for ``ALTER DATABASE`` statements).
+
+    Only supported on Fabric Data Warehouses (not SQL Analytics Endpoints).
+    SQL Analytics Endpoints are rejected with
+    :class:`~fabric_dw.exceptions.ItemKindError`.
+
+    Args:
+        target: The Data Warehouse to alter.
+        enabled: ``True`` to enable Delta Lake log publishing (``= AUTO``),
+            ``False`` to disable it (``= PAUSED``).
+        kind: The :class:`~fabric_dw.models.WarehouseKind` of the resolved item.
+            SQL Analytics Endpoints are rejected.
+        mode: The credential mode for Entra authentication.
+
+    Returns:
+        A :class:`~fabric_dw.models.WarehouseSettings` reflecting the settings
+        *after* the change (fetched via a follow-up ``get_settings`` call).
+
+    Raises:
+        ItemKindError: If *kind* is
+            :attr:`~fabric_dw.models.WarehouseKind.SQL_ENDPOINT`.
+        PermissionDeniedError: If the driver reports a permission error.
+        AuthError: If the driver reports an authentication failure.
+    """
+    _assert_not_sql_endpoint(kind)
+    ddl = _SET_DLLP_SQL_AUTO if enabled else _SET_DLLP_SQL_PAUSED
 
     def _run() -> None:
         run_query(target, ddl, mode=mode, autocommit=True, fetch="none")

--- a/src/fabric_dw/telemetry_commands.py
+++ b/src/fabric_dw/telemetry_commands.py
@@ -183,6 +183,7 @@ DOMAIN_MAP: dict[str, str] = {
     "get_warehouse_settings": "settings",
     "set_result_set_caching": "settings",
     "set_time_travel_retention": "settings",
+    "set_data_lake_log_publishing": "settings",
     # Tables (load sub-domain)
     "import_table_from_url": "tables",
 }

--- a/tests/integration/test_services_settings.py
+++ b/tests/integration/test_services_settings.py
@@ -2,7 +2,8 @@
 
 Fixture note: uses ``read_target`` from conftest for the read leg
 (``get_settings`` is dual-target) and ``shared_warehouse`` for the DWH-only
-write leg (``set_result_set_caching`` / ``set_time_travel_retention``).
+write leg (``set_result_set_caching`` / ``set_time_travel_retention`` /
+``set_data_lake_log_publishing``).
 
 The ``read_target`` fixture is parametrized over two targets:
   - ``[warehouse]``     — Data Warehouse (always runs)
@@ -21,7 +22,7 @@ from fabric_dw.models import WarehouseSettings
 from fabric_dw.services import settings
 from fabric_dw.sql import SqlTarget
 
-from .conftest import SharedWarehouseTarget
+from .conftest import SharedSqlEndpointTarget, SharedWarehouseTarget
 
 pytestmark = pytest.mark.integration
 
@@ -52,6 +53,25 @@ async def test_get_settings_returns_warehouse_settings(
     if result.time_travel_retention_days is not None:
         assert isinstance(result.time_travel_retention_days, int)
         assert result.time_travel_retention_days >= 0
+    # data_lake_log_publishing is always a bool; NULL from the driver (SQL
+    # Analytics Endpoints) is mapped to False by _row_to_settings.
+    assert isinstance(result.data_lake_log_publishing, bool)
+
+
+@pytest.mark.sql_endpoint
+async def test_get_settings_sql_endpoint_dllp_is_false(
+    shared_sql_endpoint: SharedSqlEndpointTarget,
+) -> None:
+    """get_settings on a SQL Analytics Endpoint must return data_lake_log_publishing=False.
+
+    SQL Analytics Endpoints return NULL for ``data_lake_log_publishing_desc``
+    in ``sys.databases`` (warehouse-only column).  _row_to_settings maps NULL
+    to False; this test verifies that mapping holds end-to-end with a live
+    endpoint connection.
+    """
+    result = await settings.get_settings(shared_sql_endpoint.sql_target)
+    assert isinstance(result, WarehouseSettings)
+    assert result.data_lake_log_publishing is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/cli/commands/test_settings.py
+++ b/tests/unit/cli/commands/test_settings.py
@@ -71,12 +71,14 @@ def _make_settings(
     *,
     result_set_caching: bool = True,
     days: int = 7,
+    data_lake_log_publishing: bool = True,
 ) -> WarehouseSettings:
     return WarehouseSettings(
         database="SalesWarehouse",
         result_set_caching=result_set_caching,
         time_travel_retention_days=days,
         time_travel_retention_cutoff_date=_NOW,
+        data_lake_log_publishing=data_lake_log_publishing,
     )
 
 
@@ -485,5 +487,157 @@ class TestSettingsKindWiring:
         ):
             result = runner.invoke(
                 cli, ["-w", WS_GUID, "settings", "retention", WH_GUID, "--days", "7"]
+            )
+        assert result.exit_code != 0
+
+
+# ===========================================================================
+# settings data-lake-log-publishing
+# ===========================================================================
+
+
+class TestDataLakeLogPublishing:
+    def test_enable_exits_zero(self, runner: CliRunner) -> None:
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.settings.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.settings.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.settings.set_data_lake_log_publishing",
+                new=AsyncMock(return_value=_make_settings(data_lake_log_publishing=True)),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                ["-w", WS_GUID, "settings", "data-lake-log-publishing", WH_GUID, "on"],
+            )
+        assert result.exit_code == 0
+        assert "enabled" in result.output
+
+    def test_disable_exits_zero(self, runner: CliRunner) -> None:
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.settings.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.settings.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.settings.set_data_lake_log_publishing",
+                new=AsyncMock(return_value=_make_settings(data_lake_log_publishing=False)),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                ["-w", WS_GUID, "settings", "data-lake-log-publishing", WH_GUID, "off"],
+            )
+        assert result.exit_code == 0
+        assert "disabled" in result.output
+
+    def test_json_output_includes_settings(self, runner: CliRunner) -> None:
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.settings.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.settings.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.settings.set_data_lake_log_publishing",
+                new=AsyncMock(return_value=_make_settings(data_lake_log_publishing=True)),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "-w",
+                    WS_GUID,
+                    "--json",
+                    "settings",
+                    "data-lake-log-publishing",
+                    WH_GUID,
+                    "on",
+                ],
+            )
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["data_lake_log_publishing"] is True
+
+    def test_invalid_state_returns_nonzero(self, runner: CliRunner) -> None:
+        result = runner.invoke(
+            cli,
+            ["-w", WS_GUID, "settings", "data-lake-log-publishing", WH_GUID, "maybe"],
+        )
+        assert result.exit_code != 0
+
+    def test_fabric_error_returns_nonzero(self, runner: CliRunner) -> None:
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.settings.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.settings.build_sql_target",
+                new=AsyncMock(side_effect=FabricError("permission denied")),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                ["-w", WS_GUID, "settings", "data-lake-log-publishing", WH_GUID, "on"],
+            )
+        assert result.exit_code != 0
+
+    def test_forwards_warehouse_kind(self, runner: CliRunner) -> None:
+        """data-lake-log-publishing passes kind=WAREHOUSE when the resolved entry is a Warehouse."""
+        mock_http = AsyncMock()
+        mock_svc = AsyncMock(return_value=_make_settings())
+        with (
+            patch(
+                "fabric_dw.cli.commands.settings.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.settings.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch("fabric_dw.services.settings.set_data_lake_log_publishing", new=mock_svc),
+        ):
+            runner.invoke(
+                cli,
+                ["-w", WS_GUID, "settings", "data-lake-log-publishing", WH_GUID, "on"],
+            )
+        _, kwargs = mock_svc.call_args
+        assert kwargs.get("kind") == WarehouseKind.WAREHOUSE
+
+    def test_rejects_sql_endpoint_via_real_guard(self, runner: CliRunner) -> None:
+        """data-lake-log-publishing surfaces ItemKindError as ClickException for SQL_ENDPOINT."""
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.settings.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.settings.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_sql_endpoint_entry())),
+            ),
+            patch("fabric_dw.sql.open_connection", side_effect=ItemKindError("guard")),
+        ):
+            result = runner.invoke(
+                cli,
+                ["-w", WS_GUID, "settings", "data-lake-log-publishing", WH_GUID, "on"],
             )
         assert result.exit_code != 0

--- a/tests/unit/mcp/tools/test_settings.py
+++ b/tests/unit/mcp/tools/test_settings.py
@@ -25,12 +25,14 @@ def _make_settings(
     *,
     result_set_caching: bool = True,
     time_travel_retention_days: int | None = 7,
+    data_lake_log_publishing: bool = True,
 ) -> WarehouseSettings:
     return WarehouseSettings(
         database="my-warehouse",
         result_set_caching=result_set_caching,
         time_travel_retention_days=time_travel_retention_days,
         time_travel_retention_cutoff_date=_NOW,
+        data_lake_log_publishing=data_lake_log_publishing,
     )
 
 
@@ -361,13 +363,14 @@ async def test_set_time_travel_retention_workspace_allowlist_blocks(ctx_patch) -
 
 
 def test_settings_tools_are_registered() -> None:
-    """All three settings tools are registered in the MCP server."""
+    """All settings tools are registered in the MCP server."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
     tool_names = {t.name for t in mcp._tool_manager.list_tools()}
     assert "get_warehouse_settings" in tool_names
     assert "set_result_set_caching" in tool_names
     assert "set_time_travel_retention" in tool_names
+    assert "set_data_lake_log_publishing" in tool_names
 
 
 # ---------------------------------------------------------------------------
@@ -469,4 +472,129 @@ async def test_set_time_travel_retention_rejects_sql_endpoint_via_real_guard(
         await mcp._tool_manager.call_tool(
             "set_time_travel_retention",
             {"workspace": WS_NAME, "item": "MySqlEndpoint", "days": 14},
+        )
+
+
+# ---------------------------------------------------------------------------
+# set_data_lake_log_publishing — happy path + guards
+# ---------------------------------------------------------------------------
+
+
+async def test_set_data_lake_log_publishing_enable(mock_ctx, ctx_patch) -> None:
+    """set_data_lake_log_publishing calls service with enabled=True and returns settings."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    settings = _make_settings(data_lake_log_publishing=True)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+    mock_set = AsyncMock(return_value=settings)
+
+    with (
+        ctx_patch,
+        patch("fabric_dw.services.settings.set_data_lake_log_publishing", new=mock_set),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "set_data_lake_log_publishing",
+            {"workspace": WS_NAME, "item": WH_NAME, "enabled": True},
+        )
+
+    assert isinstance(result, dict)
+    assert result["data_lake_log_publishing"] is True
+    _, kwargs = mock_set.call_args
+    assert kwargs.get("enabled") is True
+    assert kwargs.get("mode") is mock_ctx.auth_mode
+
+
+async def test_set_data_lake_log_publishing_disable(mock_ctx, ctx_patch) -> None:
+    """set_data_lake_log_publishing calls service with enabled=False and returns settings."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    settings = _make_settings(data_lake_log_publishing=False)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+    mock_set = AsyncMock(return_value=settings)
+
+    with (
+        ctx_patch,
+        patch("fabric_dw.services.settings.set_data_lake_log_publishing", new=mock_set),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "set_data_lake_log_publishing",
+            {"workspace": WS_NAME, "item": WH_NAME, "enabled": False},
+        )
+
+    assert result["data_lake_log_publishing"] is False
+    _, kwargs = mock_set.call_args
+    assert kwargs.get("enabled") is False
+
+
+async def test_set_data_lake_log_publishing_readonly_blocked(ctx_patch) -> None:
+    """set_data_lake_log_publishing is blocked by FABRIC_MCP_READONLY."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_READONLY": "1"}),
+        pytest.raises(ToolError, match="read-only"),
+    ):
+        await mcp._tool_manager.call_tool(
+            "set_data_lake_log_publishing",
+            {"workspace": WS_NAME, "item": WH_NAME, "enabled": True},
+        )
+
+
+async def test_set_data_lake_log_publishing_workspace_allowlist_blocks(ctx_patch) -> None:
+    """set_data_lake_log_publishing raises ToolError when workspace is not in allowlist."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_WORKSPACES": "other-workspace"}),
+        pytest.raises(ToolError, match="allowlist"),
+    ):
+        await mcp._tool_manager.call_tool(
+            "set_data_lake_log_publishing",
+            {"workspace": WS_NAME, "item": WH_NAME, "enabled": True},
+        )
+
+
+async def test_set_data_lake_log_publishing_forwards_kind_to_service(mock_ctx, ctx_patch) -> None:
+    """set_data_lake_log_publishing passes kind=entry.kind to the service call."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+    from tests.unit.mcp.conftest import make_item_entry  # noqa: PLC0415
+
+    settings = _make_settings()
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+    mock_set = AsyncMock(return_value=settings)
+
+    with (
+        ctx_patch,
+        patch("fabric_dw.services.settings.set_data_lake_log_publishing", new=mock_set),
+    ):
+        await mcp._tool_manager.call_tool(
+            "set_data_lake_log_publishing",
+            {"workspace": WS_NAME, "item": WH_NAME, "enabled": True},
+        )
+
+    _, kwargs = mock_set.call_args
+    from fabric_dw.models import WarehouseKind  # noqa: PLC0415
+
+    assert kwargs.get("kind") == WarehouseKind.WAREHOUSE
+
+
+async def test_set_data_lake_log_publishing_rejects_sql_endpoint_via_real_guard(
+    mock_ctx, ctx_patch
+) -> None:
+    """set_data_lake_log_publishing raises ToolError when entry.kind is SQL_ENDPOINT."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+    from tests.unit.mcp.conftest import make_sql_endpoint_entry  # noqa: PLC0415
+
+    mock_ctx.resolver.item = AsyncMock(return_value=make_sql_endpoint_entry())
+
+    with (
+        ctx_patch,
+        patch("fabric_dw.sql.open_connection", side_effect=Exception("should not connect")),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "set_data_lake_log_publishing",
+            {"workspace": WS_NAME, "item": "MySqlEndpoint", "enabled": True},
         )

--- a/tests/unit/services/test_settings.py
+++ b/tests/unit/services/test_settings.py
@@ -321,6 +321,73 @@ class TestSetDataLakeLogPublishing:
         assert "=" in settings._SET_DLLP_SQL_PAUSED
         assert "AUTO" not in settings._SET_DLLP_SQL_PAUSED
 
+    async def test_enable_dispatches_auto_ddl(self) -> None:
+        """enabled=True must dispatch the = AUTO statement (not = PAUSED).
+
+        Captures the SQL actually passed to run_query so that a ternary swap
+        (AUTO/PAUSED swapped) would fail this test even if the constants
+        themselves look correct.
+        """
+        from unittest.mock import AsyncMock  # noqa: PLC0415
+
+        target = _make_target()
+        executed_sqls: list[str] = []
+
+        def _capture_ddl(_t: object, sql: str, **_kw: object) -> None:
+            executed_sqls.append(sql)
+
+        mock_result = WarehouseSettings(
+            database="SalesWarehouse",
+            result_set_caching=True,
+            time_travel_retention_days=7,
+            time_travel_retention_cutoff_date=None,
+            data_lake_log_publishing=True,
+        )
+        with (
+            patch("fabric_dw.services.settings.run_query", side_effect=_capture_ddl),
+            patch(
+                "fabric_dw.services.settings.get_settings",
+                new=AsyncMock(return_value=mock_result),
+            ),
+        ):
+            await settings.set_data_lake_log_publishing(target, enabled=True)
+
+        assert len(executed_sqls) == 1
+        assert executed_sqls[0] == settings._SET_DLLP_SQL_AUTO
+
+    async def test_disable_dispatches_paused_ddl(self) -> None:
+        """enabled=False must dispatch the = PAUSED statement (not = AUTO).
+
+        Captures the SQL actually passed to run_query so that a ternary swap
+        would fail this test even if the constants themselves look correct.
+        """
+        from unittest.mock import AsyncMock  # noqa: PLC0415
+
+        target = _make_target()
+        executed_sqls: list[str] = []
+
+        def _capture_ddl(_t: object, sql: str, **_kw: object) -> None:
+            executed_sqls.append(sql)
+
+        mock_result = WarehouseSettings(
+            database="SalesWarehouse",
+            result_set_caching=True,
+            time_travel_retention_days=7,
+            time_travel_retention_cutoff_date=None,
+            data_lake_log_publishing=False,
+        )
+        with (
+            patch("fabric_dw.services.settings.run_query", side_effect=_capture_ddl),
+            patch(
+                "fabric_dw.services.settings.get_settings",
+                new=AsyncMock(return_value=mock_result),
+            ),
+        ):
+            await settings.set_data_lake_log_publishing(target, enabled=False)
+
+        assert len(executed_sqls) == 1
+        assert executed_sqls[0] == settings._SET_DLLP_SQL_PAUSED
+
     async def test_enable_returns_settings(self) -> None:
         target = _make_target()
         ddl_conn = _make_conn_for_ddl()

--- a/tests/unit/services/test_settings.py
+++ b/tests/unit/services/test_settings.py
@@ -23,6 +23,7 @@ _SETTINGS_COLS = [
     "is_result_set_caching_on",
     "time_travel_retention_period_days",
     "time_travel_retention_cutoff_date",
+    "data_lake_log_publishing_desc",
 ]
 
 _SETTINGS_ROW: tuple[object, ...] = (
@@ -30,6 +31,7 @@ _SETTINGS_ROW: tuple[object, ...] = (
     True,
     7,
     _NOW,
+    "AUTO",
 )
 
 _SETTINGS_ROW_CACHING_OFF: tuple[object, ...] = (
@@ -37,6 +39,7 @@ _SETTINGS_ROW_CACHING_OFF: tuple[object, ...] = (
     False,
     7,
     _NOW,
+    "AUTO",
 )
 
 _SETTINGS_ROW_NO_CUTOFF: tuple[object, ...] = (
@@ -44,6 +47,7 @@ _SETTINGS_ROW_NO_CUTOFF: tuple[object, ...] = (
     True,
     30,
     None,
+    "AUTO",
 )
 
 _SETTINGS_ROW_NULL_DAYS: tuple[object, ...] = (
@@ -51,6 +55,15 @@ _SETTINGS_ROW_NULL_DAYS: tuple[object, ...] = (
     True,
     None,  # NULL time_travel_retention_period_days (SQL Analytics Endpoint)
     None,
+    None,  # NULL data_lake_log_publishing_desc (SQL Analytics Endpoint)
+)
+
+_SETTINGS_ROW_DLLP_PAUSED: tuple[object, ...] = (
+    "SalesWarehouse",
+    True,
+    7,
+    _NOW,
+    "PAUSED",
 )
 
 
@@ -70,6 +83,7 @@ class TestGetSettings:
         assert result.result_set_caching is True
         assert result.time_travel_retention_days == 7
         assert result.time_travel_retention_cutoff_date == _NOW
+        assert result.data_lake_log_publishing is True
 
     async def test_none_cutoff_is_none(self) -> None:
         target = _make_target()
@@ -86,16 +100,17 @@ class TestGetSettings:
         assert result.result_set_caching is False
 
     async def test_selects_correct_columns(self) -> None:
-        """Verify the SQL selects the four expected columns."""
+        """Verify the SQL selects the expected columns including the new one."""
         sql = settings._GET_SETTINGS_SQL
         assert "is_result_set_caching_on" in sql
         assert "time_travel_retention_period_days" in sql
         assert "time_travel_retention_cutoff_date" in sql
+        assert "data_lake_log_publishing_desc" in sql
         assert "DB_ID()" in sql
 
     async def test_naive_cutoff_converted_to_utc(self) -> None:
         naive_ts = datetime(2024, 6, 1, 12, 0, 0)  # noqa: DTZ001
-        row: tuple[object, ...] = ("SalesWarehouse", True, 7, naive_ts)
+        row: tuple[object, ...] = ("SalesWarehouse", True, 7, naive_ts, "AUTO")
         target = _make_target()
         conn = _make_conn([row], _SETTINGS_COLS)
         with patch("fabric_dw.sql.open_connection", return_value=conn):
@@ -124,7 +139,7 @@ class TestGetSettings:
     async def test_bare_date_cutoff_promoted_to_midnight_utc(self) -> None:
         """A bare datetime.date returned by the driver must be promoted to midnight UTC."""
         bare = date(2024, 6, 1)
-        row: tuple[object, ...] = ("SalesWarehouse", True, 7, bare)
+        row: tuple[object, ...] = ("SalesWarehouse", True, 7, bare, "AUTO")
         target = _make_target()
         conn = _make_conn([row], _SETTINGS_COLS)
         with patch("fabric_dw.sql.open_connection", return_value=conn):
@@ -134,7 +149,7 @@ class TestGetSettings:
     async def test_quasi_naive_cutoff_treated_as_utc(self) -> None:
         """A quasi-naive cutoff (tzinfo present but utcoffset() returns None) is treated as UTC."""
         quasi_naive = datetime(2024, 6, 1, 12, 0, 0, tzinfo=_NoOffsetTz())
-        row: tuple[object, ...] = ("SalesWarehouse", True, 7, quasi_naive)
+        row: tuple[object, ...] = ("SalesWarehouse", True, 7, quasi_naive, "AUTO")
         target = _make_target()
         conn = _make_conn([row], _SETTINGS_COLS)
         with patch("fabric_dw.sql.open_connection", return_value=conn):
@@ -143,6 +158,30 @@ class TestGetSettings:
         assert result.time_travel_retention_cutoff_date.tzinfo == UTC
         cutoff = result.time_travel_retention_cutoff_date
         assert cutoff == datetime(2024, 6, 1, 12, 0, 0, tzinfo=UTC)
+
+    async def test_dllp_auto_maps_to_true(self) -> None:
+        """data_lake_log_publishing_desc == 'AUTO' maps to data_lake_log_publishing=True."""
+        target = _make_target()
+        conn = _make_conn([_SETTINGS_ROW], _SETTINGS_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            result = await settings.get_settings(target)
+        assert result.data_lake_log_publishing is True
+
+    async def test_dllp_paused_maps_to_false(self) -> None:
+        """data_lake_log_publishing_desc == 'PAUSED' maps to data_lake_log_publishing=False."""
+        target = _make_target()
+        conn = _make_conn([_SETTINGS_ROW_DLLP_PAUSED], _SETTINGS_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            result = await settings.get_settings(target)
+        assert result.data_lake_log_publishing is False
+
+    async def test_dllp_null_maps_to_false(self) -> None:
+        """NULL data_lake_log_publishing_desc (e.g. SQL Analytics Endpoint) maps to False."""
+        target = _make_target()
+        conn = _make_conn([_SETTINGS_ROW_NULL_DAYS], _SETTINGS_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            result = await settings.get_settings(target)
+        assert result.data_lake_log_publishing is False
 
 
 # ===========================================================================
@@ -206,7 +245,7 @@ class TestSetTimeTravelRetention:
     async def test_valid_days_returns_settings(self) -> None:
         target = _make_target()
         ddl_conn = _make_conn_for_ddl()
-        row: tuple[object, ...] = ("SalesWarehouse", True, 30, None)
+        row: tuple[object, ...] = ("SalesWarehouse", True, 30, None, "AUTO")
         read_conn = _make_conn([row], _SETTINGS_COLS)
 
         with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, read_conn]):
@@ -223,7 +262,7 @@ class TestSetTimeTravelRetention:
     async def test_boundary_min_accepted(self) -> None:
         target = _make_target()
         ddl_conn = _make_conn_for_ddl()
-        row: tuple[object, ...] = ("SalesWarehouse", True, 1, None)
+        row: tuple[object, ...] = ("SalesWarehouse", True, 1, None, "AUTO")
         read_conn = _make_conn([row], _SETTINGS_COLS)
 
         with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, read_conn]):
@@ -233,7 +272,7 @@ class TestSetTimeTravelRetention:
     async def test_boundary_max_accepted(self) -> None:
         target = _make_target()
         ddl_conn = _make_conn_for_ddl()
-        row: tuple[object, ...] = ("SalesWarehouse", True, 120, None)
+        row: tuple[object, ...] = ("SalesWarehouse", True, 120, None, "AUTO")
         read_conn = _make_conn([row], _SETTINGS_COLS)
 
         with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, read_conn]):
@@ -251,7 +290,7 @@ class TestSetTimeTravelRetention:
         """ALTER DATABASE must use autocommit=True."""
         target = _make_target()
         ddl_conn = _make_conn_for_ddl()
-        row: tuple[object, ...] = ("SalesWarehouse", True, 7, None)
+        row: tuple[object, ...] = ("SalesWarehouse", True, 7, None, "AUTO")
         read_conn = _make_conn([row], _SETTINGS_COLS)
         autocommit_values: list[bool] = []
 
@@ -262,6 +301,79 @@ class TestSetTimeTravelRetention:
         with patch("fabric_dw.sql.open_connection", side_effect=_open):
             await settings.set_time_travel_retention(target, days=7)
         assert autocommit_values[0] is True
+
+
+# ===========================================================================
+# set_data_lake_log_publishing
+# ===========================================================================
+
+
+class TestSetDataLakeLogPublishing:
+    async def test_enable_uses_auto_sql(self) -> None:
+        """AUTO keyword (with =) is used when enabled=True."""
+        assert "AUTO" in settings._SET_DLLP_SQL_AUTO
+        assert "=" in settings._SET_DLLP_SQL_AUTO
+        assert "PAUSED" not in settings._SET_DLLP_SQL_AUTO
+
+    async def test_disable_uses_paused_sql(self) -> None:
+        """PAUSED keyword (with =) is used when enabled=False."""
+        assert "PAUSED" in settings._SET_DLLP_SQL_PAUSED
+        assert "=" in settings._SET_DLLP_SQL_PAUSED
+        assert "AUTO" not in settings._SET_DLLP_SQL_PAUSED
+
+    async def test_enable_returns_settings(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        read_conn = _make_conn([_SETTINGS_ROW], _SETTINGS_COLS)
+
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, read_conn]):
+            result = await settings.set_data_lake_log_publishing(target, enabled=True)
+        assert isinstance(result, WarehouseSettings)
+        assert result.data_lake_log_publishing is True
+
+    async def test_disable_returns_settings(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        read_conn = _make_conn([_SETTINGS_ROW_DLLP_PAUSED], _SETTINGS_COLS)
+
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, read_conn]):
+            result = await settings.set_data_lake_log_publishing(target, enabled=False)
+        assert result.data_lake_log_publishing is False
+
+    async def test_alter_database_runs_with_autocommit(self) -> None:
+        """ALTER DATABASE must use autocommit=True."""
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        read_conn = _make_conn([_SETTINGS_ROW], _SETTINGS_COLS)
+        autocommit_values: list[bool] = []
+
+        def _open(_t: object, **_kw: object) -> object:
+            autocommit_values.append(bool(_kw.get("autocommit", False)))
+            return ddl_conn if not autocommit_values[:-1] else read_conn
+
+        with patch("fabric_dw.sql.open_connection", side_effect=_open):
+            await settings.set_data_lake_log_publishing(target, enabled=True)
+        # First connection (ALTER DATABASE) must be autocommit.
+        assert autocommit_values[0] is True
+
+    async def test_rejects_sql_endpoint(self) -> None:
+        """set_data_lake_log_publishing must raise ItemKindError for SQL_ENDPOINT."""
+        target = _make_target()
+        with pytest.raises(ItemKindError, match="SQL Analytics Endpoints are read-only"):
+            await settings.set_data_lake_log_publishing(
+                target, enabled=True, kind=WarehouseKind.SQL_ENDPOINT
+            )
+
+    async def test_warehouse_allowed(self) -> None:
+        """set_data_lake_log_publishing must not raise for WAREHOUSE (the default)."""
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        read_conn = _make_conn([_SETTINGS_ROW], _SETTINGS_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, read_conn]):
+            result = await settings.set_data_lake_log_publishing(
+                target, enabled=True, kind=WarehouseKind.WAREHOUSE
+            )
+        assert isinstance(result, WarehouseSettings)
 
 
 # ===========================================================================
@@ -289,7 +401,7 @@ class TestPublicConstants:
 
 
 class TestSqlEndpointGuard:
-    """set_result_set_caching and set_time_travel_retention are DWH-only."""
+    """Write operations (set_result_set_caching, set_time_travel_retention, etc.) are DWH-only."""
 
     async def test_set_result_set_caching_rejects_sql_endpoint(self) -> None:
         """set_result_set_caching must raise ItemKindError for SQL_ENDPOINT."""
@@ -322,7 +434,7 @@ class TestSqlEndpointGuard:
         """set_time_travel_retention must not raise for WAREHOUSE (the default)."""
         target = _make_target()
         ddl_conn = _make_conn_for_ddl()
-        row: tuple[object, ...] = ("SalesWarehouse", True, 7, None)
+        row: tuple[object, ...] = ("SalesWarehouse", True, 7, None, "AUTO")
         read_conn = _make_conn([row], _SETTINGS_COLS)
         with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, read_conn]):
             result = await settings.set_time_travel_retention(


### PR DESCRIPTION
## Summary

- Adds `data_lake_log_publishing: bool` to `WarehouseSettings` model; read from `data_lake_log_publishing_desc` in `sys.databases` (`AUTO` -> `True`, `PAUSED`/NULL -> `False`).
- Adds `set_data_lake_log_publishing` service function: runs `ALTER DATABASE CURRENT SET DATA_LAKE_LOG_PUBLISHING = AUTO` (enable) or `= PAUSED` (disable) with `autocommit=True`, then returns a fresh `get_settings` read-back.
- Adds `settings data-lake-log-publishing ITEM on|off` CLI subcommand mirroring `result-set-caching`.
- Adds `set_data_lake_log_publishing` MCP tool via `@mutating_tool` (blocked by `FABRIC_MCP_READONLY` and workspace allowlist).
- Adds `"set_data_lake_log_publishing": "settings"` entry to telemetry domain map.
- Updates `docs/commands/settings.md` to document the new CLI command and MCP tool.

## Test plan

- [x] `uv run ruff check src tests` - all checks passed
- [x] `uv run ruff format --check .` - all 276 files formatted
- [x] `uv run ty check src tests` - all checks passed
- [x] `uv run pytest tests/unit -q` - 5182 passed, 2 deselected
- [x] Service tests: AUTO -> enabled, PAUSED -> disabled, NULL -> False, autocommit required, SQL endpoint rejected
- [x] CLI tests: on/off exit zero, `--json` output, kind wiring, SQL endpoint rejected
- [x] MCP tests: enable/disable forwarded, `FABRIC_MCP_READONLY` blocked, workspace allowlist blocked

Closes #915

🤖 Generated with [Claude Code](https://claude.com/claude-code)