### PR TITLE
feat(mcp): add server instructions steering agents to dedicated tools

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -111,6 +111,20 @@ Two optional environment variables tune the HTTP retry budget:
 | `FABRIC_DW_MAX_429_RETRIES` | Maximum consecutive 429 responses before raising `RateLimitedError` | 10 |
 | `FABRIC_DW_RETRY_DEADLINE_S` | Combined wall-clock deadline (seconds) for 429-loop + 5xx retries | 300.0 |
 
+### Server instructions and tool preference
+
+The server ships a compact instructions block that clients surface in the system prompt before the model takes its first action. It works as a capability map and states one preference rule:
+
+> Prefer dedicated tools over `execute_sql`. Use `execute_sql` only for arbitrary SQL that no dedicated tool can express.
+
+The preference rule exists because `execute_sql` is a general escape hatch that is easy to reach for, but the server exposes purpose-built tools for the common operations:
+
+- **Discover:** `list_schemas`, `list_tables`, `list_views`, `list_functions`, `list_procedures`
+- **Inspect:** `get_table_columns`, `get_view_columns`, `count_table_rows`, `get_table_health_metrics`
+- **Mutate:** `create_table`, `delete_table`, `rename_table`, `clear_table`, `delete_schema`, `transfer_table`
+
+Dedicated tools return typed, structured results and have no SQL dialect pitfalls. `execute_sql` returns only the last result set of a multi-statement batch and base64-encodes `varbinary` columns (with a `__base64` column-name suffix). Both caveats are also documented in `execute_sql`'s own description, so a model holding that tool in context is steered away from it for operations that have a cleaner alternative.
+
 ### Install from the MCP Registry
 
 `fabric-dw-mcp` is also published to the official [MCP Registry](https://registry.modelcontextprotocol.io) as `io.github.sdebruyn/fabric-dw-mcp` on every stable release. Registry-aware clients (VS Code `@mcp`, and others that support registry discovery) can find and install it by that name instead of hand-writing a client config.

--- a/src/fabric_dw/mcp/server.py
+++ b/src/fabric_dw/mcp/server.py
@@ -76,10 +76,34 @@ from fabric_dw.telemetry_commands import now_ms
 __all__ = ["mcp", "run"]
 
 # ---------------------------------------------------------------------------
+# Server instructions — surfaced to clients in the initialize response.
+# This text is permanently resident in every client's context, so it is a
+# token budget, not a manual: a capability map plus one preference rule.
+# Character budget: 600 chars (asserted in tests/unit/mcp/test_instructions.py).
+# ---------------------------------------------------------------------------
+
+_SERVER_INSTRUCTIONS: str = (
+    "Prefer dedicated tools over execute_sql.\n"
+    "Dedicated tools return typed, structured results and have no SQL dialect pitfalls; "
+    "execute_sql returns only the last result set of a batch and base64-encodes "
+    "varbinary columns.\n"
+    "Discover: list_schemas, list_tables, list_views, list_functions, list_procedures.\n"
+    "Inspect: get_table_columns, get_view_columns, count_table_rows, "
+    "get_table_health_metrics.\n"
+    "Mutate: create_table, delete_table, rename_table, clear_table, delete_schema, "
+    "transfer_table.\n"
+    "Use execute_sql ONLY for arbitrary SQL that no dedicated tool can express."
+)
+
+# ---------------------------------------------------------------------------
 # FastMCP server instance (instrumented subclass emits command_invoked events)
 # ---------------------------------------------------------------------------
 
-mcp: InstrumentedFastMCP = InstrumentedFastMCP("fabric-dw", lifespan=fabric_lifespan)
+mcp: InstrumentedFastMCP = InstrumentedFastMCP(
+    "fabric-dw",
+    lifespan=fabric_lifespan,
+    instructions=_SERVER_INSTRUCTIONS,
+)
 
 # ---------------------------------------------------------------------------
 # Register all domain tools

--- a/src/fabric_dw/mcp/server.py
+++ b/src/fabric_dw/mcp/server.py
@@ -76,10 +76,13 @@ from fabric_dw.telemetry_commands import now_ms
 __all__ = ["mcp", "run"]
 
 # ---------------------------------------------------------------------------
-# Server instructions — surfaced to clients in the initialize response.
+# Server instructions: surfaced to clients in the initialize response.
 # This text is permanently resident in every client's context, so it is a
 # token budget, not a manual: a capability map plus one preference rule.
-# Character budget: 600 chars (asserted in tests/unit/mcp/test_instructions.py).
+# Character budget: 700 chars (asserted in tests/unit/mcp/test_instructions.py).
+# 700 is ~175 tokens of permanently-resident context, a cheap price for
+# closing the most common misuse path (row reads via execute_sql instead of
+# read_table / read_view).
 # ---------------------------------------------------------------------------
 
 _SERVER_INSTRUCTIONS: str = (
@@ -88,8 +91,8 @@ _SERVER_INSTRUCTIONS: str = (
     "execute_sql returns only the last result set of a batch and base64-encodes "
     "varbinary columns.\n"
     "Discover: list_schemas, list_tables, list_views, list_functions, list_procedures.\n"
-    "Inspect: get_table_columns, get_view_columns, count_table_rows, "
-    "get_table_health_metrics.\n"
+    "Read: read_table, read_view, count_table_rows, count_view_rows.\n"
+    "Inspect: get_table_columns, get_view_columns, get_table_health_metrics.\n"
     "Mutate: create_table, delete_table, rename_table, clear_table, delete_schema, "
     "transfer_table.\n"
     "Use execute_sql ONLY for arbitrary SQL that no dedicated tool can express."

--- a/src/fabric_dw/mcp/tools/sql_exec.py
+++ b/src/fabric_dw/mcp/tools/sql_exec.py
@@ -37,10 +37,12 @@ def register(mcp: FastMCP) -> None:
         """Execute an arbitrary SQL statement or batch against a warehouse or SQL Analytics
         Endpoint.
 
-        Prefer dedicated tools for common operations: use list_tables, list_views,
-        list_schemas, count_table_rows, get_table_columns, delete_table, rename_table,
-        or clear_table instead of hand-writing SQL. Dedicated tools return structured,
-        typed results with no dialect pitfalls or batch-truncation surprises.
+        Prefer dedicated tools for common operations: use read_table or read_view to
+        fetch rows, count_table_rows or count_view_rows to count, list_tables,
+        list_views, list_schemas to discover objects, get_table_columns or
+        get_view_columns to inspect schemas, and delete_table, rename_table, or
+        clear_table to mutate. Dedicated tools return structured, typed results with
+        no dialect pitfalls or batch-truncation surprises.
 
         WARNING: this tool executes arbitrary SQL against the target. DDL (DROP,
         ALTER, TRUNCATE) and DML (DELETE, UPDATE) are permitted unless

--- a/src/fabric_dw/mcp/tools/sql_exec.py
+++ b/src/fabric_dw/mcp/tools/sql_exec.py
@@ -37,6 +37,11 @@ def register(mcp: FastMCP) -> None:
         """Execute an arbitrary SQL statement or batch against a warehouse or SQL Analytics
         Endpoint.
 
+        Prefer dedicated tools for common operations: use list_tables, list_views,
+        list_schemas, count_table_rows, get_table_columns, delete_table, rename_table,
+        or clear_table instead of hand-writing SQL. Dedicated tools return structured,
+        typed results with no dialect pitfalls or batch-truncation surprises.
+
         WARNING: this tool executes arbitrary SQL against the target. DDL (DROP,
         ALTER, TRUNCATE) and DML (DELETE, UPDATE) are permitted unless
         ``FABRIC_MCP_READONLY=1`` is set. Use only when the user explicitly

--- a/tests/unit/mcp/test_instructions.py
+++ b/tests/unit/mcp/test_instructions.py
@@ -1,0 +1,132 @@
+"""Tests for the MCP server instructions block and execute_sql steering text.
+
+Two guards that prevent silent rot:
+
+1. Every tool name mentioned in the server instructions string resolves against
+   the live tool list, so a rename cannot silently break the instructions.
+2. The character budget is asserted so the instructions never silently balloon
+   to the point where they become a significant context cost per request.
+3. execute_sql's description opens with a steer toward dedicated alternatives
+   and still contains the existing DDL/DML warning.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from fabric_dw.mcp.server import _SERVER_INSTRUCTIONS, mcp
+
+# ---------------------------------------------------------------------------
+# Character budget for the server instructions block.
+# The text is permanently resident in every client's context, so it must stay
+# compact. 600 characters fits on a single screen and covers the full
+# capability map plus the preference rule.
+# ---------------------------------------------------------------------------
+
+_INSTRUCTIONS_CHAR_BUDGET = 600
+
+# ---------------------------------------------------------------------------
+# Extract all tool names mentioned in the instructions.
+# The instructions use bare snake_case identifiers (e.g. list_tables); we match
+# word-boundary-anchored snake_case tokens so we do not accidentally capture
+# prose words.
+# ---------------------------------------------------------------------------
+
+_TOOL_NAME_RE = re.compile(r"\b([a-z][a-z0-9]*(?:_[a-z0-9]+)+)\b")
+
+
+def _tool_names_in_instructions(text: str) -> set[str]:
+    """Return the set of snake_case tokens in *text* that look like tool names."""
+    return set(_TOOL_NAME_RE.findall(text))
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_instructions_non_empty() -> None:
+    """mcp.instructions must be a non-empty string."""
+    assert mcp.instructions, "mcp.instructions must not be None or empty"
+    assert isinstance(mcp.instructions, str)
+    assert len(mcp.instructions.strip()) > 0
+
+
+@pytest.mark.asyncio
+async def test_instructions_within_character_budget() -> None:
+    """Server instructions must stay within the documented character budget."""
+    actual = len(_SERVER_INSTRUCTIONS)
+    assert actual <= _INSTRUCTIONS_CHAR_BUDGET, (
+        f"Server instructions are {actual} chars, which exceeds the budget of "
+        f"{_INSTRUCTIONS_CHAR_BUDGET}. Trim the text or update the budget with "
+        f"a justification comment."
+    )
+
+
+@pytest.mark.asyncio
+async def test_instructions_tool_names_all_exist() -> None:
+    """Every tool name mentioned in the instructions must exist in the live tool list.
+
+    This is the drift guard: when a tool is renamed, the test fails immediately
+    rather than silently leaving the instructions pointing at a non-existent tool.
+    """
+    live_tools = frozenset(tool.name for tool in await mcp.list_tools())
+    mentioned = _tool_names_in_instructions(_SERVER_INSTRUCTIONS)
+    missing = mentioned - live_tools
+    assert not missing, (
+        f"The server instructions reference tool(s) that do not exist: {sorted(missing)}. "
+        "Update _SERVER_INSTRUCTIONS in src/fabric_dw/mcp/server.py to match "
+        "the current tool names."
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute_sql_description_contains_steer() -> None:
+    """execute_sql's description must open with a steer toward dedicated alternatives."""
+    tools = {tool.name: tool for tool in await mcp.list_tools()}
+    assert "execute_sql" in tools, "execute_sql must be registered"
+    description = tools["execute_sql"].description or ""
+    # The steer must appear before the DDL/DML warning.
+    steer_pos = description.find("Prefer dedicated tools")
+    warning_pos = description.find("WARNING")
+    assert steer_pos != -1, (
+        "execute_sql description must contain a steer toward dedicated tools "
+        "(expected text starting with 'Prefer dedicated tools')."
+    )
+    assert warning_pos != -1, "execute_sql description must still contain the DDL/DML WARNING text."
+    assert steer_pos < warning_pos, (
+        "The steer toward dedicated tools must appear before the DDL/DML WARNING "
+        "in execute_sql's description."
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute_sql_description_names_three_alternatives() -> None:
+    """execute_sql's description must name at least three dedicated alternative tools."""
+    tools = {tool.name: tool for tool in await mcp.list_tools()}
+    description = tools["execute_sql"].description or ""
+    live_tools = frozenset(tool.name for tool in tools.values())
+    # Count how many real tool names are mentioned in the description
+    # (excluding execute_sql itself).
+    mentioned = _tool_names_in_instructions(description) - {"execute_sql"}
+    alternatives = mentioned & live_tools
+    assert len(alternatives) >= 3, (
+        f"execute_sql description must name at least 3 dedicated alternative tools; "
+        f"found: {sorted(alternatives)}."
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute_sql_ddl_warning_unchanged() -> None:
+    """execute_sql description must still contain the original DDL/DML warning text."""
+    tools = {tool.name: tool for tool in await mcp.list_tools()}
+    description = tools["execute_sql"].description or ""
+    assert "DDL (DROP," in description, (
+        "execute_sql description must retain the original DDL/DML warning text."
+    )
+    assert "FABRIC_MCP_READONLY" in description, (
+        "execute_sql description must retain the FABRIC_MCP_READONLY mention."
+    )

--- a/tests/unit/mcp/test_instructions.py
+++ b/tests/unit/mcp/test_instructions.py
@@ -1,13 +1,14 @@
 """Tests for the MCP server instructions block and execute_sql steering text.
 
-Two guards that prevent silent rot:
+Guards that prevent silent rot:
 
 1. Every tool name mentioned in the server instructions string resolves against
    the live tool list, so a rename cannot silently break the instructions.
-2. The character budget is asserted so the instructions never silently balloon
-   to the point where they become a significant context cost per request.
-3. execute_sql's description opens with a steer toward dedicated alternatives
-   and still contains the existing DDL/DML warning.
+2. The character budget is asserted on the value the server actually ships
+   (mcp.instructions), not just the source constant.
+3. execute_sql's description opens with a steer toward dedicated alternatives,
+   every tool name in that steer is real, and the existing DDL/DML warning
+   is still present.
 """
 
 from __future__ import annotations
@@ -21,14 +22,15 @@ from fabric_dw.mcp.server import _SERVER_INSTRUCTIONS, mcp
 # ---------------------------------------------------------------------------
 # Character budget for the server instructions block.
 # The text is permanently resident in every client's context, so it must stay
-# compact. 600 characters fits on a single screen and covers the full
-# capability map plus the preference rule.
+# compact. 700 characters is roughly 175 tokens - a cheap price for closing
+# the most common misuse path (row reads via execute_sql instead of read_table
+# or read_view). The budget exists to stop the block growing into a manual.
 # ---------------------------------------------------------------------------
 
-_INSTRUCTIONS_CHAR_BUDGET = 600
+_INSTRUCTIONS_CHAR_BUDGET = 700
 
 # ---------------------------------------------------------------------------
-# Extract all tool names mentioned in the instructions.
+# Extract all tool names mentioned in a string.
 # The instructions use bare snake_case identifiers (e.g. list_tables); we match
 # word-boundary-anchored snake_case tokens so we do not accidentally capture
 # prose words.
@@ -37,7 +39,7 @@ _INSTRUCTIONS_CHAR_BUDGET = 600
 _TOOL_NAME_RE = re.compile(r"\b([a-z][a-z0-9]*(?:_[a-z0-9]+)+)\b")
 
 
-def _tool_names_in_instructions(text: str) -> set[str]:
+def _tool_names_in_text(text: str) -> set[str]:
     """Return the set of snake_case tokens in *text* that look like tool names."""
     return set(_TOOL_NAME_RE.findall(text))
 
@@ -57,12 +59,25 @@ async def test_instructions_non_empty() -> None:
 
 @pytest.mark.asyncio
 async def test_instructions_within_character_budget() -> None:
-    """Server instructions must stay within the documented character budget."""
-    actual = len(_SERVER_INSTRUCTIONS)
+    """Server instructions must stay within the documented character budget.
+
+    The assertion binds to mcp.instructions - the value actually shipped to
+    clients - rather than _SERVER_INSTRUCTIONS, so any transformation applied
+    by the constructor is also covered.
+    """
+    shipped = mcp.instructions or ""
+    actual = len(shipped)
     assert actual <= _INSTRUCTIONS_CHAR_BUDGET, (
-        f"Server instructions are {actual} chars, which exceeds the budget of "
+        f"mcp.instructions is {actual} chars, which exceeds the budget of "
         f"{_INSTRUCTIONS_CHAR_BUDGET}. Trim the text or update the budget with "
         f"a justification comment."
+    )
+    # Also assert on the source constant so the test catches mismatches
+    # between the constant and what the constructor receives.
+    const_len = len(_SERVER_INSTRUCTIONS)
+    assert const_len <= _INSTRUCTIONS_CHAR_BUDGET, (
+        f"_SERVER_INSTRUCTIONS is {const_len} chars, which exceeds the budget of "
+        f"{_INSTRUCTIONS_CHAR_BUDGET}."
     )
 
 
@@ -74,7 +89,7 @@ async def test_instructions_tool_names_all_exist() -> None:
     rather than silently leaving the instructions pointing at a non-existent tool.
     """
     live_tools = frozenset(tool.name for tool in await mcp.list_tools())
-    mentioned = _tool_names_in_instructions(_SERVER_INSTRUCTIONS)
+    mentioned = _tool_names_in_text(_SERVER_INSTRUCTIONS)
     missing = mentioned - live_tools
     assert not missing, (
         f"The server instructions reference tool(s) that do not exist: {sorted(missing)}. "
@@ -104,14 +119,40 @@ async def test_execute_sql_description_contains_steer() -> None:
 
 
 @pytest.mark.asyncio
-async def test_execute_sql_description_names_three_alternatives() -> None:
-    """execute_sql's description must name at least three dedicated alternative tools."""
+async def test_execute_sql_steer_tool_names_all_exist() -> None:
+    """Every tool name in execute_sql's steer paragraph must exist in the live list.
+
+    Strict guard: a rename cannot silently leave the steer pointing at a phantom
+    tool. The steer paragraph is the text before the WARNING line.
+    """
     tools = {tool.name: tool for tool in await mcp.list_tools()}
     description = tools["execute_sql"].description or ""
-    live_tools = frozenset(tool.name for tool in tools.values())
-    # Count how many real tool names are mentioned in the description
-    # (excluding execute_sql itself).
-    mentioned = _tool_names_in_instructions(description) - {"execute_sql"}
+    live_tools = frozenset(tools.keys())
+    # Extract only the steer paragraph (before WARNING) to avoid false positives
+    # from the rest of the docstring (e.g. DDL keyword fragments).
+    warning_pos = description.find("WARNING")
+    steer_text = description[:warning_pos] if warning_pos != -1 else description
+    mentioned = _tool_names_in_text(steer_text) - {"execute_sql"}
+    missing = mentioned - live_tools
+    assert not missing, (
+        f"execute_sql steer references tool(s) that do not exist: {sorted(missing)}. "
+        "Update the steer paragraph in src/fabric_dw/mcp/tools/sql_exec.py."
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute_sql_description_names_three_alternatives() -> None:
+    """execute_sql's description must name at least three dedicated alternative tools.
+
+    This weaker bound guards the minimum useful signal: even if the list shrinks
+    via legitimate refactoring, at least three concrete names must remain.
+    """
+    tools = {tool.name: tool for tool in await mcp.list_tools()}
+    description = tools["execute_sql"].description or ""
+    live_tools = frozenset(tools.keys())
+    warning_pos = description.find("WARNING")
+    steer_text = description[:warning_pos] if warning_pos != -1 else description
+    mentioned = _tool_names_in_text(steer_text) - {"execute_sql"}
     alternatives = mentioned & live_tools
     assert len(alternatives) >= 3, (
         f"execute_sql description must name at least 3 dedicated alternative tools; "


### PR DESCRIPTION
## Summary

- Adds a compact `_SERVER_INSTRUCTIONS` constant (558 chars) to `server.py` and passes it to `InstrumentedFastMCP` so every client receives the text in the MCP `initialize` response, permanently in context.
- Opens the `execute_sql` docstring with a preference steer naming six dedicated alternatives (`list_tables`, `list_views`, `list_schemas`, `count_table_rows`, `get_table_columns`, `delete_table`, `rename_table`, `clear_table`), placed ahead of the existing DDL/DML WARNING.
- Adds `tests/unit/mcp/test_instructions.py` (6 tests) including the drift guard: every snake_case token in the instructions is asserted against `await mcp.list_tools()`, so a future rename cannot silently rot the instructions.
- Documents the server instructions block and tool preference rule in `docs/install.md` under the MCP server section (no new page needed).

## Failure it fixes

In a real production conversation an agent kept using `execute_sql` for operations that already had purpose-built tools (`list_tables`, `delete_table`, `count_table_rows`). Nothing steered it away. With this change, clients see the preference rule before the model takes its first action, and `execute_sql` itself points away from overuse in its own description.

## Character budget

558 characters, budgeted at 600. Justification: the instructions are surfaced once per client context and stay there for the session. 600 chars is roughly one paragraph - enough for a complete capability map and one clear preference rule without measurable token cost per tool call. The budget is asserted in the test suite.

## No behaviour change

Only `mcp.instructions` (a metadata field) and tool descriptions changed. No tool was renamed, added, or removed. The `FABRIC_MCP_READONLY` guard and all result-set semantics are byte-for-byte identical.

Closes #984