### PR TITLE
feat: transfer tables to another schema via ALTER SCHEMA TRANSFER

### DIFF
--- a/docs/commands/tables.md
+++ b/docs/commands/tables.md
@@ -4,7 +4,7 @@ title: Tables
 
 # Tables
 
-Manage SQL tables on Microsoft Fabric Data Warehouses and SQL Analytics Endpoints. Commands and tools cover listing, counting, reading, creating (including CTAS, empty DDL from schema inference, and zero-copy clone), deleting, clearing, renaming, and loading data via `COPY INTO` from local files or remote URLs.
+Manage SQL tables on Microsoft Fabric Data Warehouses and SQL Analytics Endpoints. Commands and tools cover listing, counting, reading, creating (including CTAS, empty DDL from schema inference, and zero-copy clone), deleting, clearing, renaming, transferring to another schema, and loading data via `COPY INTO` from local files or remote URLs.
 
 **Targets:** Data Warehouse / SQL Analytics Endpoint
 
@@ -606,6 +606,34 @@ fdw [-w WORKSPACE] tables rename [OPTIONS] [ITEM] QUALIFIED_NAME
 fdw -w MyWorkspace tables rename SalesWH dbo.orders_2025 --new-name orders_archive_2025
 ```
 
+### tables transfer
+
+**Targets:** Data Warehouse only
+
+Move a table to another schema via `ALTER SCHEMA ... TRANSFER OBJECT::...`. The command emits exactly `ALTER SCHEMA [target_schema] TRANSFER OBJECT::[schema].[table]`, with every identifier validated and bracket-quoted before being embedded in the DDL.
+
+**CAUTION:** Transferring a table on a SQL Analytics Endpoint is not supported and can break the OneLake sync, so this command is rejected there - use a Fabric Data Warehouse. Permissions granted directly on the table are dropped by the engine when the schema changes. Dependent views and stored procedures that reference the table by its old schema-qualified name are not automatically updated and may need refreshing after the transfer.
+
+Reference: [ALTER SCHEMA (Transact-SQL)](https://learn.microsoft.com/sql/t-sql/statements/alter-schema-transact-sql?view=fabric&WT.mc_id=MVP_310840)
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] tables transfer [OPTIONS] [ITEM] QUALIFIED_NAME
+```
+
+`QUALIFIED_NAME` is the current dot-separated `schema.table_name`.
+
+| Option | Description |
+| --- | --- |
+| `--target-schema TEXT` | **Required.** Schema to move the table into. |
+
+**Example**
+
+```shell
+fdw -w MyWorkspace tables transfer SalesWH dbo.orders_2025 --target-schema archive
+```
+
 ## MCP tools
 
 ### clear_table
@@ -917,6 +945,25 @@ Rename a SQL table via `sp_rename`. Only supported on Fabric Data Warehouses (SQ
 - `new_name` (`str`): new bare table name (no schema prefix), e.g. `sales_v2`.
 
 **Returns:** `Table`: the updated table record.
+
+### transfer_table
+
+**Targets:** Data Warehouse only
+
+Move a SQL table to another schema via `ALTER SCHEMA ... TRANSFER OBJECT::...`. Only supported on Fabric Data Warehouses: transferring a table between schemas via T-SQL is not supported on the Fabric SQL Analytics Endpoint and can break the OneLake sync, so SQL Analytics Endpoints are rejected with a `ToolError`.
+
+**CAUTION:** Permissions granted directly on the table are dropped by the engine when the schema changes. Dependent views and stored procedures that reference the table by its old schema-qualified name are **NOT** automatically updated and may need refreshing after the transfer.
+
+Reference: [ALTER SCHEMA (Transact-SQL)](https://learn.microsoft.com/sql/t-sql/statements/alter-schema-transact-sql?view=fabric&WT.mc_id=MVP_310840)
+
+**Parameters:**
+
+- `workspace` (`str`): workspace name or GUID.
+- `item` (`str`): warehouse name or GUID. SQL Analytics Endpoints are rejected.
+- `qualified_name` (`str`): current dot-separated qualified table name, e.g. `dbo.sales`.
+- `target_schema` (`str`): schema to move the table into, e.g. `archive`.
+
+**Returns:** `Table`: the moved table record, fetched from the new schema.
 
 ### set_cluster_columns
 

--- a/src/fabric_dw/cli/commands/tables.py
+++ b/src/fabric_dw/cli/commands/tables.py
@@ -1500,3 +1500,35 @@ async def rename_cmd(
             render(t.model_dump(by_alias=True, mode="json"), json_output=ctx.json_output)
     except (ValueError, FabricError) as exc:
         raise click.ClickException(str(exc)) from exc
+
+
+@tables_group.command("transfer")
+@click.argument("item", required=False, default=None)
+@click.argument("qualified_name")
+@click.option("--target-schema", required=True, help="Schema to move the table into.")
+@click.pass_obj
+@coro
+async def transfer_cmd(
+    ctx: CliContext,
+    item: str | None,
+    qualified_name: str,
+    target_schema: str,
+) -> None:
+    """Move QUALIFIED_NAME (schema.table) on ITEM to --target-schema.
+
+    ITEM must be a Data Warehouse; transferring a table on a SQL Analytics
+    Endpoint is not supported and can break the OneLake sync, so SQL
+    Analytics Endpoints are rejected.
+    """
+    ws = resolve_workspace(ctx)
+    wh = resolve_warehouse_arg(ctx, item)
+    parse_qualified_name(qualified_name, kind="table")
+    try:
+        async with build_http_client(ctx) as http:
+            target, entry = await build_sql_target(http, ws, wh)
+            t = await _tables_svc.transfer_table(
+                target, qualified_name, target_schema, kind=entry.kind, mode=ctx.auth
+            )
+            render(t.model_dump(by_alias=True, mode="json"), json_output=ctx.json_output)
+    except (ValueError, FabricError) as exc:
+        raise click.ClickException(str(exc)) from exc

--- a/src/fabric_dw/mcp/tools/tables.py
+++ b/src/fabric_dw/mcp/tools/tables.py
@@ -594,6 +594,51 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             raise tool_err(exc) from exc
         return result.model_dump(mode="json")
 
+    @mutating_tool(mcp, "transfer_table")
+    async def transfer_table(
+        workspace: str, item: str, qualified_name: str, target_schema: str
+    ) -> dict[str, Any]:
+        """Move a SQL table to another schema via ``ALTER SCHEMA ... TRANSFER OBJECT::...``.
+
+        Data-Warehouse-only: transferring a table between schemas via T-SQL is
+        not supported on the Fabric SQL Analytics Endpoint and can break the
+        OneLake sync, so SQL Analytics Endpoints are rejected with a ``ToolError``.
+
+        CAUTION: Permissions granted directly on the table are dropped by the
+        engine when the schema changes. Dependent views and stored procedures
+        that reference the table by its old schema-qualified name are NOT
+        automatically updated and may need refreshing after the transfer.
+
+        Args:
+            workspace: Workspace name or GUID.
+            item: Warehouse name or GUID.  SQL Analytics Endpoints are rejected.
+            qualified_name: Current dot-separated qualified table name, e.g.
+                ``dbo.sales``.
+            target_schema: Schema to move the table into, e.g. ``archive``.
+        """
+        parse_qualified_name(qualified_name, kind="table")
+        ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
+        try:
+            ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
+            _log.debug(
+                "transfer_table ws=%s item=%s qualified=%r target_schema=%r",
+                ws_id,
+                entry.id,
+                qualified_name,
+                target_schema,
+            )
+            target = make_sql_target(ws_id, entry, item)
+            result = await tables_svc.transfer_table(
+                target, qualified_name, target_schema, kind=entry.kind, mode=ctx.auth_mode
+            )
+        except (ValueError, FabricError) as exc:
+            raise tool_err(exc) from exc
+        return result.model_dump(mode="json")
+
     @mutating_tool(mcp, "set_cluster_columns", destructive=True)
     async def set_cluster_columns(
         workspace: str,

--- a/src/fabric_dw/services/_helpers.py
+++ b/src/fabric_dw/services/_helpers.py
@@ -15,6 +15,7 @@ from fabric_dw.exceptions import ItemKindError
 from fabric_dw.identifiers import quote_identifier, validate_identifier
 from fabric_dw.models import WarehouseKind
 from fabric_dw.services.capacities import ACTIVE_STATE
+from fabric_dw.services.schemas import _SYSTEM_SCHEMAS
 from fabric_dw.sql import SqlTarget, run_query
 
 __all__ = [
@@ -67,6 +68,25 @@ def _assert_not_sql_endpoint(kind: WarehouseKind) -> None:
 # validated, bracket-quoted identifiers -- no SQL parsing is involved.
 # ---------------------------------------------------------------------------
 
+# Reuse the single canonical system-schema list from services.schemas (sys,
+# INFORMATION_SCHEMA, guest, and the fixed db_* role schemas) rather than a
+# second, narrower copy -- these schemas are never valid ALTER SCHEMA TRANSFER
+# targets either.  Pre-casefolded once at import time.
+#
+# Case-insensitive comparison is a deliberate, conservative client-side
+# choice, not a claim about the warehouse's actual collation: Fabric
+# Warehouses use a fixed case-sensitive binary collation
+# (Latin1_General_100_BIN2_UTF8) for user data, so a schema literally named
+# e.g. "Sys" (distinct from the engine's "sys") is technically possible on
+# the server and would be wrongly rejected here.  We accept that asymmetry
+# because (a) creating a schema that differs from a system schema only by
+# case is already confusing and best avoided, and (b) it is consistent with
+# how this codebase treats every other identifier comparison in this guard
+# family (e.g. validate_identifier's own forbidden-character checks) as a
+# fail-closed, "when in doubt, reject" client-side safety net rather than an
+# authoritative mirror of server-side semantics.
+_SYSTEM_SCHEMAS_CASEFOLDED: frozenset[str] = frozenset(s.casefold() for s in _SYSTEM_SCHEMAS)
+
 
 async def _alter_schema_transfer(
     target: SqlTarget,
@@ -90,6 +110,15 @@ async def _alter_schema_transfer(
     before being embedded in the DDL string.  This is a parameterised DDL
     statement built from validated identifiers, not SQL parsing or rewriting.
 
+    *target_schema* is rejected up front when it is a system schema (``sys``,
+    ``INFORMATION_SCHEMA``, ``guest``, or a fixed ``db_*`` role schema --
+    see :data:`~fabric_dw.services.schemas._SYSTEM_SCHEMAS`).  Those names
+    pass :func:`validate_identifier` (they are well-formed identifiers) but
+    Microsoft documents that they are never valid ALTER SCHEMA TRANSFER
+    targets, so this check catches them before any network I/O.  All four
+    transfer operations (table/view/function/procedure) inherit this check
+    for free since they all call this shared helper.
+
     This helper does **not** re-fetch the moved object -- callers re-fetch it
     from *target_schema* using their own object-specific lookup (e.g.
     ``_fetch_table``).
@@ -101,12 +130,13 @@ async def _alter_schema_transfer(
         object_name: The (unqualified) object name.  Must pass
             :func:`validate_identifier`.
         target_schema: The schema to move the object into.  Must pass
-            :func:`validate_identifier`.
+            :func:`validate_identifier` and must not be a system schema.
         mode: The credential mode for Entra authentication.
 
     Raises:
         ValueError: If *source_schema*, *object_name*, or *target_schema*
-            fails identifier validation.
+            fails identifier validation, or if *target_schema* is a system
+            schema.
         PermissionDeniedError: If the driver reports an ALTER SCHEMA permission error.
         FabricError: If the engine reports an error executing the DDL -- e.g.
             a missing source object or missing target schema.  Such errors may
@@ -118,6 +148,13 @@ async def _alter_schema_transfer(
     validate_identifier(source_schema)
     validate_identifier(object_name)
     validate_identifier(target_schema)
+
+    if target_schema.casefold() in _SYSTEM_SCHEMAS_CASEFOLDED:
+        msg = (
+            f"Target schema {target_schema!r} is a reserved system schema and "
+            "cannot be an ALTER SCHEMA TRANSFER target"
+        )
+        raise ValueError(msg)
 
     ddl = (
         f"ALTER SCHEMA {quote_identifier(target_schema)} "

--- a/src/fabric_dw/services/_helpers.py
+++ b/src/fabric_dw/services/_helpers.py
@@ -119,6 +119,16 @@ async def _alter_schema_transfer(
     transfer operations (table/view/function/procedure) inherit this check
     for free since they all call this shared helper.
 
+    This system-schema check is intentionally one-sided: only *target_schema*
+    is screened, not *source_schema*.  No real caller ever owns a regular,
+    movable user object inside ``sys``/``INFORMATION_SCHEMA``/``guest``/a
+    ``db_*`` role schema -- those schemas hold engine catalog views and
+    fixed-role placeholders, not transferable user objects -- so a
+    *source_schema* in that set would already fail at the engine with a
+    "cannot find the object" style error.  Screening only the destination,
+    where the documented restriction actually lives, keeps the check focused
+    on the one direction Microsoft calls out as always invalid.
+
     This helper does **not** re-fetch the moved object -- callers re-fetch it
     from *target_schema* using their own object-specific lookup (e.g.
     ``_fetch_table``).

--- a/src/fabric_dw/services/_helpers.py
+++ b/src/fabric_dw/services/_helpers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import re
 from collections.abc import Callable, Coroutine, Mapping, Sequence
@@ -9,9 +10,12 @@ from datetime import UTC, datetime, timedelta
 from typing import Protocol, TypeVar
 from uuid import UUID
 
+from fabric_dw.auth import CredentialMode
 from fabric_dw.exceptions import ItemKindError
+from fabric_dw.identifiers import quote_identifier, validate_identifier
 from fabric_dw.models import WarehouseKind
 from fabric_dw.services.capacities import ACTIVE_STATE
+from fabric_dw.sql import SqlTarget, run_query
 
 __all__ = [
     "SelectBodyError",
@@ -53,6 +57,77 @@ def _assert_not_sql_endpoint(kind: WarehouseKind) -> None:
     """
     if kind == WarehouseKind.SQL_ENDPOINT:
         raise ItemKindError(_SQL_ENDPOINT_READONLY_MSG)
+
+
+# ---------------------------------------------------------------------------
+# ALTER SCHEMA TRANSFER helper
+#
+# Shared by table/view/function/procedure "transfer to another schema"
+# operations.  Builds and runs a single parameterised DDL statement from
+# validated, bracket-quoted identifiers -- no SQL parsing is involved.
+# ---------------------------------------------------------------------------
+
+
+async def _alter_schema_transfer(
+    target: SqlTarget,
+    *,
+    source_schema: str,
+    object_name: str,
+    target_schema: str,
+    mode: CredentialMode = CredentialMode.DEFAULT,
+) -> None:
+    """Move an object to another schema via ``ALTER SCHEMA ... TRANSFER OBJECT::...``.
+
+    Emits exactly::
+
+        ALTER SCHEMA [target_schema] TRANSFER OBJECT::[source_schema].[object_name]
+
+    Fabric's T-SQL syntax only allows the ``OBJECT::`` entity class -- the
+    canonical Microsoft example is ``ALTER SCHEMA Sales TRANSFER
+    OBJECT::dbo.Region;`` -- so the prefix is always emitted explicitly.  All
+    three identifiers are validated via :func:`~fabric_dw.identifiers.validate_identifier`
+    and bracket-quoted via :func:`~fabric_dw.identifiers.quote_identifier`
+    before being embedded in the DDL string.  This is a parameterised DDL
+    statement built from validated identifiers, not SQL parsing or rewriting.
+
+    This helper does **not** re-fetch the moved object -- callers re-fetch it
+    from *target_schema* using their own object-specific lookup (e.g.
+    ``_fetch_table``).
+
+    Args:
+        target: The warehouse or SQL Analytics Endpoint to connect to.
+        source_schema: The object's current schema.  Must pass
+            :func:`validate_identifier`.
+        object_name: The (unqualified) object name.  Must pass
+            :func:`validate_identifier`.
+        target_schema: The schema to move the object into.  Must pass
+            :func:`validate_identifier`.
+        mode: The credential mode for Entra authentication.
+
+    Raises:
+        ValueError: If *source_schema*, *object_name*, or *target_schema*
+            fails identifier validation.
+        PermissionDeniedError: If the driver reports an ALTER SCHEMA permission error.
+        FabricError: If the engine reports an error executing the DDL -- e.g.
+            a missing source object or missing target schema.  Such errors may
+            surface as a generic :class:`~fabric_dw.exceptions.FabricServerError`
+            rather than :class:`~fabric_dw.exceptions.NotFoundError`, because
+            the engine's "cannot find the object" message is not in
+            ``_NOT_FOUND_FRAGMENTS`` (:mod:`fabric_dw.sql_errors`).
+    """
+    validate_identifier(source_schema)
+    validate_identifier(object_name)
+    validate_identifier(target_schema)
+
+    ddl = (
+        f"ALTER SCHEMA {quote_identifier(target_schema)} "
+        f"TRANSFER OBJECT::{quote_identifier(source_schema)}.{quote_identifier(object_name)}"
+    )
+
+    def _run_ddl() -> None:
+        run_query(target, ddl, mode=mode, commit=True, fetch="none")
+
+    await asyncio.to_thread(_run_ddl)
 
 
 # ---------------------------------------------------------------------------

--- a/src/fabric_dw/services/tables.py
+++ b/src/fabric_dw/services/tables.py
@@ -15,6 +15,7 @@ Public API
 - :func:`delete_table`            — ``DROP TABLE [schema].[table]``.
 - :func:`clear_table`             — ``TRUNCATE TABLE [schema].[table]``.
 - :func:`rename_table`            — ``EXEC sp_rename`` (Data-Warehouse-only).
+- :func:`transfer_table`          — ``ALTER SCHEMA ... TRANSFER OBJECT::...`` (Data-Warehouse-only).
 - :func:`recluster_table`         — transactional CTAS-swap to change (or remove) clustering.
 - :func:`get_table_health_metrics` — ``EXEC sp_get_table_health_metrics`` (SQL endpoint only).
 
@@ -47,6 +48,7 @@ from fabric_dw.models import (
     WarehouseKind,
 )
 from fabric_dw.services._helpers import (
+    _alter_schema_transfer,
     _assert_not_sql_endpoint,
     _format_ms_literal,
     build_time_travel_option,
@@ -82,6 +84,7 @@ __all__ = [
     "read_table",
     "recluster_table",
     "rename_table",
+    "transfer_table",
     "validate_identifier",
 ]
 
@@ -166,6 +169,13 @@ WHERE s.name = ? AND t.name = ?;
 # sp_rename: @objname = 'schema.oldtable', @newname = 'newtable', @objtype = 'OBJECT'
 # Names are bound as ? parameters (string args to the proc, not SQL identifiers).
 _SP_RENAME_SQL = "EXEC sp_rename ?, ?, 'OBJECT'"
+
+# Target schemas that are always invalid for ALTER SCHEMA TRANSFER (Microsoft
+# reserves these system schemas).  validate_identifier() accepts these strings
+# since they are well-formed identifiers, so this explicit check catches them
+# before any network I/O.  Compared case-insensitively (casefold) because
+# Fabric's default collation is case-insensitive for identifier matching.
+_RESERVED_TRANSFER_TARGET_SCHEMAS = frozenset({"sys", "information_schema"})
 
 # sp_get_table_health_metrics: single positional arg is the two-part name as a string
 # literal.  The name is built from validated/quoted identifiers so no raw user input
@@ -1280,6 +1290,79 @@ async def rename_table(
         return await _fetch_table(target, schema, new_name, mode=mode)
     except NotFoundError:
         msg = f"Table [{schema}].[{new_name}] not found after rename"
+        raise NotFoundError(msg) from None
+
+
+async def transfer_table(
+    target: SqlTarget,
+    qualified: str,
+    target_schema: str,
+    *,
+    kind: WarehouseKind = WarehouseKind.WAREHOUSE,
+    mode: CredentialMode = CredentialMode.DEFAULT,
+) -> Table:
+    """Move a table to another schema via ``ALTER SCHEMA ... TRANSFER OBJECT::...``.
+
+    Table transfer is Warehouse-only: Microsoft documents that transferring a
+    table between schemas via T-SQL is not supported on the Fabric SQL
+    Analytics Endpoint and can break the OneLake sync, so this mirrors
+    :func:`rename_table` and guards with
+    :func:`~fabric_dw.services._helpers._assert_not_sql_endpoint`.
+
+    .. warning::
+
+        Permissions granted directly on the table are dropped by the engine
+        when the schema changes.  Dependent views and stored procedures that
+        reference the table by its old schema-qualified name are **not**
+        automatically updated and may need refreshing after the transfer.
+
+    Args:
+        target: The warehouse to connect to.
+        qualified: The current fully-qualified name of the form ``schema.table``.
+            Parsed with :func:`~fabric_dw.identifiers.parse_qualified_name`.
+        target_schema: The schema to move the table into.  Must pass
+            :func:`validate_identifier`.  ``sys`` and ``information_schema``
+            are rejected up front as they are never valid transfer targets.
+        kind: The :class:`~fabric_dw.models.WarehouseKind` of the item.
+            SQL Endpoint items are rejected with :class:`~fabric_dw.exceptions.ItemKindError`.
+        mode: The credential mode for Entra authentication.
+
+    Returns:
+        A :class:`~fabric_dw.models.Table` reflecting the moved table
+        (fetched via ``sys.tables`` from *target_schema* after the transfer).
+
+    Raises:
+        ItemKindError: If *kind* is :attr:`~fabric_dw.models.WarehouseKind.SQL_ENDPOINT`.
+        ValueError: If *qualified* cannot be parsed, if any identifier component
+            fails identifier validation, or if *target_schema* is ``sys`` or
+            ``information_schema``.
+        NotFoundError: If the transferred table cannot be found in
+            ``sys.tables`` under *target_schema* after the transfer.
+        PermissionDeniedError: If the driver reports a permission error.
+    """
+    _assert_not_sql_endpoint(kind)
+
+    schema, table_name = parse_qualified_name(qualified)
+    validate_identifier(schema)
+    validate_identifier(table_name)
+    validate_identifier(target_schema)
+
+    if target_schema.casefold() in _RESERVED_TRANSFER_TARGET_SCHEMAS:
+        msg = f"Target schema {target_schema!r} is reserved and cannot be a TRANSFER target"
+        raise ValueError(msg)
+
+    await _alter_schema_transfer(
+        target,
+        source_schema=schema,
+        object_name=table_name,
+        target_schema=target_schema,
+        mode=mode,
+    )
+
+    try:
+        return await _fetch_table(target, target_schema, table_name, mode=mode)
+    except NotFoundError:
+        msg = f"Table [{target_schema}].[{table_name}] not found after transfer"
         raise NotFoundError(msg) from None
 
 

--- a/src/fabric_dw/services/tables.py
+++ b/src/fabric_dw/services/tables.py
@@ -170,13 +170,6 @@ WHERE s.name = ? AND t.name = ?;
 # Names are bound as ? parameters (string args to the proc, not SQL identifiers).
 _SP_RENAME_SQL = "EXEC sp_rename ?, ?, 'OBJECT'"
 
-# Target schemas that are always invalid for ALTER SCHEMA TRANSFER (Microsoft
-# reserves these system schemas).  validate_identifier() accepts these strings
-# since they are well-formed identifiers, so this explicit check catches them
-# before any network I/O.  Compared case-insensitively (casefold) because
-# Fabric's default collation is case-insensitive for identifier matching.
-_RESERVED_TRANSFER_TARGET_SCHEMAS = frozenset({"sys", "information_schema"})
-
 # sp_get_table_health_metrics: single positional arg is the two-part name as a string
 # literal.  The name is built from validated/quoted identifiers so no raw user input
 # is ever embedded.  The literal is enclosed in single quotes as T-SQL requires.
@@ -1305,9 +1298,20 @@ async def transfer_table(
 
     Table transfer is Warehouse-only: Microsoft documents that transferring a
     table between schemas via T-SQL is not supported on the Fabric SQL
-    Analytics Endpoint and can break the OneLake sync, so this mirrors
-    :func:`rename_table` and guards with
-    :func:`~fabric_dw.services._helpers._assert_not_sql_endpoint`.
+    Analytics Endpoint and can break the OneLake sync.  This restriction is
+    specific to tables -- it does not apply to views, functions, or stored
+    procedures, which are not subject to the same OneLake-sync risk and do
+    not guard with :func:`~fabric_dw.services._helpers._assert_not_sql_endpoint`.
+
+    .. warning::
+
+        ``OBJECT::[schema].[name]`` matches *any* schema-scoped object with
+        that name, not only tables.  If a view, function, or procedure
+        happens to share the qualified name, the engine transfers that
+        object instead (and drops its permissions).  When the post-transfer
+        re-fetch then finds no table named *table_name* in *target_schema*,
+        :class:`~fabric_dw.exceptions.NotFoundError` is raised with a message
+        that calls this out explicitly.
 
     .. warning::
 
@@ -1321,8 +1325,10 @@ async def transfer_table(
         qualified: The current fully-qualified name of the form ``schema.table``.
             Parsed with :func:`~fabric_dw.identifiers.parse_qualified_name`.
         target_schema: The schema to move the table into.  Must pass
-            :func:`validate_identifier`.  ``sys`` and ``information_schema``
-            are rejected up front as they are never valid transfer targets.
+            :func:`validate_identifier`.  System schemas (``sys``,
+            ``INFORMATION_SCHEMA``, ``guest``, fixed ``db_*`` role schemas)
+            are rejected by
+            :func:`~fabric_dw.services._helpers._alter_schema_transfer`.
         kind: The :class:`~fabric_dw.models.WarehouseKind` of the item.
             SQL Endpoint items are rejected with :class:`~fabric_dw.exceptions.ItemKindError`.
         mode: The credential mode for Entra authentication.
@@ -1334,10 +1340,9 @@ async def transfer_table(
     Raises:
         ItemKindError: If *kind* is :attr:`~fabric_dw.models.WarehouseKind.SQL_ENDPOINT`.
         ValueError: If *qualified* cannot be parsed, if any identifier component
-            fails identifier validation, or if *target_schema* is ``sys`` or
-            ``information_schema``.
-        NotFoundError: If the transferred table cannot be found in
-            ``sys.tables`` under *target_schema* after the transfer.
+            fails identifier validation, or if *target_schema* is a system schema.
+        NotFoundError: If no table named *table_name* is found in *target_schema*
+            after the transfer -- see the warning above about non-table objects.
         PermissionDeniedError: If the driver reports a permission error.
     """
     _assert_not_sql_endpoint(kind)
@@ -1346,10 +1351,6 @@ async def transfer_table(
     validate_identifier(schema)
     validate_identifier(table_name)
     validate_identifier(target_schema)
-
-    if target_schema.casefold() in _RESERVED_TRANSFER_TARGET_SCHEMAS:
-        msg = f"Target schema {target_schema!r} is reserved and cannot be a TRANSFER target"
-        raise ValueError(msg)
 
     await _alter_schema_transfer(
         target,
@@ -1362,7 +1363,12 @@ async def transfer_table(
     try:
         return await _fetch_table(target, target_schema, table_name, mode=mode)
     except NotFoundError:
-        msg = f"Table [{target_schema}].[{table_name}] not found after transfer"
+        msg = (
+            f"No table named [{target_schema}].[{table_name}] was found after "
+            "the transfer. ALTER SCHEMA TRANSFER moves any schema-scoped "
+            "object with that name, not only tables -- if a view, function, "
+            "or procedure shared this name, check whether it was moved instead."
+        )
         raise NotFoundError(msg) from None
 
 

--- a/src/fabric_dw/telemetry_commands.py
+++ b/src/fabric_dw/telemetry_commands.py
@@ -151,6 +151,7 @@ DOMAIN_MAP: dict[str, str] = {
     "create_empty_table": "tables",
     "clone_table": "tables",
     "rename_table": "tables",
+    "transfer_table": "tables",
     "delete_table": "tables",
     "clear_table": "tables",
     "load_table_from_url": "tables",

--- a/tests/integration/test_services_tables.py
+++ b/tests/integration/test_services_tables.py
@@ -24,7 +24,7 @@ from pathlib import Path
 import pyarrow.parquet as pq
 import pytest
 
-from fabric_dw.exceptions import FabricError, NotFoundError
+from fabric_dw.exceptions import FabricError, FabricServerError, NotFoundError
 from fabric_dw.models import Table
 from fabric_dw.services import columns as columns_svc
 from fabric_dw.services import schemas as schemas_svc
@@ -326,14 +326,21 @@ async def test_transfer_table_roundtrip(
 async def test_transfer_table_missing_target_schema_raises(
     warehouse_schema: tuple[SqlTarget, str],
 ) -> None:
-    """transfer_table against a nonexistent target schema raises a FabricError.
+    """transfer_table against a nonexistent target schema raises FabricServerError.
 
     GOTCHA (see the ``_NOT_FOUND_FRAGMENTS`` note in ``fabric_dw.sql_errors``,
-    intentionally NOT changed by this test): the engine's "cannot find the
-    object" message for a missing schema is not mapped to NotFoundError, so a
-    missing target schema surfaces as a generic FabricServerError instead.
-    This test documents that observed behaviour rather than asserting it is
-    desired -- a tighter _NOT_FOUND_FRAGMENTS match is a separate follow-up.
+    intentionally NOT changed by this test): SQL Server's "specified schema
+    name ... does not exist" message for ``ALTER SCHEMA`` does not match any
+    fragment in ``_NOT_FOUND_FRAGMENTS`` / ``_PERMISSION_DENIED_FRAGMENTS`` /
+    ``_AUTH_FAILED_FRAGMENTS``, so :func:`~fabric_dw.sql_errors.map_driver_error`
+    returns ``None`` and the error falls through to
+    :func:`~fabric_dw.sql_errors._wrap_unmapped_driver_error`, which wraps any
+    ``ddbc_error``-carrying driver exception as a non-retriable
+    :class:`~fabric_dw.exceptions.FabricServerError`. This test pins that
+    specific (not ideal) exception type rather than the broad
+    :class:`~fabric_dw.exceptions.FabricError` parent, so a future
+    ``_NOT_FOUND_FRAGMENTS`` fix (a separate, tightly-scoped follow-up) will
+    intentionally break this assertion as a signal to update it.
     """
     sql_target, schema = warehouse_schema
     table_name = "pytest_tables_transfer_missing_schema"
@@ -341,12 +348,13 @@ async def test_transfer_table_missing_target_schema_raises(
 
     try:
         await tables.create_table(sql_target, schema, table_name, select_body)
-        with pytest.raises(FabricError) as exc_info:
+        with pytest.raises(FabricServerError) as exc_info:
             await tables.transfer_table(
                 sql_target, f"{schema}.{table_name}", "pytest_nonexistent_schema_zzz"
             )
         # Document what actually surfaces today: NOT a NotFoundError.
         assert not isinstance(exc_info.value, NotFoundError)
+        assert exc_info.value.is_retriable is False
     finally:
         with contextlib.suppress(Exception):
             await tables.delete_table(sql_target, schema, table_name)
@@ -355,11 +363,14 @@ async def test_transfer_table_missing_target_schema_raises(
 async def test_transfer_table_name_collision_raises(
     warehouse_schema: tuple[SqlTarget, str],
 ) -> None:
-    """transfer_table raises when an object of the same name already exists in the target schema.
+    """transfer_table raises FabricServerError on a name collision in the target schema.
 
-    Documents the exception type the engine surfaces for a genuine name
-    collision in the target schema (as opposed to the missing-schema/missing-
-    object gotcha covered separately above).
+    SQL Server's "There is already an object named ... in the database"
+    message does not match any fragment in ``_NOT_FOUND_FRAGMENTS`` /
+    ``_PERMISSION_DENIED_FRAGMENTS`` / ``_AUTH_FAILED_FRAGMENTS`` either, so
+    (same as the missing-target-schema gotcha above) it falls through to the
+    generic, non-retriable :class:`~fabric_dw.exceptions.FabricServerError`
+    wrap rather than a more specific error type.
     """
     sql_target, schema = warehouse_schema
     table_name = "pytest_tables_transfer_collision"
@@ -371,8 +382,9 @@ async def test_transfer_table_name_collision_raises(
         await tables.create_table(sql_target, schema, table_name, select_body)
         await tables.create_table(sql_target, target_schema_name, table_name, select_body)
 
-        with pytest.raises(FabricError):
+        with pytest.raises(FabricServerError) as exc_info:
             await tables.transfer_table(sql_target, f"{schema}.{table_name}", target_schema_name)
+        assert exc_info.value.is_retriable is False
     finally:
         with contextlib.suppress(Exception):
             await tables.delete_table(sql_target, schema, table_name)

--- a/tests/integration/test_services_tables.py
+++ b/tests/integration/test_services_tables.py
@@ -27,6 +27,7 @@ import pytest
 from fabric_dw.exceptions import FabricError, NotFoundError
 from fabric_dw.models import Table
 from fabric_dw.services import columns as columns_svc
+from fabric_dw.services import schemas as schemas_svc
 from fabric_dw.services import tables
 from fabric_dw.sql import SqlTarget, run_query
 
@@ -282,6 +283,103 @@ async def test_rename_table_roundtrip(
             await tables.delete_table(sql_target, schema, old_name)
         with contextlib.suppress(Exception):
             await tables.delete_table(sql_target, schema, new_name)
+
+
+async def test_transfer_table_roundtrip(
+    warehouse_schema: tuple[SqlTarget, str],
+) -> None:
+    """Create a table, transfer it to a second schema, assert old gone / new present."""
+    sql_target, schema = warehouse_schema
+    table_name = "pytest_tables_transfer_dst"
+    select_body = "SELECT 42 AS answer"
+    target_schema_name = f"{schema}_target"
+
+    await schemas_svc.create_schema(sql_target, target_schema_name)
+    try:
+        created = await tables.create_table(sql_target, schema, table_name, select_body)
+        assert isinstance(created, Table)
+        assert created.schema_name == schema
+
+        moved = await tables.transfer_table(
+            sql_target, f"{schema}.{table_name}", target_schema_name
+        )
+        assert isinstance(moved, Table)
+        assert moved.name == table_name
+        assert moved.schema_name == target_schema_name
+        assert moved.qualified_name == f"{target_schema_name}.{table_name}"
+
+        all_tables = await tables.list_tables(sql_target)
+        in_target = {t.name for t in all_tables if t.schema_name == target_schema_name}
+        in_source = {t.name for t in all_tables if t.schema_name == schema}
+        assert table_name in in_target, f"{table_name!r} not found in {target_schema_name!r}"
+        assert table_name not in in_source, f"{table_name!r} still present in {schema!r}"
+
+    finally:
+        with contextlib.suppress(Exception):
+            await tables.delete_table(sql_target, schema, table_name)
+        with contextlib.suppress(Exception):
+            await tables.delete_table(sql_target, target_schema_name, table_name)
+        with contextlib.suppress(Exception):
+            await schemas_svc.delete_schema(sql_target, target_schema_name, cascade=True)
+
+
+async def test_transfer_table_missing_target_schema_raises(
+    warehouse_schema: tuple[SqlTarget, str],
+) -> None:
+    """transfer_table against a nonexistent target schema raises a FabricError.
+
+    GOTCHA (see the ``_NOT_FOUND_FRAGMENTS`` note in ``fabric_dw.sql_errors``,
+    intentionally NOT changed by this test): the engine's "cannot find the
+    object" message for a missing schema is not mapped to NotFoundError, so a
+    missing target schema surfaces as a generic FabricServerError instead.
+    This test documents that observed behaviour rather than asserting it is
+    desired -- a tighter _NOT_FOUND_FRAGMENTS match is a separate follow-up.
+    """
+    sql_target, schema = warehouse_schema
+    table_name = "pytest_tables_transfer_missing_schema"
+    select_body = "SELECT 1 AS id"
+
+    try:
+        await tables.create_table(sql_target, schema, table_name, select_body)
+        with pytest.raises(FabricError) as exc_info:
+            await tables.transfer_table(
+                sql_target, f"{schema}.{table_name}", "pytest_nonexistent_schema_zzz"
+            )
+        # Document what actually surfaces today: NOT a NotFoundError.
+        assert not isinstance(exc_info.value, NotFoundError)
+    finally:
+        with contextlib.suppress(Exception):
+            await tables.delete_table(sql_target, schema, table_name)
+
+
+async def test_transfer_table_name_collision_raises(
+    warehouse_schema: tuple[SqlTarget, str],
+) -> None:
+    """transfer_table raises when an object of the same name already exists in the target schema.
+
+    Documents the exception type the engine surfaces for a genuine name
+    collision in the target schema (as opposed to the missing-schema/missing-
+    object gotcha covered separately above).
+    """
+    sql_target, schema = warehouse_schema
+    table_name = "pytest_tables_transfer_collision"
+    target_schema_name = f"{schema}_collision_target"
+    select_body = "SELECT 1 AS id"
+
+    await schemas_svc.create_schema(sql_target, target_schema_name)
+    try:
+        await tables.create_table(sql_target, schema, table_name, select_body)
+        await tables.create_table(sql_target, target_schema_name, table_name, select_body)
+
+        with pytest.raises(FabricError):
+            await tables.transfer_table(sql_target, f"{schema}.{table_name}", target_schema_name)
+    finally:
+        with contextlib.suppress(Exception):
+            await tables.delete_table(sql_target, schema, table_name)
+        with contextlib.suppress(Exception):
+            await tables.delete_table(sql_target, target_schema_name, table_name)
+        with contextlib.suppress(Exception):
+            await schemas_svc.delete_schema(sql_target, target_schema_name, cascade=True)
 
 
 async def test_count_table_rows_returns_nonnegative_int(

--- a/tests/unit/cli/commands/test_tables.py
+++ b/tests/unit/cli/commands/test_tables.py
@@ -2104,6 +2104,138 @@ class TestTablesRename:
         assert result.exit_code != 0
 
 
+class TestTablesTransfer:
+    def test_transfer_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        moved = Table(
+            schema_name="archive",
+            name="sales",
+            qualified_name="archive.sales",
+            created=_NOW,
+            modified=_NOW,
+        )
+        mock_transfer = AsyncMock(return_value=moved)
+        with (
+            patch(
+                "fabric_dw.cli.commands.tables.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.tables.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.tables.transfer_table",
+                new=mock_transfer,
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "-w",
+                    WS_GUID,
+                    "--json",
+                    "tables",
+                    "transfer",
+                    WH_GUID,
+                    "dbo.sales",
+                    "--target-schema",
+                    "archive",
+                ],
+            )
+        assert result.exit_code == 0
+        mock_transfer.assert_awaited_once()
+        parsed = json.loads(result.output)
+        assert parsed["name"] == "sales"
+        assert parsed["schema_name"] == "archive"
+
+    def test_transfer_missing_target_schema_fails(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        result = runner.invoke(cli, ["-w", WS_GUID, "tables", "transfer", WH_GUID, "dbo.sales"])
+        assert result.exit_code != 0
+
+    def test_transfer_undotted_qualified_name_fails_before_io(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """An undotted QUALIFIED_NAME must yield a UsageError before any I/O is performed."""
+        _ = cache_env
+        result = runner.invoke(
+            cli,
+            ["-w", WS_GUID, "tables", "transfer", WH_GUID, "nodot", "--target-schema", "archive"],
+        )
+        assert result.exit_code != 0
+        assert "table" in result.output.lower() or "Usage" in result.output
+
+    def test_transfer_sql_endpoint_rejected(self, runner: CliRunner, cache_env: Path) -> None:
+        """SQL Endpoint items must be rejected by the service-layer guard."""
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.tables.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.tables.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_sql_endpoint_entry())),
+            ),
+            patch(
+                "fabric_dw.services.tables.transfer_table",
+                new=AsyncMock(side_effect=ItemKindError("read-only")),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "-w",
+                    WS_GUID,
+                    "tables",
+                    "transfer",
+                    SE_GUID,
+                    "dbo.sales",
+                    "--target-schema",
+                    "archive",
+                ],
+            )
+        assert result.exit_code != 0
+        assert "read-only" in result.output
+
+    def test_transfer_permission_denied_returns_nonzero(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.tables.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.tables.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.tables.transfer_table",
+                new=AsyncMock(side_effect=PermissionDeniedError("no permission")),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "-w",
+                    WS_GUID,
+                    "tables",
+                    "transfer",
+                    WH_GUID,
+                    "dbo.sales",
+                    "--target-schema",
+                    "archive",
+                ],
+            )
+        assert result.exit_code != 0
+
+
 # ===========================================================================
 # tables create — empty DDL path
 # ===========================================================================

--- a/tests/unit/cli/commands/test_tables.py
+++ b/tests/unit/cli/commands/test_tables.py
@@ -2176,6 +2176,7 @@ class TestTablesTransfer:
         """SQL Endpoint items must be rejected by the service-layer guard."""
         _ = cache_env
         mock_http = AsyncMock()
+        mock_transfer = AsyncMock(side_effect=ItemKindError("read-only"))
         with (
             patch(
                 "fabric_dw.cli.commands.tables.build_http_client",
@@ -2187,7 +2188,7 @@ class TestTablesTransfer:
             ),
             patch(
                 "fabric_dw.services.tables.transfer_table",
-                new=AsyncMock(side_effect=ItemKindError("read-only")),
+                new=mock_transfer,
             ),
         ):
             result = runner.invoke(
@@ -2205,6 +2206,58 @@ class TestTablesTransfer:
             )
         assert result.exit_code != 0
         assert "read-only" in result.output
+        # The CLI must forward kind=SQL_ENDPOINT — the rejection is enforced
+        # by the service-layer guard, not faked by the CLI hardcoding WAREHOUSE.
+        _, kwargs = mock_transfer.call_args
+        assert kwargs["kind"] == _make_sql_endpoint_entry().kind
+
+    def test_transfer_reserved_target_schema_returns_nonzero(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """--target-schema sys / information_schema must surface as a non-zero CLI exit.
+
+        Exercises the CLI's ValueError -> ClickException conversion for the
+        reserved-system-schema rejection raised by the shared
+        _alter_schema_transfer helper (acceptance criterion for this feature,
+        already covered 4x via parametrize at the service layer in
+        TestTransferTable.test_rejects_reserved_target_schema).
+        """
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.tables.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.tables.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.tables.transfer_table",
+                new=AsyncMock(
+                    side_effect=ValueError(
+                        "Target schema 'sys' is a reserved system schema and cannot be "
+                        "an ALTER SCHEMA TRANSFER target"
+                    )
+                ),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "-w",
+                    WS_GUID,
+                    "tables",
+                    "transfer",
+                    WH_GUID,
+                    "dbo.sales",
+                    "--target-schema",
+                    "sys",
+                ],
+            )
+        assert result.exit_code != 0
+        assert "reserved system schema" in result.output
 
     def test_transfer_permission_denied_returns_nonzero(
         self, runner: CliRunner, cache_env: Path

--- a/tests/unit/cli/commands/test_tables.py
+++ b/tests/unit/cli/commands/test_tables.py
@@ -2146,6 +2146,11 @@ class TestTablesTransfer:
             )
         assert result.exit_code == 0
         mock_transfer.assert_awaited_once()
+        args, kwargs = mock_transfer.call_args
+        # service is called positionally: target, qualified_name, target_schema
+        assert args[1] == "dbo.sales"
+        assert args[2] == "archive"
+        assert kwargs["kind"] == _make_item_entry().kind
         parsed = json.loads(result.output)
         assert parsed["name"] == "sales"
         assert parsed["schema_name"] == "archive"

--- a/tests/unit/mcp/tools/test_tables.py
+++ b/tests/unit/mcp/tools/test_tables.py
@@ -1150,3 +1150,128 @@ async def test_get_table_health_metrics_warehouse_raises_tool_error(mock_ctx, ct
             "get_table_health_metrics",
             {"workspace": WS_NAME, "item": WH_NAME, "qualified_name": "dbo.FactSales"},
         )
+
+
+# ---------------------------------------------------------------------------
+# transfer_table
+# ---------------------------------------------------------------------------
+
+
+async def test_transfer_table_happy_path(mock_ctx, ctx_patch) -> None:
+    """transfer_table resolves item, calls the service, and returns the moved Table dict."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    moved = _make_table(schema="archive", name="sales")
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+    mock_transfer = AsyncMock(return_value=moved)
+
+    with (
+        ctx_patch,
+        patch("fabric_dw.services.tables.transfer_table", new=mock_transfer),
+        patch.dict(os.environ, {"FABRIC_MCP_WRITES": "true"}),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "transfer_table",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_name": "dbo.sales",
+                "target_schema": "archive",
+            },
+        )
+
+    mock_transfer.assert_called_once()
+    assert result["name"] == "sales"
+    assert result["schema_name"] == "archive"
+
+
+async def test_transfer_table_readonly_blocked(mock_ctx, ctx_patch) -> None:
+    """transfer_table raises ToolError when FABRIC_MCP_READONLY is set."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_READONLY": "1"}),
+        pytest.raises(ToolError, match="read-only"),
+    ):
+        await mcp._tool_manager.call_tool(
+            "transfer_table",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_name": "dbo.sales",
+                "target_schema": "archive",
+            },
+        )
+
+
+async def test_transfer_table_sql_endpoint_raises_tool_error(mock_ctx, ctx_patch) -> None:
+    """transfer_table raises ToolError when the item is a SQL Analytics Endpoint."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_sql_endpoint_entry())
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_WRITES": "true"}),
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "transfer_table",
+            {
+                "workspace": WS_NAME,
+                "item": "MySqlEndpoint",
+                "qualified_name": "dbo.sales",
+                "target_schema": "archive",
+            },
+        )
+
+    assert "read-only" in str(exc_info.value).lower()
+
+
+async def test_transfer_table_undotted_qualified_name_raises_tool_error(
+    mock_ctx,  # noqa: ARG001
+    ctx_patch,
+) -> None:
+    """transfer_table must raise ToolError immediately for an undotted qualified_name."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        pytest.raises(ToolError, match="qualified name"),
+    ):
+        await mcp._tool_manager.call_tool(
+            "transfer_table",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_name": "nodot",
+                "target_schema": "archive",
+            },
+        )
+
+
+async def test_transfer_table_workspace_allowlist_blocks(ctx_patch) -> None:
+    """transfer_table raises ToolError when workspace is not in FABRIC_MCP_WORKSPACES."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_WORKSPACES": "other-workspace"}),
+        pytest.raises(ToolError, match="allowlist"),
+    ):
+        await mcp._tool_manager.call_tool(
+            "transfer_table",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_name": "dbo.sales",
+                "target_schema": "archive",
+            },
+        )

--- a/tests/unit/mcp/tools/test_tables.py
+++ b/tests/unit/mcp/tools/test_tables.py
@@ -1183,6 +1183,11 @@ async def test_transfer_table_happy_path(mock_ctx, ctx_patch) -> None:
         )
 
     mock_transfer.assert_called_once()
+    args, kwargs = mock_transfer.call_args
+    # service is called positionally: target, qualified_name, target_schema
+    assert args[1] == "dbo.sales"
+    assert args[2] == "archive"
+    assert kwargs["kind"] == item.kind
     assert result["name"] == "sales"
     assert result["schema_name"] == "archive"
 

--- a/tests/unit/mcp/tools/test_tool_quality.py
+++ b/tests/unit/mcp/tools/test_tool_quality.py
@@ -730,6 +730,7 @@ _ALL_MUTATING_TOOLS: list[str] = [
     "clear_table",
     "clone_table",
     "rename_table",
+    "transfer_table",
     # procedures.py
     "create_procedure",
     "update_procedure",

--- a/tests/unit/services/test_helpers.py
+++ b/tests/unit/services/test_helpers.py
@@ -3,18 +3,21 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta, timezone
+from unittest.mock import patch
 
 import pytest
 
 from fabric_dw.exceptions import ItemKindError
 from fabric_dw.models import WarehouseKind
 from fabric_dw.services._helpers import (
+    _alter_schema_transfer,
     _assert_not_sql_endpoint,
     build_time_travel_option,
     coerce_to_utc,
     compact,
     reject_non_select,
 )
+from tests.unit.services._helpers import _make_conn_for_ddl, _make_target
 
 # ---------------------------------------------------------------------------
 # coerce_to_utc
@@ -199,6 +202,71 @@ class TestAssertNotSqlEndpoint:
         assert settings_guard is _assert_not_sql_endpoint
         assert stats_guard is _assert_not_sql_endpoint
         assert tables_guard is _assert_not_sql_endpoint
+
+
+# ---------------------------------------------------------------------------
+# _alter_schema_transfer (shared by table/view/function/procedure transfer)
+# ---------------------------------------------------------------------------
+
+
+class TestAlterSchemaTransfer:
+    """_alter_schema_transfer builds and runs the ALTER SCHEMA TRANSFER DDL."""
+
+    async def test_emits_exact_ddl_shape(self) -> None:
+        target = _make_target()
+        conn = _make_conn_for_ddl()
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await _alter_schema_transfer(
+                target,
+                source_schema="dbo",
+                object_name="sales",
+                target_schema="archive",
+            )
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert call_sql == "ALTER SCHEMA [archive] TRANSFER OBJECT::[dbo].[sales]"
+
+    async def test_commits_after_execute(self) -> None:
+        target = _make_target()
+        conn = _make_conn_for_ddl()
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await _alter_schema_transfer(
+                target,
+                source_schema="dbo",
+                object_name="sales",
+                target_schema="archive",
+            )
+        conn.commit.assert_called_once()
+
+    async def test_rejects_invalid_source_schema(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await _alter_schema_transfer(
+                target,
+                source_schema="bad--schema",
+                object_name="sales",
+                target_schema="archive",
+            )
+
+    async def test_rejects_invalid_object_name(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await _alter_schema_transfer(
+                target,
+                source_schema="dbo",
+                object_name="bad;name",
+                target_schema="archive",
+            )
+
+    async def test_rejects_invalid_target_schema(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await _alter_schema_transfer(
+                target,
+                source_schema="dbo",
+                object_name="sales",
+                target_schema="bad]schema",
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/services/test_helpers.py
+++ b/tests/unit/services/test_helpers.py
@@ -17,6 +17,7 @@ from fabric_dw.services._helpers import (
     compact,
     reject_non_select,
 )
+from fabric_dw.services.schemas import _SYSTEM_SCHEMAS
 from tests.unit.services._helpers import _make_conn_for_ddl, _make_target
 
 # ---------------------------------------------------------------------------
@@ -267,6 +268,48 @@ class TestAlterSchemaTransfer:
                 object_name="sales",
                 target_schema="bad]schema",
             )
+
+    @pytest.mark.parametrize("reserved", sorted(_SYSTEM_SCHEMAS))
+    async def test_rejects_every_system_schema_as_target(self, reserved: str) -> None:
+        """Every name in the canonical _SYSTEM_SCHEMAS list must be rejected as a
+        TRANSFER target.  This is the single source of truth that all four
+        transfer operations (table/view/function/procedure) inherit by
+        calling this shared helper -- a sibling service does not need to
+        re-test the full enumeration.
+        """
+        target = _make_target()
+        with pytest.raises(ValueError, match="reserved system schema"):
+            await _alter_schema_transfer(
+                target,
+                source_schema="dbo",
+                object_name="sales",
+                target_schema=reserved,
+            )
+
+    async def test_rejects_system_schema_case_insensitively(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="reserved system schema"):
+            await _alter_schema_transfer(
+                target,
+                source_schema="dbo",
+                object_name="sales",
+                target_schema="SYS",
+            )
+
+    async def test_reserved_target_schema_check_fires_before_any_connection(self) -> None:
+        """The reserved-schema rejection must happen before any network I/O."""
+        target = _make_target()
+        with (
+            patch("fabric_dw.sql.open_connection") as mock_open,
+            pytest.raises(ValueError, match="reserved system schema"),
+        ):
+            await _alter_schema_transfer(
+                target,
+                source_schema="dbo",
+                object_name="sales",
+                target_schema="sys",
+            )
+        mock_open.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/services/test_tables.py
+++ b/tests/unit/services/test_tables.py
@@ -1792,6 +1792,102 @@ class TestRenameTable:
 
 
 # ===========================================================================
+# transfer_table
+# ===========================================================================
+
+
+class TestTransferTable:
+    async def test_emits_alter_schema_transfer(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        moved_row: tuple[object, ...] = ("archive", "sales", _NOW, _LATER)
+        fetch_conn = _make_conn([moved_row], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            await tables.transfer_table(target, "dbo.sales", "archive")
+        cursor = ddl_conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert call_sql == "ALTER SCHEMA [archive] TRANSFER OBJECT::[dbo].[sales]"
+
+    async def test_returns_table_from_target_schema(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        moved_row: tuple[object, ...] = ("archive", "sales", _NOW, _LATER)
+        fetch_conn = _make_conn([moved_row], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            result = await tables.transfer_table(target, "dbo.sales", "archive")
+        assert isinstance(result, Table)
+        assert result.schema_name == "archive"
+        assert result.name == "sales"
+        assert result.qualified_name == "archive.sales"
+
+    async def test_commits_after_execute(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        moved_row: tuple[object, ...] = ("archive", "sales", _NOW, _LATER)
+        fetch_conn = _make_conn([moved_row], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            await tables.transfer_table(target, "dbo.sales", "archive")
+        ddl_conn.commit.assert_called_once()
+
+    async def test_transfer_table_rejects_sql_endpoint(self) -> None:
+        target = _make_target()
+        with pytest.raises(ItemKindError, match="read-only"):
+            await tables.transfer_table(
+                target,
+                "dbo.sales",
+                "archive",
+                kind=WarehouseKind.SQL_ENDPOINT,
+            )
+
+    async def test_rejects_undotted_qualified_name(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="qualified"):
+            await tables.transfer_table(target, "nodot", "archive")
+
+    async def test_rejects_invalid_schema_in_qualified_name(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await tables.transfer_table(target, "bad--schema.sales", "archive")
+
+    async def test_rejects_invalid_table_in_qualified_name(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await tables.transfer_table(target, "dbo.bad--table", "archive")
+
+    async def test_rejects_invalid_target_schema(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await tables.transfer_table(target, "dbo.sales", "bad--schema")
+
+    @pytest.mark.parametrize("reserved", ["sys", "information_schema", "SYS", "Information_Schema"])
+    async def test_rejects_reserved_target_schema(self, reserved: str) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="reserved"):
+            await tables.transfer_table(target, "dbo.sales", reserved)
+
+    async def test_raises_not_found_when_fetch_returns_empty(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([], _LIST_COLS)
+        with (
+            patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]),
+            pytest.raises(NotFoundError, match="not found after transfer"),
+        ):
+            await tables.transfer_table(target, "dbo.sales", "archive")
+
+    async def test_warehouse_kind_allowed(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        moved_row: tuple[object, ...] = ("archive", "sales", _NOW, _LATER)
+        fetch_conn = _make_conn([moved_row], _LIST_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            result = await tables.transfer_table(
+                target, "dbo.sales", "archive", kind=WarehouseKind.WAREHOUSE
+            )
+        assert isinstance(result, Table)
+
+
+# ===========================================================================
 # create_empty_table
 # ===========================================================================
 

--- a/tests/unit/services/test_tables.py
+++ b/tests/unit/services/test_tables.py
@@ -1859,10 +1859,18 @@ class TestTransferTable:
         with pytest.raises(ValueError, match="Invalid SQL identifier"):
             await tables.transfer_table(target, "dbo.sales", "bad--schema")
 
-    @pytest.mark.parametrize("reserved", ["sys", "information_schema", "SYS", "Information_Schema"])
+    @pytest.mark.parametrize(
+        "reserved", ["sys", "information_schema", "SYS", "Information_Schema", "guest", "db_owner"]
+    )
     async def test_rejects_reserved_target_schema(self, reserved: str) -> None:
+        """transfer_table propagates the system-schema rejection from the shared helper.
+
+        The check itself (and its full enumeration of system schemas) is
+        exercised exhaustively in TestAlterSchemaTransfer; this is a thin
+        pass-through test confirming transfer_table does not bypass it.
+        """
         target = _make_target()
-        with pytest.raises(ValueError, match="reserved"):
+        with pytest.raises(ValueError, match="reserved system schema"):
             await tables.transfer_table(target, "dbo.sales", reserved)
 
     async def test_raises_not_found_when_fetch_returns_empty(self) -> None:
@@ -1871,7 +1879,22 @@ class TestTransferTable:
         fetch_conn = _make_conn([], _LIST_COLS)
         with (
             patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]),
-            pytest.raises(NotFoundError, match="not found after transfer"),
+            pytest.raises(NotFoundError, match="No table named"),
+        ):
+            await tables.transfer_table(target, "dbo.sales", "archive")
+
+    async def test_not_found_message_warns_about_non_table_objects(self) -> None:
+        """The post-transfer NotFoundError must call out that a same-named
+        non-table object (view/function/procedure) may have been moved
+        instead, since OBJECT::[schema].[name] matches any schema-scoped
+        object, not only tables.
+        """
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([], _LIST_COLS)
+        with (
+            patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]),
+            pytest.raises(NotFoundError, match="not only tables"),
         ):
             await tables.transfer_table(target, "dbo.sales", "archive")
 

--- a/tests/unit/test_telemetry_commands.py
+++ b/tests/unit/test_telemetry_commands.py
@@ -63,6 +63,13 @@ class TestResolveDomain:
     def test_known_mcp_tool_generate_dbt_profile(self) -> None:
         assert resolve_domain("generate_dbt_profile") == "dbt"
 
+    def test_known_mcp_tool_transfer_table(self) -> None:
+        assert resolve_domain("transfer_table") == "tables"
+
+    def test_domain_map_transfer_table_entry_is_tables(self) -> None:
+        """Pin the explicit DOMAIN_MAP entry itself (not just the resolved domain)."""
+        assert DOMAIN_MAP["transfer_table"] == "tables"
+
     def test_unknown_returns_unknown(self) -> None:
         assert resolve_domain("does_not_exist_abc") == "unknown"
 


### PR DESCRIPTION
## Summary

- Add the shared `_alter_schema_transfer(target, *, source_schema, object_name, target_schema, mode)` helper in `src/fabric_dw/services/_helpers.py`, which builds and runs `ALTER SCHEMA [target_schema] TRANSFER OBJECT::[source_schema].[object_name]` from validated, bracket-quoted identifiers (no SQL parsing). It does not re-fetch; callers re-fetch from the new schema.
- Add `transfer_table` end to end: service (`services/tables.py`), MCP tool (`mcp/tools/tables.py`, gated by `mutating_tool`, not destructive), and CLI command (`cli tables transfer ITEM QUALIFIED_NAME --target-schema X`).
- Table transfer is Warehouse-only (guarded by `_assert_not_sql_endpoint`): transferring a table on a SQL Analytics Endpoint is not supported and can break the OneLake sync.
- Reject `sys`/`information_schema` as a target schema up front (cheap polish from the issue).
- Add the `transfer_table` telemetry `DOMAIN_MAP` entry and `docs/commands/tables.md` CLI/MCP subsections, establishing the canonical MS Learn `ALTER SCHEMA` reference link that the follow-up issues (#941 view, #942 function, #943 procedure) will reuse.

This is the foundation issue; #941/#942/#943 depend on `_alter_schema_transfer` and will reuse it as-is.

## Notes for the follow-up issues

- `_alter_schema_transfer` signature: `_alter_schema_transfer(target, *, source_schema, object_name, target_schema, mode=CredentialMode.DEFAULT) -> None`. It validates all three identifiers, builds the DDL, and runs it via `run_query(..., commit=True, fetch="none")` inside `asyncio.to_thread`. It does **not** re-fetch — each caller re-fetches from `target_schema` with its own object-specific lookup (mirrors `transfer_table` calling `_fetch_table` after the DDL).
- A missing source object or missing target schema surfaces as a generic `FabricServerError`, not `NotFoundError` (the engine's "cannot find the object" message is not in `_NOT_FOUND_FRAGMENTS`). This is intentionally left unchanged per the issue notes; two integration tests document the observed behavior for both the missing-schema and name-collision cases.
- Docs admonition placement: the CLI subsection goes right after the existing `tables rename` section (before `## MCP tools`); the MCP subsection goes right after `rename_table` (before `set_cluster_columns`). The canonical MS Learn snippet is `https://learn.microsoft.com/sql/t-sql/statements/alter-schema-transact-sql?view=fabric&WT.mc_id=MVP_310840`.

## Test plan

- [x] `uv run ruff check .` and `uv run ruff format --check .` pass
- [x] `uv run ty check src tests` passes
- [x] `uv run pytest tests/unit -q` passes (5642 passed)
- [x] New unit tests: `TestAlterSchemaTransfer` (`tests/unit/services/test_helpers.py`), `TestTransferTable` (`tests/unit/services/test_tables.py`, incl. `transfer_table_rejects_sql_endpoint`), MCP tool tests (`tests/unit/mcp/tools/test_tables.py`), CLI tests (`tests/unit/cli/commands/test_tables.py`)
- [x] New integration tests added in `tests/integration/test_services_tables.py` (roundtrip + missing-target-schema + name-collision); not run locally (require live Fabric credentials, run on `main`)

Closes #940