### PR TITLE
feat(cli): add live watch mode to sql exec

### DIFF
--- a/docs/commands/sql.md
+++ b/docs/commands/sql.md
@@ -51,7 +51,11 @@ fdw -w MyWorkspace sql exec SalesWH -q "SELECT COUNT(*) FROM dbo.Sales" --watch 
 
 !!! warning "--watch re-executes the statement as-is"
 
-    With `--watch`, the query text is read once (from `-q` or `-f`) and then re-executed unchanged on every tick. The CLI has no way to tell whether a statement is read-only, so `--watch` re-runs DDL and DML exactly as given, on every interval. Only use `--watch` with statements that are safe to run repeatedly, such as a `SELECT COUNT(*)`.
+    With `--watch`, the query text is read once (from `-q` or `-f`) and then re-executed unchanged on every tick. The CLI has no way to tell whether a statement is read-only, so `--watch` re-runs DDL and DML exactly as given, verbatim, on every interval. Only use `--watch` with statements that are safe to run repeatedly, such as a `SELECT COUNT(*)`.
+
+!!! note "Exit and non-TTY behaviour"
+
+    The `--watch` loop runs until interrupted with **Ctrl-C**; it never stops on its own. Clearing the terminal is a no-op when stdout is not a TTY, so redirecting to a file (`> out.log`) or running under CI appends every refresh to the output instead of redrawing in place - the file grows without bound until the process is killed.
 
 ### sql plan
 

--- a/docs/commands/sql.md
+++ b/docs/commands/sql.md
@@ -28,6 +28,7 @@ fdw [-w WORKSPACE] sql exec [OPTIONS] [ITEM]
 | --- | --- |
 | `-q` / `--query TEXT` | SQL statement or batch to execute inline. |
 | `-f` / `--file PATH` | Path to a `.sql` file to execute. UTF-8 and UTF-8 BOM files are both supported. |
+| `--watch SECONDS` | Re-execute and redraw every positive number of seconds. Cannot be combined with `--json`. |
 
 Output defaults to a Rich table (rows/columns). Pass `--json` on the root command to emit machine-readable JSON (`{"columns": [...], "rows": [...], "rowcount": N}`).
 
@@ -39,11 +40,18 @@ fdw -w MyWorkspace sql exec SalesWH -q "SELECT TOP 5 * FROM dbo.Sales"
 
 # File input, JSON output
 fdw -w MyWorkspace --json sql exec SalesWH -f ./queries/report.sql
+
+# Live refresh: re-run the same query every 5 seconds
+fdw -w MyWorkspace sql exec SalesWH -q "SELECT COUNT(*) FROM dbo.Sales" --watch 5
 ```
 
 ```json
 {"columns": ["id", "name"], "rows": [[1, "Alice"], [2, "Bob"]], "rowcount": 2}
 ```
+
+!!! warning "--watch re-executes the statement as-is"
+
+    With `--watch`, the query text is read once (from `-q` or `-f`) and then re-executed unchanged on every tick. The CLI has no way to tell whether a statement is read-only, so `--watch` re-runs DDL and DML exactly as given, on every interval. Only use `--watch` with statements that are safe to run repeatedly, such as a `SELECT COUNT(*)`.
 
 ### sql plan
 

--- a/src/fabric_dw/cli/_watch.py
+++ b/src/fabric_dw/cli/_watch.py
@@ -1,0 +1,55 @@
+"""Shared ``--watch`` loop for CLI commands that support live refresh.
+
+Extracted from ``fabric_dw.cli.commands.queries`` so that ``queries`` and
+``sql exec`` run exactly one loop implementation instead of two copies.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
+
+import click
+
+from fabric_dw.cli._context import CliContext
+
+__all__ = ["validate_watch", "watch_loop"]
+
+
+def validate_watch(ctx: CliContext, watch: int | None) -> None:
+    """Reject streaming JSON before opening a network client."""
+    if watch is not None and ctx.json_output:
+        raise click.UsageError("--watch cannot be used with --json.")
+
+
+async def watch_loop(
+    *,
+    interval: int | None,
+    command: str,
+    tick: Callable[[], Awaitable[None]],
+) -> None:
+    """Run *tick* once, then repeat every *interval* seconds if set.
+
+    Each cycle clears the terminal and prints a watch-style header
+    (``Every Ns: <command>    <local timestamp>``) before invoking *tick*,
+    which is responsible for fetching and rendering that cycle's output.
+    When *interval* is ``None``, *tick* runs exactly once and the terminal
+    is left untouched.
+
+    Args:
+        interval: Seconds between refreshes, or ``None`` to run *tick* once.
+        command: Command name shown in the watch header.
+        tick: Async callback that fetches and renders one cycle's output.
+            Any exception it raises propagates to the caller.
+    """
+    while True:
+        if interval is not None:
+            click.clear()
+            timestamp = datetime.now(UTC).astimezone().strftime("%Y-%m-%d %H:%M:%S %Z")
+            click.echo(f"Every {interval}s: {command}    {timestamp}")
+            click.echo()
+        await tick()
+        if interval is None:
+            return
+        await asyncio.sleep(interval)

--- a/src/fabric_dw/cli/_watch.py
+++ b/src/fabric_dw/cli/_watch.py
@@ -9,17 +9,18 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
+from typing import TypeVar
 
 import click
 
-from fabric_dw.cli._context import CliContext
-
 __all__ = ["validate_watch", "watch_loop"]
 
+_T = TypeVar("_T")
 
-def validate_watch(ctx: CliContext, watch: int | None) -> None:
+
+def validate_watch(*, json_output: bool, watch: int | None) -> None:
     """Reject streaming JSON before opening a network client."""
-    if watch is not None and ctx.json_output:
+    if watch is not None and json_output:
         raise click.UsageError("--watch cannot be used with --json.")
 
 
@@ -27,29 +28,36 @@ async def watch_loop(
     *,
     interval: int | None,
     command: str,
-    tick: Callable[[], Awaitable[None]],
+    fetch: Callable[[], Awaitable[_T]],
+    render: Callable[[_T], None],
 ) -> None:
-    """Run *tick* once, then repeat every *interval* seconds if set.
+    """Fetch and render once, then repeat every *interval* seconds if set.
 
-    Each cycle clears the terminal and prints a watch-style header
-    (``Every Ns: <command>    <local timestamp>``) before invoking *tick*,
-    which is responsible for fetching and rendering that cycle's output.
-    When *interval* is ``None``, *tick* runs exactly once and the terminal
-    is left untouched.
+    Each cycle fetches first, then -- only once fresh data is in hand -- clears
+    the terminal and prints a watch-style header (``Every Ns: <command>
+    <local timestamp>``), then renders. Fetching before clearing keeps the
+    previous frame on screen for the full duration of a slow fetch instead of
+    showing a blank terminal, and makes the header timestamp reflect when the
+    data was read rather than when the tick started.
+
+    When *interval* is ``None``, *fetch*/*render* run exactly once and the
+    terminal is left untouched.
 
     Args:
-        interval: Seconds between refreshes, or ``None`` to run *tick* once.
+        interval: Seconds between refreshes, or ``None`` to run once.
         command: Command name shown in the watch header.
-        tick: Async callback that fetches and renders one cycle's output.
-            Any exception it raises propagates to the caller.
+        fetch: Async callback that retrieves one cycle's data. Any exception
+            it raises propagates to the caller.
+        render: Sync callback that renders the fetched data.
     """
     while True:
+        item = await fetch()
         if interval is not None:
             click.clear()
             timestamp = datetime.now(UTC).astimezone().strftime("%Y-%m-%d %H:%M:%S %Z")
             click.echo(f"Every {interval}s: {command}    {timestamp}")
             click.echo()
-        await tick()
+        render(item)
         if interval is None:
             return
         await asyncio.sleep(interval)

--- a/src/fabric_dw/cli/commands/queries.py
+++ b/src/fabric_dw/cli/commands/queries.py
@@ -2,15 +2,14 @@
 
 from __future__ import annotations
 
-import asyncio
 from collections.abc import Awaitable, Callable, Sequence
-from datetime import UTC, datetime
 from typing import Any, Protocol
 
 import click
 
 from fabric_dw.cli._context import CliContext
 from fabric_dw.cli._render import render
+from fabric_dw.cli._watch import validate_watch, watch_loop
 from fabric_dw.cli.commands._utils import (
     AGO_OPTION,
     LIMIT_OPTION,
@@ -34,12 +33,6 @@ class _JsonModel(Protocol):
     def model_dump(self, *, by_alias: bool, mode: str) -> dict[str, Any]: ...
 
 
-def _validate_watch(ctx: CliContext, watch: int | None) -> None:
-    """Reject streaming JSON before opening a network client."""
-    if watch is not None and ctx.json_output:
-        raise click.UsageError("--watch cannot be used with --json.")
-
-
 async def _watch_render(
     *,
     interval: int | None,
@@ -48,23 +41,23 @@ async def _watch_render(
     json_output: bool,
     fetch: Callable[[], Awaitable[Sequence[_JsonModel]]],
 ) -> None:
-    """Render once or continuously, in the familiar terminal-watch style."""
-    while True:
+    """Render once or continuously, in the familiar terminal-watch style.
+
+    Thin adapter over the shared :func:`~fabric_dw.cli._watch.watch_loop`:
+    supplies the fetch-and-render tick, while clearing, the header, and the
+    sleep live in the shared helper.
+    """
+
+    async def _tick() -> None:
         items = await fetch()
-        if interval is not None:
-            click.clear()
-            timestamp = datetime.now(UTC).astimezone().strftime("%Y-%m-%d %H:%M:%S %Z")
-            click.echo(f"Every {interval}s: {command}    {timestamp}")
-            click.echo()
         render(
             [item.model_dump(by_alias=True, mode="json") for item in items],
             json_output=json_output,
             table_title=title,
             prune_null_columns=True,
         )
-        if interval is None:
-            return
-        await asyncio.sleep(interval)
+
+    await watch_loop(interval=interval, command=command, tick=_tick)
 
 
 @click.group("queries")
@@ -81,7 +74,7 @@ def queries_group() -> None:
 @coro
 async def running_cmd(ctx: CliContext, item: str | None, watch: int | None) -> None:
     """List currently running queries on ITEM (warehouse or endpoint)."""
-    _validate_watch(ctx, watch)
+    validate_watch(ctx, watch)
     ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     try:
@@ -107,7 +100,7 @@ async def running_cmd(ctx: CliContext, item: str | None, watch: int | None) -> N
 @coro
 async def connections_cmd(ctx: CliContext, item: str | None, watch: int | None) -> None:
     """List active SQL connections on ITEM (warehouse or endpoint)."""
-    _validate_watch(ctx, watch)
+    validate_watch(ctx, watch)
     ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     try:
@@ -201,7 +194,7 @@ async def locks_cmd(
     watch: int | None,
 ) -> None:
     """List active locks from sys.dm_tran_locks on ITEM."""
-    _validate_watch(ctx, watch)
+    validate_watch(ctx, watch)
     ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     try:

--- a/src/fabric_dw/cli/commands/queries.py
+++ b/src/fabric_dw/cli/commands/queries.py
@@ -44,12 +44,12 @@ async def _watch_render(
     """Render once or continuously, in the familiar terminal-watch style.
 
     Thin adapter over the shared :func:`~fabric_dw.cli._watch.watch_loop`:
-    supplies the fetch-and-render tick, while clearing, the header, and the
-    sleep live in the shared helper.
+    supplies the fetch and render steps, while clearing, the header, and the
+    sleep live in the shared helper (which fetches before clearing, so a slow
+    fetch does not blank the terminal).
     """
 
-    async def _tick() -> None:
-        items = await fetch()
+    def _render(items: Sequence[_JsonModel]) -> None:
         render(
             [item.model_dump(by_alias=True, mode="json") for item in items],
             json_output=json_output,
@@ -57,7 +57,7 @@ async def _watch_render(
             prune_null_columns=True,
         )
 
-    await watch_loop(interval=interval, command=command, tick=_tick)
+    await watch_loop(interval=interval, command=command, fetch=fetch, render=_render)
 
 
 @click.group("queries")
@@ -74,7 +74,7 @@ def queries_group() -> None:
 @coro
 async def running_cmd(ctx: CliContext, item: str | None, watch: int | None) -> None:
     """List currently running queries on ITEM (warehouse or endpoint)."""
-    validate_watch(ctx, watch)
+    validate_watch(json_output=ctx.json_output, watch=watch)
     ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     try:
@@ -100,7 +100,7 @@ async def running_cmd(ctx: CliContext, item: str | None, watch: int | None) -> N
 @coro
 async def connections_cmd(ctx: CliContext, item: str | None, watch: int | None) -> None:
     """List active SQL connections on ITEM (warehouse or endpoint)."""
-    validate_watch(ctx, watch)
+    validate_watch(json_output=ctx.json_output, watch=watch)
     ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     try:
@@ -194,7 +194,7 @@ async def locks_cmd(
     watch: int | None,
 ) -> None:
     """List active locks from sys.dm_tran_locks on ITEM."""
-    validate_watch(ctx, watch)
+    validate_watch(json_output=ctx.json_output, watch=watch)
     ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     try:

--- a/src/fabric_dw/cli/commands/sql.py
+++ b/src/fabric_dw/cli/commands/sql.py
@@ -20,6 +20,7 @@ from fabric_dw.cli._plan_parse import parse_showplan
 from fabric_dw.cli._plan_render import operator_to_dict, render_plan_tree
 from fabric_dw.cli._plan_svg import render_plan_svg
 from fabric_dw.cli._render import render, render_result_rows, sanitise_json
+from fabric_dw.cli._watch import validate_watch, watch_loop
 from fabric_dw.cli.commands._utils import (
     build_http_client,
     build_sql_target,
@@ -29,6 +30,7 @@ from fabric_dw.cli.commands._utils import (
     resolve_workspace,
 )
 from fabric_dw.exceptions import FabricError
+from fabric_dw.models import SqlResult
 from fabric_dw.services import sql_exec as _sql_exec_svc
 
 
@@ -54,6 +56,9 @@ def sql_group() -> None:
     type=click.Path(exists=True, file_okay=True, dir_okay=False, readable=True),
     help="Path to a .sql file to execute.",
 )
+@click.option(
+    "--watch", type=click.IntRange(min=1), metavar="SECONDS", help="Refresh every SECONDS."
+)
 @click.pass_obj
 @coro
 async def sql_exec_cmd(
@@ -61,6 +66,7 @@ async def sql_exec_cmd(
     item: str | None,
     query_text: str | None,
     query_file: str | None,
+    watch: int | None,
 ) -> None:
     """Execute a SQL statement against ITEM (warehouse or SQL endpoint).
 
@@ -70,7 +76,14 @@ async def sql_exec_cmd(
 
     Output defaults to a Rich table (rows/columns).  Pass --json on the root command
     for machine-readable JSON ({columns: [...], rows: [...], rowcount: N}).
+
+    With --watch SECONDS, the query text is read once and then re-executed and
+    redrawn every SECONDS, the same way ``queries running``/``locks``/``connections``
+    do.  There is no way for the CLI to tell whether a statement is read-only, so
+    --watch simply re-runs whatever it was given, DDL and DML included.  Only use
+    --watch with statements that are safe to run repeatedly.
     """
+    validate_watch(ctx, watch)
     query = load_sql_body(query_text, query_file, inline_opt="-q/--query", file_opt="-f/--file")
 
     ws = resolve_workspace(ctx)
@@ -78,24 +91,32 @@ async def sql_exec_cmd(
     try:
         async with build_http_client(ctx) as http:
             target, _entry = await build_sql_target(http, ws, wh)
-            result = await _sql_exec_svc.execute(target, query, mode=ctx.auth)
 
-            if ctx.json_output:
-                render(
-                    result.model_dump(by_alias=True, mode="json"),
-                    json_output=True,
-                )
-            elif result.rows:
-                render_result_rows(
-                    result.columns,
-                    result.rows,
-                    json_output=False,
-                    table_title="SQL Result",
-                )
-            else:
-                click.echo(f"Query executed successfully. rowcount={result.rowcount}")
+            async def _tick() -> None:
+                result = await _sql_exec_svc.execute(target, query, mode=ctx.auth)
+                _render_sql_result(ctx, result)
+
+            await watch_loop(interval=watch, command="fdw sql exec", tick=_tick)
     except (ValueError, FabricError) as exc:
         raise click.ClickException(str(exc)) from exc
+
+
+def _render_sql_result(ctx: CliContext, result: SqlResult) -> None:
+    """Render one ``sql exec`` result set, for a single run or one watch tick."""
+    if ctx.json_output:
+        render(
+            result.model_dump(by_alias=True, mode="json"),
+            json_output=True,
+        )
+    elif result.rows:
+        render_result_rows(
+            result.columns,
+            result.rows,
+            json_output=False,
+            table_title="SQL Result",
+        )
+    else:
+        click.echo(f"Query executed successfully. rowcount={result.rowcount}")
 
 
 @sql_group.command("plan")

--- a/src/fabric_dw/cli/commands/sql.py
+++ b/src/fabric_dw/cli/commands/sql.py
@@ -57,7 +57,14 @@ def sql_group() -> None:
     help="Path to a .sql file to execute.",
 )
 @click.option(
-    "--watch", type=click.IntRange(min=1), metavar="SECONDS", help="Refresh every SECONDS."
+    "--watch",
+    type=click.IntRange(min=1),
+    metavar="SECONDS",
+    help=(
+        "Refresh every SECONDS, until interrupted with Ctrl-C. "
+        "Terminal clearing is a no-op when stdout is not a TTY, so redirecting to a "
+        "file or running in CI appends every refresh instead of redrawing."
+    ),
 )
 @click.pass_obj
 @coro
@@ -80,10 +87,13 @@ async def sql_exec_cmd(
     With --watch SECONDS, the query text is read once and then re-executed and
     redrawn every SECONDS, the same way ``queries running``/``locks``/``connections``
     do.  There is no way for the CLI to tell whether a statement is read-only, so
-    --watch simply re-runs whatever it was given, DDL and DML included.  Only use
-    --watch with statements that are safe to run repeatedly.
+    --watch simply re-runs whatever it was given, verbatim, DDL and DML included, on
+    every tick.  Only use --watch with statements that are safe to run repeatedly.
+    The loop runs until interrupted with Ctrl-C; it never stops on its own.  When
+    stdout is not a TTY (e.g. redirected to a file, or running in CI), the terminal
+    clear is a no-op, so each refresh is appended rather than redrawn.
     """
-    validate_watch(ctx, watch)
+    validate_watch(json_output=ctx.json_output, watch=watch)
     query = load_sql_body(query_text, query_file, inline_opt="-q/--query", file_opt="-f/--file")
 
     ws = resolve_workspace(ctx)
@@ -92,11 +102,13 @@ async def sql_exec_cmd(
         async with build_http_client(ctx) as http:
             target, _entry = await build_sql_target(http, ws, wh)
 
-            async def _tick() -> None:
-                result = await _sql_exec_svc.execute(target, query, mode=ctx.auth)
+            async def _fetch() -> SqlResult:
+                return await _sql_exec_svc.execute(target, query, mode=ctx.auth)
+
+            def _render(result: SqlResult) -> None:
                 _render_sql_result(ctx, result)
 
-            await watch_loop(interval=watch, command="fdw sql exec", tick=_tick)
+            await watch_loop(interval=watch, command="fdw sql exec", fetch=_fetch, render=_render)
     except (ValueError, FabricError) as exc:
         raise click.ClickException(str(exc)) from exc
 

--- a/tests/unit/cli/commands/test_queries.py
+++ b/tests/unit/cli/commands/test_queries.py
@@ -7,7 +7,7 @@ from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from pathlib import Path
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import UUID
 
 import pytest
@@ -19,15 +19,12 @@ from fabric_dw.cli.commands import queries as _queries_cmd
 from fabric_dw.exceptions import FabricError, NotFoundError, PermissionDeniedError
 from fabric_dw.models import ExecRequestHistory, QueryLock, RunningQuery, WarehouseKind
 from fabric_dw.sql import SqlTarget
+from tests.unit.cli.conftest import _StopWatchError
 
 WS_GUID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
 WH_GUID = "d4e5f6a7-b8c9-0123-def0-123456789abc"
 WS_UUID = UUID(WS_GUID)
 WH_UUID = UUID(WH_GUID)
-
-
-class _StopWatchError(Exception):
-    """Terminate a watch-loop test after the requested number of sleeps."""
 
 
 def _make_http_cm(http: object) -> object:
@@ -167,34 +164,47 @@ class TestQueriesList:
 
 @pytest.mark.anyio
 async def test_watch_render_fetches_immediately_clears_and_repeats() -> None:
-    """Watch renders immediately, redraws the terminal, then repeats after sleeping.
+    """Watch fetches immediately, then clears/redraws the terminal, then repeats.
 
     The clear/header/sleep mechanics now live in the shared
     ``fabric_dw.cli._watch.watch_loop`` helper (patched at their new home);
-    ``render`` is still called from ``queries.py``'s own tick closure.
+    ``render`` is still called from ``queries.py``'s own render closure.
+    Fetch must complete *before* the terminal is cleared on every cycle --
+    clearing first would blank the screen for the duration of a slow fetch
+    and sample the header timestamp before the data was actually read (PR
+    #1028 review round 1). A shared call-log manager pins that ordering,
+    since call counts alone cannot distinguish it from the reverse order.
     """
+    manager = MagicMock()
     fetch = AsyncMock(return_value=[_make_running_query()])
+    manager.attach_mock(fetch, "fetch")
     sleep = AsyncMock(side_effect=[None, _StopWatchError()])
     with (
         patch("fabric_dw.cli._watch.asyncio.sleep", new=sleep),
         patch("fabric_dw.cli._watch.click.clear") as clear,
         patch("fabric_dw.cli._watch.click.echo") as echo,
         patch("fabric_dw.cli.commands.queries.render") as render,
-        pytest.raises(_StopWatchError),
     ):
-        await _queries_cmd._watch_render(
-            interval=3,
-            command="fdw queries running SalesWarehouse",
-            title="Running Queries",
-            json_output=False,
-            fetch=fetch,
-        )
+        manager.attach_mock(clear, "clear")
+        manager.attach_mock(render, "render")
+        with pytest.raises(_StopWatchError):
+            await _queries_cmd._watch_render(
+                interval=3,
+                command="fdw queries running SalesWarehouse",
+                title="Running Queries",
+                json_output=False,
+                fetch=fetch,
+            )
 
     assert fetch.await_count == 2
     assert sleep.await_args_list == [((3,),), ((3,),)]
     assert clear.call_count == 2
     assert render.call_count == 2
     assert "Every 3s: fdw queries running SalesWarehouse" in echo.call_args_list[0].args[0]
+
+    relevant = {"fetch", "clear", "render"}
+    call_order = [name for name, _args, _kwargs in manager.mock_calls if name in relevant]
+    assert call_order == ["fetch", "clear", "render", "fetch", "clear", "render"]
 
 
 class TestQueriesKill:

--- a/tests/unit/cli/commands/test_queries.py
+++ b/tests/unit/cli/commands/test_queries.py
@@ -167,13 +167,18 @@ class TestQueriesList:
 
 @pytest.mark.anyio
 async def test_watch_render_fetches_immediately_clears_and_repeats() -> None:
-    """Watch renders immediately, redraws the terminal, then repeats after sleeping."""
+    """Watch renders immediately, redraws the terminal, then repeats after sleeping.
+
+    The clear/header/sleep mechanics now live in the shared
+    ``fabric_dw.cli._watch.watch_loop`` helper (patched at their new home);
+    ``render`` is still called from ``queries.py``'s own tick closure.
+    """
     fetch = AsyncMock(return_value=[_make_running_query()])
     sleep = AsyncMock(side_effect=[None, _StopWatchError()])
     with (
-        patch("fabric_dw.cli.commands.queries.asyncio.sleep", new=sleep),
-        patch("fabric_dw.cli.commands.queries.click.clear") as clear,
-        patch("fabric_dw.cli.commands.queries.click.echo") as echo,
+        patch("fabric_dw.cli._watch.asyncio.sleep", new=sleep),
+        patch("fabric_dw.cli._watch.click.clear") as clear,
+        patch("fabric_dw.cli._watch.click.echo") as echo,
         patch("fabric_dw.cli.commands.queries.render") as render,
         pytest.raises(_StopWatchError),
     ):

--- a/tests/unit/cli/commands/test_sql.py
+++ b/tests/unit/cli/commands/test_sql.py
@@ -22,19 +22,15 @@ from click.testing import CliRunner, Result
 
 from fabric_dw.cache import ItemEntry
 from fabric_dw.cli._main import cli
-from fabric_dw.cli._watch import watch_loop
 from fabric_dw.exceptions import FabricError, NotFoundError, PermissionDeniedError
 from fabric_dw.models import SqlResult, WarehouseKind
 from fabric_dw.sql import SqlTarget
+from tests.unit.cli.conftest import _StopWatchError
 
 WS_GUID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
 WH_GUID = "d4e5f6a7-b8c9-0123-def0-123456789abc"
 WS_UUID = UUID(WS_GUID)
 WH_UUID = UUID(WH_GUID)
-
-
-class _StopWatchError(Exception):
-    """Terminate a watch-loop test after the requested number of sleeps."""
 
 
 def _make_sql_target() -> SqlTarget:
@@ -519,10 +515,20 @@ class TestSqlExecWatch:
     def test_watch_renders_immediately_then_repeats_on_interval(
         self, runner: CliRunner, cache_env: Path
     ) -> None:
-        """Rows render on the first tick with no delay, then the loop clears/redraws."""
+        """Rows render on the first tick with no delay, then the loop clears/redraws.
+
+        The tick must execute the query *before* clearing the terminal on
+        every cycle: clearing first would blank the screen while the query is
+        still running and would sample the header timestamp before the row
+        data was actually fetched (PR #1028 review round 1). A shared
+        call-log manager pins that ordering; plain call counts cannot
+        distinguish it from the reverse order.
+        """
         _ = cache_env
         mock_http = AsyncMock()
+        manager = MagicMock()
         execute = AsyncMock(return_value=_make_sql_result())
+        manager.attach_mock(execute, "execute")
         sleep = AsyncMock(side_effect=[None, _StopWatchError()])
         with (
             patch(
@@ -536,7 +542,10 @@ class TestSqlExecWatch:
             patch("fabric_dw.services.sql_exec.execute", new=execute),
             patch("fabric_dw.cli._watch.asyncio.sleep", new=sleep),
             patch("fabric_dw.cli._watch.click.clear") as clear,
+            patch("fabric_dw.cli.commands.sql.render_result_rows") as render_rows,
         ):
+            manager.attach_mock(clear, "clear")
+            manager.attach_mock(render_rows, "render")
             result = runner.invoke(
                 cli,
                 [
@@ -553,8 +562,12 @@ class TestSqlExecWatch:
             )
         assert execute.await_count == 2
         assert clear.call_count == 2
+        assert render_rows.call_count == 2
         assert "Every 3s: fdw sql exec" in result.output
-        assert result.output.count("foo") == 2
+
+        relevant = {"execute", "clear", "render"}
+        call_order = [name for name, _args, _kwargs in manager.mock_calls if name in relevant]
+        assert call_order == ["execute", "clear", "render", "execute", "clear", "render"]
 
     def test_watch_reads_query_once_not_per_tick(
         self, runner: CliRunner, cache_env: Path, tmp_path: Path
@@ -683,46 +696,6 @@ class TestSqlExecWatch:
             )
         assert result.exit_code != 0
         assert "server exploded" in result.output
-
-
-class TestWatchLoop:
-    """fabric_dw.cli._watch.watch_loop — the shared loop behind ``queries`` and ``sql exec``."""
-
-    @pytest.mark.anyio
-    async def test_runs_tick_once_without_clearing_when_interval_is_none(self) -> None:
-        tick = AsyncMock()
-        with (
-            patch("fabric_dw.cli._watch.click.clear") as clear,
-            patch("fabric_dw.cli._watch.asyncio.sleep") as sleep,
-        ):
-            await watch_loop(interval=None, command="fdw sql exec", tick=tick)
-        tick.assert_awaited_once()
-        clear.assert_not_called()
-        sleep.assert_not_called()
-
-    @pytest.mark.anyio
-    async def test_clears_prints_header_and_repeats_on_interval(self) -> None:
-        tick = AsyncMock()
-        sleep = AsyncMock(side_effect=[None, _StopWatchError()])
-        with (
-            patch("fabric_dw.cli._watch.click.clear") as clear,
-            patch("fabric_dw.cli._watch.click.echo") as echo,
-            patch("fabric_dw.cli._watch.asyncio.sleep", new=sleep),
-            pytest.raises(_StopWatchError),
-        ):
-            await watch_loop(interval=5, command="fdw sql exec", tick=tick)
-        assert tick.await_count == 2
-        assert clear.call_count == 2
-        assert sleep.await_args_list == [((5,),), ((5,),)]
-        assert "Every 5s: fdw sql exec" in echo.call_args_list[0].args[0]
-
-    @pytest.mark.anyio
-    async def test_tick_error_propagates_uncaught(self) -> None:
-        async def _boom() -> None:
-            raise ValueError("boom")
-
-        with pytest.raises(ValueError, match="boom"):
-            await watch_loop(interval=None, command="fdw sql exec", tick=_boom)
 
 
 class TestSqlPlan:

--- a/tests/unit/cli/commands/test_sql.py
+++ b/tests/unit/cli/commands/test_sql.py
@@ -22,7 +22,8 @@ from click.testing import CliRunner, Result
 
 from fabric_dw.cache import ItemEntry
 from fabric_dw.cli._main import cli
-from fabric_dw.exceptions import NotFoundError, PermissionDeniedError
+from fabric_dw.cli._watch import watch_loop
+from fabric_dw.exceptions import FabricError, NotFoundError, PermissionDeniedError
 from fabric_dw.models import SqlResult, WarehouseKind
 from fabric_dw.sql import SqlTarget
 
@@ -30,6 +31,10 @@ WS_GUID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
 WH_GUID = "d4e5f6a7-b8c9-0123-def0-123456789abc"
 WS_UUID = UUID(WS_GUID)
 WH_UUID = UUID(WH_GUID)
+
+
+class _StopWatchError(Exception):
+    """Terminate a watch-loop test after the requested number of sleeps."""
 
 
 def _make_sql_target() -> SqlTarget:
@@ -467,6 +472,257 @@ class TestSqlExecDuplicateColumns:
         assert result.exit_code == 0
         assert "foo" in result.output
         assert "bar" in result.output
+
+
+class TestSqlExecWatch:
+    """sql exec --watch — interval validation, --json rejection, live refresh (issue #1027)."""
+
+    def test_watch_requires_positive_interval(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        result = runner.invoke(
+            cli, ["-w", WS_GUID, "sql", "exec", WH_GUID, "-q", "SELECT 1", "--watch", "0"]
+        )
+        assert result.exit_code != 0
+        assert "x>=1" in result.output
+
+    def test_watch_rejects_negative_interval(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        result = runner.invoke(
+            cli, ["-w", WS_GUID, "sql", "exec", WH_GUID, "-q", "SELECT 1", "--watch", "-1"]
+        )
+        assert result.exit_code != 0
+
+    def test_watch_rejects_json_before_opening_client(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        _ = cache_env
+        with patch("fabric_dw.cli.commands.sql.build_http_client") as build_client:
+            result = runner.invoke(
+                cli,
+                [
+                    "--json",
+                    "-w",
+                    WS_GUID,
+                    "sql",
+                    "exec",
+                    WH_GUID,
+                    "-q",
+                    "SELECT 1",
+                    "--watch",
+                    "1",
+                ],
+            )
+        assert result.exit_code != 0
+        assert "--watch cannot be used with --json" in result.output
+        build_client.assert_not_called()
+
+    def test_watch_renders_immediately_then_repeats_on_interval(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """Rows render on the first tick with no delay, then the loop clears/redraws."""
+        _ = cache_env
+        mock_http = AsyncMock()
+        execute = AsyncMock(return_value=_make_sql_result())
+        sleep = AsyncMock(side_effect=[None, _StopWatchError()])
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch("fabric_dw.services.sql_exec.execute", new=execute),
+            patch("fabric_dw.cli._watch.asyncio.sleep", new=sleep),
+            patch("fabric_dw.cli._watch.click.clear") as clear,
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "-w",
+                    WS_GUID,
+                    "sql",
+                    "exec",
+                    WH_GUID,
+                    "-q",
+                    "SELECT id, name FROM t",
+                    "--watch",
+                    "3",
+                ],
+            )
+        assert execute.await_count == 2
+        assert clear.call_count == 2
+        assert "Every 3s: fdw sql exec" in result.output
+        assert result.output.count("foo") == 2
+
+    def test_watch_reads_query_once_not_per_tick(
+        self, runner: CliRunner, cache_env: Path, tmp_path: Path
+    ) -> None:
+        """The -f file is read once at start-up; each tick re-executes the same text."""
+        _ = cache_env
+        sql_file = tmp_path / "query.sql"
+        sql_file.write_text("SELECT 1 AS n")
+        mock_http = AsyncMock()
+        captured_queries: list[str] = []
+
+        async def _capture_execute(_target: object, query: str, **_kwargs: object) -> SqlResult:
+            captured_queries.append(query)
+            return _make_sql_result()
+
+        sleep = AsyncMock(side_effect=[None, _StopWatchError()])
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch("fabric_dw.services.sql_exec.execute", new=_capture_execute),
+            patch("fabric_dw.cli._watch.asyncio.sleep", new=sleep),
+            patch("fabric_dw.cli._watch.click.clear"),
+        ):
+            runner.invoke(
+                cli,
+                ["-w", WS_GUID, "sql", "exec", WH_GUID, "-f", str(sql_file), "--watch", "2"],
+            )
+        assert captured_queries == ["SELECT 1 AS n", "SELECT 1 AS n"]
+
+    def test_watch_empty_result_renders_rowcount_each_tick(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """DML with no result rows prints the rowcount line on every tick."""
+        _ = cache_env
+        mock_http = AsyncMock()
+        execute = AsyncMock(return_value=_make_empty_sql_result())
+        sleep = AsyncMock(side_effect=[None, _StopWatchError()])
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch("fabric_dw.services.sql_exec.execute", new=execute),
+            patch("fabric_dw.cli._watch.asyncio.sleep", new=sleep),
+            patch("fabric_dw.cli._watch.click.clear"),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "-w",
+                    WS_GUID,
+                    "sql",
+                    "exec",
+                    WH_GUID,
+                    "-q",
+                    "DELETE FROM t",
+                    "--watch",
+                    "2",
+                ],
+            )
+        assert execute.await_count == 2
+        assert result.output.count("Query executed successfully. rowcount=3") == 2
+
+    def test_watch_without_flag_runs_once_unchanged(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """Without --watch, behaviour is exactly the pre-#1027 single-shot execution."""
+        _ = cache_env
+        mock_http = AsyncMock()
+        execute = AsyncMock(return_value=_make_sql_result())
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch("fabric_dw.services.sql_exec.execute", new=execute),
+            patch("fabric_dw.cli._watch.asyncio.sleep") as sleep,
+            patch("fabric_dw.cli._watch.click.clear") as clear,
+        ):
+            result = runner.invoke(
+                cli,
+                ["-w", WS_GUID, "sql", "exec", WH_GUID, "-q", "SELECT id, name FROM t"],
+            )
+        assert result.exit_code == 0
+        execute.assert_awaited_once()
+        clear.assert_not_called()
+        sleep.assert_not_called()
+
+    def test_watch_tick_error_ends_watch_with_click_exception(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """An error raised during a tick ends the watch as a ClickException, not a crash."""
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.sql.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.sql.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            patch(
+                "fabric_dw.services.sql_exec.execute",
+                new=AsyncMock(side_effect=FabricError("server exploded")),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                ["-w", WS_GUID, "sql", "exec", WH_GUID, "-q", "SELECT 1", "--watch", "5"],
+            )
+        assert result.exit_code != 0
+        assert "server exploded" in result.output
+
+
+class TestWatchLoop:
+    """fabric_dw.cli._watch.watch_loop — the shared loop behind ``queries`` and ``sql exec``."""
+
+    @pytest.mark.anyio
+    async def test_runs_tick_once_without_clearing_when_interval_is_none(self) -> None:
+        tick = AsyncMock()
+        with (
+            patch("fabric_dw.cli._watch.click.clear") as clear,
+            patch("fabric_dw.cli._watch.asyncio.sleep") as sleep,
+        ):
+            await watch_loop(interval=None, command="fdw sql exec", tick=tick)
+        tick.assert_awaited_once()
+        clear.assert_not_called()
+        sleep.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_clears_prints_header_and_repeats_on_interval(self) -> None:
+        tick = AsyncMock()
+        sleep = AsyncMock(side_effect=[None, _StopWatchError()])
+        with (
+            patch("fabric_dw.cli._watch.click.clear") as clear,
+            patch("fabric_dw.cli._watch.click.echo") as echo,
+            patch("fabric_dw.cli._watch.asyncio.sleep", new=sleep),
+            pytest.raises(_StopWatchError),
+        ):
+            await watch_loop(interval=5, command="fdw sql exec", tick=tick)
+        assert tick.await_count == 2
+        assert clear.call_count == 2
+        assert sleep.await_args_list == [((5,),), ((5,),)]
+        assert "Every 5s: fdw sql exec" in echo.call_args_list[0].args[0]
+
+    @pytest.mark.anyio
+    async def test_tick_error_propagates_uncaught(self) -> None:
+        async def _boom() -> None:
+            raise ValueError("boom")
+
+        with pytest.raises(ValueError, match="boom"):
+            await watch_loop(interval=None, command="fdw sql exec", tick=_boom)
 
 
 class TestSqlPlan:

--- a/tests/unit/cli/conftest.py
+++ b/tests/unit/cli/conftest.py
@@ -1,0 +1,15 @@
+"""Shared, non-fixture test helpers for tests/unit/cli/ and its subpackages.
+
+``_StopWatchError`` is not a pytest fixture -- it is a plain exception class
+imported directly by ``--watch`` loop tests to terminate an otherwise-infinite
+watch loop after a fixed number of iterations (see ``fabric_dw.cli._watch``).
+Centralised here so ``test_watch.py``, ``commands/test_queries.py``, and
+``commands/test_sql.py`` share one definition instead of three near-identical
+copies.
+"""
+
+from __future__ import annotations
+
+
+class _StopWatchError(Exception):
+    """Terminate a watch-loop test after the requested number of sleeps."""

--- a/tests/unit/cli/test_watch.py
+++ b/tests/unit/cli/test_watch.py
@@ -1,0 +1,95 @@
+"""Tests for fabric_dw.cli._watch -- the shared --watch loop (issue #1027).
+
+Covers the loop mechanics used by both ``queries`` and ``sql exec``:
+interval validation, the immediate-then-repeat cadence, and -- the subject of
+PR #1028 review round 1 -- that a cycle fetches its data *before* clearing the
+terminal, so a slow fetch never blanks the screen.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import click
+import pytest
+
+from fabric_dw.cli._watch import validate_watch, watch_loop
+from tests.unit.cli.conftest import _StopWatchError
+
+
+class TestValidateWatch:
+    """validate_watch -- reject --watch + --json before any network client opens."""
+
+    def test_allows_watch_without_json(self) -> None:
+        validate_watch(json_output=False, watch=5)
+
+    def test_allows_json_without_watch(self) -> None:
+        validate_watch(json_output=True, watch=None)
+
+    def test_allows_neither(self) -> None:
+        validate_watch(json_output=False, watch=None)
+
+    def test_rejects_watch_with_json(self) -> None:
+        with pytest.raises(click.UsageError, match="--watch cannot be used with --json"):
+            validate_watch(json_output=True, watch=5)
+
+
+class TestWatchLoop:
+    """watch_loop -- the shared loop behind ``queries`` and ``sql exec``."""
+
+    @pytest.mark.anyio
+    async def test_runs_once_without_clearing_when_interval_is_none(self) -> None:
+        fetch = AsyncMock(return_value="data")
+        render = Mock()
+        with (
+            patch("fabric_dw.cli._watch.click.clear") as clear,
+            patch("fabric_dw.cli._watch.asyncio.sleep") as sleep,
+        ):
+            await watch_loop(interval=None, command="fdw sql exec", fetch=fetch, render=render)
+        fetch.assert_awaited_once()
+        render.assert_called_once_with("data")
+        clear.assert_not_called()
+        sleep.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_fetches_before_clearing_then_renders_and_repeats(self) -> None:
+        """Regression: a cycle must fetch before clearing the terminal.
+
+        Clearing before the fetch completes would blank the screen for the
+        duration of a slow fetch and would sample the header timestamp before
+        the data was actually read. Verified here via explicit call-order
+        assertions, not just call counts (which cannot distinguish the two
+        orderings).
+        """
+        manager = MagicMock()
+        fetch = AsyncMock(side_effect=["first", "second"])
+        render = Mock()
+        manager.attach_mock(fetch, "fetch")
+        manager.attach_mock(render, "render")
+        sleep = AsyncMock(side_effect=[None, _StopWatchError()])
+        with (
+            patch("fabric_dw.cli._watch.click.clear") as clear,
+            patch("fabric_dw.cli._watch.click.echo") as echo,
+            patch("fabric_dw.cli._watch.asyncio.sleep", new=sleep),
+        ):
+            manager.attach_mock(clear, "clear")
+            with pytest.raises(_StopWatchError):
+                await watch_loop(interval=5, command="fdw sql exec", fetch=fetch, render=render)
+
+        assert fetch.await_count == 2
+        assert render.call_args_list == [(("first",),), (("second",),)]
+        assert clear.call_count == 2
+        assert sleep.await_args_list == [((5,),), ((5,),)]
+        assert "Every 5s: fdw sql exec" in echo.call_args_list[0].args[0]
+
+        relevant = {"fetch", "clear", "render"}
+        call_order = [name for name, _args, _kwargs in manager.mock_calls if name in relevant]
+        assert call_order == ["fetch", "clear", "render", "fetch", "clear", "render"]
+
+    @pytest.mark.anyio
+    async def test_fetch_error_propagates_uncaught(self) -> None:
+        async def _boom() -> None:
+            raise ValueError("boom")
+
+        with pytest.raises(ValueError, match="boom"):
+            await watch_loop(interval=None, command="fdw sql exec", fetch=_boom, render=Mock())


### PR DESCRIPTION
Closes #1027

## What changed

- Added `--watch SECONDS` to `sql exec`, so an arbitrary user-supplied query can be followed live, the same way `queries running`/`locks`/`connections` already can.
- Extracted the watch-loop mechanics (clear, header, sleep) from `queries.py` into a new shared helper, `fabric_dw.cli._watch` (`watch_loop`, `validate_watch`), so `queries` and `sql exec` run exactly one loop implementation.
- `queries.py`'s existing `--watch` commands now delegate to the shared helper; their public behaviour is unchanged.
- Documented `--watch` in `docs/commands/sql.md`, including a warning that the statement is re-executed unchanged on every tick (no SQL parsing is used to detect read-only statements, per this repo's no-SQL-parsing rule).

## Why

`sql exec` is the one place users run arbitrary queries, and following a custom query (e.g. a `SELECT COUNT(*)`) live was only possible for the built-in `queries` commands. Sharing the loop implementation also removes a second, drifting copy of the same clear/header/sleep logic.

## Validation

- Focused CLI tests: `uv run pytest tests/unit/cli/commands/test_sql.py tests/unit/cli/commands/test_queries.py` - 98 passed
- `just lint` (ruff check + format check) - passed
- `just type` (ty) - passed
- No integration tests needed: this is CLI render/loop logic; the underlying execution path is already covered (same rationale as #1015)