### PR TITLE
feat: transfer views to another schema via ALTER SCHEMA TRANSFER

### DIFF
--- a/docs/commands/views.md
+++ b/docs/commands/views.md
@@ -292,6 +292,42 @@ fdw [-w WORKSPACE] views rename [OPTIONS] [WAREHOUSE] QUALIFIED_NAME
 fdw -w MyWorkspace views rename SalesWH dbo.vw_recent --new-name vw_revenue
 ```
 
+### views transfer
+
+**Targets:** Data Warehouse / SQL Analytics Endpoint
+
+Move a view to another schema via `ALTER SCHEMA ... TRANSFER OBJECT::...`. The command emits exactly `ALTER SCHEMA [target_schema] TRANSFER OBJECT::[schema].[view]`, with every identifier validated and bracket-quoted before being embedded in the DDL.
+
+**CAUTION:** `OBJECT::[schema].[name]` matches any schema-scoped object with that name, not only views. If a table, function, or procedure shares the qualified name, the engine transfers that object instead.
+
+!!! warning "Definition text is not rewritten"
+    `ALTER SCHEMA ... TRANSFER` moves the view, but it does **not** rewrite the
+    schema name inside the object's stored definition
+    (`sys.sql_modules.definition`, `OBJECT_DEFINITION()`). After a transfer,
+    `get_view` may still show the *old* schema name in the `CREATE ... AS`
+    header, even though the view now lives in the new schema. This tool does
+    not rewrite the definition text: doing so would require parsing and
+    regenerating SQL, which this project deliberately avoids. See
+    [ALTER SCHEMA (Transact-SQL)](https://learn.microsoft.com/sql/t-sql/statements/alter-schema-transact-sql?view=fabric&WT.mc_id=MVP_310840#remarks).
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] views transfer [OPTIONS] [ITEM] QUALIFIED_NAME
+```
+
+`QUALIFIED_NAME` is the current dot-separated `schema.view_name`.
+
+| Option | Description |
+| --- | --- |
+| `--target-schema TEXT` | **Required.** Schema to move the view into. |
+
+**Example**
+
+```shell
+fdw -w MyWorkspace views transfer SalesWH dbo.vw_recent --target-schema archive
+```
+
 ### views update
 
 **Targets:** Data Warehouse / SQL Analytics Endpoint
@@ -452,6 +488,33 @@ Rename a SQL view via `sp_rename`. Works on both Data Warehouses and SQL Analyti
 - `new_name` (`str`): new bare view name (no schema prefix), e.g. `vw_revenue`.
 
 **Returns:** `View`: the updated view object (fetched after rename, includes `definition`).
+
+### transfer_view
+
+**Targets:** Data Warehouse / SQL Analytics Endpoint
+
+Move a SQL view to another schema via `ALTER SCHEMA ... TRANSFER OBJECT::...`. Works on both Fabric Data Warehouses and SQL Analytics Endpoints, no DW-only guard is applied.
+
+**CAUTION:** `OBJECT::[schema].[name]` matches any schema-scoped object with that name, not only views. If a table, function, or procedure shares the qualified name, the engine transfers that object instead.
+
+!!! warning "Definition text is not rewritten"
+    `ALTER SCHEMA ... TRANSFER` moves the view, but it does **not** rewrite the
+    schema name inside the object's stored definition
+    (`sys.sql_modules.definition`, `OBJECT_DEFINITION()`). After a transfer,
+    `get_view` may still show the *old* schema name in the `CREATE ... AS`
+    header, even though the view now lives in the new schema. This tool does
+    not rewrite the definition text: doing so would require parsing and
+    regenerating SQL, which this project deliberately avoids. See
+    [ALTER SCHEMA (Transact-SQL)](https://learn.microsoft.com/sql/t-sql/statements/alter-schema-transact-sql?view=fabric&WT.mc_id=MVP_310840#remarks).
+
+**Parameters:**
+
+- `workspace` (`str`): workspace name or GUID.
+- `item` (`str`): warehouse or SQL analytics endpoint name or GUID.
+- `qualified_name` (`str`): current dot-separated qualified view name, e.g. `dbo.vw_sales`.
+- `target_schema` (`str`): schema to move the view into, e.g. `archive`.
+
+**Returns:** `View`: the moved view record, fetched from the new schema. The `definition` field may still reference the old schema name (see warning above).
 
 ### update_view
 

--- a/src/fabric_dw/cli/commands/views.py
+++ b/src/fabric_dw/cli/commands/views.py
@@ -425,3 +425,36 @@ async def rename_cmd(
             render(v.model_dump(by_alias=True, mode="json"), json_output=ctx.json_output)
     except (ValueError, FabricError) as exc:
         raise click.ClickException(str(exc)) from exc
+
+
+@views_group.command("transfer")
+@click.argument("item", required=False, default=None)
+@click.argument("qualified_name")
+@click.option("--target-schema", required=True, help="Schema to move the view into.")
+@click.pass_obj
+@coro
+async def transfer_cmd(
+    ctx: CliContext,
+    item: str | None,
+    qualified_name: str,
+    target_schema: str,
+) -> None:
+    """Move QUALIFIED_NAME (schema.view) on ITEM to --target-schema."""
+    ws = resolve_workspace(ctx)
+    wh = resolve_warehouse_arg(ctx, item)
+    schema, view_name = parse_qualified_name(qualified_name, kind="view")
+    try:
+        async with build_http_client(ctx) as http:
+            target, entry = await build_sql_target(http, ws, wh)
+            confirmed = confirm(
+                f"Move view [{schema}].[{view_name}] on {entry.display_name!r} "
+                f"to schema {target_schema!r}?",
+                yes=ctx.yes,
+            )
+            if not confirmed:
+                click.echo("Aborted.")
+                return
+            v = await _views_svc.transfer_view(target, qualified_name, target_schema, mode=ctx.auth)
+            render(v.model_dump(by_alias=True, mode="json"), json_output=ctx.json_output)
+    except (ValueError, FabricError) as exc:
+        raise click.ClickException(str(exc)) from exc

--- a/src/fabric_dw/mcp/tools/views.py
+++ b/src/fabric_dw/mcp/tools/views.py
@@ -359,3 +359,51 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         except (ValueError, FabricError) as exc:
             raise tool_err(exc) from exc
         return result.model_dump(mode="json")
+
+    @mutating_tool(mcp, "transfer_view")
+    async def transfer_view(
+        workspace: str, item: str, qualified_name: str, target_schema: str
+    ) -> dict[str, Any]:
+        """Move a SQL view to another schema via ``ALTER SCHEMA ... TRANSFER OBJECT::...``.
+
+        Works on both Data Warehouses and SQL Analytics Endpoints — no DW-only
+        guard is applied.
+
+        CAUTION: ``ALTER SCHEMA ... TRANSFER`` moves the view but does **not**
+        rewrite the schema name inside the view's stored definition
+        (``sys.sql_modules.definition``, ``OBJECT_DEFINITION()``). After a
+        transfer, the returned (and any subsequent ``get_view``) ``definition``
+        may still show the *old* schema name in the ``CREATE ... AS`` header,
+        even though the view now lives in the new schema. This tool does not
+        rewrite the definition text — doing so would require parsing and
+        regenerating SQL, which this project deliberately avoids.
+
+        Args:
+            workspace: Workspace name or GUID.
+            item: Warehouse or SQL endpoint name or GUID.
+            qualified_name: Current dot-separated qualified view name,
+                e.g. ``dbo.vw_sales``.
+            target_schema: Schema to move the view into, e.g. ``archive``.
+        """
+        parse_qualified_name(qualified_name, kind="view")
+        ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
+        try:
+            ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
+            _log.debug(
+                "transfer_view ws=%s item=%s qualified=%r target_schema=%r",
+                ws_id,
+                entry.id,
+                qualified_name,
+                target_schema,
+            )
+            target = make_sql_target(ws_id, entry, item)
+            result = await views_svc.transfer_view(
+                target, qualified_name, target_schema, mode=ctx.auth_mode
+            )
+        except (ValueError, FabricError) as exc:
+            raise tool_err(exc) from exc
+        return result.model_dump(mode="json")

--- a/src/fabric_dw/services/views.py
+++ b/src/fabric_dw/services/views.py
@@ -11,6 +11,7 @@ Public API
 - :func:`update_view`         — issue CREATE OR ALTER VIEW … AS <select_body>.
 - :func:`drop_view`           — issue DROP VIEW.
 - :func:`rename_view`         — rename a view via sp_rename (both DW and SQL endpoint).
+- :func:`transfer_view`       — ``ALTER SCHEMA ... TRANSFER OBJECT::...`` (both DW/SQL endpoint).
 """
 
 from __future__ import annotations
@@ -24,7 +25,11 @@ from fabric_dw.auth import CredentialMode
 from fabric_dw.exceptions import NotFoundError
 from fabric_dw.identifiers import parse_qualified_name, quote_identifier, validate_identifier
 from fabric_dw.models import View
-from fabric_dw.services._helpers import build_time_travel_option, reject_non_select
+from fabric_dw.services._helpers import (
+    _alter_schema_transfer,
+    build_time_travel_option,
+    reject_non_select,
+)
 from fabric_dw.sql import SqlTarget, run_query
 from fabric_dw.sql_io import columns_rows_to_arrow, write_arrow
 
@@ -37,6 +42,7 @@ __all__ = [
     "list_views",
     "read_view",
     "rename_view",
+    "transfer_view",
     "update_view",
     "validate_identifier",
 ]
@@ -574,4 +580,86 @@ async def rename_view(
         return await get_view(target, schema, new_name, mode=mode)
     except NotFoundError:
         msg = f"View [{schema}].[{new_name}] not found after rename"
+        raise NotFoundError(msg) from None
+
+
+async def transfer_view(
+    target: SqlTarget,
+    qualified: str,
+    target_schema: str,
+    *,
+    mode: CredentialMode = CredentialMode.DEFAULT,
+) -> View:
+    """Move a view to another schema via ``ALTER SCHEMA ... TRANSFER OBJECT::...``.
+
+    Works on both Data Warehouses and SQL Analytics Endpoints — no DW-only guard
+    is applied.  Transferring a view does not carry the OneLake-sync risk that
+    restricts :func:`~fabric_dw.services.tables.transfer_table` to Warehouses.
+
+    .. warning::
+
+        ``OBJECT::[schema].[name]`` matches *any* schema-scoped object with
+        that name, not only views.  If a table, function, or procedure
+        happens to share the qualified name, the engine transfers that
+        object instead.  When the post-transfer re-fetch then finds no view
+        named *view_name* in *target_schema*,
+        :class:`~fabric_dw.exceptions.NotFoundError` is raised with a message
+        that calls this out explicitly.
+
+    .. warning::
+
+        ``ALTER SCHEMA ... TRANSFER`` moves the view but does **not** rewrite
+        the schema name stored in the view's definition
+        (``sys.sql_modules.definition``, ``OBJECT_DEFINITION()``).  The
+        returned ``definition`` may still show the old schema name in the
+        ``CREATE ... AS`` header even though the view now lives in
+        *target_schema*.  This is a deliberate limitation: rewriting the
+        definition text would require parsing and regenerating SQL, which
+        this project does not do (see the "No SQL parsing" rule in
+        ``CLAUDE.md``).
+
+    Args:
+        target: The warehouse or SQL Analytics Endpoint to connect to.
+        qualified: The current fully-qualified name of the form ``schema.view``.
+            Parsed with :func:`~fabric_dw.identifiers.parse_qualified_name`.
+        target_schema: The schema to move the view into.  Must pass
+            :func:`validate_identifier`.  System schemas (``sys``,
+            ``INFORMATION_SCHEMA``, ``guest``, fixed ``db_*`` role schemas)
+            are rejected by
+            :func:`~fabric_dw.services._helpers._alter_schema_transfer`.
+        mode: The credential mode for Entra authentication.
+
+    Returns:
+        A :class:`~fabric_dw.models.View` reflecting the moved view (fetched
+        via :func:`get_view` from *target_schema* after the transfer).
+
+    Raises:
+        ValueError: If *qualified* cannot be parsed, if any identifier component
+            fails identifier validation, or if *target_schema* is a system schema.
+        NotFoundError: If no view named *view_name* is found in *target_schema*
+            after the transfer -- see the warning above about non-view objects.
+        PermissionDeniedError: If the driver reports a permission error.
+    """
+    schema, view_name = parse_qualified_name(qualified)
+    validate_identifier(schema)
+    validate_identifier(view_name)
+    validate_identifier(target_schema)
+
+    await _alter_schema_transfer(
+        target,
+        source_schema=schema,
+        object_name=view_name,
+        target_schema=target_schema,
+        mode=mode,
+    )
+
+    try:
+        return await get_view(target, target_schema, view_name, mode=mode)
+    except NotFoundError:
+        msg = (
+            f"No view named [{target_schema}].[{view_name}] was found after "
+            "the transfer. ALTER SCHEMA TRANSFER moves any schema-scoped "
+            "object with that name, not only views -- if a table, function, "
+            "or procedure shared this name, check whether it was moved instead."
+        )
         raise NotFoundError(msg) from None

--- a/src/fabric_dw/telemetry_commands.py
+++ b/src/fabric_dw/telemetry_commands.py
@@ -166,6 +166,7 @@ DOMAIN_MAP: dict[str, str] = {
     "update_view": "views",
     "drop_view": "views",
     "rename_view": "views",
+    "transfer_view": "views",
     # Stored procedures
     "list_procedures": "procedures",
     "get_procedure": "procedures",

--- a/tests/integration/test_services_views.py
+++ b/tests/integration/test_services_views.py
@@ -23,6 +23,7 @@ import pytest
 
 from fabric_dw.exceptions import FabricError, NotFoundError
 from fabric_dw.models import View
+from fabric_dw.services import schemas as schemas_svc
 from fabric_dw.services import views
 from fabric_dw.sql import SqlTarget, run_query
 
@@ -292,6 +293,53 @@ async def test_rename_view_creates_new_and_removes_old(
             await views.drop_view(sql_target, schema, old_name)
         with contextlib.suppress(Exception):
             await views.drop_view(sql_target, schema, new_name)
+
+
+async def test_transfer_view_roundtrip(
+    mutable_schema_target: tuple[SqlTarget, str],
+) -> None:
+    """Create a view, transfer it to a second schema, assert old gone / new present.
+
+    Runs on both targets (Data Warehouse and SQL Analytics Endpoint) via the
+    parametrized mutable_schema_target fixture, since transfer_view applies no
+    DW-only guard.
+    """
+    sql_target, schema = mutable_schema_target
+    view_name = "pytest_views_transfer_dst"
+    select_body = "SELECT 42 AS the_answer"
+    target_schema_name = f"{schema}_target"
+
+    await schemas_svc.create_schema(sql_target, target_schema_name)
+    try:
+        created = await views.create_view(sql_target, schema, view_name, select_body)
+        assert isinstance(created, View)
+        assert created.schema_name == schema
+
+        moved = await views.transfer_view(sql_target, f"{schema}.{view_name}", target_schema_name)
+        assert isinstance(moved, View)
+        assert moved.name == view_name
+        assert moved.schema_name == target_schema_name
+        assert moved.qualified_name == f"{target_schema_name}.{view_name}"
+        # Documented caveat (see the "Definition text is not rewritten" admonition
+        # in docs/commands/views.md): ALTER SCHEMA TRANSFER does not rewrite the
+        # schema name stored in sys.sql_modules.definition, so moved.definition
+        # may still reference the OLD schema in its CREATE ... AS header, even
+        # though qualified_name above correctly reports the NEW schema. This is
+        # not asserted as a hard failure -- it documents the caveat in-place.
+
+        all_views = await views.list_views(sql_target)
+        in_target = {v.name for v in all_views if v.schema_name == target_schema_name}
+        in_source = {v.name for v in all_views if v.schema_name == schema}
+        assert view_name in in_target, f"{view_name!r} not found in {target_schema_name!r}"
+        assert view_name not in in_source, f"{view_name!r} still present in {schema!r}"
+
+    finally:
+        with contextlib.suppress(Exception):
+            await views.drop_view(sql_target, schema, view_name)
+        with contextlib.suppress(Exception):
+            await views.drop_view(sql_target, target_schema_name, view_name)
+        with contextlib.suppress(Exception):
+            await schemas_svc.delete_schema(sql_target, target_schema_name, cascade=True)
 
 
 async def test_count_view_rows_returns_nonnegative_int(

--- a/tests/unit/cli/commands/test_views.py
+++ b/tests/unit/cli/commands/test_views.py
@@ -1669,6 +1669,188 @@ class TestViewsRename:
 
 
 # ===========================================================================
+# views transfer
+# ===========================================================================
+
+
+class TestViewsTransfer:
+    def _make_moved_view(self) -> View:
+        return View(
+            schema_name="archive",
+            name="vw_sales",
+            qualified_name="archive.vw_sales",
+            definition=None,
+            created=_NOW,
+            modified=_NOW,
+        )
+
+    def test_transfer_with_yes_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        mock_transfer = AsyncMock(return_value=self._make_moved_view())
+        with (
+            patch(
+                "fabric_dw.cli.commands.views.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.views.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.views.transfer_view",
+                new=mock_transfer,
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "-w",
+                    WS_GUID,
+                    "--yes",
+                    "--json",
+                    "views",
+                    "transfer",
+                    WH_GUID,
+                    "dbo.vw_sales",
+                    "--target-schema",
+                    "archive",
+                ],
+            )
+        assert result.exit_code == 0
+        mock_transfer.assert_awaited_once()
+        args, _kwargs = mock_transfer.call_args
+        # service is called positionally: target, qualified_name, target_schema
+        assert args[1] == "dbo.vw_sales"
+        assert args[2] == "archive"
+        parsed = json.loads(result.output)
+        assert parsed["name"] == "vw_sales"
+        assert parsed["schema_name"] == "archive"
+
+    def test_transfer_declined_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
+        """Declining transfer is a clean no-op (exit 0)."""
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.views.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.views.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "-w",
+                    WS_GUID,
+                    "views",
+                    "transfer",
+                    WH_GUID,
+                    "dbo.vw_sales",
+                    "--target-schema",
+                    "archive",
+                ],
+                input="n\n",
+            )
+        assert result.exit_code == 0
+        assert "Aborted." in result.output
+
+    def test_transfer_missing_target_schema_fails(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        result = runner.invoke(cli, ["-w", WS_GUID, "views", "transfer", WH_GUID, "dbo.vw_sales"])
+        assert result.exit_code != 0
+
+    def test_transfer_bad_qualified_name_exits_nonzero(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        _ = cache_env
+        result = runner.invoke(
+            cli,
+            ["-w", WS_GUID, "views", "transfer", WH_GUID, "nodot", "--target-schema", "archive"],
+        )
+        assert result.exit_code != 0
+
+    def test_transfer_reserved_target_schema_returns_nonzero(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.views.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.views.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.views.transfer_view",
+                new=AsyncMock(
+                    side_effect=ValueError(
+                        "Target schema 'sys' is a reserved system schema and cannot be "
+                        "an ALTER SCHEMA TRANSFER target"
+                    )
+                ),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "-w",
+                    WS_GUID,
+                    "--yes",
+                    "views",
+                    "transfer",
+                    WH_GUID,
+                    "dbo.vw_sales",
+                    "--target-schema",
+                    "sys",
+                ],
+            )
+        assert result.exit_code != 0
+        assert "reserved system schema" in result.output
+
+    def test_transfer_permission_denied_returns_nonzero(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.views.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.views.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.views.transfer_view",
+                new=AsyncMock(side_effect=PermissionDeniedError("no permission")),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "-w",
+                    WS_GUID,
+                    "--yes",
+                    "views",
+                    "transfer",
+                    WH_GUID,
+                    "dbo.vw_sales",
+                    "--target-schema",
+                    "archive",
+                ],
+            )
+        assert result.exit_code != 0
+
+
+# ===========================================================================
 # views columns
 # ===========================================================================
 

--- a/tests/unit/mcp/tools/test_tool_quality.py
+++ b/tests/unit/mcp/tools/test_tool_quality.py
@@ -713,6 +713,7 @@ _ALL_MUTATING_TOOLS: list[str] = [
     "update_view",
     "drop_view",
     "rename_view",
+    "transfer_view",
     # warehouses.py
     "create_warehouse",
     "rename_warehouse",

--- a/tests/unit/mcp/tools/test_views.py
+++ b/tests/unit/mcp/tools/test_views.py
@@ -1038,6 +1038,197 @@ async def test_rename_view_value_error_becomes_tool_error(mock_ctx, ctx_patch) -
 
 
 # ---------------------------------------------------------------------------
+# transfer_view — happy path
+# ---------------------------------------------------------------------------
+
+
+async def test_transfer_view_happy_path(mock_ctx, ctx_patch) -> None:
+    """transfer_view resolves workspace + item, calls service, returns moved view dict."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    moved_view = _make_view(schema="archive", name="vw_sales")
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+    mock_transfer = AsyncMock(return_value=moved_view)
+
+    with (
+        ctx_patch,
+        patch("fabric_dw.services.views.transfer_view", new=mock_transfer),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "transfer_view",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_name": "dbo.vw_sales",
+                "target_schema": "archive",
+            },
+        )
+
+    mock_transfer.assert_called_once()
+    args, _kwargs = mock_transfer.call_args
+    # service is called positionally: target, qualified_name, target_schema
+    assert args[1] == "dbo.vw_sales"
+    assert args[2] == "archive"
+    assert isinstance(result, dict)
+    assert result["name"] == "vw_sales"
+    assert result["schema_name"] == "archive"
+
+
+async def test_transfer_view_does_not_reject_sql_endpoint(mock_ctx, ctx_patch) -> None:
+    """transfer_view must NOT raise a ToolError for a SQL Analytics Endpoint item."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    moved_view = _make_view(schema="archive", name="vw_sales")
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_sql_endpoint_entry())
+
+    with (
+        ctx_patch,
+        patch("fabric_dw.services.views.transfer_view", new=AsyncMock(return_value=moved_view)),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "transfer_view",
+            {
+                "workspace": WS_NAME,
+                "item": "MySqlEndpoint",
+                "qualified_name": "dbo.vw_sales",
+                "target_schema": "archive",
+            },
+        )
+
+    assert result["name"] == "vw_sales"
+
+
+# ---------------------------------------------------------------------------
+# transfer_view — error / guard paths
+# ---------------------------------------------------------------------------
+
+
+async def test_transfer_view_readonly_mode_blocked(ctx_patch) -> None:
+    """transfer_view raises ToolError in read-only mode."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_READONLY": "1"}),
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "transfer_view",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_name": "dbo.vw_sales",
+                "target_schema": "archive",
+            },
+        )
+
+    assert "read-only" in str(exc_info.value).lower()
+
+
+async def test_transfer_view_unqualified_name_raises_tool_error(ctx_patch) -> None:
+    """transfer_view raises ToolError when qualified_name has no dot."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "transfer_view",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_name": "nodot",
+                "target_schema": "archive",
+            },
+        )
+
+
+async def test_transfer_view_workspace_not_in_allowlist(ctx_patch) -> None:
+    """transfer_view raises ToolError when workspace is not in allowlist."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_WORKSPACES": "other-ws"}),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "transfer_view",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_name": "dbo.vw_sales",
+                "target_schema": "archive",
+            },
+        )
+
+
+async def test_transfer_view_fabric_error_becomes_tool_error(mock_ctx, ctx_patch) -> None:
+    """transfer_view converts FabricError to ToolError."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.views.transfer_view",
+            new=AsyncMock(side_effect=FabricError("SQL error")),
+        ),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "transfer_view",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_name": "dbo.vw_sales",
+                "target_schema": "archive",
+            },
+        )
+
+
+async def test_transfer_view_value_error_becomes_tool_error(mock_ctx, ctx_patch) -> None:
+    """transfer_view converts ValueError (e.g. reserved target schema) to ToolError."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.views.transfer_view",
+            new=AsyncMock(side_effect=ValueError("reserved system schema")),
+        ),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "transfer_view",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_name": "dbo.vw_sales",
+                "target_schema": "sys",
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
 # count_view_rows
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/services/test_views.py
+++ b/tests/unit/services/test_views.py
@@ -1384,6 +1384,135 @@ class TestRenameView:
 
 
 # ===========================================================================
+# transfer_view
+# ===========================================================================
+
+
+class TestTransferView:
+    async def test_emits_alter_schema_transfer(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        moved_row = ("archive", "vw_sales", _NOW, _LATER, "SELECT id, amount FROM dbo.sales")
+        fetch_conn = _make_conn([moved_row], _GET_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            await views.transfer_view(target, "dbo.vw_sales", "archive")
+        cursor = ddl_conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert call_sql == "ALTER SCHEMA [archive] TRANSFER OBJECT::[dbo].[vw_sales]"
+
+    async def test_returns_view_from_target_schema(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        moved_row = ("archive", "vw_sales", _NOW, _LATER, "SELECT id, amount FROM dbo.sales")
+        fetch_conn = _make_conn([moved_row], _GET_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            result = await views.transfer_view(target, "dbo.vw_sales", "archive")
+        assert isinstance(result, View)
+        assert result.schema_name == "archive"
+        assert result.name == "vw_sales"
+        assert result.qualified_name == "archive.vw_sales"
+
+    async def test_commits_after_execute(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        moved_row = ("archive", "vw_sales", _NOW, _LATER, "SELECT id, amount FROM dbo.sales")
+        fetch_conn = _make_conn([moved_row], _GET_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            await views.transfer_view(target, "dbo.vw_sales", "archive")
+        ddl_conn.commit.assert_called_once()
+
+    async def test_does_not_reject_sql_endpoint_target(self) -> None:
+        """transfer_view must NOT raise for a SQL-endpoint target (no DW-only guard)."""
+        from fabric_dw.models import WarehouseKind  # noqa: PLC0415
+
+        target = MagicMock()
+        target.kind = WarehouseKind.SQL_ENDPOINT
+
+        ddl_conn = _make_conn_for_ddl()
+        moved_row = ("archive", "vw_sales", _NOW, _LATER, "SELECT id, amount FROM dbo.sales")
+        fetch_conn = _make_conn([moved_row], _GET_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            result = await views.transfer_view(target, "dbo.vw_sales", "archive")
+
+        assert result.schema_name == "archive"
+
+    async def test_rejects_undotted_qualified_name(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="qualified"):
+            await views.transfer_view(target, "nodot", "archive")
+
+    async def test_rejects_invalid_schema_in_qualified_name(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await views.transfer_view(target, "bad--schema.vw_sales", "archive")
+
+    async def test_rejects_invalid_view_in_qualified_name(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await views.transfer_view(target, "dbo.bad--view", "archive")
+
+    async def test_rejects_invalid_target_schema(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await views.transfer_view(target, "dbo.vw_sales", "bad--schema")
+
+    @pytest.mark.parametrize(
+        "reserved", ["sys", "information_schema", "SYS", "Information_Schema", "guest", "db_owner"]
+    )
+    async def test_rejects_reserved_target_schema(self, reserved: str) -> None:
+        """transfer_view propagates the system-schema rejection from the shared helper.
+
+        The check itself (and its full enumeration of system schemas) is
+        exercised exhaustively in TestAlterSchemaTransfer; this is a thin
+        pass-through test confirming transfer_view does not bypass it.
+        """
+        target = _make_target()
+        with pytest.raises(ValueError, match="reserved system schema"):
+            await views.transfer_view(target, "dbo.vw_sales", reserved)
+
+    async def test_raises_not_found_when_fetch_returns_empty(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([], _GET_COLS)
+        with (
+            patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]),
+            pytest.raises(NotFoundError, match="No view named"),
+        ):
+            await views.transfer_view(target, "dbo.vw_sales", "archive")
+
+    async def test_not_found_message_warns_about_non_view_objects(self) -> None:
+        """The post-transfer NotFoundError must call out that a same-named
+        non-view object (table/function/procedure) may have been moved
+        instead, since OBJECT::[schema].[name] matches any schema-scoped
+        object, not only views.
+        """
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([], _GET_COLS)
+        with (
+            patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]),
+            pytest.raises(NotFoundError, match="not only views"),
+        ):
+            await views.transfer_view(target, "dbo.vw_sales", "archive")
+
+    async def test_transfer_view_returns_raw_definition(self) -> None:
+        """transfer_view returns the raw Fabric definition without header-patching.
+
+        Documents the stale-definition caveat: the fetched View's definition
+        is whatever sys.sql_modules reports verbatim, which may still
+        reference the old schema name after a transfer.
+        """
+        raw_def = "CREATE VIEW [dbo].[vw_sales] AS SELECT id, amount FROM dbo.sales"
+        moved_row = ("archive", "vw_sales", _NOW, _LATER, raw_def)
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        fetch_conn = _make_conn([moved_row], _GET_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, fetch_conn]):
+            result = await views.transfer_view(target, "dbo.vw_sales", "archive")
+        assert result.definition == raw_def
+
+
+# ===========================================================================
 # read_view — Row normalisation (#718)
 # ===========================================================================
 # _FakeRow is imported from tests.unit.services._helpers (shared definition).


### PR DESCRIPTION
## Summary

- Add `transfer_view` to the service, MCP, and CLI layers: moves a view to another schema via `ALTER SCHEMA [target_schema] TRANSFER OBJECT::[schema].[view]`, reusing the `_alter_schema_transfer` helper merged in #940.
- Unlike `transfer_table`, this feature has no `kind` parameter and applies no DW-only guard: it works on both Fabric Data Warehouses and SQL Analytics Endpoints, mirroring `rename_view`.
- Documents the stale-definition caveat as a standalone admonition in `docs/commands/views.md`: `ALTER SCHEMA ... TRANSFER` moves the view but does not rewrite the schema name inside `sys.sql_modules.definition`, so `get_view` may still show the old schema in the `CREATE ... AS` header after a transfer. This admonition text is authored here for reuse, verbatim, by #942 (functions) and #943 (procedures).
- Adds `"transfer_view": "views"` to `DOMAIN_MAP` in `telemetry_commands.py`.

## Test plan

- [x] `tests/unit/services/test_views.py::TestTransferView` - DDL shape, target-schema fetch, no-SQL-endpoint-rejection, reserved-schema rejection, not-found message wording, raw-definition passthrough.
- [x] `tests/unit/mcp/tools/test_views.py` - happy path, SQL-endpoint item allowed, read-only guard, allowlist guard, error mapping; `transfer_view` added to the `_ALL_MUTATING_TOOLS` regression list in `test_tool_quality.py`.
- [x] `tests/unit/cli/commands/test_views.py::TestViewsTransfer` - confirm/decline flow, missing/invalid args, reserved-schema and permission errors.
- [x] `tests/integration/test_services_views.py::test_transfer_view_roundtrip` - dual-target (Warehouse + SQL Analytics Endpoint via `mutable_schema_target`) create-transfer-verify roundtrip, with an inline second target schema cleaned up in `finally`. Runs only on `main` per repo policy, not triggered from this PR.
- [x] `ruff check .`, `ruff format --check .`, `ty check src tests`, `uv run pytest tests/unit` all pass locally.

Closes #941