### PR TITLE
fix(sql): never let a raw driver error reach the CLI on connect timeout

### DIFF
--- a/src/fabric_dw/cli/__init__.py
+++ b/src/fabric_dw/cli/__init__.py
@@ -39,7 +39,7 @@ def main() -> None:
         cli()
     except (SystemExit, KeyboardInterrupt):
         # SystemExit: Click's own main() already caught and cleanly rendered
-        # ClickException/UsageError/Abort and translated them into this —
+        # ClickException/UsageError/Abort and translated them into this,
         # nothing more to do.  KeyboardInterrupt: never swallow Ctrl+C.
         raise
     except BaseException as exc:
@@ -50,15 +50,15 @@ def _render_unexpected_error(exc: BaseException) -> None:
     """Render an exception that escaped every other error-handling layer.
 
     Click's own ``main()`` only catches ``ClickException`` / ``UsageError`` /
-    ``Abort`` / EPIPE ``OSError`` — anything else (e.g. a raw driver error that
+    ``Abort`` / EPIPE ``OSError``; anything else (e.g. a raw driver error that
     slipped past a connect-retry-exhaustion path, see #972) propagates
     unchanged.  This is the last line of defense so the CLI never shows a raw
     Python traceback by default: a clean, single-line message goes to stderr
     and the process exits non-zero.
 
     The full traceback is still available for debugging, but only when the
-    ``fabric_dw`` logger is at ``DEBUG`` level — the existing ``-v`` /
-    ``--verbose`` convention (see ``fabric_dw.cli._main.cli``) — never by
+    ``fabric_dw`` logger is at ``DEBUG`` level, the existing ``-v`` /
+    ``--verbose`` convention (see ``fabric_dw.cli._main.cli``), never by
     default, since it may contain internal stack frames and driver internals.
 
     This function must never itself raise: it is the last line of defense, so
@@ -68,12 +68,14 @@ def _render_unexpected_error(exc: BaseException) -> None:
     try:
         message = str(exc).replace("\r", " ").replace("\n", " ").strip() or type(exc).__name__
     except Exception:
-        # exc.__str__ itself failed (e.g. a buggy custom exception) — fall back
+        # exc.__str__ itself failed (e.g. a buggy custom exception): fall back
         # to the type name, which cannot raise.
         message = type(exc).__name__
     # Stderr write failures (e.g. a broken pipe) must not block the exit below.
     with contextlib.suppress(Exception):
         click.echo(f"Error: unexpected error: {message}", err=True)
     if logging.getLogger("fabric_dw").isEnabledFor(logging.DEBUG):
-        traceback.print_exc()
+        # Guarded too: a broken stderr must not prevent sys.exit() from firing.
+        with contextlib.suppress(Exception):
+            traceback.print_exc()
     sys.exit(_UNEXPECTED_ERROR_EXIT_CODE)

--- a/src/fabric_dw/cli/__init__.py
+++ b/src/fabric_dw/cli/__init__.py
@@ -2,13 +2,24 @@
 
 from __future__ import annotations
 
+import logging
 import sys
+import traceback
+
+import click
 
 from fabric_dw.cli._main import cli
 from fabric_dw.telemetry import suppress_telemetry
 
 # Help-option names declared on the root group's context_settings.
 _HELP_FLAGS: frozenset[str] = frozenset({"-h", "--help"})
+
+# Exit code for an unexpected/internal error that escaped every other
+# error-handling layer.  Grouped with the generic non-zero-failure code
+# documented in docs/reference/exit-codes.md (usage error / aborted prompt /
+# Fabric API error all exit 1); a dedicated code is not warranted since the
+# guard below is defense-in-depth, not the primary error-reporting path.
+_UNEXPECTED_ERROR_EXIT_CODE = 1
 
 
 def main() -> None:
@@ -23,4 +34,34 @@ def main() -> None:
     # telemetry, bringing subcommand help latency from ~2-4 s to <0.5 s.
     if _HELP_FLAGS.intersection(sys.argv[1:]):
         suppress_telemetry()
-    cli()
+    try:
+        cli()
+    except (SystemExit, KeyboardInterrupt):
+        # SystemExit: Click's own main() already caught and cleanly rendered
+        # ClickException/UsageError/Abort and translated them into this —
+        # nothing more to do.  KeyboardInterrupt: never swallow Ctrl+C.
+        raise
+    except BaseException as exc:
+        _render_unexpected_error(exc)
+
+
+def _render_unexpected_error(exc: BaseException) -> None:
+    """Render an exception that escaped every other error-handling layer.
+
+    Click's own ``main()`` only catches ``ClickException`` / ``UsageError`` /
+    ``Abort`` / EPIPE ``OSError`` — anything else (e.g. a raw driver error that
+    slipped past a connect-retry-exhaustion path, see #972) propagates
+    unchanged.  This is the last line of defense so the CLI never shows a raw
+    Python traceback by default: a clean, single-line message goes to stderr
+    and the process exits non-zero.
+
+    The full traceback is still available for debugging, but only when the
+    ``fabric_dw`` logger is at ``DEBUG`` level — the existing ``-v`` /
+    ``--verbose`` convention (see ``fabric_dw.cli._main.cli``) — never by
+    default, since it may contain internal stack frames and driver internals.
+    """
+    message = str(exc).replace("\n", " ").strip() or type(exc).__name__
+    click.echo(f"Error: unexpected error: {message}", err=True)
+    if logging.getLogger("fabric_dw").isEnabledFor(logging.DEBUG):
+        traceback.print_exc()
+    sys.exit(_UNEXPECTED_ERROR_EXIT_CODE)

--- a/src/fabric_dw/cli/__init__.py
+++ b/src/fabric_dw/cli/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import sys
 import traceback
@@ -59,9 +60,20 @@ def _render_unexpected_error(exc: BaseException) -> None:
     ``fabric_dw`` logger is at ``DEBUG`` level — the existing ``-v`` /
     ``--verbose`` convention (see ``fabric_dw.cli._main.cli``) — never by
     default, since it may contain internal stack frames and driver internals.
+
+    This function must never itself raise: it is the last line of defense, so
+    a broken ``exc.__str__`` or a write failure on a closed/broken stderr must
+    not prevent the process from exiting with the correct non-zero code.
     """
-    message = str(exc).replace("\n", " ").strip() or type(exc).__name__
-    click.echo(f"Error: unexpected error: {message}", err=True)
+    try:
+        message = str(exc).replace("\r", " ").replace("\n", " ").strip() or type(exc).__name__
+    except Exception:
+        # exc.__str__ itself failed (e.g. a buggy custom exception) — fall back
+        # to the type name, which cannot raise.
+        message = type(exc).__name__
+    # Stderr write failures (e.g. a broken pipe) must not block the exit below.
+    with contextlib.suppress(Exception):
+        click.echo(f"Error: unexpected error: {message}", err=True)
     if logging.getLogger("fabric_dw").isEnabledFor(logging.DEBUG):
         traceback.print_exc()
     sys.exit(_UNEXPECTED_ERROR_EXIT_CODE)

--- a/src/fabric_dw/services/load.py
+++ b/src/fabric_dw/services/load.py
@@ -781,6 +781,9 @@ async def copy_into_from_url(
             # Other already-mapped high-level errors (NotFoundError,
             # PermissionDeniedError, AuthError) are re-raised as-is; they carry
             # their own actionable messages and do not contain SQL statement text.
+            # This also covers a connect-retry-exhaustion FabricError (#972): it
+            # is not a credential leak, since that wrap only ever fires on the
+            # pre-connect path, before the secret-bearing COPY INTO SQL is sent.
             raise
         except Exception as exc:
             # Truly unmapped exceptions that carry no ddbc_error attribute (e.g.

--- a/src/fabric_dw/sql.py
+++ b/src/fabric_dw/sql.py
@@ -357,6 +357,13 @@ def _wrap_connect_retry_exhausted(exc: BaseException) -> BaseException:
       so this loop could retry it — wrapped here in a
       :class:`~fabric_dw.exceptions.FabricError` so a raw driver traceback never
       reaches the CLI/MCP boundary once the retry window is spent (#972).
+
+    ``__cause__`` is set explicitly on the wrap branch (chains to the driver
+    exception) and left untouched on the pass-through branch (preserves the
+    FabricCliError's own original cause, if any).  Callers must raise the
+    return value **without** ``from exc`` — since the pass-through branch
+    returns ``exc`` itself, ``raise ... from exc`` would set
+    ``exc.__cause__ = exc`` (a self-reference) and discard the real cause.
     """
     if isinstance(exc, FabricCliError):
         return exc
@@ -436,7 +443,14 @@ def _with_connect_retry(
             if time.monotonic() >= deadline:
                 # Budget exhausted — surface the last retryable error, wrapped
                 # so a raw driver exception never escapes the connect path (#972).
-                raise _wrap_connect_retry_exhausted(exc) from exc
+                # No `from exc` here (deliberately, not an oversight):
+                # _wrap_connect_retry_exhausted() already sets __cause__ itself for
+                # the wrap branch, and the pass-through branch (exc is already a
+                # FabricCliError) must keep its ORIGINAL __cause__ unchanged --
+                # `raise ... from exc` unconditionally overwrites __cause__ at the
+                # raise site, which for the pass-through branch (same object) would
+                # self-reference (`exc.__cause__ = exc`) and clobber the real cause.
+                raise _wrap_connect_retry_exhausted(exc)  # noqa: B904
             # Back off before the next attempt.  _CONNECT_RETRY_DELAYS is
             # indexed from 0 (= delay before attempt 2); clamp to last value.
             delay = _CONNECT_RETRY_DELAYS[min(attempt, len(_CONNECT_RETRY_DELAYS) - 1)]

--- a/src/fabric_dw/sql.py
+++ b/src/fabric_dw/sql.py
@@ -349,19 +349,19 @@ def _wrap_connect_retry_exhausted(exc: BaseException) -> BaseException:
     when the wall-clock deadline expires.  It is either:
 
     - Already a :class:`~fabric_dw.exceptions.FabricCliError` (e.g. an
-      ``AuthError`` whose message happened to match a retryable fragment) —
+      ``AuthError`` whose message happened to match a retryable fragment):
       returned unchanged, it is already clean.
     - A raw driver exception (e.g. ``mssql_python.exceptions.OperationalError``
       for a TCP connect/login timeout, DDBC error code 0x102) re-raised bare by
       :func:`~fabric_dw.sql_pool._translate_connect_error` Step 3 *specifically*
-      so this loop could retry it — wrapped here in a
+      so this loop could retry it, wrapped here in a
       :class:`~fabric_dw.exceptions.FabricError` so a raw driver traceback never
       reaches the CLI/MCP boundary once the retry window is spent (#972).
 
     ``__cause__`` is set explicitly on the wrap branch (chains to the driver
     exception) and left untouched on the pass-through branch (preserves the
     FabricCliError's own original cause, if any).  Callers must raise the
-    return value **without** ``from exc`` — since the pass-through branch
+    return value **without** ``from exc``, since the pass-through branch
     returns ``exc`` itself, ``raise ... from exc`` would set
     ``exc.__cause__ = exc`` (a self-reference) and discard the real cause.
     """
@@ -426,7 +426,7 @@ def _with_connect_retry(
         Any non-retryable exception from ``open_connection`` immediately.
         A clean, renderable exception (see :func:`_wrap_connect_retry_exhausted`)
         wrapping the last retryable exception when the wall-clock deadline
-        passes — never a raw driver exception (#972).
+        passes: never a raw driver exception (#972).
     """
     deadline = time.monotonic() + _resolve_sql_retry_deadline_s()
     last_exc: BaseException | None = None
@@ -441,7 +441,7 @@ def _with_connect_retry(
                 raise
             last_exc = exc
             if time.monotonic() >= deadline:
-                # Budget exhausted — surface the last retryable error, wrapped
+                # Budget exhausted, surface the last retryable error, wrapped
                 # so a raw driver exception never escapes the connect path (#972).
                 # No `from exc` here (deliberately, not an oversight):
                 # _wrap_connect_retry_exhausted() already sets __cause__ itself for

--- a/src/fabric_dw/sql.py
+++ b/src/fabric_dw/sql.py
@@ -50,6 +50,7 @@ from dataclasses import dataclass
 from typing import Any, Literal, Protocol
 
 from fabric_dw.auth import CredentialMode
+from fabric_dw.exceptions import FabricCliError, FabricError
 from fabric_dw.sql_errors import (
     _clean_driver_error_message,  # noqa: F401 (test shim: _sql_module._clean_driver_error_message)
     _is_connect_retryable,
@@ -341,6 +342,29 @@ def tenant_from_connection_string_host(host: object) -> str | None:
 # ---------------------------------------------------------------------------
 
 
+def _wrap_connect_retry_exhausted(exc: BaseException) -> BaseException:
+    """Return a clean, renderable exception for a connect-retry budget exhaustion.
+
+    ``exc`` is the last retryable exception seen by :func:`_with_connect_retry`
+    when the wall-clock deadline expires.  It is either:
+
+    - Already a :class:`~fabric_dw.exceptions.FabricCliError` (e.g. an
+      ``AuthError`` whose message happened to match a retryable fragment) —
+      returned unchanged, it is already clean.
+    - A raw driver exception (e.g. ``mssql_python.exceptions.OperationalError``
+      for a TCP connect/login timeout, DDBC error code 0x102) re-raised bare by
+      :func:`~fabric_dw.sql_pool._translate_connect_error` Step 3 *specifically*
+      so this loop could retry it — wrapped here in a
+      :class:`~fabric_dw.exceptions.FabricError` so a raw driver traceback never
+      reaches the CLI/MCP boundary once the retry window is spent (#972).
+    """
+    if isinstance(exc, FabricCliError):
+        return exc
+    wrapped = FabricError(f"SQL connection failed: {exc}; please retry")
+    wrapped.__cause__ = exc
+    return wrapped
+
+
 def _with_connect_retry(
     target: SqlTarget,
     mode: CredentialMode,
@@ -393,7 +417,9 @@ def _with_connect_retry(
 
     Raises:
         Any non-retryable exception from ``open_connection`` immediately.
-        The last retryable exception when the wall-clock deadline passes.
+        A clean, renderable exception (see :func:`_wrap_connect_retry_exhausted`)
+        wrapping the last retryable exception when the wall-clock deadline
+        passes — never a raw driver exception (#972).
     """
     deadline = time.monotonic() + _resolve_sql_retry_deadline_s()
     last_exc: BaseException | None = None
@@ -408,8 +434,9 @@ def _with_connect_retry(
                 raise
             last_exc = exc
             if time.monotonic() >= deadline:
-                # Budget exhausted — surface the last retryable error.
-                raise
+                # Budget exhausted — surface the last retryable error, wrapped
+                # so a raw driver exception never escapes the connect path (#972).
+                raise _wrap_connect_retry_exhausted(exc) from exc
             # Back off before the next attempt.  _CONNECT_RETRY_DELAYS is
             # indexed from 0 (= delay before attempt 2); clamp to last value.
             delay = _CONNECT_RETRY_DELAYS[min(attempt, len(_CONNECT_RETRY_DELAYS) - 1)]

--- a/src/fabric_dw/sql_errors.py
+++ b/src/fabric_dw/sql_errors.py
@@ -82,7 +82,7 @@ _TRANSIENT_FRAGMENTS = (
     "a transport-level error",
     # Covers the DDBC "TCP Provider: Error code <hex>" family, including the
     # connect/login timeout 0x102 (decimal 258) seen during a slow/warming-up
-    # Fabric capacity (#972) — retryable because the connection never reached
+    # Fabric capacity (#972), retryable because the connection never reached
     # the server, so no statement could have been executed.
     "tcp provider",
     # Generic socket/timeout seen during heavy transient:

--- a/src/fabric_dw/sql_errors.py
+++ b/src/fabric_dw/sql_errors.py
@@ -80,6 +80,10 @@ _TRANSIENT_FRAGMENTS = (
     "communication link failure",
     "connection was forcibly closed",
     "a transport-level error",
+    # Covers the DDBC "TCP Provider: Error code <hex>" family, including the
+    # connect/login timeout 0x102 (decimal 258) seen during a slow/warming-up
+    # Fabric capacity (#972) — retryable because the connection never reached
+    # the server, so no statement could have been executed.
     "tcp provider",
     # Generic socket/timeout seen during heavy transient:
     "connection timed out",

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -118,7 +118,7 @@ class TestCliTopLevelErrorGuard:
     raw Python traceback (#972).
 
     Click's own ``BaseCommand.main()`` only cleanly handles ``ClickException``/
-    ``UsageError``/``Abort``/EPIPE ``OSError`` — anything else (e.g. a raw
+    ``UsageError``/``Abort``/EPIPE ``OSError``; anything else (e.g. a raw
     driver error that slipped past a connect-retry-exhaustion path) propagates
     unchanged.  ``main()`` wraps ``cli()`` with a defense-in-depth guard; these
     tests exercise that guard directly by replacing ``cli()`` with a callable
@@ -166,7 +166,7 @@ class TestCliTopLevelErrorGuard:
         """The full traceback stays available behind the existing -v / --verbose convention.
 
         Verbose logging is enabled via ``setup_logging(DEBUG)`` on the
-        ``fabric_dw`` logger — never shown by default, since it may contain
+        ``fabric_dw`` logger, never shown by default, since it may contain
         driver internals.
         """
         monkeypatch.setattr(sys, "argv", ["fdw", "sql", "-q", "SELECT 1"])

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -20,6 +20,7 @@ from fabric_dw.auth import CredentialMode
 from fabric_dw.cli._context import CliContext
 from fabric_dw.cli._main import cli
 from fabric_dw.config import Defaults, UserConfig, save_config
+from fabric_dw.logging import setup_logging
 
 
 class TestCliHelp:
@@ -110,6 +111,106 @@ class TestCliUnknownCommand:
         runner = CliRunner()
         result = runner.invoke(cli, ["not-a-real-command"])
         assert result.exit_code != 0
+
+
+class TestCliTopLevelErrorGuard:
+    """fabric_dw.cli.main() must never let an unexpected exception surface as a
+    raw Python traceback (#972).
+
+    Click's own ``BaseCommand.main()`` only cleanly handles ``ClickException``/
+    ``UsageError``/``Abort``/EPIPE ``OSError`` — anything else (e.g. a raw
+    driver error that slipped past a connect-retry-exhaustion path) propagates
+    unchanged.  ``main()`` wraps ``cli()`` with a defense-in-depth guard; these
+    tests exercise that guard directly by replacing ``cli()`` with a callable
+    that raises, mirroring the existing ``TestHelpTelemetrySuppression`` pattern.
+    """
+
+    def test_unexpected_exception_prints_clean_single_line_error(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setattr(sys, "argv", ["fdw", "sql", "-q", "SELECT 1"])
+
+        def _boom() -> None:
+            raise RuntimeError(
+                "Driver Error: Client unable to establish connection; "
+                "DDBC Error: [Microsoft]TCP Provider: Error code 0x102"
+            )
+
+        with patch.object(_cli_pkg, "cli", _boom), pytest.raises(SystemExit) as exc_info:
+            _cli_pkg.main()
+
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert captured.err.startswith("Error:")
+        assert "TCP Provider" in captured.err
+        assert "Traceback" not in captured.err
+        assert captured.err.strip().count("\n") == 0, "error output must be a single line"
+        assert captured.out == ""
+
+    def test_unexpected_exception_omits_traceback_by_default(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setattr(sys, "argv", ["fdw", "sql", "-q", "SELECT 1"])
+
+        def _boom() -> None:
+            raise RuntimeError("boom")
+
+        with patch.object(_cli_pkg, "cli", _boom), pytest.raises(SystemExit):
+            _cli_pkg.main()
+
+        assert "Traceback" not in capsys.readouterr().err
+
+    def test_unexpected_exception_includes_traceback_when_debug_logging_enabled(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The full traceback stays available behind the existing -v / --verbose convention.
+
+        Verbose logging is enabled via ``setup_logging(DEBUG)`` on the
+        ``fabric_dw`` logger — never shown by default, since it may contain
+        driver internals.
+        """
+        monkeypatch.setattr(sys, "argv", ["fdw", "sql", "-q", "SELECT 1"])
+        setup_logging(logging.DEBUG)  # mirrors what the -v flag does
+
+        def _boom() -> None:
+            raise RuntimeError("boom")
+
+        with patch.object(_cli_pkg, "cli", _boom), pytest.raises(SystemExit):
+            _cli_pkg.main()
+
+        assert "Traceback (most recent call last)" in capsys.readouterr().err
+
+    def test_click_exception_from_real_command_is_unaffected(self) -> None:
+        """A ClickException raised inside an actual command still renders via Click.
+
+        Unaffected by the new top-level guard (no behaviour regression).
+        """
+        runner = CliRunner()
+        result = runner.invoke(cli, ["not-a-real-command"])
+        assert result.exit_code != 0
+        assert "Traceback" not in result.output
+
+    def test_keyboard_interrupt_is_not_swallowed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(sys, "argv", ["fdw", "sql", "-q", "SELECT 1"])
+
+        def _boom() -> None:
+            raise KeyboardInterrupt
+
+        with patch.object(_cli_pkg, "cli", _boom), pytest.raises(KeyboardInterrupt):
+            _cli_pkg.main()
+
+    def test_system_exit_from_cli_propagates_unchanged(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(sys, "argv", ["fdw", "sql", "-q", "SELECT 1"])
+
+        def _exit_5() -> None:
+            raise SystemExit(5)
+
+        with patch.object(_cli_pkg, "cli", _exit_5), pytest.raises(SystemExit) as exc_info:
+            _cli_pkg.main()
+
+        assert exc_info.value.code == 5
 
 
 class TestCliVersion:

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -180,17 +180,38 @@ class TestCliTopLevelErrorGuard:
 
         assert "Traceback (most recent call last)" in capsys.readouterr().err
 
-    def test_click_exception_from_real_command_is_unaffected(self) -> None:
-        """A ClickException raised inside an actual command still renders via Click.
+    def test_click_exception_from_real_command_is_unaffected(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A Click usage error from a real invocation still renders via Click itself.
 
-        Unaffected by the new top-level guard (no behaviour regression).
+        Goes through the actual guarded entry point (fabric_dw.cli.main()), not
+        CliRunner (which bypasses main() and never exercises the guard), so this
+        genuinely proves the new top-level guard does not interfere with Click's
+        own error rendering.
         """
-        runner = CliRunner()
-        result = runner.invoke(cli, ["not-a-real-command"])
-        assert result.exit_code != 0
-        assert "Traceback" not in result.output
+        monkeypatch.setattr(sys, "argv", ["fdw", "not-a-real-command"])
 
-    def test_keyboard_interrupt_is_not_swallowed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        with pytest.raises(SystemExit) as exc_info:
+            _cli_pkg.main()
+
+        # Click's own UsageError for an unknown command exits 2, unaffected by
+        # the guard's own exit code (_UNEXPECTED_ERROR_EXIT_CODE = 1).
+        assert exc_info.value.code == 2
+        captured = capsys.readouterr()
+        assert "No such command" in captured.err
+        assert "Traceback" not in captured.err
+        assert "unexpected error" not in captured.err
+
+    def test_keyboard_interrupt_is_not_swallowed(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A raw KeyboardInterrupt that reaches main() propagates untouched.
+
+        It must not be caught and rendered as "Error: unexpected error: ..." by
+        the new guard -- Ctrl+C exits silently (via Python's default handling),
+        exactly like the pre-#972 behaviour.
+        """
         monkeypatch.setattr(sys, "argv", ["fdw", "sql", "-q", "SELECT 1"])
 
         def _boom() -> None:
@@ -198,6 +219,10 @@ class TestCliTopLevelErrorGuard:
 
         with patch.object(_cli_pkg, "cli", _boom), pytest.raises(KeyboardInterrupt):
             _cli_pkg.main()
+
+        captured = capsys.readouterr()
+        assert captured.err == ""
+        assert captured.out == ""
 
     def test_system_exit_from_cli_propagates_unchanged(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/test_sql.py
+++ b/tests/unit/test_sql.py
@@ -2700,12 +2700,49 @@ class TestAuthFailedConnectRetry:
 
         # Must be a clean FabricError, not the raw driver exception type.
         assert not isinstance(exc_info.value, type(driver_exc))
-        assert isinstance(exc_info.value.__cause__, type(driver_exc))
+        # __cause__ must be the original driver exception itself (not a copy,
+        # and not the wrapper self-referencing — regression guard for the
+        # `raise ... from exc` self-cause bug found in review).
+        assert exc_info.value.__cause__ is driver_exc
+        assert exc_info.value.__cause__ is not exc_info.value
         msg = str(exc_info.value)
         assert "0x102" in msg
         assert "retry" in msg.lower()
         # Only one connect attempt — the deadline was already exceeded.
         assert mock_mssql.connect.call_count == 1
+
+    def test_connect_retry_exhausted_preserves_original_cause_of_pretyped_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Retry exhaustion on an already-typed FabricCliError must not self-cause.
+
+        When the connect exception is already a FabricCliError (pre-typed by
+        _translate_connect_error Step 1 — e.g. a retried AuthError), it is
+        returned unchanged by _wrap_connect_retry_exhausted().  It must keep
+        its ORIGINAL __cause__ (e.g. the underlying Azure exception it was
+        built from) rather than being overwritten to reference itself
+        (`raise exc from exc`), which would happen if the caller used
+        `raise ... from exc` unconditionally.
+        """
+        fake_time = self._fake_time_past_deadline()
+        monkeypatch.setattr(_sql_module, "time", fake_time)
+
+        underlying = ValueError("original Azure credential failure")
+        pretyped = AuthError("authentication failed for user ''")
+        pretyped.__cause__ = underlying
+
+        mock_mssql, _, _ = _make_mock_mssql()
+        mock_mssql.connect.side_effect = pretyped
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        with pytest.raises(AuthError) as exc_info:
+            run_query(_make_target(), "SELECT 1")
+
+        # Pass-through: the exact same AuthError instance, with its original
+        # cause intact — never re-pointed at itself.
+        assert exc_info.value is pretyped
+        assert exc_info.value.__cause__ is underlying
+        assert exc_info.value.__cause__ is not exc_info.value
 
     def test_auth_failed_on_execute_phase_not_retried(
         self, monkeypatch: pytest.MonkeyPatch
@@ -2900,6 +2937,52 @@ class _CommitInvalidatingConnection:
 
 class _ProgrammingError(Exception):
     """Minimal stand-in for mssql_python.exceptions.ProgrammingError."""
+
+
+class TestWrapConnectRetryExhausted:
+    """Unit tests for _wrap_connect_retry_exhausted() in isolation (#972 review follow-up).
+
+    Exercises the ``__cause__`` semantics directly, without going through the
+    full retry loop / fake clock machinery: the wrap branch must chain to the
+    original driver exception, and the pass-through branch must never
+    self-reference (``exc.__cause__ is exc``), which would silently discard a
+    pre-existing cause (e.g. an AuthError chained to the underlying Azure
+    exception).
+    """
+
+    def test_raw_driver_exception_is_wrapped_with_cause_set(self) -> None:
+        class _OperationalError(Exception):
+            """Stand-in for mssql_python.exceptions.OperationalError."""
+
+        driver_exc = _OperationalError("TCP Provider: Error code 0x102")
+
+        wrapped = _sql_module._wrap_connect_retry_exhausted(driver_exc)
+
+        assert isinstance(wrapped, FabricError)
+        assert not isinstance(wrapped, type(driver_exc))
+        assert wrapped.__cause__ is driver_exc
+        assert wrapped.__cause__ is not wrapped
+
+    def test_pretyped_fabric_cli_error_passes_through_unchanged(self) -> None:
+        underlying = ValueError("original Azure credential failure")
+        pretyped = AuthError("authentication failed for user ''")
+        pretyped.__cause__ = underlying
+
+        result = _sql_module._wrap_connect_retry_exhausted(pretyped)
+
+        # Same object, original cause preserved — never re-pointed at itself.
+        assert result is pretyped
+        assert result.__cause__ is underlying
+        assert result.__cause__ is not result
+
+    def test_pretyped_fabric_cli_error_with_no_cause_stays_none(self) -> None:
+        """A pre-typed error with no prior cause must not gain a self-reference."""
+        pretyped = AuthError("authentication failed for user ''")
+
+        result = _sql_module._wrap_connect_retry_exhausted(pretyped)
+
+        assert result is pretyped
+        assert result.__cause__ is None
 
 
 class TestFetchBeforeCommitOrdering:

--- a/tests/unit/test_sql.py
+++ b/tests/unit/test_sql.py
@@ -1220,6 +1220,23 @@ class TestIsTransientConnectionError:
         exc = Exception("TCP Provider: Error code 0x68")
         assert is_transient_connection_error(exc) is True
 
+    def test_tcp_provider_0x102_connect_login_timeout_is_transient(self) -> None:
+        """Regression guard for #972: the exact driver message from the issue.
+
+        0x102 (decimal 258) is the DDBC connect/login timeout.  Matches via the
+        generic "tcp provider" fragment — see the comment in
+        fabric_dw.sql_errors._TRANSIENT_FRAGMENTS.
+        """
+        exc = Exception(
+            "Driver Error: Client unable to establish connection; "
+            "DDBC Error: [Microsoft]TCP Provider: Error code 0x102"
+        )
+        assert is_transient_connection_error(exc) is True
+
+        from fabric_dw.sql_errors import _is_connect_retryable  # noqa: PLC0415
+
+        assert _is_connect_retryable(exc) is True
+
     def test_database_was_not_found_is_not_transient(self) -> None:
         # "database was not found" was removed from _TRANSIENT_FRAGMENTS because
         # the real Fabric driver wraps it with native error 18456, so
@@ -2621,6 +2638,74 @@ class TestAuthFailedConnectRetry:
         assert fake_time.sleep.call_count == 1
         # First backoff interval is _CONNECT_RETRY_DELAYS[0] = 5 s.
         assert fake_time.sleep.call_args.args[0] == _sql_module._CONNECT_RETRY_DELAYS[0]
+
+    # ------------------------------------------------------------------
+    # #972 — TCP 0x102 connect/login timeout: retry + retry-exhaustion wrap
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _make_tcp_0x102_exc() -> Exception:
+        """Return a driver exception shaped like the real #972 report.
+
+        A dedicated subclass (not a bare ``Exception``) stands in for
+        ``mssql_python.exceptions.OperationalError`` so tests can assert that
+        the raised error is NOT this raw driver type once retries are exhausted.
+        """
+
+        class _OperationalError(Exception):
+            pass
+
+        return _OperationalError(
+            "Driver Error: Client unable to establish connection; "
+            "DDBC Error: [Microsoft]TCP Provider: Error code 0x102"
+        )
+
+    def test_tcp_0x102_connect_retried_then_succeeds(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The exact #972 driver message is retried on the connect path."""
+        fake_time = self._fake_time_within_deadline(n_failures=1)
+        monkeypatch.setattr(_sql_module, "time", fake_time)
+
+        mock_mssql, good_conn, good_cursor = _make_mock_mssql()
+        good_cursor.description = [("n",)]
+        good_cursor.fetchall.return_value = [(1,)]
+
+        mock_mssql.connect.side_effect = [self._make_tcp_0x102_exc(), good_conn]
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        _cols, rows = run_query(_make_target(), "SELECT 1")
+
+        assert rows == [(1,)]
+        assert mock_mssql.connect.call_count == 2
+
+    def test_connect_retry_exhausted_wraps_raw_driver_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Retry exhaustion on the #972 TCP 0x102 error raises a clean FabricError.
+
+        When the connect error persists past the retry deadline, run_query must
+        raise a clean FabricError (with a retry hint) — never the raw driver
+        exception type.  This is the core regression guard for #972: a raw
+        mssql_python.OperationalError must not reach the CLI/MCP boundary.
+        """
+        fake_time = self._fake_time_past_deadline()
+        monkeypatch.setattr(_sql_module, "time", fake_time)
+
+        mock_mssql, _, _ = _make_mock_mssql()
+        driver_exc = self._make_tcp_0x102_exc()
+        mock_mssql.connect.side_effect = driver_exc
+        _patch_mssql(monkeypatch, mock_mssql)
+
+        with pytest.raises(FabricError) as exc_info:
+            run_query(_make_target(), "SELECT 1")
+
+        # Must be a clean FabricError, not the raw driver exception type.
+        assert not isinstance(exc_info.value, type(driver_exc))
+        assert isinstance(exc_info.value.__cause__, type(driver_exc))
+        msg = str(exc_info.value)
+        assert "0x102" in msg
+        assert "retry" in msg.lower()
+        # Only one connect attempt — the deadline was already exceeded.
+        assert mock_mssql.connect.call_count == 1
 
     def test_auth_failed_on_execute_phase_not_retried(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/test_sql.py
+++ b/tests/unit/test_sql.py
@@ -1224,7 +1224,7 @@ class TestIsTransientConnectionError:
         """Regression guard for #972: the exact driver message from the issue.
 
         0x102 (decimal 258) is the DDBC connect/login timeout.  Matches via the
-        generic "tcp provider" fragment — see the comment in
+        generic "tcp provider" fragment, see the comment in
         fabric_dw.sql_errors._TRANSIENT_FRAGMENTS.
         """
         exc = Exception(
@@ -2640,7 +2640,7 @@ class TestAuthFailedConnectRetry:
         assert fake_time.sleep.call_args.args[0] == _sql_module._CONNECT_RETRY_DELAYS[0]
 
     # ------------------------------------------------------------------
-    # #972 — TCP 0x102 connect/login timeout: retry + retry-exhaustion wrap
+    # #972: TCP 0x102 connect/login timeout, retry + retry-exhaustion wrap
     # ------------------------------------------------------------------
 
     @staticmethod
@@ -2683,7 +2683,7 @@ class TestAuthFailedConnectRetry:
         """Retry exhaustion on the #972 TCP 0x102 error raises a clean FabricError.
 
         When the connect error persists past the retry deadline, run_query must
-        raise a clean FabricError (with a retry hint) — never the raw driver
+        raise a clean FabricError (with a retry hint), never the raw driver
         exception type.  This is the core regression guard for #972: a raw
         mssql_python.OperationalError must not reach the CLI/MCP boundary.
         """
@@ -2701,14 +2701,14 @@ class TestAuthFailedConnectRetry:
         # Must be a clean FabricError, not the raw driver exception type.
         assert not isinstance(exc_info.value, type(driver_exc))
         # __cause__ must be the original driver exception itself (not a copy,
-        # and not the wrapper self-referencing — regression guard for the
+        # and not the wrapper self-referencing: regression guard for the
         # `raise ... from exc` self-cause bug found in review).
         assert exc_info.value.__cause__ is driver_exc
         assert exc_info.value.__cause__ is not exc_info.value
         msg = str(exc_info.value)
         assert "0x102" in msg
         assert "retry" in msg.lower()
-        # Only one connect attempt — the deadline was already exceeded.
+        # Only one connect attempt: the deadline was already exceeded.
         assert mock_mssql.connect.call_count == 1
 
     def test_connect_retry_exhausted_preserves_original_cause_of_pretyped_error(
@@ -2717,7 +2717,7 @@ class TestAuthFailedConnectRetry:
         """Retry exhaustion on an already-typed FabricCliError must not self-cause.
 
         When the connect exception is already a FabricCliError (pre-typed by
-        _translate_connect_error Step 1 — e.g. a retried AuthError), it is
+        _translate_connect_error Step 1, e.g. a retried AuthError), it is
         returned unchanged by _wrap_connect_retry_exhausted().  It must keep
         its ORIGINAL __cause__ (e.g. the underlying Azure exception it was
         built from) rather than being overwritten to reference itself
@@ -2739,7 +2739,7 @@ class TestAuthFailedConnectRetry:
             run_query(_make_target(), "SELECT 1")
 
         # Pass-through: the exact same AuthError instance, with its original
-        # cause intact — never re-pointed at itself.
+        # cause intact, never re-pointed at itself.
         assert exc_info.value is pretyped
         assert exc_info.value.__cause__ is underlying
         assert exc_info.value.__cause__ is not exc_info.value
@@ -2970,7 +2970,7 @@ class TestWrapConnectRetryExhausted:
 
         result = _sql_module._wrap_connect_retry_exhausted(pretyped)
 
-        # Same object, original cause preserved — never re-pointed at itself.
+        # Same object, original cause preserved, never re-pointed at itself.
         assert result is pretyped
         assert result.__cause__ is underlying
         assert result.__cause__ is not result


### PR DESCRIPTION
## Summary

A transient SQL connect/login timeout (`mssql_python.exceptions.OperationalError`, DDBC "TCP Provider: Error code 0x102" = 258) could reach the CLI user as a raw, unhandled Python traceback instead of a clean error. This is a pre-existing robustness gap, not a regression: on a flappy capacity it turns every transient connect blip into a crash.

Three-part fix:

1. **Classification** (`src/fabric_dw/sql_errors.py`): the 0x102 connect timeout already matches the existing `"tcp provider"` transient fragment in `_TRANSIENT_FRAGMENTS`, so `_is_connect_retryable` was already classifying it as retryable and `_with_connect_retry` was already retrying it. No functional change was needed here; added an inline comment documenting this explicitly (so a future edit doesn't accidentally narrow the fragment) plus a regression test that locks in the exact driver message from the issue.
2. **Retry exhaustion** (`src/fabric_dw/sql.py`): the real gap. When the connect-retry deadline expired, `_with_connect_retry` re-raised the bare driver exception (this is intentional bare-reraise machinery for the retry loop itself, via `_translate_connect_error` Step 3, needed so `ddbc_error` survives for native-error matching). Added `_wrap_connect_retry_exhausted()`, called only when the retry budget is spent: it wraps a raw driver exception in a `FabricError` with a clean, actionable message (`"SQL connection failed: <driver message>; please retry"`), while passing pre-typed `FabricCliError` instances (e.g. a retried `AuthError`) through unchanged, preserving their original `__cause__`. The capacity-inactive path from #963 is untouched (`CapacityInactiveError` is never retried, so it never reaches this branch).
3. **Top-level CLI guard** (`src/fabric_dw/cli/__init__.py`): defense in depth. `main()` now wraps `cli()`; any exception that still escapes every other layer (not `SystemExit`/`KeyboardInterrupt`, which are Click's own clean-exit/abort paths) is rendered as a single-line `Error: ...` message to stderr with exit code 1, never a traceback. The full traceback remains available, but only when the `fabric_dw` logger is at `DEBUG` level (the existing `-v` / `--verbose` convention), never by default. The guard itself cannot raise: a broken `exc.__str__` falls back to the type name, and a failed stderr write is suppressed, so the correct exit code always fires.

## Files changed

- `src/fabric_dw/sql_errors.py`: comment on `_TRANSIENT_FRAGMENTS` documenting 0x102 coverage.
- `src/fabric_dw/sql.py`: `_wrap_connect_retry_exhausted()` plus its use in `_with_connect_retry`'s deadline-exhausted branch.
- `src/fabric_dw/cli/__init__.py`: top-level try/except guard in `main()` plus `_render_unexpected_error()`.
- `src/fabric_dw/services/load.py`: one-line comment clarifying that the connect-retry-exhaustion `FabricError` passing through `except FabricError: raise` is not a credential leak (the wrap only fires on the pre-connect path, before the secret-bearing COPY INTO SQL is sent).
- `tests/unit/test_sql.py`: regression tests for 0x102 classification, connect retry, retry-exhaustion wrapping, and `__cause__` semantics on both the wrap and pass-through branches (including a dedicated unit test class for `_wrap_connect_retry_exhausted()` in isolation).
- `tests/unit/cli/test_main.py`: tests for the top-level guard (clean single-line error, exit code, debug-gated traceback, `SystemExit`/`KeyboardInterrupt`/Click-usage-error passthrough via the real `main()` entry point).

## Note on reproduction

The transient timeout could not be reliably reproduced live (it depends on capacity warm-up timing), so the fix is covered entirely by unit tests that simulate the driver exception via mocked `mssql_python.connect()` calls and a fake monotonic clock (matching the existing pattern in `TestAuthFailedConnectRetry`).

## Test plan

- [x] `ruff format --check .` and `ruff check .`: clean
- [x] `ty check src tests`: clean
- [x] `uv run pytest tests/unit -q`: 5793 passed
- [x] Manual smoke test: injected a raw `RuntimeError` in place of `cli()` and confirmed a clean single-line error plus exit code 1 with no traceback by default, and a full traceback when the `fabric_dw` logger is at `DEBUG` (the `-v`/`--verbose` convention)
- [x] Manual verification that `_wrap_connect_retry_exhausted()` sets `__cause__` to the driver exception on the wrap branch and preserves the original `__cause__` (no self-reference) on the pass-through branch

Closes #972

🤖 Generated with [Claude Code](https://claude.com/claude-code)
