### PR TITLE
feat: transfer procedures to another schema via ALTER SCHEMA TRANSFER

### DIFF
--- a/docs/commands/procedures.md
+++ b/docs/commands/procedures.md
@@ -132,6 +132,42 @@ fdw -w MyWorkspace procedures update SalesWH dbo.usp_archive_orders \
   --from-file ./procs/usp_archive_orders_v2.sql
 ```
 
+### procedures transfer
+
+**Targets:** Data Warehouse / SQL Analytics Endpoint
+
+Move a stored procedure to another schema via `ALTER SCHEMA ... TRANSFER OBJECT::...`. The command emits exactly `ALTER SCHEMA [target_schema] TRANSFER OBJECT::[schema].[proc]`, with every identifier validated and bracket-quoted before being embedded in the DDL.
+
+!!! warning "Definition text is not rewritten"
+    `ALTER SCHEMA ... TRANSFER` moves the procedure, but it does **not** rewrite
+    the schema name inside the object's stored definition
+    (`sys.sql_modules.definition`, `OBJECT_DEFINITION()`). After a transfer,
+    `get_procedure` may still show the *old* schema name in the `CREATE ... AS`
+    header, even though the procedure now lives in the new schema. This tool does
+    not rewrite the definition text: doing so would require parsing and
+    regenerating SQL, which this project deliberately avoids. See
+    [ALTER SCHEMA (Transact-SQL)](https://learn.microsoft.com/sql/t-sql/statements/alter-schema-transact-sql?view=fabric&WT.mc_id=MVP_310840#remarks).
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] procedures transfer [OPTIONS] [ITEM] QUALIFIED_NAME
+```
+
+`QUALIFIED_NAME` is the current dot-separated `schema.proc_name`.
+
+| Option | Description |
+| --- | --- |
+| `--target-schema TEXT` | **Required.** Schema to move the procedure into. |
+
+You will be asked to confirm unless `--yes` is passed.
+
+**Example**
+
+```shell
+fdw -w MyWorkspace procedures transfer SalesWH dbo.usp_archive_orders --target-schema archive
+```
+
 ## MCP tools
 
 ### create_procedure
@@ -194,6 +230,31 @@ List stored procedures on a warehouse or SQL Analytics Endpoint, optionally filt
 - `schema` (`str | null`, optional): when provided, only procedures in this schema are returned.
 
 **Returns:** `list[StoredProcedure]`: array of procedure objects, each with `schema_name`, `name`, `qualified_name`, `created`, and `modified`.
+
+### transfer_procedure
+
+**Targets:** Data Warehouse / SQL Analytics Endpoint
+
+Move a stored procedure to another schema via `ALTER SCHEMA ... TRANSFER OBJECT::...`. Supported on both Fabric Data Warehouses and SQL Analytics Endpoints; unlike `transfer_table`, no endpoint guard is applied here.
+
+!!! warning "Definition text is not rewritten"
+    `ALTER SCHEMA ... TRANSFER` moves the procedure, but it does **not** rewrite
+    the schema name inside the object's stored definition
+    (`sys.sql_modules.definition`, `OBJECT_DEFINITION()`). After a transfer,
+    `get_procedure` may still show the *old* schema name in the `CREATE ... AS`
+    header, even though the procedure now lives in the new schema. This tool does
+    not rewrite the definition text: doing so would require parsing and
+    regenerating SQL, which this project deliberately avoids. See
+    [ALTER SCHEMA (Transact-SQL)](https://learn.microsoft.com/sql/t-sql/statements/alter-schema-transact-sql?view=fabric&WT.mc_id=MVP_310840#remarks).
+
+**Parameters:**
+
+- `workspace` (`str`): workspace name or GUID.
+- `item` (`str`): warehouse or SQL analytics endpoint name or GUID.
+- `qualified_name` (`str`): current dot-separated qualified procedure name, e.g. `dbo.usp_load`.
+- `target_schema` (`str`): schema to move the procedure into, e.g. `archive`.
+
+**Returns:** `StoredProcedure`: the moved procedure record, fetched from the new schema.
 
 ### update_procedure
 

--- a/src/fabric_dw/cli/commands/procedures.py
+++ b/src/fabric_dw/cli/commands/procedures.py
@@ -173,3 +173,42 @@ async def drop_cmd(
                 click.echo(f"Procedure [{schema}].[{proc_name}] dropped.")
     except (ValueError, FabricError) as exc:
         raise click.ClickException(str(exc)) from exc
+
+
+@procedures_group.command("transfer")
+@click.argument("item", required=False, default=None)
+@click.argument("qualified_name")
+@click.option("--target-schema", required=True, help="Schema to move the procedure into.")
+@click.pass_obj
+@coro
+async def transfer_cmd(
+    ctx: CliContext,
+    item: str | None,
+    qualified_name: str,
+    target_schema: str,
+) -> None:
+    """Move QUALIFIED_NAME (schema.proc) on ITEM to --target-schema.
+
+    Stored procedures are supported on both Fabric Data Warehouses and SQL
+    Analytics Endpoints. You will be asked to confirm unless --yes is passed.
+    """
+    ws = resolve_workspace(ctx)
+    wh = resolve_warehouse_arg(ctx, item)
+    parse_qualified_name(qualified_name, kind="procedure")
+    try:
+        async with build_http_client(ctx) as http:
+            target, entry = await build_sql_target(http, ws, wh)
+            confirmed = confirm(
+                f"Transfer procedure {qualified_name!r} to schema {target_schema!r} on"
+                f" {entry.display_name!r}?",
+                yes=ctx.yes,
+            )
+            if not confirmed:
+                click.echo("Aborted.")
+                return
+            p = await _procs_svc.transfer_procedure(
+                target, qualified_name, target_schema, mode=ctx.auth
+            )
+            render(p.model_dump(by_alias=True, mode="json"), json_output=ctx.json_output)
+    except (ValueError, FabricError) as exc:
+        raise click.ClickException(str(exc)) from exc

--- a/src/fabric_dw/mcp/tools/procedures.py
+++ b/src/fabric_dw/mcp/tools/procedures.py
@@ -188,3 +188,49 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         except (ValueError, FabricError) as exc:
             raise tool_err(exc) from exc
         return {"dropped": True}
+
+    @mutating_tool(mcp, "transfer_procedure")
+    async def transfer_procedure(
+        workspace: str, item: str, qualified_name: str, target_schema: str
+    ) -> dict[str, Any]:
+        """Move a stored procedure to another schema via ``ALTER SCHEMA ... TRANSFER OBJECT::...``.
+
+        Stored procedures are supported on both Fabric Data Warehouses and
+        SQL Analytics Endpoints; unlike ``transfer_table``, no endpoint guard
+        is applied here.
+
+        CAUTION: ``ALTER SCHEMA ... TRANSFER`` moves the procedure but does
+        NOT rewrite the schema name inside its stored definition. After a
+        transfer, ``get_procedure`` may still show the OLD schema name in the
+        ``CREATE ... AS`` header even though the procedure now lives in the
+        new schema.
+
+        Args:
+            workspace: Workspace name or GUID.
+            item: Warehouse or SQL endpoint name or GUID.
+            qualified_name: Current dot-separated qualified procedure name,
+                e.g. ``dbo.usp_load``.
+            target_schema: Schema to move the procedure into, e.g. ``archive``.
+        """
+        parse_qualified_name(qualified_name, kind="procedure")
+        ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
+        try:
+            ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
+            _log.debug(
+                "transfer_procedure ws=%s item=%s qualified=%r target_schema=%r",
+                ws_id,
+                entry.id,
+                qualified_name,
+                target_schema,
+            )
+            target = make_sql_target(ws_id, entry, item)
+            result = await procedures_svc.transfer_procedure(
+                target, qualified_name, target_schema, mode=ctx.auth_mode
+            )
+        except (ValueError, FabricError) as exc:
+            raise tool_err(exc) from exc
+        return result.model_dump(mode="json")

--- a/src/fabric_dw/services/procedures.py
+++ b/src/fabric_dw/services/procedures.py
@@ -8,12 +8,15 @@ Public API
 - :func:`create_procedure`    — issue CREATE PROCEDURE … AS <body>.
 - :func:`update_procedure`    — issue CREATE OR ALTER PROCEDURE … AS <body>.
 - :func:`drop_procedure`      — issue DROP PROCEDURE.
+- :func:`transfer_procedure`  — ``ALTER SCHEMA ... TRANSFER OBJECT::...``.
 
 Note: Stored procedures are supported on **both** Fabric Data Warehouses and
 SQL Analytics Endpoints — no endpoint guard is applied here.  See Microsoft
 documentation: DROP PROCEDURE and ALTER PROCEDURE both list
 "SQL analytics endpoint in Microsoft Fabric" and "Warehouse in Microsoft Fabric"
-in their "Applies to" lists.
+in their "Applies to" lists.  This also applies to :func:`transfer_procedure`,
+which is not subject to the table-only OneLake-sync restriction documented on
+:func:`~fabric_dw.services.tables.transfer_table`.
 """
 
 from __future__ import annotations
@@ -24,8 +27,9 @@ from typing import cast
 
 from fabric_dw.auth import CredentialMode
 from fabric_dw.exceptions import NotFoundError
-from fabric_dw.identifiers import quote_identifier, validate_identifier
+from fabric_dw.identifiers import parse_qualified_name, quote_identifier, validate_identifier
 from fabric_dw.models import StoredProcedure
+from fabric_dw.services._helpers import _alter_schema_transfer
 from fabric_dw.sql import SqlTarget, run_query
 
 __all__ = [
@@ -33,6 +37,7 @@ __all__ = [
     "drop_procedure",
     "get_procedure",
     "list_procedures",
+    "transfer_procedure",
     "update_procedure",
     "validate_identifier",
 ]
@@ -298,3 +303,86 @@ async def drop_procedure(
         run_query(target, ddl, mode=mode, commit=True, fetch="none")
 
     await asyncio.to_thread(_run)
+
+
+async def transfer_procedure(
+    target: SqlTarget,
+    qualified: str,
+    target_schema: str,
+    *,
+    mode: CredentialMode = CredentialMode.DEFAULT,
+) -> StoredProcedure:
+    """Move a stored procedure to another schema via ``ALTER SCHEMA ... TRANSFER OBJECT::...``.
+
+    Supported on both Fabric Data Warehouses and SQL Analytics Endpoints —
+    unlike :func:`~fabric_dw.services.tables.transfer_table`, procedure
+    transfer is not subject to the table-only OneLake-sync restriction, so no
+    :func:`~fabric_dw.services._helpers._assert_not_sql_endpoint` guard is
+    applied here.
+
+    .. warning::
+
+        ``OBJECT::[schema].[name]`` matches *any* schema-scoped object with
+        that name, not only stored procedures.  If a table, view, or function
+        happens to share the qualified name, the engine transfers that
+        object instead.  When the post-transfer re-fetch then finds no
+        procedure named *procedure_name* in *target_schema*,
+        :class:`~fabric_dw.exceptions.NotFoundError` is raised with a message
+        that calls this out explicitly.
+
+    .. warning::
+
+        ``ALTER SCHEMA ... TRANSFER`` moves the procedure but does **not**
+        rewrite the schema name inside its stored definition
+        (``sys.sql_modules.definition``).  After a transfer,
+        :func:`get_procedure` may still show the *old* schema name in the
+        ``CREATE ... AS`` header even though the procedure now lives in the
+        new schema.  This is not rewritten here -- doing so would require
+        parsing and regenerating SQL, which this project deliberately avoids.
+
+    Args:
+        target: The warehouse or SQL Analytics Endpoint to connect to.
+        qualified: The current fully-qualified name of the form ``schema.proc``.
+            Parsed with :func:`~fabric_dw.identifiers.parse_qualified_name`.
+        target_schema: The schema to move the procedure into.  Must pass
+            :func:`validate_identifier`.  System schemas (``sys``,
+            ``INFORMATION_SCHEMA``, ``guest``, fixed ``db_*`` role schemas)
+            are rejected by
+            :func:`~fabric_dw.services._helpers._alter_schema_transfer`.
+        mode: The credential mode for Entra authentication.
+
+    Returns:
+        The moved :class:`~fabric_dw.models.StoredProcedure` (fetched via
+        :func:`get_procedure` from *target_schema* after the transfer).
+
+    Raises:
+        ValueError: If *qualified* cannot be parsed, if any identifier component
+            fails identifier validation, or if *target_schema* is a system schema.
+        NotFoundError: If no procedure named *procedure_name* is found in
+            *target_schema* after the transfer -- see the warning above about
+            non-procedure objects.
+        PermissionDeniedError: If the driver reports a permission error.
+    """
+    schema, procedure_name = parse_qualified_name(qualified)
+    validate_identifier(schema)
+    validate_identifier(procedure_name)
+    validate_identifier(target_schema)
+
+    await _alter_schema_transfer(
+        target,
+        source_schema=schema,
+        object_name=procedure_name,
+        target_schema=target_schema,
+        mode=mode,
+    )
+
+    try:
+        return await get_procedure(target, target_schema, procedure_name, mode=mode)
+    except NotFoundError:
+        msg = (
+            f"No procedure named [{target_schema}].[{procedure_name}] was found after "
+            "the transfer. ALTER SCHEMA TRANSFER moves any schema-scoped "
+            "object with that name, not only procedures -- if a table, view, "
+            "or function shared this name, check whether it was moved instead."
+        )
+        raise NotFoundError(msg) from None

--- a/src/fabric_dw/telemetry_commands.py
+++ b/src/fabric_dw/telemetry_commands.py
@@ -173,6 +173,7 @@ DOMAIN_MAP: dict[str, str] = {
     "create_procedure": "procedures",
     "update_procedure": "procedures",
     "drop_procedure": "procedures",
+    "transfer_procedure": "procedures",
     # Functions
     "list_functions": "functions",
     "get_function": "functions",

--- a/tests/integration/test_services_procedures.py
+++ b/tests/integration/test_services_procedures.py
@@ -26,6 +26,7 @@ import pytest
 from fabric_dw.exceptions import NotFoundError
 from fabric_dw.models import StoredProcedure
 from fabric_dw.services import procedures
+from fabric_dw.services import schemas as schemas_svc
 from fabric_dw.sql import SqlTarget
 
 pytestmark = pytest.mark.integration
@@ -162,6 +163,55 @@ async def test_drop_procedure_removes_procedure(
     # get_procedure must raise NotFoundError
     with pytest.raises(NotFoundError):
         await procedures.get_procedure(sql_target, schema, proc_name)
+
+
+async def test_transfer_procedure_roundtrip(
+    mutable_schema_target: tuple[SqlTarget, str],
+) -> None:
+    """Create a procedure, transfer it to a second schema, assert old gone / new present.
+
+    Runs on both the Data Warehouse and the SQL Analytics Endpoint (no
+    endpoint guard on procedure transfer, unlike tables).
+    """
+    sql_target, schema = mutable_schema_target
+    proc_name = "pytest_procs_transfer_dst"
+    body = "BEGIN SELECT 42 AS answer END"
+    target_schema_name = f"{schema}_target"
+
+    await schemas_svc.create_schema(sql_target, target_schema_name)
+    try:
+        created = await procedures.create_procedure(sql_target, schema, proc_name, body)
+        assert isinstance(created, StoredProcedure)
+        assert created.schema_name == schema
+
+        moved = await procedures.transfer_procedure(
+            sql_target, f"{schema}.{proc_name}", target_schema_name
+        )
+        assert isinstance(moved, StoredProcedure)
+        assert moved.name == proc_name
+        assert moved.schema_name == target_schema_name
+        assert moved.qualified_name == f"{target_schema_name}.{proc_name}"
+
+        all_procs = await procedures.list_procedures(sql_target)
+        in_target = {p.name for p in all_procs if p.schema_name == target_schema_name}
+        in_source = {p.name for p in all_procs if p.schema_name == schema}
+        assert proc_name in in_target, f"{proc_name!r} not found in {target_schema_name!r}"
+        assert proc_name not in in_source, f"{proc_name!r} still present in {schema!r}"
+
+        # Stale-definition caveat (documented, not a bug): ALTER SCHEMA TRANSFER
+        # moves the procedure but does not rewrite the schema name embedded in
+        # the stored CREATE ... AS header, so `moved.definition` may still read
+        # like it belongs to the old schema even though the procedure now lives
+        # in `target_schema_name`. We don't assert on the header text here -- this
+        # comment just documents the known, by-design discrepancy for readers.
+
+    finally:
+        with contextlib.suppress(Exception):
+            await procedures.drop_procedure(sql_target, schema, proc_name)
+        with contextlib.suppress(Exception):
+            await procedures.drop_procedure(sql_target, target_schema_name, proc_name)
+        with contextlib.suppress(Exception):
+            await schemas_svc.delete_schema(sql_target, target_schema_name, cascade=True)
 
 
 async def test_create_procedure_full_roundtrip(

--- a/tests/unit/cli/commands/test_procedures.py
+++ b/tests/unit/cli/commands/test_procedures.py
@@ -643,3 +643,237 @@ class TestProceduresDrop:
                 cli, ["--yes", "-w", WS_GUID, "procedures", "drop", WH_GUID, "dbo.usp_load"]
             )
         assert result.exit_code != 0
+
+
+# ===========================================================================
+# procedures transfer
+# ===========================================================================
+
+
+class TestProceduresTransfer:
+    def test_transfer_with_yes_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        moved = StoredProcedure(
+            schema_name="archive",
+            name="usp_load",
+            qualified_name="archive.usp_load",
+            definition=None,
+            created=_NOW,
+            modified=_NOW,
+        )
+        with (
+            patch(
+                "fabric_dw.cli.commands.procedures.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.procedures.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.procedures.transfer_procedure",
+                new=AsyncMock(return_value=moved),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--yes",
+                    "-w",
+                    WS_GUID,
+                    "procedures",
+                    "transfer",
+                    WH_GUID,
+                    "dbo.usp_load",
+                    "--target-schema",
+                    "archive",
+                ],
+            )
+        assert result.exit_code == 0
+
+    def test_transfer_declined_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
+        """Declining transfer is a clean no-op (exit 0)."""
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.procedures.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.procedures.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "-w",
+                    WS_GUID,
+                    "procedures",
+                    "transfer",
+                    WH_GUID,
+                    "dbo.usp_load",
+                    "--target-schema",
+                    "archive",
+                ],
+                input="n\n",
+            )
+        assert result.exit_code == 0
+        assert "Aborted." in result.output
+
+    def test_transfer_forwards_args(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        mock_transfer = AsyncMock(
+            return_value=StoredProcedure(
+                schema_name="archive",
+                name="usp_load",
+                qualified_name="archive.usp_load",
+                definition=None,
+                created=_NOW,
+                modified=_NOW,
+            )
+        )
+        with (
+            patch(
+                "fabric_dw.cli.commands.procedures.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.procedures.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch("fabric_dw.services.procedures.transfer_procedure", new=mock_transfer),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--yes",
+                    "-w",
+                    WS_GUID,
+                    "procedures",
+                    "transfer",
+                    WH_GUID,
+                    "dbo.usp_load",
+                    "--target-schema",
+                    "archive",
+                ],
+            )
+        assert result.exit_code == 0
+        mock_transfer.assert_awaited_once()
+        args, _kwargs = mock_transfer.call_args
+        assert args[1] == "dbo.usp_load"
+        assert args[2] == "archive"
+
+    def test_transfer_works_on_sql_endpoint(self, runner: CliRunner, cache_env: Path) -> None:
+        """transfer on a SQL Analytics Endpoint must succeed — no DW-only guard."""
+        _ = cache_env
+        mock_http = AsyncMock()
+        moved = StoredProcedure(
+            schema_name="archive",
+            name="usp_load",
+            qualified_name="archive.usp_load",
+            definition=None,
+            created=_NOW,
+            modified=_NOW,
+        )
+        with (
+            patch(
+                "fabric_dw.cli.commands.procedures.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.procedures.build_sql_target",
+                new=AsyncMock(
+                    return_value=(
+                        _make_sql_target(),
+                        _make_item_entry(kind=WarehouseKind.SQL_ENDPOINT),
+                    )
+                ),
+            ),
+            patch(
+                "fabric_dw.services.procedures.transfer_procedure",
+                new=AsyncMock(return_value=moved),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--yes",
+                    "-w",
+                    WS_GUID,
+                    "procedures",
+                    "transfer",
+                    WH_GUID,
+                    "dbo.usp_load",
+                    "--target-schema",
+                    "archive",
+                ],
+            )
+        assert result.exit_code == 0
+
+    def test_transfer_bad_qualified_name_exits_nonzero(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        _ = cache_env
+        result = runner.invoke(
+            cli,
+            [
+                "-w",
+                WS_GUID,
+                "procedures",
+                "transfer",
+                WH_GUID,
+                "no_dot",
+                "--target-schema",
+                "archive",
+            ],
+        )
+        assert result.exit_code != 0
+
+    def test_transfer_missing_target_schema_exits_nonzero(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        _ = cache_env
+        result = runner.invoke(
+            cli,
+            ["-w", WS_GUID, "procedures", "transfer", WH_GUID, "dbo.usp_load"],
+        )
+        assert result.exit_code != 0
+
+    def test_transfer_permission_denied_returns_nonzero(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.procedures.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.procedures.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.procedures.transfer_procedure",
+                new=AsyncMock(side_effect=PermissionDeniedError("no permission")),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--yes",
+                    "-w",
+                    WS_GUID,
+                    "procedures",
+                    "transfer",
+                    WH_GUID,
+                    "dbo.usp_load",
+                    "--target-schema",
+                    "archive",
+                ],
+            )
+        assert result.exit_code != 0

--- a/tests/unit/mcp/test_procedures.py
+++ b/tests/unit/mcp/test_procedures.py
@@ -444,3 +444,129 @@ async def test_drop_procedure_on_sql_endpoint_no_error(
         )
 
     assert result == {"dropped": True}
+
+
+# ===========================================================================
+# transfer_procedure
+# ===========================================================================
+
+
+async def test_transfer_procedure_happy_path(mock_ctx, ctx_patch) -> None:
+    """transfer_procedure returns the moved procedure."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = _make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+    moved = StoredProcedure(
+        schema_name="archive",
+        name="usp_load",
+        qualified_name="archive.usp_load",
+        definition="BEGIN SELECT 1 AS id END",
+        created=_NOW,
+        modified=_NOW,
+    )
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.procedures.transfer_procedure",
+            new=AsyncMock(return_value=moved),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "transfer_procedure",
+            {
+                "workspace": _WS_NAME,
+                "item": _WH_NAME,
+                "qualified_name": "dbo.usp_load",
+                "target_schema": "archive",
+            },
+        )
+
+    assert isinstance(result, dict)
+    assert result["schema_name"] == "archive"
+    assert result["name"] == "usp_load"
+
+
+async def test_transfer_procedure_forwards_args(mock_ctx, ctx_patch) -> None:
+    """transfer_procedure forwards qualified_name and target_schema to the service."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = _make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+    mock_transfer = AsyncMock(return_value=_make_proc())
+
+    with (
+        ctx_patch,
+        patch("fabric_dw.services.procedures.transfer_procedure", new=mock_transfer),
+    ):
+        await mcp._tool_manager.call_tool(
+            "transfer_procedure",
+            {
+                "workspace": _WS_NAME,
+                "item": _WH_NAME,
+                "qualified_name": "dbo.usp_load",
+                "target_schema": "archive",
+            },
+        )
+
+    mock_transfer.assert_awaited_once()
+    args, kwargs = mock_transfer.call_args
+    assert args[1] == "dbo.usp_load"
+    assert args[2] == "archive"
+    assert kwargs.get("mode") is not None
+
+
+async def test_transfer_procedure_blocked_in_readonly(
+    mock_ctx, ctx_patch, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """transfer_procedure raises ToolError when FABRIC_MCP_READONLY is set."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    monkeypatch.setenv("FABRIC_MCP_READONLY", "1")
+    item = _make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with ctx_patch, pytest.raises(ToolError, match="read-only"):
+        await mcp._tool_manager.call_tool(
+            "transfer_procedure",
+            {
+                "workspace": _WS_NAME,
+                "item": _WH_NAME,
+                "qualified_name": "dbo.usp_load",
+                "target_schema": "archive",
+            },
+        )
+
+
+async def test_transfer_procedure_on_sql_endpoint_no_error(mock_ctx, ctx_patch) -> None:
+    """transfer_procedure must NOT raise for SQL Analytics Endpoint — no DW-only guard."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = _make_item_entry(kind=WarehouseKind.SQL_ENDPOINT)
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.procedures.transfer_procedure",
+            new=AsyncMock(return_value=_make_proc()),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "transfer_procedure",
+            {
+                "workspace": _WS_NAME,
+                "item": _WH_NAME,
+                "qualified_name": "dbo.usp_load",
+                "target_schema": "archive",
+            },
+        )
+
+    assert isinstance(result, dict)

--- a/tests/unit/mcp/tools/test_tool_quality.py
+++ b/tests/unit/mcp/tools/test_tool_quality.py
@@ -736,6 +736,7 @@ _ALL_MUTATING_TOOLS: list[str] = [
     "create_procedure",
     "update_procedure",
     "drop_procedure",
+    "transfer_procedure",
     # snapshots.py
     "create_snapshot",
     "rename_snapshot",

--- a/tests/unit/services/test_procedures.py
+++ b/tests/unit/services/test_procedures.py
@@ -26,6 +26,7 @@ _GET_COLS = ["schema_name", "name", "created", "modified", "definition"]
 _PROC_ROW_1 = ("dbo", "usp_load", _NOW, _LATER)
 _PROC_ROW_2 = ("finance", "usp_monthly", _NOW, _NOW)
 _PROC_ROW_GET = ("dbo", "usp_load", _NOW, _LATER, "BEGIN SELECT 1 AS id END")
+_PROC_ROW_GET_MOVED = ("archive", "usp_load", _NOW, _LATER, "BEGIN SELECT 1 AS id END")
 
 
 # ===========================================================================
@@ -558,3 +559,112 @@ class TestDropProcedure:
             pytest.raises(RuntimeError, match="connection reset"),
         ):
             await procedures.drop_procedure(target, "dbo", "usp_load")
+
+
+# ===========================================================================
+# transfer_procedure
+# ===========================================================================
+
+
+class TestTransferProcedure:
+    async def test_emits_alter_schema_transfer(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_PROC_ROW_GET_MOVED], _GET_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            await procedures.transfer_procedure(target, "dbo.usp_load", "archive")
+        cursor = ddl_conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert call_sql == "ALTER SCHEMA [archive] TRANSFER OBJECT::[dbo].[usp_load]"
+
+    async def test_returns_procedure_from_target_schema(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_PROC_ROW_GET_MOVED], _GET_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            result = await procedures.transfer_procedure(target, "dbo.usp_load", "archive")
+        assert isinstance(result, StoredProcedure)
+        assert result.schema_name == "archive"
+        assert result.name == "usp_load"
+        assert result.qualified_name == "archive.usp_load"
+
+    async def test_commits_after_execute(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_PROC_ROW_GET_MOVED], _GET_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            await procedures.transfer_procedure(target, "dbo.usp_load", "archive")
+        ddl_conn.commit.assert_called_once()
+
+    async def test_no_endpoint_guard_raises(self) -> None:
+        """transfer_procedure must NOT raise for SQL Analytics Endpoint targets.
+
+        This asserts the absence of a DW-only guard: stored procedure transfer
+        is supported on both Fabric Data Warehouses and SQL Analytics Endpoints.
+        """
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([_PROC_ROW_GET_MOVED], _GET_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            # Must not raise — no endpoint guard, no `kind` parameter at all.
+            result = await procedures.transfer_procedure(target, "dbo.usp_load", "archive")
+        assert isinstance(result, StoredProcedure)
+
+    async def test_rejects_undotted_qualified_name(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="qualified"):
+            await procedures.transfer_procedure(target, "nodot", "archive")
+
+    async def test_rejects_invalid_schema_in_qualified_name(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await procedures.transfer_procedure(target, "bad--schema.usp_load", "archive")
+
+    async def test_rejects_invalid_procedure_in_qualified_name(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await procedures.transfer_procedure(target, "dbo.bad--proc", "archive")
+
+    async def test_rejects_invalid_target_schema(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await procedures.transfer_procedure(target, "dbo.usp_load", "bad--schema")
+
+    @pytest.mark.parametrize(
+        "reserved", ["sys", "information_schema", "SYS", "Information_Schema", "guest", "db_owner"]
+    )
+    async def test_rejects_reserved_target_schema(self, reserved: str) -> None:
+        """transfer_procedure propagates the system-schema rejection from the shared helper.
+
+        The check itself (and its full enumeration of system schemas) is
+        exercised exhaustively in TestAlterSchemaTransfer; this is a thin
+        pass-through test confirming transfer_procedure does not bypass it.
+        """
+        target = _make_target()
+        with pytest.raises(ValueError, match="reserved system schema"):
+            await procedures.transfer_procedure(target, "dbo.usp_load", reserved)
+
+    async def test_raises_not_found_when_fetch_returns_empty(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([], _GET_COLS)
+        with (
+            patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]),
+            pytest.raises(NotFoundError, match="No procedure named"),
+        ):
+            await procedures.transfer_procedure(target, "dbo.usp_load", "archive")
+
+    async def test_not_found_message_warns_about_non_procedure_objects(self) -> None:
+        """The post-transfer NotFoundError must call out that a same-named
+        non-procedure object (table/view/function) may have been moved
+        instead, since OBJECT::[schema].[name] matches any schema-scoped
+        object, not only procedures.
+        """
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([], _GET_COLS)
+        with (
+            patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]),
+            pytest.raises(NotFoundError, match="not only procedures"),
+        ):
+            await procedures.transfer_procedure(target, "dbo.usp_load", "archive")


### PR DESCRIPTION
## Summary

- Add `transfer_procedure` (service, MCP tool, CLI command), reusing the shared `_alter_schema_transfer` helper from #940.
- Stored procedures are allowed on both Warehouse and SQL analytics endpoint, so unlike `transfer_table` there is no `kind` parameter and no SQL-endpoint guard.
- `ALTER SCHEMA ... TRANSFER` moves the procedure but does not rewrite the schema name in its stored `sys.sql_modules` definition; the docs and docstrings carry the stale-definition admonition (reused verbatim from the view-transfer wording, swapped to procedure nouns).
- Telemetry: added `transfer_procedure` to `DOMAIN_MAP`.

Closes #943. Depends on #940 (already merged).

## Test plan

- [x] `ruff check .`
- [x] `ruff format --check .`
- [x] `ty check src tests`
- [x] `uv run pytest tests/unit` (5691 passed)
- [x] New unit tests: service (`TestTransferProcedure`), MCP tool (happy path, forwarded args, read-only gate, SQL-endpoint allowed), CLI (`procedures transfer`, confirm/decline, forwarded args, SQL-endpoint allowed)
- [x] `transfer_procedure` added to the `_ALL_MUTATING_TOOLS` regression guard
- [x] Dual-target integration roundtrip test added (`test_transfer_procedure_roundtrip`, Warehouse + SQL Analytics Endpoint) — not run here per project policy (integration tests are triggered manually on `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)