### PR TITLE
feat: transfer functions to another schema via ALTER SCHEMA TRANSFER

### DIFF
--- a/docs/commands/functions.md
+++ b/docs/commands/functions.md
@@ -141,6 +141,42 @@ fdw -w MyWorkspace functions update SalesWH dbo.fn_clean_input \
   --from-file ./fns/fn_clean_input_v2.sql
 ```
 
+### functions transfer
+
+**Targets:** Data Warehouse / SQL Analytics Endpoint
+
+Move a T-SQL user-defined function to another schema via `ALTER SCHEMA ... TRANSFER OBJECT::...`. The command emits exactly `ALTER SCHEMA [target_schema] TRANSFER OBJECT::[schema].[fn]`, with every identifier validated and bracket-quoted before being embedded in the DDL. Function DDL is supported on both Data Warehouses and SQL Analytics Endpoints, so no endpoint guard applies.
+
+!!! warning "Definition text is not rewritten"
+    `ALTER SCHEMA ... TRANSFER` moves the function, but it does **not** rewrite
+    the schema name inside the object's stored definition
+    (`sys.sql_modules.definition`, `OBJECT_DEFINITION()`). After a transfer,
+    `get_function` may still show the *old* schema name in the `CREATE ... AS`
+    header, even though the function now lives in the new schema. This tool does
+    not rewrite the definition text: doing so would require parsing and
+    regenerating SQL, which this project deliberately avoids. See
+    [ALTER SCHEMA (Transact-SQL)](https://learn.microsoft.com/sql/t-sql/statements/alter-schema-transact-sql?view=fabric&WT.mc_id=MVP_310840#remarks).
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] functions transfer [OPTIONS] [ITEM] QUALIFIED_NAME
+```
+
+`QUALIFIED_NAME` is the current dot-separated `schema.fn_name`.
+
+| Option | Description |
+| --- | --- |
+| `--target-schema TEXT` | **Required.** Schema to move the function into. |
+
+You will be asked to confirm unless `--yes` is passed.
+
+**Example**
+
+```shell
+fdw -w MyWorkspace functions transfer SalesWH dbo.fn_clean_input --target-schema archive
+```
+
 ## MCP tools
 
 ### create_function
@@ -228,3 +264,28 @@ Redefine a T-SQL user-defined function via `CREATE OR ALTER FUNCTION`.
 - `body` (`str`): the new function body (parameter list, RETURNS clause, and implementation).
 
 **Returns:** `FunctionDetails`: the updated function object.
+
+### transfer_function
+
+**Targets:** Data Warehouse / SQL Analytics Endpoint
+
+Move a T-SQL user-defined function to another schema via `ALTER SCHEMA ... TRANSFER OBJECT::...`. Function DDL is supported on both Data Warehouses and SQL Analytics Endpoints, so no endpoint guard applies.
+
+!!! warning "Definition text is not rewritten"
+    `ALTER SCHEMA ... TRANSFER` moves the function, but it does **not** rewrite
+    the schema name inside the object's stored definition
+    (`sys.sql_modules.definition`, `OBJECT_DEFINITION()`). After a transfer,
+    `get_function` may still show the *old* schema name in the `CREATE ... AS`
+    header, even though the function now lives in the new schema. This tool does
+    not rewrite the definition text: doing so would require parsing and
+    regenerating SQL, which this project deliberately avoids. See
+    [ALTER SCHEMA (Transact-SQL)](https://learn.microsoft.com/sql/t-sql/statements/alter-schema-transact-sql?view=fabric&WT.mc_id=MVP_310840#remarks).
+
+**Parameters:**
+
+- `workspace` (`str`): workspace name or GUID.
+- `item` (`str`): warehouse or SQL Analytics Endpoint name or GUID.
+- `qualified_name` (`str`): current dot-separated qualified function name, e.g. `dbo.fn_clean_input`.
+- `target_schema` (`str`): schema to move the function into, e.g. `archive`.
+
+**Returns:** `FunctionDetails`: the moved function record, fetched from the new schema.

--- a/src/fabric_dw/cli/commands/functions.py
+++ b/src/fabric_dw/cli/commands/functions.py
@@ -171,6 +171,46 @@ async def update_cmd(
         raise click.ClickException(str(exc)) from exc
 
 
+@functions_group.command("transfer")
+@click.argument("item", required=False, default=None)
+@click.argument("qualified_name")
+@click.option("--target-schema", required=True, help="Schema to move the function into.")
+@click.pass_obj
+@coro
+async def transfer_cmd(
+    ctx: CliContext,
+    item: str | None,
+    qualified_name: str,
+    target_schema: str,
+) -> None:
+    """Move QUALIFIED_NAME (schema.fn) on ITEM to --target-schema.
+
+    Function DDL is supported on both Data Warehouses and SQL Analytics
+    Endpoints; no endpoint guard applies. You will be asked to confirm
+    unless --yes is passed.
+    """
+    ws = resolve_workspace(ctx)
+    wh = resolve_warehouse_arg(ctx, item)
+    schema, fn_name = parse_qualified_name(qualified_name, kind="function")
+    try:
+        async with build_http_client(ctx) as http:
+            target, entry = await build_sql_target(http, ws, wh)
+            confirmed = confirm(
+                f"Move function [{schema}].[{fn_name}] to schema [{target_schema}] "
+                f"on {entry.display_name!r}?",
+                yes=ctx.yes,
+            )
+            if not confirmed:
+                click.echo("Aborted.")
+                return
+            f = await _fns_svc.transfer_function(
+                target, qualified_name, target_schema, mode=ctx.auth
+            )
+            render(f.model_dump(by_alias=True, mode="json"), json_output=ctx.json_output)
+    except (ValueError, FabricError) as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
 @functions_group.command("drop")
 @click.argument("item", required=False, default=None)
 @click.argument("qualified_name")

--- a/src/fabric_dw/mcp/tools/functions.py
+++ b/src/fabric_dw/mcp/tools/functions.py
@@ -184,6 +184,51 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             raise tool_err(exc) from exc
         return result.model_dump(mode="json")
 
+    @mutating_tool(mcp, "transfer_function")
+    async def transfer_function(
+        workspace: str, item: str, qualified_name: str, target_schema: str
+    ) -> dict[str, Any]:
+        """Move a T-SQL user-defined function to another schema via ALTER SCHEMA TRANSFER.
+
+        Function DDL is supported on both Data Warehouses and SQL Analytics
+        Endpoints -- unlike table transfer, no endpoint guard applies here.
+
+        CAUTION: ``ALTER SCHEMA ... TRANSFER`` does not rewrite the schema name
+        inside the function's stored definition (``sys.sql_modules.definition``).
+        After a transfer, ``get_function`` may still show the *old* schema name
+        in the ``CREATE ... AS`` header, even though the function now lives in
+        the new schema. This tool does not rewrite the definition text.
+
+        Args:
+            workspace: Workspace name or GUID.
+            item: Warehouse or SQL Analytics Endpoint name or GUID.
+            qualified_name: Current dot-separated qualified function name, e.g.
+                ``dbo.fn_clean_input``.
+            target_schema: Schema to move the function into, e.g. ``archive``.
+        """
+        parse_qualified_name(qualified_name, kind="function")
+        ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
+        try:
+            ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
+            _log.debug(
+                "transfer_function ws=%s item=%s qualified=%r target_schema=%r",
+                ws_id,
+                entry.id,
+                qualified_name,
+                target_schema,
+            )
+            target = make_sql_target(ws_id, entry, item)
+            result = await functions_svc.transfer_function(
+                target, qualified_name, target_schema, mode=ctx.auth_mode
+            )
+        except (ValueError, FabricError) as exc:
+            raise tool_err(exc) from exc
+        return result.model_dump(mode="json")
+
     @mutating_tool(mcp, "drop_function", destructive=True)
     async def drop_function(
         workspace: str,

--- a/src/fabric_dw/services/functions.py
+++ b/src/fabric_dw/services/functions.py
@@ -7,6 +7,7 @@ Public API
 - :func:`get_function`        — fetch a single function with its definition and parameters.
 - :func:`create_function`     — issue CREATE FUNCTION [<schema>].[<name>] AS <body>.
 - :func:`update_function`     — issue CREATE OR ALTER FUNCTION [<schema>].[<name>] AS <body>.
+- :func:`transfer_function`   — issue ALTER SCHEMA ... TRANSFER OBJECT::... (both targets).
 - :func:`drop_function`       — issue DROP FUNCTION; no-op on missing when if_exists=True.
 
 Note: User-defined functions are supported on **both** Fabric Data Warehouses and
@@ -27,8 +28,9 @@ from typing import Literal, cast
 
 from fabric_dw.auth import CredentialMode
 from fabric_dw.exceptions import NotFoundError
-from fabric_dw.identifiers import quote_identifier, validate_identifier
+from fabric_dw.identifiers import parse_qualified_name, quote_identifier, validate_identifier
 from fabric_dw.models import Function, FunctionDetails, FunctionKind, FunctionParameter
+from fabric_dw.services._helpers import _alter_schema_transfer
 from fabric_dw.sql import SqlTarget, run_query
 
 # Valid values for the ``kind`` parameter of :func:`list_functions`.
@@ -40,6 +42,7 @@ __all__ = [
     "drop_function",
     "get_function",
     "list_functions",
+    "transfer_function",
     "update_function",
     "validate_identifier",
     "validate_kind",
@@ -410,6 +413,86 @@ async def update_function(
 
     await asyncio.to_thread(_run)
     return await get_function(target, schema, function_name, mode=mode)
+
+
+async def transfer_function(
+    target: SqlTarget,
+    qualified: str,
+    target_schema: str,
+    *,
+    mode: CredentialMode = CredentialMode.DEFAULT,
+) -> FunctionDetails:
+    """Move a function to another schema via ``ALTER SCHEMA ... TRANSFER OBJECT::...``.
+
+    Supported on both Fabric Data Warehouses and SQL Analytics Endpoints —
+    unlike :func:`~fabric_dw.services.tables.transfer_table`, no endpoint
+    guard applies here, mirroring the rest of this module's function DDL.
+
+    .. warning::
+
+        ``OBJECT::[schema].[name]`` matches *any* schema-scoped object with
+        that name, not only functions.  If a table, view, or procedure
+        happens to share the qualified name, the engine transfers that
+        object instead.  When the post-transfer re-fetch then finds no
+        function named *function_name* in *target_schema*,
+        :class:`~fabric_dw.exceptions.NotFoundError` is raised with a message
+        that calls this out explicitly.
+
+    .. warning::
+
+        ``ALTER SCHEMA ... TRANSFER`` does not rewrite the schema name inside
+        the function's stored definition (``sys.sql_modules.definition``).
+        After a transfer, the re-fetched :class:`~fabric_dw.models.FunctionDetails`
+        may still show the *old* schema name in the ``CREATE ... AS`` header.
+        This is a stale-text display issue only; the function itself has moved.
+
+    Args:
+        target: The warehouse or SQL Analytics Endpoint to connect to.
+        qualified: The current fully-qualified name of the form ``schema.fn``.
+            Parsed with :func:`~fabric_dw.identifiers.parse_qualified_name`.
+        target_schema: The schema to move the function into.  Must pass
+            :func:`validate_identifier`.  System schemas (``sys``,
+            ``INFORMATION_SCHEMA``, ``guest``, fixed ``db_*`` role schemas)
+            are rejected by
+            :func:`~fabric_dw.services._helpers._alter_schema_transfer`.
+        mode: The credential mode for Entra authentication.
+
+    Returns:
+        A :class:`~fabric_dw.models.FunctionDetails` reflecting the moved
+        function (fetched via :func:`get_function` from *target_schema* after
+        the transfer).
+
+    Raises:
+        ValueError: If *qualified* cannot be parsed, if any identifier component
+            fails identifier validation, or if *target_schema* is a system schema.
+        NotFoundError: If no function named *function_name* is found in
+            *target_schema* after the transfer -- see the warning above about
+            non-function objects.
+        PermissionDeniedError: If the driver reports a permission error.
+    """
+    schema, fn_name = parse_qualified_name(qualified, kind="function")
+    validate_identifier(schema)
+    validate_identifier(fn_name)
+    validate_identifier(target_schema)
+
+    await _alter_schema_transfer(
+        target,
+        source_schema=schema,
+        object_name=fn_name,
+        target_schema=target_schema,
+        mode=mode,
+    )
+
+    try:
+        return await get_function(target, target_schema, fn_name, mode=mode)
+    except NotFoundError:
+        msg = (
+            f"No function named [{target_schema}].[{fn_name}] was found after "
+            "the transfer. ALTER SCHEMA TRANSFER moves any schema-scoped "
+            "object with that name, not only functions -- if a table, view, "
+            "or procedure shared this name, check whether it was moved instead."
+        )
+        raise NotFoundError(msg) from None
 
 
 async def drop_function(

--- a/src/fabric_dw/telemetry_commands.py
+++ b/src/fabric_dw/telemetry_commands.py
@@ -179,6 +179,7 @@ DOMAIN_MAP: dict[str, str] = {
     "get_function": "functions",
     "create_function": "functions",
     "update_function": "functions",
+    "transfer_function": "functions",
     "drop_function": "functions",
     # Statistics
     "list_statistics": "statistics",

--- a/tests/integration/test_services_functions.py
+++ b/tests/integration/test_services_functions.py
@@ -29,6 +29,7 @@ import pytest
 from fabric_dw.exceptions import NotFoundError
 from fabric_dw.models import FunctionDetails, FunctionKind
 from fabric_dw.services import functions
+from fabric_dw.services import schemas as schemas_svc
 from fabric_dw.sql import SqlTarget
 
 pytestmark = pytest.mark.integration
@@ -280,3 +281,56 @@ async def test_create_inline_tvf_and_list_by_kind(
     finally:
         with contextlib.suppress(Exception):
             await functions.drop_function(sql_target, schema, fn_name)
+
+
+async def test_transfer_function_roundtrip(
+    mutable_schema_target: tuple[SqlTarget, str],
+) -> None:
+    """Create a function, transfer it to a second schema, assert old gone / new present.
+
+    Function DDL applies on both Data Warehouses and SQL Analytics Endpoints
+    (no endpoint guard), so this runs on both targets via mutable_schema_target
+    -- unlike tables.transfer_table, which is Data-Warehouse-only.
+    """
+    sql_target, schema = mutable_schema_target
+    fn_name = "pytest_fns_transfer_dst"
+    target_schema_name = f"{schema}_target"
+
+    await schemas_svc.create_schema(sql_target, target_schema_name)
+    try:
+        created = await functions.create_function(
+            sql_target, schema, fn_name, _SCALAR_INLINEABLE_BODY
+        )
+        assert isinstance(created, FunctionDetails)
+        assert created.schema_name == schema
+
+        moved = await functions.transfer_function(
+            sql_target, f"{schema}.{fn_name}", target_schema_name
+        )
+        assert isinstance(moved, FunctionDetails)
+        assert moved.name == fn_name
+        assert moved.schema_name == target_schema_name
+        assert moved.qualified_name == f"{target_schema_name}.{fn_name}"
+
+        # Stale-definition note (documented behaviour, not asserted as a hard
+        # failure): ALTER SCHEMA TRANSFER moves the function but does not
+        # rewrite the schema name embedded in the CREATE FUNCTION header
+        # stored in sys.sql_modules.definition. `moved.definition` may
+        # therefore still reference the OLD schema name even though the
+        # function now lives in target_schema_name -- see the docs
+        # admonition in docs/commands/functions.md ("Definition text is not
+        # rewritten") and the project's no-SQL-parsing policy.
+
+        all_fns = await functions.list_functions(sql_target)
+        in_target = {f.name for f in all_fns if f.schema_name == target_schema_name}
+        in_source = {f.name for f in all_fns if f.schema_name == schema}
+        assert fn_name in in_target, f"{fn_name!r} not found in {target_schema_name!r}"
+        assert fn_name not in in_source, f"{fn_name!r} still present in {schema!r}"
+
+    finally:
+        with contextlib.suppress(Exception):
+            await functions.drop_function(sql_target, schema, fn_name)
+        with contextlib.suppress(Exception):
+            await functions.drop_function(sql_target, target_schema_name, fn_name)
+        with contextlib.suppress(Exception):
+            await schemas_svc.delete_schema(sql_target, target_schema_name, cascade=True)

--- a/tests/unit/cli/commands/test_functions.py
+++ b/tests/unit/cli/commands/test_functions.py
@@ -524,6 +524,210 @@ class TestFunctionsUpdate:
 
 
 # ===========================================================================
+# functions transfer
+# ===========================================================================
+
+
+class TestFunctionsTransfer:
+    def test_transfer_with_yes_flag(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        moved = FunctionDetails(
+            schema_name="archive",
+            name="fn_clean",
+            qualified_name="archive.fn_clean",
+            kind=FunctionKind.SCALAR,
+            is_inlineable=True,
+            definition=None,
+            parameters=[],
+            created=_NOW,
+            modified=_NOW,
+        )
+        mock_transfer = AsyncMock(return_value=moved)
+        with (
+            patch(
+                "fabric_dw.cli.commands.functions.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.functions.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.functions.transfer_function",
+                new=mock_transfer,
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--yes",
+                    "-w",
+                    WS_GUID,
+                    "--json",
+                    "functions",
+                    "transfer",
+                    WH_GUID,
+                    "dbo.fn_clean",
+                    "--target-schema",
+                    "archive",
+                ],
+            )
+        assert result.exit_code == 0
+        mock_transfer.assert_awaited_once()
+        args, _kwargs = mock_transfer.call_args
+        # service is called positionally: target, qualified_name, target_schema
+        assert args[1] == "dbo.fn_clean"
+        assert args[2] == "archive"
+        parsed = json.loads(result.output)
+        assert parsed["name"] == "fn_clean"
+        assert parsed["schema_name"] == "archive"
+
+    def test_transfer_aborted_without_yes(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.functions.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.functions.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch("fabric_dw.services.functions.transfer_function", new=AsyncMock()),
+        ):
+            # Decline the prompt
+            result = runner.invoke(
+                cli,
+                [
+                    "-w",
+                    WS_GUID,
+                    "functions",
+                    "transfer",
+                    WH_GUID,
+                    "dbo.fn_clean",
+                    "--target-schema",
+                    "archive",
+                ],
+                input="n\n",
+            )
+        assert result.exit_code == 0
+        assert "Aborted" in result.output
+
+    def test_transfer_missing_target_schema_fails(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        result = runner.invoke(
+            cli, ["-w", WS_GUID, "functions", "transfer", WH_GUID, "dbo.fn_clean"]
+        )
+        assert result.exit_code != 0
+
+    def test_transfer_undotted_qualified_name_fails_before_io(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """An undotted QUALIFIED_NAME must yield a UsageError before any I/O is performed."""
+        _ = cache_env
+        result = runner.invoke(
+            cli,
+            [
+                "-w",
+                WS_GUID,
+                "functions",
+                "transfer",
+                WH_GUID,
+                "nodot",
+                "--target-schema",
+                "archive",
+            ],
+        )
+        assert result.exit_code != 0
+
+    def test_transfer_reserved_target_schema_returns_nonzero(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """--target-schema sys / information_schema must surface as a non-zero CLI exit.
+
+        Exercises the CLI's ValueError -> ClickException conversion for the
+        reserved-system-schema rejection raised by the shared
+        _alter_schema_transfer helper (acceptance criterion for this feature,
+        already covered 4x via parametrize at the service layer in
+        TestTransferFunction.test_rejects_reserved_target_schema).
+        """
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.functions.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.functions.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.functions.transfer_function",
+                new=AsyncMock(
+                    side_effect=ValueError(
+                        "Target schema 'sys' is a reserved system schema and cannot be "
+                        "an ALTER SCHEMA TRANSFER target"
+                    )
+                ),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--yes",
+                    "-w",
+                    WS_GUID,
+                    "functions",
+                    "transfer",
+                    WH_GUID,
+                    "dbo.fn_clean",
+                    "--target-schema",
+                    "sys",
+                ],
+            )
+        assert result.exit_code != 0
+        assert "reserved system schema" in result.output
+
+    def test_transfer_permission_denied_returns_nonzero(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.functions.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.functions.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.functions.transfer_function",
+                new=AsyncMock(side_effect=PermissionDeniedError("no permission")),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--yes",
+                    "-w",
+                    WS_GUID,
+                    "functions",
+                    "transfer",
+                    WH_GUID,
+                    "dbo.fn_clean",
+                    "--target-schema",
+                    "archive",
+                ],
+            )
+        assert result.exit_code != 0
+
+
+# ===========================================================================
 # functions drop
 # ===========================================================================
 

--- a/tests/unit/mcp/tools/test_functions.py
+++ b/tests/unit/mcp/tools/test_functions.py
@@ -330,6 +330,108 @@ async def test_update_function_happy_path(mock_ctx, ctx_patch) -> None:
 
 
 # ---------------------------------------------------------------------------
+# transfer_function — mutating tool
+# ---------------------------------------------------------------------------
+
+
+async def test_transfer_function_happy_path(mock_ctx, ctx_patch) -> None:
+    """transfer_function resolves item, calls the service, and returns the moved function dict."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    moved = _make_fn_details(schema="archive", name="fn_clean")
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+    mock_transfer = AsyncMock(return_value=moved)
+
+    with (
+        ctx_patch,
+        patch("fabric_dw.services.functions.transfer_function", new=mock_transfer),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "transfer_function",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_name": "dbo.fn_clean",
+                "target_schema": "archive",
+            },
+        )
+
+    mock_transfer.assert_called_once()
+    args, _kwargs = mock_transfer.call_args
+    # service is called positionally: target, qualified_name, target_schema
+    assert args[1] == "dbo.fn_clean"
+    assert args[2] == "archive"
+    assert result["name"] == "fn_clean"
+    assert result["schema_name"] == "archive"
+
+
+async def test_transfer_function_readonly_blocked(mock_ctx, ctx_patch) -> None:
+    """transfer_function raises ToolError when FABRIC_MCP_READONLY is set."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_READONLY": "1"}),
+        pytest.raises(ToolError, match="read-only"),
+    ):
+        await mcp._tool_manager.call_tool(
+            "transfer_function",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_name": "dbo.fn_clean",
+                "target_schema": "archive",
+            },
+        )
+
+
+async def test_transfer_function_undotted_qualified_name_raises_tool_error(
+    mock_ctx,  # noqa: ARG001
+    ctx_patch,
+) -> None:
+    """transfer_function must raise ToolError immediately for an undotted qualified_name."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        pytest.raises(ToolError, match="qualified name"),
+    ):
+        await mcp._tool_manager.call_tool(
+            "transfer_function",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_name": "nodot",
+                "target_schema": "archive",
+            },
+        )
+
+
+async def test_transfer_function_workspace_allowlist_blocks(ctx_patch) -> None:
+    """transfer_function raises ToolError when workspace is not in FABRIC_MCP_WORKSPACES."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_WORKSPACES": "other-workspace"}),
+        pytest.raises(ToolError, match="allowlist"),
+    ):
+        await mcp._tool_manager.call_tool(
+            "transfer_function",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_name": "dbo.fn_clean",
+                "target_schema": "archive",
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
 # drop_function — destructive mutating tool
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/mcp/tools/test_functions.py
+++ b/tests/unit/mcp/tools/test_functions.py
@@ -366,6 +366,34 @@ async def test_transfer_function_happy_path(mock_ctx, ctx_patch) -> None:
     assert result["schema_name"] == "archive"
 
 
+async def test_transfer_function_on_sql_endpoint_succeeds(mock_ctx, ctx_patch) -> None:
+    """transfer_function on a SQL Analytics Endpoint must succeed — no endpoint guard."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    moved = _make_fn_details(schema="archive", name="fn_clean")
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_sql_endpoint_entry())
+    mock_transfer = AsyncMock(return_value=moved)
+
+    with (
+        ctx_patch,
+        patch("fabric_dw.services.functions.transfer_function", new=mock_transfer),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "transfer_function",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "qualified_name": "dbo.fn_clean",
+                "target_schema": "archive",
+            },
+        )
+
+    mock_transfer.assert_called_once()
+    assert result["name"] == "fn_clean"
+    assert result["schema_name"] == "archive"
+
+
 async def test_transfer_function_readonly_blocked(mock_ctx, ctx_patch) -> None:
     """transfer_function raises ToolError when FABRIC_MCP_READONLY is set."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415

--- a/tests/unit/mcp/tools/test_tool_quality.py
+++ b/tests/unit/mcp/tools/test_tool_quality.py
@@ -737,6 +737,8 @@ _ALL_MUTATING_TOOLS: list[str] = [
     "update_procedure",
     "drop_procedure",
     "transfer_procedure",
+    # functions.py
+    "transfer_function",
     # snapshots.py
     "create_snapshot",
     "rename_snapshot",

--- a/tests/unit/services/test_functions.py
+++ b/tests/unit/services/test_functions.py
@@ -659,6 +659,113 @@ class TestUpdateFunction:
 
 
 # ===========================================================================
+# transfer_function
+# ===========================================================================
+
+
+class TestTransferFunction:
+    async def test_emits_alter_schema_transfer(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        moved_row = ("archive", "fn_clean", "FN", "SQL_SCALAR_FUNCTION", _NOW, _LATER, "...", 1)
+        conn_fn = _make_conn([moved_row], _GET_COLS)
+        conn_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
+
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, conn_fn, conn_params]):
+            await functions.transfer_function(target, "dbo.fn_clean", "archive")
+
+        cursor = ddl_conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert call_sql == "ALTER SCHEMA [archive] TRANSFER OBJECT::[dbo].[fn_clean]"
+
+    async def test_returns_function_details_from_target_schema(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        moved_row = ("archive", "fn_clean", "FN", "SQL_SCALAR_FUNCTION", _NOW, _LATER, "...", 1)
+        conn_fn = _make_conn([moved_row], _GET_COLS)
+        conn_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
+
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, conn_fn, conn_params]):
+            result = await functions.transfer_function(target, "dbo.fn_clean", "archive")
+
+        assert isinstance(result, FunctionDetails)
+        assert result.schema_name == "archive"
+        assert result.name == "fn_clean"
+        assert result.qualified_name == "archive.fn_clean"
+
+    async def test_commits_after_execute(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        moved_row = ("archive", "fn_clean", "FN", "SQL_SCALAR_FUNCTION", _NOW, _LATER, "...", 1)
+        conn_fn = _make_conn([moved_row], _GET_COLS)
+        conn_params = _make_conn([_PARAM_RETURN, _PARAM_INPUT], _PARAM_COLS)
+
+        with patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, conn_fn, conn_params]):
+            await functions.transfer_function(target, "dbo.fn_clean", "archive")
+
+        ddl_conn.commit.assert_called_once()
+
+    async def test_rejects_undotted_qualified_name(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="qualified"):
+            await functions.transfer_function(target, "nodot", "archive")
+
+    async def test_rejects_invalid_schema_in_qualified_name(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await functions.transfer_function(target, "bad--schema.fn_clean", "archive")
+
+    async def test_rejects_invalid_function_in_qualified_name(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await functions.transfer_function(target, "dbo.bad--fn", "archive")
+
+    async def test_rejects_invalid_target_schema(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await functions.transfer_function(target, "dbo.fn_clean", "bad--schema")
+
+    @pytest.mark.parametrize(
+        "reserved", ["sys", "information_schema", "SYS", "Information_Schema", "guest", "db_owner"]
+    )
+    async def test_rejects_reserved_target_schema(self, reserved: str) -> None:
+        """transfer_function propagates the system-schema rejection from the shared helper.
+
+        The check itself (and its full enumeration of system schemas) is
+        exercised exhaustively in TestAlterSchemaTransfer; this is a thin
+        pass-through test confirming transfer_function does not bypass it.
+        """
+        target = _make_target()
+        with pytest.raises(ValueError, match="reserved system schema"):
+            await functions.transfer_function(target, "dbo.fn_clean", reserved)
+
+    async def test_raises_not_found_when_fetch_returns_empty(self) -> None:
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        conn_fn = _make_conn([], _GET_COLS)
+        with (
+            patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, conn_fn]),
+            pytest.raises(NotFoundError, match="No function named"),
+        ):
+            await functions.transfer_function(target, "dbo.fn_clean", "archive")
+
+    async def test_not_found_message_warns_about_non_function_objects(self) -> None:
+        """The post-transfer NotFoundError must call out that a same-named
+        non-function object (table/view/procedure) may have been moved
+        instead, since OBJECT::[schema].[name] matches any schema-scoped
+        object, not only functions.
+        """
+        target = _make_target()
+        ddl_conn = _make_conn_for_ddl()
+        conn_fn = _make_conn([], _GET_COLS)
+        with (
+            patch("fabric_dw.sql.open_connection", side_effect=[ddl_conn, conn_fn]),
+            pytest.raises(NotFoundError, match="not only functions"),
+        ):
+            await functions.transfer_function(target, "dbo.fn_clean", "archive")
+
+
+# ===========================================================================
 # drop_function
 # ===========================================================================
 


### PR DESCRIPTION
## Summary

- Add `transfer_function` (service layer, `functions transfer` CLI command, `transfer_function` MCP tool) to move a scalar/inline T-SQL function to another schema via `ALTER SCHEMA ... TRANSFER OBJECT::...`, reusing the `_alter_schema_transfer` helper from #940.
- Function DDL applies on both Data Warehouses and SQL Analytics Endpoints, so unlike `transfer_table`, no `kind` parameter or endpoint guard is applied here.
- Adds the stale-definition admonition to docs: the transfer does not rewrite the schema name stored inside the function's `CREATE ... AS` definition text (no SQL parsing, per repo policy).

## Test plan

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `ty check src tests` passes
- [x] `uv run pytest tests/unit` passes (5689 passed)
- [x] Unit tests added: service (`TestTransferFunction`), MCP tool (happy path, read-only blocked, undotted name, workspace allowlist), CLI (`TestFunctionsTransfer`)
- [x] `transfer_function` added to the `_ALL_MUTATING_TOOLS` regression guard in `tests/unit/mcp/tools/test_tool_quality.py`
- [x] Dual-target integration roundtrip test added in `tests/integration/test_services_functions.py` (not run here; runs via `mutable_schema_target` on CI / manual trigger)

Closes #942

🤖 Generated with [Claude Code](https://claude.com/claude-code)