### PR TITLE
fix(ownership): detect ArtifactTakeOverNotAllowedByOwner from the real Fabric/PowerBI error envelope

### DIFF
--- a/src/fabric_dw/services/ownership.py
+++ b/src/fabric_dw/services/ownership.py
@@ -16,6 +16,37 @@ _TAKEOVER_HINT = "takeover requires Admin/Member/Contributor role on the workspa
 _ALREADY_OWNER_ERROR_CODE = "ArtifactTakeOverNotAllowedByOwner"
 
 
+def _fabric_error_code(body: dict[str, object] | None) -> str | None:
+    """Extract the error code from a Fabric or Power BI error envelope.
+
+    The core Fabric REST API puts the code at the top level
+    (``{"errorCode": "..."}``), while the legacy Power BI namespace used by
+    ``/takeover`` nests it under ``error`` (and mirrors it under
+    ``error["pbi.error"]``)::
+
+        {"error": {"code": "...", "pbi.error": {"code": "..."}}}
+
+    Checks the top-level key first, then falls back to the nested shapes.
+    Returns ``None`` if *body* is ``None`` or none of the keys are present.
+    """
+    if body is None:
+        return None
+    top_level = body.get("errorCode")
+    if isinstance(top_level, str):
+        return top_level
+    error = body.get("error")
+    if isinstance(error, dict):
+        code = error.get("code")
+        if isinstance(code, str):
+            return code
+        pbi_error = error.get("pbi.error")
+        if isinstance(pbi_error, dict):
+            pbi_code = pbi_error.get("code")
+            if isinstance(pbi_code, str):
+                return pbi_code
+    return None
+
+
 async def takeover(
     http: FabricHttpClient,
     workspace_id: UUID,
@@ -68,7 +99,7 @@ async def takeover(
         # Detect the "already owner" case: Fabric returns 403 with errorCode
         # ArtifactTakeOverNotAllowedByOwner when the caller already owns the item.
         # Surface a clear, accurate message instead of the generic role hint.
-        error_code = exc.body.get("errorCode") if exc.body is not None else None
+        error_code = _fabric_error_code(exc.body)
         if error_code == _ALREADY_OWNER_ERROR_CODE:
             raise PermissionDeniedError(
                 "You are already the owner of this warehouse; nothing to take over.",

--- a/src/fabric_dw/services/ownership.py
+++ b/src/fabric_dw/services/ownership.py
@@ -96,8 +96,10 @@ async def takeover(
     try:
         await http.request("POST", HttpBase.POWERBI, path, json=None)
     except PermissionDeniedError as exc:
-        # Detect the "already owner" case: Fabric returns 403 with errorCode
-        # ArtifactTakeOverNotAllowedByOwner when the caller already owns the item.
+        # Detect the "already owner" case: Fabric returns 403 with the
+        # ArtifactTakeOverNotAllowedByOwner code when the caller already owns
+        # the item. See _fabric_error_code() for the envelope shapes this
+        # code can be nested under.
         # Surface a clear, accurate message instead of the generic role hint.
         error_code = _fabric_error_code(exc.body)
         if error_code == _ALREADY_OWNER_ERROR_CODE:

--- a/tests/unit/services/test_ownership.py
+++ b/tests/unit/services/test_ownership.py
@@ -157,6 +157,52 @@ async def test_takeover_403_already_owner_top_level_error_code_shape() -> None:
 
 
 @respx.mock
+async def test_takeover_403_already_owner_pbi_error_fallback_shape() -> None:
+    """The ``error["pbi.error"]["code"]`` fallback is used when ``error.code`` is absent.
+
+    Exercises the fallback branch of ``_fabric_error_code`` directly: a body
+    where ``error`` has no ``code`` key but does carry a nested ``pbi.error.code``.
+    """
+    body = {
+        "error": {
+            "pbi.error": {
+                "code": _ALREADY_OWNER_ERROR_CODE,
+                "parameters": {"ErrorMessage": "Owner is not allowed to takeover"},
+            }
+        }
+    }
+    respx.post(_EXPECTED_URL).mock(return_value=respx.MockResponse(403, json=body))
+
+    async with FabricHttpClient(credential=_make_credential(), rps=10) as http:
+        with pytest.raises(PermissionDeniedError) as exc_info:
+            await takeover(http, _WORKSPACE_ID, _WAREHOUSE_ID)
+
+    error_text = str(exc_info.value)
+    assert "already the owner" in error_text
+    assert _TAKEOVER_HINT not in error_text
+
+
+@respx.mock
+async def test_takeover_403_no_recognisable_error_code_shows_role_hint() -> None:
+    """A body with no code at any known key falls through to the generic role hint.
+
+    Exercises the terminal ``return None`` of ``_fabric_error_code``: an
+    ``error`` dict with neither ``code`` nor ``pbi.error``, and no top-level
+    ``errorCode`` either.
+    """
+    body = {"error": {"message": "Something else went wrong."}}
+    respx.post(_EXPECTED_URL).mock(return_value=respx.MockResponse(403, json=body))
+
+    async with FabricHttpClient(credential=_make_credential(), rps=10) as http:
+        with pytest.raises(PermissionDeniedError) as exc_info:
+            await takeover(http, _WORKSPACE_ID, _WAREHOUSE_ID)
+
+    error_text = str(exc_info.value)
+    assert _TAKEOVER_HINT in error_text
+    assert "already the owner" not in error_text
+
+
+@respx.mock
 async def test_takeover_403_generic_still_shows_role_hint() -> None:
     """A generic HTTP 403 (not ArtifactTakeOverNotAllowedByOwner) still shows the role hint."""
     body = {"error": {"code": "Forbidden", "message": "Caller lacks the required role."}}

--- a/tests/unit/services/test_ownership.py
+++ b/tests/unit/services/test_ownership.py
@@ -103,10 +103,25 @@ async def test_takeover_sends_empty_body() -> None:
 async def test_takeover_403_already_owner_raises_clear_message() -> None:
     """HTTP 403 with ArtifactTakeOverNotAllowedByOwner -> clear 'already owner' message.
 
+    Uses the real error envelope returned by the legacy Power BI ``/takeover``
+    endpoint (see issue #955): the code is nested under ``error.code`` (and
+    mirrored under ``error["pbi.error"]["code"]``), NOT at the top level. A
+    body with only a top-level ``errorCode`` key would not reproduce the bug.
+
     The misleading role hint must NOT appear in the error; the caller is not
     missing a role — they already own the warehouse.
     """
-    body = {"errorCode": _ALREADY_OWNER_ERROR_CODE, "message": "Caller is already the owner."}
+    body = {
+        "error": {
+            "code": _ALREADY_OWNER_ERROR_CODE,
+            "pbi.error": {
+                "code": _ALREADY_OWNER_ERROR_CODE,
+                "parameters": {"ErrorMessage": "Owner is not allowed to takeover"},
+                "details": [],
+                "exceptionCulprit": 1,
+            },
+        }
+    }
     respx.post(_EXPECTED_URL).mock(return_value=respx.MockResponse(403, json=body))
 
     async with FabricHttpClient(credential=_make_credential(), rps=10) as http:
@@ -117,12 +132,34 @@ async def test_takeover_403_already_owner_raises_clear_message() -> None:
     assert "already the owner" in error_text
     # The generic role hint must NOT appear for this specific error code.
     assert _TAKEOVER_HINT not in error_text
+    # The raw REST URL and raw JSON body must not leak into the message.
+    assert _EXPECTED_URL not in error_text
+    assert "pbi.error" not in error_text
+
+
+@respx.mock
+async def test_takeover_403_already_owner_top_level_error_code_shape() -> None:
+    """A top-level ``errorCode`` (Fabric-REST style) is also recognised.
+
+    Defensive coverage: some Fabric endpoints return the code at the top
+    level instead of nested under ``error``. Both shapes must be detected.
+    """
+    body = {"errorCode": _ALREADY_OWNER_ERROR_CODE, "message": "Caller is already the owner."}
+    respx.post(_EXPECTED_URL).mock(return_value=respx.MockResponse(403, json=body))
+
+    async with FabricHttpClient(credential=_make_credential(), rps=10) as http:
+        with pytest.raises(PermissionDeniedError) as exc_info:
+            await takeover(http, _WORKSPACE_ID, _WAREHOUSE_ID)
+
+    error_text = str(exc_info.value)
+    assert "already the owner" in error_text
+    assert _TAKEOVER_HINT not in error_text
 
 
 @respx.mock
 async def test_takeover_403_generic_still_shows_role_hint() -> None:
     """A generic HTTP 403 (not ArtifactTakeOverNotAllowedByOwner) still shows the role hint."""
-    body = {"errorCode": "Forbidden", "message": "Caller lacks the required role."}
+    body = {"error": {"code": "Forbidden", "message": "Caller lacks the required role."}}
     respx.post(_EXPECTED_URL).mock(return_value=respx.MockResponse(403, json=body))
 
     async with FabricHttpClient(credential=_make_credential(), rps=10) as http:


### PR DESCRIPTION
## Summary
- `warehouses takeover` on a warehouse the caller already owns leaked a raw `HTTP 403 for <url>: <body>` message plus a misleading workspace-role hint, instead of the clean "already the owner" message the code already intended to produce.
- Root cause: the already-owner detection only checked a top-level `errorCode` key on the parsed response body. The legacy Power BI namespace used by the `/takeover` endpoint does not return that shape; it nests the code under `error.code` (mirrored under `error["pbi.error"]["code"]`), e.g.:
  ```json
  {"error":{"code":"ArtifactTakeOverNotAllowedByOwner","pbi.error":{"code":"ArtifactTakeOverNotAllowedByOwner","parameters":{"ErrorMessage":"Owner is not allowed to takeover"}}}}
  ```
  So the check never matched, and the generic 403 branch (raw URL/body + role hint) ran instead.
- The existing unit test was a false green: it mocked a body shape (`{"errorCode": ...}`) that this endpoint never actually returns.

## Changes
- `src/fabric_dw/services/ownership.py`: added `_fabric_error_code(body)`, a small helper that extracts the error code from either the top-level Fabric-REST shape or the nested Power BI shape, and used it in `takeover()`'s already-owner check.
- `tests/unit/services/test_ownership.py`: rewrote `test_takeover_403_already_owner_raises_clear_message` to use the real nested Power BI envelope from the bug report (plus assertions that the raw URL and raw body text do not leak into the message), added `test_takeover_403_already_owner_top_level_error_code_shape` for the other envelope shape, and adjusted the generic-403 test to use a nested-shape body with an unrelated code so it still exercises the "no match" path realistically.
- Scope kept narrow: the generic 403 message format (raw url + body) is unchanged and out of scope, per the linked issue.

## Test plan
- [x] `uv run pytest tests/unit/services/test_ownership.py tests/unit/cli/commands/test_warehouses.py tests/unit/mcp/tools/test_warehouses.py -q` - 69 passed
- [x] `uv run pytest tests/unit -q` - 5760 passed
- [x] `uv run ruff format .` - no changes
- [x] `uv run ruff check .` - all checks passed
- [x] `uv run ty check` - all checks passed

Closes #955

🤖 Generated with [Claude Code](https://claude.com/claude-code)