### PR TITLE
feat: publish the MCP server to the MCP Registry via OCI on stable releases

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,6 +18,8 @@ permissions:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.docker_tags.outputs.version }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -84,3 +86,72 @@ jobs:
       - name: Verify image pushed
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
         run: docker manifest inspect ghcr.io/sdebruyn/fabric-dw:${{ steps.docker_tags.outputs.version }}
+
+  publish-mcp-registry:
+    name: Publish to MCP Registry
+    runs-on: ubuntu-latest
+    needs: build-and-push
+    # Registers server.json in the MCP Registry (registry.modelcontextprotocol.io).
+    # Co-located here (rather than in publish.yml) because the artifact being registered
+    # is the OCI image this workflow just pushed - `needs: build-and-push` plus that job's
+    # own "Verify image pushed" step already guarantee the image is live before this job
+    # starts, with no cross-workflow polling required.
+    # Runs only for tag pushes (never plain pushes to main); stable-vs-prerelease gating is
+    # handled inside the run body below using the same regex the repo uses elsewhere.
+    if: github.ref_type == 'tag'
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Determine prerelease flag
+        id: prerelease
+        env:
+          TAG_VERSION: ${{ needs.build-and-push.outputs.version }}
+        run: |
+          if echo "$TAG_VERSION" | grep -qE '(a|b|rc)[0-9]*$|\.dev'; then
+            echo "Prerelease tag '$TAG_VERSION' - MCP Registry tracks stable releases only; skipping."
+            echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set server.json version from the tag
+        if: steps.prerelease.outputs.is_prerelease == 'false'
+        env:
+          TAG_VERSION: ${{ needs.build-and-push.outputs.version }}
+        run: |
+          jq --arg v "$TAG_VERSION" \
+            '.version = $v | .packages[0].identifier = "ghcr.io/sdebruyn/fabric-dw:" + $v' \
+            server.json > server.json.tmp
+          mv server.json.tmp server.json
+
+      - name: Install mcp-publisher
+        if: steps.prerelease.outputs.is_prerelease == 'false'
+        run: |
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/v1.7.9/mcp-publisher_linux_amd64.tar.gz" \
+            | tar xz mcp-publisher
+
+      - name: Publish to MCP Registry (OIDC)
+        if: steps.prerelease.outputs.is_prerelease == 'false'
+        # GitHub OIDC authorizes the io.github.sdebruyn/* namespace automatically for
+        # workflow runs on an sdebruyn-owned repo - no dedicated secret needed.
+        #
+        # A re-run publishing an already-registered version is treated as success
+        # (idempotent re-run), mirroring the "already exists" handling in publish.yml's
+        # PyPI publish step. Any other failure propagates.
+        run: |
+          ./mcp-publisher login github-oidc
+          set +e
+          output=$(./mcp-publisher publish 2>&1)
+          exit_code=$?
+          set -e
+          echo "$output"
+          if [ "$exit_code" -ne 0 ]; then
+            if echo "$output" | grep -qiE 'already published|already exists|already registered'; then
+              echo "Version already on the MCP Registry - treating as success (idempotent re-run)."
+            else
+              exit "$exit_code"
+            fi
+          fi

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -128,10 +128,17 @@ jobs:
           mv server.json.tmp server.json
 
       - name: Install mcp-publisher
+        # This job holds id-token: write, so the downloaded binary is checksummed before it
+        # is extracted or executed. Hash pinned from the v1.7.9 release's checksums file
+        # (mcp-publisher_linux_amd64.tar.gz); bump both the version and the hash together.
         if: steps.prerelease.outputs.is_prerelease == 'false'
+        env:
+          MCP_PUBLISHER_SHA256: ab128162b0616090b47cf245afe0a23f3ef08936fdce19074f5ba0a4469281ac
         run: |
-          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/v1.7.9/mcp-publisher_linux_amd64.tar.gz" \
-            | tar xz mcp-publisher
+          curl -fsSL -o mcp-publisher.tar.gz \
+            "https://github.com/modelcontextprotocol/registry/releases/download/v1.7.9/mcp-publisher_linux_amd64.tar.gz"
+          echo "${MCP_PUBLISHER_SHA256}  mcp-publisher.tar.gz" | sha256sum -c -
+          tar xzf mcp-publisher.tar.gz mcp-publisher
 
       - name: Publish to MCP Registry (OIDC)
         if: steps.prerelease.outputs.is_prerelease == 'false'

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,11 @@ LABEL org.opencontainers.image.title="fabric-dw" \
       org.opencontainers.image.version="${VERSION}" \
       org.opencontainers.image.licenses="MIT"
 
+# MCP Registry ownership verification for the "oci" package type in server.json: the
+# registry checks this annotation against server.json's `name`, not identifier-matching
+# (unlike PyPI/NuGet/cargo, which check an `mcp-name:` string in the package README).
+LABEL io.modelcontextprotocol.server.name="io.github.sdebruyn/fabric-dw-mcp"
+
 # Install system dependencies using BuildKit cache mount for faster rebuilds.
 # ca-certificates: required for TLS connections to Fabric REST APIs and Azure AD.
 # mssql-python (the SQL driver) bundles its own native driver (no separate ODBC

--- a/docs/install.md
+++ b/docs/install.md
@@ -111,6 +111,12 @@ Two optional environment variables tune the HTTP retry budget:
 | `FABRIC_DW_MAX_429_RETRIES` | Maximum consecutive 429 responses before raising `RateLimitedError` | 10 |
 | `FABRIC_DW_RETRY_DEADLINE_S` | Combined wall-clock deadline (seconds) for 429-loop + 5xx retries | 300.0 |
 
+### Install from the MCP Registry
+
+`fabric-dw-mcp` is also published to the official [MCP Registry](https://registry.modelcontextprotocol.io) as `io.github.sdebruyn/fabric-dw-mcp` on every stable release. Registry-aware clients (VS Code `@mcp`, and others that support registry discovery) can find and install it by that name instead of hand-writing a client config.
+
+The registry entry runs the server as the `ghcr.io/sdebruyn/fabric-dw` Docker image (its `ENTRYPOINT` starts `fabric-dw-mcp` directly), so a client that installs from the registry needs Docker, not `uv`/`uvx`. The `uvx --from fabric-dw fabric-dw-mcp` and `pip install fabric-dw` paths above remain the recommended setup for manual client configs and do not require Docker.
+
 ### Claude Code
 
 Source: <https://code.claude.com/docs/en/mcp>

--- a/server.json
+++ b/server.json
@@ -12,7 +12,6 @@
   "packages": [
     {
       "registryType": "oci",
-      "registryBaseUrl": "https://ghcr.io",
       "identifier": "ghcr.io/sdebruyn/fabric-dw:2026.6.0",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.sdebruyn/fabric-dw-mcp",
+  "title": "fabric-dw",
+  "description": "MCP server for Microsoft Fabric Data Warehouses and SQL Analytics Endpoints",
+  "websiteUrl": "https://fdw.debruyn.dev",
+  "repository": {
+    "url": "https://github.com/sdebruyn/fabric-dw-mcp-cli",
+    "source": "github"
+  },
+  "version": "2026.6.0",
+  "packages": [
+    {
+      "registryType": "oci",
+      "registryBaseUrl": "https://ghcr.io",
+      "identifier": "ghcr.io/sdebruyn/fabric-dw:2026.6.0",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "FABRIC_AUTH",
+          "description": "Azure credential source: 'default' (DefaultAzureCredential chain), 'sp' (service principal, needs AZURE_TENANT_ID/AZURE_CLIENT_ID/AZURE_CLIENT_SECRET), or 'interactive' (browser sign-in).",
+          "default": "default",
+          "isRequired": false,
+          "isSecret": false
+        },
+        {
+          "name": "FABRIC_MCP_READONLY",
+          "description": "Set to 1 to restrict execute_sql to SELECT/WITH statements and block all mutating tools.",
+          "isRequired": false,
+          "isSecret": false
+        },
+        {
+          "name": "FABRIC_MCP_ALLOW_DESTRUCTIVE",
+          "description": "Set to 1 to enable permanently-destructive tools (delete_*, clear_table, restore_warehouse_in_place). Disabled by default.",
+          "isRequired": false,
+          "isSecret": false
+        },
+        {
+          "name": "FABRIC_MCP_WORKSPACES",
+          "description": "Comma-separated workspace names or GUIDs the server may touch. Unset allows all workspaces.",
+          "isRequired": false,
+          "isSecret": false
+        },
+        {
+          "name": "FABRIC_MCP_ALLOW_REMOTE",
+          "description": "Set to 1 to allow the HTTP transport to bind on a non-loopback address. Always front with an authenticating reverse proxy.",
+          "isRequired": false,
+          "isSecret": false
+        },
+        {
+          "name": "FABRIC_LOG_LEVEL",
+          "description": "Log level for the MCP server (DEBUG, INFO, WARNING, ERROR, CRITICAL).",
+          "default": "INFO",
+          "isRequired": false,
+          "isSecret": false
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit/test_server_json.py
+++ b/tests/unit/test_server_json.py
@@ -57,6 +57,22 @@ def test_oci_identifier_points_at_the_published_ghcr_image() -> None:
     assert identifier.startswith("ghcr.io/sdebruyn/fabric-dw:")
 
 
+def test_oci_package_omits_fields_the_registry_rejects_for_oci() -> None:
+    """The registry's server-side OCI validator rejects registryBaseUrl/version/fileSha256.
+
+    For "oci" packages the registry (internal/validators/registries/oci.go) hard-errors on
+    these three fields: the registry host and version must live in `identifier` instead
+    (e.g. "ghcr.io/owner/image:1.0.0"). `mcp-publisher validate` only runs the JSON-schema
+    check, where these fields are schema-legal, so this only surfaces at `publish` time -
+    locking it in here so a regression fails fast in the unit suite instead of the first
+    live publish.
+    """
+    package = _SERVER_JSON["packages"][0]
+    assert "registryBaseUrl" not in package
+    assert "version" not in package
+    assert "fileSha256" not in package
+
+
 def test_stdio_transport() -> None:
     """The MCP server communicates over stdio (no HTTP/SSE port to expose)."""
     assert _SERVER_JSON["packages"][0]["transport"]["type"] == "stdio"

--- a/tests/unit/test_server_json.py
+++ b/tests/unit/test_server_json.py
@@ -1,0 +1,78 @@
+"""Validate server.json (the MCP Registry manifest) and its Dockerfile ownership tie-in.
+
+server.json registers `fabric-dw-mcp` in the official MCP Registry via the "oci" package
+type (see docs/install.md#install-from-the-mcp-registry). A PyPI package entry cannot be
+used here: the registry forces `identifier` to equal the published PyPI package name
+(`fabric-dw`), and every registry-aware client inserts `identifier` as its own literal
+command token, so the composed command always resolves to the `fabric-dw` CLI rather than
+the `fabric-dw-mcp` script - there is no server.json encoding that separates the package
+name from the script name for a self-fetching runtime like `uvx`. The OCI image sidesteps
+this: its `ENTRYPOINT` already starts `fabric-dw-mcp` directly, and ownership is proven via
+a Docker `LABEL` rather than identifier-matching. This test guards both halves of that tie:
+server.json's shape and the Dockerfile LABEL staying in sync with it.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).parent.parent.parent
+_SERVER_JSON = json.loads((_REPO_ROOT / "server.json").read_text(encoding="utf-8"))
+_DOCKERFILE = (_REPO_ROOT / "Dockerfile").read_text(encoding="utf-8")
+
+_EXPECTED_SCHEMA = "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json"
+_EXPECTED_NAME = "io.github.sdebruyn/fabric-dw-mcp"
+
+
+def test_schema_url() -> None:
+    """server.json declares the pinned 2025-12-11 registry schema."""
+    assert _SERVER_JSON["$schema"] == _EXPECTED_SCHEMA
+
+
+def test_server_name() -> None:
+    """The registered server name matches the reverse-DNS namespace decided in #969."""
+    assert _SERVER_JSON["name"] == _EXPECTED_NAME
+
+
+def test_version_present_and_not_a_range() -> None:
+    """version is a concrete string (CI overwrites the placeholder from the release tag)."""
+    version = _SERVER_JSON["version"]
+    assert isinstance(version, str)
+    assert version not in ("", "latest")
+
+
+def test_single_oci_package() -> None:
+    """packages[] holds exactly one 'oci' entry; no 'pypi' entry (see module docstring)."""
+    packages = _SERVER_JSON["packages"]
+    assert len(packages) == 1
+    package = packages[0]
+    assert package["registryType"] == "oci"
+
+
+def test_oci_identifier_points_at_the_published_ghcr_image() -> None:
+    """identifier targets the image .github/workflows/docker.yml actually pushes."""
+    identifier = _SERVER_JSON["packages"][0]["identifier"]
+    assert identifier.startswith("ghcr.io/sdebruyn/fabric-dw:")
+
+
+def test_stdio_transport() -> None:
+    """The MCP server communicates over stdio (no HTTP/SSE port to expose)."""
+    assert _SERVER_JSON["packages"][0]["transport"]["type"] == "stdio"
+
+
+def test_dockerfile_label_matches_server_json_name() -> None:
+    """Dockerfile LABEL io.modelcontextprotocol.server.name must equal server.json's name.
+
+    This is the OCI ownership-verification tie-in: the MCP Registry checks this label
+    against server.json's `name`, not identifier-matching (unlike PyPI/NuGet/cargo, which
+    check an `mcp-name:` string in the package README).
+    """
+    match = re.search(
+        r'LABEL io\.modelcontextprotocol\.server\.name="([^"]+)"',
+        _DOCKERFILE,
+    )
+    assert match, "Dockerfile is missing the io.modelcontextprotocol.server.name LABEL"
+    assert match.group(1) == _EXPECTED_NAME
+    assert match.group(1) == _SERVER_JSON["name"]


### PR DESCRIPTION
## Summary

Registers `io.github.sdebruyn/fabric-dw-mcp` in the official [MCP Registry](https://registry.modelcontextprotocol.io) using the **OCI package type**, not PyPI as originally scoped in #969. See the [pivot rationale comment](https://github.com/sdebruyn/fabric-dw-mcp-cli/issues/969#issuecomment-4864567446) on the issue for the full writeup; summary below.

### Why not PyPI

A PyPI `packages[]` entry cannot launch this server. The registry forces `identifier` to equal the published PyPI package name (`fabric-dw`), and every registry-aware client composes the run command as `args = [...runtimeArguments, "<identifier>", ...packageArguments]` — `identifier` is inserted as its own literal command token, unconditionally (confirmed by reading VS Code's client-side resolver, `mcpManagementService.ts`). So the composed command always resolves to `uvx ... fabric-dw ...` (the CLI), never `fabric-dw-mcp` (the server). There is no server.json encoding that separates a PyPI package name from its console script name for a self-fetching runtime like `uvx`.

Empirically confirmed: built a local wheel of `fabric-dw` and ran the exact argv a client would compose (`uvx --from <wheel> fabric-dw fabric-dw-mcp`):

```
Usage: fabric-dw [OPTIONS] COMMAND [ARGS]...
Error: No such command 'fabric-dw-mcp'.
```

It launches the CLI and errors trying to treat `fabric-dw-mcp` as a subcommand.

### Why OCI works

This repo already publishes `ghcr.io/sdebruyn/fabric-dw` (`.github/workflows/docker.yml`), and the `Dockerfile` `ENTRYPOINT` is already `["fabric-dw-mcp"]` — so `docker run ghcr.io/sdebruyn/fabric-dw:<tag>` starts the MCP server directly, no argument gymnastics. Docker/OCI images don't tie `identifier` to a script name; ownership is proven with a `LABEL io.modelcontextprotocol.server.name` instead of PyPI's `mcp-name` README-comment mechanism.

**Validated run command:** `docker run -i --rm ghcr.io/sdebruyn/fabric-dw:<tag>` (no extra args). Built the image locally (`docker build --build-arg VERSION=2026.6.1 .`) and piped a JSON-RPC `initialize` request into `docker run -i --rm <image>`; got back a correct MCP `initialize` response (`serverInfo.name: "fabric-dw"`), confirming the bare `ENTRYPOINT` launches the right process.

## Changes

- **`server.json`** (new): schema `2025-12-11`, `name: io.github.sdebruyn/fabric-dw-mcp`, a single `packages[]` entry with `registryType: "oci"`, `identifier: "ghcr.io/sdebruyn/fabric-dw:2026.6.0"` (placeholder version = current stable; CI overwrites both the top-level `version` and this identifier's tag from the release tag; no `registryBaseUrl`, package-level `version`, or `fileSha256` - the registry's server-side OCI validator rejects all three), `transport.type: "stdio"`, and the documented `environmentVariables` (`FABRIC_AUTH`, `FABRIC_MCP_READONLY`, `FABRIC_MCP_ALLOW_DESTRUCTIVE`, `FABRIC_MCP_WORKSPACES`, `FABRIC_MCP_ALLOW_REMOTE`, `FABRIC_LOG_LEVEL`). No `pypi` entry — shipping one would silently point registry-aware clients at the CLI instead of the server. Schema-validated with `mcp-publisher validate` against the live registry's validation endpoint.
- **`Dockerfile`**: add `LABEL io.modelcontextprotocol.server.name="io.github.sdebruyn/fabric-dw-mcp"` for OCI ownership verification.
- **`.github/workflows/docker.yml`**: new `publish-mcp-registry` job, `needs: build-and-push`, gated to `github.ref_type == 'tag'` with an internal stable-vs-prerelease check reusing the existing `(a|b|rc)[0-9]*$|\.dev` regex. Sets `server.json`'s `version` and `packages[0].identifier` from the tag via `jq`, installs `mcp-publisher` (pinned to v1.7.9, tarball verified against its published SHA-256 before extraction since this job holds `id-token: write`), authenticates with `mcp-publisher login github-oidc` (`permissions: id-token: write, contents: read`), and runs `mcp-publisher publish`, treating an "already published" outcome idempotently. **Co-located in `docker.yml` rather than `publish.yml`**: the artifact being registered is the image this workflow pushes, and `needs: build-and-push` (whose own "Verify image pushed" step already confirms `docker manifest inspect` succeeds) guarantees the image is live before this job starts — no cross-workflow polling needed, and no collision with `publish.yml`'s `sync-plugin-manifest` job from #968/#970.
- **`docs/install.md`**: short "Install from the MCP Registry" subsection (already-navigated page, no new page) noting registry-aware clients discover `io.github.sdebruyn/fabric-dw-mcp`, and that the registry-installed path uses Docker while `uvx`/`pip` remain the manual-config recommendation.
- **`tests/unit/test_server_json.py`** (new): `server.json` parses; `$schema` is the 2025-12-11 URL; `name == "io.github.sdebruyn/fabric-dw-mcp"`; single `oci` package entry; `identifier` starts with `ghcr.io/sdebruyn/fabric-dw:`; `transport.type == "stdio"`; version is concrete (not empty/"latest"); the oci package entry carries none of `registryBaseUrl`/`version`/`fileSha256` (rejected server-side for oci packages); and a drift guard asserting the `Dockerfile` `LABEL io.modelcontextprotocol.server.name` exactly matches `server.json`'s `name`.

`pyproject.toml` already has `readme = "README.md"`; no change needed (unused for the OCI path anyway). `README.md` is unchanged — no `mcp-name` comment was added, since that ownership mechanism is PyPI/NuGet/cargo-specific and unused for OCI.

## Test plan

- [x] `uv run pytest tests/unit/test_server_json.py -v` — 8 passed
- [x] `ruff format --check` / `ruff check` on the new test file — clean
- [x] `uv run ty check tests/unit/test_server_json.py` — clean
- [x] `mcp-publisher validate` against the live registry validation endpoint — `✅ server.json is valid`
- [x] Built the Docker image locally and confirmed a bare `docker run -i --rm <image>` responds correctly to a piped JSON-RPC `initialize` request (validates the exact command the registry entry implies)
- [ ] CI: full unit suite, ruff, ty (not run locally per policy — CI is the build authority)
- Not run: integration tests, live registry publish (`mcp-publisher publish` was never run against the real registry; only `init` and `validate` were used)

Closes #969

🤖 Generated with [Claude Code](https://claude.com/claude-code)

