### PR TITLE
refactor(services): de-duplicate transfer_* wrappers around _alter_schema_transfer

### DIFF
--- a/src/fabric_dw/services/_helpers.py
+++ b/src/fabric_dw/services/_helpers.py
@@ -11,7 +11,7 @@ from typing import Protocol, TypeVar
 from uuid import UUID
 
 from fabric_dw.auth import CredentialMode
-from fabric_dw.exceptions import ItemKindError
+from fabric_dw.exceptions import ItemKindError, NotFoundError
 from fabric_dw.identifiers import quote_identifier, validate_identifier
 from fabric_dw.models import WarehouseKind
 from fabric_dw.services.capacities import ACTIVE_STATE
@@ -175,6 +175,114 @@ async def _alter_schema_transfer(
         run_query(target, ddl, mode=mode, commit=True, fetch="none")
 
     await asyncio.to_thread(_run_ddl)
+
+
+# ---------------------------------------------------------------------------
+# Shared transfer_* wrapper boilerplate
+#
+# Every transfer_table/transfer_view/transfer_function/transfer_procedure
+# service function repeats two pieces of boilerplate around
+# _alter_schema_transfer: the post-transfer NotFoundError wrapping message
+# (only the object noun differs) and -- previously -- a caller-side
+# validate_identifier pass that _alter_schema_transfer already performs.
+# _transfer_object below is the single place both live now.
+# ---------------------------------------------------------------------------
+
+# Canonical order used to build the "not only X -- if Y, Z, or W ..." phrase
+# in the post-transfer NotFoundError message below.  Shared across all four
+# transfer operations so the four rendered messages can never drift from a
+# single ordering or wording.
+_TRANSFERABLE_OBJECT_LABELS: tuple[str, ...] = ("table", "view", "function", "procedure")
+
+
+def _other_object_labels_phrase(object_label: str) -> str:
+    """Return e.g. ``"a view, function, or procedure"`` for ``object_label="table"``.
+
+    Args:
+        object_label: One of :data:`_TRANSFERABLE_OBJECT_LABELS`.
+
+    Returns:
+        The other three labels (in :data:`_TRANSFERABLE_OBJECT_LABELS` order),
+        formatted as a natural-language enumeration with a leading "a" and an
+        "or" before the last item.
+    """
+    others = [label for label in _TRANSFERABLE_OBJECT_LABELS if label != object_label]
+    return f"a {others[0]}, {others[1]}, or {others[2]}"
+
+
+async def _transfer_object(
+    target: SqlTarget,
+    *,
+    source_schema: str,
+    object_name: str,
+    target_schema: str,
+    object_label: str,
+    fetch: Callable[[], Coroutine[object, object, _T]],
+    mode: CredentialMode = CredentialMode.DEFAULT,
+) -> _T:
+    """Run :func:`_alter_schema_transfer`, then re-fetch via *fetch*, wrapping ``NotFoundError``.
+
+    Shared by the four ``transfer_*`` service functions
+    (:func:`~fabric_dw.services.tables.transfer_table`,
+    :func:`~fabric_dw.services.views.transfer_view`,
+    :func:`~fabric_dw.services.functions.transfer_function`,
+    :func:`~fabric_dw.services.procedures.transfer_procedure`).  Each caller
+    remains responsible for its own pre-transfer guard (only ``transfer_table``
+    applies a Warehouse-only :func:`_assert_not_sql_endpoint` guard) and for
+    parsing the caller's *qualified* string into *source_schema*/*object_name*
+    up front -- this helper only runs the transfer DDL and the re-fetch.
+
+    Identifier validation for all three of *source_schema*, *object_name*, and
+    *target_schema* happens inside :func:`_alter_schema_transfer`; callers must
+    NOT re-validate them beforehand -- that earlier caller-side validation was
+    redundant and has been removed from every ``transfer_*`` function.
+
+    Args:
+        target: The warehouse or SQL Analytics Endpoint to connect to.
+        source_schema: The object's current schema.
+        object_name: The (unqualified) object name.
+        target_schema: The schema to move the object into.
+        object_label: Singular noun for the object kind -- one of
+            :data:`_TRANSFERABLE_OBJECT_LABELS` (``"table"``, ``"view"``,
+            ``"function"``, ``"procedure"``).  Used to render the
+            ``NotFoundError`` message below.
+        fetch: Zero-argument async callable that re-fetches the object from
+            *target_schema* after the transfer, e.g.
+            ``lambda: _fetch_table(target, target_schema, table_name, mode=mode)``.
+            Its return value is returned unchanged on success.
+        mode: The credential mode for Entra authentication.
+
+    Returns:
+        Whatever *fetch* returns.
+
+    Raises:
+        ValueError: See :func:`_alter_schema_transfer`.
+        NotFoundError: If *fetch* raises :class:`~fabric_dw.exceptions.NotFoundError`,
+            re-raised with a message warning that ``ALTER SCHEMA TRANSFER
+            OBJECT::`` moves any schema-scoped object sharing that name, not
+            only objects of *object_label*'s kind.
+        PermissionDeniedError: See :func:`_alter_schema_transfer`.
+        FabricError: See :func:`_alter_schema_transfer`.
+    """
+    await _alter_schema_transfer(
+        target,
+        source_schema=source_schema,
+        object_name=object_name,
+        target_schema=target_schema,
+        mode=mode,
+    )
+
+    try:
+        return await fetch()
+    except NotFoundError:
+        others = _other_object_labels_phrase(object_label)
+        msg = (
+            f"No {object_label} named [{target_schema}].[{object_name}] was found after "
+            "the transfer. ALTER SCHEMA TRANSFER moves any schema-scoped "
+            f"object with that name, not only {object_label}s -- if {others} "
+            "shared this name, check whether it was moved instead."
+        )
+        raise NotFoundError(msg) from None
 
 
 # ---------------------------------------------------------------------------

--- a/src/fabric_dw/services/_helpers.py
+++ b/src/fabric_dw/services/_helpers.py
@@ -7,7 +7,7 @@ import logging
 import re
 from collections.abc import Callable, Coroutine, Mapping, Sequence
 from datetime import UTC, datetime, timedelta
-from typing import Protocol, TypeVar
+from typing import Literal, Protocol, TypeVar
 from uuid import UUID
 
 from fabric_dw.auth import CredentialMode
@@ -188,26 +188,56 @@ async def _alter_schema_transfer(
 # _transfer_object below is the single place both live now.
 # ---------------------------------------------------------------------------
 
+# The four object kinds that ALTER SCHEMA TRANSFER OBJECT::... can move.
+# Typed as a Literal (not bare str) so a typo'd or mis-cased object_label
+# (e.g. "Table", "tabel") fails ty/lint at every call site instead of only
+# surfacing as garbled wording on the rare post-transfer NotFoundError path.
+_TransferableObjectLabel = Literal["table", "view", "function", "procedure"]
+
 # Canonical order used to build the "not only X -- if Y, Z, or W ..." phrase
 # in the post-transfer NotFoundError message below.  Shared across all four
 # transfer operations so the four rendered messages can never drift from a
 # single ordering or wording.
-_TRANSFERABLE_OBJECT_LABELS: tuple[str, ...] = ("table", "view", "function", "procedure")
+_TRANSFERABLE_OBJECT_LABELS: tuple[_TransferableObjectLabel, ...] = (
+    "table",
+    "view",
+    "function",
+    "procedure",
+)
 
 
-def _other_object_labels_phrase(object_label: str) -> str:
+def _other_object_labels_phrase(object_label: _TransferableObjectLabel) -> str:
     """Return e.g. ``"a view, function, or procedure"`` for ``object_label="table"``.
+
+    Scales to however many labels :data:`_TRANSFERABLE_OBJECT_LABELS` holds
+    (not hardcoded to four) and fails loudly rather than silently dropping a
+    label: if *object_label* is somehow not an exact member of
+    :data:`_TRANSFERABLE_OBJECT_LABELS` at runtime (the ``Literal`` type only
+    guards static call sites), every entry would otherwise survive the filter
+    and the wrong count would be rendered without any error.
 
     Args:
         object_label: One of :data:`_TRANSFERABLE_OBJECT_LABELS`.
 
     Returns:
-        The other three labels (in :data:`_TRANSFERABLE_OBJECT_LABELS` order),
+        The other labels (in :data:`_TRANSFERABLE_OBJECT_LABELS` order),
         formatted as a natural-language enumeration with a leading "a" and an
         "or" before the last item.
+
+    Raises:
+        ValueError: If *object_label* is not in :data:`_TRANSFERABLE_OBJECT_LABELS`.
     """
+    if object_label not in _TRANSFERABLE_OBJECT_LABELS:
+        msg = (
+            f"Unknown object_label {object_label!r}; expected one of "
+            f"{', '.join(_TRANSFERABLE_OBJECT_LABELS)}"
+        )
+        raise ValueError(msg)
+
     others = [label for label in _TRANSFERABLE_OBJECT_LABELS if label != object_label]
-    return f"a {others[0]}, {others[1]}, or {others[2]}"
+    if len(others) == 1:
+        return f"a {others[0]}"
+    return f"a {', '.join(others[:-1])}, or {others[-1]}"
 
 
 async def _transfer_object(
@@ -216,7 +246,7 @@ async def _transfer_object(
     source_schema: str,
     object_name: str,
     target_schema: str,
-    object_label: str,
+    object_label: _TransferableObjectLabel,
     fetch: Callable[[], Coroutine[object, object, _T]],
     mode: CredentialMode = CredentialMode.DEFAULT,
 ) -> _T:

--- a/src/fabric_dw/services/functions.py
+++ b/src/fabric_dw/services/functions.py
@@ -30,7 +30,7 @@ from fabric_dw.auth import CredentialMode
 from fabric_dw.exceptions import NotFoundError
 from fabric_dw.identifiers import parse_qualified_name, quote_identifier, validate_identifier
 from fabric_dw.models import Function, FunctionDetails, FunctionKind, FunctionParameter
-from fabric_dw.services._helpers import _alter_schema_transfer
+from fabric_dw.services._helpers import _transfer_object
 from fabric_dw.sql import SqlTarget, run_query
 
 # Valid values for the ``kind`` parameter of :func:`list_functions`.
@@ -471,28 +471,16 @@ async def transfer_function(
         PermissionDeniedError: If the driver reports a permission error.
     """
     schema, fn_name = parse_qualified_name(qualified, kind="function")
-    validate_identifier(schema)
-    validate_identifier(fn_name)
-    validate_identifier(target_schema)
 
-    await _alter_schema_transfer(
+    return await _transfer_object(
         target,
         source_schema=schema,
         object_name=fn_name,
         target_schema=target_schema,
+        object_label="function",
+        fetch=lambda: get_function(target, target_schema, fn_name, mode=mode),
         mode=mode,
     )
-
-    try:
-        return await get_function(target, target_schema, fn_name, mode=mode)
-    except NotFoundError:
-        msg = (
-            f"No function named [{target_schema}].[{fn_name}] was found after "
-            "the transfer. ALTER SCHEMA TRANSFER moves any schema-scoped "
-            "object with that name, not only functions -- if a table, view, "
-            "or procedure shared this name, check whether it was moved instead."
-        )
-        raise NotFoundError(msg) from None
 
 
 async def drop_function(

--- a/src/fabric_dw/services/procedures.py
+++ b/src/fabric_dw/services/procedures.py
@@ -29,7 +29,7 @@ from fabric_dw.auth import CredentialMode
 from fabric_dw.exceptions import NotFoundError
 from fabric_dw.identifiers import parse_qualified_name, quote_identifier, validate_identifier
 from fabric_dw.models import StoredProcedure
-from fabric_dw.services._helpers import _alter_schema_transfer
+from fabric_dw.services._helpers import _transfer_object
 from fabric_dw.sql import SqlTarget, run_query
 
 __all__ = [
@@ -364,25 +364,13 @@ async def transfer_procedure(
         PermissionDeniedError: If the driver reports a permission error.
     """
     schema, procedure_name = parse_qualified_name(qualified)
-    validate_identifier(schema)
-    validate_identifier(procedure_name)
-    validate_identifier(target_schema)
 
-    await _alter_schema_transfer(
+    return await _transfer_object(
         target,
         source_schema=schema,
         object_name=procedure_name,
         target_schema=target_schema,
+        object_label="procedure",
+        fetch=lambda: get_procedure(target, target_schema, procedure_name, mode=mode),
         mode=mode,
     )
-
-    try:
-        return await get_procedure(target, target_schema, procedure_name, mode=mode)
-    except NotFoundError:
-        msg = (
-            f"No procedure named [{target_schema}].[{procedure_name}] was found after "
-            "the transfer. ALTER SCHEMA TRANSFER moves any schema-scoped "
-            "object with that name, not only procedures -- if a table, view, "
-            "or function shared this name, check whether it was moved instead."
-        )
-        raise NotFoundError(msg) from None

--- a/src/fabric_dw/services/tables.py
+++ b/src/fabric_dw/services/tables.py
@@ -48,9 +48,9 @@ from fabric_dw.models import (
     WarehouseKind,
 )
 from fabric_dw.services._helpers import (
-    _alter_schema_transfer,
     _assert_not_sql_endpoint,
     _format_ms_literal,
+    _transfer_object,
     build_time_travel_option,
     coerce_to_utc,
     reject_non_select,
@@ -1348,28 +1348,16 @@ async def transfer_table(
     _assert_not_sql_endpoint(kind)
 
     schema, table_name = parse_qualified_name(qualified)
-    validate_identifier(schema)
-    validate_identifier(table_name)
-    validate_identifier(target_schema)
 
-    await _alter_schema_transfer(
+    return await _transfer_object(
         target,
         source_schema=schema,
         object_name=table_name,
         target_schema=target_schema,
+        object_label="table",
+        fetch=lambda: _fetch_table(target, target_schema, table_name, mode=mode),
         mode=mode,
     )
-
-    try:
-        return await _fetch_table(target, target_schema, table_name, mode=mode)
-    except NotFoundError:
-        msg = (
-            f"No table named [{target_schema}].[{table_name}] was found after "
-            "the transfer. ALTER SCHEMA TRANSFER moves any schema-scoped "
-            "object with that name, not only tables -- if a view, function, "
-            "or procedure shared this name, check whether it was moved instead."
-        )
-        raise NotFoundError(msg) from None
 
 
 # ---------------------------------------------------------------------------

--- a/src/fabric_dw/services/views.py
+++ b/src/fabric_dw/services/views.py
@@ -26,7 +26,7 @@ from fabric_dw.exceptions import NotFoundError
 from fabric_dw.identifiers import parse_qualified_name, quote_identifier, validate_identifier
 from fabric_dw.models import View
 from fabric_dw.services._helpers import (
-    _alter_schema_transfer,
+    _transfer_object,
     build_time_travel_option,
     reject_non_select,
 )
@@ -641,25 +641,13 @@ async def transfer_view(
         PermissionDeniedError: If the driver reports a permission error.
     """
     schema, view_name = parse_qualified_name(qualified)
-    validate_identifier(schema)
-    validate_identifier(view_name)
-    validate_identifier(target_schema)
 
-    await _alter_schema_transfer(
+    return await _transfer_object(
         target,
         source_schema=schema,
         object_name=view_name,
         target_schema=target_schema,
+        object_label="view",
+        fetch=lambda: get_view(target, target_schema, view_name, mode=mode),
         mode=mode,
     )
-
-    try:
-        return await get_view(target, target_schema, view_name, mode=mode)
-    except NotFoundError:
-        msg = (
-            f"No view named [{target_schema}].[{view_name}] was found after "
-            "the transfer. ALTER SCHEMA TRANSFER moves any schema-scoped "
-            "object with that name, not only views -- if a table, function, "
-            "or procedure shared this name, check whether it was moved instead."
-        )
-        raise NotFoundError(msg) from None

--- a/tests/unit/services/test_helpers.py
+++ b/tests/unit/services/test_helpers.py
@@ -7,11 +7,14 @@ from unittest.mock import patch
 
 import pytest
 
-from fabric_dw.exceptions import ItemKindError
+from fabric_dw.exceptions import ItemKindError, NotFoundError
 from fabric_dw.models import WarehouseKind
 from fabric_dw.services._helpers import (
     _alter_schema_transfer,
     _assert_not_sql_endpoint,
+    _other_object_labels_phrase,
+    _transfer_object,
+    _TransferableObjectLabel,
     build_time_travel_option,
     coerce_to_utc,
     compact,
@@ -310,6 +313,105 @@ class TestAlterSchemaTransfer:
                 target_schema="sys",
             )
         mock_open.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _other_object_labels_phrase / _transfer_object
+# ---------------------------------------------------------------------------
+
+
+class TestOtherObjectLabelsPhrase:
+    """_other_object_labels_phrase builds the "not only X -- if ..." enumeration."""
+
+    @pytest.mark.parametrize(
+        ("object_label", "expected"),
+        [
+            ("table", "a view, function, or procedure"),
+            ("view", "a table, function, or procedure"),
+            ("function", "a table, view, or procedure"),
+            ("procedure", "a table, view, or function"),
+        ],
+    )
+    def test_renders_the_other_three_labels(
+        self, object_label: _TransferableObjectLabel, expected: str
+    ) -> None:
+        assert _other_object_labels_phrase(object_label) == expected
+
+    def test_rejects_unknown_label(self) -> None:
+        """A label outside _TRANSFERABLE_OBJECT_LABELS must fail loudly rather
+        than silently keeping all four entries and rendering a wrong list.
+        """
+        with pytest.raises(ValueError, match="Unknown object_label"):
+            _other_object_labels_phrase("Table")  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+
+
+class TestTransferObjectNotFoundMessage:
+    """_transfer_object's post-transfer NotFoundError message, pinned in full.
+
+    These assert the COMPLETE message string (not just a substring) for every
+    object kind, so the exact wording -- the Oxford comma, the "--", and the
+    pluralisation -- can never silently drift.  This is the text every
+    transfer_* function in tables.py/views.py/functions.py/procedures.py
+    relied on before the #950 consolidation; the values below were
+    reconstructed from the pre-refactor source to confirm byte-for-byte
+    equivalence.
+    """
+
+    @pytest.mark.parametrize(
+        ("object_label", "expected"),
+        [
+            (
+                "table",
+                "No table named [archive].[sales] was found after the transfer. "
+                "ALTER SCHEMA TRANSFER moves any schema-scoped object with that "
+                "name, not only tables -- if a view, function, or procedure "
+                "shared this name, check whether it was moved instead.",
+            ),
+            (
+                "view",
+                "No view named [archive].[sales] was found after the transfer. "
+                "ALTER SCHEMA TRANSFER moves any schema-scoped object with that "
+                "name, not only views -- if a table, function, or procedure "
+                "shared this name, check whether it was moved instead.",
+            ),
+            (
+                "function",
+                "No function named [archive].[sales] was found after the transfer. "
+                "ALTER SCHEMA TRANSFER moves any schema-scoped object with that "
+                "name, not only functions -- if a table, view, or procedure "
+                "shared this name, check whether it was moved instead.",
+            ),
+            (
+                "procedure",
+                "No procedure named [archive].[sales] was found after the transfer. "
+                "ALTER SCHEMA TRANSFER moves any schema-scoped object with that "
+                "name, not only procedures -- if a table, view, or function "
+                "shared this name, check whether it was moved instead.",
+            ),
+        ],
+    )
+    async def test_pins_full_message_per_object_label(
+        self, object_label: _TransferableObjectLabel, expected: str
+    ) -> None:
+        target = _make_target()
+        conn = _make_conn_for_ddl()
+
+        async def _raise_not_found() -> None:
+            raise NotFoundError("not found")
+
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(NotFoundError) as excinfo,
+        ):
+            await _transfer_object(
+                target,
+                source_schema="dbo",
+                object_name="sales",
+                target_schema="archive",
+                object_label=object_label,
+                fetch=_raise_not_found,
+            )
+        assert str(excinfo.value) == expected
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

All four `transfer_*` service functions (`transfer_table`, `transfer_view`, `transfer_function`, `transfer_procedure`) repeated, near-verbatim, two pieces of boilerplate around the shared `_alter_schema_transfer` helper, flagged by reviewers on #947 and #948 and deferred to this follow-up:

1. Caller-side `validate_identifier(...)` calls on the parsed source schema / object name -- redundant, since `_alter_schema_transfer` already validates all three identifiers.
2. The post-transfer `NotFoundError` wrapping message ("ALTER SCHEMA TRANSFER OBJECT:: moves any schema-scoped object sharing that name, not only `<object>`, so ...") -- copied four times with only the noun and the "other three" list differing.

This PR factors both into a single new helper, `_transfer_object`, defined right next to `_alter_schema_transfer` in `src/fabric_dw/services/_helpers.py`. It runs the transfer DDL, then calls a caller-supplied zero-arg `fetch` closure to re-fetch the moved object, wrapping `NotFoundError` with a message built from a shared template parameterized by `object_label` ("table"/"view"/"function"/"procedure"). The "not only X -- if Y, Z, or W ..." enumeration is generated from a single canonical `_TRANSFERABLE_OBJECT_LABELS` order so the four rendered messages can never drift apart again.

Each `transfer_*` function is now a thin call into `_transfer_object`:
- `transfer_table` keeps its `_assert_not_sql_endpoint` Warehouse-only guard before calling the shared helper.
- `transfer_view` / `transfer_function` / `transfer_procedure` keep no guard, unchanged.
- `parse_qualified_name(qualified, ...)` (including `transfer_function`'s `kind="function"` customization) stays caller-side, since it is unrelated to the two flagged duplications and produces a different error message per object.

## Behaviour

No user-visible behaviour change:
- Emitted DDL is byte-for-byte identical (`ALTER SCHEMA [...] TRANSFER OBJECT::[...].[...]`).
- Every `NotFoundError` message renders to the exact same text as before per object kind.
- Identifier validation still happens for all three identifiers, just inside `_alter_schema_transfer` (called via `_transfer_object`) instead of redundantly on the caller side first.
- `sql_errors.py` / `_NOT_FOUND_FRAGMENTS` are untouched.
- No SQL parsing introduced.

The existing unit tests in `tests/unit/services/test_{tables,views,functions,procedures}.py` and `tests/unit/services/test_helpers.py` pass unmodified -- no test changes were needed.

## Test plan

- [x] `ruff check .`
- [x] `ruff format --check .`
- [x] `ty check src tests`
- [x] `uv run pytest tests/unit` (5750 passed, 2 deselected)
- [ ] No integration tests triggered (per repo policy, run manually on main)

Closes #950

🤖 Generated with [Claude Code](https://claude.com/claude-code)