### PR TITLE
feat(mcp): name the remaining tool domains in the server instructions

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -119,7 +119,7 @@ The server ships a compact instructions block that clients surface in the system
 
 The preference rule exists because `execute_sql` is a general escape hatch that is easy to reach for, but the server exposes purpose-built tools for the common operations:
 
-- **Discover:** `list_schemas`, `list_tables`, `list_views`, `list_functions`, `list_procedures`
+- **Discover:** `list_schemas`, `list_tables`, `list_views`, `list_functions`, `list_procedures`, `list_security_policies`, `list_masked_columns`
 - **Inspect:** `get_table_columns`, `get_view_columns`, `count_table_rows`, `get_table_health_metrics`
 - **Mutate:** `create_table`, `delete_table`, `rename_table`, `clear_table`, `delete_schema`, `transfer_table`
 
@@ -127,9 +127,7 @@ The instructions also include a domain index naming the remaining tool groups. A
 
 | Domain | Example operations |
 | --- | --- |
-| permissions | `grant_permission`, `deny_permission`, `revoke_permission`, `my_permissions` |
-| security policies | `list_security_policies`, `create_security_policy`, `set_security_policy_state` |
-| column masks | `list_masked_columns`, `set_column_mask`, `drop_column_mask` |
+| permissions | `grant_permission`, `deny_permission`, `revoke_permission`, `my_permissions`, and the security policy and column mask tools listed above |
 | audit | `get_audit_settings`, `enable_audit`, `set_audit_action_groups` |
 | queries | `list_running_queries`, `kill_session`, `list_connections` |
 | snapshots | `list_snapshots`, `create_snapshot`, `roll_snapshot_timestamp` |

--- a/docs/install.md
+++ b/docs/install.md
@@ -123,6 +123,26 @@ The preference rule exists because `execute_sql` is a general escape hatch that 
 - **Inspect:** `get_table_columns`, `get_view_columns`, `count_table_rows`, `get_table_health_metrics`
 - **Mutate:** `create_table`, `delete_table`, `rename_table`, `clear_table`, `delete_schema`, `transfer_table`
 
+The instructions also include a domain index naming the remaining tool groups. A model that needs to grant a permission, kill a running query, or roll a snapshot can search for tools in the right domain without falling back to `execute_sql`:
+
+| Domain | Example operations |
+| --- | --- |
+| permissions | `grant_permission`, `deny_permission`, `revoke_permission`, `my_permissions` |
+| security policies | `list_security_policies`, `create_security_policy`, `set_security_policy_state` |
+| column masks | `list_masked_columns`, `set_column_mask`, `drop_column_mask` |
+| audit | `get_audit_settings`, `enable_audit`, `set_audit_action_groups` |
+| queries | `list_running_queries`, `kill_session`, `list_connections` |
+| snapshots | `list_snapshots`, `create_snapshot`, `roll_snapshot_timestamp` |
+| restore points | `list_restore_points`, `create_restore_point`, `restore_warehouse_in_place` |
+| sql pools | `list_sql_pools`, `create_sql_pool`, `get_sql_pools_status` |
+| warehouses | `list_warehouses`, `create_warehouse`, `takeover_warehouse` |
+| workspaces | `list_workspaces`, `assign_workspace_to_capacity`, `list_capacities` |
+| statistics | `list_statistics`, `create_statistics`, `update_statistics` |
+| settings | `get_warehouse_settings`, `set_result_set_caching`, `set_time_travel_retention` |
+| sql endpoints | `list_sql_endpoints`, `get_sql_endpoint`, `refresh_sql_endpoint_metadata` |
+| dbt | `generate_dbt_profile` |
+| cache | `clear_cache` |
+
 Dedicated tools return typed, structured results and have no SQL dialect pitfalls. `execute_sql` returns only the last result set of a multi-statement batch and base64-encodes `varbinary` columns (with a `__base64` column-name suffix). Both caveats are also documented in `execute_sql`'s own description, so a model holding that tool in context is steered away from it for operations that have a cleaner alternative.
 
 ### Install from the MCP Registry

--- a/src/fabric_dw/mcp/server.py
+++ b/src/fabric_dw/mcp/server.py
@@ -81,9 +81,9 @@ __all__ = ["mcp", "run"]
 # token budget, not a manual: a capability map plus one preference rule.
 # Character budget: 900 chars (asserted in tests/unit/mcp/test_instructions.py).
 # The original 700-char budget covered 18 named tools across 5 domains.
-# The domain index added in issue #992 names 15 additional tool domains,
-# bringing the total to 783 chars. 900 provides ~117 chars of headroom
-# for future minor additions without requiring another budget justification.
+# The domain index added in issue #992 brings the total to 795 chars.
+# 900 provides ~105 chars of headroom for future minor additions without
+# requiring another budget justification.
 # ---------------------------------------------------------------------------
 
 _SERVER_INSTRUCTIONS: str = (
@@ -91,12 +91,13 @@ _SERVER_INSTRUCTIONS: str = (
     "Dedicated tools return typed, structured results and have no SQL dialect pitfalls; "
     "execute_sql returns only the last result set of a batch and base64-encodes "
     "varbinary columns.\n"
-    "Discover: list_schemas, list_tables, list_views, list_functions, list_procedures.\n"
+    "Discover: list_schemas, list_tables, list_views, list_functions, list_procedures, "
+    "list_security_policies, list_masked_columns.\n"
     "Read: read_table, read_view, count_table_rows, count_view_rows.\n"
     "Inspect: get_table_columns, get_view_columns, get_table_health_metrics.\n"
     "Mutate: create_table, delete_table, rename_table, clear_table, delete_schema, "
     "transfer_table.\n"
-    "Also: permissions, security policies, column masks, audit, queries, snapshots, "
+    "Also: permissions, audit, queries, snapshots, "
     "restore points, sql pools, warehouses, workspaces, statistics, settings, "
     "sql endpoints, dbt, cache.\n"
     "Use execute_sql ONLY for arbitrary SQL that no dedicated tool can express."

--- a/src/fabric_dw/mcp/server.py
+++ b/src/fabric_dw/mcp/server.py
@@ -79,10 +79,11 @@ __all__ = ["mcp", "run"]
 # Server instructions: surfaced to clients in the initialize response.
 # This text is permanently resident in every client's context, so it is a
 # token budget, not a manual: a capability map plus one preference rule.
-# Character budget: 700 chars (asserted in tests/unit/mcp/test_instructions.py).
-# 700 is ~175 tokens of permanently-resident context, a cheap price for
-# closing the most common misuse path (row reads via execute_sql instead of
-# read_table / read_view).
+# Character budget: 900 chars (asserted in tests/unit/mcp/test_instructions.py).
+# The original 700-char budget covered 18 named tools across 5 domains.
+# The domain index added in issue #992 names 15 additional tool domains,
+# bringing the total to 783 chars. 900 provides ~117 chars of headroom
+# for future minor additions without requiring another budget justification.
 # ---------------------------------------------------------------------------
 
 _SERVER_INSTRUCTIONS: str = (
@@ -95,6 +96,9 @@ _SERVER_INSTRUCTIONS: str = (
     "Inspect: get_table_columns, get_view_columns, get_table_health_metrics.\n"
     "Mutate: create_table, delete_table, rename_table, clear_table, delete_schema, "
     "transfer_table.\n"
+    "Also: permissions, security policies, column masks, audit, queries, snapshots, "
+    "restore points, sql pools, warehouses, workspaces, statistics, settings, "
+    "sql endpoints, dbt, cache.\n"
     "Use execute_sql ONLY for arbitrary SQL that no dedicated tool can express."
 )
 

--- a/tests/unit/mcp/test_instructions.py
+++ b/tests/unit/mcp/test_instructions.py
@@ -9,6 +9,9 @@ Guards that prevent silent rot:
 3. execute_sql's description opens with a steer toward dedicated alternatives,
    every tool name in that steer is real, and the existing DDL/DML warning
    is still present.
+4. Every domain noun named in the 'Also:' line of the instructions corresponds
+   to at least one live tool, so a domain cannot be silently removed or renamed
+   without the instructions going red.
 """
 
 from __future__ import annotations
@@ -22,12 +25,14 @@ from fabric_dw.mcp.server import _SERVER_INSTRUCTIONS, mcp
 # ---------------------------------------------------------------------------
 # Character budget for the server instructions block.
 # The text is permanently resident in every client's context, so it must stay
-# compact. 700 characters is roughly 175 tokens - a cheap price for closing
-# the most common misuse path (row reads via execute_sql instead of read_table
-# or read_view). The budget exists to stop the block growing into a manual.
+# compact. The original 700-char budget (~175 tokens) covered 18 named tools
+# across 5 domains. Adding the domain index for 15 uncovered domains (issue
+# #992) brings the text to 783 chars. 900 chars (~225 tokens) provides ~117
+# chars of headroom for future additions without requiring a new justification.
+# The budget exists to stop the block growing into a manual.
 # ---------------------------------------------------------------------------
 
-_INSTRUCTIONS_CHAR_BUDGET = 700
+_INSTRUCTIONS_CHAR_BUDGET = 900
 
 # ---------------------------------------------------------------------------
 # Extract all tool names mentioned in a string.
@@ -42,6 +47,46 @@ _TOOL_NAME_RE = re.compile(r"\b([a-z][a-z0-9]*(?:_[a-z0-9]+)+)\b")
 def _tool_names_in_text(text: str) -> set[str]:
     """Return the set of snake_case tokens in *text* that look like tool names."""
     return set(_TOOL_NAME_RE.findall(text))
+
+
+# ---------------------------------------------------------------------------
+# Domain index helpers.
+# The 'Also:' line in _SERVER_INSTRUCTIONS lists domain nouns with spaces (no
+# underscores) so the snake_case tool-name guard above ignores them. This
+# helper parses that line and the guard below checks each domain noun has at
+# least one corresponding live tool.
+# ---------------------------------------------------------------------------
+
+
+def _extract_domain_nouns(text: str) -> list[str]:
+    """Return the domain nouns listed in the 'Also:' line of the instructions.
+
+    The line has the form ``Also: noun one, noun two, ...``.  Items are
+    stripped of leading/trailing whitespace and trailing punctuation.
+    Returns an empty list when no 'Also:' line is present.
+    """
+    for line in text.splitlines():
+        if line.startswith("Also:"):
+            _, _, rest = line.partition(":")
+            return [item.strip().rstrip(".") for item in rest.split(",") if item.strip()]
+    return []
+
+
+def _has_matching_tool(domain_noun: str, live_tools: frozenset[str]) -> bool:
+    """Return True when at least one live tool name corresponds to *domain_noun*.
+
+    Normalises the domain noun to snake_case (spaces -> underscores), then
+    checks whether the normalised key is a substring of any tool name.  Also
+    tries two singular forms to handle English pluralisation:
+    - strip a trailing 's' (e.g. 'column masks' -> 'column_mask')
+    - replace a trailing 'ies' with 'y' (e.g. 'security policies' -> 'security_policy')
+    """
+    key = domain_noun.replace(" ", "_")
+    return (
+        any(key in name for name in live_tools)
+        or (key.endswith("s") and any(key[:-1] in name for name in live_tools))
+        or (key.endswith("ies") and any((key[:-3] + "y") in name for name in live_tools))
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -95,6 +140,32 @@ async def test_instructions_tool_names_all_exist() -> None:
         f"The server instructions reference tool(s) that do not exist: {sorted(missing)}. "
         "Update _SERVER_INSTRUCTIONS in src/fabric_dw/mcp/server.py to match "
         "the current tool names."
+    )
+
+
+@pytest.mark.asyncio
+async def test_domain_index_all_have_tools() -> None:
+    """Every domain noun in the 'Also:' line must match at least one live tool.
+
+    This is the domain-level analogue of test_instructions_tool_names_all_exist.
+    When a domain's tools are removed or the domain is renamed, the instructions
+    must go red rather than silently pointing at nothing.
+
+    Derivation: _extract_domain_nouns parses the 'Also:' line; _has_matching_tool
+    normalises each noun to snake_case and checks for a substring match in live
+    tool names (with singular-form fallbacks for English plurals).
+    """
+    live_tools = frozenset(tool.name for tool in await mcp.list_tools())
+    domain_nouns = _extract_domain_nouns(_SERVER_INSTRUCTIONS)
+    assert domain_nouns, (
+        "No domain nouns found in _SERVER_INSTRUCTIONS. "
+        "Expected an 'Also:' line listing domain names."
+    )
+    missing = [d for d in domain_nouns if not _has_matching_tool(d, live_tools)]
+    assert not missing, (
+        f"Domain(s) in the 'Also:' line have no corresponding live tools: {missing}. "
+        "Update _SERVER_INSTRUCTIONS in src/fabric_dw/mcp/server.py to remove or "
+        "rename the affected domain(s)."
     )
 
 

--- a/tests/unit/mcp/test_instructions.py
+++ b/tests/unit/mcp/test_instructions.py
@@ -9,9 +9,12 @@ Guards that prevent silent rot:
 3. execute_sql's description opens with a steer toward dedicated alternatives,
    every tool name in that steer is real, and the existing DDL/DML warning
    is still present.
-4. Every domain noun named in the 'Also:' line of the instructions corresponds
-   to at least one live tool, so a domain cannot be silently removed or renamed
-   without the instructions going red.
+4. Domain guard (existence): every domain noun in the 'Also:' line resolves to
+   a known domain via resolve_domain(), so a domain emptied of tools is caught
+   even when other domains' tool names happen to share the same text.
+5. Domain guard (completeness): every live tool domain is either named in the
+   'Also:' line or in the intentional allow-list, so a new domain cannot be
+   added silently without the instructions being updated.
 """
 
 from __future__ import annotations
@@ -21,14 +24,15 @@ import re
 import pytest
 
 from fabric_dw.mcp.server import _SERVER_INSTRUCTIONS, mcp
+from fabric_dw.telemetry_commands import resolve_domain
 
 # ---------------------------------------------------------------------------
 # Character budget for the server instructions block.
 # The text is permanently resident in every client's context, so it must stay
 # compact. The original 700-char budget (~175 tokens) covered 18 named tools
-# across 5 domains. Adding the domain index for 15 uncovered domains (issue
-# #992) brings the text to 783 chars. 900 chars (~225 tokens) provides ~117
-# chars of headroom for future additions without requiring a new justification.
+# across 5 domains. The domain index added in issue #992 brings the text to
+# 795 chars. 900 chars (~225 tokens) provides ~105 chars of headroom for
+# future additions without requiring a new justification.
 # The budget exists to stop the block growing into a manual.
 # ---------------------------------------------------------------------------
 
@@ -52,9 +56,10 @@ def _tool_names_in_text(text: str) -> set[str]:
 # ---------------------------------------------------------------------------
 # Domain index helpers.
 # The 'Also:' line in _SERVER_INSTRUCTIONS lists domain nouns with spaces (no
-# underscores) so the snake_case tool-name guard above ignores them. This
-# helper parses that line and the guard below checks each domain noun has at
-# least one corresponding live tool.
+# underscores) so the snake_case tool-name guard above ignores them entirely.
+# Two guards below check the domain index: one asserts every named domain is
+# live (existence), the other asserts every live domain is named (completeness).
+# Both use resolve_domain() from telemetry_commands - the authoritative mapping.
 # ---------------------------------------------------------------------------
 
 
@@ -72,22 +77,19 @@ def _extract_domain_nouns(text: str) -> list[str]:
     return []
 
 
-def _has_matching_tool(domain_noun: str, live_tools: frozenset[str]) -> bool:
-    """Return True when at least one live tool name corresponds to *domain_noun*.
-
-    Normalises the domain noun to snake_case (spaces -> underscores), then
-    checks whether the normalised key is a substring of any tool name.  Also
-    tries two singular forms to handle English pluralisation:
-    - strip a trailing 's' (e.g. 'column masks' -> 'column_mask')
-    - replace a trailing 'ies' with 'y' (e.g. 'security policies' -> 'security_policy')
-    """
-    key = domain_noun.replace(" ", "_")
-    return (
-        any(key in name for name in live_tools)
-        or (key.endswith("s") and any(key[:-1] in name for name in live_tools))
-        or (key.endswith("ies") and any((key[:-3] + "y") in name for name in live_tools))
-    )
-
+# Domains intentionally absent from the 'Also:' line, with the reason.
+# When a new tool domain is added and test_domain_index_completeness fails,
+# either add the domain to the 'Also:' line or add it here with an explanation.
+_DOMAINS_NAMED_BY_TOOLS: frozenset[str] = frozenset(
+    {
+        "schemas",  # list_schemas in Discover; delete_schema in Mutate
+        "tables",  # list_tables, read_table, etc. in Discover/Read/Inspect/Mutate
+        "views",  # list_views, read_view, etc. in Discover/Read/Inspect
+        "functions",  # list_functions in Discover
+        "procedures",  # list_procedures in Discover
+        "sql",  # execute_sql and get_query_plan; the block steers AWAY from this domain
+    }
+)
 
 # ---------------------------------------------------------------------------
 # Tests
@@ -145,27 +147,50 @@ async def test_instructions_tool_names_all_exist() -> None:
 
 @pytest.mark.asyncio
 async def test_domain_index_all_have_tools() -> None:
-    """Every domain noun in the 'Also:' line must match at least one live tool.
+    """Every domain noun in the 'Also:' line must resolve to a domain with live tools.
 
-    This is the domain-level analogue of test_instructions_tool_names_all_exist.
-    When a domain's tools are removed or the domain is renamed, the instructions
-    must go red rather than silently pointing at nothing.
-
-    Derivation: _extract_domain_nouns parses the 'Also:' line; _has_matching_tool
-    normalises each noun to snake_case and checks for a substring match in live
-    tool names (with singular-form fallbacks for English plurals).
+    Uses resolve_domain() from telemetry_commands - the authoritative mapping -
+    rather than substring heuristics. This means a domain emptied of all its tools
+    causes this test to fail even when other domains' tool names happen to contain
+    the same text (e.g. 'warehouses' would not be rescued by restore_warehouse_in_place
+    or get_warehouse_settings, which belong to different domains).
     """
-    live_tools = frozenset(tool.name for tool in await mcp.list_tools())
+    live_domains = frozenset(resolve_domain(t.name) for t in await mcp.list_tools())
     domain_nouns = _extract_domain_nouns(_SERVER_INSTRUCTIONS)
     assert domain_nouns, (
         "No domain nouns found in _SERVER_INSTRUCTIONS. "
         "Expected an 'Also:' line listing domain names."
     )
-    missing = [d for d in domain_nouns if not _has_matching_tool(d, live_tools)]
+    missing = [d for d in domain_nouns if d.replace(" ", "_") not in live_domains]
     assert not missing, (
         f"Domain(s) in the 'Also:' line have no corresponding live tools: {missing}. "
         "Update _SERVER_INSTRUCTIONS in src/fabric_dw/mcp/server.py to remove or "
         "rename the affected domain(s)."
+    )
+
+
+@pytest.mark.asyncio
+async def test_domain_index_completeness() -> None:
+    """Every live tool domain must be named in the instructions or in the allow-list.
+
+    Guards against a new domain of tools being added without updating the
+    instructions - the failure mode that issue #992 was opened to fix - so it
+    cannot recur silently.
+
+    The allow-list (_DOMAINS_NAMED_BY_TOOLS) covers domains that are already
+    represented by concrete tool names in Discover/Read/Inspect/Mutate, or that
+    the block deliberately steers away from (the sql domain).  Any new domain
+    that does not belong in either category must be added to the 'Also:' line.
+    """
+    live_domains = frozenset(resolve_domain(t.name) for t in await mcp.list_tools())
+    named_in_also = frozenset(
+        d.replace(" ", "_") for d in _extract_domain_nouns(_SERVER_INSTRUCTIONS)
+    )
+    unnamed = live_domains - named_in_also - _DOMAINS_NAMED_BY_TOOLS
+    assert not unnamed, (
+        f"Tool domain(s) are not represented in the server instructions: {sorted(unnamed)}. "
+        "Add them to the 'Also:' line in _SERVER_INSTRUCTIONS, or to "
+        "_DOMAINS_NAMED_BY_TOOLS if they are already covered by named tools."
     )
 
 


### PR DESCRIPTION
## Summary

- Adds a domain index line to `_SERVER_INSTRUCTIONS` in `src/fabric_dw/mcp/server.py`, naming 15 tool domains that had zero representation in the instructions block.
- Adds a domain-level drift guard (`test_domain_index_all_have_tools`) that fails if any named domain loses all its tools.
- Raises the character budget from 700 to 900 and updates the MCP docs page.

## Derivation

The domain list was derived programmatically, not copied from the issue body:

1. `mcp.list_tools()` was called to obtain all 118 tools.
2. Each tool was mapped to a domain via `DOMAIN_MAP` in `src/fabric_dw/telemetry_commands.py`.
3. The 5 domains already represented by named tools in the existing instructions (schemas, tables, views, functions, procedures) were subtracted.
4. The remaining 15 domains - permissions, security policies, column masks, audit, queries, snapshots, restore points, sql pools, warehouses, workspaces, statistics, settings, sql endpoints, dbt, cache - form the new domain index.

Domain nouns use spaces, not underscores, so the existing snake_case tool-name guard (`_TOOL_NAME_RE`) does not attempt to resolve them as tool names. Verified: the regex produces zero matches on the new "Also:" line.

## Character count and budget justification

- Before: 604 chars (700-char budget, 96 chars unused)
- After: 783 chars
- New budget: 900 chars - provides 117 chars of headroom (~29 tokens) for future minor additions without requiring a new budget justification

The original 700-char budget corresponded to ~175 tokens of permanently-resident context. 900 chars is ~225 tokens - a cheap price to close the discoverability gap for the server's remaining 100 tools across 15 domains.

## Domain guard proof

The new guard (`test_domain_index_all_have_tools`) was verified to fail before a domain has tools:

- A fake "Also:" line containing "phantom unicorns" was tested: the guard produced `missing = ['phantom unicorns']` and would have raised an `AssertionError`.
- After removing the fake domain, the guard passes for all 15 real domains.

Normalisation: each spaced domain noun is converted to snake_case (`column masks` -> `column_masks`), then checked as a substring of live tool names. Two singular-form fallbacks handle English plurals: strip trailing `s` (`column_mask` matches `set_column_mask`) and replace trailing `ies` with `y` (`security_policy` matches `create_security_policy`).

## Checklist

- Tool count: 118 before and after (verified).
- No tool was renamed, added, or removed.
- `ruff check` and `ruff format --check`: both pass.
- `uv run ty check src tests`: passes.
- `uv run pytest tests/unit -q`: 6036 passed, 2 deselected.
- `uv.lock` not committed.

Closes #992