### PR TITLE
chore(deps)!: migrate to MCP Python SDK v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,11 @@ Request bodies are capped at 4 MiB; anything larger is rejected with HTTP 413. I
 
 #### Protocol versions
 
-The server speaks MCP revision `2026-07-28` and continues to serve `2025-11-25` clients from the same process, so no client change is needed. Two protocol-level notes for anyone driving the server directly: `ping` is no longer part of the protocol, and unknown methods return `-32601` (method not found) rather than `-32602`.
+The server speaks MCP revision `2026-07-28` and continues to serve `2025-11-25` clients from the same process, so no client change is needed. Two protocol-level notes for anyone driving the server directly.
+
+`ping` was removed in revision `2026-07-28`, but only for clients that negotiate that revision: a `2025-11-25` client can still call it and this server still answers. A `2026-07-28` client gets `-32601` instead. Note that the SDK's own client emits a deprecation warning from `send_ping()` in both cases, so the warning alone does not tell you whether the call worked.
+
+Unknown methods return `-32601` (method not found) under both revisions.
 
 ## Develop in a container
 

--- a/README.md
+++ b/README.md
@@ -183,6 +183,12 @@ fabric-dw-mcp --transport http [--host 127.0.0.1] [--port 8000]
 
 Binding to non-loopback addresses requires `FABRIC_MCP_ALLOW_REMOTE=1`. The HTTP transport has **no built-in authentication or TLS**. Always front it with an authenticating reverse proxy.
 
+Request bodies are capped at 4 MiB; anything larger is rejected with HTTP 413. In practice only a multi-megabyte `execute_sql` script or object definition can reach that. The stdio transport has no such limit.
+
+#### Protocol versions
+
+The server speaks MCP revision `2026-07-28` and continues to serve `2025-11-25` clients from the same process, so no client change is needed. Two protocol-level notes for anyone driving the server directly: `ping` is no longer part of the protocol, and unknown methods return `-32601` (method not found) rather than `-32602`.
+
 ## Develop in a container
 
 Open the repo in [GitHub Codespaces](https://github.com/codespaces) or VS Code's Remote-Containers extension. The devcontainer pre-installs Python 3.14, uv, Azure CLI, and the GitHub CLI.

--- a/docs/install.md
+++ b/docs/install.md
@@ -478,6 +478,12 @@ fabric-dw-mcp --transport http [--host 127.0.0.1] [--port 8000]
 
 Binding to non-loopback addresses requires `FABRIC_MCP_ALLOW_REMOTE=1`. The HTTP transport has **no built-in authentication or TLS** - always front it with an authenticating reverse proxy.
 
+Request bodies are capped at 4 MiB; anything larger is rejected with HTTP 413. In practice only a multi-megabyte `execute_sql` script or object definition can reach that. The stdio transport has no such limit.
+
+### Protocol versions
+
+The server speaks MCP revision `2026-07-28` and continues to serve `2025-11-25` clients from the same process, so no client change is needed. Two protocol-level notes for anyone driving the server directly: `ping` is no longer part of the protocol, and unknown methods return `-32601` (method not found) rather than `-32602`.
+
 ### Verify the MCP server
 
 After configuring your client, restart it and ask the assistant to list its available tools. You should see entries like `list_workspaces`, `get_warehouse`, `kill_session`, `clear_cache`, and 23 others (27 tools total).

--- a/docs/install.md
+++ b/docs/install.md
@@ -198,7 +198,7 @@ The equivalent `.mcp.json` snippet (project scope, `default` auth):
 }
 ```
 
-After adding, verify with `/mcp` inside a Claude Code session. You should see 27 tools including `list_workspaces`, `get_warehouse`, `kill_session`, and `clear_cache`.
+After adding, verify with `/mcp` inside a Claude Code session. You should see over 100 tools including `list_workspaces`, `get_warehouse`, `kill_session`, and `clear_cache`.
 
 ### Cursor
 
@@ -482,11 +482,15 @@ Request bodies are capped at 4 MiB; anything larger is rejected with HTTP 413. I
 
 ### Protocol versions
 
-The server speaks MCP revision `2026-07-28` and continues to serve `2025-11-25` clients from the same process, so no client change is needed. Two protocol-level notes for anyone driving the server directly: `ping` is no longer part of the protocol, and unknown methods return `-32601` (method not found) rather than `-32602`.
+The server speaks MCP revision `2026-07-28` and continues to serve `2025-11-25` clients from the same process, so no client change is needed. Two protocol-level notes for anyone driving the server directly.
+
+`ping` was removed in revision `2026-07-28`, but only for clients that negotiate that revision: a `2025-11-25` client can still call it and this server still answers. A `2026-07-28` client gets `-32601` instead. Note that the SDK's own client emits a deprecation warning from `send_ping()` in both cases, so the warning alone does not tell you whether the call worked.
+
+Unknown methods return `-32601` (method not found) under both revisions.
 
 ### Verify the MCP server
 
-After configuring your client, restart it and ask the assistant to list its available tools. You should see entries like `list_workspaces`, `get_warehouse`, `kill_session`, `clear_cache`, and 23 others (27 tools total).
+After configuring your client, restart it and ask the assistant to list its available tools. You should see over 100 entries, including `list_workspaces`, `get_warehouse`, `kill_session`, and `clear_cache`.
 
 ### MCP troubleshooting
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -73,6 +73,22 @@ One `command_invoked` event is emitted after every CLI command and every MCP too
 - Connection strings or any credentials
 - File paths or environment variable values
 - Any other personally-identifiable information
+- Distributed traces of any kind, including MCP protocol spans and the exception
+  text they carry
+
+### No spans are ever exported
+
+`fabric-dw` emits telemetry as OpenTelemetry **log records**, never as spans, and
+it configures Application Insights with `disable_tracing=True` so no span
+exporter is installed at all.
+
+This matters because the MCP Python SDK installs an OpenTelemetry middleware on
+every server it creates, and that middleware records the method name, the tool
+name, and, when a call fails, the full exception text on a span. For this project
+that exception text would include Fabric API errors, SQL error messages, and the
+workspace and warehouse names embedded in them, all of which the list above
+promises not to collect. With no span exporter installed, those spans are created
+in-process and go nowhere.
 
 ## Where telemetry data goes
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -74,14 +74,21 @@ One `command_invoked` event is emitted after every CLI command and every MCP too
 - File paths or environment variable values
 - Any other personally-identifiable information
 - Distributed traces of any kind, including MCP protocol spans
-- Metrics of any kind
+- Metrics of any kind, including the SDK's own delivery-statistics counters
 
-### No spans or metrics are ever exported
+### `fabric-dw` exports no spans and no metrics
 
 `fabric-dw` emits telemetry as OpenTelemetry **log records**, never as spans. It
 forces `OTEL_TRACES_EXPORTER=none` and `OTEL_METRICS_EXPORTER=none` around the
 Application Insights setup call, so no span exporter and no metric exporter is
 built. Only the logs pipeline, which carries the `customEvents` above, is active.
+
+One qualifier on "no spans are exported", because it is about this package and
+not about your process: if you embed `fabric-dw` in an application that has
+already set up its own OpenTelemetry `TracerProvider`, that provider keeps
+collecting spans and sending them wherever you configured. That is intended. What
+`fabric-dw` guarantees is that it never adds an export path of its own, and never
+points one at the maintainers.
 
 Those two variables are set unconditionally rather than deferring to a value you
 may already have in your environment, and they are restored to whatever they were
@@ -93,6 +100,16 @@ rather than the one you asked for. Deferring would therefore have handed you no
 control while quietly turning the export path back on. `OTEL_LOGS_EXPORTER` is
 left alone: setting it to `none` yourself switches off `fabric-dw`'s own events,
 which is a choice worth respecting.
+
+There is a second, separately gated pipeline that the exporter library starts on
+its own: **customer sdkstats**, a delivery-statistics channel that reports how
+many telemetry items succeeded, dropped, or were retried. Despite the name it is
+not covered by the statsbeat switch, and it builds its own metric exporter, meter
+provider, and a reader on a 15-minute timer, all pointed at the same connection
+string. A CLI command finishes long before the first export cycle, but an MCP
+server does not, and that is this project's main mode. `fabric-dw` therefore sets
+`APPLICATIONINSIGHTS_SDKSTATS_DISABLED=true` unless you have already given that
+variable a value of your own.
 
 This matters because the MCP Python SDK installs an OpenTelemetry middleware on
 every server it creates, and that middleware emits one span per inbound protocol

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -79,9 +79,20 @@ One `command_invoked` event is emitted after every CLI command and every MCP too
 ### No spans or metrics are ever exported
 
 `fabric-dw` emits telemetry as OpenTelemetry **log records**, never as spans. It
-sets `OTEL_TRACES_EXPORTER=none` and `OTEL_METRICS_EXPORTER=none` before
-initialising Application Insights, so no span exporter and no metric exporter is
+forces `OTEL_TRACES_EXPORTER=none` and `OTEL_METRICS_EXPORTER=none` around the
+Application Insights setup call, so no span exporter and no metric exporter is
 built. Only the logs pipeline, which carries the `customEvents` above, is active.
+
+Those two variables are set unconditionally rather than deferring to a value you
+may already have in your environment, and they are restored to whatever they were
+immediately afterwards, so nothing else in your process is affected. The reason
+they are not merely defaulted is that the Azure Monitor library reads them only
+to check for the exact string `none`: any other value, including an empty string
+or `otlp`, leaves the pipeline on and installs the **Azure Monitor** exporter
+rather than the one you asked for. Deferring would therefore have handed you no
+control while quietly turning the export path back on. `OTEL_LOGS_EXPORTER` is
+left alone: setting it to `none` yourself switches off `fabric-dw`'s own events,
+which is a choice worth respecting.
 
 This matters because the MCP Python SDK installs an OpenTelemetry middleware on
 every server it creates, and that middleware emits one span per inbound protocol

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -73,22 +73,38 @@ One `command_invoked` event is emitted after every CLI command and every MCP too
 - Connection strings or any credentials
 - File paths or environment variable values
 - Any other personally-identifiable information
-- Distributed traces of any kind, including MCP protocol spans and the exception
-  text they carry
+- Distributed traces of any kind, including MCP protocol spans
+- Metrics of any kind
 
-### No spans are ever exported
+### No spans or metrics are ever exported
 
-`fabric-dw` emits telemetry as OpenTelemetry **log records**, never as spans, and
-it configures Application Insights with `disable_tracing=True` so no span
-exporter is installed at all.
+`fabric-dw` emits telemetry as OpenTelemetry **log records**, never as spans. It
+sets `OTEL_TRACES_EXPORTER=none` and `OTEL_METRICS_EXPORTER=none` before
+initialising Application Insights, so no span exporter and no metric exporter is
+built. Only the logs pipeline, which carries the `customEvents` above, is active.
 
 This matters because the MCP Python SDK installs an OpenTelemetry middleware on
-every server it creates, and that middleware records the method name, the tool
-name, and, when a call fails, the full exception text on a span. For this project
-that exception text would include Fabric API errors, SQL error messages, and the
-workspace and warehouse names embedded in them, all of which the list above
-promises not to collect. With no span exporter installed, those spans are created
-in-process and go nowhere.
+every server it creates, and that middleware emits one span per inbound protocol
+message. Measured against the version this package pins, those spans carry the
+method name (`tools/call`), the protocol revision, the JSON-RPC request ID, the
+tool name, an `error.type` marker, and timings.
+
+To be precise about what that is and is not: a failing tool call does **not** put
+the exception text on the span. The MCP server converts a failing tool into an
+error result before the middleware sees it, so the middleware records only
+`error.type="tool_error"` with no message. SQL text, Fabric API error strings and
+warehouse names are therefore not in the span payload. What would leak is
+metadata: which tool ran, when, how long it took, and whether it failed. That is
+still not on the collection list above, which is why the exporters are off.
+
+Two notes for completeness. Both `disable_tracing=True` and `disable_metrics=True`
+are also passed to the Azure Monitor configuration, but neither works: the library
+overwrites caller-supplied values with its own defaults, which read only the
+environment variables. The environment variables are the mechanism; the arguments
+are a statement of intent. And a server that registered MCP *prompts* would leak
+one more thing, the client-supplied prompt name, which the middleware copies into
+the span name verbatim. `fabric-dw` registers no prompts and no resources, so this
+does not arise here.
 
 ## Where telemetry data goes
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -181,3 +181,11 @@ The client automatically retries on each 429 and waits exactly as long as the se
 3. **Restart the MCP client:** Most AI tools (Claude Desktop, Cursor, VS Code) cache the tool list at startup. After updating the config or reinstalling the package, fully quit and reopen the application.
 
 4. **Check the client logs:** Look for stderr output from the `fabric-dw-mcp` process in your AI tool's log folder - startup errors (missing env vars, import failures) are printed there.
+
+## HTTP 413 from the HTTP transport
+
+**Symptom:** A tool call over `--transport http` fails with HTTP 413 (payload too large). The same call over stdio succeeds.
+
+**Cause:** The streamable-HTTP transport caps request bodies at 4 MiB. Only a very large payload reaches that: a multi-megabyte `execute_sql` script, or a procedure or view definition passed to `create_procedure` / `create_view`.
+
+**Fix:** Split the statement, or load the script from storage with `load_table_from_url` / `import_table_from_url` rather than sending it inline. If neither fits, use the stdio transport, which has no body limit.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,19 +50,22 @@ classifiers = [
 ]
 dependencies = [
     "azure-identity>=1.19",
-    "pydantic>=2.9",
-    # Upper bound <1: httpx 1.0.dev* removed both httpx.TransportError and the http2
-    # extra. httpx-sse (a transitive dep via mcp) subclasses TransportError, so any
-    # 1.x pre-release breaks the MCP transport layer at import time. No stable httpx
-    # 1.0 has shipped yet; all evidence from the dev releases points to TransportError
-    # being gone permanently. The MCP SDK itself adopted the same <1.0.0 ceiling.
-    # Remove or raise this bound only after httpx-sse ships explicit httpx 1.x support.
+    # Floor 2.12: mcp 2.x requires pydantic>=2.12.0, so anything lower is fiction.
+    "pydantic>=2.12",
+    # Upper bound <1: httpx 1.0.dev* removed the http2 extra, and http_client.py
+    # constructs httpx.AsyncClient(http2=True) unconditionally, so any 1.x
+    # pre-release breaks our own HTTP layer. This used to be justified by
+    # httpx-sse subclassing httpx.TransportError, but mcp 2.x depends on
+    # neither httpx nor httpx-sse (it vendors its transport on httpx2), so the
+    # cap now stands purely on this project's own http2 usage. No stable httpx
+    # 1.0 has shipped yet. Remove or raise this bound only once httpx 1.x
+    # offers an http2 story we can migrate http_client.py onto.
     "httpx[http2]>=0.27,<1",
     "aiolimiter>=1.2",
     "tenacity>=9",
     "mssql-python>=1.13.0",
     "filelock>=3.16",
-    "mcp[cli]>=1.28.1,<2",
+    "mcp[cli]>=2,<3",
     "click>=8.2",
     "rich>=14",
     "anyio>=4",
@@ -190,6 +193,10 @@ filterwarnings = [
     "ignore::DeprecationWarning:pkg_resources",
     "ignore::DeprecationWarning:google",
     "ignore::DeprecationWarning:azure",
+    # Inert under mcp 2.x (MCPDeprecationWarning subclasses UserWarning, which we
+    # do not turn into an error) but kept as insurance: the policy above is to
+    # absorb third-party deprecations rather than let an upstream release break
+    # the suite unilaterally.
     "ignore::DeprecationWarning:mcp",
     "ignore::DeprecationWarning:pydantic",
     "ignore::DeprecationWarning:httpx",

--- a/src/fabric_dw/identifiers.py
+++ b/src/fabric_dw/identifiers.py
@@ -264,7 +264,7 @@ def parse_qualified_name(qualified: str, kind: str = "object") -> tuple[str, str
     - Raises :class:`ValueError` for any invalid input; upper layers
       (:func:`~fabric_dw.mcp._helpers.parse_qualified_name`,
       :func:`~fabric_dw.cli.commands._utils.parse_qualified_name`) convert
-      that into their respective error types (:class:`~mcp.server.fastmcp.exceptions.ToolError`,
+      that into their respective error types (:class:`~mcp.server.mcpserver.exceptions.ToolError`,
       :class:`click.UsageError`).
 
     Args:

--- a/src/fabric_dw/mcp/_context.py
+++ b/src/fabric_dw/mcp/_context.py
@@ -7,7 +7,7 @@ and cleared on shutdown.
 
 Design note
 -----------
-MCPServer's lifespan mechanism stores the yielded object inside the low-level
+The SDK's lifespan mechanism stores the yielded object inside the low-level
 request context (``request_context.lifespan_context``), but retrieving it
 requires injecting a ``Context`` parameter into every tool function.  Instead,
 we store the single ``ServerContext`` instance in a module-level sentinel
@@ -193,13 +193,13 @@ def build_context(
 
 
 # ---------------------------------------------------------------------------
-# MCPServer lifespan
+# MCP server lifespan
 # ---------------------------------------------------------------------------
 
 
 @asynccontextmanager
 async def fabric_lifespan(app: MCPServer) -> AsyncIterator[None]:  # noqa: ARG001
-    """MCPServer lifespan that initialises and tears down the :class:`ServerContext`.
+    """MCP server lifespan that initialises and tears down the :class:`ServerContext`.
 
     Usage::
 

--- a/src/fabric_dw/mcp/_context.py
+++ b/src/fabric_dw/mcp/_context.py
@@ -7,7 +7,7 @@ and cleared on shutdown.
 
 Design note
 -----------
-FastMCP's lifespan mechanism stores the yielded object inside the low-level
+MCPServer's lifespan mechanism stores the yielded object inside the low-level
 request context (``request_context.lifespan_context``), but retrieving it
 requires injecting a ``Context`` parameter into every tool function.  Instead,
 we store the single ``ServerContext`` instance in a module-level sentinel
@@ -41,7 +41,7 @@ from fabric_dw.http_client import FabricHttpClient
 from fabric_dw.resolver import Resolver
 
 if TYPE_CHECKING:
-    from mcp.server.fastmcp import FastMCP
+    from mcp.server.mcpserver import MCPServer
 
 __all__ = [
     "ServerContext",
@@ -193,17 +193,17 @@ def build_context(
 
 
 # ---------------------------------------------------------------------------
-# FastMCP lifespan
+# MCPServer lifespan
 # ---------------------------------------------------------------------------
 
 
 @asynccontextmanager
-async def fabric_lifespan(app: FastMCP) -> AsyncIterator[None]:  # noqa: ARG001
-    """FastMCP lifespan that initialises and tears down the :class:`ServerContext`.
+async def fabric_lifespan(app: MCPServer) -> AsyncIterator[None]:  # noqa: ARG001
+    """MCPServer lifespan that initialises and tears down the :class:`ServerContext`.
 
     Usage::
 
-        mcp = FastMCP("fabric-dw", lifespan=fabric_lifespan)
+        mcp = MCPServer("fabric-dw", lifespan=fabric_lifespan)
 
     The lifespan:
 

--- a/src/fabric_dw/mcp/_guards.py
+++ b/src/fabric_dw/mcp/_guards.py
@@ -57,7 +57,7 @@ import os
 import uuid as _uuid_mod
 from collections.abc import Sequence
 
-from mcp.server.fastmcp.exceptions import ToolError
+from mcp.server.mcpserver.exceptions import ToolError
 
 from fabric_dw.services._helpers import SelectBodyError, _validate_select_body
 

--- a/src/fabric_dw/mcp/_helpers.py
+++ b/src/fabric_dw/mcp/_helpers.py
@@ -212,7 +212,7 @@ def mutating_tool(
     return decorator
 
 
-class InstrumentedMCPServer(MCPServer):
+class InstrumentedMCPServer(MCPServer[None]):
     """A :class:`~mcp.server.mcpserver.MCPServer` subclass that wraps every
     ``@mcp.tool(name=...)`` call with a fire-and-forget ``command_invoked``
     telemetry event.
@@ -224,6 +224,11 @@ class InstrumentedMCPServer(MCPServer):
 
     No changes to any tool registration code are required: all existing
     ``@mcp.tool(name=...)`` calls automatically gain instrumentation.
+
+    The base is parameterised as ``MCPServer[None]`` because
+    :func:`~fabric_dw.mcp._context.fabric_lifespan` yields ``None``: the shared
+    :class:`~fabric_dw.mcp._context.ServerContext` is reached through a
+    module-level sentinel, not through the lifespan result.
     """
 
     def tool(  # noqa: PLR0913

--- a/src/fabric_dw/mcp/_helpers.py
+++ b/src/fabric_dw/mcp/_helpers.py
@@ -3,17 +3,17 @@
 This module provides utilities imported by every domain tool module:
 
 - :func:`fabric_err` — convert a :class:`~fabric_dw.exceptions.FabricError`
-  to a :class:`~mcp.server.fastmcp.exceptions.ToolError` with structured data.
+  to a :class:`~mcp.server.mcpserver.exceptions.ToolError` with structured data.
 - :func:`tool_err` — uniform error funnel mapping FabricError / ValueError /
   Exception to ToolError without inline ternaries.
-- :func:`mutating_tool` — decorator factory that registers a tool with FastMCP
+- :func:`mutating_tool` — decorator factory that registers a tool with MCPServer
   **and** injects :func:`~fabric_dw.mcp._guards.assert_writes_allowed` using
   the same name string, eliminating the duplication flagged by M21.
 - :func:`parse_iso8601` — parse an ISO-8601 string to :class:`~datetime.datetime`,
-  raising :class:`~mcp.server.fastmcp.exceptions.ToolError` on bad input.
+  raising :class:`~mcp.server.mcpserver.exceptions.ToolError` on bad input.
 - :func:`parse_qualified_name` — adapter around
   :func:`~fabric_dw.identifiers.parse_qualified_name` that converts
-  :class:`ValueError` to :class:`~mcp.server.fastmcp.exceptions.ToolError`.
+  :class:`ValueError` to :class:`~mcp.server.mcpserver.exceptions.ToolError`.
 - :func:`make_sql_target` — build a :class:`~fabric_dw.sql.SqlTarget` from a
   resolved item entry and workspace ID, including the connection-string guard.
 - :func:`resolve_item` — return ``(workspace_id, ItemEntry)`` in one resolver
@@ -23,7 +23,7 @@ This module provides utilities imported by every domain tool module:
 
 Telemetry
 ---------
-Both :func:`mutating_tool` and the :class:`InstrumentedFastMCP` subclass
+Both :func:`mutating_tool` and the :class:`InstrumentedMCPServer` subclass
 wrap every registered tool with a timing + ``command_invoked`` telemetry
 call (fire-and-forget, never raises).
 """
@@ -38,8 +38,8 @@ from functools import wraps
 from typing import Any, ParamSpec, TypeVar
 from uuid import UUID
 
-from mcp.server.fastmcp import FastMCP
-from mcp.server.fastmcp.exceptions import ToolError
+from mcp.server.mcpserver import MCPServer
+from mcp.server.mcpserver.exceptions import ToolError
 
 from fabric_dw.cache import ItemEntry as _ItemEntry
 from fabric_dw.exceptions import FabricError
@@ -55,7 +55,7 @@ from fabric_dw.telemetry_commands import (
 )
 
 __all__ = [
-    "InstrumentedFastMCP",
+    "InstrumentedMCPServer",
     "fabric_err",
     "make_sql_target",
     "mutating_tool",
@@ -104,7 +104,7 @@ def _wrap_mcp_tool_with_telemetry(
     never propagate to the caller.
 
     The wrapper sets ``__fabric_telemetry_wrapped__ = True`` on the returned
-    callable so that :class:`InstrumentedFastMCP` can detect already-wrapped
+    callable so that :class:`InstrumentedMCPServer` can detect already-wrapped
     functions and skip the second wrapping (preventing double-emission).
 
     Args:
@@ -135,13 +135,13 @@ def _wrap_mcp_tool_with_telemetry(
                 destructive=destructive,
             )
 
-    # Mark as already instrumented so InstrumentedFastMCP.tool() skips re-wrapping.
+    # Mark as already instrumented so InstrumentedMCPServer.tool() skips re-wrapping.
     setattr(telemetry_wrapper, _TELEMETRY_WRAPPED_ATTR, True)
     return telemetry_wrapper
 
 
 def mutating_tool(
-    mcp: FastMCP,
+    mcp: MCPServer,
     name: str,
     *,
     destructive: bool = False,
@@ -177,7 +177,7 @@ def mutating_tool(
             ...
 
     Args:
-        mcp: The :class:`~mcp.server.fastmcp.FastMCP` server instance.
+        mcp: The :class:`~mcp.server.mcpserver.MCPServer` server instance.
         name: The tool name string, used for both registration and the write guard.
         destructive: When ``True``, also call
             :func:`~fabric_dw.mcp._guards.assert_destructive_allowed` before the
@@ -212,8 +212,8 @@ def mutating_tool(
     return decorator
 
 
-class InstrumentedFastMCP(FastMCP):
-    """A :class:`~mcp.server.fastmcp.FastMCP` subclass that wraps every
+class InstrumentedMCPServer(MCPServer):
+    """A :class:`~mcp.server.mcpserver.MCPServer` subclass that wraps every
     ``@mcp.tool(name=...)`` call with a fire-and-forget ``command_invoked``
     telemetry event.
 
@@ -236,7 +236,7 @@ class InstrumentedFastMCP(FastMCP):
         meta: dict[str, Any] | None = None,
         structured_output: bool | None = None,  # noqa: FBT001
     ) -> Callable[[Any], Any]:
-        """Override :meth:`FastMCP.tool` to inject per-call telemetry."""
+        """Override :meth:`MCPServer.tool` to inject per-call telemetry."""
         parent_decorator = super().tool(
             name=name,
             title=title,
@@ -365,7 +365,7 @@ def parse_qualified_name(qualified_name: str, kind: str = "object") -> tuple[str
 
     Delegates to :func:`~fabric_dw.identifiers.parse_qualified_name` (the
     canonical implementation) and converts :class:`ValueError` to
-    :class:`~mcp.server.fastmcp.exceptions.ToolError`.
+    :class:`~mcp.server.mcpserver.exceptions.ToolError`.
 
     Semantics match :func:`~fabric_dw.identifiers.parse_qualified_name`:
 
@@ -400,7 +400,7 @@ def parse_qualified_name(qualified_name: str, kind: str = "object") -> tuple[str
 def make_sql_target(ws_id: UUID, entry: _ItemEntry, item: str) -> SqlTarget:
     """Build a :class:`~fabric_dw.sql.SqlTarget` from a resolved item entry.
 
-    Raises :class:`~mcp.server.fastmcp.exceptions.ToolError` directly when
+    Raises :class:`~mcp.server.mcpserver.exceptions.ToolError` directly when
     *entry* has no connection string, eliminating the ``try: raise FabricError
     # noqa: TRY301`` anti-pattern in every caller.
 

--- a/src/fabric_dw/mcp/_helpers.py
+++ b/src/fabric_dw/mcp/_helpers.py
@@ -6,7 +6,7 @@ This module provides utilities imported by every domain tool module:
   to a :class:`~mcp.server.mcpserver.exceptions.ToolError` with structured data.
 - :func:`tool_err` — uniform error funnel mapping FabricError / ValueError /
   Exception to ToolError without inline ternaries.
-- :func:`mutating_tool` — decorator factory that registers a tool with MCPServer
+- :func:`mutating_tool` — decorator factory that registers a tool with the MCP server
   **and** injects :func:`~fabric_dw.mcp._guards.assert_writes_allowed` using
   the same name string, eliminating the duplication flagged by M21.
 - :func:`parse_iso8601` — parse an ISO-8601 string to :class:`~datetime.datetime`,

--- a/src/fabric_dw/mcp/server.py
+++ b/src/fabric_dw/mcp/server.py
@@ -58,6 +58,7 @@ import sys
 from collections.abc import Sequence
 from typing import Literal
 
+from fabric_dw import __version__
 from fabric_dw.config import load_config
 from fabric_dw.logging import setup_logging
 from fabric_dw.mcp._context import fabric_lifespan
@@ -112,6 +113,10 @@ mcp: InstrumentedMCPServer = InstrumentedMCPServer(
     "fabric-dw",
     lifespan=fabric_lifespan,
     instructions=_SERVER_INSTRUCTIONS,
+    # Reported to clients as `serverInfo.version` in the initialize response.
+    # The SDK defaults it to the empty string, so without this the server has
+    # no version at all on the wire.
+    version=__version__,
 )
 
 # ---------------------------------------------------------------------------
@@ -180,6 +185,15 @@ def run(argv: Sequence[str] | None = None) -> None:
         a non-loopback address requires ``FABRIC_MCP_ALLOW_REMOTE=1``.
     ``--port PORT``
         TCP port for HTTP transport (default ``8000``).
+
+    Both are passed straight through to ``MCPServer.run()``, which is overloaded
+    per transport; the stdio overload takes no keyword arguments at all.
+
+    The HTTP transport caps request bodies at 4 MiB and answers anything larger
+    with HTTP 413.  The default is kept: for this server the only realistic way
+    to reach it is a single ``execute_sql`` script or a procedure or view
+    definition of several megabytes.  ``max_request_body_size`` on ``run()`` is
+    the escape hatch if that ever becomes a real constraint.
     """
     setup_logging(_resolve_log_level())
 
@@ -212,30 +226,29 @@ def run(argv: Sequence[str] | None = None) -> None:
         "streamable-http" if args.transport == "http" else "stdio"
     )
 
-    if transport == "streamable-http":
-        if args.host not in _LOOPBACK_HOSTS:
-            if not _guards_env_flag("FABRIC_MCP_ALLOW_REMOTE"):
-                logger.error(
-                    "refusing to bind HTTP transport on %s:%s — this would expose the server "
-                    "network-wide without authentication or TLS. "
-                    "Set FABRIC_MCP_ALLOW_REMOTE=1 to override (ensure a reverse proxy provides "
-                    "authentication and TLS termination).",
-                    args.host,
-                    args.port,
-                )
-                sys.exit(1)
-            logger.warning(
-                "WARNING: HTTP transport is bound on %s:%s (non-loopback). "
-                "The MCP protocol has NO built-in authentication or TLS. "
-                "Ensure an authenticating reverse proxy fronts this endpoint before "
-                "exposing it to untrusted networks.",
+    # Unchanged loopback guard.  It used to sit under a second `if transport ==
+    # "streamable-http"` block that also assigned mcp.settings.host/port; with
+    # that assignment gone the two conditions collapse into one `and`, which
+    # short-circuits identically.
+    if transport == "streamable-http" and args.host not in _LOOPBACK_HOSTS:
+        if not _guards_env_flag("FABRIC_MCP_ALLOW_REMOTE"):
+            logger.error(
+                "refusing to bind HTTP transport on %s:%s — this would expose the server "
+                "network-wide without authentication or TLS. "
+                "Set FABRIC_MCP_ALLOW_REMOTE=1 to override (ensure a reverse proxy provides "
+                "authentication and TLS termination).",
                 args.host,
                 args.port,
             )
-
-        # Update MCPServer settings before run so uvicorn picks them up.
-        mcp.settings.host = args.host
-        mcp.settings.port = args.port
+            sys.exit(1)
+        logger.warning(
+            "WARNING: HTTP transport is bound on %s:%s (non-loopback). "
+            "The MCP protocol has NO built-in authentication or TLS. "
+            "Ensure an authenticating reverse proxy fronts this endpoint before "
+            "exposing it to untrusted networks.",
+            args.host,
+            args.port,
+        )
 
     # A2: print first-run notice to stderr before stdio transport starts so
     # the notice never pollutes the MCP stdio protocol stream.
@@ -246,7 +259,15 @@ def run(argv: Sequence[str] | None = None) -> None:
     start_ms = now_ms()
     exc_seen: BaseException | None = None
     try:
-        mcp.run(transport=transport)
+        # Host and port are transport-specific run() kwargs.  There is no
+        # settings object to mutate: MCPServer exposes no `.settings.host` /
+        # `.settings.port` and assigning to them raises.  run() is overloaded
+        # per transport and the stdio overload accepts no kwargs at all, hence
+        # the two branches.
+        if transport == "streamable-http":
+            mcp.run(transport="streamable-http", host=args.host, port=args.port)
+        else:
+            mcp.run(transport="stdio")
     except BaseException as exc:
         exc_seen = exc
         raise

--- a/src/fabric_dw/mcp/server.py
+++ b/src/fabric_dw/mcp/server.py
@@ -1,4 +1,4 @@
-"""MCPServer server exposing all fabric-dw service functions as MCP tools.
+"""MCP server exposing all fabric-dw service functions as MCP tools.
 
 Architecture
 ------------
@@ -21,7 +21,7 @@ Context access
 Every tool function calls :func:`~fabric_dw.mcp._context.get_context` to
 obtain the shared :class:`~fabric_dw.mcp._context.ServerContext`.  The sentinel
 pattern (module-level ``ServerContext | None``) was chosen over injecting a
-``Context`` parameter into every tool because MCPServer's lifespan context is
+``Context`` parameter into every tool because the SDK's lifespan context is
 not ergonomically accessible from tool functions without either adding a
 ``Context`` import to every tool or using fragile ``request_context``
 internals.  The sentinel is safe for streamable-HTTP concurrency because it is
@@ -105,7 +105,7 @@ _SERVER_INSTRUCTIONS: str = (
 )
 
 # ---------------------------------------------------------------------------
-# MCPServer server instance (instrumented subclass emits command_invoked events)
+# MCP server instance (instrumented subclass emits command_invoked events)
 # ---------------------------------------------------------------------------
 
 mcp: InstrumentedMCPServer = InstrumentedMCPServer(
@@ -161,7 +161,7 @@ def _resolve_log_level() -> int:
 
 
 def run(argv: Sequence[str] | None = None) -> None:
-    """Parse CLI arguments and start the MCPServer server.
+    """Parse CLI arguments and start the MCP server.
 
     Args:
         argv: Argument list (defaults to ``sys.argv[1:]`` when ``None``).

--- a/src/fabric_dw/mcp/server.py
+++ b/src/fabric_dw/mcp/server.py
@@ -1,4 +1,4 @@
-"""FastMCP server exposing all fabric-dw service functions as MCP tools.
+"""MCPServer server exposing all fabric-dw service functions as MCP tools.
 
 Architecture
 ------------
@@ -8,7 +8,7 @@ per-domain sub-modules under :mod:`fabric_dw.mcp.tools`.
 Startup / Shutdown
 ------------------
 A :func:`~fabric_dw.mcp._context.fabric_lifespan` async context manager is
-passed to the :class:`~mcp.server.fastmcp.FastMCP` constructor.  On startup
+passed to the :class:`~mcp.server.mcpserver.MCPServer` constructor.  On startup
 it calls :func:`~fabric_dw.mcp._context.build_context` to construct one
 :class:`~fabric_dw.mcp._context.ServerContext` (HTTP client, cache, resolver,
 auth mode) and stores it in a module-level sentinel accessible via
@@ -21,7 +21,7 @@ Context access
 Every tool function calls :func:`~fabric_dw.mcp._context.get_context` to
 obtain the shared :class:`~fabric_dw.mcp._context.ServerContext`.  The sentinel
 pattern (module-level ``ServerContext | None``) was chosen over injecting a
-``Context`` parameter into every tool because FastMCP's lifespan context is
+``Context`` parameter into every tool because MCPServer's lifespan context is
 not ergonomically accessible from tool functions without either adding a
 ``Context`` import to every tool or using fragile ``request_context``
 internals.  The sentinel is safe for streamable-HTTP concurrency because it is
@@ -62,7 +62,7 @@ from fabric_dw.config import load_config
 from fabric_dw.logging import setup_logging
 from fabric_dw.mcp._context import fabric_lifespan
 from fabric_dw.mcp._guards import env_flag as _guards_env_flag
-from fabric_dw.mcp._helpers import InstrumentedFastMCP
+from fabric_dw.mcp._helpers import InstrumentedMCPServer
 from fabric_dw.mcp.tools import register_all
 from fabric_dw.telemetry import (
     maybe_print_first_run_notice,
@@ -105,10 +105,10 @@ _SERVER_INSTRUCTIONS: str = (
 )
 
 # ---------------------------------------------------------------------------
-# FastMCP server instance (instrumented subclass emits command_invoked events)
+# MCPServer server instance (instrumented subclass emits command_invoked events)
 # ---------------------------------------------------------------------------
 
-mcp: InstrumentedFastMCP = InstrumentedFastMCP(
+mcp: InstrumentedMCPServer = InstrumentedMCPServer(
     "fabric-dw",
     lifespan=fabric_lifespan,
     instructions=_SERVER_INSTRUCTIONS,
@@ -161,7 +161,7 @@ def _resolve_log_level() -> int:
 
 
 def run(argv: Sequence[str] | None = None) -> None:
-    """Parse CLI arguments and start the FastMCP server.
+    """Parse CLI arguments and start the MCPServer server.
 
     Args:
         argv: Argument list (defaults to ``sys.argv[1:]`` when ``None``).
@@ -233,7 +233,7 @@ def run(argv: Sequence[str] | None = None) -> None:
                 args.port,
             )
 
-        # Update FastMCP settings before run so uvicorn picks them up.
+        # Update MCPServer settings before run so uvicorn picks them up.
         mcp.settings.host = args.host
         mcp.settings.port = args.port
 

--- a/src/fabric_dw/mcp/tools/__init__.py
+++ b/src/fabric_dw/mcp/tools/__init__.py
@@ -1,8 +1,8 @@
 """Per-domain MCP tool registration modules.
 
-Each sub-module exposes a ``register(mcp: FastMCP) -> None`` function that
+Each sub-module exposes a ``register(mcp: MCPServer) -> None`` function that
 decorates and registers that domain's tools against the provided
-:class:`~mcp.server.fastmcp.FastMCP` instance.
+:class:`~mcp.server.mcpserver.MCPServer` instance.
 
 Domains
 -------
@@ -31,7 +31,7 @@ Domains
 
 from __future__ import annotations
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 
 from fabric_dw.mcp.tools import (
     audit,
@@ -84,7 +84,7 @@ _DOMAINS = [
 ]
 
 
-def register_all(mcp: FastMCP) -> None:
+def register_all(mcp: MCPServer) -> None:
     """Register all domain tools against *mcp*."""
     for domain in _DOMAINS:
         domain.register(mcp)

--- a/src/fabric_dw/mcp/tools/audit.py
+++ b/src/fabric_dw/mcp/tools/audit.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Annotated, Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 from pydantic import Field
 
 from fabric_dw.exceptions import FabricError
@@ -19,7 +19,7 @@ __all__ = ["register"]
 _log = logging.getLogger(__name__)
 
 
-def register(mcp: FastMCP) -> None:  # noqa: PLR0915
+def register(mcp: MCPServer) -> None:  # noqa: PLR0915
     """Register audit tools against *mcp*."""
 
     @mcp.tool(name="get_audit_settings")

--- a/src/fabric_dw/mcp/tools/cache.py
+++ b/src/fabric_dw/mcp/tools/cache.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Any, Literal
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 
 from fabric_dw.mcp._context import get_context
 
@@ -14,7 +14,7 @@ __all__ = ["register"]
 _log = logging.getLogger(__name__)
 
 
-def register(mcp: FastMCP) -> None:
+def register(mcp: MCPServer) -> None:
     """Register cache tools against *mcp*."""
 
     @mcp.tool(name="clear_cache")

--- a/src/fabric_dw/mcp/tools/capabilities.py
+++ b/src/fabric_dw/mcp/tools/capabilities.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 
 from fabric_dw.telemetry_commands import resolve_domain
 
@@ -13,7 +13,7 @@ __all__ = ["register"]
 _log = logging.getLogger(__name__)
 
 
-def register(mcp: FastMCP) -> None:
+def register(mcp: MCPServer) -> None:
     """Register capabilities tools against *mcp*."""
 
     @mcp.tool(name="list_capabilities")

--- a/src/fabric_dw/mcp/tools/dbt.py
+++ b/src/fabric_dw/mcp/tools/dbt.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import logging
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 
 from fabric_dw.exceptions import FabricError
 from fabric_dw.mcp._context import get_context
@@ -33,7 +33,7 @@ __all__ = ["register"]
 _log = logging.getLogger(__name__)
 
 
-def register(mcp: FastMCP) -> None:
+def register(mcp: MCPServer) -> None:
     """Register dbt tools against *mcp*."""
 
     @mcp.tool(name="generate_dbt_profile")

--- a/src/fabric_dw/mcp/tools/functions.py
+++ b/src/fabric_dw/mcp/tools/functions.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 
 from fabric_dw.exceptions import FabricError
 from fabric_dw.mcp._context import get_context
@@ -32,7 +32,7 @@ __all__ = ["register"]
 _log = logging.getLogger(__name__)
 
 
-def register(mcp: FastMCP) -> None:  # noqa: PLR0915
+def register(mcp: MCPServer) -> None:  # noqa: PLR0915
     """Register T-SQL user-defined function tools against *mcp*."""
 
     @mcp.tool(name="list_functions")

--- a/src/fabric_dw/mcp/tools/load.py
+++ b/src/fabric_dw/mcp/tools/load.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Annotated, Any, Literal
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 from pydantic import Field
 
 from fabric_dw.exceptions import FabricError
@@ -39,7 +39,7 @@ def _absent_table_msg(schema: str, table: str) -> str:
     )
 
 
-def register(mcp: FastMCP) -> None:  # noqa: PLR0915
+def register(mcp: MCPServer) -> None:  # noqa: PLR0915
     """Register table-load tools against *mcp*."""
 
     @mutating_tool(mcp, "load_table_from_url")
@@ -153,7 +153,7 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             max_errors: Maximum errors before aborting.
             rejected_row_location: URL for rejected-row output.
         """
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         schema, table_name = parse_qualified_name(qualified_name, kind="table")
         ctx = get_context()
@@ -379,7 +379,7 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
 
         # SQL Endpoint guard: COPY INTO is Warehouse-only.
         if file_type not in ("CSV", "PARQUET"):
-            from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+            from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
             raise ToolError(f"Unsupported file_type {file_type!r}; must be CSV or PARQUET")
 
@@ -419,7 +419,7 @@ def register(mcp: FastMCP) -> None:  # noqa: PLR0915
             )
             sql_target = make_sql_target(ws_id, entry, item)
 
-            from mcp.server.fastmcp.exceptions import (  # noqa: PLC0415
+            from mcp.server.mcpserver.exceptions import (  # noqa: PLC0415
                 ToolError as _ToolError,
             )
 

--- a/src/fabric_dw/mcp/tools/permissions.py
+++ b/src/fabric_dw/mcp/tools/permissions.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 
 from fabric_dw.exceptions import FabricError
 from fabric_dw.mcp._context import get_context
@@ -47,7 +47,7 @@ __all__ = ["register"]
 _log = logging.getLogger(__name__)
 
 
-def register(mcp: FastMCP) -> None:  # noqa: PLR0915
+def register(mcp: MCPServer) -> None:  # noqa: PLR0915
     """Register permission tools against *mcp*."""
 
     # -------------------------------------------------------------------------

--- a/src/fabric_dw/mcp/tools/procedures.py
+++ b/src/fabric_dw/mcp/tools/procedures.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 
 from fabric_dw.exceptions import FabricError
 from fabric_dw.mcp._context import get_context
@@ -26,7 +26,7 @@ __all__ = ["register"]
 _log = logging.getLogger(__name__)
 
 
-def register(mcp: FastMCP) -> None:  # noqa: PLR0915
+def register(mcp: MCPServer) -> None:  # noqa: PLR0915
     """Register stored procedure tools against *mcp*."""
 
     @mcp.tool(name="list_procedures")

--- a/src/fabric_dw/mcp/tools/queries.py
+++ b/src/fabric_dw/mcp/tools/queries.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import logging
 from typing import Annotated, Any
 
-from mcp.server.fastmcp import FastMCP
-from mcp.server.fastmcp.exceptions import ToolError
+from mcp.server.mcpserver import MCPServer
+from mcp.server.mcpserver.exceptions import ToolError
 from pydantic import Field
 
 from fabric_dw.exceptions import FabricError
@@ -26,7 +26,7 @@ __all__ = ["register"]
 _log = logging.getLogger(__name__)
 
 
-def register(mcp: FastMCP) -> None:  # noqa: PLR0915
+def register(mcp: MCPServer) -> None:  # noqa: PLR0915
     """Register query tools against *mcp*."""
 
     @mcp.tool(name="list_running_queries")

--- a/src/fabric_dw/mcp/tools/restore.py
+++ b/src/fabric_dw/mcp/tools/restore.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 
 from fabric_dw.exceptions import FabricError
 from fabric_dw.mcp._context import get_context
@@ -20,7 +20,7 @@ __all__ = ["register"]
 _log = logging.getLogger(__name__)
 
 
-def register(mcp: FastMCP) -> None:  # noqa: PLR0915
+def register(mcp: MCPServer) -> None:  # noqa: PLR0915
     """Register restore point tools against *mcp*."""
 
     @mcp.tool(name="list_restore_points")

--- a/src/fabric_dw/mcp/tools/schemas.py
+++ b/src/fabric_dw/mcp/tools/schemas.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 
 from fabric_dw.exceptions import FabricError
 from fabric_dw.mcp._context import get_context
@@ -25,7 +25,7 @@ __all__ = ["register"]
 _log = logging.getLogger(__name__)
 
 
-def register(mcp: FastMCP) -> None:
+def register(mcp: MCPServer) -> None:
     """Register schema tools against *mcp*."""
 
     @mcp.tool(name="list_schemas")

--- a/src/fabric_dw/mcp/tools/settings.py
+++ b/src/fabric_dw/mcp/tools/settings.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Annotated, Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 from pydantic import Field
 
 from fabric_dw.exceptions import FabricError
@@ -27,7 +27,7 @@ __all__ = ["register"]
 _log = logging.getLogger(__name__)
 
 
-def register(mcp: FastMCP) -> None:
+def register(mcp: MCPServer) -> None:
     """Register settings tools against *mcp*."""
 
     @mcp.tool(name="get_warehouse_settings")

--- a/src/fabric_dw/mcp/tools/snapshots.py
+++ b/src/fabric_dw/mcp/tools/snapshots.py
@@ -6,8 +6,8 @@ import logging
 from datetime import UTC, datetime
 from typing import Any
 
-from mcp.server.fastmcp import FastMCP
-from mcp.server.fastmcp.exceptions import ToolError
+from mcp.server.mcpserver import MCPServer
+from mcp.server.mcpserver.exceptions import ToolError
 
 from fabric_dw.exceptions import FabricError
 from fabric_dw.mcp._context import get_context
@@ -29,7 +29,7 @@ __all__ = ["register"]
 _log = logging.getLogger(__name__)
 
 
-def register(mcp: FastMCP) -> None:  # noqa: PLR0915
+def register(mcp: MCPServer) -> None:  # noqa: PLR0915
     """Register snapshot tools against *mcp*."""
 
     @mcp.tool(name="list_snapshots")

--- a/src/fabric_dw/mcp/tools/sql_endpoints.py
+++ b/src/fabric_dw/mcp/tools/sql_endpoints.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from mcp.server.fastmcp import FastMCP
-from mcp.server.fastmcp.exceptions import ToolError
+from mcp.server.mcpserver import MCPServer
+from mcp.server.mcpserver.exceptions import ToolError
 
 from fabric_dw.exceptions import FabricError
 from fabric_dw.mcp._context import get_context
@@ -23,7 +23,7 @@ __all__ = ["register"]
 _log = logging.getLogger(__name__)
 
 
-def register(mcp: FastMCP) -> None:
+def register(mcp: MCPServer) -> None:
     """Register SQL endpoint tools against *mcp*."""
 
     @mcp.tool(name="list_sql_endpoints")

--- a/src/fabric_dw/mcp/tools/sql_exec.py
+++ b/src/fabric_dw/mcp/tools/sql_exec.py
@@ -6,8 +6,8 @@ import json
 import logging
 from typing import Annotated, Any, Literal, assert_never
 
-from mcp.server.fastmcp import FastMCP
-from mcp.server.fastmcp.exceptions import ToolError
+from mcp.server.mcpserver import MCPServer
+from mcp.server.mcpserver.exceptions import ToolError
 from pydantic import Field
 
 from fabric_dw.exceptions import FabricError
@@ -24,7 +24,7 @@ __all__ = ["register"]
 _log = logging.getLogger(__name__)
 
 
-def register(mcp: FastMCP) -> None:
+def register(mcp: MCPServer) -> None:
     """Register sql_exec tools against *mcp*."""
 
     @mcp.tool(name="execute_sql")

--- a/src/fabric_dw/mcp/tools/sql_pools.py
+++ b/src/fabric_dw/mcp/tools/sql_pools.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import logging
 from typing import Annotated, Any
 
-from mcp.server.fastmcp import FastMCP
-from mcp.server.fastmcp.exceptions import ToolError
+from mcp.server.mcpserver import MCPServer
+from mcp.server.mcpserver.exceptions import ToolError
 from pydantic import Field, ValidationError
 
 from fabric_dw.exceptions import AlreadyExistsError, FabricError, NotFoundError
@@ -30,7 +30,7 @@ __all__ = ["register"]
 _log = logging.getLogger(__name__)
 
 
-def register(mcp: FastMCP) -> None:  # noqa: PLR0915
+def register(mcp: MCPServer) -> None:  # noqa: PLR0915
     """Register SQL Pools tools against *mcp*."""
 
     @mcp.tool(name="get_sql_pools_status")

--- a/src/fabric_dw/mcp/tools/statistics.py
+++ b/src/fabric_dw/mcp/tools/statistics.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Annotated, Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 from pydantic import Field
 
 from fabric_dw.exceptions import FabricError
@@ -27,7 +27,7 @@ __all__ = ["register"]
 _log = logging.getLogger(__name__)
 
 
-def register(mcp: FastMCP) -> None:  # noqa: PLR0915
+def register(mcp: MCPServer) -> None:  # noqa: PLR0915
     """Register statistics tools against *mcp*."""
 
     @mcp.tool(name="list_statistics")

--- a/src/fabric_dw/mcp/tools/tables.py
+++ b/src/fabric_dw/mcp/tools/tables.py
@@ -6,7 +6,7 @@ import logging
 from datetime import UTC, datetime
 from typing import Annotated, Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 from pydantic import Field
 
 from fabric_dw.exceptions import FabricError
@@ -49,7 +49,7 @@ def _parse_column_dict(i: int, col: object) -> ColumnSpec:
 _log = logging.getLogger(__name__)
 
 
-def register(mcp: FastMCP) -> None:  # noqa: PLR0915
+def register(mcp: MCPServer) -> None:  # noqa: PLR0915
     """Register table tools against *mcp*."""
 
     @mcp.tool(name="list_tables")

--- a/src/fabric_dw/mcp/tools/views.py
+++ b/src/fabric_dw/mcp/tools/views.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Annotated, Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 from pydantic import Field
 
 from fabric_dw.exceptions import FabricError
@@ -30,7 +30,7 @@ __all__ = ["register"]
 _log = logging.getLogger(__name__)
 
 
-def register(mcp: FastMCP) -> None:  # noqa: PLR0915
+def register(mcp: MCPServer) -> None:  # noqa: PLR0915
     """Register view tools against *mcp*."""
 
     @mcp.tool(name="list_views")

--- a/src/fabric_dw/mcp/tools/warehouses.py
+++ b/src/fabric_dw/mcp/tools/warehouses.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from mcp.server.fastmcp import FastMCP
-from mcp.server.fastmcp.exceptions import ToolError
+from mcp.server.mcpserver import MCPServer
+from mcp.server.mcpserver.exceptions import ToolError
 
 from fabric_dw.exceptions import FabricError
 from fabric_dw.mcp._context import get_context
@@ -23,7 +23,7 @@ __all__ = ["register"]
 _log = logging.getLogger(__name__)
 
 
-def register(mcp: FastMCP) -> None:  # noqa: PLR0915
+def register(mcp: MCPServer) -> None:  # noqa: PLR0915
     """Register warehouse tools against *mcp*."""
 
     @mcp.tool(name="list_warehouses")

--- a/src/fabric_dw/mcp/tools/workspaces.py
+++ b/src/fabric_dw/mcp/tools/workspaces.py
@@ -6,8 +6,8 @@ import logging
 from typing import Any
 from uuid import UUID
 
-from mcp.server.fastmcp import FastMCP
-from mcp.server.fastmcp.exceptions import ToolError
+from mcp.server.mcpserver import MCPServer
+from mcp.server.mcpserver.exceptions import ToolError
 
 from fabric_dw.exceptions import FabricError
 from fabric_dw.mcp._context import get_context
@@ -26,7 +26,7 @@ def _workspace_in_allowlist(ws: Workspace, allowed: frozenset[str]) -> bool:
     return ws.name.strip().lower() in allowed or str(ws.id).strip().lower() in allowed
 
 
-def register(mcp: FastMCP) -> None:  # noqa: PLR0915
+def register(mcp: MCPServer) -> None:  # noqa: PLR0915
     """Register workspace tools against *mcp*."""
 
     @mutating_tool(mcp, "assign_workspace_to_capacity")

--- a/src/fabric_dw/services/_helpers.py
+++ b/src/fabric_dw/services/_helpers.py
@@ -678,7 +678,7 @@ class SelectBodyError(ValueError):
 
     Subclasses :class:`ValueError` so callers that catch ``ValueError`` still
     work.  The ``kind`` attribute lets the MCP layer translate this to a
-    :class:`~mcp.server.fastmcp.exceptions.ToolError` with a context-specific
+    :class:`~mcp.server.mcpserver.exceptions.ToolError` with a context-specific
     message without re-parsing the string.
 
     Attributes:

--- a/src/fabric_dw/telemetry.py
+++ b/src/fabric_dw/telemetry.py
@@ -24,12 +24,13 @@ Architecture notes
   ``cache_tenant_id_from_token()`` (#366).
 - Auto-HTTP instrumentation is explicitly disabled to prevent MSAL OAuth
   request URLs (containing tenant IDs) from leaking as span attributes.
-- ``OTEL_TRACES_EXPORTER=none`` means no span exporter is ever installed, so
-  spans emitted by code this project does not own are never exported.  This is
-  not hypothetical: MCP Python SDK v2 installs an OpenTelemetry middleware on
-  every server unconditionally, which emits one span per inbound protocol
-  message.  Note that the env var, not the ``disable_tracing`` kwarg, is what
-  delivers this; the kwarg is silently overwritten by the library.
+- No span or metric exporter is ever installed, so spans emitted by code this
+  project does not own are never exported.  This is not hypothetical: MCP Python
+  SDK v2 installs an OpenTelemetry middleware on every server unconditionally,
+  which emits one span per inbound protocol message.  ``OTEL_TRACES_EXPORTER``
+  and ``OTEL_METRICS_EXPORTER`` are hard-set to ``none`` around the
+  ``configure_azure_monitor`` call and restored afterwards; the matching kwargs
+  are silently overwritten by the library and do not work.
 - ``shutdown_on_exit`` is disabled; a bounded ``force_flush`` + ``provider.shutdown()``
   (≤8 s total) is performed at app exit in a daemon thread so the CLI never hangs.
   The explicit ``force_flush`` call before ``shutdown()`` is required to reliably
@@ -636,6 +637,15 @@ _INSTRUMENTATION_OPTIONS: dict[str, dict[str, bool]] = {
     "urllib3": {"enabled": False},
 }
 
+# Environment applied around the configure_azure_monitor call to switch off the
+# trace and metric pipelines.  Only the exact string "none" works; see the long
+# comment at the call site for why this is a hard set rather than a setdefault,
+# and why OTEL_LOGS_EXPORTER is deliberately absent.
+_OTEL_EXPORTERS_OFF: dict[str, str] = {
+    "OTEL_TRACES_EXPORTER": "none",
+    "OTEL_METRICS_EXPORTER": "none",
+}
+
 
 def _harden_azure_sdk_logging() -> None:
     """Raise the level of noisy Azure SDK loggers to CRITICAL and detach them from root.
@@ -710,11 +720,12 @@ def _get_tracer() -> object | None:
       log records carrying ``microsoft.custom_event.name`` are exported as
       ``EventData`` (``customEvents`` table) — the reason this function now sets
       up a logger instead of a tracer.
-    - ``OTEL_TRACES_EXPORTER=none`` / ``OTEL_METRICS_EXPORTER=none`` are what
-      actually switch off the trace and metric pipelines.  The matching
+    - ``OTEL_TRACES_EXPORTER=none`` / ``OTEL_METRICS_EXPORTER=none``, hard-set
+      around the ``configure_azure_monitor`` call and restored afterwards, are
+      what actually switch off the trace and metric pipelines.  The matching
       ``disable_tracing`` / ``disable_metrics`` kwargs do NOT work: the library
       overwrites caller-supplied values with its own defaults (see the long
-      comment at the ``os.environ.setdefault`` calls).  Verified by inspecting
+      comment at the call site).  Verified by inspecting
       the resulting global providers, which are the no-op ``ProxyTracerProvider``
       and ``_ProxyMeterProvider``, not SDK providers with Azure exporters.
 
@@ -788,38 +799,6 @@ def _get_tracer() -> object | None:
             # respected.
             os.environ.setdefault("APPLICATIONINSIGHTS_STATSBEAT_DISABLED_ALL", "true")
 
-            # PRIVACY / correctness, load-bearing: these two env vars are the ONLY
-            # working way to switch off the trace and metric pipelines.
-            #
-            # `configure_azure_monitor(disable_tracing=True, disable_metrics=True)`
-            # looks like it should do this, and does not.  In
-            # azure-monitor-opentelemetry 1.8.9, `_get_configurations()` copies the
-            # caller's kwargs into a dict and THEN runs a `_default_*` pass in which
-            # `_default_disable_tracing` / `_default_disable_metrics` assign
-            # unconditionally, clobbering whatever the caller passed.  Contrast
-            # `_default_connection_string`, which early-returns when the key is
-            # already present.  Those two defaults consult only
-            # OTEL_TRACES_EXPORTER / OTEL_METRICS_EXPORTER, so the env var wins and
-            # the kwarg does not.  Measured against the locked version:
-            #     passed {'disable_tracing': True} -> effective disable_tracing=False
-            #     with OTEL_TRACES_EXPORTER=none   -> effective disable_tracing=True
-            # The kwargs below are kept as a statement of intent, but they are NOT
-            # what delivers it.  Do not remove these two lines on the assumption
-            # that the kwargs cover it.
-            #
-            # Why tracing must be off: we emit customEvents as OTel *log records*
-            # and author no spans, but MCP Python SDK v2 installs an
-            # OpenTelemetryMiddleware on every server unconditionally, which emits
-            # one SERVER span per inbound protocol message.  With an exporter
-            # installed those spans ship to Application Insights, carrying method
-            # and tool names, request IDs and timings that the documented
-            # collection list does not cover.  See docs/telemetry.md.
-            #
-            # setdefault, so an operator who deliberately sets either variable
-            # (e.g. to run a local OTLP collector) keeps control.
-            os.environ.setdefault("OTEL_TRACES_EXPORTER", "none")
-            os.environ.setdefault("OTEL_METRICS_EXPORTER", "none")
-
             # Build the OTel Resource that populates native Part A fields and prevents
             # hostname fallback for cloud_RoleInstance / ai.device.id (#477).
             resource = _build_otel_resource(_current_surface)
@@ -835,10 +814,10 @@ def _get_tracer() -> object | None:
                 "disable_logging": False,
                 # NOTE: these next two are statements of intent, NOT the mechanism.
                 # azure-monitor-opentelemetry clobbers both with its own defaults
-                # (see the OTEL_*_EXPORTER setdefault block above, which is what
-                # actually disables these pipelines).  They are kept so the intent
-                # is visible at the call site and so the arguments become effective
-                # for free if upstream ever stops overwriting caller kwargs.
+                # (see _OTEL_EXPORTERS_OFF below, which is what actually disables
+                # these pipelines).  They are kept so the intent is visible at the
+                # call site and so the arguments become effective for free if
+                # upstream ever stops overwriting caller kwargs.
                 "disable_metrics": True,
                 "disable_tracing": True,
                 # A1: disable PerformanceCounters — not covered by disable_metrics in
@@ -859,7 +838,47 @@ def _get_tracer() -> object | None:
             if resource is not None:
                 configure_kwargs["resource"] = resource
 
-            configure_azure_monitor(**configure_kwargs)
+            # PRIVACY, load-bearing.  These two env vars are the ONLY working way
+            # to switch off the trace and metric pipelines, and they must be set
+            # HARD, not with setdefault.
+            #
+            # Why the kwargs above do not do it: in azure-monitor-opentelemetry
+            # 1.8.9 `_get_configurations()` copies the caller's kwargs into a dict
+            # and THEN runs a `_default_*` pass in which `_default_disable_tracing`
+            # / `_default_disable_metrics` assign unconditionally, clobbering
+            # whatever the caller passed.  Contrast `_default_connection_string`,
+            # which early-returns when the key is already present.  Those defaults
+            # consult only these env vars, and only for an exact `== "none"` after
+            # lower/strip.
+            #
+            # Why NOT setdefault: any pre-existing value that is not literally
+            # "none" leaves the pipeline ON, and what then gets installed is the
+            # AzureMonitorTraceExporter pointed at the maintainer's ingestion
+            # endpoint, NOT the exporter the operator asked for.  Measured:
+            #     (unset)                     -> ProxyTracerProvider, no exporters
+            #     OTEL_TRACES_EXPORTER=otlp   -> AzureMonitorTraceExporter installed
+            #     OTEL_TRACES_EXPORTER=""     -> AzureMonitorTraceExporter installed
+            # So setdefault gives the operator no control (outside the separate
+            # auto-instrumentation entry point, `== "none"` is the only thing this
+            # distro ever reads these for) and one silent third-party export path.
+            # A host process that already installed its own TracerProvider is
+            # unaffected either way: OpenTelemetry refuses to override an existing
+            # provider, so the user's provider wins.
+            #
+            # Scoped and restored, because fabric-dw can be embedded as a library
+            # and must not mutate the host process environment beyond this call.
+            # OTEL_LOGS_EXPORTER is deliberately NOT touched: a user setting it to
+            # "none" disables our own customEvents, which is the safe direction.
+            _prev_otel = {k: os.environ.get(k) for k in _OTEL_EXPORTERS_OFF}
+            os.environ.update(_OTEL_EXPORTERS_OFF)
+            try:
+                configure_azure_monitor(**configure_kwargs)
+            finally:
+                for _key, _old in _prev_otel.items():
+                    if _old is None:
+                        os.environ.pop(_key, None)
+                    else:
+                        os.environ[_key] = _old
             # Obtain the OTel Logger via the global LoggerProvider set up by
             # configure_azure_monitor.  This logger is used in emit_event to fire
             # customEvents as log records (not spans).

--- a/src/fabric_dw/telemetry.py
+++ b/src/fabric_dw/telemetry.py
@@ -24,10 +24,12 @@ Architecture notes
   ``cache_tenant_id_from_token()`` (#366).
 - Auto-HTTP instrumentation is explicitly disabled to prevent MSAL OAuth
   request URLs (containing tenant IDs) from leaking as span attributes.
-- ``disable_tracing=True`` means no span exporter is ever installed, so spans
-  emitted by code this project does not own are never exported.  This is not
-  hypothetical: MCP Python SDK v2 installs an OpenTelemetry middleware on every
-  server unconditionally, and it records exception text on failure.
+- ``OTEL_TRACES_EXPORTER=none`` means no span exporter is ever installed, so
+  spans emitted by code this project does not own are never exported.  This is
+  not hypothetical: MCP Python SDK v2 installs an OpenTelemetry middleware on
+  every server unconditionally, which emits one span per inbound protocol
+  message.  Note that the env var, not the ``disable_tracing`` kwarg, is what
+  delivers this; the kwarg is silently overwritten by the library.
 - ``shutdown_on_exit`` is disabled; a bounded ``force_flush`` + ``provider.shutdown()``
   (≤8 s total) is performed at app exit in a daemon thread so the CLI never hangs.
   The explicit ``force_flush`` call before ``shutdown()`` is required to reliably
@@ -708,13 +710,35 @@ def _get_tracer() -> object | None:
       log records carrying ``microsoft.custom_event.name`` are exported as
       ``EventData`` (``customEvents`` table) — the reason this function now sets
       up a logger instead of a tracer.
-    - ``disable_metrics=True`` prevents generic metric exporters from starting.
-    - ``disable_tracing=True`` prevents a span exporter from being installed at
-      all.  This project emits no spans of its own, but MCP Python SDK v2 puts
-      an OpenTelemetry middleware on every server unconditionally, and that
-      middleware records exception text (Fabric API errors, SQL error messages)
-      and identifiers (workspace and warehouse names) onto SERVER spans.  With a
-      TracerProvider installed those would be exported to Application Insights.
+    - ``OTEL_TRACES_EXPORTER=none`` / ``OTEL_METRICS_EXPORTER=none`` are what
+      actually switch off the trace and metric pipelines.  The matching
+      ``disable_tracing`` / ``disable_metrics`` kwargs do NOT work: the library
+      overwrites caller-supplied values with its own defaults (see the long
+      comment at the ``os.environ.setdefault`` calls).  Verified by inspecting
+      the resulting global providers, which are the no-op ``ProxyTracerProvider``
+      and ``_ProxyMeterProvider``, not SDK providers with Azure exporters.
+
+      Tracing must stay off because MCP Python SDK v2 installs an
+      OpenTelemetry middleware on every server unconditionally, emitting one
+      SERVER span per inbound protocol message.  Measured, those spans carry
+      ``mcp.method.name``, ``mcp.protocol.version``, ``jsonrpc.request.id``,
+      ``gen_ai.operation.name``, ``gen_ai.tool.name``, ``error.type`` and span
+      timings.  They do NOT carry tool exception text: ``MCPServer`` converts a
+      failing tool into ``CallToolResult(is_error=True)`` before the middleware
+      sees it, so the middleware's ``record_exception`` branch never fires for
+      tool errors and only ``error.type="tool_error"`` is set.  The leak is
+      therefore metadata, not payload — but it is metadata the documented
+      collection list in ``docs/telemetry.md`` does not cover, which is reason
+      enough.  (``prompts/get`` would additionally echo the client-supplied
+      prompt name into the span name and ``gen_ai.prompt.name``; this project
+      registers no prompts.  ``resources/read`` does not echo, since its params
+      carry ``uri`` rather than ``name``.)
+
+      The exporter-side fix is preferred over the producer-side one (dropping
+      the middleware from ``MCPServer.middleware``, a public but explicitly
+      "Provisional" property whose signature is expected to change before v2 is
+      final).  One global switch covers every library that might emit spans,
+      needs no per-instance wiring, and does not depend on a provisional API.
     - ``enable_performance_counters=False`` disables the PerformanceCounters
       subsystem (CPU / memory poller) which is NOT covered by ``disable_metrics``
       in azure-monitor-opentelemetry 1.8+.  On short-lived processes its
@@ -764,6 +788,38 @@ def _get_tracer() -> object | None:
             # respected.
             os.environ.setdefault("APPLICATIONINSIGHTS_STATSBEAT_DISABLED_ALL", "true")
 
+            # PRIVACY / correctness, load-bearing: these two env vars are the ONLY
+            # working way to switch off the trace and metric pipelines.
+            #
+            # `configure_azure_monitor(disable_tracing=True, disable_metrics=True)`
+            # looks like it should do this, and does not.  In
+            # azure-monitor-opentelemetry 1.8.9, `_get_configurations()` copies the
+            # caller's kwargs into a dict and THEN runs a `_default_*` pass in which
+            # `_default_disable_tracing` / `_default_disable_metrics` assign
+            # unconditionally, clobbering whatever the caller passed.  Contrast
+            # `_default_connection_string`, which early-returns when the key is
+            # already present.  Those two defaults consult only
+            # OTEL_TRACES_EXPORTER / OTEL_METRICS_EXPORTER, so the env var wins and
+            # the kwarg does not.  Measured against the locked version:
+            #     passed {'disable_tracing': True} -> effective disable_tracing=False
+            #     with OTEL_TRACES_EXPORTER=none   -> effective disable_tracing=True
+            # The kwargs below are kept as a statement of intent, but they are NOT
+            # what delivers it.  Do not remove these two lines on the assumption
+            # that the kwargs cover it.
+            #
+            # Why tracing must be off: we emit customEvents as OTel *log records*
+            # and author no spans, but MCP Python SDK v2 installs an
+            # OpenTelemetryMiddleware on every server unconditionally, which emits
+            # one SERVER span per inbound protocol message.  With an exporter
+            # installed those spans ship to Application Insights, carrying method
+            # and tool names, request IDs and timings that the documented
+            # collection list does not cover.  See docs/telemetry.md.
+            #
+            # setdefault, so an operator who deliberately sets either variable
+            # (e.g. to run a local OTLP collector) keeps control.
+            os.environ.setdefault("OTEL_TRACES_EXPORTER", "none")
+            os.environ.setdefault("OTEL_METRICS_EXPORTER", "none")
+
             # Build the OTel Resource that populates native Part A fields and prevents
             # hostname fallback for cloud_RoleInstance / ai.device.id (#477).
             resource = _build_otel_resource(_current_surface)
@@ -777,23 +833,13 @@ def _get_tracer() -> object | None:
                 # microsoft.custom_event.name are silently dropped and events never
                 # appear in the App Insights "Usage → Events" or "Usage → Users" blades.
                 "disable_logging": False,
+                # NOTE: these next two are statements of intent, NOT the mechanism.
+                # azure-monitor-opentelemetry clobbers both with its own defaults
+                # (see the OTEL_*_EXPORTER setdefault block above, which is what
+                # actually disables these pipelines).  They are kept so the intent
+                # is visible at the call site and so the arguments become effective
+                # for free if upstream ever stops overwriting caller kwargs.
                 "disable_metrics": True,
-                # PRIVACY, load-bearing: never install a span exporter.  We emit
-                # customEvents as log records, so nothing in this project needs the
-                # trace pipeline; leaving it on would silently export spans we do
-                # not author.  MCP Python SDK v2 installs an OpenTelemetry
-                # middleware on every server unconditionally
-                # (mcp.server.lowlevel.Server.__init__), and it emits one SERVER
-                # span per inbound message carrying mcp.method.name,
-                # jsonrpc.request.id, gen_ai.tool.name, plus span.record_exception()
-                # and set_status(ERROR, str(e)) on failure.  With a TracerProvider
-                # installed here, that puts Fabric API error text, SQL error
-                # messages, workspace names, and warehouse names on the wire to
-                # Application Insights.  Disabling the pipeline at the source is
-                # preferable to the SDK's own recipe of mutating
-                # mcp._lowlevel_server.middleware, which its docs flag as a
-                # provisional private import.  Pinned by
-                # test_get_tracer_passes_disable_tracing_true.
                 "disable_tracing": True,
                 # A1: disable PerformanceCounters — not covered by disable_metrics in
                 # azure-monitor-opentelemetry 1.8+; its _get_processor_time callback
@@ -842,7 +888,7 @@ def flush_telemetry(timeout_ms: int = 2000) -> None:
     exporter is slow or unreachable.  The thread is daemon so the OS kills it
     when the main thread exits (no hang possible).
 
-    Both the tracer provider (a no-op while ``disable_tracing=True``) and the
+    Both the tracer provider (a no-op while ``OTEL_TRACES_EXPORTER=none``) and the
     logger provider (customEvents log pipeline) are flushed so no records are lost.
 
     Args:
@@ -858,9 +904,11 @@ def flush_telemetry(timeout_ms: int = 2000) -> None:
 
         # Tracer provider — belt-and-suspenders.  Spans ARE created in-process
         # (the MCP SDK middleware makes one per inbound message), but with
-        # disable_tracing=True no exporter is attached, so the global provider is
-        # the no-op default and has no force_flush.  The getattr guard handles
-        # that; the branch stays so a future opt-in to tracing still flushes.
+        # OTEL_TRACES_EXPORTER=none no exporter is attached, so the global
+        # provider is the no-op ProxyTracerProvider, which has no force_flush.
+        # Verified against the locked azure-monitor-opentelemetry, not assumed.
+        # The getattr guard handles that; the branch stays so a future opt-in to
+        # tracing still flushes.
         with contextlib.suppress(Exception):
             from opentelemetry import trace as _trace  # noqa: PLC0415
 
@@ -975,10 +1023,10 @@ def shutdown_telemetry(timeout_ms: int = 8000) -> None:
             if callable(log_shutdown):
                 log_shutdown()
 
-        # Tracer provider — belt-and-suspenders.  With disable_tracing=True the
-        # global provider is the no-op default and has no shutdown; the getattr
-        # guard handles that.  The branch stays so a future opt-in still tears
-        # the trace pipeline down.
+        # Tracer provider — belt-and-suspenders.  With OTEL_TRACES_EXPORTER=none
+        # the global provider is the no-op ProxyTracerProvider and has no
+        # shutdown; the getattr guard handles that.  Verified, not assumed.  The
+        # branch stays so a future opt-in still tears the trace pipeline down.
         with contextlib.suppress(Exception):
             from opentelemetry import trace as _trace  # noqa: PLC0415
 

--- a/src/fabric_dw/telemetry.py
+++ b/src/fabric_dw/telemetry.py
@@ -24,13 +24,20 @@ Architecture notes
   ``cache_tenant_id_from_token()`` (#366).
 - Auto-HTTP instrumentation is explicitly disabled to prevent MSAL OAuth
   request URLs (containing tenant IDs) from leaking as span attributes.
-- No span or metric exporter is ever installed, so spans emitted by code this
-  project does not own are never exported.  This is not hypothetical: MCP Python
-  SDK v2 installs an OpenTelemetry middleware on every server unconditionally,
-  which emits one span per inbound protocol message.  ``OTEL_TRACES_EXPORTER``
-  and ``OTEL_METRICS_EXPORTER`` are hard-set to ``none`` around the
-  ``configure_azure_monitor`` call and restored afterwards; the matching kwargs
-  are silently overwritten by the library and do not work.
+- This package installs no span or metric exporter of its own, so spans emitted
+  by code it does not own are never exported *to Application Insights*.  This is
+  not hypothetical: MCP Python SDK v2 installs an OpenTelemetry middleware on
+  every server unconditionally, which emits one span per inbound protocol
+  message.  ``OTEL_TRACES_EXPORTER`` and ``OTEL_METRICS_EXPORTER`` are hard-set
+  to ``none`` around the ``configure_azure_monitor`` call and restored
+  afterwards; the matching kwargs are silently overwritten by the library and do
+  not work.  Note the qualifier: a host process that embeds fabric-dw and has
+  already installed its own ``TracerProvider`` still collects those spans and
+  sends them wherever it chose.  That is correct and desirable; what this
+  prevents is *this package* adding an export path the user did not ask for.
+- ``APPLICATIONINSIGHTS_SDKSTATS_DISABLED`` suppresses the customer-sdkstats
+  channel, which is separate from statsbeat and would otherwise run its own
+  metrics pipeline on our connection string.
 - ``shutdown_on_exit`` is disabled; a bounded ``force_flush`` + ``provider.shutdown()``
   (≤8 s total) is performed at app exit in a daemon thread so the CLI never hangs.
   The explicit ``force_flush`` call before ``shutdown()`` is required to reliably
@@ -799,6 +806,31 @@ def _get_tracer() -> object | None:
             # respected.
             os.environ.setdefault("APPLICATIONINSIGHTS_STATSBEAT_DISABLED_ALL", "true")
 
+            # Customer sdkstats: a SECOND, separately-gated telemetry-about-telemetry
+            # channel.  Note the different variable name; the statsbeat one above does
+            # NOT gate this.
+            #
+            # AzureMonitorLogExporter.__init__ calls collect_customer_sdkstats()
+            # unconditionally, which stands up a singleton manager holding its own
+            # AzureMonitorMetricExporter on OUR connection string, a private
+            # MeterProvider, and a PeriodicExportingMetricReader on a 15-minute
+            # interval.  It exports item.success.count / item.drop.count /
+            # item.retry.count with language, exporter version and compute type.
+            # Measured without this line, and even with OTEL_METRICS_EXPORTER=none,
+            # the manager reports enabled and initialised, holds a live
+            # PeriodicExportingMetricReader, and the process carries an
+            # "AzureMonitorMetricExporter Storage" thread alongside the reader's own.
+            # That is a metrics pipeline, which contradicts docs/telemetry.md.  A CLI
+            # run shorter than the 15-minute interval never reaches an export cycle,
+            # but a long-lived MCP server does, and that is this project's main mode.
+            #
+            # setdefault, not a hard set: the gate is `disabled.lower() != "true"`, so
+            # an operator setting it to "false" genuinely re-enables collection.  That
+            # makes it a real override rather than a discarded value (unlike the
+            # OTEL_*_EXPORTER pair below), and the failure direction is benign: more
+            # Microsoft-internal telemetry, opted into deliberately.
+            os.environ.setdefault("APPLICATIONINSIGHTS_SDKSTATS_DISABLED", "true")
+
             # Build the OTel Resource that populates native Part A fields and prevents
             # hostname fallback for cloud_RoleInstance / ai.device.id (#477).
             resource = _build_otel_resource(_current_surface)
@@ -867,6 +899,10 @@ def _get_tracer() -> object | None:
             #
             # Scoped and restored, because fabric-dw can be embedded as a library
             # and must not mutate the host process environment beyond this call.
+            # Mutating os.environ is process-global, but the window is safe: it sits
+            # inside the double-checked _sdk_init_lock so it runs exactly once, and
+            # both entry points (the CLI and the MCP server) reach it on the main
+            # thread before any transport or worker concurrency starts.
             # OTEL_LOGS_EXPORTER is deliberately NOT touched: a user setting it to
             # "none" disables our own customEvents, which is the safe direction.
             _prev_otel = {k: os.environ.get(k) for k in _OTEL_EXPORTERS_OFF}

--- a/src/fabric_dw/telemetry.py
+++ b/src/fabric_dw/telemetry.py
@@ -24,6 +24,10 @@ Architecture notes
   ``cache_tenant_id_from_token()`` (#366).
 - Auto-HTTP instrumentation is explicitly disabled to prevent MSAL OAuth
   request URLs (containing tenant IDs) from leaking as span attributes.
+- ``disable_tracing=True`` means no span exporter is ever installed, so spans
+  emitted by code this project does not own are never exported.  This is not
+  hypothetical: MCP Python SDK v2 installs an OpenTelemetry middleware on every
+  server unconditionally, and it records exception text on failure.
 - ``shutdown_on_exit`` is disabled; a bounded ``force_flush`` + ``provider.shutdown()``
   (≤8 s total) is performed at app exit in a daemon thread so the CLI never hangs.
   The explicit ``force_flush`` call before ``shutdown()`` is required to reliably
@@ -72,8 +76,8 @@ release — re-check when upgrading azure-monitor-opentelemetry-exporter.
 
 The logs pipeline must be active for customEvents to flow, so
 ``disable_logging=False`` is passed to ``configure_azure_monitor``.  All other
-safeguards (no auto-instrumentation, no metrics, no live metrics, no statsbeat,
-no atexit hang) are kept exactly as before.
+safeguards (no tracing, no auto-instrumentation, no metrics, no live metrics,
+no statsbeat, no atexit hang) are kept exactly as before.
 """
 
 from __future__ import annotations
@@ -705,6 +709,12 @@ def _get_tracer() -> object | None:
       ``EventData`` (``customEvents`` table) — the reason this function now sets
       up a logger instead of a tracer.
     - ``disable_metrics=True`` prevents generic metric exporters from starting.
+    - ``disable_tracing=True`` prevents a span exporter from being installed at
+      all.  This project emits no spans of its own, but MCP Python SDK v2 puts
+      an OpenTelemetry middleware on every server unconditionally, and that
+      middleware records exception text (Fabric API errors, SQL error messages)
+      and identifiers (workspace and warehouse names) onto SERVER spans.  With a
+      TracerProvider installed those would be exported to Application Insights.
     - ``enable_performance_counters=False`` disables the PerformanceCounters
       subsystem (CPU / memory poller) which is NOT covered by ``disable_metrics``
       in azure-monitor-opentelemetry 1.8+.  On short-lived processes its
@@ -768,6 +778,23 @@ def _get_tracer() -> object | None:
                 # appear in the App Insights "Usage → Events" or "Usage → Users" blades.
                 "disable_logging": False,
                 "disable_metrics": True,
+                # PRIVACY, load-bearing: never install a span exporter.  We emit
+                # customEvents as log records, so nothing in this project needs the
+                # trace pipeline; leaving it on would silently export spans we do
+                # not author.  MCP Python SDK v2 installs an OpenTelemetry
+                # middleware on every server unconditionally
+                # (mcp.server.lowlevel.Server.__init__), and it emits one SERVER
+                # span per inbound message carrying mcp.method.name,
+                # jsonrpc.request.id, gen_ai.tool.name, plus span.record_exception()
+                # and set_status(ERROR, str(e)) on failure.  With a TracerProvider
+                # installed here, that puts Fabric API error text, SQL error
+                # messages, workspace names, and warehouse names on the wire to
+                # Application Insights.  Disabling the pipeline at the source is
+                # preferable to the SDK's own recipe of mutating
+                # mcp._lowlevel_server.middleware, which its docs flag as a
+                # provisional private import.  Pinned by
+                # test_get_tracer_passes_disable_tracing_true.
+                "disable_tracing": True,
                 # A1: disable PerformanceCounters — not covered by disable_metrics in
                 # azure-monitor-opentelemetry 1.8+; its _get_processor_time callback
                 # divides by zero on short-lived processes and logs a traceback (#399).
@@ -815,8 +842,8 @@ def flush_telemetry(timeout_ms: int = 2000) -> None:
     exporter is slow or unreachable.  The thread is daemon so the OS kills it
     when the main thread exits (no hang possible).
 
-    Both the tracer provider (spans, if any) and the logger provider (customEvents
-    log pipeline) are flushed so no records are lost.
+    Both the tracer provider (a no-op while ``disable_tracing=True``) and the
+    logger provider (customEvents log pipeline) are flushed so no records are lost.
 
     Args:
         timeout_ms: Maximum milliseconds to wait for the flush.  Defaults to
@@ -829,8 +856,11 @@ def flush_telemetry(timeout_ms: int = 2000) -> None:
         # Each pipeline is flushed independently so a failure in one does
         # not prevent the other from running.
 
-        # Tracer provider — belt-and-suspenders; no spans are emitted in the
-        # new path, but kept here in case the SDK creates internal spans.
+        # Tracer provider — belt-and-suspenders.  Spans ARE created in-process
+        # (the MCP SDK middleware makes one per inbound message), but with
+        # disable_tracing=True no exporter is attached, so the global provider is
+        # the no-op default and has no force_flush.  The getattr guard handles
+        # that; the branch stays so a future opt-in to tracing still flushes.
         with contextlib.suppress(Exception):
             from opentelemetry import trace as _trace  # noqa: PLC0415
 
@@ -945,8 +975,10 @@ def shutdown_telemetry(timeout_ms: int = 8000) -> None:
             if callable(log_shutdown):
                 log_shutdown()
 
-        # Tracer provider — belt-and-suspenders; no spans are emitted in the
-        # new path, but kept so any SDK-internal spans are flushed.
+        # Tracer provider — belt-and-suspenders.  With disable_tracing=True the
+        # global provider is the no-op default and has no shutdown; the getattr
+        # guard handles that.  The branch stays so a future opt-in still tears
+        # the trace pipeline down.
         with contextlib.suppress(Exception):
             from opentelemetry import trace as _trace  # noqa: PLC0415
 

--- a/src/fabric_dw/telemetry_commands.py
+++ b/src/fabric_dw/telemetry_commands.py
@@ -352,7 +352,7 @@ def map_status(exc: BaseException | None) -> str:
             return "api_error"
 
     with contextlib.suppress(ImportError):
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         if isinstance(exc, ToolError):
             return "user_error"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,10 +26,16 @@ applied:
 - ``_reset_telemetry_module_globals`` — resets ``_tenant_id_override`` and the
   ``_tenant_id_cache`` sentinel between tests so values cannot bleed across tests
   in the same process.
+
+A third fixture, ``_restore_sdk_env``, applies to *every* test rather than only
+the self-managed modules: it restores the ``OTEL_*`` / ``APPLICATIONINSIGHTS_*``
+variables that ``_get_tracer()`` writes straight to ``os.environ``, which
+``monkeypatch`` cannot roll back when the key was absent to begin with.
 """
 
 from __future__ import annotations
 
+import os
 import sys
 from collections.abc import Generator
 from types import ModuleType
@@ -110,6 +116,45 @@ def _disable_telemetry_globally(
     if request.path is not None and request.path.name in _TELEMETRY_SELF_MANAGED_MODULES:
         return
     monkeypatch.setenv("FABRIC_DW_TELEMETRY_OPT_OUT", "1")
+
+
+# Environment variables that ``fabric_dw.telemetry._get_tracer()`` writes directly
+# to ``os.environ``.  Three test modules reach the real ``_get_tracer()``, so
+# without a restore these escape into the rest of the pytest process.
+_SDK_ENV_VARS = (
+    "OTEL_TRACES_EXPORTER",
+    "OTEL_METRICS_EXPORTER",
+    "OTEL_LOGS_EXPORTER",
+    "APPLICATIONINSIGHTS_STATSBEAT_DISABLED_ALL",
+    "APPLICATIONINSIGHTS_SDKSTATS_DISABLED",
+)
+
+
+@pytest.fixture(autouse=True)
+def _restore_sdk_env() -> Generator[None, None, None]:
+    """Snapshot and restore the env vars ``_get_tracer()`` writes.
+
+    ``monkeypatch.delenv(..., raising=False)`` records nothing when the key is
+    already absent, so a subsequent real assignment inside ``_get_tracer()`` has
+    no teardown and leaks process-globally.  A full ``tests/unit`` run used to end
+    with ``APPLICATIONINSIGHTS_STATSBEAT_DISABLED_ALL`` set, sourced from
+    ``test_telemetry_commands.py``.
+
+    Deliberately unconditional rather than gated on
+    ``_TELEMETRY_SELF_MANAGED_MODULES``: the cost is a dict of five lookups per
+    test, and gating would mean a future module that reaches ``_get_tracer()``
+    silently reintroduces the leak until someone remembers to extend the
+    frozenset.  Nothing depends on these variables surviving a test.
+    """
+    saved = {key: os.environ.get(key) for key in _SDK_ENV_VARS}
+    try:
+        yield
+    finally:
+        for key, value in saved.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/_call.py
+++ b/tests/unit/_call.py
@@ -2,7 +2,7 @@
 
 Every test that asserts on a tool's raw Python return value invokes it
 through ``mcp._tool_manager.call_tool(name, arguments)`` rather than the
-public ``MCPServer.call_tool()`` / ``MCPServer.call_tool()`` API. That is
+public ``MCPServer.call_tool()`` API. That is
 deliberate: the public API always runs with ``convert_result=True`` and
 wraps the return value in a ``CallToolResult``, which would force every
 such assertion to be rewritten against ``.structured_content`` /

--- a/tests/unit/_call.py
+++ b/tests/unit/_call.py
@@ -2,7 +2,7 @@
 
 Every test that asserts on a tool's raw Python return value invokes it
 through ``mcp._tool_manager.call_tool(name, arguments)`` rather than the
-public ``FastMCP.call_tool()`` / ``MCPServer.call_tool()`` API. That is
+public ``MCPServer.call_tool()`` / ``MCPServer.call_tool()`` API. That is
 deliberate: the public API always runs with ``convert_result=True`` and
 wraps the return value in a ``CallToolResult``, which would force every
 such assertion to be rewritten against ``.structured_content`` /
@@ -16,7 +16,7 @@ Used by:
 - every test module under ``tests/unit/mcp/`` (and ``tests/unit/mcp/tools/``)
   that calls an MCP tool directly against the production ``mcp`` singleton
 - ``tests/unit/test_telemetry_commands.py``, which builds its own
-  ``InstrumentedFastMCP`` instances and calls tools on those instead
+  ``InstrumentedMCPServer`` instances and calls tools on those instead
 
 Centralising the call here removes ~580 direct references to the private
 SDK internal, and gives the suite a single place to update instead of one
@@ -30,10 +30,10 @@ from __future__ import annotations
 
 from typing import Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 
 
-async def call_tool(mcp: FastMCP, name: str, arguments: dict[str, Any]) -> Any:
+async def call_tool(mcp: MCPServer, name: str, arguments: dict[str, Any]) -> Any:
     """Call the MCP tool *name* with *arguments* and return its raw return value.
 
     Thin wrapper around ``mcp._tool_manager.call_tool(name, arguments)``. See

--- a/tests/unit/_call.py
+++ b/tests/unit/_call.py
@@ -20,9 +20,9 @@ Used by:
 
 Centralising the call here removes ~580 direct references to the private
 SDK internal, and gives the suite a single place to update instead of one
-per call site. In MCP SDK v2, ``ToolManager.call_tool()`` gains a required
+per call site. In MCP SDK v2, ``ToolManager.call_tool()`` gained a required
 ``context`` positional argument; that is the reason this wrapper exists,
-so the v2 migration only has to change the body of :func:`call_tool` rather
+so the v2 migration only had to change the body of :func:`call_tool` rather
 than every call site.
 """
 
@@ -30,14 +30,21 @@ from __future__ import annotations
 
 from typing import Any
 
-from mcp.server.mcpserver import MCPServer
+from mcp.server.mcpserver import Context, MCPServer
 
 
 async def call_tool(mcp: MCPServer, name: str, arguments: dict[str, Any]) -> Any:
     """Call the MCP tool *name* with *arguments* and return its raw return value.
 
-    Thin wrapper around ``mcp._tool_manager.call_tool(name, arguments)``. See
-    the module docstring for why this goes through the private tool manager
+    Thin wrapper around ``mcp._tool_manager.call_tool(name, arguments, context)``.
+    See the module docstring for why this goes through the private tool manager
     instead of the public, result-wrapping ``call_tool()`` API.
+
+    The ``context`` is built exactly the way ``MCPServer.call_tool()`` builds it
+    when no request context exists, so tools see the same object they would from
+    the public API. No tool in this project takes a ``Context`` parameter (the
+    shared ``ServerContext`` is reached through a module-level sentinel instead),
+    so nothing reads it; it is required by the signature, not by the callees.
     """
-    return await mcp._tool_manager.call_tool(name, arguments)
+    context: Context[Any, Any] = Context(mcp_server=mcp, subscriptions=mcp._subscriptions)
+    return await mcp._tool_manager.call_tool(name, arguments, context)

--- a/tests/unit/_tool_introspection.py
+++ b/tests/unit/_tool_introspection.py
@@ -1,7 +1,7 @@
 """Shared live MCP tool introspection helper for unit tests.
 
 Single source of truth: build a fresh MCP server via the production
-registration path (``InstrumentedFastMCP`` + ``register_all``) and
+registration path (``InstrumentedMCPServer`` + ``register_all``) and
 enumerate all registered tools.  Used by:
 
 - ``tests/unit/test_telemetry_commands.py`` — domain-coverage checks
@@ -19,16 +19,16 @@ SNAKE_CASE_RE: re.Pattern[str] = re.compile(r"^[a-z][a-z0-9]*(_[a-z0-9]+)*$")
 
 
 def collect_live_mcp_tool_names() -> frozenset[str]:
-    """Register all MCP tools against a fresh InstrumentedFastMCP; return tool names.
+    """Register all MCP tools against a fresh InstrumentedMCPServer; return tool names.
 
-    Uses ``InstrumentedFastMCP`` (the same class the production MCP server
+    Uses ``InstrumentedMCPServer`` (the same class the production MCP server
     instantiates) and ``register_all()`` so that any tool added to the server
     automatically appears here.  Tool names are enumerated via the public
     ``asyncio.run(mcp.list_tools())`` API to avoid relying on private internals.
     """
-    from fabric_dw.mcp._helpers import InstrumentedFastMCP  # noqa: PLC0415
+    from fabric_dw.mcp._helpers import InstrumentedMCPServer  # noqa: PLC0415
     from fabric_dw.mcp.tools import register_all  # noqa: PLC0415
 
-    mcp = InstrumentedFastMCP("coverage-check")
+    mcp = InstrumentedMCPServer("coverage-check")
     register_all(mcp)
     return frozenset(tool.name for tool in asyncio.run(mcp.list_tools()))

--- a/tests/unit/mcp/test_contract.py
+++ b/tests/unit/mcp/test_contract.py
@@ -3,7 +3,7 @@
 Architecture note
 -----------------
 ``mcp.shared.memory.create_connected_server_and_client_session`` wires a
-real FastMCP server to a real :class:`~mcp.ClientSession` via in-memory
+real MCPServer server to a real :class:`~mcp.ClientSession` via in-memory
 anyio streams, exercising the full MCP JSON-RPC handshake without any TCP
 sockets.  This gives us a contract-level check that:
 
@@ -94,7 +94,7 @@ def contract_ctx():
 async def live_tools(contract_ctx):
     """Return the list of Tool objects enumerated via the MCP protocol.
 
-    Wires a real FastMCP server to a real ClientSession through in-memory
+    Wires a real MCPServer server to a real ClientSession through in-memory
     streams (no TCP), so this exercises the same JSON-RPC ``tools/list``
     handshake the production server uses.
     """
@@ -234,7 +234,7 @@ async def test_call_tool_list_workspaces_round_trips(contract_ctx) -> None:
         assert len(parsed) >= 1
         workspace_data = parsed[0]
     else:
-        # Some FastMCP versions embed the list inside a wrapper
+        # Some MCPServer versions embed the list inside a wrapper
         workspace_data = parsed
     assert str(WS_ID) in json.dumps(workspace_data)
 

--- a/tests/unit/mcp/test_contract.py
+++ b/tests/unit/mcp/test_contract.py
@@ -2,9 +2,7 @@
 
 Architecture note
 -----------------
-``mcp.shared.memory.create_connected_server_and_client_session`` wires a
-real MCPServer server to a real :class:`~mcp.ClientSession` via in-memory
-anyio streams, exercising the full MCP JSON-RPC handshake without any TCP
+:class:`mcp.client.Client` connects to an in-process server without any TCP
 sockets.  This gives us a contract-level check that:
 
 1. ``list_tools`` returns the expected tool names.
@@ -12,12 +10,32 @@ sockets.  This gives us a contract-level check that:
    and returns structured content.
 3. A destructive-guarded tool (``delete_restore_point``) raises an error
    when ``FABRIC_MCP_ALLOW_DESTRUCTIVE`` is unset.
+4. The server identifies itself with the fabric-dw version in ``serverInfo``.
 
 Unlike ``test_server.py`` (which goes through the shared ``call_tool()`` test
 helper, itself a thin wrapper around ``_tool_manager.call_tool``), these tests
 go through the MCP serialisation layer (JSON-RPC encoding/decoding,
 ``CallToolResult`` wrapping, etc.) so they would catch regressions in tool
 registration, schema export, and result serialisation.
+
+``mode`` is pinned, never defaulted
+-----------------------------------
+``Client`` defaults to ``mode="auto"``, and for an in-process server that
+dispatches through a ``DirectDispatcher``: no JSON-RPC framing, no initialize
+handshake, Python objects handed straight across.  Under that mode every
+assertion in this file would still pass while the serialisation layer this file
+exists to cover went completely untested.
+
+So the mode is always explicit here, and both are exercised via the
+``client_mode`` fixture:
+
+``legacy``
+    Forces the initialize handshake and full JSON-RPC framing.  This is the
+    path a stdio or streamable-HTTP client actually takes, and the one that
+    makes these serialisation tests worth running.
+``auto``
+    The modern per-request path.  Skips framing but still runs handler lookup,
+    parameter validation, middleware, and v2's new result-schema validation.
 
 Testing strategy
 ----------------
@@ -86,24 +104,42 @@ def contract_ctx():
 
 
 # ---------------------------------------------------------------------------
+# Fixture: the connect mode, always explicit.  See the module docstring for why
+# the `Client` default of "auto" must never be relied on here.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(params=["legacy", "auto"])
+def client_mode(request) -> str:
+    """The ``Client(mode=...)`` value under test.
+
+    ``legacy`` is the load-bearing one: it is the only mode that puts JSON-RPC
+    framing and the initialize handshake in the path, which is what this file
+    is here to cover.  ``auto`` is included so the modern per-request path is
+    covered too.
+    """
+    return request.param
+
+
+# ---------------------------------------------------------------------------
 # Fixture: live tool list via the full MCP protocol round-trip
 # ---------------------------------------------------------------------------
 
 
 @pytest.fixture
-async def live_tools(contract_ctx):
+async def live_tools(contract_ctx, client_mode):
     """Return the list of Tool objects enumerated via the MCP protocol.
 
-    Wires a real MCPServer server to a real ClientSession through in-memory
-    streams (no TCP), so this exercises the same JSON-RPC ``tools/list``
-    handshake the production server uses.
+    Connects a real :class:`mcp.client.Client` to the production server
+    in-process (no TCP), so this exercises the same ``tools/list`` round-trip
+    the production server serves.
     """
-    from mcp.shared.memory import create_connected_server_and_client_session  # noqa: PLC0415
+    from mcp.client import Client  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
     with patch("fabric_dw.mcp._context.build_context", return_value=contract_ctx):
-        async with create_connected_server_and_client_session(mcp) as client:
+        async with Client(mcp, mode=client_mode) as client:
             result = await client.list_tools()
 
     return result.tools
@@ -198,7 +234,7 @@ async def test_list_tools_contains_destructive_tool(live_tools) -> None:
 # ---------------------------------------------------------------------------
 
 
-async def test_call_tool_list_workspaces_round_trips(contract_ctx) -> None:
+async def test_call_tool_list_workspaces_round_trips(contract_ctx, client_mode) -> None:
     """Calling list_workspaces via MCP protocol returns serialised workspace data.
 
     Verifies:
@@ -206,7 +242,7 @@ async def test_call_tool_list_workspaces_round_trips(contract_ctx) -> None:
     - The result content contains the expected workspace data.
     - The protocol wraps the return value as TextContent (JSON string).
     """
-    from mcp.shared.memory import create_connected_server_and_client_session  # noqa: PLC0415
+    from mcp.client import Client  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -216,11 +252,11 @@ async def test_call_tool_list_workspaces_round_trips(contract_ctx) -> None:
         patch("fabric_dw.mcp._context.build_context", return_value=contract_ctx),
         patch("fabric_dw.services.workspaces.list_all", new=AsyncMock(return_value=[ws])),
     ):
-        async with create_connected_server_and_client_session(mcp) as client:
+        async with Client(mcp, mode=client_mode) as client:
             result = await client.call_tool("list_workspaces", {})
 
     assert result is not None
-    assert not result.isError
+    assert not result.is_error
     # The MCP protocol wraps results in ContentBlock items.
     assert len(result.content) >= 1
     # Extract text from the first content block.
@@ -234,14 +270,14 @@ async def test_call_tool_list_workspaces_round_trips(contract_ctx) -> None:
         assert len(parsed) >= 1
         workspace_data = parsed[0]
     else:
-        # Some MCPServer versions embed the list inside a wrapper
+        # Some SDK versions embed the list inside a wrapper
         workspace_data = parsed
     assert str(WS_ID) in json.dumps(workspace_data)
 
 
-async def test_call_tool_list_workspaces_empty_returns_list(contract_ctx) -> None:
+async def test_call_tool_list_workspaces_empty_returns_list(contract_ctx, client_mode) -> None:
     """list_workspaces with no workspaces returns a successful result."""
-    from mcp.shared.memory import create_connected_server_and_client_session  # noqa: PLC0415
+    from mcp.client import Client  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -249,11 +285,11 @@ async def test_call_tool_list_workspaces_empty_returns_list(contract_ctx) -> Non
         patch("fabric_dw.mcp._context.build_context", return_value=contract_ctx),
         patch("fabric_dw.services.workspaces.list_all", new=AsyncMock(return_value=[])),
     ):
-        async with create_connected_server_and_client_session(mcp) as client:
+        async with Client(mcp, mode=client_mode) as client:
             result = await client.call_tool("list_workspaces", {})
 
     assert result is not None
-    assert not result.isError
+    assert not result.is_error
 
 
 # ---------------------------------------------------------------------------
@@ -262,15 +298,15 @@ async def test_call_tool_list_workspaces_empty_returns_list(contract_ctx) -> Non
 
 
 async def test_destructive_tool_blocked_without_env_flag(
-    contract_ctx, monkeypatch: pytest.MonkeyPatch
+    contract_ctx, client_mode, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """delete_restore_point raises a ToolError when FABRIC_MCP_ALLOW_DESTRUCTIVE is unset.
 
-    The MCP protocol returns this as ``isError=True`` on the CallToolResult.
+    The MCP protocol returns this as ``is_error=True`` on the CallToolResult.
     This validates that the guard logic survives the full protocol round-trip
     (the guard runs inside the tool function, which the protocol invokes).
     """
-    from mcp.shared.memory import create_connected_server_and_client_session  # noqa: PLC0415
+    from mcp.client import Client  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -278,9 +314,10 @@ async def test_destructive_tool_blocked_without_env_flag(
     monkeypatch.delenv("FABRIC_MCP_ALLOW_DESTRUCTIVE", raising=False)
 
     with patch("fabric_dw.mcp._context.build_context", return_value=contract_ctx):
-        async with create_connected_server_and_client_session(
+        async with Client(
             mcp,
-            raise_exceptions=False,  # Return errors as isError=True instead of raising
+            mode=client_mode,
+            raise_exceptions=False,  # Return errors as is_error=True instead of raising
         ) as client:
             result = await client.call_tool(
                 "delete_restore_point",
@@ -292,19 +329,19 @@ async def test_destructive_tool_blocked_without_env_flag(
             )
 
     # The protocol must reflect the ToolError as an error result.
-    assert result.isError, (
-        f"Expected isError=True for destructive tool without flag; got: {result!r}"
+    assert result.is_error, (
+        f"Expected is_error=True for destructive tool without flag; got: {result!r}"
     )
 
 
 async def test_destructive_tool_allowed_with_env_flag(
-    contract_ctx, monkeypatch: pytest.MonkeyPatch
+    contract_ctx, client_mode, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """delete_restore_point proceeds when FABRIC_MCP_ALLOW_DESTRUCTIVE=1.
 
     The service layer is mocked so no real HTTP occurs.
     """
-    from mcp.shared.memory import create_connected_server_and_client_session  # noqa: PLC0415
+    from mcp.client import Client  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -319,9 +356,7 @@ async def test_destructive_tool_allowed_with_env_flag(
             new=AsyncMock(return_value=None),
         ),
     ):
-        async with create_connected_server_and_client_session(
-            mcp, raise_exceptions=False
-        ) as client:
+        async with Client(mcp, mode=client_mode, raise_exceptions=False) as client:
             result = await client.call_tool(
                 "delete_restore_point",
                 {
@@ -331,4 +366,37 @@ async def test_destructive_tool_allowed_with_env_flag(
                 },
             )
 
-    assert not result.isError, f"Expected success; got error: {result!r}"
+    assert not result.is_error, f"Expected success; got error: {result!r}"
+
+
+# ---------------------------------------------------------------------------
+# 4. serverInfo — the server identifies itself over the protocol
+# ---------------------------------------------------------------------------
+
+
+async def test_server_info_reports_fabric_dw_version(contract_ctx, client_mode) -> None:
+    """The version the client sees must be the fabric-dw version.
+
+    Under SDK v1 the server reported the SDK's own version here; under v2 the
+    constructor defaults it to the empty string. Either way it has to be passed
+    explicitly, and this is the assertion that proves the client actually
+    receives it.
+
+    ``serverInfo`` is only guaranteed on legacy connections; on modern ones it
+    is an optional ``_meta`` stamp, so an absent value is tolerated there but a
+    wrong one is not.
+    """
+    from mcp.client import Client  # noqa: PLC0415
+
+    from fabric_dw import __version__  # noqa: PLC0415
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with patch("fabric_dw.mcp._context.build_context", return_value=contract_ctx):
+        async with Client(mcp, mode=client_mode) as client:
+            info = client.server_info
+
+    if client_mode == "legacy":
+        assert info is not None, "legacy connections always carry serverInfo"
+    if info is not None:
+        assert info.name == "fabric-dw"
+        assert info.version == __version__

--- a/tests/unit/mcp/test_contract.py
+++ b/tests/unit/mcp/test_contract.py
@@ -64,8 +64,9 @@ from tests.unit.mcp.conftest import WS_ID, WS_NAME, make_item_entry
 
 # ---------------------------------------------------------------------------
 # Minimum tool count — guards against catastrophic registration drops.
-# Set just below the current count (~96) so adding tools never requires a
-# bump, while a whole-domain disappearance (≥6 tools) is still caught.
+# Set well below the current count (121 at time of writing) so adding tools
+# never requires a bump, while a whole-domain disappearance is still caught.
+# The exact number is deliberately not asserted; only a floor is.
 # ---------------------------------------------------------------------------
 
 MIN_TOOL_COUNT = 90
@@ -382,9 +383,14 @@ async def test_server_info_reports_fabric_dw_version(contract_ctx, client_mode) 
     explicitly, and this is the assertion that proves the client actually
     receives it.
 
-    ``serverInfo`` is only guaranteed on legacy connections; on modern ones it
-    is an optional ``_meta`` stamp, so an absent value is tolerated there but a
-    wrong one is not.
+    The SDK guarantees ``serverInfo`` only on legacy connections; on modern ones
+    it is an optional ``_meta`` stamp. This server populates it in both cases
+    (measured), so both modes assert unconditionally rather than tolerating
+    ``None``. A version of this test that skipped its assertions whenever
+    ``info`` happened to be ``None`` would assert nothing at all under ``auto``,
+    which is worse than not running it there. If a future SDK stops stamping
+    ``serverInfo`` on modern connections, this fails loudly and the decision to
+    accept that gets made deliberately.
     """
     from mcp.client import Client  # noqa: PLC0415
 
@@ -395,8 +401,10 @@ async def test_server_info_reports_fabric_dw_version(contract_ctx, client_mode) 
         async with Client(mcp, mode=client_mode) as client:
             info = client.server_info
 
-    if client_mode == "legacy":
-        assert info is not None, "legacy connections always carry serverInfo"
-    if info is not None:
-        assert info.name == "fabric-dw"
-        assert info.version == __version__
+    assert info is not None, (
+        f"no serverInfo on a {client_mode} connection; the client cannot tell "
+        "which server or version it is talking to"
+    )
+    assert info.name == "fabric-dw"
+    assert info.version == __version__
+    assert info.version, "server version must not be empty"

--- a/tests/unit/mcp/test_procedures.py
+++ b/tests/unit/mcp/test_procedures.py
@@ -144,7 +144,7 @@ async def test_list_procedures_workspace_allowlist_blocks(
     mock_ctx, ctx_patch, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """list_procedures raises ToolError when workspace is not in the allowlist."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -194,7 +194,7 @@ async def test_get_procedure_happy_path(mock_ctx, ctx_patch) -> None:
 
 async def test_get_procedure_bad_qualified_name_raises_tool_error(mock_ctx, ctx_patch) -> None:
     """get_procedure raises ToolError when qualified_name has no dot."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -249,7 +249,7 @@ async def test_create_procedure_blocked_in_readonly(
     mock_ctx, ctx_patch, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """create_procedure raises ToolError when FABRIC_MCP_READONLY is set."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -339,7 +339,7 @@ async def test_update_procedure_blocked_in_readonly(
     mock_ctx, ctx_patch, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """update_procedure raises ToolError when FABRIC_MCP_READONLY is set."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -397,7 +397,7 @@ async def test_drop_procedure_blocked_without_destructive_flag(
     mock_ctx, ctx_patch, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """drop_procedure raises ToolError when FABRIC_MCP_ALLOW_DESTRUCTIVE is not set."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -418,7 +418,7 @@ async def test_drop_procedure_blocked_in_readonly(
     mock_ctx, ctx_patch, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """drop_procedure raises ToolError when FABRIC_MCP_READONLY is set."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -541,7 +541,7 @@ async def test_transfer_procedure_blocked_in_readonly(
     mock_ctx, ctx_patch, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """transfer_procedure raises ToolError when FABRIC_MCP_READONLY is set."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 

--- a/tests/unit/mcp/test_security.py
+++ b/tests/unit/mcp/test_security.py
@@ -68,7 +68,7 @@ class TestAssertReadonlySql:
         begins with a line comment is rejected because its first word token is
         not SELECT or WITH.  Unset FABRIC_MCP_READONLY for such queries.
         """
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         with pytest.raises(ToolError, match="non-SELECT"):
             self._call("-- get rows\nSELECT id FROM dbo.t")
@@ -79,7 +79,7 @@ class TestAssertReadonlySql:
         No comment stripping means the raw first word is from the comment body.
         Unset FABRIC_MCP_READONLY for such queries.
         """
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         with pytest.raises(ToolError, match="non-SELECT"):
             self._call("/* admin query */ SELECT id FROM dbo.t")
@@ -94,50 +94,50 @@ class TestAssertReadonlySql:
     # Reject cases
 
     def test_rejects_drop(self) -> None:
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         with pytest.raises(ToolError, match="non-SELECT"):
             self._call("DROP TABLE dbo.t")
 
     def test_rejects_insert(self) -> None:
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         with pytest.raises(ToolError, match="non-SELECT"):
             self._call("INSERT INTO t VALUES (1)")
 
     def test_rejects_update(self) -> None:
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         with pytest.raises(ToolError, match="non-SELECT"):
             self._call("UPDATE t SET x=1")
 
     def test_rejects_delete(self) -> None:
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         with pytest.raises(ToolError, match="non-SELECT"):
             self._call("DELETE FROM t WHERE 1=1")
 
     def test_rejects_multi_statement_batch(self) -> None:
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         with pytest.raises(ToolError, match="multi-statement"):
             self._call("SELECT 1; DROP TABLE t")
 
     def test_rejects_two_selects_separated_by_semicolon(self) -> None:
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         with pytest.raises(ToolError, match="multi-statement"):
             self._call("SELECT 1; SELECT 2")
 
     def test_rejects_empty_statement(self) -> None:
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         with pytest.raises(ToolError, match="non-SELECT"):
             self._call("   ")
 
     def test_rejects_comment_only_then_drop(self) -> None:
         """A block comment before DROP must still be rejected."""
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         with pytest.raises(ToolError, match="non-SELECT"):
             self._call("/* safe */ DROP TABLE t")
@@ -148,28 +148,28 @@ class TestAssertReadonlySql:
 
     def test_rejects_cte_then_insert(self) -> None:
         """CRITICAL: WITH ... INSERT must be rejected (CTE-wrapped DML bypass)."""
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         with pytest.raises(ToolError):
             self._call("WITH x AS (SELECT 1) INSERT INTO t VALUES (1)")
 
     def test_rejects_cte_then_update(self) -> None:
         """WITH ... UPDATE must be rejected."""
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         with pytest.raises(ToolError):
             self._call("WITH cte AS (SELECT id FROM t) UPDATE t SET x=1")
 
     def test_rejects_cte_then_delete(self) -> None:
         """WITH ... DELETE must be rejected."""
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         with pytest.raises(ToolError):
             self._call("WITH cte AS (SELECT 1) DELETE FROM t WHERE 1=1")
 
     def test_rejects_cte_then_merge(self) -> None:
         """WITH ... MERGE must be rejected."""
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         with pytest.raises(ToolError):
             self._call(
@@ -179,28 +179,28 @@ class TestAssertReadonlySql:
 
     def test_rejects_nested_block_comment_payload(self) -> None:
         """HIGH: nested block comment leaves residual code: /* /* */ DROP TABLE t."""
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         with pytest.raises(ToolError):
             self._call("/* /* */ SELECT */ DROP TABLE t")
 
     def test_rejects_select_into(self) -> None:
         """MEDIUM: SELECT * INTO dbo.backup FROM t must be rejected (INTO forbidden)."""
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         with pytest.raises(ToolError):
             self._call("SELECT * INTO dbo.backup FROM t")
 
     def test_rejects_unbalanced_block_comment_open(self) -> None:
         """Unbalanced /* must be rejected."""
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         with pytest.raises(ToolError):
             self._call("/* unterminated SELECT 1")
 
     def test_rejects_unbalanced_block_comment_close(self) -> None:
         """Residual */ (after stripping outer comment) must be rejected."""
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         with pytest.raises(ToolError):
             self._call("SELECT 1 */ DROP TABLE t")
@@ -213,7 +213,7 @@ class TestAssertReadonlySql:
         trips the multi-statement guard.  Unset FABRIC_MCP_READONLY for such
         queries.
         """
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         with pytest.raises(ToolError, match="multi-statement"):
             self._call("SELECT id FROM t WHERE name = 'a;b'")
@@ -230,7 +230,7 @@ class TestAssertReadonlySql:
         raw text is scanned and the token 'delete' is found inside the brackets.
         Unset FABRIC_MCP_READONLY for such queries.
         """
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         with pytest.raises(ToolError):
             self._call("SELECT [delete] FROM t")
@@ -241,14 +241,14 @@ class TestAssertReadonlySql:
 
     def test_rejects_exec(self) -> None:
         """EXEC must be rejected."""
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         with pytest.raises(ToolError):
             self._call("EXEC sp_who")
 
     def test_rejects_xp_cmdshell_token(self) -> None:
         """xp_cmdshell token must be rejected even inside a WITH."""
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         with pytest.raises(ToolError):
             self._call("SELECT xp_cmdshell('dir')")
@@ -259,56 +259,56 @@ class TestAssertReadonlySql:
 
     def test_rejects_waitfor_delay_after_select(self) -> None:
         """CRITICAL: SELECT 1\\nWAITFOR DELAY must be rejected (DoS via connection hang)."""
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         with pytest.raises(ToolError, match="WAITFOR"):
             self._call("SELECT 1\nWAITFOR DELAY '99:0:0'")
 
     def test_rejects_use_after_select(self) -> None:
         """CRITICAL: SELECT 1\\nUSE master must be rejected (database context switch)."""
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         with pytest.raises(ToolError, match="USE"):
             self._call("SELECT 1\nUSE master")
 
     def test_rejects_waitfor_as_first_token(self) -> None:
         """WAITFOR as the first token must be rejected."""
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         with pytest.raises(ToolError):
             self._call("WAITFOR DELAY '00:01:00'")
 
     def test_rejects_use_as_first_token(self) -> None:
         """USE as the first token must be rejected."""
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         with pytest.raises(ToolError):
             self._call("USE master")
 
     def test_rejects_dbcc_after_select(self) -> None:
         """DBCC must be rejected even when following a valid SELECT."""
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         with pytest.raises(ToolError, match="DBCC"):
             self._call("SELECT 1\nDBCC FREEPROCCACHE")
 
     def test_rejects_shutdown(self) -> None:
         """SHUTDOWN must be rejected."""
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         with pytest.raises(ToolError, match="SHUTDOWN"):
             self._call("SELECT 1\nSHUTDOWN")
 
     def test_rejects_reconfigure(self) -> None:
         """RECONFIGURE must be rejected."""
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         with pytest.raises(ToolError, match="RECONFIGURE"):
             self._call("SELECT 1\nRECONFIGURE")
 
     def test_rejects_dbcc_standalone(self) -> None:
         """DBCC as the first token must be rejected."""
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         with pytest.raises(ToolError):
             self._call("DBCC CHECKDB")
@@ -319,7 +319,7 @@ class TestAssertReadonlySql:
         This pins the current behaviour: the batch is rejected due to the
         multi-statement rule, not due to SET being forbidden.
         """
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         with pytest.raises(ToolError, match=r"multi-statement|non-SELECT"):
             self._call("SET NOCOUNT ON;\nSELECT 1")
@@ -335,7 +335,7 @@ class TestAssertReadonlySql:
         embed a write keyword in a string literal.  Unset FABRIC_MCP_READONLY
         to run such queries.
         """
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         with pytest.raises(ToolError):
             self._call("SELECT * FROM cdc WHERE op='DELETE'")
@@ -345,14 +345,14 @@ class TestAssertReadonlySql:
 
         Raw-scan policy: the token scanner sees 'delete' from [delete] and blocks it.
         """
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         with pytest.raises(ToolError):
             self._call("SELECT [delete] FROM t")
 
     def test_rejects_forbidden_keyword_as_dquote_identifier(self) -> None:
         """SECURITY: a forbidden keyword used as a double-quoted identifier is rejected."""
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         with pytest.raises(ToolError):
             self._call('SELECT "drop" FROM t')
@@ -362,7 +362,7 @@ class TestAssertReadonlySql:
 
         Raw-scan policy: ';' in any context (including string literals) is rejected.
         """
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         with pytest.raises(ToolError, match="multi-statement"):
             self._call("SELECT id FROM t WHERE name = 'a;b'")
@@ -373,63 +373,63 @@ class TestAssertReadonlySql:
 
     def test_rejects_bracket_quote_trick_delete(self) -> None:
         """CRITICAL #788: bracket-identifier with embedded quote hides DELETE."""
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         with pytest.raises(ToolError):
             self._call("SELECT [a'];DELETE FROM t WHERE c='x'")
 
     def test_rejects_bracket_quote_trick_drop(self) -> None:
         """CRITICAL #788: bracket-identifier with embedded quote hides DROP."""
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         with pytest.raises(ToolError):
             self._call("SELECT [a'];DROP TABLE t WHERE c='x'")
 
     def test_rejects_bracket_quote_trick_update(self) -> None:
         """CRITICAL #788: bracket-identifier with embedded quote hides UPDATE."""
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         with pytest.raises(ToolError):
             self._call("SELECT [a'];UPDATE t SET x=1 WHERE c='x'")
 
     def test_rejects_bracket_quote_trick_insert(self) -> None:
         """CRITICAL #788: bracket-identifier with embedded quote hides INSERT."""
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         with pytest.raises(ToolError):
             self._call("SELECT [a'];INSERT INTO t VALUES (1) WHERE c='x'")
 
     def test_rejects_bracket_quote_trick_merge(self) -> None:
         """CRITICAL #788: bracket-identifier with embedded quote hides MERGE."""
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         with pytest.raises(ToolError):
             self._call("SELECT [a'];MERGE t USING s ON 1=0 WHERE c='x'")
 
     def test_rejects_bracket_quote_trick_truncate(self) -> None:
         """CRITICAL #788: bracket-identifier with embedded quote hides TRUNCATE."""
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         with pytest.raises(ToolError):
             self._call("SELECT [a'];TRUNCATE TABLE t WHERE c='x'")
 
     def test_rejects_bracket_quote_trick_exec(self) -> None:
         """CRITICAL #788: bracket-identifier with embedded quote hides EXEC."""
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         with pytest.raises(ToolError):
             self._call("SELECT [a'];EXEC sp_who WHERE c='x'")
 
     def test_rejects_dquote_identifier_bypass(self) -> None:
         """CRITICAL #788: double-quote identifier bypass hides DELETE."""
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         with pytest.raises(ToolError):
             self._call("SELECT \"a'\";DELETE FROM t WHERE c='x'")
 
     def test_rejects_string_literal_hides_keyword(self) -> None:
         """CRITICAL #788: string literal that previously hid a forbidden keyword."""
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         with pytest.raises(ToolError):
             self._call("SELECT * FROM t WHERE x='DROP TABLE t--'")
@@ -445,7 +445,7 @@ class TestAssertReadonlySql:
         at the '--' inside the string, removing the semicolon-separated DML.
         The fully-raw scan catches the semicolon immediately.
         """
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         with pytest.raises(ToolError, match="multi-statement"):
             self._call("SELECT '--';DELETE FROM t")
@@ -457,21 +457,21 @@ class TestAssertReadonlySql:
         block-comment stripper consumed '/*' ... '*/' spanning the DML payload.
         The fully-raw scan catches the first semicolon.
         """
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         with pytest.raises(ToolError, match="multi-statement"):
             self._call("SELECT '/*' AS a;DROP TABLE t;SELECT '*/' AS b")
 
     def test_rejects_string_block_comment_hides_update(self) -> None:
         """CRITICAL #797: fake block-comment delimiters in strings hide UPDATE."""
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         with pytest.raises(ToolError, match="multi-statement"):
             self._call("SELECT '/*' AS a;UPDATE t SET x=1;SELECT '*/' AS b")
 
     def test_rejects_string_block_comment_hides_insert(self) -> None:
         """CRITICAL #797: fake block-comment delimiters in strings hide INSERT."""
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         with pytest.raises(ToolError, match="multi-statement"):
             self._call("SELECT '/*' x;INSERT INTO t VALUES(1);SELECT '*/' y")
@@ -504,7 +504,7 @@ class TestAssertReadonlySql:
         Trailing '-- end' contains no forbidden keyword so that part would pass,
         but the leading comment fails first.  Unset FABRIC_MCP_READONLY to run.
         """
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         with pytest.raises(ToolError, match="non-SELECT"):
             self._call("/* admin */ SELECT id FROM t -- end")
@@ -526,7 +526,7 @@ class TestAssertWritesAllowed:
 
     @pytest.mark.parametrize("flag_value", ["1", "true", "yes", "TRUE", "YES"])
     def test_blocks_when_readonly_truthy(self, flag_value: str) -> None:
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         from fabric_dw.mcp._guards import assert_writes_allowed  # noqa: PLC0415
 
@@ -552,7 +552,7 @@ class TestAssertDestructiveAllowed:
     """FABRIC_MCP_ALLOW_DESTRUCTIVE gates destructive tools."""
 
     def test_blocks_when_env_not_set(self) -> None:
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         from fabric_dw.mcp._guards import assert_destructive_allowed  # noqa: PLC0415
 
@@ -567,7 +567,7 @@ class TestAssertDestructiveAllowed:
             assert_destructive_allowed()  # must not raise
 
     def test_blocks_when_flag_falsy(self) -> None:
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         from fabric_dw.mcp._guards import assert_destructive_allowed  # noqa: PLC0415
 
@@ -613,7 +613,7 @@ class TestAssertWorkspaceAllowed:
             assert_workspace_allowed("my-workspace", resolved_id=guid)
 
     def test_blocks_unlisted_workspace(self) -> None:
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         from fabric_dw.mcp._guards import assert_workspace_allowed  # noqa: PLC0415
 
@@ -624,7 +624,7 @@ class TestAssertWorkspaceAllowed:
             assert_workspace_allowed("dev")
 
     def test_blocks_when_neither_name_nor_id_match(self) -> None:
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         from fabric_dw.mcp._guards import assert_workspace_allowed  # noqa: PLC0415
 
@@ -788,7 +788,7 @@ class TestAssertWorkspaceAllowedConfigLayer:
 
     def test_config_layer_blocks_unlisted(self) -> None:
         """Config-only allowlist blocks workspaces not in the list."""
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         from fabric_dw.mcp._guards import assert_workspace_allowed  # noqa: PLC0415
 
@@ -813,7 +813,7 @@ class TestAssertWorkspaceAllowedConfigLayer:
 
     def test_env_overrides_config(self) -> None:
         """Env allowlist overrides config; workspace in config but not env is blocked."""
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         from fabric_dw.mcp._guards import assert_workspace_allowed  # noqa: PLC0415
 
@@ -836,7 +836,7 @@ class TestAssertWorkspaceAllowedConfigLayer:
 
     def test_empty_env_falls_through_config_blocks(self) -> None:
         """Empty env falls through to config; config restriction is applied."""
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         from fabric_dw.mcp._guards import assert_workspace_allowed  # noqa: PLC0415
 
@@ -963,7 +963,7 @@ async def test_execute_sql_no_truncation_when_under_limit() -> None:
 
 async def test_execute_sql_blocked_by_readonly_mode() -> None:
     """execute_sql raises ToolError when FABRIC_MCP_READONLY is set and query is DROP."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -1032,7 +1032,7 @@ async def test_execute_sql_allowed_in_readonly_mode_for_select() -> None:
 
 async def test_delete_warehouse_blocked_without_destructive_flag() -> None:
     """delete_warehouse raises ToolError when FABRIC_MCP_ALLOW_DESTRUCTIVE is not set."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -1051,7 +1051,7 @@ async def test_delete_warehouse_blocked_without_destructive_flag() -> None:
 
 async def test_delete_snapshot_blocked_without_destructive_flag() -> None:
     """delete_snapshot raises ToolError when FABRIC_MCP_ALLOW_DESTRUCTIVE is not set."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -1074,7 +1074,7 @@ async def test_delete_snapshot_blocked_without_destructive_flag() -> None:
 
 async def test_get_workspace_blocked_by_workspace_allowlist() -> None:
     """get_workspace raises ToolError when workspace not in FABRIC_MCP_WORKSPACES."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw import auth as _auth  # noqa: PLC0415
     from fabric_dw.mcp._context import ServerContext  # noqa: PLC0415
@@ -1103,7 +1103,7 @@ async def test_get_workspace_blocked_by_workspace_allowlist() -> None:
 
 async def test_list_warehouses_all_workspaces_blocked_when_allowlist_set() -> None:
     """list_warehouses(all_workspaces=True) raises ToolError when FABRIC_MCP_WORKSPACES is set."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw import auth as _auth  # noqa: PLC0415
     from fabric_dw.mcp._context import ServerContext  # noqa: PLC0415
@@ -1130,7 +1130,7 @@ async def test_list_warehouses_all_workspaces_blocked_when_allowlist_set() -> No
 
 async def test_list_sql_endpoints_all_workspaces_blocked_when_allowlist_set() -> None:
     """list_sql_endpoints(all_workspaces=True) raises ToolError when allowlist is set."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw import auth as _auth  # noqa: PLC0415
     from fabric_dw.mcp._context import ServerContext  # noqa: PLC0415
@@ -1216,7 +1216,7 @@ def test_run_http_loopback_host_does_not_require_flag() -> None:
 
 async def test_drop_view_blocked_without_destructive_flag() -> None:
     """M03: drop_view raises ToolError when FABRIC_MCP_ALLOW_DESTRUCTIVE is not set."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -1280,7 +1280,7 @@ async def test_drop_view_allowed_with_destructive_flag() -> None:
 
 async def test_refresh_sql_endpoint_metadata_recreate_blocked_without_destructive_flag() -> None:
     """M04: recreate_tables=True raises ToolError without FABRIC_MCP_ALLOW_DESTRUCTIVE."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -1475,7 +1475,7 @@ def test_assert_workspace_allowed_name_passes_pre_resolve_when_allowlist_guid_on
 
 def test_assert_workspace_allowed_name_blocked_post_resolve_when_allowlist_guid_only() -> None:
     """M13: post-resolve call blocks when the resolved GUID is not in the allowlist."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp._guards import assert_workspace_allowed  # noqa: PLC0415
 
@@ -1501,7 +1501,7 @@ def test_assert_workspace_allowed_name_passes_post_resolve_when_guid_matches() -
 
 def test_assert_workspace_allowed_still_blocks_name_when_allowlist_has_names() -> None:
     """M13: pre-resolve call blocks when allowlist has name-shaped entries that don't match."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp._guards import assert_workspace_allowed  # noqa: PLC0415
 
@@ -1562,7 +1562,7 @@ async def test_get_workspace_blocked_by_config_allowlist_env_unset() -> None:
     1.  The tool reads ctx.workspace_allowlist from ServerContext.
     2.  When FABRIC_MCP_WORKSPACES is absent, the config layer still restricts access.
     """
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw import auth as _auth  # noqa: PLC0415
     from fabric_dw.cache import LookupCache  # noqa: PLC0415
@@ -1654,7 +1654,7 @@ class TestGuidCanonicalization:
 
     def test_non_listed_workspace_still_blocked_with_non_canonical_entry(self) -> None:
         """A workspace not on the allowlist is still denied even when the entry is non-canonical."""
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         from fabric_dw.mcp._guards import assert_workspace_allowed  # noqa: PLC0415
 
@@ -1737,7 +1737,7 @@ class TestMixedNameGuidAllowlist:
 
     def test_post_resolve_blocks_when_guid_not_in_mixed_allowlist(self) -> None:
         """Post-resolve call blocks when the resolved GUID is NOT in a mixed allowlist."""
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         from fabric_dw.mcp._guards import assert_workspace_allowed  # noqa: PLC0415
 

--- a/tests/unit/mcp/test_server.py
+++ b/tests/unit/mcp/test_server.py
@@ -2,12 +2,13 @@
 
 Testing strategy
 ----------------
-MCPServer 1.x ships no in-process test transport in its public API, so we use
-unit-style mocking via the shared ``mock_ctx`` / ``ctx_patch`` fixtures defined
-in ``conftest.py``.
+These are unit-style tests: the ``ServerContext`` is mocked via the shared
+``mock_ctx`` / ``ctx_patch`` fixtures defined in ``conftest.py``, and tools are
+invoked directly rather than over the protocol.  ``test_contract.py`` covers the
+protocol round-trip through the SDK's in-process ``mcp.client.Client``.
 
 Tools are called via ``call_tool(mcp, name, args)`` which is the
-same call path MCPServer uses at runtime, giving realistic coverage of the
+same call path the MCP server uses at runtime, giving realistic coverage of the
 ``@mcp.tool`` decorator, Pydantic validation, and guard logic.
 
 The ``ServerContext`` (http / cache / resolver) is injected by patching
@@ -232,7 +233,7 @@ def _make_item_access() -> ItemAccess:
 
 
 def test_core_tools_registered() -> None:
-    """Every core tool must be registered in the MCPServer server.
+    """Every core tool must be registered in the MCP server.
 
     ``CORE_TOOLS`` is a stable subset of fundamental tools spanning all major
     domains.  A registration regression (e.g. a broken ``register_all`` call)

--- a/tests/unit/mcp/test_server.py
+++ b/tests/unit/mcp/test_server.py
@@ -517,14 +517,21 @@ def test_run_http_forwards_host_and_port_to_run() -> None:
     raises.  Host and port are transport-specific ``run()`` kwargs instead, so
     this pins that they are actually forwarded rather than silently dropped,
     which would leave the server on the SDK's 127.0.0.1:8000 defaults.
+
+    Both values must differ from every default in play or the test cannot fail.
+    ``127.0.0.1`` is simultaneously the argparse default AND the SDK's own
+    ``run()`` default, so a hardcoded host would still satisfy an assertion
+    written against it.  ``localhost`` is used instead: still loopback, so the
+    guard does not demand ``FABRIC_MCP_ALLOW_REMOTE``, but distinct from both
+    defaults.  The port is likewise nowhere near 8000.
     """
     from fabric_dw.mcp import run  # noqa: PLC0415
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
     with patch.object(mcp, "run") as mock_run:
-        run(["--transport", "http", "--host", "127.0.0.1", "--port", "9123"])
+        run(["--transport", "http", "--host", "localhost", "--port", "9123"])
 
-    mock_run.assert_called_once_with(transport="streamable-http", host="127.0.0.1", port=9123)
+    mock_run.assert_called_once_with(transport="streamable-http", host="localhost", port=9123)
 
 
 def test_run_stdio_passes_no_transport_kwargs() -> None:

--- a/tests/unit/mcp/test_server.py
+++ b/tests/unit/mcp/test_server.py
@@ -2,12 +2,12 @@
 
 Testing strategy
 ----------------
-FastMCP 1.x ships no in-process test transport in its public API, so we use
+MCPServer 1.x ships no in-process test transport in its public API, so we use
 unit-style mocking via the shared ``mock_ctx`` / ``ctx_patch`` fixtures defined
 in ``conftest.py``.
 
 Tools are called via ``call_tool(mcp, name, args)`` which is the
-same call path FastMCP uses at runtime, giving realistic coverage of the
+same call path MCPServer uses at runtime, giving realistic coverage of the
 ``@mcp.tool`` decorator, Pydantic validation, and guard logic.
 
 The ``ServerContext`` (http / cache / resolver) is injected by patching
@@ -232,7 +232,7 @@ def _make_item_access() -> ItemAccess:
 
 
 def test_core_tools_registered() -> None:
-    """Every core tool must be registered in the FastMCP server.
+    """Every core tool must be registered in the MCPServer server.
 
     ``CORE_TOOLS`` is a stable subset of fundamental tools spanning all major
     domains.  A registration regression (e.g. a broken ``register_all`` call)
@@ -254,10 +254,10 @@ def test_registered_tools_no_duplicates() -> None:
     """
     import asyncio  # noqa: PLC0415
 
-    from fabric_dw.mcp._helpers import InstrumentedFastMCP  # noqa: PLC0415
+    from fabric_dw.mcp._helpers import InstrumentedMCPServer  # noqa: PLC0415
     from fabric_dw.mcp.tools import register_all  # noqa: PLC0415
 
-    mcp = InstrumentedFastMCP("dup-check")
+    mcp = InstrumentedMCPServer("dup-check")
     register_all(mcp)
     all_tools = asyncio.run(mcp.list_tools())
     all_names = [t.name for t in all_tools]
@@ -283,10 +283,10 @@ def test_registered_tools_non_empty_descriptions() -> None:
     """
     import asyncio  # noqa: PLC0415
 
-    from fabric_dw.mcp._helpers import InstrumentedFastMCP  # noqa: PLC0415
+    from fabric_dw.mcp._helpers import InstrumentedMCPServer  # noqa: PLC0415
     from fabric_dw.mcp.tools import register_all  # noqa: PLC0415
 
-    mcp = InstrumentedFastMCP("desc-check")
+    mcp = InstrumentedMCPServer("desc-check")
     register_all(mcp)
     all_tools = asyncio.run(mcp.list_tools())
     missing_desc = [t.name for t in all_tools if not (t.description or "").strip()]
@@ -392,7 +392,7 @@ async def test_clear_cache_scope_items(mock_ctx, ctx_patch) -> None:
 
 async def test_fabric_error_becomes_tool_error(ctx_patch) -> None:
     """A FabricError raised by the service layer must become a ToolError."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -467,7 +467,7 @@ async def test_list_warehouses_happy_path(mock_ctx, ctx_patch) -> None:
 
 
 def test_run_uses_stdio_by_default() -> None:
-    """run() with no args calls FastMCP.run(transport='stdio')."""
+    """run() with no args calls MCPServer.run(transport='stdio')."""
     from fabric_dw.mcp import run  # noqa: PLC0415
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -483,7 +483,7 @@ def test_run_uses_stdio_by_default() -> None:
 
 
 def test_run_accepts_http_transport() -> None:
-    """run(['--transport', 'http']) calls FastMCP.run(transport='streamable-http')."""
+    """run(['--transport', 'http']) calls MCPServer.run(transport='streamable-http')."""
     from fabric_dw.mcp import run  # noqa: PLC0415
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -564,7 +564,7 @@ async def test_list_running_queries_happy_path(mock_ctx, ctx_patch) -> None:
 
 async def test_not_found_error_becomes_tool_error(mock_ctx, ctx_patch) -> None:
     """NotFoundError (a FabricError subclass) must become a ToolError."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -586,7 +586,7 @@ async def test_not_found_error_becomes_tool_error(mock_ctx, ctx_patch) -> None:
 
 async def test_create_snapshot_bad_datetime_becomes_tool_error(ctx_patch) -> None:
     """create_snapshot raises ToolError when snapshot_dt is not ISO-8601."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -612,7 +612,7 @@ async def test_roll_snapshot_timestamp_bad_datetime_becomes_tool_error(
     ctx_patch,
 ) -> None:
     """roll_snapshot_timestamp raises ToolError when new_dt is not ISO-8601."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -843,7 +843,7 @@ async def test_list_sql_endpoints_all_workspaces(ctx_patch) -> None:
 
 async def test_list_warehouses_all_workspaces_blocked_by_allowlist(ctx_patch) -> None:
     """all_workspaces=True raises ToolError when FABRIC_MCP_WORKSPACES is set (warehouses)."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -857,7 +857,7 @@ async def test_list_warehouses_all_workspaces_blocked_by_allowlist(ctx_patch) ->
 
 async def test_list_sql_endpoints_all_workspaces_blocked_by_allowlist(ctx_patch) -> None:
     """all_workspaces=True raises ToolError when FABRIC_MCP_WORKSPACES is set (sql_endpoints)."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -968,7 +968,7 @@ async def test_set_audit_retention_happy_path(mock_ctx, ctx_patch) -> None:
 
 async def test_set_audit_retention_value_error_becomes_tool_error(mock_ctx, ctx_patch) -> None:
     """set_audit_retention converts ValueError (disabled audit or out-of-range) to ToolError."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -1029,7 +1029,7 @@ async def test_execute_sql_happy_path(mock_ctx, ctx_patch) -> None:
 
 async def test_execute_sql_no_connection_string_raises_tool_error(mock_ctx, ctx_patch) -> None:
     """execute_sql raises ToolError when the item has no connection string."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -1084,7 +1084,7 @@ async def test_list_item_permissions_permission_denied_becomes_tool_error(
     mock_ctx, ctx_patch
 ) -> None:
     """list_item_permissions wraps PermissionDeniedError into ToolError."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -1117,7 +1117,7 @@ _SE_ID = UUID("bbbbbbbb-cccc-dddd-eeee-ffffffffffff")
 
 async def test_create_table_sql_endpoint_raises_tool_error(mock_ctx, ctx_patch) -> None:
     """create_table must raise ToolError when the item is a SQL Endpoint."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -1150,7 +1150,7 @@ async def test_delete_table_sql_endpoint_raises_tool_error(mock_ctx, ctx_patch) 
     FABRIC_MCP_ALLOW_DESTRUCTIVE=1 is set so the destructive guard passes and
     the SQL-endpoint read-only guard fires instead.
     """
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -1179,7 +1179,7 @@ async def test_clear_table_sql_endpoint_raises_tool_error(mock_ctx, ctx_patch) -
     FABRIC_MCP_ALLOW_DESTRUCTIVE=1 is set so the destructive guard passes and
     the SQL-endpoint read-only guard fires instead.
     """
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -1275,7 +1275,7 @@ async def test_clone_table_with_at_timestamp(mock_ctx, ctx_patch) -> None:
 
 async def test_clone_table_readonly_mode_blocked(ctx_patch) -> None:
     """clone_table must raise ToolError in readonly mode (FABRIC_MCP_READONLY=1)."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -1300,7 +1300,7 @@ async def test_clone_table_readonly_mode_blocked(ctx_patch) -> None:
 
 async def test_clone_table_workspace_not_in_allowlist(ctx_patch) -> None:
     """clone_table must raise ToolError when workspace is not in FABRIC_MCP_WORKSPACES."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -1325,7 +1325,7 @@ async def test_clone_table_workspace_not_in_allowlist(ctx_patch) -> None:
 
 async def test_clone_table_sql_endpoint_raises_tool_error(mock_ctx, ctx_patch) -> None:
     """clone_table must raise ToolError when the item is a SQL Endpoint."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -1588,7 +1588,7 @@ async def test_read_view_happy_path(mock_ctx, ctx_patch) -> None:
 
 async def test_read_view_no_connection_string_raises_tool_error(mock_ctx, ctx_patch) -> None:
     """read_view raises ToolError when the item has no connection string."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -1609,7 +1609,7 @@ async def test_read_view_no_connection_string_raises_tool_error(mock_ctx, ctx_pa
 
 async def test_read_view_bad_qualified_name_raises_tool_error(mock_ctx, ctx_patch) -> None:
     """read_view raises ToolError when qualified_name has no dot."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -1675,7 +1675,7 @@ async def test_rename_table_happy_path(mock_ctx, ctx_patch) -> None:
 
 async def test_rename_table_readonly_blocked(mock_ctx, ctx_patch) -> None:
     """rename_table raises ToolError when FABRIC_MCP_READONLY is set."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -1701,7 +1701,7 @@ async def test_rename_table_readonly_blocked(mock_ctx, ctx_patch) -> None:
 
 async def test_rename_table_sql_endpoint_raises_tool_error(mock_ctx, ctx_patch) -> None:
     """rename_table must raise ToolError when the item is a SQL Analytics Endpoint."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -1731,7 +1731,7 @@ async def test_rename_table_sql_endpoint_raises_tool_error(mock_ctx, ctx_patch) 
 
 async def test_rename_table_workspace_allowlist_blocks(mock_ctx, ctx_patch) -> None:
     """rename_table raises ToolError when workspace is not in FABRIC_MCP_WORKSPACES."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -1760,7 +1760,7 @@ async def test_rename_table_undotted_qualified_name_raises_tool_error(
     ctx_patch,
 ) -> None:
     """rename_table must raise ToolError immediately for an undotted qualified_name."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -1831,7 +1831,7 @@ async def test_rename_view_blocked_by_readonly(ctx_patch) -> None:
     """rename_view raises ToolError when FABRIC_MCP_READONLY is set."""
     import os  # noqa: PLC0415
 
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -1856,7 +1856,7 @@ async def test_rename_view_blocked_by_workspace_allowlist(ctx_patch) -> None:
     """rename_view raises ToolError when workspace is not in FABRIC_MCP_WORKSPACES."""
     import os  # noqa: PLC0415
 
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -1919,7 +1919,7 @@ async def test_rename_view_accepts_sql_endpoint_item(mock_ctx, ctx_patch) -> Non
 
 async def test_rename_view_bad_qualified_name_raises_tool_error(ctx_patch) -> None:
     """rename_view raises ToolError when qualified_name has no dot."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -2006,7 +2006,7 @@ async def test_get_query_plan_allowed_under_readonly(
 
 async def test_get_query_plan_no_connection_string_raises_tool_error(mock_ctx, ctx_patch) -> None:
     """get_query_plan raises ToolError when the item has no connection string."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -2043,7 +2043,7 @@ def _make_reclustered_table() -> Table:
 
 async def test_set_cluster_columns_requires_destructive_flag() -> None:
     """set_cluster_columns raises ToolError without FABRIC_MCP_ALLOW_DESTRUCTIVE=1."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -2104,7 +2104,7 @@ async def test_set_cluster_columns_sql_endpoint_raises_tool_error(mock_ctx, ctx_
     FABRIC_MCP_ALLOW_DESTRUCTIVE=1 is set so the destructive guard passes and
     the SQL-endpoint clustering guard fires instead.
     """
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 

--- a/tests/unit/mcp/test_server.py
+++ b/tests/unit/mcp/test_server.py
@@ -467,6 +467,21 @@ async def test_list_warehouses_happy_path(mock_ctx, ctx_patch) -> None:
 # ---------------------------------------------------------------------------
 
 
+def test_server_reports_its_own_version() -> None:
+    """The server must advertise the fabric-dw version, not an empty string.
+
+    Under SDK v1 the constructor defaulted this to the SDK's own version, which
+    was wrong but at least non-empty.  v2 defaults it to ``""``, so it has to be
+    passed explicitly.  ``test_contract.py`` checks the same value as it appears
+    in ``serverInfo`` over the protocol.
+    """
+    from fabric_dw import __version__  # noqa: PLC0415
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    assert mcp.version == __version__
+    assert mcp.version, "server version must not be empty"
+
+
 def test_run_uses_stdio_by_default() -> None:
     """run() with no args calls MCPServer.run(transport='stdio')."""
     from fabric_dw.mcp import run  # noqa: PLC0415
@@ -491,7 +506,41 @@ def test_run_accepts_http_transport() -> None:
     with patch.object(mcp, "run") as mock_run:
         run(["--transport", "http"])
 
-    mock_run.assert_called_once_with(transport="streamable-http")
+    mock_run.assert_called_once_with(transport="streamable-http", host="127.0.0.1", port=8000)
+
+
+def test_run_http_forwards_host_and_port_to_run() -> None:
+    """--host and --port reach MCPServer.run() as keyword arguments.
+
+    v2 removed the mutable settings object the previous implementation assigned
+    to (``mcp.settings.host`` / ``mcp.settings.port``); assigning to those now
+    raises.  Host and port are transport-specific ``run()`` kwargs instead, so
+    this pins that they are actually forwarded rather than silently dropped,
+    which would leave the server on the SDK's 127.0.0.1:8000 defaults.
+    """
+    from fabric_dw.mcp import run  # noqa: PLC0415
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with patch.object(mcp, "run") as mock_run:
+        run(["--transport", "http", "--host", "127.0.0.1", "--port", "9123"])
+
+    mock_run.assert_called_once_with(transport="streamable-http", host="127.0.0.1", port=9123)
+
+
+def test_run_stdio_passes_no_transport_kwargs() -> None:
+    """The stdio branch must not forward host/port.
+
+    The v2 ``run()`` stdio overload accepts no keyword arguments, so passing
+    host or port there is a type error even though the runtime ``**kwargs``
+    signature would swallow them.
+    """
+    from fabric_dw.mcp import run  # noqa: PLC0415
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    with patch.object(mcp, "run") as mock_run:
+        run(["--host", "0.0.0.0", "--port", "9123"])  # noqa: S104
+
+    mock_run.assert_called_once_with(transport="stdio")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/mcp/test_server_telemetry.py
+++ b/tests/unit/mcp/test_server_telemetry.py
@@ -103,7 +103,6 @@ def test_normal_return_emits_ok_and_shuts_down() -> None:
         ),
     ):
         mock_mcp.run.return_value = None
-        mock_mcp.settings = MagicMock()
         _run()
 
     assert len(calls) == 1
@@ -134,7 +133,6 @@ def test_keyboard_interrupt_emits_ok_and_shuts_down_and_reraises() -> None:
         ),
     ):
         mock_mcp.run.side_effect = KeyboardInterrupt()
-        mock_mcp.settings = MagicMock()
 
         with pytest.raises(KeyboardInterrupt):
             _run()
@@ -167,7 +165,6 @@ def test_unexpected_exception_emits_api_error_and_shuts_down_and_reraises() -> N
         ),
     ):
         mock_mcp.run.side_effect = RuntimeError("boom")
-        mock_mcp.settings = MagicMock()
 
         with pytest.raises(RuntimeError, match="boom"):
             _run()
@@ -197,7 +194,6 @@ def test_system_exit_zero_emits_ok(code: int | None) -> None:
         patch("fabric_dw.mcp.server.shutdown_telemetry"),
     ):
         mock_mcp.run.side_effect = SystemExit(code)
-        mock_mcp.settings = MagicMock()
 
         with pytest.raises(SystemExit):
             _run()
@@ -220,7 +216,6 @@ def test_system_exit_nonzero_emits_api_error() -> None:
         patch("fabric_dw.mcp.server.shutdown_telemetry"),
     ):
         mock_mcp.run.side_effect = SystemExit(1)
-        mock_mcp.settings = MagicMock()
 
         with pytest.raises(SystemExit):
             _run()
@@ -252,7 +247,6 @@ def test_shutdown_runs_even_if_record_app_exited_raises() -> None:
         ),
     ):
         mock_mcp.run.return_value = None
-        mock_mcp.settings = MagicMock()
         # The telemetry error must be swallowed; run() should not propagate it.
         _run()
 
@@ -282,7 +276,6 @@ def test_call_order_record_before_shutdown() -> None:
         patch("fabric_dw.mcp.server.shutdown_telemetry", new=manager.shutdown),
     ):
         mock_mcp.run.return_value = None
-        mock_mcp.settings = MagicMock()
         _run()
 
     call_names = [c[0] for c in manager.mock_calls]
@@ -314,6 +307,5 @@ def test_keyboard_interrupt_during_teardown_is_swallowed() -> None:
         patch("fabric_dw.mcp.server.shutdown_telemetry", side_effect=KeyboardInterrupt()),
     ):
         mock_mcp.run.return_value = None
-        mock_mcp.settings = MagicMock()
         # The KeyboardInterrupt from shutdown_telemetry must NOT escape run().
         _run()  # must return normally without raising

--- a/tests/unit/mcp/tools/test_audit.py
+++ b/tests/unit/mcp/tools/test_audit.py
@@ -117,7 +117,7 @@ async def test_get_audit_settings_disabled_state(mock_ctx, ctx_patch) -> None:
 
 async def test_get_audit_settings_fabric_error_becomes_tool_error(mock_ctx, ctx_patch) -> None:
     """get_audit_settings converts FabricError to ToolError."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -141,7 +141,7 @@ async def test_get_audit_settings_fabric_error_becomes_tool_error(mock_ctx, ctx_
 
 async def test_get_audit_settings_workspace_not_in_allowlist(ctx_patch) -> None:
     """get_audit_settings raises ToolError when workspace is not in allowlist."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -217,7 +217,7 @@ async def test_enable_audit_with_retention_days(mock_ctx, ctx_patch) -> None:
 
 async def test_enable_audit_readonly_mode_blocked(ctx_patch) -> None:
     """enable_audit raises ToolError in read-only mode."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -237,7 +237,7 @@ async def test_enable_audit_readonly_mode_blocked(ctx_patch) -> None:
 
 async def test_enable_audit_workspace_not_in_allowlist(ctx_patch) -> None:
     """enable_audit raises ToolError when workspace is not in allowlist."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -255,7 +255,7 @@ async def test_enable_audit_workspace_not_in_allowlist(ctx_patch) -> None:
 
 async def test_enable_audit_fabric_error_becomes_tool_error(mock_ctx, ctx_patch) -> None:
     """enable_audit converts FabricError to ToolError."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -311,7 +311,7 @@ async def test_disable_audit_happy_path(mock_ctx, ctx_patch) -> None:
 
 async def test_disable_audit_readonly_mode_blocked(ctx_patch) -> None:
     """disable_audit raises ToolError in read-only mode."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -331,7 +331,7 @@ async def test_disable_audit_readonly_mode_blocked(ctx_patch) -> None:
 
 async def test_disable_audit_workspace_not_in_allowlist(ctx_patch) -> None:
     """disable_audit raises ToolError when workspace is not in allowlist."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -349,7 +349,7 @@ async def test_disable_audit_workspace_not_in_allowlist(ctx_patch) -> None:
 
 async def test_disable_audit_fabric_error_becomes_tool_error(mock_ctx, ctx_patch) -> None:
     """disable_audit converts FabricError to ToolError."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -499,7 +499,7 @@ async def test_set_audit_action_groups_enabled_warehouse_state_unchanged(
 
 async def test_set_audit_action_groups_readonly_mode_blocked(ctx_patch) -> None:
     """set_audit_action_groups raises ToolError in read-only mode."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -523,7 +523,7 @@ async def test_set_audit_action_groups_readonly_mode_blocked(ctx_patch) -> None:
 
 async def test_set_audit_action_groups_workspace_not_in_allowlist(ctx_patch) -> None:
     """set_audit_action_groups raises ToolError when workspace is not in allowlist."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -545,7 +545,7 @@ async def test_set_audit_action_groups_workspace_not_in_allowlist(ctx_patch) -> 
 
 async def test_set_audit_action_groups_fabric_error_becomes_tool_error(mock_ctx, ctx_patch) -> None:
     """set_audit_action_groups converts FabricError to ToolError."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -605,7 +605,7 @@ async def test_add_audit_group_happy_path(mock_ctx, ctx_patch) -> None:
 
 async def test_add_audit_group_readonly_mode_blocked(ctx_patch) -> None:
     """add_audit_group raises ToolError in read-only mode."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -625,7 +625,7 @@ async def test_add_audit_group_readonly_mode_blocked(ctx_patch) -> None:
 
 async def test_add_audit_group_workspace_not_in_allowlist(ctx_patch) -> None:
     """add_audit_group raises ToolError when workspace is not in allowlist."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -643,7 +643,7 @@ async def test_add_audit_group_workspace_not_in_allowlist(ctx_patch) -> None:
 
 async def test_add_audit_group_value_error_becomes_tool_error(mock_ctx, ctx_patch) -> None:
     """add_audit_group converts ValueError (audit disabled) to ToolError."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -669,7 +669,7 @@ async def test_add_audit_group_value_error_becomes_tool_error(mock_ctx, ctx_patc
 
 async def test_add_audit_group_fabric_error_becomes_tool_error(mock_ctx, ctx_patch) -> None:
     """add_audit_group converts FabricError to ToolError."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -728,7 +728,7 @@ async def test_remove_audit_group_happy_path(mock_ctx, ctx_patch) -> None:
 
 async def test_remove_audit_group_readonly_mode_blocked(ctx_patch) -> None:
     """remove_audit_group raises ToolError in read-only mode."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -748,7 +748,7 @@ async def test_remove_audit_group_readonly_mode_blocked(ctx_patch) -> None:
 
 async def test_remove_audit_group_workspace_not_in_allowlist(ctx_patch) -> None:
     """remove_audit_group raises ToolError when workspace is not in allowlist."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -766,7 +766,7 @@ async def test_remove_audit_group_workspace_not_in_allowlist(ctx_patch) -> None:
 
 async def test_remove_audit_group_value_error_becomes_tool_error(mock_ctx, ctx_patch) -> None:
     """remove_audit_group converts ValueError (audit disabled) to ToolError."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -792,7 +792,7 @@ async def test_remove_audit_group_value_error_becomes_tool_error(mock_ctx, ctx_p
 
 async def test_remove_audit_group_fabric_error_becomes_tool_error(mock_ctx, ctx_patch) -> None:
     """remove_audit_group converts FabricError to ToolError."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -849,7 +849,7 @@ async def test_set_audit_retention_happy_path(mock_ctx, ctx_patch) -> None:
 
 async def test_set_audit_retention_readonly_mode_blocked(ctx_patch) -> None:
     """set_audit_retention raises ToolError in read-only mode."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -869,7 +869,7 @@ async def test_set_audit_retention_readonly_mode_blocked(ctx_patch) -> None:
 
 async def test_set_audit_retention_workspace_not_in_allowlist(ctx_patch) -> None:
     """set_audit_retention raises ToolError when workspace is not in allowlist."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -887,7 +887,7 @@ async def test_set_audit_retention_workspace_not_in_allowlist(ctx_patch) -> None
 
 async def test_set_audit_retention_value_error_becomes_tool_error(mock_ctx, ctx_patch) -> None:
     """set_audit_retention converts ValueError (disabled audit) to ToolError."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -913,7 +913,7 @@ async def test_set_audit_retention_value_error_becomes_tool_error(mock_ctx, ctx_
 
 async def test_set_audit_retention_fabric_error_becomes_tool_error(mock_ctx, ctx_patch) -> None:
     """set_audit_retention converts FabricError to ToolError."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 

--- a/tests/unit/mcp/tools/test_dbt.py
+++ b/tests/unit/mcp/tools/test_dbt.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 import yaml
-from mcp.server.fastmcp.exceptions import ToolError
+from mcp.server.mcpserver.exceptions import ToolError
 
 from fabric_dw.services.dbt_scaffold import DbtAuthMode
 from tests.unit._call import call_tool

--- a/tests/unit/mcp/tools/test_functions.py
+++ b/tests/unit/mcp/tools/test_functions.py
@@ -6,7 +6,7 @@ Goal:   ≥90% branch coverage.
 Strategy
 --------
 - All calls routed via the shared ``call_tool()`` helper (``tests/unit/_call.py``),
-  which wraps ``mcp._tool_manager.call_tool`` (same path MCPServer uses at
+  which wraps ``mcp._tool_manager.call_tool`` (same path the MCP server uses at
   runtime) so the ``@mcp.tool`` decorator, Pydantic validation, and guards
   are all exercised.
 - ``ServerContext`` injected by patching ``fabric_dw.mcp._context._SERVER_CTX``

--- a/tests/unit/mcp/tools/test_functions.py
+++ b/tests/unit/mcp/tools/test_functions.py
@@ -6,7 +6,7 @@ Goal:   ≥90% branch coverage.
 Strategy
 --------
 - All calls routed via the shared ``call_tool()`` helper (``tests/unit/_call.py``),
-  which wraps ``mcp._tool_manager.call_tool`` (same path FastMCP uses at
+  which wraps ``mcp._tool_manager.call_tool`` (same path MCPServer uses at
   runtime) so the ``@mcp.tool`` decorator, Pydantic validation, and guards
   are all exercised.
 - ``ServerContext`` injected by patching ``fabric_dw.mcp._context._SERVER_CTX``
@@ -21,7 +21,7 @@ from datetime import UTC, datetime
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from mcp.server.fastmcp.exceptions import ToolError
+from mcp.server.mcpserver.exceptions import ToolError
 
 from fabric_dw.exceptions import FabricError, NotFoundError
 from fabric_dw.models import FunctionDetails, FunctionKind

--- a/tests/unit/mcp/tools/test_load.py
+++ b/tests/unit/mcp/tools/test_load.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from mcp.server.fastmcp.exceptions import ToolError
+from mcp.server.mcpserver.exceptions import ToolError
 
 from fabric_dw.models import CopyIntoResult
 from tests.unit._call import call_tool

--- a/tests/unit/mcp/tools/test_permissions.py
+++ b/tests/unit/mcp/tools/test_permissions.py
@@ -175,7 +175,7 @@ async def test_grant_permission_happy_path(mock_ctx, ctx_patch) -> None:
 
 async def test_grant_permission_blocked_by_readonly(mock_ctx, ctx_patch) -> None:
     """grant_permission is blocked when FABRIC_MCP_READONLY is set."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -234,7 +234,7 @@ async def test_grant_permission_not_destructive_gated(mock_ctx, ctx_patch) -> No
 
 async def test_grant_permission_invalid_permissions_raises_tool_error(mock_ctx, ctx_patch) -> None:
     """grant_permission raises ToolError when the permissions string is invalid."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -302,7 +302,7 @@ async def test_deny_permission_happy_path(mock_ctx, ctx_patch) -> None:
 
 async def test_deny_permission_blocked_by_readonly(mock_ctx, ctx_patch) -> None:
     """deny_permission is blocked when FABRIC_MCP_READONLY is set."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -395,7 +395,7 @@ async def test_revoke_permission_happy_path(mock_ctx, ctx_patch) -> None:
 
 async def test_revoke_permission_blocked_by_readonly(mock_ctx, ctx_patch) -> None:
     """revoke_permission is blocked when FABRIC_MCP_READONLY is set."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -423,7 +423,7 @@ async def test_revoke_permission_blocked_by_readonly(mock_ctx, ctx_patch) -> Non
 
 async def test_revoke_permission_blocked_by_missing_destructive_env(mock_ctx, ctx_patch) -> None:
     """revoke_permission is blocked when FABRIC_MCP_ALLOW_DESTRUCTIVE is unset."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -727,7 +727,7 @@ async def test_create_security_policy_rejects_predicate_type_key(mock_ctx, ctx_p
     silently building a FILTER predicate -- exercises the real service validation (only
     run_query is mocked), since silently downgrading an intended BLOCK to FILTER would be
     a security-relevant footgun for an MCP caller."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -768,7 +768,7 @@ async def test_create_security_policy_rejects_predicate_type_key(mock_ctx, ctx_p
 
 async def test_drop_security_policy_blocked_without_destructive_env(mock_ctx, ctx_patch) -> None:
     """drop_security_policy is blocked when FABRIC_MCP_ALLOW_DESTRUCTIVE is not set."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 

--- a/tests/unit/mcp/tools/test_permissions.py
+++ b/tests/unit/mcp/tools/test_permissions.py
@@ -865,11 +865,11 @@ async def test_add_drop_security_predicate_schemas_omit_predicate_type() -> None
 
     tools = {t.name: t for t in await mcp.list_tools()}
 
-    add_props = tools["add_security_predicate"].inputSchema["properties"]
+    add_props = tools["add_security_predicate"].input_schema["properties"]
     assert "predicate_type" not in add_props
     assert "operation" not in add_props
 
-    drop_props = tools["drop_security_predicate"].inputSchema["properties"]
+    drop_props = tools["drop_security_predicate"].input_schema["properties"]
     assert "predicate_type" not in drop_props
     assert "operation" not in drop_props
 

--- a/tests/unit/mcp/tools/test_queries.py
+++ b/tests/unit/mcp/tools/test_queries.py
@@ -180,7 +180,7 @@ async def test_list_running_queries_happy_path(mock_ctx, ctx_patch) -> None:
 
 async def test_list_running_queries_fabric_error(mock_ctx, ctx_patch) -> None:
     """list_running_queries wraps FabricError as ToolError."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -205,7 +205,7 @@ async def test_list_running_queries_fabric_error(mock_ctx, ctx_patch) -> None:
 
 async def test_list_running_queries_workspace_not_allowed(ctx_patch) -> None:
     """list_running_queries raises ToolError when workspace not in allowlist."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -280,7 +280,7 @@ async def test_list_connections_happy_path(mock_ctx, ctx_patch) -> None:
 
 async def test_list_connections_fabric_error(mock_ctx, ctx_patch) -> None:
     """list_connections wraps FabricError as ToolError."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -305,7 +305,7 @@ async def test_list_connections_fabric_error(mock_ctx, ctx_patch) -> None:
 
 async def test_list_connections_workspace_not_allowed(ctx_patch) -> None:
     """list_connections raises ToolError when workspace not in allowlist."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -352,7 +352,7 @@ async def test_kill_session_happy_path(mock_ctx, ctx_patch) -> None:
 
 async def test_kill_session_fabric_error(mock_ctx, ctx_patch) -> None:
     """kill_session wraps FabricError as ToolError."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -377,7 +377,7 @@ async def test_kill_session_fabric_error(mock_ctx, ctx_patch) -> None:
 
 async def test_kill_session_value_error(mock_ctx, ctx_patch) -> None:
     """kill_session wraps ValueError as ToolError."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -404,7 +404,7 @@ async def test_kill_session_value_error(mock_ctx, ctx_patch) -> None:
 
 async def test_kill_session_readonly_blocked(ctx_patch) -> None:
     """kill_session raises ToolError in read-only mode."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -424,7 +424,7 @@ async def test_kill_session_readonly_blocked(ctx_patch) -> None:
 
 async def test_kill_session_workspace_not_allowed(ctx_patch) -> None:
     """kill_session raises ToolError when workspace not in allowlist."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -443,7 +443,7 @@ async def test_kill_session_workspace_not_allowed(ctx_patch) -> None:
 @pytest.mark.parametrize("bad_session_id", [0, -1])
 async def test_kill_session_rejects_non_positive_session_id(ctx_patch, bad_session_id: int) -> None:
     """kill_session raises ToolError for session_id=0 or session_id=-1 (Field(ge=1) bound)."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -549,7 +549,7 @@ async def test_list_request_history_with_since_until(mock_ctx, ctx_patch) -> Non
 
 async def test_list_request_history_bad_since(ctx_patch) -> None:
     """list_request_history raises ToolError on invalid ISO-8601 since."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -568,7 +568,7 @@ async def test_list_request_history_bad_since(ctx_patch) -> None:
 
 async def test_list_request_history_bad_until(ctx_patch) -> None:
     """list_request_history raises ToolError on invalid ISO-8601 until."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -587,7 +587,7 @@ async def test_list_request_history_bad_until(ctx_patch) -> None:
 
 async def test_list_request_history_fabric_error(mock_ctx, ctx_patch) -> None:
     """list_request_history wraps FabricError as ToolError."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -612,7 +612,7 @@ async def test_list_request_history_fabric_error(mock_ctx, ctx_patch) -> None:
 
 async def test_list_request_history_workspace_not_allowed(ctx_patch) -> None:
     """list_request_history raises ToolError when workspace not in allowlist."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -693,7 +693,7 @@ async def test_list_session_history_with_since_until(mock_ctx, ctx_patch) -> Non
 
 async def test_list_session_history_bad_since(ctx_patch) -> None:
     """list_session_history raises ToolError on invalid ISO-8601 since."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -712,7 +712,7 @@ async def test_list_session_history_bad_since(ctx_patch) -> None:
 
 async def test_list_session_history_bad_until(ctx_patch) -> None:
     """list_session_history raises ToolError on invalid ISO-8601 until."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -731,7 +731,7 @@ async def test_list_session_history_bad_until(ctx_patch) -> None:
 
 async def test_list_session_history_fabric_error(mock_ctx, ctx_patch) -> None:
     """list_session_history wraps FabricError as ToolError."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -756,7 +756,7 @@ async def test_list_session_history_fabric_error(mock_ctx, ctx_patch) -> None:
 
 async def test_list_session_history_workspace_not_allowed(ctx_patch) -> None:
     """list_session_history raises ToolError when workspace not in allowlist."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -838,7 +838,7 @@ async def test_list_frequent_queries_with_since_until(mock_ctx, ctx_patch) -> No
 
 async def test_list_frequent_queries_bad_since(ctx_patch) -> None:
     """list_frequent_queries raises ToolError on invalid ISO-8601 since."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -857,7 +857,7 @@ async def test_list_frequent_queries_bad_since(ctx_patch) -> None:
 
 async def test_list_frequent_queries_bad_until(ctx_patch) -> None:
     """list_frequent_queries raises ToolError on invalid ISO-8601 until."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -876,7 +876,7 @@ async def test_list_frequent_queries_bad_until(ctx_patch) -> None:
 
 async def test_list_frequent_queries_fabric_error(mock_ctx, ctx_patch) -> None:
     """list_frequent_queries wraps FabricError as ToolError."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -901,7 +901,7 @@ async def test_list_frequent_queries_fabric_error(mock_ctx, ctx_patch) -> None:
 
 async def test_list_frequent_queries_workspace_not_allowed(ctx_patch) -> None:
     """list_frequent_queries raises ToolError when workspace not in allowlist."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -983,7 +983,7 @@ async def test_list_long_running_queries_with_since_until(mock_ctx, ctx_patch) -
 
 async def test_list_long_running_queries_bad_since(ctx_patch) -> None:
     """list_long_running_queries raises ToolError on invalid ISO-8601 since."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -1002,7 +1002,7 @@ async def test_list_long_running_queries_bad_since(ctx_patch) -> None:
 
 async def test_list_long_running_queries_bad_until(ctx_patch) -> None:
     """list_long_running_queries raises ToolError on invalid ISO-8601 until."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -1021,7 +1021,7 @@ async def test_list_long_running_queries_bad_until(ctx_patch) -> None:
 
 async def test_list_long_running_queries_fabric_error(mock_ctx, ctx_patch) -> None:
     """list_long_running_queries wraps FabricError as ToolError."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -1046,7 +1046,7 @@ async def test_list_long_running_queries_fabric_error(mock_ctx, ctx_patch) -> No
 
 async def test_list_long_running_queries_workspace_not_allowed(ctx_patch) -> None:
     """list_long_running_queries raises ToolError when workspace not in allowlist."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -1082,7 +1082,7 @@ _RAW_DRIVER_EXC = _FakeDriverError(_FakeDriverError._INTERNAL_DETAIL)
 
 async def test_list_running_queries_raw_driver_exc_raises_tool_error(mock_ctx, ctx_patch) -> None:
     """A raw driver exception from list_running is converted to ToolError."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -1110,7 +1110,7 @@ async def test_list_running_queries_raw_driver_exc_raises_tool_error(mock_ctx, c
 
 async def test_list_connections_raw_driver_exc_raises_tool_error(mock_ctx, ctx_patch) -> None:
     """A raw driver exception from list_connections is converted to ToolError."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -1138,7 +1138,7 @@ async def test_list_connections_raw_driver_exc_raises_tool_error(mock_ctx, ctx_p
 
 async def test_kill_session_raw_driver_exc_raises_tool_error(mock_ctx, ctx_patch) -> None:
     """A raw driver exception from queries.kill is converted to ToolError without leaking."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -1242,7 +1242,7 @@ async def test_list_locks_returns_dicts(mock_ctx, ctx_patch) -> None:
 
 async def test_list_locks_fabric_error_raises_tool_error(mock_ctx, ctx_patch) -> None:
     """list_locks wraps FabricError as ToolError."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -1291,7 +1291,7 @@ async def test_list_locks_empty_result(mock_ctx, ctx_patch) -> None:
 
 async def test_list_locks_raw_driver_exc_raises_tool_error(mock_ctx, ctx_patch) -> None:
     """A raw driver exception from list_locks is converted to ToolError."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -1389,7 +1389,7 @@ async def test_get_request_detail_happy_path_not_found(mock_ctx, ctx_patch) -> N
 
 async def test_get_request_detail_fabric_error(mock_ctx, ctx_patch) -> None:
     """get_request_detail wraps FabricError as ToolError."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -1414,7 +1414,7 @@ async def test_get_request_detail_fabric_error(mock_ctx, ctx_patch) -> None:
 
 async def test_get_request_detail_permission_denied(mock_ctx, ctx_patch) -> None:
     """get_request_detail wraps PermissionDeniedError as ToolError."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -1439,7 +1439,7 @@ async def test_get_request_detail_permission_denied(mock_ctx, ctx_patch) -> None
 
 async def test_get_request_detail_workspace_not_allowed(ctx_patch) -> None:
     """get_request_detail raises ToolError when workspace not in allowlist."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -1457,7 +1457,7 @@ async def test_get_request_detail_workspace_not_allowed(ctx_patch) -> None:
 
 async def test_get_request_detail_raw_driver_exc_raises_tool_error(mock_ctx, ctx_patch) -> None:
     """A raw driver exception is converted to ToolError without leaking internal details."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 

--- a/tests/unit/mcp/tools/test_restore.py
+++ b/tests/unit/mcp/tools/test_restore.py
@@ -21,7 +21,7 @@ import os
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from mcp.server.fastmcp.exceptions import ToolError
+from mcp.server.mcpserver.exceptions import ToolError
 
 from fabric_dw.exceptions import FabricError, NotFoundError
 from fabric_dw.models import RestorePoint

--- a/tests/unit/mcp/tools/test_settings.py
+++ b/tests/unit/mcp/tools/test_settings.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from mcp.server.fastmcp.exceptions import ToolError
+from mcp.server.mcpserver.exceptions import ToolError
 
 from fabric_dw.exceptions import NotFoundError
 from fabric_dw.models import WarehouseSettings

--- a/tests/unit/mcp/tools/test_snapshots.py
+++ b/tests/unit/mcp/tools/test_snapshots.py
@@ -22,7 +22,7 @@ from unittest.mock import AsyncMock, patch
 from uuid import UUID
 
 import pytest
-from mcp.server.fastmcp.exceptions import ToolError
+from mcp.server.mcpserver.exceptions import ToolError
 
 from fabric_dw.exceptions import FabricError, NotFoundError
 from fabric_dw.models import WarehouseSnapshot

--- a/tests/unit/mcp/tools/test_sql_endpoints.py
+++ b/tests/unit/mcp/tools/test_sql_endpoints.py
@@ -14,7 +14,7 @@ from unittest.mock import AsyncMock, patch
 from uuid import UUID
 
 import pytest
-from mcp.server.fastmcp.exceptions import ToolError
+from mcp.server.mcpserver.exceptions import ToolError
 
 from fabric_dw.exceptions import NotFoundError
 from fabric_dw.models import Warehouse, WarehouseKind

--- a/tests/unit/mcp/tools/test_sql_exec.py
+++ b/tests/unit/mcp/tools/test_sql_exec.py
@@ -270,7 +270,7 @@ async def test_get_query_plan_mermaid_no_xml_key(mock_ctx, ctx_patch) -> None:
 async def test_get_query_plan_invalid_format_raises_tool_error(mock_ctx, ctx_patch) -> None:
     """An unsupported format value raises ToolError.
 
-    This exercises MCPServer's *schema-validation* layer (Pydantic rejects the
+    This exercises the MCP server's *schema-validation* layer (Pydantic rejects the
     Literal before the function body runs), not the in-body ``assert_never``.
     Removing the ``assert_never`` would not make this test pass through the body.
     """

--- a/tests/unit/mcp/tools/test_sql_exec.py
+++ b/tests/unit/mcp/tools/test_sql_exec.py
@@ -270,11 +270,11 @@ async def test_get_query_plan_mermaid_no_xml_key(mock_ctx, ctx_patch) -> None:
 async def test_get_query_plan_invalid_format_raises_tool_error(mock_ctx, ctx_patch) -> None:
     """An unsupported format value raises ToolError.
 
-    This exercises FastMCP's *schema-validation* layer (Pydantic rejects the
+    This exercises MCPServer's *schema-validation* layer (Pydantic rejects the
     Literal before the function body runs), not the in-body ``assert_never``.
     Removing the ``assert_never`` would not make this test pass through the body.
     """
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -322,7 +322,7 @@ _SENSITIVE_QUERY = "SELECT col FROM dbo.Payments WHERE user_id = 42"
 
 async def test_execute_sql_raw_driver_exc_raises_tool_error(mock_ctx, ctx_patch) -> None:
     """A raw driver exception from execute() is converted to ToolError at the tool boundary."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -348,7 +348,7 @@ async def test_execute_sql_raw_driver_exc_does_not_leak_internal_detail(
     mock_ctx, ctx_patch
 ) -> None:
     """ToolError message from a raw driver exception must not contain the raw exception text."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -378,7 +378,7 @@ async def test_execute_sql_raw_driver_exc_does_not_leak_internal_detail(
 
 async def test_get_query_plan_raw_driver_exc_raises_tool_error(mock_ctx, ctx_patch) -> None:
     """A raw driver exception from get_plan() is converted to ToolError at the tool boundary."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -404,7 +404,7 @@ async def test_get_query_plan_raw_driver_exc_does_not_leak_internal_detail(
     mock_ctx, ctx_patch
 ) -> None:
     """ToolError message from a raw driver exception must not contain the raw exception text."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 

--- a/tests/unit/mcp/tools/test_sql_pools.py
+++ b/tests/unit/mcp/tools/test_sql_pools.py
@@ -144,7 +144,7 @@ async def test_get_sql_pools_status_disabled(mock_ctx, ctx_patch) -> None:
 
 async def test_get_sql_pools_status_resolver_fabric_error(mock_ctx, ctx_patch) -> None:
     """get_sql_pools_status wraps FabricError from resolver as ToolError."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -163,7 +163,7 @@ async def test_get_sql_pools_status_resolver_fabric_error(mock_ctx, ctx_patch) -
 
 async def test_get_sql_pools_status_workspace_not_allowed(ctx_patch) -> None:
     """get_sql_pools_status raises ToolError when workspace not in allowlist."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -183,7 +183,7 @@ async def test_get_sql_pools_status_workspace_not_allowed(ctx_patch) -> None:
 
 async def test_get_sql_pools_status_service_fabric_error(mock_ctx, ctx_patch) -> None:
     """get_sql_pools_status surfaces FabricError from service as ToolError."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -279,7 +279,7 @@ async def test_list_sql_pools_happy_path(mock_ctx, ctx_patch) -> None:
 
 async def test_list_sql_pools_fabric_error(mock_ctx, ctx_patch) -> None:
     """list_sql_pools wraps FabricError as ToolError."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -302,7 +302,7 @@ async def test_list_sql_pools_fabric_error(mock_ctx, ctx_patch) -> None:
 
 async def test_list_sql_pools_workspace_not_allowed(ctx_patch) -> None:
     """list_sql_pools raises ToolError when workspace not in allowlist."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -351,7 +351,7 @@ async def test_get_sql_pool_happy_path(mock_ctx, ctx_patch) -> None:
 
 async def test_get_sql_pool_not_found_in_config(mock_ctx, ctx_patch) -> None:
     """get_sql_pool raises ToolError when the named pool is absent from config."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -377,7 +377,7 @@ async def test_get_sql_pool_not_found_in_config(mock_ctx, ctx_patch) -> None:
 
 async def test_get_sql_pool_fabric_error(mock_ctx, ctx_patch) -> None:
     """get_sql_pool propagates FabricError as ToolError."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -400,7 +400,7 @@ async def test_get_sql_pool_fabric_error(mock_ctx, ctx_patch) -> None:
 
 async def test_get_sql_pool_workspace_not_allowed(ctx_patch) -> None:
     """get_sql_pool raises ToolError when workspace is not in allowlist."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -490,7 +490,7 @@ async def test_create_sql_pool_with_classifier(mock_ctx, ctx_patch) -> None:
 
 async def test_create_sql_pool_already_exists(mock_ctx, ctx_patch) -> None:
     """create_sql_pool raises ToolError (not AlreadyExistsError) when pool exists."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -515,7 +515,7 @@ async def test_create_sql_pool_already_exists(mock_ctx, ctx_patch) -> None:
 
 async def test_create_sql_pool_fabric_error(mock_ctx, ctx_patch) -> None:
     """create_sql_pool wraps generic FabricError as ToolError."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -538,7 +538,7 @@ async def test_create_sql_pool_fabric_error(mock_ctx, ctx_patch) -> None:
 
 async def test_create_sql_pool_pool_missing_after_create(mock_ctx, ctx_patch) -> None:
     """create_sql_pool raises ToolError when pool absent from response (eventual consistency)."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -565,7 +565,7 @@ async def test_create_sql_pool_pool_missing_after_create(mock_ctx, ctx_patch) ->
 
 async def test_create_sql_pool_readonly_blocked(ctx_patch) -> None:
     """create_sql_pool raises ToolError in read-only mode."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -585,7 +585,7 @@ async def test_create_sql_pool_readonly_blocked(ctx_patch) -> None:
 
 async def test_create_sql_pool_workspace_not_allowed(ctx_patch) -> None:
     """create_sql_pool raises ToolError when workspace is not in allowlist."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -634,7 +634,7 @@ async def test_update_sql_pool_happy_path(mock_ctx, ctx_patch) -> None:
 
 async def test_update_sql_pool_not_found(mock_ctx, ctx_patch) -> None:
     """update_sql_pool raises ToolError when pool does not exist."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -659,7 +659,7 @@ async def test_update_sql_pool_not_found(mock_ctx, ctx_patch) -> None:
 
 async def test_update_sql_pool_fabric_error(mock_ctx, ctx_patch) -> None:
     """update_sql_pool wraps FabricError as ToolError."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -682,7 +682,7 @@ async def test_update_sql_pool_fabric_error(mock_ctx, ctx_patch) -> None:
 
 async def test_update_sql_pool_missing_after_update(mock_ctx, ctx_patch) -> None:
     """update_sql_pool raises ToolError when pool absent from response after update."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -708,7 +708,7 @@ async def test_update_sql_pool_missing_after_update(mock_ctx, ctx_patch) -> None
 
 async def test_update_sql_pool_readonly_blocked(ctx_patch) -> None:
     """update_sql_pool raises ToolError in read-only mode."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -754,7 +754,7 @@ async def test_delete_sql_pool_happy_path(mock_ctx, ctx_patch) -> None:
 
 async def test_delete_sql_pool_not_found(mock_ctx, ctx_patch) -> None:
     """delete_sql_pool raises ToolError when pool does not exist."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -780,7 +780,7 @@ async def test_delete_sql_pool_not_found(mock_ctx, ctx_patch) -> None:
 
 async def test_delete_sql_pool_fabric_error(mock_ctx, ctx_patch) -> None:
     """delete_sql_pool wraps FabricError as ToolError."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -804,7 +804,7 @@ async def test_delete_sql_pool_fabric_error(mock_ctx, ctx_patch) -> None:
 
 async def test_delete_sql_pool_destructive_disabled(ctx_patch) -> None:
     """delete_sql_pool raises ToolError when FABRIC_MCP_ALLOW_DESTRUCTIVE is not set."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -826,7 +826,7 @@ async def test_delete_sql_pool_destructive_disabled(ctx_patch) -> None:
 
 async def test_delete_sql_pool_readonly_blocked(ctx_patch) -> None:
     """delete_sql_pool raises ToolError in read-only mode."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -873,7 +873,7 @@ async def test_enable_sql_pools_happy_path(mock_ctx, ctx_patch) -> None:
 
 async def test_enable_sql_pools_fabric_error(mock_ctx, ctx_patch) -> None:
     """enable_sql_pools wraps FabricError as ToolError."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -902,7 +902,7 @@ async def test_enable_sql_pools_no_pools_defined_raises_tool_error(mock_ctx, ctx
     catches FabricError; BadRequestError is a subclass, so it must be caught and
     re-raised as ToolError — not escape as a raw exception.
     """
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -927,7 +927,7 @@ async def test_enable_sql_pools_no_pools_defined_raises_tool_error(mock_ctx, ctx
 
 async def test_enable_sql_pools_readonly_blocked(ctx_patch) -> None:
     """enable_sql_pools raises ToolError in read-only mode."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -945,7 +945,7 @@ async def test_enable_sql_pools_readonly_blocked(ctx_patch) -> None:
 
 async def test_enable_sql_pools_workspace_not_allowed(ctx_patch) -> None:
     """enable_sql_pools raises ToolError when workspace not in allowlist."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -992,7 +992,7 @@ async def test_disable_sql_pools_happy_path(mock_ctx, ctx_patch) -> None:
 
 async def test_disable_sql_pools_fabric_error(mock_ctx, ctx_patch) -> None:
     """disable_sql_pools wraps FabricError as ToolError."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -1015,7 +1015,7 @@ async def test_disable_sql_pools_fabric_error(mock_ctx, ctx_patch) -> None:
 
 async def test_disable_sql_pools_readonly_blocked(ctx_patch) -> None:
     """disable_sql_pools raises ToolError in read-only mode."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -1033,7 +1033,7 @@ async def test_disable_sql_pools_readonly_blocked(ctx_patch) -> None:
 
 async def test_disable_sql_pools_workspace_not_allowed(ctx_patch) -> None:
     """disable_sql_pools raises ToolError when workspace not in allowlist."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -1116,7 +1116,7 @@ async def test_list_sql_pool_insights_with_since_until(mock_ctx, ctx_patch) -> N
 
 async def test_list_sql_pool_insights_bad_since(ctx_patch) -> None:
     """list_sql_pool_insights raises ToolError on invalid ISO-8601 since."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -1135,7 +1135,7 @@ async def test_list_sql_pool_insights_bad_since(ctx_patch) -> None:
 
 async def test_list_sql_pool_insights_bad_until(ctx_patch) -> None:
     """list_sql_pool_insights raises ToolError on invalid ISO-8601 until."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -1154,7 +1154,7 @@ async def test_list_sql_pool_insights_bad_until(ctx_patch) -> None:
 
 async def test_list_sql_pool_insights_fabric_error(mock_ctx, ctx_patch) -> None:
     """list_sql_pool_insights wraps FabricError as ToolError."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -1179,7 +1179,7 @@ async def test_list_sql_pool_insights_fabric_error(mock_ctx, ctx_patch) -> None:
 
 async def test_list_sql_pool_insights_workspace_not_allowed(ctx_patch) -> None:
     """list_sql_pool_insights raises ToolError when workspace not in allowlist."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 

--- a/tests/unit/mcp/tools/test_statistics.py
+++ b/tests/unit/mcp/tools/test_statistics.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from mcp.server.fastmcp.exceptions import ToolError
+from mcp.server.mcpserver.exceptions import ToolError
 
 from fabric_dw.exceptions import ItemKindError, NotFoundError
 from fabric_dw.models import Statistic, StatisticDetails

--- a/tests/unit/mcp/tools/test_tables.py
+++ b/tests/unit/mcp/tools/test_tables.py
@@ -20,7 +20,7 @@ from datetime import UTC, datetime
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from mcp.server.fastmcp.exceptions import ToolError
+from mcp.server.mcpserver.exceptions import ToolError
 
 from fabric_dw.exceptions import ItemKindError, NotFoundError
 from fabric_dw.models import ClusterColumn, ResultSet, Table, TableRowCount, WarehouseKind
@@ -356,7 +356,7 @@ async def test_read_table_without_as_of_passes_none(mock_ctx, ctx_patch) -> None
 
 async def test_read_table_invalid_as_of_raises_tool_error(mock_ctx, ctx_patch) -> None:
     """read_table raises ToolError when as_of is not a valid ISO-8601 string."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -833,7 +833,7 @@ async def test_count_table_rows_without_as_of_passes_none(mock_ctx, ctx_patch) -
 
 async def test_count_table_rows_invalid_as_of_raises_tool_error(mock_ctx, ctx_patch) -> None:
     """count_table_rows raises ToolError when as_of is not a valid ISO-8601 string."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 

--- a/tests/unit/mcp/tools/test_tool_quality.py
+++ b/tests/unit/mcp/tools/test_tool_quality.py
@@ -8,7 +8,7 @@ Coverage
 4. ``resolve_item`` — returns (ws_id, entry) in one call.
 5. ``safe_rows`` — applies json_safe to all cells.
 6. ``parse_qualified_name`` — consistent ToolError on bad input.
-7. Int param bounds — MCPServer rejects out-of-range values.
+7. Int param bounds — the MCP server rejects out-of-range values.
 8. ``next()`` fallback in create_sql_pool / update_sql_pool.
 9. ``clear_cache`` scope + stats.
 """
@@ -302,7 +302,7 @@ class TestParseQualifiedName:
 
 
 async def test_read_table_count_bound_rejection() -> None:
-    """read_table must reject count > 10000 at the MCPServer schema layer."""
+    """read_table must reject count > 10000 at the MCP schema layer."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
     ctx = _make_ctx()
@@ -323,7 +323,7 @@ async def test_read_table_count_bound_rejection() -> None:
 
 
 async def test_read_view_count_bound_rejection() -> None:
-    """read_view must reject count > 10000 at the MCPServer schema layer."""
+    """read_view must reject count > 10000 at the MCP schema layer."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
     ctx = _make_ctx()

--- a/tests/unit/mcp/tools/test_tool_quality.py
+++ b/tests/unit/mcp/tools/test_tool_quality.py
@@ -8,7 +8,7 @@ Coverage
 4. ``resolve_item`` — returns (ws_id, entry) in one call.
 5. ``safe_rows`` — applies json_safe to all cells.
 6. ``parse_qualified_name`` — consistent ToolError on bad input.
-7. Int param bounds — FastMCP rejects out-of-range values.
+7. Int param bounds — MCPServer rejects out-of-range values.
 8. ``next()`` fallback in create_sql_pool / update_sql_pool.
 9. ``clear_cache`` scope + stats.
 """
@@ -22,7 +22,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import UUID
 
 import pytest
-from mcp.server.fastmcp.exceptions import ToolError
+from mcp.server.mcpserver.exceptions import ToolError
 
 from fabric_dw import auth as _auth
 from fabric_dw.cache import ItemEntry
@@ -302,7 +302,7 @@ class TestParseQualifiedName:
 
 
 async def test_read_table_count_bound_rejection() -> None:
-    """read_table must reject count > 10000 at the FastMCP schema layer."""
+    """read_table must reject count > 10000 at the MCPServer schema layer."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
     ctx = _make_ctx()
@@ -323,7 +323,7 @@ async def test_read_table_count_bound_rejection() -> None:
 
 
 async def test_read_view_count_bound_rejection() -> None:
-    """read_view must reject count > 10000 at the FastMCP schema layer."""
+    """read_view must reject count > 10000 at the MCPServer schema layer."""
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
     ctx = _make_ctx()

--- a/tests/unit/mcp/tools/test_views.py
+++ b/tests/unit/mcp/tools/test_views.py
@@ -6,7 +6,7 @@ Goal:   ≥95 % branch coverage.
 Strategy
 --------
 - All calls routed via the shared ``call_tool()`` helper (``tests/unit/_call.py``),
-  which wraps ``mcp._tool_manager.call_tool`` (same path FastMCP uses at
+  which wraps ``mcp._tool_manager.call_tool`` (same path MCPServer uses at
   runtime) so the ``@mcp.tool`` decorator, Pydantic validation, and guards
   are all exercised.
 - ``ServerContext`` injected by patching ``fabric_dw.mcp._context._SERVER_CTX``
@@ -142,7 +142,7 @@ async def test_list_views_empty_result(mock_ctx, ctx_patch) -> None:
 
 async def test_list_views_fabric_error_becomes_tool_error(mock_ctx, ctx_patch) -> None:
     """list_views converts FabricError to ToolError."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -166,7 +166,7 @@ async def test_list_views_fabric_error_becomes_tool_error(mock_ctx, ctx_patch) -
 
 async def test_list_views_no_connection_string_tool_error(mock_ctx, ctx_patch) -> None:
     """list_views raises ToolError when the item has no connection string."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -186,7 +186,7 @@ async def test_list_views_no_connection_string_tool_error(mock_ctx, ctx_patch) -
 
 async def test_list_views_workspace_not_in_allowlist(ctx_patch) -> None:
     """list_views raises ToolError when workspace is not in FABRIC_MCP_WORKSPACES."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -291,7 +291,7 @@ async def test_read_view_with_count(mock_ctx, ctx_patch) -> None:
 
 async def test_read_view_unqualified_name_raises_tool_error(ctx_patch) -> None:
     """read_view raises ToolError when qualified_name has no dot."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -310,7 +310,7 @@ async def test_read_view_unqualified_name_raises_tool_error(ctx_patch) -> None:
 
 async def test_read_view_fabric_error_becomes_tool_error(mock_ctx, ctx_patch) -> None:
     """read_view converts FabricError to ToolError."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -334,7 +334,7 @@ async def test_read_view_fabric_error_becomes_tool_error(mock_ctx, ctx_patch) ->
 
 async def test_read_view_workspace_not_in_allowlist(ctx_patch) -> None:
     """read_view raises ToolError when workspace is not in allowlist."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -409,7 +409,7 @@ async def test_read_view_without_as_of_passes_none(mock_ctx, ctx_patch) -> None:
 
 async def test_read_view_invalid_as_of_raises_tool_error(mock_ctx, ctx_patch) -> None:
     """read_view raises ToolError when as_of is not a valid ISO-8601 string."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -468,7 +468,7 @@ async def test_get_view_happy_path(mock_ctx, ctx_patch) -> None:
 
 async def test_get_view_unqualified_name_raises_tool_error(ctx_patch) -> None:
     """get_view raises ToolError when qualified_name has no dot."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -485,7 +485,7 @@ async def test_get_view_unqualified_name_raises_tool_error(ctx_patch) -> None:
 
 async def test_get_view_fabric_error_becomes_tool_error(mock_ctx, ctx_patch) -> None:
     """get_view converts FabricError to ToolError."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -509,7 +509,7 @@ async def test_get_view_fabric_error_becomes_tool_error(mock_ctx, ctx_patch) -> 
 
 async def test_get_view_workspace_not_in_allowlist(ctx_patch) -> None:
     """get_view raises ToolError when workspace is not in allowlist."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -564,7 +564,7 @@ async def test_create_view_happy_path(mock_ctx, ctx_patch) -> None:
 
 async def test_create_view_readonly_mode_blocked(ctx_patch) -> None:
     """create_view raises ToolError in read-only mode."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -589,7 +589,7 @@ async def test_create_view_readonly_mode_blocked(ctx_patch) -> None:
 
 async def test_create_view_unqualified_name_raises_tool_error(ctx_patch) -> None:
     """create_view raises ToolError when qualified_name has no dot."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -611,7 +611,7 @@ async def test_create_view_unqualified_name_raises_tool_error(ctx_patch) -> None
 
 async def test_create_view_workspace_not_in_allowlist(ctx_patch) -> None:
     """create_view raises ToolError when workspace is not in allowlist."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -634,7 +634,7 @@ async def test_create_view_workspace_not_in_allowlist(ctx_patch) -> None:
 
 async def test_create_view_fabric_error_becomes_tool_error(mock_ctx, ctx_patch) -> None:
     """create_view converts FabricError to ToolError."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -700,7 +700,7 @@ async def test_update_view_happy_path(mock_ctx, ctx_patch) -> None:
 
 async def test_update_view_readonly_mode_blocked(ctx_patch) -> None:
     """update_view raises ToolError in read-only mode."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -725,7 +725,7 @@ async def test_update_view_readonly_mode_blocked(ctx_patch) -> None:
 
 async def test_update_view_unqualified_name_raises_tool_error(ctx_patch) -> None:
     """update_view raises ToolError when qualified_name has no dot."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -747,7 +747,7 @@ async def test_update_view_unqualified_name_raises_tool_error(ctx_patch) -> None
 
 async def test_update_view_workspace_not_in_allowlist(ctx_patch) -> None:
     """update_view raises ToolError when workspace is not in allowlist."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -770,7 +770,7 @@ async def test_update_view_workspace_not_in_allowlist(ctx_patch) -> None:
 
 async def test_update_view_fabric_error_becomes_tool_error(mock_ctx, ctx_patch) -> None:
     """update_view converts FabricError to ToolError."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -833,7 +833,7 @@ async def test_drop_view_happy_path(mock_ctx, ctx_patch) -> None:
 
 async def test_drop_view_readonly_mode_blocked(ctx_patch) -> None:
     """drop_view raises ToolError in read-only mode."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -853,7 +853,7 @@ async def test_drop_view_readonly_mode_blocked(ctx_patch) -> None:
 
 async def test_drop_view_unqualified_name_raises_tool_error(ctx_patch) -> None:
     """drop_view raises ToolError when qualified_name has no dot."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -870,7 +870,7 @@ async def test_drop_view_unqualified_name_raises_tool_error(ctx_patch) -> None:
 
 async def test_drop_view_workspace_not_in_allowlist(ctx_patch) -> None:
     """drop_view raises ToolError when workspace is not in allowlist."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -891,7 +891,7 @@ async def test_drop_view_workspace_not_in_allowlist(ctx_patch) -> None:
 
 async def test_drop_view_fabric_error_becomes_tool_error(mock_ctx, ctx_patch) -> None:
     """drop_view converts FabricError to ToolError."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -953,7 +953,7 @@ async def test_rename_view_happy_path(mock_ctx, ctx_patch) -> None:
 
 async def test_rename_view_readonly_mode_blocked(ctx_patch) -> None:
     """rename_view raises ToolError in read-only mode."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -978,7 +978,7 @@ async def test_rename_view_readonly_mode_blocked(ctx_patch) -> None:
 
 async def test_rename_view_unqualified_name_raises_tool_error(ctx_patch) -> None:
     """rename_view raises ToolError when qualified_name has no dot."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -1000,7 +1000,7 @@ async def test_rename_view_unqualified_name_raises_tool_error(ctx_patch) -> None
 
 async def test_rename_view_workspace_not_in_allowlist(ctx_patch) -> None:
     """rename_view raises ToolError when workspace is not in allowlist."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -1023,7 +1023,7 @@ async def test_rename_view_workspace_not_in_allowlist(ctx_patch) -> None:
 
 async def test_rename_view_fabric_error_becomes_tool_error(mock_ctx, ctx_patch) -> None:
     """rename_view converts FabricError to ToolError."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -1052,7 +1052,7 @@ async def test_rename_view_fabric_error_becomes_tool_error(mock_ctx, ctx_patch) 
 
 async def test_rename_view_value_error_becomes_tool_error(mock_ctx, ctx_patch) -> None:
     """rename_view converts ValueError (e.g. validation error) to ToolError."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -1151,7 +1151,7 @@ async def test_transfer_view_does_not_reject_sql_endpoint(mock_ctx, ctx_patch) -
 
 async def test_transfer_view_readonly_mode_blocked(ctx_patch) -> None:
     """transfer_view raises ToolError in read-only mode."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -1176,7 +1176,7 @@ async def test_transfer_view_readonly_mode_blocked(ctx_patch) -> None:
 
 async def test_transfer_view_unqualified_name_raises_tool_error(ctx_patch) -> None:
     """transfer_view raises ToolError when qualified_name has no dot."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -1198,7 +1198,7 @@ async def test_transfer_view_unqualified_name_raises_tool_error(ctx_patch) -> No
 
 async def test_transfer_view_workspace_not_in_allowlist(ctx_patch) -> None:
     """transfer_view raises ToolError when workspace is not in allowlist."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -1221,7 +1221,7 @@ async def test_transfer_view_workspace_not_in_allowlist(ctx_patch) -> None:
 
 async def test_transfer_view_fabric_error_becomes_tool_error(mock_ctx, ctx_patch) -> None:
     """transfer_view converts FabricError to ToolError."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -1250,7 +1250,7 @@ async def test_transfer_view_fabric_error_becomes_tool_error(mock_ctx, ctx_patch
 
 async def test_transfer_view_value_error_becomes_tool_error(mock_ctx, ctx_patch) -> None:
     """transfer_view converts ValueError (e.g. reserved target schema) to ToolError."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -1310,7 +1310,7 @@ async def test_count_view_rows_happy_path(mock_ctx, ctx_patch) -> None:
 
 async def test_count_view_rows_fabric_error_becomes_tool_error(mock_ctx, ctx_patch) -> None:
     """count_view_rows wraps FabricError into ToolError."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -1334,7 +1334,7 @@ async def test_count_view_rows_fabric_error_becomes_tool_error(mock_ctx, ctx_pat
 
 async def test_count_view_rows_workspace_allowlist_blocks(ctx_patch) -> None:
     """count_view_rows raises ToolError when workspace is not in FABRIC_MCP_WORKSPACES."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -1352,7 +1352,7 @@ async def test_count_view_rows_workspace_allowlist_blocks(ctx_patch) -> None:
 
 async def test_count_view_rows_bad_qualified_name_raises_tool_error(ctx_patch) -> None:
     """count_view_rows raises ToolError when qualified_name has no dot."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -1426,7 +1426,7 @@ async def test_count_view_rows_without_as_of_passes_none(mock_ctx, ctx_patch) ->
 
 async def test_count_view_rows_invalid_as_of_raises_tool_error(mock_ctx, ctx_patch) -> None:
     """count_view_rows raises ToolError when as_of is not a valid ISO-8601 string."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -1477,7 +1477,7 @@ _VIEW_COLUMNS = [
 
 async def test_get_view_columns_happy_path(mock_ctx, ctx_patch) -> None:
     """get_view_columns resolves workspace/item, calls service, returns list."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: F401, PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: F401, PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -1505,7 +1505,7 @@ async def test_get_view_columns_happy_path(mock_ctx, ctx_patch) -> None:
 
 async def test_get_view_columns_not_found_raises_tool_error(mock_ctx, ctx_patch) -> None:
     """get_view_columns raises ToolError when the view does not exist."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 

--- a/tests/unit/mcp/tools/test_views.py
+++ b/tests/unit/mcp/tools/test_views.py
@@ -6,7 +6,7 @@ Goal:   ≥95 % branch coverage.
 Strategy
 --------
 - All calls routed via the shared ``call_tool()`` helper (``tests/unit/_call.py``),
-  which wraps ``mcp._tool_manager.call_tool`` (same path MCPServer uses at
+  which wraps ``mcp._tool_manager.call_tool`` (same path the MCP server uses at
   runtime) so the ``@mcp.tool`` decorator, Pydantic validation, and guards
   are all exercised.
 - ``ServerContext`` injected by patching ``fabric_dw.mcp._context._SERVER_CTX``

--- a/tests/unit/mcp/tools/test_warehouses.py
+++ b/tests/unit/mcp/tools/test_warehouses.py
@@ -19,7 +19,7 @@ import os
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from mcp.server.fastmcp.exceptions import ToolError
+from mcp.server.mcpserver.exceptions import ToolError
 
 from fabric_dw.exceptions import NotFoundError
 from fabric_dw.models import ItemAccess, Warehouse, WarehouseKind

--- a/tests/unit/mcp/tools/test_workspaces.py
+++ b/tests/unit/mcp/tools/test_workspaces.py
@@ -14,7 +14,7 @@ import os
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from mcp.server.fastmcp.exceptions import ToolError
+from mcp.server.mcpserver.exceptions import ToolError
 
 from fabric_dw.exceptions import NotFoundError
 from tests.unit._call import call_tool
@@ -196,7 +196,7 @@ async def test_list_capacities_happy_path(ctx_patch) -> None:
 
 async def test_list_capacities_fabric_error_becomes_tool_error(ctx_patch) -> None:
     """list_capacities wraps FabricError into ToolError."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.exceptions import PermissionDeniedError  # noqa: PLC0415
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
@@ -246,7 +246,7 @@ async def test_assign_workspace_to_capacity_invalid_uuid_raises_tool_error(
     ctx_patch,
 ) -> None:
     """assign_workspace_to_capacity raises ToolError when capacity_id is not a UUID."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -263,7 +263,7 @@ async def test_assign_workspace_to_capacity_invalid_uuid_raises_tool_error(
 
 async def test_assign_workspace_to_capacity_readonly_blocks(ctx_patch) -> None:
     """assign_workspace_to_capacity raises ToolError when FABRIC_MCP_READONLY is set."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -281,7 +281,7 @@ async def test_assign_workspace_to_capacity_readonly_blocks(ctx_patch) -> None:
 
 async def test_assign_workspace_to_capacity_allowlist_blocks(ctx_patch) -> None:
     """assign_workspace_to_capacity raises ToolError when workspace is not in allowlist."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
@@ -301,7 +301,7 @@ async def test_assign_workspace_to_capacity_fabric_error_becomes_tool_error(
     mock_ctx, ctx_patch
 ) -> None:
     """assign_workspace_to_capacity wraps FabricError into ToolError."""
-    from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+    from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
     from fabric_dw.exceptions import NotFoundError  # noqa: PLC0415
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -32,6 +32,39 @@ def _reload_telemetry() -> Any:
     return importlib.import_module("fabric_dw.telemetry")
 
 
+# Environment variables that ``_get_tracer()`` writes to ``os.environ``. Tests in
+# this module call it for real, so without a restore these escape into the rest
+# of the pytest process.
+_SDK_ENV_VARS = (
+    "OTEL_TRACES_EXPORTER",
+    "OTEL_METRICS_EXPORTER",
+    "OTEL_LOGS_EXPORTER",
+    "APPLICATIONINSIGHTS_STATSBEAT_DISABLED_ALL",
+)
+
+
+@pytest.fixture(autouse=True)
+def _restore_sdk_env() -> Generator[None, None, None]:
+    """Snapshot and restore the env vars ``_get_tracer()`` writes.
+
+    ``monkeypatch.delenv(..., raising=False)`` records nothing when the key is
+    already absent, so a subsequent real assignment inside ``_get_tracer()`` has
+    no teardown and leaks process-globally. Nothing breaks today, but it is
+    state escaping a test, and it would mask a future test written without its
+    own defence. Autouse so the pre-existing tests that call ``_get_tracer()``
+    are covered too, not just the ones added for #1043.
+    """
+    saved = {k: os.environ.get(k) for k in _SDK_ENV_VARS}
+    try:
+        yield
+    finally:
+        for key, value in saved.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
 # ---------------------------------------------------------------------------
 # Opt-out: telemetry_enabled()
 # ---------------------------------------------------------------------------
@@ -1134,10 +1167,20 @@ def test_get_tracer_passes_enable_performance_counters_false(
 # false assurance as asserting on the kwarg, just relocated.
 #
 # What they assert instead is the decisive fact, end to end and without a
-# network: the environment ``_get_tracer()`` establishes, fed through the REAL
+# network: the environment the library sees AT CALL TIME, fed through the REAL
 # azure-monitor-opentelemetry decision functions, resolves to "tracing off" and
 # "metrics off". That composition is what determines whether an exporter gets
 # built, so it cannot pass while the pipeline is live.
+#
+# Call time matters: the exporter variables are set only for the duration of the
+# ``configure_azure_monitor`` call and restored immediately afterwards, so
+# reading ``os.environ`` after ``_get_tracer()`` returns proves nothing.
+
+_WATCHED_OTEL_VARS = (
+    "OTEL_TRACES_EXPORTER",
+    "OTEL_METRICS_EXPORTER",
+    "OTEL_LOGS_EXPORTER",
+)
 #
 # The real-process check was run by hand against the locked versions: point
 # telemetry._DEFAULT_CONNECTION_STRING at an unroutable IngestionEndpoint, call
@@ -1148,41 +1191,96 @@ def test_get_tracer_passes_enable_performance_counters_false(
 # because of the autouse mock described above.
 
 
-def _env_after_get_tracer(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Any:
-    """Run ``_get_tracer()`` and return the module, leaving its env vars in place.
+def _run_get_tracer(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    request: pytest.FixtureRequest,
+    preset: dict[str, str] | None = None,
+) -> tuple[Any, dict[str, str | None], dict[str, str | None]]:
+    """Run ``_get_tracer()`` and capture the environment as the library would see it.
 
-    ``configure_azure_monitor`` is mocked by the autouse fixture, but the
-    ``os.environ.setdefault`` calls under test run before it, so the environment
-    this leaves behind is exactly the one the real library would have read.
+    The exporter variables are now set only for the duration of the
+    ``configure_azure_monitor`` call and restored immediately afterwards, so
+    reading ``os.environ`` after the fact proves nothing. Instead this snapshots
+    the variables from inside the mocked call, which is the exact moment the real
+    library reads them.
+
+    *preset* seeds the environment beforehand, to exercise the case where the
+    caller's process already has these variables set.
+
+    The autouse ``_mock_configure_azure_monitor`` fixture is resolved through
+    *request* rather than injected by name, because its value is needed (to hang
+    a side effect on) and a leading-underscore fixture parameter trips PT019.
+
+    Returns ``(module, env_at_call_time, env_after)``.
     """
+    configure_mock = request.getfixturevalue("_mock_configure_azure_monitor")
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
     monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
     monkeypatch.delenv("DO_NOT_TRACK", raising=False)
-    # setdefault means a pre-existing value would win, which would make these
-    # tests pass for the wrong reason. Clear all three first.
-    monkeypatch.delenv("OTEL_TRACES_EXPORTER", raising=False)
-    monkeypatch.delenv("OTEL_METRICS_EXPORTER", raising=False)
-    monkeypatch.delenv("OTEL_LOGS_EXPORTER", raising=False)
+
+    # Start from a known-clean slate so a value inherited from the surrounding
+    # process cannot make these tests pass for the wrong reason. Teardown is
+    # handled by the autouse _restore_sdk_env fixture, which also covers the
+    # assignments _get_tracer() makes directly to os.environ.
+    for key in _WATCHED_OTEL_VARS:
+        monkeypatch.delenv(key, raising=False)
+    for key, value in (preset or {}).items():
+        monkeypatch.setenv(key, value)
+
+    captured: dict[str, str | None] = {}
+
+    def _snapshot(**_kwargs: object) -> None:
+        captured.update({k: os.environ.get(k) for k in _WATCHED_OTEL_VARS})
+
+    configure_mock.side_effect = _snapshot
 
     mod = _reload_telemetry()
     mod._sdk_initialised = False
     mod._tracer = None
     mod._otel_logger = None
     mod._get_tracer()
-    return mod
+
+    after = {k: os.environ.get(k) for k in _WATCHED_OTEL_VARS}
+    return mod, captured, after
+
+
+def _resolves_disabled(kind: str, env_at_call: dict[str, str | None]) -> bool:
+    """Ask the REAL library whether *kind* resolves to disabled for that environment."""
+    from azure.monitor.opentelemetry._utils import configurations as _cfg  # noqa: PLC0415
+
+    fn = {
+        "tracing": _cfg._default_disable_tracing,
+        "metrics": _cfg._default_disable_metrics,
+        "logging": _cfg._default_disable_logging,
+    }[kind]
+    var = {
+        "tracing": "OTEL_TRACES_EXPORTER",
+        "metrics": "OTEL_METRICS_EXPORTER",
+        "logging": "OTEL_LOGS_EXPORTER",
+    }[kind]
+    with patch.dict(os.environ, {}, clear=False):
+        value = env_at_call.get(var)
+        if value is None:
+            os.environ.pop(var, None)
+        else:
+            os.environ[var] = value
+        resolved: dict[str, Any] = {f"disable_{kind}": True}
+        fn(resolved)
+        return bool(resolved[f"disable_{kind}"])
 
 
 def test_get_tracer_disables_the_trace_pipeline_effectively(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, request: pytest.FixtureRequest
 ) -> None:
-    """The environment _get_tracer() sets must make the real library disable tracing.
+    """The environment the library sees must make it disable tracing.
 
     Asserting that ``configure_azure_monitor`` merely RECEIVES
     ``disable_tracing=True`` would be worthless: the library throws that value
     away. ``_get_configurations`` copies caller kwargs into a dict and then runs
     ``_default_disable_tracing``, which assigns unconditionally and consults only
-    ``OTEL_TRACES_EXPORTER``. So this feeds our environment through that real
-    decision function and asserts the outcome.
+    ``OTEL_TRACES_EXPORTER``. So this captures the environment at call time and
+    feeds it through that real decision function.
 
     Why it matters: MCP Python SDK v2 installs an OpenTelemetry middleware on
     every server unconditionally, emitting one SERVER span per inbound protocol
@@ -1192,22 +1290,12 @@ def test_get_tracer_disables_the_trace_pipeline_effectively(
 
     Do not "simplify" this into an assertion about kwargs.
     """
-    from azure.monitor.opentelemetry._utils.configurations import (  # noqa: PLC0415
-        _default_disable_tracing,
-    )
-
-    mod = _env_after_get_tracer(monkeypatch, tmp_path)
+    mod, at_call, _after = _run_get_tracer(monkeypatch, tmp_path, request)
     try:
-        assert os.environ.get("OTEL_TRACES_EXPORTER") == "none", (
-            "_get_tracer must set OTEL_TRACES_EXPORTER=none; it is the only thing "
-            "that actually disables the trace pipeline (#1043)."
-        )
-        effective: dict[str, Any] = {"disable_tracing": True}
-        _default_disable_tracing(effective)
-        assert effective["disable_tracing"] is True, (
-            "The real library resolves tracing as ENABLED under the environment "
-            "_get_tracer() leaves behind, so MCP protocol spans would be exported "
-            "to Application Insights."
+        assert at_call["OTEL_TRACES_EXPORTER"] == "none"
+        assert _resolves_disabled("tracing", at_call), (
+            "The real library resolves tracing as ENABLED, so MCP protocol spans "
+            "would be exported to Application Insights."
         )
     finally:
         mod._sdk_initialised = False
@@ -1216,28 +1304,18 @@ def test_get_tracer_disables_the_trace_pipeline_effectively(
 
 
 def test_get_tracer_disables_the_metrics_pipeline_effectively(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, request: pytest.FixtureRequest
 ) -> None:
     """Same for metrics, which has been silently enabled all along.
 
     ``disable_metrics=True`` has never worked, for the identical reason, so this
     project has been starting a metrics pipeline it documents as disabled.
     """
-    from azure.monitor.opentelemetry._utils.configurations import (  # noqa: PLC0415
-        _default_disable_metrics,
-    )
-
-    mod = _env_after_get_tracer(monkeypatch, tmp_path)
+    mod, at_call, _after = _run_get_tracer(monkeypatch, tmp_path, request)
     try:
-        assert os.environ.get("OTEL_METRICS_EXPORTER") == "none", (
-            "_get_tracer must set OTEL_METRICS_EXPORTER=none; the disable_metrics "
-            "kwarg is discarded by the library (#1043)."
-        )
-        effective: dict[str, Any] = {"disable_metrics": True}
-        _default_disable_metrics(effective)
-        assert effective["disable_metrics"] is True, (
-            "The real library resolves metrics as ENABLED under the environment "
-            "_get_tracer() leaves behind."
+        assert at_call["OTEL_METRICS_EXPORTER"] == "none"
+        assert _resolves_disabled("metrics", at_call), (
+            "The real library resolves metrics as ENABLED."
         )
     finally:
         mod._sdk_initialised = False
@@ -1245,31 +1323,113 @@ def test_get_tracer_disables_the_metrics_pipeline_effectively(
         mod._otel_logger = None
 
 
+@pytest.mark.parametrize("preset", ["otlp", "console", "", "azure_monitor", "NONE_BUT_TYPO"])
+def test_preexisting_exporter_env_cannot_reopen_the_export_path(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    request: pytest.FixtureRequest,
+    preset: str,
+) -> None:
+    """A value already in the environment must not re-enable the export path.
+
+    This is the reason these variables are hard-set rather than defaulted. The
+    library treats anything other than the exact string ``none`` as "exporter
+    enabled", and what it then installs is the AzureMonitorTraceExporter pointed
+    at the maintainer's ingestion endpoint, NOT whatever the operator named. With
+    ``setdefault`` this test fails for every parameter below, and a user with
+    ``OTEL_TRACES_EXPORTER`` set for their own stack silently ships MCP protocol
+    spans to a third party.
+
+    The empty string is included deliberately: it is falsy but not ``none``, and
+    it is what an unset-looking ``export OTEL_TRACES_EXPORTER=`` produces.
+    """
+    mod, at_call, after = _run_get_tracer(
+        monkeypatch,
+        tmp_path,
+        request,
+        preset={"OTEL_TRACES_EXPORTER": preset, "OTEL_METRICS_EXPORTER": preset},
+    )
+    try:
+        assert _resolves_disabled("tracing", at_call), (
+            f"OTEL_TRACES_EXPORTER={preset!r} in the caller's environment left the "
+            "trace pipeline ENABLED, so the Azure exporter would ship MCP protocol "
+            "spans to Application Insights."
+        )
+        assert _resolves_disabled("metrics", at_call), (
+            f"OTEL_METRICS_EXPORTER={preset!r} left the metrics pipeline ENABLED."
+        )
+        # ...and the caller's environment is handed back untouched, because
+        # fabric-dw can be embedded as a library.
+        assert after["OTEL_TRACES_EXPORTER"] == preset
+        assert after["OTEL_METRICS_EXPORTER"] == preset
+    finally:
+        mod._sdk_initialised = False
+        mod._tracer = None
+        mod._otel_logger = None
+
+
+def test_get_tracer_restores_the_exporter_env_when_it_was_unset(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, request: pytest.FixtureRequest
+) -> None:
+    """With nothing pre-set, the variables must be absent again afterwards.
+
+    fabric-dw can be imported into a host process; it must not leave OTel
+    configuration behind for whatever else runs there.
+    """
+    mod, at_call, after = _run_get_tracer(monkeypatch, tmp_path, request)
+    try:
+        assert at_call["OTEL_TRACES_EXPORTER"] == "none", "set during the call"
+        assert after["OTEL_TRACES_EXPORTER"] is None, "and removed again afterwards"
+        assert after["OTEL_METRICS_EXPORTER"] is None
+    finally:
+        mod._sdk_initialised = False
+        mod._tracer = None
+        mod._otel_logger = None
+
+
 def test_get_tracer_leaves_the_logs_pipeline_enabled(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, request: pytest.FixtureRequest
 ) -> None:
     """Disabling traces and metrics must NOT disable logs.
 
     customEvents are emitted as OTel log records, so the logs pipeline is the one
-    that has to stay on. Without this, adding ``OTEL_LOGS_EXPORTER=none`` to the
-    block above (an easy symmetry mistake) would silently kill all telemetry
+    that has to stay on. Without this, adding ``OTEL_LOGS_EXPORTER`` to the
+    hard-set block (an easy symmetry mistake) would silently kill all telemetry
     rather than just the parts we do not want.
     """
-    from azure.monitor.opentelemetry._utils.configurations import (  # noqa: PLC0415
-        _default_disable_logging,
-    )
-
-    mod = _env_after_get_tracer(monkeypatch, tmp_path)
+    mod, at_call, _after = _run_get_tracer(monkeypatch, tmp_path, request)
     try:
-        assert os.environ.get("OTEL_LOGS_EXPORTER") != "none", (
-            "_get_tracer must NOT disable the logs exporter; customEvents ride on it."
+        assert at_call["OTEL_LOGS_EXPORTER"] != "none", (
+            "_get_tracer must never disable the logs exporter; customEvents ride on it."
         )
-        effective: dict[str, Any] = {"disable_logging": False}
-        _default_disable_logging(effective)
-        assert effective["disable_logging"] is False, (
+        assert not _resolves_disabled("logging", at_call), (
             "The logs pipeline resolved to DISABLED, which would drop every "
             "customEvent this project emits."
         )
+    finally:
+        mod._sdk_initialised = False
+        mod._tracer = None
+        mod._otel_logger = None
+
+
+def test_user_can_still_disable_our_own_events_via_otel_logs_exporter(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, request: pytest.FixtureRequest
+) -> None:
+    """``OTEL_LOGS_EXPORTER=none`` is respected, unlike the trace/metric ones.
+
+    That asymmetry is deliberate and worth pinning: switching off the logs
+    exporter switches off *our* telemetry, which is the safe direction, so the
+    user's value is left alone.
+    """
+    mod, at_call, _after = _run_get_tracer(
+        monkeypatch,
+        tmp_path,
+        request,
+        preset={"OTEL_LOGS_EXPORTER": "none"},
+    )
+    try:
+        assert at_call["OTEL_LOGS_EXPORTER"] == "none", "the user's value must survive"
+        assert _resolves_disabled("logging", at_call)
     finally:
         mod._sdk_initialised = False
         mod._tracer = None

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -32,39 +32,6 @@ def _reload_telemetry() -> Any:
     return importlib.import_module("fabric_dw.telemetry")
 
 
-# Environment variables that ``_get_tracer()`` writes to ``os.environ``. Tests in
-# this module call it for real, so without a restore these escape into the rest
-# of the pytest process.
-_SDK_ENV_VARS = (
-    "OTEL_TRACES_EXPORTER",
-    "OTEL_METRICS_EXPORTER",
-    "OTEL_LOGS_EXPORTER",
-    "APPLICATIONINSIGHTS_STATSBEAT_DISABLED_ALL",
-)
-
-
-@pytest.fixture(autouse=True)
-def _restore_sdk_env() -> Generator[None, None, None]:
-    """Snapshot and restore the env vars ``_get_tracer()`` writes.
-
-    ``monkeypatch.delenv(..., raising=False)`` records nothing when the key is
-    already absent, so a subsequent real assignment inside ``_get_tracer()`` has
-    no teardown and leaks process-globally. Nothing breaks today, but it is
-    state escaping a test, and it would mask a future test written without its
-    own defence. Autouse so the pre-existing tests that call ``_get_tracer()``
-    are covered too, not just the ones added for #1043.
-    """
-    saved = {k: os.environ.get(k) for k in _SDK_ENV_VARS}
-    try:
-        yield
-    finally:
-        for key, value in saved.items():
-            if value is None:
-                os.environ.pop(key, None)
-            else:
-                os.environ[key] = value
-
-
 # ---------------------------------------------------------------------------
 # Opt-out: telemetry_enabled()
 # ---------------------------------------------------------------------------
@@ -1180,6 +1147,7 @@ _WATCHED_OTEL_VARS = (
     "OTEL_TRACES_EXPORTER",
     "OTEL_METRICS_EXPORTER",
     "OTEL_LOGS_EXPORTER",
+    "APPLICATIONINSIGHTS_SDKSTATS_DISABLED",
 )
 #
 # The real-process check was run by hand against the locked versions: point
@@ -1381,6 +1349,62 @@ def test_get_tracer_restores_the_exporter_env_when_it_was_unset(
         assert at_call["OTEL_TRACES_EXPORTER"] == "none", "set during the call"
         assert after["OTEL_TRACES_EXPORTER"] is None, "and removed again afterwards"
         assert after["OTEL_METRICS_EXPORTER"] is None
+    finally:
+        mod._sdk_initialised = False
+        mod._tracer = None
+        mod._otel_logger = None
+
+
+def test_get_tracer_disables_customer_sdkstats(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, request: pytest.FixtureRequest
+) -> None:
+    """Customer sdkstats must be off, or we run a metrics pipeline we deny running.
+
+    ``AzureMonitorLogExporter.__init__`` calls ``collect_customer_sdkstats()``
+    unconditionally, which stands up its own ``AzureMonitorMetricExporter`` on our
+    connection string, a private ``MeterProvider``, and a
+    ``PeriodicExportingMetricReader`` on a 15-minute timer. Measured without the
+    env var, even with ``OTEL_METRICS_EXPORTER=none``:
+
+        customer sdkstats: enabled=True initialized=True shutdown=False
+        reader: PeriodicExportingMetricReader
+
+    Note the variable is NOT the statsbeat one; that switch does not gate this.
+    A CLI run ends before the first export cycle, but a long-lived MCP server does
+    not, and that is this project's main mode.
+    """
+    mod, at_call, _after = _run_get_tracer(monkeypatch, tmp_path, request)
+    try:
+        assert at_call["APPLICATIONINSIGHTS_SDKSTATS_DISABLED"] == "true", (
+            "customer sdkstats left enabled; docs/telemetry.md promises no metrics "
+            "of any kind are exported (#1043)."
+        )
+    finally:
+        mod._sdk_initialised = False
+        mod._tracer = None
+        mod._otel_logger = None
+
+
+def test_operator_can_re_enable_customer_sdkstats(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, request: pytest.FixtureRequest
+) -> None:
+    """The sdkstats switch is a setdefault, so an explicit value wins.
+
+    Unlike the OTEL_*_EXPORTER pair, the library honours this variable properly
+    (its check is ``!= "true"``), so deferring to an operator's value is a real
+    override rather than a discarded one. The failure direction is benign too:
+    more Microsoft-internal telemetry, opted into deliberately.
+    """
+    mod, at_call, _after = _run_get_tracer(
+        monkeypatch,
+        tmp_path,
+        request,
+        preset={"APPLICATIONINSIGHTS_SDKSTATS_DISABLED": "false"},
+    )
+    try:
+        assert at_call["APPLICATIONINSIGHTS_SDKSTATS_DISABLED"] == "false", (
+            "an explicit operator value must survive"
+        )
     finally:
         mod._sdk_initialised = False
         mod._tracer = None

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -1121,88 +1121,208 @@ def test_get_tracer_passes_enable_performance_counters_false(
 
 
 # ---------------------------------------------------------------------------
-# Privacy: no span exporter is ever installed (#1043)
+# Privacy: no span or metric exporter is ever installed (#1043)
 # ---------------------------------------------------------------------------
+#
+# What these tests can and cannot do
+# ----------------------------------
+# ``_mock_configure_azure_monitor`` in tests/conftest.py is autouse for this
+# module and no-ops ``configure_azure_monitor``, deliberately: a real call would
+# reach the production App Insights resource. So a test here CANNOT assert on
+# the resulting global TracerProvider, because in this process no provider is
+# ever installed and every such assertion would pass vacuously. That is the same
+# false assurance as asserting on the kwarg, just relocated.
+#
+# What they assert instead is the decisive fact, end to end and without a
+# network: the environment ``_get_tracer()`` establishes, fed through the REAL
+# azure-monitor-opentelemetry decision functions, resolves to "tracing off" and
+# "metrics off". That composition is what determines whether an exporter gets
+# built, so it cannot pass while the pipeline is live.
+#
+# The real-process check was run by hand against the locked versions: point
+# telemetry._DEFAULT_CONNECTION_STRING at an unroutable IngestionEndpoint, call
+# _get_tracer(), then inspect the global provider. Before the fix that yields an
+# SDK TracerProvider carrying a BatchSpanProcessor and an
+# AzureMonitorTraceExporter; after it, the no-op ProxyTracerProvider with no
+# force_flush and no span processors. That check cannot live in this module
+# because of the autouse mock described above.
 
 
-def test_get_tracer_passes_disable_tracing_true(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
-    """_get_tracer must pass disable_tracing=True to configure_azure_monitor.
+def _env_after_get_tracer(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Any:
+    """Run ``_get_tracer()`` and return the module, leaving its env vars in place.
 
-    This project emits customEvents as OTel *log records* and authors no spans
-    of its own, so the trace pipeline has no legitimate producer here.  It does
-    have an illegitimate one: MCP Python SDK v2 installs an OpenTelemetry
-    middleware on every server unconditionally, and that middleware emits a
-    SERVER span per inbound message carrying ``mcp.method.name``,
-    ``jsonrpc.request.id`` and ``gen_ai.tool.name``, then calls
-    ``span.record_exception(e)`` and ``set_status(ERROR, str(e))`` on failure.
-
-    If a TracerProvider with an Application Insights exporter were installed,
-    Fabric API error text, SQL error messages, workspace names and warehouse
-    names would be exported on every failed tool call.  Passing
-    ``disable_tracing=True`` means no exporter exists to carry them.
-
-    Do not relax this without a deliberate privacy review: the SDK middleware is
-    on by default and the leak is silent.
+    ``configure_azure_monitor`` is mocked by the autouse fixture, but the
+    ``os.environ.setdefault`` calls under test run before it, so the environment
+    this leaves behind is exactly the one the real library would have read.
     """
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
     monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+    # setdefault means a pre-existing value would win, which would make these
+    # tests pass for the wrong reason. Clear all three first.
+    monkeypatch.delenv("OTEL_TRACES_EXPORTER", raising=False)
+    monkeypatch.delenv("OTEL_METRICS_EXPORTER", raising=False)
+    monkeypatch.delenv("OTEL_LOGS_EXPORTER", raising=False)
 
     mod = _reload_telemetry()
-
-    captured_kwargs: dict[str, object] = {}
-
-    def fake_configure(**kwargs: object) -> None:
-        captured_kwargs.update(kwargs)
-
-    fake_otel_logger = object()
-
-    fake_azure_mod: Any = types.ModuleType("azure.monitor.opentelemetry")
-    fake_azure_mod.configure_azure_monitor = fake_configure
-
-    fake_logs_mod: Any = types.ModuleType("opentelemetry._logs")
-    fake_logs_mod.get_logger = lambda *_a, **_kw: fake_otel_logger
-    fake_logs_mod.LogRecord = object
-    fake_logs_mod.SeverityNumber = object
-
     mod._sdk_initialised = False
     mod._tracer = None
     mod._otel_logger = None
-
-    monkeypatch.setitem(sys.modules, "azure.monitor.opentelemetry", fake_azure_mod)
-    monkeypatch.setitem(sys.modules, "opentelemetry._logs", fake_logs_mod)
-
     mod._get_tracer()
+    return mod
 
-    assert captured_kwargs.get("disable_tracing") is True, (
-        "configure_azure_monitor must receive disable_tracing=True. Without it the "
-        "MCP SDK v2 OpenTelemetry middleware exports protocol spans, including "
-        "exception text (Fabric API errors, SQL error messages) and identifiers "
-        "(workspace and warehouse names), to Application Insights (#1043)."
+
+def test_get_tracer_disables_the_trace_pipeline_effectively(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The environment _get_tracer() sets must make the real library disable tracing.
+
+    Asserting that ``configure_azure_monitor`` merely RECEIVES
+    ``disable_tracing=True`` would be worthless: the library throws that value
+    away. ``_get_configurations`` copies caller kwargs into a dict and then runs
+    ``_default_disable_tracing``, which assigns unconditionally and consults only
+    ``OTEL_TRACES_EXPORTER``. So this feeds our environment through that real
+    decision function and asserts the outcome.
+
+    Why it matters: MCP Python SDK v2 installs an OpenTelemetry middleware on
+    every server unconditionally, emitting one SERVER span per inbound protocol
+    message with ``mcp.method.name``, ``jsonrpc.request.id``,
+    ``gen_ai.tool.name``, ``error.type`` and timings. That is metadata the
+    documented collection list in docs/telemetry.md does not cover.
+
+    Do not "simplify" this into an assertion about kwargs.
+    """
+    from azure.monitor.opentelemetry._utils.configurations import (  # noqa: PLC0415
+        _default_disable_tracing,
     )
 
-    # Reset SDK state so the module is clean for any subsequent tests.
-    mod._sdk_initialised = False
-    mod._tracer = None
-    mod._otel_logger = None
+    mod = _env_after_get_tracer(monkeypatch, tmp_path)
+    try:
+        assert os.environ.get("OTEL_TRACES_EXPORTER") == "none", (
+            "_get_tracer must set OTEL_TRACES_EXPORTER=none; it is the only thing "
+            "that actually disables the trace pipeline (#1043)."
+        )
+        effective: dict[str, Any] = {"disable_tracing": True}
+        _default_disable_tracing(effective)
+        assert effective["disable_tracing"] is True, (
+            "The real library resolves tracing as ENABLED under the environment "
+            "_get_tracer() leaves behind, so MCP protocol spans would be exported "
+            "to Application Insights."
+        )
+    finally:
+        mod._sdk_initialised = False
+        mod._tracer = None
+        mod._otel_logger = None
+
+
+def test_get_tracer_disables_the_metrics_pipeline_effectively(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Same for metrics, which has been silently enabled all along.
+
+    ``disable_metrics=True`` has never worked, for the identical reason, so this
+    project has been starting a metrics pipeline it documents as disabled.
+    """
+    from azure.monitor.opentelemetry._utils.configurations import (  # noqa: PLC0415
+        _default_disable_metrics,
+    )
+
+    mod = _env_after_get_tracer(monkeypatch, tmp_path)
+    try:
+        assert os.environ.get("OTEL_METRICS_EXPORTER") == "none", (
+            "_get_tracer must set OTEL_METRICS_EXPORTER=none; the disable_metrics "
+            "kwarg is discarded by the library (#1043)."
+        )
+        effective: dict[str, Any] = {"disable_metrics": True}
+        _default_disable_metrics(effective)
+        assert effective["disable_metrics"] is True, (
+            "The real library resolves metrics as ENABLED under the environment "
+            "_get_tracer() leaves behind."
+        )
+    finally:
+        mod._sdk_initialised = False
+        mod._tracer = None
+        mod._otel_logger = None
+
+
+def test_get_tracer_leaves_the_logs_pipeline_enabled(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Disabling traces and metrics must NOT disable logs.
+
+    customEvents are emitted as OTel log records, so the logs pipeline is the one
+    that has to stay on. Without this, adding ``OTEL_LOGS_EXPORTER=none`` to the
+    block above (an easy symmetry mistake) would silently kill all telemetry
+    rather than just the parts we do not want.
+    """
+    from azure.monitor.opentelemetry._utils.configurations import (  # noqa: PLC0415
+        _default_disable_logging,
+    )
+
+    mod = _env_after_get_tracer(monkeypatch, tmp_path)
+    try:
+        assert os.environ.get("OTEL_LOGS_EXPORTER") != "none", (
+            "_get_tracer must NOT disable the logs exporter; customEvents ride on it."
+        )
+        effective: dict[str, Any] = {"disable_logging": False}
+        _default_disable_logging(effective)
+        assert effective["disable_logging"] is False, (
+            "The logs pipeline resolved to DISABLED, which would drop every "
+            "customEvent this project emits."
+        )
+    finally:
+        mod._sdk_initialised = False
+        mod._tracer = None
+        mod._otel_logger = None
+
+
+def test_configure_azure_monitor_still_ignores_the_disable_kwargs() -> None:
+    """Pin the upstream bug that makes the OTEL_* env vars necessary.
+
+    If a future azure-monitor-opentelemetry release starts honouring the
+    ``disable_tracing`` / ``disable_metrics`` kwargs, this test fails. That is a
+    prompt to simplify telemetry.py back to plain kwargs, not a regression.
+
+    The targeted ``_default_*`` helpers are called directly rather than
+    ``_get_configurations`` because the latter runs OTel resource detectors,
+    which probe the network and trip pytest-socket.
+    """
+    from azure.monitor.opentelemetry._utils.configurations import (  # noqa: PLC0415
+        _default_disable_metrics,
+        _default_disable_tracing,
+    )
+
+    for name, fn in (
+        ("disable_tracing", _default_disable_tracing),
+        ("disable_metrics", _default_disable_metrics),
+    ):
+        env_var = f"OTEL_{'TRACES' if 'tracing' in name else 'METRICS'}_EXPORTER"
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop(env_var, None)
+            passed: dict[str, Any] = {name: True}
+            fn(passed)
+            assert passed[name] is False, (
+                f"azure-monitor-opentelemetry now honours {name}=True. The "
+                f"{env_var}=none workaround in fabric_dw/telemetry.py can be "
+                "removed in favour of the kwarg."
+            )
 
 
 def test_mcp_server_otel_middleware_is_installed_by_the_sdk() -> None:
-    """Pin the upstream fact that makes disable_tracing=True load-bearing.
+    """Pin the upstream fact that makes disabling the trace pipeline load-bearing.
 
     MCP Python SDK v2 appends an ``OpenTelemetryMiddleware`` to every low-level
-    ``Server`` in ``__init__``, with no opt-out short of mutating the private
-    ``middleware`` list.  If a future SDK release makes that opt-in instead,
-    this test fails and the ``disable_tracing=True`` rationale in
-    ``telemetry.py`` can be revisited.  Until then it must stay.
+    ``Server`` in ``__init__``. The only producer-side opt-out is mutating
+    ``MCPServer.middleware``, a public but explicitly "Provisional" property. If
+    a future SDK release makes the middleware opt-in instead, this test fails and
+    the rationale in ``telemetry.py`` can be revisited. Until then it must stay.
     """
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
 
-    middleware_types = {type(m).__name__ for m in mcp._lowlevel_server.middleware}
+    middleware_types = {type(m).__name__ for m in mcp.middleware}
     assert "OpenTelemetryMiddleware" in middleware_types, (
         "The MCP SDK no longer installs OpenTelemetryMiddleware unconditionally. "
-        "Re-read the disable_tracing=True rationale in fabric_dw/telemetry.py "
+        "Re-read the tracing rationale in fabric_dw/telemetry.py "
         f"before changing anything. Installed middleware: {sorted(middleware_types)}"
     )
 

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -1121,6 +1121,93 @@ def test_get_tracer_passes_enable_performance_counters_false(
 
 
 # ---------------------------------------------------------------------------
+# Privacy: no span exporter is ever installed (#1043)
+# ---------------------------------------------------------------------------
+
+
+def test_get_tracer_passes_disable_tracing_true(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """_get_tracer must pass disable_tracing=True to configure_azure_monitor.
+
+    This project emits customEvents as OTel *log records* and authors no spans
+    of its own, so the trace pipeline has no legitimate producer here.  It does
+    have an illegitimate one: MCP Python SDK v2 installs an OpenTelemetry
+    middleware on every server unconditionally, and that middleware emits a
+    SERVER span per inbound message carrying ``mcp.method.name``,
+    ``jsonrpc.request.id`` and ``gen_ai.tool.name``, then calls
+    ``span.record_exception(e)`` and ``set_status(ERROR, str(e))`` on failure.
+
+    If a TracerProvider with an Application Insights exporter were installed,
+    Fabric API error text, SQL error messages, workspace names and warehouse
+    names would be exported on every failed tool call.  Passing
+    ``disable_tracing=True`` means no exporter exists to carry them.
+
+    Do not relax this without a deliberate privacy review: the SDK middleware is
+    on by default and the leak is silent.
+    """
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.delenv("FABRIC_DW_TELEMETRY_OPT_OUT", raising=False)
+
+    mod = _reload_telemetry()
+
+    captured_kwargs: dict[str, object] = {}
+
+    def fake_configure(**kwargs: object) -> None:
+        captured_kwargs.update(kwargs)
+
+    fake_otel_logger = object()
+
+    fake_azure_mod: Any = types.ModuleType("azure.monitor.opentelemetry")
+    fake_azure_mod.configure_azure_monitor = fake_configure
+
+    fake_logs_mod: Any = types.ModuleType("opentelemetry._logs")
+    fake_logs_mod.get_logger = lambda *_a, **_kw: fake_otel_logger
+    fake_logs_mod.LogRecord = object
+    fake_logs_mod.SeverityNumber = object
+
+    mod._sdk_initialised = False
+    mod._tracer = None
+    mod._otel_logger = None
+
+    monkeypatch.setitem(sys.modules, "azure.monitor.opentelemetry", fake_azure_mod)
+    monkeypatch.setitem(sys.modules, "opentelemetry._logs", fake_logs_mod)
+
+    mod._get_tracer()
+
+    assert captured_kwargs.get("disable_tracing") is True, (
+        "configure_azure_monitor must receive disable_tracing=True. Without it the "
+        "MCP SDK v2 OpenTelemetry middleware exports protocol spans, including "
+        "exception text (Fabric API errors, SQL error messages) and identifiers "
+        "(workspace and warehouse names), to Application Insights (#1043)."
+    )
+
+    # Reset SDK state so the module is clean for any subsequent tests.
+    mod._sdk_initialised = False
+    mod._tracer = None
+    mod._otel_logger = None
+
+
+def test_mcp_server_otel_middleware_is_installed_by_the_sdk() -> None:
+    """Pin the upstream fact that makes disable_tracing=True load-bearing.
+
+    MCP Python SDK v2 appends an ``OpenTelemetryMiddleware`` to every low-level
+    ``Server`` in ``__init__``, with no opt-out short of mutating the private
+    ``middleware`` list.  If a future SDK release makes that opt-in instead,
+    this test fails and the ``disable_tracing=True`` rationale in
+    ``telemetry.py`` can be revisited.  Until then it must stay.
+    """
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    middleware_types = {type(m).__name__ for m in mcp._lowlevel_server.middleware}
+    assert "OpenTelemetryMiddleware" in middleware_types, (
+        "The MCP SDK no longer installs OpenTelemetryMiddleware unconditionally. "
+        "Re-read the disable_tracing=True rationale in fabric_dw/telemetry.py "
+        f"before changing anything. Installed middleware: {sorted(middleware_types)}"
+    )
+
+
+# ---------------------------------------------------------------------------
 # Concurrency: logger assigned before init flag, under a lock (#846)
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_telemetry_commands.py
+++ b/tests/unit/test_telemetry_commands.py
@@ -191,7 +191,7 @@ class TestMapStatus:
         assert map_status(exc) == "api_error"
 
     def test_tool_error_is_user_error(self) -> None:
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         exc = ToolError("bad tool call")
         assert map_status(exc) == "user_error"
@@ -618,7 +618,7 @@ class TestMcpCommandInvokedInstrumentation:
     def test_wrap_status_user_error_on_tool_error(self) -> None:
         import asyncio  # noqa: PLC0415
 
-        from mcp.server.fastmcp.exceptions import ToolError  # noqa: PLC0415
+        from mcp.server.mcpserver.exceptions import ToolError  # noqa: PLC0415
 
         from fabric_dw.mcp._helpers import _wrap_mcp_tool_with_telemetry  # noqa: PLC0415
 
@@ -713,15 +713,15 @@ class TestMcpCommandInvokedInstrumentation:
 
         This is the regression test for the double-emission bug: mutating_tool()
         calls _wrap_mcp_tool_with_telemetry (layer 1) and then mcp.tool() which
-        triggers InstrumentedFastMCP.tool() (potential layer 2).  The fix marks
+        triggers InstrumentedMCPServer.tool() (potential layer 2).  The fix marks
         already-wrapped callables with __fabric_telemetry_wrapped__ so that
-        InstrumentedFastMCP.tool() skips the second wrapping.
+        InstrumentedMCPServer.tool() skips the second wrapping.
         """
         import asyncio  # noqa: PLC0415
 
-        from fabric_dw.mcp._helpers import InstrumentedFastMCP, mutating_tool  # noqa: PLC0415
+        from fabric_dw.mcp._helpers import InstrumentedMCPServer, mutating_tool  # noqa: PLC0415
 
-        instrumented_mcp: InstrumentedFastMCP = InstrumentedFastMCP("test-server")
+        instrumented_mcp: InstrumentedMCPServer = InstrumentedMCPServer("test-server")
 
         @mutating_tool(instrumented_mcp, "create_warehouse")
         async def create_warehouse(name: str) -> dict:  # type: ignore[return]
@@ -741,9 +741,9 @@ class TestMcpCommandInvokedInstrumentation:
         """A read-only tool registered via @mcp.tool() emits EXACTLY ONE command_invoked."""
         import asyncio  # noqa: PLC0415
 
-        from fabric_dw.mcp._helpers import InstrumentedFastMCP  # noqa: PLC0415
+        from fabric_dw.mcp._helpers import InstrumentedMCPServer  # noqa: PLC0415
 
-        instrumented_mcp: InstrumentedFastMCP = InstrumentedFastMCP("test-server-ro")
+        instrumented_mcp: InstrumentedMCPServer = InstrumentedMCPServer("test-server-ro")
 
         @instrumented_mcp.tool(name="list_warehouses")
         async def list_warehouses(workspace: str) -> list:  # type: ignore[return]

--- a/uv.lock
+++ b/uv.lock
@@ -6,7 +6,8 @@ resolution-markers = [
     "python_full_version == '3.14.*' and sys_platform == 'win32'",
     "python_full_version == '3.14.*' and sys_platform != 'win32'",
     "python_full_version < '3.14' and sys_platform == 'win32'",
-    "python_full_version < '3.14' and sys_platform != 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "(python_full_version < '3.12' and sys_platform == 'emscripten') or (python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32')",
 ]
 
 [[package]]
@@ -713,10 +714,10 @@ requires-dist = [
     { name = "click", specifier = ">=8.2" },
     { name = "filelock", specifier = ">=3.16" },
     { name = "httpx", extras = ["http2"], specifier = ">=0.27,<1" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.28.1,<2" },
+    { name = "mcp", extras = ["cli"], specifier = ">=2,<3" },
     { name = "mssql-python", specifier = ">=1.13.0" },
     { name = "pyarrow", specifier = ">=17.0" },
-    { name = "pydantic", specifier = ">=2.9" },
+    { name = "pydantic", specifier = ">=2.12" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "rich", specifier = ">=14" },
     { name = "tenacity", specifier = ">=9" },
@@ -911,6 +912,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11", marker = "python_full_version < '3.12' or python_full_version >= '3.14' or sys_platform != 'emscripten'" },
+    { name = "truststore", marker = "python_full_version < '3.12' or python_full_version >= '3.14' or sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/ad/f4f0e57345f1870f3e8cb624e058d7eca6e5a27d33bcc3311d9b618734cd/httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648", size = 67548, upload-time = "2026-08-18T13:22:08.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/74/d370e55600d9bcfa0d9794b0166126d49291a3d2b20c268fc98c453a4948/httpcore2-2.12.0-py3-none-any.whl", hash = "sha256:7e04258ce01013d7d615e5b910a3b27fac937d7a95038227e79652b4ba3b4ceb", size = 83074, upload-time = "2026-08-18T13:22:05.854Z" },
+]
+
+[[package]]
 name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
@@ -931,12 +945,29 @@ http2 = [
 ]
 
 [[package]]
-name = "httpx-sse"
-version = "0.4.3"
+name = "httpx2"
+version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+dependencies = [
+    { name = "anyio", marker = "sys_platform != 'emscripten'" },
+    { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "python_full_version >= '3.12' and sys_platform == 'emscripten'" },
+    { name = "idna" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/f8/579a8b51e42e38ee32647df9f08aa25643ae788e275cc625b199829c4671/httpx2-2.12.0.tar.gz", hash = "sha256:7631fe9887a8a2275f4a2540e053aa670fcc50742864a9ae7c66e609fdcf12cf", size = 100040, upload-time = "2026-08-18T13:22:09.086Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/411ba65569158e862368917aaf56597f3e5fa3b91b0502919638465a08f3/httpx2-2.12.0-py3-none-any.whl", hash = "sha256:cc8b6eecb8661c146b8f89a60e97456ee086e91a784ed31ac450c3a9e613dd36", size = 95427, upload-time = "2026-08-18T13:22:06.834Z" },
+]
+
+[[package]]
+name = "httpx2-jsfetch"
+version = "1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872, upload-time = "2026-08-07T00:13:07.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382, upload-time = "2026-08-07T00:13:06.567Z" },
 ]
 
 [[package]]
@@ -1111,15 +1142,15 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.28.1"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
+    { name = "httpx2" },
     { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
     { name = "pydantic" },
-    { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
@@ -1129,15 +1160,28 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/33/32d4dff2c95bb5d897c3ef4c83649a08996b17b58f0a326d2495d4c81179/mcp-2.0.0.tar.gz", hash = "sha256:0f440e735c13ece8bb19bc62cf0b86f4313448432fbb77d35e14034f4e050728", size = 1662284, upload-time = "2026-07-28T13:45:32.346Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
+    { url = "https://files.pythonhosted.org/packages/67/72/7d7897418912c1d12e87556630dfb7bf0eac71160e9bef8b447960804ee3/mcp-2.0.0-py3-none-any.whl", hash = "sha256:1cb4c75d2d2c7b8c1d756355e5d82a39f2822cc7f13e22a2051d7ca3592349d6", size = 349980, upload-time = "2026-07-28T13:45:28.853Z" },
 ]
 
 [package.optional-dependencies]
 cli = [
     { name = "python-dotenv" },
     { name = "typer" },
+]
+
+[[package]]
+name = "mcp-types"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/56/9b8e1c152f61f6c6b07c4b5896c88c7d0ae90bac6ee6306f852fcc5c1eb0/mcp_types-2.0.0.tar.gz", hash = "sha256:d7d939b9285c9961ae8866ba75ef85da34d12bafe276efbf4eb6a131786d8379", size = 66632, upload-time = "2026-07-28T13:45:33.804Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/4c/c78d78c3d52b0ac594ad7cc8ef5972adfe070e3597a8a4c6ce0cd39196ea/mcp_types-2.0.0-py3-none-any.whl", hash = "sha256:6b2de797ca2797f568b79529e1b25948e34de511bcc0bd82fef1039a6d1b8eb0", size = 69649, upload-time = "2026-07-28T13:45:30.713Z" },
 ]
 
 [[package]]
@@ -1953,20 +1997,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pydantic-settings"
-version = "2.14.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "typing-inspection" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
-]
-
-[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2570,6 +2600,15 @@ wheels = [
 ]
 
 [[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
+]
+
+[[package]]
 name = "ty"
 version = "0.0.73"
 source = { registry = "https://pypi.org/simple" }
@@ -2653,8 +2692,8 @@ name = "uvicorn"
 version = "0.49.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "h11" },
+    { name = "click", marker = "python_full_version < '3.12' or python_full_version >= '3.14' or sys_platform != 'emscripten'" },
+    { name = "h11", marker = "python_full_version < '3.12' or python_full_version >= '3.14' or sys_platform != 'emscripten'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c4/1f/fa18009dea8469069cca78a4e877a008ab78f08b064bfc9ab891579077ff/uvicorn-0.49.0.tar.gz", hash = "sha256:ebf4271aa580d9de97f93192d4595176df6e91f9aae919ca73e4fc07df1e66a3", size = 91284, upload-time = "2026-06-03T22:01:30.448Z" }
 wheels = [


### PR DESCRIPTION
Closes #1043

Migrates from MCP Python SDK 1.28.1 to 2.0.0. Not a version bump: the module tree `mcp.server.fastmcp` does not exist in v2, with no alias, shim or deprecation period, so every module importing it fails at import time.

## The one that breaks silently: OpenTelemetry

Read this part even if you skim the rest. It changed substantially after review; the first version of this fix did not work.

### What v2 does

v2's low-level `Server.__init__` unconditionally does `self.middleware = [OpenTelemetryMiddleware()]`. There is no constructor flag to opt out. That middleware emits one SERVER span per inbound protocol message. The SDK documents this as free unless an exporter is installed. This repo installs one, via `configure_azure_monitor(...)` in `src/fabric_dw/telemetry.py`, which had no `disable_tracing`.

### What actually leaks, measured

The original version of this PR claimed Fabric API errors, SQL error messages and warehouse names would flow to Application Insights. **That was wrong**, and it is corrected here rather than left standing, because an overstated rationale is how a correct fix gets reverted later by someone who checks the claim and finds it false.

Captured from real exported spans on a deliberately failing tool call, in both client modes:

```
span='tools/call list_workspaces'
  status=StatusCode.ERROR | desc=None
  attrs={'mcp.method.name': 'tools/call', 'mcp.protocol.version': '2025-11-25',
         'jsonrpc.request.id': '2', 'gen_ai.operation.name': 'execute_tool',
         'gen_ai.tool.name': 'list_workspaces', 'error.type': 'tool_error'}
  events=[]
```

No status description, no `record_exception` event, no payload. `MCPServer` converts a failing tool into `CallToolResult(is_error=True)` before the middleware sees it, so the middleware's `except Exception` branch never fires for tool errors and only `error.type="tool_error"` is set.

So the real exposure is **metadata, not payload**: which tool ran, under which protocol revision, with which request ID, how long it took, and whether it failed. That is still nothing the documented collection list in `docs/telemetry.md` covers, which is reason enough to switch it off, but it is a much narrower claim than the one this PR originally made.

One genuine echo channel does exist in the middleware: `prompts/get` copies the client-supplied prompt name verbatim into the span name and `gen_ai.prompt.name`. This project registers no prompts, so it does not arise. (`resources/read` does **not** echo, contrary to an early note: its params carry `uri`, not `name`, and the middleware reads `params["name"]`.)

### The fix, and why the obvious one is a no-op

`disable_tracing=True` **does not work**. azure-monitor-opentelemetry 1.8.9's `_get_configurations()` copies caller kwargs into a dict and then runs a `_default_*` pass in which `_default_disable_tracing` assigns unconditionally, clobbering the caller's value. Contrast `_default_connection_string`, which early-returns when the key is present. Measured against the locked version:

```
passed {'disable_tracing': True} -> effective disable_tracing=False
passed {'disable_metrics': True} -> effective disable_metrics=False
with OTEL_TRACES_EXPORTER=none   -> effective disable_tracing=True
```

The fix is to set `OTEL_TRACES_EXPORTER` and `OTEL_METRICS_EXPORTER` to `none`, **unconditionally**, scoped to the `configure_azure_monitor` call and restored to their previous values immediately afterwards. The kwargs stay as a statement of intent with a comment saying plainly that they are not the mechanism.

This started out as `setdefault` and that was wrong: review caught that it left the hole open. If the caller's environment already had `OTEL_TRACES_EXPORTER` set to anything other than the literal `none`, our value was never applied. Measured in a real process:

```
preset=(unset)   -> ProxyTracerProvider, span_exporters=[]
preset='otlp'    -> TracerProvider, ['AzureMonitorTraceExporter'], 2 metric readers
preset='console' -> TracerProvider, ['AzureMonitorTraceExporter'], 2 metric readers
preset=''        -> TracerProvider, ['AzureMonitorTraceExporter'], 2 metric readers
```

The empty string matters: it is falsy but not `none`, and it is exactly what `export OTEL_TRACES_EXPORTER=` produces.

The rationale for deferring was also factually wrong. It claimed an operator setting the variable "keeps control", but outside the separate auto-instrumentation entry point the only reads in the whole distro are three `== "none"` checks. `OTEL_TRACES_EXPORTER=otlp` never installs an OTLP exporter for this process; it installs the **Azure** exporter aimed at the maintainer's ingestion endpoint. Deferring gave the operator no control and one silent third-party export path, which `flush_telemetry()` would then actively force-flush at exit.

Restoring afterwards matters because fabric-dw can be embedded as a library and must not leave OTel configuration behind for the host process. Verified: with `otlp` pre-set the provider is `ProxyTracerProvider` with no exporters, and the variable still reads `otlp` after the call.

Two neighbours are deliberately left alone, because the reasoning genuinely differs:

- `APPLICATIONINSIGHTS_STATSBEAT_DISABLED_ALL` keeps `setdefault`. Its check is `!= "true"`, so setting it to `false` really does re-enable statsbeat: a meaningful override rather than a discarded value. The failure direction is benign too, since the operator opts into more Microsoft-internal telemetry rather than silently into third-party export.
- `OTEL_LOGS_EXPORTER` is untouched. Setting it to `none` disables this project's own customEvents, which is the safe direction and worth respecting. A test now pins that the user's value survives.

Verified end to end through the project's own `_get_tracer()` in a `--no-dev` environment:

```
BEFORE: TracerProvider: opentelemetry.sdk.trace.TracerProvider
        span processors: ['_GenAIMainAgentSpanProcessor', 'BatchSpanProcessor']
          exporter: AzureMonitorTraceExporter
AFTER:  TracerProvider: opentelemetry.trace.ProxyTracerProvider
        has force_flush: False
        span processors: []
```

The logs pipeline is untouched in both, which is required: customEvents ride on it.

### Pre-existing bug fixed here: customer sdkstats

`docs/telemetry.md` promises no metrics of any kind are exported. That was false, and this PR is what sharpened the promise, so it had to be made true.

`AzureMonitorLogExporter.__init__` calls `collect_customer_sdkstats()` unconditionally, standing up its own `AzureMonitorMetricExporter` on this project's connection string, a private `MeterProvider`, and a `PeriodicExportingMetricReader` on a 15-minute timer. It is gated by `APPLICATIONINSIGHTS_SDKSTATS_DISABLED`, which despite the name is **not** the statsbeat variable already set here, and it is unaffected by `OTEL_METRICS_EXPORTER=none`. Measured:

```
before: enabled=True  initialized=True  reader=PeriodicExportingMetricReader
        threads=['AzureMonitorLogExporter Storage',
                 'AzureMonitorMetricExporter Storage',
                 'OtelPeriodicExportingMetricReader']
after:  enabled=False initialized=False reader=None
        threads=['AzureMonitorLogExporter Storage']
```

A CLI command exits long before the first export cycle. A long-lived MCP server does not, and that is this project's main mode.

`setdefault` here, deliberately, unlike the `OTEL_*` pair: the gate is `!= "true"`, so the library genuinely honours an operator's value. Setting it to `false` really does re-enable collection (verified), which makes it a real override rather than a discarded one, and the failure direction is benign. Both halves are pinned by tests.

### Pre-existing bug fixed here: metrics were never disabled

`disable_metrics=True` is clobbered by the identical bug and **has never worked**, since long before this migration. The project has been starting a metrics pipeline it documents as disabled. `OTEL_METRICS_EXPORTER=none` fixes it in the same pass. Flagging it separately so it is not mistaken for migration fallout: the same probe shows `MeterProvider: opentelemetry.sdk.metrics._internal.MeterProvider` before and `_ProxyMeterProvider` after.

### Tests that can actually fail

The first version pinned this with a test asserting the kwarg reached a **faked** `configure_azure_monitor`. That test stayed green while the real library ignored the kwarg: exactly the false assurance it was supposed to prevent, made worse by a docstring promising a privacy guarantee it did not deliver.

A test in `test_telemetry.py` also cannot assert on the resulting global provider: `_mock_configure_azure_monitor` is autouse there and no-ops the call, so any provider assertion passes vacuously. That trap was hit and backed out during this fix.

The replacements feed the environment `_get_tracer()` establishes through the **real** library decision functions and assert the outcome, which is what determines whether an exporter is built. Verified by mutation, removing either setdefault:

```
FAILED test_get_tracer_disables_the_trace_pipeline_effectively
FAILED test_get_tracer_disables_the_metrics_pipeline_effectively
```

And reverting the hard set back to `setdefault` fails the hole test on every parametrisation, including the empty string:

```
FAILED test_preexisting_exporter_env_cannot_reopen_the_export_path[otlp]
FAILED test_preexisting_exporter_env_cannot_reopen_the_export_path[console]
FAILED test_preexisting_exporter_env_cannot_reopen_the_export_path[]
FAILED test_preexisting_exporter_env_cannot_reopen_the_export_path[azure_monitor]
FAILED test_preexisting_exporter_env_cannot_reopen_the_export_path[NONE_BUT_TYPO]
```

A third test pins that logs stay **enabled**, so the obvious symmetry mistake of adding `OTEL_LOGS_EXPORTER=none` cannot silently kill all telemetry. A fourth pins the upstream kwarg bug itself, so if a future release starts honouring the kwargs, it fails and prompts a simplification rather than leaving a permanent workaround. State resets moved into `finally` so a mid-test failure cannot leak globals into the rest of the suite.

### Accuracy corrections in the same area

- The `middleware` rationale claimed the producer-side fix was "a provisional private import". `MCPServer.middleware` is a **public** property whose docstring says "Provisional". Provisional is not private. The exporter-side fix is still the right call, now justified accurately: one global switch, covers any library that emits spans, no dependence on a provisional API.
- Two comments in the flush and shutdown paths claimed the global provider was already the no-op default. That was false when written and became true only with this fix. Re-verified rather than assumed.
- `docs/telemetry.md` promised "no span exporter is installed at all", which was a false promise while the kwarg was the only mechanism. It now describes what actually delivers it, and states precisely what would and would not leak.

## The mechanical transform

Commit `0bd82ad` is exactly three scripted substitutions applied to the 54 files matched by `git grep -l -E 'mcp\.server\.fastmcp|FastMCP'`:

```
sed -i \
  -e 's/\bmcp\.server\.fastmcp\b/mcp.server.mcpserver/g' \
  -e 's/\bInstrumentedFastMCP\b/InstrumentedMCPServer/g' \
  -e 's/\bFastMCP\b/MCPServer/g'
```

Please audit the transform rather than the 776 near-identical lines. `\bFastMCP\b` cannot match inside `InstrumentedFastMCP` (no word boundary after `d`), so rules two and three do not interfere. Line counts, all verified fully consumed afterwards:

| v1 | v2 | lines |
| --- | --- | --- |
| `from mcp.server.fastmcp.exceptions import ToolError` | `from mcp.server.mcpserver.exceptions import ToolError` | 276 (255 with a trailing `# noqa`, preserved) |
| `from mcp.server.fastmcp import FastMCP` | `from mcp.server.mcpserver import MCPServer` | 25 |
| bare `FastMCP`, `InstrumentedFastMCP`, docstring cross-refs | `MCPServer`, `InstrumentedMCPServer` | remainder |

`ToolError` is unchanged in v2 apart from its module path. Only its base class was renamed, from `FastMCPError` to `MCPServerError`, which this repo never references.

A substitution this broad also rewrites prose inside docstrings, where `ruff format` cannot normalise the result. Commit `92a030c` is the hand sweep over those, kept separate so the mechanical commit stays purely mechanical.

Three smaller renames ride outside that transform because they are different symbols: `result.isError` to `result.is_error`, `.inputSchema` to `.input_schema`, and `create_connected_server_and_client_session` to `mcp.client.Client`.

## Judgement calls

**Host and port move from settings to `run()`.** `MCPServer` has no `.settings`; assigning `mcp.settings.host` raises `ValueError`. v2 overloads `run()` per transport with host and port as transport-specific kwargs, and the stdio overload accepts no kwargs at all, so the single call becomes two branches. The loopback guard is unchanged in behaviour: it previously sat inside a `if transport == "streamable-http":` block that also did the settings assignment, so with that gone the block held one nested `if` and the two conditions are joined with `and`, which short-circuits identically. Two new tests pin that host and port really reach `run()` (dropping them would silently leave the server on the SDK's own 127.0.0.1:8000 defaults) and that the stdio branch forwards neither.

**`test_contract.py` mode is pinned, never defaulted.** `Client` defaults to `mode="auto"`, and for an in-process server that dispatches through a `DirectDispatcher`: no JSON-RPC framing, no initialize handshake, Python objects handed straight across. That file exists specifically to cover the serialisation layer, so accepting the default would have left every assertion passing while the thing under test went away. A `client_mode` fixture parametrises every test over both modes: `legacy` for the full JSON-RPC path a real stdio or HTTP client takes, `auto` for the modern per-request path (no framing, but still handler lookup, parameter validation, middleware, and v2's new result-schema validation). Verified rather than assumed: under `legacy` the client negotiates 2025-11-25 through a `JSONRPCDispatcher`, under `auto` it negotiates 2026-07-28 through a `DirectDispatcher`.

**The server reports its own version.** `version=` now comes from `fabric_dw.__version__`. Under v1 the server reported the SDK's version as its own, which was wrong; under v2 the parameter defaults to `""`. Pinned twice: at the constructor in `test_server.py`, and over the protocol in `test_contract.py`, since only the latter proves the client actually receives it.

**`InstrumentedMCPServer` subclasses `MCPServer[None]`.** `MCPServer` is generic in its lifespan result type and `fabric_lifespan` yields `None`. The v2 `.tool()` signature is identical and still returns the function untouched, so the override body needed no edit.

**`pydantic>=2.9` was fiction.** mcp 2.x requires `pydantic>=2.12.0`, so the declared floor is raised to match what actually resolves.

**The `httpx<1` cap stays, on a new justification.** Its comment justified itself with httpx-sse, a transitive dep of mcp 1.x. mcp 2.x depends on neither httpx nor httpx-sse (it uses httpx2), so that justification is gone. The cap stays on its own merit: the httpx 1.0 dev line removed the `http2` extra and `http_client.py` constructs `httpx.AsyncClient(http2=True)` unconditionally. Comment rewritten to say that.

**`ignore::DeprecationWarning:mcp` stays, marked inert.** It now covers nothing, because `MCPDeprecationWarning` subclasses `UserWarning` and mcp 2.x emits no stdlib `DeprecationWarning` anywhere. It is kept as insurance, consistent with the stated policy for the rest of that list ("ignore them so upstream changes don't break our suite unilaterally"), with a comment recording that it is currently a no-op. Deliberate: v2 pulls in several new transitive deps (mcp-types, httpx2, starlette, sse-starlette, jsonschema, pyjwt, python-multipart, truststore) and an inert filter costs nothing, whereas removing it makes the suite brittle to an upstream 2.x change for no benefit.

**Stale prose corrected while the files were open.** `tests/unit/mcp/test_server.py` opened by asserting the SDK "ships no in-process test transport in its public API". That was untrue even under v1, where `test_contract.py` used `create_connected_server_and_client_session`, and doubly untrue under v2. It was deliberately left alone in #1042 and folded into this issue.

## A correction to the research in #1043

Recorded here so the next reader of that issue does not inherit the imprecision.

The issue says v2 gives `call_tool` a required `context` positional argument. That is true of `ToolManager.call_tool` (`mcp/server/mcpserver/tools/tool_manager.py:75-81`), where `context` is the third positional and has no default. It is **not** true of `MCPServer.call_tool` (`mcp/server/mcpserver/server.py:498-504`), where `context` is optional and defaults to `None`, with the method constructing one itself when it is absent. The issue's wording conflates the two methods.

The conclusion it drew was still correct: `tests/unit/_call.py` deliberately goes through the private tool manager rather than the public API, so it is the one site that had to change, and it is the one site that changed.

Two other claims in that issue were checked rather than assumed, and both held:

- `_tool_manager` still exists under that exact name in v2 (`server.py:190`, used at 483, 504, 599 and 619). The issue's warning about an automated read producing a false "renamed to `_lowlevel_server`" claim was well placed, and that rename did not happen.
- The `"params": {"_meta": {}}` wire change is real. Captured from actual frames: `tools/list` now sends `{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{"_meta":{}}}`, where v1 sent no `params` member at all.

## Behaviour visible to MCP clients

Documented in the README, the install guide, and a new troubleshooting entry:

- Streamable HTTP now caps request bodies at 4 MiB and returns HTTP 413 above that; v1 had no limit. The default is kept. For this server the only realistic way to reach it is a single multi-megabyte `execute_sql` script or object definition, and `max_request_body_size` on `run()` stays available. stdio is unaffected.
- The server speaks revision 2026-07-28 while still serving 2025-11-25 clients from the same process, so no client configuration changes. `ping` was removed in 2026-07-28 but only for clients that negotiate that revision: measured, a 2025-11-25 client still calls it successfully and this server still answers, while a 2026-07-28 client gets `-32601`. The SDK's own client emits a deprecation warning from `send_ping()` in both cases, so that warning does not indicate whether the call worked. Unknown methods return `-32601` under both revisions.
- `ToolError` still surfaces as `CallToolResult(is_error=True)` with the same message format, so error payloads are unchanged.
- Every outbound request now carries `"params": {"_meta": {}}`. No configuration restores the v1 wire shape.
- On a non-loopback bind (`FABRIC_MCP_ALLOW_REMOTE=1`), the transport performs no Host or Origin validation, because v2 computes `transport_security` from the runtime host rather than the constructor default. No code change here; tracked in #1046.

One latent bug is fixed for free: streamable-HTTP lifespan now runs once at manager startup rather than per session. Under v1, one session tearing down cleared `_SERVER_CTX` for every other in-flight session, which made the "read-only after startup" claim in `server.py` only half true. It is true now.

## Not affected, verified against the code

`MCP_*` env vars and pydantic-settings (no pydantic-settings dependency here; the project's own vars are `FABRIC_MCP_*` read by `_guards.env_flag`), `Context.client_id` (no tool takes a `Context`), `FileResource(is_binary=)` (no resources registered), the OAuth provider changes (no auth provider passed), and `MCPServer.get_context()` (`_context.py` deliberately uses a module-level sentinel). The decorator API is unchanged, including docstring-to-description handling and structured output. All registered tools are `async def`, so the change where sync handlers move to a worker thread does not apply.

## Pre-existing bugs fixed here, not migration fallout

Three, all called out so they are not attributed to the SDK bump:

- Customer sdkstats ran an undisclosed metrics pipeline on this project's connection string, gated by a variable neither the statsbeat switch nor `OTEL_METRICS_EXPORTER` covers. Detail in the OpenTelemetry section above.
- `disable_metrics=True` has never worked, for the same kwarg-clobbering reason as `disable_tracing`. A metrics pipeline documented as disabled has been running. Fixed by `OTEL_METRICS_EXPORTER=none` in the same pass.
- Three stale tool counts: `docs/install.md` claimed 27 tools in two separate places and a comment in `test_contract.py` said "~96", against an actual 121. The second `install.md` copy surfaced only by sweeping for the figure rather than fixing the one reported line. All three now avoid a precise number that will rot again.

## On the size

The 500-line and 6-file guideline cannot hold here, and pretending otherwise would be worse than saying so. `mcp.server.fastmcp` either resolves or it does not; there is no intermediate state where half the repo imports it and the tree still builds. With #1042 landed first, this is ~776 lines across 62 files excluding the lockfile, and the bulk of that is one auditable substitution in a single commit. The commits are ordered so the mechanical churn and the judgement calls can be reviewed separately.

## Verification

Beyond CI, a real stdio handshake was driven against the installed `fabric-dw-mcp` binary in a production-dependency-only environment: protocol 2025-11-25 negotiated, `serverInfo` reporting `fabric-dw` and the real version, 121 tools listed, and a guarded destructive tool returning `is_error=True` with the v1 message format unchanged. The HTTP transport was smoke-tested the same way on a loopback port, which confirms the host and port kwargs actually take effect rather than falling back to the SDK defaults.

The OpenTelemetry fix was verified in a real process rather than through the unit test, for the reasons above: the effective global `TracerProvider` is `ProxyTracerProvider` with no `force_flush` and no span processors after the fix, and an `AzureMonitorTraceExporter` behind a `BatchSpanProcessor` before it. Exported span contents were captured with an in-memory exporter to establish what actually leaks.

Local checks, all green:

- `uv lock` then `uv lock --check`
- `ruff check .` and `ruff format --check .` (355 files)
- `ty check src tests`
- `pytest tests/unit`: 6098 passed
- `pytest tests/unit -m slow`: 2 passed
- `uv sync --locked --no-dev && fabric-dw-mcp --help`
- No occurrence of `FastMCP` or `fastmcp` remains anywhere in the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)


