### PR TITLE
feat(permissions): dynamic data masking (permissions mask subgroup) (#920)

### DIFF
--- a/docs/commands/permissions.md
+++ b/docs/commands/permissions.md
@@ -871,4 +871,4 @@ column.
 - `table_name` (`str`): name of the target table.
 - `column_name` (`str`): name of the column whose mask to remove.
 
-**Returns:** `{ "unmasked": true, "table_schema": str, "table_name": str, "column_name": str }`.
+**Returns:** `{ "dropped": true, "table_schema": str, "table_name": str, "column_name": str }`.

--- a/docs/commands/permissions.md
+++ b/docs/commands/permissions.md
@@ -6,7 +6,7 @@ title: Permissions
 
 Manage Fabric item-level and T-SQL in-database permissions.
 
-Four distinct permission planes are exposed under the `permissions` top-level group:
+Five distinct permission planes are exposed under the `permissions` top-level group:
 
 - `permissions item` - Fabric item-level permissions (REST admin API). Covers which principals
   have access to a Warehouse or SQL Analytics Endpoint item.
@@ -17,6 +17,7 @@ Four distinct permission planes are exposed under the `permissions` top-level gr
   column lists rather than whole objects.
 - `permissions rls` - Row-level security. Manages security policies with filter and block
   predicates that reference existing predicate functions.
+- `permissions mask` - Dynamic data masking. Applies, inspects, and removes column-level masks.
 
 **Targets:** Data Warehouse / SQL Analytics Endpoint
 
@@ -548,6 +549,120 @@ fdw [-w WORKSPACE] [-y] permissions rls drop [ITEM] [POLICY_NAME]
 fdw -w MyWorkspace -y permissions rls drop SalesWH rls.SalesFilter
 ```
 
+Dynamic data masking (DDM) applies column-level masks that hide sensitive values from users who
+lack the `UNMASK` permission. Masked data is stored unchanged; only the presentation is altered.
+Use `permissions grant` / `permissions revoke` with the `UNMASK` permission token to control
+which principals see unmasked values.
+
+Reference: [Dynamic data masking in Fabric Data Warehouse](https://learn.microsoft.com/fabric/data-warehouse/dynamic-data-masking?WT.mc_id=MVP_310840)
+
+Supported mask functions:
+
+| Type | Arguments | Effect |
+| --- | --- | --- |
+| `default` | none | Full mask per data type (e.g. `XXXX` for strings, `0` for numerics). |
+| `email` | none | Shows first letter and `.com` suffix, e.g. `aXXX@XXXX.com`. |
+| `random` | `--start LOW --end HIGH` | Replaces numeric values with a random number in `[LOW, HIGH]`. |
+| `partial` | `--prefix N --padding STR --suffix M` | Shows `N` leading and `M` trailing characters; fills the rest with `STR`. |
+
+### permissions mask list
+
+**Targets:** Data Warehouse / SQL Analytics Endpoint
+
+List all columns with dynamic data masking applied, optionally filtered to a single table.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] [--json] permissions mask list [ITEM] [SCHEMA.TABLE]
+```
+
+| Option | Description |
+| --- | --- |
+| `ITEM` | Data Warehouse or SQL Analytics Endpoint name (optional; uses config default). |
+| `SCHEMA.TABLE` | Restrict output to this table (optional). |
+
+**Example**
+
+```shell
+# All masked columns in the warehouse
+fdw -w MyWorkspace permissions mask list SalesWH
+
+# Masked columns in a single table
+fdw -w MyWorkspace permissions mask list SalesWH dbo.Customers
+```
+
+### permissions mask set
+
+**Targets:** Data Warehouse / SQL Analytics Endpoint
+
+Apply or replace a dynamic data mask on a single column. If the column already has a mask,
+`ADD MASKED` replaces it without error.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] permissions mask set [ITEM] SCHEMA.TABLE
+    --column COL --function TYPE
+    [--start LOW] [--end HIGH]
+    [--prefix N] [--padding STR] [--suffix M]
+```
+
+| Option | Description |
+| --- | --- |
+| `ITEM` | Data Warehouse or SQL Analytics Endpoint name. |
+| `SCHEMA.TABLE` | Schema-qualified table name (positional). |
+| `--column COL` | Column to apply the mask to (required). |
+| `--function TYPE` | Mask type: `default`, `email`, `random`, or `partial` (required). |
+| `--start LOW` | Lower bound for `random` mask (required when `--function random`). |
+| `--end HIGH` | Upper bound for `random` mask (required when `--function random`). |
+| `--prefix N` | Leading characters to expose for `partial` mask (required when `--function partial`). |
+| `--padding STR` | Replacement text for `partial` mask (required when `--function partial`). Cannot contain `"`, `)`, `;`, `--`, or control characters. |
+| `--suffix M` | Trailing characters to expose for `partial` mask (required when `--function partial`). |
+
+**Example**
+
+```shell
+# Email mask
+fdw -w MyWorkspace permissions mask set SalesWH dbo.Customers \
+    --column Email --function email
+
+# Random numeric mask
+fdw -w MyWorkspace permissions mask set SalesWH dbo.Employees \
+    --column Salary --function random --start 1 --end 99999
+
+# Partial mask showing the last 4 digits of a phone number
+fdw -w MyWorkspace permissions mask set SalesWH dbo.Customers \
+    --column Phone --function partial --prefix 0 --padding "XXX-XXX-" --suffix 4
+```
+
+### permissions mask drop
+
+**Targets:** Data Warehouse / SQL Analytics Endpoint
+
+Remove a masking function from a column. The column reverts to returning its actual value for
+all users (subject to normal column permissions). This is a destructive operation.
+
+Requires confirmation (`--yes` / `-y`) unless `FABRIC_MCP_ALLOW_DESTRUCTIVE=1` is set.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] [-y] permissions mask drop [ITEM] SCHEMA.TABLE --column COL
+```
+
+| Option | Description |
+| --- | --- |
+| `ITEM` | Data Warehouse or SQL Analytics Endpoint name. |
+| `SCHEMA.TABLE` | Schema-qualified table name (positional). |
+| `--column COL` | Column whose mask to remove (required). |
+
+**Example**
+
+```shell
+fdw -w MyWorkspace -y permissions mask drop SalesWH dbo.Customers --column Email
+```
+
 ## MCP tools
 
 ### list_item_permissions
@@ -696,3 +811,64 @@ because revoke removes an existing permission (destructive operation).
   grantee has granted the permission to (`CASCADE`).
 
 **Returns:** `{ "revoked": true, "permissions": str, "principal": str, "scope": str }`.
+
+### list_masked_columns
+
+**Targets:** Data Warehouse / SQL Analytics Endpoint
+
+List columns with dynamic data masking applied, reading from `sys.masked_columns`.
+
+**Parameters:**
+
+- `workspace` (`str`): workspace name or GUID.
+- `item` (`str`): Warehouse or SQL endpoint name or GUID.
+- `table_schema` (`str | null`, optional): schema filter (case-insensitive). Omit for all schemas.
+- `table_name` (`str | null`, optional): table name filter (case-insensitive). Omit for all tables.
+
+**Returns:** `list[MaskedColumn]`: array of records with `schema_name`, `table_name`, `column_name`, and `masking_function`.
+
+### set_column_mask
+
+**Targets:** Data Warehouse / SQL Analytics Endpoint
+
+Apply or replace a dynamic data mask on a column. Executes
+`ALTER TABLE ... ALTER COLUMN ... ADD MASKED WITH (FUNCTION = '...')`.
+
+Blocked by `FABRIC_MCP_READONLY`. Does NOT require `FABRIC_MCP_ALLOW_DESTRUCTIVE`.
+
+**Parameters:**
+
+- `workspace` (`str`): workspace name or GUID.
+- `item` (`str`): Warehouse or SQL endpoint name or GUID.
+- `table_schema` (`str`): schema name of the target table.
+- `table_name` (`str`): name of the target table.
+- `column_name` (`str`): name of the column to mask.
+- `fn_type` (`str`): mask function type - `"default"`, `"email"`, `"random"`, or `"partial"` (case-insensitive).
+- `start` (`int | null`, optional): lower bound for `random` mask (required when `fn_type` is `"random"`).
+- `end` (`int | null`, optional): upper bound for `random` mask (required when `fn_type` is `"random"`). Must be >= `start`.
+- `prefix` (`int | null`, optional): leading characters to expose for `partial` mask (required when `fn_type` is `"partial"`).
+- `padding` (`str | null`, optional): replacement text for `partial` mask (required when `fn_type` is `"partial"`). Cannot contain `"`, `)`, `;`, `--`, control characters (including U+0085, U+2028, U+2029), and is capped at 128 characters.
+- `suffix` (`int | null`, optional): trailing characters to expose for `partial` mask (required when `fn_type` is `"partial"`).
+
+**Returns:** `{ "masked": true, "table_schema": str, "table_name": str, "column_name": str, "masking_function": str }`.
+
+### drop_column_mask
+
+**Targets:** Data Warehouse / SQL Analytics Endpoint
+
+Remove a dynamic data mask from a column. Executes
+`ALTER TABLE ... ALTER COLUMN ... DROP MASKED`.
+
+Blocked by `FABRIC_MCP_READONLY`. Also requires `FABRIC_MCP_ALLOW_DESTRUCTIVE=1` because
+removing a mask is destructive: unmasked data becomes visible to all users who can query the
+column.
+
+**Parameters:**
+
+- `workspace` (`str`): workspace name or GUID.
+- `item` (`str`): Warehouse or SQL endpoint name or GUID.
+- `table_schema` (`str`): schema name of the target table.
+- `table_name` (`str`): name of the target table.
+- `column_name` (`str`): name of the column whose mask to remove.
+
+**Returns:** `{ "unmasked": true, "table_schema": str, "table_name": str, "column_name": str }`.

--- a/src/fabric_dw/cli/_main.py
+++ b/src/fabric_dw/cli/_main.py
@@ -47,6 +47,7 @@ _DESTRUCTIVE_CLI_COMMANDS: frozenset[str] = frozenset(
     {
         "functions.drop",
         "permissions.cls.revoke",
+        "permissions.mask.drop",
         "permissions.sql.revoke",
         "procedures.drop",
         "restore-points.delete",

--- a/src/fabric_dw/cli/commands/permissions.py
+++ b/src/fabric_dw/cli/commands/permissions.py
@@ -1194,3 +1194,213 @@ async def rls_drop_cmd(ctx: CliContext, item: str | None, policy: str) -> None:
     except (ValueError, FabricError) as exc:
         raise click.ClickException(str(exc)) from exc
     click.echo(f"Dropped security policy {policy!r}.")
+
+
+# ---------------------------------------------------------------------------
+# permissions mask sub-group (dynamic data masking)
+# ---------------------------------------------------------------------------
+
+
+from fabric_dw.services import mask as _mask_svc  # noqa: E402
+
+
+@permissions_group.group("mask")
+def mask_group() -> None:
+    """Dynamic data masking: apply or remove column masks."""
+
+
+def _parse_mask_table_ref(table_expr: str) -> tuple[str, str]:
+    """Split SCHEMA.TABLE into (schema, table_name) for mask commands.
+
+    Args:
+        table_expr: Qualified table name (e.g. ``"dbo.Sales"``).
+
+    Returns:
+        ``(schema, table_name)`` tuple.
+
+    Raises:
+        click.UsageError: If *table_expr* is not a two-part qualified name.
+    """
+    try:
+        return _parse_qualified_name(table_expr, "table")
+    except ValueError as exc:
+        raise click.UsageError(f"TABLE: {exc}") from exc
+
+
+@mask_group.command("list")
+@click.argument("item", required=False, default=None)
+@click.argument("table", required=False, default=None, metavar="[SCHEMA.TABLE]")
+@click.pass_obj
+@coro
+async def mask_list_cmd(ctx: CliContext, item: str | None, table: str | None) -> None:
+    """List columns with dynamic data masks on ITEM.
+
+    When TABLE is given (as SCHEMA.TABLE), only masks for that table are shown.
+    """
+    ws = resolve_workspace(ctx)
+    it = resolve_warehouse_arg(ctx, item)
+    table_schema: str | None = None
+    table_name: str | None = None
+    if table is not None:
+        table_schema, table_name = _parse_mask_table_ref(table)
+    try:
+        async with build_http_client(ctx) as http:
+            target, _entry = await build_sql_target(http, ws, it)
+            columns = await _mask_svc.list_masked_columns(
+                target,
+                table_schema=table_schema,
+                table_name=table_name,
+                mode=ctx.auth,
+            )
+            from fabric_dw.cli._render import render  # noqa: PLC0415
+
+            render(
+                [c.model_dump(mode="json") for c in columns],
+                json_output=ctx.json_output,
+                table_title="Masked Columns",
+                prune_null_columns=True,
+            )
+    except (ValueError, FabricError) as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@mask_group.command("set")
+@click.argument("item", required=False, default=None)
+@click.argument("table", metavar="SCHEMA.TABLE")
+@click.option(
+    "--column",
+    "column_name",
+    required=True,
+    metavar="COL",
+    help="Column to apply the mask to.",
+)
+@click.option(
+    "--function",
+    "fn_type",
+    required=True,
+    type=click.Choice(["default", "email", "random", "partial"], case_sensitive=False),
+    help="Mask function type.",
+)
+@click.option("--start", "start", type=int, default=None, help="Lower bound for random() mask.")
+@click.option("--end", "end", type=int, default=None, help="Upper bound for random() mask.")
+@click.option(
+    "--prefix",
+    "prefix",
+    type=int,
+    default=None,
+    help="Leading characters to expose for partial() mask.",
+)
+@click.option(
+    "--padding",
+    "padding",
+    default=None,
+    metavar="STR",
+    help="Replacement padding string for partial() mask.",
+)
+@click.option(
+    "--suffix",
+    "suffix",
+    type=int,
+    default=None,
+    help="Trailing characters to expose for partial() mask.",
+)
+@click.pass_obj
+@coro
+async def mask_set_cmd(
+    ctx: CliContext,
+    item: str | None,
+    table: str,
+    column_name: str,
+    fn_type: str,
+    start: int | None,
+    end: int | None,
+    prefix: int | None,
+    padding: str | None,
+    suffix: int | None,
+) -> None:
+    """Apply or replace a dynamic data mask on a column of ITEM.
+
+    TABLE must be in SCHEMA.TABLE format.  Specify the mask function with
+    --function and any required arguments:
+
+    \b
+      default  -- no extra args required
+      email    -- no extra args required
+      random   -- requires --start and --end
+      partial  -- requires --prefix, --padding, and --suffix
+    """
+    table_schema, table_name = _parse_mask_table_ref(table)
+    ws = resolve_workspace(ctx)
+    it = resolve_warehouse_arg(ctx, item)
+    try:
+        async with build_http_client(ctx) as http:
+            target, _entry = await build_sql_target(http, ws, it)
+            mask_fn_literal = await _mask_svc.set_column_mask(
+                target,
+                table_schema,
+                table_name,
+                column_name,
+                fn_type,
+                start=start,
+                end=end,
+                prefix=prefix,
+                padding=padding,
+                suffix=suffix,
+                mode=ctx.auth,
+            )
+    except ValueError as exc:
+        raise click.UsageError(str(exc)) from exc
+    except FabricError as exc:
+        raise click.ClickException(str(exc)) from exc
+    click.echo(
+        f"Mask {mask_fn_literal!r} applied to [{table_schema}].[{table_name}].[{column_name}]."
+    )
+
+
+@mask_group.command("drop")
+@click.argument("item", required=False, default=None)
+@click.argument("table", metavar="SCHEMA.TABLE")
+@click.option(
+    "--column",
+    "column_name",
+    required=True,
+    metavar="COL",
+    help="Column whose mask to remove.",
+)
+@click.pass_obj
+@coro
+async def mask_drop_cmd(
+    ctx: CliContext,
+    item: str | None,
+    table: str,
+    column_name: str,
+) -> None:
+    """Remove a dynamic data mask from a column of ITEM.
+
+    TABLE must be in SCHEMA.TABLE format.
+
+    This is a destructive operation: the mask is permanently removed.
+    A confirmation prompt is shown unless --yes / -y is passed.
+    """
+    table_schema, table_name = _parse_mask_table_ref(table)
+    if not confirm_destructive(
+        f"Remove mask from [{table_schema}].[{table_name}].[{column_name}]?",
+        yes=ctx.yes,
+    ):
+        click.echo("Aborted.")
+        return
+    ws = resolve_workspace(ctx)
+    it = resolve_warehouse_arg(ctx, item)
+    try:
+        async with build_http_client(ctx) as http:
+            target, _entry = await build_sql_target(http, ws, it)
+            await _mask_svc.drop_column_mask(
+                target,
+                table_schema,
+                table_name,
+                column_name,
+                mode=ctx.auth,
+            )
+    except (ValueError, FabricError) as exc:
+        raise click.ClickException(str(exc)) from exc
+    click.echo(f"Mask removed from [{table_schema}].[{table_name}].[{column_name}].")

--- a/src/fabric_dw/mcp/tools/permissions.py
+++ b/src/fabric_dw/mcp/tools/permissions.py
@@ -38,6 +38,7 @@ from fabric_dw.mcp._helpers import (
     resolve_item,
     tool_err,
 )
+from fabric_dw.services import mask as _mask_svc
 from fabric_dw.services import permissions as _permissions_svc
 from fabric_dw.services import rls as _rls_svc
 
@@ -697,3 +698,189 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         except (ValueError, FabricError) as exc:
             raise tool_err(exc) from exc
         return {"dropped": True, "policy_name": policy_name}
+
+    # -------------------------------------------------------------------------
+    # Dynamic data masking tools
+    # -------------------------------------------------------------------------
+
+    @mcp.tool(name="list_masked_columns")
+    async def list_masked_columns_tool(
+        workspace: str,
+        item: str,
+        table_schema: str | None = None,
+        table_name: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """List columns with dynamic data masking from sys.masked_columns.
+
+        Returns all masked columns on the target Data Warehouse or SQL Analytics
+        Endpoint.  Filter by *table_schema* and/or *table_name* to narrow results.
+
+        Args:
+            workspace: Workspace name or GUID.
+            item: Warehouse or SQL endpoint name or GUID.
+            table_schema: Optional schema filter (case-insensitive). Pass ``None``
+                to include all schemas.
+            table_name: Optional table name filter (case-insensitive). Pass ``None``
+                to include all tables.
+        """
+        ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
+        try:
+            ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
+            _log.debug("list_masked_columns ws=%s item=%s", ws_id, entry.id)
+            target = make_sql_target(ws_id, entry, item)
+            result = await _mask_svc.list_masked_columns(
+                target,
+                table_schema=table_schema,
+                table_name=table_name,
+                mode=ctx.auth_mode,
+            )
+        except (ValueError, FabricError) as exc:
+            raise tool_err(exc) from exc
+        return [c.model_dump(mode="json") for c in result]
+
+    @mutating_tool(mcp, "set_column_mask")
+    async def set_column_mask_tool(  # noqa: PLR0913
+        workspace: str,
+        item: str,
+        table_schema: str,
+        table_name: str,
+        column_name: str,
+        fn_type: str,
+        start: int | None = None,
+        end: int | None = None,
+        prefix: int | None = None,
+        padding: str | None = None,
+        suffix: int | None = None,
+    ) -> dict[str, Any]:
+        """Apply or replace a dynamic data mask on a column.
+
+        Executes ``ALTER TABLE ... ALTER COLUMN ... ADD MASKED WITH (FUNCTION = '...')``.
+        ``ADD MASKED`` replaces any existing mask on the column without error.
+
+        Blocked by ``FABRIC_MCP_READONLY``.
+
+        Supported mask function types:
+
+        - ``"default"`` -- full masking; no extra args.
+        - ``"email"`` -- email masking (exposes first char and ``".com"`` suffix); no extra args.
+        - ``"random"`` -- numeric random mask; requires *start* and *end*.
+        - ``"partial"`` -- custom string partial mask; requires *prefix*, *padding*, and *suffix*.
+
+        Args:
+            workspace: Workspace name or GUID.
+            item: Warehouse or SQL endpoint name or GUID.
+            table_schema: Schema name of the target table.
+            table_name: Name of the target table.
+            column_name: Name of the column to mask.
+            fn_type: Mask function type -- ``"default"``, ``"email"``, ``"random"``,
+                or ``"partial"`` (case-insensitive).
+            start: Lower bound for ``random()`` masking (required when *fn_type* is
+                ``"random"``). Must be <= *end*.
+            end: Upper bound for ``random()`` masking (required when *fn_type* is
+                ``"random"``).
+            prefix: Leading characters to expose for ``partial()`` masking (required
+                when *fn_type* is ``"partial"``).
+            padding: Replacement padding string for ``partial()`` masking (required
+                when *fn_type* is ``"partial"``). Must not contain ``"``, ``)``,
+                ``;``, ``--``, control characters (including U+0085, U+2028,
+                U+2029), and must not exceed 128 characters.
+            suffix: Trailing characters to expose for ``partial()`` masking (required
+                when *fn_type* is ``"partial"``).
+        """
+        ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
+        try:
+            ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
+            target = make_sql_target(ws_id, entry, item)
+            mask_fn_literal = await _mask_svc.set_column_mask(
+                target,
+                table_schema,
+                table_name,
+                column_name,
+                fn_type,
+                start=start,
+                end=end,
+                prefix=prefix,
+                padding=padding,
+                suffix=suffix,
+                mode=ctx.auth_mode,
+            )
+            _log.debug(
+                "set_column_mask ws=%s item=%s table=%s.%s col=%s fn=%r",
+                ws_id,
+                entry.id,
+                table_schema,
+                table_name,
+                column_name,
+                mask_fn_literal,
+            )
+        except (ValueError, FabricError) as exc:
+            raise tool_err(exc) from exc
+        return {
+            "masked": True,
+            "table_schema": table_schema,
+            "table_name": table_name,
+            "column_name": column_name,
+            "masking_function": mask_fn_literal,
+        }
+
+    @mutating_tool(mcp, "drop_column_mask", destructive=True)
+    async def drop_column_mask_tool(
+        workspace: str,
+        item: str,
+        table_schema: str,
+        table_name: str,
+        column_name: str,
+    ) -> dict[str, Any]:
+        """Remove a dynamic data mask from a column.
+
+        Executes ``ALTER TABLE ... ALTER COLUMN ... DROP MASKED``.
+        This is a permanently destructive operation -- the mask is removed from the
+        column and unmasked values become visible to all users who query the column.
+        Requires ``FABRIC_MCP_ALLOW_DESTRUCTIVE=1``.
+
+        Args:
+            workspace: Workspace name or GUID.
+            item: Warehouse or SQL endpoint name or GUID.
+            table_schema: Schema name of the target table.
+            table_name: Name of the target table.
+            column_name: Name of the column whose mask to remove.
+        """
+        ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
+        try:
+            ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
+            _log.debug(
+                "drop_column_mask ws=%s item=%s table=%s.%s col=%s",
+                ws_id,
+                entry.id,
+                table_schema,
+                table_name,
+                column_name,
+            )
+            target = make_sql_target(ws_id, entry, item)
+            await _mask_svc.drop_column_mask(
+                target,
+                table_schema,
+                table_name,
+                column_name,
+                mode=ctx.auth_mode,
+            )
+        except (ValueError, FabricError) as exc:
+            raise tool_err(exc) from exc
+        return {
+            "dropped": True,
+            "table_schema": table_schema,
+            "table_name": table_name,
+            "column_name": column_name,
+        }

--- a/src/fabric_dw/models.py
+++ b/src/fabric_dw/models.py
@@ -1128,3 +1128,29 @@ class SecurityPolicy(_FabricBase):
     policy_name: str
     is_enabled: bool
     predicates: list[SecurityPredicate]
+
+
+# ---------------------------------------------------------------------------
+# Dynamic data masking models
+# ---------------------------------------------------------------------------
+
+
+class MaskedColumn(_FabricBase):
+    """A column with a dynamic data masking function applied.
+
+    Sourced from ``sys.masked_columns`` joined to ``sys.columns``,
+    ``sys.objects``, and ``sys.schemas``.
+
+    Attributes:
+        schema_name: Schema of the table that owns the masked column.
+        table_name: Name of the table that owns the masked column.
+        column_name: Name of the masked column.
+        masking_function: The masking function literal stored in the catalog,
+            e.g. ``"default()"``, ``"email()"``, ``"random(1,12)"``, or
+            ``'partial(2,"XXXX",2)'``.
+    """
+
+    schema_name: str
+    table_name: str
+    column_name: str
+    masking_function: str

--- a/src/fabric_dw/services/mask.py
+++ b/src/fabric_dw/services/mask.py
@@ -1,0 +1,399 @@
+"""Dynamic data masking service functions for Microsoft Fabric Data Warehouses.
+
+Reads from ``sys.masked_columns`` and issues
+``ALTER TABLE ... ALTER COLUMN ... ADD MASKED WITH (FUNCTION = '...')`` and
+``ALTER TABLE ... ALTER COLUMN ... DROP MASKED`` statements.
+
+Statement-building safety
+--------------------------
+All statements are built from:
+- Validated, bracket-quoted identifiers via
+  :func:`~fabric_dw.identifiers.validate_identifier` +
+  :func:`~fabric_dw.identifiers.quote_identifier`.
+- Column names validated via :func:`~fabric_dw.identifiers.validate_column_name`
+  + :func:`~fabric_dw.identifiers.quote_identifier`.
+- Fixed allowlist for mask function type (``default``, ``email``, ``random``,
+  ``partial``).
+- Numeric arguments for ``random`` and ``partial`` are validated as integers.
+- The ``partial`` padding string is validated and escaped by
+  :func:`_validate_and_escape_padding`.
+
+No SQL text is ever parsed or rewritten.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from fabric_dw.auth import CredentialMode
+from fabric_dw.identifiers import (
+    quote_identifier,
+    validate_column_name,
+    validate_identifier,
+)
+from fabric_dw.models import MaskedColumn
+from fabric_dw.sql import SqlTarget, run_query
+
+__all__ = [
+    "VALID_MASK_FUNCTION_TYPES",
+    "drop_column_mask",
+    "list_masked_columns",
+    "set_column_mask",
+]
+
+# ---------------------------------------------------------------------------
+# Allowlists
+# ---------------------------------------------------------------------------
+
+#: Valid mask function type tokens (lowercase).
+VALID_MASK_FUNCTION_TYPES: frozenset[str] = frozenset({"default", "email", "random", "partial"})
+
+_MAX_PADDING_LEN = 128
+
+# Unicode line/paragraph separators that act as line breaks in some parsers.
+_UNICODE_LINE_SEPS: frozenset[str] = frozenset({"\x85", "\u2028", "\u2029"})
+
+# ---------------------------------------------------------------------------
+# SQL templates (read)
+# ---------------------------------------------------------------------------
+
+_LIST_MASKED_COLUMNS_SQL = """\
+SELECT
+    s.name AS schema_name,
+    o.name AS table_name,
+    c.name AS column_name,
+    mc.masking_function
+FROM sys.masked_columns mc
+JOIN sys.columns c ON mc.object_id = c.object_id AND mc.column_id = c.column_id
+JOIN sys.objects o ON mc.object_id = o.object_id
+JOIN sys.schemas s ON o.schema_id = s.schema_id
+WHERE mc.is_masked = 1
+ORDER BY s.name, o.name, c.name;
+"""
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+def _validate_and_escape_padding(padding: str) -> str:
+    """Validate and escape a padding string for use inside ``partial(...)`` mask function.
+
+    The full SQL statement embeds the padding as:
+    ``ALTER TABLE ... ADD MASKED WITH (FUNCTION = 'partial(N,"<padding>",M)')``.
+    The padding is inside double quotes ``"..."`` within the outer single-quoted
+    SQL string literal ``'...'``.
+
+    Validation rules:
+
+    - Rejects empty padding.
+    - Rejects strings longer than 128 characters.
+    - Rejects ``"`` (double quote): cannot safely escape inside the ``"..."``
+      inner delimiters.
+    - Rejects ``)`` (close-paren): would close the ``partial(...)`` call prematurely.
+    - Rejects control characters (``ord(c) < 0x20`` or ``ord(c) == 0x7F``).
+    - Rejects Unicode line separators U+0085, U+2028, U+2029.
+    - Rejects ``--`` (SQL line comment sequence).
+    - Rejects ``;`` (statement separator).
+
+    Single quotes are escaped by doubling (``'`` -> ``''``) per T-SQL string
+    literal rules, because the padding lives inside the outer ``'...'`` literal.
+
+    Args:
+        padding: The raw padding string from the caller.
+
+    Returns:
+        The escaped padding string, safe for embedding in the SQL string literal.
+
+    Raises:
+        ValueError: If the padding fails any validation rule.
+    """
+    if not padding:
+        msg = "padding must not be empty"
+        raise ValueError(msg)
+    if len(padding) > _MAX_PADDING_LEN:
+        msg = f"padding must not exceed {_MAX_PADDING_LEN} characters; got {len(padding)}"
+        raise ValueError(msg)
+    if '"' in padding:
+        msg = (
+            'padding must not contain a double quote (") '
+            '-- it would break the inner "..." delimiter'
+        )
+        raise ValueError(msg)
+    if ")" in padding:
+        msg = "padding must not contain ')' -- it would close the partial() call prematurely"
+        raise ValueError(msg)
+    for ch in padding:
+        if ord(ch) < 0x20 or ord(ch) == 0x7F:  # noqa: PLR2004
+            msg = f"padding must not contain control characters; found ord={ord(ch):#04x}"
+            raise ValueError(msg)
+        if ch in _UNICODE_LINE_SEPS:
+            msg = f"padding must not contain Unicode line separators; found U+{ord(ch):04X}"
+            raise ValueError(msg)
+    if "--" in padding:
+        msg = "padding must not contain SQL line comment sequence '--'"
+        raise ValueError(msg)
+    if ";" in padding:
+        msg = "padding must not contain statement separator ';'"
+        raise ValueError(msg)
+    # T-SQL string escaping: single quote -> doubled single quote.
+    return padding.replace("'", "''")
+
+
+def _build_mask_function(
+    fn_type: str,
+    *,
+    start: int | None = None,
+    end: int | None = None,
+    prefix: int | None = None,
+    padding: str | None = None,
+    suffix: int | None = None,
+) -> str:
+    """Build a mask function literal for use in ``ADD MASKED WITH (FUNCTION = '...')``.
+
+    The returned string is the raw function call (without surrounding quotes),
+    e.g. ``"default()"``, ``"email()"``, ``"random(1, 12)"``, or
+    ``'partial(2,"XXXX",2)'``.
+
+    Args:
+        fn_type: Mask function type - one of ``"default"``, ``"email"``,
+            ``"random"``, ``"partial"`` (case-insensitive).
+        start: Lower bound for ``random()`` masking (required for ``random``).
+        end: Upper bound for ``random()`` masking (required for ``random``).
+            Must be >= *start*.
+        prefix: Number of leading characters to expose for ``partial()`` masking
+            (required for ``partial``).
+        padding: Replacement padding string for ``partial()`` masking (required
+            for ``partial``). Validated and escaped by
+            :func:`_validate_and_escape_padding`.
+        suffix: Number of trailing characters to expose for ``partial()`` masking
+            (required for ``partial``).
+
+    Returns:
+        The mask function literal string (no outer quotes).
+
+    Raises:
+        ValueError: If *fn_type* is unknown, required arguments are missing,
+            or inapplicable arguments are provided for the chosen function.
+    """
+    lower = fn_type.lower()
+    if lower not in VALID_MASK_FUNCTION_TYPES:
+        msg = (
+            f"Invalid mask function type {fn_type!r}: "
+            f"must be one of {', '.join(sorted(VALID_MASK_FUNCTION_TYPES))}"
+        )
+        raise ValueError(msg)
+
+    if lower in {"default", "email"}:
+        _extra = [
+            name
+            for name, val in (
+                ("--start", start),
+                ("--end", end),
+                ("--prefix", prefix),
+                ("--padding", padding),
+                ("--suffix", suffix),
+            )
+            if val is not None
+        ]
+        if _extra:
+            msg = f"{lower}() mask does not accept arguments; unexpected: {', '.join(_extra)}"
+            raise ValueError(msg)
+        return f"{lower}()"
+
+    if lower == "random":
+        _extra = [
+            name
+            for name, val in (
+                ("--prefix", prefix),
+                ("--padding", padding),
+                ("--suffix", suffix),
+            )
+            if val is not None
+        ]
+        if _extra:
+            msg = f"random() mask does not accept: {', '.join(_extra)}; use --start and --end"
+            raise ValueError(msg)
+        if start is None or end is None:
+            msg = "random() mask requires both --start and --end arguments"
+            raise ValueError(msg)
+        if int(start) > int(end):
+            msg = f"random() mask requires start <= end; got start={start}, end={end}"
+            raise ValueError(msg)
+        return f"random({int(start)}, {int(end)})"
+
+    # partial
+    _extra = [name for name, val in (("--start", start), ("--end", end)) if val is not None]
+    if _extra:
+        msg = (
+            f"partial() mask does not accept: {', '.join(_extra)}; "
+            "use --prefix, --padding, and --suffix"
+        )
+        raise ValueError(msg)
+    if prefix is None or padding is None or suffix is None:
+        msg = "partial() mask requires --prefix, --padding, and --suffix arguments"
+        raise ValueError(msg)
+    escaped = _validate_and_escape_padding(padding)
+    return f'partial({int(prefix)},"{escaped}",{int(suffix)})'
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+async def list_masked_columns(
+    target: SqlTarget,
+    *,
+    table_schema: str | None = None,
+    table_name: str | None = None,
+    mode: CredentialMode = CredentialMode.DEFAULT,
+) -> list[MaskedColumn]:
+    """Return columns that have dynamic data masking applied.
+
+    Reads from ``sys.masked_columns`` joined to ``sys.columns``, ``sys.objects``,
+    and ``sys.schemas``.
+
+    Args:
+        target: SQL connection target.
+        table_schema: Optional schema filter (case-insensitive match).
+        table_name: Optional table name filter (case-insensitive match).
+        mode: Credential mode for Entra authentication.
+
+    Returns:
+        List of :class:`~fabric_dw.models.MaskedColumn` objects, ordered by
+        schema, table, then column name.
+    """
+
+    def _run() -> list[MaskedColumn]:
+        cols, rows = run_query(target, _LIST_MASKED_COLUMNS_SQL, mode=mode)
+        result: list[MaskedColumn] = []
+        for row in rows:
+            d = dict(zip(cols, row, strict=True))
+            s_name = str(d["schema_name"])
+            t_name = str(d["table_name"])
+            c_name = str(d["column_name"])
+            m_fn = str(d["masking_function"])
+
+            if table_schema is not None and s_name.lower() != table_schema.lower():
+                continue
+            if table_name is not None and t_name.lower() != table_name.lower():
+                continue
+
+            result.append(
+                MaskedColumn(
+                    schema_name=s_name,
+                    table_name=t_name,
+                    column_name=c_name,
+                    masking_function=m_fn,
+                )
+            )
+        return result
+
+    return await asyncio.to_thread(_run)
+
+
+async def set_column_mask(
+    target: SqlTarget,
+    table_schema: str,
+    table_name: str,
+    column_name: str,
+    fn_type: str,
+    *,
+    start: int | None = None,
+    end: int | None = None,
+    prefix: int | None = None,
+    padding: str | None = None,
+    suffix: int | None = None,
+    mode: CredentialMode = CredentialMode.DEFAULT,
+) -> str:
+    """Apply or replace a dynamic data mask on a column.
+
+    Executes
+    ``ALTER TABLE [schema].[table] ALTER COLUMN [col] ADD MASKED WITH (FUNCTION = '...')``.
+    ``ADD MASKED`` replaces any existing mask on the column without error.
+
+    Args:
+        target: SQL connection target.
+        table_schema: Schema name of the target table.
+        table_name: Name of the target table.
+        column_name: Name of the column to mask.
+        fn_type: Mask function type - ``"default"``, ``"email"``, ``"random"``,
+            or ``"partial"`` (case-insensitive).
+        start: Lower bound for ``random()`` masking (required for ``random``).
+        end: Upper bound for ``random()`` masking (required for ``random``).
+            Must be >= *start*.
+        prefix: Leading characters to expose for ``partial()`` masking
+            (required for ``partial``).
+        padding: Replacement padding string for ``partial()`` masking (required
+            for ``partial``). Validated and escaped internally.
+        suffix: Trailing characters to expose for ``partial()`` masking
+            (required for ``partial``).
+        mode: Credential mode for Entra authentication.
+
+    Returns:
+        The mask function literal that was applied, e.g. ``"email()"``.
+
+    Raises:
+        ValueError: If any identifier is invalid or the mask function args are wrong.
+    """
+    validate_identifier(table_schema)
+    validate_identifier(table_name)
+    validate_column_name(column_name)
+    mask_fn_literal = _build_mask_function(
+        fn_type,
+        start=start,
+        end=end,
+        prefix=prefix,
+        padding=padding,
+        suffix=suffix,
+    )
+    table_ref = f"{quote_identifier(table_schema)}.{quote_identifier(table_name)}"
+    col_ref = quote_identifier(column_name)
+    ddl = (
+        f"ALTER TABLE {table_ref} ALTER COLUMN {col_ref} "
+        f"ADD MASKED WITH (FUNCTION = '{mask_fn_literal}');"
+    )
+
+    def _run() -> None:
+        run_query(target, ddl, mode=mode, autocommit=True, fetch="none")
+
+    await asyncio.to_thread(_run)
+    return mask_fn_literal
+
+
+async def drop_column_mask(
+    target: SqlTarget,
+    table_schema: str,
+    table_name: str,
+    column_name: str,
+    *,
+    mode: CredentialMode = CredentialMode.DEFAULT,
+) -> None:
+    """Remove a dynamic data mask from a column.
+
+    Executes ``ALTER TABLE [schema].[table] ALTER COLUMN [col] DROP MASKED``.
+
+    This is a destructive operation: the masking rule is permanently removed.
+
+    Args:
+        target: SQL connection target.
+        table_schema: Schema name of the target table.
+        table_name: Name of the target table.
+        column_name: Name of the column to unmask.
+        mode: Credential mode for Entra authentication.
+
+    Raises:
+        ValueError: If any identifier is invalid.
+    """
+    validate_identifier(table_schema)
+    validate_identifier(table_name)
+    validate_column_name(column_name)
+    table_ref = f"{quote_identifier(table_schema)}.{quote_identifier(table_name)}"
+    col_ref = quote_identifier(column_name)
+    ddl = f"ALTER TABLE {table_ref} ALTER COLUMN {col_ref} DROP MASKED;"
+
+    def _run() -> None:
+        run_query(target, ddl, mode=mode, autocommit=True, fetch="none")
+
+    await asyncio.to_thread(_run)

--- a/src/fabric_dw/services/permissions.py
+++ b/src/fabric_dw/services/permissions.py
@@ -88,6 +88,9 @@ _ACCESS_DETAILS_KEY = "accessDetails"
 # ---------------------------------------------------------------------------
 
 #: Permissions valid on OBJECT-class securables (tables, views, functions, procedures).
+#: UNMASK is included here so that ``GRANT UNMASK ON OBJECT::[schema].[table] TO [principal]``
+#: and the column-level form ``GRANT UNMASK ON OBJECT::[s].[t] ([col]) TO [principal]``
+#: are accepted.  Reference: https://learn.microsoft.com/fabric/data-warehouse/dynamic-data-masking
 OBJECT_PERMISSIONS: frozenset[str] = frozenset(
     {
         "SELECT",
@@ -100,6 +103,7 @@ OBJECT_PERMISSIONS: frozenset[str] = frozenset(
         "CONTROL",
         "VIEW DEFINITION",
         "TAKE OWNERSHIP",
+        "UNMASK",
     }
 )
 
@@ -119,6 +123,8 @@ SCHEMA_PERMISSIONS: frozenset[str] = frozenset(
 )
 
 #: Permissions valid on DATABASE-class securables.
+#: UNMASK is included here so that ``GRANT UNMASK TO [principal]`` (database scope) is accepted.
+#: Reference: https://learn.microsoft.com/fabric/data-warehouse/dynamic-data-masking
 DATABASE_PERMISSIONS: frozenset[str] = frozenset(
     {
         "CONNECT",
@@ -136,6 +142,7 @@ DATABASE_PERMISSIONS: frozenset[str] = frozenset(
         "CREATE PROCEDURE",
         "CREATE FUNCTION",
         "CREATE SCHEMA",
+        "UNMASK",
     }
 )
 
@@ -147,8 +154,13 @@ _ALLOWLISTS: dict[str, frozenset[str]] = {
 }
 
 #: Permissions that may be applied at column-level within OBJECT scope.
-#: See https://learn.microsoft.com/fabric/data-warehouse/column-level-security
-COLUMN_APPLICABLE_PERMISSIONS: frozenset[str] = frozenset({"SELECT", "UPDATE", "REFERENCES"})
+#: Includes UNMASK so that ``GRANT UNMASK ON OBJECT::[s].[t] ([col]) TO [principal]``
+#: can be issued via the existing ``permissions sql grant`` / ``permissions cls grant`` commands.
+#: See https://learn.microsoft.com/fabric/data-warehouse/column-level-security and
+#: https://learn.microsoft.com/fabric/data-warehouse/dynamic-data-masking
+COLUMN_APPLICABLE_PERMISSIONS: frozenset[str] = frozenset(
+    {"SELECT", "UPDATE", "REFERENCES", "UNMASK"}
+)
 
 # ---------------------------------------------------------------------------
 # SQL templates (reads)

--- a/src/fabric_dw/telemetry_commands.py
+++ b/src/fabric_dw/telemetry_commands.py
@@ -98,6 +98,10 @@ DOMAIN_MAP: dict[str, str] = {
     "drop_security_predicate": "permissions",
     "set_security_policy_state": "permissions",
     "drop_security_policy": "permissions",
+    # Dynamic data masking
+    "list_masked_columns": "permissions",
+    "set_column_mask": "permissions",
+    "drop_column_mask": "permissions",
     # Audit
     "get_audit_settings": "audit",
     "enable_audit": "audit",

--- a/tests/integration/test_services_mask.py
+++ b/tests/integration/test_services_mask.py
@@ -1,0 +1,272 @@
+"""Integration tests for dynamic data masking service functions.
+
+Run with: pytest -m integration tests/integration/test_services_mask.py
+
+Covers the set -> list (assert masked) -> drop -> list (assert unmasked) round-trip
+for dynamic data masking.
+
+The test creates a minimal table, applies masks to its columns, asserts the catalog
+reports them correctly, then drops the masks.  Teardown drops the table.
+
+Data Warehouse and SQL Analytics Endpoint: ALTER TABLE ... ALTER COLUMN ADD/DROP MASKED
+requires ALTER ANY MASK and ALTER on the target table, which the test service principal
+has via its workspace role.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import uuid
+from collections.abc import AsyncIterator
+
+import pytest
+import pytest_asyncio
+
+from fabric_dw.services import mask as mask_svc
+from fabric_dw.sql import SqlTarget, run_query
+
+pytestmark = pytest.mark.integration
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _unique_table_name() -> str:
+    """Return a short, collision-resistant table name safe for Fabric DDL."""
+    return f"pytest_mask_{uuid.uuid4().hex[:8]}"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def mask_table(
+    warehouse_schema: tuple[SqlTarget, str],
+) -> AsyncIterator[tuple[SqlTarget, str, str]]:
+    """Create a minimal table for mask tests and drop it in teardown.
+
+    Yields ``(sql_target, schema_name, table_name)``.
+
+    The table has two columns: ``Email`` (varchar) and ``Phone`` (varchar).
+    Teardown suppresses exceptions so a missing table (e.g. from a failed
+    CREATE) does not mask the original test error.
+    """
+    sql_target, schema_name = warehouse_schema
+    table_name = _unique_table_name()
+
+    await asyncio.to_thread(
+        run_query,
+        sql_target,
+        (
+            f"CREATE TABLE [{schema_name}].[{table_name}] ("
+            "    Email VARCHAR(256) NULL,"
+            "    Phone VARCHAR(20) NULL,"
+            "    Salary INT NULL"
+            ");"
+        ),
+        autocommit=True,
+        fetch="none",
+    )
+    try:
+        yield sql_target, schema_name, table_name
+    finally:
+        with contextlib.suppress(Exception):
+            await asyncio.to_thread(
+                run_query,
+                sql_target,
+                f"DROP TABLE IF EXISTS [{schema_name}].[{table_name}];",
+                autocommit=True,
+                fetch="none",
+            )
+
+
+# ---------------------------------------------------------------------------
+# Integration tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_set_and_list_default_mask(
+    mask_table: tuple[SqlTarget, str, str],
+) -> None:
+    """set_column_mask (default) -> list_masked_columns round-trip."""
+    sql_target, schema_name, table_name = mask_table
+
+    await mask_svc.set_column_mask(
+        sql_target,
+        schema_name,
+        table_name,
+        "Email",
+        "default()",
+    )
+
+    columns = await mask_svc.list_masked_columns(
+        sql_target,
+        table_schema=schema_name,
+        table_name=table_name,
+    )
+    assert any(c.column_name == "Email" for c in columns), (
+        f"Email not found in masked columns: {columns}"
+    )
+    email_col = next(c for c in columns if c.column_name == "Email")
+    assert "default" in email_col.masking_function.lower()
+
+
+@pytest.mark.integration
+async def test_set_and_list_email_mask(
+    mask_table: tuple[SqlTarget, str, str],
+) -> None:
+    """set_column_mask (email) -> list_masked_columns round-trip."""
+    sql_target, schema_name, table_name = mask_table
+
+    await mask_svc.set_column_mask(
+        sql_target,
+        schema_name,
+        table_name,
+        "Email",
+        "email()",
+    )
+
+    columns = await mask_svc.list_masked_columns(
+        sql_target,
+        table_schema=schema_name,
+        table_name=table_name,
+    )
+    email_col = next((c for c in columns if c.column_name == "Email"), None)
+    assert email_col is not None, "Email not found in masked columns"
+    assert "email" in email_col.masking_function.lower()
+
+
+@pytest.mark.integration
+async def test_set_and_list_random_mask(
+    mask_table: tuple[SqlTarget, str, str],
+) -> None:
+    """set_column_mask (random) -> list_masked_columns round-trip."""
+    sql_target, schema_name, table_name = mask_table
+    from fabric_dw.services.mask import _build_mask_function  # noqa: PLC0415
+
+    mask_fn = _build_mask_function("random", start=1, end=999999)
+    await mask_svc.set_column_mask(
+        sql_target,
+        schema_name,
+        table_name,
+        "Salary",
+        mask_fn,
+    )
+
+    columns = await mask_svc.list_masked_columns(
+        sql_target,
+        table_schema=schema_name,
+        table_name=table_name,
+    )
+    salary_col = next((c for c in columns if c.column_name == "Salary"), None)
+    assert salary_col is not None, "Salary not found in masked columns"
+    assert "random" in salary_col.masking_function.lower()
+
+
+@pytest.mark.integration
+async def test_set_and_list_partial_mask(
+    mask_table: tuple[SqlTarget, str, str],
+) -> None:
+    """set_column_mask (partial) -> list_masked_columns round-trip."""
+    sql_target, schema_name, table_name = mask_table
+    from fabric_dw.services.mask import _build_mask_function  # noqa: PLC0415
+
+    mask_fn = _build_mask_function("partial", prefix=0, padding="XXX-XXX-", suffix=4)
+    await mask_svc.set_column_mask(
+        sql_target,
+        schema_name,
+        table_name,
+        "Phone",
+        mask_fn,
+    )
+
+    columns = await mask_svc.list_masked_columns(
+        sql_target,
+        table_schema=schema_name,
+        table_name=table_name,
+    )
+    phone_col = next((c for c in columns if c.column_name == "Phone"), None)
+    assert phone_col is not None, "Phone not found in masked columns"
+    assert "partial" in phone_col.masking_function.lower()
+
+
+@pytest.mark.integration
+async def test_drop_mask_removes_column_from_list(
+    mask_table: tuple[SqlTarget, str, str],
+) -> None:
+    """set_column_mask -> drop_column_mask -> list (asserts column no longer masked)."""
+    sql_target, schema_name, table_name = mask_table
+
+    # Apply a mask
+    await mask_svc.set_column_mask(
+        sql_target,
+        schema_name,
+        table_name,
+        "Email",
+        "email()",
+    )
+
+    # Verify it appears
+    columns_before = await mask_svc.list_masked_columns(
+        sql_target,
+        table_schema=schema_name,
+        table_name=table_name,
+    )
+    assert any(c.column_name == "Email" for c in columns_before)
+
+    # Drop the mask
+    await mask_svc.drop_column_mask(
+        sql_target,
+        schema_name,
+        table_name,
+        "Email",
+    )
+
+    # Verify it is gone
+    columns_after = await mask_svc.list_masked_columns(
+        sql_target,
+        table_schema=schema_name,
+        table_name=table_name,
+    )
+    assert not any(c.column_name == "Email" for c in columns_after), (
+        "Email still appears as masked after DROP MASKED"
+    )
+
+
+@pytest.mark.integration
+async def test_set_mask_replaces_existing_mask(
+    mask_table: tuple[SqlTarget, str, str],
+) -> None:
+    """ADD MASKED replaces an existing mask without error."""
+    sql_target, schema_name, table_name = mask_table
+
+    await mask_svc.set_column_mask(
+        sql_target,
+        schema_name,
+        table_name,
+        "Email",
+        "default()",
+    )
+    # Replace with email()
+    await mask_svc.set_column_mask(
+        sql_target,
+        schema_name,
+        table_name,
+        "Email",
+        "email()",
+    )
+
+    columns = await mask_svc.list_masked_columns(
+        sql_target,
+        table_schema=schema_name,
+        table_name=table_name,
+    )
+    email_col = next((c for c in columns if c.column_name == "Email"), None)
+    assert email_col is not None
+    assert "email" in email_col.masking_function.lower()

--- a/tests/unit/services/test_mask.py
+++ b/tests/unit/services/test_mask.py
@@ -1,0 +1,685 @@
+"""Unit tests for dynamic data masking service functions in fabric_dw.services.mask."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from fabric_dw.models import MaskedColumn
+from fabric_dw.services import mask as mask_svc
+from fabric_dw.sql import SqlTarget
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+_TARGET = SqlTarget(
+    workspace_id="ws-1",
+    database="SalesDW",
+    connection_string="server.datawarehouse.fabric.microsoft.com",
+)
+
+_LIST_COLS = ["schema_name", "table_name", "column_name", "masking_function"]
+
+
+# ---------------------------------------------------------------------------
+# _validate_and_escape_padding
+# ---------------------------------------------------------------------------
+
+
+class TestValidateAndEscapePadding:
+    def test_simple_string_unchanged(self) -> None:
+        from fabric_dw.services.mask import _validate_and_escape_padding  # noqa: PLC0415
+
+        assert _validate_and_escape_padding("XXXX") == "XXXX"
+
+    def test_hyphen_allowed(self) -> None:
+        from fabric_dw.services.mask import _validate_and_escape_padding  # noqa: PLC0415
+
+        assert _validate_and_escape_padding("-") == "-"
+
+    def test_single_quote_doubled(self) -> None:
+        from fabric_dw.services.mask import _validate_and_escape_padding  # noqa: PLC0415
+
+        assert _validate_and_escape_padding("O'Reilly") == "O''Reilly"
+
+    def test_empty_raises(self) -> None:
+        from fabric_dw.services.mask import _validate_and_escape_padding  # noqa: PLC0415
+
+        with pytest.raises(ValueError, match="must not be empty"):
+            _validate_and_escape_padding("")
+
+    def test_too_long_raises(self) -> None:
+        from fabric_dw.services.mask import _validate_and_escape_padding  # noqa: PLC0415
+
+        with pytest.raises(ValueError, match="must not exceed 128"):
+            _validate_and_escape_padding("X" * 129)
+
+    def test_exactly_128_chars_ok(self) -> None:
+        from fabric_dw.services.mask import _validate_and_escape_padding  # noqa: PLC0415
+
+        result = _validate_and_escape_padding("X" * 128)
+        assert result == "X" * 128
+
+    def test_double_quote_raises(self) -> None:
+        from fabric_dw.services.mask import _validate_and_escape_padding  # noqa: PLC0415
+
+        with pytest.raises(ValueError, match="double quote"):
+            _validate_and_escape_padding('X"Y')
+
+    def test_close_paren_raises(self) -> None:
+        from fabric_dw.services.mask import _validate_and_escape_padding  # noqa: PLC0415
+
+        with pytest.raises(ValueError, match=r"'\)'"):
+            _validate_and_escape_padding("X)Y")
+
+    def test_control_char_raises(self) -> None:
+        from fabric_dw.services.mask import _validate_and_escape_padding  # noqa: PLC0415
+
+        with pytest.raises(ValueError, match="control characters"):
+            _validate_and_escape_padding("X\x00Y")
+
+    def test_tab_raises(self) -> None:
+        from fabric_dw.services.mask import _validate_and_escape_padding  # noqa: PLC0415
+
+        with pytest.raises(ValueError, match="control characters"):
+            _validate_and_escape_padding("X\tY")
+
+    def test_del_raises(self) -> None:
+        from fabric_dw.services.mask import _validate_and_escape_padding  # noqa: PLC0415
+
+        with pytest.raises(ValueError, match="control characters"):
+            _validate_and_escape_padding("X\x7fY")
+
+    def test_unicode_nel_raises(self) -> None:
+        """U+0085 (NEL) must be rejected."""
+        from fabric_dw.services.mask import _validate_and_escape_padding  # noqa: PLC0415
+
+        with pytest.raises(ValueError, match="Unicode line separators"):
+            _validate_and_escape_padding("X\x85Y")
+
+    def test_unicode_line_sep_raises(self) -> None:
+        """U+2028 (LINE SEPARATOR) must be rejected."""
+        from fabric_dw.services.mask import _validate_and_escape_padding  # noqa: PLC0415
+
+        with pytest.raises(ValueError, match="Unicode line separators"):
+            _validate_and_escape_padding("X\u2028Y")
+
+    def test_unicode_para_sep_raises(self) -> None:
+        """U+2029 (PARAGRAPH SEPARATOR) must be rejected."""
+        from fabric_dw.services.mask import _validate_and_escape_padding  # noqa: PLC0415
+
+        with pytest.raises(ValueError, match="Unicode line separators"):
+            _validate_and_escape_padding("X\u2029Y")
+
+    def test_sql_comment_raises(self) -> None:
+        from fabric_dw.services.mask import _validate_and_escape_padding  # noqa: PLC0415
+
+        with pytest.raises(ValueError, match="comment"):
+            _validate_and_escape_padding("X--Y")
+
+    def test_semicolon_raises(self) -> None:
+        from fabric_dw.services.mask import _validate_and_escape_padding  # noqa: PLC0415
+
+        with pytest.raises(ValueError, match="separator"):
+            _validate_and_escape_padding("X;Y")
+
+
+# ---------------------------------------------------------------------------
+# _build_mask_function
+# ---------------------------------------------------------------------------
+
+
+class TestBuildMaskFunction:
+    def test_default(self) -> None:
+        from fabric_dw.services.mask import _build_mask_function  # noqa: PLC0415
+
+        assert _build_mask_function("default") == "default()"
+
+    def test_default_case_insensitive(self) -> None:
+        from fabric_dw.services.mask import _build_mask_function  # noqa: PLC0415
+
+        assert _build_mask_function("DEFAULT") == "default()"
+
+    def test_email(self) -> None:
+        from fabric_dw.services.mask import _build_mask_function  # noqa: PLC0415
+
+        assert _build_mask_function("email") == "email()"
+
+    def test_random(self) -> None:
+        from fabric_dw.services.mask import _build_mask_function  # noqa: PLC0415
+
+        assert _build_mask_function("random", start=1, end=12) == "random(1, 12)"
+
+    def test_random_missing_start_raises(self) -> None:
+        from fabric_dw.services.mask import _build_mask_function  # noqa: PLC0415
+
+        with pytest.raises(ValueError, match="--start"):
+            _build_mask_function("random", end=12)
+
+    def test_random_missing_end_raises(self) -> None:
+        from fabric_dw.services.mask import _build_mask_function  # noqa: PLC0415
+
+        with pytest.raises(ValueError, match="--end"):
+            _build_mask_function("random", start=1)
+
+    def test_random_start_gt_end_raises(self) -> None:
+        from fabric_dw.services.mask import _build_mask_function  # noqa: PLC0415
+
+        with pytest.raises(ValueError, match="start <= end"):
+            _build_mask_function("random", start=10, end=5)
+
+    def test_random_start_eq_end_ok(self) -> None:
+        from fabric_dw.services.mask import _build_mask_function  # noqa: PLC0415
+
+        assert _build_mask_function("random", start=5, end=5) == "random(5, 5)"
+
+    def test_partial_basic(self) -> None:
+        from fabric_dw.services.mask import _build_mask_function  # noqa: PLC0415
+
+        result = _build_mask_function("partial", prefix=2, padding="XXXX", suffix=2)
+        assert result == 'partial(2,"XXXX",2)'
+
+    def test_partial_phone_number(self) -> None:
+        from fabric_dw.services.mask import _build_mask_function  # noqa: PLC0415
+
+        result = _build_mask_function("partial", prefix=1, padding="XXXXXXX", suffix=0)
+        assert result == 'partial(1,"XXXXXXX",0)'
+
+    def test_partial_ssn_prefix(self) -> None:
+        from fabric_dw.services.mask import _build_mask_function  # noqa: PLC0415
+
+        result = _build_mask_function("partial", prefix=0, padding="XXX-XX-", suffix=4)
+        assert result == 'partial(0,"XXX-XX-",4)'
+
+    def test_partial_single_quote_in_padding_escaped(self) -> None:
+        from fabric_dw.services.mask import _build_mask_function  # noqa: PLC0415
+
+        # single quote in padding must be doubled for T-SQL string escaping
+        result = _build_mask_function("partial", prefix=1, padding="X'X", suffix=1)
+        assert result == "partial(1,\"X''X\",1)"
+
+    def test_partial_missing_prefix_raises(self) -> None:
+        from fabric_dw.services.mask import _build_mask_function  # noqa: PLC0415
+
+        with pytest.raises(ValueError, match="--prefix"):
+            _build_mask_function("partial", padding="X", suffix=1)
+
+    def test_partial_missing_padding_raises(self) -> None:
+        from fabric_dw.services.mask import _build_mask_function  # noqa: PLC0415
+
+        with pytest.raises(ValueError, match="--padding"):
+            _build_mask_function("partial", prefix=1, suffix=1)
+
+    def test_partial_missing_suffix_raises(self) -> None:
+        from fabric_dw.services.mask import _build_mask_function  # noqa: PLC0415
+
+        with pytest.raises(ValueError, match="--suffix"):
+            _build_mask_function("partial", prefix=1, padding="X")
+
+    def test_unknown_type_raises(self) -> None:
+        from fabric_dw.services.mask import _build_mask_function  # noqa: PLC0415
+
+        with pytest.raises(ValueError, match="Invalid mask function type"):
+            _build_mask_function("full")
+
+    # SF-1: cross-arg validation
+
+    def test_default_rejects_start(self) -> None:
+        from fabric_dw.services.mask import _build_mask_function  # noqa: PLC0415
+
+        with pytest.raises(ValueError, match="does not accept"):
+            _build_mask_function("default", start=1)
+
+    def test_default_rejects_end(self) -> None:
+        from fabric_dw.services.mask import _build_mask_function  # noqa: PLC0415
+
+        with pytest.raises(ValueError, match="does not accept"):
+            _build_mask_function("default", end=10)
+
+    def test_default_rejects_prefix(self) -> None:
+        from fabric_dw.services.mask import _build_mask_function  # noqa: PLC0415
+
+        with pytest.raises(ValueError, match="does not accept"):
+            _build_mask_function("default", prefix=2)
+
+    def test_default_rejects_padding(self) -> None:
+        from fabric_dw.services.mask import _build_mask_function  # noqa: PLC0415
+
+        with pytest.raises(ValueError, match="does not accept"):
+            _build_mask_function("default", padding="X")
+
+    def test_default_rejects_suffix(self) -> None:
+        from fabric_dw.services.mask import _build_mask_function  # noqa: PLC0415
+
+        with pytest.raises(ValueError, match="does not accept"):
+            _build_mask_function("default", suffix=2)
+
+    def test_email_rejects_start(self) -> None:
+        from fabric_dw.services.mask import _build_mask_function  # noqa: PLC0415
+
+        with pytest.raises(ValueError, match="does not accept"):
+            _build_mask_function("email", start=1)
+
+    def test_email_rejects_padding(self) -> None:
+        from fabric_dw.services.mask import _build_mask_function  # noqa: PLC0415
+
+        with pytest.raises(ValueError, match="does not accept"):
+            _build_mask_function("email", padding="X")
+
+    def test_random_rejects_prefix(self) -> None:
+        from fabric_dw.services.mask import _build_mask_function  # noqa: PLC0415
+
+        with pytest.raises(ValueError, match="does not accept"):
+            _build_mask_function("random", start=1, end=10, prefix=2)
+
+    def test_random_rejects_padding(self) -> None:
+        from fabric_dw.services.mask import _build_mask_function  # noqa: PLC0415
+
+        with pytest.raises(ValueError, match="does not accept"):
+            _build_mask_function("random", start=1, end=10, padding="X")
+
+    def test_random_rejects_suffix(self) -> None:
+        from fabric_dw.services.mask import _build_mask_function  # noqa: PLC0415
+
+        with pytest.raises(ValueError, match="does not accept"):
+            _build_mask_function("random", start=1, end=10, suffix=2)
+
+    def test_partial_rejects_start(self) -> None:
+        from fabric_dw.services.mask import _build_mask_function  # noqa: PLC0415
+
+        with pytest.raises(ValueError, match="does not accept"):
+            _build_mask_function("partial", prefix=1, padding="X", suffix=1, start=1)
+
+    def test_partial_rejects_end(self) -> None:
+        from fabric_dw.services.mask import _build_mask_function  # noqa: PLC0415
+
+        with pytest.raises(ValueError, match="does not accept"):
+            _build_mask_function("partial", prefix=1, padding="X", suffix=1, end=10)
+
+
+# ---------------------------------------------------------------------------
+# list_masked_columns
+# ---------------------------------------------------------------------------
+
+
+class TestListMaskedColumns:
+    async def test_returns_masked_column_objects(self) -> None:
+        rows = [
+            ("dbo", "Employees", "Email", "email()"),
+            ("dbo", "Employees", "Phone", 'partial(0,"XXX-XXX-",4)'),
+        ]
+
+        def _mock(_target: object, _sql: str, **_kw: object) -> tuple:
+            return _LIST_COLS, rows
+
+        with patch("fabric_dw.services.mask.run_query", side_effect=_mock):
+            result = await mask_svc.list_masked_columns(_TARGET)
+
+        assert len(result) == 2
+        col = result[0]
+        assert isinstance(col, MaskedColumn)
+        assert col.schema_name == "dbo"
+        assert col.table_name == "Employees"
+        assert col.column_name == "Email"
+        assert col.masking_function == "email()"
+
+    async def test_returns_empty_list_when_no_masks(self) -> None:
+        def _mock(_target: object, _sql: str, **_kw: object) -> tuple:
+            return _LIST_COLS, []
+
+        with patch("fabric_dw.services.mask.run_query", side_effect=_mock):
+            result = await mask_svc.list_masked_columns(_TARGET)
+
+        assert result == []
+
+    async def test_filters_by_schema(self) -> None:
+        rows = [
+            ("dbo", "T1", "col1", "default()"),
+            ("hr", "T2", "col2", "email()"),
+        ]
+
+        def _mock(_target: object, _sql: str, **_kw: object) -> tuple:
+            return _LIST_COLS, rows
+
+        with patch("fabric_dw.services.mask.run_query", side_effect=_mock):
+            result = await mask_svc.list_masked_columns(_TARGET, table_schema="hr")
+
+        assert len(result) == 1
+        assert result[0].schema_name == "hr"
+
+    async def test_filters_by_table_name(self) -> None:
+        rows = [
+            ("dbo", "Employees", "col1", "default()"),
+            ("dbo", "Customers", "col2", "email()"),
+        ]
+
+        def _mock(_target: object, _sql: str, **_kw: object) -> tuple:
+            return _LIST_COLS, rows
+
+        with patch("fabric_dw.services.mask.run_query", side_effect=_mock):
+            result = await mask_svc.list_masked_columns(_TARGET, table_name="Customers")
+
+        assert len(result) == 1
+        assert result[0].table_name == "Customers"
+
+    async def test_filter_is_case_insensitive(self) -> None:
+        rows = [
+            ("dbo", "Employees", "col1", "default()"),
+        ]
+
+        def _mock(_target: object, _sql: str, **_kw: object) -> tuple:
+            return _LIST_COLS, rows
+
+        with patch("fabric_dw.services.mask.run_query", side_effect=_mock):
+            result = await mask_svc.list_masked_columns(_TARGET, table_schema="DBO")
+
+        assert len(result) == 1
+
+    async def test_exact_sql_query(self) -> None:
+        """list_masked_columns must issue exactly _LIST_MASKED_COLUMNS_SQL."""
+        captured: list[str] = []
+
+        def _mock(_target: object, _sql: str, **_kw: object) -> tuple:
+            captured.append(_sql)
+            return _LIST_COLS, []
+
+        with patch("fabric_dw.services.mask.run_query", side_effect=_mock):
+            await mask_svc.list_masked_columns(_TARGET)
+
+        assert captured[0] == mask_svc._LIST_MASKED_COLUMNS_SQL
+
+
+# ---------------------------------------------------------------------------
+# set_column_mask - SQL shape (S1: structured args, N-1: space in random)
+# ---------------------------------------------------------------------------
+
+
+class TestSetColumnMask:
+    async def test_default_mask_exact_sql(self) -> None:
+        captured: list[str] = []
+
+        def _mock(_target: object, _sql: str, **_kw: object) -> tuple:
+            captured.append(_sql)
+            return [], []
+
+        with patch("fabric_dw.services.mask.run_query", side_effect=_mock):
+            result = await mask_svc.set_column_mask(
+                _TARGET,
+                "dbo",
+                "Employees",
+                "LastName",
+                "default",
+            )
+
+        assert result == "default()"
+        assert captured[0] == (
+            "ALTER TABLE [dbo].[Employees] ALTER COLUMN [LastName] "
+            "ADD MASKED WITH (FUNCTION = 'default()');"
+        )
+
+    async def test_email_mask_exact_sql(self) -> None:
+        captured: list[str] = []
+
+        def _mock(_target: object, _sql: str, **_kw: object) -> tuple:
+            captured.append(_sql)
+            return [], []
+
+        with patch("fabric_dw.services.mask.run_query", side_effect=_mock):
+            result = await mask_svc.set_column_mask(
+                _TARGET,
+                "dbo",
+                "Employees",
+                "Email",
+                "email",
+            )
+
+        assert result == "email()"
+        assert captured[0] == (
+            "ALTER TABLE [dbo].[Employees] ALTER COLUMN [Email] "
+            "ADD MASKED WITH (FUNCTION = 'email()');"
+        )
+
+    async def test_random_mask_exact_sql(self) -> None:
+        captured: list[str] = []
+
+        def _mock(_target: object, _sql: str, **_kw: object) -> tuple:
+            captured.append(_sql)
+            return [], []
+
+        with patch("fabric_dw.services.mask.run_query", side_effect=_mock):
+            result = await mask_svc.set_column_mask(
+                _TARGET,
+                "dbo",
+                "Orders",
+                "Amount",
+                "random",
+                start=1,
+                end=12,
+            )
+
+        assert result == "random(1, 12)"
+        assert captured[0] == (
+            "ALTER TABLE [dbo].[Orders] ALTER COLUMN [Amount] "
+            "ADD MASKED WITH (FUNCTION = 'random(1, 12)');"
+        )
+
+    async def test_partial_mask_exact_sql(self) -> None:
+        captured: list[str] = []
+
+        def _mock(_target: object, _sql: str, **_kw: object) -> tuple:
+            captured.append(_sql)
+            return [], []
+
+        with patch("fabric_dw.services.mask.run_query", side_effect=_mock):
+            result = await mask_svc.set_column_mask(
+                _TARGET,
+                "dbo",
+                "Employees",
+                "Phone",
+                "partial",
+                prefix=0,
+                padding="XXX-XXX-",
+                suffix=4,
+            )
+
+        assert result == 'partial(0,"XXX-XXX-",4)'
+        assert captured[0] == (
+            "ALTER TABLE [dbo].[Employees] ALTER COLUMN [Phone] "
+            "ADD MASKED WITH (FUNCTION = 'partial(0,\"XXX-XXX-\",4)');"
+        )
+
+    async def test_returns_mask_fn_literal(self) -> None:
+        def _mock(_target: object, _sql: str, **_kw: object) -> tuple:
+            return [], []
+
+        with patch("fabric_dw.services.mask.run_query", side_effect=_mock):
+            literal = await mask_svc.set_column_mask(_TARGET, "dbo", "T", "col", "email")
+
+        assert literal == "email()"
+
+    async def test_invalid_schema_raises(self) -> None:
+        with pytest.raises(ValueError, match="Invalid"):
+            await mask_svc.set_column_mask(
+                _TARGET,
+                "bad schema",
+                "T",
+                "col",
+                "default",
+            )
+
+    async def test_invalid_table_raises(self) -> None:
+        with pytest.raises(ValueError, match="Invalid"):
+            await mask_svc.set_column_mask(
+                _TARGET,
+                "dbo",
+                "bad; table",
+                "col",
+                "default",
+            )
+
+    async def test_invalid_column_raises(self) -> None:
+        with pytest.raises(ValueError, match="Column name"):
+            await mask_svc.set_column_mask(
+                _TARGET,
+                "dbo",
+                "T",
+                "",
+                "default",
+            )
+
+    async def test_invalid_fn_type_raises(self) -> None:
+        with pytest.raises(ValueError, match="Invalid mask function type"):
+            await mask_svc.set_column_mask(
+                _TARGET,
+                "dbo",
+                "T",
+                "col",
+                "full",
+            )
+
+
+# ---------------------------------------------------------------------------
+# drop_column_mask - SQL shape
+# ---------------------------------------------------------------------------
+
+
+class TestDropColumnMask:
+    async def test_drop_mask_exact_sql(self) -> None:
+        captured: list[str] = []
+
+        def _mock(_target: object, _sql: str, **_kw: object) -> tuple:
+            captured.append(_sql)
+            return [], []
+
+        with patch("fabric_dw.services.mask.run_query", side_effect=_mock):
+            await mask_svc.drop_column_mask(
+                _TARGET,
+                "dbo",
+                "Employees",
+                "Email",
+            )
+
+        assert captured[0] == ("ALTER TABLE [dbo].[Employees] ALTER COLUMN [Email] DROP MASKED;")
+
+    async def test_different_schema_and_table(self) -> None:
+        captured: list[str] = []
+
+        def _mock(_target: object, _sql: str, **_kw: object) -> tuple:
+            captured.append(_sql)
+            return [], []
+
+        with patch("fabric_dw.services.mask.run_query", side_effect=_mock):
+            await mask_svc.drop_column_mask(
+                _TARGET,
+                "hr",
+                "Personnel",
+                "SSN",
+            )
+
+        assert captured[0] == ("ALTER TABLE [hr].[Personnel] ALTER COLUMN [SSN] DROP MASKED;")
+
+    async def test_invalid_schema_raises(self) -> None:
+        with pytest.raises(ValueError, match="Invalid"):
+            await mask_svc.drop_column_mask(
+                _TARGET,
+                "bad schema",
+                "T",
+                "col",
+            )
+
+    async def test_invalid_table_raises(self) -> None:
+        with pytest.raises(ValueError, match="Invalid"):
+            await mask_svc.drop_column_mask(
+                _TARGET,
+                "dbo",
+                "bad; table",
+                "col",
+            )
+
+    async def test_invalid_column_raises(self) -> None:
+        with pytest.raises(ValueError, match="Column name"):
+            await mask_svc.drop_column_mask(
+                _TARGET,
+                "dbo",
+                "T",
+                "",
+            )
+
+
+# ---------------------------------------------------------------------------
+# UNMASK in permissions allowlists
+# ---------------------------------------------------------------------------
+
+
+class TestUnmaskInPermissionsAllowlists:
+    def test_unmask_in_database_permissions(self) -> None:
+        from fabric_dw.services.permissions import DATABASE_PERMISSIONS  # noqa: PLC0415
+
+        assert "UNMASK" in DATABASE_PERMISSIONS
+
+    def test_unmask_in_object_permissions(self) -> None:
+        from fabric_dw.services.permissions import OBJECT_PERMISSIONS  # noqa: PLC0415
+
+        assert "UNMASK" in OBJECT_PERMISSIONS
+
+    def test_unmask_in_column_applicable_permissions(self) -> None:
+        from fabric_dw.services.permissions import COLUMN_APPLICABLE_PERMISSIONS  # noqa: PLC0415
+
+        assert "UNMASK" in COLUMN_APPLICABLE_PERMISSIONS
+
+    def test_unmask_not_in_schema_permissions(self) -> None:
+        """UNMASK is not a schema-level permission - schemas contain no masked columns."""
+        from fabric_dw.services.permissions import SCHEMA_PERMISSIONS  # noqa: PLC0415
+
+        assert "UNMASK" not in SCHEMA_PERMISSIONS
+
+
+# ---------------------------------------------------------------------------
+# UNMASK grant SQL shapes (pinning tests)
+# ---------------------------------------------------------------------------
+
+
+class TestUnmaskGrantSql:
+    async def test_grant_unmask_database_scope(self) -> None:
+        """GRANT UNMASK TO [principal]; (DATABASE scope - no ON clause)."""
+        from fabric_dw.services import permissions as perm_svc  # noqa: PLC0415
+
+        captured: list[str] = []
+
+        def _mock(_target: object, _sql: str, **_kw: object) -> tuple:
+            captured.append(_sql)
+            return [], []
+
+        with patch("fabric_dw.services.permissions.run_query", side_effect=_mock):
+            await perm_svc.grant_permission(
+                _TARGET,
+                "UNMASK",
+                "alice@contoso.com",
+                "DATABASE",
+            )
+
+        assert captured[0] == "GRANT UNMASK TO [alice@contoso.com];"
+
+    async def test_grant_unmask_object_scope_with_column(self) -> None:
+        """GRANT UNMASK ON OBJECT::[dbo].[t] ([c]) TO [principal];"""
+        from fabric_dw.services import permissions as perm_svc  # noqa: PLC0415
+
+        captured: list[str] = []
+
+        def _mock(_target: object, _sql: str, **_kw: object) -> tuple:
+            captured.append(_sql)
+            return [], []
+
+        with patch("fabric_dw.services.permissions.run_query", side_effect=_mock):
+            await perm_svc.grant_permission(
+                _TARGET,
+                "UNMASK",
+                "alice@contoso.com",
+                "OBJECT",
+                object_name="dbo.t",
+                columns=["c"],
+            )
+
+        assert captured[0] == "GRANT UNMASK ON OBJECT::[dbo].[t] ([c]) TO [alice@contoso.com];"

--- a/tests/unit/test_cli_destructive_parity.py
+++ b/tests/unit/test_cli_destructive_parity.py
@@ -51,6 +51,7 @@ _MCP_TO_CLI_DESTRUCTIVE_MAP: dict[str, str | tuple[str, ...]] = {
     "drop_view": "views.drop",
     "delete_warehouse": "warehouses.delete",
     "drop_security_policy": "permissions.rls.drop",
+    "drop_column_mask": "permissions.mask.drop",
 }
 
 # ---------------------------------------------------------------------------
@@ -219,6 +220,9 @@ class TestDestructiveCliCommandsEmitDestructiveOp:
     def test_warehouses_delete_is_destructive(self) -> None:
         assert "warehouses.delete" in _DESTRUCTIVE_CLI_COMMANDS
 
+    def test_permissions_mask_drop_is_destructive(self) -> None:
+        assert "permissions.mask.drop" in _DESTRUCTIVE_CLI_COMMANDS
+
 
 # ---------------------------------------------------------------------------
 # Emit-level tests: emit_command_invoked is called with destructive=True
@@ -334,6 +338,25 @@ class TestEmitDestructiveOpOnAbort:
         )
         assert destructive is True, (
             f"permissions rls drop did not emit destructive_op=True on abort; got {destructive!r}"
+        )
+
+    def test_permissions_mask_drop_emits_destructive_on_abort(self) -> None:
+        """permissions mask drop aborted at prompt must still report destructive_op=True."""
+        destructive = _invoke_and_capture_destructive(
+            [
+                "-w",
+                "myws",
+                "permissions",
+                "mask",
+                "drop",
+                "mydw",
+                "dbo.Employees",
+                "--column",
+                "Email",
+            ]
+        )
+        assert destructive is True, (
+            f"permissions mask drop did not emit destructive_op=True on abort; got {destructive!r}"
         )
 
 


### PR DESCRIPTION
## Summary

- Adds a `permissions mask` CLI subgroup with `list`, `set`, and `drop` commands for Microsoft Fabric Dynamic Data Masking (DDM)
- Adds three MCP tools: `list_masked_columns`, `set_column_mask`, and `drop_column_mask`
- Supports all four Fabric mask function types: `default()`, `email()`, `random(low,high)`, and `partial(prefix,"padding",suffix)`
- Adds `UNMASK` to the permission allowlists (object-scope, database-scope, and column-applicable) so it can be granted/revoked via the existing `permissions grant`/`revoke` commands

## Implementation

**New service** (`src/fabric_dw/services/mask.py`):
- Reads `sys.masked_columns` joined to `sys.columns`, `sys.objects`, and `sys.schemas`
- Issues `ALTER TABLE [s].[t] ALTER COLUMN [c] ADD MASKED WITH (FUNCTION = '...');`
- Issues `ALTER TABLE [s].[t] ALTER COLUMN [c] DROP MASKED;`
- `_validate_and_escape_padding` rejects `"`, `)`, control chars, `--`, `;` in partial() padding; escapes single quotes per T-SQL rules
- No SQL parsing: only the mask function literal is composed; all object names are bracket-quoted identifiers

**New model** (`MaskedColumn` in `models.py`): schema_name, table_name, column_name, masking_function

**CLI** (`permissions mask list/set/drop` in `cli/commands/permissions.py`):
- `drop` requires `--yes` / `-y` or `FABRIC_MCP_ALLOW_DESTRUCTIVE=1`

**MCP tools** (`mcp/tools/permissions.py`):
- `drop_column_mask` is registered as `destructive=True` via `mutating_tool`

**Drift guard** (`tests/unit/test_cli_destructive_parity.py`):
- `drop_column_mask` added to `_MCP_TO_CLI_DESTRUCTIVE_MAP`
- Two new tests verify destructive emit behavior

## Test plan

- [x] `uv run ruff check src/ tests/` - passes
- [x] `uv run ruff format --check src/ tests/` - passes
- [x] `uv run ty check src/` - passes
- [x] `uv run pytest tests/unit/ -q` - 5592 passed, 0 failed
- [ ] Integration tests in `tests/integration/test_services_mask.py` - cover set/list/drop round-trips for all four mask types (run against live Fabric capacity)

Closes #920

🤖 Generated with [Claude Code](https://claude.com/claude-code)