### PR TITLE
docs: refresh the project tagline to reflect the full feature set

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <a href="LICENSE"><img src="https://img.shields.io/github/license/sdebruyn/fabric-dw-mcp-cli" alt="License"></a>
 </p>
 
-Python CLI and MCP server for administering Microsoft Fabric Data Warehouses and SQL Analytics Endpoints.
+Python CLI and MCP server for Microsoft Fabric Data Warehouses and SQL Analytics Endpoints: administer, query, optimize, and secure them from your terminal or your AI agent.
 
 **Full documentation: [fdw.debruyn.dev](https://fdw.debruyn.dev)**
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ title: Home
   <a href="https://pypi.org/project/fabric-dw/"><img src="https://img.shields.io/pypi/pyversions/fabric-dw" alt="Python versions"></a>
 </p>
 
-> Python CLI + MCP server for Microsoft Fabric Data Warehouse administration.
+> Python CLI and MCP server for Microsoft Fabric Data Warehouses and SQL Analytics Endpoints: administer, query, optimize, and secure them from your terminal or your AI agent.
 
 !!! tip "Just announced"
     Read the story behind `fabric-dw` in the [announcement blog post](https://debruyn.dev/2026/introducing-the-fabric-data-warehouse-cli-and-mcp-server/).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "fabric-dw"
 dynamic = ["version"]
 requires-python = ">=3.11"
-description = "Python CLI + MCP server for administering Microsoft Fabric Data Warehouses and SQL Analytics Endpoints"
+description = "Python CLI and MCP server for Microsoft Fabric Data Warehouses and SQL Analytics Endpoints: administer, query, optimize, and secure them from your terminal or your AI agent"
 readme = "README.md"
 license = { text = "MIT" }
 authors = [{ name = "Sam Debruyn", email = "sam@debruyn.dev" }]

--- a/src/fabric_dw/__init__.py
+++ b/src/fabric_dw/__init__.py
@@ -1,4 +1,5 @@
-"""fabric-dw: Python CLI and MCP server for Microsoft Fabric Data Warehouses and SQL Analytics Endpoints."""
+"""fabric-dw: Python CLI and MCP server for Microsoft Fabric Data Warehouses
+and SQL Analytics Endpoints."""
 
 from fabric_dw._version import __version__
 

--- a/src/fabric_dw/__init__.py
+++ b/src/fabric_dw/__init__.py
@@ -1,4 +1,4 @@
-"""fabric-dw — Python CLI + MCP server for Microsoft Fabric Data Warehouse."""
+"""fabric-dw: Python CLI and MCP server for Microsoft Fabric Data Warehouses and SQL Analytics Endpoints."""
 
 from fabric_dw._version import __version__
 

--- a/zensical.toml
+++ b/zensical.toml
@@ -1,7 +1,7 @@
 [project]
 site_dir = "docs_build/site"
 site_name = "fabric-dw"
-site_description = "Python CLI + MCP server for administering Microsoft Fabric Data Warehouses and SQL Analytics Endpoints."
+site_description = "Python CLI and MCP server for Microsoft Fabric Data Warehouses and SQL Analytics Endpoints: administer, query, optimize, and secure them from your terminal or your AI agent."
 site_url = "https://fdw.debruyn.dev"
 site_author = "Sam Debruyn"
 repo_url = "https://github.com/sdebruyn/fabric-dw-mcp-cli"


### PR DESCRIPTION
## Summary

- Updates the project short description across all user-facing locations to the approved wording: covers both surfaces (CLI + MCP server) and all four capabilities (administer, query, optimize, secure).
- Removes the forbidden em-dash from the `__init__.py` module docstring.
- Docs build confirmed: `zensical build` exits with no issues.

## Files changed

| File | Before | After |
|------|--------|-------|
| `docs/index.md` | `Python CLI + MCP server for Microsoft Fabric Data Warehouse administration.` | new tagline |
| `README.md` | `Python CLI and MCP server for administering Microsoft Fabric Data Warehouses and SQL Analytics Endpoints.` | new tagline |
| `zensical.toml` | `Python CLI + MCP server for administering Microsoft Fabric Data Warehouses and SQL Analytics Endpoints.` | new tagline |
| `pyproject.toml` | `Python CLI + MCP server for administering Microsoft Fabric Data Warehouses and SQL Analytics Endpoints` | new tagline (no trailing period, PyPI convention) |
| `src/fabric_dw/__init__.py` | `fabric-dw — Python CLI + MCP server for Microsoft Fabric Data Warehouse.` (em-dash) | `fabric-dw: Python CLI and MCP server for Microsoft Fabric Data Warehouses and SQL Analytics Endpoints.` |

## Test plan

- [x] `uv run --group docs zensical build` passes with no issues
- [ ] Verify PyPI description renders correctly after release