### PR TITLE
feat(queries): add show command and remove always-null query_text

### DIFF
--- a/docs/commands/queries.md
+++ b/docs/commands/queries.md
@@ -188,26 +188,6 @@ fdw -w MyWorkspace queries running SalesWH
  42          running  1500                user@co.io   SELECT   A1B2C3D4-1234-5678-ABCD-EF012345678  750       100    1000           50
 ```
 
-### queries show
-
-**Targets:** Data Warehouse / SQL Analytics Endpoint
-
-Look up a single completed query by its `distributed_statement_id` from `queryinsights.exec_requests_history`. Use the `dist_statement_id` returned by `queries running` to retrieve the full query text and execution metrics.
-
-See the [Fabric Query Insights documentation](https://learn.microsoft.com/fabric/data-warehouse/query-insights?WT.mc_id=MVP_310840) for more details.
-
-**Synopsis**
-
-```
-fdw [-w WORKSPACE] queries show [WAREHOUSE] DIST_STATEMENT_ID
-```
-
-**Example**
-
-```shell
-fdw -w MyWorkspace queries show SalesWH A1B2C3D4-1234-5678-ABCD-EF0123456789
-```
-
 ### queries sessions
 
 **Targets:** Data Warehouse / SQL Analytics Endpoint
@@ -234,6 +214,26 @@ fdw [-w WORKSPACE] queries sessions [OPTIONS] [WAREHOUSE]
 ```shell
 fdw -w MyWorkspace queries sessions SalesWH
 fdw -w MyWorkspace queries sessions SalesWH --ago 90m
+```
+
+### queries show
+
+**Targets:** Data Warehouse / SQL Analytics Endpoint
+
+Look up a single completed query by its `distributed_statement_id` from `queryinsights.exec_requests_history`. Use the `dist_statement_id` returned by `queries running` to retrieve the full query text and execution metrics.
+
+See the [Fabric Query Insights documentation](https://learn.microsoft.com/fabric/data-warehouse/query-insights?WT.mc_id=MVP_310840) for more details.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] queries show [WAREHOUSE] DIST_STATEMENT_ID
+```
+
+**Example**
+
+```shell
+fdw -w MyWorkspace queries show SalesWH A1B2C3D4-1234-5678-ABCD-EF0123456789
 ```
 
 ## MCP tools

--- a/docs/commands/queries.md
+++ b/docs/commands/queries.md
@@ -168,7 +168,7 @@ fdw -w MyWorkspace queries long-running SalesWH --ago 2d
 
 **Targets:** Data Warehouse / SQL Analytics Endpoint
 
-List all currently running queries on a warehouse or SQL Analytics Endpoint. Queries `sys.dm_exec_sessions` joined with `sys.dm_exec_requests`. The `query_text` field is always `null` because `sys.dm_exec_sql_text` is not supported on Fabric DW - use `dist_statement_id` to look up the full query text in `queryinsights.exec_requests_history`.
+List all currently running queries on a warehouse or SQL Analytics Endpoint. Queries `sys.dm_exec_sessions` joined with `sys.dm_exec_requests`. Use `dist_statement_id` with `queries show` to retrieve the full query text and execution metrics after the query completes.
 
 **Synopsis**
 
@@ -186,6 +186,26 @@ fdw -w MyWorkspace queries running SalesWH
  session_id  status   total_elapsed_time  login_name   command  dist_statement_id                     cpu_time  reads  logical_reads  row_count
  ----------  -------  ------------------  -----------  -------  ------------------------------------  --------  -----  -------------  ---------
  42          running  1500                user@co.io   SELECT   A1B2C3D4-1234-5678-ABCD-EF012345678  750       100    1000           50
+```
+
+### queries show
+
+**Targets:** Data Warehouse / SQL Analytics Endpoint
+
+Look up a single completed query by its `distributed_statement_id` from `queryinsights.exec_requests_history`. Use the `dist_statement_id` returned by `queries running` to retrieve the full query text and execution metrics.
+
+See the [Fabric Query Insights documentation](https://learn.microsoft.com/fabric/data-warehouse/query-insights?WT.mc_id=MVP_310840) for more details.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] queries show [WAREHOUSE] DIST_STATEMENT_ID
+```
+
+**Example**
+
+```shell
+fdw -w MyWorkspace queries show SalesWH A1B2C3D4-1234-5678-ABCD-EF0123456789
 ```
 
 ### queries sessions
@@ -219,6 +239,22 @@ fdw -w MyWorkspace queries sessions SalesWH --ago 90m
 ## MCP tools
 
 The tools below cover running queries, active connections, locks, and queryinsights history. History tools share the same parameter shape: `workspace`, `warehouse`, optional `limit`, optional `since`, and optional `until`.
+
+### get_request_detail
+
+**Targets:** Data Warehouse / SQL Analytics Endpoint
+
+Look up a single completed query from `queryinsights.exec_requests_history` by its `distributed_statement_id`. Use the `dist_statement_id` returned by `list_running_queries` to retrieve full query text and execution metrics after the query completes.
+
+See the [Fabric Query Insights documentation](https://learn.microsoft.com/fabric/data-warehouse/query-insights?WT.mc_id=MVP_310840) for details on the queryinsights schema and required permissions.
+
+**Parameters:**
+
+- `workspace` (`str`): workspace name or GUID.
+- `item` (`str`): warehouse or SQL Analytics Endpoint name or GUID.
+- `dist_statement_id` (`str`): the `distributed_statement_id` GUID to look up.
+
+**Returns:** `dict | null`: the matching request-history row as a dict (same schema as `list_request_history` rows), or `null` if no matching row exists.
 
 ### kill_session
 
@@ -323,7 +359,7 @@ Return all currently-executing queries on a warehouse.
 - `workspace` (`str`): workspace name or GUID.
 - `warehouse` (`str`): warehouse name or GUID.
 
-**Returns:** `list[RunningQuery]`: array of query objects, each with `session_id`, `request_id`, `status`, `start_time`, `total_elapsed_time` (ms), `login_name`, `command`, `query_text` (always `null` - use `dist_statement_id` to look up full query text in `queryinsights.exec_requests_history`), `dist_statement_id` (for cross-tool correlation with Capacity Metrics and queryinsights), `blocking_session_id`, `wait_type`, `wait_time` (ms), `cpu_time` (ms), `reads`, `writes`, `logical_reads`, `row_count`, and `open_transaction_count`.
+**Returns:** `list[RunningQuery]`: array of query objects, each with `session_id`, `request_id`, `status`, `start_time`, `total_elapsed_time` (ms), `login_name`, `command`, `dist_statement_id` (for cross-tool correlation with Capacity Metrics and queryinsights - use with `get_request_detail` to retrieve full query text), `blocking_session_id`, `wait_type`, `wait_time` (ms), `cpu_time` (ms), `reads`, `writes`, `logical_reads`, `row_count`, and `open_transaction_count`.
 
 ### list_session_history
 

--- a/docs/guides/query-performance.md
+++ b/docs/guides/query-performance.md
@@ -67,7 +67,7 @@ fdw queries running
 fdw queries connections
 ```
 
-`queries running` (MCP [`list_running_queries`](../commands/queries.md#list_running_queries)) returns each in-flight query with its `session_id`, `start_time`, `total_elapsed_time`, `login_name`, and `query_text`: enough to spot a single session that is dominating the warehouse. `queries connections` (MCP [`list_connections`](../commands/queries.md#list_connections)) reads `sys.dm_exec_connections` and surfaces lower-level connection detail (including idle connections) that the running view omits.
+`queries running` (MCP [`list_running_queries`](../commands/queries.md#list_running_queries)) returns each in-flight query with its `session_id`, `start_time`, `total_elapsed_time`, `login_name`, and `dist_statement_id`: enough to spot a single session that is dominating the warehouse. Use `dist_statement_id` with `queries show` (MCP `get_request_detail`) after the query completes to retrieve the full query text and execution metrics. `queries connections` (MCP [`list_connections`](../commands/queries.md#list_connections)) reads `sys.dm_exec_connections` and surfaces lower-level connection detail (including idle connections) that the running view omits.
 
 If a live query is clearly runaway and you have Admin rights, jump straight to [Step 9 - Mitigate runaway queries](#step-9-mitigate-runaway-queries). Otherwise, move on to the history views to build a picture over time.
 

--- a/src/fabric_dw/cli/commands/queries.py
+++ b/src/fabric_dw/cli/commands/queries.py
@@ -171,6 +171,42 @@ async def locks_cmd(
 
 
 # ---------------------------------------------------------------------------
+# show
+# ---------------------------------------------------------------------------
+
+
+@queries_group.command("show")
+@click.argument("item", required=False, default=None)
+@click.argument("dist_statement_id")
+@click.pass_obj
+@coro
+async def show_cmd(ctx: CliContext, item: str | None, dist_statement_id: str) -> None:
+    """Look up a completed query by DIST_STATEMENT_ID from queryinsights.exec_requests_history."""
+    ws = resolve_workspace(ctx)
+    wh = resolve_warehouse_arg(ctx, item)
+    try:
+        async with build_http_client(ctx) as http:
+            target, _ = await build_sql_target(http, ws, wh)
+            result = await _qi_svc.get_request_detail(target, dist_statement_id, mode=ctx.auth)
+            if result is None:
+                if ctx.json_output:
+                    render(None, json_output=True)
+                else:
+                    click.echo(
+                        f"No request found with distributed_statement_id {dist_statement_id!r}."
+                    )
+                return
+            render(
+                result.model_dump(by_alias=True, mode="json"),
+                json_output=ctx.json_output,
+                table_title="Request Detail",
+                prune_null_columns=True,
+            )
+    except (ValueError, FabricError) as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+# ---------------------------------------------------------------------------
 # history
 # ---------------------------------------------------------------------------
 

--- a/src/fabric_dw/mcp/tools/queries.py
+++ b/src/fabric_dw/mcp/tools/queries.py
@@ -298,6 +298,50 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             raise ToolError("Listing locks failed due to a driver or network error.") from exc
         return [lock.model_dump(by_alias=True, mode="json") for lock in result]
 
+    @mcp.tool(name="get_request_detail")
+    async def get_request_detail(
+        workspace: str,
+        item: str,
+        dist_statement_id: str,
+    ) -> dict[str, Any] | None:
+        """Look up a completed query from queryinsights.exec_requests_history.
+
+        Uses distributed_statement_id to retrieve full query text and execution
+        metrics after the query completes.
+
+        Args:
+            workspace: Workspace name or GUID.
+            item: Warehouse or SQL Analytics Endpoint name or GUID.
+            dist_statement_id: The GUID identifying the distributed statement to look up.
+        """
+        ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
+        try:
+            ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
+            _log.debug(
+                "get_request_detail ws=%s item=%s dist_statement_id=%s",
+                ws_id,
+                entry.id,
+                dist_statement_id,
+            )
+            target = make_sql_target(ws_id, entry, item)
+            result = await _qi_svc.get_request_detail(target, dist_statement_id, mode=ctx.auth_mode)
+        except (ValueError, FabricError) as exc:
+            raise tool_err(exc) from exc
+        except Exception as exc:
+            if isinstance(exc, ToolError):
+                raise
+            _log.debug("get_request_detail: unhandled driver exception (suppressed)", exc_info=True)
+            raise ToolError(
+                "Request detail lookup failed due to a driver or network error."
+            ) from exc
+        if result is None:
+            return None
+        return result.model_dump(by_alias=True, mode="json")
+
     @mcp.tool(name="list_long_running_queries")
     async def list_long_running_queries(
         workspace: str,

--- a/src/fabric_dw/models.py
+++ b/src/fabric_dw/models.py
@@ -307,7 +307,6 @@ class RunningQuery(_FabricBase):
     total_elapsed_time_ms: int = Field(alias="total_elapsed_time")
     login_name: str | None = None
     command: str | None = None
-    query_text: str | None = None
     dist_statement_id: str | None = None
     blocking_session_id: int | None = None
     wait_type: str | None = None

--- a/src/fabric_dw/services/queries.py
+++ b/src/fabric_dw/services/queries.py
@@ -23,11 +23,9 @@ __all__ = [
 ]
 
 # NOTE: sys.dm_exec_sql_text is not supported on Fabric DW (Fabric Synapse
-# Analytics uses a different execution engine), so the OUTER APPLY for
-# query_text is omitted.  The query_text column is included in the SELECT as a
-# literal NULL so the RunningQuery model field is populated with None.
-# Use dist_statement_id to correlate with queryinsights.exec_requests_history
-# to look up the full query text for a specific request.
+# Analytics uses a different execution engine).  Use dist_statement_id to
+# correlate with queryinsights.exec_requests_history to look up the full query
+# text for a specific request (see query_insights.get_request_detail).
 #
 # The LEFT JOIN was changed to INNER JOIN: the feature intent is to return only
 # sessions that have an *active* request (status in running/runnable/suspended).
@@ -43,7 +41,6 @@ SELECT
     r.total_elapsed_time,
     s.login_name,
     r.command,
-    NULL AS query_text,
     r.dist_statement_id,
     NULLIF(r.blocking_session_id, 0) AS blocking_session_id,
     r.wait_type,

--- a/src/fabric_dw/services/query_insights.py
+++ b/src/fabric_dw/services/query_insights.py
@@ -40,6 +40,7 @@ __all__ = [
     "FREQUENTLY_RUN_QUERIES_COLUMNS",
     "LONG_RUNNING_QUERIES_COLUMNS",
     "SQL_POOL_INSIGHTS_COLUMNS",
+    "get_request_detail",
     "list_frequent_queries",
     "list_long_running_queries",
     "list_request_history",
@@ -481,6 +482,47 @@ async def list_long_running_queries(
         until=until,
         mode=mode,
     )
+
+
+# Stored as a named variable (not an inline f-string) to avoid bandit B608 / ruff S608.
+# The only substituted value is the column list, which is a trusted module-level constant.
+_GET_REQUEST_DETAIL_SQL = (
+    "SELECT TOP (1)\n    "
+    + ",\n    ".join(EXEC_REQUESTS_HISTORY_COLUMNS)
+    + "\nFROM queryinsights.exec_requests_history\nWHERE distributed_statement_id = ?;\n"
+)
+
+
+async def get_request_detail(
+    target: SqlTarget,
+    dist_statement_id: str,
+    *,
+    mode: CredentialMode = CredentialMode.DEFAULT,
+) -> ExecRequestHistory | None:
+    """Return a single completed request from ``queryinsights.exec_requests_history``.
+
+    Looks up the row whose ``distributed_statement_id`` matches *dist_statement_id*.
+    The ``dist_statement_id`` returned by the running-queries DMV can be used here
+    to retrieve the full query text and execution metrics after the query completes.
+
+    Args:
+        target: The warehouse or SQL analytics endpoint to query.
+        dist_statement_id: The GUID identifying the distributed statement to look up.
+        mode: The credential mode for Entra authentication.
+
+    Returns:
+        An :class:`~fabric_dw.models.ExecRequestHistory` instance if found, or
+        ``None`` if no matching row exists.
+
+    Raises:
+        PermissionDeniedError: If the caller lacks Contributor or above permission.
+    """
+    rows = await asyncio.to_thread(
+        _execute_sql, target, _GET_REQUEST_DETAIL_SQL, mode, [dist_statement_id]
+    )
+    if not rows:
+        return None
+    return ExecRequestHistory.model_validate(rows[0])
 
 
 async def list_sql_pool_insights(

--- a/src/fabric_dw/services/query_insights.py
+++ b/src/fabric_dw/services/query_insights.py
@@ -485,9 +485,10 @@ async def list_long_running_queries(
 
 
 # Stored as a named variable (not an inline f-string) to avoid bandit B608 / ruff S608.
-# The only substituted value is the column list, which is a trusted module-level constant.
+# The only substituted value is the column list, which is a trusted module-level constant;
+# the WHERE clause uses a ? parameter placeholder — no user input is embedded in the string.
 _GET_REQUEST_DETAIL_SQL = (
-    "SELECT TOP (1)\n    "
+    "SELECT TOP (1)\n    "  # nosec B608 -- columns from trusted constant; WHERE uses ?
     + ",\n    ".join(EXEC_REQUESTS_HISTORY_COLUMNS)
     + "\nFROM queryinsights.exec_requests_history\nWHERE distributed_statement_id = ?;\n"
 )

--- a/src/fabric_dw/telemetry_commands.py
+++ b/src/fabric_dw/telemetry_commands.py
@@ -119,6 +119,7 @@ DOMAIN_MAP: dict[str, str] = {
     "list_frequent_queries": "queries",
     "list_long_running_queries": "queries",
     "list_locks": "queries",
+    "get_request_detail": "queries",
     # SQL execution
     "execute_sql": "sql",
     "get_query_plan": "sql",

--- a/tests/unit/cli/commands/test_queries.py
+++ b/tests/unit/cli/commands/test_queries.py
@@ -520,6 +520,31 @@ class TestQueriesShow:
         assert result.exit_code == 0
         assert "No request found" in result.output
 
+    def test_show_json_output_when_not_found(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.queries.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.queries.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.query_insights.get_request_detail",
+                new=AsyncMock(return_value=None),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                ["--json", "-w", WS_GUID, "queries", "show", WH_GUID, "nonexistent-id"],
+            )
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed is None
+
     def test_show_fabric_error_exits_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
         _ = cache_env
         mock_http = AsyncMock()

--- a/tests/unit/cli/commands/test_queries.py
+++ b/tests/unit/cli/commands/test_queries.py
@@ -16,7 +16,7 @@ from click.testing import CliRunner
 from fabric_dw.cache import ItemEntry
 from fabric_dw.cli._main import cli
 from fabric_dw.exceptions import FabricError, NotFoundError, PermissionDeniedError
-from fabric_dw.models import QueryLock, RunningQuery, WarehouseKind
+from fabric_dw.models import ExecRequestHistory, QueryLock, RunningQuery, WarehouseKind
 from fabric_dw.sql import SqlTarget
 
 WS_GUID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
@@ -63,7 +63,18 @@ def _make_running_query() -> RunningQuery:
             "total_elapsed_time": 5000,
             "login_name": "user@example.com",
             "command": "SELECT",
-            "query_text": None,
+        }
+    )
+
+
+def _make_exec_request_history() -> ExecRequestHistory:
+    return ExecRequestHistory.model_validate(
+        {
+            "distributed_statement_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            "database_name": "SalesWarehouse",
+            "status": "Succeeded",
+            "session_id": 42,
+            "command": "SELECT TOP 10 * FROM dbo.sales",
         }
     )
 
@@ -429,6 +440,103 @@ class TestQueriesLongRunning:
             ),
         ):
             result = runner.invoke(cli, ["-w", WS_GUID, "queries", "long-running", WH_GUID])
+        assert result.exit_code != 0
+
+
+class TestQueriesShow:
+    """queries show -- happy path, not-found, and FabricError."""
+
+    def test_show_exits_zero_when_found(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.queries.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.queries.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.query_insights.get_request_detail",
+                new=AsyncMock(return_value=_make_exec_request_history()),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                ["-w", WS_GUID, "queries", "show", WH_GUID, "a1b2c3d4-e5f6-7890-abcd-ef1234567890"],
+            )
+        assert result.exit_code == 0
+
+    def test_show_json_output_when_found(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.queries.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.queries.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.query_insights.get_request_detail",
+                new=AsyncMock(return_value=_make_exec_request_history()),
+            ),
+        ):
+            dist_id = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+            result = runner.invoke(
+                cli,
+                ["--json", "-w", WS_GUID, "queries", "show", WH_GUID, dist_id],
+            )
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert isinstance(parsed, dict)
+        assert parsed["status"] == "Succeeded"
+
+    def test_show_exits_zero_when_not_found(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.queries.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.queries.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.query_insights.get_request_detail",
+                new=AsyncMock(return_value=None),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                ["-w", WS_GUID, "queries", "show", WH_GUID, "nonexistent-id"],
+            )
+        assert result.exit_code == 0
+        assert "No request found" in result.output
+
+    def test_show_fabric_error_exits_nonzero(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.queries.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.queries.build_sql_target",
+                new=AsyncMock(side_effect=FabricError("server error")),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                ["-w", WS_GUID, "queries", "show", WH_GUID, "some-id"],
+            )
         assert result.exit_code != 0
 
 

--- a/tests/unit/mcp/test_server.py
+++ b/tests/unit/mcp/test_server.py
@@ -179,7 +179,6 @@ def _make_running_query() -> RunningQuery:
             "total_elapsed_time": 1000,
             "login_name": "user@example.com",
             "command": "SELECT 1",
-            "query_text": None,
         }
     )
 

--- a/tests/unit/mcp/tools/test_queries.py
+++ b/tests/unit/mcp/tools/test_queries.py
@@ -26,7 +26,7 @@ from uuid import UUID
 
 import pytest
 
-from fabric_dw.exceptions import FabricError
+from fabric_dw.exceptions import FabricError, PermissionDeniedError
 from fabric_dw.models import (
     Connection,
     ExecRequestHistory,
@@ -64,7 +64,6 @@ def _make_running_query() -> RunningQuery:
             "total_elapsed_time": 1000,
             "login_name": "user@example.com",
             "command": "SELECT 1",
-            "query_text": None,
         }
     )
 
@@ -1264,6 +1263,166 @@ async def test_list_locks_raw_driver_exc_raises_tool_error(mock_ctx, ctx_patch) 
         await mcp._tool_manager.call_tool(
             "list_locks",
             {"workspace": _WS_NAME, "item": _WH_NAME},
+        )
+
+    assert _FakeDriverError._INTERNAL_DETAIL not in str(exc_info.value), (
+        "raw driver exception detail must not appear in the ToolError message"
+    )
+
+
+# ---------------------------------------------------------------------------
+# get_request_detail
+# ---------------------------------------------------------------------------
+
+_DIST_STMT_ID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+
+
+def _make_exec_request_history_for_mcp() -> ExecRequestHistory:
+    return ExecRequestHistory.model_validate(
+        {
+            "distributed_statement_id": _DIST_STMT_ID,
+            "database_name": "SalesWarehouse",
+            "status": "Succeeded",
+            "session_id": 42,
+            "command": "SELECT TOP 10 * FROM dbo.sales",
+        }
+    )
+
+
+async def test_get_request_detail_happy_path_found(mock_ctx, ctx_patch) -> None:
+    """get_request_detail returns serialised dict when found."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    hist = _make_exec_request_history_for_mcp()
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.query_insights.get_request_detail",
+            new=AsyncMock(return_value=hist),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "get_request_detail",
+            {"workspace": _WS_NAME, "item": _WH_NAME, "dist_statement_id": _DIST_STMT_ID},
+        )
+
+    assert isinstance(result, dict)
+    assert result["status"] == "Succeeded"
+    assert result["database_name"] == "SalesWarehouse"
+
+
+async def test_get_request_detail_happy_path_not_found(mock_ctx, ctx_patch) -> None:
+    """get_request_detail returns None when no matching row exists."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.query_insights.get_request_detail",
+            new=AsyncMock(return_value=None),
+        ),
+    ):
+        result = await mcp._tool_manager.call_tool(
+            "get_request_detail",
+            {"workspace": _WS_NAME, "item": _WH_NAME, "dist_statement_id": "nonexistent-id"},
+        )
+
+    assert result is None
+
+
+async def test_get_request_detail_fabric_error(mock_ctx, ctx_patch) -> None:
+    """get_request_detail wraps FabricError as ToolError."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.query_insights.get_request_detail",
+            new=AsyncMock(side_effect=FabricError("sql error")),
+        ),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "get_request_detail",
+            {"workspace": _WS_NAME, "item": _WH_NAME, "dist_statement_id": _DIST_STMT_ID},
+        )
+
+
+async def test_get_request_detail_permission_denied(mock_ctx, ctx_patch) -> None:
+    """get_request_detail wraps PermissionDeniedError as ToolError."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    item = make_item_entry()
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=item)
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.query_insights.get_request_detail",
+            new=AsyncMock(side_effect=PermissionDeniedError("no permission")),
+        ),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "get_request_detail",
+            {"workspace": _WS_NAME, "item": _WH_NAME, "dist_statement_id": _DIST_STMT_ID},
+        )
+
+
+async def test_get_request_detail_workspace_not_allowed(ctx_patch) -> None:
+    """get_request_detail raises ToolError when workspace not in allowlist."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_WORKSPACES": "other-ws"}),
+        pytest.raises(ToolError),
+    ):
+        await mcp._tool_manager.call_tool(
+            "get_request_detail",
+            {"workspace": _WS_NAME, "item": _WH_NAME, "dist_statement_id": _DIST_STMT_ID},
+        )
+
+
+async def test_get_request_detail_raw_driver_exc_raises_tool_error(mock_ctx, ctx_patch) -> None:
+    """A raw driver exception is converted to ToolError without leaking internal details."""
+    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=_WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.query_insights.get_request_detail",
+            new=AsyncMock(side_effect=_RAW_DRIVER_EXC),
+        ),
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await mcp._tool_manager.call_tool(
+            "get_request_detail",
+            {"workspace": _WS_NAME, "item": _WH_NAME, "dist_statement_id": _DIST_STMT_ID},
         )
 
     assert _FakeDriverError._INTERNAL_DETAIL not in str(exc_info.value), (

--- a/tests/unit/services/test_queries.py
+++ b/tests/unit/services/test_queries.py
@@ -26,7 +26,6 @@ _COLS = [
     "total_elapsed_time",
     "login_name",
     "command",
-    "query_text",
     "dist_statement_id",
     "blocking_session_id",
     "wait_type",
@@ -47,7 +46,6 @@ _ROW_1_TUPLE = (
     1500,
     "user@example.com",
     "SELECT",
-    None,
     "A1B2C3D4-1234-5678-ABCD-EF0123456789",
     None,
     None,
@@ -68,7 +66,6 @@ _ROW_2_TUPLE = (
     3000,
     "admin@example.com",
     "UPDATE",
-    None,
     "B2C3D4E5-2345-6789-BCDE-F01234567890",
     42,
     "LCK_M_S",
@@ -123,7 +120,6 @@ async def test_list_running_parses_fields_correctly() -> None:
     assert q.total_elapsed_time_ms == 1500
     assert q.login_name == "user@example.com"
     assert q.command == "SELECT"
-    assert q.query_text is None
     assert q.dist_statement_id == "A1B2C3D4-1234-5678-ABCD-EF0123456789"
     assert q.blocking_session_id is None
     assert q.wait_type is None
@@ -134,16 +130,6 @@ async def test_list_running_parses_fields_correctly() -> None:
     assert q.logical_reads == 1000
     assert q.row_count == 50
     assert q.open_transaction_count == 0
-
-
-async def test_list_running_handles_null_query_text() -> None:
-    target = _make_target()
-    conn = _make_conn([_ROW_2_TUPLE], _COLS)
-
-    with patch("fabric_dw.sql.open_connection", return_value=conn):
-        result = await queries.list_running(target)
-
-    assert result[0].query_text is None
 
 
 async def test_list_running_parses_blocking_and_wait_fields() -> None:

--- a/tests/unit/services/test_query_insights.py
+++ b/tests/unit/services/test_query_insights.py
@@ -22,6 +22,7 @@ from fabric_dw.services.query_insights import (
     FREQUENTLY_RUN_QUERIES_COLUMNS,
     LONG_RUNNING_QUERIES_COLUMNS,
     SQL_POOL_INSIGHTS_COLUMNS,
+    get_request_detail,
 )
 from tests.unit.services._helpers import _FakeRow, _make_conn, _make_target
 
@@ -838,6 +839,84 @@ async def test_list_request_history_both_bounds_passed_as_params() -> None:
 # Regression: Row→tuple normalisation (#719)
 # ---------------------------------------------------------------------------
 # _FakeRow is imported from tests.unit.services._helpers (shared definition).
+
+
+# ---------------------------------------------------------------------------
+# get_request_detail
+# ---------------------------------------------------------------------------
+
+_DIST_STMT_ID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+
+
+async def test_get_request_detail_returns_model_when_found() -> None:
+    target = _make_target()
+    conn = _make_conn([_REQ_HIST_ROW], _REQ_HIST_COLS)
+    with patch("fabric_dw.sql.open_connection", return_value=conn):
+        result = await get_request_detail(target, _DIST_STMT_ID)
+    assert isinstance(result, ExecRequestHistory)
+    assert result.database_name == "MyWarehouse"
+    assert result.status == "Succeeded"
+
+
+async def test_get_request_detail_returns_none_when_not_found() -> None:
+    target = _make_target()
+    conn = _make_conn([], _REQ_HIST_COLS)
+    with patch("fabric_dw.sql.open_connection", return_value=conn):
+        result = await get_request_detail(target, _DIST_STMT_ID)
+    assert result is None
+
+
+async def test_get_request_detail_sql_references_exec_requests_history() -> None:
+    target = _make_target()
+    conn = _make_conn([], _REQ_HIST_COLS)
+    with patch("fabric_dw.sql.open_connection", return_value=conn):
+        await get_request_detail(target, _DIST_STMT_ID)
+    cursor = conn.cursor.return_value
+    call_sql: str = cursor.execute.call_args[0][0]
+    assert "queryinsights.exec_requests_history" in call_sql
+
+
+async def test_get_request_detail_sql_uses_where_clause() -> None:
+    target = _make_target()
+    conn = _make_conn([], _REQ_HIST_COLS)
+    with patch("fabric_dw.sql.open_connection", return_value=conn):
+        await get_request_detail(target, _DIST_STMT_ID)
+    cursor = conn.cursor.return_value
+    call_sql: str = cursor.execute.call_args[0][0]
+    assert "WHERE distributed_statement_id = ?" in call_sql
+
+
+async def test_get_request_detail_passes_id_as_param() -> None:
+    target = _make_target()
+    conn = _make_conn([], _REQ_HIST_COLS)
+    with patch("fabric_dw.sql.open_connection", return_value=conn):
+        await get_request_detail(target, _DIST_STMT_ID)
+    cursor = conn.cursor.return_value
+    call_params = cursor.execute.call_args[0][1]
+    assert _DIST_STMT_ID in call_params
+
+
+async def test_get_request_detail_maps_permission_denied() -> None:
+    target = _make_target()
+    conn = MagicMock()
+    cursor = MagicMock()
+    cursor.execute.side_effect = Exception("permission was denied on object X")
+    conn.cursor.return_value = cursor
+    with (
+        patch("fabric_dw.sql.open_connection", return_value=conn),
+        pytest.raises(PermissionDeniedError),
+    ):
+        await get_request_detail(target, _DIST_STMT_ID)
+
+
+async def test_get_request_detail_sql_uses_top_1() -> None:
+    target = _make_target()
+    conn = _make_conn([], _REQ_HIST_COLS)
+    with patch("fabric_dw.sql.open_connection", return_value=conn):
+        await get_request_detail(target, _DIST_STMT_ID)
+    cursor = conn.cursor.return_value
+    call_sql: str = cursor.execute.call_args[0][0]
+    assert "TOP (1)" in call_sql
 
 
 async def test_execute_sql_row_objects_produce_correct_dicts() -> None:

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -255,7 +255,6 @@ class TestRunningQuery:
             "total_elapsed_time": 5432,
             "login_name": "user@example.com",
             "command": "SELECT",
-            "query_text": "SELECT * FROM sales.orders",
         }
         obj = RunningQuery.model_validate(payload)
         dumped = obj.model_dump(by_alias=True, mode="json", exclude_none=True)
@@ -270,12 +269,10 @@ class TestRunningQuery:
             "total_elapsed_time": 100,
             "login_name": None,
             "command": None,
-            "query_text": None,
         }
         obj = RunningQuery.model_validate(payload)
         assert obj.login_name is None
         assert obj.command is None
-        assert obj.query_text is None
 
     def test_extra_fields_ignored(self) -> None:
         payload = {
@@ -286,7 +283,6 @@ class TestRunningQuery:
             "total_elapsed_time": 200,
             "login_name": "admin",
             "command": "SELECT",
-            "query_text": "SELECT 1",
             "unknownColumn": "noise",
         }
         obj = RunningQuery.model_validate(payload)
@@ -301,7 +297,6 @@ class TestRunningQuery:
             "total_elapsed_time": 200,
             "login_name": None,
             "command": None,
-            "query_text": None,
         }
         obj = RunningQuery.model_validate(payload)
         with pytest.raises(ValidationError):


### PR DESCRIPTION
## Summary

- Remove `query_text` from `RunningQuery` model and SQL (`sys.dm_exec_sql_text` is not supported on Fabric DW, so the field was always null and provided no value)
- Add `queries show <dist_statement_id>` CLI command to look up full query details from `queryinsights.exec_requests_history`
- Add `get_request_detail` MCP tool for the same lookup
- Add `get_request_detail` service function in the query_insights module
- Add `get_request_detail` to `DOMAIN_MAP` in `telemetry_commands.py`

The `dist_statement_id` returned by `queries running` can now be used with `queries show` to get the full query text and execution details.

Closes #1009

## Test plan

- [ ] Unit tests pass for new service function, CLI command, and MCP tool
- [ ] Lint and format checks pass
- [ ] Manual test: `fdw queries running` no longer shows query_text column
- [ ] Manual test: `fdw queries show <dist_statement_id>` returns query details
- [ ] Manual test: `fdw queries show <nonexistent-id>` shows "No request found" message

🤖 Generated with [Claude Code](https://claude.com/claude-code)