### PR TITLE
docs: add permissions to nav and a PR Definition-of-Done checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,8 +6,14 @@
 
 - [ ] All gates pass locally (`just check`)
 - [ ] Unit tests pass (`just test`)
-- [ ] Integration tests pass where applicable (`just integration`, requires `az login` and the `integration` label on the PR)
+- [ ] Integration tests updated where applicable (under `tests/integration/`, marked `@pytest.mark.integration`). Do not apply the `integration` label or trigger the suite on the PR; it runs on main and is triggered by the maintainer.
 - [ ] Manual testing steps (if any):
+
+## Definition of Done
+
+- [ ] Docs created/updated for any user-facing change. **A new docs page is also added to the `nav` in `zensical.toml`** (a page not in nav is invisible in the rendered docs).
+- [ ] Unit tests created/updated.
+- [ ] Integration tests created/updated for changes that touch Fabric (T-SQL / API), under `tests/integration/` marked `@pytest.mark.integration`. (Do not apply the `integration` label or trigger the integration suite on the PR; it runs on main and is triggered by the maintainer.)
 
 ## Linked issue
 

--- a/zensical.toml
+++ b/zensical.toml
@@ -22,6 +22,7 @@ nav = [
     { "Configuration & defaults" = "commands/config.md" },
     { "dbt" = "commands/dbt.md" },
     { "Functions" = "commands/functions.md" },
+    { "Permissions" = "commands/permissions.md" },
     { "Queries" = "commands/queries.md" },
     { "Restore Points" = "commands/restore-points.md" },
     { "Running SQL" = "commands/sql.md" },


### PR DESCRIPTION
## Summary

Two process-hygiene fixes in one PR:

1. **Missing nav entry:** The `permissions` command group was added in #916 and its page (`docs/commands/permissions.md`) exists and is deployed, but it was never registered in the `nav` array of `zensical.toml`. As a result it was invisible in the rendered site navigation (staging and production). Added at the correct alphabetical position (between Functions and Queries).

2. **PR template Definition of Done:** Extended `.github/PULL_REQUEST_TEMPLATE.md` with a Definition of Done checklist covering docs-nav registration, unit tests, and integration tests. Also corrected the pre-existing integration-tests item: the integration suite runs on main and is triggered by the maintainer, not on PRs via the `integration` label.

**Orphaned-page audit:** All other `docs/commands/*.md` files have a matching nav entry. `permissions.md` was the only one missing.

**Build verification:** `uv run --group docs zensical build` reports no issues on both commits. `docs_build/site/commands/permissions/index.html` exists and the nav includes a Permissions link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)