### PR TITLE
fix(tables): scope max-errors and cluster-by warnings to what users need

### DIFF
--- a/docs/commands/tables.md
+++ b/docs/commands/tables.md
@@ -84,7 +84,7 @@ Change (or remove) the data-clustering columns of an existing table via a transa
 
 !!! warning "Dependent views and stored procedures"
 
-    Dependent views and stored procedures that reference this table by name are **NOT** automatically updated by `sp_rename` and may need refreshing after the swap.
+    Dependent views and stored procedures that reference this table by name are **NOT** automatically updated by `sp_rename` and may need refreshing after the swap. The CLI checks for dependents via catalog metadata and only prints this warning when the table actually has some.
 
 The operation is atomic: all three steps run inside a single transaction. Any failure rolls back automatically - no orphan temp table is left behind.
 

--- a/docs/commands/tables.md
+++ b/docs/commands/tables.md
@@ -82,9 +82,9 @@ Change (or remove) the data-clustering columns of an existing table via a transa
 
 **Performance note:** This operation copies the entire table. Runtime is proportional to table size.
 
-!!! warning "Dependent views and stored procedures"
+!!! warning "Dependent objects"
 
-    Dependent views and stored procedures that reference this table by name are **NOT** automatically updated by `sp_rename` and may need refreshing after the swap. The CLI checks for dependents via catalog metadata and only prints this warning when the table actually has some.
+    Dependent objects (views, stored procedures, etc.) that reference this table by name are **NOT** automatically updated by `sp_rename` and may need refreshing after the swap. The CLI checks for dependents via catalog metadata (`sys.sql_expression_dependencies`) and only prints this warning when the table actually has some. That catalog view only tracks statically resolvable by-name references, so a dependent that reaches the table exclusively through dynamic SQL (`EXEC(...)` / `sp_executesql`) is not detected and produces no warning.
 
 The operation is atomic: all three steps run inside a single transaction. Any failure rolls back automatically - no orphan temp table is left behind.
 

--- a/src/fabric_dw/cli/commands/tables.py
+++ b/src/fabric_dw/cli/commands/tables.py
@@ -738,12 +738,20 @@ async def cluster_by_cmd(
             ):
                 click.echo("Aborted.")
                 return
-            click.echo(
-                "WARNING: Dependent views and stored procedures referencing this table "
-                "are NOT automatically updated by this CLUSTER BY rebuild (CTAS-swap) "
-                "and may need refreshing.",
-                err=True,
+            # #957: only warn when the table actually has dependents (checked via
+            # sys.sql_expression_dependencies, a parameterized metadata query — not
+            # SQL text parsing). A clean rebuild of a table with no dependents
+            # should produce no warning.
+            dependents = await _tables_svc.get_table_dependents(
+                target, schema, table_name, mode=ctx.auth
             )
+            if dependents:
+                click.echo(
+                    "WARNING: Dependent views and stored procedures referencing this table "
+                    "are NOT automatically updated by this CLUSTER BY rebuild (CTAS-swap) "
+                    "and may need refreshing: " + ", ".join(sorted(dependents)),
+                    err=True,
+                )
             t = await _tables_svc.recluster_table(
                 target,
                 schema,

--- a/src/fabric_dw/cli/commands/tables.py
+++ b/src/fabric_dw/cli/commands/tables.py
@@ -717,9 +717,15 @@ async def cluster_by_cmd(
     Omit --cluster-by entirely to remove clustering (rebuilds without CLUSTER BY).
 
     \b
-    WARNING: Dependent views and stored procedures that reference this table by
-    name are NOT automatically updated by this CLUSTER BY rebuild (which
-    recreates the table via CTAS and sp_rename) and may need refreshing.
+    WARNING: If this table has dependent objects (views, stored procedures,
+    etc. that reference it by name), a warning is printed before the rebuild —
+    those objects are NOT automatically updated by this CLUSTER BY rebuild
+    (which recreates the table via CTAS and sp_rename) and may need
+    refreshing. Dependents are detected via catalog metadata
+    (sys.sql_expression_dependencies), which only tracks statically
+    resolvable by-name references; a dependent that reaches this table only
+    through dynamic SQL (EXEC(...) / sp_executesql) will NOT be detected and
+    no warning will be printed for it.
 
     Only supported on Fabric Data Warehouses (not SQL Analytics Endpoints).
     This operation copies the full table — runtime is proportional to table size.
@@ -741,15 +747,17 @@ async def cluster_by_cmd(
             # #957: only warn when the table actually has dependents (checked via
             # sys.sql_expression_dependencies, a parameterized metadata query — not
             # SQL text parsing). A clean rebuild of a table with no dependents
-            # should produce no warning.
+            # should produce no warning. Passing kind short-circuits the query
+            # for SQL Analytics Endpoints (recluster_table rejects those anyway).
             dependents = await _tables_svc.get_table_dependents(
-                target, schema, table_name, mode=ctx.auth
+                target, schema, table_name, kind=entry.kind, mode=ctx.auth
             )
             if dependents:
                 click.echo(
-                    "WARNING: Dependent views and stored procedures referencing this table "
-                    "are NOT automatically updated by this CLUSTER BY rebuild (CTAS-swap) "
-                    "and may need refreshing: " + ", ".join(sorted(dependents)),
+                    "WARNING: Dependent objects referencing this table by name "
+                    "(views, stored procedures, etc.) are NOT automatically updated "
+                    "by this CLUSTER BY rebuild (CTAS-swap) and may need refreshing: "
+                    + ", ".join(sorted(dependents)),
                     err=True,
                 )
             t = await _tables_svc.recluster_table(

--- a/src/fabric_dw/services/load.py
+++ b/src/fabric_dw/services/load.py
@@ -714,10 +714,13 @@ async def copy_into_from_url(
     # "Option 'MAXERRORS' is not supported for specified format 'PARQUET'".
     # Clear the value here (defence-in-depth alongside the gate in
     # _build_copy_into_sql) so every caller — local-file and URL — is covered.
+    # The message stays format-neutral (never "Parquet") and drops the internal
+    # function-name prefix (#956): a --format json load stages as Parquet
+    # internally, but that implementation detail should not leak into
+    # user-facing text — "CSV loads only" is true and unambiguous either way.
     if max_errors is not None and file_type == "PARQUET":
         _logger.warning(
-            "copy_into_from_url: --max-errors is not supported for Parquet COPY INTO "
-            "(Fabric rejects MAXERRORS for FILE_TYPE='PARQUET'); ignoring max_errors=%d",
+            "--max-errors is only supported for CSV loads; ignoring max_errors=%d",
             max_errors,
         )
         max_errors = None

--- a/src/fabric_dw/services/tables.py
+++ b/src/fabric_dw/services/tables.py
@@ -17,7 +17,7 @@ Public API
 - :func:`rename_table`            — ``EXEC sp_rename`` (Data-Warehouse-only).
 - :func:`transfer_table`          — ``ALTER SCHEMA ... TRANSFER OBJECT::...`` (Data-Warehouse-only).
 - :func:`recluster_table`         — transactional CTAS-swap to change (or remove) clustering.
-- :func:`get_table_dependents`    — views/procedures referencing a table by name.
+- :func:`get_table_dependents`    — objects referencing a table by name.
 - :func:`get_table_health_metrics` — ``EXEC sp_get_table_health_metrics`` (SQL endpoint only).
 
 List-source note
@@ -504,9 +504,10 @@ async def get_table_dependents(
     schema: str,
     table_name: str,
     *,
+    kind: WarehouseKind = WarehouseKind.WAREHOUSE,
     mode: CredentialMode = CredentialMode.DEFAULT,
 ) -> list[str]:
-    """Return schema-qualified names of views/procedures that reference *table_name*.
+    """Return schema-qualified names of objects that reference *table_name* by name.
 
     Queries ``sys.sql_expression_dependencies`` (joined to ``sys.objects`` /
     ``sys.schemas`` to resolve the referencing entity's name), a catalog view
@@ -515,15 +516,26 @@ async def get_table_dependents(
     dependents; this is not an error. Used to scope the CLUSTER BY rebuild
     advisory (#957) to tables that actually have dependents.
 
+    Limitation: ``sys.sql_expression_dependencies`` only tracks statically
+    resolvable by-name references. A dependent that references the table
+    exclusively through dynamic SQL (``EXEC(...)`` / ``sp_executesql``) is
+    invisible to this query and will not be reported — detecting that would
+    require parsing SQL text, which this repo does not do.
+
     Args:
         target: The warehouse to query.
         schema: The schema name.  Must pass :func:`validate_identifier`.
         table_name: The table name.  Must pass :func:`validate_identifier`.
+        kind: The :class:`~fabric_dw.models.WarehouseKind` of the item.  When
+            :attr:`~fabric_dw.models.WarehouseKind.SQL_ENDPOINT`, the current
+            (and only) caller — the CLUSTER BY advisory — does not apply
+            (clustering is Data-Warehouse-only), so no query is issued and an
+            empty list is returned.
         mode: The credential mode for Entra authentication.
 
     Returns:
         A (possibly empty) list of ``"schema.name"`` strings, one per distinct
-        referencing view or stored procedure.
+        referencing object (view, stored procedure, function, or trigger).
 
     Raises:
         ValueError: If *schema* or *table_name* fails identifier validation.
@@ -531,6 +543,8 @@ async def get_table_dependents(
     """
     validate_identifier(schema)
     validate_identifier(table_name)
+    if kind == WarehouseKind.SQL_ENDPOINT:
+        return []
     qualified = f"{quote_identifier(schema)}.{quote_identifier(table_name)}"
 
     def _run() -> list[str]:

--- a/src/fabric_dw/services/tables.py
+++ b/src/fabric_dw/services/tables.py
@@ -17,6 +17,7 @@ Public API
 - :func:`rename_table`            — ``EXEC sp_rename`` (Data-Warehouse-only).
 - :func:`transfer_table`          — ``ALTER SCHEMA ... TRANSFER OBJECT::...`` (Data-Warehouse-only).
 - :func:`recluster_table`         — transactional CTAS-swap to change (or remove) clustering.
+- :func:`get_table_dependents`    — views/procedures referencing a table by name.
 - :func:`get_table_health_metrics` — ``EXEC sp_get_table_health_metrics`` (SQL endpoint only).
 
 List-source note
@@ -76,6 +77,7 @@ __all__ = [
     "delete_table",
     "export_table",
     "get_cluster_columns",
+    "get_table_dependents",
     "get_table_health_metrics",
     "infer_columns_from_csv",
     "infer_columns_from_json",
@@ -156,6 +158,19 @@ JOIN sys.columns c ON t.object_id = c.object_id
 JOIN sys.index_columns ic ON c.object_id = ic.object_id AND c.column_id = ic.column_id
 WHERE ic.data_clustering_ordinal > 0 AND s.name = ? AND t.name = ?
 ORDER BY ic.data_clustering_ordinal;
+"""
+
+# sys.sql_expression_dependencies is a catalog view populated by the engine at
+# object-creation time via by-name resolution — this is metadata lookup, not
+# SQL text parsing.  referenced_id is resolved through OBJECT_ID(?) so the
+# table's bracket-quoted qualified name is passed as a bound parameter, never
+# concatenated into the query text.
+_TABLE_DEPENDENTS_SQL = """\
+SELECT DISTINCT rs.name AS referencing_schema, ro.name AS referencing_name
+FROM sys.sql_expression_dependencies sed
+JOIN sys.objects ro ON ro.object_id = sed.referencing_id
+JOIN sys.schemas rs ON rs.schema_id = ro.schema_id
+WHERE sed.referenced_id = OBJECT_ID(?);
 """
 
 _FETCH_TABLE_SQL = """\
@@ -480,6 +495,52 @@ async def get_cluster_columns(
         return [
             ClusterColumn(column_name=str(row[0]), clustering_ordinal=int(row[1])) for row in rows
         ]
+
+    return await asyncio.to_thread(_run)
+
+
+async def get_table_dependents(
+    target: SqlTarget,
+    schema: str,
+    table_name: str,
+    *,
+    mode: CredentialMode = CredentialMode.DEFAULT,
+) -> list[str]:
+    """Return schema-qualified names of views/procedures that reference *table_name*.
+
+    Queries ``sys.sql_expression_dependencies`` (joined to ``sys.objects`` /
+    ``sys.schemas`` to resolve the referencing entity's name), a catalog view
+    the engine populates from by-name resolution at object-creation time — no
+    SQL text is parsed. Returns an empty list when the table has no known
+    dependents; this is not an error. Used to scope the CLUSTER BY rebuild
+    advisory (#957) to tables that actually have dependents.
+
+    Args:
+        target: The warehouse to query.
+        schema: The schema name.  Must pass :func:`validate_identifier`.
+        table_name: The table name.  Must pass :func:`validate_identifier`.
+        mode: The credential mode for Entra authentication.
+
+    Returns:
+        A (possibly empty) list of ``"schema.name"`` strings, one per distinct
+        referencing view or stored procedure.
+
+    Raises:
+        ValueError: If *schema* or *table_name* fails identifier validation.
+        PermissionDeniedError: If the driver reports a permission error.
+    """
+    validate_identifier(schema)
+    validate_identifier(table_name)
+    qualified = f"{quote_identifier(schema)}.{quote_identifier(table_name)}"
+
+    def _run() -> list[str]:
+        _cols, rows = run_query(
+            target,
+            _TABLE_DEPENDENTS_SQL,
+            params=[qualified],
+            mode=mode,
+        )
+        return [f"{row[0]}.{row[1]}" for row in rows]
 
     return await asyncio.to_thread(_run)
 

--- a/tests/unit/cli/commands/test_tables.py
+++ b/tests/unit/cli/commands/test_tables.py
@@ -3681,6 +3681,10 @@ class TestTablesClusterBy:
                 new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
             ),
             patch("fabric_dw.services.tables.recluster_table", new=mock_recluster),
+            patch(
+                "fabric_dw.services.tables.get_table_dependents",
+                new=AsyncMock(return_value=[]),
+            ),
         ):
             result = runner.invoke(
                 cli,
@@ -3714,6 +3718,10 @@ class TestTablesClusterBy:
                 new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
             ),
             patch("fabric_dw.services.tables.recluster_table", new=mock_recluster),
+            patch(
+                "fabric_dw.services.tables.get_table_dependents",
+                new=AsyncMock(return_value=[]),
+            ),
         ):
             result = runner.invoke(
                 cli,
@@ -3752,6 +3760,10 @@ class TestTablesClusterBy:
                 new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
             ),
             patch("fabric_dw.services.tables.recluster_table", new=mock_recluster),
+            patch(
+                "fabric_dw.services.tables.get_table_dependents",
+                new=AsyncMock(return_value=[]),
+            ),
         ):
             result = runner.invoke(
                 cli,
@@ -3777,6 +3789,10 @@ class TestTablesClusterBy:
                 "fabric_dw.services.tables.recluster_table",
                 new=AsyncMock(side_effect=ItemKindError("clustering")),
             ),
+            patch(
+                "fabric_dw.services.tables.get_table_dependents",
+                new=AsyncMock(return_value=[]),
+            ),
         ):
             result = runner.invoke(
                 cli,
@@ -3784,8 +3800,10 @@ class TestTablesClusterBy:
             )
         assert result.exit_code != 0
 
-    def test_always_prints_warning(self, runner: CliRunner, cache_env: Path) -> None:
-        """The dependent-views warning is emitted when the swap proceeds; not --verbose gated."""
+    def test_warning_emitted_when_table_has_dependents(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """The dependent-views warning is emitted when the table has dependents (#957)."""
         _ = cache_env
         mock_http = AsyncMock()
         mock_recluster = AsyncMock(return_value=_make_table())
@@ -3799,6 +3817,10 @@ class TestTablesClusterBy:
                 new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
             ),
             patch("fabric_dw.services.tables.recluster_table", new=mock_recluster),
+            patch(
+                "fabric_dw.services.tables.get_table_dependents",
+                new=AsyncMock(return_value=["dbo.v_sales_summary"]),
+            ),
         ):
             result = runner.invoke(
                 cli,
@@ -3810,7 +3832,37 @@ class TestTablesClusterBy:
         # default on the runner fixture).
         assert "WARNING" in result.output
         assert "CTAS-swap" in result.output
+        assert "dbo.v_sales_summary" in result.output
         assert "sp_rename" not in result.output
+
+    def test_no_warning_when_table_has_no_dependents(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """No dependent-views warning when the table has zero dependents (#957)."""
+        _ = cache_env
+        mock_http = AsyncMock()
+        mock_recluster = AsyncMock(return_value=_make_table())
+        with (
+            patch(
+                "fabric_dw.cli.commands.tables.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.tables.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch("fabric_dw.services.tables.recluster_table", new=mock_recluster),
+            patch(
+                "fabric_dw.services.tables.get_table_dependents",
+                new=AsyncMock(return_value=[]),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                ["-w", WS_GUID, "--yes", "tables", "cluster-by", WH_GUID, "dbo.sales"],
+            )
+        assert result.exit_code == 0, result.output
+        assert "CTAS-swap" not in result.output
 
 
 # ===========================================================================

--- a/tests/unit/services/test_load.py
+++ b/tests/unit/services/test_load.py
@@ -951,13 +951,18 @@ class TestMaxErrorsParquetWarning:
 
         assert result.rows_loaded == 2
 
-        # A WARNING must have been logged mentioning max-errors and Parquet.
+        # A WARNING must have been logged mentioning max-errors, but it must stay
+        # format-neutral (#956): no "Parquet" wording and no leaked internal
+        # function name, since the same message covers json-converted loads too.
         warning_messages = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
         assert any(
             "max-errors" in msg.lower() or "max_errors" in msg.lower() for msg in warning_messages
         ), f"Expected a warning about max_errors/max-errors; got: {warning_messages}"
-        assert any("parquet" in msg.lower() for msg in warning_messages), (
-            f"Expected warning to mention 'parquet'; got: {warning_messages}"
+        assert not any("parquet" in msg.lower() for msg in warning_messages), (
+            f"Warning must not mention 'parquet'; got: {warning_messages}"
+        )
+        assert not any("copy_into_from_url" in msg for msg in warning_messages), (
+            f"Warning must not leak the internal function name; got: {warning_messages}"
         )
 
     async def test_copy_into_from_url_csv_with_max_errors_no_warning(
@@ -994,7 +999,12 @@ class TestMaxErrorsParquetWarning:
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture
     ) -> None:
         """When format=json (converted to Parquet) and max_errors is set, a WARNING
-        must be emitted (via copy_into_from_url) and the load must succeed."""
+        must be emitted (via copy_into_from_url) and the load must succeed.
+
+        The message must not say "Parquet" (#956): the user asked for json, and the
+        client-side conversion to Parquet is an internal implementation detail that
+        would otherwise confuse a --format json caller.
+        """
         json_file = tmp_path / "data.json"
         json_file.write_text('{"id": 1}\n', encoding="utf-8")
 
@@ -1031,13 +1041,17 @@ class TestMaxErrorsParquetWarning:
         # Load must succeed.
         assert result.rows_loaded == 1
 
-        # A WARNING must have been logged mentioning max-errors and Parquet.
+        # A WARNING must have been logged mentioning max-errors, without saying
+        # "Parquet" or leaking the internal copy_into_from_url function name.
         warning_messages = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
         assert any(
             "max-errors" in msg.lower() or "max_errors" in msg.lower() for msg in warning_messages
         ), f"Expected a warning about max_errors/max-errors; got: {warning_messages}"
-        assert any("parquet" in msg.lower() for msg in warning_messages), (
-            f"Expected warning to mention 'parquet'; got: {warning_messages}"
+        assert not any("parquet" in msg.lower() for msg in warning_messages), (
+            f"Warning must not mention 'parquet' for a json-format load; got: {warning_messages}"
+        )
+        assert not any("copy_into_from_url" in msg for msg in warning_messages), (
+            f"Warning must not leak the internal function name; got: {warning_messages}"
         )
 
     async def test_parquet_load_with_max_errors_emits_warning(

--- a/tests/unit/services/test_tables.py
+++ b/tests/unit/services/test_tables.py
@@ -929,6 +929,86 @@ class TestGetClusterColumns:
 
 
 # ===========================================================================
+# get_table_dependents (#957)
+# ===========================================================================
+
+
+class TestGetTableDependents:
+    async def test_maps_rows_to_qualified_names(self) -> None:
+        target = _make_target()
+        rows: list[tuple[object, ...]] = [("dbo", "v_sales_summary"), ("rpt", "p_refresh_sales")]
+        conn = _make_conn(rows, ["referencing_schema", "referencing_name"])
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            result = await tables.get_table_dependents(target, "dbo", "sales")
+        assert result == ["dbo.v_sales_summary", "rpt.p_refresh_sales"]
+
+    async def test_returns_empty_list_when_no_dependents(self) -> None:
+        target = _make_target()
+        conn = _make_conn([], ["referencing_schema", "referencing_name"])
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            result = await tables.get_table_dependents(target, "dbo", "sales")
+        assert result == []
+
+    async def test_sql_references_sys_sql_expression_dependencies(self) -> None:
+        target = _make_target()
+        conn = _make_conn([], ["referencing_schema", "referencing_name"])
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await tables.get_table_dependents(target, "dbo", "sales")
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert "sys.sql_expression_dependencies" in call_sql
+        assert "OBJECT_ID(?)" in call_sql
+
+    async def test_binds_bracket_quoted_qualified_name_as_param(self) -> None:
+        """The OBJECT_ID(?) parameter must be the bracket-quoted 'schema.table'
+        string, bound — never concatenated into the query text."""
+        target = _make_target()
+        conn = _make_conn([], ["referencing_schema", "referencing_name"])
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await tables.get_table_dependents(target, "myschema", "mytable")
+        cursor = conn.cursor.return_value
+        call_args = cursor.execute.call_args
+        params = call_args[0][1] if len(call_args[0]) > 1 else (call_args[1] or {}).get("params")
+        assert params is not None
+        assert list(params) == ["[myschema].[mytable]"]
+
+    async def test_validates_schema_identifier(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await tables.get_table_dependents(target, "bad;schema", "sales")
+
+    async def test_validates_table_name_identifier(self) -> None:
+        target = _make_target()
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            await tables.get_table_dependents(target, "dbo", "bad--table")
+
+    async def test_sql_endpoint_short_circuits_without_query(self) -> None:
+        """SQL Analytics Endpoints don't support CLUSTER BY (the only caller of
+        this function), so no I/O should be issued for them (#959 review)."""
+        target = _make_target()
+        with patch("fabric_dw.sql.open_connection") as mock_open:
+            result = await tables.get_table_dependents(
+                target, "dbo", "sales", kind=WarehouseKind.SQL_ENDPOINT
+            )
+        assert result == []
+        mock_open.assert_not_called()
+
+    async def test_permission_denied_propagates(self) -> None:
+        target = _make_target()
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.execute.side_effect = Exception(
+            "permission was denied on object sys.sql_expression_dependencies"
+        )
+        conn.cursor.return_value = cursor
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(PermissionDeniedError),
+        ):
+            await tables.get_table_dependents(target, "dbo", "sales")
+
+
+# ===========================================================================
 # ResultSet native-type fidelity
 # ===========================================================================
 


### PR DESCRIPTION
## Summary
- `copy_into_from_url` no longer leaks the internal `copy_into_from_url:` function-name prefix in its max-errors WARNING, and the message no longer hard-codes "Parquet" (which was misleading for `--format json` loads that are converted to Parquet client-side before COPY INTO). The message is now format-neutral: max-errors is CSV-only, stated without naming an internal function or an unrequested source format.
- `tables cluster-by` no longer prints an unconditional advisory WARNING about dependent views/stored procedures. It now queries `sys.sql_expression_dependencies` (joined to `sys.objects` / `sys.schemas`, a parameterized catalog-metadata lookup, not SQL text parsing) and only warns when the table actually has dependents, naming them in the message.

## Acceptance criteria

**#956**
- WARNING text no longer contains `copy_into_from_url`.
- WARNING text no longer says "Parquet" for a `--format json` load (verified for the raw Parquet `copy_into_from_url` path and the json-conversion path in `load_local_file`).
- Covers both the local-file and URL COPY INTO paths (single choke point in `copy_into_from_url`), so CLI and MCP tool surfaces are both fixed.

**#957**
- New `get_table_dependents()` in `services/tables.py` queries `sys.sql_expression_dependencies` for objects referencing the table by name.
- `tables cluster-by` only prints the WARNING when `get_table_dependents()` returns a non-empty list; the message now also names the dependents.
- Added a test asserting no warning is emitted for a table with zero dependents, and a test asserting the warning (with the dependent's name) is emitted when dependents exist.

## Test plan
- [x] `uv run ruff format .` / `uv run ruff check .` clean
- [x] `uv run ty check` clean
- [x] `uv run pytest tests/unit -q` — 5760 passed
- [x] New/updated unit tests: `tests/unit/services/test_load.py` (max-errors warning wording), `tests/unit/cli/commands/test_tables.py` (cluster-by dependents-conditional warning)

Closes #956
Closes #957

🤖 Generated with [Claude Code](https://claude.com/claude-code)