### PR TITLE
feat(read): time-travel option for tables and views (FOR TIMESTAMP AS OF)

### DIFF
--- a/docs/commands/tables.md
+++ b/docs/commands/tables.md
@@ -174,11 +174,18 @@ fdw -w MyWorkspace tables clone SalesWH \
 
 Return the total row count of a table using `SELECT COUNT_BIG(*)`.
 
+Use `--as-of` or `--ago` to count rows as they were at an earlier point in time (time travel). The same retention window applies as for `tables read`.
+
 **Synopsis**
 
 ```
-fdw [-w WORKSPACE] tables count [WAREHOUSE] QUALIFIED_NAME
+fdw [-w WORKSPACE] tables count [OPTIONS] [WAREHOUSE] QUALIFIED_NAME
 ```
+
+| Option | Description |
+| --- | --- |
+| `--as-of ISO8601` | Count rows as they were at this UTC timestamp. Mutually exclusive with `--ago`. | |
+| `--ago DURATION` | Count rows as they were this duration ago (e.g. `1h`, `90m`, `2d`). Mutually exclusive with `--as-of`. | |
 
 **Example**
 
@@ -188,6 +195,12 @@ fdw -w MyWorkspace --json tables count SalesWH dbo.orders
 
 ```json
 {"schema": "dbo", "name": "orders", "row_count": 999999}
+```
+
+```shell
+# Point-in-time row count
+fdw -w MyWorkspace --json tables count SalesWH dbo.orders --as-of 2024-03-15T10:00:00Z
+fdw -w MyWorkspace --json tables count SalesWH dbo.orders --ago 1h
 ```
 
 ### tables create
@@ -608,11 +621,14 @@ Results are ordered by ordinal position. Raises a `ToolError` if the table does 
 
 Return the total row count of a table via `SELECT COUNT_BIG(*)`.
 
+Supports time-travel counts via `as_of`: supply an ISO-8601 UTC timestamp to count rows as they were at that point in time. The same retention window applies as for `read_table`.
+
 **Parameters:**
 
 - `workspace` (`str`): workspace name or GUID.
 - `item` (`str`): warehouse or SQL analytics endpoint name or GUID.
 - `qualified_name` (`str`): dot-separated table name, e.g. `dbo.sales`.
+- `as_of` (`str`, optional): ISO-8601 UTC timestamp for a point-in-time count. Omit to count the latest data.
 
 **Returns:** `{ "schema": str, "name": str, "row_count": int }`: the schema name, table name, and total row count.
 

--- a/docs/commands/tables.md
+++ b/docs/commands/tables.md
@@ -485,6 +485,8 @@ Read up to `--count` rows from a table and emit them as JSON (default), CSV, or 
 
 CSV and Parquet formats require `--output`. JSON is emitted to stdout by default.
 
+Use `--as-of` or `--ago` to read the table as it was at an earlier point in time (time travel). Fabric supports `OPTION (FOR TIMESTAMP AS OF ...)` on `SELECT` statements; the retention window is 1-120 days (default 30). Timestamps outside the retention window error server-side - no client-side pre-validation is performed.
+
 **Synopsis**
 
 ```
@@ -496,6 +498,8 @@ fdw [-w WORKSPACE] tables read [OPTIONS] [WAREHOUSE] QUALIFIED_NAME
 | `--count N` | Maximum rows to return. | `10` |
 | `--format {json\|csv\|parquet}` | Output format. | `json` |
 | `--output PATH` | Write to file instead of stdout. Required for `csv` and `parquet`. | |
+| `--as-of ISO8601` | Read the table as it was at this UTC timestamp. Mutually exclusive with `--ago`. | |
+| `--ago DURATION` | Read the table as it was this duration ago (e.g. `1h`, `90m`, `2d`). Mutually exclusive with `--as-of`. | |
 
 **Example**
 
@@ -508,6 +512,12 @@ fdw -w MyWorkspace tables read SalesWH dbo.orders --count 5
   {"id": 1, "amount": 99.99, "customer_id": 42},
   ...
 ]
+```
+
+```shell
+# Point-in-time read
+fdw -w MyWorkspace tables read SalesWH dbo.orders --as-of 2024-03-15T10:00:00Z
+fdw -w MyWorkspace tables read SalesWH dbo.orders --ago 2d
 ```
 
 ### tables rename
@@ -816,12 +826,15 @@ Load data into a Data Warehouse table via `COPY INTO` from a remote URL. For One
 
 Return up to `count` rows from a table as JSON-serialisable columns and rows.
 
+Supports time-travel reads via `as_of`: supply an ISO-8601 UTC timestamp to read the table as it was at that point in time. The Fabric retention window is 1-120 days (default 30); timestamps outside the window error server-side.
+
 **Parameters:**
 
 - `workspace` (`str`): workspace name or GUID.
 - `item` (`str`): warehouse or SQL analytics endpoint name or GUID.
 - `qualified_name` (`str`): dot-separated table name, e.g. `dbo.sales`.
 - `count` (`int`, default `10`): maximum rows to return.
+- `as_of` (`str | null`, optional): ISO-8601 UTC timestamp for a point-in-time read, e.g. `2024-03-15T10:00:00Z`. Omit to read the latest data.
 
 **Returns:** `{ "columns": list[str], "rows": list[list] }`: column names and row arrays.
 

--- a/docs/commands/views.md
+++ b/docs/commands/views.md
@@ -171,6 +171,8 @@ Read up to `--count` rows from a view and emit them as JSON (default), CSV, or P
 
 CSV and Parquet formats require `--output`. JSON is emitted to stdout by default.
 
+Use `--as-of` or `--ago` to read the view as it was at an earlier point in time (time travel). The data visible through the view is time-travelled; the view definition itself is not affected. Timestamps outside the Fabric retention window (1-120 days, default 30) error server-side.
+
 **Synopsis**
 
 ```
@@ -182,6 +184,8 @@ fdw [-w WORKSPACE] views read [OPTIONS] [WAREHOUSE] QUALIFIED_NAME
 | `--count N` | Maximum rows to return. | `10` |
 | `--format {json\|csv\|parquet}` | Output format. | `json` |
 | `--output PATH` | Write to file instead of stdout. Required for `csv` and `parquet`. | |
+| `--as-of ISO8601` | Read the view as it was at this UTC timestamp. Mutually exclusive with `--ago`. | |
+| `--ago DURATION` | Read the view as it was this duration ago (e.g. `1h`, `90m`, `2d`). Mutually exclusive with `--as-of`. | |
 
 **Example**
 
@@ -194,6 +198,12 @@ fdw -w MyWorkspace views read SalesWH dbo.vw_sales --count 5
   {"id": 1, "amount": 99.99, "customer_id": 42},
   ...
 ]
+```
+
+```shell
+# Point-in-time read
+fdw -w MyWorkspace views read SalesWH dbo.vw_sales --as-of 2024-03-15T10:00:00Z
+fdw -w MyWorkspace views read SalesWH dbo.vw_sales --ago 2d
 ```
 
 ### views rename
@@ -351,12 +361,15 @@ List SQL views on a warehouse or SQL Analytics Endpoint, optionally filtered to 
 
 Return up to `count` rows from a view as JSON-serialisable columns and rows.
 
+Supports time-travel reads via `as_of`: supply an ISO-8601 UTC timestamp to read the view as it was at that point in time. The Fabric retention window is 1-120 days (default 30); timestamps outside the window error server-side.
+
 **Parameters:**
 
 - `workspace` (`str`): workspace name or GUID.
 - `item` (`str`): warehouse or SQL analytics endpoint name or GUID.
 - `qualified_name` (`str`): dot-separated schema and view name, e.g. `dbo.vw_sales`.
 - `count` (`int`, default `10`): maximum rows to return.
+- `as_of` (`str | null`, optional): ISO-8601 UTC timestamp for a point-in-time read, e.g. `2024-03-15T10:00:00Z`. Omit to read the latest data.
 
 **Returns:** `{ "columns": list[str], "rows": list[list] }`: column names and row arrays.
 

--- a/docs/commands/views.md
+++ b/docs/commands/views.md
@@ -43,11 +43,18 @@ fdw -w MyWorkspace views columns SalesWH dbo.vw_sales
 
 Return the total row count of a view using `SELECT COUNT_BIG(*)`.
 
+Use `--as-of` or `--ago` to count rows as they were at an earlier point in time (time travel). The same retention window applies as for `views read`.
+
 **Synopsis**
 
 ```
-fdw [-w WORKSPACE] views count [WAREHOUSE] QUALIFIED_NAME
+fdw [-w WORKSPACE] views count [OPTIONS] [WAREHOUSE] QUALIFIED_NAME
 ```
+
+| Option | Description |
+| --- | --- |
+| `--as-of ISO8601` | Count rows as they were at this UTC timestamp. Mutually exclusive with `--ago`. | |
+| `--ago DURATION` | Count rows as they were this duration ago (e.g. `1h`, `90m`, `2d`). Mutually exclusive with `--as-of`. | |
 
 **Example**
 
@@ -57,6 +64,12 @@ fdw -w MyWorkspace --json views count SalesWH dbo.vw_sales
 
 ```json
 {"schema": "dbo", "name": "vw_sales", "row_count": 12345}
+```
+
+```shell
+# Point-in-time row count
+fdw -w MyWorkspace --json views count SalesWH dbo.vw_sales --as-of 2024-03-15T10:00:00Z
+fdw -w MyWorkspace --json views count SalesWH dbo.vw_sales --ago 1h
 ```
 
 ### views create
@@ -266,11 +279,14 @@ fdw -w MyWorkspace views update SalesWH dbo.vw_recent \
 
 Return the total row count of a view via `SELECT COUNT_BIG(*)`.
 
+Supports time-travel counts via `as_of`: supply an ISO-8601 UTC timestamp to count rows as they were at that point in time. The same retention window applies as for `read_view`.
+
 **Parameters:**
 
 - `workspace` (`str`): workspace name or GUID.
 - `item` (`str`): warehouse or SQL analytics endpoint name or GUID.
 - `qualified_name` (`str`): dot-separated schema and view name, e.g. `dbo.vw_sales`.
+- `as_of` (`str`, optional): ISO-8601 UTC timestamp for a point-in-time count. Omit to count the latest data.
 
 **Returns:** `{ "schema": str, "name": str, "row_count": int }`: the schema name, view name, and total row count.
 

--- a/src/fabric_dw/cli/commands/_utils.py
+++ b/src/fabric_dw/cli/commands/_utils.py
@@ -455,6 +455,30 @@ def resolve_as_of(as_of: str | None, ago: str | None) -> datetime | None:
     return None
 
 
+#: Shared Click option for ``--as-of`` used by time-travel commands (tables/views read + count).
+AS_OF_OPTION = click.option(
+    "--as-of",
+    "as_of",
+    default=None,
+    metavar="ISO8601",
+    help=(
+        "Point-in-time snapshot: read as it was at this UTC timestamp (ISO-8601). "
+        "Mutually exclusive with --ago."
+    ),
+)
+
+#: Shared Click option for ``--ago`` used by time-travel commands (tables/views read + count).
+TIME_TRAVEL_AGO_OPTION = click.option(
+    "--ago",
+    "ago",
+    default=None,
+    metavar="DURATION",
+    help=(
+        "Point-in-time snapshot: read as it was this duration ago (e.g. 1h, 90m, 2d). "
+        "Mutually exclusive with --as-of."
+    ),
+)
+
 #: Shared Click option for ``--ago`` used by query-insights commands.
 AGO_OPTION = click.option(
     "--ago",

--- a/src/fabric_dw/cli/commands/_utils.py
+++ b/src/fabric_dw/cli/commands/_utils.py
@@ -426,6 +426,35 @@ def resolve_since(since: str | None, ago: str | None) -> datetime | None:
     return None
 
 
+def resolve_as_of(as_of: str | None, ago: str | None) -> datetime | None:
+    """Resolve the effective point-in-time datetime from ``--as-of`` and ``--ago``.
+
+    Exactly one of *as_of* or *ago* may be provided.  When *ago* is given the
+    result is a tz-aware UTC datetime equal to ``datetime.now(UTC) - parse_duration(ago)``.
+
+    Companion to :func:`resolve_since` but names ``--as-of``/``--ago`` in its
+    error message instead of ``--since``/``--ago``.
+
+    Args:
+        as_of: Raw ISO-8601 string from ``--as-of`` (or *None*).
+        ago: Raw duration string from ``--ago`` (or *None*).
+
+    Returns:
+        A :class:`~datetime.datetime` (tz-aware UTC) or *None* when both are absent.
+
+    Raises:
+        click.UsageError: If both *as_of* and *ago* are set, or if either
+            value is invalid.
+    """
+    if as_of is not None and ago is not None:
+        raise click.UsageError("--as-of and --ago are mutually exclusive.")
+    if ago is not None:
+        return datetime.now(UTC) - parse_duration(ago)
+    if as_of is not None:
+        return parse_iso_datetime(as_of, "--as-of")
+    return None
+
+
 #: Shared Click option for ``--ago`` used by query-insights commands.
 AGO_OPTION = click.option(
     "--ago",

--- a/src/fabric_dw/cli/commands/tables.py
+++ b/src/fabric_dw/cli/commands/tables.py
@@ -209,21 +209,45 @@ async def columns_cmd(
 @tables_group.command("count")
 @click.argument("item", required=False, default=None)
 @click.argument("qualified_name")
+@click.option(
+    "--as-of",
+    "as_of",
+    default=None,
+    metavar="ISO8601",
+    help=(
+        "Count rows as they were at this UTC timestamp (ISO-8601). Mutually exclusive with --ago."
+    ),
+)
+@click.option(
+    "--ago",
+    "ago",
+    default=None,
+    metavar="DURATION",
+    help=(
+        "Count rows as they were this duration ago (e.g. 1h, 90m, 2d). "
+        "Mutually exclusive with --as-of."
+    ),
+)
 @click.pass_obj
 @coro
 async def count_cmd(
     ctx: CliContext,
     item: str | None,
     qualified_name: str,
+    as_of: str | None,
+    ago: str | None,
 ) -> None:
     """Count rows in QUALIFIED_NAME (schema.table) on ITEM."""
     ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     schema, table_name = parse_qualified_name(qualified_name, kind="table")
+    as_of_dt = resolve_as_of(as_of, ago)
     try:
         async with build_http_client(ctx) as http:
             target, _entry = await build_sql_target(http, ws, wh)
-            result = await _tables_svc.count_table_rows(target, schema, table_name, mode=ctx.auth)
+            result = await _tables_svc.count_table_rows(
+                target, schema, table_name, as_of=as_of_dt, mode=ctx.auth
+            )
             render(
                 result.model_dump(mode="json"),
                 json_output=ctx.json_output,

--- a/src/fabric_dw/cli/commands/tables.py
+++ b/src/fabric_dw/cli/commands/tables.py
@@ -23,6 +23,7 @@ from fabric_dw.cli.commands._utils import (
     load_sql_body,
     parse_iso_datetime,
     parse_qualified_name,
+    resolve_as_of,
     resolve_item,
     resolve_warehouse_arg,
     resolve_workspace,
@@ -85,6 +86,25 @@ async def list_cmd(ctx: CliContext, item: str | None, schema: str | None) -> Non
     help="Output format.",
 )
 @click.option("--output", default=None, help="Write to this file instead of stdout.")
+@click.option(
+    "--as-of",
+    "as_of",
+    default=None,
+    metavar="ISO8601",
+    help=(
+        "Read the table as it was at this UTC timestamp (ISO-8601). Mutually exclusive with --ago."
+    ),
+)
+@click.option(
+    "--ago",
+    "ago",
+    default=None,
+    metavar="DURATION",
+    help=(
+        "Read the table as it was this duration ago (e.g. 1h, 90m, 2d). "
+        "Mutually exclusive with --as-of."
+    ),
+)
 @click.pass_obj
 @coro
 async def read_cmd(
@@ -94,12 +114,15 @@ async def read_cmd(
     count: int,
     fmt: str,
     output: str | None,
+    as_of: str | None,
+    ago: str | None,
 ) -> None:
     """Read up to COUNT rows from QUALIFIED_NAME (schema.table) on ITEM."""
     ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     schema, table_name = parse_qualified_name(qualified_name, kind="table")
     output_path = Path(output) if output else None
+    as_of_dt = resolve_as_of(as_of, ago)
 
     # --format takes precedence when explicitly supplied (i.e. differs from the default
     # JSON value); if --format is omitted (or is the default "json"), the global --json
@@ -113,7 +136,7 @@ async def read_cmd(
         async with build_http_client(ctx) as http:
             target, _entry = await build_sql_target(http, ws, wh)
             result = await _tables_svc.read_table(
-                target, schema, table_name, count=count, mode=ctx.auth
+                target, schema, table_name, count=count, as_of=as_of_dt, mode=ctx.auth
             )
             arrow_table = columns_rows_to_arrow(result.columns, result.rows)
             write_arrow(arrow_table, effective_fmt, output_path)

--- a/src/fabric_dw/cli/commands/tables.py
+++ b/src/fabric_dw/cli/commands/tables.py
@@ -16,6 +16,8 @@ from fabric_dw.cli._context import CliContext
 from fabric_dw.cli._main import _CLI_CONDITIONAL_DESTRUCTIVE_KEY
 from fabric_dw.cli._render import render, render_result_rows
 from fabric_dw.cli.commands._utils import (
+    AS_OF_OPTION,
+    TIME_TRAVEL_AGO_OPTION,
     build_http_client,
     build_sql_target,
     confirm_destructive,
@@ -86,25 +88,8 @@ async def list_cmd(ctx: CliContext, item: str | None, schema: str | None) -> Non
     help="Output format.",
 )
 @click.option("--output", default=None, help="Write to this file instead of stdout.")
-@click.option(
-    "--as-of",
-    "as_of",
-    default=None,
-    metavar="ISO8601",
-    help=(
-        "Read the table as it was at this UTC timestamp (ISO-8601). Mutually exclusive with --ago."
-    ),
-)
-@click.option(
-    "--ago",
-    "ago",
-    default=None,
-    metavar="DURATION",
-    help=(
-        "Read the table as it was this duration ago (e.g. 1h, 90m, 2d). "
-        "Mutually exclusive with --as-of."
-    ),
-)
+@AS_OF_OPTION
+@TIME_TRAVEL_AGO_OPTION
 @click.pass_obj
 @coro
 async def read_cmd(
@@ -209,25 +194,8 @@ async def columns_cmd(
 @tables_group.command("count")
 @click.argument("item", required=False, default=None)
 @click.argument("qualified_name")
-@click.option(
-    "--as-of",
-    "as_of",
-    default=None,
-    metavar="ISO8601",
-    help=(
-        "Count rows as they were at this UTC timestamp (ISO-8601). Mutually exclusive with --ago."
-    ),
-)
-@click.option(
-    "--ago",
-    "ago",
-    default=None,
-    metavar="DURATION",
-    help=(
-        "Count rows as they were this duration ago (e.g. 1h, 90m, 2d). "
-        "Mutually exclusive with --as-of."
-    ),
-)
+@AS_OF_OPTION
+@TIME_TRAVEL_AGO_OPTION
 @click.pass_obj
 @coro
 async def count_cmd(

--- a/src/fabric_dw/cli/commands/views.py
+++ b/src/fabric_dw/cli/commands/views.py
@@ -155,21 +155,45 @@ async def columns_cmd(
 @views_group.command("count")
 @click.argument("item", required=False, default=None)
 @click.argument("qualified_name")
+@click.option(
+    "--as-of",
+    "as_of",
+    default=None,
+    metavar="ISO8601",
+    help=(
+        "Count rows as they were at this UTC timestamp (ISO-8601). Mutually exclusive with --ago."
+    ),
+)
+@click.option(
+    "--ago",
+    "ago",
+    default=None,
+    metavar="DURATION",
+    help=(
+        "Count rows as they were this duration ago (e.g. 1h, 90m, 2d). "
+        "Mutually exclusive with --as-of."
+    ),
+)
 @click.pass_obj
 @coro
 async def count_cmd(
     ctx: CliContext,
     item: str | None,
     qualified_name: str,
+    as_of: str | None,
+    ago: str | None,
 ) -> None:
     """Count rows in QUALIFIED_NAME (schema.view) on ITEM."""
     ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     schema, view_name = parse_qualified_name(qualified_name, kind="view")
+    as_of_dt = resolve_as_of(as_of, ago)
     try:
         async with build_http_client(ctx) as http:
             target, _entry = await build_sql_target(http, ws, wh)
-            row_count = await _views_svc.count_view_rows(target, schema, view_name, mode=ctx.auth)
+            row_count = await _views_svc.count_view_rows(
+                target, schema, view_name, as_of=as_of_dt, mode=ctx.auth
+            )
             render(
                 {"schema": schema, "name": view_name, "row_count": row_count},
                 json_output=ctx.json_output,

--- a/src/fabric_dw/cli/commands/views.py
+++ b/src/fabric_dw/cli/commands/views.py
@@ -9,6 +9,8 @@ import click
 from fabric_dw.cli._context import CliContext
 from fabric_dw.cli._render import confirm, render
 from fabric_dw.cli.commands._utils import (
+    AS_OF_OPTION,
+    TIME_TRAVEL_AGO_OPTION,
     build_http_client,
     build_sql_target,
     confirm_destructive,
@@ -66,25 +68,8 @@ async def list_cmd(ctx: CliContext, item: str | None, schema: str | None) -> Non
     help="Output format.",
 )
 @click.option("--output", default=None, help="Write to this file instead of stdout.")
-@click.option(
-    "--as-of",
-    "as_of",
-    default=None,
-    metavar="ISO8601",
-    help=(
-        "Read the view as it was at this UTC timestamp (ISO-8601). Mutually exclusive with --ago."
-    ),
-)
-@click.option(
-    "--ago",
-    "ago",
-    default=None,
-    metavar="DURATION",
-    help=(
-        "Read the view as it was this duration ago (e.g. 1h, 90m, 2d). "
-        "Mutually exclusive with --as-of."
-    ),
-)
+@AS_OF_OPTION
+@TIME_TRAVEL_AGO_OPTION
 @click.pass_obj
 @coro
 async def read_cmd(
@@ -155,25 +140,8 @@ async def columns_cmd(
 @views_group.command("count")
 @click.argument("item", required=False, default=None)
 @click.argument("qualified_name")
-@click.option(
-    "--as-of",
-    "as_of",
-    default=None,
-    metavar="ISO8601",
-    help=(
-        "Count rows as they were at this UTC timestamp (ISO-8601). Mutually exclusive with --ago."
-    ),
-)
-@click.option(
-    "--ago",
-    "ago",
-    default=None,
-    metavar="DURATION",
-    help=(
-        "Count rows as they were this duration ago (e.g. 1h, 90m, 2d). "
-        "Mutually exclusive with --as-of."
-    ),
-)
+@AS_OF_OPTION
+@TIME_TRAVEL_AGO_OPTION
 @click.pass_obj
 @coro
 async def count_cmd(

--- a/src/fabric_dw/cli/commands/views.py
+++ b/src/fabric_dw/cli/commands/views.py
@@ -15,6 +15,7 @@ from fabric_dw.cli.commands._utils import (
     coro,
     load_sql_body,
     parse_qualified_name,
+    resolve_as_of,
     resolve_warehouse_arg,
     resolve_workspace,
 )
@@ -65,6 +66,25 @@ async def list_cmd(ctx: CliContext, item: str | None, schema: str | None) -> Non
     help="Output format.",
 )
 @click.option("--output", default=None, help="Write to this file instead of stdout.")
+@click.option(
+    "--as-of",
+    "as_of",
+    default=None,
+    metavar="ISO8601",
+    help=(
+        "Read the view as it was at this UTC timestamp (ISO-8601). Mutually exclusive with --ago."
+    ),
+)
+@click.option(
+    "--ago",
+    "ago",
+    default=None,
+    metavar="DURATION",
+    help=(
+        "Read the view as it was this duration ago (e.g. 1h, 90m, 2d). "
+        "Mutually exclusive with --as-of."
+    ),
+)
 @click.pass_obj
 @coro
 async def read_cmd(
@@ -74,12 +94,15 @@ async def read_cmd(
     count: int,
     fmt: str,
     output: str | None,
+    as_of: str | None,
+    ago: str | None,
 ) -> None:
     """Read up to COUNT rows from QUALIFIED_NAME (schema.view) on ITEM."""
     ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     schema, view_name = parse_qualified_name(qualified_name, kind="view")
     output_path = Path(output) if output else None
+    as_of_dt = resolve_as_of(as_of, ago)
 
     # --format takes precedence when explicitly supplied (i.e. differs from the default
     # JSON value); if --format is omitted (or is the default "json"), the global --json
@@ -93,7 +116,7 @@ async def read_cmd(
         async with build_http_client(ctx) as http:
             target, _entry = await build_sql_target(http, ws, wh)
             columns, rows = await _views_svc.read_view(
-                target, schema, view_name, count=count, mode=ctx.auth
+                target, schema, view_name, count=count, as_of=as_of_dt, mode=ctx.auth
             )
             arrow_table = columns_rows_to_arrow(columns, rows)
             write_arrow(arrow_table, effective_fmt, output_path)

--- a/src/fabric_dw/mcp/_helpers.py
+++ b/src/fabric_dw/mcp/_helpers.py
@@ -344,9 +344,20 @@ def parse_iso8601(value: str | None, param: str) -> datetime | None:
     if value is None:
         return None
     try:
-        return datetime.fromisoformat(value)
+        dt = datetime.fromisoformat(value)
     except ValueError as exc:
         raise ToolError(f"invalid {param} {value!r}: expected ISO-8601") from exc
+    # Sanity range check matching the CLI's parse_iso_datetime guard: reject
+    # obviously-wrong years (e.g. epoch 0 or year 9999) that would produce an
+    # opaque server error rather than a clear ToolError.
+    _year_min = 2000
+    _year_max = 2100
+    if not (_year_min <= dt.year <= _year_max):
+        raise ToolError(
+            f"invalid {param} {value!r}: year {dt.year} is out of the expected range "
+            f"({_year_min}-{_year_max}). Check the timestamp."
+        )
+    return dt
 
 
 def parse_qualified_name(qualified_name: str, kind: str = "object") -> tuple[str, str]:

--- a/src/fabric_dw/mcp/tools/tables.py
+++ b/src/fabric_dw/mcp/tools/tables.py
@@ -130,6 +130,7 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         workspace: str,
         item: str,
         qualified_name: str,
+        as_of: str | None = None,
     ) -> dict[str, Any]:
         """Return the total row count of a table via ``SELECT COUNT_BIG(*)``.
 
@@ -139,8 +140,12 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             workspace: Workspace name or GUID.
             item: Warehouse or SQL endpoint name or GUID.
             qualified_name: Dot-separated qualified table name, e.g. ``dbo.sales``.
+            as_of: Optional ISO-8601 UTC timestamp for a point-in-time (time-travel)
+                count.  When supplied the query uses ``OPTION (FOR TIMESTAMP AS OF ...)``.
+                Omit to count the latest data.
         """
         schema, table_name = parse_qualified_name(qualified_name, kind="table")
+        as_of_dt = parse_iso8601(as_of, "as_of")
         ctx = get_context()
         assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
@@ -149,15 +154,16 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
                 workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
             )
             _log.debug(
-                "count_table_rows ws=%s item=%s table=%s.%s",
+                "count_table_rows ws=%s item=%s table=%s.%s as_of=%s",
                 ws_id,
                 entry.id,
                 schema,
                 table_name,
+                as_of,
             )
             target = make_sql_target(ws_id, entry, item)
             result = await tables_svc.count_table_rows(
-                target, schema, table_name, mode=ctx.auth_mode
+                target, schema, table_name, as_of=as_of_dt, mode=ctx.auth_mode
             )
         except (ValueError, FabricError) as exc:
             raise tool_err(exc) from exc

--- a/src/fabric_dw/mcp/tools/tables.py
+++ b/src/fabric_dw/mcp/tools/tables.py
@@ -83,6 +83,7 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         item: str,
         qualified_name: str,
         count: Annotated[int, Field(ge=1, le=10000)] = 10,
+        as_of: str | None = None,
     ) -> dict[str, Any]:
         """Return up to *count* rows from a table as JSON-serialisable columns + rows.
 
@@ -91,8 +92,12 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             item: Warehouse or SQL endpoint name or GUID.
             qualified_name: Dot-separated qualified table name, e.g. ``dbo.sales``.
             count: Maximum number of rows to return (1-10000, default 10).
+            as_of: Optional ISO-8601 UTC timestamp for a point-in-time (time-travel)
+                read.  When supplied the query uses ``OPTION (FOR TIMESTAMP AS OF ...)``.
+                Omit to read the latest data.
         """
         schema, table_name = parse_qualified_name(qualified_name, kind="table")
+        as_of_dt = parse_iso8601(as_of, "as_of")
         ctx = get_context()
         assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
@@ -101,16 +106,17 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
                 workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
             )
             _log.debug(
-                "read_table ws=%s item=%s table=%s.%s count=%d",
+                "read_table ws=%s item=%s table=%s.%s count=%d as_of=%s",
                 ws_id,
                 entry.id,
                 schema,
                 table_name,
                 count,
+                as_of,
             )
             target = make_sql_target(ws_id, entry, item)
             result = await tables_svc.read_table(
-                target, schema, table_name, count=count, mode=ctx.auth_mode
+                target, schema, table_name, count=count, as_of=as_of_dt, mode=ctx.auth_mode
             )
         except (ValueError, FabricError) as exc:
             raise tool_err(exc) from exc

--- a/src/fabric_dw/mcp/tools/views.py
+++ b/src/fabric_dw/mcp/tools/views.py
@@ -16,6 +16,7 @@ from fabric_dw.mcp._guards import (
 from fabric_dw.mcp._helpers import (
     make_sql_target,
     mutating_tool,
+    parse_iso8601,
     parse_qualified_name,
     resolve_item,
     safe_rows,
@@ -63,6 +64,7 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         item: str,
         qualified_name: str,
         count: Annotated[int, Field(ge=1, le=10000)] = 10,
+        as_of: str | None = None,
     ) -> dict[str, Any]:
         """Return up to *count* rows from a view as JSON-serialisable columns + rows.
 
@@ -71,8 +73,12 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             item: Warehouse or SQL endpoint name or GUID.
             qualified_name: Dot-separated qualified view name, e.g. ``dbo.vw_sales``.
             count: Maximum number of rows to return (1-10000, default 10).
+            as_of: Optional ISO-8601 UTC timestamp for a point-in-time (time-travel)
+                read.  When supplied the query uses ``OPTION (FOR TIMESTAMP AS OF ...)``.
+                Omit to read the latest data.
         """
         schema, view_name = parse_qualified_name(qualified_name, kind="view")
+        as_of_dt = parse_iso8601(as_of, "as_of")
         ctx = get_context()
         assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
@@ -81,16 +87,17 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
                 workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
             )
             _log.debug(
-                "read_view ws=%s item=%s view=%s.%s count=%d",
+                "read_view ws=%s item=%s view=%s.%s count=%d as_of=%s",
                 ws_id,
                 entry.id,
                 schema,
                 view_name,
                 count,
+                as_of,
             )
             target = make_sql_target(ws_id, entry, item)
             columns, rows = await views_svc.read_view(
-                target, schema, view_name, count=count, mode=ctx.auth_mode
+                target, schema, view_name, count=count, as_of=as_of_dt, mode=ctx.auth_mode
             )
         except (ValueError, FabricError) as exc:
             raise tool_err(exc) from exc

--- a/src/fabric_dw/mcp/tools/views.py
+++ b/src/fabric_dw/mcp/tools/views.py
@@ -111,6 +111,7 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         workspace: str,
         item: str,
         qualified_name: str,
+        as_of: str | None = None,
     ) -> dict[str, Any]:
         """Return the total row count of a view via ``SELECT COUNT_BIG(*)``.
 
@@ -120,8 +121,12 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             workspace: Workspace name or GUID.
             item: Warehouse or SQL endpoint name or GUID.
             qualified_name: Dot-separated qualified view name, e.g. ``dbo.vw_sales``.
+            as_of: Optional ISO-8601 UTC timestamp for a point-in-time (time-travel)
+                count.  When supplied the query uses ``OPTION (FOR TIMESTAMP AS OF ...)``.
+                Omit to count the latest data.
         """
         schema, view_name = parse_qualified_name(qualified_name, kind="view")
+        as_of_dt = parse_iso8601(as_of, "as_of")
         ctx = get_context()
         assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
@@ -130,15 +135,16 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
                 workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
             )
             _log.debug(
-                "count_view_rows ws=%s item=%s view=%s.%s",
+                "count_view_rows ws=%s item=%s view=%s.%s as_of=%s",
                 ws_id,
                 entry.id,
                 schema,
                 view_name,
+                as_of,
             )
             target = make_sql_target(ws_id, entry, item)
             row_count = await views_svc.count_view_rows(
-                target, schema, view_name, mode=ctx.auth_mode
+                target, schema, view_name, as_of=as_of_dt, mode=ctx.auth_mode
             )
         except (ValueError, FabricError) as exc:
             raise tool_err(exc) from exc

--- a/src/fabric_dw/services/_helpers.py
+++ b/src/fabric_dw/services/_helpers.py
@@ -80,6 +80,29 @@ def coerce_to_utc(dt: datetime) -> datetime:
     return dt.astimezone(UTC)
 
 
+def _format_ms_literal(dt: datetime) -> str:
+    """Return a ``yyyy-MM-ddTHH:mm:ss.fff`` literal for *dt*, rounded to the nearest millisecond.
+
+    Uses :class:`~datetime.timedelta` carry so that microsecond values
+    >= 999_500 roll cleanly into the next second rather than producing an
+    invalid ``.1000`` fragment.
+
+    Args:
+        dt: A UTC-aware :class:`~datetime.datetime`.  The caller is responsible
+            for ensuring the value is already in UTC.
+
+    Returns:
+        A string such as ``"2024-03-15T10:30:45.123"``.
+    """
+    # Round to the nearest millisecond (half-to-even via Python round()) rather
+    # than truncating, so e.g. 123_750 us -> 124 ms instead of silently losing
+    # 0.75 ms.  round() can return 1000 for microsecond values >= 999_500 us;
+    # use timedelta to carry the extra millisecond into the seconds field correctly.
+    dt_rounded = dt.replace(microsecond=0) + timedelta(milliseconds=round(dt.microsecond / 1000))
+    ms_str = f"{dt_rounded.microsecond // 1000:03d}"
+    return dt_rounded.strftime("%Y-%m-%dT%H:%M:%S.") + ms_str
+
+
 def build_time_travel_option(as_of: datetime | None) -> str:
     """Build the Fabric ``OPTION (FOR TIMESTAMP AS OF ...)`` SQL fragment.
 
@@ -108,14 +131,7 @@ def build_time_travel_option(as_of: datetime | None) -> str:
     if as_of is None:
         return ""
     at = coerce_to_utc(as_of)
-    # Round to the nearest millisecond (half-to-even via Python round()) rather
-    # than truncating, so 123_750 us -> 124 ms instead of silently losing 0.75 ms.
-    # round() can return 1000 for microsecond values >= 999_500 us; use timedelta
-    # to carry correctly into the seconds field.
-    at_rounded = at.replace(microsecond=0) + timedelta(milliseconds=round(at.microsecond / 1000))
-    ms_str = f"{at_rounded.microsecond // 1000:03d}"
-    literal = at_rounded.strftime("%Y-%m-%dT%H:%M:%S.") + ms_str
-    return f" OPTION (FOR TIMESTAMP AS OF '{literal}')"
+    return f" OPTION (FOR TIMESTAMP AS OF '{_format_ms_literal(at)}')"
 
 
 class _HasNameAndId(Protocol):

--- a/src/fabric_dw/services/_helpers.py
+++ b/src/fabric_dw/services/_helpers.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import re
 from collections.abc import Callable, Coroutine, Mapping, Sequence
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Protocol, TypeVar
 from uuid import UUID
 
@@ -15,6 +15,7 @@ from fabric_dw.services.capacities import ACTIVE_STATE
 
 __all__ = [
     "SelectBodyError",
+    "build_time_travel_option",
     "coerce_to_utc",
     "compact",
     "reject_non_select",
@@ -77,6 +78,44 @@ def coerce_to_utc(dt: datetime) -> datetime:
     if dt.tzinfo is None or dt.tzinfo.utcoffset(dt) is None:
         return dt.replace(tzinfo=UTC)
     return dt.astimezone(UTC)
+
+
+def build_time_travel_option(as_of: datetime | None) -> str:
+    """Build the Fabric ``OPTION (FOR TIMESTAMP AS OF ...)`` SQL fragment.
+
+    Converts *as_of* to UTC, rounds to the nearest millisecond (half-to-even),
+    and formats the literal as ``yyyy-MM-ddTHH:mm:ss.fff``.
+
+    Args:
+        as_of: The point-in-time datetime, or *None* to return an empty string.
+            Naive datetimes are assumed UTC (via :func:`coerce_to_utc`); tz-aware
+            datetimes are converted to UTC.
+
+    Returns:
+        A string like ``" OPTION (FOR TIMESTAMP AS OF '2024-03-15T10:30:45.123')"``
+        when *as_of* is set, or ``""`` when *as_of* is *None*.
+
+    Note:
+        Callers that assemble SQL from a fixed-format template ending in ``";"``
+        should insert this fragment before re-adding the semicolon::
+
+            as_of_clause = build_time_travel_option(as_of)
+            sql = template[:-1] + as_of_clause + ";"
+
+        When *as_of* is *None* the result is byte-for-byte identical to the
+        original template (no semicolon stripping occurs effectively).
+    """
+    if as_of is None:
+        return ""
+    at = coerce_to_utc(as_of)
+    # Round to the nearest millisecond (half-to-even via Python round()) rather
+    # than truncating, so 123_750 us -> 124 ms instead of silently losing 0.75 ms.
+    # round() can return 1000 for microsecond values >= 999_500 us; use timedelta
+    # to carry correctly into the seconds field.
+    at_rounded = at.replace(microsecond=0) + timedelta(milliseconds=round(at.microsecond / 1000))
+    ms_str = f"{at_rounded.microsecond // 1000:03d}"
+    literal = at_rounded.strftime("%Y-%m-%dT%H:%M:%S.") + ms_str
+    return f" OPTION (FOR TIMESTAMP AS OF '{literal}')"
 
 
 class _HasNameAndId(Protocol):

--- a/src/fabric_dw/services/tables.py
+++ b/src/fabric_dw/services/tables.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime
 from pathlib import Path
 from typing import cast
 from uuid import uuid4
@@ -48,6 +48,7 @@ from fabric_dw.models import (
 )
 from fabric_dw.services._helpers import (
     _assert_not_sql_endpoint,
+    _format_ms_literal,
     build_time_travel_option,
     coerce_to_utc,
     reject_non_select,
@@ -860,18 +861,7 @@ async def clone_table(
         # The AT clause does not support bound parameters in T-SQL DDL, so we
         # embed a fixed-format literal derived from the already-validated datetime
         # object -- never an arbitrary user string.
-        #
-        # Round to the nearest millisecond (half-to-even via Python round())
-        # rather than truncating, so that e.g. 123_750 us -> 124 ms instead
-        # of silently shifting the point-in-time 0.75 ms earlier.
-        # round() can return 1000 for microsecond values >= 999_500 us;
-        # use timedelta to roll the carry into the seconds field correctly.
-        at_rounded = at.replace(microsecond=0) + timedelta(
-            milliseconds=round(at.microsecond / 1000)
-        )
-        ms_part = f"{at_rounded.microsecond // 1000:03d}"
-        at_literal = at_rounded.strftime("%Y-%m-%dT%H:%M:%S.") + ms_part
-        ddl = f"{ddl} AT '{at_literal}'"
+        ddl = f"{ddl} AT '{_format_ms_literal(at)}'"
 
     def _run_ddl() -> None:
         # Clone DDL runs on an autocommit connection so the implicit transaction

--- a/src/fabric_dw/services/tables.py
+++ b/src/fabric_dw/services/tables.py
@@ -239,6 +239,7 @@ async def read_table(
     table_name: str,
     *,
     count: int = 10,
+    as_of: datetime | None = None,
     mode: CredentialMode = CredentialMode.DEFAULT,
 ) -> ResultSet:
     """Return up to *count* rows from *schema*.*table_name*.
@@ -254,6 +255,11 @@ async def read_table(
         schema: The schema name.  Must pass :func:`validate_identifier`.
         table_name: The table name.  Must pass :func:`validate_identifier`.
         count: Maximum number of rows to return (default 10).
+        as_of: Optional point-in-time for time-travel reads.  When set, the
+            query includes ``OPTION (FOR TIMESTAMP AS OF '<utc-literal>')``.
+            Naive datetimes are assumed UTC (via :func:`~._helpers.coerce_to_utc`);
+            tz-aware datetimes are converted to UTC.  Microseconds are rounded
+            to the nearest millisecond.  *None* leaves the SQL unchanged.
         mode: The credential mode for Entra authentication.
 
     Returns:
@@ -272,6 +278,19 @@ async def read_table(
         schema_q=quote_identifier(schema),
         table_q=quote_identifier(table_name),
     )
+    if as_of is not None:
+        # Normalise to UTC so the literal is always UTC regardless of the
+        # caller's tzinfo.  Mirror the rounding logic used in clone_table:
+        # round to the nearest millisecond (half-to-even via Python round())
+        # rather than truncating, so 123_750 us -> 124 ms not 123 ms.
+        at = coerce_to_utc(as_of)
+        at_rounded = at.replace(microsecond=0) + timedelta(
+            milliseconds=round(at.microsecond / 1000)
+        )
+        ms_str = f"{at_rounded.microsecond // 1000:03d}"
+        literal = at_rounded.strftime("%Y-%m-%dT%H:%M:%S.") + ms_str
+        # The template ends with ";". Insert the time-travel hint before it.
+        read_sql = f"{read_sql[:-1]} OPTION (FOR TIMESTAMP AS OF '{literal}');"
 
     def _run() -> ResultSet:
         cols, rows = run_query(target, read_sql, mode=mode)

--- a/src/fabric_dw/services/tables.py
+++ b/src/fabric_dw/services/tables.py
@@ -46,7 +46,12 @@ from fabric_dw.models import (
     TableRowCount,
     WarehouseKind,
 )
-from fabric_dw.services._helpers import _assert_not_sql_endpoint, coerce_to_utc, reject_non_select
+from fabric_dw.services._helpers import (
+    _assert_not_sql_endpoint,
+    build_time_travel_option,
+    coerce_to_utc,
+    reject_non_select,
+)
 from fabric_dw.services.schema_infer import (
     infer_columns_from_csv,
     infer_columns_from_json,
@@ -273,24 +278,16 @@ async def read_table(
     validate_identifier(schema)
     validate_identifier(table_name)
 
-    read_sql = _READ_TABLE_SQL.format(
+    base_sql = _READ_TABLE_SQL.format(
         count=int(count),
         schema_q=quote_identifier(schema),
         table_q=quote_identifier(table_name),
     )
-    if as_of is not None:
-        # Normalise to UTC so the literal is always UTC regardless of the
-        # caller's tzinfo.  Mirror the rounding logic used in clone_table:
-        # round to the nearest millisecond (half-to-even via Python round())
-        # rather than truncating, so 123_750 us -> 124 ms not 123 ms.
-        at = coerce_to_utc(as_of)
-        at_rounded = at.replace(microsecond=0) + timedelta(
-            milliseconds=round(at.microsecond / 1000)
-        )
-        ms_str = f"{at_rounded.microsecond // 1000:03d}"
-        literal = at_rounded.strftime("%Y-%m-%dT%H:%M:%S.") + ms_str
-        # The template ends with ";". Insert the time-travel hint before it.
-        read_sql = f"{read_sql[:-1]} OPTION (FOR TIMESTAMP AS OF '{literal}');"
+    as_of_clause = build_time_travel_option(as_of)
+    # When as_of_clause is empty the result is byte-for-byte identical to base_sql.
+    # The template always ends with ";"; strip it, append the (possibly empty) hint,
+    # then re-add it.
+    read_sql = base_sql[:-1] + as_of_clause + ";"
 
     def _run() -> ResultSet:
         cols, rows = run_query(target, read_sql, mode=mode)
@@ -307,6 +304,7 @@ async def count_table_rows(
     schema: str,
     table_name: str,
     *,
+    as_of: datetime | None = None,
     mode: CredentialMode = CredentialMode.DEFAULT,
 ) -> TableRowCount:
     """Return the total row count of *schema*.*table_name* via ``COUNT_BIG(*)``.
@@ -318,6 +316,10 @@ async def count_table_rows(
         target: The warehouse or SQL Analytics Endpoint to query.
         schema: The schema name.  Must pass :func:`validate_identifier`.
         table_name: The table name.  Must pass :func:`validate_identifier`.
+        as_of: Optional point-in-time for time-travel counts.  When set, the
+            query includes ``OPTION (FOR TIMESTAMP AS OF '<utc-literal>')``.
+            See :func:`~._helpers.build_time_travel_option` for formatting details.
+            *None* leaves the SQL unchanged.
         mode: The credential mode for Entra authentication.
 
     Returns:
@@ -332,10 +334,12 @@ async def count_table_rows(
     validate_identifier(schema)
     validate_identifier(table_name)
 
-    count_sql = _COUNT_TABLE_SQL.format(
+    base_sql = _COUNT_TABLE_SQL.format(
         schema_q=quote_identifier(schema),
         table_q=quote_identifier(table_name),
     )
+    as_of_clause = build_time_travel_option(as_of)
+    count_sql = base_sql[:-1] + as_of_clause + ";"
 
     def _run() -> TableRowCount:
         _cols, rows = run_query(target, count_sql, mode=mode)

--- a/src/fabric_dw/services/views.py
+++ b/src/fabric_dw/services/views.py
@@ -16,14 +16,14 @@ Public API
 from __future__ import annotations
 
 import asyncio
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import cast
 
 from fabric_dw.auth import CredentialMode
 from fabric_dw.exceptions import NotFoundError
 from fabric_dw.identifiers import parse_qualified_name, quote_identifier, validate_identifier
 from fabric_dw.models import View
-from fabric_dw.services._helpers import reject_non_select
+from fabric_dw.services._helpers import coerce_to_utc, reject_non_select
 from fabric_dw.sql import SqlTarget, run_query
 
 __all__ = [
@@ -158,6 +158,7 @@ async def read_view(
     view_name: str,
     *,
     count: int = 10,
+    as_of: datetime | None = None,
     mode: CredentialMode = CredentialMode.DEFAULT,
 ) -> tuple[list[str], list[tuple[object, ...]]]:
     """Return up to *count* rows from *schema*.*view_name*.
@@ -170,6 +171,11 @@ async def read_view(
         schema: The schema name.  Must pass :func:`validate_identifier`.
         view_name: The view name.  Must pass :func:`validate_identifier`.
         count: Maximum number of rows to return (default 10).
+        as_of: Optional point-in-time for time-travel reads.  When set, the
+            query includes ``OPTION (FOR TIMESTAMP AS OF '<utc-literal>')``.
+            Naive datetimes are assumed UTC (via :func:`~._helpers.coerce_to_utc`);
+            tz-aware datetimes are converted to UTC.  Microseconds are rounded
+            to the nearest millisecond.  *None* leaves the SQL unchanged.
         mode: The credential mode for Entra authentication.
 
     Returns:
@@ -192,6 +198,19 @@ async def read_view(
         schema_q=quote_identifier(schema),
         view_q=quote_identifier(view_name),
     )
+    if as_of is not None:
+        # Normalise to UTC so the literal is always UTC regardless of the
+        # caller's tzinfo.  Mirror the rounding logic used in clone_table:
+        # round to the nearest millisecond (half-to-even via Python round())
+        # rather than truncating, so 123_750 us -> 124 ms not 123 ms.
+        at = coerce_to_utc(as_of)
+        at_rounded = at.replace(microsecond=0) + timedelta(
+            milliseconds=round(at.microsecond / 1000)
+        )
+        ms_str = f"{at_rounded.microsecond // 1000:03d}"
+        literal = at_rounded.strftime("%Y-%m-%dT%H:%M:%S.") + ms_str
+        # The template ends with ";". Insert the time-travel hint before it.
+        read_sql = f"{read_sql[:-1]} OPTION (FOR TIMESTAMP AS OF '{literal}');"
 
     def _run() -> tuple[list[str], list[tuple[object, ...]]]:
         # run_query raises NotFoundError (via map_driver_error) for SQL error 208

--- a/src/fabric_dw/services/views.py
+++ b/src/fabric_dw/services/views.py
@@ -16,14 +16,14 @@ Public API
 from __future__ import annotations
 
 import asyncio
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import cast
 
 from fabric_dw.auth import CredentialMode
 from fabric_dw.exceptions import NotFoundError
 from fabric_dw.identifiers import parse_qualified_name, quote_identifier, validate_identifier
 from fabric_dw.models import View
-from fabric_dw.services._helpers import coerce_to_utc, reject_non_select
+from fabric_dw.services._helpers import build_time_travel_option, reject_non_select
 from fabric_dw.sql import SqlTarget, run_query
 
 __all__ = [
@@ -193,24 +193,14 @@ async def read_view(
 
     # Identifiers are validated; bracket-quote them for the FROM clause.
     # TOP count is an internal int (not user-supplied string), safe to embed.
-    read_sql = _READ_VIEW_SQL.format(
+    base_sql = _READ_VIEW_SQL.format(
         count=int(count),
         schema_q=quote_identifier(schema),
         view_q=quote_identifier(view_name),
     )
-    if as_of is not None:
-        # Normalise to UTC so the literal is always UTC regardless of the
-        # caller's tzinfo.  Mirror the rounding logic used in clone_table:
-        # round to the nearest millisecond (half-to-even via Python round())
-        # rather than truncating, so 123_750 us -> 124 ms not 123 ms.
-        at = coerce_to_utc(as_of)
-        at_rounded = at.replace(microsecond=0) + timedelta(
-            milliseconds=round(at.microsecond / 1000)
-        )
-        ms_str = f"{at_rounded.microsecond // 1000:03d}"
-        literal = at_rounded.strftime("%Y-%m-%dT%H:%M:%S.") + ms_str
-        # The template ends with ";". Insert the time-travel hint before it.
-        read_sql = f"{read_sql[:-1]} OPTION (FOR TIMESTAMP AS OF '{literal}');"
+    as_of_clause = build_time_travel_option(as_of)
+    # When as_of_clause is empty the result is byte-for-byte identical to base_sql.
+    read_sql = base_sql[:-1] + as_of_clause + ";"
 
     def _run() -> tuple[list[str], list[tuple[object, ...]]]:
         # run_query raises NotFoundError (via map_driver_error) for SQL error 208
@@ -231,6 +221,7 @@ async def count_view_rows(
     schema: str,
     view_name: str,
     *,
+    as_of: datetime | None = None,
     mode: CredentialMode = CredentialMode.DEFAULT,
 ) -> int:
     """Return the total row count of *schema*.*view_name* via ``COUNT_BIG(*)``.
@@ -242,6 +233,10 @@ async def count_view_rows(
         target: The warehouse or SQL Analytics Endpoint to query.
         schema: The schema name.  Must pass :func:`validate_identifier`.
         view_name: The view name.  Must pass :func:`validate_identifier`.
+        as_of: Optional point-in-time for time-travel counts.  When set, the
+            query includes ``OPTION (FOR TIMESTAMP AS OF '<utc-literal>')``.
+            See :func:`~._helpers.build_time_travel_option` for formatting details.
+            *None* leaves the SQL unchanged.
         mode: The credential mode for Entra authentication.
 
     Returns:
@@ -255,10 +250,12 @@ async def count_view_rows(
     validate_identifier(schema)
     validate_identifier(view_name)
 
-    count_sql = _COUNT_VIEW_SQL.format(
+    base_sql = _COUNT_VIEW_SQL.format(
         schema_q=quote_identifier(schema),
         view_q=quote_identifier(view_name),
     )
+    as_of_clause = build_time_travel_option(as_of)
+    count_sql = base_sql[:-1] + as_of_clause + ";"
 
     def _run() -> int:
         _cols, rows = run_query(target, count_sql, mode=mode)

--- a/tests/integration/test_services_tables.py
+++ b/tests/integration/test_services_tables.py
@@ -302,6 +302,207 @@ async def test_count_table_rows_returns_nonnegative_int(
 
 
 # ---------------------------------------------------------------------------
+# Time-travel: read_table and count_table_rows with as_of
+# ---------------------------------------------------------------------------
+#
+# The pre-seeded ``sample.colors`` table (created during session setup, well
+# before these tests run) provides stable, known-count data.  Using a "current"
+# timestamp as as_of is safe because the table has a long committed history.
+#
+# Caveats (expected server-side errors, not bugs):
+#   - A timestamp before the object's creation time raises a SQL error.
+#   - A timestamp outside the configured retention window (1-120 days, default
+#     30) raises a SQL error.
+#   - A freshly-created table may have no committed history at the requested
+#     point; this is tested in ``test_time_travel_on_fresh_table_*`` below and
+#     handled by a pytest.skip rather than a failure.
+
+# Fragments from SQL engine error messages that mean the requested timestamp has
+# no committed history for the object (expected on freshly-created tables).
+_TIME_TRAVEL_SKIP_FRAGMENTS = (
+    ("no version",),
+    ("history",),
+    ("at time",),
+    ("point in time",),
+    ("timestamp",),
+)
+
+
+def _is_time_travel_unavailable(exc: BaseException) -> bool:
+    """Return True when *exc* means no committed history exists at the requested timestamp."""
+    msg = str(exc).lower()
+    return any(all(frag in msg for frag in frags) for frags in _TIME_TRAVEL_SKIP_FRAGMENTS)
+
+
+async def test_read_table_with_as_of_returns_seeded_rows(
+    read_target: SqlTarget,
+) -> None:
+    """read_table with as_of=now succeeds and returns the seeded rows.
+
+    Uses the pre-seeded sample.colors table (created during session setup) so
+    that any current timestamp is guaranteed to be within its committed history.
+    Proves that the generated OPTION (FOR TIMESTAMP AS OF ...) clause is
+    syntactically and semantically accepted by the Fabric SQL engine end-to-end.
+    """
+    as_of = datetime.now(tz=UTC)
+    try:
+        result = await tables.read_table(
+            read_target, SEED_SCHEMA_NAME, "colors", count=10, as_of=as_of
+        )
+    except Exception as exc:
+        if _is_time_travel_unavailable(exc):
+            pytest.skip(f"No committed history at {as_of.isoformat()}: {exc}")
+        raise
+    assert "id" in result.columns
+    assert "name" in result.columns
+    assert len(result.rows) == 3  # Three seeded rows: red, green, blue
+
+
+async def test_count_table_rows_with_as_of_returns_seeded_count(
+    read_target: SqlTarget,
+) -> None:
+    """count_table_rows with as_of=now succeeds and returns the seeded row count.
+
+    Same guarantee as test_read_table_with_as_of_returns_seeded_rows: the
+    pre-seeded sample.colors table has a long committed history, so any current
+    timestamp is a valid point-in-time anchor.
+    """
+    as_of = datetime.now(tz=UTC)
+    try:
+        result = await tables.count_table_rows(read_target, SEED_SCHEMA_NAME, "colors", as_of=as_of)
+    except Exception as exc:
+        if _is_time_travel_unavailable(exc):
+            pytest.skip(f"No committed history at {as_of.isoformat()}: {exc}")
+        raise
+    assert isinstance(result.row_count, int)
+    assert result.row_count == 3  # Three seeded rows: red, green, blue
+
+
+async def test_read_table_as_of_matches_read_without_as_of(
+    read_target: SqlTarget,
+) -> None:
+    """read_table with as_of=now returns the same data as read without as_of.
+
+    Confirms the OPTION clause is non-destructive: for stable seeded data,
+    a current point-in-time read must match a plain (latest) read.
+    """
+    result_plain = await tables.read_table(read_target, SEED_SCHEMA_NAME, "colors", count=100)
+    as_of = datetime.now(tz=UTC)
+    try:
+        result_timed = await tables.read_table(
+            read_target, SEED_SCHEMA_NAME, "colors", count=100, as_of=as_of
+        )
+    except Exception as exc:
+        if _is_time_travel_unavailable(exc):
+            pytest.skip(f"No committed history at {as_of.isoformat()}: {exc}")
+        raise
+    assert result_plain.columns == result_timed.columns
+    assert sorted(str(r) for r in result_plain.rows) == sorted(str(r) for r in result_timed.rows)
+
+
+async def test_count_table_rows_as_of_matches_count_without_as_of(
+    read_target: SqlTarget,
+) -> None:
+    """count_table_rows with as_of=now returns the same count as without as_of."""
+    result_plain = await tables.count_table_rows(read_target, SEED_SCHEMA_NAME, "colors")
+    as_of = datetime.now(tz=UTC)
+    try:
+        result_timed = await tables.count_table_rows(
+            read_target, SEED_SCHEMA_NAME, "colors", as_of=as_of
+        )
+    except Exception as exc:
+        if _is_time_travel_unavailable(exc):
+            pytest.skip(f"No committed history at {as_of.isoformat()}: {exc}")
+        raise
+    assert result_plain.row_count == result_timed.row_count
+
+
+async def test_time_travel_on_fresh_table_read(
+    warehouse_schema: tuple[SqlTarget, str],
+) -> None:
+    """read_table with as_of set to a server-side timestamp (after DDL) succeeds or skips.
+
+    A freshly-created table may have no committed version visible at the
+    captured server timestamp (Fabric distributed compute may not have flushed
+    the write to the time-travel history yet).  The test skips rather than fails
+    in that case, because the server-side rejection is expected behavior, not a
+    code bug.  When the table DOES have a committed history, the call must return
+    the seeded rows.
+    """
+    sql_target, schema = warehouse_schema
+    table_name = "pytest_timetravel_read"
+    select_body = "SELECT 1 AS id, 'alpha' AS label UNION ALL SELECT 2, 'beta'"
+
+    try:
+        await tables.create_table(sql_target, schema, table_name, select_body)
+
+        # Capture a server-side timestamp after the DDL commit to avoid
+        # client/server clock skew (same technique as test_clone_table_at_point_in_time).
+        def _get_server_ts() -> datetime:
+            _, rows = run_query(sql_target, "SELECT SYSUTCDATETIME() AS ts")
+            raw = rows[0][0]
+            if isinstance(raw, datetime):
+                return raw.replace(tzinfo=UTC) if raw.tzinfo is None else raw.astimezone(UTC)
+            parsed = datetime.fromisoformat(str(raw))
+            return parsed.replace(tzinfo=UTC) if parsed.tzinfo is None else parsed.astimezone(UTC)
+
+        as_of: datetime = await asyncio.to_thread(_get_server_ts)
+
+        try:
+            result = await tables.read_table(sql_target, schema, table_name, count=10, as_of=as_of)
+        except Exception as exc:
+            if _is_time_travel_unavailable(exc) or isinstance(exc, FabricError):
+                pytest.skip(
+                    f"No committed history at {as_of.isoformat()} for a freshly-created "
+                    f"table (expected on distributed compute): {exc}"
+                )
+            raise
+        assert len(result.rows) == 2
+    finally:
+        with contextlib.suppress(Exception):
+            await tables.delete_table(sql_target, schema, table_name)
+
+
+async def test_time_travel_on_fresh_table_count(
+    warehouse_schema: tuple[SqlTarget, str],
+) -> None:
+    """count_table_rows with as_of set to a server-side timestamp succeeds or skips.
+
+    Same freshly-created-table caveat as test_time_travel_on_fresh_table_read.
+    """
+    sql_target, schema = warehouse_schema
+    table_name = "pytest_timetravel_count"
+    select_body = "SELECT 1 AS id UNION ALL SELECT 2 UNION ALL SELECT 3"
+
+    try:
+        await tables.create_table(sql_target, schema, table_name, select_body)
+
+        def _get_server_ts() -> datetime:
+            _, rows = run_query(sql_target, "SELECT SYSUTCDATETIME() AS ts")
+            raw = rows[0][0]
+            if isinstance(raw, datetime):
+                return raw.replace(tzinfo=UTC) if raw.tzinfo is None else raw.astimezone(UTC)
+            parsed = datetime.fromisoformat(str(raw))
+            return parsed.replace(tzinfo=UTC) if parsed.tzinfo is None else parsed.astimezone(UTC)
+
+        as_of: datetime = await asyncio.to_thread(_get_server_ts)
+
+        try:
+            result = await tables.count_table_rows(sql_target, schema, table_name, as_of=as_of)
+        except Exception as exc:
+            if _is_time_travel_unavailable(exc) or isinstance(exc, FabricError):
+                pytest.skip(
+                    f"No committed history at {as_of.isoformat()} for a freshly-created "
+                    f"table (expected on distributed compute): {exc}"
+                )
+            raise
+        assert result.row_count == 3
+    finally:
+        with contextlib.suppress(Exception):
+            await tables.delete_table(sql_target, schema, table_name)
+
+
+# ---------------------------------------------------------------------------
 # SQL-endpoint-only: get_table_health_metrics (sp_get_table_health_metrics)
 # ---------------------------------------------------------------------------
 #

--- a/tests/integration/test_services_views.py
+++ b/tests/integration/test_services_views.py
@@ -15,14 +15,16 @@ The ``mutable_schema_target`` fixture is parametrized over two targets:
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
+from datetime import UTC, datetime
 
 import pytest
 
-from fabric_dw.exceptions import NotFoundError
+from fabric_dw.exceptions import FabricError, NotFoundError
 from fabric_dw.models import View
 from fabric_dw.services import views
-from fabric_dw.sql import SqlTarget
+from fabric_dw.sql import SqlTarget, run_query
 
 pytestmark = pytest.mark.integration
 
@@ -306,6 +308,123 @@ async def test_count_view_rows_returns_nonnegative_int(
         assert isinstance(count, int)
         assert count >= 0
         assert count == 2
+    finally:
+        with contextlib.suppress(Exception):
+            await views.drop_view(sql_target, schema, view_name)
+
+
+# ---------------------------------------------------------------------------
+# Time-travel: read_view and count_view_rows with as_of
+# ---------------------------------------------------------------------------
+#
+# Both functions are tested with a server-side timestamp captured AFTER the view
+# is created to avoid client/server clock skew.
+#
+# Caveats (expected server-side errors, not bugs):
+#   - A timestamp before the underlying view was created errors server-side.
+#   - A timestamp outside the configured retention window errors server-side.
+#   - A freshly-created view may have no committed version visible at the
+#     captured timestamp (Fabric distributed compute flush latency); the tests
+#     skip rather than fail in that case.
+
+# Fragments from SQL engine error messages that mean no committed history exists
+# at the requested timestamp.
+_TIME_TRAVEL_SKIP_FRAGMENTS = (
+    ("no version",),
+    ("history",),
+    ("at time",),
+    ("point in time",),
+    ("timestamp",),
+)
+
+
+def _is_time_travel_unavailable(exc: BaseException) -> bool:
+    """Return True when *exc* means no committed history exists at the requested timestamp."""
+    msg = str(exc).lower()
+    return any(all(frag in msg for frag in frags) for frags in _TIME_TRAVEL_SKIP_FRAGMENTS)
+
+
+def _get_server_ts(sql_target: SqlTarget) -> datetime:
+    """Return a UTC-aware server-side timestamp via SYSUTCDATETIME()."""
+    _, rows = run_query(sql_target, "SELECT SYSUTCDATETIME() AS ts")
+    raw = rows[0][0]
+    if isinstance(raw, datetime):
+        return raw.replace(tzinfo=UTC) if raw.tzinfo is None else raw.astimezone(UTC)
+    parsed = datetime.fromisoformat(str(raw))
+    return parsed.replace(tzinfo=UTC) if parsed.tzinfo is None else parsed.astimezone(UTC)
+
+
+async def test_read_view_with_as_of_succeeds_or_skips(
+    mutable_schema_target: tuple[SqlTarget, str],
+) -> None:
+    """read_view with as_of set to a server-side post-creation timestamp succeeds or skips.
+
+    Creates a view, captures a server-side timestamp after the DDL commit, then
+    calls read_view with as_of.  Proves the OPTION (FOR TIMESTAMP AS OF ...)
+    clause is syntactically and semantically accepted by Fabric end-to-end.
+
+    A freshly-created view may have no committed history at the captured
+    timestamp (Fabric distributed compute flush latency); the test skips in that
+    case rather than failing, because the rejection is expected server behavior,
+    not a code bug.
+    """
+    sql_target, schema = mutable_schema_target
+    view_name = "pytest_views_timetravel_read"
+    select_body = "SELECT 1 AS id, 'alpha' AS label UNION ALL SELECT 2, 'beta'"
+
+    try:
+        await views.create_view(sql_target, schema, view_name, select_body)
+
+        # Capture a server-side timestamp AFTER the DDL commit to ensure the
+        # as_of is >= the view creation time from the server's perspective.
+        as_of: datetime = await asyncio.to_thread(_get_server_ts, sql_target)
+
+        try:
+            cols, rows = await views.read_view(sql_target, schema, view_name, count=10, as_of=as_of)
+        except Exception as exc:
+            if _is_time_travel_unavailable(exc) or isinstance(exc, FabricError):
+                pytest.skip(
+                    f"No committed history at {as_of.isoformat()} for a freshly-created "
+                    f"view (expected on distributed compute): {exc}"
+                )
+            raise
+        assert "id" in cols
+        assert "label" in cols
+        assert len(rows) == 2
+    finally:
+        with contextlib.suppress(Exception):
+            await views.drop_view(sql_target, schema, view_name)
+
+
+async def test_count_view_rows_with_as_of_succeeds_or_skips(
+    mutable_schema_target: tuple[SqlTarget, str],
+) -> None:
+    """count_view_rows with as_of set to a server-side post-creation timestamp succeeds or skips.
+
+    Same freshly-created-view caveat as test_read_view_with_as_of_succeeds_or_skips.
+    When the server does have committed history at the timestamp, the call must
+    return the correct row count.
+    """
+    sql_target, schema = mutable_schema_target
+    view_name = "pytest_views_timetravel_count"
+    select_body = "SELECT 1 AS id UNION ALL SELECT 2 UNION ALL SELECT 3"
+
+    try:
+        await views.create_view(sql_target, schema, view_name, select_body)
+
+        as_of: datetime = await asyncio.to_thread(_get_server_ts, sql_target)
+
+        try:
+            count = await views.count_view_rows(sql_target, schema, view_name, as_of=as_of)
+        except Exception as exc:
+            if _is_time_travel_unavailable(exc) or isinstance(exc, FabricError):
+                pytest.skip(
+                    f"No committed history at {as_of.isoformat()} for a freshly-created "
+                    f"view (expected on distributed compute): {exc}"
+                )
+            raise
+        assert isinstance(count, int)
+        assert count == 3
     finally:
         with contextlib.suppress(Exception):
             await views.drop_view(sql_target, schema, view_name)

--- a/tests/unit/cli/commands/test_ago_option.py
+++ b/tests/unit/cli/commands/test_ago_option.py
@@ -347,6 +347,7 @@ class TestResolveAsOf:
             resolve_as_of("2024-01-01T00:00:00", "1h")
         msg = str(exc_info.value)
         assert "--as-of" in msg
+        assert "--ago" in msg
         assert "--since" not in msg
 
     def test_ago_set_returns_now_minus_delta(self) -> None:

--- a/tests/unit/cli/commands/test_ago_option.py
+++ b/tests/unit/cli/commands/test_ago_option.py
@@ -17,7 +17,7 @@ from click.testing import CliRunner
 
 from fabric_dw.cache import ItemEntry
 from fabric_dw.cli._main import cli
-from fabric_dw.cli.commands._utils import parse_duration, resolve_since
+from fabric_dw.cli.commands._utils import parse_duration, resolve_as_of, resolve_since
 from fabric_dw.models import (
     ExecRequestHistory,
     ExecSessionHistory,
@@ -328,6 +328,60 @@ class TestResolveSince:
     def test_invalid_ago_raises_usage_error(self) -> None:
         with pytest.raises(click.UsageError):
             resolve_since(None, "bad")
+
+
+# ---------------------------------------------------------------------------
+# resolve_as_of
+# ---------------------------------------------------------------------------
+
+
+class TestResolveAsOf:
+    """resolve_as_of merges --as-of and --ago into a single datetime | None."""
+
+    def test_both_set_raises_usage_error(self) -> None:
+        with pytest.raises(click.UsageError, match="mutually exclusive"):
+            resolve_as_of("2024-01-01T00:00:00", "1h")
+
+    def test_error_names_as_of_not_since(self) -> None:
+        with pytest.raises(click.UsageError) as exc_info:
+            resolve_as_of("2024-01-01T00:00:00", "1h")
+        msg = str(exc_info.value)
+        assert "--as-of" in msg
+        assert "--since" not in msg
+
+    def test_ago_set_returns_now_minus_delta(self) -> None:
+        before = datetime.now(UTC)
+        result = resolve_as_of(None, "1h")
+        after = datetime.now(UTC)
+        assert result is not None
+        expected_low = before - timedelta(hours=1)
+        expected_high = after - timedelta(hours=1)
+        assert expected_low <= result <= expected_high
+
+    def test_ago_result_is_tz_aware_utc(self) -> None:
+        result = resolve_as_of(None, "30m")
+        assert result is not None
+        assert result.tzinfo is not None
+        expected = datetime.now(UTC) - timedelta(minutes=30)
+        assert abs((result - expected).total_seconds()) < 5
+
+    def test_as_of_set_returns_parsed_datetime(self) -> None:
+        result = resolve_as_of("2024-06-01T10:00:00Z", None)
+        assert result is not None
+        assert result.year == 2024
+        assert result.month == 6
+        assert result.day == 1
+
+    def test_both_none_returns_none(self) -> None:
+        assert resolve_as_of(None, None) is None
+
+    def test_invalid_as_of_raises_usage_error(self) -> None:
+        with pytest.raises(click.UsageError):
+            resolve_as_of("not-a-date", None)
+
+    def test_invalid_ago_raises_usage_error(self) -> None:
+        with pytest.raises(click.UsageError):
+            resolve_as_of(None, "bad")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/cli/commands/test_tables.py
+++ b/tests/unit/cli/commands/test_tables.py
@@ -348,6 +348,138 @@ class TestTablesRead:
             result = runner.invoke(cli, ["-w", WS_GUID, "tables", "read", WH_GUID, "dbo.missing"])
         assert result.exit_code != 0
 
+    # -- time-travel options --
+
+    def test_read_with_as_of_passes_datetime_to_service(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """--as-of is parsed and threaded to the service as a datetime."""
+        _ = cache_env
+        mock_read = AsyncMock(return_value=ResultSet(columns=["id"], rows=[(1,)]))
+        with (
+            patch(
+                "fabric_dw.cli.commands.tables.build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.tables.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch("fabric_dw.services.tables.read_table", new=mock_read),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "-w",
+                    WS_GUID,
+                    "tables",
+                    "read",
+                    WH_GUID,
+                    "dbo.sales",
+                    "--as-of",
+                    "2024-03-15T10:30:00",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        _, kwargs = mock_read.call_args
+        assert kwargs.get("as_of") is not None
+        assert isinstance(kwargs["as_of"], datetime)
+
+    def test_read_with_ago_passes_datetime_to_service(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """--ago is parsed into a datetime and threaded to the service."""
+        _ = cache_env
+        mock_read = AsyncMock(return_value=ResultSet(columns=["id"], rows=[(1,)]))
+        with (
+            patch(
+                "fabric_dw.cli.commands.tables.build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.tables.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch("fabric_dw.services.tables.read_table", new=mock_read),
+        ):
+            result = runner.invoke(
+                cli,
+                ["-w", WS_GUID, "tables", "read", WH_GUID, "dbo.sales", "--ago", "1h"],
+            )
+        assert result.exit_code == 0, result.output
+        _, kwargs = mock_read.call_args
+        assert kwargs.get("as_of") is not None
+        assert isinstance(kwargs["as_of"], datetime)
+
+    def test_read_with_both_as_of_and_ago_exits_nonzero(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """--as-of and --ago together exit nonzero (mutually exclusive)."""
+        _ = cache_env
+        result = runner.invoke(
+            cli,
+            [
+                "-w",
+                WS_GUID,
+                "tables",
+                "read",
+                WH_GUID,
+                "dbo.sales",
+                "--as-of",
+                "2024-01-01T00:00:00",
+                "--ago",
+                "1h",
+            ],
+        )
+        assert result.exit_code != 0
+
+    def test_read_both_error_names_as_of_and_ago(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """Error for --as-of + --ago names both options correctly (not --since)."""
+        _ = cache_env
+        result = runner.invoke(
+            cli,
+            [
+                "-w",
+                WS_GUID,
+                "tables",
+                "read",
+                WH_GUID,
+                "dbo.sales",
+                "--as-of",
+                "2024-01-01T00:00:00",
+                "--ago",
+                "1h",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "--as-of" in result.output
+        assert "--ago" in result.output
+        assert "--since" not in result.output
+
+    def test_read_without_time_travel_passes_none_as_of(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """Without --as-of or --ago, service is called with as_of=None."""
+        _ = cache_env
+        mock_read = AsyncMock(return_value=ResultSet(columns=["id"], rows=[(1,)]))
+        with (
+            patch(
+                "fabric_dw.cli.commands.tables.build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.tables.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch("fabric_dw.services.tables.read_table", new=mock_read),
+        ):
+            result = runner.invoke(cli, ["-w", WS_GUID, "tables", "read", WH_GUID, "dbo.sales"])
+        assert result.exit_code == 0, result.output
+        _, kwargs = mock_read.call_args
+        assert kwargs.get("as_of") is None
+
 
 # ===========================================================================
 # tables count

--- a/tests/unit/cli/commands/test_tables.py
+++ b/tests/unit/cli/commands/test_tables.py
@@ -433,9 +433,7 @@ class TestTablesRead:
         )
         assert result.exit_code != 0
 
-    def test_read_both_error_names_as_of_and_ago(
-        self, runner: CliRunner, cache_env: Path
-    ) -> None:
+    def test_read_both_error_names_as_of_and_ago(self, runner: CliRunner, cache_env: Path) -> None:
         """Error for --as-of + --ago names both options correctly (not --since)."""
         _ = cache_env
         result = runner.invoke(

--- a/tests/unit/cli/commands/test_tables.py
+++ b/tests/unit/cli/commands/test_tables.py
@@ -565,6 +565,120 @@ class TestTablesCount:
             result = runner.invoke(cli, ["-w", WS_GUID, "tables", "count", WH_GUID, "dbo.missing"])
         assert result.exit_code != 0
 
+    def test_count_with_as_of_passes_datetime_to_service(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """--as-of is parsed into a datetime and threaded to count_table_rows."""
+        _ = cache_env
+        mock_count = AsyncMock(
+            return_value=TableRowCount(schema_name="dbo", name="sales", row_count=5)
+        )
+        with (
+            patch(
+                "fabric_dw.cli.commands.tables.build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.tables.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch("fabric_dw.services.tables.count_table_rows", new=mock_count),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "-w",
+                    WS_GUID,
+                    "tables",
+                    "count",
+                    WH_GUID,
+                    "dbo.sales",
+                    "--as-of",
+                    "2024-03-15T10:30:00",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        _, kwargs = mock_count.call_args
+        assert kwargs.get("as_of") is not None
+        assert isinstance(kwargs["as_of"], datetime)
+
+    def test_count_with_ago_passes_datetime_to_service(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """--ago is parsed into a datetime and threaded to count_table_rows."""
+        _ = cache_env
+        mock_count = AsyncMock(
+            return_value=TableRowCount(schema_name="dbo", name="sales", row_count=3)
+        )
+        with (
+            patch(
+                "fabric_dw.cli.commands.tables.build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.tables.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch("fabric_dw.services.tables.count_table_rows", new=mock_count),
+        ):
+            result = runner.invoke(
+                cli,
+                ["-w", WS_GUID, "tables", "count", WH_GUID, "dbo.sales", "--ago", "1h"],
+            )
+        assert result.exit_code == 0, result.output
+        _, kwargs = mock_count.call_args
+        assert kwargs.get("as_of") is not None
+        assert isinstance(kwargs["as_of"], datetime)
+
+    def test_count_with_both_as_of_and_ago_exits_nonzero(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """--as-of and --ago together exit nonzero (mutually exclusive)."""
+        _ = cache_env
+        result = runner.invoke(
+            cli,
+            [
+                "-w",
+                WS_GUID,
+                "tables",
+                "count",
+                WH_GUID,
+                "dbo.sales",
+                "--as-of",
+                "2024-01-01T00:00:00",
+                "--ago",
+                "1h",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "--as-of" in result.output
+        assert "--ago" in result.output
+        assert "--since" not in result.output
+
+    def test_count_without_time_travel_passes_none_as_of(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """Without --as-of or --ago, service is called with as_of=None."""
+        _ = cache_env
+        mock_count = AsyncMock(
+            return_value=TableRowCount(schema_name="dbo", name="sales", row_count=0)
+        )
+        with (
+            patch(
+                "fabric_dw.cli.commands.tables.build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.tables.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch("fabric_dw.services.tables.count_table_rows", new=mock_count),
+        ):
+            result = runner.invoke(cli, ["-w", WS_GUID, "tables", "count", WH_GUID, "dbo.sales"])
+        assert result.exit_code == 0, result.output
+        _, kwargs = mock_count.call_args
+        assert kwargs.get("as_of") is None
+
 
 # ===========================================================================
 # tables create

--- a/tests/unit/cli/commands/test_views.py
+++ b/tests/unit/cli/commands/test_views.py
@@ -369,9 +369,7 @@ class TestViewsRead:
         )
         assert result.exit_code != 0
 
-    def test_read_both_error_names_as_of_and_ago(
-        self, runner: CliRunner, cache_env: Path
-    ) -> None:
+    def test_read_both_error_names_as_of_and_ago(self, runner: CliRunner, cache_env: Path) -> None:
         """Error for --as-of + --ago names both options correctly (not --since)."""
         _ = cache_env
         result = runner.invoke(
@@ -599,9 +597,7 @@ class TestViewsCount:
             ),
             patch("fabric_dw.services.views.count_view_rows", new=mock_count),
         ):
-            result = runner.invoke(
-                cli, ["-w", WS_GUID, "views", "count", WH_GUID, "dbo.vw_sales"]
-            )
+            result = runner.invoke(cli, ["-w", WS_GUID, "views", "count", WH_GUID, "dbo.vw_sales"])
         assert result.exit_code == 0, result.output
         _, kwargs = mock_count.call_args
         assert kwargs.get("as_of") is None

--- a/tests/unit/cli/commands/test_views.py
+++ b/tests/unit/cli/commands/test_views.py
@@ -284,6 +284,138 @@ class TestViewsRead:
             result = runner.invoke(cli, ["-w", WS_GUID, "views", "read", WH_GUID, "dbo.vw_missing"])
         assert result.exit_code != 0
 
+    # -- time-travel options --
+
+    def test_read_with_as_of_passes_datetime_to_service(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """--as-of is parsed and threaded to the service as a datetime."""
+        _ = cache_env
+        mock_read = AsyncMock(return_value=(["id"], [(1,)]))
+        with (
+            patch(
+                "fabric_dw.cli.commands.views.build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.views.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch("fabric_dw.services.views.read_view", new=mock_read),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "-w",
+                    WS_GUID,
+                    "views",
+                    "read",
+                    WH_GUID,
+                    "dbo.vw_sales",
+                    "--as-of",
+                    "2024-03-15T10:30:00",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        _, kwargs = mock_read.call_args
+        assert kwargs.get("as_of") is not None
+        assert isinstance(kwargs["as_of"], datetime)
+
+    def test_read_with_ago_passes_datetime_to_service(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """--ago is parsed into a datetime and threaded to the service."""
+        _ = cache_env
+        mock_read = AsyncMock(return_value=(["id"], [(1,)]))
+        with (
+            patch(
+                "fabric_dw.cli.commands.views.build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.views.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch("fabric_dw.services.views.read_view", new=mock_read),
+        ):
+            result = runner.invoke(
+                cli,
+                ["-w", WS_GUID, "views", "read", WH_GUID, "dbo.vw_sales", "--ago", "1h"],
+            )
+        assert result.exit_code == 0, result.output
+        _, kwargs = mock_read.call_args
+        assert kwargs.get("as_of") is not None
+        assert isinstance(kwargs["as_of"], datetime)
+
+    def test_read_with_both_as_of_and_ago_exits_nonzero(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """--as-of and --ago together exit nonzero (mutually exclusive)."""
+        _ = cache_env
+        result = runner.invoke(
+            cli,
+            [
+                "-w",
+                WS_GUID,
+                "views",
+                "read",
+                WH_GUID,
+                "dbo.vw_sales",
+                "--as-of",
+                "2024-01-01T00:00:00",
+                "--ago",
+                "1h",
+            ],
+        )
+        assert result.exit_code != 0
+
+    def test_read_both_error_names_as_of_and_ago(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """Error for --as-of + --ago names both options correctly (not --since)."""
+        _ = cache_env
+        result = runner.invoke(
+            cli,
+            [
+                "-w",
+                WS_GUID,
+                "views",
+                "read",
+                WH_GUID,
+                "dbo.vw_sales",
+                "--as-of",
+                "2024-01-01T00:00:00",
+                "--ago",
+                "1h",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "--as-of" in result.output
+        assert "--ago" in result.output
+        assert "--since" not in result.output
+
+    def test_read_without_time_travel_passes_none_as_of(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """Without --as-of or --ago, service is called with as_of=None."""
+        _ = cache_env
+        mock_read = AsyncMock(return_value=(["id"], [(1,)]))
+        with (
+            patch(
+                "fabric_dw.cli.commands.views.build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.views.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch("fabric_dw.services.views.read_view", new=mock_read),
+        ):
+            result = runner.invoke(cli, ["-w", WS_GUID, "views", "read", WH_GUID, "dbo.vw_sales"])
+        assert result.exit_code == 0, result.output
+        _, kwargs = mock_read.call_args
+        assert kwargs.get("as_of") is None
+
 
 # ===========================================================================
 # views count

--- a/tests/unit/cli/commands/test_views.py
+++ b/tests/unit/cli/commands/test_views.py
@@ -496,6 +496,116 @@ class TestViewsCount:
             result = runner.invoke(cli, ["-w", WS_GUID, "views", "count", WH_GUID, "dbo.missing"])
         assert result.exit_code != 0
 
+    def test_count_with_as_of_passes_datetime_to_service(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """--as-of is parsed into a datetime and threaded to count_view_rows."""
+        _ = cache_env
+        mock_count = AsyncMock(return_value=5)
+        with (
+            patch(
+                "fabric_dw.cli.commands.views.build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.views.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch("fabric_dw.services.views.count_view_rows", new=mock_count),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "-w",
+                    WS_GUID,
+                    "views",
+                    "count",
+                    WH_GUID,
+                    "dbo.vw_sales",
+                    "--as-of",
+                    "2024-03-15T10:30:00",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        _, kwargs = mock_count.call_args
+        assert kwargs.get("as_of") is not None
+        assert isinstance(kwargs["as_of"], datetime)
+
+    def test_count_with_ago_passes_datetime_to_service(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """--ago is parsed into a datetime and threaded to count_view_rows."""
+        _ = cache_env
+        mock_count = AsyncMock(return_value=3)
+        with (
+            patch(
+                "fabric_dw.cli.commands.views.build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.views.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch("fabric_dw.services.views.count_view_rows", new=mock_count),
+        ):
+            result = runner.invoke(
+                cli,
+                ["-w", WS_GUID, "views", "count", WH_GUID, "dbo.vw_sales", "--ago", "1h"],
+            )
+        assert result.exit_code == 0, result.output
+        _, kwargs = mock_count.call_args
+        assert kwargs.get("as_of") is not None
+        assert isinstance(kwargs["as_of"], datetime)
+
+    def test_count_with_both_as_of_and_ago_exits_nonzero(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """--as-of and --ago together exit nonzero (mutually exclusive)."""
+        _ = cache_env
+        result = runner.invoke(
+            cli,
+            [
+                "-w",
+                WS_GUID,
+                "views",
+                "count",
+                WH_GUID,
+                "dbo.vw_sales",
+                "--as-of",
+                "2024-01-01T00:00:00",
+                "--ago",
+                "1h",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "--as-of" in result.output
+        assert "--ago" in result.output
+        assert "--since" not in result.output
+
+    def test_count_without_time_travel_passes_none_as_of(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """Without --as-of or --ago, service is called with as_of=None."""
+        _ = cache_env
+        mock_count = AsyncMock(return_value=0)
+        with (
+            patch(
+                "fabric_dw.cli.commands.views.build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.views.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch("fabric_dw.services.views.count_view_rows", new=mock_count),
+        ):
+            result = runner.invoke(
+                cli, ["-w", WS_GUID, "views", "count", WH_GUID, "dbo.vw_sales"]
+            )
+        assert result.exit_code == 0, result.output
+        _, kwargs = mock_count.call_args
+        assert kwargs.get("as_of") is None
+
 
 # ===========================================================================
 # views get

--- a/tests/unit/mcp/tools/test_tables.py
+++ b/tests/unit/mcp/tools/test_tables.py
@@ -284,6 +284,88 @@ async def test_read_table_workspace_allowlist_blocks(ctx_patch) -> None:
 
 
 # ---------------------------------------------------------------------------
+# read_table — as_of (time-travel)
+# ---------------------------------------------------------------------------
+
+
+async def test_read_table_with_as_of_passes_to_service(mock_ctx, ctx_patch) -> None:
+    """read_table parses as_of ISO-8601 and threads the datetime to the service."""
+    from datetime import datetime  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+    mock_read = AsyncMock(return_value=ResultSet(columns=["id"], rows=[(1,)]))
+
+    with (
+        ctx_patch,
+        patch("fabric_dw.services.tables.read_table", new=mock_read),
+    ):
+        await mcp._tool_manager.call_tool(
+            "read_table",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_name": "dbo.sales",
+                "as_of": "2024-03-15T10:30:00",
+            },
+        )
+
+    _, kwargs = mock_read.call_args
+    assert kwargs.get("as_of") is not None
+    assert isinstance(kwargs["as_of"], datetime)
+
+
+async def test_read_table_without_as_of_passes_none(mock_ctx, ctx_patch) -> None:
+    """read_table without as_of calls the service with as_of=None."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+    mock_read = AsyncMock(return_value=ResultSet(columns=["id"], rows=[(1,)]))
+
+    with (
+        ctx_patch,
+        patch("fabric_dw.services.tables.read_table", new=mock_read),
+    ):
+        await mcp._tool_manager.call_tool(
+            "read_table",
+            {"workspace": WS_NAME, "item": WH_NAME, "qualified_name": "dbo.sales"},
+        )
+
+    _, kwargs = mock_read.call_args
+    assert kwargs.get("as_of") is None
+
+
+async def test_read_table_invalid_as_of_raises_tool_error(mock_ctx, ctx_patch) -> None:
+    """read_table raises ToolError when as_of is not a valid ISO-8601 string."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "read_table",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_name": "dbo.sales",
+                "as_of": "not-a-date",
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
 # delete_table — happy-path return path (line 163)
 # NOTE: SQL-endpoint guard tested in test_server.py — not duplicated here.
 # ---------------------------------------------------------------------------

--- a/tests/unit/mcp/tools/test_tables.py
+++ b/tests/unit/mcp/tools/test_tables.py
@@ -785,9 +785,7 @@ async def test_count_table_rows_without_as_of_passes_none(mock_ctx, ctx_patch) -
     item = make_item_entry()
     mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
     mock_ctx.resolver.item = AsyncMock(return_value=item)
-    mock_count = AsyncMock(
-        return_value=TableRowCount(schema_name="dbo", name="sales", row_count=0)
-    )
+    mock_count = AsyncMock(return_value=TableRowCount(schema_name="dbo", name="sales", row_count=0))
 
     with (
         ctx_patch,

--- a/tests/unit/mcp/tools/test_tables.py
+++ b/tests/unit/mcp/tools/test_tables.py
@@ -742,6 +742,92 @@ async def test_count_table_rows_bad_qualified_name_raises_tool_error(ctx_patch) 
 
 
 # ---------------------------------------------------------------------------
+# count_table_rows — as_of (time-travel)
+# ---------------------------------------------------------------------------
+
+
+async def test_count_table_rows_with_as_of_passes_to_service(mock_ctx, ctx_patch) -> None:
+    """count_table_rows parses as_of ISO-8601 and threads the datetime to the service."""
+    from datetime import datetime  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+    mock_count = AsyncMock(
+        return_value=TableRowCount(schema_name="dbo", name="sales", row_count=10)
+    )
+
+    with (
+        ctx_patch,
+        patch("fabric_dw.services.tables.count_table_rows", new=mock_count),
+    ):
+        await mcp._tool_manager.call_tool(
+            "count_table_rows",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_name": "dbo.sales",
+                "as_of": "2024-03-15T10:30:00",
+            },
+        )
+
+    _, kwargs = mock_count.call_args
+    assert kwargs.get("as_of") is not None
+    assert isinstance(kwargs["as_of"], datetime)
+
+
+async def test_count_table_rows_without_as_of_passes_none(mock_ctx, ctx_patch) -> None:
+    """count_table_rows without as_of calls the service with as_of=None."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+    mock_count = AsyncMock(
+        return_value=TableRowCount(schema_name="dbo", name="sales", row_count=0)
+    )
+
+    with (
+        ctx_patch,
+        patch("fabric_dw.services.tables.count_table_rows", new=mock_count),
+    ):
+        await mcp._tool_manager.call_tool(
+            "count_table_rows",
+            {"workspace": WS_NAME, "item": WH_NAME, "qualified_name": "dbo.sales"},
+        )
+
+    _, kwargs = mock_count.call_args
+    assert kwargs.get("as_of") is None
+
+
+async def test_count_table_rows_invalid_as_of_raises_tool_error(mock_ctx, ctx_patch) -> None:
+    """count_table_rows raises ToolError when as_of is not a valid ISO-8601 string."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "count_table_rows",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_name": "dbo.sales",
+                "as_of": "not-a-date",
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
 # get_cluster_columns — happy path, empty result, SQL endpoint guard, error funnel
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/mcp/tools/test_views.py
+++ b/tests/unit/mcp/tools/test_views.py
@@ -337,6 +337,85 @@ async def test_read_view_workspace_not_in_allowlist(ctx_patch) -> None:
 
 
 # ---------------------------------------------------------------------------
+# read_view — as_of (time-travel)
+# ---------------------------------------------------------------------------
+
+
+async def test_read_view_with_as_of_passes_to_service(mock_ctx, ctx_patch) -> None:
+    """read_view parses as_of ISO-8601 and threads the datetime to the service."""
+    from datetime import datetime  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+    mock_svc = AsyncMock(return_value=(["id"], [(1,)]))
+
+    with (
+        ctx_patch,
+        patch("fabric_dw.services.views.read_view", new=mock_svc),
+    ):
+        await mcp._tool_manager.call_tool(
+            "read_view",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_name": "dbo.vw_sales",
+                "as_of": "2024-03-15T10:30:00",
+            },
+        )
+
+    _, kwargs = mock_svc.call_args
+    assert kwargs.get("as_of") is not None
+    assert isinstance(kwargs["as_of"], datetime)
+
+
+async def test_read_view_without_as_of_passes_none(mock_ctx, ctx_patch) -> None:
+    """read_view without as_of calls the service with as_of=None."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+    mock_svc = AsyncMock(return_value=(["id"], [(1,)]))
+
+    with (
+        ctx_patch,
+        patch("fabric_dw.services.views.read_view", new=mock_svc),
+    ):
+        await mcp._tool_manager.call_tool(
+            "read_view",
+            {"workspace": WS_NAME, "item": WH_NAME, "qualified_name": "dbo.vw_sales"},
+        )
+
+    _, kwargs = mock_svc.call_args
+    assert kwargs.get("as_of") is None
+
+
+async def test_read_view_invalid_as_of_raises_tool_error(mock_ctx, ctx_patch) -> None:
+    """read_view raises ToolError when as_of is not a valid ISO-8601 string."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+
+    with (
+        ctx_patch,
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "read_view",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_name": "dbo.vw_sales",
+                "as_of": "not-a-date",
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
 # get_view — happy path
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/mcp/tools/test_views.py
+++ b/tests/unit/mcp/tools/test_views.py
@@ -1124,6 +1124,85 @@ async def test_count_view_rows_bad_qualified_name_raises_tool_error(ctx_patch) -
 
 
 # ---------------------------------------------------------------------------
+# count_view_rows — as_of (time-travel)
+# ---------------------------------------------------------------------------
+
+
+async def test_count_view_rows_with_as_of_passes_to_service(mock_ctx, ctx_patch) -> None:
+    """count_view_rows parses as_of ISO-8601 and threads the datetime to the service."""
+    from datetime import datetime  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+    mock_count = AsyncMock(return_value=10)
+
+    with (
+        ctx_patch,
+        patch("fabric_dw.services.views.count_view_rows", new=mock_count),
+    ):
+        await mcp._tool_manager.call_tool(
+            "count_view_rows",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_name": "dbo.vw_sales",
+                "as_of": "2024-03-15T10:30:00",
+            },
+        )
+
+    _, kwargs = mock_count.call_args
+    assert kwargs.get("as_of") is not None
+    assert isinstance(kwargs["as_of"], datetime)
+
+
+async def test_count_view_rows_without_as_of_passes_none(mock_ctx, ctx_patch) -> None:
+    """count_view_rows without as_of calls the service with as_of=None."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+    mock_count = AsyncMock(return_value=0)
+
+    with (
+        ctx_patch,
+        patch("fabric_dw.services.views.count_view_rows", new=mock_count),
+    ):
+        await mcp._tool_manager.call_tool(
+            "count_view_rows",
+            {"workspace": WS_NAME, "item": WH_NAME, "qualified_name": "dbo.vw_sales"},
+        )
+
+    _, kwargs = mock_count.call_args
+    assert kwargs.get("as_of") is None
+
+
+async def test_count_view_rows_invalid_as_of_raises_tool_error(mock_ctx, ctx_patch) -> None:
+    """count_view_rows raises ToolError when as_of is not a valid ISO-8601 string."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+
+    with (
+        ctx_patch,
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "count_view_rows",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_name": "dbo.vw_sales",
+                "as_of": "not-a-date",
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
 # get_view_columns — happy path + not found
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/services/test_helpers.py
+++ b/tests/unit/services/test_helpers.py
@@ -10,6 +10,7 @@ from fabric_dw.exceptions import ItemKindError
 from fabric_dw.models import WarehouseKind
 from fabric_dw.services._helpers import (
     _assert_not_sql_endpoint,
+    build_time_travel_option,
     coerce_to_utc,
     compact,
     reject_non_select,
@@ -198,3 +199,33 @@ class TestAssertNotSqlEndpoint:
         assert settings_guard is _assert_not_sql_endpoint
         assert stats_guard is _assert_not_sql_endpoint
         assert tables_guard is _assert_not_sql_endpoint
+
+
+# ---------------------------------------------------------------------------
+# build_time_travel_option
+# ---------------------------------------------------------------------------
+
+
+class TestBuildTimeTravelOption:
+    """Unit tests for build_time_travel_option and its _format_ms_literal helper."""
+
+    def test_carry_rolls_into_next_second(self) -> None:
+        """999_750 us rounds to 1000 ms; the timedelta carry must produce ...:01.000.
+
+        Without the timedelta carry the naive f-string approach would emit
+        ``...:00.1000``, which is an invalid literal.  This test specifically
+        covers the >=999_500 us branch that was previously untested.
+        """
+        # 2024-01-15T12:00:00.999750 UTC rounds to 2024-01-15T12:00:01.000
+        dt = datetime(2024, 1, 15, 12, 0, 0, 999_750, tzinfo=UTC)
+        result = build_time_travel_option(dt)
+        assert result == " OPTION (FOR TIMESTAMP AS OF '2024-01-15T12:00:01.000')"
+
+    def test_carry_rolls_into_next_minute(self) -> None:
+        """999_750 us on a 59-second boundary must carry all the way to :00.000."""
+        dt = datetime(2024, 1, 15, 12, 0, 59, 999_750, tzinfo=UTC)
+        result = build_time_travel_option(dt)
+        assert result == " OPTION (FOR TIMESTAMP AS OF '2024-01-15T12:01:00.000')"
+
+    def test_none_returns_empty_string(self) -> None:
+        assert build_time_travel_option(None) == ""

--- a/tests/unit/services/test_tables.py
+++ b/tests/unit/services/test_tables.py
@@ -617,6 +617,70 @@ class TestCountTableRows:
         ):
             await tables.count_table_rows(target, "dbo", "missing")
 
+    # -- time-travel (as_of) --
+
+    async def test_as_of_appends_option_for_timestamp(self) -> None:
+        """count_table_rows appends OPTION (FOR TIMESTAMP AS OF ...) when as_of is set."""
+        target = _make_target()
+        conn = _make_conn([(99,)], ["row_count"])
+        as_of = datetime(2024, 3, 15, 10, 30, 45, 123_000, tzinfo=UTC)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await tables.count_table_rows(target, "dbo", "sales", as_of=as_of)
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert "OPTION (FOR TIMESTAMP AS OF '2024-03-15T10:30:45.123')" in call_sql
+
+    async def test_as_of_none_sql_unchanged(self) -> None:
+        """count_table_rows SQL is byte-for-byte identical to the template when as_of is None."""
+        from fabric_dw.services.tables import _COUNT_TABLE_SQL  # noqa: PLC0415
+
+        target = _make_target()
+        conn = _make_conn([(0,)], ["row_count"])
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await tables.count_table_rows(target, "dbo", "sales")
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        expected = _COUNT_TABLE_SQL.format(schema_q="[dbo]", table_q="[sales]")
+        assert call_sql == expected
+
+    async def test_as_of_utc_coercion(self) -> None:
+        """count_table_rows coerces a tz-aware non-UTC datetime to UTC before formatting."""
+        target = _make_target()
+        conn = _make_conn([(5,)], ["row_count"])
+        # CET = UTC+1: 11:30 CET == 10:30 UTC
+        cet = timezone(timedelta(hours=1))
+        as_of = datetime(2024, 3, 15, 11, 30, 0, tzinfo=cet)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await tables.count_table_rows(target, "dbo", "sales", as_of=as_of)
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert "2024-03-15T10:30:00.000" in call_sql
+
+    async def test_as_of_millisecond_rounding(self) -> None:
+        """count_table_rows rounds microseconds to the nearest millisecond (half-to-even)."""
+        target = _make_target()
+        conn = _make_conn([(7,)], ["row_count"])
+        # 123_750 us -> round(123.75) -> 124 ms
+        as_of = datetime(2024, 3, 15, 10, 30, 45, 123_750, tzinfo=UTC)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await tables.count_table_rows(target, "dbo", "sales", as_of=as_of)
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert "2024-03-15T10:30:45.124" in call_sql
+
+    async def test_as_of_clause_position_before_semicolon(self) -> None:
+        """OPTION clause appears before the trailing semicolon in the count SQL."""
+        target = _make_target()
+        conn = _make_conn([(3,)], ["row_count"])
+        as_of = datetime(2024, 1, 1, 0, 0, 0, tzinfo=UTC)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await tables.count_table_rows(target, "dbo", "sales", as_of=as_of)
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        option_idx = call_sql.index("OPTION")
+        semicolon_idx = call_sql.rindex(";")
+        assert option_idx < semicolon_idx
+
 
 # ===========================================================================
 # get_cluster_columns

--- a/tests/unit/services/test_tables.py
+++ b/tests/unit/services/test_tables.py
@@ -472,6 +472,70 @@ class TestReadTable:
             await tables.read_table(target, "dbo", "sales")
         conn.close.assert_called_once()
 
+    # -- time-travel (as_of) --
+
+    async def test_as_of_appends_option_for_timestamp(self) -> None:
+        """read_table appends OPTION (FOR TIMESTAMP AS OF ...) when as_of is set."""
+        target = _make_target()
+        conn = _make_conn([(1,)], ["id"])
+        as_of = datetime(2024, 3, 15, 10, 30, 45, 123_000, tzinfo=UTC)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await tables.read_table(target, "dbo", "sales", as_of=as_of)
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert "OPTION (FOR TIMESTAMP AS OF '2024-03-15T10:30:45.123')" in call_sql
+
+    async def test_as_of_none_sql_unchanged(self) -> None:
+        """read_table SQL is byte-for-byte identical to the template when as_of is None."""
+        from fabric_dw.services.tables import _READ_TABLE_SQL  # noqa: PLC0415
+
+        target = _make_target()
+        conn = _make_conn([(1,)], ["id"])
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await tables.read_table(target, "dbo", "sales", count=10)
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        expected = _READ_TABLE_SQL.format(count=10, schema_q="[dbo]", table_q="[sales]")
+        assert call_sql == expected
+
+    async def test_as_of_utc_coercion(self) -> None:
+        """read_table coerces a tz-aware non-UTC datetime to UTC before formatting."""
+        target = _make_target()
+        conn = _make_conn([(1,)], ["id"])
+        # CET = UTC+1: 11:30 CET == 10:30 UTC
+        cet = timezone(timedelta(hours=1))
+        as_of = datetime(2024, 3, 15, 11, 30, 0, tzinfo=cet)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await tables.read_table(target, "dbo", "sales", as_of=as_of)
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert "2024-03-15T10:30:00.000" in call_sql
+
+    async def test_as_of_millisecond_rounding(self) -> None:
+        """read_table rounds microseconds to the nearest millisecond (half-to-even)."""
+        target = _make_target()
+        conn = _make_conn([(1,)], ["id"])
+        # 123_750 us -> round(123.75) -> 124 ms
+        as_of = datetime(2024, 3, 15, 10, 30, 45, 123_750, tzinfo=UTC)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await tables.read_table(target, "dbo", "sales", as_of=as_of)
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert "2024-03-15T10:30:45.124" in call_sql
+
+    async def test_as_of_clause_position_before_semicolon(self) -> None:
+        """OPTION clause appears before the trailing semicolon in the SQL."""
+        target = _make_target()
+        conn = _make_conn([(1,)], ["id"])
+        as_of = datetime(2024, 1, 1, 0, 0, 0, tzinfo=UTC)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await tables.read_table(target, "dbo", "sales", as_of=as_of)
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        option_idx = call_sql.index("OPTION")
+        semicolon_idx = call_sql.rindex(";")
+        assert option_idx < semicolon_idx
+
 
 # ===========================================================================
 # count_table_rows

--- a/tests/unit/services/test_views.py
+++ b/tests/unit/services/test_views.py
@@ -504,6 +504,70 @@ class TestCountViewRows:
         ):
             await views.count_view_rows(target, "dbo", "missing")
 
+    # -- time-travel (as_of) --
+
+    async def test_as_of_appends_option_for_timestamp(self) -> None:
+        """count_view_rows appends OPTION (FOR TIMESTAMP AS OF ...) when as_of is set."""
+        target = _make_target()
+        conn = _make_conn([(99,)], ["row_count"])
+        as_of = datetime(2024, 3, 15, 10, 30, 45, 123_000, tzinfo=UTC)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await views.count_view_rows(target, "dbo", "vw_sales", as_of=as_of)
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert "OPTION (FOR TIMESTAMP AS OF '2024-03-15T10:30:45.123')" in call_sql
+
+    async def test_as_of_none_sql_unchanged(self) -> None:
+        """count_view_rows SQL is byte-for-byte identical to the template when as_of is None."""
+        from fabric_dw.services.views import _COUNT_VIEW_SQL  # noqa: PLC0415
+
+        target = _make_target()
+        conn = _make_conn([(0,)], ["row_count"])
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await views.count_view_rows(target, "dbo", "vw_sales")
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        expected = _COUNT_VIEW_SQL.format(schema_q="[dbo]", view_q="[vw_sales]")
+        assert call_sql == expected
+
+    async def test_as_of_utc_coercion(self) -> None:
+        """count_view_rows coerces a tz-aware non-UTC datetime to UTC before formatting."""
+        target = _make_target()
+        conn = _make_conn([(5,)], ["row_count"])
+        # CET = UTC+1: 11:30 CET == 10:30 UTC
+        cet = timezone(timedelta(hours=1))
+        as_of = datetime(2024, 3, 15, 11, 30, 0, tzinfo=cet)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await views.count_view_rows(target, "dbo", "vw_sales", as_of=as_of)
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert "2024-03-15T10:30:00.000" in call_sql
+
+    async def test_as_of_millisecond_rounding(self) -> None:
+        """count_view_rows rounds microseconds to the nearest millisecond (half-to-even)."""
+        target = _make_target()
+        conn = _make_conn([(7,)], ["row_count"])
+        # 123_750 us -> round(123.75) -> 124 ms
+        as_of = datetime(2024, 3, 15, 10, 30, 45, 123_750, tzinfo=UTC)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await views.count_view_rows(target, "dbo", "vw_sales", as_of=as_of)
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert "2024-03-15T10:30:45.124" in call_sql
+
+    async def test_as_of_clause_position_before_semicolon(self) -> None:
+        """OPTION clause appears before the trailing semicolon in the count SQL."""
+        target = _make_target()
+        conn = _make_conn([(3,)], ["row_count"])
+        as_of = datetime(2024, 1, 1, 0, 0, 0, tzinfo=UTC)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await views.count_view_rows(target, "dbo", "vw_sales", as_of=as_of)
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        option_idx = call_sql.index("OPTION")
+        semicolon_idx = call_sql.rindex(";")
+        assert option_idx < semicolon_idx
+
 
 # ===========================================================================
 # get_view

--- a/tests/unit/services/test_views.py
+++ b/tests/unit/services/test_views.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -368,6 +368,70 @@ class TestReadView:
         call_sql: str = cursor.execute.call_args[0][0].upper()
         # Assert the full TOP clause to avoid accidental matches on other numbers.
         assert "TOP (10)" in call_sql
+
+    # -- time-travel (as_of) --
+
+    async def test_as_of_appends_option_for_timestamp(self) -> None:
+        """read_view appends OPTION (FOR TIMESTAMP AS OF ...) when as_of is set."""
+        target = _make_target()
+        conn = _make_conn([(1,)], ["id"])
+        as_of = datetime(2024, 3, 15, 10, 30, 45, 123_000, tzinfo=UTC)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await read_view(target, "dbo", "vw_sales", as_of=as_of)
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert "OPTION (FOR TIMESTAMP AS OF '2024-03-15T10:30:45.123')" in call_sql
+
+    async def test_as_of_none_sql_unchanged(self) -> None:
+        """read_view SQL is byte-for-byte identical to the template when as_of is None."""
+        from fabric_dw.services.views import _READ_VIEW_SQL  # noqa: PLC0415
+
+        target = _make_target()
+        conn = _make_conn([(1,)], ["id"])
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await read_view(target, "dbo", "vw_sales", count=10)
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        expected = _READ_VIEW_SQL.format(count=10, schema_q="[dbo]", view_q="[vw_sales]")
+        assert call_sql == expected
+
+    async def test_as_of_utc_coercion(self) -> None:
+        """read_view coerces a tz-aware non-UTC datetime to UTC before formatting."""
+        target = _make_target()
+        conn = _make_conn([(1,)], ["id"])
+        # CET = UTC+1: 11:30 CET == 10:30 UTC
+        cet = timezone(timedelta(hours=1))
+        as_of = datetime(2024, 3, 15, 11, 30, 0, tzinfo=cet)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await read_view(target, "dbo", "vw_sales", as_of=as_of)
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert "2024-03-15T10:30:00.000" in call_sql
+
+    async def test_as_of_millisecond_rounding(self) -> None:
+        """read_view rounds microseconds to the nearest millisecond (half-to-even)."""
+        target = _make_target()
+        conn = _make_conn([(1,)], ["id"])
+        # 123_750 us -> round(123.75) -> 124 ms
+        as_of = datetime(2024, 3, 15, 10, 30, 45, 123_750, tzinfo=UTC)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await read_view(target, "dbo", "vw_sales", as_of=as_of)
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert "2024-03-15T10:30:45.124" in call_sql
+
+    async def test_as_of_clause_position_before_semicolon(self) -> None:
+        """OPTION clause appears before the trailing semicolon in the SQL."""
+        target = _make_target()
+        conn = _make_conn([(1,)], ["id"])
+        as_of = datetime(2024, 1, 1, 0, 0, 0, tzinfo=UTC)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await read_view(target, "dbo", "vw_sales", as_of=as_of)
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        option_idx = call_sql.index("OPTION")
+        semicolon_idx = call_sql.rindex(";")
+        assert option_idx < semicolon_idx
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

Add optional point-in-time (time-travel) selectors to the read commands and tools for tables and views, using Fabric's `OPTION (FOR TIMESTAMP AS OF '<utc-literal>')` hint on `SELECT`.

- **Service layer** (`services/tables.py`, `services/views.py`): add `as_of: datetime | None = None` to `read_table`/`read_view`. Builds the `OPTION` clause from a parsed datetime using the same UTC coercion and millisecond rounding as `clone_table`. SQL is byte-for-byte unchanged when `as_of` is `None`.
- **CLI** (`cli/commands/tables.py`, `cli/commands/views.py`, `cli/commands/_utils.py`): add `--as-of ISO8601` and `--ago DURATION` to `tables read` and `views read`. Mutually exclusive; error message names `--as-of`/`--ago` correctly (not `--since`). New `resolve_as_of()` helper alongside `resolve_since()`.
- **MCP** (`mcp/tools/tables.py`, `mcp/tools/views.py`): add optional `as_of` (ISO-8601 string) parameter to `read_table`/`read_view`. Parsed with `parse_iso8601`; threaded to the service as `datetime | None`.
- **Docs**: updated `docs/commands/tables.md` and `docs/commands/views.md` for both CLI options and MCP parameters.

No SQL parsing: the timestamp literal is rendered from a validated `datetime` object; identifiers remain bracket-quoted via the existing channel.

## Test plan

- [x] Service: `as_of` set appends exact `OPTION (FOR TIMESTAMP AS OF '<literal>')` with 3-digit ms + UTC coercion; `as_of=None` leaves SQL byte-for-byte unchanged
- [x] Service: millisecond rounding (half-to-even) verified (123_750 us -> 124 ms)
- [x] Service: OPTION clause position is before the trailing semicolon
- [x] CLI: `--as-of` parsed to datetime and threaded to service; `--ago` likewise
- [x] CLI: `--as-of + --ago` exits nonzero with error naming both options (not `--since`)
- [x] CLI: neither option passes `as_of=None` to service (unchanged behavior)
- [x] MCP: `as_of` parsed and threaded; omitted passes `None`; invalid raises `ToolError`
- [x] `resolve_as_of()`: full coverage including mutual-exclusion error text check
- [x] All 680 existing tests in the touched modules continue to pass; 0 regressions

Closes #921