### PR TITLE
fix(audit): CLI set-groups must not enable auditing (align with set_audit_action_groups)

### DIFF
--- a/docs/commands/audit.md
+++ b/docs/commands/audit.md
@@ -121,7 +121,7 @@ fdw -w MyWorkspace audit remove-group SalesWH BATCH_COMPLETED_GROUP
 
 **Targets:** Data Warehouse / SQL Analytics Endpoint
 
-Set the audit action groups for a warehouse or SQL Analytics Endpoint. Pass `--group` / `-g` once per action group. This replaces the existing list of groups.
+Set the audit action groups for a warehouse or SQL Analytics Endpoint. Pass `--group` / `-g` once per action group. This replaces the existing list of groups; it does not toggle the audit enabled/disabled state, so if auditing was Disabled before the call it remains Disabled afterwards.
 
 **Synopsis**
 

--- a/src/fabric_dw/cli/commands/audit.py
+++ b/src/fabric_dw/cli/commands/audit.py
@@ -181,6 +181,10 @@ async def set_groups_cmd(ctx: CliContext, item: str | None, groups: tuple[str, .
     Pass --group for each action group name, e.g.
     --group BATCH_COMPLETED_GROUP --group SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP.
 
+    Only replaces the action groups. Does not toggle the audit enabled or
+    disabled state; if auditing was Disabled before the call it remains Disabled
+    afterwards.
+
     NOTE: Each audit write reads current settings via an eventually-consistent GET
     that lags PATCHes by minutes. Two rapid writes may silently revert the first.
     Space audit writes at least a few minutes apart.
@@ -191,7 +195,7 @@ async def set_groups_cmd(ctx: CliContext, item: str | None, groups: tuple[str, .
         async with build_http_client(ctx) as http:
             ws_id, entry = await resolve_item(http, ws, wh)
             obj = await _audit_svc.set_action_groups(
-                http, ws_id, entry.id, list(groups), entry.kind
+                http, ws_id, entry.id, list(groups), entry.kind, ensure_enabled=False
             )
             render(obj.model_dump(by_alias=True, mode="json"), json_output=ctx.json_output)
     except (ValueError, FabricError) as exc:

--- a/tests/unit/cli/commands/test_audit.py
+++ b/tests/unit/cli/commands/test_audit.py
@@ -424,6 +424,79 @@ class TestAuditSetGroups:
         assert "BATCH_COMPLETED_GROUP" in groups_arg
         assert "SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP" in groups_arg
 
+    def test_set_groups_passes_ensure_enabled_false(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """set-groups always passes ensure_enabled=False to the service.
+
+        Regression guard for #960: aligns the CLI with the MCP tool
+        set_audit_action_groups (#876/#878) -- set-groups must not silently
+        enable auditing on a Disabled warehouse, so it must call
+        set_action_groups with ensure_enabled=False.
+        """
+        _ = cache_env
+        mock_http = AsyncMock()
+        mock_http.request = AsyncMock(return_value=_make_response(200, AUDIT_SETTINGS_PAYLOAD))
+        mock_set_groups = AsyncMock(return_value=_make_audit_settings())
+        with (
+            patch(
+                "fabric_dw.cli.commands.audit.build_http_client",
+                new=_make_cm(mock_http, None),
+            ),
+            patch(
+                "fabric_dw.cli.commands.audit.resolve_item",
+                new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
+            ),
+            patch("fabric_dw.cli.commands.audit._audit_svc.set_action_groups", new=mock_set_groups),
+        ):
+            runner.invoke(
+                cli,
+                ["-w", WS_GUID, "audit", "set-groups", WH_GUID, "--group", "BATCH_COMPLETED_GROUP"],
+            )
+
+        _, kwargs = mock_set_groups.call_args
+        assert kwargs.get("ensure_enabled") is False
+
+    def test_set_groups_disabled_warehouse_state_unchanged(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """set-groups on a Disabled warehouse replaces groups and leaves state Disabled.
+
+        Regression guard for #960: unlike add-group/remove-group/set-retention,
+        set-groups does not require auditing to already be enabled and must not
+        enable it as a side effect -- consistent with the MCP tool
+        set_audit_action_groups (#876/#878).
+        """
+        _ = cache_env
+        groups = ["BATCH_COMPLETED_GROUP"]
+        settings = _make_audit_settings().model_copy(
+            update={"state": "Disabled", "action_groups": groups}
+        )
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.audit.build_http_client",
+                new=_make_cm(mock_http, None),
+            ),
+            patch(
+                "fabric_dw.cli.commands.audit.resolve_item",
+                new=AsyncMock(return_value=(WS_UUID, _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.cli.commands.audit._audit_svc.set_action_groups",
+                new=AsyncMock(return_value=settings),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                ["-w", WS_GUID, "--json", "audit", "set-groups", WH_GUID, "--group", groups[0]],
+            )
+
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["state"] == "Disabled"
+        assert groups[0] in parsed["auditActionsAndGroups"]
+
     def test_set_groups_invalid_name_returns_nonzero(
         self, runner: CliRunner, cache_env: Path
     ) -> None:


### PR DESCRIPTION
## Summary

- PR #878 fixed the MCP tool `set_audit_action_groups` (issue #876) so that replacing action groups round-trips the current audit state (Enabled or Disabled) instead of forcing `state=Enabled`, by passing `ensure_enabled=False` to `set_action_groups` in the service layer.
- The CLI command `audit set-groups` was missed by that fix: it still called `set_action_groups` with the service default `ensure_enabled=True`, so on a warehouse where auditing was intentionally Disabled, running `set-groups` silently PATCHed `state=Enabled` as a side effect of replacing the action groups -- exit 0, no warning, no error.
- This completes #878 for the CLI: `set-groups` now passes `ensure_enabled=False` too, so both the CLI and the MCP tool consistently replace the action groups without toggling the audit enabled/disabled state on a disabled config. `#876`'s design decision (replace groups, don't require/force enabled, don't refuse) is preserved unchanged for both surfaces.
- Updated the CLI command's `--help` docstring and the CLI `set-groups` section of `docs/commands/audit.md` to document this explicitly (mirroring the MCP tool's documented behavior from #876), since it was previously silent/undocumented on the CLI side.

## Test plan

- [x] New unit test: CLI `audit set-groups` always passes `ensure_enabled=False` to the service (`tests/unit/cli/commands/test_audit.py`), mirroring the existing MCP tool regression test from #876.
- [x] New unit test: CLI `audit set-groups` on a Disabled warehouse replaces the action groups and returns/renders `state: Disabled` unchanged (no enable, no error).
- [x] Existing "happy path, already enabled" CLI test kept unchanged.
- [x] Service layer (`set_action_groups`, `ensure_enabled` parameter and default) and all of #876's existing regression tests (service + MCP tool) are untouched.
- [x] `uv run ruff format .`, `uv run ruff check .`, `uv run ty check` all pass.
- [x] `uv run pytest tests/unit -q` -- 5773 passed (2 more than baseline, from the new tests).

Closes #960