### PR TITLE
test(integration): fix silently-skipping REVOKE GRANT OPTION FOR column test

### DIFF
--- a/src/fabric_dw/services/permissions.py
+++ b/src/fabric_dw/services/permissions.py
@@ -789,8 +789,10 @@ async def revoke_permission(
             ``COLUMN_APPLICABLE_PERMISSIONS``.
         grant_option_only: When ``True``, only revokes the ``GRANT OPTION FOR``
             (leaves the base permission in place).
-        cascade: When ``True``, adds ``CASCADE`` (required when the grantee has
-            granted the permission to others).
+        cascade: When ``True``, adds ``CASCADE``. Required whenever the principal
+            holds the permission ``WITH GRANT OPTION`` and you revoke it (or
+            revoke ``GRANT OPTION FOR`` it), regardless of whether that
+            principal has actually re-granted it to anyone else.
         mode: Credential mode for Entra authentication.
 
     Raises:

--- a/tests/integration/test_services_sql_permissions.py
+++ b/tests/integration/test_services_sql_permissions.py
@@ -494,11 +494,14 @@ async def test_revoke_grant_option_for_column_level_grant(
     """REVOKE GRANT OPTION FOR on a column-level grant must downgrade to a plain GRANT.
 
     Fabric T-SQL: first GRANT SELECT ... WITH GRANT OPTION, then
-    ``REVOKE GRANT OPTION FOR SELECT ON OBJECT::[schema].[table] ([col]) FROM [role]``.
+    ``REVOKE GRANT OPTION FOR SELECT ON OBJECT::[schema].[table] ([col]) FROM [role] CASCADE``.
     The resulting row must have state GRANT (not GRANT_WITH_GRANT_OPTION).
 
-    If Fabric does not support this syntax at the column level, the test skips with
-    a clear message rather than failing opaquely.
+    CASCADE is required here, not optional: per the T-SQL REVOKE reference, "The REVOKE
+    statement will fail if CASCADE is not specified when you are revoking a permission
+    from a principal that was granted that permission with GRANT OPTION specified." This
+    applies regardless of whether the grantee has actually re-granted the permission to
+    anyone else, and it is not a column-level limitation.
     """
     sql_target, schema_name, role_name = temp_role
     table_name = "pytest_cls_gof_tbl"
@@ -522,21 +525,16 @@ async def test_revoke_grant_option_for_column_level_grant(
         with_grant_option=True,
     )
 
-    try:
-        await permissions.revoke_permission(
-            sql_target,
-            "SELECT",
-            role_name,
-            "OBJECT",
-            object_name=qualified_name,
-            columns=["revenue"],
-            grant_option_only=True,
-        )
-    except Exception as exc:
-        pytest.skip(
-            f"Fabric rejected REVOKE GRANT OPTION FOR at column level "
-            f"(not supported on this capacity): {exc}"
-        )
+    await permissions.revoke_permission(
+        sql_target,
+        "SELECT",
+        role_name,
+        "OBJECT",
+        object_name=qualified_name,
+        columns=["revenue"],
+        grant_option_only=True,
+        cascade=True,
+    )
 
     result = await permissions.list_sql_permissions(
         sql_target, principal=role_name, object_name=qualified_name

--- a/tests/unit/services/test_sql_permissions.py
+++ b/tests/unit/services/test_sql_permissions.py
@@ -1066,3 +1066,36 @@ class TestRevokePermissionWithColumns:
             "REVOKE GRANT OPTION FOR SELECT ON OBJECT::[dbo].[sales]"
             " ([email], [phone]) FROM [alice@contoso.com];"
         )
+
+    async def test_revoke_grant_option_for_with_columns_and_cascade_exact_sql(self) -> None:
+        """REVOKE GRANT OPTION FOR + columns + CASCADE: exact SQL pin for the 3-way combination.
+
+        Fabric requires CASCADE whenever GRANT OPTION FOR is revoked from a principal
+        that holds the permission WITH GRANT OPTION, including at column level. The
+        integration test ``test_revoke_grant_option_for_column_level_grant`` depends on
+        this exact statement shape; pin it here so a future f-string refactor of
+        ``revoke_permission`` can't silently break the 3-way path.
+        """
+        captured: list[str] = []
+
+        def _mock_run_query(_target: object, sql: str, **_kwargs: object) -> tuple:
+            captured.append(sql)
+            return [], []
+
+        with patch("fabric_dw.services.permissions.run_query", side_effect=_mock_run_query):
+            await perms_svc.revoke_permission(
+                _TARGET,
+                "SELECT",
+                "alice@contoso.com",
+                "OBJECT",
+                object_name="dbo.sales",
+                columns=["email"],
+                grant_option_only=True,
+                cascade=True,
+            )
+
+        stmt = captured[0]
+        assert stmt == (
+            "REVOKE GRANT OPTION FOR SELECT ON OBJECT::[dbo].[sales]"
+            " ([email]) FROM [alice@contoso.com] CASCADE;"
+        )


### PR DESCRIPTION
## Root cause

`test_revoke_grant_option_for_column_level_grant` GRANTs `SELECT ... WITH GRANT OPTION` on a column, then calls `revoke_permission(..., grant_option_only=True)` without `cascade=True`, wrapped in a `try/except Exception: pytest.skip(...)`. The call always raised:

```
To revoke or deny grantable privileges, specify the CASCADE option.
```

This is not a column-level limitation. It is the standard SQL Server / T-SQL requirement: revoking the `GRANT OPTION FOR` on a permission that was granted `WITH GRANT OPTION` requires `CASCADE`, regardless of scope (column, object, schema, database) and regardless of whether the grantee has actually re-granted the permission to anyone else. Because the call never passed `cascade=True`, the revoke always failed and the test always silently skipped, verifying nothing.

## Evidence (Microsoft Learn)

[REVOKE (Transact-SQL)](https://learn.microsoft.com/sql/t-sql/statements/revoke-transact-sql?view=sql-server-ver17&WT.mc_id=MVP_310840), which documents the syntax shared by SQL Server, Azure SQL Database, and Fabric SQL database, as well as Azure Synapse Analytics, Parallel Data Warehouse, and Microsoft Fabric warehouse:

> The REVOKE statement will fail if CASCADE is not specified when you are revoking a permission from a principal that was granted that permission with GRANT OPTION specified.

> CASCADE Indicates that the permission that is being revoked is also revoked from other principals to which it has been granted by this principal. When you are using the CASCADE argument, you must also include the GRANT OPTION FOR argument.

`revoke_permission` in `src/fabric_dw/services/permissions.py` already supports `cascade: bool = False`, which appends ` CASCADE` to the emitted `REVOKE` statement, and the CLI already exposes `--cascade`. The production code was correct; only the test call was missing the flag.

## Fix (chosen branch: fix the test, not remove it)

The evidence strongly supports that `REVOKE GRANT OPTION FOR ... CASCADE` at the column level is the documented, supported way to downgrade a column-level `WITH GRANT OPTION` grant to a plain `GRANT` on Fabric warehouse, so:

- Added `cascade=True` to the `revoke_permission` call.
- Removed the `try/except Exception: pytest.skip(...)` wrapper entirely, so a real failure now fails loudly instead of being swallowed.
- Updated the docstring to drop the "skips if not supported" language and explain why CASCADE is required.
- Kept the import of `pytest` (it's still used for `pytestmark = pytest.mark.integration`).

## Follow-up from review

A reviewer flagged that the `cascade` parameter docstring on the production `revoke_permission` function (`src/fabric_dw/services/permissions.py`) understated the rule, scoping CASCADE to "the grantee has granted the permission to others" — narrower than the actual unconditional T-SQL rule this test proves (the role granted to no one, yet CASCADE was still required). Folded into this PR:

- Reworded the `cascade` docstring to state the unconditional rule, consistent with the MS Learn wording quoted above.
- Added a unit test (`test_revoke_grant_option_for_with_columns_and_cascade_exact_sql` in `tests/unit/services/test_sql_permissions.py`) that pins the exact emitted SQL for the 3-way combination (`grant_option_only=True`, `columns=[...]`, `cascade=True`) this integration test now depends on, so a future f-string refactor of `revoke_permission` can't silently break that path.

`cascade` stays an explicit, independent flag (not auto-forced when `grant_option_only=True`) — auto-forcing it would silently perform a destructive cascade-revoke.

## Other skip patterns in this file

Grepped the file for `pytest.skip` / `xfail` / `skipif`: no other matches remain. This was the only instance of the anti-pattern in `tests/integration/test_services_sql_permissions.py`.

## Validation

Cannot run integration tests here (no live Fabric credentials; they run on `main`). Validated locally instead:
- `ruff check` — passed
- `ruff format --check` — passed
- `ty check src tests` — passed
- `pytest tests/integration/test_services_sql_permissions.py --collect-only -q -m integration` — all 16 tests collect cleanly, including the fixed one
- `pytest tests/unit/services/test_sql_permissions.py` — 71 passed, including the new 3-way exact-SQL pin
- `pytest tests/unit -k permission` — 301 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)