### PR TITLE
test(integration): apply RLS security policy to a user table instead of sys.objects

### DIFF
--- a/tests/integration/test_services_rls.py
+++ b/tests/integration/test_services_rls.py
@@ -2,8 +2,7 @@
 
 Run with: pytest -m integration tests/integration/test_services_rls.py
 
-Covers the create -> list -> set-state -> add-predicate -> drop-predicate -> drop
-round-trip for security policies.
+Covers the create -> list -> set-state -> drop round-trip for security policies.
 
 Each test run creates a minimal TVF inline, uses it for the test, then drops it
 in teardown -- making the suite hermetic without requiring a pre-existing TVF.

--- a/tests/integration/test_services_rls.py
+++ b/tests/integration/test_services_rls.py
@@ -44,6 +44,11 @@ def _unique_fn_name() -> str:
     return f"pytest_rls_fn_{uuid.uuid4().hex[:8]}"
 
 
+def _unique_table_name() -> str:
+    """Return a short, collision-resistant table name safe for Fabric DDL."""
+    return f"pytest_rls_tbl_{uuid.uuid4().hex[:8]}"
+
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -91,25 +96,60 @@ async def rls_schema_and_fn(
 
 
 @pytest_asyncio.fixture
-async def rls_policy_fixture(
+async def rls_schema_fn_and_table(
     rls_schema_and_fn: tuple[SqlTarget, str, str],
+) -> AsyncIterator[tuple[SqlTarget, str, str, str]]:
+    """Extend rls_schema_and_fn with a user table suitable as an RLS target.
+
+    Yields ``(sql_target, schema_name, fn_name, tbl_name)``.
+
+    Creates a table with ``(id INT, user_id INT)`` columns.  The ``user_id``
+    column matches the predicate function's ``@user_id INT`` parameter so the
+    filter predicate ``[fn]([user_id]) ON [schema].[table]`` is valid.
+
+    Teardown drops the table after the caller has dropped any security policies
+    that reference it (fixture teardown is LIFO, so policies created by
+    dependent fixtures are always dropped first).
+    """
+    sql_target, schema_name, fn_name = rls_schema_and_fn
+    tbl_name = _unique_table_name()
+
+    await asyncio.to_thread(
+        run_query,
+        sql_target,
+        f"CREATE TABLE [{schema_name}].[{tbl_name}] (id INT, user_id INT);",
+        autocommit=True,
+        fetch="none",
+    )
+    try:
+        yield sql_target, schema_name, fn_name, tbl_name
+    finally:
+        with contextlib.suppress(Exception):
+            await asyncio.to_thread(
+                run_query,
+                sql_target,
+                f"DROP TABLE [{schema_name}].[{tbl_name}];",
+                autocommit=True,
+                fetch="none",
+            )
+
+
+@pytest_asyncio.fixture
+async def rls_policy_fixture(
+    rls_schema_fn_and_table: tuple[SqlTarget, str, str, str],
 ) -> AsyncIterator[tuple[SqlTarget, str, str, str, str]]:
     """Create a security policy and drop it in teardown.
 
     Yields ``(sql_target, schema_name, fn_name, table_schema, policy_name)``.
 
-    Uses a system table (``sys.objects``) as the target because it always
-    exists -- no test table needs to be created.
+    The security policy targets a real user table created by
+    ``rls_schema_fn_and_table`` -- Fabric does not allow RLS on system views.
 
     Note: Some Fabric capacity SKUs do not support RLS.  The fixture skips
-    the test module if CREATE SECURITY POLICY fails with a not-supported error.
+    the test if CREATE SECURITY POLICY fails with a not-supported error.
     """
-    sql_target, schema_name, fn_name = rls_schema_and_fn
+    sql_target, schema_name, fn_name, tbl_name = rls_schema_fn_and_table
     policy_name = _unique_policy_name()
-    # Use an existing system-accessible table so we do not need to create one.
-    # sys.objects is always present in every Fabric warehouse.
-    target_table_schema = "sys"
-    target_table_name = "objects"
 
     try:
         await rls_svc.create_security_policy(
@@ -120,9 +160,9 @@ async def rls_policy_fixture(
                     "predicate_type": "FILTER",
                     "fn_schema": schema_name,
                     "fn_name": fn_name,
-                    "fn_args": ["object_id"],
-                    "table_schema": target_table_schema,
-                    "table_name": target_table_name,
+                    "fn_args": ["user_id"],
+                    "table_schema": schema_name,
+                    "table_name": tbl_name,
                 }
             ],
             state=False,
@@ -134,7 +174,7 @@ async def rls_policy_fixture(
         raise
 
     try:
-        yield sql_target, schema_name, fn_name, target_table_schema, policy_name
+        yield sql_target, schema_name, fn_name, schema_name, policy_name
     finally:
         with contextlib.suppress(Exception):
             await rls_svc.drop_security_policy(sql_target, f"{schema_name}.{policy_name}")
@@ -181,10 +221,10 @@ async def test_set_policy_state_enable(
 
 
 async def test_drop_security_policy(
-    rls_schema_and_fn: tuple[SqlTarget, str, str],
+    rls_schema_fn_and_table: tuple[SqlTarget, str, str, str],
 ) -> None:
     """drop_security_policy removes the policy so it no longer appears in list."""
-    sql_target, schema_name, fn_name = rls_schema_and_fn
+    sql_target, schema_name, fn_name, tbl_name = rls_schema_fn_and_table
     policy_name = _unique_policy_name()
     qualified = f"{schema_name}.{policy_name}"
 
@@ -197,9 +237,9 @@ async def test_drop_security_policy(
                     "predicate_type": "FILTER",
                     "fn_schema": schema_name,
                     "fn_name": fn_name,
-                    "fn_args": ["object_id"],
-                    "table_schema": "sys",
-                    "table_name": "objects",
+                    "fn_args": ["user_id"],
+                    "table_schema": schema_name,
+                    "table_name": tbl_name,
                 }
             ],
             state=False,


### PR DESCRIPTION
## Root cause

The tests targeted `[sys].[objects]` as the RLS policy table because it is always present in every warehouse. However, Fabric does not allow attaching a `CREATE SECURITY POLICY ... ADD FILTER PREDICATE` to a system catalog view -- only user tables are supported. This caused:

- `test_create_and_list_security_policy` to ERROR at setup (fixture failed)
- `test_drop_security_policy` to FAIL with `FabricServerError: Cannot find the object "sys.objects" because it does not exist or you do not have permissions.`

The existing skip guard (`"not supported" in err_str`) did not match this error message, so the tests fell through to a hard failure rather than a skip.

## Fix

- Added a `_unique_table_name()` helper (matches the existing naming pattern).
- Added a new `rls_schema_fn_and_table` fixture that wraps `rls_schema_and_fn` and creates a `(id INT, user_id INT)` user table. The `user_id INT` column type matches the predicate function's `@user_id INT` parameter, making the filter predicate valid.
- Updated `rls_policy_fixture` to depend on `rls_schema_fn_and_table` and target the user table with `fn_args: ["user_id"]`.
- Updated `test_drop_security_policy` to use `rls_schema_fn_and_table` directly and apply the same predicate shape.
- Fixture teardown order is LIFO: policy dropped first (by `rls_policy_fixture`), then table, then function -- which is the correct dependency order.
- The service code in `src/fabric_dw/services/rls.py` is unchanged; the bug was entirely in the test fixture.

## Verification

```
uv run ruff check tests/integration/test_services_rls.py   # All checks passed
uv run ruff format --check tests/integration/test_services_rls.py  # Already formatted
uv run ty check tests/integration/test_services_rls.py    # All checks passed
uv run pytest tests/integration/test_services_rls.py --collect-only -m integration  # 3 tests collected
```

The SQL shape emitted by `rls.py` for `CREATE SECURITY POLICY ... ADD FILTER PREDICATE [schema].[fn]([user_id]) ON [schema].[table]` is identical to what was used before -- only the target object changes from `[sys].[objects]` to a warehouse user table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)