### PR TITLE
ci(docs): fix sticky PR comment posting the literal file path

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -214,10 +214,10 @@ jobs:
 
           if [ -n "$COMMENT_ID" ]; then
             gh api --method PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID}" \
-              -f body=@/tmp/preview-comment.md
+              -F body=@/tmp/preview-comment.md
           else
             gh api --method POST "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
-              -f body=@/tmp/preview-comment.md
+              -F body=@/tmp/preview-comment.md
           fi
 
       - name: Update job summary with real preview URL


### PR DESCRIPTION
## Root cause

The "Post preview URL as sticky PR comment" step in `.github/workflows/docs.yml` builds the comment markdown into `/tmp/preview-comment.md`, then calls:

```
gh api --method PATCH "repos/.../issues/comments/${COMMENT_ID}" -f body=@/tmp/preview-comment.md
gh api --method POST  "repos/.../issues/${PR_NUMBER}/comments"   -f body=@/tmp/preview-comment.md
```

`gh api`'s `-f` / `--field` flag sends its argument as a literal string. Only `-F` / `--field` with the documented `@file` convention (actually exposed via `-F`, not `-f`) reads the value from a file. Because `-f` was used, the comment body became the literal text `@/tmp/preview-comment.md` instead of the markdown content, including the `<!-- docs-preview-url -->` marker that the sticky-comment lookup depends on.

## Fix

Change both calls from `-f body=@/tmp/preview-comment.md` to `-F body=@/tmp/preview-comment.md`. `-F` interprets the leading `@` as "read this file's contents," while the result is still treated as a plain string field (no unwanted JSON/number coercion, since the file just contains markdown text). This is the minimal change: the `<!-- docs-preview-url -->` marker still ends up in the posted body, so the next run's sticky-comment lookup (`select(.body | contains(...))`) keeps working unchanged.

Checked the rest of `.github/workflows/` for the same `-f body=@...` / `--raw-field` misuse pattern; no other occurrences found.

## Test plan

- [x] `actionlint .github/workflows/docs.yml` passes with no findings
- [ ] Open this PR against a path matched by the `docs.yml` trigger (e.g. touch `README.md`) and confirm the preview comment shows the rendered markdown with a working preview URL, not the literal `@/tmp/preview-comment.md` string
- [ ] Push a second commit to the same PR and confirm the existing comment is updated in place (PATCH path) rather than duplicated

🤖 Generated with [Claude Code](https://claude.com/claude-code)