### PR TITLE
fix(tests): strip benign IMDS timeout tracebacks from stderr checks

### DIFF
--- a/tests/_stderr_helpers.py
+++ b/tests/_stderr_helpers.py
@@ -1,0 +1,27 @@
+"""Shared stderr sanitization utilities used by both unit and integration tests."""
+
+from __future__ import annotations
+
+import re
+
+# Matches the benign Azure Identity IMDS timeout block that appears when
+# the Instance Metadata Service endpoint is unreachable (e.g. outside Azure).
+# The trailing newline is optional because the block may be the last content
+# in stderr without a final newline.
+_IMDS_BLOCK_RE = re.compile(
+    r"Failed to receive Azure VM metadata: timed out\n"
+    r"Traceback \(most recent call last\):.*?TimeoutError: timed out\n?",
+    re.DOTALL,
+)
+
+
+def sanitize_stderr(stderr: str) -> str:
+    """Strip known-benign Azure Identity IMDS timeout tracebacks from stderr.
+
+    When the Azure Identity library probes the Instance Metadata Service (IMDS)
+    and the endpoint is unreachable (e.g. outside Azure), it logs a Python
+    traceback to stderr. This is harmless but causes the forbidden-pattern check
+    for 'Traceback (most recent call last)' to fire. Strip these blocks so that
+    real unexpected tracebacks are still caught.
+    """
+    return _IMDS_BLOCK_RE.sub("", stderr)

--- a/tests/integration/test_cli_smoke.py
+++ b/tests/integration/test_cli_smoke.py
@@ -36,6 +36,7 @@ import json
 import logging
 import math
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -91,6 +92,29 @@ _STDERR_FORBIDDEN = (
     "Error getting processor time",
     "_get_processor_time",
 )
+
+# ---------------------------------------------------------------------------
+# Benign Azure Identity IMDS noise stripping.
+# ---------------------------------------------------------------------------
+
+_IMDS_BLOCK_RE = re.compile(
+    r"Failed to receive Azure VM metadata: timed out\n"
+    r"Traceback \(most recent call last\):.*?TimeoutError: timed out\n",
+    re.DOTALL,
+)
+
+
+def _sanitize_stderr(stderr: str) -> str:
+    """Strip known-benign Azure Identity IMDS timeout tracebacks from stderr.
+
+    When the Azure Identity library probes the Instance Metadata Service (IMDS)
+    and the endpoint is unreachable (e.g. outside Azure), it logs a Python
+    traceback to stderr. This is harmless but causes the forbidden-pattern check
+    for 'Traceback (most recent call last)' to fire. Strip these blocks so that
+    real unexpected tracebacks are still caught.
+    """
+    return _IMDS_BLOCK_RE.sub("", stderr)
+
 
 # ---------------------------------------------------------------------------
 # Binary resolution — deferred so a missing binary skips tests, not errors.
@@ -332,8 +356,9 @@ def test_help_exits_zero_and_clean_stderr() -> None:
     result = _run("--help")
     assert result.returncode == 0, f"--help exited {result.returncode}; stderr:\n{result.stderr}"
     assert result.stdout.strip(), "--help produced no output"
+    sanitized = _sanitize_stderr(result.stderr)
     for forbidden in _STDERR_FORBIDDEN:
-        assert forbidden not in result.stderr, (
+        assert forbidden not in sanitized, (
             f"'--help' stderr contains forbidden pattern {forbidden!r}:\n{result.stderr}"
         )
 
@@ -350,8 +375,9 @@ def test_workspaces_list_clean_stderr_and_nonempty_stdout() -> None:
         f"workspaces list exited {result.returncode}; stderr:\n{result.stderr}"
     )
     assert result.stdout.strip(), "workspaces list produced no output"
+    sanitized = _sanitize_stderr(result.stderr)
     for forbidden in _STDERR_FORBIDDEN:
-        assert forbidden not in result.stderr, (
+        assert forbidden not in sanitized, (
             f"'workspaces list' stderr contains forbidden pattern {forbidden!r}:\n{result.stderr}"
         )
 
@@ -373,8 +399,9 @@ def test_workspaces_get_json_valid(
     parsed = json.loads(stdout)
     assert isinstance(parsed, dict), f"expected a JSON object, got: {type(parsed)}"
     assert "id" in parsed, f"expected 'id' key in workspace JSON; got keys: {list(parsed)}"
+    sanitized = _sanitize_stderr(result.stderr)
     for forbidden in _STDERR_FORBIDDEN:
-        assert forbidden not in result.stderr, (
+        assert forbidden not in sanitized, (
             f"'workspaces get --json' stderr contains forbidden pattern "
             f"{forbidden!r}:\n{result.stderr}"
         )
@@ -410,7 +437,8 @@ def test_sql_exec_select1_clean_stderr(
         f"sql exec exited {result.returncode}; stderr:\n{result.stderr}\nstdout:\n{result.stdout}"
     )
     assert result.stdout.strip(), "sql exec produced no output"
+    sanitized = _sanitize_stderr(result.stderr)
     for forbidden in _STDERR_FORBIDDEN:
-        assert forbidden not in result.stderr, (
+        assert forbidden not in sanitized, (
             f"'sql exec' stderr contains forbidden pattern {forbidden!r}:\n{result.stderr}"
         )

--- a/tests/integration/test_cli_smoke.py
+++ b/tests/integration/test_cli_smoke.py
@@ -36,7 +36,6 @@ import json
 import logging
 import math
 import os
-import re
 import shutil
 import subprocess
 import sys
@@ -46,6 +45,7 @@ import pytest
 import pytest_asyncio
 
 from fabric_dw.sql import _resolve_sql_retry_deadline_s
+from tests._stderr_helpers import sanitize_stderr as _sanitize_stderr
 
 from .conftest import SharedWarehouseTarget
 
@@ -92,29 +92,6 @@ _STDERR_FORBIDDEN = (
     "Error getting processor time",
     "_get_processor_time",
 )
-
-# ---------------------------------------------------------------------------
-# Benign Azure Identity IMDS noise stripping.
-# ---------------------------------------------------------------------------
-
-_IMDS_BLOCK_RE = re.compile(
-    r"Failed to receive Azure VM metadata: timed out\n"
-    r"Traceback \(most recent call last\):.*?TimeoutError: timed out\n",
-    re.DOTALL,
-)
-
-
-def _sanitize_stderr(stderr: str) -> str:
-    """Strip known-benign Azure Identity IMDS timeout tracebacks from stderr.
-
-    When the Azure Identity library probes the Instance Metadata Service (IMDS)
-    and the endpoint is unreachable (e.g. outside Azure), it logs a Python
-    traceback to stderr. This is harmless but causes the forbidden-pattern check
-    for 'Traceback (most recent call last)' to fire. Strip these blocks so that
-    real unexpected tracebacks are still caught.
-    """
-    return _IMDS_BLOCK_RE.sub("", stderr)
-
 
 # ---------------------------------------------------------------------------
 # Binary resolution — deferred so a missing binary skips tests, not errors.

--- a/tests/integration/test_journey_config_defaults.py
+++ b/tests/integration/test_journey_config_defaults.py
@@ -42,13 +42,13 @@ import uuid
 import pytest
 
 from fabric_dw.services import schemas as _schemas_svc
+from tests._stderr_helpers import sanitize_stderr as _sanitize_stderr
 
 from .conftest import SharedWarehouseTarget
 from .test_cli_smoke import (
     _SQL_SMOKE_SUBPROCESS_TIMEOUT_S,
     _STDERR_FORBIDDEN,
     _child_env,
-    _sanitize_stderr,
 )
 
 _logger = logging.getLogger(__name__)

--- a/tests/integration/test_journey_config_defaults.py
+++ b/tests/integration/test_journey_config_defaults.py
@@ -48,6 +48,7 @@ from .test_cli_smoke import (
     _SQL_SMOKE_SUBPROCESS_TIMEOUT_S,
     _STDERR_FORBIDDEN,
     _child_env,
+    _sanitize_stderr,
 )
 
 _logger = logging.getLogger(__name__)
@@ -116,8 +117,9 @@ def _step(
             f"journey step {list(args)!r} exited {result.returncode}.\n"
             f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
         )
+    sanitized = _sanitize_stderr(result.stderr)
     for forbidden in _STDERR_FORBIDDEN:
-        if forbidden in result.stderr:
+        if forbidden in sanitized:
             pytest.fail(
                 f"journey step {list(args)!r} stderr contains forbidden pattern "
                 f"{forbidden!r}:\n{result.stderr}"

--- a/tests/unit/test_sanitize_stderr.py
+++ b/tests/unit/test_sanitize_stderr.py
@@ -1,0 +1,43 @@
+"""Unit tests for the _sanitize_stderr() helper in test_cli_smoke."""
+
+from __future__ import annotations
+
+from tests.integration.test_cli_smoke import _sanitize_stderr
+
+_IMDS_BLOCK = (
+    "Failed to receive Azure VM metadata: timed out\n"
+    "Traceback (most recent call last):\n"
+    '  File "/path/to/azure/identity/_credentials/imds.py", line 42, in get_token\n'
+    "    response = await self._client.get(request)\n"
+    "TimeoutError: timed out\n"
+)
+
+_REAL_TRACEBACK = (
+    "Traceback (most recent call last):\n"
+    '  File "some_module.py", line 10, in do_thing\n'
+    "    raise RuntimeError('boom')\n"
+    "RuntimeError: boom\n"
+)
+
+
+def test_empty_string_returns_empty() -> None:
+    assert _sanitize_stderr("") == ""
+
+
+def test_imds_block_only_returns_empty() -> None:
+    result = _sanitize_stderr(_IMDS_BLOCK)
+    assert "Traceback" not in result
+    assert "TimeoutError" not in result
+
+
+def test_imds_block_with_real_traceback_preserves_real_traceback() -> None:
+    combined = _IMDS_BLOCK + _REAL_TRACEBACK
+    result = _sanitize_stderr(combined)
+    assert "RuntimeError: boom" in result
+    assert "Traceback (most recent call last):" in result
+    assert "Failed to receive Azure VM metadata" not in result
+
+
+def test_no_imds_block_returns_unchanged() -> None:
+    stderr = "Some warning: something happened\nAnother line\n"
+    assert _sanitize_stderr(stderr) == stderr

--- a/tests/unit/test_sanitize_stderr.py
+++ b/tests/unit/test_sanitize_stderr.py
@@ -1,8 +1,8 @@
-"""Unit tests for the _sanitize_stderr() helper in test_cli_smoke."""
+"""Unit tests for the sanitize_stderr() helper in tests._stderr_helpers."""
 
 from __future__ import annotations
 
-from tests.integration.test_cli_smoke import _sanitize_stderr
+from tests._stderr_helpers import sanitize_stderr
 
 _IMDS_BLOCK = (
     "Failed to receive Azure VM metadata: timed out\n"
@@ -11,6 +11,8 @@ _IMDS_BLOCK = (
     "    response = await self._client.get(request)\n"
     "TimeoutError: timed out\n"
 )
+
+_IMDS_BLOCK_NO_TRAILING_NEWLINE = _IMDS_BLOCK.rstrip("\n")
 
 _REAL_TRACEBACK = (
     "Traceback (most recent call last):\n"
@@ -21,18 +23,24 @@ _REAL_TRACEBACK = (
 
 
 def test_empty_string_returns_empty() -> None:
-    assert _sanitize_stderr("") == ""
+    assert sanitize_stderr("") == ""
 
 
 def test_imds_block_only_returns_empty() -> None:
-    result = _sanitize_stderr(_IMDS_BLOCK)
+    result = sanitize_stderr(_IMDS_BLOCK)
+    assert "Traceback" not in result
+    assert "TimeoutError" not in result
+
+
+def test_imds_block_without_trailing_newline_is_stripped() -> None:
+    result = sanitize_stderr(_IMDS_BLOCK_NO_TRAILING_NEWLINE)
     assert "Traceback" not in result
     assert "TimeoutError" not in result
 
 
 def test_imds_block_with_real_traceback_preserves_real_traceback() -> None:
     combined = _IMDS_BLOCK + _REAL_TRACEBACK
-    result = _sanitize_stderr(combined)
+    result = sanitize_stderr(combined)
     assert "RuntimeError: boom" in result
     assert "Traceback (most recent call last):" in result
     assert "Failed to receive Azure VM metadata" not in result
@@ -40,4 +48,4 @@ def test_imds_block_with_real_traceback_preserves_real_traceback() -> None:
 
 def test_no_imds_block_returns_unchanged() -> None:
     stderr = "Some warning: something happened\nAnother line\n"
-    assert _sanitize_stderr(stderr) == stderr
+    assert sanitize_stderr(stderr) == stderr

--- a/tests/unit/test_shutdown_clean.py
+++ b/tests/unit/test_shutdown_clean.py
@@ -44,6 +44,8 @@ import sys
 
 import pytest
 
+from tests._stderr_helpers import sanitize_stderr as _sanitize_stderr
+
 # ---------------------------------------------------------------------------
 # Subprocess helpers
 # ---------------------------------------------------------------------------
@@ -147,10 +149,10 @@ def test_cli_exits_without_shutdown_noise_on_help() -> None:
         check=False,
     )
 
-    stderr = result.stderr
+    stderr = _sanitize_stderr(result.stderr)
     for forbidden in _FORBIDDEN_STDERR_SUBSTRINGS:
         assert forbidden not in stderr, (
-            f"Forbidden string {forbidden!r} found in stderr.\nFull stderr:\n{stderr}"
+            f"Forbidden string {forbidden!r} found in stderr.\nFull stderr:\n{result.stderr}"
         )
 
 
@@ -183,8 +185,8 @@ def test_cli_exits_without_shutdown_noise_on_auth_command() -> None:
         check=False,
     )
 
-    stderr = result.stderr
+    stderr = _sanitize_stderr(result.stderr)
     for forbidden in _FORBIDDEN_STDERR_SUBSTRINGS:
         assert forbidden not in stderr, (
-            f"Forbidden string {forbidden!r} found in stderr.\nFull stderr:\n{stderr}"
+            f"Forbidden string {forbidden!r} found in stderr.\nFull stderr:\n{result.stderr}"
         )


### PR DESCRIPTION
## Summary

- Add `_sanitize_stderr()` to `test_cli_smoke.py` that strips Azure Identity IMDS timeout tracebacks using `re.sub` with `re.DOTALL`
- Apply `_sanitize_stderr()` before all 4 forbidden-pattern checks in `test_cli_smoke.py` and the `_step()` check in `test_journey_config_defaults.py`
- Add 4 unit tests in `tests/unit/test_sanitize_stderr.py` covering: empty string, IMDS-only, IMDS + real traceback (real one preserved), and no-IMDS cases
- Export `_sanitize_stderr` from `test_cli_smoke` for use in `test_journey_config_defaults`

## Test plan

- [ ] `uv run pytest tests/unit/test_sanitize_stderr.py -x -q` passes (4/4 locally)
- [ ] `uv run ruff check` passes
- [ ] `uv run ruff format --check` passes
- [ ] Integration test `test_config_defaults_journey` no longer flakes when Azure Identity logs an IMDS timeout traceback

Closes #1011

🤖 Generated with [Claude Code](https://claude.com/claude-code)