### PR TITLE
ci(docs): post the real PR preview URL as a sticky PR comment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -178,28 +178,52 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: staging
-      url: https://pr-${{ github.event.number }}.${{ env.STAGING_PROJECT }}.pages.dev
+      # The real preview URL comes from the wrangler-action step output and
+      # cannot be referenced here (this block is evaluated before steps run).
+      # The URL is surfaced as a sticky PR comment and in the job summary instead.
     concurrency:
       group: docs-preview-pr-${{ github.event.number }}
       cancel-in-progress: true
     permissions:
       contents: read
+      pull-requests: write
     steps:
       - uses: actions/download-artifact@v4
         with:
           name: docs-site
           path: docs_build/site
 
-      - uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd  # v3
+      - id: deploy
+        uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd  # v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_PAGES_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: pages deploy docs_build/site --project-name=${{ env.STAGING_PROJECT }} --branch=pr-${{ github.event.number }}
 
-      - name: Post preview URL to job summary
+      - name: Post preview URL as sticky PR comment
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.number }}
+          PREVIEW_URL: ${{ steps.deploy.outputs.pages-deployment-alias-url || steps.deploy.outputs.deployment-url }}
+        run: |
+          MARKER="<!-- docs-preview-url -->"
+          printf '%s\n## Docs preview\n\nPreview URL: %s\n' "$MARKER" "$PREVIEW_URL" > /tmp/preview-comment.md
+
+          COMMENT_ID=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+            --jq '.[] | select(.body | contains("<!-- docs-preview-url -->")) | .id' | head -n1)
+
+          if [ -n "$COMMENT_ID" ]; then
+            gh api --method PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID}" \
+              --field body="$(cat /tmp/preview-comment.md)"
+          else
+            gh api --method POST "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+              --field body="$(cat /tmp/preview-comment.md)"
+          fi
+
+      - name: Update job summary with real preview URL
+        env:
+          PREVIEW_URL: ${{ steps.deploy.outputs.pages-deployment-alias-url || steps.deploy.outputs.deployment-url }}
         run: |
           echo "## PR Preview" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "Preview URL: https://pr-${PR_NUMBER}.${STAGING_PROJECT}.pages.dev" >> "$GITHUB_STEP_SUMMARY"
+          echo "Preview URL: ${PREVIEW_URL}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -209,15 +209,15 @@ jobs:
           MARKER="<!-- docs-preview-url -->"
           printf '%s\n## Docs preview\n\nPreview URL: %s\n' "$MARKER" "$PREVIEW_URL" > /tmp/preview-comment.md
 
-          COMMENT_ID=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+          COMMENT_ID=$(gh api --paginate "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
             --jq '.[] | select(.body | contains("<!-- docs-preview-url -->")) | .id' | head -n1)
 
           if [ -n "$COMMENT_ID" ]; then
             gh api --method PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID}" \
-              --field body="$(cat /tmp/preview-comment.md)"
+              -f body=@/tmp/preview-comment.md
           else
             gh api --method POST "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
-              --field body="$(cat /tmp/preview-comment.md)"
+              -f body=@/tmp/preview-comment.md
           fi
 
       - name: Update job summary with real preview URL


### PR DESCRIPTION
## Summary

Two bugs were found in the `deploy-preview` job of `.github/workflows/docs.yml`:

- **No PR comment was ever posted.** The job only wrote the preview URL to the Actions run summary (`$GITHUB_STEP_SUMMARY`), which is only visible inside the Actions UI. The job also had only `permissions: contents: read`, so it could not write to the PR at all.
- **The constructed preview URL was wrong.** The job built the URL as `https://pr-<number>.<STAGING_PROJECT>.pages.dev`, but the Cloudflare Pages `.pages.dev` subdomain is not the project name. The real alias URL for PR 932, for example, is `https://pr-932.fabric-dw-mcp-cli-ckg.pages.dev/` — a different subdomain.

## Fix

- Added `id: deploy` to the `cloudflare/wrangler-action` step so its outputs are referenceable.
- Read the real branch-alias URL from `steps.deploy.outputs.pages-deployment-alias-url` (the `https://<branch>.<subdomain>.pages.dev` alias introduced in wrangler >= 3.78.0), with `steps.deploy.outputs.deployment-url` as a fallback for the per-deployment hash URL. Both are documented outputs of the pinned action version.
- Added `pull-requests: write` to the job's `permissions` block. The existing fork-PR gate (`head.repo.full_name == github.repository`) already restricts this to non-fork PRs, so the GITHUB_TOKEN write scope is safe here.
- Posted a sticky PR comment via the preinstalled `gh` CLI (`gh api`): the comment body contains a hidden HTML marker (`<!-- docs-preview-url -->`). On each push the step lists existing comments, finds the one with the marker, and PATCHes it — so only one comment ever appears on the PR.
- Removed the hardcoded wrong `environment.url`. The `environment` block is evaluated before steps run, so step outputs cannot be referenced there. Displaying a broken URL is worse than no URL, so the field was removed.
- Updated the job summary echo to use the same real step-output URL.

## Wrangler-action output field verification

The exact output name `pages-deployment-alias-url` was verified by fetching the raw `action.yml` at the pinned commit `9acf94ace14e7dc412b076f2c5c20b8ce93c79cd`. The file lists it explicitly with description: "If the command was a Pages deployment, this will be the URL of the deployment alias (if it exists) - needs wrangler >= 3.78.0".

## Test plan

- [ ] Open a docs-touching PR from a non-fork branch and confirm the `deploy-preview` job posts a PR comment containing the real `.pages.dev` alias URL.
- [ ] Push a second commit to the same PR and confirm the existing comment is updated (not a new one added).
- [ ] Confirm the job summary also shows the real URL.
- [ ] Confirm fork PRs still skip the job (no secrets).

---

actionlint: no findings (ran against the modified file, exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)