### PR TITLE
test(integration): update mask tests for the structured set_column_mask signature

### DIFF
--- a/tests/integration/test_services_mask.py
+++ b/tests/integration/test_services_mask.py
@@ -102,7 +102,7 @@ async def test_set_and_list_default_mask(
         schema_name,
         table_name,
         "Email",
-        "default()",
+        fn_type="default",
     )
 
     columns = await mask_svc.list_masked_columns(
@@ -129,7 +129,7 @@ async def test_set_and_list_email_mask(
         schema_name,
         table_name,
         "Email",
-        "email()",
+        fn_type="email",
     )
 
     columns = await mask_svc.list_masked_columns(
@@ -148,15 +148,15 @@ async def test_set_and_list_random_mask(
 ) -> None:
     """set_column_mask (random) -> list_masked_columns round-trip."""
     sql_target, schema_name, table_name = mask_table
-    from fabric_dw.services.mask import _build_mask_function  # noqa: PLC0415
 
-    mask_fn = _build_mask_function("random", start=1, end=999999)
     await mask_svc.set_column_mask(
         sql_target,
         schema_name,
         table_name,
         "Salary",
-        mask_fn,
+        fn_type="random",
+        start=1,
+        end=999999,
     )
 
     columns = await mask_svc.list_masked_columns(
@@ -175,15 +175,16 @@ async def test_set_and_list_partial_mask(
 ) -> None:
     """set_column_mask (partial) -> list_masked_columns round-trip."""
     sql_target, schema_name, table_name = mask_table
-    from fabric_dw.services.mask import _build_mask_function  # noqa: PLC0415
 
-    mask_fn = _build_mask_function("partial", prefix=0, padding="XXX-XXX-", suffix=4)
     await mask_svc.set_column_mask(
         sql_target,
         schema_name,
         table_name,
         "Phone",
-        mask_fn,
+        fn_type="partial",
+        prefix=0,
+        padding="XXX-XXX-",
+        suffix=4,
     )
 
     columns = await mask_svc.list_masked_columns(
@@ -209,7 +210,7 @@ async def test_drop_mask_removes_column_from_list(
         schema_name,
         table_name,
         "Email",
-        "email()",
+        fn_type="email",
     )
 
     # Verify it appears
@@ -251,7 +252,7 @@ async def test_set_mask_replaces_existing_mask(
         schema_name,
         table_name,
         "Email",
-        "default()",
+        fn_type="default",
     )
     # Replace with email()
     await mask_svc.set_column_mask(
@@ -259,7 +260,7 @@ async def test_set_mask_replaces_existing_mask(
         schema_name,
         table_name,
         "Email",
-        "email()",
+        fn_type="email",
     )
 
     columns = await mask_svc.list_masked_columns(


### PR DESCRIPTION
## Summary

- The S1 refactor in #932 changed `set_column_mask` to accept a structured `fn_type` argument (plus keyword `start`/`end`/`prefix`/`padding`/`suffix`) and build the mask literal internally. The unit tests and CLI/MCP callers were updated at that time; the integration test file was missed because the suite only runs on main.
- All six `set_column_mask` calls in `tests/integration/test_services_mask.py` are updated to the new structured form.
- The unused `_build_mask_function` pre-calls and their `noqa`-guarded local imports are removed.
- List/assert logic is unchanged: the stored `masking_function` catalog values are unaffected.

## Test plan

- [ ] `uv run ruff check` / `ruff format --check` / `ty check` pass on the file (verified locally).
- [ ] `uv run pytest tests/integration/test_services_mask.py --collect-only -m integration` collects all 6 tests cleanly (verified locally).
- [ ] No remaining `_build_mask_function` usage and no `fn_type=` value containing `(` in the file (grep-verified locally).
- [ ] Integration suite on main passes all 6 mask tests once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)