### PR TITLE
fix: set autocommit=True on execute_sql connection

### DIFF
--- a/src/fabric_dw/services/sql_exec.py
+++ b/src/fabric_dw/services/sql_exec.py
@@ -194,7 +194,7 @@ async def execute(
     """
 
     def _run() -> SqlResult:
-        conn, _, _, _ = sql._with_connect_retry(target, mode, autocommit=False)
+        conn, _, _, _ = sql._with_connect_retry(target, mode, autocommit=True)
         with closing(conn):
             cursor = conn.cursor()
             with closing(cursor):


### PR DESCRIPTION
## Summary

Fixes silent rollback of DDL/DML statements in `execute_sql` due to missing autocommit.

### Problem

`execute_sql` opened its connection with `autocommit=False`, causing every statement to run inside an implicit transaction that was never committed. When the connection closed, the transaction was rolled back — silently discarding all mutations (CREATE TABLE, INSERT, UPDATE, DELETE, DROP, etc.).

### Root Cause

In `src/fabric_dw/services/sql_exec.py`, line 197:
```python
conn, _, _, _ = sql._with_connect_retry(target, mode, autocommit=False)
```

This is the same root cause as #776 (`KILL` always fails). Other services (snapshots, queries, permissions, rls, tables, mask, settings) already use `autocommit=True` for their DDL/DML operations.

### Fix

Change `autocommit=False` to `autocommit=True` in the `execute()` helper, matching the pattern used everywhere else in the codebase.

### Verification

- All `execute_sql` unit tests pass (happy path, no connection string, max rows truncation, readonly gate)
- All `execute_sql` security tests pass
- Ruff lint and format checks pass

Closes #1000
