### PR TITLE
test(integration): make time-travel reads and point-in-time clone deterministic

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -5,6 +5,7 @@ import os
 import time
 import uuid
 from collections.abc import AsyncIterator
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, NamedTuple
 from uuid import UUID
 
@@ -75,6 +76,34 @@ _SNAP_SQL_READINESS_POLL_S = 5.0
 # Dual-target mutating tests MUST use the ``mutable_schema_target`` fixture;
 # ``warehouse_schema`` is for DWH-only DDL (e.g. tables) only.
 SEED_SCHEMA_NAME = "sample"
+
+
+def get_server_timestamp(target: SqlTarget) -> datetime:
+    """Return a UTC-aware server-side timestamp via ``SELECT SYSUTCDATETIME()``.
+
+    Capturing the timestamp from the same server the test will read/clone
+    against avoids client/server clock skew: a client clock that trails the
+    server could make an ``as_of``/``AT`` value appear to be *before* an
+    object's creation time, and a client clock that leads the server could
+    make it appear to be in the server's near-future.
+
+    This is synchronous (TDS), so async callers must offload it via
+    ``asyncio.to_thread``.  Shared by the time-travel (``as_of=``) and
+    point-in-time clone (``AT``) integration tests in
+    ``test_services_tables.py`` to avoid duplicating the UTC-normalisation
+    logic across call sites; ``test_services_views.py`` has an
+    as-yet-unconsolidated analog of the same logic (``_get_server_ts``).
+    """
+    _, rows = run_query(target, "SELECT SYSUTCDATETIME() AS ts")
+    raw = rows[0][0]
+    # mssql_python returns datetime objects; ensure timezone-aware UTC.
+    if isinstance(raw, datetime):
+        return raw.replace(tzinfo=UTC) if raw.tzinfo is None else raw.astimezone(UTC)
+    # Fallback: parse ISO string if the driver returns a string.  Attach UTC
+    # only if the parsed datetime is naive; if it already carries an offset,
+    # convert instead so the offset is not silently discarded.
+    parsed = datetime.fromisoformat(str(raw))
+    return parsed.replace(tzinfo=UTC) if parsed.tzinfo is None else parsed.astimezone(UTC)
 
 
 class SharedWarehouseTarget(NamedTuple):

--- a/tests/integration/test_services_tables.py
+++ b/tests/integration/test_services_tables.py
@@ -28,7 +28,7 @@ from pathlib import Path
 import pyarrow.parquet as pq
 import pytest
 
-from fabric_dw.exceptions import FabricError, FabricServerError, NotFoundError
+from fabric_dw.exceptions import FabricServerError, NotFoundError
 from fabric_dw.models import Table
 from fabric_dw.services import columns as columns_svc
 from fabric_dw.services import schemas as schemas_svc
@@ -74,24 +74,6 @@ async def test_get_table_columns_on_seeded_table(
     assert len(result) == 2
     col_names = {c["name"] for c in result}
     assert col_names == {"id", "name"}
-
-
-# ---------------------------------------------------------------------------
-# Fragments that indicate the SQL engine rejected an AT timestamp because the
-# table has no committed history at the requested point in time.  These are
-# expected and trigger a pytest.skip rather than a test failure.
-_CLONE_AT_SKIP_FRAGMENTS = (
-    ("clone", "point in time"),
-    ("no version",),
-    ("history",),
-    ("at time",),
-)
-
-
-def _is_clone_at_unavailable(exc: BaseException) -> bool:
-    """Return True when *exc* is a SQL engine rejection of an AT timestamp."""
-    msg = str(exc).lower()
-    return any(all(frag in msg for frag in frags) for frags in _CLONE_AT_SKIP_FRAGMENTS)
 
 
 async def test_list_tables_returns_list(
@@ -177,17 +159,19 @@ async def test_clone_table_at_point_in_time(
 ) -> None:
     """clone_table with AT timestamp clones the table at the specified point in time.
 
-    The AT timestamp must be >= the object creation time and <= the clone
-    transaction time.  We capture the timestamp via ``SELECT SYSUTCDATETIME()``
-    executed against the same server AFTER the table is created.  This
-    eliminates client/server clock skew (the server timestamp is always >= the
-    DDL commit on the same server) and ensures the AT is in the past relative to
-    the subsequent clone transaction.
-
-    If the engine rejects the timestamp because the table has no committed
-    history at the requested point (e.g. some engines require a version to
-    have been committed *before* the AT time), the test is skipped rather than
-    failed, as this is an expected engine limitation for freshly-created tables.
+    CLONE OF ... AT is Warehouse-only and is governed by the same automatic,
+    from-creation time-travel retention as the ``as_of`` read tests above (see
+    https://learn.microsoft.com/fabric/data-warehouse/clone-table
+    ?WT.mc_id=MVP_310840: "Warehouse in Microsoft Fabric automatically
+    preserves and maintains the data history").  The AT timestamp must be >=
+    the object creation time and <= the clone transaction time.  We capture
+    the timestamp via ``SELECT SYSUTCDATETIME()`` executed against the same
+    server AFTER the source table's CTAS has been awaited to completion (a
+    synchronous commit), which guarantees AT >= creation time, and the sleep
+    below guarantees AT < the clone transaction time.  With both bounds
+    satisfied there is no documented case where the engine still rejects the
+    timestamp, so this asserts directly with no skip: a failure here is a
+    real regression.
     """
     sql_target, schema = warehouse_schema
     source_name = "pytest_clone_at_source"
@@ -228,25 +212,12 @@ async def test_clone_table_at_point_in_time(
         # 5 s is comfortably larger than any observed inter-node clock skew.
         await asyncio.sleep(5)
 
-        try:
-            cloned = await tables.clone_table(
-                sql_target,
-                f"{schema}.{source_name}",
-                f"{schema}.{clone_name}",
-                at=at_dt,
-            )
-        except Exception as exc:
-            # A freshly-created table may have no committed history older than
-            # the AT timestamp; the engine raises a SQL error when the AT time
-            # predates any committed version.  Skip only for those expected
-            # SQL/driver rejections; re-raise Python-level bugs (TypeError etc.)
-            # so regressions are not silently hidden.
-            if not isinstance(exc, FabricError) and not _is_clone_at_unavailable(exc):
-                raise
-            pytest.skip(
-                f"Point-in-time clone not feasible on a freshly created table "
-                f"(no history at {at_dt.isoformat()}): {exc}"
-            )
+        cloned = await tables.clone_table(
+            sql_target,
+            f"{schema}.{source_name}",
+            f"{schema}.{clone_name}",
+            at=at_dt,
+        )
 
         assert isinstance(cloned, Table)
         assert cloned.name == clone_name

--- a/tests/integration/test_services_tables.py
+++ b/tests/integration/test_services_tables.py
@@ -12,6 +12,10 @@ Fixture notes:
 - ``shared_sql_endpoint``: used for the SQL-endpoint-only ``get_table_health_metrics``
   test (``sp_get_table_health_metrics`` targets lakehouse Delta tables and is only
   available on SQL Analytics Endpoints, not on Data Warehouses).
+- ``shared_warehouse``: used directly (not via ``read_target``) for the time-travel
+  (``as_of=``) tests on the pre-seeded schema, which only run against the warehouse
+  because time travel is structurally unavailable on the hand-seeded SQL endpoint
+  table — see the comment block above those tests for details.
 """
 
 from __future__ import annotations
@@ -31,7 +35,7 @@ from fabric_dw.services import schemas as schemas_svc
 from fabric_dw.services import tables
 from fabric_dw.sql import SqlTarget, run_query
 
-from .conftest import SEED_SCHEMA_NAME, SharedSqlEndpointTarget
+from .conftest import SEED_SCHEMA_NAME, SharedSqlEndpointTarget, SharedWarehouseTarget
 
 pytestmark = pytest.mark.integration
 
@@ -417,37 +421,37 @@ async def test_count_table_rows_returns_nonnegative_int(
 # Time-travel: read_table and count_table_rows with as_of
 # ---------------------------------------------------------------------------
 #
-# The pre-seeded ``sample.colors`` table (created during session setup, well
-# before these tests run) provides stable, known-count data.  Using a "current"
-# timestamp as as_of is safe because the table has a long committed history.
+# These tests run against the WAREHOUSE ONLY (``shared_warehouse``, not the
+# dual-target ``read_target`` fixture).  The two Fabric surfaces have
+# structurally different time-travel availability:
 #
-# Caveats (expected server-side errors, not bugs):
+#   - Warehouse: every table is automatically versioned, and retention "begins
+#     automatically from the moment the warehouse is created" (default 30
+#     days, see https://learn.microsoft.com/fabric/data-warehouse/time-travel
+#     ?WT.mc_id=MVP_310840).  The pre-seeded sample.colors table is created
+#     during session setup, well before these tests run, so a "now" as_of
+#     timestamp is always within its committed history.  A failure here is a
+#     real regression, not an environment limitation, so these tests assert
+#     directly with no skip.
+#   - SQL analytics endpoint: time travel "is only enabled for SQL analytics
+#     endpoints created with the New metadata sync (preview) enabled" (same
+#     doc above).  The endpoint's sample.colors in this test suite is a
+#     hand-written minimal Delta table uploaded straight to OneLake (see
+#     ``_seed_lakehouse_sample_data`` in conftest.py), not a table produced by
+#     that metadata-sync path, so ``FOR TIMESTAMP AS OF`` structurally cannot
+#     succeed against it ("The object isn't versioned, so time travel isn't
+#     supported.").  There is no setup that would make this leg pass, so it is
+#     intentionally not exercised here rather than silently skipped per-test.
+#
+# Caveats that remain real, expected server-side errors on the warehouse leg
+# (not exercised by these tests, just documented):
 #   - A timestamp before the object's creation time raises a SQL error.
 #   - A timestamp outside the configured retention window (1-120 days, default
 #     30) raises a SQL error.
-#   - A freshly-created table may have no committed history at the requested
-#     point; this is tested in ``test_time_travel_on_fresh_table_*`` below and
-#     handled by a pytest.skip rather than a failure.
-
-# Fragments from SQL engine error messages that mean the requested timestamp has
-# no committed history for the object (expected on freshly-created tables).
-_TIME_TRAVEL_SKIP_FRAGMENTS = (
-    ("no version",),
-    ("history",),
-    ("at time",),
-    ("point in time",),
-    ("timestamp",),
-)
-
-
-def _is_time_travel_unavailable(exc: BaseException) -> bool:
-    """Return True when *exc* means no committed history exists at the requested timestamp."""
-    msg = str(exc).lower()
-    return any(all(frag in msg for frag in frags) for frags in _TIME_TRAVEL_SKIP_FRAGMENTS)
 
 
 async def test_read_table_with_as_of_returns_seeded_rows(
-    read_target: SqlTarget,
+    shared_warehouse: SharedWarehouseTarget,
 ) -> None:
     """read_table with as_of=now succeeds and returns the seeded rows.
 
@@ -455,91 +459,80 @@ async def test_read_table_with_as_of_returns_seeded_rows(
     that any current timestamp is guaranteed to be within its committed history.
     Proves that the generated OPTION (FOR TIMESTAMP AS OF ...) clause is
     syntactically and semantically accepted by the Fabric SQL engine end-to-end.
+    Warehouse-only: see the comment block above for why.
     """
+    sql_target = shared_warehouse.sql_target
     as_of = datetime.now(tz=UTC)
-    try:
-        result = await tables.read_table(
-            read_target, SEED_SCHEMA_NAME, "colors", count=10, as_of=as_of
-        )
-    except Exception as exc:
-        if _is_time_travel_unavailable(exc):
-            pytest.skip(f"No committed history at {as_of.isoformat()}: {exc}")
-        raise
+    result = await tables.read_table(sql_target, SEED_SCHEMA_NAME, "colors", count=10, as_of=as_of)
     assert "id" in result.columns
     assert "name" in result.columns
     assert len(result.rows) == 3  # Three seeded rows: red, green, blue
 
 
 async def test_count_table_rows_with_as_of_returns_seeded_count(
-    read_target: SqlTarget,
+    shared_warehouse: SharedWarehouseTarget,
 ) -> None:
     """count_table_rows with as_of=now succeeds and returns the seeded row count.
 
     Same guarantee as test_read_table_with_as_of_returns_seeded_rows: the
     pre-seeded sample.colors table has a long committed history, so any current
-    timestamp is a valid point-in-time anchor.
+    timestamp is a valid point-in-time anchor.  Warehouse-only: see the comment
+    block above for why.
     """
+    sql_target = shared_warehouse.sql_target
     as_of = datetime.now(tz=UTC)
-    try:
-        result = await tables.count_table_rows(read_target, SEED_SCHEMA_NAME, "colors", as_of=as_of)
-    except Exception as exc:
-        if _is_time_travel_unavailable(exc):
-            pytest.skip(f"No committed history at {as_of.isoformat()}: {exc}")
-        raise
+    result = await tables.count_table_rows(sql_target, SEED_SCHEMA_NAME, "colors", as_of=as_of)
     assert isinstance(result.row_count, int)
     assert result.row_count == 3  # Three seeded rows: red, green, blue
 
 
 async def test_read_table_as_of_matches_read_without_as_of(
-    read_target: SqlTarget,
+    shared_warehouse: SharedWarehouseTarget,
 ) -> None:
     """read_table with as_of=now returns the same data as read without as_of.
 
     Confirms the OPTION clause is non-destructive: for stable seeded data,
     a current point-in-time read must match a plain (latest) read.
+    Warehouse-only: see the comment block above for why.
     """
-    result_plain = await tables.read_table(read_target, SEED_SCHEMA_NAME, "colors", count=100)
+    sql_target = shared_warehouse.sql_target
+    result_plain = await tables.read_table(sql_target, SEED_SCHEMA_NAME, "colors", count=100)
     as_of = datetime.now(tz=UTC)
-    try:
-        result_timed = await tables.read_table(
-            read_target, SEED_SCHEMA_NAME, "colors", count=100, as_of=as_of
-        )
-    except Exception as exc:
-        if _is_time_travel_unavailable(exc):
-            pytest.skip(f"No committed history at {as_of.isoformat()}: {exc}")
-        raise
+    result_timed = await tables.read_table(
+        sql_target, SEED_SCHEMA_NAME, "colors", count=100, as_of=as_of
+    )
     assert result_plain.columns == result_timed.columns
     assert sorted(str(r) for r in result_plain.rows) == sorted(str(r) for r in result_timed.rows)
 
 
 async def test_count_table_rows_as_of_matches_count_without_as_of(
-    read_target: SqlTarget,
+    shared_warehouse: SharedWarehouseTarget,
 ) -> None:
-    """count_table_rows with as_of=now returns the same count as without as_of."""
-    result_plain = await tables.count_table_rows(read_target, SEED_SCHEMA_NAME, "colors")
+    """count_table_rows with as_of=now returns the same count as without as_of.
+
+    Warehouse-only: see the comment block above for why.
+    """
+    sql_target = shared_warehouse.sql_target
+    result_plain = await tables.count_table_rows(sql_target, SEED_SCHEMA_NAME, "colors")
     as_of = datetime.now(tz=UTC)
-    try:
-        result_timed = await tables.count_table_rows(
-            read_target, SEED_SCHEMA_NAME, "colors", as_of=as_of
-        )
-    except Exception as exc:
-        if _is_time_travel_unavailable(exc):
-            pytest.skip(f"No committed history at {as_of.isoformat()}: {exc}")
-        raise
+    result_timed = await tables.count_table_rows(
+        sql_target, SEED_SCHEMA_NAME, "colors", as_of=as_of
+    )
     assert result_plain.row_count == result_timed.row_count
 
 
 async def test_time_travel_on_fresh_table_read(
     warehouse_schema: tuple[SqlTarget, str],
 ) -> None:
-    """read_table with as_of set to a server-side timestamp (after DDL) succeeds or skips.
+    """read_table with as_of set to a server-side timestamp (after DDL) returns the seeded rows.
 
-    A freshly-created table may have no committed version visible at the
-    captured server timestamp (Fabric distributed compute may not have flushed
-    the write to the time-travel history yet).  The test skips rather than fails
-    in that case, because the server-side rejection is expected behavior, not a
-    code bug.  When the table DOES have a committed history, the call must return
-    the seeded rows.
+    The server-side timestamp is captured via ``SYSUTCDATETIME()`` AFTER the
+    CTAS that creates the table has been awaited to completion, so the as_of
+    is guaranteed to be at or after the commit.  Warehouse DDL commits are
+    synchronous (the CTAS statement does not return until committed) and
+    warehouse time travel has no separate propagation delay documented by
+    Microsoft Learn, so this is deterministic, not a "succeeds or skips"
+    scenario: a failure here means a real regression.
     """
     sql_target, schema = warehouse_schema
     table_name = "pytest_timetravel_read"
@@ -560,15 +553,7 @@ async def test_time_travel_on_fresh_table_read(
 
         as_of: datetime = await asyncio.to_thread(_get_server_ts)
 
-        try:
-            result = await tables.read_table(sql_target, schema, table_name, count=10, as_of=as_of)
-        except Exception as exc:
-            if _is_time_travel_unavailable(exc) or isinstance(exc, FabricError):
-                pytest.skip(
-                    f"No committed history at {as_of.isoformat()} for a freshly-created "
-                    f"table (expected on distributed compute): {exc}"
-                )
-            raise
+        result = await tables.read_table(sql_target, schema, table_name, count=10, as_of=as_of)
         assert len(result.rows) == 2
     finally:
         with contextlib.suppress(Exception):
@@ -578,9 +563,9 @@ async def test_time_travel_on_fresh_table_read(
 async def test_time_travel_on_fresh_table_count(
     warehouse_schema: tuple[SqlTarget, str],
 ) -> None:
-    """count_table_rows with as_of set to a server-side timestamp succeeds or skips.
+    """count_table_rows with as_of set to a server-side timestamp returns the seeded count.
 
-    Same freshly-created-table caveat as test_time_travel_on_fresh_table_read.
+    Same determinism rationale as test_time_travel_on_fresh_table_read.
     """
     sql_target, schema = warehouse_schema
     table_name = "pytest_timetravel_count"
@@ -599,15 +584,7 @@ async def test_time_travel_on_fresh_table_count(
 
         as_of: datetime = await asyncio.to_thread(_get_server_ts)
 
-        try:
-            result = await tables.count_table_rows(sql_target, schema, table_name, as_of=as_of)
-        except Exception as exc:
-            if _is_time_travel_unavailable(exc) or isinstance(exc, FabricError):
-                pytest.skip(
-                    f"No committed history at {as_of.isoformat()} for a freshly-created "
-                    f"table (expected on distributed compute): {exc}"
-                )
-            raise
+        result = await tables.count_table_rows(sql_target, schema, table_name, as_of=as_of)
         assert result.row_count == 3
     finally:
         with contextlib.suppress(Exception):

--- a/tests/integration/test_services_tables.py
+++ b/tests/integration/test_services_tables.py
@@ -22,8 +22,10 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-from datetime import UTC, datetime
+import time
+from collections.abc import Awaitable, Callable
 from pathlib import Path
+from typing import TypeVar
 
 import pyarrow.parquet as pq
 import pytest
@@ -33,9 +35,16 @@ from fabric_dw.models import Table
 from fabric_dw.services import columns as columns_svc
 from fabric_dw.services import schemas as schemas_svc
 from fabric_dw.services import tables
-from fabric_dw.sql import SqlTarget, run_query
+from fabric_dw.sql import SqlTarget
 
-from .conftest import SEED_SCHEMA_NAME, SharedSqlEndpointTarget, SharedWarehouseTarget
+from .conftest import (
+    SEED_SCHEMA_NAME,
+    SharedSqlEndpointTarget,
+    SharedWarehouseTarget,
+    get_server_timestamp,
+)
+
+_T = TypeVar("_T")
 
 pytestmark = pytest.mark.integration
 
@@ -189,20 +198,7 @@ async def test_clone_table_at_point_in_time(
         # Using a client-side timestamp risks client/server clock skew (~60ms)
         # where the client clock trails the server, making the AT appear to be
         # *before* the object was created from the server's perspective.
-        def _get_server_ts() -> datetime:
-            _, rows = run_query(sql_target, "SELECT SYSUTCDATETIME() AS ts")
-            raw = rows[0][0]
-            # mssql_python returns datetime objects; ensure timezone-aware UTC.
-            if isinstance(raw, datetime):
-                return raw.replace(tzinfo=UTC) if raw.tzinfo is None else raw.astimezone(UTC)
-            # Fallback: parse ISO string if the driver returns a string.
-            # Then attach UTC only if the parsed datetime is
-            # naive; if it already carries an offset, convert instead so the offset
-            # is not silently discarded.
-            parsed = datetime.fromisoformat(str(raw))
-            return parsed.replace(tzinfo=UTC) if parsed.tzinfo is None else parsed.astimezone(UTC)
-
-        at_dt: datetime = await asyncio.to_thread(_get_server_ts)
+        at_dt = await asyncio.to_thread(get_server_timestamp, sql_target)
 
         # Sleep so the upcoming clone transaction starts well after `at_dt`.
         # Without this buffer, Fabric's distributed compute can assign a
@@ -419,6 +415,12 @@ async def test_count_table_rows_returns_nonnegative_int(
 #   - A timestamp before the object's creation time raises a SQL error.
 #   - A timestamp outside the configured retention window (1-120 days, default
 #     30) raises a SQL error.
+#
+# All as_of timestamps below are captured via the shared
+# ``conftest.get_server_timestamp`` helper (``SELECT SYSUTCDATETIME()`` on
+# the target itself) rather than the client clock, so a CI runner clock that
+# runs ahead of the Fabric server can never push as_of into the server's
+# near-future.
 
 
 async def test_read_table_with_as_of_returns_seeded_rows(
@@ -433,7 +435,7 @@ async def test_read_table_with_as_of_returns_seeded_rows(
     Warehouse-only: see the comment block above for why.
     """
     sql_target = shared_warehouse.sql_target
-    as_of = datetime.now(tz=UTC)
+    as_of = await asyncio.to_thread(get_server_timestamp, sql_target)
     result = await tables.read_table(sql_target, SEED_SCHEMA_NAME, "colors", count=10, as_of=as_of)
     assert "id" in result.columns
     assert "name" in result.columns
@@ -451,7 +453,7 @@ async def test_count_table_rows_with_as_of_returns_seeded_count(
     block above for why.
     """
     sql_target = shared_warehouse.sql_target
-    as_of = datetime.now(tz=UTC)
+    as_of = await asyncio.to_thread(get_server_timestamp, sql_target)
     result = await tables.count_table_rows(sql_target, SEED_SCHEMA_NAME, "colors", as_of=as_of)
     assert isinstance(result.row_count, int)
     assert result.row_count == 3  # Three seeded rows: red, green, blue
@@ -468,7 +470,7 @@ async def test_read_table_as_of_matches_read_without_as_of(
     """
     sql_target = shared_warehouse.sql_target
     result_plain = await tables.read_table(sql_target, SEED_SCHEMA_NAME, "colors", count=100)
-    as_of = datetime.now(tz=UTC)
+    as_of = await asyncio.to_thread(get_server_timestamp, sql_target)
     result_timed = await tables.read_table(
         sql_target, SEED_SCHEMA_NAME, "colors", count=100, as_of=as_of
     )
@@ -485,11 +487,72 @@ async def test_count_table_rows_as_of_matches_count_without_as_of(
     """
     sql_target = shared_warehouse.sql_target
     result_plain = await tables.count_table_rows(sql_target, SEED_SCHEMA_NAME, "colors")
-    as_of = datetime.now(tz=UTC)
+    as_of = await asyncio.to_thread(get_server_timestamp, sql_target)
     result_timed = await tables.count_table_rows(
         sql_target, SEED_SCHEMA_NAME, "colors", as_of=as_of
     )
     assert result_plain.row_count == result_timed.row_count
+
+
+# ---------------------------------------------------------------------------
+# Time-travel: read_table and count_table_rows with as_of on a FRESH table
+# ---------------------------------------------------------------------------
+#
+# Unlike the long-lived seeded sample.colors above, these tables are created
+# moments before the as_of read.  The CTAS commit is synchronous and the
+# as_of timestamp is captured strictly after it, so in principle the read is
+# already deterministic.  As defense-in-depth against a theoretical (never
+# observed) just-after-commit propagation delay between the connection that
+# ran the CTAS and the connection that runs the as_of read, the read/count is
+# wrapped in a short, bounded retry: only the narrow "no committed
+# history/version yet" error shape is retried, anything else propagates
+# immediately, and the loop's last exception propagates (never a skip) once
+# the window is exhausted.  This keeps the assertion exactly as strong as a
+# plain call while removing the timing dependency as a source of flakiness.
+
+# Total time budget for the just-after-commit retry below.  Generous relative
+# to the empirically observed (~5s) inter-node clock skew bound used by
+# test_clone_table_at_point_in_time's sleep, while staying short enough that
+# a genuine regression still fails fast.
+_AS_OF_RETRY_TIMEOUT_S = 15.0
+# Delay between retry attempts.
+_AS_OF_RETRY_POLL_INTERVAL_S = 1.0
+
+# Fragments from SQL engine error messages that mean the requested as_of
+# timestamp has no committed history/version yet for the object.  Only these
+# are retried by _retry_until_queryable; every other error propagates on the
+# first attempt so a real bug fails immediately instead of waiting out the
+# whole retry window.
+_NOT_YET_QUERYABLE_FRAGMENTS = (
+    ("no version",),
+    ("history",),
+    ("at time",),
+    ("point in time",),
+    ("timestamp",),
+)
+
+
+def _is_not_yet_queryable(exc: BaseException) -> bool:
+    """Return True when *exc* means the as_of point in time has no committed history yet."""
+    msg = str(exc).lower()
+    return any(all(frag in msg for frag in frags) for frags in _NOT_YET_QUERYABLE_FRAGMENTS)
+
+
+async def _retry_until_queryable(call: Callable[[], Awaitable[_T]]) -> _T:
+    """Retry *call* until it succeeds or the bounded retry window elapses.
+
+    Only retries on :func:`_is_not_yet_queryable` errors; any other exception
+    (a real bug, a permission error, etc.) is re-raised immediately.  Once the
+    window is exhausted the last exception propagates -- this never skips.
+    """
+    deadline = time.monotonic() + _AS_OF_RETRY_TIMEOUT_S
+    while True:
+        try:
+            return await call()
+        except Exception as exc:
+            if not _is_not_yet_queryable(exc) or time.monotonic() >= deadline:
+                raise
+            await asyncio.sleep(_AS_OF_RETRY_POLL_INTERVAL_S)
 
 
 async def test_time_travel_on_fresh_table_read(
@@ -497,13 +560,10 @@ async def test_time_travel_on_fresh_table_read(
 ) -> None:
     """read_table with as_of set to a server-side timestamp (after DDL) returns the seeded rows.
 
-    The server-side timestamp is captured via ``SYSUTCDATETIME()`` AFTER the
-    CTAS that creates the table has been awaited to completion, so the as_of
-    is guaranteed to be at or after the commit.  Warehouse DDL commits are
-    synchronous (the CTAS statement does not return until committed) and
-    warehouse time travel has no separate propagation delay documented by
-    Microsoft Learn, so this is deterministic, not a "succeeds or skips"
-    scenario: a failure here means a real regression.
+    The server-side timestamp is captured via ``get_server_timestamp`` AFTER
+    the CTAS that creates the table has been awaited to completion, so the
+    as_of is guaranteed to be at or after the commit.  See the comment block
+    above this test group for the bounded-retry rationale.
     """
     sql_target, schema = warehouse_schema
     table_name = "pytest_timetravel_read"
@@ -514,17 +574,11 @@ async def test_time_travel_on_fresh_table_read(
 
         # Capture a server-side timestamp after the DDL commit to avoid
         # client/server clock skew (same technique as test_clone_table_at_point_in_time).
-        def _get_server_ts() -> datetime:
-            _, rows = run_query(sql_target, "SELECT SYSUTCDATETIME() AS ts")
-            raw = rows[0][0]
-            if isinstance(raw, datetime):
-                return raw.replace(tzinfo=UTC) if raw.tzinfo is None else raw.astimezone(UTC)
-            parsed = datetime.fromisoformat(str(raw))
-            return parsed.replace(tzinfo=UTC) if parsed.tzinfo is None else parsed.astimezone(UTC)
+        as_of = await asyncio.to_thread(get_server_timestamp, sql_target)
 
-        as_of: datetime = await asyncio.to_thread(_get_server_ts)
-
-        result = await tables.read_table(sql_target, schema, table_name, count=10, as_of=as_of)
+        result = await _retry_until_queryable(
+            lambda: tables.read_table(sql_target, schema, table_name, count=10, as_of=as_of)
+        )
         assert len(result.rows) == 2
     finally:
         with contextlib.suppress(Exception):
@@ -545,17 +599,11 @@ async def test_time_travel_on_fresh_table_count(
     try:
         await tables.create_table(sql_target, schema, table_name, select_body)
 
-        def _get_server_ts() -> datetime:
-            _, rows = run_query(sql_target, "SELECT SYSUTCDATETIME() AS ts")
-            raw = rows[0][0]
-            if isinstance(raw, datetime):
-                return raw.replace(tzinfo=UTC) if raw.tzinfo is None else raw.astimezone(UTC)
-            parsed = datetime.fromisoformat(str(raw))
-            return parsed.replace(tzinfo=UTC) if parsed.tzinfo is None else parsed.astimezone(UTC)
+        as_of = await asyncio.to_thread(get_server_timestamp, sql_target)
 
-        as_of: datetime = await asyncio.to_thread(_get_server_ts)
-
-        result = await tables.count_table_rows(sql_target, schema, table_name, as_of=as_of)
+        result = await _retry_until_queryable(
+            lambda: tables.count_table_rows(sql_target, schema, table_name, as_of=as_of)
+        )
         assert result.row_count == 3
     finally:
         with contextlib.suppress(Exception):


### PR DESCRIPTION
## Summary

Same class of fix as the recent REVOKE GRANT OPTION fix: a test that can never pass under its setup must run deterministically or be restricted, not silently skip. This PR fixes two such cases in `tests/integration/test_services_tables.py`, then hardens both against review feedback.

### 1. Time-travel (`as_of=`) reads on the pre-seeded schema

The seeded-table as_of tests (`test_read_table_with_as_of_returns_seeded_rows`, `test_count_table_rows_with_as_of_returns_seeded_count`, `test_read_table_as_of_matches_read_without_as_of`, `test_count_table_rows_as_of_matches_count_without_as_of`) ran on both the warehouse and the SQL analytics endpoint via the dual `read_target` fixture, with a `pytest.skip` whenever `_is_time_travel_unavailable` matched the error message. One of these skips was hit on the SQL-endpoint leg with: `The object isn't versioned, so time travel isn't supported. Remove the query hint 'FOR TIMESTAMP AS OF' or specify a versioned object.`

Per [Microsoft Learn](https://learn.microsoft.com/fabric/data-warehouse/time-travel?WT.mc_id=MVP_310840), this is not a flaky prerequisite miss, it is structural:

- **Warehouse**: every table is automatically versioned, and retention "begins automatically from the moment the warehouse is created" (default 30 days). The pre-seeded `sample.colors` table is created during session setup, well before these tests run, so any `as_of=now()` is always within committed history. A failure on the warehouse leg is a real regression, never an environment limitation.
- **SQL analytics endpoint**: "time travel for SQL analytics endpoints is only enabled for SQL analytics endpoints created with the [New metadata sync (preview)](https://learn.microsoft.com/fabric/data-engineering/sql-analytics-endpoint-metadata-sync?WT.mc_id=MVP_310840) enabled." This suite's `sample.colors`/`sample.numbers` on the endpoint is a hand-written minimal Delta table uploaded straight to OneLake (`_seed_lakehouse_sample_data` in `conftest.py`), not a table produced by that metadata-sync path. There is no setup that would make `FOR TIMESTAMP AS OF` succeed against it, so this leg can effectively only ever skip.

Changes:
- Switched the 4 seeded-table tests from the dual `read_target` fixture to `shared_warehouse` directly (warehouse-only, matching the existing pattern used by `test_services_settings.py` / `test_services_sql_plan.py`), and removed the `try/except _is_time_travel_unavailable -> pytest.skip` wrapper so each test asserts directly. A new comment block explains the warehouse-vs-endpoint distinction with the MS Learn citations above.
- The fresh-table as_of tests (`test_time_travel_on_fresh_table_read` / `_count`) previously skipped on `_is_time_travel_unavailable(exc) OR isinstance(exc, FabricError)`, a blanket condition that swallowed any server-side error, real bugs included. Converted both to plain deterministic assertions with no skip: the server-side timestamp is captured after the CTAS that creates the table has been awaited to completion, and warehouse DDL commits are synchronous (the CTAS statement does not return until committed), with no separate propagation delay documented for warehouse time travel.
- `_is_time_travel_unavailable` and `_TIME_TRAVEL_SKIP_FRAGMENTS` had no remaining callers and were removed.

### 2. Point-in-time table clone (`clone_table(..., at=...)`)

`test_clone_table_at_point_in_time` had the identical blanket-swallow shape in a separate helper:

```python
if not isinstance(exc, FabricError) and not _is_clone_at_unavailable(exc):
    raise
pytest.skip(...)
```

By De Morgan's, this skips whenever `isinstance(exc, FabricError)` is true, regardless of `_is_clone_at_unavailable`, i.e. it swallowed essentially any server-side error during the point-in-time clone, not just the narrow "no committed history" case.

`CREATE TABLE AS CLONE OF ... AT` is [Warehouse-only and relies on the same automatic, from-creation time-travel retention](https://learn.microsoft.com/fabric/data-warehouse/clone-table?WT.mc_id=MVP_310840) as the as_of reads above. The test already captures the AT timestamp via a server-side timestamp after the source table's CTAS is awaited to completion (guaranteeing AT >= creation time) and already sleeps 5s before issuing the clone (guaranteeing AT < the clone transaction time). With both documented bounds satisfied, there is no remaining case where the engine should reject the timestamp, so this is converted to a plain deterministic assertion with no skip, mirroring the fresh-table fix above.

`_is_clone_at_unavailable` and `_CLONE_AT_SKIP_FRAGMENTS` had no remaining callers and were removed, along with the now-unused `FabricError` import.

### 3. Hardening from review feedback

- The two fresh-table as_of tests (`test_time_travel_on_fresh_table_read`/`_count`) had no buffer at all after removing the skip, so a transient just-after-commit propagation delay (never observed, but theoretically possible) would have hard-failed CI indistinguishably from a real regression. They now wrap the as_of call in a bounded retry (`_retry_until_queryable`: 15s total budget, 1s poll interval) that only retries the narrow "no committed history/version yet" error shape; any other exception propagates immediately, and once the window is exhausted the last exception propagates uncaught (never a skip). This keeps the assertions exactly as strong as before while removing the timing dependency. The long-lived seeded table was deliberately not reused here, that would lose fresh-write round-trip coverage.
- The four seeded-table as_of tests now capture `as_of` via a server-side `SELECT SYSUTCDATETIME()` instead of the client clock (`datetime.now(tz=UTC)`), removing the last client/server clock-skew dependency in this test group.
- The `_get_server_ts()` closure, previously duplicated in three places in this file, is now one shared `get_server_timestamp(target)` helper in `conftest.py` (next to `SEED_SCHEMA_NAME`), reused by the fresh-table tests, the clone test, and the four seeded tests. `test_services_views.py` has its own pre-existing analog (`_get_server_ts` at line 395) that was not touched, to keep this PR scoped to `test_services_tables.py`; flagging it as a follow-up candidate now that a shared helper exists.
- The clone test's `await asyncio.sleep(5)` is left intact, it is the intentional `AT < clone-transaction-time` guard, and is now by design the sole timing guard in that test.

## Test plan

- [x] `uv run pytest tests/integration/test_services_tables.py --collect-only -q` and `uv run pytest -m integration tests/integration/test_services_tables.py --collect-only -q` — 24 tests collect; the 4 seeded-table as_of tests are now unparametrized (warehouse-only, no `[sql_endpoint]`/`[warehouse]` variants)
- [x] `uv run pytest -m "integration or sql_endpoint" tests/integration --collect-only -q` — whole integration dir still collects (252 tests)
- [x] `uv run ruff check` / `uv run ruff format --check` on the changed files and the whole `tests/integration/` dir — clean
- [x] `uv run ty check` on the changed files and the whole `tests/integration/` dir — clean
- [ ] Live integration run (no creds available in this environment; run on main per project convention)

🤖 Generated with [Claude Code](https://claude.com/claude-code)