### PR TITLE
fix(permissions)!: remove unsupported BLOCK predicates from row-level security

### DIFF
--- a/docs/commands/permissions.md
+++ b/docs/commands/permissions.md
@@ -834,8 +834,7 @@ List all row-level security policies and their predicates from `sys.security_pol
 Create a row-level security policy with one or more FILTER predicates. Executes
 `CREATE SECURITY POLICY`.
 
-Fabric Data Warehouse currently supports FILTER predicates only (BLOCK is rejected by both
-`CREATE SECURITY POLICY` and `ALTER SECURITY POLICY`).
+There is no predicate-type option (#966): Fabric Data Warehouse supports FILTER predicates only.
 
 Blocked by `FABRIC_MCP_READONLY`. Does NOT require `FABRIC_MCP_ALLOW_DESTRUCTIVE`.
 
@@ -845,7 +844,6 @@ Blocked by `FABRIC_MCP_READONLY`. Does NOT require `FABRIC_MCP_ALLOW_DESTRUCTIVE
 - `item` (`str`): Warehouse or SQL endpoint name or GUID.
 - `policy_name` (`str`): qualified policy name (`"schema.name"` or `"name"`).
 - `predicates` (`list[dict]`): list of predicate definitions. Each entry must include:
-  - `predicate_type` (`str`): `"FILTER"` (the only supported value).
   - `fn_schema` (`str`, optional): schema of the predicate function. Omit when the function lives in the default schema.
   - `fn_name` (`str`): name of the predicate function.
   - `fn_args` (`list[str]`): column names to pass to the function.

--- a/docs/commands/permissions.md
+++ b/docs/commands/permissions.md
@@ -15,8 +15,8 @@ Five distinct permission planes are exposed under the `permissions` top-level gr
   statements.
 - `permissions cls` - Column-level security. Applies `GRANT`, `DENY`, and `REVOKE` to named
   column lists rather than whole objects.
-- `permissions rls` - Row-level security. Manages security policies with filter and block
-  predicates that reference existing predicate functions.
+- `permissions rls` - Row-level security. Manages security policies with FILTER predicates that
+  reference existing predicate functions (BLOCK predicates are not supported by Fabric).
 - `permissions mask` - Dynamic data masking. Applies, inspects, and removes column-level masks.
 
 **Targets:** Data Warehouse / SQL Analytics Endpoint
@@ -399,9 +399,13 @@ fdw -w MyWorkspace permissions cls list SalesWH --object dbo.sales
 fdw -w MyWorkspace --json permissions cls list SalesWH --object dbo.sales
 ```
 
-Control row-level security (RLS) policies. Each policy contains one or more filter or block
-predicates that reference existing predicate functions (table-valued functions). The CLI
-never authors or modifies predicate function bodies.
+Control row-level security (RLS) policies. Each policy contains one or more FILTER predicates
+that reference existing predicate functions (table-valued functions). The CLI never authors or
+modifies predicate function bodies.
+
+**Note:** Fabric Data Warehouse currently supports FILTER predicates only. BLOCK predicates are
+rejected by both `CREATE SECURITY POLICY` and `ALTER SECURITY POLICY`, so `--block` is not
+offered by any `rls` command.
 
 ### permissions rls list
 
@@ -426,52 +430,42 @@ fdw -w MyWorkspace --json permissions rls list SalesWH
 
 **Targets:** Data Warehouse / SQL Analytics Endpoint
 
-Create a new row-level security policy with one filter or block predicate.
+Create a new row-level security policy with one FILTER predicate.
 
 **Synopsis**
 
 ```
 fdw [-w WORKSPACE] permissions rls create [ITEM] [POLICY_NAME]
-    { --filter SCHEMA.FN(COL,...) | --block SCHEMA.FN(COL,...) }
+    --filter SCHEMA.FN(COL,...)
     --on SCHEMA.TABLE
-    [--operation AFTER-INSERT|AFTER-UPDATE|BEFORE-UPDATE|BEFORE-DELETE]
     [--state on|off]
 ```
 
 | Option | Description |
 | --- | --- |
-| `--filter SCHEMA.FN(COL,...)` | Add a FILTER predicate (mutually exclusive with `--block`). |
-| `--block SCHEMA.FN(COL,...)` | Add a BLOCK predicate (mutually exclusive with `--filter`). |
+| `--filter SCHEMA.FN(COL,...)` | The FILTER predicate function reference (required). |
 | `--on SCHEMA.TABLE` | Target table for the predicate (required). |
-| `--operation OP` | Block operation: `after-insert`, `after-update`, `before-update`, `before-delete` (BLOCK only). |
 | `--state on\|off` | Initial policy state (default: `on`). |
 
 **Example**
 
 ```shell
-# Filter predicate, enabled
 fdw -w MyWorkspace permissions rls create SalesWH rls.SalesFilter \
     --filter rls.fn_filter(SalesRep) --on dbo.Sales
-
-# Block predicate, disabled initially
-fdw -w MyWorkspace permissions rls create SalesWH rls.SalesBlock \
-    --block rls.fn_block(SalesRep) --on dbo.Sales \
-    --operation after-insert --state off
 ```
 
 ### permissions rls add-predicate
 
 **Targets:** Data Warehouse / SQL Analytics Endpoint
 
-Add an additional predicate to an existing policy.
+Add an additional FILTER predicate to an existing policy.
 
 **Synopsis**
 
 ```
 fdw [-w WORKSPACE] permissions rls add-predicate [ITEM] [POLICY_NAME]
-    { --filter SCHEMA.FN(COL,...) | --block SCHEMA.FN(COL,...) }
+    --filter SCHEMA.FN(COL,...)
     --on SCHEMA.TABLE
-    [--operation AFTER-INSERT|AFTER-UPDATE|BEFORE-UPDATE|BEFORE-DELETE]
 ```
 
 **Example**
@@ -485,27 +479,24 @@ fdw -w MyWorkspace permissions rls add-predicate SalesWH rls.SalesFilter \
 
 **Targets:** Data Warehouse / SQL Analytics Endpoint
 
-Drop a predicate from an existing policy.
+Drop the FILTER predicate from an existing policy for a given table.
 
 **Synopsis**
 
 ```
 fdw [-w WORKSPACE] permissions rls drop-predicate [ITEM] [POLICY_NAME]
-    { --filter | --block }
     --on SCHEMA.TABLE
 ```
 
 | Option | Description |
 | --- | --- |
-| `--filter` | Target a FILTER predicate (flag, no value). |
-| `--block` | Target a BLOCK predicate (flag, no value). |
-| `--on SCHEMA.TABLE` | Table whose predicate is dropped. |
+| `--on SCHEMA.TABLE` | Table whose FILTER predicate is dropped. |
 
 **Example**
 
 ```shell
 fdw -w MyWorkspace permissions rls drop-predicate SalesWH rls.SalesFilter \
-    --filter --on dbo.Sales
+    --on dbo.Sales
 ```
 
 ### permissions rls set-state
@@ -840,7 +831,11 @@ List all row-level security policies and their predicates from `sys.security_pol
 
 **Targets:** Data Warehouse / SQL Analytics Endpoint
 
-Create a row-level security policy with one or more predicates. Executes `CREATE SECURITY POLICY`.
+Create a row-level security policy with one or more FILTER predicates. Executes
+`CREATE SECURITY POLICY`.
+
+Fabric Data Warehouse currently supports FILTER predicates only (BLOCK is rejected by both
+`CREATE SECURITY POLICY` and `ALTER SECURITY POLICY`).
 
 Blocked by `FABRIC_MCP_READONLY`. Does NOT require `FABRIC_MCP_ALLOW_DESTRUCTIVE`.
 
@@ -850,14 +845,12 @@ Blocked by `FABRIC_MCP_READONLY`. Does NOT require `FABRIC_MCP_ALLOW_DESTRUCTIVE
 - `item` (`str`): Warehouse or SQL endpoint name or GUID.
 - `policy_name` (`str`): qualified policy name (`"schema.name"` or `"name"`).
 - `predicates` (`list[dict]`): list of predicate definitions. Each entry must include:
-  - `predicate_type` (`str`): `"FILTER"` or `"BLOCK"`.
+  - `predicate_type` (`str`): `"FILTER"` (the only supported value).
   - `fn_schema` (`str`, optional): schema of the predicate function. Omit when the function lives in the default schema.
   - `fn_name` (`str`): name of the predicate function.
   - `fn_args` (`list[str]`): column names to pass to the function.
   - `table_schema` (`str`): schema of the target table.
   - `table_name` (`str`): name of the target table.
-  - `operation` (`str`, optional): block operation - `"AFTER_INSERT"`, `"AFTER_UPDATE"`,
-    `"BEFORE_UPDATE"`, or `"BEFORE_DELETE"` (BLOCK predicates only).
 - `state` (`bool`, default `true`): initial policy state - `true` to enable, `false` to disable.
 
 **Returns:** `{ "created": true, "policy_name": str, "state": bool }`.
@@ -866,8 +859,11 @@ Blocked by `FABRIC_MCP_READONLY`. Does NOT require `FABRIC_MCP_ALLOW_DESTRUCTIVE
 
 **Targets:** Data Warehouse / SQL Analytics Endpoint
 
-Add a predicate to an existing row-level security policy. Executes
-`ALTER SECURITY POLICY ... ADD FILTER|BLOCK PREDICATE`.
+Add a FILTER predicate to an existing row-level security policy. Executes
+`ALTER SECURITY POLICY ... ADD FILTER PREDICATE`.
+
+Fabric Data Warehouse currently supports FILTER predicates only, so no `predicate_type` or
+`operation` parameter is offered.
 
 Blocked by `FABRIC_MCP_READONLY`. Does NOT require `FABRIC_MCP_ALLOW_DESTRUCTIVE`.
 
@@ -876,24 +872,24 @@ Blocked by `FABRIC_MCP_READONLY`. Does NOT require `FABRIC_MCP_ALLOW_DESTRUCTIVE
 - `workspace` (`str`): workspace name or GUID.
 - `item` (`str`): Warehouse or SQL endpoint name or GUID.
 - `policy_name` (`str`): qualified policy name (`"schema.name"` or `"name"`).
-- `predicate_type` (`str`): `"FILTER"` or `"BLOCK"`.
 - `fn_name` (`str`): name of the predicate function.
 - `fn_args` (`list[str]`): column names to pass to the predicate function.
 - `table_schema` (`str`): schema name of the target table.
 - `table_name` (`str`): name of the target table.
 - `fn_schema` (`str | null`, optional): schema of the predicate function. Omit when the function
   lives in the default schema.
-- `operation` (`str | null`, optional): block operation - `"AFTER_INSERT"`, `"AFTER_UPDATE"`,
-  `"BEFORE_UPDATE"`, or `"BEFORE_DELETE"` (BLOCK predicates only).
 
-**Returns:** `{ "added": true, "policy_name": str, "predicate_type": str, "table": str }`.
+**Returns:** `{ "added": true, "policy_name": str, "predicate_type": "FILTER", "table": str }`.
 
 ### drop_security_predicate
 
 **Targets:** Data Warehouse / SQL Analytics Endpoint
 
-Drop a predicate from an existing row-level security policy. Executes
-`ALTER SECURITY POLICY ... DROP FILTER|BLOCK PREDICATE ON`.
+Drop the FILTER predicate from an existing row-level security policy. Executes
+`ALTER SECURITY POLICY ... DROP FILTER PREDICATE ON`.
+
+Fabric Data Warehouse currently supports FILTER predicates only, so no `predicate_type`
+parameter is offered.
 
 Blocked by `FABRIC_MCP_READONLY`. Does NOT require `FABRIC_MCP_ALLOW_DESTRUCTIVE`.
 
@@ -902,11 +898,10 @@ Blocked by `FABRIC_MCP_READONLY`. Does NOT require `FABRIC_MCP_ALLOW_DESTRUCTIVE
 - `workspace` (`str`): workspace name or GUID.
 - `item` (`str`): Warehouse or SQL endpoint name or GUID.
 - `policy_name` (`str`): qualified policy name (`"schema.name"` or `"name"`).
-- `predicate_type` (`str`): `"FILTER"` or `"BLOCK"`.
 - `table_schema` (`str`): schema name of the target table.
 - `table_name` (`str`): name of the target table.
 
-**Returns:** `{ "dropped": true, "policy_name": str, "predicate_type": str, "table": str }`.
+**Returns:** `{ "dropped": true, "policy_name": str, "predicate_type": "FILTER", "table": str }`.
 
 ### set_security_policy_state
 

--- a/src/fabric_dw/cli/commands/permissions.py
+++ b/src/fabric_dw/cli/commands/permissions.py
@@ -883,9 +883,8 @@ async def rls_create_cmd(
 ) -> None:
     """Create a security policy POLICY on ITEM with an initial FILTER predicate.
 
-    Fabric Data Warehouse currently supports FILTER predicates only -- BLOCK
-    predicates are rejected by both CREATE and ALTER SECURITY POLICY, so
-    --block is not offered.
+    Fabric Data Warehouse supports FILTER predicates only (#966): there is no
+    --block option and no predicate-type choice to make.
 
     Use 'permissions rls add-predicate' to add further predicates.
 
@@ -910,7 +909,6 @@ async def rls_create_cmd(
                 policy,
                 [
                     {
-                        "predicate_type": "FILTER",
                         "fn_schema": fn_schema,
                         "fn_name": fn_name,
                         "fn_args": fn_args,
@@ -954,9 +952,8 @@ async def rls_add_predicate_cmd(
 ) -> None:
     """Add a FILTER predicate to an existing security policy POLICY on ITEM.
 
-    Fabric Data Warehouse currently supports FILTER predicates only -- BLOCK
-    predicates are rejected by ALTER SECURITY POLICY, so --block is not
-    offered.
+    Fabric Data Warehouse supports FILTER predicates only (#966): there is no
+    --block option and no predicate-type choice to make.
 
     POLICY may be schema-qualified (e.g. rls.MySalesFilter) or bare (MySalesFilter).
     --on specifies the target table.
@@ -972,7 +969,6 @@ async def rls_add_predicate_cmd(
             await _rls_svc.add_predicate(
                 target,
                 policy,
-                "FILTER",
                 fn_schema,
                 fn_name,
                 fn_args,
@@ -1005,8 +1001,8 @@ async def rls_drop_predicate_cmd(
 ) -> None:
     """Drop the FILTER predicate from security policy POLICY on ITEM.
 
-    Fabric Data Warehouse currently supports FILTER predicates only, so this
-    always drops a FILTER predicate; --block is not offered.
+    Fabric Data Warehouse supports FILTER predicates only (#966): there is no
+    --block option and no predicate-type choice to make.
     --on specifies the target table.
     """
     ws = resolve_workspace(ctx)
@@ -1019,7 +1015,6 @@ async def rls_drop_predicate_cmd(
             await _rls_svc.drop_predicate(
                 target,
                 policy,
-                "FILTER",
                 table_schema,
                 table_name,
                 mode=ctx.auth,

--- a/src/fabric_dw/cli/commands/permissions.py
+++ b/src/fabric_dw/cli/commands/permissions.py
@@ -853,16 +853,9 @@ async def rls_list_cmd(ctx: CliContext, item: str | None) -> None:
 @click.option(
     "--filter",
     "filter_fn",
-    default=None,
+    required=True,
     metavar="SCHEMA.FN(col,...)",
-    help="Filter predicate function reference (mutually exclusive with --block).",
-)
-@click.option(
-    "--block",
-    "block_fn",
-    default=None,
-    metavar="SCHEMA.FN(col,...)",
-    help="Block predicate function reference (mutually exclusive with --filter).",
+    help="Filter predicate function reference.",
 )
 @click.option(
     "--on",
@@ -870,15 +863,6 @@ async def rls_list_cmd(ctx: CliContext, item: str | None) -> None:
     required=True,
     metavar="SCHEMA.TABLE",
     help="Target table for the predicate (e.g. dbo.Sales).",
-)
-@click.option(
-    "--operation",
-    type=click.Choice(
-        ["after-insert", "after-update", "before-update", "before-delete"],
-        case_sensitive=False,
-    ),
-    default=None,
-    help="Block predicate DML operation (required for BLOCK when ambiguous).",
 )
 @click.option(
     "--state",
@@ -893,47 +877,30 @@ async def rls_create_cmd(
     ctx: CliContext,
     item: str | None,
     policy: str,
-    filter_fn: str | None,
-    block_fn: str | None,
+    filter_fn: str,
     target_table: str,
-    operation: str | None,
     state: str,
 ) -> None:
-    """Create a security policy POLICY on ITEM with an initial predicate.
+    """Create a security policy POLICY on ITEM with an initial FILTER predicate.
 
-    Specify exactly one of --filter or --block to define the initial predicate.
+    Fabric Data Warehouse currently supports FILTER predicates only -- BLOCK
+    predicates are rejected by both CREATE and ALTER SECURITY POLICY, so
+    --block is not offered.
+
     Use 'permissions rls add-predicate' to add further predicates.
 
     POLICY may be schema-qualified (e.g. rls.MySalesFilter) or bare (MySalesFilter).
     --on specifies the target table (e.g. dbo.Sales).
 
-    Examples:
+    Example:
 
         fdw -w MyWS permissions rls create MyWH rls.SalesFilter \\
             --filter "rls.fn_filter(SalesRep)" --on dbo.Sales
-
-        fdw -w MyWS permissions rls create MyWH rls.SalesBlock \\
-            --block "rls.fn_block(SalesRep)" --on dbo.Sales --operation after-insert
     """
-    if (filter_fn is None) == (block_fn is None):
-        raise click.UsageError("Specify exactly one of --filter or --block.")
-
     ws = resolve_workspace(ctx)
     it = resolve_warehouse_arg(ctx, item)
 
-    if filter_fn is not None:
-        if operation is not None:
-            raise click.UsageError("--operation is only valid with --block predicates")
-        fn_schema, fn_name, fn_args = _parse_fn_ref(filter_fn, "--filter")
-        predicate_type = "FILTER"
-        op: str | None = None  # FILTER predicates have no operation
-    else:
-        if block_fn is None:  # pragma: no cover
-            raise click.UsageError("Expected --block value")
-        fn_schema, fn_name, fn_args = _parse_fn_ref(block_fn, "--block")
-        predicate_type = "BLOCK"
-        op = operation  # service's _validate_operation normalizes hyphens to underscores
-
+    fn_schema, fn_name, fn_args = _parse_fn_ref(filter_fn, "--filter")
     table_schema, table_name = _parse_table_ref(target_table, "--on")
     try:
         async with build_http_client(ctx) as http:
@@ -943,13 +910,12 @@ async def rls_create_cmd(
                 policy,
                 [
                     {
-                        "predicate_type": predicate_type,
+                        "predicate_type": "FILTER",
                         "fn_schema": fn_schema,
                         "fn_name": fn_name,
                         "fn_args": fn_args,
                         "table_schema": table_schema,
                         "table_name": table_name,
-                        "operation": op,
                     }
                 ],
                 state=state.lower() == "on",
@@ -957,9 +923,7 @@ async def rls_create_cmd(
             )
     except (ValueError, FabricError) as exc:
         raise click.ClickException(str(exc)) from exc
-    click.echo(
-        f"Created security policy {policy!r} with {predicate_type} predicate on {target_table!r}."
-    )
+    click.echo(f"Created security policy {policy!r} with FILTER predicate on {target_table!r}.")
 
 
 @rls_group.command("add-predicate")
@@ -968,16 +932,9 @@ async def rls_create_cmd(
 @click.option(
     "--filter",
     "filter_fn",
-    default=None,
+    required=True,
     metavar="SCHEMA.FN(col,...)",
-    help="Filter predicate function reference (mutually exclusive with --block).",
-)
-@click.option(
-    "--block",
-    "block_fn",
-    default=None,
-    metavar="SCHEMA.FN(col,...)",
-    help="Block predicate function reference (mutually exclusive with --filter).",
+    help="Filter predicate function reference.",
 )
 @click.option(
     "--on",
@@ -986,52 +943,28 @@ async def rls_create_cmd(
     metavar="SCHEMA.TABLE",
     help="Target table for the predicate (e.g. dbo.Sales).",
 )
-@click.option(
-    "--operation",
-    type=click.Choice(
-        ["after-insert", "after-update", "before-update", "before-delete"],
-        case_sensitive=False,
-    ),
-    default=None,
-    help="Block predicate DML operation.",
-)
 @click.pass_obj
 @coro
 async def rls_add_predicate_cmd(
     ctx: CliContext,
     item: str | None,
     policy: str,
-    filter_fn: str | None,
-    block_fn: str | None,
+    filter_fn: str,
     target_table: str,
-    operation: str | None,
 ) -> None:
-    """Add a predicate to an existing security policy POLICY on ITEM.
+    """Add a FILTER predicate to an existing security policy POLICY on ITEM.
 
-    Specify exactly one of --filter or --block.
+    Fabric Data Warehouse currently supports FILTER predicates only -- BLOCK
+    predicates are rejected by ALTER SECURITY POLICY, so --block is not
+    offered.
 
     POLICY may be schema-qualified (e.g. rls.MySalesFilter) or bare (MySalesFilter).
     --on specifies the target table.
     """
-    if (filter_fn is None) == (block_fn is None):
-        raise click.UsageError("Specify exactly one of --filter or --block.")
-
     ws = resolve_workspace(ctx)
     it = resolve_warehouse_arg(ctx, item)
 
-    if filter_fn is not None:
-        if operation is not None:
-            raise click.UsageError("--operation is only valid with --block predicates")
-        fn_schema, fn_name, fn_args = _parse_fn_ref(filter_fn, "--filter")
-        predicate_type = "FILTER"
-        op: str | None = None
-    else:
-        if block_fn is None:  # pragma: no cover
-            raise click.UsageError("Expected --block value")
-        fn_schema, fn_name, fn_args = _parse_fn_ref(block_fn, "--block")
-        predicate_type = "BLOCK"
-        op = operation  # service's _validate_operation normalizes hyphens to underscores
-
+    fn_schema, fn_name, fn_args = _parse_fn_ref(filter_fn, "--filter")
     table_schema, table_name = _parse_table_ref(target_table, "--on")
     try:
         async with build_http_client(ctx) as http:
@@ -1039,43 +972,28 @@ async def rls_add_predicate_cmd(
             await _rls_svc.add_predicate(
                 target,
                 policy,
-                predicate_type,
+                "FILTER",
                 fn_schema,
                 fn_name,
                 fn_args,
                 table_schema,
                 table_name,
-                operation=op,
                 mode=ctx.auth,
             )
     except (ValueError, FabricError) as exc:
         raise click.ClickException(str(exc)) from exc
-    click.echo(f"Added {predicate_type} predicate to policy {policy!r} on {target_table!r}.")
+    click.echo(f"Added FILTER predicate to policy {policy!r} on {target_table!r}.")
 
 
 @rls_group.command("drop-predicate")
 @click.argument("item", required=False, default=None)
 @click.argument("policy")
 @click.option(
-    "--filter",
-    "predicate_filter",
-    is_flag=True,
-    default=False,
-    help="Drop a FILTER predicate (mutually exclusive with --block).",
-)
-@click.option(
-    "--block",
-    "predicate_block",
-    is_flag=True,
-    default=False,
-    help="Drop a BLOCK predicate (mutually exclusive with --filter).",
-)
-@click.option(
     "--on",
     "target_table",
     required=True,
     metavar="SCHEMA.TABLE",
-    help="Target table whose predicate to drop.",
+    help="Target table whose FILTER predicate to drop.",
 )
 @click.pass_obj
 @coro
@@ -1083,22 +1001,16 @@ async def rls_drop_predicate_cmd(
     ctx: CliContext,
     item: str | None,
     policy: str,
-    predicate_filter: bool,
-    predicate_block: bool,
     target_table: str,
 ) -> None:
-    """Drop a predicate from security policy POLICY on ITEM.
+    """Drop the FILTER predicate from security policy POLICY on ITEM.
 
-    Specify exactly one of --filter or --block to identify the predicate type.
+    Fabric Data Warehouse currently supports FILTER predicates only, so this
+    always drops a FILTER predicate; --block is not offered.
     --on specifies the target table.
     """
-    if predicate_filter == predicate_block:
-        raise click.UsageError("Specify exactly one of --filter or --block.")
-
     ws = resolve_workspace(ctx)
     it = resolve_warehouse_arg(ctx, item)
-
-    predicate_type = "FILTER" if predicate_filter else "BLOCK"
 
     table_schema, table_name = _parse_table_ref(target_table, "--on")
     try:
@@ -1107,14 +1019,14 @@ async def rls_drop_predicate_cmd(
             await _rls_svc.drop_predicate(
                 target,
                 policy,
-                predicate_type,
+                "FILTER",
                 table_schema,
                 table_name,
                 mode=ctx.auth,
             )
     except (ValueError, FabricError) as exc:
         raise click.ClickException(str(exc)) from exc
-    click.echo(f"Dropped {predicate_type} predicate from policy {policy!r} on {target_table!r}.")
+    click.echo(f"Dropped FILTER predicate from policy {policy!r} on {target_table!r}.")
 
 
 @rls_group.command("set-state")

--- a/src/fabric_dw/mcp/tools/permissions.py
+++ b/src/fabric_dw/mcp/tools/permissions.py
@@ -455,18 +455,17 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
     ) -> dict[str, Any]:
         """Create a row-level security policy.
 
-        Executes ``CREATE SECURITY POLICY`` with one or more filter or block
-        predicates.  Each entry in *predicates* must include:
+        Executes ``CREATE SECURITY POLICY`` with one or more filter
+        predicates. Fabric Data Warehouse currently supports FILTER
+        predicates only -- BLOCK is rejected by both CREATE and ALTER
+        SECURITY POLICY. Each entry in *predicates* must include:
 
-        - ``predicate_type``: ``"FILTER"`` or ``"BLOCK"``
+        - ``predicate_type``: ``"FILTER"`` (the only supported value)
         - ``fn_schema``: schema of the predicate function
         - ``fn_name``: name of the predicate function
         - ``fn_args``: list of column names to pass to the function
         - ``table_schema``: schema of the target table
         - ``table_name``: name of the target table
-        - ``operation`` (optional): block operation -- ``"AFTER_INSERT"``,
-          ``"AFTER_UPDATE"``, ``"BEFORE_UPDATE"``, or ``"BEFORE_DELETE"``
-          (BLOCK predicates only)
 
         Args:
             workspace: Workspace name or GUID.
@@ -506,32 +505,29 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         workspace: str,
         item: str,
         policy_name: str,
-        predicate_type: str,
         fn_name: str,
         fn_args: list[str],
         table_schema: str,
         table_name: str,
         fn_schema: str | None = None,
-        operation: str | None = None,
     ) -> dict[str, Any]:
-        """Add a predicate to an existing row-level security policy.
+        """Add a FILTER predicate to an existing row-level security policy.
 
-        Executes ``ALTER SECURITY POLICY ... ADD FILTER|BLOCK PREDICATE``.
+        Executes ``ALTER SECURITY POLICY ... ADD FILTER PREDICATE``. Fabric
+        Data Warehouse currently supports FILTER predicates only -- BLOCK is
+        rejected by ALTER SECURITY POLICY, so no predicate-type or operation
+        parameter is offered.
 
         Args:
             workspace: Workspace name or GUID.
             item: Warehouse or SQL endpoint name or GUID.
             policy_name: Qualified policy name (``"schema.name"`` or ``"name"``).
-            predicate_type: ``"FILTER"`` or ``"BLOCK"``.
             fn_name: Name of the predicate function.
             fn_args: Column names to pass to the predicate function.
             table_schema: Schema name of the target table.
             table_name: Name of the target table.
             fn_schema: Schema name of the predicate function (optional -- omit
                 when the function lives in the default schema).
-            operation: Block operation (BLOCK predicates only) -- one of
-                ``"AFTER_INSERT"``, ``"AFTER_UPDATE"``, ``"BEFORE_UPDATE"``,
-                ``"BEFORE_DELETE"``.
         """
         ctx = get_context()
         assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
@@ -541,23 +537,21 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
                 workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
             )
             _log.debug(
-                "add_security_predicate ws=%s item=%s policy=%r type=%r",
+                "add_security_predicate ws=%s item=%s policy=%r",
                 ws_id,
                 entry.id,
                 policy_name,
-                predicate_type,
             )
             target = make_sql_target(ws_id, entry, item)
             await _rls_svc.add_predicate(
                 target,
                 policy_name,
-                predicate_type,
+                "FILTER",
                 fn_schema,
                 fn_name,
                 fn_args,
                 table_schema,
                 table_name,
-                operation=operation,
                 mode=ctx.auth_mode,
             )
         except (ValueError, FabricError) as exc:
@@ -565,29 +559,29 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         return {
             "added": True,
             "policy_name": policy_name,
-            "predicate_type": predicate_type,
+            "predicate_type": "FILTER",
             "table": f"{table_schema}.{table_name}",
         }
 
     @mutating_tool(mcp, "drop_security_predicate")
-    async def drop_security_predicate_tool(  # noqa: PLR0913
+    async def drop_security_predicate_tool(
         workspace: str,
         item: str,
         policy_name: str,
-        predicate_type: str,
         table_schema: str,
         table_name: str,
     ) -> dict[str, Any]:
-        """Drop a predicate from an existing row-level security policy.
+        """Drop the FILTER predicate from an existing row-level security policy.
 
-        Executes ``ALTER SECURITY POLICY ... DROP FILTER|BLOCK PREDICATE ON``.
-        The T-SQL ``DROP PREDICATE ON`` syntax takes no operation qualifier.
+        Executes ``ALTER SECURITY POLICY ... DROP FILTER PREDICATE ON``. The
+        T-SQL ``DROP PREDICATE ON`` syntax takes no operation qualifier.
+        Fabric Data Warehouse currently supports FILTER predicates only, so
+        no predicate-type parameter is offered.
 
         Args:
             workspace: Workspace name or GUID.
             item: Warehouse or SQL endpoint name or GUID.
             policy_name: Qualified policy name (``"schema.name"`` or ``"name"``).
-            predicate_type: ``"FILTER"`` or ``"BLOCK"``.
             table_schema: Schema name of the target table.
             table_name: Name of the target table.
         """
@@ -599,17 +593,16 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
                 workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
             )
             _log.debug(
-                "drop_security_predicate ws=%s item=%s policy=%r type=%r",
+                "drop_security_predicate ws=%s item=%s policy=%r",
                 ws_id,
                 entry.id,
                 policy_name,
-                predicate_type,
             )
             target = make_sql_target(ws_id, entry, item)
             await _rls_svc.drop_predicate(
                 target,
                 policy_name,
-                predicate_type,
+                "FILTER",
                 table_schema,
                 table_name,
                 mode=ctx.auth_mode,
@@ -619,7 +612,7 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
         return {
             "dropped": True,
             "policy_name": policy_name,
-            "predicate_type": predicate_type,
+            "predicate_type": "FILTER",
             "table": f"{table_schema}.{table_name}",
         }
 

--- a/src/fabric_dw/mcp/tools/permissions.py
+++ b/src/fabric_dw/mcp/tools/permissions.py
@@ -455,12 +455,11 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
     ) -> dict[str, Any]:
         """Create a row-level security policy.
 
-        Executes ``CREATE SECURITY POLICY`` with one or more filter
-        predicates. Fabric Data Warehouse currently supports FILTER
-        predicates only -- BLOCK is rejected by both CREATE and ALTER
-        SECURITY POLICY. Each entry in *predicates* must include:
+        Executes ``CREATE SECURITY POLICY`` with one or more FILTER
+        predicates. There is no predicate-type option (#966): Fabric Data
+        Warehouse supports FILTER predicates only. Each entry in *predicates*
+        must include:
 
-        - ``predicate_type``: ``"FILTER"`` (the only supported value)
         - ``fn_schema``: schema of the predicate function
         - ``fn_name``: name of the predicate function
         - ``fn_args``: list of column names to pass to the function
@@ -513,10 +512,9 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
     ) -> dict[str, Any]:
         """Add a FILTER predicate to an existing row-level security policy.
 
-        Executes ``ALTER SECURITY POLICY ... ADD FILTER PREDICATE``. Fabric
-        Data Warehouse currently supports FILTER predicates only -- BLOCK is
-        rejected by ALTER SECURITY POLICY, so no predicate-type or operation
-        parameter is offered.
+        Executes ``ALTER SECURITY POLICY ... ADD FILTER PREDICATE``. There is
+        no predicate-type or operation parameter (#966): Fabric Data
+        Warehouse supports FILTER predicates only.
 
         Args:
             workspace: Workspace name or GUID.
@@ -546,7 +544,6 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             await _rls_svc.add_predicate(
                 target,
                 policy_name,
-                "FILTER",
                 fn_schema,
                 fn_name,
                 fn_args,
@@ -575,8 +572,8 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
 
         Executes ``ALTER SECURITY POLICY ... DROP FILTER PREDICATE ON``. The
         T-SQL ``DROP PREDICATE ON`` syntax takes no operation qualifier.
-        Fabric Data Warehouse currently supports FILTER predicates only, so
-        no predicate-type parameter is offered.
+        There is no predicate-type parameter (#966): Fabric Data Warehouse
+        supports FILTER predicates only.
 
         Args:
             workspace: Workspace name or GUID.
@@ -602,7 +599,6 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             await _rls_svc.drop_predicate(
                 target,
                 policy_name,
-                "FILTER",
                 table_schema,
                 table_name,
                 mode=ctx.auth_mode,

--- a/src/fabric_dw/services/rls.py
+++ b/src/fabric_dw/services/rls.py
@@ -273,10 +273,11 @@ async def create_security_policy(
     policy_ref = _resolve_policy_ref(policy_name)
     state_sql = "ON" if state else "OFF"
 
+    _required = {"fn_name", "fn_args", "table_schema", "table_name"}
+    _allowed = _required | {"fn_schema"}
+
     clauses: list[str] = []
     for i, spec in enumerate(predicates):
-        _required = {"fn_name", "fn_args", "table_schema", "table_name"}
-        _allowed = _required | {"fn_schema"}
         _missing = _required - spec.keys()
         if _missing:
             missing_list = ", ".join(sorted(_missing))

--- a/src/fabric_dw/services/rls.py
+++ b/src/fabric_dw/services/rls.py
@@ -4,6 +4,13 @@ Reads from ``sys.security_policies`` / ``sys.security_predicates`` and issues
 ``CREATE SECURITY POLICY``, ``ALTER SECURITY POLICY``, and
 ``DROP SECURITY POLICY`` statements.
 
+FILTER predicates only (#966)
+------------------------------
+Fabric Data Warehouse rejects BLOCK predicates for both ``CREATE`` and
+``ALTER SECURITY POLICY`` ("BLOCK PREDICATE is not supported"). BLOCK support
+was removed after #919 shipped it untested; only FILTER predicates are
+exposed and validated here.
+
 Statement-building safety
 --------------------------
 All statements are built from:
@@ -13,9 +20,7 @@ All statements are built from:
 - Column names for predicate function arguments validated via
   :func:`~fabric_dw.identifiers.validate_column_name` +
   :func:`~fabric_dw.identifiers.quote_identifier`.
-- Fixed allowlists for predicate type (``FILTER`` / ``BLOCK``) and
-  block operation (``AFTER_INSERT`` / ``AFTER_UPDATE`` / ``BEFORE_UPDATE`` /
-  ``BEFORE_DELETE``).
+- A fixed allowlist for predicate type (``FILTER`` only).
 
 No SQL text is ever parsed or rewritten.
 """
@@ -37,7 +42,6 @@ from fabric_dw.models import SecurityPolicy, SecurityPredicate
 from fabric_dw.sql import SqlTarget, run_query
 
 __all__ = [
-    "VALID_BLOCK_OPERATIONS",
     "VALID_PREDICATE_TYPES",
     "add_predicate",
     "create_security_policy",
@@ -51,21 +55,10 @@ __all__ = [
 # Allowlists
 # ---------------------------------------------------------------------------
 
-#: Valid predicate type tokens (uppercase).
-VALID_PREDICATE_TYPES: frozenset[str] = frozenset({"FILTER", "BLOCK"})
-
-#: Valid block operation tokens (uppercase, underscore-separated).
-VALID_BLOCK_OPERATIONS: frozenset[str] = frozenset(
-    {"AFTER_INSERT", "AFTER_UPDATE", "BEFORE_UPDATE", "BEFORE_DELETE"}
-)
-
-#: Maps internal operation token to SQL clause fragment.
-_OPERATION_TO_SQL: dict[str, str] = {
-    "AFTER_INSERT": "AFTER INSERT",
-    "AFTER_UPDATE": "AFTER UPDATE",
-    "BEFORE_UPDATE": "BEFORE UPDATE",
-    "BEFORE_DELETE": "BEFORE DELETE",
-}
+#: Valid predicate type tokens (uppercase). BLOCK is intentionally absent
+#: (#966): Fabric Data Warehouse rejects it for both CREATE and ALTER
+#: SECURITY POLICY.
+VALID_PREDICATE_TYPES: frozenset[str] = frozenset({"FILTER"})
 
 # ---------------------------------------------------------------------------
 # SQL templates (read)
@@ -99,45 +92,19 @@ def _validate_predicate_type(predicate_type: str) -> str:
         predicate_type: Raw predicate type string (case-insensitive).
 
     Returns:
-        The uppercase token -- ``"FILTER"`` or ``"BLOCK"``.
+        The uppercase token -- currently only ``"FILTER"``.
 
     Raises:
-        ValueError: If *predicate_type* is not ``FILTER`` or ``BLOCK``.
+        ValueError: If *predicate_type* is not ``FILTER``. In particular,
+            ``"BLOCK"`` is rejected here (#966): Fabric Data Warehouse
+            rejects BLOCK PREDICATE for both CREATE and ALTER SECURITY
+            POLICY, so it is never sent to the server.
     """
     upper = predicate_type.upper()
     if upper not in VALID_PREDICATE_TYPES:
         msg = (
             f"Invalid predicate type {predicate_type!r}: "
             f"must be one of {', '.join(sorted(VALID_PREDICATE_TYPES))}"
-        )
-        raise ValueError(msg)
-    return upper
-
-
-def _validate_operation(operation: str | None) -> str | None:
-    """Validate and normalise a block predicate operation token.
-
-    Accepts tokens with underscores (``AFTER_INSERT``) or spaces
-    (``AFTER INSERT``), case-insensitively, and returns the canonical
-    underscore form.  Returns ``None`` when *operation* is ``None``.
-
-    Args:
-        operation: Operation token or ``None`` for no restriction.
-
-    Returns:
-        Normalised uppercase token (e.g. ``"AFTER_INSERT"``) or ``None``.
-
-    Raises:
-        ValueError: If *operation* is not in :data:`VALID_BLOCK_OPERATIONS`.
-    """
-    if operation is None:
-        return None
-    # Normalise spaces or hyphens to underscores before checking.
-    upper = operation.upper().replace(" ", "_").replace("-", "_")
-    if upper not in VALID_BLOCK_OPERATIONS:
-        msg = (
-            f"Invalid block operation {operation!r}: "
-            f"must be one of {', '.join(sorted(VALID_BLOCK_OPERATIONS))}"
         )
         raise ValueError(msg)
     return upper
@@ -212,38 +179,27 @@ def _build_predicate_clause(
     fn_args: list[str],
     table_schema: str,
     table_name: str,
-    operation: str | None,
 ) -> str:
-    """Build one ``ADD FILTER|BLOCK PREDICATE fn(...) ON table [OP]`` clause.
+    """Build one ``ADD FILTER PREDICATE fn(...) ON table`` clause.
 
     Args:
-        predicate_type: ``"FILTER"`` or ``"BLOCK"`` (already validated).
+        predicate_type: ``"FILTER"`` (already validated; this is the only
+            token :data:`VALID_PREDICATE_TYPES` accepts).
         fn_schema: Schema of the predicate function (may be ``None``).
         fn_name: Name of the predicate function.
         fn_args: Column name arguments for the predicate function.
         table_schema: Schema of the target table.
         table_name: Name of the target table.
-        operation: Block operation token (e.g. ``"AFTER_INSERT"``), or
-            ``None`` to omit the operation clause.  Must be ``None`` for
-            FILTER predicates.
 
     Returns:
-        The ``ADD ... PREDICATE ...`` clause string (no trailing semicolon).
-
-    Raises:
-        ValueError: If a FILTER predicate is given a non-``None`` operation.
+        The ``ADD FILTER PREDICATE ...`` clause string (no trailing
+        semicolon).
     """
-    if predicate_type == "FILTER" and operation is not None:
-        msg = "FILTER predicates do not accept an operation"
-        raise ValueError(msg)
     fn_call = _build_fn_call(fn_schema, fn_name, fn_args)
     validate_identifier(table_schema)
     validate_identifier(table_name)
     table_ref = f"{quote_identifier(table_schema)}.{quote_identifier(table_name)}"
-    clause = f"ADD {predicate_type} PREDICATE {fn_call} ON {table_ref}"
-    if predicate_type == "BLOCK" and operation is not None:
-        clause += f" {_OPERATION_TO_SQL[operation]}"
-    return clause
+    return f"ADD {predicate_type} PREDICATE {fn_call} ON {table_ref}"
 
 
 # ---------------------------------------------------------------------------
@@ -319,17 +275,17 @@ async def create_security_policy(
 ) -> None:
     """Create a security policy with one or more predicates.
 
-    Executes ``CREATE SECURITY POLICY ... ADD FILTER|BLOCK PREDICATE ...``.
+    Executes ``CREATE SECURITY POLICY ... ADD FILTER PREDICATE ...``.
 
     Each element of *predicates* must be a dict with keys:
 
-    - ``predicate_type``: ``"FILTER"`` or ``"BLOCK"``
+    - ``predicate_type``: ``"FILTER"`` (the only supported value; see
+      :data:`VALID_PREDICATE_TYPES`)
     - ``fn_schema``: schema of the predicate function (``str`` or ``None``)
     - ``fn_name``: name of the predicate function
     - ``fn_args``: list of column name strings
     - ``table_schema``: schema of the target table
     - ``table_name``: name of the target table
-    - ``operation``: block operation token (``None`` for FILTER or unspecified)
 
     Args:
         target: SQL connection target.
@@ -359,7 +315,6 @@ async def create_security_policy(
             msg = f"Predicate at index {i} is missing required key(s): {missing_list}"
             raise ValueError(msg)
         ptype = _validate_predicate_type(str(spec["predicate_type"]))
-        op = _validate_operation(spec.get("operation"))  # type: ignore[arg-type]
         fn_schema_raw = spec.get("fn_schema")
         fn_schema = str(fn_schema_raw) if fn_schema_raw else None
         fn_name = str(spec["fn_name"])
@@ -367,9 +322,7 @@ async def create_security_policy(
         table_schema = str(spec["table_schema"])
         table_name = str(spec["table_name"])
         clauses.append(
-            _build_predicate_clause(
-                ptype, fn_schema, fn_name, fn_args, table_schema, table_name, op
-            )
+            _build_predicate_clause(ptype, fn_schema, fn_name, fn_args, table_schema, table_name)
         )
 
     predicate_sql = ",\n    ".join(clauses)
@@ -393,24 +346,22 @@ async def add_predicate(
     table_schema: str,
     table_name: str,
     *,
-    operation: str | None = None,
     mode: CredentialMode = CredentialMode.DEFAULT,
 ) -> None:
     """Add a predicate to an existing security policy.
 
-    Executes ``ALTER SECURITY POLICY ... ADD FILTER|BLOCK PREDICATE ...``.
+    Executes ``ALTER SECURITY POLICY ... ADD FILTER PREDICATE ...``.
 
     Args:
         target: SQL connection target.
         policy_name: Security policy name (optionally schema-qualified).
-        predicate_type: ``"FILTER"`` or ``"BLOCK"``.
+        predicate_type: ``"FILTER"`` (the only supported value; see
+            :data:`VALID_PREDICATE_TYPES`).
         fn_schema: Schema of the predicate function, or ``None``.
         fn_name: Name of the predicate function.
         fn_args: Column name arguments for the predicate function.
         table_schema: Schema of the target table.
         table_name: Name of the target table.
-        operation: Block operation token (e.g. ``"AFTER_INSERT"``), or
-            ``None`` to omit the operation clause.
         mode: Credential mode for Entra authentication.
 
     Raises:
@@ -418,10 +369,7 @@ async def add_predicate(
     """
     policy_ref = _resolve_policy_ref(policy_name)
     ptype = _validate_predicate_type(predicate_type)
-    op = _validate_operation(operation)
-    clause = _build_predicate_clause(
-        ptype, fn_schema, fn_name, fn_args, table_schema, table_name, op
-    )
+    clause = _build_predicate_clause(ptype, fn_schema, fn_name, fn_args, table_schema, table_name)
     ddl = f"ALTER SECURITY POLICY {policy_ref}\n    {clause};"
 
     def _run() -> None:
@@ -441,15 +389,16 @@ async def drop_predicate(
 ) -> None:
     """Drop a predicate from an existing security policy.
 
-    Executes ``ALTER SECURITY POLICY ... DROP FILTER|BLOCK PREDICATE ON ...``.
+    Executes ``ALTER SECURITY POLICY ... DROP FILTER PREDICATE ON ...``.
 
-    The T-SQL ``DROP { FILTER | BLOCK } PREDICATE ON`` clause takes no
-    operation qualifier -- the operation is not part of the drop syntax.
+    The T-SQL ``DROP FILTER PREDICATE ON`` clause takes no operation
+    qualifier -- the operation is not part of the drop syntax.
 
     Args:
         target: SQL connection target.
         policy_name: Security policy name (optionally schema-qualified).
-        predicate_type: ``"FILTER"`` or ``"BLOCK"``.
+        predicate_type: ``"FILTER"`` (the only supported value; see
+            :data:`VALID_PREDICATE_TYPES`).
         table_schema: Schema of the target table.
         table_name: Name of the target table.
         mode: Credential mode for Entra authentication.

--- a/src/fabric_dw/services/rls.py
+++ b/src/fabric_dw/services/rls.py
@@ -8,8 +8,10 @@ FILTER predicates only (#966)
 ------------------------------
 Fabric Data Warehouse rejects BLOCK predicates for both ``CREATE`` and
 ``ALTER SECURITY POLICY`` ("BLOCK PREDICATE is not supported"). BLOCK support
-was removed after #919 shipped it untested; only FILTER predicates are
-exposed and validated here.
+was added in #919 but shipped untested and always fails against real Fabric,
+so it has been removed entirely: this module builds FILTER predicates only,
+and no function here accepts a predicate-type argument -- there is nothing
+to choose between.
 
 Statement-building safety
 --------------------------
@@ -20,7 +22,6 @@ All statements are built from:
 - Column names for predicate function arguments validated via
   :func:`~fabric_dw.identifiers.validate_column_name` +
   :func:`~fabric_dw.identifiers.quote_identifier`.
-- A fixed allowlist for predicate type (``FILTER`` only).
 
 No SQL text is ever parsed or rewritten.
 """
@@ -42,7 +43,6 @@ from fabric_dw.models import SecurityPolicy, SecurityPredicate
 from fabric_dw.sql import SqlTarget, run_query
 
 __all__ = [
-    "VALID_PREDICATE_TYPES",
     "add_predicate",
     "create_security_policy",
     "drop_predicate",
@@ -50,15 +50,6 @@ __all__ = [
     "list_security_policies",
     "set_policy_state",
 ]
-
-# ---------------------------------------------------------------------------
-# Allowlists
-# ---------------------------------------------------------------------------
-
-#: Valid predicate type tokens (uppercase). BLOCK is intentionally absent
-#: (#966): Fabric Data Warehouse rejects it for both CREATE and ALTER
-#: SECURITY POLICY.
-VALID_PREDICATE_TYPES: frozenset[str] = frozenset({"FILTER"})
 
 # ---------------------------------------------------------------------------
 # SQL templates (read)
@@ -83,31 +74,6 @@ ORDER BY sp.name, pred.predicate_type_desc;
 # ---------------------------------------------------------------------------
 # Private helpers
 # ---------------------------------------------------------------------------
-
-
-def _validate_predicate_type(predicate_type: str) -> str:
-    """Validate and uppercase the predicate type.
-
-    Args:
-        predicate_type: Raw predicate type string (case-insensitive).
-
-    Returns:
-        The uppercase token -- currently only ``"FILTER"``.
-
-    Raises:
-        ValueError: If *predicate_type* is not ``FILTER``. In particular,
-            ``"BLOCK"`` is rejected here (#966): Fabric Data Warehouse
-            rejects BLOCK PREDICATE for both CREATE and ALTER SECURITY
-            POLICY, so it is never sent to the server.
-    """
-    upper = predicate_type.upper()
-    if upper not in VALID_PREDICATE_TYPES:
-        msg = (
-            f"Invalid predicate type {predicate_type!r}: "
-            f"must be one of {', '.join(sorted(VALID_PREDICATE_TYPES))}"
-        )
-        raise ValueError(msg)
-    return upper
 
 
 def _resolve_policy_ref(policy_name: str) -> str:
@@ -173,7 +139,6 @@ def _build_fn_call(
 
 
 def _build_predicate_clause(
-    predicate_type: str,
     fn_schema: str | None,
     fn_name: str,
     fn_args: list[str],
@@ -183,8 +148,6 @@ def _build_predicate_clause(
     """Build one ``ADD FILTER PREDICATE fn(...) ON table`` clause.
 
     Args:
-        predicate_type: ``"FILTER"`` (already validated; this is the only
-            token :data:`VALID_PREDICATE_TYPES` accepts).
         fn_schema: Schema of the predicate function (may be ``None``).
         fn_name: Name of the predicate function.
         fn_args: Column name arguments for the predicate function.
@@ -199,7 +162,7 @@ def _build_predicate_clause(
     validate_identifier(table_schema)
     validate_identifier(table_name)
     table_ref = f"{quote_identifier(table_schema)}.{quote_identifier(table_name)}"
-    return f"ADD {predicate_type} PREDICATE {fn_call} ON {table_ref}"
+    return f"ADD FILTER PREDICATE {fn_call} ON {table_ref}"
 
 
 # ---------------------------------------------------------------------------
@@ -273,14 +236,14 @@ async def create_security_policy(
     state: bool = True,
     mode: CredentialMode = CredentialMode.DEFAULT,
 ) -> None:
-    """Create a security policy with one or more predicates.
+    """Create a security policy with one or more FILTER predicates.
 
-    Executes ``CREATE SECURITY POLICY ... ADD FILTER PREDICATE ...``.
+    Executes ``CREATE SECURITY POLICY ... ADD FILTER PREDICATE ...``. There is
+    no predicate-type option (#966): Fabric Data Warehouse supports FILTER
+    predicates only, so every predicate built here is a FILTER predicate.
 
     Each element of *predicates* must be a dict with keys:
 
-    - ``predicate_type``: ``"FILTER"`` (the only supported value; see
-      :data:`VALID_PREDICATE_TYPES`)
     - ``fn_schema``: schema of the predicate function (``str`` or ``None``)
     - ``fn_name``: name of the predicate function
     - ``fn_args``: list of column name strings
@@ -308,13 +271,12 @@ async def create_security_policy(
 
     clauses: list[str] = []
     for i, spec in enumerate(predicates):
-        _required = {"predicate_type", "fn_name", "fn_args", "table_schema", "table_name"}
+        _required = {"fn_name", "fn_args", "table_schema", "table_name"}
         _missing = _required - spec.keys()
         if _missing:
             missing_list = ", ".join(sorted(_missing))
             msg = f"Predicate at index {i} is missing required key(s): {missing_list}"
             raise ValueError(msg)
-        ptype = _validate_predicate_type(str(spec["predicate_type"]))
         fn_schema_raw = spec.get("fn_schema")
         fn_schema = str(fn_schema_raw) if fn_schema_raw else None
         fn_name = str(spec["fn_name"])
@@ -322,7 +284,7 @@ async def create_security_policy(
         table_schema = str(spec["table_schema"])
         table_name = str(spec["table_name"])
         clauses.append(
-            _build_predicate_clause(ptype, fn_schema, fn_name, fn_args, table_schema, table_name)
+            _build_predicate_clause(fn_schema, fn_name, fn_args, table_schema, table_name)
         )
 
     predicate_sql = ",\n    ".join(clauses)
@@ -339,7 +301,6 @@ async def create_security_policy(
 async def add_predicate(
     target: SqlTarget,
     policy_name: str,
-    predicate_type: str,
     fn_schema: str | None,
     fn_name: str,
     fn_args: list[str],
@@ -348,15 +309,15 @@ async def add_predicate(
     *,
     mode: CredentialMode = CredentialMode.DEFAULT,
 ) -> None:
-    """Add a predicate to an existing security policy.
+    """Add a FILTER predicate to an existing security policy.
 
-    Executes ``ALTER SECURITY POLICY ... ADD FILTER PREDICATE ...``.
+    Executes ``ALTER SECURITY POLICY ... ADD FILTER PREDICATE ...``. There is
+    no predicate-type argument (#966): Fabric Data Warehouse supports FILTER
+    predicates only.
 
     Args:
         target: SQL connection target.
         policy_name: Security policy name (optionally schema-qualified).
-        predicate_type: ``"FILTER"`` (the only supported value; see
-            :data:`VALID_PREDICATE_TYPES`).
         fn_schema: Schema of the predicate function, or ``None``.
         fn_name: Name of the predicate function.
         fn_args: Column name arguments for the predicate function.
@@ -368,8 +329,7 @@ async def add_predicate(
         ValueError: If any identifier or argument is invalid.
     """
     policy_ref = _resolve_policy_ref(policy_name)
-    ptype = _validate_predicate_type(predicate_type)
-    clause = _build_predicate_clause(ptype, fn_schema, fn_name, fn_args, table_schema, table_name)
+    clause = _build_predicate_clause(fn_schema, fn_name, fn_args, table_schema, table_name)
     ddl = f"ALTER SECURITY POLICY {policy_ref}\n    {clause};"
 
     def _run() -> None:
@@ -381,15 +341,16 @@ async def add_predicate(
 async def drop_predicate(
     target: SqlTarget,
     policy_name: str,
-    predicate_type: str,
     table_schema: str,
     table_name: str,
     *,
     mode: CredentialMode = CredentialMode.DEFAULT,
 ) -> None:
-    """Drop a predicate from an existing security policy.
+    """Drop the FILTER predicate from an existing security policy.
 
     Executes ``ALTER SECURITY POLICY ... DROP FILTER PREDICATE ON ...``.
+    There is no predicate-type argument (#966): Fabric Data Warehouse
+    supports FILTER predicates only.
 
     The T-SQL ``DROP FILTER PREDICATE ON`` clause takes no operation
     qualifier -- the operation is not part of the drop syntax.
@@ -397,8 +358,6 @@ async def drop_predicate(
     Args:
         target: SQL connection target.
         policy_name: Security policy name (optionally schema-qualified).
-        predicate_type: ``"FILTER"`` (the only supported value; see
-            :data:`VALID_PREDICATE_TYPES`).
         table_schema: Schema of the target table.
         table_name: Name of the target table.
         mode: Credential mode for Entra authentication.
@@ -407,11 +366,10 @@ async def drop_predicate(
         ValueError: If any identifier is invalid.
     """
     policy_ref = _resolve_policy_ref(policy_name)
-    ptype = _validate_predicate_type(predicate_type)
     validate_identifier(table_schema)
     validate_identifier(table_name)
     table_ref = f"{quote_identifier(table_schema)}.{quote_identifier(table_name)}"
-    ddl = f"ALTER SECURITY POLICY {policy_ref}\n    DROP {ptype} PREDICATE ON {table_ref};"
+    ddl = f"ALTER SECURITY POLICY {policy_ref}\n    DROP FILTER PREDICATE ON {table_ref};"
 
     def _run() -> None:
         run_query(target, ddl, mode=mode, autocommit=True, fetch="none")

--- a/src/fabric_dw/services/rls.py
+++ b/src/fabric_dw/services/rls.py
@@ -242,7 +242,10 @@ async def create_security_policy(
     no predicate-type option (#966): Fabric Data Warehouse supports FILTER
     predicates only, so every predicate built here is a FILTER predicate.
 
-    Each element of *predicates* must be a dict with keys:
+    Each element of *predicates* must be a dict with exactly these keys (no
+    more, no fewer -- unrecognised keys are rejected rather than silently
+    ignored, so e.g. a stray ``"predicate_type": "BLOCK"`` surfaces as an
+    error instead of silently building a FILTER predicate):
 
     - ``fn_schema``: schema of the predicate function (``str`` or ``None``)
     - ``fn_name``: name of the predicate function
@@ -260,7 +263,8 @@ async def create_security_policy(
         mode: Credential mode for Entra authentication.
 
     Raises:
-        ValueError: If *predicates* is empty or any spec is invalid.
+        ValueError: If *predicates* is empty, a spec is missing a required
+            key, or a spec contains an unrecognised key.
     """
     if not predicates:
         msg = "At least one predicate is required to create a security policy"
@@ -272,10 +276,21 @@ async def create_security_policy(
     clauses: list[str] = []
     for i, spec in enumerate(predicates):
         _required = {"fn_name", "fn_args", "table_schema", "table_name"}
+        _allowed = _required | {"fn_schema"}
         _missing = _required - spec.keys()
         if _missing:
             missing_list = ", ".join(sorted(_missing))
             msg = f"Predicate at index {i} is missing required key(s): {missing_list}"
+            raise ValueError(msg)
+        # Reject unrecognised keys outright rather than silently ignoring them (#967).
+        # This is generic key-set hygiene, not a predicate-type check: a stray
+        # "predicate_type": "BLOCK" is caught the same way a typo like "table" would
+        # be, so a caller never gets a silent FILTER built from a spec that implied
+        # something else was requested.
+        _unknown = spec.keys() - _allowed
+        if _unknown:
+            unknown_list = ", ".join(sorted(_unknown))
+            msg = f"Predicate at index {i} has unknown key(s): {unknown_list}"
             raise ValueError(msg)
         fn_schema_raw = spec.get("fn_schema")
         fn_schema = str(fn_schema_raw) if fn_schema_raw else None

--- a/tests/unit/cli/commands/test_permissions_rls.py
+++ b/tests/unit/cli/commands/test_permissions_rls.py
@@ -147,45 +147,8 @@ class TestRlsCreate:
             )
         assert result.exit_code == 0, result.output
 
-    def test_create_block_with_operation(self, runner: CliRunner, cache_env: Path) -> None:
-        _ = cache_env
-        mock_svc = AsyncMock(return_value=None)
-        with (
-            patch(
-                "fabric_dw.cli.commands.permissions.build_http_client",
-                new=_make_http_cm(AsyncMock()),
-            ),
-            patch(
-                "fabric_dw.cli.commands.permissions.build_sql_target",
-                new=AsyncMock(return_value=(_make_sql_target(), _make_wh_entry())),
-            ),
-            patch("fabric_dw.services.rls.create_security_policy", new=mock_svc),
-        ):
-            result = runner.invoke(
-                cli,
-                [
-                    "-w",
-                    WS_GUID,
-                    "permissions",
-                    "rls",
-                    "create",
-                    WH_GUID,
-                    "rls.SalesBlock",
-                    "--block",
-                    "rls.fn_block(SalesRep)",
-                    "--on",
-                    "dbo.Sales",
-                    "--operation",
-                    "after-insert",
-                ],
-            )
-        assert result.exit_code == 0, result.output
-        _, kwargs = mock_svc.call_args
-        assert kwargs["state"] is True
-        preds = mock_svc.call_args.args[2]
-        assert preds[0]["operation"] == "after-insert"  # CLI passes raw; service normalizes
-
-    def test_create_both_filter_and_block_fails(self, runner: CliRunner, cache_env: Path) -> None:
+    def test_create_no_block_option(self, runner: CliRunner, cache_env: Path) -> None:
+        """--block is not offered (#966): Fabric rejects BLOCK PREDICATE for CREATE."""
         _ = cache_env
         result = runner.invoke(
             cli,
@@ -206,10 +169,34 @@ class TestRlsCreate:
             ],
         )
         assert result.exit_code != 0
+        assert "no such option" in result.output.lower()
 
-    def test_create_neither_filter_nor_block_fails(
-        self, runner: CliRunner, cache_env: Path
-    ) -> None:
+    def test_create_no_operation_option(self, runner: CliRunner, cache_env: Path) -> None:
+        """--operation is not offered (#966): it only ever applied to BLOCK predicates."""
+        _ = cache_env
+        result = runner.invoke(
+            cli,
+            [
+                "-w",
+                WS_GUID,
+                "permissions",
+                "rls",
+                "create",
+                WH_GUID,
+                "rls.Policy",
+                "--filter",
+                "rls.fn(col)",
+                "--on",
+                "dbo.T",
+                "--operation",
+                "after-insert",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "no such option" in result.output.lower()
+
+    def test_create_without_filter_fails(self, runner: CliRunner, cache_env: Path) -> None:
+        """--filter is required now that it is the only predicate option."""
         _ = cache_env
         result = runner.invoke(
             cli,
@@ -301,6 +288,47 @@ class TestRlsAddPredicate:
                 ],
             )
         assert result.exit_code == 0, result.output
+        assert mock_svc.call_args.args[2] == "FILTER"
+
+    def test_add_no_block_option(self, runner: CliRunner, cache_env: Path) -> None:
+        """--block is not offered (#966): Fabric rejects BLOCK PREDICATE for ALTER."""
+        _ = cache_env
+        result = runner.invoke(
+            cli,
+            [
+                "-w",
+                WS_GUID,
+                "permissions",
+                "rls",
+                "add-predicate",
+                WH_GUID,
+                "rls.SalesFilter",
+                "--block",
+                "rls.fn_block(col)",
+                "--on",
+                "dbo.Sales",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "no such option" in result.output.lower()
+
+    def test_add_without_filter_fails(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        result = runner.invoke(
+            cli,
+            [
+                "-w",
+                WS_GUID,
+                "permissions",
+                "rls",
+                "add-predicate",
+                WH_GUID,
+                "rls.SalesFilter",
+                "--on",
+                "dbo.Sales",
+            ],
+        )
+        assert result.exit_code != 0
 
 
 # ---------------------------------------------------------------------------
@@ -309,7 +337,8 @@ class TestRlsAddPredicate:
 
 
 class TestRlsDropPredicate:
-    def test_drop_filter_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
+    def test_drop_exits_zero(self, runner: CliRunner, cache_env: Path) -> None:
+        """No predicate-type selector is offered -- only FILTER exists, identified by --on."""
         _ = cache_env
         mock_svc = AsyncMock(return_value=None)
         with (
@@ -333,14 +362,16 @@ class TestRlsDropPredicate:
                     "drop-predicate",
                     WH_GUID,
                     "rls.SalesFilter",
-                    "--filter",
                     "--on",
                     "dbo.Sales",
                 ],
             )
         assert result.exit_code == 0, result.output
+        assert mock_svc.call_args.args[2] == "FILTER"
 
-    def test_drop_both_flags_fails(self, runner: CliRunner, cache_env: Path) -> None:
+    def test_drop_no_filter_or_block_option(self, runner: CliRunner, cache_env: Path) -> None:
+        """Neither --filter nor --block is offered (#966): only FILTER predicates exist,
+        so there is nothing left to select between."""
         _ = cache_env
         result = runner.invoke(
             cli,
@@ -353,12 +384,12 @@ class TestRlsDropPredicate:
                 WH_GUID,
                 "rls.P",
                 "--filter",
-                "--block",
                 "--on",
                 "dbo.T",
             ],
         )
         assert result.exit_code != 0
+        assert "no such option" in result.output.lower()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/cli/commands/test_permissions_rls.py
+++ b/tests/unit/cli/commands/test_permissions_rls.py
@@ -288,7 +288,11 @@ class TestRlsAddPredicate:
                 ],
             )
         assert result.exit_code == 0, result.output
-        assert mock_svc.call_args.args[2] == "FILTER"
+        # add_predicate(target, policy, fn_schema, fn_name, fn_args, table_schema, table_name,
+        # mode=...) -- no predicate_type argument exists (#966).
+        args = mock_svc.call_args.args
+        assert args[2] == "rls"  # fn_schema
+        assert args[3] == "fn_filter"  # fn_name
 
     def test_add_no_block_option(self, runner: CliRunner, cache_env: Path) -> None:
         """--block is not offered (#966): Fabric rejects BLOCK PREDICATE for ALTER."""
@@ -367,7 +371,11 @@ class TestRlsDropPredicate:
                 ],
             )
         assert result.exit_code == 0, result.output
-        assert mock_svc.call_args.args[2] == "FILTER"
+        # drop_predicate no longer takes a predicate_type argument (#966); confirm the
+        # positional args shifted accordingly -- table_schema, then table_name.
+        args = mock_svc.call_args.args
+        assert args[2] == "dbo"  # table_schema
+        assert args[3] == "Sales"  # table_name
 
     def test_drop_no_filter_or_block_option(self, runner: CliRunner, cache_env: Path) -> None:
         """Neither --filter nor --block is offered (#966): only FILTER predicates exist,

--- a/tests/unit/mcp/tools/test_permissions.py
+++ b/tests/unit/mcp/tools/test_permissions.py
@@ -774,7 +774,6 @@ async def test_add_security_predicate_fn_schema_optional(mock_ctx, ctx_patch) ->
                 "workspace": WS_NAME,
                 "item": WH_NAME,
                 "policy_name": "rls.SalesFilter",
-                "predicate_type": "FILTER",
                 "fn_name": "fn_filter",
                 "fn_args": ["SalesRep"],
                 "table_schema": "dbo",
@@ -784,13 +783,32 @@ async def test_add_security_predicate_fn_schema_optional(mock_ctx, ctx_patch) ->
         )
 
     assert result["added"] is True
-    # Verify fn_schema=None was passed to the service
-    _, kwargs = mock_svc.call_args
-    assert kwargs.get("fn_schema") is None or mock_svc.call_args[0][3] is None
+    assert result["predicate_type"] == "FILTER"
+    # Verify "FILTER" and fn_schema=None were passed to the service positionally.
+    args, _kwargs = mock_svc.call_args
+    assert args[2] == "FILTER"
+    assert args[3] is None
+
+
+async def test_add_drop_security_predicate_schemas_omit_predicate_type() -> None:
+    """predicate_type / operation are not accepted parameters (#966): FILTER is implicit
+    since it is the only value Fabric supports, so the tool schemas no longer offer a
+    choice (this is pure schema introspection -- no I/O, no mocked resolver needed)."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    tools = {t.name: t for t in await mcp.list_tools()}
+
+    add_props = tools["add_security_predicate"].inputSchema["properties"]
+    assert "predicate_type" not in add_props
+    assert "operation" not in add_props
+
+    drop_props = tools["drop_security_predicate"].inputSchema["properties"]
+    assert "predicate_type" not in drop_props
+    assert "operation" not in drop_props
 
 
 async def test_drop_security_predicate_dispatches_correct_args(mock_ctx, ctx_patch) -> None:
-    """drop_security_predicate calls drop_predicate with the right args and no operation kwarg."""
+    """drop_security_predicate calls drop_predicate with FILTER and no operation kwarg."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
     item = make_item_entry()
@@ -810,7 +828,6 @@ async def test_drop_security_predicate_dispatches_correct_args(mock_ctx, ctx_pat
                 "workspace": WS_NAME,
                 "item": WH_NAME,
                 "policy_name": "rls.SalesFilter",
-                "predicate_type": "FILTER",
                 "table_schema": "dbo",
                 "table_name": "Sales",
             },
@@ -818,9 +835,11 @@ async def test_drop_security_predicate_dispatches_correct_args(mock_ctx, ctx_pat
 
     assert result["dropped"] is True
     assert result["policy_name"] == "rls.SalesFilter"
+    assert result["predicate_type"] == "FILTER"
     mock_svc.assert_called_once()
-    # Verify no 'operation' kwarg is forwarded to the service.
-    _, kwargs = mock_svc.call_args
+    # Verify "FILTER" was passed positionally and no 'operation' kwarg is forwarded.
+    args, kwargs = mock_svc.call_args
+    assert args[2] == "FILTER"
     assert "operation" not in kwargs
 
 

--- a/tests/unit/mcp/tools/test_permissions.py
+++ b/tests/unit/mcp/tools/test_permissions.py
@@ -701,6 +701,49 @@ async def test_create_security_policy_calls_service_with_correct_args(mock_ctx, 
     mock_svc.assert_called_once()
 
 
+async def test_create_security_policy_rejects_predicate_type_key(mock_ctx, ctx_patch) -> None:
+    """A predicates entry carrying "predicate_type" surfaces a ToolError (#967) instead of
+    silently building a FILTER predicate -- exercises the real service validation (only
+    run_query is mocked), since silently downgrading an intended BLOCK to FILTER would be
+    a security-relevant footgun for an MCP caller."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    predicates = [
+        {
+            "predicate_type": "BLOCK",
+            "fn_name": "fn_block",
+            "fn_args": ["SalesRep"],
+            "table_schema": "dbo",
+            "table_name": "Sales",
+        }
+    ]
+    os.environ.pop("FABRIC_MCP_READONLY", None)
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {}),
+        patch("fabric_dw.services.rls.run_query") as mock_run_query,
+        pytest.raises(ToolError, match="unknown key"),
+    ):
+        await mcp._tool_manager.call_tool(
+            "create_security_policy",
+            {
+                "workspace": WS_NAME,
+                "item": WH_NAME,
+                "policy_name": "rls.SalesBlock",
+                "predicates": predicates,
+                "state": True,
+            },
+        )
+    # No SQL is ever built or executed for a rejected spec.
+    mock_run_query.assert_not_called()
+
+
 async def test_drop_security_policy_blocked_without_destructive_env(mock_ctx, ctx_patch) -> None:
     """drop_security_policy is blocked when FABRIC_MCP_ALLOW_DESTRUCTIVE is not set."""
     from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415

--- a/tests/unit/mcp/tools/test_permissions.py
+++ b/tests/unit/mcp/tools/test_permissions.py
@@ -673,7 +673,6 @@ async def test_create_security_policy_calls_service_with_correct_args(mock_ctx, 
     mock_svc = AsyncMock(return_value=None)
     predicates = [
         {
-            "predicate_type": "FILTER",
             "fn_name": "fn_filter",
             "fn_args": ["SalesRep"],
             "table_schema": "dbo",
@@ -784,10 +783,10 @@ async def test_add_security_predicate_fn_schema_optional(mock_ctx, ctx_patch) ->
 
     assert result["added"] is True
     assert result["predicate_type"] == "FILTER"
-    # Verify "FILTER" and fn_schema=None were passed to the service positionally.
+    # add_predicate(target, policy_name, fn_schema, fn_name, ...) -- no predicate_type
+    # argument exists (#966). Verify fn_schema=None was passed positionally.
     args, _kwargs = mock_svc.call_args
-    assert args[2] == "FILTER"
-    assert args[3] is None
+    assert args[2] is None
 
 
 async def test_add_drop_security_predicate_schemas_omit_predicate_type() -> None:
@@ -808,7 +807,7 @@ async def test_add_drop_security_predicate_schemas_omit_predicate_type() -> None
 
 
 async def test_drop_security_predicate_dispatches_correct_args(mock_ctx, ctx_patch) -> None:
-    """drop_security_predicate calls drop_predicate with FILTER and no operation kwarg."""
+    """drop_security_predicate calls drop_predicate with no predicate_type/operation kwarg."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
     item = make_item_entry()
@@ -837,9 +836,10 @@ async def test_drop_security_predicate_dispatches_correct_args(mock_ctx, ctx_pat
     assert result["policy_name"] == "rls.SalesFilter"
     assert result["predicate_type"] == "FILTER"
     mock_svc.assert_called_once()
-    # Verify "FILTER" was passed positionally and no 'operation' kwarg is forwarded.
+    # drop_predicate no longer takes a predicate_type argument (#966); confirm
+    # table_schema was passed positionally and no 'operation' kwarg is forwarded.
     args, kwargs = mock_svc.call_args
-    assert args[2] == "FILTER"
+    assert args[2] == "dbo"
     assert "operation" not in kwargs
 
 

--- a/tests/unit/services/test_rls.py
+++ b/tests/unit/services/test_rls.py
@@ -33,37 +33,6 @@ _LIST_COLS = [
 
 
 # ---------------------------------------------------------------------------
-# _validate_predicate_type
-# ---------------------------------------------------------------------------
-
-
-class TestValidatePredicateType:
-    def test_filter_accepted(self) -> None:
-        from fabric_dw.services.rls import _validate_predicate_type  # noqa: PLC0415
-
-        assert _validate_predicate_type("FILTER") == "FILTER"
-
-    def test_case_insensitive(self) -> None:
-        from fabric_dw.services.rls import _validate_predicate_type  # noqa: PLC0415
-
-        assert _validate_predicate_type("filter") == "FILTER"
-
-    def test_invalid_raises(self) -> None:
-        from fabric_dw.services.rls import _validate_predicate_type  # noqa: PLC0415
-
-        with pytest.raises(ValueError, match="Invalid predicate type"):
-            _validate_predicate_type("SELECT")
-
-    def test_block_rejected(self) -> None:
-        """BLOCK is no longer a valid predicate type (#966): Fabric rejects BLOCK PREDICATE
-        for both CREATE and ALTER SECURITY POLICY."""
-        from fabric_dw.services.rls import _validate_predicate_type  # noqa: PLC0415
-
-        with pytest.raises(ValueError, match="Invalid predicate type"):
-            _validate_predicate_type("BLOCK")
-
-
-# ---------------------------------------------------------------------------
 # _resolve_policy_ref
 # ---------------------------------------------------------------------------
 
@@ -246,7 +215,6 @@ class TestCreateSecurityPolicy:
                 "rls.SalesFilter",
                 [
                     {
-                        "predicate_type": "FILTER",
                         "fn_schema": "rls",
                         "fn_name": "fn_filter",
                         "fn_args": ["SalesRep"],
@@ -276,7 +244,6 @@ class TestCreateSecurityPolicy:
                 "MyPolicy",
                 [
                     {
-                        "predicate_type": "FILTER",
                         "fn_schema": None,
                         "fn_name": "fn_filter",
                         "fn_args": ["col"],
@@ -289,23 +256,35 @@ class TestCreateSecurityPolicy:
 
         assert "STATE = OFF" in captured[0]
 
-    async def test_block_predicate_type_rejected(self) -> None:
-        """BLOCK is rejected before any SQL is built (#966)."""
-        with pytest.raises(ValueError, match="Invalid predicate type"):
+    async def test_predicate_type_key_has_no_effect(self) -> None:
+        """There is no predicate-type concept (#966): a stray "predicate_type": "BLOCK"
+        key in the spec dict is simply not read, and the built clause is FILTER
+        regardless -- there is no code path that could turn it into BLOCK."""
+        captured: list[str] = []
+
+        def _mock(_target: object, _sql: str, **_kw: object) -> tuple:
+            captured.append(_sql)
+            return [], []
+
+        with patch("fabric_dw.services.rls.run_query", side_effect=_mock):
             await rls_svc.create_security_policy(
                 _TARGET,
-                "rls.SalesBlock",
+                "rls.SalesFilter",
                 [
                     {
                         "predicate_type": "BLOCK",
                         "fn_schema": "rls",
-                        "fn_name": "fn_block",
+                        "fn_name": "fn_filter",
                         "fn_args": ["SalesRep"],
                         "table_schema": "dbo",
                         "table_name": "Sales",
                     }
                 ],
             )
+
+        stmt = captured[0]
+        assert "ADD FILTER PREDICATE" in stmt
+        assert "BLOCK" not in stmt
 
     async def test_multi_predicate_create(self) -> None:
         captured: list[str] = []
@@ -320,7 +299,6 @@ class TestCreateSecurityPolicy:
                 "rls.Combined",
                 [
                     {
-                        "predicate_type": "FILTER",
                         "fn_schema": "rls",
                         "fn_name": "fn_filter_a",
                         "fn_args": ["col_a"],
@@ -328,7 +306,6 @@ class TestCreateSecurityPolicy:
                         "table_name": "T",
                     },
                     {
-                        "predicate_type": "FILTER",
                         "fn_schema": "rls",
                         "fn_name": "fn_filter_b",
                         "fn_args": ["col_b"],
@@ -357,7 +334,6 @@ class TestCreateSecurityPolicy:
                 "bad; policy",
                 [
                     {
-                        "predicate_type": "FILTER",
                         "fn_schema": "rls",
                         "fn_name": "fn",
                         "fn_args": ["col"],
@@ -385,7 +361,6 @@ class TestAddPredicate:
             await rls_svc.add_predicate(
                 _TARGET,
                 "rls.SalesFilter",
-                "FILTER",
                 "rls",
                 "fn_filter",
                 ["SalesRep"],
@@ -398,26 +373,6 @@ class TestAddPredicate:
             "ALTER SECURITY POLICY [rls].[SalesFilter]\n"
             "    ADD FILTER PREDICATE [rls].[fn_filter]([SalesRep]) ON [dbo].[Sales];"
         )
-
-    async def test_block_predicate_type_rejected(self) -> None:
-        """BLOCK is rejected before any SQL is built (#966)."""
-        with pytest.raises(ValueError, match="Invalid predicate type"):
-            await rls_svc.add_predicate(
-                _TARGET,
-                "rls.SalesBlock",
-                "BLOCK",
-                "rls",
-                "fn_block",
-                ["SalesRep"],
-                "dbo",
-                "Sales",
-            )
-
-    async def test_invalid_predicate_type_raises(self) -> None:
-        with pytest.raises(ValueError, match="Invalid predicate type"):
-            await rls_svc.add_predicate(
-                _TARGET, "MyPolicy", "DENY", "rls", "fn", ["col"], "dbo", "T"
-            )
 
 
 # ---------------------------------------------------------------------------
@@ -437,7 +392,6 @@ class TestDropPredicate:
             await rls_svc.drop_predicate(
                 _TARGET,
                 "rls.SalesFilter",
-                "FILTER",
                 "dbo",
                 "Sales",
             )
@@ -446,17 +400,6 @@ class TestDropPredicate:
         assert stmt == (
             "ALTER SECURITY POLICY [rls].[SalesFilter]\n    DROP FILTER PREDICATE ON [dbo].[Sales];"
         )
-
-    async def test_block_predicate_type_rejected(self) -> None:
-        """BLOCK is rejected before any SQL is built (#966)."""
-        with pytest.raises(ValueError, match="Invalid predicate type"):
-            await rls_svc.drop_predicate(
-                _TARGET,
-                "rls.SalesBlock",
-                "BLOCK",
-                "dbo",
-                "Sales",
-            )
 
 
 # ---------------------------------------------------------------------------
@@ -546,7 +489,7 @@ class TestBuildPredicateClause:
     def test_filter_clause_exact_sql(self) -> None:
         from fabric_dw.services.rls import _build_predicate_clause  # noqa: PLC0415
 
-        result = _build_predicate_clause("FILTER", "rls", "fn", ["col"], "dbo", "T")
+        result = _build_predicate_clause("rls", "fn", ["col"], "dbo", "T")
         assert result == "ADD FILTER PREDICATE [rls].[fn]([col]) ON [dbo].[T]"
 
 
@@ -563,7 +506,6 @@ class TestCreateSecurityPolicyMissingKeys:
                 "rls.SalesFilter",
                 [
                     {
-                        "predicate_type": "FILTER",
                         # fn_name intentionally omitted
                         "fn_args": ["col"],
                         "table_schema": "dbo",
@@ -579,7 +521,6 @@ class TestCreateSecurityPolicyMissingKeys:
                 "rls.SalesFilter",
                 [
                     {
-                        "predicate_type": "FILTER",
                         "fn_name": "fn_filter",
                         "fn_args": ["col"],
                         # table_schema intentionally omitted

--- a/tests/unit/services/test_rls.py
+++ b/tests/unit/services/test_rls.py
@@ -43,16 +43,10 @@ class TestValidatePredicateType:
 
         assert _validate_predicate_type("FILTER") == "FILTER"
 
-    def test_block_accepted(self) -> None:
-        from fabric_dw.services.rls import _validate_predicate_type  # noqa: PLC0415
-
-        assert _validate_predicate_type("BLOCK") == "BLOCK"
-
     def test_case_insensitive(self) -> None:
         from fabric_dw.services.rls import _validate_predicate_type  # noqa: PLC0415
 
         assert _validate_predicate_type("filter") == "FILTER"
-        assert _validate_predicate_type("block") == "BLOCK"
 
     def test_invalid_raises(self) -> None:
         from fabric_dw.services.rls import _validate_predicate_type  # noqa: PLC0415
@@ -60,43 +54,13 @@ class TestValidatePredicateType:
         with pytest.raises(ValueError, match="Invalid predicate type"):
             _validate_predicate_type("SELECT")
 
+    def test_block_rejected(self) -> None:
+        """BLOCK is no longer a valid predicate type (#966): Fabric rejects BLOCK PREDICATE
+        for both CREATE and ALTER SECURITY POLICY."""
+        from fabric_dw.services.rls import _validate_predicate_type  # noqa: PLC0415
 
-# ---------------------------------------------------------------------------
-# _validate_operation
-# ---------------------------------------------------------------------------
-
-
-class TestValidateOperation:
-    def test_none_returns_none(self) -> None:
-        from fabric_dw.services.rls import _validate_operation  # noqa: PLC0415
-
-        assert _validate_operation(None) is None
-
-    def test_after_insert_accepted(self) -> None:
-        from fabric_dw.services.rls import _validate_operation  # noqa: PLC0415
-
-        assert _validate_operation("AFTER_INSERT") == "AFTER_INSERT"
-
-    def test_space_separated_normalised(self) -> None:
-        from fabric_dw.services.rls import _validate_operation  # noqa: PLC0415
-
-        assert _validate_operation("AFTER INSERT") == "AFTER_INSERT"
-
-    def test_hyphen_normalised(self) -> None:
-        from fabric_dw.services.rls import _validate_operation  # noqa: PLC0415
-
-        assert _validate_operation("after-insert") == "AFTER_INSERT"
-
-    def test_before_delete_accepted(self) -> None:
-        from fabric_dw.services.rls import _validate_operation  # noqa: PLC0415
-
-        assert _validate_operation("BEFORE_DELETE") == "BEFORE_DELETE"
-
-    def test_invalid_raises(self) -> None:
-        from fabric_dw.services.rls import _validate_operation  # noqa: PLC0415
-
-        with pytest.raises(ValueError, match="Invalid block operation"):
-            _validate_operation("AFTER_COMMIT")
+        with pytest.raises(ValueError, match="Invalid predicate type"):
+            _validate_predicate_type("BLOCK")
 
 
 # ---------------------------------------------------------------------------
@@ -288,7 +252,6 @@ class TestCreateSecurityPolicy:
                         "fn_args": ["SalesRep"],
                         "table_schema": "dbo",
                         "table_name": "Sales",
-                        "operation": None,
                     }
                 ],
             )
@@ -319,7 +282,6 @@ class TestCreateSecurityPolicy:
                         "fn_args": ["col"],
                         "table_schema": "dbo",
                         "table_name": "T",
-                        "operation": None,
                     }
                 ],
                 state=False,
@@ -327,14 +289,9 @@ class TestCreateSecurityPolicy:
 
         assert "STATE = OFF" in captured[0]
 
-    async def test_block_predicate_with_operation(self) -> None:
-        captured: list[str] = []
-
-        def _mock(_target: object, _sql: str, **_kw: object) -> tuple:
-            captured.append(_sql)
-            return [], []
-
-        with patch("fabric_dw.services.rls.run_query", side_effect=_mock):
+    async def test_block_predicate_type_rejected(self) -> None:
+        """BLOCK is rejected before any SQL is built (#966)."""
+        with pytest.raises(ValueError, match="Invalid predicate type"):
             await rls_svc.create_security_policy(
                 _TARGET,
                 "rls.SalesBlock",
@@ -346,17 +303,9 @@ class TestCreateSecurityPolicy:
                         "fn_args": ["SalesRep"],
                         "table_schema": "dbo",
                         "table_name": "Sales",
-                        "operation": "AFTER_INSERT",
                     }
                 ],
             )
-
-        stmt = captured[0]
-        assert stmt == (
-            "CREATE SECURITY POLICY [rls].[SalesBlock]\n"
-            "    ADD BLOCK PREDICATE [rls].[fn_block]([SalesRep]) ON [dbo].[Sales] AFTER INSERT\n"
-            "    WITH (STATE = ON);"
-        )
 
     async def test_multi_predicate_create(self) -> None:
         captured: list[str] = []
@@ -373,20 +322,18 @@ class TestCreateSecurityPolicy:
                     {
                         "predicate_type": "FILTER",
                         "fn_schema": "rls",
-                        "fn_name": "fn_filter",
-                        "fn_args": ["col"],
+                        "fn_name": "fn_filter_a",
+                        "fn_args": ["col_a"],
                         "table_schema": "dbo",
                         "table_name": "T",
-                        "operation": None,
                     },
                     {
-                        "predicate_type": "BLOCK",
+                        "predicate_type": "FILTER",
                         "fn_schema": "rls",
-                        "fn_name": "fn_block",
-                        "fn_args": ["col"],
+                        "fn_name": "fn_filter_b",
+                        "fn_args": ["col_b"],
                         "table_schema": "dbo",
-                        "table_name": "T",
-                        "operation": "AFTER_INSERT",
+                        "table_name": "U",
                     },
                 ],
             )
@@ -394,8 +341,8 @@ class TestCreateSecurityPolicy:
         stmt = captured[0]
         assert stmt == (
             "CREATE SECURITY POLICY [rls].[Combined]\n"
-            "    ADD FILTER PREDICATE [rls].[fn_filter]([col]) ON [dbo].[T],\n"
-            "    ADD BLOCK PREDICATE [rls].[fn_block]([col]) ON [dbo].[T] AFTER INSERT\n"
+            "    ADD FILTER PREDICATE [rls].[fn_filter_a]([col_a]) ON [dbo].[T],\n"
+            "    ADD FILTER PREDICATE [rls].[fn_filter_b]([col_b]) ON [dbo].[U]\n"
             "    WITH (STATE = ON);"
         )
 
@@ -416,7 +363,6 @@ class TestCreateSecurityPolicy:
                         "fn_args": ["col"],
                         "table_schema": "dbo",
                         "table_name": "T",
-                        "operation": None,
                     }
                 ],
             )
@@ -453,40 +399,9 @@ class TestAddPredicate:
             "    ADD FILTER PREDICATE [rls].[fn_filter]([SalesRep]) ON [dbo].[Sales];"
         )
 
-    async def test_block_predicate_with_operation_exact_sql(self) -> None:
-        captured: list[str] = []
-
-        def _mock(_target: object, _sql: str, **_kw: object) -> tuple:
-            captured.append(_sql)
-            return [], []
-
-        with patch("fabric_dw.services.rls.run_query", side_effect=_mock):
-            await rls_svc.add_predicate(
-                _TARGET,
-                "rls.SalesBlock",
-                "BLOCK",
-                "rls",
-                "fn_block",
-                ["SalesRep"],
-                "dbo",
-                "Sales",
-                operation="AFTER_INSERT",
-            )
-
-        stmt = captured[0]
-        assert stmt == (
-            "ALTER SECURITY POLICY [rls].[SalesBlock]\n"
-            "    ADD BLOCK PREDICATE [rls].[fn_block]([SalesRep]) ON [dbo].[Sales] AFTER INSERT;"
-        )
-
-    async def test_block_predicate_without_operation(self) -> None:
-        captured: list[str] = []
-
-        def _mock(_target: object, _sql: str, **_kw: object) -> tuple:
-            captured.append(_sql)
-            return [], []
-
-        with patch("fabric_dw.services.rls.run_query", side_effect=_mock):
+    async def test_block_predicate_type_rejected(self) -> None:
+        """BLOCK is rejected before any SQL is built (#966)."""
+        with pytest.raises(ValueError, match="Invalid predicate type"):
             await rls_svc.add_predicate(
                 _TARGET,
                 "rls.SalesBlock",
@@ -497,12 +412,6 @@ class TestAddPredicate:
                 "dbo",
                 "Sales",
             )
-
-        stmt = captured[0]
-        # No AFTER/BEFORE clause when operation is None
-        assert "ADD BLOCK PREDICATE" in stmt
-        assert "AFTER" not in stmt
-        assert "BEFORE" not in stmt
 
     async def test_invalid_predicate_type_raises(self) -> None:
         with pytest.raises(ValueError, match="Invalid predicate type"):
@@ -538,15 +447,9 @@ class TestDropPredicate:
             "ALTER SECURITY POLICY [rls].[SalesFilter]\n    DROP FILTER PREDICATE ON [dbo].[Sales];"
         )
 
-    async def test_block_predicate_no_operation_clause(self) -> None:
-        """DROP PREDICATE emits no operation clause -- T-SQL syntax has no such clause."""
-        captured: list[str] = []
-
-        def _mock(_target: object, _sql: str, **_kw: object) -> tuple:
-            captured.append(_sql)
-            return [], []
-
-        with patch("fabric_dw.services.rls.run_query", side_effect=_mock):
+    async def test_block_predicate_type_rejected(self) -> None:
+        """BLOCK is rejected before any SQL is built (#966)."""
+        with pytest.raises(ValueError, match="Invalid predicate type"):
             await rls_svc.drop_predicate(
                 _TARGET,
                 "rls.SalesBlock",
@@ -554,30 +457,6 @@ class TestDropPredicate:
                 "dbo",
                 "Sales",
             )
-
-        stmt = captured[0]
-        assert stmt == (
-            "ALTER SECURITY POLICY [rls].[SalesBlock]\n    DROP BLOCK PREDICATE ON [dbo].[Sales];"
-        )
-
-    async def test_block_without_operation_emits_no_op_clause(self) -> None:
-        captured: list[str] = []
-
-        def _mock(_target: object, _sql: str, **_kw: object) -> tuple:
-            captured.append(_sql)
-            return [], []
-
-        with patch("fabric_dw.services.rls.run_query", side_effect=_mock):
-            await rls_svc.drop_predicate(
-                _TARGET,
-                "rls.SalesBlock",
-                "BLOCK",
-                "dbo",
-                "Sales",
-            )
-
-        stmt = captured[0]
-        assert "DROP BLOCK PREDICATE ON [dbo].[Sales];" in stmt
 
 
 # ---------------------------------------------------------------------------
@@ -659,22 +538,16 @@ class TestDropSecurityPolicy:
 
 
 # ---------------------------------------------------------------------------
-# _build_predicate_clause - FILTER rejects operation
+# _build_predicate_clause - FILTER-only clause shape
 # ---------------------------------------------------------------------------
 
 
-class TestBuildPredicateClauseFilterRejectsOperation:
-    def test_filter_with_operation_raises(self) -> None:
+class TestBuildPredicateClause:
+    def test_filter_clause_exact_sql(self) -> None:
         from fabric_dw.services.rls import _build_predicate_clause  # noqa: PLC0415
 
-        with pytest.raises(ValueError, match="FILTER predicates do not accept an operation"):
-            _build_predicate_clause("FILTER", "rls", "fn", ["col"], "dbo", "T", "AFTER_INSERT")
-
-    def test_block_with_operation_succeeds(self) -> None:
-        from fabric_dw.services.rls import _build_predicate_clause  # noqa: PLC0415
-
-        result = _build_predicate_clause("BLOCK", "rls", "fn", ["col"], "dbo", "T", "AFTER_INSERT")
-        assert "AFTER INSERT" in result
+        result = _build_predicate_clause("FILTER", "rls", "fn", ["col"], "dbo", "T")
+        assert result == "ADD FILTER PREDICATE [rls].[fn]([col]) ON [dbo].[T]"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/services/test_rls.py
+++ b/tests/unit/services/test_rls.py
@@ -256,17 +256,16 @@ class TestCreateSecurityPolicy:
 
         assert "STATE = OFF" in captured[0]
 
-    async def test_predicate_type_key_has_no_effect(self) -> None:
-        """There is no predicate-type concept (#966): a stray "predicate_type": "BLOCK"
-        key in the spec dict is simply not read, and the built clause is FILTER
-        regardless -- there is no code path that could turn it into BLOCK."""
-        captured: list[str] = []
-
-        def _mock(_target: object, _sql: str, **_kw: object) -> tuple:
-            captured.append(_sql)
-            return [], []
-
-        with patch("fabric_dw.services.rls.run_query", side_effect=_mock):
+    async def test_unknown_predicate_key_rejected(self) -> None:
+        """A spec carrying "predicate_type" is rejected (#967): silently ignoring it and
+        always building FILTER would let a caller believe a BLOCK-style write-block is
+        enforced when only a FILTER read-filter was actually created. This is generic
+        key-set hygiene, not a predicate-type/BLOCK-aware check -- see
+        test_unknown_predicate_key_rejected_is_generic_not_block_specific below."""
+        with (
+            patch("fabric_dw.services.rls.run_query") as mock_run,
+            pytest.raises(ValueError, match="unknown key"),
+        ):
             await rls_svc.create_security_policy(
                 _TARGET,
                 "rls.SalesFilter",
@@ -281,10 +280,47 @@ class TestCreateSecurityPolicy:
                     }
                 ],
             )
+        # No SQL is ever built or executed for a rejected spec.
+        mock_run.assert_not_called()
 
-        stmt = captured[0]
-        assert "ADD FILTER PREDICATE" in stmt
-        assert "BLOCK" not in stmt
+    async def test_operation_key_rejected(self) -> None:
+        """ "operation" is likewise not a recognised key (#967) -- it only ever meant
+        anything for BLOCK predicates, which do not exist here."""
+        with pytest.raises(ValueError, match="unknown key"):
+            await rls_svc.create_security_policy(
+                _TARGET,
+                "rls.SalesFilter",
+                [
+                    {
+                        "fn_schema": "rls",
+                        "fn_name": "fn_filter",
+                        "fn_args": ["SalesRep"],
+                        "table_schema": "dbo",
+                        "table_name": "Sales",
+                        "operation": "AFTER_INSERT",
+                    }
+                ],
+            )
+
+    async def test_unknown_predicate_key_rejected_is_generic_not_block_specific(self) -> None:
+        """The rejection has no concept of "BLOCK" or "predicate type" at all -- any
+        unrecognised key is rejected identically, including one that has nothing to do
+        with predicate types (proving this is not a disguised BLOCK-vs-FILTER allowlist)."""
+        with pytest.raises(ValueError, match="unknown key"):
+            await rls_svc.create_security_policy(
+                _TARGET,
+                "rls.SalesFilter",
+                [
+                    {
+                        "fn_schema": "rls",
+                        "fn_name": "fn_filter",
+                        "fn_args": ["SalesRep"],
+                        "table_schema": "dbo",
+                        "table_name": "Sales",
+                        "foo": "bar",
+                    }
+                ],
+            )
 
     async def test_multi_predicate_create(self) -> None:
         captured: list[str] = []


### PR DESCRIPTION
## Summary

Fabric Data Warehouse rejects `BLOCK PREDICATE` for both `CREATE SECURITY POLICY` and `ALTER SECURITY POLICY` ("BLOCK PREDICATE is not supported"). BLOCK support was added in #919, but the RLS integration tests only ever exercised FILTER predicates, so BLOCK shipped untested and always fails against real Fabric.

Following the repo's established pattern for backend-unsupported functionality (precedent: `rename_function` removal, #897), this PR removes BLOCK support entirely as a pure removal, with no guarded or always-erroring stub anywhere. FILTER predicates are fully unaffected: their SQL shape, validation, and behavior are unchanged.

## End state (after 074e281, 28da11f, 119b9b7)

**services/rls.py**
- `VALID_PREDICATE_TYPES`, `_validate_predicate_type`, `VALID_BLOCK_OPERATIONS`, `_validate_operation`, and `_OPERATION_TO_SQL` are all gone. There is no predicate-type concept anywhere in this module's write path.
- `add_predicate()`, `drop_predicate()`, and `_build_predicate_clause()` no longer take a `predicate_type` (or `operation`) parameter at all -- they only know how to build/drop a FILTER predicate. There is no branch that could produce anything else.
- `create_security_policy()`'s predicate spec dicts accept exactly `{fn_schema, fn_name, fn_args, table_schema, table_name}`. Any other key -- including `predicate_type` or `operation` -- raises `ValueError` before any SQL is built. This is generic key-set hygiene (a stray `predicate_type` is rejected the same way a typo like `table` would be), not a disguised BLOCK-vs-FILTER allowlist: it has no concept of "BLOCK" and rejects any unrecognised key identically.
- FILTER predicate SQL is byte-for-byte unchanged from before this PR.

**CLI (`permissions.py`)**
- `rls create` / `rls add-predicate`: `--block` and `--operation` are gone (hard "no such option" error); `--filter` is required.
- `rls drop-predicate`: `--filter` and `--block` are both gone (nothing left to select between); the predicate is identified by `--on` alone.

**MCP (`permissions.py`)**
- `add_security_predicate` / `drop_security_predicate`: the `predicate_type` and `operation` parameters are removed from the function signatures entirely -- confirmed via `mcp.list_tools()` schema introspection that neither field exists in either tool's `inputSchema`.
- `create_security_policy`: `predicates` stays a freeform `list[dict]` (can't restrict dict values via JSON Schema), but the service now rejects any unrecognised key in each entry, so passing `predicate_type` (with any value) surfaces a `ToolError` instead of a silently-downgraded policy.

**Docs**: `docs/commands/permissions.md` updated throughout the `rls` sections (CLI + MCP) to remove BLOCK/operation references, with a note that Fabric supports FILTER predicates only.

**Read path**: `list_security_policies` (read-only, reflects `sys.security_predicates` as-is) is untouched -- it still faithfully reports the real `predicate_type_desc` of any row already in the catalog, including a legacy BLOCK predicate if one somehow exists there.

## Why the unknown-key check (not a predicate-type allowlist)

An earlier version of this PR kept a FILTER-only allowlist that turned `predicate_type: "BLOCK"` into a `ValueError` -- independent review flagged that as not a true pure removal (BLOCK was still a recognised, checked concept). That was replaced with the current design: `create_security_policy` doesn't know what `predicate_type` *means* anymore, it just refuses to silently ignore unexpected input. A second review round then flagged a related risk in that generalized design: a stray `predicate_type: "BLOCK"` key going unvalidated would let a caller believe a write-block was enforced when only a read-filter was created (a silent security-intent downgrade). The unknown-key rejection in 119b9b7 closes that gap generically, without reintroducing any BLOCK-specific logic.

## Test plan

- [x] `uv run ruff format .` / `uv run ruff check .` clean
- [x] `uv run ty check` clean
- [x] `uv run pytest tests/unit -q` -- 5772 passed
- [x] `tests/integration/test_services_rls.py` already exercises FILTER only and needed no changes
- [x] Regression tests: BLOCK removed at CLI (`--block`/`--operation` -> "no such option"), MCP schema (predicate_type/operation absent from `add_security_predicate`/`drop_security_predicate` schemas), and service layer (unknown-key rejection in `create_security_policy`, proven generic via an unrelated unrecognised key, and proven to surface as a `ToolError` through the MCP tool)

Closes #966

🤖 Generated with [Claude Code](https://claude.com/claude-code)