### PR TITLE
fix(test): ensure a warehouse exists before sql-pools integration tests

### DIFF
--- a/tests/integration/test_services_sql_pools.py
+++ b/tests/integration/test_services_sql_pools.py
@@ -16,6 +16,8 @@ from fabric_dw.http_client import FabricHttpClient
 from fabric_dw.models import SqlPool, SqlPoolsConfiguration
 from fabric_dw.services import sql_pools
 
+from .conftest import SharedWarehouseTarget
+
 # ``maxResourcePercentage`` is a single global budget per workspace (sum ≤ 100),
 # and every test here mutates the one shared ``FABRIC_TEST_WORKSPACE_ID`` config.
 # ``xdist_group`` pins the whole module onto a single xdist worker so these
@@ -121,6 +123,7 @@ async def _remove_stale_pytest_pools(
 async def _clean_stale_pools(
     http: FabricHttpClient,
     workspace_id: UUID,
+    shared_warehouse: SharedWarehouseTarget,  # noqa: ARG001
 ) -> AsyncGenerator[None, None]:
     """Autouse fixture: sweep stale pytest-prefixed pools before every test.
 
@@ -128,6 +131,14 @@ async def _clean_stale_pools(
     left behind by an interrupted prior run is removed before the workspace
     configuration is read or modified.  This protects every test regardless
     of run order.
+
+    The ``shared_warehouse`` parameter is requested for its side effect only:
+    the sql-pools configuration endpoint (GET .../sqlPoolsConfiguration) returns
+    HTTP 500 when the workspace contains no warehouse or SQL analytics endpoint.
+    Declaring this session-scoped fixture as a dependency guarantees that at
+    least one warehouse exists in the workspace before ``get_configuration`` is
+    called here or in any test in this module.
+    See: https://learn.microsoft.com/fabric/data-warehouse/custom-sql-pools#limitations?WT.mc_id=MVP_310840
     """
     await _remove_stale_pytest_pools(http, workspace_id)
     yield


### PR DESCRIPTION
## Root cause

The Fabric sql-pools configuration endpoint (`GET /v1/workspaces/{ws}/warehouses/sqlPoolsConfiguration`) returns HTTP 500 with `isRetriable: false` when the workspace contains no warehouse or SQL analytics endpoint. This is a documented limitation of the preview API:

> A workspace must contain one or more warehouses or SQL analytics endpoints before running the APIs.

Source: https://learn.microsoft.com/fabric/data-warehouse/custom-sql-pools#limitations?WT.mc_id=MVP_310840

The three tests in `tests/integration/test_services_sql_pools.py` only requested the `http` and `workspace_id` fixtures - never `shared_warehouse`. The autouse `_clean_stale_pools` fixture called `sql_pools.get_configuration()` before every test in the module. At the start of each CI run (after the workspace wipe), no warehouse existed yet, so the very first call to `get_configuration` returned 500, erroring the entire module before any test body ran.

## Fix

Added `shared_warehouse: SharedWarehouseTarget` as a parameter of `_clean_stale_pools`. This is the only change needed.

## Fixture execution order

Pytest's fundamental scope rule guarantees that a fixture with broader scope is always set up before a fixture with narrower scope that depends on it. `shared_warehouse` is session-scoped (`scope="session"`); `_clean_stale_pools` is function-scoped (`scope="function"`). When pytest resolves the dependency graph for the first test in this module, it sets up `shared_warehouse` first (once for the whole session - creating the warehouse in the workspace), then sets up `_clean_stale_pools`. By the time `_clean_stale_pools` calls `get_configuration`, the warehouse already exists and the endpoint returns 200.

The parameter is requested for its side effect only (the warehouse provisioning), so it carries a `# noqa: ARG001` comment, matching the existing codebase pattern.

Adding it to `_clean_stale_pools` is sufficient. The three test functions do not need `shared_warehouse` in their own signatures because the autouse fixture has already satisfied the precondition before each test body runs.

## What was verified

- `uv run pytest tests/integration/test_services_sql_pools.py --collect-only -m integration`: all 3 tests collect without import or fixture errors.
- `ruff check` and `ruff format --check`: pass.
- `uv run ty check src tests`: pass.

What could NOT be verified without Fabric credentials: that the endpoint actually returns 200 when a warehouse exists, and that the module no longer errors in CI. The CI run on `main` is the real proof.

Closes #994