### PR TITLE
ci(release): keep server.json version in sync on stable tags (#976)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,8 +51,9 @@ jobs:
       - name: Log plugin.json version (informational)
         # Run only for tag/dispatch releases; skip for dev builds pushed to main.
         # Prerelease tags (aN/bN/rcN/.devN) are exempt - plugin.json tracks stable only.
-        # The sync-plugin-manifest job (below) auto-bumps plugin.json on main after publish;
-        # a mismatch here is expected when the maintainer tags without a prior release-prep PR.
+        # The sync-plugin-manifest job (below) auto-bumps the release manifests (plugin.json,
+        # its Copilot mirror, and server.json) on main after publish; a mismatch here is
+        # expected when the maintainer tags without a prior release-prep PR.
         # The context value is passed via env: to avoid ${{ }} script-injection into the run body.
         if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -156,7 +156,7 @@ jobs:
           prerelease: ${{ steps.prerelease.outputs.is_prerelease }}
 
   sync-plugin-manifest:
-    name: Sync plugin manifests to default branch
+    name: Sync release manifests to default branch
     runs-on: ubuntu-latest
     needs: publish
     # Run only for tag/dispatch triggers (never for branch pushes or PRs).
@@ -181,12 +181,12 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_BUMP_TOKEN }}
 
-      - name: Bump plugin manifest versions on default branch
+      - name: Bump release manifest versions on default branch
         run: |
           version="${EFFECTIVE_TAG#v}"
           # Skip prerelease tags (aN/bN/rcN suffixes or .dev in the version string).
           if echo "$version" | grep -qE '(a|b|rc)[0-9]*$|\.dev'; then
-            echo "Prerelease tag '$version' - plugin manifests track stable only; skipping bump."
+            echo "Prerelease tag '$version' - release manifests track stable only; skipping bump."
             exit 0
           fi
           # Strict calver validation BEFORE touching any file. Guards against junk
@@ -196,6 +196,18 @@ jobs:
             echo "::error::Derived version '$version' does not match expected calver format (YYYY.M.N). Aborting." >&2
             exit 1
           fi
+          # Shared monotonicity guard: prints "yes" when $2 (candidate) is older than $1
+          # (current), "no" otherwise. Reused below for every release manifest so a stale
+          # re-run or an out-of-order workflow_dispatch can never regress a committed version.
+          is_downgrade() {
+            python3 -c "
+          import sys
+          cur = tuple(int(x) for x in sys.argv[1].split('.'))
+          new = tuple(int(x) for x in sys.argv[2].split('.'))
+          print('yes' if new < cur else 'no')
+          " "$1" "$2"
+          }
+          changed=()
           # plugins/fabric-dw/.claude-plugin/plugin.json is the version source of truth;
           # plugins/fabric-dw/.github/plugin/plugin.json is its Copilot CLI mirror and must
           # never drift from it. Both carry a "version" field, so both are bumped here. The
@@ -205,18 +217,10 @@ jobs:
             "plugins/fabric-dw/.claude-plugin/plugin.json"
             "plugins/fabric-dw/.github/plugin/plugin.json"
           )
-          changed=()
           for plugin_json in "${plugin_manifests[@]}"; do
             # Monotonicity guard: refuse to write a version older than what is already on HEAD.
-            # Prevents an old re-run or stale workflow_dispatch from regressing a manifest.
             current_version=$(python3 -c "import json; print(json.load(open('$plugin_json'))['version'])")
-            is_downgrade=$(python3 -c "
-          import sys
-          cur = tuple(int(x) for x in sys.argv[1].split('.'))
-          new = tuple(int(x) for x in sys.argv[2].split('.'))
-          print('yes' if new < cur else 'no')
-          " "$current_version" "$version")
-            if [ "$is_downgrade" = "yes" ]; then
+            if [ "$(is_downgrade "$current_version" "$version")" = "yes" ]; then
               echo "Notice: tag '$version' is older than current $plugin_json '$current_version' - skipping to prevent downgrade."
               continue
             fi
@@ -227,9 +231,28 @@ jobs:
               changed+=("$plugin_json")
             fi
           done
+          # server.json (the MCP Registry manifest) carries the version in two places: a
+          # top-level "version" and the OCI image tag embedded in packages[0].identifier.
+          # Mirror the exact transform docker.yml's publish-mcp-registry job applies at
+          # publish time (jq '.version = $v | .packages[0].identifier = "ghcr.io/..." + $v')
+          # so the committed file matches what was actually registered.
+          server_json="server.json"
+          current_version=$(python3 -c "import json; print(json.load(open('$server_json'))['version'])")
+          if [ "$(is_downgrade "$current_version" "$version")" = "yes" ]; then
+            echo "Notice: tag '$version' is older than current $server_json '$current_version' - skipping to prevent downgrade."
+          else
+            # Same sed approach as the plugin manifests above, plus a second targeted
+            # replacement for the OCI identifier. Delimiter is '#' (not '/') because the
+            # replacement value itself contains slashes and a colon.
+            sed -i 's/"version": "[^"]*"/"version": "'"$version"'"/' "$server_json"
+            sed -i 's#"identifier": "ghcr.io/sdebruyn/fabric-dw:[^"]*"#"identifier": "ghcr.io/sdebruyn/fabric-dw:'"$version"'"#' "$server_json"
+            if ! git diff --quiet "$server_json"; then
+              changed+=("$server_json")
+            fi
+          fi
           # No-op guard: if no manifest changed, skip the commit.
           if [ "${#changed[@]}" -eq 0 ]; then
-            echo "Plugin manifests already at '$version' - nothing to commit."
+            echo "Release manifests already at '$version' - nothing to commit."
             exit 0
           fi
           git config user.name "github-actions[bot]"
@@ -237,14 +260,14 @@ jobs:
           git add "${changed[@]}"
           # [skip ci] is REQUIRED: a PAT push (unlike GITHUB_TOKEN) triggers workflow runs,
           # so omitting it would spawn an unwanted dev-build on the default branch.
-          git commit -m "chore: bump plugin manifests to $version [skip ci]"
+          git commit -m "chore: bump release manifests to $version [skip ci]"
           # Push with bounded retry to handle non-fast-forward races
           # (the default branch may have advanced after the tag was cut).
           max_attempts=3
           attempt=1
           while [ "$attempt" -le "$max_attempts" ]; do
             if git push origin "$DEFAULT_BRANCH"; then
-              echo "Pushed plugin manifest bump for $version to $DEFAULT_BRANCH."
+              echo "Pushed release manifest bump for $version to $DEFAULT_BRANCH."
               break
             fi
             if [ "$attempt" -eq "$max_attempts" ]; then

--- a/server.json
+++ b/server.json
@@ -8,11 +8,11 @@
     "url": "https://github.com/sdebruyn/fabric-dw-mcp-cli",
     "source": "github"
   },
-  "version": "2026.6.0",
+  "version": "2026.7.0",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/sdebruyn/fabric-dw:2026.6.0",
+      "identifier": "ghcr.io/sdebruyn/fabric-dw:2026.7.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary

The committed `server.json` was stale: `version` and `packages[0].identifier` were both pinned to `2026.6.0`, even though v2026.7.0 shipped and the MCP Registry correctly holds `2026.7.0`.

Cause: `docker.yml`'s `publish-mcp-registry` job rewrites `server.json` in place with `jq` (setting `.version` and `.packages[0].identifier` from the tag) right before publishing, but never commits that change back. `publish.yml`'s `sync-plugin-manifest` job already keeps `plugin.json` (and its Copilot mirror) in sync after a stable tag, but `server.json` was never added to it, so the repo copy silently drifts from what was actually registered on every stable release.

## Changes

- **`server.json`**: bump the committed `version` and `packages[0].identifier` to `2026.7.0` (2 value changes only; everything else preserved byte-for-byte).
- **`.github/workflows/publish.yml`**: extend the `sync-plugin-manifest` job (renamed to "Sync release manifests to default branch" since it now covers more than the plugin manifests) to also bump `server.json`'s `version` and `packages[0].identifier` on the default branch after a stable tag:
  - Uses the same transform `docker.yml` applies at publish time, mirrored with `sed` (a `#`-delimited pattern for the identifier line, since the value contains slashes and a colon).
  - Applies the same per-file monotonicity guard (refuses to write an older version), now factored into a small `is_downgrade` helper shared by the plugin manifests and `server.json` instead of being duplicated inline.
  - Same prerelease skip, same no-op guard, and `server.json` is added to the same `[skip ci]` commit as the plugin manifests.
- No behavioral change to the `plugin.json` bump, PyPI publish, GitHub Release, or MCP Registry publish steps.

This is a CI/config change plus a version bump only; no application code is touched.

## Test plan

- [x] `git diff` touches only `server.json` (2 value changes) and `.github/workflows/publish.yml` (the sync job extension).
- [x] Committed `server.json` parses as valid JSON with `version` and `packages[0].identifier` both at `2026.7.0`.
- [x] Dry-ran the new `sed` commands against a scratch copy of `server.json`: confirmed exactly the 2 intended lines change and the rest of the file is byte-for-byte identical.
- [x] `actionlint` on the modified workflow: clean.
- [x] YAML parses via `yaml.safe_load`.
- [x] `uv run pytest tests/unit -q`: 5812 passed, 2 deselected.

Closes #976

🤖 Generated with [Claude Code](https://claude.com/claude-code)