### PR TITLE
fix(cli): right-align positional args so optional ITEM can be omitted

### DIFF
--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -21,6 +21,20 @@ Resolution order for the workspace (see also [Selecting a workspace](../concepts
 
 The warehouse follows the same order using the optional `[WAREHOUSE]` / `[ITEM]` positional or `FABRIC_DW_DEFAULT_WAREHOUSE`.
 
+For example, once a default workspace and warehouse are stored, commands that show `[WAREHOUSE]` or `[ITEM]` in brackets can be invoked without repeating those values:
+
+```shell
+# Without defaults: every argument must be supplied explicitly.
+fdw schemas delete MyWarehouse my_old_schema
+
+# With defaults configured: omit the optional warehouse positional.
+fdw config set workspace MyWorkspace
+fdw config set warehouse MyWarehouse
+fdw schemas delete my_old_schema
+```
+
+The short form `fdw schemas delete my_old_schema` is equivalent: the stored warehouse is resolved automatically and `my_old_schema` is treated as the schema name, not the warehouse.
+
 ## HTTP retry budget
 
 The 429 retry budget (consecutive retries and combined wall-clock deadline) can also be configured. Resolution order:

--- a/docs/commands/restore-points.md
+++ b/docs/commands/restore-points.md
@@ -46,7 +46,7 @@ Delete a user-defined restore point. System-created restore points cannot be del
 **Synopsis**
 
 ```
-fdw [-w WORKSPACE] restore-points delete WAREHOUSE RESTORE_POINT_ID
+fdw [-w WORKSPACE] restore-points delete [WAREHOUSE] RESTORE_POINT_ID
 ```
 
 **Example**
@@ -64,7 +64,7 @@ Get details for a single restore point by ID.
 **Synopsis**
 
 ```
-fdw [-w WORKSPACE] restore-points get WAREHOUSE RESTORE_POINT_ID
+fdw [-w WORKSPACE] restore-points get [WAREHOUSE] RESTORE_POINT_ID
 ```
 
 **Example**
@@ -106,7 +106,7 @@ Rename a restore point and optionally update its description.
 **Synopsis**
 
 ```
-fdw [-w WORKSPACE] restore-points rename [OPTIONS] WAREHOUSE RESTORE_POINT_ID NEW_NAME
+fdw [-w WORKSPACE] restore-points rename [OPTIONS] [WAREHOUSE] RESTORE_POINT_ID NEW_NAME
 ```
 
 | Option | Description |
@@ -128,7 +128,7 @@ Restore a warehouse in-place to a restore point. **This is a destructive operati
 **Synopsis**
 
 ```
-fdw [-w WORKSPACE] restore-points restore WAREHOUSE RESTORE_POINT_ID
+fdw [-w WORKSPACE] restore-points restore [WAREHOUSE] RESTORE_POINT_ID
 ```
 
 **Example**

--- a/src/fabric_dw/cli/_main.py
+++ b/src/fabric_dw/cli/_main.py
@@ -10,6 +10,7 @@ import time
 from typing import Any
 
 import click
+from click.core import ParameterSource
 
 from fabric_dw import __version__
 from fabric_dw.auth import CredentialMode
@@ -314,6 +315,15 @@ def _patch_command_for_global_options(cmd: click.Command) -> None:
 
     Recurses into sub-groups' already-registered commands so that nested
     command trees are fully covered when a sub-group is added to the root.
+
+    For leaf commands, also wraps ``parse_args`` to right-align positional
+    values onto declared slots.  This fixes commands that have one or more
+    leading optional positionals followed by one or more required positionals:
+    Click fills slots strictly left-to-right (ignoring ``required``), so the
+    first supplied value normally lands in the optional slot and the required
+    slot is reported missing.  The wrapper detects this shape and redistributes
+    the supplied values so trailing required slots are filled first, leaving the
+    leading optional slot empty when the user omits the warehouse / item.
     """
     if getattr(cmd, "_global_opts_patched", False):
         return
@@ -332,6 +342,92 @@ def _patch_command_for_global_options(cmd: click.Command) -> None:
     if isinstance(cmd, click.Group):
         for sub in cmd.commands.values():
             _patch_command_for_global_options(sub)
+    else:
+        # Right-align positional arguments for leaf commands that have one or
+        # more leading optional positionals followed by required positionals.
+        _wrap_parse_args_for_right_align(cmd)
+
+
+def _wrap_parse_args_for_right_align(cmd: click.Command) -> None:
+    """Wrap ``cmd.parse_args`` to right-align supplied positional values.
+
+    When a command declares ``[opt?] req1 req2`` and the user omits the
+    optional positional, Click fills the optional slot with the first supplied
+    value and leaves the required slot empty.  This wrapper detects that shape
+    and redistributes the values so required slots are filled first.
+
+    Only the leading consecutive optional positionals are right-aligned.  An
+    optional positional that follows a required one (unusual and not present in
+    this codebase) is left as-is.
+
+    Shell completion (``ctx.resilient_parsing=True``) bypasses the wrapper so
+    completion candidates are never perturbed.
+    """
+    original_parse_args = cmd.parse_args
+
+    def _wrapped_parse_args(ctx: click.Context, args: list[str]) -> list[str]:  # noqa: PLR0912
+        # Shell completion must not be perturbed.
+        if ctx.resilient_parsing:
+            return original_parse_args(ctx, args)
+
+        pos_params = [p for p in cmd.params if isinstance(p, click.Argument)]
+
+        # Count consecutive leading optional positionals.
+        n_leading_optional = 0
+        for p in pos_params:
+            if not p.required:
+                n_leading_optional += 1
+            else:
+                break
+
+        # Count required positionals.
+        n_required = sum(1 for p in pos_params if p.required)
+
+        # No right-align needed: either no leading optional or no required slot.
+        if n_leading_optional == 0 or n_required == 0:
+            return original_parse_args(ctx, args)
+
+        # Temporarily relax all positionals so Click does not raise
+        # MissingParameter internally before we can reorder.  The params are
+        # singletons on a module-level Command, so restoration must happen
+        # unconditionally even if parse_args raises (e.g. over-supply).
+        saved_required = [p.required for p in pos_params]
+        for p in pos_params:
+            p.required = False
+        try:
+            result = original_parse_args(ctx, args)
+        finally:
+            for p, req in zip(pos_params, saved_required, strict=False):
+                p.required = req
+
+        # Collect values Click assigned from the command line, in slot order.
+        cl_values = [
+            ctx.params[p.name]
+            for p in pos_params
+            if ctx.get_parameter_source(p.name) is ParameterSource.COMMANDLINE
+        ]
+
+        # All slots already filled: nothing to reorder.
+        if len(cl_values) == len(pos_params):
+            return result
+
+        # Reset the leading optional slots so they do not carry a stale value.
+        for p in pos_params[:n_leading_optional]:
+            ctx.params[p.name] = None
+            ctx.set_parameter_source(p.name, ParameterSource.DEFAULT)
+
+        # Fill required slots left-to-right from the collected values.
+        required_params = [p for p in pos_params if p.required]
+        for idx, p in enumerate(required_params):
+            if idx < len(cl_values):
+                ctx.params[p.name] = cl_values[idx]
+                ctx.set_parameter_source(p.name, ParameterSource.COMMANDLINE)
+            else:
+                raise click.MissingParameter(ctx=ctx, param=p)
+
+        return result
+
+    cmd.parse_args = _wrapped_parse_args  # ty: ignore[invalid-assignment]
 
 
 # ---------------------------------------------------------------------------

--- a/src/fabric_dw/cli/_main.py
+++ b/src/fabric_dw/cli/_main.py
@@ -364,8 +364,8 @@ def _wrap_parse_args_for_right_align(cmd: click.Command) -> None:
     Shape requirements (all must hold, otherwise the original parse_args is
     called unmodified):
 
-    * Exactly one leading optional positional followed by one or more required
-      positionals (``[opt] req+``).
+    * Exactly one leading optional positional whose ``default`` is ``None``,
+      followed by one or more required positionals (``[opt] req+``).
     * All positionals have ``nargs == 1`` (no variadic arguments).
     * No trailing optional positional after the required ones.
 
@@ -380,8 +380,13 @@ def _wrap_parse_args_for_right_align(cmd: click.Command) -> None:
         if ctx.resilient_parsing:
             return original_parse_args(ctx, args)
 
-        # Help flags are eager: skip the relaxation window so that required
-        # positionals are not rendered as optional in the generated help text.
+        # Bail out immediately for help tokens so that the relaxation window
+        # below does not make required positionals appear optional in the
+        # generated help text.  The scan deliberately ignores ``--`` (the
+        # end-of-options marker): ``--help`` is not a plausible positional
+        # value (schema name, session id, etc.), so "fdw cmd -- --help"
+        # produces the same Click error it always would -- no silent
+        # mis-binding occurs.
         if any(a in _HELP_TOKENS for a in args):
             return original_parse_args(ctx, args)
 
@@ -404,6 +409,14 @@ def _wrap_parse_args_for_right_align(cmd: click.Command) -> None:
         if any(p.nargs != 1 for p in pos_params):
             return original_parse_args(ctx, args)
         if any(not p.required for p in pos_params[1:]):
+            return original_parse_args(ctx, args)
+
+        # Guard against a leading optional with a non-None default.  The reset
+        # below unconditionally stores None in that slot, which would silently
+        # discard any real default.  All current leading optionals declare
+        # ``default=None``; bailing out here protects against a future command
+        # that uses a different default without realising the impact.
+        if pos_params[0].default is not None:
             return original_parse_args(ctx, args)
 
         # Temporarily relax all positionals (required=False, type=STRING,

--- a/src/fabric_dw/cli/_main.py
+++ b/src/fabric_dw/cli/_main.py
@@ -348,26 +348,41 @@ def _patch_command_for_global_options(cmd: click.Command) -> None:
         _wrap_parse_args_for_right_align(cmd)
 
 
+_HELP_TOKENS: frozenset[str] = frozenset(("-h", "--help"))
+
+
 def _wrap_parse_args_for_right_align(cmd: click.Command) -> None:
     """Wrap ``cmd.parse_args`` to right-align supplied positional values.
 
-    When a command declares ``[opt?] req1 req2`` and the user omits the
+    When a command declares ``[opt] req1 req2`` and the user omits the
     optional positional, Click fills the optional slot with the first supplied
     value and leaves the required slot empty.  This wrapper detects that shape
-    and redistributes the values so required slots are filled first.
+    and redistributes the values so required slots are filled first, then calls
+    ``Parameter.process_value`` on each relocated slot so that type conversion
+    (e.g. Choice case-normalisation, INT casting) is applied correctly.
 
-    Only the leading consecutive optional positionals are right-aligned.  An
-    optional positional that follows a required one (unusual and not present in
-    this codebase) is left as-is.
+    Shape requirements (all must hold, otherwise the original parse_args is
+    called unmodified):
 
-    Shell completion (``ctx.resilient_parsing=True``) bypasses the wrapper so
-    completion candidates are never perturbed.
+    * Exactly one leading optional positional followed by one or more required
+      positionals (``[opt] req+``).
+    * All positionals have ``nargs == 1`` (no variadic arguments).
+    * No trailing optional positional after the required ones.
+
+    Shell completion (``ctx.resilient_parsing=True``) and help-flag invocations
+    (``--help`` / ``-h``) bypass the wrapper so completion candidates and help
+    text are never perturbed.
     """
     original_parse_args = cmd.parse_args
 
-    def _wrapped_parse_args(ctx: click.Context, args: list[str]) -> list[str]:  # noqa: PLR0912
+    def _wrapped_parse_args(ctx: click.Context, args: list[str]) -> list[str]:  # noqa: PLR0911,PLR0912
         # Shell completion must not be perturbed.
         if ctx.resilient_parsing:
+            return original_parse_args(ctx, args)
+
+        # Help flags are eager: skip the relaxation window so that required
+        # positionals are not rendered as optional in the generated help text.
+        if any(a in _HELP_TOKENS for a in args):
             return original_parse_args(ctx, args)
 
         pos_params = [p for p in cmd.params if isinstance(p, click.Argument)]
@@ -380,47 +395,70 @@ def _wrap_parse_args_for_right_align(cmd: click.Command) -> None:
             else:
                 break
 
-        # Count required positionals.
         n_required = sum(1 for p in pos_params if p.required)
 
-        # No right-align needed: either no leading optional or no required slot.
-        if n_leading_optional == 0 or n_required == 0:
+        # Shape guard: exactly one leading optional, all others required, no
+        # variadic arguments, no trailing optional after the required ones.
+        if n_leading_optional != 1 or n_required == 0:
+            return original_parse_args(ctx, args)
+        if any(p.nargs != 1 for p in pos_params):
+            return original_parse_args(ctx, args)
+        if any(not p.required for p in pos_params[1:]):
             return original_parse_args(ctx, args)
 
-        # Temporarily relax all positionals so Click does not raise
-        # MissingParameter internally before we can reorder.  The params are
-        # singletons on a module-level Command, so restoration must happen
-        # unconditionally even if parse_args raises (e.g. over-supply).
+        # Temporarily relax all positionals (required=False, type=STRING,
+        # callback=None) so Click fills every slot with raw strings without
+        # raising MissingParameter or triggering callbacks.  The params are
+        # module-level singletons, so restoration must happen unconditionally
+        # even if parse_args raises (e.g. on over-supply).
         saved_required = [p.required for p in pos_params]
+        saved_types = [p.type for p in pos_params]
+        saved_callbacks = [p.callback for p in pos_params]
         for p in pos_params:
             p.required = False
+            p.type = click.STRING
+            p.callback = None
         try:
             result = original_parse_args(ctx, args)
         finally:
-            for p, req in zip(pos_params, saved_required, strict=False):
+            for p, req, typ, cb in zip(
+                pos_params, saved_required, saved_types, saved_callbacks, strict=False
+            ):
                 p.required = req
+                p.type = typ
+                p.callback = cb
 
-        # Collect values Click assigned from the command line, in slot order.
+        # Collect raw strings Click assigned from the command line, in
+        # declaration order.  Because type=STRING was active, all COMMANDLINE
+        # values are plain strings regardless of the original param type.
         cl_values = [
             ctx.params[p.name]
             for p in pos_params
             if ctx.get_parameter_source(p.name) is ParameterSource.COMMANDLINE
         ]
+        n_cl = len(cl_values)
+        n_pos = len(pos_params)
+        opt_param = pos_params[0]
+        req_params_list = pos_params[1:]  # all required (shape guard above)
 
-        # All slots already filled: nothing to reorder.
-        if len(cl_values) == len(pos_params):
+        if n_cl == n_pos:
+            # Full form: all slots were provided.  No relocation needed, but
+            # types were STRING during the delegated parse so we must call
+            # process_value on every slot to apply type conversion and callbacks.
+            for p in pos_params:
+                if ctx.get_parameter_source(p.name) is ParameterSource.COMMANDLINE:
+                    ctx.params[p.name] = p.process_value(ctx, ctx.params[p.name])
             return result
 
-        # Reset the leading optional slots so they do not carry a stale value.
-        for p in pos_params[:n_leading_optional]:
-            ctx.params[p.name] = None
-            ctx.set_parameter_source(p.name, ParameterSource.DEFAULT)
+        # Short form: fewer values than slots.  Reset the optional slot and
+        # distribute the collected raw values to the required slots, applying
+        # type conversion and callbacks via process_value.
+        ctx.params[opt_param.name] = None
+        ctx.set_parameter_source(opt_param.name, ParameterSource.DEFAULT)
 
-        # Fill required slots left-to-right from the collected values.
-        required_params = [p for p in pos_params if p.required]
-        for idx, p in enumerate(required_params):
-            if idx < len(cl_values):
-                ctx.params[p.name] = cl_values[idx]
+        for idx, p in enumerate(req_params_list):
+            if idx < n_cl:
+                ctx.params[p.name] = p.process_value(ctx, cl_values[idx])
                 ctx.set_parameter_source(p.name, ParameterSource.COMMANDLINE)
             else:
                 raise click.MissingParameter(ctx=ctx, param=p)

--- a/tests/unit/cli/test_positional_right_align.py
+++ b/tests/unit/cli/test_positional_right_align.py
@@ -30,6 +30,7 @@ from click.testing import CliRunner
 from fabric_dw.cli._main import (
     _COMMAND_MAP,
     _patch_command_for_global_options,
+    _wrap_parse_args_for_right_align,
     cli,
 )
 
@@ -70,7 +71,7 @@ def _leading_optional_count(pos_params: list[click.Argument]) -> int:
     return count
 
 
-def _test_value_for_type(param_type: click.ParamType) -> str:
+def _test_value_for_type(param_type: click.ParamType) -> str:  # noqa: PLR0911
     """Return a valid CLI string token for the given Click parameter type.
 
     The drift guard uses fake but type-compatible values so that Click can
@@ -81,7 +82,14 @@ def _test_value_for_type(param_type: click.ParamType) -> str:
     if isinstance(param_type, click.types.FloatParamType):
         return "1.0"
     if isinstance(param_type, click.Choice):
-        return str(param_type.choices[0])
+        first = str(param_type.choices[0])
+        if not param_type.case_sensitive:
+            # Return the case-swapped form so the drift guard can tell whether
+            # process_value was called.  A raw STRING bind preserves the
+            # swapped case; a properly converted value matches choices[0].
+            swapped = first.swapcase()
+            return swapped if swapped != first else first
+        return first
     if isinstance(param_type, click.types.UUIDParameterType):
         return "00000000-0000-0000-0000-000000000001"
     if isinstance(param_type, click.types.BoolParamType):
@@ -105,9 +113,12 @@ def _expected_python_value(param_type: click.ParamType, raw: str) -> Any:
         return uuid.UUID(raw)
     if isinstance(param_type, click.types.BoolParamType):
         return raw.lower() in ("1", "true", "t", "yes", "y", "on")
-    # Choice, STRING, Path, unrecognised: value is returned as a string.
-    # _test_value_for_type returns choices[0] verbatim, which matches exactly,
-    # so Choice.convert returns it unchanged (no case mutation needed here).
+    if isinstance(param_type, click.Choice):
+        # Click returns the matched entry from choices.  _test_value_for_type
+        # may supply a case-swapped form (for case-insensitive choices), so the
+        # expected result is always choices[0] -- the normalised form.
+        return str(param_type.choices[0])
+    # STRING, Path, unrecognised: returned as-is.
     return raw
 
 
@@ -274,6 +285,67 @@ class TestDriftGuard:
         """Zero args must raise MissingParameter or UsageError for missing required."""
         with _relaxed_options(cmd), pytest.raises((click.MissingParameter, click.UsageError)):
             _make_context(cmd, []).close()
+
+
+# ---------------------------------------------------------------------------
+# Shape-guard bail-out tests: synthetic commands outside [opt] req+ shape
+# ---------------------------------------------------------------------------
+
+
+class TestShapeGuardBailout:
+    """Shapes outside ``[opt] req+`` must delegate straight to native Click parsing.
+
+    Each test builds a throwaway ``click.Command`` with a shape the guard
+    rejects (two leading optionals, a variadic positional, or a trailing
+    optional after a required positional), applies ``_wrap_parse_args_for_right_align``
+    directly, and verifies that the native left-to-right behaviour is
+    preserved.  The observable difference: supplying one value fills the
+    optional slot (native), so the required slot stays empty and Click raises
+    ``MissingParameter``.  If the wrapper incorrectly fired it would move
+    the value to the required slot and return without error.
+    """
+
+    @staticmethod
+    def _cmd(*params: click.Argument) -> click.Command:
+        """Build a bare click.Command and attach the parse_args wrapper."""
+        cmd = click.Command("test", params=list(params), callback=lambda **_: None)
+        _wrap_parse_args_for_right_align(cmd)
+        return cmd
+
+    def test_two_leading_optionals_not_reordered(self) -> None:
+        """n_leading_optional == 2 must fall through to native parse."""
+        cmd = self._cmd(
+            click.Argument(["opt1"], required=False, default=None),
+            click.Argument(["opt2"], required=False, default=None),
+            click.Argument(["req"], required=True),
+        )
+        # Native: one value fills opt1, req remains missing -> MissingParameter.
+        # Right-align (incorrectly triggered) would put the value in req and
+        # return successfully.
+        with pytest.raises((click.MissingParameter, click.UsageError)):
+            _make_context(cmd, ["val"]).close()
+
+    def test_nargs_not_one_not_reordered(self) -> None:
+        """A positional with nargs != 1 must fall through to native parse."""
+        cmd = self._cmd(
+            click.Argument(["opt"], required=False, default=None),
+            click.Argument(["req"], required=True),
+            click.Argument(["rest"], nargs=-1, required=False),
+        )
+        # Native: one value fills opt, req remains missing -> MissingParameter.
+        with pytest.raises((click.MissingParameter, click.UsageError)):
+            _make_context(cmd, ["val"]).close()
+
+    def test_trailing_optional_not_reordered(self) -> None:
+        """A trailing optional after a required positional must fall through."""
+        cmd = self._cmd(
+            click.Argument(["opt"], required=False, default=None),
+            click.Argument(["req"], required=True),
+            click.Argument(["trailing"], required=False, default=None),
+        )
+        # Native: one value fills opt, req remains missing -> MissingParameter.
+        with pytest.raises((click.MissingParameter, click.UsageError)):
+            _make_context(cmd, ["val"]).close()
 
 
 # ---------------------------------------------------------------------------
@@ -667,38 +739,61 @@ class TestShellCompletion:
 
 
 class TestRequiredFlagNotMutated:
-    """The required flag on positional params must not be permanently changed."""
+    """The required, type and callback attributes must not be permanently changed.
 
-    def test_required_unchanged_after_failed_parse(self) -> None:
-        """After a zero-args MissingParameter, p.required is still as declared."""
+    The wrapper temporarily mutates all three on module-level singletons and
+    restores them unconditionally in a ``finally`` block.  These tests confirm
+    that all three are intact after both a failed and a successful parse.  A
+    regression that broke ``type`` restoration would leave every positional
+    permanently typed as ``click.STRING``, silently accepting values that
+    should be rejected and returning strings where callers expect ints.
+    """
+
+    def test_attributes_unchanged_after_failed_parse(self) -> None:
+        """After a zero-args MissingParameter, required, type and callback are intact."""
         group = _load_group("schemas")
         delete_cmd = group.commands["delete"]
         pos_params = [p for p in delete_cmd.params if isinstance(p, click.Argument)]
-        # Record original flags.
+        # Record originals before any parse.
         original_required = {p.name: p.required for p in pos_params}
+        original_types = {p.name: p.type for p in pos_params}
+        original_callbacks = {p.name: p.callback for p in pos_params}
 
         # Trigger a failed parse (zero args -> MissingParameter).
         with pytest.raises((click.MissingParameter, click.UsageError)):
             _make_context(delete_cmd, []).close()
 
-        # Flags must be exactly as before.
         for p in pos_params:
             assert p.required == original_required[p.name], (
-                f"required flag for {p.name!r} was mutated: "
-                f"expected {original_required[p.name]}, got {p.required}"
+                f"required for {p.name!r} was mutated after failed parse"
+            )
+            assert p.type is original_types[p.name], (
+                f"type for {p.name!r} was mutated after failed parse: "
+                f"expected {original_types[p.name]!r}, got {p.type!r}"
+            )
+            assert p.callback is original_callbacks[p.name], (
+                f"callback for {p.name!r} was mutated after failed parse"
             )
 
-    def test_required_unchanged_after_successful_parse(self) -> None:
-        """After a short-form parse, p.required is still as declared."""
+    def test_attributes_unchanged_after_successful_parse(self) -> None:
+        """After a short-form parse, required, type and callback are intact."""
         group = _load_group("schemas")
         delete_cmd = group.commands["delete"]
         pos_params = [p for p in delete_cmd.params if isinstance(p, click.Argument)]
         original_required = {p.name: p.required for p in pos_params}
+        original_types = {p.name: p.type for p in pos_params}
+        original_callbacks = {p.name: p.callback for p in pos_params}
 
         ctx = _make_context(delete_cmd, ["my_schema"])
         ctx.close()
 
         for p in pos_params:
             assert p.required == original_required[p.name], (
-                f"required flag for {p.name!r} was mutated after successful parse"
+                f"required for {p.name!r} was mutated after successful parse"
+            )
+            assert p.type is original_types[p.name], (
+                f"type for {p.name!r} was mutated after successful parse"
+            )
+            assert p.callback is original_callbacks[p.name], (
+                f"callback for {p.name!r} was mutated after successful parse"
             )

--- a/tests/unit/cli/test_positional_right_align.py
+++ b/tests/unit/cli/test_positional_right_align.py
@@ -1,0 +1,567 @@
+"""Tests for the right-align positional fix in `_patch_command_for_global_options`.
+
+Issue #981: commands with a leading optional positional (ITEM / WAREHOUSE /
+WORKSPACE) followed by required positionals fail with "Missing argument" when
+the optional is omitted, because Click fills slots left-to-right and the first
+supplied value lands in the optional slot.
+
+The fix wraps `parse_args` on every leaf command that has this shape so that
+supplied values are right-aligned onto the required slots first.
+
+All tests are parse-only (no Fabric connection, no destructive ops).
+"""
+
+from __future__ import annotations
+
+import importlib
+from collections.abc import AsyncIterator, Generator
+from contextlib import asynccontextmanager, contextmanager
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import click
+import pytest
+from click.core import ParameterSource
+from click.testing import CliRunner
+
+from fabric_dw.cli._main import (
+    _COMMAND_MAP,
+    _patch_command_for_global_options,
+    cli,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_group(group_name: str) -> click.Group:
+    """Import and patch the Click group for *group_name*."""
+    spec = _COMMAND_MAP[group_name]
+    module_path, attr_name = spec.rsplit(":", 1)
+    module = importlib.import_module(module_path)
+    group: click.Group = getattr(module, attr_name)
+    _patch_command_for_global_options(group)
+    return group
+
+
+def _walk_leaf_commands(group: click.Group, prefix: str) -> list[tuple[str, click.Command]]:
+    """Recursively collect (dotted_name, command) for all non-Group commands."""
+    results: list[tuple[str, click.Command]] = []
+    for name, cmd in group.commands.items():
+        dotted = f"{prefix}.{name}"
+        if isinstance(cmd, click.Group):
+            results.extend(_walk_leaf_commands(cmd, dotted))
+        else:
+            results.append((dotted, cmd))
+    return results
+
+
+def _leading_optional_count(pos_params: list[click.Argument]) -> int:
+    count = 0
+    for p in pos_params:
+        if not p.required:
+            count += 1
+        else:
+            break
+    return count
+
+
+def _test_value_for_type(param_type: click.ParamType) -> str:
+    """Return a valid CLI string token for the given Click parameter type.
+
+    The drift guard uses fake but type-compatible values so that Click can
+    convert them without raising BadParameter.
+    """
+    if isinstance(param_type, click.types.IntParamType):
+        return "1"
+    if isinstance(param_type, click.types.FloatParamType):
+        return "1.0"
+    if isinstance(param_type, click.Choice):
+        return param_type.choices[0]
+    if isinstance(param_type, click.types.UUIDParameterType):
+        return "00000000-0000-0000-0000-000000000001"
+    if isinstance(param_type, click.types.BoolParamType):
+        return "true"
+    # STRING, Path, unrecognised: use a safe generic string.
+    return "val"
+
+
+@contextmanager
+def _relaxed_options(cmd: click.Command) -> Generator[None, None, None]:
+    """Temporarily mark all required Options on *cmd* as not required.
+
+    Some commands have required options (e.g. --principal, --from) that would
+    block parse_args from completing when only positional args are supplied.
+    Relaxing them lets the drift guard focus on positional slot assignment.
+    """
+    req_opts = [p for p in cmd.params if isinstance(p, click.Option) and p.required]
+    for opt in req_opts:
+        opt.required = False
+    try:
+        yield
+    finally:
+        for opt in req_opts:
+            opt.required = True
+
+
+def _make_context(cmd: click.Command, args: list[str]) -> click.Context:
+    """Call make_context and return the context (caller must close it).
+
+    Click mutates the args list in-place during parsing, so a copy is passed
+    to preserve the caller's list for subsequent assertions.
+    """
+    return cmd.make_context(cmd.name or "cmd", list(args))
+
+
+# ---------------------------------------------------------------------------
+# Drift guard: walk the full lazy tree and assert the invariant for every
+# command that has the [optional..., required...] positional shape.
+# ---------------------------------------------------------------------------
+
+# Each case is (dotted_name, cmd, opt_params, req_params) where *_params are
+# click.Argument objects so tests can access both names and types.
+_DriftCase = tuple[str, click.Command, list[click.Argument], list[click.Argument]]
+
+
+def _collect_right_align_cases() -> list[_DriftCase]:
+    """Return one case per affected command.
+
+    Walks the full lazy command tree by importing each group module.  The patch
+    is idempotent so repeated loads are safe.
+    """
+    cases: list[_DriftCase] = []
+    for group_name in _COMMAND_MAP:
+        group = _load_group(group_name)
+        for dotted_name, cmd in _walk_leaf_commands(group, group_name):
+            pos_params: list[click.Argument] = [
+                p for p in cmd.params if isinstance(p, click.Argument)
+            ]
+            n_leading_opt = _leading_optional_count(pos_params)
+            n_required = sum(1 for p in pos_params if p.required)
+            if n_leading_opt > 0 and n_required > 0:
+                opt_params = pos_params[:n_leading_opt]
+                req_params = [p for p in pos_params if p.required]
+                cases.append((dotted_name, cmd, opt_params, req_params))
+    return cases
+
+
+_RIGHT_ALIGN_CASES = _collect_right_align_cases()
+_CASE_IDS = [c[0] for c in _RIGHT_ALIGN_CASES]
+
+
+@pytest.mark.parametrize(
+    ("dotted_name", "cmd", "opt_params", "req_params"),
+    _RIGHT_ALIGN_CASES,
+    ids=_CASE_IDS,
+)
+class TestDriftGuard:
+    """Table-driven invariant: every affected command must right-align positionals.
+
+    Required options (e.g. --principal, --from) are temporarily relaxed so that
+    missing-option errors do not block the positional-parsing assertions.
+
+    Argument types are respected: integer args get "1", Choice args get the
+    first valid choice, etc., so Click's type conversion does not fail.
+    """
+
+    def test_short_form_fills_required_slots(
+        self,
+        dotted_name: str,
+        cmd: click.Command,
+        opt_params: list[click.Argument],
+        req_params: list[click.Argument],
+    ) -> None:
+        """Supplying only the required positionals leaves optional slots empty."""
+        args = [_test_value_for_type(p.type) for p in req_params]
+
+        with _relaxed_options(cmd):
+            ctx = _make_context(cmd, args)
+        try:
+            for p in opt_params:
+                assert ctx.params[p.name] is None, (
+                    f"{dotted_name}: optional slot {p.name!r} should be None in short form"
+                )
+            for p in req_params:
+                # Check source rather than value; type conversion may alter representation.
+                assert ctx.get_parameter_source(p.name) is ParameterSource.COMMANDLINE, (
+                    f"{dotted_name}: required slot {p.name!r} must have COMMANDLINE source"
+                )
+        finally:
+            ctx.close()
+
+    def test_full_form_fills_all_slots(
+        self,
+        dotted_name: str,
+        cmd: click.Command,
+        opt_params: list[click.Argument],
+        req_params: list[click.Argument],
+    ) -> None:
+        """Supplying all positionals fills every slot in declaration order."""
+        all_args = [_test_value_for_type(p.type) for p in opt_params] + [
+            _test_value_for_type(p.type) for p in req_params
+        ]
+
+        with _relaxed_options(cmd):
+            ctx = _make_context(cmd, all_args)
+        try:
+            for p in opt_params:
+                assert ctx.get_parameter_source(p.name) is ParameterSource.COMMANDLINE, (
+                    f"{dotted_name}: optional slot {p.name!r} must be COMMANDLINE when supplied"
+                )
+            for p in req_params:
+                assert ctx.get_parameter_source(p.name) is ParameterSource.COMMANDLINE, (
+                    f"{dotted_name}: required slot {p.name!r} must be COMMANDLINE when supplied"
+                )
+        finally:
+            ctx.close()
+
+    def test_zero_args_raises_missing(
+        self,
+        dotted_name: str,  # noqa: ARG002
+        cmd: click.Command,
+        opt_params: list[click.Argument],  # noqa: ARG002
+        req_params: list[click.Argument],  # noqa: ARG002
+    ) -> None:
+        """Zero args must raise MissingParameter or UsageError for missing required."""
+        with _relaxed_options(cmd), pytest.raises((click.MissingParameter, click.UsageError)):
+            _make_context(cmd, []).close()
+
+
+# ---------------------------------------------------------------------------
+# Targeted regression tests for specific shapes
+# ---------------------------------------------------------------------------
+
+
+class TestSchemasDelete:
+    """schemas delete: [item?, name]"""
+
+    def setup_method(self) -> None:
+        group = _load_group("schemas")
+        self.cmd = group.commands["delete"]
+
+    def test_short_form_item_is_none(self) -> None:
+        ctx = _make_context(self.cmd, ["my_schema"])
+        try:
+            assert ctx.params["item"] is None
+            assert ctx.params["name"] == "my_schema"
+            assert ctx.get_parameter_source("item") is ParameterSource.DEFAULT
+            assert ctx.get_parameter_source("name") is ParameterSource.COMMANDLINE
+        finally:
+            ctx.close()
+
+    def test_full_form_both_filled(self) -> None:
+        ctx = _make_context(self.cmd, ["MyWH", "my_schema"])
+        try:
+            assert ctx.params["item"] == "MyWH"
+            assert ctx.params["name"] == "my_schema"
+            assert ctx.get_parameter_source("item") is ParameterSource.COMMANDLINE
+            assert ctx.get_parameter_source("name") is ParameterSource.COMMANDLINE
+        finally:
+            ctx.close()
+
+    def test_zero_args_raises_missing_name(self) -> None:
+        with pytest.raises(click.MissingParameter) as exc_info:
+            _make_context(self.cmd, []).close()
+        msg = exc_info.value.format_message()
+        assert "Missing argument" in msg
+        assert "NAME" in msg
+
+    def test_over_supply_raises_extra_args(self) -> None:
+        with pytest.raises((click.UsageError, SystemExit)):
+            _make_context(self.cmd, ["WH", "schema", "extra"]).close()
+
+
+class TestStatisticsDelete:
+    """statistics delete: [item?, qualified_table, stat_name]"""
+
+    def setup_method(self) -> None:
+        group = _load_group("statistics")
+        self.cmd = group.commands["delete"]
+
+    def test_short_form_two_args(self) -> None:
+        ctx = _make_context(self.cmd, ["dbo.t", "stat_name"])
+        try:
+            assert ctx.params["item"] is None
+            assert ctx.params["qualified_table"] == "dbo.t"
+            assert ctx.params["stat_name"] == "stat_name"
+        finally:
+            ctx.close()
+
+    def test_full_form_three_args(self) -> None:
+        ctx = _make_context(self.cmd, ["MyWH", "dbo.t", "stat_name"])
+        try:
+            assert ctx.params["item"] == "MyWH"
+            assert ctx.params["qualified_table"] == "dbo.t"
+            assert ctx.params["stat_name"] == "stat_name"
+        finally:
+            ctx.close()
+
+    def test_one_arg_raises_missing(self) -> None:
+        with pytest.raises((click.MissingParameter, click.UsageError)):
+            _make_context(self.cmd, ["only_one"]).close()
+
+    def test_zero_args_raises_missing(self) -> None:
+        with pytest.raises((click.MissingParameter, click.UsageError)):
+            _make_context(self.cmd, []).close()
+
+
+class TestRestorePointsRename:
+    """restore-points rename: [item?, restore_point_id, new_name]"""
+
+    def setup_method(self) -> None:
+        group = _load_group("restore-points")
+        self.cmd = group.commands["rename"]
+
+    def test_short_form_two_args(self) -> None:
+        ctx = _make_context(self.cmd, ["rp_id", "new_name"])
+        try:
+            assert ctx.params["item"] is None
+            assert ctx.params["restore_point_id"] == "rp_id"
+            assert ctx.params["new_name"] == "new_name"
+        finally:
+            ctx.close()
+
+    def test_full_form_three_args(self) -> None:
+        ctx = _make_context(self.cmd, ["MyWH", "rp_id", "new_name"])
+        try:
+            assert ctx.params["item"] == "MyWH"
+            assert ctx.params["restore_point_id"] == "rp_id"
+            assert ctx.params["new_name"] == "new_name"
+        finally:
+            ctx.close()
+
+    def test_zero_args_raises_missing(self) -> None:
+        with pytest.raises((click.MissingParameter, click.UsageError)):
+            _make_context(self.cmd, []).close()
+
+
+class TestWorkspacesSetCollation:
+    """workspaces set-collation: [workspace?, collation]"""
+
+    def setup_method(self) -> None:
+        group = _load_group("workspaces")
+        self.cmd = group.commands["set-collation"]
+
+    def test_short_form_workspace_is_none(self) -> None:
+        ctx = _make_context(self.cmd, ["Latin1_General_100_BIN2_UTF8"])
+        try:
+            assert ctx.params["workspace"] is None
+            assert ctx.params["collation"] == "Latin1_General_100_BIN2_UTF8"
+        finally:
+            ctx.close()
+
+    def test_full_form_both_filled(self) -> None:
+        ctx = _make_context(self.cmd, ["MyWS", "Latin1_General_100_BIN2_UTF8"])
+        try:
+            assert ctx.params["workspace"] == "MyWS"
+            assert ctx.params["collation"] == "Latin1_General_100_BIN2_UTF8"
+        finally:
+            ctx.close()
+
+    def test_zero_args_raises_missing(self) -> None:
+        with pytest.raises((click.MissingParameter, click.UsageError)):
+            _make_context(self.cmd, []).close()
+
+
+class TestWarehousesRename:
+    """warehouses rename: [warehouse?, new_name]"""
+
+    def setup_method(self) -> None:
+        group = _load_group("warehouses")
+        self.cmd = group.commands["rename"]
+
+    def test_short_form_warehouse_is_none(self) -> None:
+        ctx = _make_context(self.cmd, ["new_wh_name"])
+        try:
+            assert ctx.params["warehouse"] is None
+            assert ctx.params["new_name"] == "new_wh_name"
+        finally:
+            ctx.close()
+
+    def test_full_form_both_filled(self) -> None:
+        ctx = _make_context(self.cmd, ["OldWH", "new_wh_name"])
+        try:
+            assert ctx.params["warehouse"] == "OldWH"
+            assert ctx.params["new_name"] == "new_wh_name"
+        finally:
+            ctx.close()
+
+    def test_zero_args_raises_missing(self) -> None:
+        with pytest.raises((click.MissingParameter, click.UsageError)):
+            _make_context(self.cmd, []).close()
+
+
+# ---------------------------------------------------------------------------
+# Env-var resolution: short form with FABRIC_DW_DEFAULT_WAREHOUSE set
+# ---------------------------------------------------------------------------
+
+
+def _make_http_cm(http: Any) -> Any:
+    """Return an async context manager that yields *http*."""
+
+    @asynccontextmanager
+    async def _cm(_ctx: Any) -> AsyncIterator[Any]:
+        yield http
+
+    return _cm
+
+
+class TestEnvVarResolution:
+    """schemas delete my_schema with the env var set must pass item=None to
+    resolve_warehouse_arg so the function can fall back to the env var."""
+
+    def test_delete_short_form_passes_none_to_resolve_warehouse(
+        self, tmp_path: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Short-form invoke passes item=None to resolve_warehouse_arg."""
+        monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+        monkeypatch.setenv("FABRIC_DW_DEFAULT_WAREHOUSE", "my_default_wh")
+
+        captured_values: list[Any] = []
+
+        def _fake_resolve_wh(_ctx: Any, value: Any) -> str:
+            captured_values.append(value)
+            return "my_default_wh"
+
+        mock_http = AsyncMock()
+
+        with (
+            patch(
+                "fabric_dw.cli.commands.schemas.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.schemas.build_sql_target",
+                new=AsyncMock(
+                    return_value=(
+                        MagicMock(),
+                        MagicMock(
+                            display_name="my_default_wh",
+                            id="some-uuid",
+                        ),
+                    )
+                ),
+            ),
+            patch(
+                "fabric_dw.cli.commands.schemas.resolve_warehouse_arg",
+                side_effect=_fake_resolve_wh,
+            ),
+            patch(
+                "fabric_dw.services.schemas.delete_schema",
+                new=AsyncMock(),
+            ),
+            patch(
+                "fabric_dw.cli.commands.schemas.confirm_destructive",
+                return_value=True,
+            ),
+        ):
+            runner = CliRunner()
+            runner.invoke(
+                cli,
+                ["-w", "some-workspace", "--yes", "schemas", "delete", "my_schema"],
+            )
+
+        assert captured_values, "resolve_warehouse_arg was never called"
+        assert captured_values[0] is None, (
+            f"Expected item=None passed to resolve_warehouse_arg, got {captured_values[0]!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Unchanged commands: schemas list must not be affected
+# ---------------------------------------------------------------------------
+
+
+class TestSchemasListUnchanged:
+    """schemas list [ITEM] has only an optional positional; must be unchanged."""
+
+    def setup_method(self) -> None:
+        group = _load_group("schemas")
+        self.cmd = group.commands["list"]
+
+    def test_list_no_args_item_is_none(self) -> None:
+        ctx = _make_context(self.cmd, [])
+        try:
+            assert ctx.params["item"] is None
+            assert ctx.get_parameter_source("item") is ParameterSource.DEFAULT
+        finally:
+            ctx.close()
+
+    def test_list_with_arg_item_is_set(self) -> None:
+        ctx = _make_context(self.cmd, ["MyWH"])
+        try:
+            assert ctx.params["item"] == "MyWH"
+            assert ctx.get_parameter_source("item") is ParameterSource.COMMANDLINE
+        finally:
+            ctx.close()
+
+
+# ---------------------------------------------------------------------------
+# Shell completion: wrapper must return early when resilient_parsing=True
+# ---------------------------------------------------------------------------
+
+
+class TestShellCompletion:
+    """When resilient_parsing is True, the wrapper must not rewrite params."""
+
+    def test_resilient_parsing_leaves_left_to_right_order(self) -> None:
+        """With resilient_parsing=True, the original left-to-right fill is preserved.
+
+        The test confirms that no exception is raised and the context is valid,
+        which means the wrapper delegated straight to the original parse_args.
+        """
+        group = _load_group("schemas")
+        delete_cmd = group.commands["delete"]
+        # make_context does not expose resilient_parsing directly; create the
+        # context manually to set the flag.
+        ctx = click.Context(delete_cmd, info_name="delete", resilient_parsing=True)
+        # Should not raise; wrapper must bypass reordering.
+        delete_cmd.parse_args(ctx, ["my_schema"])
+        # With resilient_parsing the wrapper delegates straight through, so Click
+        # may fill slots in its default left-to-right order or leave them empty.
+        # The key assertion: no exception was raised and item is not rewritten.
+        ctx.close()
+
+
+# ---------------------------------------------------------------------------
+# Required-flag invariant: flags must be intact after a failed parse
+# ---------------------------------------------------------------------------
+
+
+class TestRequiredFlagNotMutated:
+    """The required flag on positional params must not be permanently changed."""
+
+    def test_required_unchanged_after_failed_parse(self) -> None:
+        """After a zero-args MissingParameter, p.required is still as declared."""
+        group = _load_group("schemas")
+        delete_cmd = group.commands["delete"]
+        pos_params = [p for p in delete_cmd.params if isinstance(p, click.Argument)]
+        # Record original flags.
+        original_required = {p.name: p.required for p in pos_params}
+
+        # Trigger a failed parse (zero args -> MissingParameter).
+        with pytest.raises((click.MissingParameter, click.UsageError)):
+            _make_context(delete_cmd, []).close()
+
+        # Flags must be exactly as before.
+        for p in pos_params:
+            assert p.required == original_required[p.name], (
+                f"required flag for {p.name!r} was mutated: "
+                f"expected {original_required[p.name]}, got {p.required}"
+            )
+
+    def test_required_unchanged_after_successful_parse(self) -> None:
+        """After a short-form parse, p.required is still as declared."""
+        group = _load_group("schemas")
+        delete_cmd = group.commands["delete"]
+        pos_params = [p for p in delete_cmd.params if isinstance(p, click.Argument)]
+        original_required = {p.name: p.required for p in pos_params}
+
+        ctx = _make_context(delete_cmd, ["my_schema"])
+        ctx.close()
+
+        for p in pos_params:
+            assert p.required == original_required[p.name], (
+                f"required flag for {p.name!r} was mutated after successful parse"
+            )

--- a/tests/unit/cli/test_positional_right_align.py
+++ b/tests/unit/cli/test_positional_right_align.py
@@ -81,7 +81,7 @@ def _test_value_for_type(param_type: click.ParamType) -> str:
     if isinstance(param_type, click.types.FloatParamType):
         return "1.0"
     if isinstance(param_type, click.Choice):
-        return param_type.choices[0]
+        return str(param_type.choices[0])
     if isinstance(param_type, click.types.UUIDParameterType):
         return "00000000-0000-0000-0000-000000000001"
     if isinstance(param_type, click.types.BoolParamType):

--- a/tests/unit/cli/test_positional_right_align.py
+++ b/tests/unit/cli/test_positional_right_align.py
@@ -6,7 +6,9 @@ the optional is omitted, because Click fills slots left-to-right and the first
 supplied value lands in the optional slot.
 
 The fix wraps `parse_args` on every leaf command that has this shape so that
-supplied values are right-aligned onto the required slots first.
+supplied values are right-aligned onto the required slots first, and type
+conversion / normalisation is applied via ``process_value`` on every relocated
+slot.
 
 All tests are parse-only (no Fabric connection, no destructive ops).
 """
@@ -14,6 +16,7 @@ All tests are parse-only (no Fabric connection, no destructive ops).
 from __future__ import annotations
 
 import importlib
+import uuid
 from collections.abc import AsyncIterator, Generator
 from contextlib import asynccontextmanager, contextmanager
 from typing import Any
@@ -85,6 +88,27 @@ def _test_value_for_type(param_type: click.ParamType) -> str:
         return "true"
     # STRING, Path, unrecognised: use a safe generic string.
     return "val"
+
+
+def _expected_python_value(param_type: click.ParamType, raw: str) -> Any:
+    """Return the Python value expected after Click type conversion of *raw*.
+
+    Used by the drift guard to verify that ``process_value`` was called so
+    that type conversion (INT casting, Choice normalisation, UUID parsing)
+    is applied to relocated positional values.
+    """
+    if isinstance(param_type, click.types.IntParamType):
+        return int(raw)
+    if isinstance(param_type, click.types.FloatParamType):
+        return float(raw)
+    if isinstance(param_type, click.types.UUIDParameterType):
+        return uuid.UUID(raw)
+    if isinstance(param_type, click.types.BoolParamType):
+        return raw.lower() in ("1", "true", "t", "yes", "y", "on")
+    # Choice, STRING, Path, unrecognised: value is returned as a string.
+    # _test_value_for_type returns choices[0] verbatim, which matches exactly,
+    # so Choice.convert returns it unchanged (no case mutation needed here).
+    return raw
 
 
 @contextmanager
@@ -172,7 +196,12 @@ class TestDriftGuard:
         opt_params: list[click.Argument],
         req_params: list[click.Argument],
     ) -> None:
-        """Supplying only the required positionals leaves optional slots empty."""
+        """Supplying only the required positionals leaves optional slots empty.
+
+        Also verifies that type conversion was applied (e.g. INT args become
+        Python ints, Choice args are normalised) so that ``process_value`` is
+        confirmed to have been called on every relocated slot.
+        """
         args = [_test_value_for_type(p.type) for p in req_params]
 
         with _relaxed_options(cmd):
@@ -182,10 +211,19 @@ class TestDriftGuard:
                 assert ctx.params[p.name] is None, (
                     f"{dotted_name}: optional slot {p.name!r} should be None in short form"
                 )
-            for p in req_params:
-                # Check source rather than value; type conversion may alter representation.
+            for p, raw in zip(req_params, args, strict=False):
                 assert ctx.get_parameter_source(p.name) is ParameterSource.COMMANDLINE, (
                     f"{dotted_name}: required slot {p.name!r} must have COMMANDLINE source"
+                )
+                expected = _expected_python_value(p.type, raw)
+                assert ctx.params[p.name] == expected, (
+                    f"{dotted_name}: slot {p.name!r} value {ctx.params[p.name]!r} "
+                    f"should be {expected!r} after type conversion"
+                )
+                assert isinstance(ctx.params[p.name], type(expected)), (
+                    f"{dotted_name}: slot {p.name!r} has Python type "
+                    f"{type(ctx.params[p.name]).__name__!r}, "
+                    f"expected {type(expected).__name__!r}"
                 )
         finally:
             ctx.close()
@@ -197,21 +235,31 @@ class TestDriftGuard:
         opt_params: list[click.Argument],
         req_params: list[click.Argument],
     ) -> None:
-        """Supplying all positionals fills every slot in declaration order."""
-        all_args = [_test_value_for_type(p.type) for p in opt_params] + [
-            _test_value_for_type(p.type) for p in req_params
-        ]
+        """Supplying all positionals fills every slot in declaration order.
+
+        Also verifies that type conversion was applied to each slot so that
+        the full form does not regress when ``type=STRING`` is used during the
+        delegated parse.
+        """
+        all_params = opt_params + req_params
+        all_args = [_test_value_for_type(p.type) for p in all_params]
 
         with _relaxed_options(cmd):
             ctx = _make_context(cmd, all_args)
         try:
-            for p in opt_params:
+            for p, raw in zip(all_params, all_args, strict=False):
                 assert ctx.get_parameter_source(p.name) is ParameterSource.COMMANDLINE, (
-                    f"{dotted_name}: optional slot {p.name!r} must be COMMANDLINE when supplied"
+                    f"{dotted_name}: slot {p.name!r} must be COMMANDLINE when supplied"
                 )
-            for p in req_params:
-                assert ctx.get_parameter_source(p.name) is ParameterSource.COMMANDLINE, (
-                    f"{dotted_name}: required slot {p.name!r} must be COMMANDLINE when supplied"
+                expected = _expected_python_value(p.type, raw)
+                assert ctx.params[p.name] == expected, (
+                    f"{dotted_name}: slot {p.name!r} value {ctx.params[p.name]!r} "
+                    f"should be {expected!r} after type conversion"
+                )
+                assert isinstance(ctx.params[p.name], type(expected)), (
+                    f"{dotted_name}: slot {p.name!r} has Python type "
+                    f"{type(ctx.params[p.name]).__name__!r}, "
+                    f"expected {type(expected).__name__!r}"
                 )
         finally:
             ctx.close()
@@ -390,6 +438,95 @@ class TestWarehousesRename:
     def test_zero_args_raises_missing(self) -> None:
         with pytest.raises((click.MissingParameter, click.UsageError)):
             _make_context(self.cmd, []).close()
+
+
+# ---------------------------------------------------------------------------
+# Type-conversion regression: Choice normalisation and INT casting
+# ---------------------------------------------------------------------------
+
+
+class TestSettingsResultSetCachingTypeConversion:
+    """settings result-set-caching [item?, state:Choice(['on','off'])].
+
+    Verifies that Choice case-normalisation is applied after right-alignment so
+    that ``fdw settings result-set-caching ON`` stores ``'on'`` (not ``'ON'``).
+    The command body checks ``state == 'on'`` (line 93 of settings.py), so a
+    stale uppercase string would silently disable caching when the user said ON.
+    """
+
+    def setup_method(self) -> None:
+        group = _load_group("settings")
+        self.cmd = group.commands["result-set-caching"]
+
+    def test_short_form_uppercase_is_normalised(self) -> None:
+        """Short form with uppercase 'ON' must store lowercase 'on'."""
+        ctx = _make_context(self.cmd, ["ON"])
+        try:
+            assert ctx.params["item"] is None
+            assert ctx.params["state"] == "on", (
+                f"Expected 'on' after Choice normalisation, got {ctx.params['state']!r}"
+            )
+            assert ctx.get_parameter_source("state") is ParameterSource.COMMANDLINE
+        finally:
+            ctx.close()
+
+    def test_short_form_lowercase_is_unchanged(self) -> None:
+        ctx = _make_context(self.cmd, ["on"])
+        try:
+            assert ctx.params["item"] is None
+            assert ctx.params["state"] == "on"
+        finally:
+            ctx.close()
+
+    def test_full_form_uppercase_is_normalised(self) -> None:
+        """Full form with uppercase 'ON' must also store lowercase 'on'."""
+        ctx = _make_context(self.cmd, ["MyWH", "ON"])
+        try:
+            assert ctx.params["item"] == "MyWH"
+            assert ctx.params["state"] == "on", (
+                f"Expected 'on' after Choice normalisation, got {ctx.params['state']!r}"
+            )
+        finally:
+            ctx.close()
+
+    def test_invalid_state_raises(self) -> None:
+        with pytest.raises((click.BadParameter, click.UsageError, SystemExit)):
+            _make_context(self.cmd, ["INVALID"]).close()
+
+
+class TestQueriesKillTypeConversion:
+    """queries kill [item?, session_id:INT].
+
+    Verifies that INT casting is applied after right-alignment so that
+    ``fdw queries kill 12345`` stores the Python int ``12345``, not the
+    string ``'12345'``.
+    """
+
+    def setup_method(self) -> None:
+        group = _load_group("queries")
+        self.cmd = group.commands["kill"]
+
+    def test_short_form_session_id_is_int(self) -> None:
+        ctx = _make_context(self.cmd, ["12345"])
+        try:
+            assert ctx.params["item"] is None
+            assert ctx.params["session_id"] == 12345
+            assert isinstance(ctx.params["session_id"], int)
+        finally:
+            ctx.close()
+
+    def test_full_form_session_id_is_int(self) -> None:
+        ctx = _make_context(self.cmd, ["MyWH", "12345"])
+        try:
+            assert ctx.params["item"] == "MyWH"
+            assert ctx.params["session_id"] == 12345
+            assert isinstance(ctx.params["session_id"], int)
+        finally:
+            ctx.close()
+
+    def test_non_integer_raises(self) -> None:
+        with pytest.raises((click.BadParameter, click.UsageError, SystemExit)):
+            _make_context(self.cmd, ["not_an_int"]).close()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Root cause

Click fills positional slots strictly left-to-right and ignores the `required` flag during unpacking. When a command declares `[item?] name`, passing one argument puts it in the optional slot, leaving the required slot empty. Result: `fdw schemas delete my_schema` dies with `Missing argument 'NAME'.` instead of resolving the warehouse from `FABRIC_DW_DEFAULT_WAREHOUSE` or the config default.

This affected 61 leaf commands across 15 groups: every command with a leading optional positional (ITEM / WAREHOUSE / WORKSPACE) followed by one or more required positionals.

## Mechanism

The existing `_patch_command_for_global_options` hook already wraps every leaf command's `invoke`. This PR adds a second wrapper for `parse_args` (via `_wrap_parse_args_for_right_align`, called for non-Group commands from the same hook).

Shape requirements (all must hold; commands not matching fall through to original `parse_args` unmodified):

- Exactly one leading optional positional followed by one or more required positionals.
- All positionals have `nargs == 1` (no variadic arguments).
- No trailing optional positional after the required ones.

The wrapper:

1. Bails out when `ctx.resilient_parsing` is True - shell completion is unaffected.
2. Bails out when `--help` or `-h` is in `args` - help text is not perturbed by the relaxation window.
3. Bails out when the command does not match the `[opt] req+` shape described above.
4. Temporarily sets `required=False`, `type=click.STRING`, and `callback=None` on all positionals, delegates to the original `parse_args` (which now fills all slots with raw strings), and restores all three attributes unconditionally in a `finally` block.
5. Detects which slots Click assigned from the command line by `ParameterSource.COMMANDLINE`.
6. If all slots are filled (full form), calls `Parameter.process_value` on each slot to apply type conversion, Choice case-normalisation, and callbacks with the value already in its correct slot.
7. If fewer slots are filled (short form), resets the optional slot to `None`/`DEFAULT`, then distributes the raw strings to the required slots and calls `Parameter.process_value` on each, applying the same conversions.
8. Raises `click.MissingParameter(ctx=ctx, param=p)` for any required slot still without a value, reproducing Click's own error wording.

Over-supply errors (`Got unexpected extra arguments`) remain handled by the original `parse_args`.

## Why it is non-breaking

- Commands not matching the shape (`n_leading_optional != 1`, variadic args, trailing optional) delegate straight to the original `parse_args`.
- Full-form invocations: all slots are filled and `process_value` is called in-place; the net result is identical to what Click would have produced without the wrapper.
- The `required`, `type`, and `callback` attributes are module-level singletons - the `finally` block restores all three unconditionally even if `parse_args` raises.

## Side note: `state` comparison inconsistency in `settings.py`

Noticed during this work but not fixed here to keep the scope contained: `settings.py` line 93 uses `state == "on"` while line 135 uses `state.lower() == "on"`. Both receive a `click.Choice(["on", "off"], case_sensitive=False)` value, which `process_value` normalises to lowercase after this fix, so both comparisons produce the correct result. The inconsistency is harmless but worth aligning in a follow-up.

## Changes

- `src/fabric_dw/cli/_main.py`: add `_wrap_parse_args_for_right_align` and call it from `_patch_command_for_global_options` for leaf commands.
- `tests/unit/cli/test_positional_right_align.py`: 213 tests. Table-driven drift guard walks the full lazy command tree and asserts short-form/full-form/zero-args invariants, value equality, and Python types for every affected command. Targeted regression tests cover Choice normalisation (`settings result-set-caching`) and INT casting (`queries kill`).
- `docs/commands/restore-points.md`: four synopsis lines showed `WAREHOUSE` unbracketed; corrected to `[WAREHOUSE]`.
- `docs/commands/config.md`: adds a concrete short-form example.

Closes #981