### PR TITLE
feat: add live query watch mode

### DIFF
--- a/docs/commands/queries.md
+++ b/docs/commands/queries.md
@@ -19,8 +19,12 @@ List all active SQL connections on a warehouse or SQL Analytics Endpoint. This q
 **Synopsis**
 
 ```
-fdw [-w WORKSPACE] queries connections [WAREHOUSE]
+fdw [-w WORKSPACE] queries connections [OPTIONS] [WAREHOUSE]
 ```
+
+| Option | Description |
+| --- | --- |
+| `--watch SECONDS` | Refresh the live view every positive number of seconds. Cannot be combined with `--json`. |
 
 **Example**
 
@@ -127,6 +131,7 @@ fdw [-w WORKSPACE] queries locks [OPTIONS] [ITEM]
 | `--waiting-only` | Only show locks with `request_status` in `WAIT` or `CONVERT` (includes lock-upgrade waits). | off |
 | `--blocked-only` | Only show sessions blocked by another session (victims). The blocker's ID appears in `blocking_session_id`. | off |
 | `--include-database` | Include DATABASE-scoped lock rows. | off |
+| `--watch SECONDS` | Refresh the live view every positive number of seconds. Cannot be combined with `--json`. | - |
 
 **Example**
 
@@ -173,8 +178,12 @@ List all currently running queries on a warehouse or SQL Analytics Endpoint. Que
 **Synopsis**
 
 ```
-fdw [-w WORKSPACE] queries running [WAREHOUSE]
+fdw [-w WORKSPACE] queries running [OPTIONS] [WAREHOUSE]
 ```
+
+| Option | Description |
+| --- | --- |
+| `--watch SECONDS` | Refresh the live view every positive number of seconds. Cannot be combined with `--json`. |
 
 **Example**
 

--- a/src/fabric_dw/cli/commands/queries.py
+++ b/src/fabric_dw/cli/commands/queries.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
+from collections.abc import Awaitable, Callable, Sequence
+from datetime import UTC, datetime
+from typing import Any, Protocol
+
 import click
 
 from fabric_dw.cli._context import CliContext
@@ -25,6 +30,43 @@ from fabric_dw.services import queries as _queries_svc
 from fabric_dw.services import query_insights as _qi_svc
 
 
+class _JsonModel(Protocol):
+    def model_dump(self, *, by_alias: bool, mode: str) -> dict[str, Any]: ...
+
+
+def _validate_watch(ctx: CliContext, watch: int | None) -> None:
+    """Reject streaming JSON before opening a network client."""
+    if watch is not None and ctx.json_output:
+        raise click.UsageError("--watch cannot be used with --json.")
+
+
+async def _watch_render(
+    *,
+    interval: int | None,
+    command: str,
+    title: str,
+    json_output: bool,
+    fetch: Callable[[], Awaitable[Sequence[_JsonModel]]],
+) -> None:
+    """Render once or continuously, in the familiar terminal-watch style."""
+    while True:
+        items = await fetch()
+        if interval is not None:
+            click.clear()
+            timestamp = datetime.now(UTC).astimezone().strftime("%Y-%m-%d %H:%M:%S %Z")
+            click.echo(f"Every {interval}s: {command}    {timestamp}")
+            click.echo()
+        render(
+            [item.model_dump(by_alias=True, mode="json") for item in items],
+            json_output=json_output,
+            table_title=title,
+            prune_null_columns=True,
+        )
+        if interval is None:
+            return
+        await asyncio.sleep(interval)
+
+
 @click.group("queries")
 def queries_group() -> None:
     """Inspect and manage running queries on Fabric warehouses and SQL Analytics Endpoints."""
@@ -32,21 +74,25 @@ def queries_group() -> None:
 
 @queries_group.command("running")
 @click.argument("item", required=False, default=None)
+@click.option(
+    "--watch", type=click.IntRange(min=1), metavar="SECONDS", help="Refresh every SECONDS."
+)
 @click.pass_obj
 @coro
-async def running_cmd(ctx: CliContext, item: str | None) -> None:
+async def running_cmd(ctx: CliContext, item: str | None, watch: int | None) -> None:
     """List currently running queries on ITEM (warehouse or endpoint)."""
+    _validate_watch(ctx, watch)
     ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     try:
         async with build_http_client(ctx) as http:
             target, _entry = await build_sql_target(http, ws, wh)
-            items = await _queries_svc.list_running(target, mode=ctx.auth)
-            render(
-                [q.model_dump(by_alias=True, mode="json") for q in items],
+            await _watch_render(
+                interval=watch,
+                command="fdw queries running",
+                title="Running Queries",
                 json_output=ctx.json_output,
-                table_title="Running Queries",
-                prune_null_columns=True,
+                fetch=lambda: _queries_svc.list_running(target, mode=ctx.auth),
             )
     except (ValueError, FabricError) as exc:
         raise click.ClickException(str(exc)) from exc
@@ -54,21 +100,25 @@ async def running_cmd(ctx: CliContext, item: str | None) -> None:
 
 @queries_group.command("connections")
 @click.argument("item", required=False, default=None)
+@click.option(
+    "--watch", type=click.IntRange(min=1), metavar="SECONDS", help="Refresh every SECONDS."
+)
 @click.pass_obj
 @coro
-async def connections_cmd(ctx: CliContext, item: str | None) -> None:
+async def connections_cmd(ctx: CliContext, item: str | None, watch: int | None) -> None:
     """List active SQL connections on ITEM (warehouse or endpoint)."""
+    _validate_watch(ctx, watch)
     ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     try:
         async with build_http_client(ctx) as http:
             target, _entry = await build_sql_target(http, ws, wh)
-            items = await _queries_svc.list_connections(target, mode=ctx.auth)
-            render(
-                [c.model_dump(by_alias=True, mode="json") for c in items],
+            await _watch_render(
+                interval=watch,
+                command="fdw queries connections",
+                title="SQL Connections",
                 json_output=ctx.json_output,
-                table_title="SQL Connections",
-                prune_null_columns=True,
+                fetch=lambda: _queries_svc.list_connections(target, mode=ctx.auth),
             )
     except (ValueError, FabricError) as exc:
         raise click.ClickException(str(exc)) from exc
@@ -136,6 +186,9 @@ async def kill_cmd(ctx: CliContext, item: str | None, session_id: int) -> None:
     default=False,
     help="Include DATABASE-scoped lock rows (excluded by default).",
 )
+@click.option(
+    "--watch", type=click.IntRange(min=1), metavar="SECONDS", help="Refresh every SECONDS."
+)
 @click.pass_obj
 @coro
 async def locks_cmd(
@@ -145,26 +198,28 @@ async def locks_cmd(
     waiting_only: bool,
     blocked_only: bool,
     include_database: bool,
+    watch: int | None,
 ) -> None:
     """List active locks from sys.dm_tran_locks on ITEM."""
+    _validate_watch(ctx, watch)
     ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     try:
         async with build_http_client(ctx) as http:
             target, _entry = await build_sql_target(http, ws, wh)
-            items = await _queries_svc.list_locks(
-                target,
-                limit=limit,
-                waiting_only=waiting_only,
-                blocked_only=blocked_only,
-                include_database=include_database,
-                mode=ctx.auth,
-            )
-            render(
-                [lock.model_dump(by_alias=True, mode="json") for lock in items],
+            await _watch_render(
+                interval=watch,
+                command="fdw queries locks",
+                title="Active Locks",
                 json_output=ctx.json_output,
-                table_title="Active Locks",
-                prune_null_columns=True,
+                fetch=lambda: _queries_svc.list_locks(
+                    target,
+                    limit=limit,
+                    waiting_only=waiting_only,
+                    blocked_only=blocked_only,
+                    include_database=include_database,
+                    mode=ctx.auth,
+                ),
             )
     except (ValueError, FabricError) as exc:
         raise click.ClickException(str(exc)) from exc

--- a/tests/unit/cli/commands/test_queries.py
+++ b/tests/unit/cli/commands/test_queries.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from pathlib import Path
@@ -15,6 +15,7 @@ from click.testing import CliRunner
 
 from fabric_dw.cache import ItemEntry
 from fabric_dw.cli._main import cli
+from fabric_dw.cli.commands import queries as _queries_cmd
 from fabric_dw.exceptions import FabricError, NotFoundError, PermissionDeniedError
 from fabric_dw.models import ExecRequestHistory, QueryLock, RunningQuery, WarehouseKind
 from fabric_dw.sql import SqlTarget
@@ -23,6 +24,10 @@ WS_GUID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
 WH_GUID = "d4e5f6a7-b8c9-0123-def0-123456789abc"
 WS_UUID = UUID(WS_GUID)
 WH_UUID = UUID(WH_GUID)
+
+
+class _StopWatchError(Exception):
+    """Terminate a watch-loop test after the requested number of sleeps."""
 
 
 def _make_http_cm(http: object) -> object:
@@ -139,6 +144,52 @@ class TestQueriesList:
         ):
             result = runner.invoke(cli, ["-w", WS_GUID, "queries", "running", WH_GUID])
         assert result.exit_code != 0
+
+    def test_watch_rejects_json_before_opening_client(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        _ = cache_env
+        with patch("fabric_dw.cli.commands.queries.build_http_client") as build_client:
+            result = runner.invoke(
+                cli,
+                ["--json", "-w", WS_GUID, "queries", "running", "--watch", "1", WH_GUID],
+            )
+        assert result.exit_code != 0
+        assert "--watch cannot be used with --json" in result.output
+        build_client.assert_not_called()
+
+    def test_watch_requires_positive_interval(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        result = runner.invoke(cli, ["-w", WS_GUID, "queries", "running", "--watch", "0", WH_GUID])
+        assert result.exit_code != 0
+        assert "x>=1" in result.output
+
+
+@pytest.mark.anyio
+async def test_watch_render_fetches_immediately_clears_and_repeats() -> None:
+    """Watch renders immediately, redraws the terminal, then repeats after sleeping."""
+    fetch = AsyncMock(return_value=[_make_running_query()])
+    sleep = AsyncMock(side_effect=[None, _StopWatchError()])
+    with (
+        patch("fabric_dw.cli.commands.queries.asyncio.sleep", new=sleep),
+        patch("fabric_dw.cli.commands.queries.click.clear") as clear,
+        patch("fabric_dw.cli.commands.queries.click.echo") as echo,
+        patch("fabric_dw.cli.commands.queries.render") as render,
+        pytest.raises(_StopWatchError),
+    ):
+        await _queries_cmd._watch_render(
+            interval=3,
+            command="fdw queries running SalesWarehouse",
+            title="Running Queries",
+            json_output=False,
+            fetch=fetch,
+        )
+
+    assert fetch.await_count == 2
+    assert sleep.await_args_list == [((3,),), ((3,),)]
+    assert clear.call_count == 2
+    assert render.call_count == 2
+    assert "Every 3s: fdw queries running SalesWarehouse" in echo.call_args_list[0].args[0]
 
 
 class TestQueriesKill:
@@ -293,6 +344,31 @@ class TestQueriesListConnections:
         ):
             result = runner.invoke(cli, ["-w", WS_GUID, "queries", "connections", WH_GUID])
         assert result.exit_code != 0
+
+    def test_connections_watch_uses_live_fetch(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        list_connections = AsyncMock(return_value=[])
+
+        async def _render_once(
+            *, fetch: Callable[[], Awaitable[object]], **_kwargs: object
+        ) -> None:
+            await fetch()
+
+        with (
+            patch("fabric_dw.cli.commands.queries.build_http_client", new=_make_http_cm(mock_http)),
+            patch(
+                "fabric_dw.cli.commands.queries.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch("fabric_dw.services.queries.list_connections", new=list_connections),
+            patch("fabric_dw.cli.commands.queries._watch_render", new=_render_once),
+        ):
+            result = runner.invoke(
+                cli, ["-w", WS_GUID, "queries", "connections", "--watch", "2", WH_GUID]
+            )
+        assert result.exit_code == 0
+        list_connections.assert_awaited_once()
 
 
 class TestQueriesRequestHistory:
@@ -651,6 +727,53 @@ class TestQueriesLocks:
         assert result.exit_code == 0
         call_kwargs = mock_list_locks.call_args
         assert call_kwargs.kwargs.get("waiting_only") is True
+
+    def test_locks_watch_forwards_filters(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        list_locks = AsyncMock(return_value=[])
+
+        async def _render_once(
+            *, fetch: Callable[[], Awaitable[object]], **_kwargs: object
+        ) -> None:
+            await fetch()
+
+        with (
+            patch("fabric_dw.cli.commands.queries.build_http_client", new=_make_http_cm(mock_http)),
+            patch(
+                "fabric_dw.cli.commands.queries.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch("fabric_dw.services.queries.list_locks", new=list_locks),
+            patch("fabric_dw.cli.commands.queries._watch_render", new=_render_once),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "-w",
+                    WS_GUID,
+                    "queries",
+                    "locks",
+                    "--watch",
+                    "2",
+                    "--waiting-only",
+                    "--blocked-only",
+                    "--include-database",
+                    "--limit",
+                    "7",
+                    WH_GUID,
+                ],
+            )
+        assert result.exit_code == 0
+        assert list_locks.await_args is not None
+        call_kwargs = list_locks.await_args.kwargs
+        assert call_kwargs == {
+            "limit": 7,
+            "waiting_only": True,
+            "blocked_only": True,
+            "include_database": True,
+            "mode": call_kwargs["mode"],
+        }
 
     def test_locks_blocked_only_flag_passes_through(
         self, runner: CliRunner, cache_env: Path


### PR DESCRIPTION
Closes #1014

## What changed

- Added `--watch SECONDS` to `queries running`, `queries locks`, and `queries connections`.
- Refreshes terminal output in a watch-style loop and rejects `--watch` with `--json`.

## Why

Live query and lock inspection needs a built-in, readable way to follow changes over time.

## Validation

- Focused CLI tests: 35 passed
- Ruff and type checks passed
- Independent review: clean