### PR TITLE
ci: let dependabot manage uv.lock and skip its docs preview

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,9 @@
 version: 2
 updates:
-  - package-ecosystem: pip
+  # `uv`, not `pip`: the pip ecosystem edits pyproject.toml without regenerating
+  # uv.lock, which makes `uv lock --check` (and every `uv sync --locked` job after
+  # it) fail on each dependency PR. The uv ecosystem moves both files together.
+  - package-ecosystem: uv
     directory: /
     schedule:
       interval: weekly

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,7 +12,7 @@ name: Docs
 # Both conditions are required so a malformed-but-non-prerelease tag can never
 # reach production.
 #
-# Fork PRs: the deploy-preview job is skipped (secrets are absent on fork PRs).
+# Fork and dependabot PRs: the deploy-preview job is skipped (secrets are absent).
 
 on:
   push:
@@ -171,10 +171,15 @@ jobs:
   deploy-preview:
     name: Deploy PR preview
     needs: build
-    # Skip for fork PRs: secrets are not exposed, so the deploy would fail.
+    # Skip when secrets are not exposed, which would make the deploy fail:
+    #   - fork PRs
+    #   - dependabot PRs: the branch lives in this repo, so the fork check above
+    #     passes, but dependabot runs get a read-only token and the separate
+    #     Dependabot secrets store, so CLOUDFLARE_API_TOKEN is absent.
     if: >-
       github.event_name == 'pull_request' &&
-      github.event.pull_request.head.repo.full_name == github.repository
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     environment:
       name: staging


### PR DESCRIPTION
Two unrelated causes made every dependabot PR go red. Both are fixed here.

## `package-ecosystem: pip` never updated `uv.lock`

The pip ecosystem does not know about `uv.lock`, so dependabot edited `pyproject.toml` alone. That failed `uv lock --check` in the Lint job, and every other job then died on `uv sync --locked`. On #1020 and #1022 all checks were red within ten seconds, which needed a manual `uv lock` on each branch before they could merge.

Switching the entry to `package-ecosystem: uv` makes dependabot move `pyproject.toml` and `uv.lock` together. The grouping config is unchanged.

This also matters for the exact `ruff==` pin from #1029: under the pip ecosystem the next ruff bump would have broken in exactly the same way.

## `Deploy PR preview` failed on every dependabot PR

The guard excluded fork PRs only:

```yaml
github.event.pull_request.head.repo.full_name == github.repository
```

Dependabot branches live in this repo, so that check passes. But dependabot runs get a read-only token and the separate Dependabot secrets store, so `CLOUDFLARE_API_TOKEN` is unset and wrangler fails. Excluding the actor as well is the smaller of the two options; the alternative is storing the token as a Dependabot secret, which grants a bot deploy credentials for no real gain on a dependency bump.

Note that this check goes green as soon as a human or agent pushes to the branch, because the run is then no longer dependabot's. That masked the problem on all three PRs merged today.

## Verification

Both files parse as YAML and the resolved `if:` expression is as intended. There is no local harness for dependabot config; the real proof is the next scheduled dependency PR arriving with a matching `uv.lock`.