### PR TITLE
docs(guides): note that objects can move across schemas via transfer

### DIFF
--- a/docs/guides/tables-and-views.md
+++ b/docs/guides/tables-and-views.md
@@ -294,12 +294,21 @@ fdw tables clone \
   --at 2026-05-20T14:00:00
 ```
 
-**Rename** a table or view (`sp_rename`; the new name must be **unqualified**: you can't move objects across schemas):
+**Rename** a table or view (`sp_rename`; the new name must be **unqualified** - `sp_rename` itself can't move an object across schemas, it only renames in place):
 
 ```shell
 fdw tables rename SalesWH sales.orders_2025 --new-name orders_archive_2025
 fdw views rename SalesWH sales.vw_recent --new-name vw_revenue
 ```
+
+**Move** a table or view to a different schema with `transfer` (`ALTER SCHEMA ... TRANSFER OBJECT::...`; a separate operation from rename, and the way to actually relocate an object):
+
+```shell
+fdw tables transfer SalesWH sales.orders_2025 --target-schema archive
+fdw views transfer SalesWH sales.vw_recent --target-schema archive
+```
+
+The same operation is available for functions and procedures. See [Tables](../commands/tables.md#tables-transfer), [Views](../commands/views.md#views-transfer), [Functions](../commands/functions.md#functions-transfer), and [Procedures](../commands/procedures.md#procedures-transfer) for the full flag reference, including two caveats worth knowing up front: table transfer is **Data Warehouse only** (it's rejected on a SQL Analytics Endpoint, since moving a table between schemas there can break the OneLake sync), and for views, functions, and procedures the transfer does not rewrite the stored definition text, so the object's `CREATE ... AS` header may still show the old schema name afterward.
 
 **Clear** a table (`TRUNCATE TABLE`: removes all rows, keeps the structure):
 
@@ -323,7 +332,7 @@ fdw --yes schemas delete SalesWH sales --cascade
 
 `schemas delete --cascade` first drops **all tables, views, functions, and stored procedures** in the schema. Without `--cascade`, the engine rejects `DROP SCHEMA` on a non-empty schema. On a SQL Analytics Endpoint, cascade can't drop tables (no `DROP TABLE` there), so a schema still holding tables won't drop - remove them from the warehouse first.
 
-**MCP equivalents:** `clone_table`, `rename_table` / `rename_view`, `clear_table`, `get_table_health_metrics`, `drop_view`, `delete_table`, `delete_schema(..., cascade=True)`.
+**MCP equivalents:** `clone_table`, `rename_table` / `rename_view`, `transfer_table` / `transfer_view`, `clear_table`, `get_table_health_metrics`, `drop_view`, `delete_table`, `delete_schema(..., cascade=True)`.
 
 ### Destructive operations and the `--yes` flag
 
@@ -400,6 +409,7 @@ Every authoring and inspection step above maps to an MCP tool. The exceptions ar
 | Row count | `tables count` | `count_table_rows` |
 | Clone table | `tables clone` | `clone_table` |
 | Rename table | `tables rename` | `rename_table` |
+| Transfer table to another schema | `tables transfer` | `transfer_table` |
 | Set / remove clustering | `tables cluster-by` | `set_cluster_columns` |
 | Clustering columns | `tables cluster-columns` | `get_cluster_columns` |
 | Truncate table | `tables clear` | `clear_table` |
@@ -415,6 +425,7 @@ Every authoring and inspection step above maps to an MCP tool. The exceptions ar
 | Read view rows | `views read` | `read_view` |
 | View row count | `views count` | `count_view_rows` |
 | Rename view | `views rename` | `rename_view` |
+| Transfer view to another schema | `views transfer` | `transfer_view` |
 | Drop view | `views drop` | `drop_view` |
 | Create statistic | `statistics create` | `create_statistics` |
 | Update statistic | `statistics update` | `update_statistics` |


### PR DESCRIPTION
## Summary

`docs/guides/tables-and-views.md` told readers that objects cannot be moved across schemas, in the Rename section. That was true for `sp_rename` but is now stale: `transfer_table` / `transfer_view` / `transfer_function` / `transfer_procedure` shipped (#940-#943) and the guide never mentioned them.

## Changes

- Reworded the rename caveat so it stays accurate (`sp_rename` still can't move an object across schemas) without implying objects can never move.
- Added a short "Move" subsection introducing the `transfer` operation right after rename, with CLI examples for tables and views.
- Linked to the per-domain command references (`tables.md#tables-transfer`, `views.md#views-transfer`, `functions.md#functions-transfer`, `procedures.md#procedures-transfer`) for the full flag list, instead of re-documenting it here.
- Called out the two caveats already documented in those references (table transfer is Data Warehouse only because of the OneLake-sync risk on a SQL Analytics Endpoint, and views/functions/procedures transfer does not rewrite the stored definition text).
- Added `transfer_table` / `transfer_view` to the "MCP equivalents" line and the CLI-vs-MCP workflow table so they stay consistent with the new subsection.

No nav change needed, the guide page already exists in `zensical.toml`.

## Test plan

- [x] `uv run --group docs zensical build` completes with "No issues found" (no broken links / markdown errors).
- [x] Manually reviewed rendered Markdown for heading/link well-formedness.
- [x] Confirmed no em-dashes were introduced.

Closes #951

🤖 Generated with [Claude Code](https://claude.com/claude-code)