### PR TITLE
feat(mcp): add list_capabilities tool for domain-grouped tool discovery

### DIFF
--- a/docs/reference/mcp-capabilities.md
+++ b/docs/reference/mcp-capabilities.md
@@ -1,0 +1,35 @@
+---
+title: MCP capabilities
+---
+
+# MCP capabilities
+
+The `list_capabilities` tool returns all available MCP tools grouped by domain. Call it first to discover what dedicated tools exist before falling back to `execute_sql`.
+
+## Why use it
+
+Dedicated tools return typed, structured results and have no SQL dialect pitfalls. `execute_sql` returns only the last result set of a batch and base64-encodes varbinary columns. Knowing which dedicated tools are available helps you choose the right tool for each task.
+
+## Return format
+
+The tool returns a `dict[str, list[str]]` mapping each domain name to a sorted list of tool names in that domain. The dict itself is sorted by domain key.
+
+Example (truncated):
+
+```json
+{
+  "audit": ["disable_audit", "enable_audit", "get_audit_settings", "..."],
+  "cache": ["clear_cache"],
+  "server": ["list_capabilities"],
+  "tables": ["clear_table", "clone_table", "count_table_rows", "..."],
+  "..."
+}
+```
+
+## Parameters
+
+None.
+
+## Usage
+
+Call `list_capabilities` at the start of a session to orient yourself, then use the domain grouping to pick the most specific tool for each operation. Fall back to `execute_sql` only when no dedicated tool covers the required SQL.

--- a/src/fabric_dw/mcp/server.py
+++ b/src/fabric_dw/mcp/server.py
@@ -82,7 +82,8 @@ __all__ = ["mcp", "run"]
 # Character budget: 900 chars (asserted in tests/unit/mcp/test_instructions.py).
 # The original 700-char budget covered 18 named tools across 5 domains.
 # The domain index added in issue #992 brings the total to 795 chars.
-# 900 provides ~105 chars of headroom for future minor additions without
+# Adding list_capabilities + server domain (#1018) brings the total to 822 chars.
+# 900 provides ~78 chars of headroom for future minor additions without
 # requiring another budget justification.
 # ---------------------------------------------------------------------------
 
@@ -91,15 +92,15 @@ _SERVER_INSTRUCTIONS: str = (
     "Dedicated tools return typed, structured results and have no SQL dialect pitfalls; "
     "execute_sql returns only the last result set of a batch and base64-encodes "
     "varbinary columns.\n"
-    "Discover: list_schemas, list_tables, list_views, list_functions, list_procedures, "
-    "list_security_policies, list_masked_columns.\n"
+    "Discover: list_capabilities, list_schemas, list_tables, list_views, list_functions, "
+    "list_procedures, list_security_policies, list_masked_columns.\n"
     "Read: read_table, read_view, count_table_rows, count_view_rows.\n"
     "Inspect: get_table_columns, get_view_columns, get_table_health_metrics.\n"
     "Mutate: create_table, delete_table, rename_table, clear_table, delete_schema, "
     "transfer_table.\n"
     "Also: permissions, audit, queries, snapshots, "
     "restore points, sql pools, warehouses, workspaces, statistics, settings, "
-    "sql endpoints, dbt, cache.\n"
+    "sql endpoints, dbt, cache, server.\n"
     "Use execute_sql ONLY for arbitrary SQL that no dedicated tool can express."
 )
 

--- a/src/fabric_dw/mcp/tools/__init__.py
+++ b/src/fabric_dw/mcp/tools/__init__.py
@@ -26,6 +26,7 @@ Domains
 - :mod:`.settings` — warehouse database settings (result-set caching, time-travel retention)
 - :mod:`.cache` — cache management (clear_cache)
 - :mod:`.dbt` — generate dbt-fabric project file contents
+- :mod:`.capabilities` — list all available tools grouped by domain
 """
 
 from __future__ import annotations
@@ -35,6 +36,7 @@ from mcp.server.fastmcp import FastMCP
 from fabric_dw.mcp.tools import (
     audit,
     cache,
+    capabilities,
     dbt,
     functions,
     load,
@@ -78,6 +80,7 @@ _DOMAINS = [
     sql_pools,
     cache,
     dbt,
+    capabilities,
 ]
 
 

--- a/src/fabric_dw/mcp/tools/capabilities.py
+++ b/src/fabric_dw/mcp/tools/capabilities.py
@@ -1,0 +1,39 @@
+"""MCP tool for listing available tools grouped by domain."""
+
+from __future__ import annotations
+
+import logging
+
+from mcp.server.fastmcp import FastMCP
+
+from fabric_dw.telemetry_commands import resolve_domain
+
+__all__ = ["register"]
+
+_log = logging.getLogger(__name__)
+
+
+def register(mcp: FastMCP) -> None:
+    """Register capabilities tools against *mcp*."""
+
+    @mcp.tool(name="list_capabilities")
+    async def list_capabilities() -> dict[str, list[str]]:
+        """List all available MCP tools grouped by domain.
+
+        Call this tool first to discover what dedicated tools are available
+        before falling back to ``execute_sql``.  Dedicated tools return typed,
+        structured results and avoid SQL dialect pitfalls.
+
+        Returns:
+            A dict mapping domain name to a sorted list of tool names in that
+            domain.  The dict itself is sorted by domain key.
+        """
+        _log.info("list_capabilities called")
+        tools = await mcp.list_tools()
+        grouped: dict[str, list[str]] = {}
+        for tool in tools:
+            domain = resolve_domain(tool.name)
+            grouped.setdefault(domain, []).append(tool.name)
+        for domain, names in grouped.items():
+            grouped[domain] = sorted(names)
+        return dict(sorted(grouped.items()))

--- a/src/fabric_dw/telemetry_commands.py
+++ b/src/fabric_dw/telemetry_commands.py
@@ -211,6 +211,8 @@ DOMAIN_MAP: dict[str, str] = {
     "set_data_lake_log_publishing": "settings",
     # Tables (load sub-domain)
     "import_table_from_url": "tables",
+    # Server meta
+    "list_capabilities": "server",
 }
 
 # ---------------------------------------------------------------------------
@@ -240,6 +242,7 @@ _KNOWN_DOMAINS: frozenset[str] = frozenset(
         "completion",
         "settings",
         "permissions",
+        "server",
     }
 )
 

--- a/tests/unit/mcp/test_instructions.py
+++ b/tests/unit/mcp/test_instructions.py
@@ -31,7 +31,8 @@ from fabric_dw.telemetry_commands import resolve_domain
 # The text is permanently resident in every client's context, so it must stay
 # compact. The original 700-char budget (~175 tokens) covered 18 named tools
 # across 5 domains. The domain index added in issue #992 brings the text to
-# 795 chars. 900 chars (~225 tokens) provides ~105 chars of headroom for
+# 795 chars. Adding list_capabilities + server domain (#1018) brings it to
+# 822 chars. 900 chars (~225 tokens) provides ~78 chars of headroom for
 # future additions without requiring a new justification.
 # The budget exists to stop the block growing into a manual.
 # ---------------------------------------------------------------------------

--- a/tests/unit/mcp/tools/test_capabilities.py
+++ b/tests/unit/mcp/tools/test_capabilities.py
@@ -1,0 +1,54 @@
+"""Unit tests for fabric_dw.mcp.tools.capabilities — list_capabilities tool."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_list_capabilities_returns_grouped_dict() -> None:
+    """list_capabilities returns a dict[str, list[str]]."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    result = await mcp._tool_manager.call_tool("list_capabilities", {})
+
+    assert isinstance(result, dict)
+    for domain, tools in result.items():
+        assert isinstance(domain, str)
+        assert isinstance(tools, list)
+        for tool_name in tools:
+            assert isinstance(tool_name, str)
+
+
+@pytest.mark.asyncio
+async def test_list_capabilities_server_domain_contains_itself() -> None:
+    """result['server'] must contain 'list_capabilities'."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    result = await mcp._tool_manager.call_tool("list_capabilities", {})
+
+    assert "server" in result
+    assert "list_capabilities" in result["server"]
+
+
+@pytest.mark.asyncio
+async def test_list_capabilities_all_registered_tools_are_present() -> None:
+    """Every tool from mcp.list_tools() must appear somewhere in the result."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    live_tools = {tool.name for tool in await mcp.list_tools()}
+    result = await mcp._tool_manager.call_tool("list_capabilities", {})
+    found_tools = {name for tools in result.values() for name in tools}
+
+    assert live_tools == found_tools
+
+
+@pytest.mark.asyncio
+async def test_list_capabilities_values_are_sorted() -> None:
+    """Each domain's tool list must be in sorted order."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    result = await mcp._tool_manager.call_tool("list_capabilities", {})
+
+    for domain, tools in result.items():
+        assert tools == sorted(tools), f"Tools in domain '{domain}' are not sorted"

--- a/tests/unit/mcp/tools/test_capabilities.py
+++ b/tests/unit/mcp/tools/test_capabilities.py
@@ -2,10 +2,7 @@
 
 from __future__ import annotations
 
-import pytest
 
-
-@pytest.mark.asyncio
 async def test_list_capabilities_returns_grouped_dict() -> None:
     """list_capabilities returns a dict[str, list[str]]."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
@@ -20,7 +17,6 @@ async def test_list_capabilities_returns_grouped_dict() -> None:
             assert isinstance(tool_name, str)
 
 
-@pytest.mark.asyncio
 async def test_list_capabilities_server_domain_contains_itself() -> None:
     """result['server'] must contain 'list_capabilities'."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
@@ -31,7 +27,6 @@ async def test_list_capabilities_server_domain_contains_itself() -> None:
     assert "list_capabilities" in result["server"]
 
 
-@pytest.mark.asyncio
 async def test_list_capabilities_all_registered_tools_are_present() -> None:
     """Every tool from mcp.list_tools() must appear somewhere in the result."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
@@ -43,12 +38,12 @@ async def test_list_capabilities_all_registered_tools_are_present() -> None:
     assert live_tools == found_tools
 
 
-@pytest.mark.asyncio
 async def test_list_capabilities_values_are_sorted() -> None:
-    """Each domain's tool list must be in sorted order."""
+    """Each domain's tool list and the dict keys must be in sorted order."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
     result = await mcp._tool_manager.call_tool("list_capabilities", {})
 
+    assert list(result.keys()) == sorted(result.keys())
     for domain, tools in result.items():
         assert tools == sorted(tools), f"Tools in domain '{domain}' are not sorted"

--- a/zensical.toml
+++ b/zensical.toml
@@ -42,6 +42,7 @@ nav = [
     { "Concepts" = "concepts.md" },
     { "Authentication" = "authentication.md" },
     { "Agent Skills" = "skills.md" },
+    { "MCP capabilities" = "reference/mcp-capabilities.md" },
     { "Exit codes" = "reference/exit-codes.md" },
     { "Shell Completion" = "completion.md" },
     { "Troubleshooting" = "troubleshooting.md" },


### PR DESCRIPTION
## Summary

- New `list_capabilities` MCP tool returns all available tools grouped by domain
- Helps AI agents discover dedicated tools before falling back to `execute_sql`
- Telemetry showed `execute_sql` accounts for 51% of MCP calls despite server instructions

Closes #1018

## Test plan

- [ ] Unit tests: grouped dict structure, self-reference, completeness, sort order
- [ ] Lint + type check green
- [ ] Docs page renders correctly