### PR TITLE
feat(permissions): row-level security (permissions rls subgroup) (#919)

### DIFF
--- a/docs/commands/permissions.md
+++ b/docs/commands/permissions.md
@@ -546,3 +546,159 @@ fdw -w MyWorkspace permissions cls list SalesWH --object dbo.sales
 # Raw JSON
 fdw -w MyWorkspace --json permissions cls list SalesWH --object dbo.sales
 ```
+
+---
+
+## Row-level security (`permissions rls`)
+
+**Targets:** Data Warehouse / SQL Analytics Endpoint
+
+Control row-level security (RLS) policies. Each policy contains one or more filter or block
+predicates that reference existing predicate functions (table-valued functions). The CLI
+never authors or modifies predicate function bodies.
+
+### permissions rls list
+
+List all security policies and their predicates.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] [--json] permissions rls list [ITEM]
+```
+
+**Example**
+
+```shell
+fdw -w MyWorkspace permissions rls list SalesWH
+fdw -w MyWorkspace --json permissions rls list SalesWH
+```
+
+---
+
+### permissions rls create
+
+Create a new row-level security policy with one filter or block predicate.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] permissions rls create [ITEM] [POLICY_NAME]
+    { --filter SCHEMA.FN(COL,...) | --block SCHEMA.FN(COL,...) }
+    --on SCHEMA.TABLE
+    [--operation AFTER-INSERT|AFTER-UPDATE|BEFORE-UPDATE|BEFORE-DELETE]
+    [--state on|off]
+```
+
+| Option | Description |
+| --- | --- |
+| `--filter SCHEMA.FN(COL,...)` | Add a FILTER predicate (mutually exclusive with `--block`). |
+| `--block SCHEMA.FN(COL,...)` | Add a BLOCK predicate (mutually exclusive with `--filter`). |
+| `--on SCHEMA.TABLE` | Target table for the predicate (required). |
+| `--operation OP` | Block operation: `after-insert`, `after-update`, `before-update`, `before-delete` (BLOCK only). |
+| `--state on\|off` | Initial policy state (default: `on`). |
+
+**Example**
+
+```shell
+# Filter predicate, enabled
+fdw -w MyWorkspace permissions rls create SalesWH rls.SalesFilter \
+    --filter rls.fn_filter(SalesRep) --on dbo.Sales
+
+# Block predicate, disabled initially
+fdw -w MyWorkspace permissions rls create SalesWH rls.SalesBlock \
+    --block rls.fn_block(SalesRep) --on dbo.Sales \
+    --operation after-insert --state off
+```
+
+---
+
+### permissions rls add-predicate
+
+Add an additional predicate to an existing policy.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] permissions rls add-predicate [ITEM] [POLICY_NAME]
+    { --filter SCHEMA.FN(COL,...) | --block SCHEMA.FN(COL,...) }
+    --on SCHEMA.TABLE
+    [--operation AFTER-INSERT|AFTER-UPDATE|BEFORE-UPDATE|BEFORE-DELETE]
+```
+
+**Example**
+
+```shell
+fdw -w MyWorkspace permissions rls add-predicate SalesWH rls.SalesFilter \
+    --filter rls.fn_filter(Region) --on dbo.Regions
+```
+
+---
+
+### permissions rls drop-predicate
+
+Drop a predicate from an existing policy.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] permissions rls drop-predicate [ITEM] [POLICY_NAME]
+    { --filter | --block }
+    --on SCHEMA.TABLE
+    [--operation AFTER-INSERT|AFTER-UPDATE|BEFORE-UPDATE|BEFORE-DELETE]
+```
+
+| Option | Description |
+| --- | --- |
+| `--filter` | Target a FILTER predicate (flag, no value). |
+| `--block` | Target a BLOCK predicate (flag, no value). |
+| `--on SCHEMA.TABLE` | Table whose predicate is dropped. |
+| `--operation OP` | Block operation to identify the exact BLOCK predicate. |
+
+**Example**
+
+```shell
+fdw -w MyWorkspace permissions rls drop-predicate SalesWH rls.SalesFilter \
+    --filter --on dbo.Sales
+```
+
+---
+
+### permissions rls set-state
+
+Enable or disable an existing security policy (reversible, not destructive).
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] permissions rls set-state [ITEM] [POLICY_NAME]
+    { --enable | --disable }
+```
+
+**Example**
+
+```shell
+fdw -w MyWorkspace permissions rls set-state SalesWH rls.SalesFilter --enable
+fdw -w MyWorkspace permissions rls set-state SalesWH rls.SalesFilter --disable
+```
+
+---
+
+### permissions rls drop
+
+**Destructive.** Drop an entire security policy (and all its predicates).
+
+Requires confirmation (`--yes` / `-y`) or the `FABRIC_MCP_ALLOW_DESTRUCTIVE=1` environment
+variable when called via MCP.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] [-y] permissions rls drop [ITEM] [POLICY_NAME]
+```
+
+**Example**
+
+```shell
+fdw -w MyWorkspace -y permissions rls drop SalesWH rls.SalesFilter
+```

--- a/docs/commands/permissions.md
+++ b/docs/commands/permissions.md
@@ -645,7 +645,6 @@ Drop a predicate from an existing policy.
 fdw [-w WORKSPACE] permissions rls drop-predicate [ITEM] [POLICY_NAME]
     { --filter | --block }
     --on SCHEMA.TABLE
-    [--operation AFTER-INSERT|AFTER-UPDATE|BEFORE-UPDATE|BEFORE-DELETE]
 ```
 
 | Option | Description |
@@ -653,7 +652,6 @@ fdw [-w WORKSPACE] permissions rls drop-predicate [ITEM] [POLICY_NAME]
 | `--filter` | Target a FILTER predicate (flag, no value). |
 | `--block` | Target a BLOCK predicate (flag, no value). |
 | `--on SCHEMA.TABLE` | Table whose predicate is dropped. |
-| `--operation OP` | Block operation to identify the exact BLOCK predicate. |
 
 **Example**
 

--- a/src/fabric_dw/cli/_main.py
+++ b/src/fabric_dw/cli/_main.py
@@ -60,6 +60,7 @@ _DESTRUCTIVE_CLI_COMMANDS: frozenset[str] = frozenset(
         "tables.cluster-by",
         "views.drop",
         "warehouses.delete",
+        "permissions.rls.drop",
     }
 )
 

--- a/src/fabric_dw/cli/commands/permissions.py
+++ b/src/fabric_dw/cli/commands/permissions.py
@@ -733,3 +733,483 @@ async def cls_list_cmd(
             )
     except (ValueError, FabricError) as exc:
         raise click.ClickException(str(exc)) from exc
+
+
+# ---------------------------------------------------------------------------
+# permissions rls helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_table_ref(table_expr: str, option_name: str) -> tuple[str, str]:
+    """Split SCHEMA.TABLE into (schema, table_name).
+
+    Args:
+        table_expr: Qualified table name (e.g. ``"dbo.Sales"``).
+        option_name: CLI option name for error messages (e.g. ``"--on"``).
+
+    Returns:
+        ``(schema, table_name)`` tuple.
+
+    Raises:
+        click.UsageError: If *table_expr* is not a two-part qualified name.
+    """
+    if "." not in table_expr:
+        raise click.UsageError(
+            f"{option_name}: expected SCHEMA.TABLE (e.g. dbo.Sales), got {table_expr!r}"
+        )
+    schema, name = table_expr.split(".", 1)
+    if not schema.strip() or not name.strip():
+        raise click.UsageError(f"{option_name}: schema and table name must not be empty")
+    return schema.strip(), name.strip()
+
+
+def _parse_fn_ref(fn_expr: str, option_name: str) -> tuple[str | None, str, list[str]]:
+    """Parse a structured predicate function reference.
+
+    Accepts the form ``schema.fn_name(col1, col2)`` or ``fn_name(col1)``.
+    This is structured user input parsing -- not SQL DDL parsing.
+
+    Args:
+        fn_expr: Function reference string from the CLI.
+        option_name: CLI option name for error messages (e.g. ``"--filter"``).
+
+    Returns:
+        ``(fn_schema, fn_name, cols)`` where ``fn_schema`` may be ``None``
+        when no schema prefix is present.
+
+    Raises:
+        click.UsageError: On malformed input.
+    """
+    if "(" not in fn_expr or not fn_expr.endswith(")"):
+        raise click.UsageError(
+            f"{option_name}: expected SCHEMA.FN(col,...) or FN(col,...), got {fn_expr!r}"
+        )
+    paren_open = fn_expr.index("(")
+    fn_ref = fn_expr[:paren_open].strip()
+    args_str = fn_expr[paren_open + 1 : -1]
+
+    if "." in fn_ref:
+        dot = fn_ref.index(".")
+        fn_schema: str | None = fn_ref[:dot].strip()
+        fn_name = fn_ref[dot + 1 :].strip()
+    else:
+        fn_schema = None
+        fn_name = fn_ref.strip()
+
+    if not fn_name:
+        raise click.UsageError(f"{option_name}: function name must not be empty")
+
+    cols = [c.strip() for c in args_str.split(",") if c.strip()]
+    if not cols:
+        raise click.UsageError(
+            f"{option_name}: at least one column argument is required, e.g. FN(col)"
+        )
+    return fn_schema, fn_name, cols
+
+
+def _normalise_operation(operation: str | None) -> str | None:
+    """Convert a CLI operation string to the service layer token.
+
+    Maps ``"after-insert"`` -> ``"AFTER_INSERT"`` etc.
+    Returns ``None`` when *operation* is ``None``.
+    """
+    if operation is None:
+        return None
+    return operation.upper().replace("-", "_")
+
+
+# ---------------------------------------------------------------------------
+# permissions rls sub-group (row-level security)
+# ---------------------------------------------------------------------------
+
+
+@permissions_group.group("rls")
+def rls_group() -> None:
+    """Row-level security: CREATE / ALTER / DROP SECURITY POLICY."""
+
+
+from fabric_dw.services import rls as _rls_svc  # noqa: E402
+
+
+@rls_group.command("list")
+@click.argument("item", required=False, default=None)
+@click.pass_obj
+@coro
+async def rls_list_cmd(ctx: CliContext, item: str | None) -> None:
+    """List security policies on ITEM (warehouse or SQL endpoint).
+
+    Shows all security policies together with their attached predicates.
+    """
+    ws = resolve_workspace(ctx)
+    it = resolve_warehouse_arg(ctx, item)
+    try:
+        async with build_http_client(ctx) as http:
+            target, _entry = await build_sql_target(http, ws, it)
+            policies = await _rls_svc.list_security_policies(target, mode=ctx.auth)
+            rows = [p.model_dump(mode="json") for p in policies]
+            render(
+                rows,
+                json_output=ctx.json_output,
+                table_title="Security Policies",
+                prune_null_columns=True,
+            )
+    except (ValueError, FabricError) as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@rls_group.command("create")
+@click.argument("item", required=False, default=None)
+@click.argument("policy")
+@click.option(
+    "--filter",
+    "filter_fn",
+    default=None,
+    metavar="SCHEMA.FN(col,...)",
+    help="Filter predicate function reference (mutually exclusive with --block).",
+)
+@click.option(
+    "--block",
+    "block_fn",
+    default=None,
+    metavar="SCHEMA.FN(col,...)",
+    help="Block predicate function reference (mutually exclusive with --filter).",
+)
+@click.option(
+    "--on",
+    "target_table",
+    required=True,
+    metavar="SCHEMA.TABLE",
+    help="Target table for the predicate (e.g. dbo.Sales).",
+)
+@click.option(
+    "--operation",
+    type=click.Choice(
+        ["after-insert", "after-update", "before-update", "before-delete"],
+        case_sensitive=False,
+    ),
+    default=None,
+    help="Block predicate DML operation (required for BLOCK when ambiguous).",
+)
+@click.option(
+    "--state",
+    type=click.Choice(["on", "off"], case_sensitive=False),
+    default="on",
+    show_default=True,
+    help="Initial policy state.",
+)
+@click.pass_obj
+@coro
+async def rls_create_cmd(
+    ctx: CliContext,
+    item: str | None,
+    policy: str,
+    filter_fn: str | None,
+    block_fn: str | None,
+    target_table: str,
+    operation: str | None,
+    state: str,
+) -> None:
+    """Create a security policy POLICY on ITEM with an initial predicate.
+
+    Specify exactly one of --filter or --block to define the initial predicate.
+    Use 'permissions rls add-predicate' to add further predicates.
+
+    POLICY may be schema-qualified (e.g. rls.MySalesFilter) or bare (MySalesFilter).
+    --on specifies the target table (e.g. dbo.Sales).
+
+    Examples:
+
+        fdw -w MyWS permissions rls create MyWH rls.SalesFilter \\
+            --filter "rls.fn_filter(SalesRep)" --on dbo.Sales
+
+        fdw -w MyWS permissions rls create MyWH rls.SalesBlock \\
+            --block "rls.fn_block(SalesRep)" --on dbo.Sales --operation after-insert
+    """
+    if (filter_fn is None) == (block_fn is None):
+        raise click.UsageError("Specify exactly one of --filter or --block.")
+
+    ws = resolve_workspace(ctx)
+    it = resolve_warehouse_arg(ctx, item)
+
+    if filter_fn is not None:
+        fn_schema, fn_name, fn_args = _parse_fn_ref(filter_fn, "--filter")
+        predicate_type = "FILTER"
+        op: str | None = None  # FILTER predicates have no operation
+    else:
+        if block_fn is None:  # pragma: no cover
+            raise click.UsageError("Expected --block value")
+        fn_schema, fn_name, fn_args = _parse_fn_ref(block_fn, "--block")
+        predicate_type = "BLOCK"
+        op = _normalise_operation(operation)
+
+    table_schema, table_name = _parse_table_ref(target_table, "--on")
+    try:
+        async with build_http_client(ctx) as http:
+            target, _entry = await build_sql_target(http, ws, it)
+            await _rls_svc.create_security_policy(
+                target,
+                policy,
+                [
+                    {
+                        "predicate_type": predicate_type,
+                        "fn_schema": fn_schema,
+                        "fn_name": fn_name,
+                        "fn_args": fn_args,
+                        "table_schema": table_schema,
+                        "table_name": table_name,
+                        "operation": op,
+                    }
+                ],
+                state=state.lower() == "on",
+                mode=ctx.auth,
+            )
+    except (ValueError, FabricError) as exc:
+        raise click.ClickException(str(exc)) from exc
+    click.echo(
+        f"Created security policy {policy!r} with {predicate_type} predicate on {target_table!r}."
+    )
+
+
+@rls_group.command("add-predicate")
+@click.argument("item", required=False, default=None)
+@click.argument("policy")
+@click.option(
+    "--filter",
+    "filter_fn",
+    default=None,
+    metavar="SCHEMA.FN(col,...)",
+    help="Filter predicate function reference (mutually exclusive with --block).",
+)
+@click.option(
+    "--block",
+    "block_fn",
+    default=None,
+    metavar="SCHEMA.FN(col,...)",
+    help="Block predicate function reference (mutually exclusive with --filter).",
+)
+@click.option(
+    "--on",
+    "target_table",
+    required=True,
+    metavar="SCHEMA.TABLE",
+    help="Target table for the predicate (e.g. dbo.Sales).",
+)
+@click.option(
+    "--operation",
+    type=click.Choice(
+        ["after-insert", "after-update", "before-update", "before-delete"],
+        case_sensitive=False,
+    ),
+    default=None,
+    help="Block predicate DML operation.",
+)
+@click.pass_obj
+@coro
+async def rls_add_predicate_cmd(
+    ctx: CliContext,
+    item: str | None,
+    policy: str,
+    filter_fn: str | None,
+    block_fn: str | None,
+    target_table: str,
+    operation: str | None,
+) -> None:
+    """Add a predicate to an existing security policy POLICY on ITEM.
+
+    Specify exactly one of --filter or --block.
+
+    POLICY may be schema-qualified (e.g. rls.MySalesFilter) or bare (MySalesFilter).
+    --on specifies the target table.
+    """
+    if (filter_fn is None) == (block_fn is None):
+        raise click.UsageError("Specify exactly one of --filter or --block.")
+
+    ws = resolve_workspace(ctx)
+    it = resolve_warehouse_arg(ctx, item)
+
+    if filter_fn is not None:
+        fn_schema, fn_name, fn_args = _parse_fn_ref(filter_fn, "--filter")
+        predicate_type = "FILTER"
+        op: str | None = None
+    else:
+        if block_fn is None:  # pragma: no cover
+            raise click.UsageError("Expected --block value")
+        fn_schema, fn_name, fn_args = _parse_fn_ref(block_fn, "--block")
+        predicate_type = "BLOCK"
+        op = _normalise_operation(operation)
+
+    table_schema, table_name = _parse_table_ref(target_table, "--on")
+    try:
+        async with build_http_client(ctx) as http:
+            target, _entry = await build_sql_target(http, ws, it)
+            await _rls_svc.add_predicate(
+                target,
+                policy,
+                predicate_type,
+                fn_schema,
+                fn_name,
+                fn_args,
+                table_schema,
+                table_name,
+                operation=op,
+                mode=ctx.auth,
+            )
+    except (ValueError, FabricError) as exc:
+        raise click.ClickException(str(exc)) from exc
+    click.echo(f"Added {predicate_type} predicate to policy {policy!r} on {target_table!r}.")
+
+
+@rls_group.command("drop-predicate")
+@click.argument("item", required=False, default=None)
+@click.argument("policy")
+@click.option(
+    "--filter",
+    "predicate_filter",
+    is_flag=True,
+    default=False,
+    help="Drop a FILTER predicate (mutually exclusive with --block).",
+)
+@click.option(
+    "--block",
+    "predicate_block",
+    is_flag=True,
+    default=False,
+    help="Drop a BLOCK predicate (mutually exclusive with --filter).",
+)
+@click.option(
+    "--on",
+    "target_table",
+    required=True,
+    metavar="SCHEMA.TABLE",
+    help="Target table whose predicate to drop.",
+)
+@click.option(
+    "--operation",
+    type=click.Choice(
+        ["after-insert", "after-update", "before-update", "before-delete"],
+        case_sensitive=False,
+    ),
+    default=None,
+    help="Block predicate DML operation (identifies which BLOCK predicate to drop).",
+)
+@click.pass_obj
+@coro
+async def rls_drop_predicate_cmd(
+    ctx: CliContext,
+    item: str | None,
+    policy: str,
+    predicate_filter: bool,
+    predicate_block: bool,
+    target_table: str,
+    operation: str | None,
+) -> None:
+    """Drop a predicate from security policy POLICY on ITEM.
+
+    Specify exactly one of --filter or --block to identify the predicate type.
+    --on specifies the target table. For BLOCK predicates, use --operation to
+    identify which one when multiple BLOCK predicates target the same table.
+    """
+    if predicate_filter == predicate_block:
+        raise click.UsageError("Specify exactly one of --filter or --block.")
+
+    ws = resolve_workspace(ctx)
+    it = resolve_warehouse_arg(ctx, item)
+
+    predicate_type = "FILTER" if predicate_filter else "BLOCK"
+    op = _normalise_operation(operation)
+
+    table_schema, table_name = _parse_table_ref(target_table, "--on")
+    try:
+        async with build_http_client(ctx) as http:
+            target, _entry = await build_sql_target(http, ws, it)
+            await _rls_svc.drop_predicate(
+                target,
+                policy,
+                predicate_type,
+                table_schema,
+                table_name,
+                operation=op,
+                mode=ctx.auth,
+            )
+    except (ValueError, FabricError) as exc:
+        raise click.ClickException(str(exc)) from exc
+    click.echo(f"Dropped {predicate_type} predicate from policy {policy!r} on {target_table!r}.")
+
+
+@rls_group.command("set-state")
+@click.argument("item", required=False, default=None)
+@click.argument("policy")
+@click.option(
+    "--enable",
+    "set_enable",
+    is_flag=True,
+    default=False,
+    help="Enable the policy (STATE = ON). Mutually exclusive with --disable.",
+)
+@click.option(
+    "--disable",
+    "set_disable",
+    is_flag=True,
+    default=False,
+    help="Disable the policy (STATE = OFF). Mutually exclusive with --enable.",
+)
+@click.pass_obj
+@coro
+async def rls_set_state_cmd(
+    ctx: CliContext,
+    item: str | None,
+    policy: str,
+    set_enable: bool,
+    set_disable: bool,
+) -> None:
+    """Enable or disable security policy POLICY on ITEM.
+
+    Specify exactly one of --enable or --disable.
+
+    This is a mutating but non-destructive operation: no data or policy
+    definitions are removed.
+    """
+    if set_enable == set_disable:
+        raise click.UsageError("Specify exactly one of --enable or --disable.")
+
+    ws = resolve_workspace(ctx)
+    it = resolve_warehouse_arg(ctx, item)
+    enabled = set_enable
+
+    try:
+        async with build_http_client(ctx) as http:
+            target, _entry = await build_sql_target(http, ws, it)
+            await _rls_svc.set_policy_state(target, policy, enabled=enabled, mode=ctx.auth)
+    except (ValueError, FabricError) as exc:
+        raise click.ClickException(str(exc)) from exc
+    state_label = "enabled" if enabled else "disabled"
+    click.echo(f"Security policy {policy!r} {state_label}.")
+
+
+@rls_group.command("drop")
+@click.argument("item", required=False, default=None)
+@click.argument("policy")
+@click.pass_obj
+@coro
+async def rls_drop_cmd(ctx: CliContext, item: str | None, policy: str) -> None:
+    """Drop security policy POLICY on ITEM.
+
+    This is a destructive operation: the policy and all attached predicates
+    are permanently removed.  A confirmation prompt is shown unless --yes / -y
+    is passed.
+    """
+    ws = resolve_workspace(ctx)
+    it = resolve_warehouse_arg(ctx, item)
+    if not confirm_destructive(
+        f"Drop security policy {policy!r}?",
+        yes=ctx.yes,
+    ):
+        click.echo("Aborted.")
+        return
+    try:
+        async with build_http_client(ctx) as http:
+            target, _entry = await build_sql_target(http, ws, it)
+            await _rls_svc.drop_security_policy(target, policy, mode=ctx.auth)
+    except (ValueError, FabricError) as exc:
+        raise click.ClickException(str(exc)) from exc
+    click.echo(f"Dropped security policy {policy!r}.")

--- a/src/fabric_dw/cli/commands/permissions.py
+++ b/src/fabric_dw/cli/commands/permissions.py
@@ -31,6 +31,7 @@ from fabric_dw.cli.commands._utils import (
     resolve_workspace,
 )
 from fabric_dw.exceptions import FabricError
+from fabric_dw.identifiers import parse_qualified_name as _parse_qualified_name
 from fabric_dw.services import permissions as _permissions_svc
 
 # ---------------------------------------------------------------------------
@@ -743,6 +744,10 @@ async def cls_list_cmd(
 def _parse_table_ref(table_expr: str, option_name: str) -> tuple[str, str]:
     """Split SCHEMA.TABLE into (schema, table_name).
 
+    Delegates to :func:`fabric_dw.identifiers.parse_qualified_name`, converting
+    :class:`ValueError` into a :class:`click.UsageError` prefixed with the
+    option name.
+
     Args:
         table_expr: Qualified table name (e.g. ``"dbo.Sales"``).
         option_name: CLI option name for error messages (e.g. ``"--on"``).
@@ -753,14 +758,10 @@ def _parse_table_ref(table_expr: str, option_name: str) -> tuple[str, str]:
     Raises:
         click.UsageError: If *table_expr* is not a two-part qualified name.
     """
-    if "." not in table_expr:
-        raise click.UsageError(
-            f"{option_name}: expected SCHEMA.TABLE (e.g. dbo.Sales), got {table_expr!r}"
-        )
-    schema, name = table_expr.split(".", 1)
-    if not schema.strip() or not name.strip():
-        raise click.UsageError(f"{option_name}: schema and table name must not be empty")
-    return schema.strip(), name.strip()
+    try:
+        return _parse_qualified_name(table_expr, "table")
+    except ValueError as exc:
+        raise click.UsageError(f"{option_name}: {exc}") from exc
 
 
 def _parse_fn_ref(fn_expr: str, option_name: str) -> tuple[str | None, str, list[str]]:
@@ -805,17 +806,6 @@ def _parse_fn_ref(fn_expr: str, option_name: str) -> tuple[str | None, str, list
             f"{option_name}: at least one column argument is required, e.g. FN(col)"
         )
     return fn_schema, fn_name, cols
-
-
-def _normalise_operation(operation: str | None) -> str | None:
-    """Convert a CLI operation string to the service layer token.
-
-    Maps ``"after-insert"`` -> ``"AFTER_INSERT"`` etc.
-    Returns ``None`` when *operation* is ``None``.
-    """
-    if operation is None:
-        return None
-    return operation.upper().replace("-", "_")
 
 
 # ---------------------------------------------------------------------------
@@ -932,6 +922,8 @@ async def rls_create_cmd(
     it = resolve_warehouse_arg(ctx, item)
 
     if filter_fn is not None:
+        if operation is not None:
+            raise click.UsageError("--operation is only valid with --block predicates")
         fn_schema, fn_name, fn_args = _parse_fn_ref(filter_fn, "--filter")
         predicate_type = "FILTER"
         op: str | None = None  # FILTER predicates have no operation
@@ -940,7 +932,7 @@ async def rls_create_cmd(
             raise click.UsageError("Expected --block value")
         fn_schema, fn_name, fn_args = _parse_fn_ref(block_fn, "--block")
         predicate_type = "BLOCK"
-        op = _normalise_operation(operation)
+        op = operation  # service's _validate_operation normalizes hyphens to underscores
 
     table_schema, table_name = _parse_table_ref(target_table, "--on")
     try:
@@ -1028,6 +1020,8 @@ async def rls_add_predicate_cmd(
     it = resolve_warehouse_arg(ctx, item)
 
     if filter_fn is not None:
+        if operation is not None:
+            raise click.UsageError("--operation is only valid with --block predicates")
         fn_schema, fn_name, fn_args = _parse_fn_ref(filter_fn, "--filter")
         predicate_type = "FILTER"
         op: str | None = None
@@ -1036,7 +1030,7 @@ async def rls_add_predicate_cmd(
             raise click.UsageError("Expected --block value")
         fn_schema, fn_name, fn_args = _parse_fn_ref(block_fn, "--block")
         predicate_type = "BLOCK"
-        op = _normalise_operation(operation)
+        op = operation  # service's _validate_operation normalizes hyphens to underscores
 
     table_schema, table_name = _parse_table_ref(target_table, "--on")
     try:
@@ -1083,15 +1077,6 @@ async def rls_add_predicate_cmd(
     metavar="SCHEMA.TABLE",
     help="Target table whose predicate to drop.",
 )
-@click.option(
-    "--operation",
-    type=click.Choice(
-        ["after-insert", "after-update", "before-update", "before-delete"],
-        case_sensitive=False,
-    ),
-    default=None,
-    help="Block predicate DML operation (identifies which BLOCK predicate to drop).",
-)
 @click.pass_obj
 @coro
 async def rls_drop_predicate_cmd(
@@ -1101,13 +1086,11 @@ async def rls_drop_predicate_cmd(
     predicate_filter: bool,
     predicate_block: bool,
     target_table: str,
-    operation: str | None,
 ) -> None:
     """Drop a predicate from security policy POLICY on ITEM.
 
     Specify exactly one of --filter or --block to identify the predicate type.
-    --on specifies the target table. For BLOCK predicates, use --operation to
-    identify which one when multiple BLOCK predicates target the same table.
+    --on specifies the target table.
     """
     if predicate_filter == predicate_block:
         raise click.UsageError("Specify exactly one of --filter or --block.")
@@ -1116,7 +1099,6 @@ async def rls_drop_predicate_cmd(
     it = resolve_warehouse_arg(ctx, item)
 
     predicate_type = "FILTER" if predicate_filter else "BLOCK"
-    op = _normalise_operation(operation)
 
     table_schema, table_name = _parse_table_ref(target_table, "--on")
     try:
@@ -1128,7 +1110,6 @@ async def rls_drop_predicate_cmd(
                 predicate_type,
                 table_schema,
                 table_name,
-                operation=op,
                 mode=ctx.auth,
             )
     except (ValueError, FabricError) as exc:

--- a/src/fabric_dw/identifiers.py
+++ b/src/fabric_dw/identifiers.py
@@ -49,6 +49,10 @@ _PRINCIPAL_NAME_RE = re.compile(r"^[A-Za-z0-9@.\-_'# ]{1,128}\Z")
 _CTRL_LOW = 0x20  # characters below this (0x00-0x1F) are control chars
 _CTRL_DEL = 0x7F  # DEL character
 
+# Unicode line/paragraph separators that must not appear in column names.
+# U+0085 (NEL), U+2028 (LINE SEPARATOR), U+2029 (PARAGRAPH SEPARATOR)
+_UNICODE_LINE_SEPS: frozenset[str] = frozenset({"\x85", "\u2028", "\u2029"})
+
 # Maximum length for SQL Server sysname / NVARCHAR(128) identifier columns.
 _MAX_NAME_LEN = 128
 
@@ -234,6 +238,10 @@ def validate_column_name(name: str) -> str:
     # Reject control characters (NUL, CR, LF, and all < U+0020 or U+007F)
     if any(ord(c) < _CTRL_LOW or ord(c) == _CTRL_DEL for c in name):
         msg = f"Invalid column name {name!r}: contains control character(s)"
+        raise ValueError(msg)
+    # Reject unicode line/paragraph separators (U+0085, U+2028, U+2029)
+    if any(c in _UNICODE_LINE_SEPS for c in name):
+        msg = f"Invalid column name {name!r}: contains unicode line separator"
         raise ValueError(msg)
     if len(name) > _MAX_NAME_LEN:
         msg = f"Invalid column name {name!r}: exceeds 128 characters"

--- a/src/fabric_dw/mcp/tools/permissions.py
+++ b/src/fabric_dw/mcp/tools/permissions.py
@@ -39,6 +39,7 @@ from fabric_dw.mcp._helpers import (
     tool_err,
 )
 from fabric_dw.services import permissions as _permissions_svc
+from fabric_dw.services import rls as _rls_svc
 
 __all__ = ["register"]
 
@@ -413,3 +414,289 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             "scope": scope.upper(),
             "columns": columns,
         }
+
+    # -------------------------------------------------------------------------
+    # Row-level security (RLS) tools
+    # -------------------------------------------------------------------------
+
+    @mcp.tool(name="list_security_policies")
+    async def list_security_policies_tool(workspace: str, item: str) -> list[dict[str, Any]]:
+        """List row-level security policies from sys.security_policies.
+
+        Returns all security policies and their predicates for the target
+        Data Warehouse or SQL Analytics Endpoint.
+
+        Args:
+            workspace: Workspace name or GUID.
+            item: Warehouse or SQL endpoint name or GUID.
+        """
+        ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
+        try:
+            ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
+            _log.debug("list_security_policies ws=%s item=%s", ws_id, entry.id)
+            target = make_sql_target(ws_id, entry, item)
+            result = await _rls_svc.list_security_policies(target, mode=ctx.auth_mode)
+        except (ValueError, FabricError) as exc:
+            raise tool_err(exc) from exc
+        return [p.model_dump(mode="json") for p in result]
+
+    @mutating_tool(mcp, "create_security_policy")
+    async def create_security_policy_tool(
+        workspace: str,
+        item: str,
+        policy_name: str,
+        predicates: list[dict[str, Any]],
+        state: bool = True,  # noqa: FBT001, FBT002
+    ) -> dict[str, Any]:
+        """Create a row-level security policy.
+
+        Executes ``CREATE SECURITY POLICY`` with one or more filter or block
+        predicates.  Each entry in *predicates* must include:
+
+        - ``predicate_type``: ``"FILTER"`` or ``"BLOCK"``
+        - ``fn_schema``: schema of the predicate function
+        - ``fn_name``: name of the predicate function
+        - ``fn_args``: list of column names to pass to the function
+        - ``table_schema``: schema of the target table
+        - ``table_name``: name of the target table
+        - ``operation`` (optional): block operation -- ``"AFTER_INSERT"``,
+          ``"AFTER_UPDATE"``, ``"BEFORE_UPDATE"``, or ``"BEFORE_DELETE"``
+          (BLOCK predicates only)
+
+        Args:
+            workspace: Workspace name or GUID.
+            item: Warehouse or SQL endpoint name or GUID.
+            policy_name: Qualified policy name (``"schema.name"`` or ``"name"``).
+            predicates: List of predicate definitions (see above).
+            state: Initial policy state -- ``True`` to enable, ``False`` to disable
+                (default: ``True``).
+        """
+        ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
+        try:
+            ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
+            _log.debug(
+                "create_security_policy ws=%s item=%s policy=%r",
+                ws_id,
+                entry.id,
+                policy_name,
+            )
+            target = make_sql_target(ws_id, entry, item)
+            await _rls_svc.create_security_policy(
+                target,
+                policy_name,
+                predicates,
+                state=state,
+                mode=ctx.auth_mode,
+            )
+        except (ValueError, FabricError) as exc:
+            raise tool_err(exc) from exc
+        return {"created": True, "policy_name": policy_name, "state": state}
+
+    @mutating_tool(mcp, "add_security_predicate")
+    async def add_security_predicate_tool(  # noqa: PLR0913
+        workspace: str,
+        item: str,
+        policy_name: str,
+        predicate_type: str,
+        fn_schema: str,
+        fn_name: str,
+        fn_args: list[str],
+        table_schema: str,
+        table_name: str,
+        operation: str | None = None,
+    ) -> dict[str, Any]:
+        """Add a predicate to an existing row-level security policy.
+
+        Executes ``ALTER SECURITY POLICY ... ADD FILTER|BLOCK PREDICATE``.
+
+        Args:
+            workspace: Workspace name or GUID.
+            item: Warehouse or SQL endpoint name or GUID.
+            policy_name: Qualified policy name (``"schema.name"`` or ``"name"``).
+            predicate_type: ``"FILTER"`` or ``"BLOCK"``.
+            fn_schema: Schema name of the predicate function.
+            fn_name: Name of the predicate function.
+            fn_args: Column names to pass to the predicate function.
+            table_schema: Schema name of the target table.
+            table_name: Name of the target table.
+            operation: Block operation (BLOCK predicates only) -- one of
+                ``"AFTER_INSERT"``, ``"AFTER_UPDATE"``, ``"BEFORE_UPDATE"``,
+                ``"BEFORE_DELETE"``.
+        """
+        ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
+        try:
+            ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
+            _log.debug(
+                "add_security_predicate ws=%s item=%s policy=%r type=%r",
+                ws_id,
+                entry.id,
+                policy_name,
+                predicate_type,
+            )
+            target = make_sql_target(ws_id, entry, item)
+            await _rls_svc.add_predicate(
+                target,
+                policy_name,
+                predicate_type,
+                fn_schema,
+                fn_name,
+                fn_args,
+                table_schema,
+                table_name,
+                operation=operation,
+                mode=ctx.auth_mode,
+            )
+        except (ValueError, FabricError) as exc:
+            raise tool_err(exc) from exc
+        return {
+            "added": True,
+            "policy_name": policy_name,
+            "predicate_type": predicate_type,
+            "table": f"{table_schema}.{table_name}",
+        }
+
+    @mutating_tool(mcp, "drop_security_predicate")
+    async def drop_security_predicate_tool(  # noqa: PLR0913
+        workspace: str,
+        item: str,
+        policy_name: str,
+        predicate_type: str,
+        table_schema: str,
+        table_name: str,
+        operation: str | None = None,
+    ) -> dict[str, Any]:
+        """Drop a predicate from an existing row-level security policy.
+
+        Executes ``ALTER SECURITY POLICY ... DROP FILTER|BLOCK PREDICATE ON``.
+
+        Args:
+            workspace: Workspace name or GUID.
+            item: Warehouse or SQL endpoint name or GUID.
+            policy_name: Qualified policy name (``"schema.name"`` or ``"name"``).
+            predicate_type: ``"FILTER"`` or ``"BLOCK"``.
+            table_schema: Schema name of the target table.
+            table_name: Name of the target table.
+            operation: Block operation (BLOCK predicates only) -- one of
+                ``"AFTER_INSERT"``, ``"AFTER_UPDATE"``, ``"BEFORE_UPDATE"``,
+                ``"BEFORE_DELETE"``.
+        """
+        ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
+        try:
+            ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
+            _log.debug(
+                "drop_security_predicate ws=%s item=%s policy=%r type=%r",
+                ws_id,
+                entry.id,
+                policy_name,
+                predicate_type,
+            )
+            target = make_sql_target(ws_id, entry, item)
+            await _rls_svc.drop_predicate(
+                target,
+                policy_name,
+                predicate_type,
+                table_schema,
+                table_name,
+                operation=operation,
+                mode=ctx.auth_mode,
+            )
+        except (ValueError, FabricError) as exc:
+            raise tool_err(exc) from exc
+        return {
+            "dropped": True,
+            "policy_name": policy_name,
+            "predicate_type": predicate_type,
+            "table": f"{table_schema}.{table_name}",
+        }
+
+    @mutating_tool(mcp, "set_security_policy_state")
+    async def set_security_policy_state_tool(
+        workspace: str,
+        item: str,
+        policy_name: str,
+        enabled: bool,  # noqa: FBT001
+    ) -> dict[str, Any]:
+        """Enable or disable a row-level security policy.
+
+        Executes ``ALTER SECURITY POLICY ... WITH (STATE = ON|OFF)``.
+        Not destructive -- enabling or disabling a policy is reversible.
+
+        Args:
+            workspace: Workspace name or GUID.
+            item: Warehouse or SQL endpoint name or GUID.
+            policy_name: Qualified policy name (``"schema.name"`` or ``"name"``).
+            enabled: ``True`` to enable the policy, ``False`` to disable it.
+        """
+        ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
+        try:
+            ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
+            _log.debug(
+                "set_security_policy_state ws=%s item=%s policy=%r enabled=%r",
+                ws_id,
+                entry.id,
+                policy_name,
+                enabled,
+            )
+            target = make_sql_target(ws_id, entry, item)
+            await _rls_svc.set_policy_state(
+                target, policy_name, enabled=enabled, mode=ctx.auth_mode
+            )
+        except (ValueError, FabricError) as exc:
+            raise tool_err(exc) from exc
+        return {"policy_name": policy_name, "enabled": enabled}
+
+    @mutating_tool(mcp, "drop_security_policy", destructive=True)
+    async def drop_security_policy_tool(
+        workspace: str,
+        item: str,
+        policy_name: str,
+    ) -> dict[str, Any]:
+        """Drop a row-level security policy.
+
+        Executes ``DROP SECURITY POLICY``.  This is a permanently destructive
+        operation -- the policy and all its predicates are removed.
+        Requires ``FABRIC_MCP_ALLOW_DESTRUCTIVE=1``.
+
+        Args:
+            workspace: Workspace name or GUID.
+            item: Warehouse or SQL endpoint name or GUID.
+            policy_name: Qualified policy name (``"schema.name"`` or ``"name"``).
+        """
+        ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
+        try:
+            ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
+            _log.debug(
+                "drop_security_policy ws=%s item=%s policy=%r",
+                ws_id,
+                entry.id,
+                policy_name,
+            )
+            target = make_sql_target(ws_id, entry, item)
+            await _rls_svc.drop_security_policy(target, policy_name, mode=ctx.auth_mode)
+        except (ValueError, FabricError) as exc:
+            raise tool_err(exc) from exc
+        return {"dropped": True, "policy_name": policy_name}

--- a/src/fabric_dw/mcp/tools/permissions.py
+++ b/src/fabric_dw/mcp/tools/permissions.py
@@ -506,11 +506,11 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         item: str,
         policy_name: str,
         predicate_type: str,
-        fn_schema: str,
         fn_name: str,
         fn_args: list[str],
         table_schema: str,
         table_name: str,
+        fn_schema: str | None = None,
         operation: str | None = None,
     ) -> dict[str, Any]:
         """Add a predicate to an existing row-level security policy.
@@ -522,11 +522,12 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             item: Warehouse or SQL endpoint name or GUID.
             policy_name: Qualified policy name (``"schema.name"`` or ``"name"``).
             predicate_type: ``"FILTER"`` or ``"BLOCK"``.
-            fn_schema: Schema name of the predicate function.
             fn_name: Name of the predicate function.
             fn_args: Column names to pass to the predicate function.
             table_schema: Schema name of the target table.
             table_name: Name of the target table.
+            fn_schema: Schema name of the predicate function (optional -- omit
+                when the function lives in the default schema).
             operation: Block operation (BLOCK predicates only) -- one of
                 ``"AFTER_INSERT"``, ``"AFTER_UPDATE"``, ``"BEFORE_UPDATE"``,
                 ``"BEFORE_DELETE"``.
@@ -575,11 +576,11 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         predicate_type: str,
         table_schema: str,
         table_name: str,
-        operation: str | None = None,
     ) -> dict[str, Any]:
         """Drop a predicate from an existing row-level security policy.
 
         Executes ``ALTER SECURITY POLICY ... DROP FILTER|BLOCK PREDICATE ON``.
+        The T-SQL ``DROP PREDICATE ON`` syntax takes no operation qualifier.
 
         Args:
             workspace: Workspace name or GUID.
@@ -588,9 +589,6 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             predicate_type: ``"FILTER"`` or ``"BLOCK"``.
             table_schema: Schema name of the target table.
             table_name: Name of the target table.
-            operation: Block operation (BLOCK predicates only) -- one of
-                ``"AFTER_INSERT"``, ``"AFTER_UPDATE"``, ``"BEFORE_UPDATE"``,
-                ``"BEFORE_DELETE"``.
         """
         ctx = get_context()
         assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
@@ -613,7 +611,6 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
                 predicate_type,
                 table_schema,
                 table_name,
-                operation=operation,
                 mode=ctx.auth_mode,
             )
         except (ValueError, FabricError) as exc:

--- a/src/fabric_dw/models.py
+++ b/src/fabric_dw/models.py
@@ -1081,3 +1081,50 @@ class WarehouseSnapshotApiPayload(_FabricBase):
         ``properties`` dict, or an empty instance if the key is absent.
         """
         return cls.model_validate(as_props(item.get("properties")))
+
+
+# ---------------------------------------------------------------------------
+# Row-level security models
+# ---------------------------------------------------------------------------
+
+
+class SecurityPredicate(_FabricBase):
+    """A single predicate attached to a security policy.
+
+    Sourced from ``sys.security_predicates`` joined to ``sys.security_policies``.
+
+    Attributes:
+        predicate_type: ``FILTER`` or ``BLOCK``.
+        operation: The DML operation for BLOCK predicates as returned by the
+            catalog (e.g. ``AFTER INSERT``, ``BEFORE DELETE``).
+            ``None`` for FILTER predicates.
+        schema_name: Schema of the target table.
+        table_name: Name of the target table.
+        predicate_definition: The full TVF call expression as stored in the
+            catalog (e.g. ``[rls].[fn_filter]([SalesRep])``).
+    """
+
+    predicate_type: str
+    operation: str | None
+    schema_name: str
+    table_name: str
+    predicate_definition: str
+
+
+class SecurityPolicy(_FabricBase):
+    """A security policy with its associated predicates.
+
+    Sourced from ``sys.security_policies`` joined to ``sys.security_predicates``.
+
+    Attributes:
+        policy_schema: Schema in which the policy lives.
+        policy_name: Name of the security policy.
+        is_enabled: Whether the policy is active (STATE = ON).
+        predicates: Ordered list of predicates attached to this policy.
+            Empty when the policy has no predicates.
+    """
+
+    policy_schema: str
+    policy_name: str
+    is_enabled: bool
+    predicates: list[SecurityPredicate]

--- a/src/fabric_dw/services/rls.py
+++ b/src/fabric_dw/services/rls.py
@@ -224,11 +224,18 @@ def _build_predicate_clause(
         table_schema: Schema of the target table.
         table_name: Name of the target table.
         operation: Block operation token (e.g. ``"AFTER_INSERT"``), or
-            ``None`` to omit the operation clause.
+            ``None`` to omit the operation clause.  Must be ``None`` for
+            FILTER predicates.
 
     Returns:
         The ``ADD ... PREDICATE ...`` clause string (no trailing semicolon).
+
+    Raises:
+        ValueError: If a FILTER predicate is given a non-``None`` operation.
     """
+    if predicate_type == "FILTER" and operation is not None:
+        msg = "FILTER predicates do not accept an operation"
+        raise ValueError(msg)
     fn_call = _build_fn_call(fn_schema, fn_name, fn_args)
     validate_identifier(table_schema)
     validate_identifier(table_name)
@@ -282,9 +289,9 @@ async def list_security_policies(
                 raw_op = d["operation_desc"]
                 pred = SecurityPredicate(
                     predicate_type=str(d["predicate_type_desc"]),
-                    operation=str(raw_op) if raw_op is not None else None,
-                    schema_name=str(d["table_schema"]),
-                    table_name=str(d["table_name"]),
+                    operation=raw_op.replace(" ", "_") if raw_op is not None else None,
+                    schema_name=d["table_schema"],
+                    table_name=d["table_name"],
                     predicate_definition=str(d["predicate_definition"]),
                 )
                 predicates_by_key[key].append(pred)
@@ -344,7 +351,13 @@ async def create_security_policy(
     state_sql = "ON" if state else "OFF"
 
     clauses: list[str] = []
-    for spec in predicates:
+    for i, spec in enumerate(predicates):
+        _required = {"predicate_type", "fn_name", "fn_args", "table_schema", "table_name"}
+        _missing = _required - spec.keys()
+        if _missing:
+            missing_list = ", ".join(sorted(_missing))
+            msg = f"Predicate at index {i} is missing required key(s): {missing_list}"
+            raise ValueError(msg)
         ptype = _validate_predicate_type(str(spec["predicate_type"]))
         op = _validate_operation(spec.get("operation"))  # type: ignore[arg-type]
         fn_schema_raw = spec.get("fn_schema")
@@ -424,16 +437,14 @@ async def drop_predicate(
     table_schema: str,
     table_name: str,
     *,
-    operation: str | None = None,
     mode: CredentialMode = CredentialMode.DEFAULT,
 ) -> None:
     """Drop a predicate from an existing security policy.
 
     Executes ``ALTER SECURITY POLICY ... DROP FILTER|BLOCK PREDICATE ON ...``.
 
-    For BLOCK predicates with an operation clause, the operation disambiguates
-    which predicate to remove when multiple BLOCK predicates target the same
-    table.
+    The T-SQL ``DROP { FILTER | BLOCK } PREDICATE ON`` clause takes no
+    operation qualifier -- the operation is not part of the drop syntax.
 
     Args:
         target: SQL connection target.
@@ -441,8 +452,6 @@ async def drop_predicate(
         predicate_type: ``"FILTER"`` or ``"BLOCK"``.
         table_schema: Schema of the target table.
         table_name: Name of the target table.
-        operation: Block operation token (e.g. ``"AFTER_INSERT"``), or
-            ``None`` to drop without an operation clause.
         mode: Credential mode for Entra authentication.
 
     Raises:
@@ -450,14 +459,10 @@ async def drop_predicate(
     """
     policy_ref = _resolve_policy_ref(policy_name)
     ptype = _validate_predicate_type(predicate_type)
-    op = _validate_operation(operation)
     validate_identifier(table_schema)
     validate_identifier(table_name)
     table_ref = f"{quote_identifier(table_schema)}.{quote_identifier(table_name)}"
-    op_clause = f" {_OPERATION_TO_SQL[op]}" if op is not None else ""
-    ddl = (
-        f"ALTER SECURITY POLICY {policy_ref}\n    DROP {ptype} PREDICATE ON {table_ref}{op_clause};"
-    )
+    ddl = f"ALTER SECURITY POLICY {policy_ref}\n    DROP {ptype} PREDICATE ON {table_ref};"
 
     def _run() -> None:
         run_query(target, ddl, mode=mode, autocommit=True, fetch="none")

--- a/src/fabric_dw/services/rls.py
+++ b/src/fabric_dw/services/rls.py
@@ -1,0 +1,525 @@
+"""Row-level security service functions for Microsoft Fabric Data Warehouses.
+
+Reads from ``sys.security_policies`` / ``sys.security_predicates`` and issues
+``CREATE SECURITY POLICY``, ``ALTER SECURITY POLICY``, and
+``DROP SECURITY POLICY`` statements.
+
+Statement-building safety
+--------------------------
+All statements are built from:
+- Validated, bracket-quoted identifiers via
+  :func:`~fabric_dw.identifiers.validate_identifier` +
+  :func:`~fabric_dw.identifiers.quote_identifier`.
+- Column names for predicate function arguments validated via
+  :func:`~fabric_dw.identifiers.validate_column_name` +
+  :func:`~fabric_dw.identifiers.quote_identifier`.
+- Fixed allowlists for predicate type (``FILTER`` / ``BLOCK``) and
+  block operation (``AFTER_INSERT`` / ``AFTER_UPDATE`` / ``BEFORE_UPDATE`` /
+  ``BEFORE_DELETE``).
+
+No SQL text is ever parsed or rewritten.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections import defaultdict
+from typing import Any
+
+from fabric_dw.auth import CredentialMode
+from fabric_dw.identifiers import (
+    parse_qualified_name,
+    quote_identifier,
+    validate_column_name,
+    validate_identifier,
+)
+from fabric_dw.models import SecurityPolicy, SecurityPredicate
+from fabric_dw.sql import SqlTarget, run_query
+
+__all__ = [
+    "VALID_BLOCK_OPERATIONS",
+    "VALID_PREDICATE_TYPES",
+    "add_predicate",
+    "create_security_policy",
+    "drop_predicate",
+    "drop_security_policy",
+    "list_security_policies",
+    "set_policy_state",
+]
+
+# ---------------------------------------------------------------------------
+# Allowlists
+# ---------------------------------------------------------------------------
+
+#: Valid predicate type tokens (uppercase).
+VALID_PREDICATE_TYPES: frozenset[str] = frozenset({"FILTER", "BLOCK"})
+
+#: Valid block operation tokens (uppercase, underscore-separated).
+VALID_BLOCK_OPERATIONS: frozenset[str] = frozenset(
+    {"AFTER_INSERT", "AFTER_UPDATE", "BEFORE_UPDATE", "BEFORE_DELETE"}
+)
+
+#: Maps internal operation token to SQL clause fragment.
+_OPERATION_TO_SQL: dict[str, str] = {
+    "AFTER_INSERT": "AFTER INSERT",
+    "AFTER_UPDATE": "AFTER UPDATE",
+    "BEFORE_UPDATE": "BEFORE UPDATE",
+    "BEFORE_DELETE": "BEFORE DELETE",
+}
+
+# ---------------------------------------------------------------------------
+# SQL templates (read)
+# ---------------------------------------------------------------------------
+
+_LIST_POLICIES_SQL = """\
+SELECT
+    sp.name AS policy_name,
+    ss.name AS policy_schema,
+    sp.is_enabled,
+    pred.predicate_type_desc,
+    pred.predicate_definition,
+    pred.operation_desc,
+    OBJECT_SCHEMA_NAME(pred.target_object_id) AS table_schema,
+    OBJECT_NAME(pred.target_object_id) AS table_name
+FROM sys.security_policies AS sp
+JOIN sys.schemas AS ss ON sp.schema_id = ss.schema_id
+LEFT JOIN sys.security_predicates AS pred ON pred.object_id = sp.object_id
+ORDER BY sp.name, pred.predicate_type_desc;
+"""
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+def _validate_predicate_type(predicate_type: str) -> str:
+    """Validate and uppercase the predicate type.
+
+    Args:
+        predicate_type: Raw predicate type string (case-insensitive).
+
+    Returns:
+        The uppercase token -- ``"FILTER"`` or ``"BLOCK"``.
+
+    Raises:
+        ValueError: If *predicate_type* is not ``FILTER`` or ``BLOCK``.
+    """
+    upper = predicate_type.upper()
+    if upper not in VALID_PREDICATE_TYPES:
+        msg = (
+            f"Invalid predicate type {predicate_type!r}: "
+            f"must be one of {', '.join(sorted(VALID_PREDICATE_TYPES))}"
+        )
+        raise ValueError(msg)
+    return upper
+
+
+def _validate_operation(operation: str | None) -> str | None:
+    """Validate and normalise a block predicate operation token.
+
+    Accepts tokens with underscores (``AFTER_INSERT``) or spaces
+    (``AFTER INSERT``), case-insensitively, and returns the canonical
+    underscore form.  Returns ``None`` when *operation* is ``None``.
+
+    Args:
+        operation: Operation token or ``None`` for no restriction.
+
+    Returns:
+        Normalised uppercase token (e.g. ``"AFTER_INSERT"``) or ``None``.
+
+    Raises:
+        ValueError: If *operation* is not in :data:`VALID_BLOCK_OPERATIONS`.
+    """
+    if operation is None:
+        return None
+    # Normalise spaces or hyphens to underscores before checking.
+    upper = operation.upper().replace(" ", "_").replace("-", "_")
+    if upper not in VALID_BLOCK_OPERATIONS:
+        msg = (
+            f"Invalid block operation {operation!r}: "
+            f"must be one of {', '.join(sorted(VALID_BLOCK_OPERATIONS))}"
+        )
+        raise ValueError(msg)
+    return upper
+
+
+def _resolve_policy_ref(policy_name: str) -> str:
+    """Return a bracket-quoted policy reference for use in DDL.
+
+    Accepts ``"schema.name"`` (two-part) or ``"name"`` (bare name).
+    Both parts are validated via :func:`validate_identifier`.
+
+    Args:
+        policy_name: The policy name, optionally schema-qualified.
+
+    Returns:
+        A bracket-quoted string, e.g. ``"[rls].[MySalesFilter]"`` or
+        ``"[MySalesFilter]"``.
+
+    Raises:
+        ValueError: If any identifier part is invalid.
+    """
+    if "." in policy_name:
+        schema, name = parse_qualified_name(policy_name, "policy")
+        validate_identifier(schema)
+        validate_identifier(name)
+        return f"{quote_identifier(schema)}.{quote_identifier(name)}"
+    validate_identifier(policy_name)
+    return quote_identifier(policy_name)
+
+
+def _build_fn_call(
+    fn_schema: str | None,
+    fn_name: str,
+    fn_args: list[str],
+) -> str:
+    """Build a bracket-quoted predicate function call expression.
+
+    Produces ``[fn_schema].[fn_name]([col1], [col2])`` or
+    ``[fn_name]([col1], [col2])`` when *fn_schema* is ``None`` or empty.
+
+    Args:
+        fn_schema: Schema of the predicate function, or ``None`` / ``""``
+            when not schema-qualified.
+        fn_name: Name of the predicate function.
+        fn_args: Column names passed to the function.  Each is validated via
+            :func:`validate_column_name` and bracket-quoted.
+
+    Returns:
+        The complete function call expression.
+
+    Raises:
+        ValueError: If any identifier or column name is invalid, or if
+            *fn_args* is empty.
+    """
+    if not fn_args:
+        msg = "Predicate function must have at least one column argument"
+        raise ValueError(msg)
+    validate_identifier(fn_name)
+    for col in fn_args:
+        validate_column_name(col)
+    cols_sql = ", ".join(quote_identifier(c) for c in fn_args)
+    if fn_schema:
+        validate_identifier(fn_schema)
+        return f"{quote_identifier(fn_schema)}.{quote_identifier(fn_name)}({cols_sql})"
+    return f"{quote_identifier(fn_name)}({cols_sql})"
+
+
+def _build_predicate_clause(
+    predicate_type: str,
+    fn_schema: str | None,
+    fn_name: str,
+    fn_args: list[str],
+    table_schema: str,
+    table_name: str,
+    operation: str | None,
+) -> str:
+    """Build one ``ADD FILTER|BLOCK PREDICATE fn(...) ON table [OP]`` clause.
+
+    Args:
+        predicate_type: ``"FILTER"`` or ``"BLOCK"`` (already validated).
+        fn_schema: Schema of the predicate function (may be ``None``).
+        fn_name: Name of the predicate function.
+        fn_args: Column name arguments for the predicate function.
+        table_schema: Schema of the target table.
+        table_name: Name of the target table.
+        operation: Block operation token (e.g. ``"AFTER_INSERT"``), or
+            ``None`` to omit the operation clause.
+
+    Returns:
+        The ``ADD ... PREDICATE ...`` clause string (no trailing semicolon).
+    """
+    fn_call = _build_fn_call(fn_schema, fn_name, fn_args)
+    validate_identifier(table_schema)
+    validate_identifier(table_name)
+    table_ref = f"{quote_identifier(table_schema)}.{quote_identifier(table_name)}"
+    clause = f"ADD {predicate_type} PREDICATE {fn_call} ON {table_ref}"
+    if predicate_type == "BLOCK" and operation is not None:
+        clause += f" {_OPERATION_TO_SQL[operation]}"
+    return clause
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+async def list_security_policies(
+    target: SqlTarget,
+    *,
+    mode: CredentialMode = CredentialMode.DEFAULT,
+) -> list[SecurityPolicy]:
+    """Return all security policies with their predicates.
+
+    Reads from ``sys.security_policies`` joined to ``sys.security_predicates``.
+    Policies with no predicates are returned with an empty ``predicates`` list.
+
+    Args:
+        target: SQL connection target.
+        mode: Credential mode for Entra authentication.
+
+    Returns:
+        List of :class:`~fabric_dw.models.SecurityPolicy` objects.
+    """
+
+    def _run() -> list[SecurityPolicy]:
+        cols, rows = run_query(target, _LIST_POLICIES_SQL, mode=mode)
+
+        # Preserve insertion order (Python 3.7+ dict guarantee).
+        policy_meta: dict[tuple[str, str], tuple[str, str, bool]] = {}
+        predicates_by_key: dict[tuple[str, str], list[SecurityPredicate]] = defaultdict(list)
+
+        for row in rows:
+            d = dict(zip(cols, row, strict=True))
+            p_schema = str(d["policy_schema"])
+            p_name = str(d["policy_name"])
+            key = (p_schema, p_name)
+
+            if key not in policy_meta:
+                policy_meta[key] = (p_schema, p_name, bool(d["is_enabled"]))
+
+            if d["predicate_type_desc"] is not None:
+                raw_op = d["operation_desc"]
+                pred = SecurityPredicate(
+                    predicate_type=str(d["predicate_type_desc"]),
+                    operation=str(raw_op) if raw_op is not None else None,
+                    schema_name=str(d["table_schema"]),
+                    table_name=str(d["table_name"]),
+                    predicate_definition=str(d["predicate_definition"]),
+                )
+                predicates_by_key[key].append(pred)
+
+        return [
+            SecurityPolicy(
+                policy_schema=schema,
+                policy_name=name,
+                is_enabled=is_enabled,
+                predicates=predicates_by_key[key],
+            )
+            for key, (schema, name, is_enabled) in policy_meta.items()
+        ]
+
+    return await asyncio.to_thread(_run)
+
+
+async def create_security_policy(
+    target: SqlTarget,
+    policy_name: str,
+    predicates: list[dict[str, Any]],
+    *,
+    state: bool = True,
+    mode: CredentialMode = CredentialMode.DEFAULT,
+) -> None:
+    """Create a security policy with one or more predicates.
+
+    Executes ``CREATE SECURITY POLICY ... ADD FILTER|BLOCK PREDICATE ...``.
+
+    Each element of *predicates* must be a dict with keys:
+
+    - ``predicate_type``: ``"FILTER"`` or ``"BLOCK"``
+    - ``fn_schema``: schema of the predicate function (``str`` or ``None``)
+    - ``fn_name``: name of the predicate function
+    - ``fn_args``: list of column name strings
+    - ``table_schema``: schema of the target table
+    - ``table_name``: name of the target table
+    - ``operation``: block operation token (``None`` for FILTER or unspecified)
+
+    Args:
+        target: SQL connection target.
+        policy_name: Security policy name, optionally schema-qualified
+            (e.g. ``"rls.MySalesFilter"`` or ``"MySalesFilter"``).
+        predicates: Non-empty list of predicate specification dicts.
+        state: Initial policy state -- ``True`` for ``ON`` (default),
+            ``False`` for ``OFF``.
+        mode: Credential mode for Entra authentication.
+
+    Raises:
+        ValueError: If *predicates* is empty or any spec is invalid.
+    """
+    if not predicates:
+        msg = "At least one predicate is required to create a security policy"
+        raise ValueError(msg)
+
+    policy_ref = _resolve_policy_ref(policy_name)
+    state_sql = "ON" if state else "OFF"
+
+    clauses: list[str] = []
+    for spec in predicates:
+        ptype = _validate_predicate_type(str(spec["predicate_type"]))
+        op = _validate_operation(spec.get("operation"))  # type: ignore[arg-type]
+        fn_schema_raw = spec.get("fn_schema")
+        fn_schema = str(fn_schema_raw) if fn_schema_raw else None
+        fn_name = str(spec["fn_name"])
+        fn_args = [str(a) for a in spec["fn_args"]]
+        table_schema = str(spec["table_schema"])
+        table_name = str(spec["table_name"])
+        clauses.append(
+            _build_predicate_clause(
+                ptype, fn_schema, fn_name, fn_args, table_schema, table_name, op
+            )
+        )
+
+    predicate_sql = ",\n    ".join(clauses)
+    ddl = (
+        f"CREATE SECURITY POLICY {policy_ref}\n    {predicate_sql}\n    WITH (STATE = {state_sql});"
+    )
+
+    def _run() -> None:
+        run_query(target, ddl, mode=mode, autocommit=True, fetch="none")
+
+    await asyncio.to_thread(_run)
+
+
+async def add_predicate(
+    target: SqlTarget,
+    policy_name: str,
+    predicate_type: str,
+    fn_schema: str | None,
+    fn_name: str,
+    fn_args: list[str],
+    table_schema: str,
+    table_name: str,
+    *,
+    operation: str | None = None,
+    mode: CredentialMode = CredentialMode.DEFAULT,
+) -> None:
+    """Add a predicate to an existing security policy.
+
+    Executes ``ALTER SECURITY POLICY ... ADD FILTER|BLOCK PREDICATE ...``.
+
+    Args:
+        target: SQL connection target.
+        policy_name: Security policy name (optionally schema-qualified).
+        predicate_type: ``"FILTER"`` or ``"BLOCK"``.
+        fn_schema: Schema of the predicate function, or ``None``.
+        fn_name: Name of the predicate function.
+        fn_args: Column name arguments for the predicate function.
+        table_schema: Schema of the target table.
+        table_name: Name of the target table.
+        operation: Block operation token (e.g. ``"AFTER_INSERT"``), or
+            ``None`` to omit the operation clause.
+        mode: Credential mode for Entra authentication.
+
+    Raises:
+        ValueError: If any identifier or argument is invalid.
+    """
+    policy_ref = _resolve_policy_ref(policy_name)
+    ptype = _validate_predicate_type(predicate_type)
+    op = _validate_operation(operation)
+    clause = _build_predicate_clause(
+        ptype, fn_schema, fn_name, fn_args, table_schema, table_name, op
+    )
+    ddl = f"ALTER SECURITY POLICY {policy_ref}\n    {clause};"
+
+    def _run() -> None:
+        run_query(target, ddl, mode=mode, autocommit=True, fetch="none")
+
+    await asyncio.to_thread(_run)
+
+
+async def drop_predicate(
+    target: SqlTarget,
+    policy_name: str,
+    predicate_type: str,
+    table_schema: str,
+    table_name: str,
+    *,
+    operation: str | None = None,
+    mode: CredentialMode = CredentialMode.DEFAULT,
+) -> None:
+    """Drop a predicate from an existing security policy.
+
+    Executes ``ALTER SECURITY POLICY ... DROP FILTER|BLOCK PREDICATE ON ...``.
+
+    For BLOCK predicates with an operation clause, the operation disambiguates
+    which predicate to remove when multiple BLOCK predicates target the same
+    table.
+
+    Args:
+        target: SQL connection target.
+        policy_name: Security policy name (optionally schema-qualified).
+        predicate_type: ``"FILTER"`` or ``"BLOCK"``.
+        table_schema: Schema of the target table.
+        table_name: Name of the target table.
+        operation: Block operation token (e.g. ``"AFTER_INSERT"``), or
+            ``None`` to drop without an operation clause.
+        mode: Credential mode for Entra authentication.
+
+    Raises:
+        ValueError: If any identifier is invalid.
+    """
+    policy_ref = _resolve_policy_ref(policy_name)
+    ptype = _validate_predicate_type(predicate_type)
+    op = _validate_operation(operation)
+    validate_identifier(table_schema)
+    validate_identifier(table_name)
+    table_ref = f"{quote_identifier(table_schema)}.{quote_identifier(table_name)}"
+    op_clause = f" {_OPERATION_TO_SQL[op]}" if op is not None else ""
+    ddl = (
+        f"ALTER SECURITY POLICY {policy_ref}\n    DROP {ptype} PREDICATE ON {table_ref}{op_clause};"
+    )
+
+    def _run() -> None:
+        run_query(target, ddl, mode=mode, autocommit=True, fetch="none")
+
+    await asyncio.to_thread(_run)
+
+
+async def set_policy_state(
+    target: SqlTarget,
+    policy_name: str,
+    *,
+    enabled: bool,
+    mode: CredentialMode = CredentialMode.DEFAULT,
+) -> None:
+    """Enable or disable a security policy.
+
+    Executes ``ALTER SECURITY POLICY ... WITH (STATE = ON|OFF)``.
+
+    Args:
+        target: SQL connection target.
+        policy_name: Security policy name (optionally schema-qualified).
+        enabled: ``True`` to enable (STATE = ON), ``False`` to disable.
+        mode: Credential mode for Entra authentication.
+
+    Raises:
+        ValueError: If the policy name is invalid.
+    """
+    policy_ref = _resolve_policy_ref(policy_name)
+    state_sql = "ON" if enabled else "OFF"
+    ddl = f"ALTER SECURITY POLICY {policy_ref} WITH (STATE = {state_sql});"
+
+    def _run() -> None:
+        run_query(target, ddl, mode=mode, autocommit=True, fetch="none")
+
+    await asyncio.to_thread(_run)
+
+
+async def drop_security_policy(
+    target: SqlTarget,
+    policy_name: str,
+    *,
+    mode: CredentialMode = CredentialMode.DEFAULT,
+) -> None:
+    """Drop a security policy.
+
+    Executes ``DROP SECURITY POLICY [schema].[name]``.
+
+    This is a destructive operation: the policy and all its predicates are
+    removed permanently.
+
+    Args:
+        target: SQL connection target.
+        policy_name: Security policy name (optionally schema-qualified).
+        mode: Credential mode for Entra authentication.
+
+    Raises:
+        ValueError: If the policy name is invalid.
+    """
+    policy_ref = _resolve_policy_ref(policy_name)
+    ddl = f"DROP SECURITY POLICY {policy_ref};"
+
+    def _run() -> None:
+        run_query(target, ddl, mode=mode, autocommit=True, fetch="none")
+
+    await asyncio.to_thread(_run)

--- a/src/fabric_dw/telemetry_commands.py
+++ b/src/fabric_dw/telemetry_commands.py
@@ -91,6 +91,13 @@ DOMAIN_MAP: dict[str, str] = {
     "grant_permission": "permissions",
     "deny_permission": "permissions",
     "revoke_permission": "permissions",
+    # RLS
+    "list_security_policies": "permissions",
+    "create_security_policy": "permissions",
+    "add_security_predicate": "permissions",
+    "drop_security_predicate": "permissions",
+    "set_security_policy_state": "permissions",
+    "drop_security_policy": "permissions",
     # Audit
     "get_audit_settings": "audit",
     "enable_audit": "audit",

--- a/tests/integration/test_services_rls.py
+++ b/tests/integration/test_services_rls.py
@@ -1,0 +1,219 @@
+"""Integration tests for row-level security service functions.
+
+Run with: pytest -m integration tests/integration/test_services_rls.py
+
+Covers the create -> list -> set-state -> add-predicate -> drop-predicate -> drop
+round-trip for security policies.
+
+Each test run creates a minimal TVF inline, uses it for the test, then drops it
+in teardown -- making the suite hermetic without requiring a pre-existing TVF.
+
+Data Warehouse only: CREATE FUNCTION / CREATE SECURITY POLICY require
+db_ddladmin or higher.  The shared warm warehouse grants this to the test
+service principal; the SQL analytics endpoint does not.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import uuid
+from collections.abc import AsyncIterator
+
+import pytest
+import pytest_asyncio
+
+from fabric_dw.services import rls as rls_svc
+from fabric_dw.sql import SqlTarget, run_query
+
+pytestmark = pytest.mark.integration
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _unique_policy_name() -> str:
+    """Return a short, collision-resistant policy name safe for Fabric DDL."""
+    return f"pytest_pol_{uuid.uuid4().hex[:8]}"
+
+
+def _unique_fn_name() -> str:
+    """Return a short, collision-resistant function name safe for Fabric DDL."""
+    return f"pytest_rls_fn_{uuid.uuid4().hex[:8]}"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def rls_schema_and_fn(
+    warehouse_schema: tuple[SqlTarget, str],
+) -> AsyncIterator[tuple[SqlTarget, str, str]]:
+    """Create a minimal predicate TVF and drop it in teardown.
+
+    Yields ``(sql_target, schema_name, fn_name)``.
+
+    The TVF signature matches what RLS predicates require:
+    ``RETURNS TABLE WITH SCHEMABINDING AS RETURN SELECT 1 AS authorized WHERE ...``.
+
+    Teardown suppresses exceptions so a missing function (e.g. from a failed
+    CREATE) does not mask the original test error.
+    """
+    sql_target, schema_name = warehouse_schema
+    fn_name = _unique_fn_name()
+
+    await asyncio.to_thread(
+        run_query,
+        sql_target,
+        (
+            f"CREATE FUNCTION [{schema_name}].[{fn_name}](@user_id INT) "
+            "RETURNS TABLE WITH SCHEMABINDING "
+            "AS RETURN SELECT 1 AS authorized WHERE @user_id > 0;"
+        ),
+        autocommit=True,
+        fetch="none",
+    )
+    try:
+        yield sql_target, schema_name, fn_name
+    finally:
+        with contextlib.suppress(Exception):
+            await asyncio.to_thread(
+                run_query,
+                sql_target,
+                f"DROP FUNCTION [{schema_name}].[{fn_name}];",
+                autocommit=True,
+                fetch="none",
+            )
+
+
+@pytest_asyncio.fixture
+async def rls_policy_fixture(
+    rls_schema_and_fn: tuple[SqlTarget, str, str],
+) -> AsyncIterator[tuple[SqlTarget, str, str, str, str]]:
+    """Create a security policy and drop it in teardown.
+
+    Yields ``(sql_target, schema_name, fn_name, table_schema, policy_name)``.
+
+    Uses a system table (``sys.objects``) as the target because it always
+    exists -- no test table needs to be created.
+
+    Note: Some Fabric capacity SKUs do not support RLS.  The fixture skips
+    the test module if CREATE SECURITY POLICY fails with a not-supported error.
+    """
+    sql_target, schema_name, fn_name = rls_schema_and_fn
+    policy_name = _unique_policy_name()
+    # Use an existing system-accessible table so we do not need to create one.
+    # sys.objects is always present in every Fabric warehouse.
+    target_table_schema = "sys"
+    target_table_name = "objects"
+
+    try:
+        await rls_svc.create_security_policy(
+            sql_target,
+            f"{schema_name}.{policy_name}",
+            [
+                {
+                    "predicate_type": "FILTER",
+                    "fn_schema": schema_name,
+                    "fn_name": fn_name,
+                    "fn_args": ["object_id"],
+                    "table_schema": target_table_schema,
+                    "table_name": target_table_name,
+                }
+            ],
+            state=False,
+        )
+    except Exception as exc:
+        err_str = str(exc).lower()
+        if "not supported" in err_str or "does not support" in err_str:
+            pytest.skip(f"RLS is not supported on this endpoint: {exc}")
+        raise
+
+    try:
+        yield sql_target, schema_name, fn_name, target_table_schema, policy_name
+    finally:
+        with contextlib.suppress(Exception):
+            await rls_svc.drop_security_policy(sql_target, f"{schema_name}.{policy_name}")
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+async def test_create_and_list_security_policy(
+    rls_policy_fixture: tuple[SqlTarget, str, str, str, str],
+) -> None:
+    """A freshly created policy appears in list_security_policies."""
+    sql_target, _schema_name, _fn_name, _target_table_schema, policy_name = rls_policy_fixture
+
+    policies = await rls_svc.list_security_policies(sql_target)
+    names = [p.policy_name for p in policies]
+    assert policy_name in names, f"Policy {policy_name!r} not found in list. Found: {names}"
+
+
+async def test_set_policy_state_enable(
+    rls_policy_fixture: tuple[SqlTarget, str, str, str, str],
+) -> None:
+    """set_policy_state toggles the policy between enabled and disabled."""
+    sql_target, schema_name, _fn_name, _table_schema, policy_name = rls_policy_fixture
+    qualified = f"{schema_name}.{policy_name}"
+
+    # Policy was created disabled (state=False); enable it.
+    await rls_svc.set_policy_state(sql_target, qualified, enabled=True)
+
+    policies = await rls_svc.list_security_policies(sql_target)
+    pol = next((p for p in policies if p.policy_name == policy_name), None)
+    assert pol is not None
+    assert pol.is_enabled is True
+
+    # Disable again.
+    await rls_svc.set_policy_state(sql_target, qualified, enabled=False)
+
+    policies = await rls_svc.list_security_policies(sql_target)
+    pol = next((p for p in policies if p.policy_name == policy_name), None)
+    assert pol is not None
+    assert pol.is_enabled is False
+
+
+async def test_drop_security_policy(
+    rls_schema_and_fn: tuple[SqlTarget, str, str],
+) -> None:
+    """drop_security_policy removes the policy so it no longer appears in list."""
+    sql_target, schema_name, fn_name = rls_schema_and_fn
+    policy_name = _unique_policy_name()
+    qualified = f"{schema_name}.{policy_name}"
+
+    try:
+        await rls_svc.create_security_policy(
+            sql_target,
+            qualified,
+            [
+                {
+                    "predicate_type": "FILTER",
+                    "fn_schema": schema_name,
+                    "fn_name": fn_name,
+                    "fn_args": ["object_id"],
+                    "table_schema": "sys",
+                    "table_name": "objects",
+                }
+            ],
+            state=False,
+        )
+    except Exception as exc:
+        err_str = str(exc).lower()
+        if "not supported" in err_str or "does not support" in err_str:
+            pytest.skip(f"RLS is not supported on this endpoint: {exc}")
+        raise
+
+    await rls_svc.drop_security_policy(sql_target, qualified)
+
+    policies = await rls_svc.list_security_policies(sql_target)
+    names = [p.policy_name for p in policies]
+    assert policy_name not in names, (
+        f"Policy {policy_name!r} still present after drop. Found: {names}"
+    )

--- a/tests/unit/cli/commands/test_permissions_rls.py
+++ b/tests/unit/cli/commands/test_permissions_rls.py
@@ -1,0 +1,490 @@
+"""Unit tests for permissions rls CLI sub-commands."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+from uuid import UUID
+
+from click.testing import CliRunner
+
+from fabric_dw.cache import ItemEntry
+from fabric_dw.cli._main import cli
+from fabric_dw.models import SecurityPolicy, SecurityPredicate, WarehouseKind
+from fabric_dw.sql import SqlTarget
+
+WS_GUID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+WH_GUID = "d4e5f6a7-b8c9-0123-def0-123456789abc"
+WS_UUID = UUID(WS_GUID)
+WH_UUID = UUID(WH_GUID)
+
+
+def _make_http_cm(http: object) -> object:
+    @asynccontextmanager
+    async def _cm(_ctx: object) -> AsyncIterator[object]:
+        yield http
+
+    return _cm
+
+
+def _make_sql_target() -> SqlTarget:
+    return SqlTarget(
+        workspace_id=WS_GUID,
+        database="SalesWarehouse",
+        connection_string="wh.datawarehouse.fabric.microsoft.com",
+    )
+
+
+def _make_wh_entry() -> ItemEntry:
+    return ItemEntry(
+        id=WH_UUID,
+        kind=WarehouseKind.WAREHOUSE,
+        connection_string="wh.datawarehouse.fabric.microsoft.com",
+        fetched_at=datetime.now(tz=UTC),
+        display_name="SalesWarehouse",
+    )
+
+
+def _make_security_policy() -> SecurityPolicy:
+    pred = SecurityPredicate(
+        predicate_type="FILTER",
+        operation=None,
+        schema_name="dbo",
+        table_name="Sales",
+        predicate_definition="[rls].[fn_filter]([SalesRep])",
+    )
+    return SecurityPolicy(
+        policy_schema="rls",
+        policy_name="SalesFilter",
+        is_enabled=True,
+        predicates=[pred],
+    )
+
+
+# ---------------------------------------------------------------------------
+# permissions rls list
+# ---------------------------------------------------------------------------
+
+
+class TestRlsList:
+    def test_list_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        with (
+            patch(
+                "fabric_dw.cli.commands.permissions.build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.permissions.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_wh_entry())),
+            ),
+            patch(
+                "fabric_dw.services.rls.list_security_policies",
+                new=AsyncMock(return_value=[_make_security_policy()]),
+            ),
+        ):
+            result = runner.invoke(cli, ["-w", WS_GUID, "permissions", "rls", "list", WH_GUID])
+        assert result.exit_code == 0, result.output
+
+    def test_list_empty_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        with (
+            patch(
+                "fabric_dw.cli.commands.permissions.build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.permissions.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_wh_entry())),
+            ),
+            patch(
+                "fabric_dw.services.rls.list_security_policies",
+                new=AsyncMock(return_value=[]),
+            ),
+        ):
+            result = runner.invoke(cli, ["-w", WS_GUID, "permissions", "rls", "list", WH_GUID])
+        assert result.exit_code == 0, result.output
+
+
+# ---------------------------------------------------------------------------
+# permissions rls create
+# ---------------------------------------------------------------------------
+
+
+class TestRlsCreate:
+    def test_create_filter_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_svc = AsyncMock(return_value=None)
+        with (
+            patch(
+                "fabric_dw.cli.commands.permissions.build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.permissions.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_wh_entry())),
+            ),
+            patch("fabric_dw.services.rls.create_security_policy", new=mock_svc),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "-w",
+                    WS_GUID,
+                    "permissions",
+                    "rls",
+                    "create",
+                    WH_GUID,
+                    "rls.SalesFilter",
+                    "--filter",
+                    "rls.fn_filter(SalesRep)",
+                    "--on",
+                    "dbo.Sales",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+
+    def test_create_block_with_operation(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_svc = AsyncMock(return_value=None)
+        with (
+            patch(
+                "fabric_dw.cli.commands.permissions.build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.permissions.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_wh_entry())),
+            ),
+            patch("fabric_dw.services.rls.create_security_policy", new=mock_svc),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "-w",
+                    WS_GUID,
+                    "permissions",
+                    "rls",
+                    "create",
+                    WH_GUID,
+                    "rls.SalesBlock",
+                    "--block",
+                    "rls.fn_block(SalesRep)",
+                    "--on",
+                    "dbo.Sales",
+                    "--operation",
+                    "after-insert",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        _, kwargs = mock_svc.call_args
+        assert kwargs["state"] is True
+        preds = mock_svc.call_args.args[2]
+        assert preds[0]["operation"] == "AFTER_INSERT"
+
+    def test_create_both_filter_and_block_fails(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        result = runner.invoke(
+            cli,
+            [
+                "-w",
+                WS_GUID,
+                "permissions",
+                "rls",
+                "create",
+                WH_GUID,
+                "rls.Policy",
+                "--filter",
+                "rls.fn(col)",
+                "--block",
+                "rls.fn(col)",
+                "--on",
+                "dbo.T",
+            ],
+        )
+        assert result.exit_code != 0
+
+    def test_create_neither_filter_nor_block_fails(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        _ = cache_env
+        result = runner.invoke(
+            cli,
+            [
+                "-w",
+                WS_GUID,
+                "permissions",
+                "rls",
+                "create",
+                WH_GUID,
+                "rls.Policy",
+                "--on",
+                "dbo.T",
+            ],
+        )
+        assert result.exit_code != 0
+
+    def test_create_state_off(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_svc = AsyncMock(return_value=None)
+        with (
+            patch(
+                "fabric_dw.cli.commands.permissions.build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.permissions.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_wh_entry())),
+            ),
+            patch("fabric_dw.services.rls.create_security_policy", new=mock_svc),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "-w",
+                    WS_GUID,
+                    "permissions",
+                    "rls",
+                    "create",
+                    WH_GUID,
+                    "rls.P",
+                    "--filter",
+                    "rls.fn(col)",
+                    "--on",
+                    "dbo.T",
+                    "--state",
+                    "off",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        _, kwargs = mock_svc.call_args
+        assert kwargs["state"] is False
+
+
+# ---------------------------------------------------------------------------
+# permissions rls add-predicate
+# ---------------------------------------------------------------------------
+
+
+class TestRlsAddPredicate:
+    def test_add_filter_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_svc = AsyncMock(return_value=None)
+        with (
+            patch(
+                "fabric_dw.cli.commands.permissions.build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.permissions.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_wh_entry())),
+            ),
+            patch("fabric_dw.services.rls.add_predicate", new=mock_svc),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "-w",
+                    WS_GUID,
+                    "permissions",
+                    "rls",
+                    "add-predicate",
+                    WH_GUID,
+                    "rls.SalesFilter",
+                    "--filter",
+                    "rls.fn_filter(col)",
+                    "--on",
+                    "dbo.Sales",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+
+
+# ---------------------------------------------------------------------------
+# permissions rls drop-predicate
+# ---------------------------------------------------------------------------
+
+
+class TestRlsDropPredicate:
+    def test_drop_filter_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_svc = AsyncMock(return_value=None)
+        with (
+            patch(
+                "fabric_dw.cli.commands.permissions.build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.permissions.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_wh_entry())),
+            ),
+            patch("fabric_dw.services.rls.drop_predicate", new=mock_svc),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "-w",
+                    WS_GUID,
+                    "permissions",
+                    "rls",
+                    "drop-predicate",
+                    WH_GUID,
+                    "rls.SalesFilter",
+                    "--filter",
+                    "--on",
+                    "dbo.Sales",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+
+    def test_drop_both_flags_fails(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        result = runner.invoke(
+            cli,
+            [
+                "-w",
+                WS_GUID,
+                "permissions",
+                "rls",
+                "drop-predicate",
+                WH_GUID,
+                "rls.P",
+                "--filter",
+                "--block",
+                "--on",
+                "dbo.T",
+            ],
+        )
+        assert result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# permissions rls set-state
+# ---------------------------------------------------------------------------
+
+
+class TestRlsSetState:
+    def test_enable_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_svc = AsyncMock(return_value=None)
+        with (
+            patch(
+                "fabric_dw.cli.commands.permissions.build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.permissions.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_wh_entry())),
+            ),
+            patch("fabric_dw.services.rls.set_policy_state", new=mock_svc),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "-w",
+                    WS_GUID,
+                    "permissions",
+                    "rls",
+                    "set-state",
+                    WH_GUID,
+                    "rls.SalesFilter",
+                    "--enable",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        _, kwargs = mock_svc.call_args
+        assert kwargs["enabled"] is True
+
+    def test_disable_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_svc = AsyncMock(return_value=None)
+        with (
+            patch(
+                "fabric_dw.cli.commands.permissions.build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.permissions.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_wh_entry())),
+            ),
+            patch("fabric_dw.services.rls.set_policy_state", new=mock_svc),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "-w",
+                    WS_GUID,
+                    "permissions",
+                    "rls",
+                    "set-state",
+                    WH_GUID,
+                    "rls.SalesFilter",
+                    "--disable",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        _, kwargs = mock_svc.call_args
+        assert kwargs["enabled"] is False
+
+
+# ---------------------------------------------------------------------------
+# permissions rls drop (destructive)
+# ---------------------------------------------------------------------------
+
+
+class TestRlsDrop:
+    def test_drop_aborted_without_yes(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        result = runner.invoke(
+            cli,
+            [
+                "-w",
+                WS_GUID,
+                "permissions",
+                "rls",
+                "drop",
+                WH_GUID,
+                "rls.SalesFilter",
+            ],
+        )
+        # Aborted without confirmation -- Click Abort -> exit_code 1
+        assert result.exit_code != 0
+        assert "Aborted" in result.output
+
+    def test_drop_with_yes_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_svc = AsyncMock(return_value=None)
+        with (
+            patch(
+                "fabric_dw.cli.commands.permissions.build_http_client",
+                new=_make_http_cm(AsyncMock()),
+            ),
+            patch(
+                "fabric_dw.cli.commands.permissions.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_wh_entry())),
+            ),
+            patch("fabric_dw.services.rls.drop_security_policy", new=mock_svc),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "-w",
+                    WS_GUID,
+                    "-y",
+                    "permissions",
+                    "rls",
+                    "drop",
+                    WH_GUID,
+                    "rls.SalesFilter",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        mock_svc.assert_called_once()
+
+    def test_drop_is_in_destructive_commands(self) -> None:
+        from fabric_dw.cli._main import _DESTRUCTIVE_CLI_COMMANDS  # noqa: PLC0415
+
+        assert "permissions.rls.drop" in _DESTRUCTIVE_CLI_COMMANDS

--- a/tests/unit/cli/commands/test_permissions_rls.py
+++ b/tests/unit/cli/commands/test_permissions_rls.py
@@ -183,7 +183,7 @@ class TestRlsCreate:
         _, kwargs = mock_svc.call_args
         assert kwargs["state"] is True
         preds = mock_svc.call_args.args[2]
-        assert preds[0]["operation"] == "AFTER_INSERT"
+        assert preds[0]["operation"] == "after-insert"  # CLI passes raw; service normalizes
 
     def test_create_both_filter_and_block_fails(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env

--- a/tests/unit/mcp/tools/test_permissions.py
+++ b/tests/unit/mcp/tools/test_permissions.py
@@ -622,3 +622,197 @@ async def test_revoke_permission_with_columns_happy_path(mock_ctx, ctx_patch) ->
     assert result["revoked"] is True
     _args, kwargs = mock_svc.call_args
     assert kwargs.get("columns") == ["email"]
+
+
+# ---------------------------------------------------------------------------
+# RLS tools: list_security_policies, create_security_policy, drop_security_policy
+# add_security_predicate, drop_security_predicate, set_security_policy_state
+# ---------------------------------------------------------------------------
+
+
+async def test_list_security_policies_returns_correct_structure(mock_ctx, ctx_patch) -> None:
+    """list_security_policies returns a list of serialised SecurityPolicy dicts."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+    from fabric_dw.models import SecurityPolicy  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    policy = SecurityPolicy(
+        policy_schema="rls",
+        policy_name="SalesFilter",
+        is_enabled=True,
+        predicates=[],
+    )
+    mock_list = AsyncMock(return_value=[policy])
+    with (
+        ctx_patch,
+        patch("fabric_dw.services.rls.list_security_policies", new=mock_list),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "list_security_policies",
+            {"workspace": WS_NAME, "item": WH_NAME},
+        )
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0]["policy_name"] == "SalesFilter"
+    assert result[0]["policy_schema"] == "rls"
+    assert result[0]["is_enabled"] is True
+
+
+async def test_create_security_policy_calls_service_with_correct_args(mock_ctx, ctx_patch) -> None:
+    """create_security_policy calls the service and returns a success dict."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    mock_svc = AsyncMock(return_value=None)
+    predicates = [
+        {
+            "predicate_type": "FILTER",
+            "fn_name": "fn_filter",
+            "fn_args": ["SalesRep"],
+            "table_schema": "dbo",
+            "table_name": "Sales",
+        }
+    ]
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {}),
+        patch("fabric_dw.services.rls.create_security_policy", new=mock_svc),
+    ):
+        os.environ.pop("FABRIC_MCP_READONLY", None)
+        result = await mcp._tool_manager.call_tool(
+            "create_security_policy",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "policy_name": "rls.SalesFilter",
+                "predicates": predicates,
+                "state": True,
+            },
+        )
+
+    assert result["created"] is True
+    assert result["policy_name"] == "rls.SalesFilter"
+    mock_svc.assert_called_once()
+
+
+async def test_drop_security_policy_blocked_without_destructive_env(mock_ctx, ctx_patch) -> None:
+    """drop_security_policy is blocked when FABRIC_MCP_ALLOW_DESTRUCTIVE is not set."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    os.environ.pop("FABRIC_MCP_READONLY", None)
+    os.environ.pop("FABRIC_MCP_ALLOW_DESTRUCTIVE", None)
+    with ctx_patch, patch.dict(os.environ, {}), pytest.raises(ToolError, match="destructive"):
+        await mcp._tool_manager.call_tool(
+            "drop_security_policy",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "policy_name": "rls.SalesFilter",
+            },
+        )
+
+
+async def test_drop_security_policy_succeeds_with_destructive_env(mock_ctx, ctx_patch) -> None:
+    """drop_security_policy succeeds when FABRIC_MCP_ALLOW_DESTRUCTIVE=1."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    mock_svc = AsyncMock(return_value=None)
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_ALLOW_DESTRUCTIVE": "1"}),
+        patch("fabric_dw.services.rls.drop_security_policy", new=mock_svc),
+    ):
+        os.environ.pop("FABRIC_MCP_READONLY", None)
+        result = await mcp._tool_manager.call_tool(
+            "drop_security_policy",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "policy_name": "rls.SalesFilter",
+            },
+        )
+
+    assert result["dropped"] is True
+    assert result["policy_name"] == "rls.SalesFilter"
+
+
+async def test_add_security_predicate_fn_schema_optional(mock_ctx, ctx_patch) -> None:
+    """add_security_predicate succeeds without fn_schema (it is optional)."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    mock_svc = AsyncMock(return_value=None)
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {}),
+        patch("fabric_dw.services.rls.add_predicate", new=mock_svc),
+    ):
+        os.environ.pop("FABRIC_MCP_READONLY", None)
+        result = await mcp._tool_manager.call_tool(
+            "add_security_predicate",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "policy_name": "rls.SalesFilter",
+                "predicate_type": "FILTER",
+                "fn_name": "fn_filter",
+                "fn_args": ["SalesRep"],
+                "table_schema": "dbo",
+                "table_name": "Sales",
+                # fn_schema intentionally omitted -- should default to None
+            },
+        )
+
+    assert result["added"] is True
+    # Verify fn_schema=None was passed to the service
+    _, kwargs = mock_svc.call_args
+    assert kwargs.get("fn_schema") is None or mock_svc.call_args[0][3] is None
+
+
+async def test_set_security_policy_state_returns_correct_dict(mock_ctx, ctx_patch) -> None:
+    """set_security_policy_state returns a dict with policy_name and enabled."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    mock_svc = AsyncMock(return_value=None)
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {}),
+        patch("fabric_dw.services.rls.set_policy_state", new=mock_svc),
+    ):
+        os.environ.pop("FABRIC_MCP_READONLY", None)
+        result = await mcp._tool_manager.call_tool(
+            "set_security_policy_state",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "policy_name": "rls.SalesFilter",
+                "enabled": False,
+            },
+        )
+
+    assert result["policy_name"] == "rls.SalesFilter"
+    assert result["enabled"] is False

--- a/tests/unit/mcp/tools/test_permissions.py
+++ b/tests/unit/mcp/tools/test_permissions.py
@@ -789,6 +789,41 @@ async def test_add_security_predicate_fn_schema_optional(mock_ctx, ctx_patch) ->
     assert kwargs.get("fn_schema") is None or mock_svc.call_args[0][3] is None
 
 
+async def test_drop_security_predicate_dispatches_correct_args(mock_ctx, ctx_patch) -> None:
+    """drop_security_predicate calls drop_predicate with the right args and no operation kwarg."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    mock_svc = AsyncMock(return_value=None)
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {}),
+        patch("fabric_dw.services.rls.drop_predicate", new=mock_svc),
+    ):
+        os.environ.pop("FABRIC_MCP_READONLY", None)
+        result = await mcp._tool_manager.call_tool(
+            "drop_security_predicate",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "policy_name": "rls.SalesFilter",
+                "predicate_type": "FILTER",
+                "table_schema": "dbo",
+                "table_name": "Sales",
+            },
+        )
+
+    assert result["dropped"] is True
+    assert result["policy_name"] == "rls.SalesFilter"
+    mock_svc.assert_called_once()
+    # Verify no 'operation' kwarg is forwarded to the service.
+    _, kwargs = mock_svc.call_args
+    assert "operation" not in kwargs
+
+
 async def test_set_security_policy_state_returns_correct_dict(mock_ctx, ctx_patch) -> None:
     """set_security_policy_state returns a dict with policy_name and enabled."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415

--- a/tests/unit/services/test_rls.py
+++ b/tests/unit/services/test_rls.py
@@ -1,0 +1,652 @@
+"""Unit tests for row-level security service functions in fabric_dw.services.rls."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from fabric_dw.models import SecurityPolicy, SecurityPredicate
+from fabric_dw.services import rls as rls_svc
+from fabric_dw.sql import SqlTarget
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+_TARGET = SqlTarget(
+    workspace_id="ws-1",
+    database="SalesDW",
+    connection_string="server.datawarehouse.fabric.microsoft.com",
+)
+
+_LIST_COLS = [
+    "policy_name",
+    "policy_schema",
+    "is_enabled",
+    "predicate_type_desc",
+    "predicate_definition",
+    "operation_desc",
+    "table_schema",
+    "table_name",
+]
+
+
+# ---------------------------------------------------------------------------
+# _validate_predicate_type
+# ---------------------------------------------------------------------------
+
+
+class TestValidatePredicateType:
+    def test_filter_accepted(self) -> None:
+        from fabric_dw.services.rls import _validate_predicate_type  # noqa: PLC0415
+
+        assert _validate_predicate_type("FILTER") == "FILTER"
+
+    def test_block_accepted(self) -> None:
+        from fabric_dw.services.rls import _validate_predicate_type  # noqa: PLC0415
+
+        assert _validate_predicate_type("BLOCK") == "BLOCK"
+
+    def test_case_insensitive(self) -> None:
+        from fabric_dw.services.rls import _validate_predicate_type  # noqa: PLC0415
+
+        assert _validate_predicate_type("filter") == "FILTER"
+        assert _validate_predicate_type("block") == "BLOCK"
+
+    def test_invalid_raises(self) -> None:
+        from fabric_dw.services.rls import _validate_predicate_type  # noqa: PLC0415
+
+        with pytest.raises(ValueError, match="Invalid predicate type"):
+            _validate_predicate_type("SELECT")
+
+
+# ---------------------------------------------------------------------------
+# _validate_operation
+# ---------------------------------------------------------------------------
+
+
+class TestValidateOperation:
+    def test_none_returns_none(self) -> None:
+        from fabric_dw.services.rls import _validate_operation  # noqa: PLC0415
+
+        assert _validate_operation(None) is None
+
+    def test_after_insert_accepted(self) -> None:
+        from fabric_dw.services.rls import _validate_operation  # noqa: PLC0415
+
+        assert _validate_operation("AFTER_INSERT") == "AFTER_INSERT"
+
+    def test_space_separated_normalised(self) -> None:
+        from fabric_dw.services.rls import _validate_operation  # noqa: PLC0415
+
+        assert _validate_operation("AFTER INSERT") == "AFTER_INSERT"
+
+    def test_hyphen_normalised(self) -> None:
+        from fabric_dw.services.rls import _validate_operation  # noqa: PLC0415
+
+        assert _validate_operation("after-insert") == "AFTER_INSERT"
+
+    def test_before_delete_accepted(self) -> None:
+        from fabric_dw.services.rls import _validate_operation  # noqa: PLC0415
+
+        assert _validate_operation("BEFORE_DELETE") == "BEFORE_DELETE"
+
+    def test_invalid_raises(self) -> None:
+        from fabric_dw.services.rls import _validate_operation  # noqa: PLC0415
+
+        with pytest.raises(ValueError, match="Invalid block operation"):
+            _validate_operation("AFTER_COMMIT")
+
+
+# ---------------------------------------------------------------------------
+# _resolve_policy_ref
+# ---------------------------------------------------------------------------
+
+
+class TestResolvePolicyRef:
+    def test_bare_name(self) -> None:
+        from fabric_dw.services.rls import _resolve_policy_ref  # noqa: PLC0415
+
+        assert _resolve_policy_ref("MyPolicy") == "[MyPolicy]"
+
+    def test_schema_qualified(self) -> None:
+        from fabric_dw.services.rls import _resolve_policy_ref  # noqa: PLC0415
+
+        assert _resolve_policy_ref("rls.MyPolicy") == "[rls].[MyPolicy]"
+
+    def test_invalid_identifier_raises(self) -> None:
+        from fabric_dw.services.rls import _resolve_policy_ref  # noqa: PLC0415
+
+        with pytest.raises(ValueError, match="Invalid"):
+            _resolve_policy_ref("bad; policy")
+
+
+# ---------------------------------------------------------------------------
+# _build_fn_call
+# ---------------------------------------------------------------------------
+
+
+class TestBuildFnCall:
+    def test_schema_qualified_single_col(self) -> None:
+        from fabric_dw.services.rls import _build_fn_call  # noqa: PLC0415
+
+        result = _build_fn_call("rls", "fn_filter", ["SalesRep"])
+        assert result == "[rls].[fn_filter]([SalesRep])"
+
+    def test_no_schema_two_cols(self) -> None:
+        from fabric_dw.services.rls import _build_fn_call  # noqa: PLC0415
+
+        result = _build_fn_call(None, "fn_filter", ["col_a", "col_b"])
+        assert result == "[fn_filter]([col_a], [col_b])"
+
+    def test_empty_fn_schema_treated_as_none(self) -> None:
+        from fabric_dw.services.rls import _build_fn_call  # noqa: PLC0415
+
+        result = _build_fn_call("", "fn_filter", ["SalesRep"])
+        assert result == "[fn_filter]([SalesRep])"
+
+    def test_empty_args_raises(self) -> None:
+        from fabric_dw.services.rls import _build_fn_call  # noqa: PLC0415
+
+        with pytest.raises(ValueError, match="at least one column"):
+            _build_fn_call("rls", "fn_filter", [])
+
+    def test_invalid_col_raises(self) -> None:
+        from fabric_dw.services.rls import _build_fn_call  # noqa: PLC0415
+
+        with pytest.raises(ValueError, match="Invalid"):
+            _build_fn_call("rls", "fn_filter", ["ok", "bad; col"])
+
+
+# ---------------------------------------------------------------------------
+# list_security_policies
+# ---------------------------------------------------------------------------
+
+
+class TestListSecurityPolicies:
+    async def test_returns_policy_objects(self) -> None:
+        rows = [
+            (
+                "SalesFilter",
+                "rls",
+                1,
+                "FILTER",
+                "[rls].[fn_filter]([SalesRep])",
+                None,
+                "dbo",
+                "Sales",
+            ),
+        ]
+
+        def _mock(_target: object, _sql: str, **_kw: object) -> tuple:
+            return _LIST_COLS, rows
+
+        with patch("fabric_dw.services.rls.run_query", side_effect=_mock):
+            result = await rls_svc.list_security_policies(_TARGET)
+
+        assert len(result) == 1
+        pol = result[0]
+        assert isinstance(pol, SecurityPolicy)
+        assert pol.policy_name == "SalesFilter"
+        assert pol.policy_schema == "rls"
+        assert pol.is_enabled is True
+        assert len(pol.predicates) == 1
+        pred = pol.predicates[0]
+        assert isinstance(pred, SecurityPredicate)
+        assert pred.predicate_type == "FILTER"
+        assert pred.operation is None
+        assert pred.schema_name == "dbo"
+        assert pred.table_name == "Sales"
+
+    async def test_policy_with_no_predicates(self) -> None:
+        rows = [
+            ("EmptyPolicy", "dbo", 0, None, None, None, None, None),
+        ]
+
+        def _mock(_target: object, _sql: str, **_kw: object) -> tuple:
+            return _LIST_COLS, rows
+
+        with patch("fabric_dw.services.rls.run_query", side_effect=_mock):
+            result = await rls_svc.list_security_policies(_TARGET)
+
+        assert len(result) == 1
+        assert result[0].predicates == []
+        assert result[0].is_enabled is False
+
+    async def test_policy_with_block_predicate_preserves_operation(self) -> None:
+        rows = [
+            (
+                "SalesPolicy",
+                "rls",
+                1,
+                "BLOCK",
+                "[rls].[fn_block]([SalesRep])",
+                "AFTER INSERT",
+                "dbo",
+                "Sales",
+            ),
+        ]
+
+        def _mock(_target: object, _sql: str, **_kw: object) -> tuple:
+            return _LIST_COLS, rows
+
+        with patch("fabric_dw.services.rls.run_query", side_effect=_mock):
+            result = await rls_svc.list_security_policies(_TARGET)
+
+        pred = result[0].predicates[0]
+        assert pred.predicate_type == "BLOCK"
+        assert pred.operation == "AFTER INSERT"
+
+    async def test_multiple_predicates_grouped_under_one_policy(self) -> None:
+        rows = [
+            ("SalesFilter", "rls", 1, "BLOCK", "[rls].[fn]([col])", "AFTER INSERT", "dbo", "Sales"),
+            ("SalesFilter", "rls", 1, "FILTER", "[rls].[fn]([col])", None, "dbo", "Sales"),
+        ]
+
+        def _mock(_target: object, _sql: str, **_kw: object) -> tuple:
+            return _LIST_COLS, rows
+
+        with patch("fabric_dw.services.rls.run_query", side_effect=_mock):
+            result = await rls_svc.list_security_policies(_TARGET)
+
+        assert len(result) == 1
+        assert len(result[0].predicates) == 2
+
+    async def test_returns_empty_list_when_no_policies(self) -> None:
+        def _mock(_target: object, _sql: str, **_kw: object) -> tuple:
+            return _LIST_COLS, []
+
+        with patch("fabric_dw.services.rls.run_query", side_effect=_mock):
+            result = await rls_svc.list_security_policies(_TARGET)
+
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# create_security_policy - SQL shape
+# ---------------------------------------------------------------------------
+
+
+class TestCreateSecurityPolicy:
+    async def test_filter_predicate_exact_sql(self) -> None:
+        captured: list[str] = []
+
+        def _mock(_target: object, _sql: str, **_kw: object) -> tuple:
+            captured.append(_sql)
+            return [], []
+
+        with patch("fabric_dw.services.rls.run_query", side_effect=_mock):
+            await rls_svc.create_security_policy(
+                _TARGET,
+                "rls.SalesFilter",
+                [
+                    {
+                        "predicate_type": "FILTER",
+                        "fn_schema": "rls",
+                        "fn_name": "fn_filter",
+                        "fn_args": ["SalesRep"],
+                        "table_schema": "dbo",
+                        "table_name": "Sales",
+                        "operation": None,
+                    }
+                ],
+            )
+
+        stmt = captured[0]
+        assert stmt == (
+            "CREATE SECURITY POLICY [rls].[SalesFilter]\n"
+            "    ADD FILTER PREDICATE [rls].[fn_filter]([SalesRep]) ON [dbo].[Sales]\n"
+            "    WITH (STATE = ON);"
+        )
+
+    async def test_state_off(self) -> None:
+        captured: list[str] = []
+
+        def _mock(_target: object, _sql: str, **_kw: object) -> tuple:
+            captured.append(_sql)
+            return [], []
+
+        with patch("fabric_dw.services.rls.run_query", side_effect=_mock):
+            await rls_svc.create_security_policy(
+                _TARGET,
+                "MyPolicy",
+                [
+                    {
+                        "predicate_type": "FILTER",
+                        "fn_schema": None,
+                        "fn_name": "fn_filter",
+                        "fn_args": ["col"],
+                        "table_schema": "dbo",
+                        "table_name": "T",
+                        "operation": None,
+                    }
+                ],
+                state=False,
+            )
+
+        assert "STATE = OFF" in captured[0]
+
+    async def test_block_predicate_with_operation(self) -> None:
+        captured: list[str] = []
+
+        def _mock(_target: object, _sql: str, **_kw: object) -> tuple:
+            captured.append(_sql)
+            return [], []
+
+        with patch("fabric_dw.services.rls.run_query", side_effect=_mock):
+            await rls_svc.create_security_policy(
+                _TARGET,
+                "rls.SalesBlock",
+                [
+                    {
+                        "predicate_type": "BLOCK",
+                        "fn_schema": "rls",
+                        "fn_name": "fn_block",
+                        "fn_args": ["SalesRep"],
+                        "table_schema": "dbo",
+                        "table_name": "Sales",
+                        "operation": "AFTER_INSERT",
+                    }
+                ],
+            )
+
+        stmt = captured[0]
+        assert "ADD BLOCK PREDICATE" in stmt
+        assert "AFTER INSERT" in stmt
+
+    async def test_multi_predicate_create(self) -> None:
+        captured: list[str] = []
+
+        def _mock(_target: object, _sql: str, **_kw: object) -> tuple:
+            captured.append(_sql)
+            return [], []
+
+        with patch("fabric_dw.services.rls.run_query", side_effect=_mock):
+            await rls_svc.create_security_policy(
+                _TARGET,
+                "rls.Combined",
+                [
+                    {
+                        "predicate_type": "FILTER",
+                        "fn_schema": "rls",
+                        "fn_name": "fn_filter",
+                        "fn_args": ["col"],
+                        "table_schema": "dbo",
+                        "table_name": "T",
+                        "operation": None,
+                    },
+                    {
+                        "predicate_type": "BLOCK",
+                        "fn_schema": "rls",
+                        "fn_name": "fn_block",
+                        "fn_args": ["col"],
+                        "table_schema": "dbo",
+                        "table_name": "T",
+                        "operation": "AFTER_INSERT",
+                    },
+                ],
+            )
+
+        stmt = captured[0]
+        assert "ADD FILTER PREDICATE" in stmt
+        assert "ADD BLOCK PREDICATE" in stmt
+
+    async def test_empty_predicates_raises(self) -> None:
+        with pytest.raises(ValueError, match="At least one predicate"):
+            await rls_svc.create_security_policy(_TARGET, "MyPolicy", [])
+
+    async def test_invalid_policy_name_raises(self) -> None:
+        with pytest.raises(ValueError, match="Invalid"):
+            await rls_svc.create_security_policy(
+                _TARGET,
+                "bad; policy",
+                [
+                    {
+                        "predicate_type": "FILTER",
+                        "fn_schema": "rls",
+                        "fn_name": "fn",
+                        "fn_args": ["col"],
+                        "table_schema": "dbo",
+                        "table_name": "T",
+                        "operation": None,
+                    }
+                ],
+            )
+
+
+# ---------------------------------------------------------------------------
+# add_predicate - SQL shape
+# ---------------------------------------------------------------------------
+
+
+class TestAddPredicate:
+    async def test_filter_predicate_exact_sql(self) -> None:
+        captured: list[str] = []
+
+        def _mock(_target: object, _sql: str, **_kw: object) -> tuple:
+            captured.append(_sql)
+            return [], []
+
+        with patch("fabric_dw.services.rls.run_query", side_effect=_mock):
+            await rls_svc.add_predicate(
+                _TARGET,
+                "rls.SalesFilter",
+                "FILTER",
+                "rls",
+                "fn_filter",
+                ["SalesRep"],
+                "dbo",
+                "Sales",
+            )
+
+        stmt = captured[0]
+        assert stmt == (
+            "ALTER SECURITY POLICY [rls].[SalesFilter]\n"
+            "    ADD FILTER PREDICATE [rls].[fn_filter]([SalesRep]) ON [dbo].[Sales];"
+        )
+
+    async def test_block_predicate_with_operation_exact_sql(self) -> None:
+        captured: list[str] = []
+
+        def _mock(_target: object, _sql: str, **_kw: object) -> tuple:
+            captured.append(_sql)
+            return [], []
+
+        with patch("fabric_dw.services.rls.run_query", side_effect=_mock):
+            await rls_svc.add_predicate(
+                _TARGET,
+                "rls.SalesBlock",
+                "BLOCK",
+                "rls",
+                "fn_block",
+                ["SalesRep"],
+                "dbo",
+                "Sales",
+                operation="AFTER_INSERT",
+            )
+
+        stmt = captured[0]
+        assert stmt == (
+            "ALTER SECURITY POLICY [rls].[SalesBlock]\n"
+            "    ADD BLOCK PREDICATE [rls].[fn_block]([SalesRep]) ON [dbo].[Sales] AFTER INSERT;"
+        )
+
+    async def test_block_predicate_without_operation(self) -> None:
+        captured: list[str] = []
+
+        def _mock(_target: object, _sql: str, **_kw: object) -> tuple:
+            captured.append(_sql)
+            return [], []
+
+        with patch("fabric_dw.services.rls.run_query", side_effect=_mock):
+            await rls_svc.add_predicate(
+                _TARGET,
+                "rls.SalesBlock",
+                "BLOCK",
+                "rls",
+                "fn_block",
+                ["SalesRep"],
+                "dbo",
+                "Sales",
+            )
+
+        stmt = captured[0]
+        # No AFTER/BEFORE clause when operation is None
+        assert "ADD BLOCK PREDICATE" in stmt
+        assert "AFTER" not in stmt
+        assert "BEFORE" not in stmt
+
+    async def test_invalid_predicate_type_raises(self) -> None:
+        with pytest.raises(ValueError, match="Invalid predicate type"):
+            await rls_svc.add_predicate(
+                _TARGET, "MyPolicy", "DENY", "rls", "fn", ["col"], "dbo", "T"
+            )
+
+
+# ---------------------------------------------------------------------------
+# drop_predicate - SQL shape
+# ---------------------------------------------------------------------------
+
+
+class TestDropPredicate:
+    async def test_filter_predicate_exact_sql(self) -> None:
+        captured: list[str] = []
+
+        def _mock(_target: object, _sql: str, **_kw: object) -> tuple:
+            captured.append(_sql)
+            return [], []
+
+        with patch("fabric_dw.services.rls.run_query", side_effect=_mock):
+            await rls_svc.drop_predicate(
+                _TARGET,
+                "rls.SalesFilter",
+                "FILTER",
+                "dbo",
+                "Sales",
+            )
+
+        stmt = captured[0]
+        assert stmt == (
+            "ALTER SECURITY POLICY [rls].[SalesFilter]\n    DROP FILTER PREDICATE ON [dbo].[Sales];"
+        )
+
+    async def test_block_predicate_with_operation_exact_sql(self) -> None:
+        captured: list[str] = []
+
+        def _mock(_target: object, _sql: str, **_kw: object) -> tuple:
+            captured.append(_sql)
+            return [], []
+
+        with patch("fabric_dw.services.rls.run_query", side_effect=_mock):
+            await rls_svc.drop_predicate(
+                _TARGET,
+                "rls.SalesBlock",
+                "BLOCK",
+                "dbo",
+                "Sales",
+                operation="AFTER_INSERT",
+            )
+
+        stmt = captured[0]
+        assert stmt == (
+            "ALTER SECURITY POLICY [rls].[SalesBlock]\n"
+            "    DROP BLOCK PREDICATE ON [dbo].[Sales] AFTER INSERT;"
+        )
+
+    async def test_block_without_operation_emits_no_op_clause(self) -> None:
+        captured: list[str] = []
+
+        def _mock(_target: object, _sql: str, **_kw: object) -> tuple:
+            captured.append(_sql)
+            return [], []
+
+        with patch("fabric_dw.services.rls.run_query", side_effect=_mock):
+            await rls_svc.drop_predicate(
+                _TARGET,
+                "rls.SalesBlock",
+                "BLOCK",
+                "dbo",
+                "Sales",
+            )
+
+        stmt = captured[0]
+        assert "DROP BLOCK PREDICATE ON [dbo].[Sales];" in stmt
+
+
+# ---------------------------------------------------------------------------
+# set_policy_state - SQL shape
+# ---------------------------------------------------------------------------
+
+
+class TestSetPolicyState:
+    async def test_enable_exact_sql(self) -> None:
+        captured: list[str] = []
+
+        def _mock(_target: object, _sql: str, **_kw: object) -> tuple:
+            captured.append(_sql)
+            return [], []
+
+        with patch("fabric_dw.services.rls.run_query", side_effect=_mock):
+            await rls_svc.set_policy_state(_TARGET, "rls.SalesFilter", enabled=True)
+
+        assert captured[0] == "ALTER SECURITY POLICY [rls].[SalesFilter] WITH (STATE = ON);"
+
+    async def test_disable_exact_sql(self) -> None:
+        captured: list[str] = []
+
+        def _mock(_target: object, _sql: str, **_kw: object) -> tuple:
+            captured.append(_sql)
+            return [], []
+
+        with patch("fabric_dw.services.rls.run_query", side_effect=_mock):
+            await rls_svc.set_policy_state(_TARGET, "rls.SalesFilter", enabled=False)
+
+        assert captured[0] == "ALTER SECURITY POLICY [rls].[SalesFilter] WITH (STATE = OFF);"
+
+    async def test_bare_name(self) -> None:
+        captured: list[str] = []
+
+        def _mock(_target: object, _sql: str, **_kw: object) -> tuple:
+            captured.append(_sql)
+            return [], []
+
+        with patch("fabric_dw.services.rls.run_query", side_effect=_mock):
+            await rls_svc.set_policy_state(_TARGET, "MyPolicy", enabled=True)
+
+        assert captured[0] == "ALTER SECURITY POLICY [MyPolicy] WITH (STATE = ON);"
+
+
+# ---------------------------------------------------------------------------
+# drop_security_policy - SQL shape
+# ---------------------------------------------------------------------------
+
+
+class TestDropSecurityPolicy:
+    async def test_schema_qualified_exact_sql(self) -> None:
+        captured: list[str] = []
+
+        def _mock(_target: object, _sql: str, **_kw: object) -> tuple:
+            captured.append(_sql)
+            return [], []
+
+        with patch("fabric_dw.services.rls.run_query", side_effect=_mock):
+            await rls_svc.drop_security_policy(_TARGET, "rls.SalesFilter")
+
+        assert captured[0] == "DROP SECURITY POLICY [rls].[SalesFilter];"
+
+    async def test_bare_name_exact_sql(self) -> None:
+        captured: list[str] = []
+
+        def _mock(_target: object, _sql: str, **_kw: object) -> tuple:
+            captured.append(_sql)
+            return [], []
+
+        with patch("fabric_dw.services.rls.run_query", side_effect=_mock):
+            await rls_svc.drop_security_policy(_TARGET, "MyPolicy")
+
+        assert captured[0] == "DROP SECURITY POLICY [MyPolicy];"
+
+    async def test_invalid_name_raises(self) -> None:
+        with pytest.raises(ValueError, match="Invalid"):
+            await rls_svc.drop_security_policy(_TARGET, "bad; policy")

--- a/tests/unit/services/test_rls.py
+++ b/tests/unit/services/test_rls.py
@@ -236,7 +236,7 @@ class TestListSecurityPolicies:
 
         pred = result[0].predicates[0]
         assert pred.predicate_type == "BLOCK"
-        assert pred.operation == "AFTER INSERT"
+        assert pred.operation == "AFTER_INSERT"
 
     async def test_multiple_predicates_grouped_under_one_policy(self) -> None:
         rows = [
@@ -352,8 +352,11 @@ class TestCreateSecurityPolicy:
             )
 
         stmt = captured[0]
-        assert "ADD BLOCK PREDICATE" in stmt
-        assert "AFTER INSERT" in stmt
+        assert stmt == (
+            "CREATE SECURITY POLICY [rls].[SalesBlock]\n"
+            "    ADD BLOCK PREDICATE [rls].[fn_block]([SalesRep]) ON [dbo].[Sales] AFTER INSERT\n"
+            "    WITH (STATE = ON);"
+        )
 
     async def test_multi_predicate_create(self) -> None:
         captured: list[str] = []
@@ -389,8 +392,12 @@ class TestCreateSecurityPolicy:
             )
 
         stmt = captured[0]
-        assert "ADD FILTER PREDICATE" in stmt
-        assert "ADD BLOCK PREDICATE" in stmt
+        assert stmt == (
+            "CREATE SECURITY POLICY [rls].[Combined]\n"
+            "    ADD FILTER PREDICATE [rls].[fn_filter]([col]) ON [dbo].[T],\n"
+            "    ADD BLOCK PREDICATE [rls].[fn_block]([col]) ON [dbo].[T] AFTER INSERT\n"
+            "    WITH (STATE = ON);"
+        )
 
     async def test_empty_predicates_raises(self) -> None:
         with pytest.raises(ValueError, match="At least one predicate"):
@@ -531,7 +538,8 @@ class TestDropPredicate:
             "ALTER SECURITY POLICY [rls].[SalesFilter]\n    DROP FILTER PREDICATE ON [dbo].[Sales];"
         )
 
-    async def test_block_predicate_with_operation_exact_sql(self) -> None:
+    async def test_block_predicate_no_operation_clause(self) -> None:
+        """DROP PREDICATE emits no operation clause -- T-SQL syntax has no such clause."""
         captured: list[str] = []
 
         def _mock(_target: object, _sql: str, **_kw: object) -> tuple:
@@ -545,13 +553,11 @@ class TestDropPredicate:
                 "BLOCK",
                 "dbo",
                 "Sales",
-                operation="AFTER_INSERT",
             )
 
         stmt = captured[0]
         assert stmt == (
-            "ALTER SECURITY POLICY [rls].[SalesBlock]\n"
-            "    DROP BLOCK PREDICATE ON [dbo].[Sales] AFTER INSERT;"
+            "ALTER SECURITY POLICY [rls].[SalesBlock]\n    DROP BLOCK PREDICATE ON [dbo].[Sales];"
         )
 
     async def test_block_without_operation_emits_no_op_clause(self) -> None:
@@ -650,3 +656,61 @@ class TestDropSecurityPolicy:
     async def test_invalid_name_raises(self) -> None:
         with pytest.raises(ValueError, match="Invalid"):
             await rls_svc.drop_security_policy(_TARGET, "bad; policy")
+
+
+# ---------------------------------------------------------------------------
+# _build_predicate_clause - FILTER rejects operation
+# ---------------------------------------------------------------------------
+
+
+class TestBuildPredicateClauseFilterRejectsOperation:
+    def test_filter_with_operation_raises(self) -> None:
+        from fabric_dw.services.rls import _build_predicate_clause  # noqa: PLC0415
+
+        with pytest.raises(ValueError, match="FILTER predicates do not accept an operation"):
+            _build_predicate_clause("FILTER", "rls", "fn", ["col"], "dbo", "T", "AFTER_INSERT")
+
+    def test_block_with_operation_succeeds(self) -> None:
+        from fabric_dw.services.rls import _build_predicate_clause  # noqa: PLC0415
+
+        result = _build_predicate_clause("BLOCK", "rls", "fn", ["col"], "dbo", "T", "AFTER_INSERT")
+        assert "AFTER INSERT" in result
+
+
+# ---------------------------------------------------------------------------
+# create_security_policy - missing required key raises ValueError
+# ---------------------------------------------------------------------------
+
+
+class TestCreateSecurityPolicyMissingKeys:
+    async def test_missing_fn_name_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="missing required key"):
+            await rls_svc.create_security_policy(
+                _TARGET,
+                "rls.SalesFilter",
+                [
+                    {
+                        "predicate_type": "FILTER",
+                        # fn_name intentionally omitted
+                        "fn_args": ["col"],
+                        "table_schema": "dbo",
+                        "table_name": "T",
+                    }
+                ],
+            )
+
+    async def test_missing_table_schema_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="missing required key"):
+            await rls_svc.create_security_policy(
+                _TARGET,
+                "rls.SalesFilter",
+                [
+                    {
+                        "predicate_type": "FILTER",
+                        "fn_name": "fn_filter",
+                        "fn_args": ["col"],
+                        # table_schema intentionally omitted
+                        "table_name": "T",
+                    }
+                ],
+            )

--- a/tests/unit/test_cli_destructive_parity.py
+++ b/tests/unit/test_cli_destructive_parity.py
@@ -327,6 +327,15 @@ class TestEmitDestructiveOpOnAbort:
             f"permissions cls revoke did not emit destructive_op=True on abort; got {destructive!r}"
         )
 
+    def test_permissions_rls_drop_emits_destructive_on_abort(self) -> None:
+        """permissions rls drop aborted at prompt must still report destructive_op=True."""
+        destructive = _invoke_and_capture_destructive(
+            ["-w", "myws", "permissions", "rls", "drop", "mydw", "rls.SalesFilter"]
+        )
+        assert destructive is True, (
+            f"permissions rls drop did not emit destructive_op=True on abort; got {destructive!r}"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Non-destructive confirming commands must NOT set destructive_op

--- a/tests/unit/test_cli_destructive_parity.py
+++ b/tests/unit/test_cli_destructive_parity.py
@@ -50,6 +50,7 @@ _MCP_TO_CLI_DESTRUCTIVE_MAP: dict[str, str | tuple[str, ...]] = {
     "set_cluster_columns": "tables.cluster-by",
     "drop_view": "views.drop",
     "delete_warehouse": "warehouses.delete",
+    "drop_security_policy": "permissions.rls.drop",
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_identifiers.py
+++ b/tests/unit/test_identifiers.py
@@ -7,6 +7,7 @@ import pytest
 from fabric_dw.identifiers import (
     parse_qualified_name,
     quote_identifier,
+    validate_column_name,
     validate_identifier,
 )
 
@@ -184,3 +185,31 @@ class TestParseQualifiedName:
     def test_whitespace_object_raises_with_kind_label(self) -> None:
         with pytest.raises(ValueError, match="view part must not be empty"):
             parse_qualified_name("dbo.  ", kind="view")
+
+
+# ---------------------------------------------------------------------------
+# validate_column_name -- unicode line separator rejection
+# ---------------------------------------------------------------------------
+
+
+class TestValidateColumnNameUnicodeLineSeps:
+    """validate_column_name must reject unicode line/paragraph separators."""
+
+    def test_nel_u0085_rejected(self) -> None:
+        with pytest.raises(ValueError, match="unicode line separator"):
+            validate_column_name("col\x85name")
+
+    def test_line_separator_u2028_rejected(self) -> None:
+        with pytest.raises(ValueError, match="unicode line separator"):
+            validate_column_name("col\u2028name")
+
+    def test_paragraph_separator_u2029_rejected(self) -> None:
+        with pytest.raises(ValueError, match="unicode line separator"):
+            validate_column_name("col\u2029name")
+
+    def test_normal_column_name_still_valid(self) -> None:
+        assert validate_column_name("my column") == "my column"
+
+    def test_empty_column_name_still_rejected(self) -> None:
+        with pytest.raises(ValueError, match="empty"):
+            validate_column_name("")


### PR DESCRIPTION
## Summary

- Adds `permissions rls` subgroup with 6 CLI commands: `list`, `create`, `add-predicate`, `drop-predicate`, `set-state`, and `drop` (destructive-gated)
- Adds 6 MCP tools: `list_security_policies`, `create_security_policy`, `add_security_predicate`, `drop_security_predicate`, `set_security_policy_state`, and `drop_security_policy` (destructive-gated)
- Adds `SecurityPredicate` and `SecurityPolicy` Pydantic models
- Adds `services/rls.py` service layer querying `sys.security_policies LEFT JOIN sys.security_predicates`; all identifiers are bracket-quoted and validated - no SQL text parsing
- Updates destructive parity drift guard, telemetry domain map, and `_DESTRUCTIVE_CLI_COMMANDS`
- Full unit test coverage for service layer (SQL statement shapes pinned) and CLI commands

## Test plan

- [x] `uv run ruff check src/ tests/` - all checks passed
- [x] `uv run ruff format --check src/ tests/` - all files formatted
- [x] `uv run ty check src/` - all checks passed
- [x] `uv run pytest tests/unit/ -q` - 5523 passed, 0 failed

Closes #919

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>