### PR TITLE
docs: document uv tool install as a persistent install method

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,11 @@ Authentication is configured via the `FABRIC_AUTH` environment variable. The def
 pip install fabric-dw
 # or run without installing:
 uvx fabric-dw --help
+# or install persistently on PATH:
+uv tool install fabric-dw
 ```
 
-After installation, the `fdw` command is a short alias for `fabric-dw`; both invoke the same entry point.
+After installation, the `fdw` command is a short alias for `fabric-dw`; both invoke the same entry point. See the [Install](https://fdw.debruyn.dev/install/) docs for MCP server setup, upgrading, and prerelease builds.
 
 ## Quick Start
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -39,6 +39,34 @@ uvx fabric-dw --help
 
 [`uvx`](https://docs.astral.sh/uv/guides/tools/) fetches and runs the published package on demand without a global install. No setup is required beyond having `uv` available.
 
+### Persistent install with uv tool install
+
+If you want `fdw` to stay on `PATH` between sessions instead of being fetched on demand, use [`uv tool install`](https://docs.astral.sh/uv/guides/tools/) - the `uv` equivalent of `pipx install`:
+
+```bash
+uv tool install fabric-dw
+```
+
+Unlike `uvx`, which re-fetches and runs the package on demand without installing anything, `uv tool install` installs both entry points the package ships - `fdw` (this CLI) and `fabric-dw-mcp` (the [MCP server](#mcp)) - as persistent executables on `PATH`.
+
+Upgrade to the latest release with:
+
+```bash
+uv tool upgrade fabric-dw
+```
+
+`fabric-dw` also publishes prerelease dev builds. To install the latest one, allow prereleases explicitly:
+
+```bash
+uv tool install --prerelease allow fabric-dw
+```
+
+Uninstall with:
+
+```bash
+uv tool uninstall fabric-dw
+```
+
 ### Verify
 
 After installation, confirm the CLI is available:
@@ -67,6 +95,8 @@ uvx --from fabric-dw fabric-dw-mcp
 The package is named `fabric-dw`, but the MCP entry point it ships is `fabric-dw-mcp`. Because the two names differ, `uvx` needs `--from fabric-dw` to know which package provides the `fabric-dw-mcp` command - `uvx fabric-dw-mcp` on its own would try to fetch a (non-existent) package called `fabric-dw-mcp` and fail.
 
 Every client snippet below configures `uvx --from fabric-dw fabric-dw-mcp` as the entry point, so your AI tool always picks up the latest published version. Pin a version with `uvx --from fabric-dw==2026.6.0 fabric-dw-mcp` if you need reproducibility.
+
+Prefer a persistent install over fetching on demand? Run `uv tool install fabric-dw` once (see [Persistent install with uv tool install](#persistent-install-with-uv-tool-install) above); it also puts `fabric-dw-mcp` directly on `PATH`, so client configs can point their `command` at `fabric-dw-mcp` with no `args` instead of `uvx --from fabric-dw fabric-dw-mcp`.
 
 You will also need an Azure credential the server can use to call the Fabric REST and SQL APIs. Set the `FABRIC_AUTH` environment variable to select a source (see [Authentication](#authentication) above):
 


### PR DESCRIPTION
## Summary

- `docs/install.md` documented `pip install fabric-dw` and `uvx --from fabric-dw ...` / `uvx fabric-dw --help` (on-demand runner), but not `uv tool install`, which is the recommended way to get a persistent `fdw` / `fabric-dw-mcp` on `PATH` via `uv` (the analogue of `pipx install`).
- Added a "Persistent install with uv tool install" subsection to the CLI install section of `docs/install.md`, right after the existing pip/uvx snippet, covering:
  - `uv tool install fabric-dw` -- installs both entry points (`fdw` and `fabric-dw-mcp`) persistently on `PATH`, contrasted with `uvx`'s fetch-and-run-on-demand behavior.
  - `uv tool upgrade fabric-dw` to upgrade.
  - `uv tool install --prerelease allow fabric-dw` to install the latest prerelease dev build (this package publishes prerelease dev builds).
  - `uv tool uninstall fabric-dw` to uninstall.
- Added a short cross-reference note in the MCP install section's `uvx` TL;DR, since `uv tool install` also puts `fabric-dw-mcp` on `PATH`, letting client configs use `fabric-dw-mcp` directly instead of `uvx --from fabric-dw fabric-dw-mcp`.
- `README.md` mirrors the CLI install methods, so added a matching `uv tool install fabric-dw` line there for parity, plus a link to the full Install docs page.
- Verified the `uv tool install` / `upgrade` / `uninstall` commands and the `--prerelease allow` flag against `uv tool install --help` / `uv tool upgrade --help` / `uv tool uninstall --help` rather than guessing.

## Test plan

- [x] `uv run --with zensical zensical build --strict` -- builds clean, no broken links/anchors (verifies the new `#persistent-install-with-uv-tool-install` cross-reference anchor resolves).
- [x] No `learn.microsoft.com` links were added (only `docs.astral.sh` uv-docs links), so the `WT.mc_id=MVP_310840` convention doesn't apply to this change; existing learn.microsoft.com links left untouched.
- [x] Docs-only change; no code touched.

Closes #964