### PR TITLE
fix: unify CapacityNotActive REST error with the friendly SQL-path message

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -58,9 +58,11 @@ fabric_dw.exceptions.PermissionDenied: permission was denied on the object ...
 
 ## Capacity paused - cryptic 5xx or 404 errors
 
-**Symptoms:** Commands fail with `FabricServerError` (HTTP 5xx) or `NotFound` (HTTP 404) even though the workspace and warehouse clearly exist. The Fabric portal may show the capacity as **Paused**.
+**Symptoms:** Commands fail even though the workspace and warehouse clearly exist. The Fabric portal may show the capacity as **Paused**.
 
-**What happened:** Microsoft Fabric capacities can be paused to save cost. While paused, the Fabric REST API returns unreliable error codes instead of a clear "capacity is paused" message.
+**What happened:** Microsoft Fabric capacities can be paused to save cost. `sql exec` and other SQL-path commands, as well as REST/item commands that hit a plain HTTP 404 with error code `CapacityNotActive` (for example `snapshots create`), surface a clean `CapacityInactiveError` message: "The Fabric capacity for this workspace is paused or inactive. Resume it before running SQL, see [learn.microsoft.com/fabric/data-warehouse/pause-resume](https://learn.microsoft.com/fabric/data-warehouse/pause-resume?WT.mc_id=MVP_310840)".
+
+Some REST error shapes are not yet mapped to that message and can still look cryptic: a non-retriable HTTP 5xx, or the HTTP 400 "Datamart server error" that `restore-points create` can return, which does not reliably mention the capacity at all. If you see either of those and the capacity is paused, treat it as the same root cause.
 
 **Resolution:** Resume the capacity before running commands.
 

--- a/src/fabric_dw/exceptions.py
+++ b/src/fabric_dw/exceptions.py
@@ -117,6 +117,17 @@ class FabricServerError(FabricError):
         self.is_retriable = is_retriable
 
 
+# Actionable message surfaced to the caller when the Fabric capacity backing a
+# workspace is paused/inactive.  Shared by the SQL connect-error path
+# (fabric_dw.sql_pool) and the REST/item HTTP error path (fabric_dw.http_client)
+# so both surfaces present the identical, actionable wording.
+CAPACITY_INACTIVE_MESSAGE: str = (
+    "The Fabric capacity for this workspace is paused or inactive. "
+    "Resume it before running SQL, see "
+    "https://learn.microsoft.com/fabric/data-warehouse/pause-resume"
+)
+
+
 class CapacityInactiveError(FabricError):
     """Raised when the Fabric capacity backing the workspace is paused or inactive.
 

--- a/src/fabric_dw/http_client.py
+++ b/src/fabric_dw/http_client.py
@@ -65,8 +65,10 @@ from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponen
 
 from fabric_dw import auth, telemetry
 from fabric_dw.exceptions import (
+    CAPACITY_INACTIVE_MESSAGE,
     AuthError,
     BadRequestError,
+    CapacityInactiveError,
     FabricError,
     FabricServerError,
     NotFoundError,
@@ -81,6 +83,7 @@ _logger = logging.getLogger("fabric_dw.http")
 __all__ = [
     "FabricHttpClient",
     "HttpBase",
+    "fabric_error_code",
 ]
 
 # Module-level defaults (used as constructor defaults)
@@ -107,6 +110,11 @@ _STATUS_TO_EXC: dict[int, type[FabricError]] = {
     http.HTTPStatus.FORBIDDEN: PermissionDeniedError,
     http.HTTPStatus.NOT_FOUND: NotFoundError,
 }
+
+# Fabric error code returned (as a plain HTTP 404) when the REST/item API call
+# targets a workspace whose backing capacity is paused/inactive. Indistinguishable
+# from a genuine "item not found" 404 unless the error envelope is inspected.
+_CAPACITY_NOT_ACTIVE_ERROR_CODE = "CapacityNotActive"
 
 
 class HttpBase(StrEnum):
@@ -188,6 +196,40 @@ def _parse_json_body(resp: httpx.Response) -> dict[str, object] | None:
             return parsed
     except (ValueError, json.JSONDecodeError):
         pass
+    return None
+
+
+def fabric_error_code(body: dict[str, object] | None) -> str | None:
+    """Extract the error code from a Fabric or Power BI error envelope.
+
+    The core Fabric REST API puts the code at the top level
+    (``{"errorCode": "..."}``), while the legacy Power BI namespace (used by,
+    e.g., the warehouse ``/takeover`` endpoint) nests it under ``error`` (and
+    mirrors it under ``error["pbi.error"]``)::
+
+        {"error": {"code": "...", "pbi.error": {"code": "..."}}}
+
+    Checks the top-level key first, then falls back to the nested shapes.
+    Returns ``None`` if *body* is ``None`` or none of the keys are present.
+    Shared by callers that need to branch on a specific Fabric error code
+    (e.g. ``ArtifactTakeOverNotAllowedByOwner``, ``CapacityNotActive``)
+    rather than string-matching the raw response text.
+    """
+    if body is None:
+        return None
+    top_level = body.get("errorCode")
+    if isinstance(top_level, str):
+        return top_level
+    error = body.get("error")
+    if isinstance(error, dict):
+        code = error.get("code")
+        if isinstance(code, str):
+            return code
+        pbi_error = error.get("pbi.error")
+        if isinstance(pbi_error, dict):
+            pbi_code = pbi_error.get("code")
+            if isinstance(pbi_code, str):
+                return pbi_code
     return None
 
 
@@ -577,6 +619,12 @@ class FabricHttpClient:
         for any 5xx response.  JSON body is parsed best-effort (only
         ``ValueError``/``json.JSONDecodeError`` are suppressed).  The
         ``x-ms-request-id`` header is captured for all raised exceptions.
+
+        A 404 whose error envelope carries the ``CapacityNotActive`` code is
+        special-cased to ``CapacityInactiveError`` with the same friendly,
+        actionable message the SQL connect path uses, instead of the generic
+        ``NotFoundError`` with the raw backend body -- a paused capacity is
+        not the same failure as a missing item.
         """
         status = resp.status_code
         request_id = resp.headers.get("x-ms-request-id")
@@ -586,6 +634,16 @@ class FabricHttpClient:
 
         exc_class = _STATUS_TO_EXC.get(status)
         if exc_class is not None:
+            if (
+                status == http.HTTPStatus.NOT_FOUND
+                and fabric_error_code(body) == _CAPACITY_NOT_ACTIVE_ERROR_CODE
+            ):
+                raise CapacityInactiveError(
+                    CAPACITY_INACTIVE_MESSAGE,
+                    status=status,
+                    request_id=request_id,
+                    body=body,
+                )
             raise exc_class(
                 f"HTTP {status} for {url}: {resp.text}",
                 status=status,

--- a/src/fabric_dw/services/_helpers.py
+++ b/src/fabric_dw/services/_helpers.py
@@ -527,7 +527,7 @@ async def scan_all_workspaces(
             ``list[T]`` of items for that workspace.
         logger: Logger for per-workspace and summary warnings.
         skip_errors: Exception types to skip with a WARNING log (e.g.
-            PermissionDeniedError, NotFoundError).
+            PermissionDeniedError, NotFoundError, CapacityInactiveError).
         capacity_states: Optional ``{capacity_id_lower: state}`` map for
             proactive capacity filtering.  Pass ``None`` to disable proactive
             filtering and rely on the defensive fallback only.

--- a/src/fabric_dw/services/ownership.py
+++ b/src/fabric_dw/services/ownership.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from uuid import UUID
 
 from fabric_dw.exceptions import ItemKindError, PermissionDeniedError
-from fabric_dw.http_client import FabricHttpClient, HttpBase
+from fabric_dw.http_client import FabricHttpClient, HttpBase, fabric_error_code
 from fabric_dw.models import WarehouseKind
 
 __all__ = ["takeover"]
@@ -14,37 +14,6 @@ _TAKEOVER_HINT = "takeover requires Admin/Member/Contributor role on the workspa
 
 # Fabric error code returned when the caller is already the owner of the item.
 _ALREADY_OWNER_ERROR_CODE = "ArtifactTakeOverNotAllowedByOwner"
-
-
-def _fabric_error_code(body: dict[str, object] | None) -> str | None:
-    """Extract the error code from a Fabric or Power BI error envelope.
-
-    The core Fabric REST API puts the code at the top level
-    (``{"errorCode": "..."}``), while the legacy Power BI namespace used by
-    ``/takeover`` nests it under ``error`` (and mirrors it under
-    ``error["pbi.error"]``)::
-
-        {"error": {"code": "...", "pbi.error": {"code": "..."}}}
-
-    Checks the top-level key first, then falls back to the nested shapes.
-    Returns ``None`` if *body* is ``None`` or none of the keys are present.
-    """
-    if body is None:
-        return None
-    top_level = body.get("errorCode")
-    if isinstance(top_level, str):
-        return top_level
-    error = body.get("error")
-    if isinstance(error, dict):
-        code = error.get("code")
-        if isinstance(code, str):
-            return code
-        pbi_error = error.get("pbi.error")
-        if isinstance(pbi_error, dict):
-            pbi_code = pbi_error.get("code")
-            if isinstance(pbi_code, str):
-                return pbi_code
-    return None
 
 
 async def takeover(
@@ -98,10 +67,10 @@ async def takeover(
     except PermissionDeniedError as exc:
         # Detect the "already owner" case: Fabric returns 403 with the
         # ArtifactTakeOverNotAllowedByOwner code when the caller already owns
-        # the item. See _fabric_error_code() for the envelope shapes this
+        # the item. See fabric_error_code() for the envelope shapes this
         # code can be nested under.
         # Surface a clear, accurate message instead of the generic role hint.
-        error_code = _fabric_error_code(exc.body)
+        error_code = fabric_error_code(exc.body)
         if error_code == _ALREADY_OWNER_ERROR_CODE:
             raise PermissionDeniedError(
                 "You are already the owner of this warehouse; nothing to take over.",

--- a/src/fabric_dw/services/sql_endpoints.py
+++ b/src/fabric_dw/services/sql_endpoints.py
@@ -7,7 +7,12 @@ import logging
 from uuid import UUID
 
 from fabric_dw._fabric_api import resolve_lakehouse_connection_string
-from fabric_dw.exceptions import FabricServerError, NotFoundError, PermissionDeniedError
+from fabric_dw.exceptions import (
+    CapacityInactiveError,
+    FabricServerError,
+    NotFoundError,
+    PermissionDeniedError,
+)
 from fabric_dw.http_client import FabricHttpClient, HttpBase
 from fabric_dw.models import TableSyncStatus, Warehouse, WarehouseKind
 from fabric_dw.services._helpers import scan_all_workspaces
@@ -100,8 +105,10 @@ async def list_all_workspaces(http: FabricHttpClient) -> list[Warehouse]:
     defensive fallback applies: a non-retriable 5xx per workspace is silently
     skipped at ``DEBUG`` level.
 
-    Workspaces that raise :class:`~fabric_dw.exceptions.PermissionDeniedError`
-    or :class:`~fabric_dw.exceptions.NotFoundError` are skipped with a
+    Workspaces that raise :class:`~fabric_dw.exceptions.PermissionDeniedError`,
+    :class:`~fabric_dw.exceptions.NotFoundError`, or
+    :class:`~fabric_dw.exceptions.CapacityInactiveError` (capacity paused
+    between the proactive filter and the fan-out call) are skipped with a
     per-workspace ``WARNING`` log; a summary ``WARNING`` is logged after the scan.
 
     Args:
@@ -137,7 +144,11 @@ async def list_all_workspaces(http: FabricHttpClient) -> list[Warehouse]:
         workspaces,
         lambda ws: list_endpoints(http, ws.id),
         logger=_logger,
-        skip_errors=(PermissionDeniedError, NotFoundError),
+        # CapacityInactiveError: proactive capacity filtering is best-effort
+        # (see _get_capacity_states_safe above) and the capacity can also flip
+        # inactive between the filter check and the fan-out call; skip that one
+        # workspace like an inaccessible one instead of aborting the whole scan.
+        skip_errors=(PermissionDeniedError, NotFoundError, CapacityInactiveError),
         capacity_states=capacity_states,
     )
 

--- a/src/fabric_dw/services/warehouses.py
+++ b/src/fabric_dw/services/warehouses.py
@@ -8,7 +8,12 @@ from datetime import UTC, datetime
 from uuid import UUID
 
 from fabric_dw.cache import ItemEntry, LookupCache
-from fabric_dw.exceptions import FabricServerError, NotFoundError, PermissionDeniedError
+from fabric_dw.exceptions import (
+    CapacityInactiveError,
+    FabricServerError,
+    NotFoundError,
+    PermissionDeniedError,
+)
 from fabric_dw.http_client import FabricHttpClient, HttpBase, _parse_json_body
 from fabric_dw.models import Warehouse, WarehouseKind
 from fabric_dw.services._helpers import compact, scan_all_workspaces
@@ -151,8 +156,10 @@ async def list_all_workspaces(
     defensive fallback applies: a non-retriable 5xx per workspace is silently
     skipped at ``DEBUG`` level.
 
-    Workspaces that raise :class:`~fabric_dw.exceptions.PermissionDeniedError`
-    or :class:`~fabric_dw.exceptions.NotFoundError` are skipped with a
+    Workspaces that raise :class:`~fabric_dw.exceptions.PermissionDeniedError`,
+    :class:`~fabric_dw.exceptions.NotFoundError`, or
+    :class:`~fabric_dw.exceptions.CapacityInactiveError` (capacity paused
+    between the proactive filter and the fan-out call) are skipped with a
     per-workspace ``WARNING`` log; a summary ``WARNING`` is logged after the scan.
 
     Args:
@@ -191,7 +198,11 @@ async def list_all_workspaces(
         workspaces,
         lambda ws: list_warehouses(http, ws.id, warehouses_only=warehouses_only),
         logger=_logger,
-        skip_errors=(PermissionDeniedError, NotFoundError),
+        # CapacityInactiveError: proactive capacity filtering is best-effort
+        # (see _get_capacity_states_safe above) and the capacity can also flip
+        # inactive between the filter check and the fan-out call; skip that one
+        # workspace like an inaccessible one instead of aborting the whole scan.
+        skip_errors=(PermissionDeniedError, NotFoundError, CapacityInactiveError),
         capacity_states=capacity_states,
     )
 

--- a/src/fabric_dw/sql_pool.py
+++ b/src/fabric_dw/sql_pool.py
@@ -35,7 +35,12 @@ from typing import TYPE_CHECKING, Any, Never
 
 from fabric_dw.auth import CredentialMode, get_sql_token_struct
 from fabric_dw.config import UserConfig as _UserConfig
-from fabric_dw.exceptions import CapacityInactiveError, FabricCliError, FabricError
+from fabric_dw.exceptions import (
+    CAPACITY_INACTIVE_MESSAGE,
+    CapacityInactiveError,
+    FabricCliError,
+    FabricError,
+)
 from fabric_dw.sql_errors import _is_connect_retryable
 
 if TYPE_CHECKING:
@@ -580,13 +585,6 @@ def _make_pool_key(target: SqlTarget, mode: CredentialMode) -> _PoolKey:
 # in the driver message returned at connect time.
 _CAPACITY_INACTIVE_FRAGMENT: str = "capacity is currently not active"
 
-# Actionable message surfaced to the caller when the capacity is paused.
-_CAPACITY_INACTIVE_MSG: str = (
-    "The Fabric capacity for this workspace is paused or inactive. "
-    "Resume it before running SQL, see "
-    "https://learn.microsoft.com/fabric/data-warehouse/pause-resume"
-)
-
 
 def _translate_connect_error(exc: Exception) -> Never:
     """Translate a driver-level connect failure into a clean FabricError.
@@ -628,7 +626,7 @@ def _translate_connect_error(exc: Exception) -> Never:
     # so the error is never silently retried for ~120 s).
     msg = str(exc).lower()
     if _CAPACITY_INACTIVE_FRAGMENT in msg:
-        err: FabricError = CapacityInactiveError(_CAPACITY_INACTIVE_MSG)
+        err: FabricError = CapacityInactiveError(CAPACITY_INACTIVE_MESSAGE)
         err.__cause__ = exc
         raise err
     # Step 3: retryable driver errors -- re-raise bare to preserve ddbc_error.

--- a/tests/unit/services/test_capacity_skip.py
+++ b/tests/unit/services/test_capacity_skip.py
@@ -498,6 +498,51 @@ async def test_genuine_403_still_warns(caplog: pytest.LogCaptureFixture) -> None
 
 
 # ---------------------------------------------------------------------------
+# (g2) A per-workspace CapacityNotActive 404 is skipped like an access error
+# (issue #962: the REST/item CapacityNotActive mapping to CapacityInactiveError
+# must not abort the whole -A scan when the capacity flips inactive between
+# the proactive filter and the fan-out call).
+# ---------------------------------------------------------------------------
+
+
+async def test_capacity_inactive_error_skipped_like_access_error(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A CapacityInactiveError from one workspace is skipped; other workspaces still return."""
+    from fabric_dw.exceptions import CapacityInactiveError  # noqa: PLC0415
+    from fabric_dw.services.warehouses import list_all_workspaces  # noqa: PLC0415
+
+    ws_a = _make_workspace(_WS_ACTIVE, _CAP_ACTIVE)
+    ws_b = _make_workspace(_WS_INACTIVE, _CAP_INACTIVE)
+    wh_a = _make_wh(_WS_ACTIVE, _WH_ACTIVE)
+
+    with (
+        caplog.at_level(logging.WARNING, logger="fabric_dw.warehouses"),
+        patch(
+            "fabric_dw.services.warehouses._list_all_workspaces",
+            new=AsyncMock(return_value=[ws_a, ws_b]),
+        ),
+        patch(
+            "fabric_dw.services.warehouses.get_capacity_states",
+            new=AsyncMock(return_value=None),  # fallback mode: both workspaces are attempted
+        ),
+        patch(
+            "fabric_dw.services.warehouses.list_warehouses",
+            new=AsyncMock(
+                side_effect=[[wh_a], CapacityInactiveError("capacity is paused or inactive")]
+            ),
+        ),
+    ):
+        result = await list_all_workspaces(AsyncMock())
+
+    # The other workspace's results are still returned; the scan is not aborted.
+    assert len(result) == 1
+    assert result[0].id == _WH_ACTIVE
+    warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("skipping workspace" in r.message for r in warning_records)
+
+
+# ---------------------------------------------------------------------------
 # (h) An unexpected error still surfaces (propagates)
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/services/test_ownership.py
+++ b/tests/unit/services/test_ownership.py
@@ -160,7 +160,7 @@ async def test_takeover_403_already_owner_top_level_error_code_shape() -> None:
 async def test_takeover_403_already_owner_pbi_error_fallback_shape() -> None:
     """The ``error["pbi.error"]["code"]`` fallback is used when ``error.code`` is absent.
 
-    Exercises the fallback branch of ``_fabric_error_code`` directly: a body
+    Exercises the fallback branch of ``fabric_error_code`` directly: a body
     where ``error`` has no ``code`` key but does carry a nested ``pbi.error.code``.
     """
     body = {
@@ -186,7 +186,7 @@ async def test_takeover_403_already_owner_pbi_error_fallback_shape() -> None:
 async def test_takeover_403_no_recognisable_error_code_shows_role_hint() -> None:
     """A body with no code at any known key falls through to the generic role hint.
 
-    Exercises the terminal ``return None`` of ``_fabric_error_code``: an
+    Exercises the terminal ``return None`` of ``fabric_error_code``: an
     ``error`` dict with neither ``code`` nor ``pbi.error``, and no top-level
     ``errorCode`` either.
     """

--- a/tests/unit/test_http_client.py
+++ b/tests/unit/test_http_client.py
@@ -22,6 +22,7 @@ from fabric_dw.auth import FABRIC_SCOPE, SQL_SCOPE
 from fabric_dw.exceptions import (
     AuthError,
     BadRequestError,
+    CapacityInactiveError,
     FabricError,
     FabricServerError,
     NotFoundError,
@@ -35,6 +36,7 @@ from fabric_dw.http_client import (
     FabricHttpClient,
     HttpBase,
     _parse_retry_after,
+    fabric_error_code,
 )
 
 # ---------------------------------------------------------------------------
@@ -118,6 +120,39 @@ def test_parse_retry_after_http_date() -> None:
     result = _parse_retry_after("Wed, 21 Oct 2026 07:28:00 GMT")
     # frozen at 07:27:00 → 60 seconds until 07:28:00
     assert result == pytest.approx(60.0, abs=1.0)
+
+
+# ---------------------------------------------------------------------------
+# fabric_error_code
+# ---------------------------------------------------------------------------
+
+
+def test_fabric_error_code_none_body() -> None:
+    """A None body has no error code."""
+    assert fabric_error_code(None) is None
+
+
+def test_fabric_error_code_top_level_shape() -> None:
+    """The core Fabric REST shape puts the code at the top level."""
+    assert fabric_error_code({"errorCode": "ItemNotFound"}) == "ItemNotFound"
+
+
+def test_fabric_error_code_nested_error_shape() -> None:
+    """The legacy Power BI shape nests the code under error.code."""
+    assert fabric_error_code({"error": {"code": "Forbidden"}}) == "Forbidden"
+
+
+def test_fabric_error_code_pbi_error_fallback_shape() -> None:
+    """The pbi.error fallback is used when error.code is absent."""
+    body: dict[str, object] = {
+        "error": {"pbi.error": {"code": "ArtifactTakeOverNotAllowedByOwner"}}
+    }
+    assert fabric_error_code(body) == "ArtifactTakeOverNotAllowedByOwner"
+
+
+def test_fabric_error_code_no_recognisable_shape_returns_none() -> None:
+    """A body with none of the known keys returns None."""
+    assert fabric_error_code({"error": {"message": "something went wrong"}}) is None
 
 
 # ---------------------------------------------------------------------------
@@ -268,6 +303,68 @@ async def test_404_raises_not_found() -> None:
         async with client:
             with pytest.raises(NotFoundError):
                 await client.request("GET", HttpBase.FABRIC, "/items")
+
+
+# ---------------------------------------------------------------------------
+# 404 CapacityNotActive -> CapacityInactiveError (issue #962)
+# ---------------------------------------------------------------------------
+
+
+async def test_404_capacity_not_active_raises_capacity_inactive_error() -> None:
+    """HTTP 404 with errorCode CapacityNotActive maps to CapacityInactiveError.
+
+    REST/item commands (e.g. snapshots create) must surface the same
+    friendly "capacity is paused or inactive" message the SQL connect path
+    already uses, not a raw HTTP 404 + backend body.
+    """
+    body = {
+        "errorCode": "CapacityNotActive",
+        "message": "Capacity 00000000-0000-0000-0000-000000000000 is not active",
+    }
+    with respx.mock:
+        respx.get("https://api.fabric.microsoft.com/v1/items").mock(
+            return_value=httpx.Response(404, json=body)
+        )
+        client = await _get_client()
+        async with client:
+            with pytest.raises(CapacityInactiveError) as exc_info:
+                await client.request("GET", HttpBase.FABRIC, "/items")
+
+    error_text = str(exc_info.value)
+    assert "paused or inactive" in error_text
+    assert "https://learn.microsoft.com/fabric/data-warehouse/pause-resume" in error_text
+    # The raw REST URL and raw JSON body must not leak into the message.
+    assert "https://api.fabric.microsoft.com" not in error_text
+    assert "CapacityNotActive" not in error_text
+
+
+async def test_404_capacity_not_active_nested_envelope_shape() -> None:
+    """The nested ``error.code`` envelope shape is also recognised for CapacityNotActive."""
+    body = {"error": {"code": "CapacityNotActive", "message": "Capacity is not active"}}
+    with respx.mock:
+        respx.get("https://api.fabric.microsoft.com/v1/items").mock(
+            return_value=httpx.Response(404, json=body)
+        )
+        client = await _get_client()
+        async with client:
+            with pytest.raises(CapacityInactiveError) as exc_info:
+                await client.request("GET", HttpBase.FABRIC, "/items")
+
+    assert "paused or inactive" in str(exc_info.value)
+
+
+async def test_404_generic_still_raises_not_found() -> None:
+    """A 404 with an unrelated (or missing) error code is unchanged: plain NotFoundError."""
+    with respx.mock:
+        respx.get("https://api.fabric.microsoft.com/v1/items").mock(
+            return_value=httpx.Response(404, json={"errorCode": "ItemNotFound"})
+        )
+        client = await _get_client()
+        async with client:
+            with pytest.raises(NotFoundError) as exc_info:
+                await client.request("GET", HttpBase.FABRIC, "/items")
+
+    assert not isinstance(exc_info.value, CapacityInactiveError)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- REST/item commands (e.g. `snapshots create`, `restore-points create`) surfaced a raw `HTTP 404 for <url>: <body>` when the workspace's Fabric capacity was paused/inactive, while the SQL connect path (`sql exec`, etc.) already surfaced a clean message: "The Fabric capacity for this workspace is paused or inactive. Resume it before running SQL, see https://learn.microsoft.com/fabric/data-warehouse/pause-resume".
- The REST API reports this condition as a plain HTTP 404 with error code `CapacityNotActive` in the response envelope, indistinguishable from a genuine "item not found" 404 unless the envelope is inspected.

## Changes
- `src/fabric_dw/http_client.py`: `_map_status()` now checks, for 404 responses only, whether the parsed body's error code is `CapacityNotActive` (via the new shared `fabric_error_code()` helper) and if so raises `CapacityInactiveError` with the same friendly message instead of the generic `NotFoundError` with the raw backend body. Other 404s (including `ItemNotFound`) are unaffected.
- `src/fabric_dw/http_client.py`: promoted the error-envelope-code extraction added for the ownership-takeover fix (#958) from a private helper in `services/ownership.py` into a shared, public `fabric_error_code()` here, since it is now needed by two independent call sites. Handles both the top-level Fabric-REST shape (`{"errorCode": "..."}`) and the nested legacy Power BI shape (`{"error": {"code": "...", "pbi.error": {"code": "..."}}}`).
- `src/fabric_dw/services/ownership.py`: removed the now-duplicated private helper and imports the shared one instead. No behavior change.
- `src/fabric_dw/exceptions.py`: moved the friendly capacity-inactive message from a private constant in `sql_pool.py` into a shared, public `CAPACITY_INACTIVE_MESSAGE` next to `CapacityInactiveError`, so the SQL and REST paths reuse the identical wording and cannot drift apart.
- `src/fabric_dw/sql_pool.py`: uses the shared constant instead of its own local copy. No behavior change (identical message text).

## Out of scope
- The `restore-points create` 400 "Datamart server error" case mentioned in the issue does not reliably carry the capacity error code in its envelope, so it is intentionally left unmapped per the issue's own scoping note.
- No SQL parsing involved; this is REST/JSON error-envelope mapping only, keyed off the error code, not string-matching.

## Test plan
- [x] New unit tests in `tests/unit/test_http_client.py`: a 404 with top-level `errorCode: CapacityNotActive` maps to `CapacityInactiveError` (asserts friendly message + docs link present, raw URL/body and raw error code absent from the message); the nested `error.code` envelope shape is also recognised; a generic 404 (e.g. `ItemNotFound`) is unchanged (`NotFoundError`, not `CapacityInactiveError`). Plus direct unit tests for the new `fabric_error_code()` helper covering all four shapes (top-level, nested `error.code`, nested `pbi.error.code` fallback, no match).
- [x] Existing `tests/unit/services/test_ownership.py` and `tests/unit/test_sql.py` pass unchanged (behavior preserved through the refactor).
- [x] `uv run ruff format .` - no changes after fixing one line length
- [x] `uv run ruff check .` - all checks passed
- [x] `uv run ty check` - all checks passed
- [x] `uv run pytest tests/unit -q` - 5779 passed, 2 deselected

Closes #962

🤖 Generated with [Claude Code](https://claude.com/claude-code)