### PR TITLE
fix(ci): assert lockfile consistency in the remaining workflows

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           python-version: "3.14"
 
-      - run: uv sync --frozen --no-dev
+      - run: uv sync --locked --no-dev
 
       - name: Compute Docker tags and version
         id: docker_tags

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -97,7 +97,7 @@ jobs:
         with:
           python-version: "3.14"
 
-      - run: uv sync --frozen
+      - run: uv sync --locked
 
       - name: Build wheel and install for journey test
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -74,7 +74,7 @@ jobs:
             echo "plugin.json version '$plugin_version' already matches tag '$version'."
           fi
 
-      - run: uv sync --frozen --no-dev
+      - run: uv sync --locked --no-dev
 
       - run: uv build
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -48,5 +48,5 @@ jobs:
           fetch-depth: 0
       - uses: astral-sh/setup-uv@v8.3.0
         with: { enable-cache: true }
-      - run: uv sync --frozen
+      - run: uv sync --locked
       - run: uvx --quiet 'pip-audit==2.10.1' --strict

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,10 @@ ENV SETUPTOOLS_SCM_PRETEND_VERSION_FOR_FABRIC_DW=${VERSION}
 
 COPY pyproject.toml uv.lock README.md LICENSE ./
 COPY src/ src/
-# Build the wheel, then install all runtime deps from the frozen lock into a venv.
-# uv sync --frozen reads uv.lock and installs exactly the locked versions (no fresh resolution).
+# Build the wheel, then install all runtime deps from the locked lockfile into a venv.
+# uv sync --locked asserts uv.lock is up to date with pyproject.toml, then installs the pinned versions.
 RUN uv build --wheel && \
-    uv sync --frozen --no-dev --no-install-project && \
+    uv sync --locked --no-dev --no-install-project && \
     uv pip install --no-deps dist/*.whl
 
 # Runtime stage — copy the pre-built venv from the build stage (all deps already pinned by lock).


### PR DESCRIPTION
## What changed

Replace `uv sync --frozen` with `uv sync --locked` in four workflow files and the Dockerfile:

- **`security.yml`** (line 51): 1 line changed
- **`docker.yml`** (line 36): 1 line changed (`--no-dev` preserved)
- **`publish.yml`** (line 77): 1 line changed (`--no-dev` preserved)
- **`integration.yml`** (line 100): 1 line changed
- **`Dockerfile`** (line 23): 1 line changed (`--no-dev` and `--no-install-project` preserved); inline comment updated to describe `--locked` semantics accurately

`ci.yml` was already converted in PR #989 and is untouched.

## Why --locked beats --frozen

`--frozen` skips the lockfile-versus-manifest consistency check and installs directly from `uv.lock`, regardless of whether `pyproject.toml` has drifted away from it. `--locked` asserts that the lockfile is in sync with `pyproject.toml` and exits 1 if it is not - catching manifest/lockfile desync at install time rather than silently shipping from a stale dependency set.

For release workflows (`publish.yml`) this is especially important: a lockfile desync will now fail fast before a release is published rather than going undetected.

## Dockerfile inclusion rationale

The Dockerfile was not in the original scope of #990, but both `pyproject.toml` and `uv.lock` are COPYed into the build stage on the line immediately preceding the `uv sync` call, so `--locked` has everything it needs to perform its check. In CI the gap was already covered because `docker.yml`'s runner-level `uv sync --locked --no-dev` runs before the image build in the same job and would fail first on a desync. The only uncovered path was an out-of-band local `docker build`. Folding this one-line fix into this PR closes that gap without the overhead of a separate issue and PR.

## Deliberate non-change

`integration.yml` line 112 contains:

```
uv export --frozen --no-dev --no-emit-project -o /tmp/journey-reqs.txt
```

This is `uv export`, not `uv sync`. The `--frozen` flag on `uv export` has different semantics - it tells uv not to update the lockfile before exporting. This is correct behavior for the journey wheel-build step and has been left unchanged.

## Verification

- `grep -rn 'uv sync --frozen' .github/workflows/` - no results
- `grep -rn 'uv sync --locked' .github/workflows/` - returns security.yml:51, docker.yml:36, publish.yml:77, integration.yml:100 (plus ci.yml from #989)
- `grep -rn 'uv export --frozen' .github/workflows/` - still returns integration.yml:112, unchanged
- `actionlint` ran on all four workflow files with no errors

Closes #990