### PR TITLE
test(integration): drop removed predicate_type key from RLS specs (#974)

### DIFF
--- a/tests/integration/test_services_rls.py
+++ b/tests/integration/test_services_rls.py
@@ -156,7 +156,6 @@ async def rls_policy_fixture(
             f"{schema_name}.{policy_name}",
             [
                 {
-                    "predicate_type": "FILTER",
                     "fn_schema": schema_name,
                     "fn_name": fn_name,
                     "fn_args": ["user_id"],
@@ -233,7 +232,6 @@ async def test_drop_security_policy(
             qualified,
             [
                 {
-                    "predicate_type": "FILTER",
                     "fn_schema": schema_name,
                     "fn_name": fn_name,
                     "fn_args": ["user_id"],


### PR DESCRIPTION
## Summary
- #967 removed BLOCK predicates from row-level security and made `create_security_policy` reject unrecognized spec keys, since FILTER is now the only, implicit predicate type
- The RLS integration test fixtures in `tests/integration/test_services_rls.py` still passed `"predicate_type": "FILTER"` in the predicate spec dicts, which is now rejected as an unknown key, causing setup errors in three integration tests
- Removed the redundant `predicate_type` key from both `create_security_policy(...)` call sites; test-only change, no production code touched

## Root cause
The unit, MCP, and CLI layers were already updated for the new spec shape in #967, but these integration tests were missed because they do not run in PR CI (only on `main`), so the mismatch was only surfaced by a failing scheduled/main run.

## Test plan
- [x] `grep -rn 'predicate_type' tests/integration/` returns no matches
- [x] `git diff` touches only the two removed lines in `tests/integration/test_services_rls.py`
- [x] `uv run pytest tests/unit -q` passes (5812 passed, 2 deselected)
- [ ] Integration suite (runs on `main` / triggered manually by a maintainer, not run here)

Closes #974