### PR TITLE
chore(cli): clean up result renderer inconsistencies from #1036 review

### DIFF
--- a/docs/commands/tables.md
+++ b/docs/commands/tables.md
@@ -390,6 +390,8 @@ Run `sp_get_table_health_metrics` against a single table to surface Delta/Parque
 
 The proc is Generally Available (announced at Build 2026) but Microsoft Learn has no dedicated reference page yet. Output columns are passed through verbatim - the exact column names and types are determined by the proc and may change across Fabric releases.
 
+`--json` on a zero-row result prints `[]`, with no column names included. This is different from `sql exec --json`, which always emits `{"columns": [...], "rows": [...], "rowcount": N}` even when `rows` is empty. `tables health-check --json` follows the convention shared by every other list-style `--json` command in this CLI instead: the output is always a JSON array, regardless of row count. If you need the column names of a table with no health issues, they are also available unconditionally through the `get_table_health_metrics` MCP tool.
+
 **Synopsis**
 
 ```

--- a/src/fabric_dw/cli/_render.py
+++ b/src/fabric_dw/cli/_render.py
@@ -639,7 +639,7 @@ def _render_positional_table(
     *,
     console: Console,
     title: str | None,
-    prune_null_columns: bool = False,
+    prune_null_columns: bool,
 ) -> None:
     """Render *columns* and *rows* as a Rich table using positional access.
 
@@ -648,13 +648,21 @@ def _render_positional_table(
     (e.g. ``SELECT 1 AS id, 2 AS id``) each keep their own header and value
     instead of being collapsed by dict keying.
 
+    *prune_null_columns* is required, not defaulted (issue #1041): this
+    function has exactly one caller, :func:`render_result_rows`, which always
+    forwards its own *prune_null_columns* explicitly.  A default here would be
+    dead configuration whose only effect could be to silently diverge from
+    :func:`render_result_rows`'s default again, which is exactly the trap the
+    two signatures previously set for each other.  Making the value required
+    turns a future mismatch into a ``TypeError`` at the call site instead of
+    a silent behaviour change.
+
     When *prune_null_columns* is *True*, columns whose value is ``None`` in
-    every row are omitted.  Defaults to *False* (matching the default on
-    :func:`render_result_rows`, this function's only caller) so raw SQL
-    output keeps every column regardless of nullability unless the caller
-    opts in.  Pruning is always skipped when *rows* is empty: with no rows,
-    every column would vacuously look "all-None" and pruning would drop
-    every header, defeating the point of showing the empty result's shape.
+    every row are omitted.  Pass *False* to keep every column regardless of
+    nullability — this is what raw SQL output (``sql exec``) needs.  Pruning
+    is always skipped when *rows* is empty: with no rows, every column would
+    vacuously look "all-None" and pruning would drop every header, defeating
+    the point of showing the empty result's shape.
 
     When *rows* is empty, *columns* still go through the same horizontal-fit
     check as a non-empty result: if the headers fit, an empty table with
@@ -745,11 +753,19 @@ def render_result_rows(
         ``[]`` and *columns* is silently dropped — a zero-row result carries
         no shape information in JSON, unlike the table path, which still
         renders the column headers.  This is deliberate, not an oversight
-        (see issue #1041): every list-style ``--json`` CLI command backed by
-        this function emits a bare JSON array, and preserving the column
-        list on an empty result would require switching that one case to a
-        JSON object, which is a breaking type change for any script doing
-        ``for row in json.loads(output)``.  Consumers that need the column
+        (see issue #1041), and in practice it only affects one command:
+        ``tables health-check --json`` is the only production caller that
+        reaches this branch with ``json_output=True`` (``sql exec`` calls
+        this function only for its table path and bypasses the JSON branch
+        entirely — see below).  Changing this one case to preserve *columns*
+        would mean returning a JSON object instead of an array specifically
+        when the result is empty, a breaking type change for any script
+        doing ``for row in json.loads(output)``.  It would also make
+        ``tables health-check --json`` the only command whose output shape
+        depends on row count: :func:`render`, the function every other
+        list-style ``--json`` CLI command goes through, always emits a bare
+        array regardless of emptiness, and this function's JSON branch keeps
+        that same shape for consistency.  Consumers that need the column
         shape of an empty result have it through ``sql exec --json``, which
         bypasses this function entirely and dumps its own
         ``{"columns": [...], "rows": [...], "rowcount": N}`` model, or

--- a/src/fabric_dw/cli/_render.py
+++ b/src/fabric_dw/cli/_render.py
@@ -639,7 +639,7 @@ def _render_positional_table(
     *,
     console: Console,
     title: str | None,
-    prune_null_columns: bool = True,
+    prune_null_columns: bool = False,
 ) -> None:
     """Render *columns* and *rows* as a Rich table using positional access.
 
@@ -648,13 +648,13 @@ def _render_positional_table(
     (e.g. ``SELECT 1 AS id, 2 AS id``) each keep their own header and value
     instead of being collapsed by dict keying.
 
-    When *prune_null_columns* is *True* (default), columns whose value is
-    ``None`` in every row are omitted.  Pass *False* to keep all columns,
-    e.g. for raw SQL output where every column must appear regardless of
-    nullability.  Pruning is always skipped when *rows* is empty: with no
-    rows, every column would vacuously look "all-None" and pruning would
-    drop every header, defeating the point of showing the empty result's
-    shape.
+    When *prune_null_columns* is *True*, columns whose value is ``None`` in
+    every row are omitted.  Defaults to *False* (matching the default on
+    :func:`render_result_rows`, this function's only caller) so raw SQL
+    output keeps every column regardless of nullability unless the caller
+    opts in.  Pruning is always skipped when *rows* is empty: with no rows,
+    every column would vacuously look "all-None" and pruning would drop
+    every header, defeating the point of showing the empty result's shape.
 
     When *rows* is empty, *columns* still go through the same horizontal-fit
     check as a non-empty result: if the headers fit, an empty table with
@@ -739,6 +739,23 @@ def render_result_rows(
     For JSON output the rows are zipped into per-row dicts; duplicate column
     names follow standard dict semantics (last value wins), which matches the
     behaviour of the previous dict-based rendering.
+
+    .. note::
+        On an empty result (``rows=[]``), the JSON branch always emits a bare
+        ``[]`` and *columns* is silently dropped — a zero-row result carries
+        no shape information in JSON, unlike the table path, which still
+        renders the column headers.  This is deliberate, not an oversight
+        (see issue #1041): every list-style ``--json`` CLI command backed by
+        this function emits a bare JSON array, and preserving the column
+        list on an empty result would require switching that one case to a
+        JSON object, which is a breaking type change for any script doing
+        ``for row in json.loads(output)``.  Consumers that need the column
+        shape of an empty result have it through ``sql exec --json``, which
+        bypasses this function entirely and dumps its own
+        ``{"columns": [...], "rows": [...], "rowcount": N}`` model, or
+        through the MCP tool surface (e.g. ``get_table_health_metrics``,
+        which always returns ``{"columns": ..., "rows": ...}`` regardless of
+        row count).
 
     Args:
         columns: Ordered list of column names as returned by the query.

--- a/src/fabric_dw/cli/commands/sql.py
+++ b/src/fabric_dw/cli/commands/sql.py
@@ -78,8 +78,11 @@ async def sql_exec_cmd(
     """Execute a SQL statement against ITEM (warehouse or SQL endpoint).
 
     Provide the query via -q/--query or -f/--file (not both).
-    Multi-statement batches are supported; only the last result set is returned.
-    DDL/DML statements return empty columns and rows.
+    Multi-statement batches are supported; the CLI keeps the last result set that
+    has a column list (i.e. the last query), not the last statement. A batch that
+    ends with DDL/DML after a query shows the query's result and does not
+    separately report that the DDL/DML ran. A statement with no result set at all
+    returns empty columns and rows.
 
     Output defaults to a Rich table (rows/columns).  Pass --json on the root command
     for machine-readable JSON ({columns: [...], rows: [...], rowcount: N}).

--- a/src/fabric_dw/cli/commands/sql.py
+++ b/src/fabric_dw/cli/commands/sql.py
@@ -80,8 +80,9 @@ async def sql_exec_cmd(
     Provide the query via -q/--query or -f/--file (not both).
     Multi-statement batches are supported; the CLI keeps the last result set that
     has a column list (i.e. the last query), not the last statement. A batch that
-    ends with DDL/DML after a query shows the query's result and does not
-    separately report that the DDL/DML ran. A statement with no result set at all
+    ends with DDL/DML after a query, such as SELECT id FROM t; UPDATE t SET x = 1;,
+    shows the SELECT result and does not separately report that the UPDATE ran.
+    A statement with no result set at all (DDL/DML with nothing else in the batch)
     returns empty columns and rows.
 
     Output defaults to a Rich table (rows/columns).  Pass --json on the root command

--- a/src/fabric_dw/mcp/tools/sql_exec.py
+++ b/src/fabric_dw/mcp/tools/sql_exec.py
@@ -51,8 +51,12 @@ def register(mcp: MCPServer) -> None:
         read-only investigation.
 
         Supports both Warehouse and SQL Analytics Endpoint items.  Multi-statement
-        batches are allowed; only the **last** result set is returned.  DDL/DML
-        statements that produce no result set return ``columns=[]`` and ``rows=[]``.
+        batches are allowed; the tool keeps the last result set that has a column
+        list (i.e. the last query), not the last statement.  A batch that ends with
+        DDL/DML after a query, such as ``SELECT id FROM t; UPDATE t SET x = 1;``,
+        returns the ``SELECT`` result and does not separately report that the
+        ``UPDATE`` ran.  A statement with no result set at all (DDL/DML with nothing
+        else in the batch) returns ``columns=[]`` and ``rows=[]``.
 
         ``datetime`` and ``Decimal`` column values are pre-serialised to strings.
         ``bytes`` / varbinary columns are base64-encoded and their column names are

--- a/src/fabric_dw/models.py
+++ b/src/fabric_dw/models.py
@@ -994,8 +994,10 @@ class SqlResult(_FabricBase):
     """Result set returned by :func:`~fabric_dw.services.sql_exec.execute`.
 
     Attributes:
-        columns: Ordered list of column names from the last result set.
-            Empty for DDL/DML statements that produce no result set.
+        columns: Ordered list of column names from the last result set that
+            has a column list (i.e. the last query in the batch, not the
+            last statement). Empty when no statement in the batch produced a
+            result set (DDL/DML with nothing else in the batch).
         rows: Each element is one row; values are JSON-serialisable scalars
             (``str``, ``int``, ``float``, ``bool``, ``None``).
             ``datetime`` values are pre-serialised to ISO-8601 strings.

--- a/src/fabric_dw/services/sql_exec.py
+++ b/src/fabric_dw/services/sql_exec.py
@@ -2,7 +2,8 @@
 
 Public API
 ----------
-- :func:`execute` — run an arbitrary SQL batch and return the last result set.
+- :func:`execute` — run an arbitrary SQL batch and return the last result set
+  that has columns.
 - :func:`get_plan` — capture the estimated SHOWPLAN_XML for a query without executing it.
 """
 
@@ -155,12 +156,16 @@ async def execute(
     mode: CredentialMode = CredentialMode.DEFAULT,
     row_limit: int | None = None,
 ) -> SqlResult:
-    """Execute *query* against *target* and return the last result set.
+    """Execute *query* against *target* and return the last result set that has columns.
 
     The function executes the SQL batch as-is (no read-only enforcement).
-    Multi-statement batches are supported; only the **last** result set is
-    returned.  DDL/DML statements that produce no result set return an empty
-    ``SqlResult`` (``columns=[]``, ``rows=[]``).
+    Multi-statement batches are supported; the function keeps the last result
+    set that has a column list (i.e. the last query), not the last statement.
+    A batch that ends with DDL/DML after a query, such as
+    ``SELECT id FROM t; UPDATE t SET x = 1;``, returns the ``SELECT`` result
+    and does not separately report that the ``UPDATE`` ran.  A statement with
+    no result set at all (DDL/DML with nothing else in the batch) returns an
+    empty ``SqlResult`` (``columns=[]``, ``rows=[]``).
 
     ``datetime`` and ``Decimal`` values are serialised to strings before being
     placed in ``SqlResult.rows``.  ``bytes`` / ``varbinary`` values are

--- a/tests/unit/cli/commands/test_sql.py
+++ b/tests/unit/cli/commands/test_sql.py
@@ -321,7 +321,7 @@ class TestSqlExec:
                 ],
             )
         assert result.exit_code == 0
-        assert "rowcount" in result.output
+        assert "Query executed successfully. rowcount=3" in result.output
 
 
 class TestSqlExecErrors:

--- a/tests/unit/cli/commands/test_tables.py
+++ b/tests/unit/cli/commands/test_tables.py
@@ -3984,6 +3984,49 @@ class TestTablesHealthCheck:
         parsed = json.loads(result.output)
         assert parsed == []
 
+    def test_health_check_zero_rows_json_output_is_empty_list(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """Columns present but zero rows, through the full CLI command (issue #1041).
+
+        Unlike ``test_health_check_empty_result`` above, which mocks a result
+        with no columns at all, this exercises the actual asymmetry #1041
+        discusses: a result that has a column list but no rows. The JSON
+        branch of ``render_result_rows`` deliberately still emits a bare
+        ``[]`` here, discarding the column list, so that every list-style
+        ``--json`` CLI command keeps returning a JSON array rather than
+        switching to an object on the empty case. This is a decision, not a
+        gap: see the ``.. note::`` on ``render_result_rows`` in
+        ``src/fabric_dw/cli/_render.py``. Consumers that need the column
+        shape of an empty result have it through ``sql exec --json`` or the
+        MCP ``get_table_health_metrics`` tool, neither of which goes through
+        ``render_result_rows``.
+        """
+        _ = cache_env
+        mock_http = AsyncMock()
+        fake_cols = ["issue", "severity"]
+        with (
+            patch(
+                "fabric_dw.cli.commands.tables.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.tables.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_sql_endpoint_entry())),
+            ),
+            patch(
+                "fabric_dw.services.tables.get_table_health_metrics",
+                new=AsyncMock(return_value=ResultSet(columns=fake_cols, rows=[])),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                ["-w", WS_GUID, "--json", "tables", "health-check", SE_GUID, "dbo.FactSales"],
+            )
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.output)
+        assert parsed == []
+
     def test_health_check_zero_rows_renders_table_headers(
         self, runner: CliRunner, cache_env: Path
     ) -> None:

--- a/tests/unit/cli/test_render.py
+++ b/tests/unit/cli/test_render.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 import json
 from datetime import UTC, datetime
 from io import StringIO
@@ -15,6 +16,7 @@ from fabric_dw.cli._render import (
     _format_nested,
     _is_guid_column,
     _make_bar,
+    _render_positional_table,
     confirm,
     render,
     render_permissions_table,
@@ -2230,3 +2232,37 @@ class TestRenderResultRowsEmptyRows:
         render_result_rows(["id", "name"], [], json_output=True)
         captured = capsys.readouterr()
         assert json.loads(captured.out) == []
+
+
+class TestPruneNullColumnsDefaultConsistency:
+    """``prune_null_columns`` must default the same way on both layers (issue #1041).
+
+    ``_render_positional_table`` used to default to *True* while its only
+    public wrapper, ``render_result_rows``, defaulted to *False*. Reading
+    either signature in isolation gave the wrong idea about what happens by
+    default. Both now default to *False*, matching what every current call
+    site already passes explicitly.
+    """
+
+    def test_defaults_match_across_both_functions(self) -> None:
+        render_result_rows_default = (
+            inspect.signature(render_result_rows).parameters["prune_null_columns"].default
+        )
+        positional_table_default = (
+            inspect.signature(_render_positional_table).parameters["prune_null_columns"].default
+        )
+        assert render_result_rows_default is positional_table_default is False
+
+    def test_positional_table_keeps_all_null_column_by_default(self) -> None:
+        """With no explicit flag, ``_render_positional_table`` must not prune."""
+        sio = StringIO()
+        console = Console(file=sio, width=200, highlight=False, no_color=True)
+        _render_positional_table(
+            ["a", "b"],
+            [[None, 5], [None, 10]],
+            console=console,
+            title=None,
+        )
+        output = sio.getvalue()
+        assert "a" in output
+        assert "b" in output

--- a/tests/unit/cli/test_render.py
+++ b/tests/unit/cli/test_render.py
@@ -2228,41 +2228,70 @@ class TestRenderResultRowsEmptyRows:
         assert "(0 rows)" in output
 
     def test_empty_rows_json_output_is_empty_list(self, capsys: pytest.CaptureFixture[str]) -> None:
-        """The JSON path is unaffected: zero rows still serialise to []."""
+        """Zero rows still serialise to [], dropping *columns* — deliberate, not a bug.
+
+        This is the JSON-branch asymmetry issue #1041 discusses: the table
+        path above still renders headers for an empty result, but the JSON
+        branch collapses to a bare ``[]`` with no shape information at all.
+        The decision recorded in #1041 is to keep this behaviour rather than
+        change it, because ``render_result_rows``'s JSON branch backs every
+        list-style ``--json`` CLI command that uses it and must keep
+        returning a JSON array; see the ``.. note::`` on ``render_result_rows``
+        in ``src/fabric_dw/cli/_render.py`` for the full reasoning. Do not
+        "fix" this without re-reading that note and #1041.
+        """
         render_result_rows(["id", "name"], [], json_output=True)
         captured = capsys.readouterr()
         assert json.loads(captured.out) == []
 
 
-class TestPruneNullColumnsDefaultConsistency:
-    """``prune_null_columns`` must default the same way on both layers (issue #1041).
+class TestPruneNullColumnsDefault:
+    """``prune_null_columns`` defaults (issue #1041).
 
     ``_render_positional_table`` used to default to *True* while its only
-    public wrapper, ``render_result_rows``, defaulted to *False*. Reading
-    either signature in isolation gave the wrong idea about what happens by
-    default. Both now default to *False*, matching what every current call
-    site already passes explicitly.
+    caller, ``render_result_rows``, defaulted to *False*. Reading either
+    signature in isolation gave the wrong idea about what happens by
+    default, and the two could silently drift apart in the future.
+
+    The fix is not "pick a matching default for both": ``render_result_rows``
+    keeps ``prune_null_columns=False`` because ``fdw sql exec``
+    (``src/fabric_dw/cli/commands/sql.py``) calls it without passing
+    ``prune_null_columns`` at all and relies on that default to show every
+    column a query returned, including all-NULL ones. Flipping that default
+    would silently break ``sql exec`` output.
+
+    ``_render_positional_table``, by contrast, has exactly one caller
+    (``render_result_rows``), which always forwards the flag explicitly. Its
+    default was therefore dead configuration whose only effect was the
+    divergence #1041 reported — so instead of defaulting it to match, the
+    parameter is now required keyword-only. A future mismatch becomes a
+    ``TypeError`` at the call site rather than a second default to keep in
+    sync.
     """
 
-    def test_defaults_match_across_both_functions(self) -> None:
-        render_result_rows_default = (
-            inspect.signature(render_result_rows).parameters["prune_null_columns"].default
-        )
-        positional_table_default = (
-            inspect.signature(_render_positional_table).parameters["prune_null_columns"].default
-        )
-        assert render_result_rows_default is positional_table_default is False
+    def test_render_result_rows_default_is_false(self) -> None:
+        """``sql exec`` depends on this default; guard it directly against drift."""
+        default = inspect.signature(render_result_rows).parameters["prune_null_columns"].default
+        assert default is False
 
-    def test_positional_table_keeps_all_null_column_by_default(self) -> None:
-        """With no explicit flag, ``_render_positional_table`` must not prune."""
+    def test_positional_table_requires_prune_null_columns(self) -> None:
+        """No default left to diverge: the parameter must be required."""
+        param = inspect.signature(_render_positional_table).parameters["prune_null_columns"]
+        assert param.default is inspect.Parameter.empty
+        assert param.kind is inspect.Parameter.KEYWORD_ONLY
+
+    def test_positional_table_keeps_all_null_column_when_not_pruning(self) -> None:
+        """With ``prune_null_columns=False``, ``_render_positional_table`` must not prune."""
         sio = StringIO()
         console = Console(file=sio, width=200, highlight=False, no_color=True)
         _render_positional_table(
-            ["a", "b"],
+            ["alpha", "beta"],
             [[None, 5], [None, 10]],
             console=console,
             title=None,
+            prune_null_columns=False,
         )
         output = sio.getvalue()
-        assert "a" in output
-        assert "b" in output
+        assert "alpha" in output
+        assert "beta" in output
+        assert "NULL" in output


### PR DESCRIPTION
## What changed

Three independent reviews of #1036 (zero-row `SELECT` rendering) surfaced a cluster of smaller inconsistencies in the result renderer that were deliberately left out of that PR to keep it focused. This addresses them.

### 1. Inverted default for `prune_null_columns`

`_render_positional_table` in `src/fabric_dw/cli/_render.py` used to default `prune_null_columns=True`, while its only caller, `render_result_rows`, defaulted to `False`. Reading either signature in isolation gave the wrong idea about what happens by default, and the two could silently drift apart again in the future.

The fix is not "pick one matching default": `render_result_rows` keeps `prune_null_columns=False` because `fdw sql exec` (`src/fabric_dw/cli/commands/sql.py`) calls it without passing the flag at all and depends on that default to show every column a query returned, including all-NULL ones. `_render_positional_table` has exactly one caller, which always forwards the flag explicitly, so its default was dead configuration whose only effect was the divergence this issue reported. Its `prune_null_columns` parameter is now required keyword-only instead of defaulted, so a future mismatch is a `TypeError` at the call site rather than a silent behaviour change. Tests (`TestPruneNullColumnsDefault` in `tests/unit/cli/test_render.py`) guard the `render_result_rows` default directly, confirm `_render_positional_table`'s parameter is required, and pin the all-NULL-column behaviour.

### 2. JSON branch of `render_result_rows` discards columns on an empty result

Investigated and discussed with the reviewer; decision: leave the behaviour as is, document it as deliberate.

`render_result_rows`'s JSON branch collapses an empty result to a bare `[]`, discarding `columns`. Only one production caller reaches this branch with `json_output=True`: `tables health-check --json` (`sql exec --json` bypasses `render_result_rows` entirely and dumps its own model). Preserving the column list on an empty result would mean switching that one case from a JSON array to a JSON object, a breaking type change for any script doing `for row in json.loads(output)`, and it would make `tables health-check --json` the only list-style `--json` CLI command whose output shape depends on row count; every other one, enforced by `render()`, always emits a bare array.

The data isn't actually unavailable to machine consumers: `sql exec --json` already returns `{"columns": [...], "rows": [...], "rowcount": N}` unconditionally (documented in `docs/commands/sql.md`), and the MCP tool `get_table_health_metrics` already returns `{"columns": ..., "rows": ...}` regardless of row count, since it never routes through `render_result_rows`.

Documented as a `.. note::` on `render_result_rows` in `src/fabric_dw/cli/_render.py`, scoped precisely to the one caller it actually affects, and added a short note to `docs/commands/tables.md` where a script author comparing it against `docs/commands/sql.md` would look. Added the CLI-command-level test this decision was missing: `test_health_check_zero_rows_json_output_is_empty_list` in `tests/unit/cli/commands/test_tables.py` exercises `tables health-check --json` with columns present and zero rows through the full command (the existing `test_health_check_empty_result` only covers the case with no columns at all). The function-level scenario (columns present, zero rows, JSON) was already locked in by `test_empty_rows_json_output_is_empty_list`, added in #1036; its docstring now points at the note and the new test so a future "fix" attempt runs into the reasoning first.

### 3. `sql_exec.execute` documented the wrong discriminator

The docstring and tool descriptions said "only the last result set is returned". The code actually keeps the last result set that has a `cursor.description`, which is not the same thing: for `SELECT id FROM t; UPDATE t SET x = 1;`, the returned result is the `SELECT`, not nothing. `docs/commands/sql.md` already had the correct wording from #1036; this corrects the remaining copies:

- `src/fabric_dw/services/sql_exec.py`: module docstring and `execute()`'s docstring.
- `src/fabric_dw/mcp/tools/sql_exec.py`: the `execute_sql` tool description (textual docstring change only, no import/structural touch).
- `src/fabric_dw/cli/commands/sql.py`: `sql exec --help` text carried the same wording. It also carried the concrete `SELECT id FROM t; UPDATE t SET x = 1;` example and the `(DDL/DML with nothing else in the batch)` qualifier, both restored after an earlier pass dropped them and left two adjacent sentences reading as contradictory.
- `src/fabric_dw/models.py`: `SqlResult.columns`'s docstring, the most-read remaining copy of the same wording, since it documents the public return type of `execute` and the model `sql exec --json` dumps verbatim.

Left `src/fabric_dw/mcp/server.py`'s server-instructions string and the two docs pages (`docs/install.md`, `docs/reference/mcp-capabilities.md`) as-is: their phrasing ("returns only the last result set of a batch") is already accurate as worded, since a DDL/DML statement has no "result set" to begin with.

### 4. Weak assertion in `test_dml_no_rows_shows_rowcount`

Tightened from `assert "rowcount" in result.output` to the actual expected line, `"Query executed successfully. rowcount=3" in result.output`.

## Validation

- `just lint` (ruff check + format): pass
- `just type` (ty): pass
- `uv run pytest tests/unit/cli`: 1760 passed, 1 deselected
- `uv run pytest tests/unit/mcp tests/unit/services/test_sql_exec.py`: 929 passed (sanity check since item 3 touches `mcp/tools/` and the service)

No SQL text is parsed or rewritten anywhere in this change.

Closes #1041

🤖 Generated with [Claude Code](https://claude.com/claude-code)
