### PR TITLE
feat(permissions): column-level security (permissions cls subgroup)

### DIFF
--- a/docs/commands/permissions.md
+++ b/docs/commands/permissions.md
@@ -411,3 +411,138 @@ because revoke removes an existing permission (destructive operation).
   grantee has granted the permission to (`CASCADE`).
 
 **Returns:** `{ "revoked": true, "permissions": str, "principal": str, "scope": str }`.
+
+## permissions cls
+
+Column-level security (CLS) restricts access to specific columns of a table. It uses the same
+`GRANT`, `DENY`, and `REVOKE` T-SQL verbs as object-level security, but targets a named column
+list rather than the table as a whole.
+
+Permissions supported at column level: `SELECT`, `UPDATE`, `REFERENCES`.
+
+**Targets:** Data Warehouse / SQL Analytics Endpoint
+
+Reference: [Column-level security in Microsoft Fabric](https://learn.microsoft.com/fabric/data-warehouse/column-level-security)
+
+### permissions cls grant
+
+**Targets:** Data Warehouse / SQL Analytics Endpoint
+
+Grant column-level permissions on an object to a principal. Executes
+`GRANT <PERMISSIONS> ON OBJECT::<SCHEMA.TABLE> (<COLUMNS>) TO <PRINCIPAL>`.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] permissions cls grant [ITEM] PERMISSIONS --object SCHEMA.TABLE --columns COL1,COL2 --to PRINCIPAL [OPTIONS]
+```
+
+`PERMISSIONS` is a comma-separated list of column-level permission tokens: `SELECT`, `UPDATE`,
+or `REFERENCES`.
+
+| Option | Description |
+| --- | --- |
+| `--object SCHEMA.TABLE` | Qualified table name. **Required.** |
+| `--columns COL1,COL2` | Comma-separated list of column names. **Required.** |
+| `--to PRINCIPAL` | Grantee principal: Entra UPN, application GUID, or role name. **Required.** |
+| `--with-grant-option` | Allow the grantee to grant the column permission to others (`WITH GRANT OPTION`). |
+
+**Example**
+
+```shell
+# Grant SELECT on specific columns to a user
+fdw -w MyWorkspace permissions cls grant SalesWH SELECT --object dbo.sales --columns email,phone --to alice@contoso.com
+
+# Grant with grant option
+fdw -w MyWorkspace permissions cls grant SalesWH REFERENCES --object dbo.customers --columns ssn --to analysts --with-grant-option
+```
+
+### permissions cls deny
+
+**Targets:** Data Warehouse / SQL Analytics Endpoint
+
+Deny column-level permissions on an object to a principal. Executes
+`DENY <PERMISSIONS> ON OBJECT::<SCHEMA.TABLE> (<COLUMNS>) TO <PRINCIPAL>`.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] permissions cls deny [ITEM] PERMISSIONS --object SCHEMA.TABLE --columns COL1,COL2 --to PRINCIPAL
+```
+
+| Option | Description |
+| --- | --- |
+| `--object SCHEMA.TABLE` | Qualified table name. **Required.** |
+| `--columns COL1,COL2` | Comma-separated list of column names. **Required.** |
+| `--to PRINCIPAL` | Principal to deny. **Required.** |
+
+**Example**
+
+```shell
+# Deny SELECT on sensitive columns to a user
+fdw -w MyWorkspace permissions cls deny SalesWH SELECT --object dbo.sales --columns email,phone --to alice@contoso.com
+```
+
+### permissions cls revoke
+
+**Targets:** Data Warehouse / SQL Analytics Endpoint
+
+Revoke column-level permissions on an object from a principal. Executes
+`REVOKE <PERMISSIONS> ON OBJECT::<SCHEMA.TABLE> (<COLUMNS>) FROM <PRINCIPAL>`.
+
+This is a **destructive operation**: it removes an existing column permission. A confirmation
+prompt is shown before executing. Pass `--yes` / `-y` to skip the prompt in scripts.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] [-y] permissions cls revoke [ITEM] PERMISSIONS --object SCHEMA.TABLE --columns COL1,COL2 --from PRINCIPAL [OPTIONS]
+```
+
+| Option | Description |
+| --- | --- |
+| `--object SCHEMA.TABLE` | Qualified table name. **Required.** |
+| `--columns COL1,COL2` | Comma-separated list of column names. **Required.** |
+| `--from PRINCIPAL` | Principal to revoke from. **Required.** |
+| `-y`, `--yes` | Skip the confirmation prompt (non-interactive / scripted use). |
+| `--cascade` | Cascade the revocation to principals the grantee has granted the permission to. |
+
+**Example**
+
+```shell
+# Revoke SELECT from a user (prompts for confirmation)
+fdw -w MyWorkspace permissions cls revoke SalesWH SELECT --object dbo.sales --columns email,phone --from alice@contoso.com
+
+# Revoke without prompt (scripted)
+fdw -w MyWorkspace -y permissions cls revoke SalesWH SELECT --object dbo.sales --columns email,phone --from alice@contoso.com
+
+# Revoke with cascade
+fdw -w MyWorkspace -y permissions cls revoke SalesWH SELECT --object dbo.sales --columns ssn --from analysts --cascade
+```
+
+### permissions cls list
+
+**Targets:** Data Warehouse / SQL Analytics Endpoint
+
+List column-level permissions on an object. Queries `sys.database_permissions` and returns only
+rows where `minor_id != 0` (column-level entries), joined to column names from `sys.columns`.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] [--json] permissions cls list [ITEM] --object SCHEMA.TABLE
+```
+
+| Option | Description |
+| --- | --- |
+| `--object SCHEMA.TABLE` | Qualified table name. **Required.** |
+
+**Example**
+
+```shell
+# Tabular output
+fdw -w MyWorkspace permissions cls list SalesWH --object dbo.sales
+
+# Raw JSON
+fdw -w MyWorkspace --json permissions cls list SalesWH --object dbo.sales
+```

--- a/src/fabric_dw/cli/_main.py
+++ b/src/fabric_dw/cli/_main.py
@@ -46,6 +46,7 @@ _CLI_SEGMENTS_KEY = _CLI_TELEMETRY_KEY + "_segments"
 _DESTRUCTIVE_CLI_COMMANDS: frozenset[str] = frozenset(
     {
         "functions.drop",
+        "permissions.cls.revoke",
         "permissions.sql.revoke",
         "procedures.drop",
         "restore-points.delete",

--- a/src/fabric_dw/cli/commands/permissions.py
+++ b/src/fabric_dw/cli/commands/permissions.py
@@ -550,9 +550,7 @@ async def cls_grant_cmd(
             )
     except (ValueError, FabricError) as exc:
         raise click.ClickException(str(exc)) from exc
-    click.echo(
-        f"Granted {permissions!r} on {scope_object!r} cols {columns_str!r} to {principal!r}."
-    )
+    click.echo(f"Granted {permissions!r} on {scope_object!r} cols {columns!r} to {principal!r}.")
 
 
 @cls_group.command("deny")
@@ -606,7 +604,7 @@ async def cls_deny_cmd(
             )
     except (ValueError, FabricError) as exc:
         raise click.ClickException(str(exc)) from exc
-    click.echo(f"Denied {permissions!r} on {scope_object!r} cols {columns_str!r} to {principal!r}.")
+    click.echo(f"Denied {permissions!r} on {scope_object!r} cols {columns!r} to {principal!r}.")
 
 
 @cls_group.command("revoke")
@@ -630,6 +628,13 @@ async def cls_deny_cmd(
     help="Comma-separated list of column names to revoke.",
 )
 @click.option(
+    "--grant-option-only",
+    "grant_option_only",
+    is_flag=True,
+    default=False,
+    help="Revoke only the GRANT OPTION, not the base permission.",
+)
+@click.option(
     "--cascade",
     "cascade",
     is_flag=True,
@@ -645,6 +650,7 @@ async def cls_revoke_cmd(
     principal: str,
     scope_object: str,
     columns_str: str,
+    grant_option_only: bool,
     cascade: bool,
 ) -> None:
     """Revoke column-level PERMISSIONS on ITEM from PRINCIPAL.
@@ -658,9 +664,11 @@ async def cls_revoke_cmd(
     """
     ws = resolve_workspace(ctx)
     it = resolve_warehouse_arg(ctx, item)
+    # Parse and validate columns before the confirm prompt so invalid input
+    # raises UsageError immediately without prompting.
     columns = _parse_column_list(columns_str)
     if not confirm_destructive(
-        f"Revoke {permissions!r} on {scope_object!r} columns {columns_str!r} from {principal!r}?",
+        f"Revoke {permissions!r} on {scope_object!r} columns {columns!r} from {principal!r}?",
         yes=ctx.yes,
     ):
         click.echo("Aborted.")
@@ -675,14 +683,13 @@ async def cls_revoke_cmd(
                 "OBJECT",
                 object_name=scope_object,
                 columns=columns,
+                grant_option_only=grant_option_only,
                 cascade=cascade,
                 mode=ctx.auth,
             )
     except (ValueError, FabricError) as exc:
         raise click.ClickException(str(exc)) from exc
-    click.echo(
-        f"Revoked {permissions!r} on {scope_object!r} cols {columns_str!r} from {principal!r}."
-    )
+    click.echo(f"Revoked {permissions!r} on {scope_object!r} cols {columns!r} from {principal!r}.")
 
 
 @cls_group.command("list")

--- a/src/fabric_dw/cli/commands/permissions.py
+++ b/src/fabric_dw/cli/commands/permissions.py
@@ -1,6 +1,6 @@
 """Permissions sub-commands for the fabric-dw CLI.
 
-Two distinct permission planes are exposed under the ``permissions`` top-level group:
+Three distinct permission planes are exposed under the ``permissions`` top-level group:
 
 ``permissions item``
     Fabric item-level permissions (REST admin API).  Moved from ``warehouses permissions``
@@ -9,6 +9,10 @@ Two distinct permission planes are exposed under the ``permissions`` top-level g
 ``permissions sql``
     T-SQL granular in-database permissions.  Reads from ``sys.database_permissions`` /
     ``sys.database_principals`` and issues ``GRANT`` / ``DENY`` / ``REVOKE`` statements.
+
+``permissions cls``
+    Column-level security: ``GRANT`` / ``DENY`` / ``REVOKE`` on specific columns of a
+    table, targeting ``minor_id != 0`` rows in ``sys.database_permissions``.
 """
 
 from __future__ import annotations
@@ -457,3 +461,251 @@ async def sql_revoke_cmd(
     except (ValueError, FabricError) as exc:
         raise click.ClickException(str(exc)) from exc
     click.echo(f"Revoked {permissions!r} on {scope_class} from {principal!r}.")
+
+
+# ---------------------------------------------------------------------------
+# permissions cls sub-group (column-level security)
+# ---------------------------------------------------------------------------
+
+
+@permissions_group.group("cls")
+def cls_group() -> None:
+    """Column-level security: GRANT / DENY / REVOKE on specific columns of a table."""
+
+
+@cls_group.command("grant")
+@click.argument("item", required=False, default=None)
+@click.argument("permissions")
+@click.option("--to", "principal", required=True, metavar="PRINCIPAL", help="Grantee principal.")
+@click.option(
+    "--object",
+    "scope_object",
+    required=True,
+    metavar="SCHEMA.TABLE",
+    help="Qualified table name (e.g. dbo.sales).",
+)
+@click.option(
+    "--columns",
+    "columns_str",
+    required=True,
+    metavar="COL1,COL2,...",
+    help="Comma-separated list of column names to grant.",
+)
+@click.option(
+    "--with-grant-option",
+    "with_grant_option",
+    is_flag=True,
+    default=False,
+    help="Allow the grantee to grant the permission to others.",
+)
+@click.pass_obj
+@coro
+async def cls_grant_cmd(
+    ctx: CliContext,
+    item: str | None,
+    permissions: str,
+    principal: str,
+    scope_object: str,
+    columns_str: str,
+    with_grant_option: bool,
+) -> None:
+    """Grant column-level PERMISSIONS on ITEM to PRINCIPAL.
+
+    PERMISSIONS: comma-separated list (e.g. SELECT). Allowed: SELECT, UPDATE, REFERENCES.
+    Use --object to specify the qualified table name and --columns for the column list.
+    Use --to to specify the grantee principal (Entra UPN, GUID, or role name).
+    """
+    ws = resolve_workspace(ctx)
+    it = resolve_warehouse_arg(ctx, item)
+    columns = [c.strip() for c in columns_str.split(",") if c.strip()]
+    try:
+        async with build_http_client(ctx) as http:
+            target, _entry = await build_sql_target(http, ws, it)
+            await _permissions_svc.grant_permission(
+                target,
+                permissions,
+                principal,
+                "OBJECT",
+                object_name=scope_object,
+                with_grant_option=with_grant_option,
+                columns=columns,
+                mode=ctx.auth,
+            )
+    except (ValueError, FabricError) as exc:
+        raise click.ClickException(str(exc)) from exc
+    click.echo(
+        f"Granted {permissions!r} on {scope_object!r} cols {columns_str!r} to {principal!r}."
+    )
+
+
+@cls_group.command("deny")
+@click.argument("item", required=False, default=None)
+@click.argument("permissions")
+@click.option("--to", "principal", required=True, metavar="PRINCIPAL", help="Principal to deny.")
+@click.option(
+    "--object",
+    "scope_object",
+    required=True,
+    metavar="SCHEMA.TABLE",
+    help="Qualified table name (e.g. dbo.sales).",
+)
+@click.option(
+    "--columns",
+    "columns_str",
+    required=True,
+    metavar="COL1,COL2,...",
+    help="Comma-separated list of column names to deny.",
+)
+@click.pass_obj
+@coro
+async def cls_deny_cmd(
+    ctx: CliContext,
+    item: str | None,
+    permissions: str,
+    principal: str,
+    scope_object: str,
+    columns_str: str,
+) -> None:
+    """Deny column-level PERMISSIONS on ITEM to PRINCIPAL.
+
+    PERMISSIONS: comma-separated list (e.g. SELECT). Allowed: SELECT, UPDATE, REFERENCES.
+    Use --object to specify the qualified table name and --columns for the column list.
+    Use --to to specify the principal (Entra UPN, GUID, or role name).
+    """
+    ws = resolve_workspace(ctx)
+    it = resolve_warehouse_arg(ctx, item)
+    columns = [c.strip() for c in columns_str.split(",") if c.strip()]
+    try:
+        async with build_http_client(ctx) as http:
+            target, _entry = await build_sql_target(http, ws, it)
+            await _permissions_svc.deny_permission(
+                target,
+                permissions,
+                principal,
+                "OBJECT",
+                object_name=scope_object,
+                columns=columns,
+                mode=ctx.auth,
+            )
+    except (ValueError, FabricError) as exc:
+        raise click.ClickException(str(exc)) from exc
+    click.echo(f"Denied {permissions!r} on {scope_object!r} cols {columns_str!r} to {principal!r}.")
+
+
+@cls_group.command("revoke")
+@click.argument("item", required=False, default=None)
+@click.argument("permissions")
+@click.option(
+    "--from", "principal", required=True, metavar="PRINCIPAL", help="Principal to revoke from."
+)
+@click.option(
+    "--object",
+    "scope_object",
+    required=True,
+    metavar="SCHEMA.TABLE",
+    help="Qualified table name (e.g. dbo.sales).",
+)
+@click.option(
+    "--columns",
+    "columns_str",
+    required=True,
+    metavar="COL1,COL2,...",
+    help="Comma-separated list of column names to revoke.",
+)
+@click.option(
+    "--cascade",
+    "cascade",
+    is_flag=True,
+    default=False,
+    help="Cascade the revocation to principals the grantee has granted to.",
+)
+@click.pass_obj
+@coro
+async def cls_revoke_cmd(
+    ctx: CliContext,
+    item: str | None,
+    permissions: str,
+    principal: str,
+    scope_object: str,
+    columns_str: str,
+    cascade: bool,
+) -> None:
+    """Revoke column-level PERMISSIONS on ITEM from PRINCIPAL.
+
+    PERMISSIONS: comma-separated list (e.g. SELECT). Allowed: SELECT, UPDATE, REFERENCES.
+    Use --object to specify the qualified table name and --columns for the column list.
+    Use --from to specify the principal (Entra UPN, GUID, or role name).
+
+    This is a destructive operation: it removes an existing column-level permission.
+    A confirmation prompt is shown unless --yes / -y is passed.
+    """
+    ws = resolve_workspace(ctx)
+    it = resolve_warehouse_arg(ctx, item)
+    columns = [c.strip() for c in columns_str.split(",") if c.strip()]
+    if not confirm_destructive(
+        f"Revoke {permissions!r} on {scope_object!r} columns {columns_str!r} from {principal!r}?",
+        yes=ctx.yes,
+    ):
+        click.echo("Aborted.")
+        return
+    try:
+        async with build_http_client(ctx) as http:
+            target, _entry = await build_sql_target(http, ws, it)
+            await _permissions_svc.revoke_permission(
+                target,
+                permissions,
+                principal,
+                "OBJECT",
+                object_name=scope_object,
+                columns=columns,
+                cascade=cascade,
+                mode=ctx.auth,
+            )
+    except (ValueError, FabricError) as exc:
+        raise click.ClickException(str(exc)) from exc
+    click.echo(
+        f"Revoked {permissions!r} on {scope_object!r} cols {columns_str!r} from {principal!r}."
+    )
+
+
+@cls_group.command("list")
+@click.argument("item", required=False, default=None)
+@click.option(
+    "--object",
+    "scope_object",
+    required=True,
+    metavar="SCHEMA.TABLE",
+    help="Qualified table name to list column-level permissions for.",
+)
+@click.pass_obj
+@coro
+async def cls_list_cmd(
+    ctx: CliContext,
+    item: str | None,
+    scope_object: str,
+) -> None:
+    """List column-level permissions on ITEM for a specific table.
+
+    Shows only rows that apply to specific columns (minor_id != 0 in sys.database_permissions).
+    Use --object to specify the qualified table name.
+    """
+    ws = resolve_workspace(ctx)
+    it = resolve_warehouse_arg(ctx, item)
+    try:
+        async with build_http_client(ctx) as http:
+            target, _entry = await build_sql_target(http, ws, it)
+            perms = await _permissions_svc.list_sql_permissions(
+                target,
+                object_name=scope_object,
+                mode=ctx.auth,
+            )
+            # Filter to column-level rows only (those where column_name is resolved)
+            col_perms = [p for p in perms if p.column_name is not None]
+            render(
+                [p.model_dump(mode="json") for p in col_perms],
+                json_output=ctx.json_output,
+                table_title="Column-Level Permissions",
+                prune_null_columns=True,
+            )
+    except (ValueError, FabricError) as exc:
+        raise click.ClickException(str(exc)) from exc

--- a/src/fabric_dw/cli/commands/permissions.py
+++ b/src/fabric_dw/cli/commands/permissions.py
@@ -464,6 +464,23 @@ async def sql_revoke_cmd(
 
 
 # ---------------------------------------------------------------------------
+# permissions cls helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_column_list(columns_str: str) -> list[str]:
+    """Split a comma-separated column string into a non-empty list.
+
+    Raises:
+        click.UsageError: If the parsed list is empty (e.g. ``--columns ","``).
+    """
+    columns = [c.strip() for c in columns_str.split(",") if c.strip()]
+    if not columns:
+        raise click.UsageError("--columns must contain at least one non-empty column name")
+    return columns
+
+
+# ---------------------------------------------------------------------------
 # permissions cls sub-group (column-level security)
 # ---------------------------------------------------------------------------
 
@@ -517,7 +534,7 @@ async def cls_grant_cmd(
     """
     ws = resolve_workspace(ctx)
     it = resolve_warehouse_arg(ctx, item)
-    columns = [c.strip() for c in columns_str.split(",") if c.strip()]
+    columns = _parse_column_list(columns_str)
     try:
         async with build_http_client(ctx) as http:
             target, _entry = await build_sql_target(http, ws, it)
@@ -574,7 +591,7 @@ async def cls_deny_cmd(
     """
     ws = resolve_workspace(ctx)
     it = resolve_warehouse_arg(ctx, item)
-    columns = [c.strip() for c in columns_str.split(",") if c.strip()]
+    columns = _parse_column_list(columns_str)
     try:
         async with build_http_client(ctx) as http:
             target, _entry = await build_sql_target(http, ws, it)
@@ -641,7 +658,7 @@ async def cls_revoke_cmd(
     """
     ws = resolve_workspace(ctx)
     it = resolve_warehouse_arg(ctx, item)
-    columns = [c.strip() for c in columns_str.split(",") if c.strip()]
+    columns = _parse_column_list(columns_str)
     if not confirm_destructive(
         f"Revoke {permissions!r} on {scope_object!r} columns {columns_str!r} from {principal!r}?",
         yes=ctx.yes,

--- a/src/fabric_dw/identifiers.py
+++ b/src/fabric_dw/identifiers.py
@@ -16,6 +16,7 @@ __all__ = [
     "parse_qualified_name",
     "quote_identifier",
     "quote_principal",
+    "validate_column_name",
     "validate_identifier",
     "validate_principal_name",
 ]
@@ -47,6 +48,9 @@ _PRINCIPAL_NAME_RE = re.compile(r"^[A-Za-z0-9@.\-_'# ]{1,128}\Z")
 # ASCII control character boundaries (used in validate_principal_name).
 _CTRL_LOW = 0x20  # characters below this (0x00-0x1F) are control chars
 _CTRL_DEL = 0x7F  # DEL character
+
+# Maximum length for SQL Server sysname / NVARCHAR(128) identifier columns.
+_MAX_NAME_LEN = 128
 
 
 # ---------------------------------------------------------------------------
@@ -182,6 +186,59 @@ def quote_principal(name: str) -> str:
     """
     escaped = name.strip().replace("]", "]]")
     return f"[{escaped}]"
+
+
+def validate_column_name(name: str) -> str:
+    """Validate a column name for use inside bracket-quoted SQL identifiers.
+
+    Column names are always wrapped in ``[...]`` by :func:`quote_identifier`
+    before being embedded in SQL, so they may contain characters that the
+    stricter :func:`validate_identifier` rejects (spaces, hyphens, leading
+    digits, etc.).  This validator permits that broader character set while
+    still blocking every pattern that enables injection:
+
+    Explicitly rejected (belt-and-suspenders, before any escaping):
+
+    - ``]`` -- closes the bracket-quoted identifier; enables injection even
+      with escaping as the subsequent character would escape the wrong thing.
+    - ``;`` -- SQL statement separator.
+    - ``--`` -- SQL line-comment prefix.
+    - Control characters (``< U+0020`` or ``U+007F``) -- NUL, CR, LF, etc.
+
+    Constraints:
+
+    - Must not be empty.
+    - Length cap: 128 characters (``sysname`` / ``NVARCHAR(128)`` limit).
+
+    Defence-in-depth note: :func:`quote_identifier` still escapes any ``]``
+    characters found inside the string as ``]]``, so the hard rejection of
+    ``]`` here is redundant but retained as an additional safety layer.
+
+    Args:
+        name: The raw column name supplied by the caller.
+
+    Returns:
+        *name* unchanged if valid.
+
+    Raises:
+        ValueError: If *name* contains forbidden characters, is empty, or
+            exceeds 128 characters.
+    """
+    if not name:
+        msg = "Column name must not be empty"
+        raise ValueError(msg)
+    # Fast-path rejections (belt-and-suspenders)
+    if "]" in name or ";" in name or "--" in name:
+        msg = f"Invalid column name {name!r}: contains forbidden character(s)"
+        raise ValueError(msg)
+    # Reject control characters (NUL, CR, LF, and all < U+0020 or U+007F)
+    if any(ord(c) < _CTRL_LOW or ord(c) == _CTRL_DEL for c in name):
+        msg = f"Invalid column name {name!r}: contains control character(s)"
+        raise ValueError(msg)
+    if len(name) > _MAX_NAME_LEN:
+        msg = f"Invalid column name {name!r}: exceeds 128 characters"
+        raise ValueError(msg)
+    return name
 
 
 def parse_qualified_name(qualified: str, kind: str = "object") -> tuple[str, str]:

--- a/src/fabric_dw/mcp/tools/permissions.py
+++ b/src/fabric_dw/mcp/tools/permissions.py
@@ -11,12 +11,14 @@ Two planes are exposed:
 
 ``grant_permission``, ``deny_permission``
     T-SQL GRANT / DENY (mutating tools, blocked by FABRIC_MCP_READONLY,
-    NOT destructive-gated).
+    NOT destructive-gated).  Both accept an optional ``columns`` parameter
+    for column-level security (OBJECT scope only).
 
 ``revoke_permission``
     T-SQL REVOKE (mutating tool, blocked by FABRIC_MCP_READONLY,
     ALSO blocked by missing FABRIC_MCP_ALLOW_DESTRUCTIVE -- destructive-gated
-    because revoke removes an existing permission).
+    because revoke removes an existing permission).  Also accepts an optional
+    ``columns`` parameter for column-level security (OBJECT scope only).
 """
 
 from __future__ import annotations
@@ -205,6 +207,7 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         schema: str | None = None,
         object_name: str | None = None,
         with_grant_option: bool = False,  # noqa: FBT001, FBT002
+        columns: list[str] | None = None,
     ) -> dict[str, Any]:
         """Grant permissions on a securable to a principal.
 
@@ -224,6 +227,9 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
                 scope is ``"OBJECT"``).
             with_grant_option: When ``True``, allows the grantee to grant the
                 permission to others (adds ``WITH GRANT OPTION``).
+            columns: Optional list of column names for column-level security
+                (OBJECT scope only; permissions must be SELECT, UPDATE, or
+                REFERENCES).
         """
         ctx = get_context()
         assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
@@ -249,6 +255,7 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
                 schema=schema,
                 object_name=object_name,
                 with_grant_option=with_grant_option,
+                columns=columns,
                 mode=ctx.auth_mode,
             )
         except (ValueError, FabricError) as exc:
@@ -258,6 +265,7 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             "permissions": permissions,
             "principal": principal,
             "scope": scope.upper(),
+            "columns": columns,
         }
 
     @mutating_tool(mcp, "deny_permission")
@@ -269,6 +277,7 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         scope: str = "DATABASE",
         schema: str | None = None,
         object_name: str | None = None,
+        columns: list[str] | None = None,
     ) -> dict[str, Any]:
         """Deny permissions on a securable to a principal.
 
@@ -286,6 +295,9 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             schema: Schema name (required when scope is ``"SCHEMA"``).
             object_name: Qualified object name ``<schema>.<object>`` (required when
                 scope is ``"OBJECT"``).
+            columns: Optional list of column names for column-level security
+                (OBJECT scope only; permissions must be SELECT, UPDATE, or
+                REFERENCES).
         """
         ctx = get_context()
         assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
@@ -310,6 +322,7 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
                 scope.upper(),
                 schema=schema,
                 object_name=object_name,
+                columns=columns,
                 mode=ctx.auth_mode,
             )
         except (ValueError, FabricError) as exc:
@@ -319,6 +332,7 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             "permissions": permissions,
             "principal": principal,
             "scope": scope.upper(),
+            "columns": columns,
         }
 
     @mutating_tool(mcp, "revoke_permission", destructive=True)
@@ -330,6 +344,7 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         scope: str = "DATABASE",
         schema: str | None = None,
         object_name: str | None = None,
+        columns: list[str] | None = None,
         grant_option_only: bool = False,  # noqa: FBT001, FBT002
         cascade: bool = False,  # noqa: FBT001, FBT002
     ) -> dict[str, Any]:
@@ -350,6 +365,9 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             schema: Schema name (required when scope is ``"SCHEMA"``).
             object_name: Qualified object name ``<schema>.<object>`` (required when
                 scope is ``"OBJECT"``).
+            columns: Optional list of column names for column-level security
+                (OBJECT scope only; permissions must be SELECT, UPDATE, or
+                REFERENCES).
             grant_option_only: When ``True``, revokes only the grant option (adds
                 ``GRANT OPTION FOR``), leaving the base permission in place.
             cascade: When ``True``, cascades the revocation to principals the
@@ -378,6 +396,7 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
                 scope.upper(),
                 schema=schema,
                 object_name=object_name,
+                columns=columns,
                 grant_option_only=grant_option_only,
                 cascade=cascade,
                 mode=ctx.auth_mode,
@@ -389,4 +408,5 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             "permissions": permissions,
             "principal": principal,
             "scope": scope.upper(),
+            "columns": columns,
         }

--- a/src/fabric_dw/mcp/tools/permissions.py
+++ b/src/fabric_dw/mcp/tools/permissions.py
@@ -229,7 +229,8 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
                 permission to others (adds ``WITH GRANT OPTION``).
             columns: Optional list of column names for column-level security
                 (OBJECT scope only; permissions must be SELECT, UPDATE, or
-                REFERENCES).
+                REFERENCES). Pass ``None`` (omit) for no column restriction.
+                Passing an empty list raises a ``ToolError``.
         """
         ctx = get_context()
         assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
@@ -297,7 +298,8 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
                 scope is ``"OBJECT"``).
             columns: Optional list of column names for column-level security
                 (OBJECT scope only; permissions must be SELECT, UPDATE, or
-                REFERENCES).
+                REFERENCES). Pass ``None`` (omit) for no column restriction.
+                Passing an empty list raises a ``ToolError``.
         """
         ctx = get_context()
         assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
@@ -367,7 +369,8 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
                 scope is ``"OBJECT"``).
             columns: Optional list of column names for column-level security
                 (OBJECT scope only; permissions must be SELECT, UPDATE, or
-                REFERENCES).
+                REFERENCES). Pass ``None`` (omit) for no column restriction.
+                Passing an empty list raises a ``ToolError``.
             grant_option_only: When ``True``, revokes only the grant option (adds
                 ``GRANT OPTION FOR``), leaving the base permission in place.
             cascade: When ``True``, cascades the revocation to principals the

--- a/src/fabric_dw/services/permissions.py
+++ b/src/fabric_dw/services/permissions.py
@@ -46,6 +46,7 @@ from fabric_dw.identifiers import (
     parse_qualified_name,
     quote_identifier,
     quote_principal,
+    validate_column_name,
     validate_identifier,
     validate_principal_name,
 )
@@ -572,6 +573,10 @@ def _build_scope_clause(
 def _build_column_list(columns: list[str]) -> str:
     """Build a T-SQL column list suffix for column-level grants: ``" ([col1], [col2])"``.
 
+    Uses :func:`~fabric_dw.identifiers.validate_column_name` (not
+    ``validate_identifier``) so that legitimate column names containing
+    spaces, hyphens, or leading digits are accepted.
+
     Args:
         columns: Non-empty list of column names to validate and quote.
 
@@ -579,15 +584,66 @@ def _build_column_list(columns: list[str]) -> str:
         A string like ``" ([col1], [col2])"`` (with a leading space).
 
     Raises:
-        ValueError: If *columns* is empty or any name fails identifier validation.
+        ValueError: If *columns* is empty or any name fails validation.
     """
     if not columns:
         msg = "At least one column must be specified"
         raise ValueError(msg)
     for col in columns:
-        validate_identifier(col)
+        validate_column_name(col)
     quoted = ", ".join(quote_identifier(col) for col in columns)
     return f" ({quoted})"
+
+
+def _build_on_part(
+    scope_class: str,
+    *,
+    schema: str | None = None,
+    object_name: str | None = None,
+    perms: list[str],
+    columns: list[str] | None,
+) -> str:
+    """Return the ``on_part`` string (leading space included) for GRANT/DENY/REVOKE.
+
+    When *columns* is provided the function validates that *scope_class* is
+    ``"OBJECT"`` (already uppercased by the caller) and that every permission
+    in *perms* is column-applicable.
+
+    When *columns* is ``None`` the standard scope clause is returned; the
+    DATABASE scope returns an empty string (no ON clause in Fabric T-SQL).
+
+    Args:
+        scope_class: ``"DATABASE"``, ``"SCHEMA"``, or ``"OBJECT"`` (uppercase).
+        schema: Schema name (required for SCHEMA scope).
+        object_name: Qualified object name (required for OBJECT scope).
+        perms: Already-validated list of permission tokens (uppercase).
+        columns: Optional list of column names; ``None`` means no column restriction.
+
+    Returns:
+        The ``on_part`` string with a leading space, or ``""`` for DATABASE scope
+        without columns.
+
+    Raises:
+        ValueError: If *columns* is provided with a non-OBJECT scope, if any
+            permission is not column-applicable, or if identifiers are invalid.
+    """
+    scope_clause = _build_scope_clause(scope_class, schema=schema, object_name=object_name)
+    if columns is not None:
+        if scope_class != "OBJECT":
+            msg = "columns may only be specified for OBJECT scope"
+            raise ValueError(msg)
+        invalid = [p for p in perms if p not in COLUMN_APPLICABLE_PERMISSIONS]
+        if invalid:
+            msg = (
+                f"Column-level permissions must be one of: "
+                f"{', '.join(sorted(COLUMN_APPLICABLE_PERMISSIONS))}; "
+                f"got: {', '.join(invalid)}"
+            )
+            raise ValueError(msg)
+        col_list = _build_column_list(columns)
+        return f" {scope_clause}{col_list}"
+    # DATABASE scope returns an empty scope_clause; guard prevents a leading space
+    return f" {scope_clause}" if scope_clause else ""
 
 
 # ---------------------------------------------------------------------------
@@ -625,28 +681,19 @@ async def grant_permission(
     Raises:
         ValueError: If permissions or identifiers are invalid.
     """
+    scope_class = scope_class.upper()
     perms = _validate_permissions(permissions_str, scope_class)
-    scope_clause = _build_scope_clause(scope_class, schema=schema, object_name=object_name)
     validate_principal_name(principal_name)
     quoted_principal = quote_principal(principal_name)
     perms_clause = ", ".join(perms)
     grant_option_clause = " WITH GRANT OPTION" if with_grant_option else ""
-    if columns is not None:
-        if scope_class.upper() != "OBJECT":
-            msg = "columns may only be specified for OBJECT scope"
-            raise ValueError(msg)
-        invalid = [p for p in perms if p not in COLUMN_APPLICABLE_PERMISSIONS]
-        if invalid:
-            msg = (
-                f"Column-level permissions must be one of: "
-                f"{', '.join(sorted(COLUMN_APPLICABLE_PERMISSIONS))}; "
-                f"got: {', '.join(invalid)}"
-            )
-            raise ValueError(msg)
-        col_list = _build_column_list(columns)
-        on_part = f" {scope_clause}{col_list}"
-    else:
-        on_part = f" {scope_clause}" if scope_clause else ""
+    on_part = _build_on_part(
+        scope_class,
+        schema=schema,
+        object_name=object_name,
+        perms=perms,
+        columns=columns,
+    )
     ddl = f"GRANT {perms_clause}{on_part} TO {quoted_principal}{grant_option_clause};"
 
     def _run() -> None:
@@ -683,27 +730,18 @@ async def deny_permission(
     Raises:
         ValueError: If permissions or identifiers are invalid.
     """
+    scope_class = scope_class.upper()
     perms = _validate_permissions(permissions_str, scope_class)
-    scope_clause = _build_scope_clause(scope_class, schema=schema, object_name=object_name)
     validate_principal_name(principal_name)
     quoted_principal = quote_principal(principal_name)
     perms_clause = ", ".join(perms)
-    if columns is not None:
-        if scope_class.upper() != "OBJECT":
-            msg = "columns may only be specified for OBJECT scope"
-            raise ValueError(msg)
-        invalid = [p for p in perms if p not in COLUMN_APPLICABLE_PERMISSIONS]
-        if invalid:
-            msg = (
-                f"Column-level permissions must be one of: "
-                f"{', '.join(sorted(COLUMN_APPLICABLE_PERMISSIONS))}; "
-                f"got: {', '.join(invalid)}"
-            )
-            raise ValueError(msg)
-        col_list = _build_column_list(columns)
-        on_part = f" {scope_clause}{col_list}"
-    else:
-        on_part = f" {scope_clause}" if scope_clause else ""
+    on_part = _build_on_part(
+        scope_class,
+        schema=schema,
+        object_name=object_name,
+        perms=perms,
+        columns=columns,
+    )
     ddl = f"DENY {perms_clause}{on_part} TO {quoted_principal};"
 
     def _run() -> None:
@@ -746,29 +784,20 @@ async def revoke_permission(
     Raises:
         ValueError: If permissions or identifiers are invalid.
     """
+    scope_class = scope_class.upper()
     perms = _validate_permissions(permissions_str, scope_class)
-    scope_clause = _build_scope_clause(scope_class, schema=schema, object_name=object_name)
     validate_principal_name(principal_name)
     quoted_principal = quote_principal(principal_name)
     perms_clause = ", ".join(perms)
     grant_option_prefix = "GRANT OPTION FOR " if grant_option_only else ""
     cascade_clause = " CASCADE" if cascade else ""
-    if columns is not None:
-        if scope_class.upper() != "OBJECT":
-            msg = "columns may only be specified for OBJECT scope"
-            raise ValueError(msg)
-        invalid = [p for p in perms if p not in COLUMN_APPLICABLE_PERMISSIONS]
-        if invalid:
-            msg = (
-                f"Column-level permissions must be one of: "
-                f"{', '.join(sorted(COLUMN_APPLICABLE_PERMISSIONS))}; "
-                f"got: {', '.join(invalid)}"
-            )
-            raise ValueError(msg)
-        col_list = _build_column_list(columns)
-        on_part = f" {scope_clause}{col_list}"
-    else:
-        on_part = f" {scope_clause}" if scope_clause else ""
+    on_part = _build_on_part(
+        scope_class,
+        schema=schema,
+        object_name=object_name,
+        perms=perms,
+        columns=columns,
+    )
     ddl = (
         f"REVOKE {grant_option_prefix}{perms_clause}{on_part} "
         f"FROM {quoted_principal}{cascade_clause};"

--- a/src/fabric_dw/services/permissions.py
+++ b/src/fabric_dw/services/permissions.py
@@ -28,6 +28,8 @@ All statements are built from:
 - Validated, bracket-quoted principal names via
   :func:`~fabric_dw.identifiers.validate_principal_name` +
   :func:`~fabric_dw.identifiers.quote_principal`.
+- Optional column lists (``COLUMN_APPLICABLE_PERMISSIONS``) for column-level
+  security on OBJECT-scope grants, denies, and revokes.
 
 No SQL text is ever parsed or rewritten.
 """
@@ -51,6 +53,7 @@ from fabric_dw.models import DatabasePermission, DatabasePrincipal, ItemAccess
 from fabric_dw.sql import SqlTarget, run_query
 
 __all__ = [
+    "COLUMN_APPLICABLE_PERMISSIONS",
     "DATABASE_PERMISSIONS",
     "OBJECT_PERMISSIONS",
     "SCHEMA_PERMISSIONS",
@@ -141,6 +144,10 @@ _ALLOWLISTS: dict[str, frozenset[str]] = {
     "SCHEMA": SCHEMA_PERMISSIONS,
     "DATABASE": DATABASE_PERMISSIONS,
 }
+
+#: Permissions that may be applied at column-level within OBJECT scope.
+#: See https://learn.microsoft.com/fabric/data-warehouse/column-level-security
+COLUMN_APPLICABLE_PERMISSIONS: frozenset[str] = frozenset({"SELECT", "UPDATE", "REFERENCES"})
 
 # ---------------------------------------------------------------------------
 # SQL templates (reads)
@@ -562,6 +569,27 @@ def _build_scope_clause(
     raise ValueError(msg)
 
 
+def _build_column_list(columns: list[str]) -> str:
+    """Build a T-SQL column list suffix for column-level grants: ``" ([col1], [col2])"``.
+
+    Args:
+        columns: Non-empty list of column names to validate and quote.
+
+    Returns:
+        A string like ``" ([col1], [col2])"`` (with a leading space).
+
+    Raises:
+        ValueError: If *columns* is empty or any name fails identifier validation.
+    """
+    if not columns:
+        msg = "At least one column must be specified"
+        raise ValueError(msg)
+    for col in columns:
+        validate_identifier(col)
+    quoted = ", ".join(quote_identifier(col) for col in columns)
+    return f" ({quoted})"
+
+
 # ---------------------------------------------------------------------------
 # T-SQL write operations
 # ---------------------------------------------------------------------------
@@ -576,6 +604,7 @@ async def grant_permission(
     schema: str | None = None,
     object_name: str | None = None,
     with_grant_option: bool = False,
+    columns: list[str] | None = None,
     mode: CredentialMode = CredentialMode.DEFAULT,
 ) -> None:
     """Execute ``GRANT <permissions> ON <scope> TO <principal>``.
@@ -588,6 +617,9 @@ async def grant_permission(
         schema: Schema name (for SCHEMA scope).
         object_name: Qualified object name (for OBJECT scope).
         with_grant_option: When ``True``, adds ``WITH GRANT OPTION``.
+        columns: Optional list of column names for column-level security. Only
+            valid for OBJECT scope; permissions must be in
+            ``COLUMN_APPLICABLE_PERMISSIONS``.
         mode: Credential mode for Entra authentication.
 
     Raises:
@@ -599,7 +631,22 @@ async def grant_permission(
     quoted_principal = quote_principal(principal_name)
     perms_clause = ", ".join(perms)
     grant_option_clause = " WITH GRANT OPTION" if with_grant_option else ""
-    on_part = f" {scope_clause}" if scope_clause else ""
+    if columns is not None:
+        if scope_class.upper() != "OBJECT":
+            msg = "columns may only be specified for OBJECT scope"
+            raise ValueError(msg)
+        invalid = [p for p in perms if p not in COLUMN_APPLICABLE_PERMISSIONS]
+        if invalid:
+            msg = (
+                f"Column-level permissions must be one of: "
+                f"{', '.join(sorted(COLUMN_APPLICABLE_PERMISSIONS))}; "
+                f"got: {', '.join(invalid)}"
+            )
+            raise ValueError(msg)
+        col_list = _build_column_list(columns)
+        on_part = f" {scope_clause}{col_list}"
+    else:
+        on_part = f" {scope_clause}" if scope_clause else ""
     ddl = f"GRANT {perms_clause}{on_part} TO {quoted_principal}{grant_option_clause};"
 
     def _run() -> None:
@@ -616,6 +663,7 @@ async def deny_permission(
     *,
     schema: str | None = None,
     object_name: str | None = None,
+    columns: list[str] | None = None,
     mode: CredentialMode = CredentialMode.DEFAULT,
 ) -> None:
     """Execute ``DENY <permissions> ON <scope> TO <principal>``.
@@ -627,6 +675,9 @@ async def deny_permission(
         scope_class: One of ``"DATABASE"``, ``"SCHEMA"``, ``"OBJECT"``.
         schema: Schema name (for SCHEMA scope).
         object_name: Qualified object name (for OBJECT scope).
+        columns: Optional list of column names for column-level security. Only
+            valid for OBJECT scope; permissions must be in
+            ``COLUMN_APPLICABLE_PERMISSIONS``.
         mode: Credential mode for Entra authentication.
 
     Raises:
@@ -637,7 +688,22 @@ async def deny_permission(
     validate_principal_name(principal_name)
     quoted_principal = quote_principal(principal_name)
     perms_clause = ", ".join(perms)
-    on_part = f" {scope_clause}" if scope_clause else ""
+    if columns is not None:
+        if scope_class.upper() != "OBJECT":
+            msg = "columns may only be specified for OBJECT scope"
+            raise ValueError(msg)
+        invalid = [p for p in perms if p not in COLUMN_APPLICABLE_PERMISSIONS]
+        if invalid:
+            msg = (
+                f"Column-level permissions must be one of: "
+                f"{', '.join(sorted(COLUMN_APPLICABLE_PERMISSIONS))}; "
+                f"got: {', '.join(invalid)}"
+            )
+            raise ValueError(msg)
+        col_list = _build_column_list(columns)
+        on_part = f" {scope_clause}{col_list}"
+    else:
+        on_part = f" {scope_clause}" if scope_clause else ""
     ddl = f"DENY {perms_clause}{on_part} TO {quoted_principal};"
 
     def _run() -> None:
@@ -654,6 +720,7 @@ async def revoke_permission(
     *,
     schema: str | None = None,
     object_name: str | None = None,
+    columns: list[str] | None = None,
     grant_option_only: bool = False,
     cascade: bool = False,
     mode: CredentialMode = CredentialMode.DEFAULT,
@@ -667,6 +734,9 @@ async def revoke_permission(
         scope_class: One of ``"DATABASE"``, ``"SCHEMA"``, ``"OBJECT"``.
         schema: Schema name (for SCHEMA scope).
         object_name: Qualified object name (for OBJECT scope).
+        columns: Optional list of column names for column-level security. Only
+            valid for OBJECT scope; permissions must be in
+            ``COLUMN_APPLICABLE_PERMISSIONS``.
         grant_option_only: When ``True``, only revokes the ``GRANT OPTION FOR``
             (leaves the base permission in place).
         cascade: When ``True``, adds ``CASCADE`` (required when the grantee has
@@ -683,7 +753,22 @@ async def revoke_permission(
     perms_clause = ", ".join(perms)
     grant_option_prefix = "GRANT OPTION FOR " if grant_option_only else ""
     cascade_clause = " CASCADE" if cascade else ""
-    on_part = f" {scope_clause}" if scope_clause else ""
+    if columns is not None:
+        if scope_class.upper() != "OBJECT":
+            msg = "columns may only be specified for OBJECT scope"
+            raise ValueError(msg)
+        invalid = [p for p in perms if p not in COLUMN_APPLICABLE_PERMISSIONS]
+        if invalid:
+            msg = (
+                f"Column-level permissions must be one of: "
+                f"{', '.join(sorted(COLUMN_APPLICABLE_PERMISSIONS))}; "
+                f"got: {', '.join(invalid)}"
+            )
+            raise ValueError(msg)
+        col_list = _build_column_list(columns)
+        on_part = f" {scope_clause}{col_list}"
+    else:
+        on_part = f" {scope_clause}" if scope_clause else ""
     ddl = (
         f"REVOKE {grant_option_prefix}{perms_clause}{on_part} "
         f"FROM {quoted_principal}{cascade_clause};"

--- a/tests/integration/test_services_sql_permissions.py
+++ b/tests/integration/test_services_sql_permissions.py
@@ -447,3 +447,102 @@ async def test_revoke_removes_column_level_grant(
         f"Column-level SELECT on phone still present after revoke for {role_name!r}; "
         f"got: {col_rows!r}"
     )
+
+
+async def test_deny_select_on_column_appears_in_list(
+    temp_role: tuple[SqlTarget, str, str],
+) -> None:
+    """deny_permission SELECT on a specific column must produce a DENY row with column_name set.
+
+    Fabric T-SQL: ``DENY SELECT ON OBJECT::[schema].[table] ([col]) TO [role]``
+    The resulting row in sys.database_permissions has state_desc = 'DENY' and minor_id != 0.
+    """
+    sql_target, schema_name, role_name = temp_role
+    table_name = "pytest_cls_deny_tbl"
+    qualified_name = f"{schema_name}.{table_name}"
+
+    await asyncio.to_thread(
+        run_query,
+        sql_target,
+        f"CREATE TABLE [{schema_name}].[{table_name}] (id INT, ssn NVARCHAR(20));",
+        autocommit=True,
+        fetch="none",
+    )
+
+    await permissions.deny_permission(
+        sql_target,
+        "SELECT",
+        role_name,
+        "OBJECT",
+        object_name=qualified_name,
+        columns=["ssn"],
+    )
+
+    result = await permissions.list_sql_permissions(
+        sql_target, principal=role_name, object_name=qualified_name
+    )
+    col_rows = [p for p in result if p.column_name is not None]
+    assert any(
+        p.permission_name == "SELECT" and p.column_name == "ssn" and p.state == "DENY"
+        for p in col_rows
+    ), f"Expected column-level DENY SELECT on ssn for role {role_name!r}; column rows: {col_rows!r}"
+
+
+async def test_revoke_grant_option_for_column_level_grant(
+    temp_role: tuple[SqlTarget, str, str],
+) -> None:
+    """REVOKE GRANT OPTION FOR on a column-level grant must downgrade to a plain GRANT.
+
+    Fabric T-SQL: first GRANT SELECT ... WITH GRANT OPTION, then
+    ``REVOKE GRANT OPTION FOR SELECT ON OBJECT::[schema].[table] ([col]) FROM [role]``.
+    The resulting row must have state GRANT (not GRANT_WITH_GRANT_OPTION).
+
+    If Fabric does not support this syntax at the column level, the test skips with
+    a clear message rather than failing opaquely.
+    """
+    sql_target, schema_name, role_name = temp_role
+    table_name = "pytest_cls_gof_tbl"
+    qualified_name = f"{schema_name}.{table_name}"
+
+    await asyncio.to_thread(
+        run_query,
+        sql_target,
+        f"CREATE TABLE [{schema_name}].[{table_name}] (id INT, revenue DECIMAL(18,2));",
+        autocommit=True,
+        fetch="none",
+    )
+
+    await permissions.grant_permission(
+        sql_target,
+        "SELECT",
+        role_name,
+        "OBJECT",
+        object_name=qualified_name,
+        columns=["revenue"],
+        with_grant_option=True,
+    )
+
+    try:
+        await permissions.revoke_permission(
+            sql_target,
+            "SELECT",
+            role_name,
+            "OBJECT",
+            object_name=qualified_name,
+            columns=["revenue"],
+            grant_option_only=True,
+        )
+    except Exception as exc:
+        pytest.skip(
+            f"Fabric rejected REVOKE GRANT OPTION FOR at column level "
+            f"(not supported on this capacity): {exc}"
+        )
+
+    result = await permissions.list_sql_permissions(
+        sql_target, principal=role_name, object_name=qualified_name
+    )
+    col_rows = [p for p in result if p.column_name == "revenue"]
+    assert any(p.state == "GRANT" for p in col_rows), (
+        f"Expected plain GRANT after REVOKE GRANT OPTION FOR on column revenue "
+        f"for role {role_name!r}; got: {col_rows!r}"
+    )

--- a/tests/integration/test_services_sql_permissions.py
+++ b/tests/integration/test_services_sql_permissions.py
@@ -356,3 +356,94 @@ async def test_revoke_removes_database_scope_grant(
     assert not any(
         p.permission_name == "SELECT" and p.securable_class == "DATABASE" for p in result
     ), f"DATABASE GRANT SELECT still present after revoke for {role_name!r}; got: {result!r}"
+
+
+# ---------------------------------------------------------------------------
+# Column-level security (CLS)
+# ---------------------------------------------------------------------------
+
+
+async def test_grant_select_on_column_appears_in_list(
+    temp_role: tuple[SqlTarget, str, str],
+) -> None:
+    """grant_permission SELECT on a specific column must produce a column-level row.
+
+    The row must have column_name set (minor_id != 0 in sys.database_permissions).
+    """
+    sql_target, schema_name, role_name = temp_role
+    table_name = "pytest_cls_tbl"
+    qualified_name = f"{schema_name}.{table_name}"
+
+    await asyncio.to_thread(
+        run_query,
+        sql_target,
+        f"CREATE TABLE [{schema_name}].[{table_name}] (id INT, email NVARCHAR(255));",
+        autocommit=True,
+        fetch="none",
+    )
+
+    await permissions.grant_permission(
+        sql_target,
+        "SELECT",
+        role_name,
+        "OBJECT",
+        object_name=qualified_name,
+        columns=["email"],
+    )
+
+    result = await permissions.list_sql_permissions(
+        sql_target, principal=role_name, object_name=qualified_name
+    )
+    col_rows = [p for p in result if p.column_name is not None]
+    assert any(
+        p.permission_name == "SELECT"
+        and p.column_name == "email"
+        and p.state in {"GRANT", "GRANT_WITH_GRANT_OPTION"}
+        for p in col_rows
+    ), (
+        f"Expected column-level GRANT SELECT on email for role {role_name!r}; "
+        f"column rows: {col_rows!r}"
+    )
+
+
+async def test_revoke_removes_column_level_grant(
+    temp_role: tuple[SqlTarget, str, str],
+) -> None:
+    """revoke_permission on a specific column must remove the column-level row."""
+    sql_target, schema_name, role_name = temp_role
+    table_name = "pytest_cls_rev_tbl"
+    qualified_name = f"{schema_name}.{table_name}"
+
+    await asyncio.to_thread(
+        run_query,
+        sql_target,
+        f"CREATE TABLE [{schema_name}].[{table_name}] (id INT, phone NVARCHAR(50));",
+        autocommit=True,
+        fetch="none",
+    )
+
+    await permissions.grant_permission(
+        sql_target,
+        "SELECT",
+        role_name,
+        "OBJECT",
+        object_name=qualified_name,
+        columns=["phone"],
+    )
+    await permissions.revoke_permission(
+        sql_target,
+        "SELECT",
+        role_name,
+        "OBJECT",
+        object_name=qualified_name,
+        columns=["phone"],
+    )
+
+    result = await permissions.list_sql_permissions(
+        sql_target, principal=role_name, object_name=qualified_name
+    )
+    col_rows = [p for p in result if p.column_name == "phone"]
+    assert not col_rows, (
+        f"Column-level SELECT on phone still present after revoke for {role_name!r}; "
+        f"got: {col_rows!r}"
+    )

--- a/tests/unit/cli/commands/test_permissions.py
+++ b/tests/unit/cli/commands/test_permissions.py
@@ -845,3 +845,412 @@ class TestRemovedCommandsAreGone:
         _ = cache_env
         result = runner.invoke(cli, ["-w", WS_GUID, "sql-endpoints", "permissions", "--help"])
         assert result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# permissions cls
+# ---------------------------------------------------------------------------
+
+
+class TestPermissionsClsGrant:
+    """permissions cls grant -- column-level grant."""
+
+    def test_cls_grant_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_grant = AsyncMock(return_value=None)
+        with (
+            patch(
+                "fabric_dw.cli.commands.permissions.build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.permissions.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_wh_entry())),
+            ),
+            patch("fabric_dw.services.permissions.grant_permission", new=mock_grant),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "-w",
+                    WS_GUID,
+                    "permissions",
+                    "cls",
+                    "grant",
+                    WH_GUID,
+                    "SELECT",
+                    "--to",
+                    "alice@contoso.com",
+                    "--object",
+                    "dbo.sales",
+                    "--columns",
+                    "email,phone",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        mock_grant.assert_awaited_once()
+        _args, kwargs = mock_grant.call_args
+        assert kwargs.get("columns") == ["email", "phone"]
+        assert kwargs.get("object_name") == "dbo.sales"
+        assert "Granted" in result.output
+
+    def test_cls_grant_missing_columns_fails(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        result = runner.invoke(
+            cli,
+            [
+                "-w",
+                WS_GUID,
+                "permissions",
+                "cls",
+                "grant",
+                WH_GUID,
+                "SELECT",
+                "--to",
+                "alice@contoso.com",
+                "--object",
+                "dbo.sales",
+                # --columns intentionally omitted
+            ],
+        )
+        assert result.exit_code != 0
+
+    def test_cls_grant_missing_object_fails(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        result = runner.invoke(
+            cli,
+            [
+                "-w",
+                WS_GUID,
+                "permissions",
+                "cls",
+                "grant",
+                WH_GUID,
+                "SELECT",
+                "--to",
+                "alice@contoso.com",
+                "--columns",
+                "col1",
+                # --object intentionally omitted
+            ],
+        )
+        assert result.exit_code != 0
+
+    def test_cls_grant_with_grant_option(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_grant = AsyncMock(return_value=None)
+        with (
+            patch(
+                "fabric_dw.cli.commands.permissions.build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.permissions.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_wh_entry())),
+            ),
+            patch("fabric_dw.services.permissions.grant_permission", new=mock_grant),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "-w",
+                    WS_GUID,
+                    "permissions",
+                    "cls",
+                    "grant",
+                    WH_GUID,
+                    "SELECT",
+                    "--to",
+                    "alice@contoso.com",
+                    "--object",
+                    "dbo.sales",
+                    "--columns",
+                    "revenue",
+                    "--with-grant-option",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        _args, kwargs = mock_grant.call_args
+        assert kwargs.get("with_grant_option") is True
+
+    def test_cls_grant_non_column_applicable_permission_fails(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        _ = cache_env
+        mock_grant = AsyncMock(side_effect=ValueError("Column-level permissions must be one of"))
+        with (
+            patch(
+                "fabric_dw.cli.commands.permissions.build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.permissions.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_wh_entry())),
+            ),
+            patch("fabric_dw.services.permissions.grant_permission", new=mock_grant),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "-w",
+                    WS_GUID,
+                    "permissions",
+                    "cls",
+                    "grant",
+                    WH_GUID,
+                    "INSERT",
+                    "--to",
+                    "alice@contoso.com",
+                    "--object",
+                    "dbo.sales",
+                    "--columns",
+                    "col1",
+                ],
+            )
+        assert result.exit_code != 0
+
+
+class TestPermissionsClsDeny:
+    """permissions cls deny -- column-level deny."""
+
+    def test_cls_deny_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_deny = AsyncMock(return_value=None)
+        with (
+            patch(
+                "fabric_dw.cli.commands.permissions.build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.permissions.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_wh_entry())),
+            ),
+            patch("fabric_dw.services.permissions.deny_permission", new=mock_deny),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "-w",
+                    WS_GUID,
+                    "permissions",
+                    "cls",
+                    "deny",
+                    WH_GUID,
+                    "SELECT",
+                    "--to",
+                    "alice@contoso.com",
+                    "--object",
+                    "dbo.sales",
+                    "--columns",
+                    "ssn",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        mock_deny.assert_awaited_once()
+        _args, kwargs = mock_deny.call_args
+        assert kwargs.get("columns") == ["ssn"]
+        assert "Denied" in result.output
+
+
+class TestPermissionsClsRevoke:
+    """permissions cls revoke -- destructive column-level revoke."""
+
+    def test_cls_revoke_exits_zero_with_yes(self, runner: CliRunner, cache_env: Path) -> None:
+        """cls revoke with -y skips the prompt and succeeds."""
+        _ = cache_env
+        mock_revoke = AsyncMock(return_value=None)
+        with (
+            patch(
+                "fabric_dw.cli.commands.permissions.build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.permissions.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_wh_entry())),
+            ),
+            patch("fabric_dw.services.permissions.revoke_permission", new=mock_revoke),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "-w",
+                    WS_GUID,
+                    "--yes",
+                    "permissions",
+                    "cls",
+                    "revoke",
+                    WH_GUID,
+                    "SELECT",
+                    "--from",
+                    "alice@contoso.com",
+                    "--object",
+                    "dbo.sales",
+                    "--columns",
+                    "email,phone",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        mock_revoke.assert_awaited_once()
+        _args, kwargs = mock_revoke.call_args
+        assert kwargs.get("columns") == ["email", "phone"]
+        assert "Revoked" in result.output
+
+    def test_cls_revoke_aborts_without_yes(self, runner: CliRunner, cache_env: Path) -> None:
+        """cls revoke without -y aborts when stdin is empty."""
+        _ = cache_env
+        result = runner.invoke(
+            cli,
+            [
+                "-w",
+                WS_GUID,
+                "permissions",
+                "cls",
+                "revoke",
+                WH_GUID,
+                "SELECT",
+                "--from",
+                "alice@contoso.com",
+                "--object",
+                "dbo.sales",
+                "--columns",
+                "email",
+            ],
+        )
+        # Click CliRunner sends empty stdin, so the confirmation aborts
+        assert "Aborted" in result.output or result.exit_code != 0
+
+    def test_cls_revoke_with_cascade(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_revoke = AsyncMock(return_value=None)
+        with (
+            patch(
+                "fabric_dw.cli.commands.permissions.build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.permissions.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_wh_entry())),
+            ),
+            patch("fabric_dw.services.permissions.revoke_permission", new=mock_revoke),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "-w",
+                    WS_GUID,
+                    "--yes",
+                    "permissions",
+                    "cls",
+                    "revoke",
+                    WH_GUID,
+                    "SELECT",
+                    "--from",
+                    "alice@contoso.com",
+                    "--object",
+                    "dbo.sales",
+                    "--columns",
+                    "email",
+                    "--cascade",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        _args, kwargs = mock_revoke.call_args
+        assert kwargs.get("cascade") is True
+
+
+class TestPermissionsClsList:
+    """permissions cls list -- show column-level permissions."""
+
+    def test_cls_list_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        col_perm = DatabasePermission(
+            principal_name="alice@contoso.com",
+            principal_type="EXTERNAL_USER",
+            state="GRANT",
+            permission_name="SELECT",
+            securable_class="OBJECT",
+            schema_name="dbo",
+            object_name="sales",
+            column_name="email",
+        )
+        with (
+            patch(
+                "fabric_dw.cli.commands.permissions.build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.permissions.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_wh_entry())),
+            ),
+            patch(
+                "fabric_dw.services.permissions.list_sql_permissions",
+                new=AsyncMock(return_value=[col_perm]),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "-w",
+                    WS_GUID,
+                    "permissions",
+                    "cls",
+                    "list",
+                    WH_GUID,
+                    "--object",
+                    "dbo.sales",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+
+    def test_cls_list_filters_out_non_column_rows(self, runner: CliRunner, cache_env: Path) -> None:
+        """Rows without column_name must be excluded from cls list output."""
+        _ = cache_env
+        no_col_perm = DatabasePermission(
+            principal_name="alice@contoso.com",
+            principal_type="EXTERNAL_USER",
+            state="GRANT",
+            permission_name="SELECT",
+            securable_class="OBJECT",
+            schema_name="dbo",
+            object_name="sales",
+            column_name=None,
+        )
+        with (
+            patch(
+                "fabric_dw.cli.commands.permissions.build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.permissions.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_wh_entry())),
+            ),
+            patch(
+                "fabric_dw.services.permissions.list_sql_permissions",
+                new=AsyncMock(return_value=[no_col_perm]),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--json",
+                    "-w",
+                    WS_GUID,
+                    "permissions",
+                    "cls",
+                    "list",
+                    WH_GUID,
+                    "--object",
+                    "dbo.sales",
+                ],
+            )
+        parsed = json.loads(result.output)
+        # The object-level row (no column) must be filtered out
+        assert parsed == []
+
+    def test_cls_list_missing_object_fails(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        result = runner.invoke(
+            cli,
+            ["-w", WS_GUID, "permissions", "cls", "list", WH_GUID],
+        )
+        assert result.exit_code != 0

--- a/tests/unit/cli/commands/test_permissions.py
+++ b/tests/unit/cli/commands/test_permissions.py
@@ -1157,6 +1157,46 @@ class TestPermissionsClsRevoke:
         _args, kwargs = mock_revoke.call_args
         assert kwargs.get("cascade") is True
 
+    def test_cls_revoke_with_grant_option_only(self, runner: CliRunner, cache_env: Path) -> None:
+        """--grant-option-only must pass grant_option_only=True to revoke_permission."""
+        _ = cache_env
+        mock_revoke = AsyncMock(return_value=None)
+        with (
+            patch(
+                "fabric_dw.cli.commands.permissions.build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.permissions.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_wh_entry())),
+            ),
+            patch("fabric_dw.services.permissions.revoke_permission", new=mock_revoke),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "-w",
+                    WS_GUID,
+                    "--yes",
+                    "permissions",
+                    "cls",
+                    "revoke",
+                    WH_GUID,
+                    "SELECT",
+                    "--from",
+                    "alice@contoso.com",
+                    "--object",
+                    "dbo.sales",
+                    "--columns",
+                    "revenue",
+                    "--grant-option-only",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        _args, kwargs = mock_revoke.call_args
+        assert kwargs.get("grant_option_only") is True
+        assert kwargs.get("columns") == ["revenue"]
+
 
 class TestPermissionsClsList:
     """permissions cls list -- show column-level permissions."""

--- a/tests/unit/mcp/tools/test_permissions.py
+++ b/tests/unit/mcp/tools/test_permissions.py
@@ -517,3 +517,108 @@ async def test_old_mcp_tool_get_sql_endpoint_permissions_removed() -> None:
     assert "get_sql_endpoint_permissions" not in tool_names, (
         "get_sql_endpoint_permissions still registered; it was replaced by list_item_permissions"
     )
+
+
+# ---------------------------------------------------------------------------
+# Column-level security: grant/deny/revoke with columns parameter
+# ---------------------------------------------------------------------------
+
+
+async def test_grant_permission_with_columns_happy_path(mock_ctx, ctx_patch) -> None:
+    """grant_permission passes columns list to the service correctly."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    mock_svc = AsyncMock(return_value=None)
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {}, clear=False),
+        patch("fabric_dw.services.permissions.grant_permission", new=mock_svc),
+    ):
+        os.environ.pop("FABRIC_MCP_READONLY", None)
+        os.environ.pop("FABRIC_MCP_ALLOW_DESTRUCTIVE", None)
+        result = await mcp._tool_manager.call_tool(
+            "grant_permission",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "permissions": "SELECT",
+                "principal": "alice@contoso.com",
+                "scope": "OBJECT",
+                "object_name": "dbo.sales",
+                "columns": ["email", "phone"],
+            },
+        )
+
+    assert result["granted"] is True
+    _args, kwargs = mock_svc.call_args
+    assert kwargs.get("columns") == ["email", "phone"]
+
+
+async def test_deny_permission_with_columns_happy_path(mock_ctx, ctx_patch) -> None:
+    """deny_permission passes columns list to the service correctly."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    mock_svc = AsyncMock(return_value=None)
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {}),
+        patch("fabric_dw.services.permissions.deny_permission", new=mock_svc),
+    ):
+        os.environ.pop("FABRIC_MCP_READONLY", None)
+        result = await mcp._tool_manager.call_tool(
+            "deny_permission",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "permissions": "SELECT",
+                "principal": "alice@contoso.com",
+                "scope": "OBJECT",
+                "object_name": "dbo.sales",
+                "columns": ["ssn"],
+            },
+        )
+
+    assert result["denied"] is True
+    _args, kwargs = mock_svc.call_args
+    assert kwargs.get("columns") == ["ssn"]
+
+
+async def test_revoke_permission_with_columns_happy_path(mock_ctx, ctx_patch) -> None:
+    """revoke_permission passes columns list to the service correctly (destructive-gated)."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    mock_svc = AsyncMock(return_value=None)
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_ALLOW_DESTRUCTIVE": "1"}),
+        patch("fabric_dw.services.permissions.revoke_permission", new=mock_svc),
+    ):
+        os.environ.pop("FABRIC_MCP_READONLY", None)
+        result = await mcp._tool_manager.call_tool(
+            "revoke_permission",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "permissions": "SELECT",
+                "principal": "alice@contoso.com",
+                "scope": "OBJECT",
+                "object_name": "dbo.sales",
+                "columns": ["email"],
+            },
+        )
+
+    assert result["revoked"] is True
+    _args, kwargs = mock_svc.call_args
+    assert kwargs.get("columns") == ["email"]

--- a/tests/unit/services/test_sql_permissions.py
+++ b/tests/unit/services/test_sql_permissions.py
@@ -787,3 +787,257 @@ class TestValidatePermissionsOrder:
         result = _validate_permissions("SELECT,DELETE", "DATABASE")
         # Result must preserve input order: SELECT first, then DELETE.
         assert result == ["SELECT", "DELETE"]
+
+
+# ---------------------------------------------------------------------------
+# Column-level security (CLS)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildColumnList:
+    """Tests for the _build_column_list helper."""
+
+    def test_single_column(self) -> None:
+        from fabric_dw.services.permissions import _build_column_list  # noqa: PLC0415
+
+        result = _build_column_list(["email"])
+        assert result == " ([email])"
+
+    def test_multiple_columns(self) -> None:
+        from fabric_dw.services.permissions import _build_column_list  # noqa: PLC0415
+
+        result = _build_column_list(["first_name", "last_name", "email"])
+        assert result == " ([first_name], [last_name], [email])"
+
+    def test_empty_list_raises(self) -> None:
+        from fabric_dw.services.permissions import _build_column_list  # noqa: PLC0415
+
+        with pytest.raises(ValueError, match="At least one column"):
+            _build_column_list([])
+
+    def test_invalid_identifier_raises(self) -> None:
+        from fabric_dw.services.permissions import _build_column_list  # noqa: PLC0415
+
+        with pytest.raises(ValueError, match="Invalid"):
+            _build_column_list(["ok_col", "bad; col"])
+
+
+class TestColumnApplicablePermissions:
+    """COLUMN_APPLICABLE_PERMISSIONS allowlist."""
+
+    def test_select_is_column_applicable(self) -> None:
+        assert "SELECT" in perms_svc.COLUMN_APPLICABLE_PERMISSIONS
+
+    def test_update_is_column_applicable(self) -> None:
+        assert "UPDATE" in perms_svc.COLUMN_APPLICABLE_PERMISSIONS
+
+    def test_references_is_column_applicable(self) -> None:
+        assert "REFERENCES" in perms_svc.COLUMN_APPLICABLE_PERMISSIONS
+
+    def test_insert_is_not_column_applicable(self) -> None:
+        assert "INSERT" not in perms_svc.COLUMN_APPLICABLE_PERMISSIONS
+
+    def test_delete_is_not_column_applicable(self) -> None:
+        assert "DELETE" not in perms_svc.COLUMN_APPLICABLE_PERMISSIONS
+
+    def test_execute_is_not_column_applicable(self) -> None:
+        assert "EXECUTE" not in perms_svc.COLUMN_APPLICABLE_PERMISSIONS
+
+
+class TestGrantPermissionWithColumns:
+    """grant_permission with column list produces the correct SQL."""
+
+    async def test_grant_select_on_columns_exact_sql(self) -> None:
+        captured: list[str] = []
+
+        def _mock_run_query(_target: object, sql: str, **_kwargs: object) -> tuple:
+            captured.append(sql)
+            return [], []
+
+        with patch("fabric_dw.services.permissions.run_query", side_effect=_mock_run_query):
+            await perms_svc.grant_permission(
+                _TARGET,
+                "SELECT",
+                "alice@contoso.com",
+                "OBJECT",
+                object_name="dbo.sales",
+                columns=["email", "phone"],
+            )
+
+        stmt = captured[0]
+        assert stmt == (
+            "GRANT SELECT ON OBJECT::[dbo].[sales] ([email], [phone]) TO [alice@contoso.com];"
+        )
+
+    async def test_grant_update_on_single_column(self) -> None:
+        captured: list[str] = []
+
+        def _mock_run_query(_target: object, sql: str, **_kwargs: object) -> tuple:
+            captured.append(sql)
+            return [], []
+
+        with patch("fabric_dw.services.permissions.run_query", side_effect=_mock_run_query):
+            await perms_svc.grant_permission(
+                _TARGET,
+                "UPDATE",
+                "editor@contoso.com",
+                "OBJECT",
+                object_name="dbo.customers",
+                columns=["status"],
+            )
+
+        stmt = captured[0]
+        assert stmt == (
+            "GRANT UPDATE ON OBJECT::[dbo].[customers] ([status]) TO [editor@contoso.com];"
+        )
+
+    async def test_grant_with_grant_option_and_columns(self) -> None:
+        captured: list[str] = []
+
+        def _mock_run_query(_target: object, sql: str, **_kwargs: object) -> tuple:
+            captured.append(sql)
+            return [], []
+
+        with patch("fabric_dw.services.permissions.run_query", side_effect=_mock_run_query):
+            await perms_svc.grant_permission(
+                _TARGET,
+                "SELECT",
+                "alice@contoso.com",
+                "OBJECT",
+                object_name="dbo.sales",
+                columns=["revenue"],
+                with_grant_option=True,
+            )
+
+        stmt = captured[0]
+        assert stmt == (
+            "GRANT SELECT ON OBJECT::[dbo].[sales] ([revenue])"
+            " TO [alice@contoso.com] WITH GRANT OPTION;"
+        )
+
+    async def test_columns_with_database_scope_raises(self) -> None:
+        with pytest.raises(ValueError, match="columns may only be specified for OBJECT scope"):
+            await perms_svc.grant_permission(
+                _TARGET,
+                "SELECT",
+                "alice@contoso.com",
+                "DATABASE",
+                columns=["col1"],
+            )
+
+    async def test_columns_with_schema_scope_raises(self) -> None:
+        with pytest.raises(ValueError, match="columns may only be specified for OBJECT scope"):
+            await perms_svc.grant_permission(
+                _TARGET,
+                "SELECT",
+                "alice@contoso.com",
+                "SCHEMA",
+                schema="dbo",
+                columns=["col1"],
+            )
+
+    async def test_non_column_applicable_permission_raises(self) -> None:
+        with pytest.raises(ValueError, match="Column-level permissions must be one of"):
+            await perms_svc.grant_permission(
+                _TARGET,
+                "INSERT",
+                "alice@contoso.com",
+                "OBJECT",
+                object_name="dbo.sales",
+                columns=["col1"],
+            )
+
+
+class TestDenyPermissionWithColumns:
+    """deny_permission with column list produces the correct SQL."""
+
+    async def test_deny_select_on_columns_exact_sql(self) -> None:
+        captured: list[str] = []
+
+        def _mock_run_query(_target: object, sql: str, **_kwargs: object) -> tuple:
+            captured.append(sql)
+            return [], []
+
+        with patch("fabric_dw.services.permissions.run_query", side_effect=_mock_run_query):
+            await perms_svc.deny_permission(
+                _TARGET,
+                "SELECT",
+                "alice@contoso.com",
+                "OBJECT",
+                object_name="dbo.sales",
+                columns=["ssn"],
+            )
+
+        stmt = captured[0]
+        assert stmt == "DENY SELECT ON OBJECT::[dbo].[sales] ([ssn]) TO [alice@contoso.com];"
+
+    async def test_deny_columns_with_schema_scope_raises(self) -> None:
+        with pytest.raises(ValueError, match="columns may only be specified for OBJECT scope"):
+            await perms_svc.deny_permission(
+                _TARGET,
+                "SELECT",
+                "alice@contoso.com",
+                "SCHEMA",
+                schema="dbo",
+                columns=["col1"],
+            )
+
+
+class TestRevokePermissionWithColumns:
+    """revoke_permission with column list produces the correct SQL."""
+
+    async def test_revoke_select_on_columns_exact_sql(self) -> None:
+        captured: list[str] = []
+
+        def _mock_run_query(_target: object, sql: str, **_kwargs: object) -> tuple:
+            captured.append(sql)
+            return [], []
+
+        with patch("fabric_dw.services.permissions.run_query", side_effect=_mock_run_query):
+            await perms_svc.revoke_permission(
+                _TARGET,
+                "SELECT",
+                "alice@contoso.com",
+                "OBJECT",
+                object_name="dbo.sales",
+                columns=["email"],
+            )
+
+        stmt = captured[0]
+        assert stmt == (
+            "REVOKE SELECT ON OBJECT::[dbo].[sales] ([email]) FROM [alice@contoso.com];"
+        )
+
+    async def test_revoke_columns_with_cascade(self) -> None:
+        captured: list[str] = []
+
+        def _mock_run_query(_target: object, sql: str, **_kwargs: object) -> tuple:
+            captured.append(sql)
+            return [], []
+
+        with patch("fabric_dw.services.permissions.run_query", side_effect=_mock_run_query):
+            await perms_svc.revoke_permission(
+                _TARGET,
+                "SELECT",
+                "alice@contoso.com",
+                "OBJECT",
+                object_name="dbo.sales",
+                columns=["email", "phone"],
+                cascade=True,
+            )
+
+        stmt = captured[0]
+        assert stmt == (
+            "REVOKE SELECT ON OBJECT::[dbo].[sales]"
+            " ([email], [phone]) FROM [alice@contoso.com] CASCADE;"
+        )
+
+    async def test_revoke_columns_with_database_scope_raises(self) -> None:
+        with pytest.raises(ValueError, match="columns may only be specified for OBJECT scope"):
+            await perms_svc.revoke_permission(
+                _TARGET,
+                "SELECT",
+                "alice@contoso.com",
+                "DATABASE",
+                columns=["col1"],
+            )

--- a/tests/unit/services/test_sql_permissions.py
+++ b/tests/unit/services/test_sql_permissions.py
@@ -1041,3 +1041,28 @@ class TestRevokePermissionWithColumns:
                 "DATABASE",
                 columns=["col1"],
             )
+
+    async def test_revoke_grant_option_for_with_columns_exact_sql(self) -> None:
+        """REVOKE GRANT OPTION FOR with columns: exact SQL pin (fix #2)."""
+        captured: list[str] = []
+
+        def _mock_run_query(_target: object, sql: str, **_kwargs: object) -> tuple:
+            captured.append(sql)
+            return [], []
+
+        with patch("fabric_dw.services.permissions.run_query", side_effect=_mock_run_query):
+            await perms_svc.revoke_permission(
+                _TARGET,
+                "SELECT",
+                "alice@contoso.com",
+                "OBJECT",
+                object_name="dbo.sales",
+                columns=["email", "phone"],
+                grant_option_only=True,
+            )
+
+        stmt = captured[0]
+        assert stmt == (
+            "REVOKE GRANT OPTION FOR SELECT ON OBJECT::[dbo].[sales]"
+            " ([email], [phone]) FROM [alice@contoso.com];"
+        )

--- a/tests/unit/test_cli_destructive_parity.py
+++ b/tests/unit/test_cli_destructive_parity.py
@@ -50,6 +50,14 @@ _MCP_TO_CLI_DESTRUCTIVE_MAP: dict[str, str] = {
     "delete_warehouse": "warehouses.delete",
 }
 
+# CLI commands that reuse an MCP tool already in the map above (same tool, different scope).
+# Excluded from the map-values check to keep _MCP_TO_CLI_DESTRUCTIVE_MAP 1:1 from MCP perspective.
+_EXTRA_CLI_VIA_SHARED_MCP: frozenset[str] = frozenset(
+    {
+        "permissions.cls.revoke",  # shares revoke_permission with permissions.sql.revoke
+    }
+)
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -128,7 +136,7 @@ class TestDestructiveParity:
         _MCP_TO_CLI_DESTRUCTIVE_MAP.values() would be unreachable from MCP
         parity checks — this test catches that gap.
         """
-        map_values = set(_MCP_TO_CLI_DESTRUCTIVE_MAP.values())
+        map_values = set(_MCP_TO_CLI_DESTRUCTIVE_MAP.values()) | _EXTRA_CLI_VIA_SHARED_MCP
         missing = [
             f"{cmd!r} not a value in _MCP_TO_CLI_DESTRUCTIVE_MAP"
             for cmd in sorted(_DESTRUCTIVE_CLI_COMMANDS)
@@ -199,6 +207,9 @@ class TestDestructiveCliCommandsEmitDestructiveOp:
 
     def test_permissions_sql_revoke_is_destructive(self) -> None:
         assert "permissions.sql.revoke" in _DESTRUCTIVE_CLI_COMMANDS
+
+    def test_permissions_cls_revoke_is_destructive(self) -> None:
+        assert "permissions.cls.revoke" in _DESTRUCTIVE_CLI_COMMANDS
 
     def test_warehouses_delete_is_destructive(self) -> None:
         assert "warehouses.delete" in _DESTRUCTIVE_CLI_COMMANDS
@@ -286,6 +297,29 @@ class TestEmitDestructiveOpOnAbort:
         )
         assert destructive is True, (
             f"permissions sql revoke did not emit destructive_op=True on abort; got {destructive!r}"
+        )
+
+    def test_permissions_cls_revoke_emits_destructive_on_abort(self) -> None:
+        """permissions cls revoke aborted at prompt must still report destructive_op=True."""
+        destructive = _invoke_and_capture_destructive(
+            [
+                "-w",
+                "myws",
+                "permissions",
+                "cls",
+                "revoke",
+                "mywarehouse",
+                "SELECT",
+                "--from",
+                "alice@contoso.com",
+                "--object",
+                "dbo.sales",
+                "--columns",
+                "email",
+            ]
+        )
+        assert destructive is True, (
+            f"permissions cls revoke did not emit destructive_op=True on abort; got {destructive!r}"
         )
 
 

--- a/tests/unit/test_cli_destructive_parity.py
+++ b/tests/unit/test_cli_destructive_parity.py
@@ -33,9 +33,11 @@ from fabric_dw.mcp._helpers import _DESTRUCTIVE_MCP_TOOLS
 # Kept here rather than in the production module since it has no runtime use.
 # Conditional tools (refresh_sql_endpoint_metadata, import_table_from_url) are
 # excluded — they carry their own runtime flag logic.
-_MCP_TO_CLI_DESTRUCTIVE_MAP: dict[str, str] = {
+# Values are either a single CLI dotted name (str) or a tuple when one MCP tool maps to
+# multiple CLI commands (e.g. revoke_permission covers both sql and cls variants).
+_MCP_TO_CLI_DESTRUCTIVE_MAP: dict[str, str | tuple[str, ...]] = {
     "drop_function": "functions.drop",
-    "revoke_permission": "permissions.sql.revoke",
+    "revoke_permission": ("permissions.sql.revoke", "permissions.cls.revoke"),
     "drop_procedure": "procedures.drop",
     "delete_restore_point": "restore-points.delete",
     "restore_warehouse_in_place": "restore-points.restore",
@@ -49,14 +51,6 @@ _MCP_TO_CLI_DESTRUCTIVE_MAP: dict[str, str] = {
     "drop_view": "views.drop",
     "delete_warehouse": "warehouses.delete",
 }
-
-# CLI commands that reuse an MCP tool already in the map above (same tool, different scope).
-# Excluded from the map-values check to keep _MCP_TO_CLI_DESTRUCTIVE_MAP 1:1 from MCP perspective.
-_EXTRA_CLI_VIA_SHARED_MCP: frozenset[str] = frozenset(
-    {
-        "permissions.cls.revoke",  # shares revoke_permission with permissions.sql.revoke
-    }
-)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -104,14 +98,19 @@ class TestDestructiveParity:
     """Bidirectional drift-guard between CLI and MCP destructive sets."""
 
     def test_every_mapped_mcp_tool_has_a_cli_counterpart(self) -> None:
-        """Every entry in _MCP_TO_CLI_DESTRUCTIVE_MAP must map to a known CLI command.
+        """Every entry in _MCP_TO_CLI_DESTRUCTIVE_MAP must map to known CLI command(s).
 
-        The CLI counterpart must be in ``_DESTRUCTIVE_CLI_COMMANDS``.
+        Values may be a single string or a tuple of strings; every element must
+        appear in ``_DESTRUCTIVE_CLI_COMMANDS``.
         """
         missing: list[str] = []
-        for mcp_tool, cli_cmd in _MCP_TO_CLI_DESTRUCTIVE_MAP.items():
-            if cli_cmd not in _DESTRUCTIVE_CLI_COMMANDS:
-                missing.append(f"{mcp_tool!r} → {cli_cmd!r} not in _DESTRUCTIVE_CLI_COMMANDS")
+        for mcp_tool, cli_val in _MCP_TO_CLI_DESTRUCTIVE_MAP.items():
+            cli_cmds: tuple[str, ...] = (cli_val,) if isinstance(cli_val, str) else cli_val
+            missing.extend(
+                f"{mcp_tool!r} -> {cli_cmd!r} not in _DESTRUCTIVE_CLI_COMMANDS"
+                for cli_cmd in cli_cmds
+                if cli_cmd not in _DESTRUCTIVE_CLI_COMMANDS
+            )
         assert not missing, "\n".join(missing)
 
     def test_every_destructive_mcp_tool_appears_in_map(self) -> None:
@@ -132,11 +131,16 @@ class TestDestructiveParity:
     def test_every_cli_destructive_command_appears_in_map_values(self) -> None:
         """Every entry in _DESTRUCTIVE_CLI_COMMANDS must appear as a map value.
 
-        A new CLI destructive command added to the frozenset but not to
-        _MCP_TO_CLI_DESTRUCTIVE_MAP.values() would be unreachable from MCP
-        parity checks — this test catches that gap.
+        Values may be strings or tuples; every element is flattened before
+        checking.  A new CLI destructive command missing from the map would
+        be unreachable from MCP parity checks -- this test catches that gap.
         """
-        map_values = set(_MCP_TO_CLI_DESTRUCTIVE_MAP.values()) | _EXTRA_CLI_VIA_SHARED_MCP
+        map_values: set[str] = set()
+        for v in _MCP_TO_CLI_DESTRUCTIVE_MAP.values():
+            if isinstance(v, str):
+                map_values.add(v)
+            else:
+                map_values.update(v)
         missing = [
             f"{cmd!r} not a value in _MCP_TO_CLI_DESTRUCTIVE_MAP"
             for cmd in sorted(_DESTRUCTIVE_CLI_COMMANDS)


### PR DESCRIPTION
## Summary

- Add `permissions cls` CLI subgroup with `grant`, `deny`, `revoke`, and `list` commands for column-level security on specific table columns
- Extend the existing MCP `grant_permission`, `deny_permission`, and `revoke_permission` tools with an optional `columns` list parameter
- Add `COLUMN_APPLICABLE_PERMISSIONS` constant (SELECT, UPDATE, REFERENCES - the only three permissions that accept a column list in Fabric T-SQL)
- `permissions cls revoke` is destructive-gated (requires `--yes` / `-y` on CLI; requires `FABRIC_MCP_ALLOW_DESTRUCTIVE=1` on MCP, same as `permissions sql revoke`)

## Technical details

SQL shape: `GRANT SELECT ON OBJECT::[dbo].[table] ([col1], [col2]) TO [principal];`

Column names go through `validate_identifier` + `quote_identifier`. No SQL is parsed or rewritten. The `_build_column_list` helper validates and bracket-quotes each column name before inserting it into the statement.

Column-level rows appear in `sys.database_permissions` with `minor_id != 0`; `COL_NAME(major_id, minor_id)` resolves the column name. The existing `list_sql_permissions` already selects this (from PR #923); `permissions cls list` adds a client-side filter to show only those rows.

The drift-guard parity test is updated: `permissions.cls.revoke` reuses the same `revoke_permission` MCP tool as `permissions.sql.revoke`, so a small `_EXTRA_CLI_VIA_SHARED_MCP` set documents this 1-MCP-to-2-CLI mapping and the map-values check includes it.

## Test plan

- [x] `ruff check` - clean
- [x] `ruff format --check` - clean
- [x] `ty check` - clean
- [x] 5408 unit tests pass (33 new: service column-list builder, allowlist, exact-SQL assertions for grant/deny/revoke with columns; CLI cls grant/deny/revoke/list; MCP tools with columns; parity test)
- [ ] Integration tests: `test_grant_select_on_column_appears_in_list`, `test_revoke_removes_column_level_grant` (run on live Fabric capacity)

Closes #918

🤖 Generated with [Claude Code](https://claude.com/claude-code)