### PR TITLE
ci(docs): build and deploy docs via GitHub Actions (prod on stable, staging on main + PR previews)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,8 +6,11 @@ name: Docs
 #   workflow_dispatch with a stable tag input -> same as stable tag
 #   pull_request (non-fork, docs paths changed) -> build + PR preview under staging project
 #
-# Stable detection mirrors .github/workflows/publish.yml:
-# a tag is prerelease if it matches (a|b|rc)[0-9]*$|\.dev; only clean tags reach production.
+# Stable detection mirrors .github/workflows/publish.yml exactly:
+# a tag is stable if (a) it does NOT match (a|b|rc)[0-9]*$|\.dev AND (b) it
+# matches the calver allowlist ^20[0-9]{2}\.([1-9]|1[0-2])\.(0|[1-9][0-9]*)$.
+# Both conditions are required so a malformed-but-non-prerelease tag can never
+# reach production.
 #
 # Fork PRs: the deploy-preview job is skipped (secrets are absent on fork PRs).
 
@@ -18,6 +21,7 @@ on:
   pull_request:
     paths:
       - "docs/**"
+      - "pyproject.toml"
       - "zensical.toml"
       - "wrangler.toml"
       - "README.md"
@@ -66,10 +70,13 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
           INPUT_TAG: ${{ inputs.tag || '' }}
         run: |
-          # Mirrors the stable-detection pattern from .github/workflows/publish.yml.
-          # A tag is stable if it does NOT match (a|b|rc)[0-9]*$|\.dev.
-          # Non-tag triggers (branch push, PR, workflow_dispatch without a tag) are always
-          # classified as non-stable, which prevents an accidental production deploy.
+          # Mirrors the stable-detection logic from .github/workflows/publish.yml exactly.
+          # A tag is stable only when BOTH conditions hold:
+          #   (a) it does NOT match the prerelease pattern (a|b|rc)[0-9]*$|\.dev
+          #   (b) it matches the calver allowlist ^20[0-9]{2}\.([1-9]|1[0-2])\.(0|[1-9][0-9]*)$
+          # Requiring the allowlist prevents a malformed-but-non-prerelease tag (e.g. v2026.13.0)
+          # from being classified as stable and deploying to production.
+          # Non-tag triggers are always non-stable to prevent accidental production deploys.
           if [ "$REF_TYPE" != "tag" ] && [ -z "$INPUT_TAG" ]; then
             echo "Non-tag trigger — not a stable release."
             echo "is_stable=false" >> "$GITHUB_OUTPUT"
@@ -80,10 +87,15 @@ jobs:
           if echo "$version" | grep -qE '(a|b|rc)[0-9]*$|\.dev'; then
             echo "Prerelease tag '$version' — production deploy will be skipped."
             echo "is_stable=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "Stable tag '$version' — production deploy will run."
-            echo "is_stable=true" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+          if ! echo "$version" | grep -qE '^20[0-9]{2}\.([1-9]|1[0-2])\.(0|[1-9][0-9]*)$'; then
+            echo "Tag '$version' does not match the expected calver format (YYYY.M.N) — production deploy will be skipped."
+            echo "is_stable=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "Stable tag '$version' — production deploy will run."
+          echo "is_stable=true" >> "$GITHUB_OUTPUT"
 
       - name: Build documentation
         # docs is a uv dependency-group (PEP 735), not a project extra;
@@ -119,10 +131,13 @@ jobs:
           name: docs-site
           path: docs_build/site
 
-      - uses: cloudflare/wrangler-action@v3
+      - uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd  # v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_PAGES_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # OPERATOR NOTE: --branch=main promotes this deploy to the custom domain only if
+          # fdw-prd has its production branch configured as "main" in Cloudflare Pages.
+          # If a different branch name is configured, update --branch to match it.
           command: pages deploy docs_build/site --project-name=${{ env.PROD_PROJECT }} --branch=main
 
   deploy-staging:
@@ -144,10 +159,13 @@ jobs:
           name: docs-site
           path: docs_build/site
 
-      - uses: cloudflare/wrangler-action@v3
+      - uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd  # v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_PAGES_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # OPERATOR NOTE: --branch=main promotes this deploy to the custom domain only if
+          # fdw-staging has its production branch configured as "main" in Cloudflare Pages.
+          # If a different branch name is configured, update --branch to match it.
           command: pages deploy docs_build/site --project-name=${{ env.STAGING_PROJECT }} --branch=main
 
   deploy-preview:
@@ -172,7 +190,7 @@ jobs:
           name: docs-site
           path: docs_build/site
 
-      - uses: cloudflare/wrangler-action@v3
+      - uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd  # v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_PAGES_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,7 +34,7 @@ on:
 
 env:
   PROD_PROJECT: fdw-prd
-  STAGING_PROJECT: PLACEHOLDER_STAGING_PROJECT
+  STAGING_PROJECT: fdw-staging
 
 concurrency:
   group: docs-${{ github.ref }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,187 @@
+name: Docs
+
+# Deploy matrix:
+#   push to main           -> build + staging deploy  (staging.fdw.debruyn.dev)
+#   stable v* tag          -> build + production deploy (fdw.debruyn.dev)
+#   workflow_dispatch with a stable tag input -> same as stable tag
+#   pull_request (non-fork, docs paths changed) -> build + PR preview under staging project
+#
+# Stable detection mirrors .github/workflows/publish.yml:
+# a tag is prerelease if it matches (a|b|rc)[0-9]*$|\.dev; only clean tags reach production.
+#
+# Fork PRs: the deploy-preview job is skipped (secrets are absent on fork PRs).
+
+on:
+  push:
+    branches: [main]
+    tags: ["v[0-9]*"]
+  pull_request:
+    paths:
+      - "docs/**"
+      - "zensical.toml"
+      - "wrangler.toml"
+      - "README.md"
+      - "CONTRIBUTING.md"
+      - "LICENSE"
+      - "SECURITY.md"
+      - "CODE_OF_CONDUCT.md"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Stable tag to deploy to production (e.g. v2026.6.0). Leave blank to build only."
+        required: false
+
+env:
+  PROD_PROJECT: fdw-prd
+  STAGING_PROJECT: PLACEHOLDER_STAGING_PROJECT
+
+concurrency:
+  group: docs-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build docs
+    runs-on: ubuntu-latest
+    outputs:
+      is_stable: ${{ steps.detect.outputs.is_stable }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.tag || github.ref }}
+
+      - uses: astral-sh/setup-uv@v8.2.0
+        with:
+          enable-cache: true
+
+      - name: Detect stable release
+        id: detect
+        env:
+          REF_TYPE: ${{ github.ref_type }}
+          REF_NAME: ${{ github.ref_name }}
+          INPUT_TAG: ${{ inputs.tag || '' }}
+        run: |
+          # Mirrors the stable-detection pattern from .github/workflows/publish.yml.
+          # A tag is stable if it does NOT match (a|b|rc)[0-9]*$|\.dev.
+          # Non-tag triggers (branch push, PR, workflow_dispatch without a tag) are always
+          # classified as non-stable, which prevents an accidental production deploy.
+          if [ "$REF_TYPE" != "tag" ] && [ -z "$INPUT_TAG" ]; then
+            echo "Non-tag trigger — not a stable release."
+            echo "is_stable=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          effective_tag="${INPUT_TAG:-$REF_NAME}"
+          version="${effective_tag#v}"
+          if echo "$version" | grep -qE '(a|b|rc)[0-9]*$|\.dev'; then
+            echo "Prerelease tag '$version' — production deploy will be skipped."
+            echo "is_stable=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Stable tag '$version' — production deploy will run."
+            echo "is_stable=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build documentation
+        # docs is a uv dependency-group (PEP 735), not a project extra;
+        # use --group, not --extra.
+        run: uv run --group docs zensical build
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: docs-site
+          path: docs_build/site
+          if-no-files-found: error
+
+  deploy-production:
+    name: Deploy to production (fdw.debruyn.dev)
+    needs: build
+    # Production deploys only on a stable tag push or a workflow_dispatch that
+    # resolved to a stable tag. Never on main pushes, PRs, or prerelease tags.
+    if: >-
+      (github.ref_type == 'tag' || github.event_name == 'workflow_dispatch') &&
+      needs.build.outputs.is_stable == 'true'
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: https://fdw.debruyn.dev
+    concurrency:
+      group: docs-production
+      cancel-in-progress: false
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: docs-site
+          path: docs_build/site
+
+      - uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_PAGES_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy docs_build/site --project-name=${{ env.PROD_PROJECT }} --branch=main
+
+  deploy-staging:
+    name: Deploy to staging (staging.fdw.debruyn.dev)
+    needs: build
+    if: github.event_name == 'push' && github.ref_type == 'branch' && github.ref_name == 'main'
+    runs-on: ubuntu-latest
+    environment:
+      name: staging
+      url: https://staging.fdw.debruyn.dev
+    concurrency:
+      group: docs-staging
+      cancel-in-progress: false
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: docs-site
+          path: docs_build/site
+
+      - uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_PAGES_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy docs_build/site --project-name=${{ env.STAGING_PROJECT }} --branch=main
+
+  deploy-preview:
+    name: Deploy PR preview
+    needs: build
+    # Skip for fork PRs: secrets are not exposed, so the deploy would fail.
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    environment:
+      name: staging
+      url: https://pr-${{ github.event.number }}.${{ env.STAGING_PROJECT }}.pages.dev
+    concurrency:
+      group: docs-preview-pr-${{ github.event.number }}
+      cancel-in-progress: true
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: docs-site
+          path: docs_build/site
+
+      - uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_PAGES_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy docs_build/site --project-name=${{ env.STAGING_PROJECT }} --branch=pr-${{ github.event.number }}
+
+      - name: Post preview URL to job summary
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          echo "## PR Preview" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Preview URL: https://pr-${PR_NUMBER}.${STAGING_PROJECT}.pages.dev" >> "$GITHUB_STEP_SUMMARY"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,7 +1,1 @@
-name = "fabric-dw"
-pages_build_output_dir = "docs_build/site"
 compatibility_date = "2026-06-07"
-
-[vars]
-SKIP_DEPENDENCY_INSTALL = "1"
-PYTHON_VERSION = "3.13.3"


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/docs.yml`: build docs with `uv run --group docs zensical build`, upload the site as an artifact, then gate each deploy path separately.
- Reconciles `wrangler.toml`: removes `name`, `pages_build_output_dir`, and `[vars]` (all belonged to Cloudflare's now-disabled Git auto-build); keeps only `compatibility_date`. Project name and output directory are now passed explicitly on every `wrangler pages deploy` CLI call.

## Deploy paths

| Trigger | Project env var | Branch flag | Resulting URL |
|---|---|---|---|
| Stable `v*` tag or `workflow_dispatch` with stable tag | `PROD_PROJECT` (`fdw-prd`) | `--branch=main` | fdw.debruyn.dev |
| Push to `main` | `STAGING_PROJECT` (`fdw-staging`) | `--branch=main` | staging.fdw.debruyn.dev |
| `pull_request` (non-fork only) | `STAGING_PROJECT` (`fdw-staging`) | `--branch=pr-<number>` | Preview alias under fdw-staging.pages.dev |

## Security / correctness notes

- Stable detection mirrors `publish.yml` exactly: a tag is stable only when it (a) does NOT match `(a|b|rc)[0-9]*$|\.dev` AND (b) matches the calver allowlist `^20[0-9]{2}\.([1-9]|1[0-2])\.(0|[1-9][0-9]*)$`. Both gates are required so a malformed-but-non-prerelease tag cannot reach production.
- Fork PR safety: `deploy-preview` is gated on `github.event.pull_request.head.repo.full_name == github.repository`; secrets are never exposed to forks.
- Secrets used: `CLOUDFLARE_PAGES_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` (already created in the repo).
- Concurrency: workflow-level group prevents racing deploys per ref; each deploy job also carries a per-environment concurrency group.
- Build command: `uv run --group docs zensical build` (`docs` is a PEP 735 dependency-group, not a project extra; `--group` not `--extra`). Verified locally: `docs_build/site/index.html` exists after the build.
- `cloudflare/wrangler-action` is SHA-pinned to `9acf94ace14e7dc412b076f2c5c20b8ce93c79cd` (v3) for supply-chain hardening.
- Lint: `actionlint` reports no findings.

## Prerequisites (maintainer, outside this PR)

1. Create the two Cloudflare Pages projects (`fdw-prd`, `fdw-staging`) and attach their custom domains.
2. **Configure `main` as the production branch in both Cloudflare projects.** Both deploy commands use `--branch=main`; Cloudflare Pages promotes a deployment to the custom domain only when the deployed branch matches the project's configured production branch. If a different branch name is configured, update `--branch` in the workflow to match.
3. Disable the existing Cloudflare Pages Git auto-build integration so Cloudflare no longer rebuilds on push.
4. Confirm `CLOUDFLARE_PAGES_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` secrets are in place (already done per issue).

## Follow-up (not blocking)

SEO deduplication for staging (e.g. a `_headers` file with `X-Robots-Tag: noindex` added only to staging/PR builds) is noted as a potential improvement. Zensical's support for per-environment `_headers` injection was not investigated; it can be tracked separately.

Closes #926