### PR TITLE
feat(telemetry): collect MCP protocol spans and record the connecting client

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -23,14 +23,12 @@ Every telemetry event includes a shared envelope of standard fields:
 
 | Event | When | Extra fields |
 |---|---|---|
-| `app_started` | Once per process | - (`auth_mode` omitted - see note below) |
-| `mcp_server_started` | When the MCP server boots | - (`auth_mode` omitted - see note below) |
-| `mcp_client_connected` | The first time each distinct MCP client identifies itself to a server process | `mcp_client` |
+| `app_started` | Once per process | - |
+| `mcp_server_started` | When the MCP server boots | - |
+| `mcp_client_connected` | First time each distinct MCP client identifies itself | `mcp_client` |
 | `app_exited` | On process exit | `duration_ms`, `exit_status` (ok / user_error / api_error), `error_category` |
 
-> **Note on `auth_mode` in lifecycle-start events:** `app_started`, `mcp_server_started` and `mcp_client_connected` fire before any token is acquired. Emitting `auth_mode` at that point would produce a possibly-wrong value derived from environment-variable heuristics (e.g. `interactive` for a plain `az login`). The accurate value is only available after the first token acquisition and is emitted on `command_invoked` and `app_exited`.
-
-> **Why the client is a separate event:** `mcp_server_started` fires when the process boots, which is before any client has connected, so the client cannot be a field on it. One long-lived server can also serve several clients over HTTP, which a single per-process field could not represent. The event fires once per distinct client rather than once per connection, so a client reconnecting all day does not produce an event per reconnect.
+> `auth_mode` is omitted from the three start events: they fire before any sign-in, so there is nothing accurate to report yet. It appears on `command_invoked` and `app_exited`.
 
 ### `command_invoked`: per-command usage
 
@@ -44,20 +42,7 @@ One `command_invoked` event is emitted after every CLI command and every MCP too
 | `status` | `success`, `user_error` (validation/usage problems), or `api_error` (HTTP/driver/unexpected). |
 | `duration_ms_bucket` | Bucketed wall-clock duration: `<100ms`, `<1s`, `<10s`, or `>10s`. |
 | `destructive_op` | `true` only for permanently-destructive MCP tools (delete, clear, restore in-place). Omitted otherwise. |
-| `mcp_client` | Which MCP client made the call (see below). MCP only; absent on CLI commands. |
-
-#### Which MCP client is connected
-
-At connection setup a client sends `clientInfo`, a name and version describing itself. `fabric-dw` records the name, so usage can be broken down by client (Claude Desktop, VS Code, Cursor, a custom integration). The version is not recorded: it changes with every client release and answers no question this project has.
-
-This is the client software identifying itself, not user input travelling through the server, and that distinction is the line this project draws:
-
-| Value | Who decides the content | Collected |
-|---|---|---|
-| `clientInfo.name` | the client software, about itself | Yes. A small, self-describing set of values |
-| a prompt or tool name on a request | whoever composed the request, free text | No. Unfiltered outside input, stripped before export |
-
-The name is recorded as sent, trimmed and capped at 64 characters, rather than mapped onto a fixed list of known clients. A fixed list can only confirm the clients somebody already thought of, and would silently file every new or renamed client under `other`. A client that sends no `clientInfo`, which the protocol permits from revision 2026-07-28 on, is recorded as `unknown`.
+| `mcp_client` | The name the connected MCP client reports for itself (e.g. `claude-ai`), capped at 64 characters. MCP only; `unknown` when the client gives no name. |
 
 #### Domain rollup
 
@@ -83,116 +68,18 @@ The name is recorded as sent, trimmed and capped at 64 characters, rather than m
 | `config` | `config` | - |
 | `completion` | `completion` | - |
 
-### MCP protocol spans
+### MCP protocol messages
 
-When you run the MCP server, `fabric-dw` also collects the OpenTelemetry spans
-the MCP Python SDK produces: one span per inbound protocol message. This is
-instrumentation the SDK maintains, so it covers every message type and keeps
-covering new ones as the protocol grows, which hand-written events do not. Over
-`command_invoked` it adds the non-tool protocol methods (`initialize`,
-`tools/list`, `prompts/list`, ...), the negotiated protocol revision, exact
-timings rather than buckets, and a per-message error classification.
-
-The CLI produces no protocol spans and therefore installs no trace pipeline at
-all.
-
-Each exported span carries a fixed set of fields and nothing else:
+Running the MCP server also records one entry per protocol message it handles, which covers the messages that are not tool calls (`initialize`, `tools/list`, and so on).
 
 | Field | Description |
 |---|---|
-| span name | The protocol method, e.g. `tools/call`. |
-| span kind | Inbound message, or a request the server sent to the client. |
-| start and end time | The message's duration. |
-| `mcp.method.name` | The protocol method again, as a queryable field. |
-| `mcp.protocol.version` | The negotiated protocol revision, e.g. `2025-06-18`. |
-| `jsonrpc.request.id` | The request's numeric id, for correlating a request with its response. |
-| `gen_ai.operation.name` | `execute_tool` on a `tools/call`, absent otherwise. |
-| `error.type` | A JSON-RPC error code, `tool_error`, or the class name of a server-side exception. |
-| `rpc.response.status_code` | The JSON-RPC error code, when the message failed. |
-| trace and span IDs | Random identifiers, so a message's spans can be correlated with each other. |
+| method | The protocol method, e.g. `tools/call`. A method this server does not implement is recorded as `<unknown>`, never as the text that was sent. |
+| duration | How long the message took to handle. |
+| outcome | Whether it succeeded, and if not, the error code or the name of the error type. |
+| protocol version | The MCP revision the client and the server agreed on, e.g. `2025-06-18`. |
 
-Spans do not carry the event envelope listed at the top of this page. What they
-do carry alongside the table above is the same resource description every event
-carries: `anonymous_install_id`, `app_version`, and the surface (`mcp`).
-
-#### What is stripped before a span is exported
-
-Anything on a span that the client chose is removed. This is not hypothetical:
-several such values land on a span as produced, and the values are as free-form
-as whatever the sender typed.
-
-- **The client-supplied name on a request.** A `prompts/get` or `tools/call`
-  names what it wants, and the SDK copies that name into the span name and into
-  a `gen_ai.prompt.name` / `gen_ai.tool.name` attribute. Registering no prompts
-  is not protection: the resulting `Unknown prompt: <name>` error puts the same
-  value into the span's status description as well. The span name is rebuilt
-  from the method alone and both attributes are dropped. Which tool ran is
-  already recorded, by name, on `command_invoked`.
-- **Error messages and stack traces.** The status description is dropped and
-  span events are dropped entirely, which is what removes the exception message
-  and the full Python stack trace the SDK attaches on some failure paths. The
-  `error.type` classification above is kept in their place.
-- **A method name the protocol does not define.** The instrumentation covers
-  the "method not found" path too, so a client calling a made-up method would
-  otherwise have that string exported. Method names are checked against the
-  protocol's own list and anything else is recorded as `<unknown>`, which still
-  counts the call without quoting it.
-- **A non-numeric JSON-RPC request id.** The id is the client's to choose and
-  may be any string, so only an integer id is recorded.
-- **Everything else.** Spans are rebuilt from the allowlist in the table above
-  rather than filtered, so a field a future SDK release adds is dropped until it
-  has been looked at.
-
-#### Spans from anything other than the MCP SDK are never exported
-
-The export path drops every span that did not come from the MCP SDK's own
-tracer. All of OpenTelemetry's automatic instrumentation is switched off in this
-package, so nothing else produces spans in the first place, but the drop is
-unconditional so that stays true no matter what a future dependency starts
-doing. HTTP client instrumentation in particular would attach request URLs, and
-this project's URLs contain workspace and warehouse identifiers.
-
-One qualifier, because it is about this package and not about your process: if
-you embed `fabric-dw` in an application that has already set up its own
-OpenTelemetry `TracerProvider`, that provider keeps collecting spans and sending
-them wherever you configured, and `fabric-dw` leaves it alone rather than
-replacing it. Its own pipeline then stands down entirely, so in that case the
-MCP spans go to your destination and not to the maintainers.
-
-### `fabric-dw` exports no metrics
-
-`fabric-dw` forces `OTEL_METRICS_EXPORTER=none` around the Application Insights
-setup call, so no metric exporter is built. `OTEL_TRACES_EXPORTER` is forced to
-`none` there too, because the exporter that call would install ships spans
-exactly as produced, including everything listed above as stripped; the trace
-pipeline is built separately afterwards, with the filtering in front of it.
-
-Those two variables are set unconditionally rather than deferring to a value you
-may already have in your environment, and they are restored to whatever they were
-immediately afterwards, so nothing else in your process is affected. The reason
-they are not merely defaulted is that the Azure Monitor library reads them only
-to check for the exact string `none`: any other value, including an empty string
-or `otlp`, leaves the pipeline on and installs the **Azure Monitor** exporter
-rather than the one you asked for. Deferring would therefore have handed you no
-control while quietly turning an unfiltered export path back on.
-`OTEL_LOGS_EXPORTER` is left alone: setting it to `none` yourself switches off
-`fabric-dw`'s own events, which is a choice worth respecting.
-
-Both `disable_tracing=True` and `disable_metrics=True` are also passed to the
-Azure Monitor configuration, but neither works: the library overwrites
-caller-supplied values with its own defaults, which read only the environment
-variables. The environment variables are the mechanism; the arguments are a
-statement of intent.
-
-There is a second, separately gated pipeline that the exporter library starts on
-its own: **customer sdkstats**, a delivery-statistics channel that reports how
-many telemetry items succeeded, dropped, or were retried. Despite the name it is
-not covered by the statsbeat switch, and it builds its own metric exporter, meter
-provider, and a reader on a 15-minute timer, all pointed at the same connection
-string. A CLI command finishes long before the first export cycle, but an MCP
-server does not, and that is this project's main mode. `fabric-dw` therefore sets
-`APPLICATIONINSIGHTS_SDKSTATS_DISABLED=true` unless you have already given that
-variable a value of your own.
+Anything you choose the content of is removed first: prompt and tool names, error messages, stack traces, and request IDs that are not plain numbers never leave your machine.
 
 ### What is deliberately NOT collected
 
@@ -201,11 +88,8 @@ variable a value of your own.
 - Connection strings or any credentials
 - File paths or environment variable values
 - Any other personally-identifiable information
-- Any value chosen by whoever composed an MCP request: prompt names, the name on
-  a call for a tool that does not exist, unknown method names, or a string
-  JSON-RPC request id (see above)
-- Spans from anything other than the MCP SDK's protocol instrumentation
-- Metrics of any kind, including the SDK's own delivery-statistics counters
+- Prompt names, tool names, error messages and stack traces from MCP requests
+- Metrics of any kind
 
 ## Where telemetry data goes
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -66,29 +66,89 @@ One `command_invoked` event is emitted after every CLI command and every MCP too
 | `config` | `config` | - |
 | `completion` | `completion` | - |
 
-### What is deliberately NOT collected
+### MCP protocol spans
 
-- SQL text, query results, or row counts
-- Workspace, warehouse, schema, table, column, or snapshot names/IDs
-- Connection strings or any credentials
-- File paths or environment variable values
-- Any other personally-identifiable information
-- Distributed traces of any kind, including MCP protocol spans
-- Metrics of any kind, including the SDK's own delivery-statistics counters
+When you run the MCP server, `fabric-dw` also collects the OpenTelemetry spans
+the MCP Python SDK produces: one span per inbound protocol message. This is
+instrumentation the SDK maintains, so it covers every message type and keeps
+covering new ones as the protocol grows, which hand-written events do not. Over
+`command_invoked` it adds the non-tool protocol methods (`initialize`,
+`tools/list`, `prompts/list`, ...), the negotiated protocol revision, exact
+timings rather than buckets, and a per-message error classification.
 
-### `fabric-dw` exports no spans and no metrics
+The CLI produces no protocol spans and therefore installs no trace pipeline at
+all.
 
-`fabric-dw` emits telemetry as OpenTelemetry **log records**, never as spans. It
-forces `OTEL_TRACES_EXPORTER=none` and `OTEL_METRICS_EXPORTER=none` around the
-Application Insights setup call, so no span exporter and no metric exporter is
-built. Only the logs pipeline, which carries the `customEvents` above, is active.
+Each exported span carries a fixed set of fields and nothing else:
 
-One qualifier on "no spans are exported", because it is about this package and
-not about your process: if you embed `fabric-dw` in an application that has
-already set up its own OpenTelemetry `TracerProvider`, that provider keeps
-collecting spans and sending them wherever you configured. That is intended. What
-`fabric-dw` guarantees is that it never adds an export path of its own, and never
-points one at the maintainers.
+| Field | Description |
+|---|---|
+| span name | The protocol method, e.g. `tools/call`. |
+| span kind | Inbound message, or a request the server sent to the client. |
+| start and end time | The message's duration. |
+| `mcp.method.name` | The protocol method again, as a queryable field. |
+| `mcp.protocol.version` | The negotiated protocol revision, e.g. `2025-06-18`. |
+| `jsonrpc.request.id` | The request's numeric id, for correlating a request with its response. |
+| `gen_ai.operation.name` | `execute_tool` on a `tools/call`, absent otherwise. |
+| `error.type` | A JSON-RPC error code, `tool_error`, or the class name of a server-side exception. |
+| `rpc.response.status_code` | The JSON-RPC error code, when the message failed. |
+| trace and span IDs | Random identifiers, so a message's spans can be correlated with each other. |
+
+Spans do not carry the event envelope listed at the top of this page. What they
+do carry alongside the table above is the same resource description every event
+carries: `anonymous_install_id`, `app_version`, and the surface (`mcp`).
+
+#### What is stripped before a span is exported
+
+Anything on a span that the client chose is removed. This is not hypothetical:
+several such values land on a span as produced, and the values are as free-form
+as whatever the sender typed.
+
+- **The client-supplied name on a request.** A `prompts/get` or `tools/call`
+  names what it wants, and the SDK copies that name into the span name and into
+  a `gen_ai.prompt.name` / `gen_ai.tool.name` attribute. Registering no prompts
+  is not protection: the resulting `Unknown prompt: <name>` error puts the same
+  value into the span's status description as well. The span name is rebuilt
+  from the method alone and both attributes are dropped. Which tool ran is
+  already recorded, by name, on `command_invoked`.
+- **Error messages and stack traces.** The status description is dropped and
+  span events are dropped entirely, which is what removes the exception message
+  and the full Python stack trace the SDK attaches on some failure paths. The
+  `error.type` classification above is kept in their place.
+- **A method name the protocol does not define.** The instrumentation covers
+  the "method not found" path too, so a client calling a made-up method would
+  otherwise have that string exported. Method names are checked against the
+  protocol's own list and anything else is recorded as `<unknown>`, which still
+  counts the call without quoting it.
+- **A non-numeric JSON-RPC request id.** The id is the client's to choose and
+  may be any string, so only an integer id is recorded.
+- **Everything else.** Spans are rebuilt from the allowlist in the table above
+  rather than filtered, so a field a future SDK release adds is dropped until it
+  has been looked at.
+
+#### Spans from anything other than the MCP SDK are never exported
+
+The export path drops every span that did not come from the MCP SDK's own
+tracer. All of OpenTelemetry's automatic instrumentation is switched off in this
+package, so nothing else produces spans in the first place, but the drop is
+unconditional so that stays true no matter what a future dependency starts
+doing. HTTP client instrumentation in particular would attach request URLs, and
+this project's URLs contain workspace and warehouse identifiers.
+
+One qualifier, because it is about this package and not about your process: if
+you embed `fabric-dw` in an application that has already set up its own
+OpenTelemetry `TracerProvider`, that provider keeps collecting spans and sending
+them wherever you configured, and `fabric-dw` leaves it alone rather than
+replacing it. Its own pipeline then stands down entirely, so in that case the
+MCP spans go to your destination and not to the maintainers.
+
+### `fabric-dw` exports no metrics
+
+`fabric-dw` forces `OTEL_METRICS_EXPORTER=none` around the Application Insights
+setup call, so no metric exporter is built. `OTEL_TRACES_EXPORTER` is forced to
+`none` there too, because the exporter that call would install ships spans
+exactly as produced, including everything listed above as stripped; the trace
+pipeline is built separately afterwards, with the filtering in front of it.
 
 Those two variables are set unconditionally rather than deferring to a value you
 may already have in your environment, and they are restored to whatever they were
@@ -97,9 +157,15 @@ they are not merely defaulted is that the Azure Monitor library reads them only
 to check for the exact string `none`: any other value, including an empty string
 or `otlp`, leaves the pipeline on and installs the **Azure Monitor** exporter
 rather than the one you asked for. Deferring would therefore have handed you no
-control while quietly turning the export path back on. `OTEL_LOGS_EXPORTER` is
-left alone: setting it to `none` yourself switches off `fabric-dw`'s own events,
-which is a choice worth respecting.
+control while quietly turning an unfiltered export path back on.
+`OTEL_LOGS_EXPORTER` is left alone: setting it to `none` yourself switches off
+`fabric-dw`'s own events, which is a choice worth respecting.
+
+Both `disable_tracing=True` and `disable_metrics=True` are also passed to the
+Azure Monitor configuration, but neither works: the library overwrites
+caller-supplied values with its own defaults, which read only the environment
+variables. The environment variables are the mechanism; the arguments are a
+statement of intent.
 
 There is a second, separately gated pipeline that the exporter library starts on
 its own: **customer sdkstats**, a delivery-statistics channel that reports how
@@ -111,28 +177,18 @@ server does not, and that is this project's main mode. `fabric-dw` therefore set
 `APPLICATIONINSIGHTS_SDKSTATS_DISABLED=true` unless you have already given that
 variable a value of your own.
 
-This matters because the MCP Python SDK installs an OpenTelemetry middleware on
-every server it creates, and that middleware emits one span per inbound protocol
-message. Measured against the version this package pins, those spans carry the
-method name (`tools/call`), the protocol revision, the JSON-RPC request ID, the
-tool name, an `error.type` marker, and timings.
+### What is deliberately NOT collected
 
-To be precise about what that is and is not: a failing tool call does **not** put
-the exception text on the span. The MCP server converts a failing tool into an
-error result before the middleware sees it, so the middleware records only
-`error.type="tool_error"` with no message. SQL text, Fabric API error strings and
-warehouse names are therefore not in the span payload. What would leak is
-metadata: which tool ran, when, how long it took, and whether it failed. That is
-still not on the collection list above, which is why the exporters are off.
-
-Two notes for completeness. Both `disable_tracing=True` and `disable_metrics=True`
-are also passed to the Azure Monitor configuration, but neither works: the library
-overwrites caller-supplied values with its own defaults, which read only the
-environment variables. The environment variables are the mechanism; the arguments
-are a statement of intent. And a server that registered MCP *prompts* would leak
-one more thing, the client-supplied prompt name, which the middleware copies into
-the span name verbatim. `fabric-dw` registers no prompts and no resources, so this
-does not arise here.
+- SQL text, query results, or row counts
+- Workspace, warehouse, schema, table, column, or snapshot names/IDs
+- Connection strings or any credentials
+- File paths or environment variable values
+- Any other personally-identifiable information
+- Any value chosen by whoever composed an MCP request: prompt names, the name on
+  a call for a tool that does not exist, unknown method names, or a string
+  JSON-RPC request id (see above)
+- Spans from anything other than the MCP SDK's protocol instrumentation
+- Metrics of any kind, including the SDK's own delivery-statistics counters
 
 ## Where telemetry data goes
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -42,7 +42,7 @@ One `command_invoked` event is emitted after every CLI command and every MCP too
 | `status` | `success`, `user_error` (validation/usage problems), or `api_error` (HTTP/driver/unexpected). |
 | `duration_ms_bucket` | Bucketed wall-clock duration: `<100ms`, `<1s`, `<10s`, or `>10s`. |
 | `destructive_op` | `true` only for permanently-destructive MCP tools (delete, clear, restore in-place). Omitted otherwise. |
-| `mcp_client` | The name the connected MCP client reports for itself (e.g. `claude-ai`), capped at 64 characters. MCP only; `unknown` when the client gives no name. |
+| `mcp_client` | The name the connected MCP client reports for itself (e.g. `claude-ai`), capped at 64 characters. MCP only; `unknown` when the client gives no name, and `other` past the first 8 distinct names a server process sees. |
 
 #### Domain rollup
 
@@ -74,12 +74,12 @@ Running the MCP server also records one entry per protocol message it handles, w
 
 | Field | Description |
 |---|---|
-| method | The protocol method, e.g. `tools/call`. A method this server does not implement is recorded as `<unknown>`, never as the text that was sent. |
+| method | The protocol method, e.g. `tools/call`. A method the MCP protocol does not define is recorded as `<unknown>`, never as the text that was sent. |
 | duration | How long the message took to handle. |
 | outcome | Whether it succeeded, and if not, the error code or the name of the error type. |
 | protocol version | The MCP revision the client and the server agreed on, e.g. `2025-06-18`. |
 
-Anything you choose the content of is removed first: prompt and tool names, error messages, stack traces, and request IDs that are not plain numbers never leave your machine.
+Anything you choose the content of is removed from these entries first: prompt and tool names, error messages, stack traces, request IDs that are not plain numbers, and the trace IDs a client can put in a request.
 
 ### What is deliberately NOT collected
 
@@ -88,7 +88,8 @@ Anything you choose the content of is removed first: prompt and tool names, erro
 - Connection strings or any credentials
 - File paths or environment variable values
 - Any other personally-identifiable information
-- Prompt names, tool names, error messages and stack traces from MCP requests
+- Names you put in an MCP request: prompt names, and the tool name on a call for a tool that does not exist
+- Error messages, stack traces, and trace IDs taken off the wire
 - Metrics of any kind
 
 ## Where telemetry data goes

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -25,9 +25,12 @@ Every telemetry event includes a shared envelope of standard fields:
 |---|---|---|
 | `app_started` | Once per process | - (`auth_mode` omitted - see note below) |
 | `mcp_server_started` | When the MCP server boots | - (`auth_mode` omitted - see note below) |
+| `mcp_client_connected` | The first time each distinct MCP client identifies itself to a server process | `mcp_client` |
 | `app_exited` | On process exit | `duration_ms`, `exit_status` (ok / user_error / api_error), `error_category` |
 
-> **Note on `auth_mode` in lifecycle-start events:** `app_started` and `mcp_server_started` fire at process start, before any token is acquired. Emitting `auth_mode` at that point would produce a possibly-wrong value derived from environment-variable heuristics (e.g. `interactive` for a plain `az login`). The accurate value is only available after the first token acquisition and is emitted on `command_invoked` and `app_exited`.
+> **Note on `auth_mode` in lifecycle-start events:** `app_started`, `mcp_server_started` and `mcp_client_connected` fire before any token is acquired. Emitting `auth_mode` at that point would produce a possibly-wrong value derived from environment-variable heuristics (e.g. `interactive` for a plain `az login`). The accurate value is only available after the first token acquisition and is emitted on `command_invoked` and `app_exited`.
+
+> **Why the client is a separate event:** `mcp_server_started` fires when the process boots, which is before any client has connected, so the client cannot be a field on it. One long-lived server can also serve several clients over HTTP, which a single per-process field could not represent. The event fires once per distinct client rather than once per connection, so a client reconnecting all day does not produce an event per reconnect.
 
 ### `command_invoked`: per-command usage
 
@@ -41,6 +44,20 @@ One `command_invoked` event is emitted after every CLI command and every MCP too
 | `status` | `success`, `user_error` (validation/usage problems), or `api_error` (HTTP/driver/unexpected). |
 | `duration_ms_bucket` | Bucketed wall-clock duration: `<100ms`, `<1s`, `<10s`, or `>10s`. |
 | `destructive_op` | `true` only for permanently-destructive MCP tools (delete, clear, restore in-place). Omitted otherwise. |
+| `mcp_client` | Which MCP client made the call (see below). MCP only; absent on CLI commands. |
+
+#### Which MCP client is connected
+
+At connection setup a client sends `clientInfo`, a name and version describing itself. `fabric-dw` records the name, so usage can be broken down by client (Claude Desktop, VS Code, Cursor, a custom integration). The version is not recorded: it changes with every client release and answers no question this project has.
+
+This is the client software identifying itself, not user input travelling through the server, and that distinction is the line this project draws:
+
+| Value | Who decides the content | Collected |
+|---|---|---|
+| `clientInfo.name` | the client software, about itself | Yes. A small, self-describing set of values |
+| a prompt or tool name on a request | whoever composed the request, free text | No. Unfiltered outside input, stripped before export |
+
+The name is recorded as sent, trimmed and capped at 64 characters, rather than mapped onto a fixed list of known clients. A fixed list can only confirm the clients somebody already thought of, and would silently file every new or renamed client under `other`. A client that sends no `clientInfo`, which the protocol permits from revision 2026-07-28 on, is recorded as `unknown`.
 
 #### Domain rollup
 

--- a/src/fabric_dw/mcp/_client_info.py
+++ b/src/fabric_dw/mcp/_client_info.py
@@ -31,6 +31,7 @@ as ``unknown``, which the protocol permits.
 from __future__ import annotations
 
 from collections.abc import Mapping
+from contextlib import ExitStack, suppress
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -84,14 +85,15 @@ class ClientInfoMiddleware:
         call_next: CallNext,
     ) -> HandlerResult:
         """Record the connecting client, then hand the message on."""
-        try:
-            # Resolved per call rather than bound at import, which is how every
-            # telemetry call site outside the two entry points reaches this
-            # module (see telemetry_commands.emit_command_invoked and auth.py).
-            from fabric_dw.telemetry import mcp_client_scope  # noqa: PLC0415
+        with ExitStack() as stack:
+            # Only the recording is best-effort.  call_next stays outside the
+            # suppression, so a handler's exception propagates untouched.
+            with suppress(Exception):
+                # Resolved per call rather than bound at import, which is how
+                # every telemetry call site outside the two entry points reaches
+                # this module (see telemetry_commands.emit_command_invoked and
+                # auth.py).
+                from fabric_dw.telemetry import mcp_client_scope  # noqa: PLC0415
 
-            scope = mcp_client_scope(client_name_from_context(ctx))
-        except Exception:
-            return await call_next(ctx)
-        with scope:
+                stack.enter_context(mcp_client_scope(client_name_from_context(ctx)))
             return await call_next(ctx)

--- a/src/fabric_dw/mcp/_client_info.py
+++ b/src/fabric_dw/mcp/_client_info.py
@@ -1,0 +1,97 @@
+"""Server middleware that records which MCP client is on the other end (#1048).
+
+What is collected and why it is safe
+------------------------------------
+``clientInfo.name`` is the client software describing itself (``claude-ai``,
+``mcp-inspector``, an in-house integration), not user input travelling through
+the server.  That is what separates it from, say, the prompt name on a
+``prompts/get`` request, which is free text chosen by whoever composed the
+request and is stripped out of the protocol spans by
+:mod:`fabric_dw.telemetry_spans`.  The version is deliberately not recorded:
+it changes with every client release and answers no question this project has.
+
+Where the value comes from
+--------------------------
+Two protocol eras, two accessors, both public API:
+
+- The handshake era (2025 and earlier) puts ``clientInfo`` in the ``initialize``
+  request.  Middleware runs before params validation, so ``ctx.params`` is the
+  raw wire mapping and the key is camelCase.  The value has to be read here,
+  because the SDK commits it to the connection only *after* the middleware
+  chain returns.
+- The 2026-07-28 era drops the handshake and carries client info in each
+  request's ``_meta`` envelope.  The SDK turns that into
+  ``ctx.session.client_params`` before the first message reaches middleware.
+
+Reading both means the client is recorded on the first message of a connection
+in either era, and a client that identifies itself in neither place is recorded
+as ``unknown``, which the protocol permits.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from mcp.server.context import CallNext, HandlerResult, ServerRequestContext
+
+__all__ = ["ClientInfoMiddleware", "client_name_from_context"]
+
+
+def client_name_from_context(ctx: ServerRequestContext[Any, Any]) -> object:
+    """Return the raw ``clientInfo.name`` for *ctx*, or ``None``.
+
+    Returns the value untouched; :func:`~fabric_dw.telemetry.normalise_mcp_client`
+    owns turning it into something recordable.
+
+    Args:
+        ctx: The per-request context handed to the middleware.
+
+    Returns:
+        Whatever the client put in ``clientInfo.name``, or ``None`` when it
+        supplied no client info this code can reach.
+    """
+    if ctx.method == "initialize":
+        params: Mapping[str, Any] | None = ctx.params
+        info = params.get("clientInfo") if params is not None else None
+        # A middleware sees the unvalidated wire params, so nothing guarantees
+        # the shape; anything else falls through to the session below.
+        if isinstance(info, Mapping):
+            return info.get("name")
+
+    client_params = ctx.session.client_params
+    if client_params is None or client_params.client_info is None:
+        return None
+    return client_params.client_info.name
+
+
+class ClientInfoMiddleware:
+    """Wrap every inbound message in a :func:`~fabric_dw.telemetry.mcp_client_scope`.
+
+    Registered via the ``middleware=`` constructor argument of ``MCPServer``,
+    which runs it inside the SDK's own built-ins, so the OpenTelemetry span for
+    the message is already open by the time this runs.
+
+    Telemetry must never break the server: a failure to read or record the
+    client is swallowed and the message is handled exactly as if this middleware
+    were not installed.
+    """
+
+    async def __call__(
+        self,
+        ctx: ServerRequestContext[Any, Any],
+        call_next: CallNext,
+    ) -> HandlerResult:
+        """Record the connecting client, then hand the message on."""
+        try:
+            # Resolved per call rather than bound at import, which is how every
+            # telemetry call site outside the two entry points reaches this
+            # module (see telemetry_commands.emit_command_invoked and auth.py).
+            from fabric_dw.telemetry import mcp_client_scope  # noqa: PLC0415
+
+            scope = mcp_client_scope(client_name_from_context(ctx))
+        except Exception:
+            return await call_next(ctx)
+        with scope:
+            return await call_next(ctx)

--- a/src/fabric_dw/mcp/server.py
+++ b/src/fabric_dw/mcp/server.py
@@ -61,6 +61,7 @@ from typing import Literal
 from fabric_dw import __version__
 from fabric_dw.config import load_config
 from fabric_dw.logging import setup_logging
+from fabric_dw.mcp._client_info import ClientInfoMiddleware
 from fabric_dw.mcp._context import fabric_lifespan
 from fabric_dw.mcp._guards import env_flag as _guards_env_flag
 from fabric_dw.mcp._helpers import InstrumentedMCPServer
@@ -117,6 +118,10 @@ mcp: InstrumentedMCPServer = InstrumentedMCPServer(
     # The SDK defaults it to the empty string, so without this the server has
     # no version at all on the wire.
     version=__version__,
+    # Records which client is connected, so telemetry can be broken down per
+    # client (#1048).  Passed to the constructor rather than appended to
+    # `mcp.middleware`, which the SDK marks provisional.
+    middleware=[ClientInfoMiddleware()],
 )
 
 # ---------------------------------------------------------------------------

--- a/src/fabric_dw/telemetry.py
+++ b/src/fabric_dw/telemetry.py
@@ -24,17 +24,20 @@ Architecture notes
   ``cache_tenant_id_from_token()`` (#366).
 - Auto-HTTP instrumentation is explicitly disabled to prevent MSAL OAuth
   request URLs (containing tenant IDs) from leaking as span attributes.
-- This package installs no span or metric exporter of its own, so spans emitted
-  by code it does not own are never exported *to Application Insights*.  This is
-  not hypothetical: MCP Python SDK v2 installs an OpenTelemetry middleware on
-  every server unconditionally, which emits one span per inbound protocol
-  message.  ``OTEL_TRACES_EXPORTER`` and ``OTEL_METRICS_EXPORTER`` are hard-set
-  to ``none`` around the ``configure_azure_monitor`` call and restored
-  afterwards; the matching kwargs are silently overwritten by the library and do
-  not work.  Note the qualifier: a host process that embeds fabric-dw and has
-  already installed its own ``TracerProvider`` still collects those spans and
-  sends them wherever it chose.  That is correct and desirable; what this
-  prevents is *this package* adding an export path the user did not ask for.
+- This package installs no metric exporter, and the only spans it exports are
+  the MCP protocol spans emitted by MCP Python SDK v2, which installs an
+  OpenTelemetry middleware on every server unconditionally (#1049).
+  ``OTEL_TRACES_EXPORTER`` and ``OTEL_METRICS_EXPORTER`` are hard-set to
+  ``none`` around the ``configure_azure_monitor`` call and restored afterwards;
+  the matching kwargs are silently overwritten by the library and do not work.
+  The trace pipeline is then built separately, on the MCP surface only, by
+  :mod:`fabric_dw.telemetry_spans`, whose exporter drops every span that did not
+  come from the MCP SDK and rebuilds the rest from an allowlist so no
+  client-supplied string is exported.  Note the qualifier: a host process that
+  embeds fabric-dw and has already installed its own ``TracerProvider`` keeps
+  it, and its spans keep going wherever it chose.  That is correct and
+  desirable; what this prevents is *this package* adding an export path the user
+  did not ask for.
 - ``APPLICATIONINSIGHTS_SDKSTATS_DISABLED`` suppresses the customer-sdkstats
   channel, which is separate from statsbeat and would otherwise run its own
   metrics pipeline on our connection string.
@@ -645,9 +648,16 @@ _INSTRUMENTATION_OPTIONS: dict[str, dict[str, bool]] = {
 }
 
 # Environment applied around the configure_azure_monitor call to switch off the
-# trace and metric pipelines.  Only the exact string "none" works; see the long
-# comment at the call site for why this is a hard set rather than a setdefault,
-# and why OTEL_LOGS_EXPORTER is deliberately absent.
+# metric pipeline and to keep the library from building a trace pipeline of its
+# own.  Only the exact string "none" works; see the long comment at the call
+# site for why this is a hard set rather than a setdefault, and why
+# OTEL_LOGS_EXPORTER is deliberately absent.
+#
+# OTEL_TRACES_EXPORTER stays "none" even though this package now DOES export
+# spans: what the library would install is an unfiltered AzureMonitorTraceExporter
+# that ships every span in the process verbatim.  The trace pipeline is instead
+# built by telemetry_spans.install_mcp_span_pipeline, whose exporter drops
+# non-MCP spans and rebuilds the rest from an allowlist.
 _OTEL_EXPORTERS_OFF: dict[str, str] = {
     "OTEL_TRACES_EXPORTER": "none",
     "OTEL_METRICS_EXPORTER": "none",
@@ -729,34 +739,26 @@ def _get_tracer() -> object | None:
       up a logger instead of a tracer.
     - ``OTEL_TRACES_EXPORTER=none`` / ``OTEL_METRICS_EXPORTER=none``, hard-set
       around the ``configure_azure_monitor`` call and restored afterwards, are
-      what actually switch off the trace and metric pipelines.  The matching
-      ``disable_tracing`` / ``disable_metrics`` kwargs do NOT work: the library
-      overwrites caller-supplied values with its own defaults (see the long
-      comment at the call site).  Verified by inspecting
+      what actually keep the library from building trace and metric pipelines
+      of its own.  The matching ``disable_tracing`` / ``disable_metrics`` kwargs
+      do NOT work: the library overwrites caller-supplied values with its own
+      defaults (see the long comment at the call site).  Verified by inspecting
       the resulting global providers, which are the no-op ``ProxyTracerProvider``
       and ``_ProxyMeterProvider``, not SDK providers with Azure exporters.
 
-      Tracing must stay off because MCP Python SDK v2 installs an
+      Metrics stay off entirely.  Traces do not: MCP Python SDK v2 installs an
       OpenTelemetry middleware on every server unconditionally, emitting one
-      SERVER span per inbound protocol message.  Measured, those spans carry
-      ``mcp.method.name``, ``mcp.protocol.version``, ``jsonrpc.request.id``,
-      ``gen_ai.operation.name``, ``gen_ai.tool.name``, ``error.type`` and span
-      timings.  They do NOT carry tool exception text: ``MCPServer`` converts a
-      failing tool into ``CallToolResult(is_error=True)`` before the middleware
-      sees it, so the middleware's ``record_exception`` branch never fires for
-      tool errors and only ``error.type="tool_error"`` is set.  The leak is
-      therefore metadata, not payload — but it is metadata the documented
-      collection list in ``docs/telemetry.md`` does not cover, which is reason
-      enough.  (``prompts/get`` would additionally echo the client-supplied
-      prompt name into the span name and ``gen_ai.prompt.name``; this project
-      registers no prompts.  ``resources/read`` does not echo, since its params
-      carry ``uri`` rather than ``name``.)
-
-      The exporter-side fix is preferred over the producer-side one (dropping
-      the middleware from ``MCPServer.middleware``, a public but explicitly
-      "Provisional" property whose signature is expected to change before v2 is
-      final).  One global switch covers every library that might emit spans,
-      needs no per-instance wiring, and does not depend on a provisional API.
+      SERVER span per inbound protocol message, and #1049 decided to collect
+      those.  What the library would have installed is an unfiltered exporter,
+      and parts of every such span are chosen by the client: the span name, the
+      status description, ``gen_ai.prompt.name`` / ``gen_ai.tool.name``, an
+      exception event carrying message and stacktrace, ``mcp.method.name`` for
+      a method the server does not implement, and ``jsonrpc.request.id``.  So
+      the span pipeline is built separately by
+      :func:`fabric_dw.telemetry_spans.install_mcp_span_pipeline`, which wraps
+      the Azure exporter in a sanitiser that drops non-MCP spans and rebuilds
+      the rest from an allowlist.  It is installed only on the MCP surface,
+      since the CLI emits no protocol spans.
     - ``enable_performance_counters=False`` disables the PerformanceCounters
       subsystem (CPU / memory poller) which is NOT covered by ``disable_metrics``
       in azure-monitor-opentelemetry 1.8+.  On short-lived processes its
@@ -915,6 +917,17 @@ def _get_tracer() -> object | None:
                         os.environ.pop(_key, None)
                     else:
                         os.environ[_key] = _old
+
+            # MCP protocol spans (#1049).  Only on the MCP surface: the CLI
+            # produces no protocol spans, so installing a trace pipeline there
+            # would claim the process-wide TracerProvider and run a batch
+            # exporter thread for a stream that is always empty.
+            if _current_surface == "mcp":
+                from fabric_dw.telemetry_spans import (  # noqa: PLC0415
+                    install_mcp_span_pipeline,
+                )
+
+                install_mcp_span_pipeline(_DEFAULT_CONNECTION_STRING, resource)
             # Obtain the OTel Logger via the global LoggerProvider set up by
             # configure_azure_monitor.  This logger is used in emit_event to fire
             # customEvents as log records (not spans).
@@ -943,7 +956,7 @@ def flush_telemetry(timeout_ms: int = 2000) -> None:
     exporter is slow or unreachable.  The thread is daemon so the OS kills it
     when the main thread exits (no hang possible).
 
-    Both the tracer provider (a no-op while ``OTEL_TRACES_EXPORTER=none``) and the
+    Both the tracer provider (the MCP protocol spans, on the MCP surface) and the
     logger provider (customEvents log pipeline) are flushed so no records are lost.
 
     Args:
@@ -957,13 +970,10 @@ def flush_telemetry(timeout_ms: int = 2000) -> None:
         # Each pipeline is flushed independently so a failure in one does
         # not prevent the other from running.
 
-        # Tracer provider — belt-and-suspenders.  Spans ARE created in-process
-        # (the MCP SDK middleware makes one per inbound message), but with
-        # OTEL_TRACES_EXPORTER=none no exporter is attached, so the global
-        # provider is the no-op ProxyTracerProvider, which has no force_flush.
-        # Verified against the locked azure-monitor-opentelemetry, not assumed.
-        # The getattr guard handles that; the branch stays so a future opt-in to
-        # tracing still flushes.
+        # Tracer provider — carries the MCP protocol spans on the MCP surface.
+        # On the CLI surface no provider is installed, so the global one is the
+        # no-op ProxyTracerProvider, which has no force_flush; the getattr guard
+        # handles that.
         with contextlib.suppress(Exception):
             from opentelemetry import trace as _trace  # noqa: PLC0415
 
@@ -1078,10 +1088,11 @@ def shutdown_telemetry(timeout_ms: int = 8000) -> None:
             if callable(log_shutdown):
                 log_shutdown()
 
-        # Tracer provider — belt-and-suspenders.  With OTEL_TRACES_EXPORTER=none
-        # the global provider is the no-op ProxyTracerProvider and has no
-        # shutdown; the getattr guard handles that.  Verified, not assumed.  The
-        # branch stays so a future opt-in still tears the trace pipeline down.
+        # Tracer provider — the MCP protocol spans.  On the CLI surface the
+        # global provider is the no-op ProxyTracerProvider and has no shutdown;
+        # the getattr guard handles that.  The provider is created with
+        # shutdown_on_exit=False, so this call is the only thing that tears the
+        # trace pipeline down.
         with contextlib.suppress(Exception):
             from opentelemetry import trace as _trace  # noqa: PLC0415
 

--- a/src/fabric_dw/telemetry.py
+++ b/src/fabric_dw/telemetry.py
@@ -1068,7 +1068,9 @@ def shutdown_telemetry(timeout_ms: int = 8000) -> None:
     Args:
         timeout_ms: Maximum milliseconds to wait for the full flush+shutdown
             sequence.  Defaults to 8000 (8 s): ~6 s for force_flush (HTTP POST
-            round-trip) + ~2 s for provider cleanup.
+            round-trip) + ~2 s for provider cleanup.  With a span pipeline
+            installed the flush half is split between the two pipelines, 3 s
+            each; without one the logs pipeline keeps all 6 s.
     """
     global _sdk_shutdown  # noqa: PLW0603
 
@@ -1079,15 +1081,25 @@ def shutdown_telemetry(timeout_ms: int = 8000) -> None:
     _sdk_shutdown = True
 
     # Reserve ~2 s for the provider.shutdown() cleanup calls; the rest goes to
-    # force_flush, split between the two pipelines that have one.  At the
-    # default timeout_ms=8000 that is 3 s each — both well within the
-    # daemon-thread join cap (timeout_ms/1000 + 0.5 s).  Splitting matters: the
-    # logs branch runs first, and before the split a slow network there could
-    # eat the whole budget and leave the last batch of spans unflushed.  If
-    # timeout_ms were set below 4000 the floor kicks in, which still fits inside
-    # the join cap because the daemon thread is killed when the main thread
-    # exits — the cap is a worst-case wall-clock bound, not a guarantee.
-    flush_timeout_ms = max((timeout_ms - 2000) // 2, 1000)
+    # force_flush.  At the default timeout_ms=8000 that is 6 s, and it is split
+    # in two ONLY when a span pipeline exists to spend half of it: the logs
+    # branch runs first, so without a split a slow network there could eat the
+    # whole budget and leave the last batch of spans unflushed.
+    #
+    # The condition is load-bearing, not tidiness.  The logs pipeline is the
+    # critical one — it carries every command_invoked and app_exited — and the
+    # App Insights POST typically takes 2 to 4 s.  Splitting unconditionally
+    # would halve that budget on the CLI, which has no span pipeline to protect
+    # and is the surface most exposed to a short-lived process.
+    #
+    # If timeout_ms were set below 4000 the floor kicks in, which still fits
+    # inside the daemon-thread join cap (timeout_ms/1000 + 0.5 s) because the
+    # thread is killed when the main thread exits — the cap is a worst-case
+    # wall-clock bound, not a guarantee.
+    flush_budget_ms = max(timeout_ms - 2000, 2000)
+    flush_timeout_ms = (
+        max(flush_budget_ms // 2, 1000) if _span_pipeline_installed else flush_budget_ms
+    )
 
     def _do_shutdown() -> None:
         # Each pipeline is flushed then shut down independently so a failure in

--- a/src/fabric_dw/telemetry.py
+++ b/src/fabric_dw/telemetry.py
@@ -749,8 +749,10 @@ def _get_tracer() -> object | None:
       of its own.  The matching ``disable_tracing`` / ``disable_metrics`` kwargs
       do NOT work: the library overwrites caller-supplied values with its own
       defaults (see the long comment at the call site).  Verified by inspecting
-      the resulting global providers, which are the no-op ``ProxyTracerProvider``
-      and ``_ProxyMeterProvider``, not SDK providers with Azure exporters.
+      the global providers immediately after the call, which are the no-op
+      ``ProxyTracerProvider`` and ``_ProxyMeterProvider``, not SDK providers with
+      Azure exporters.  The meter provider stays that way; the tracer provider is
+      replaced below, on the MCP surface, by one this package builds itself.
 
       Metrics stay off entirely.  Traces do not: MCP Python SDK v2 installs an
       OpenTelemetry middleware on every server unconditionally, emitting one

--- a/src/fabric_dw/telemetry.py
+++ b/src/fabric_dw/telemetry.py
@@ -106,6 +106,7 @@ from contextvars import ContextVar
 from pathlib import Path
 
 __all__ = [
+    "MCP_CLIENT_OTHER",
     "MCP_CLIENT_UNKNOWN",
     "cache_tenant_id_from_token",
     "current_mcp_client",
@@ -637,6 +638,10 @@ _sdk_initialised: bool = False
 # inside the lock makes init idempotent under concurrent first calls.
 _sdk_init_lock: threading.Lock = threading.Lock()
 _current_surface: str = "cli"
+# True only when install_mcp_span_pipeline() actually claimed the process-wide
+# TracerProvider.  False when a host application had already installed one, in
+# which case that provider is theirs to flush and shut down, not ours.
+_span_pipeline_installed: bool = False
 
 # Instrumentation options passed to configure_azure_monitor.
 # ALL auto-HTTP / Azure SDK instrumentors are DISABLED so that MSAL's OAuth
@@ -780,7 +785,7 @@ def _get_tracer() -> object | None:
     - ``_harden_azure_sdk_logging()`` is called before ``configure_azure_monitor``
       so the SDK's own logger tree is silenced before any network attempt (#411).
     """
-    global _otel_logger, _tracer, _sdk_initialised  # noqa: PLW0603
+    global _otel_logger, _tracer, _sdk_initialised, _span_pipeline_installed  # noqa: PLW0603
 
     # Fast path (no lock): already initialised by a previous call.
     if _sdk_initialised:
@@ -935,7 +940,14 @@ def _get_tracer() -> object | None:
                     install_mcp_span_pipeline,
                 )
 
-                install_mcp_span_pipeline(_DEFAULT_CONNECTION_STRING, resource)
+                # Load-bearing, not bookkeeping: flush_telemetry and
+                # shutdown_telemetry must not touch a TracerProvider this
+                # package did not install.  When a host application already had
+                # one, shutting it down at our exit would kill the host's own
+                # exporter for the rest of its life.
+                _span_pipeline_installed = install_mcp_span_pipeline(
+                    _DEFAULT_CONNECTION_STRING, resource
+                )
             # Obtain the OTel Logger via the global LoggerProvider set up by
             # configure_azure_monitor.  This logger is used in emit_event to fire
             # customEvents as log records (not spans).
@@ -978,17 +990,18 @@ def flush_telemetry(timeout_ms: int = 2000) -> None:
         # Each pipeline is flushed independently so a failure in one does
         # not prevent the other from running.
 
-        # Tracer provider — carries the MCP protocol spans on the MCP surface.
-        # On the CLI surface no provider is installed, so the global one is the
-        # no-op ProxyTracerProvider, which has no force_flush; the getattr guard
-        # handles that.
-        with contextlib.suppress(Exception):
-            from opentelemetry import trace as _trace  # noqa: PLC0415
+        # Tracer provider — carries the MCP protocol spans, and only ours.
+        # _span_pipeline_installed is False on the CLI surface and whenever a
+        # host application's provider won, and the global provider is then not
+        # this package's to flush.
+        if _span_pipeline_installed:
+            with contextlib.suppress(Exception):
+                from opentelemetry import trace as _trace  # noqa: PLC0415
 
-            provider = _trace.get_tracer_provider()
-            force_flush = getattr(provider, "force_flush", None)
-            if callable(force_flush):
-                force_flush(timeout_millis=timeout_ms)
+                provider = _trace.get_tracer_provider()
+                force_flush = getattr(provider, "force_flush", None)
+                if callable(force_flush):
+                    force_flush(timeout_millis=timeout_ms)
 
         # Logger provider — this is the primary pipeline for customEvents.
         with contextlib.suppress(Exception):
@@ -1011,10 +1024,10 @@ _sdk_shutdown: bool = False
 def shutdown_telemetry(timeout_ms: int = 8000) -> None:
     """Shut down the OpenTelemetry providers with a bounded timeout.
 
-    Calls ``force_flush`` then ``shutdown()`` on both the tracer provider and
-    the logger provider.  The logger provider path is critical: it must export
-    all pending customEvents (``command_invoked``, ``app_exited``) that were
-    enqueued just before shutdown is called.
+    Calls ``force_flush`` then ``shutdown()`` on the logger provider, and on the
+    tracer provider when this package installed it.  The logger provider path is
+    critical: it must export all pending customEvents (``command_invoked``,
+    ``app_exited``) that were enqueued just before shutdown is called.
 
     Why force_flush before shutdown?
     ---------------------------------
@@ -1027,8 +1040,8 @@ def shutdown_telemetry(timeout_ms: int = 8000) -> None:
     shorter than the HTTP round-trip to the App Insights ingestion endpoint
     (typically 2-4 s), the daemon thread is killed before the POST completes.
 
-    Calling ``force_flush(timeout_ms - 2000)`` **before** ``shutdown()`` ensures
-    all queued records are exported with a generous bound.  The remaining 2 s is
+    Calling ``force_flush`` **before** ``shutdown()`` ensures all queued records
+    are exported with a generous bound.  The remaining 2 s is
     then used for the provider ``shutdown()`` which cleans up the connection pool
     (preventing the ``AttributeError: 'NoneType' object has no attribute 'Empty'``
     at interpreter exit when urllib3 pool is finalised after queue module teardown).
@@ -1065,14 +1078,16 @@ def shutdown_telemetry(timeout_ms: int = 8000) -> None:
         return
     _sdk_shutdown = True
 
-    # Reserve ~2 s for the provider.shutdown() cleanup call; the rest goes to
-    # force_flush.  At the default timeout_ms=8000 this gives 6 s for
-    # force_flush and 2 s for shutdown — both well within the daemon-thread
-    # join cap (timeout_ms/1000 + 0.5 s).  If timeout_ms were set below 4000
-    # the floor kicks in and both allocations become 2 s, which still fits
-    # inside the join cap because the daemon thread is killed when the main
-    # thread exits — the cap is a worst-case wall-clock bound, not a guarantee.
-    flush_timeout_ms = max(timeout_ms - 2000, 2000)
+    # Reserve ~2 s for the provider.shutdown() cleanup calls; the rest goes to
+    # force_flush, split between the two pipelines that have one.  At the
+    # default timeout_ms=8000 that is 3 s each — both well within the
+    # daemon-thread join cap (timeout_ms/1000 + 0.5 s).  Splitting matters: the
+    # logs branch runs first, and before the split a slow network there could
+    # eat the whole budget and leave the last batch of spans unflushed.  If
+    # timeout_ms were set below 4000 the floor kicks in, which still fits inside
+    # the join cap because the daemon thread is killed when the main thread
+    # exits — the cap is a worst-case wall-clock bound, not a guarantee.
+    flush_timeout_ms = max((timeout_ms - 2000) // 2, 1000)
 
     def _do_shutdown() -> None:
         # Each pipeline is flushed then shut down independently so a failure in
@@ -1096,18 +1111,26 @@ def shutdown_telemetry(timeout_ms: int = 8000) -> None:
             if callable(log_shutdown):
                 log_shutdown()
 
-        # Tracer provider — the MCP protocol spans.  On the CLI surface the
-        # global provider is the no-op ProxyTracerProvider and has no shutdown;
-        # the getattr guard handles that.  The provider is created with
+        # Tracer provider — the MCP protocol spans, and only ours.  Guarded on
+        # _span_pipeline_installed: when a host application's provider won the
+        # race, shutting it down here would permanently kill the exporter of the
+        # process that embedded us.  The provider is created with
         # shutdown_on_exit=False, so this call is the only thing that tears the
         # trace pipeline down.
-        with contextlib.suppress(Exception):
-            from opentelemetry import trace as _trace  # noqa: PLC0415
+        #
+        # force_flush first, for the same reason as the logs branch: the last
+        # batch of spans is otherwise at the mercy of the worker's schedule.
+        if _span_pipeline_installed:
+            with contextlib.suppress(Exception):
+                from opentelemetry import trace as _trace  # noqa: PLC0415
 
-            provider = _trace.get_tracer_provider()
-            shutdown_fn = getattr(provider, "shutdown", None)
-            if callable(shutdown_fn):
-                shutdown_fn()
+                provider = _trace.get_tracer_provider()
+                span_force_flush = getattr(provider, "force_flush", None)
+                if callable(span_force_flush):
+                    span_force_flush(timeout_millis=flush_timeout_ms)
+                shutdown_fn = getattr(provider, "shutdown", None)
+                if callable(shutdown_fn):
+                    shutdown_fn()
 
     t = threading.Thread(target=_do_shutdown, daemon=True)
     t.start()
@@ -1273,10 +1296,24 @@ def record_mcp_server_started() -> None:
 #: permits, or sends one this code cannot read.
 MCP_CLIENT_UNKNOWN = "unknown"
 
-#: Longest client name recorded.  ``clientInfo.name`` is chosen by the client
-#: software about itself, so it is a small set in practice, but nothing on the
-#: wire bounds it; truncating keeps one odd client from bloating every event.
+#: Value recorded once this process has seen more distinct client names than
+#: :data:`_MCP_CLIENT_LIMIT`.
+MCP_CLIENT_OTHER = "other"
+
+#: Longest client name recorded.
 _MCP_CLIENT_MAX_LEN = 64
+
+#: How many distinct client names one process records before collapsing the
+#: rest into :data:`MCP_CLIENT_OTHER`.
+#:
+#: The cap is not about hostile clients alone.  On protocol revision 2026-07-28
+#: the name rides every request's ``_meta`` rather than a handshake, so it can
+#: differ per message on one connection, and a client that appends a build hash
+#: or a session id to its name (an ordinary bug) would otherwise emit one
+#: ``mcp_client_connected`` per request against the daily ingestion cap and grow
+#: the seen-set without bound for the life of the process.  Eight keeps the
+#: long-tail signal the field exists for while making it useless as a channel.
+_MCP_CLIENT_LIMIT = 8
 
 # The connecting client for the request being handled.  A ContextVar rather
 # than a module global because one long-lived MCP server over streamable HTTP
@@ -1285,31 +1322,47 @@ _MCP_CLIENT_MAX_LEN = 64
 _mcp_client_var: ContextVar[str | None] = ContextVar("fabric_dw_mcp_client", default=None)
 
 # Clients this process has already announced, so mcp_client_connected fires
-# once per distinct client rather than once per inbound message.
+# once per distinct client rather than once per inbound message.  Bounded by
+# _MCP_CLIENT_LIMIT (+1 for the "other" bucket itself).
 _seen_mcp_clients: set[str] = set()
 
 
 def normalise_mcp_client(raw_name: object) -> str:
     """Return a bounded client name for *raw_name*.
 
-    Recorded verbatim (bar the length cap) rather than mapped onto a fixed list
-    of known clients: the question this field answers is which clients are out
-    there, and a fixed list can only ever confirm the ones already guessed,
+    Recorded verbatim, bar the filtering below, rather than mapped onto a fixed
+    list of known clients: the question this field answers is which clients are
+    out there, and a fixed list can only ever confirm the ones already guessed,
     turning every new or renamed client into ``other`` until somebody notices.
+
+    Verbatim still means vetted.  Non-printable characters are removed before
+    the length cap, because ``strip()`` leaves embedded newlines, tabs and NULs
+    in the middle of a name and those went into a custom dimension as-is.
 
     Args:
         raw_name: The ``clientInfo.name`` value, or anything at all.
 
     Returns:
-        The trimmed, truncated name, or :data:`MCP_CLIENT_UNKNOWN` when
-        *raw_name* is not a usable string.
+        The filtered, trimmed, truncated name, or :data:`MCP_CLIENT_UNKNOWN`
+        when *raw_name* is not a usable string.
     """
     if not isinstance(raw_name, str):
         return MCP_CLIENT_UNKNOWN
-    name = raw_name.strip()
+    # str.isprintable() is False for control characters, newline, tab and NUL,
+    # and True for ordinary space and for the letters of any script.
+    name = "".join(char for char in raw_name if char.isprintable()).strip()
     if not name:
         return MCP_CLIENT_UNKNOWN
     return name[:_MCP_CLIENT_MAX_LEN]
+
+
+def _bounded_mcp_client(name: str) -> str:
+    """Return *name*, or :data:`MCP_CLIENT_OTHER` once the per-process cap is full."""
+    if name in _seen_mcp_clients:
+        return name
+    if len(_seen_mcp_clients) >= _MCP_CLIENT_LIMIT:
+        return MCP_CLIENT_OTHER
+    return name
 
 
 def current_mcp_client() -> str | None:
@@ -1327,7 +1380,8 @@ def mcp_client_scope(raw_name: object) -> Iterator[None]:
 
     Emits ``mcp_client_connected`` the first time this process sees a given
     client, and makes the name readable via :func:`current_mcp_client` for the
-    duration of the block so ``command_invoked`` can carry it.
+    duration of the block so ``command_invoked`` can carry it.  Both use the
+    bounded name, so the two events always agree.
 
     Fire-and-forget: nothing in here raises.
 
@@ -1335,7 +1389,7 @@ def mcp_client_scope(raw_name: object) -> Iterator[None]:
         raw_name: The ``clientInfo.name`` the client sent, in whatever shape it
             arrived.
     """
-    name = normalise_mcp_client(raw_name)
+    name = _bounded_mcp_client(normalise_mcp_client(raw_name))
     token = _mcp_client_var.set(name)
     try:
         if name not in _seen_mcp_clients:

--- a/src/fabric_dw/telemetry.py
+++ b/src/fabric_dw/telemetry.py
@@ -101,14 +101,20 @@ import os
 import sys
 import threading
 import uuid
+from collections.abc import Iterator
+from contextvars import ContextVar
 from pathlib import Path
 
 __all__ = [
+    "MCP_CLIENT_UNKNOWN",
     "cache_tenant_id_from_token",
+    "current_mcp_client",
     "decode_tid_from_token",
     "emit_event",
     "flush_telemetry",
     "maybe_print_first_run_notice",
+    "mcp_client_scope",
+    "normalise_mcp_client",
     "record_app_exited",
     "record_app_started",
     "record_mcp_server_started",
@@ -1255,6 +1261,91 @@ def record_mcp_server_started() -> None:
     ``command_invoked`` events after the auth layer calls :func:`set_auth_mode`.
     """
     emit_event("mcp_server_started", {}, omit_keys={"auth_mode"})
+
+
+# ---------------------------------------------------------------------------
+# Connecting MCP client (#1048)
+# ---------------------------------------------------------------------------
+
+#: Value recorded when a client sends no ``clientInfo``, which the protocol
+#: permits, or sends one this code cannot read.
+MCP_CLIENT_UNKNOWN = "unknown"
+
+#: Longest client name recorded.  ``clientInfo.name`` is chosen by the client
+#: software about itself, so it is a small set in practice, but nothing on the
+#: wire bounds it; truncating keeps one odd client from bloating every event.
+_MCP_CLIENT_MAX_LEN = 64
+
+# The connecting client for the request being handled.  A ContextVar rather
+# than a module global because one long-lived MCP server over streamable HTTP
+# serves several connections concurrently, each with its own client; a global
+# would report whichever connected last.
+_mcp_client_var: ContextVar[str | None] = ContextVar("fabric_dw_mcp_client", default=None)
+
+# Clients this process has already announced, so mcp_client_connected fires
+# once per distinct client rather than once per inbound message.
+_seen_mcp_clients: set[str] = set()
+
+
+def normalise_mcp_client(raw_name: object) -> str:
+    """Return a bounded client name for *raw_name*.
+
+    Recorded verbatim (bar the length cap) rather than mapped onto a fixed list
+    of known clients: the question this field answers is which clients are out
+    there, and a fixed list can only ever confirm the ones already guessed,
+    turning every new or renamed client into ``other`` until somebody notices.
+
+    Args:
+        raw_name: The ``clientInfo.name`` value, or anything at all.
+
+    Returns:
+        The trimmed, truncated name, or :data:`MCP_CLIENT_UNKNOWN` when
+        *raw_name* is not a usable string.
+    """
+    if not isinstance(raw_name, str):
+        return MCP_CLIENT_UNKNOWN
+    name = raw_name.strip()
+    if not name:
+        return MCP_CLIENT_UNKNOWN
+    return name[:_MCP_CLIENT_MAX_LEN]
+
+
+def current_mcp_client() -> str | None:
+    """Return the MCP client handling the current request, or ``None``.
+
+    ``None`` on the CLI surface, and on any MCP code path reached outside a
+    request (nothing sets the context variable there).
+    """
+    return _mcp_client_var.get()
+
+
+@contextlib.contextmanager
+def mcp_client_scope(raw_name: object) -> Iterator[None]:
+    """Record *raw_name* as the connecting client for the enclosing block.
+
+    Emits ``mcp_client_connected`` the first time this process sees a given
+    client, and makes the name readable via :func:`current_mcp_client` for the
+    duration of the block so ``command_invoked`` can carry it.
+
+    Fire-and-forget: nothing in here raises.
+
+    Args:
+        raw_name: The ``clientInfo.name`` the client sent, in whatever shape it
+            arrived.
+    """
+    name = normalise_mcp_client(raw_name)
+    token = _mcp_client_var.set(name)
+    try:
+        if name not in _seen_mcp_clients:
+            _seen_mcp_clients.add(name)
+            # auth_mode is omitted for the same reason as the other lifecycle
+            # events: the first client connects before any token is acquired,
+            # so only the env heuristic would be available here.
+            emit_event("mcp_client_connected", {"mcp_client": name}, omit_keys={"auth_mode"})
+        yield
+    finally:
+        with contextlib.suppress(ValueError):
+            _mcp_client_var.reset(token)
 
 
 def maybe_print_first_run_notice() -> None:

--- a/src/fabric_dw/telemetry_commands.py
+++ b/src/fabric_dw/telemetry_commands.py
@@ -402,6 +402,10 @@ def emit_command_invoked(
     Fire-and-forget: all exceptions are swallowed and nothing is raised.
     When telemetry is disabled this is a guaranteed no-op (no work done).
 
+    On the MCP surface the event also carries ``mcp_client``, the name the
+    connecting client gave for itself, so usage can be broken down per client
+    (#1048).  The dimension is absent on the CLI surface.
+
     Args:
         name: The command name — for CLI: ``"<group>.<subcommand>"``,
               for MCP: the tool name.
@@ -410,7 +414,11 @@ def emit_command_invoked(
         destructive: Whether this is a permanently-destructive operation.
     """
     try:
-        from fabric_dw.telemetry import emit_event, telemetry_enabled  # noqa: PLC0415
+        from fabric_dw.telemetry import (  # noqa: PLC0415
+            current_mcp_client,
+            emit_event,
+            telemetry_enabled,
+        )
 
         if not telemetry_enabled():
             return
@@ -429,6 +437,12 @@ def emit_command_invoked(
         }
         if destructive:
             attrs["destructive_op"] = True
+        # Which MCP client sent this call (#1048).  Absent on the CLI surface,
+        # where nothing sets it, so the dimension only ever appears on events
+        # where it means something.
+        mcp_client = current_mcp_client()
+        if mcp_client is not None:
+            attrs["mcp_client"] = mcp_client
 
         emit_event("command_invoked", attrs)
     except Exception:

--- a/src/fabric_dw/telemetry_spans.py
+++ b/src/fabric_dw/telemetry_spans.py
@@ -1,0 +1,345 @@
+"""Sanitised export path for the MCP SDK's OpenTelemetry protocol spans.
+
+Why this module exists
+----------------------
+MCP Python SDK v2 installs an ``OpenTelemetryMiddleware`` on every server it
+creates, which emits one span per inbound protocol message.  That is free,
+upstream-maintained instrumentation covering every message type, including the
+ones this project's hand-written ``command_invoked`` event does not know about,
+so it is worth collecting (#1049).
+
+It cannot be collected as-is.  Parts of every span are chosen by the client and
+are free text, and this project promises in ``docs/telemetry.md`` that no
+identifiers and no free-text payload are ever sent.  Measured against a server
+that registers no prompts at all, a single ``prompts/get`` puts a
+client-supplied string into four places:
+
+- the span name (``prompts/get <name>``),
+- the status description (``Unknown prompt: <name>``),
+- the ``gen_ai.prompt.name`` attribute,
+- an ``exception`` span event, whose ``exception.message`` and
+  ``exception.stacktrace`` both contain it.
+
+Two more values are client-chosen even though they look structural:
+``mcp.method.name`` is echoed verbatim for a method the server does not
+implement (the middleware wraps the ``METHOD_NOT_FOUND`` path), and
+``jsonrpc.request.id`` is whatever string the client put in the JSON-RPC
+envelope.
+
+Design
+------
+Rather than blocklisting the known-bad fields, every exported span is rebuilt
+from an allowlist, so a field added by a future SDK release is dropped until
+someone deliberately admits it:
+
+- Spans whose instrumentation scope is not the MCP SDK's are dropped
+  entirely.  ``configure_azure_monitor`` installs a process-wide provider, so
+  this is what keeps a third-party library's spans (HTTP URLs carrying
+  workspace and warehouse identifiers, say) out of the export path without
+  depending on the auto-instrumentation switches staying off.
+- ``mcp.method.name`` is kept only when it is a method the MCP protocol
+  defines, using the SDK's own maps so new protocol methods are covered
+  without a change here.  Anything else becomes ``<unknown>``.
+- The span name is rebuilt from that sanitised method name, which drops the
+  client-supplied suffix.
+- ``mcp.protocol.version`` is kept only when it is a protocol revision the SDK
+  knows.
+- ``jsonrpc.request.id`` is kept only when it is an integer id.
+- The status *code* is kept; the status *description* is dropped.
+- Events and links are dropped, which is what removes the exception message
+  and stacktrace.
+
+Spans are read-only once ended, so the sanitiser builds a replacement
+``ReadableSpan`` instead of editing in place.
+
+The provider installed here loses to a host application that already installed
+its own ``TracerProvider``: OpenTelemetry refuses to override an existing
+global provider, and :func:`install_mcp_span_pipeline` detects that and stands
+down, leaving the host's spans going to the host's own destination.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from functools import lru_cache
+from typing import TYPE_CHECKING, Any
+
+from azure.monitor.opentelemetry.exporter import (
+    AzureMonitorTraceExporter as _AzureMonitorTraceExporter,
+)
+from opentelemetry import trace as _trace
+from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor, SpanExporter, SpanExportResult
+from opentelemetry.sdk.trace.sampling import ALWAYS_ON
+from opentelemetry.trace.status import Status
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+# This module is imported lazily (from telemetry._get_tracer, on the MCP
+# surface only), so the imports above cost nothing on a run with telemetry
+# disabled, and nothing at all on the CLI surface.  By the time it is imported,
+# configure_azure_monitor has already pulled in the Azure exporter package.
+#
+# ``_trace`` and ``_AzureMonitorTraceExporter`` are module-level handles rather
+# than imports inside install_mcp_span_pipeline so that there is exactly one
+# object to substitute when testing the install path, which must never run for
+# real: it claims a process-wide global and opens a connection to Application
+# Insights.
+
+__all__ = [
+    "MCP_SDK_SCOPE",
+    "UNKNOWN_METHOD",
+    "install_mcp_span_pipeline",
+    "sanitise_span",
+]
+
+_log = logging.getLogger(__name__)
+
+#: Instrumentation scope name used by ``mcp.shared._otel``.  Spans from any
+#: other scope are dropped rather than exported.
+MCP_SDK_SCOPE = "mcp-python-sdk"
+
+#: Placeholder substituted for a method name the MCP protocol does not define
+#: (which means the client chose the string).  Cannot collide with a real
+#: method name.
+UNKNOWN_METHOD = "<unknown>"
+
+#: The only value ``OpenTelemetryMiddleware`` ever writes for this attribute.
+#: Passing through the literal rather than the value keeps it bounded if the
+#: SDK ever starts deriving it from the request.
+_GEN_AI_OPERATION = "execute_tool"
+
+#: Attributes copied through untouched.  Both are server-side classifications:
+#: a JSON-RPC error code, the string ``tool_error``, or the qualified name of
+#: an exception class raised inside this process.  None can carry client input.
+_PASSTHROUGH_ATTRIBUTES = frozenset({"error.type", "rpc.response.status_code"})
+
+
+@lru_cache(maxsize=1)
+def _known_methods() -> frozenset[str]:
+    """Return every method name the MCP protocol defines, in both directions.
+
+    Read from ``mcp_types``, which is documented as supported public API and
+    is updated upstream when the protocol gains a method.  Returns an empty set
+    if the import fails, which degrades to every method being reported as
+    :data:`UNKNOWN_METHOD` rather than to leaking an unvetted string.
+    """
+    try:
+        from mcp_types.methods import (  # noqa: PLC0415
+            SERVER_NOTIFICATIONS,
+            SERVER_REQUESTS,
+            SPEC_CLIENT_METHODS,
+            SPEC_CLIENT_NOTIFICATION_METHODS,
+        )
+    except Exception:
+        _log.debug("Could not read the MCP method maps", exc_info=True)
+        return frozenset()
+
+    server_side = {method for method, _version in SERVER_REQUESTS}
+    server_side |= {method for method, _version in SERVER_NOTIFICATIONS}
+    return frozenset(SPEC_CLIENT_METHODS | SPEC_CLIENT_NOTIFICATION_METHODS | server_side)
+
+
+@lru_cache(maxsize=1)
+def _known_protocol_versions() -> frozenset[str]:
+    """Return the protocol revisions the SDK knows, or an empty set on failure."""
+    try:
+        from mcp_types.version import KNOWN_PROTOCOL_VERSIONS  # noqa: PLC0415
+    except Exception:
+        _log.debug("Could not read the MCP protocol versions", exc_info=True)
+        return frozenset()
+    return frozenset(KNOWN_PROTOCOL_VERSIONS)
+
+
+def _safe_method(value: object) -> str:
+    """Return *value* when it is a protocol method name, else :data:`UNKNOWN_METHOD`."""
+    if isinstance(value, str) and value in _known_methods():
+        return value
+    return UNKNOWN_METHOD
+
+
+def _safe_request_id(value: object) -> str | None:
+    """Return *value* when it is an integer JSON-RPC id, else ``None``.
+
+    JSON-RPC allows a string id, and the client picks it, so a string id is
+    free text and is dropped.  Every SDK client counts integers.
+
+    The check is a digit test rather than ``int(value)``, which also accepts
+    surrounding whitespace, digit separators (``1_000``) and non-ASCII numerals.
+    """
+    if not isinstance(value, str):
+        return None
+    digits = value.removeprefix("-")
+    if digits.isascii() and digits.isdigit():
+        return value
+    return None
+
+
+def _sanitise_attributes(attributes: object) -> dict[str, Any]:
+    """Return the allowlisted subset of *attributes* with each value vetted.
+
+    A span's attributes are a ``BoundedAttributes`` mapping, not a ``dict``, so
+    the guard here is on ``Mapping``.
+    """
+    if not isinstance(attributes, Mapping):
+        return {"mcp.method.name": UNKNOWN_METHOD}
+
+    out: dict[str, Any] = {"mcp.method.name": _safe_method(attributes.get("mcp.method.name"))}
+
+    version = attributes.get("mcp.protocol.version")
+    if isinstance(version, str) and version in _known_protocol_versions():
+        out["mcp.protocol.version"] = version
+
+    request_id = _safe_request_id(attributes.get("jsonrpc.request.id"))
+    if request_id is not None:
+        out["jsonrpc.request.id"] = request_id
+
+    if attributes.get("gen_ai.operation.name") == _GEN_AI_OPERATION:
+        out["gen_ai.operation.name"] = _GEN_AI_OPERATION
+
+    for key in _PASSTHROUGH_ATTRIBUTES:
+        value = attributes.get(key)
+        if value is not None:
+            out[key] = value
+
+    return out
+
+
+def sanitise_span(span: ReadableSpan) -> ReadableSpan | None:
+    """Return a replacement span safe to export, or ``None`` to drop it.
+
+    ``None`` is returned for any span that did not come from the MCP SDK's
+    tracer.  A span from that tracer whose shape this code does not recognise
+    is still exported, but reduced to :data:`UNKNOWN_METHOD` and a status code.
+
+    Args:
+        span: The ended span handed to the exporter.
+
+    Returns:
+        A new :class:`~opentelemetry.sdk.trace.ReadableSpan` carrying only
+        vetted values, or ``None`` when the span must not be exported.
+    """
+    scope = span.instrumentation_scope
+    if scope is None or scope.name != MCP_SDK_SCOPE:
+        return None
+
+    attributes = _sanitise_attributes(span.attributes)
+    method = attributes["mcp.method.name"]
+
+    # The status description is dropped, not rewritten: for `prompts/get` it is
+    # the "Unknown prompt: <name>" message that echoes the client's string, and
+    # every other description is equally free-form.  The status code survives,
+    # and `error.type` carries the machine-readable classification.
+    status = Status(span.status.status_code)
+
+    return ReadableSpan(
+        # The client-supplied target is a suffix on the SDK's span name, so the
+        # name is rebuilt from the vetted method instead.  The span kind, which
+        # is preserved, is what distinguishes an inbound message (SERVER, the
+        # `requests` table) from a server-initiated one (CLIENT, `dependencies`).
+        name=method,
+        context=span.get_span_context(),
+        parent=span.parent,
+        resource=span.resource,
+        attributes=attributes,
+        # Dropped: the SDK's `record_exception` branch puts the exception
+        # message and full stacktrace in an event, and a `prompts/get` for an
+        # unregistered name reaches exactly that branch.
+        events=(),
+        links=(),
+        kind=span.kind,
+        instrumentation_scope=scope,
+        status=status,
+        start_time=span.start_time,
+        end_time=span.end_time,
+    )
+
+
+class SanitisingSpanExporter(SpanExporter):
+    """Wrap a :class:`SpanExporter`, sanitising every span on the way out.
+
+    Implemented as a wrapper rather than a ``SpanProcessor`` because a
+    processor cannot stop the exporter that sits behind it from seeing the
+    original span; only the exporter seam can drop and replace.
+    """
+
+    def __init__(self, inner: SpanExporter) -> None:
+        self._inner = inner
+
+    def export(self, spans: Sequence[ReadableSpan], **kwargs: Any) -> SpanExportResult:  # noqa: ANN401
+        """Export the sanitised form of *spans*, dropping the ones that fail vetting."""
+        safe: list[ReadableSpan] = []
+        for span in spans:
+            try:
+                sanitised = sanitise_span(span)
+            except Exception:
+                # A span this code cannot process is dropped, never forwarded:
+                # failing open would export exactly the values this class exists
+                # to remove.
+                _log.debug("Dropping a span the sanitiser could not process", exc_info=True)
+                continue
+            if sanitised is not None:
+                safe.append(sanitised)
+
+        if not safe:
+            return SpanExportResult.SUCCESS
+        return self._inner.export(safe, **kwargs)
+
+    def shutdown(self) -> None:
+        """Shut down the wrapped exporter."""
+        self._inner.shutdown()
+
+    def force_flush(self, timeout_millis: int = 30_000) -> bool:
+        """Flush the wrapped exporter."""
+        return self._inner.force_flush(timeout_millis)
+
+
+def install_mcp_span_pipeline(connection_string: str, resource: object | None) -> bool:
+    """Install the global TracerProvider that exports sanitised MCP spans.
+
+    Called once, from ``telemetry._get_tracer``, and only on the MCP surface:
+    the CLI produces no protocol spans, so there is nothing there for this
+    pipeline to carry and no reason for it to claim the process-wide provider.
+
+    A host application that already installed a ``TracerProvider`` keeps it.
+    OpenTelemetry refuses to override an existing global provider, so this
+    function sets one and then checks whether the set took effect, standing
+    down when it did not.  The provider is built before the exporter so that
+    losing the race costs nothing.
+
+    Args:
+        connection_string: The Application Insights connection string.
+        resource: The OTel ``Resource`` shared with the logs pipeline, so spans
+            carry the same ``cloud_RoleName`` / ``application_Version`` fields
+            as the events.  ``None`` falls back to the SDK default resource.
+
+    Returns:
+        ``True`` when this process now exports MCP protocol spans, ``False``
+        when a host provider won the race or setup failed.  Never raises.
+    """
+    try:
+        provider = TracerProvider(
+            resource=resource,  # ty: ignore[invalid-argument-type]
+            # ALWAYS_ON rather than the default ParentBased sampler: an MCP
+            # client propagates W3C trace context into `_meta`, so the default
+            # would hand our collection decision to the client's own sampler
+            # and silently drop spans for any client that samples below 100%.
+            sampler=ALWAYS_ON,
+            # Same reason as the logs pipeline: the default atexit hook has an
+            # unbounded flush that can hang the process.  shutdown_telemetry()
+            # tears this provider down with a bounded timeout instead.
+            shutdown_on_exit=False,
+        )
+        _trace.set_tracer_provider(provider)
+        if _trace.get_tracer_provider() is not provider:
+            _log.debug("A TracerProvider was already installed; leaving it alone")
+            return False
+
+        exporter = _AzureMonitorTraceExporter(connection_string=connection_string)
+        provider.add_span_processor(BatchSpanProcessor(SanitisingSpanExporter(exporter)))
+    except Exception:
+        _log.debug("Failed to install the MCP span pipeline", exc_info=True)
+        return False
+    return True

--- a/src/fabric_dw/telemetry_spans.py
+++ b/src/fabric_dw/telemetry_spans.py
@@ -60,9 +60,13 @@ down, leaving the host's spans going to the host's own destination.
 
 from __future__ import annotations
 
+import contextlib
+import hashlib
+import hmac
 import logging
+import os
+import secrets
 from collections.abc import Mapping
-from functools import lru_cache
 from typing import TYPE_CHECKING, Any
 
 from azure.monitor.opentelemetry.exporter import (
@@ -72,6 +76,7 @@ from opentelemetry import trace as _trace
 from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor, SpanExporter, SpanExportResult
 from opentelemetry.sdk.trace.sampling import ALWAYS_ON
+from opentelemetry.trace import DEFAULT_TRACE_STATE, SpanContext, TraceFlags
 from opentelemetry.trace.status import Status
 
 if TYPE_CHECKING:
@@ -111,21 +116,64 @@ UNKNOWN_METHOD = "<unknown>"
 #: SDK ever starts deriving it from the request.
 _GEN_AI_OPERATION = "execute_tool"
 
-#: Attributes copied through untouched.  Both are server-side classifications:
-#: a JSON-RPC error code, the string ``tool_error``, or the qualified name of
-#: an exception class raised inside this process.  None can carry client input.
-_PASSTHROUGH_ATTRIBUTES = frozenset({"error.type", "rpc.response.status_code"})
+#: The one non-numeric ``error.type`` the middleware writes itself.
+_TOOL_ERROR = "tool_error"
+
+#: Longest ``jsonrpc.request.id`` recorded, in digits: the int64 range.  The id
+#: is client-chosen, and the attributes handed to the exporter are a plain dict,
+#: so no OpenTelemetry attribute limit applies and nothing else bounds this.  A
+#: 4000-digit id measured at 4824 bytes on the wire before this cap existed.
+_MAX_REQUEST_ID_DIGITS = 19
+
+#: Longest ``error.type`` recorded.  Server-side exception class names are far
+#: shorter; the cap exists so the invariant does not rest on that.
+_MAX_ERROR_TYPE_LEN = 64
+
+# Per-process key for remapping trace ids.  The MCP SDK parents every inbound
+# span on trace context lifted off the wire, so the trace id and the parent span
+# id are chosen by the client, and Azure exports them as `ai.operation.id` and
+# `ai.operation.parentId`.  Measured before this existed: a `traceparent` of
+# `00-74656e616e742d7365637265742d3031-3862797465735858-01` put the bytes
+# `tenant-secret-01` into `ai.operation.id`, on any message including a
+# notification, which needs no response.
+#
+# An HMAC keyed on a value the client cannot see keeps spans that genuinely
+# belong to one trace grouped, while making the exported id something the client
+# neither chooses nor can predict.  It is not stored and dies with the process.
+_TRACE_ID_SECRET = secrets.token_bytes(32)
 
 
-@lru_cache(maxsize=1)
+def _remap_trace_id(trace_id: int) -> int:
+    """Return a trace id derived from *trace_id* that the client cannot choose."""
+    digest = hmac.new(
+        _TRACE_ID_SECRET, trace_id.to_bytes(16, "big", signed=False), hashlib.sha256
+    ).digest()
+    # A trace id of 0 is invalid per the spec; the odds are negligible but the
+    # fallback costs one comparison.
+    return int.from_bytes(digest[:16], "big") or 1
+
+
+# Caches for the two lookups below.  Deliberately not ``lru_cache``: the first
+# call happens on the BatchSpanProcessor worker thread, and caching a failure
+# there would pin every span in the process to UNKNOWN_METHOD until restart,
+# announced only at debug level.  Only a successful read is remembered.
+_methods_cache: frozenset[str] | None = None
+_versions_cache: frozenset[str] | None = None
+
+
 def _known_methods() -> frozenset[str]:
     """Return every method name the MCP protocol defines, in both directions.
 
     Read from ``mcp_types``, which is documented as supported public API and
     is updated upstream when the protocol gains a method.  Returns an empty set
     if the import fails, which degrades to every method being reported as
-    :data:`UNKNOWN_METHOD` rather than to leaking an unvetted string.
+    :data:`UNKNOWN_METHOD` rather than to leaking an unvetted string, and
+    retries on the next span rather than caching the failure.
     """
+    global _methods_cache  # noqa: PLW0603
+
+    if _methods_cache is not None:
+        return _methods_cache
     try:
         from mcp_types.methods import (  # noqa: PLC0415
             SERVER_NOTIFICATIONS,
@@ -139,18 +187,26 @@ def _known_methods() -> frozenset[str]:
 
     server_side = {method for method, _version in SERVER_REQUESTS}
     server_side |= {method for method, _version in SERVER_NOTIFICATIONS}
-    return frozenset(SPEC_CLIENT_METHODS | SPEC_CLIENT_NOTIFICATION_METHODS | server_side)
+    _methods_cache = frozenset(SPEC_CLIENT_METHODS | SPEC_CLIENT_NOTIFICATION_METHODS | server_side)
+    return _methods_cache
 
 
-@lru_cache(maxsize=1)
 def _known_protocol_versions() -> frozenset[str]:
-    """Return the protocol revisions the SDK knows, or an empty set on failure."""
+    """Return the protocol revisions the SDK knows, or an empty set on failure.
+
+    Same no-caching-of-failures rule as :func:`_known_methods`.
+    """
+    global _versions_cache  # noqa: PLW0603
+
+    if _versions_cache is not None:
+        return _versions_cache
     try:
         from mcp_types.version import KNOWN_PROTOCOL_VERSIONS  # noqa: PLC0415
     except Exception:
         _log.debug("Could not read the MCP protocol versions", exc_info=True)
         return frozenset()
-    return frozenset(KNOWN_PROTOCOL_VERSIONS)
+    _versions_cache = frozenset(KNOWN_PROTOCOL_VERSIONS)
+    return _versions_cache
 
 
 def _safe_method(value: object) -> str:
@@ -161,18 +217,54 @@ def _safe_method(value: object) -> str:
 
 
 def _safe_request_id(value: object) -> str | None:
-    """Return *value* when it is an integer JSON-RPC id, else ``None``.
+    """Return *value* when it is a small integer JSON-RPC id, else ``None``.
 
     JSON-RPC allows a string id, and the client picks it, so a string id is
-    free text and is dropped.  Every SDK client counts integers.
+    free text and is dropped.  The digit test is used rather than ``int(value)``,
+    which also accepts surrounding whitespace, digit separators (``1_000``) and
+    non-ASCII numerals.
 
-    The check is a digit test rather than ``int(value)``, which also accepts
-    surrounding whitespace, digit separators (``1_000``) and non-ASCII numerals.
+    Length is capped at the int64 range.  Digits alone are still a channel: a
+    4000-digit id is 4 KB of client-chosen base-10 data, and leading zeros
+    encode too.  Every SDK client counts small integers, so the cap costs
+    nothing real.
     """
     if not isinstance(value, str):
         return None
     digits = value.removeprefix("-")
-    if digits.isascii() and digits.isdigit():
+    if not digits.isascii() or not digits.isdigit():
+        return None
+    if len(digits) > _MAX_REQUEST_ID_DIGITS:
+        return None
+    return value
+
+
+def _safe_status_code(value: object) -> str | None:
+    """Return *value* when it is a JSON-RPC error code, else ``None``."""
+    if not isinstance(value, str):
+        return None
+    digits = value.removeprefix("-")
+    if digits.isascii() and digits.isdigit() and len(digits) <= _MAX_ERROR_TYPE_LEN:
+        return value
+    return None
+
+
+def _safe_error_type(value: object) -> str | None:
+    """Return *value* when it is a server-side error classification, else ``None``.
+
+    The middleware writes one of three things here: a JSON-RPC error code, the
+    literal ``tool_error``, or the qualified name of an exception class raised
+    inside this process.  None of those can carry client input **today**, but
+    that is a property of the current SDK rather than of this code, and the
+    server-to-client direction (``sampling/createMessage`` and friends) would
+    put a peer's error on a span.  So the invariant is checked rather than
+    assumed: a numeric code, the known literal, or a dotted Python identifier.
+    """
+    if not isinstance(value, str) or not value or len(value) > _MAX_ERROR_TYPE_LEN:
+        return None
+    if value == _TOOL_ERROR or _safe_status_code(value) is not None:
+        return value
+    if value.isascii() and all(part.isidentifier() for part in value.split(".")):
         return value
     return None
 
@@ -199,10 +291,13 @@ def _sanitise_attributes(attributes: object) -> dict[str, Any]:
     if attributes.get("gen_ai.operation.name") == _GEN_AI_OPERATION:
         out["gen_ai.operation.name"] = _GEN_AI_OPERATION
 
-    for key in _PASSTHROUGH_ATTRIBUTES:
-        value = attributes.get(key)
-        if value is not None:
-            out[key] = value
+    error_type = _safe_error_type(attributes.get("error.type"))
+    if error_type is not None:
+        out["error.type"] = error_type
+
+    status_code = _safe_status_code(attributes.get("rpc.response.status_code"))
+    if status_code is not None:
+        out["rpc.response.status_code"] = status_code
 
     return out
 
@@ -211,8 +306,10 @@ def sanitise_span(span: ReadableSpan) -> ReadableSpan | None:
     """Return a replacement span safe to export, or ``None`` to drop it.
 
     ``None`` is returned for any span that did not come from the MCP SDK's
-    tracer.  A span from that tracer whose shape this code does not recognise
-    is still exported, but reduced to :data:`UNKNOWN_METHOD` and a status code.
+    tracer, and for one carrying no span context, which the exporter could not
+    serialise anyway.  A span from that tracer whose shape this code does not
+    recognise is still exported, but reduced to :data:`UNKNOWN_METHOD` and a
+    status code.
 
     Args:
         span: The ended span handed to the exporter.
@@ -225,6 +322,10 @@ def sanitise_span(span: ReadableSpan) -> ReadableSpan | None:
     if scope is None or scope.name != MCP_SDK_SCOPE:
         return None
 
+    context = span.get_span_context()
+    if context is None:
+        return None
+
     attributes = _sanitise_attributes(span.attributes)
     method = attributes["mcp.method.name"]
 
@@ -234,14 +335,30 @@ def sanitise_span(span: ReadableSpan) -> ReadableSpan | None:
     # and `error.type` carries the machine-readable classification.
     status = Status(span.status.status_code)
 
+    # The span's identity is rebuilt, not copied.  The SDK parents each inbound
+    # span on the W3C context in the request's `_meta`, so the trace id, the
+    # parent span id and the tracestate all come off the wire, and Azure exports
+    # the first two as `ai.operation.id` and `ai.operation.parentId`.  Only the
+    # span id is minted locally, so only the span id is kept as-is; the trace id
+    # is remapped so spans of one trace stay grouped without the client choosing
+    # the value, the parent link is cut, and the tracestate is dropped rather
+    # than relying on the exporter continuing not to serialise it.
+    safe_context = SpanContext(
+        trace_id=_remap_trace_id(context.trace_id),
+        span_id=context.span_id,
+        is_remote=False,
+        trace_flags=TraceFlags(TraceFlags.SAMPLED),
+        trace_state=DEFAULT_TRACE_STATE,
+    )
+
     return ReadableSpan(
         # The client-supplied target is a suffix on the SDK's span name, so the
         # name is rebuilt from the vetted method instead.  The span kind, which
         # is preserved, is what distinguishes an inbound message (SERVER, the
         # `requests` table) from a server-initiated one (CLIENT, `dependencies`).
         name=method,
-        context=span.get_span_context(),
-        parent=span.parent,
+        context=safe_context,
+        parent=None,
         resource=span.resource,
         attributes=attributes,
         # Dropped: the SDK's `record_exception` branch puts the exception
@@ -305,9 +422,11 @@ def install_mcp_span_pipeline(connection_string: str, resource: object | None) -
 
     A host application that already installed a ``TracerProvider`` keeps it.
     OpenTelemetry refuses to override an existing global provider, so this
-    function sets one and then checks whether the set took effect, standing
-    down when it did not.  The provider is built before the exporter so that
-    losing the race costs nothing.
+    function claims the global **last**, after the provider is fully built, and
+    checks whether the claim took effect.  Order matters: claiming first and
+    then failing to build the exporter would leave an empty provider installed
+    permanently, recording every span in the process into nothing and locking
+    the host out for good, while still reporting failure to the caller.
 
     Args:
         connection_string: The Application Insights connection string.
@@ -317,9 +436,31 @@ def install_mcp_span_pipeline(connection_string: str, resource: object | None) -
 
     Returns:
         ``True`` when this process now exports MCP protocol spans, ``False``
-        when a host provider won the race or setup failed.  Never raises.
+        when a host provider won the race or setup failed.  The caller records
+        this: ``flush_telemetry`` and ``shutdown_telemetry`` must only tear down
+        a provider this function installed.  Never raises.
     """
+    provider = None
     try:
+        # A host that configured OTEL_PYTHON_TRACER_PROVIDER rather than calling
+        # set_tracer_provider() has not claimed the global yet; this read is what
+        # makes OpenTelemetry load and install it, so the check below sees it.
+        _trace.get_tracer_provider()
+
+        # The Azure trace exporter appends an `_OTELRESOURCE_` MetricData
+        # envelope to every non-empty export unless this is set, so switching
+        # spans on would otherwise start sending metrics that docs/telemetry.md
+        # says are never sent.  It is read at export time, not at construction,
+        # so it cannot be scoped and restored the way the OTEL_*_EXPORTER pair
+        # is.  setdefault, like APPLICATIONINSIGHTS_SDKSTATS_DISABLED: the gate
+        # is `!= "true"`, so an operator's explicit value is a real override.
+        #
+        # Third one of these now (statsbeat, customer sdkstats, this): assume
+        # any Azure Monitor exporter has a side channel behind an environment
+        # variable until proven otherwise.
+        os.environ.setdefault("APPLICATIONINSIGHTS_OPENTELEMETRY_RESOURCE_METRIC_DISABLED", "true")
+
+        exporter = _AzureMonitorTraceExporter(connection_string=connection_string)
         provider = TracerProvider(
             resource=resource,  # ty: ignore[invalid-argument-type]
             # ALWAYS_ON rather than the default ParentBased sampler: an MCP
@@ -332,14 +473,18 @@ def install_mcp_span_pipeline(connection_string: str, resource: object | None) -
             # tears this provider down with a bounded timeout instead.
             shutdown_on_exit=False,
         )
+        provider.add_span_processor(BatchSpanProcessor(SanitisingSpanExporter(exporter)))
+
         _trace.set_tracer_provider(provider)
         if _trace.get_tracer_provider() is not provider:
             _log.debug("A TracerProvider was already installed; leaving it alone")
+            # Stop the batch worker and close the exporter we built but lost.
+            provider.shutdown()
             return False
-
-        exporter = _AzureMonitorTraceExporter(connection_string=connection_string)
-        provider.add_span_processor(BatchSpanProcessor(SanitisingSpanExporter(exporter)))
     except Exception:
         _log.debug("Failed to install the MCP span pipeline", exc_info=True)
+        if provider is not None:
+            with contextlib.suppress(Exception):
+                provider.shutdown()
         return False
     return True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -218,6 +218,9 @@ def _reset_telemetry_module_globals(
        - ``_sdk_initialised``, ``_tracer``, ``_otel_logger`` → initial values
          (prevents a test that calls ``_get_tracer()`` from leaving a live logger
          object that causes subsequent tests to skip the SDK init path entirely)
+       - ``_seen_mcp_clients`` → empty set
+         (``mcp_client_connected`` fires once per distinct client per process, so
+         an entry left behind silences the event in a later test)
 
     All resets are applied *before* and *after* each test (yield fixture) so state
     never leaks from a previous test even if it raised.
@@ -285,6 +288,14 @@ def _reset_telemetry_module_globals(
             ns["_sdk_initialised"] = False
             ns["_tracer"] = None
             ns["_otel_logger"] = None
+            # Clients already announced this process: mcp_client_connected fires
+            # once per distinct client, so a leftover entry would make a later
+            # test see no event at all.
+            assert "_seen_mcp_clients" in ns, (
+                "_seen_mcp_clients not found in fabric_dw.telemetry — "
+                "update both telemetry.py and tests/conftest.py"
+            )
+            ns["_seen_mcp_clients"] = set()
 
     _reset()
     yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -127,6 +127,7 @@ _SDK_ENV_VARS = (
     "OTEL_LOGS_EXPORTER",
     "APPLICATIONINSIGHTS_STATSBEAT_DISABLED_ALL",
     "APPLICATIONINSIGHTS_SDKSTATS_DISABLED",
+    "APPLICATIONINSIGHTS_OPENTELEMETRY_RESOURCE_METRIC_DISABLED",
 )
 
 
@@ -200,10 +201,9 @@ def _reset_telemetry_module_globals(
     Two tiers of reset are applied:
 
     1. **All tests** — the per-process caches added in #844 (``_install_method_cache``
-       and ``_config_disabled_cache``) are always reset.  Any test that calls
-       ``telemetry_enabled()`` on the shared module instance can set these caches;
-       without a universal teardown they bleed into subsequent tests regardless of
-       which module file those tests live in.
+       and ``_config_disabled_cache``) are always reset, and so is
+       ``_seen_mcp_clients``: any test that drives an MCP server populates it, and
+       a leftover entry silences ``mcp_client_connected`` in a later test.
 
     2. **Self-managed telemetry modules only** (``test_telemetry.py``,
        ``test_telemetry_commands.py``, ``test_app_exited_emission.py``) — the
@@ -218,9 +218,6 @@ def _reset_telemetry_module_globals(
        - ``_sdk_initialised``, ``_tracer``, ``_otel_logger`` → initial values
          (prevents a test that calls ``_get_tracer()`` from leaving a live logger
          object that causes subsequent tests to skip the SDK init path entirely)
-       - ``_seen_mcp_clients`` → empty set
-         (``mcp_client_connected`` fires once per distinct client per process, so
-         an entry left behind silences the event in a later test)
 
     All resets are applied *before* and *after* each test (yield fixture) so state
     never leaks from a previous test even if it raised.
@@ -276,6 +273,16 @@ def _reset_telemetry_module_globals(
             )
             ns["_install_method_cache"] = None
             ns["_config_disabled_cache"] = None
+            # Clients already announced this process: mcp_client_connected fires
+            # once per distinct client, so a leftover entry makes a later test
+            # see no event at all.  Reset for EVERY test, not only the
+            # self-managed ones: tests/unit/mcp/test_client_info.py drives a real
+            # server and populates this set without being in that list.
+            assert "_seen_mcp_clients" in ns, (
+                "_seen_mcp_clients not found in fabric_dw.telemetry — "
+                "update both telemetry.py and tests/conftest.py"
+            )
+            ns["_seen_mcp_clients"] = set()
             if not is_self_managed:
                 continue
             # Heavier globals: only needed for tests that exercise the telemetry
@@ -288,14 +295,6 @@ def _reset_telemetry_module_globals(
             ns["_sdk_initialised"] = False
             ns["_tracer"] = None
             ns["_otel_logger"] = None
-            # Clients already announced this process: mcp_client_connected fires
-            # once per distinct client, so a leftover entry would make a later
-            # test see no event at all.
-            assert "_seen_mcp_clients" in ns, (
-                "_seen_mcp_clients not found in fabric_dw.telemetry — "
-                "update both telemetry.py and tests/conftest.py"
-            )
-            ns["_seen_mcp_clients"] = set()
 
     _reset()
     yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -179,7 +179,15 @@ def _mock_configure_azure_monitor(
     if request.path is None or request.path.name not in _TELEMETRY_SELF_MANAGED_MODULES:
         yield MagicMock()
         return
-    with patch("azure.monitor.opentelemetry.configure_azure_monitor") as mock_configure:
+    # install_mcp_span_pipeline is stubbed alongside it: on the MCP surface
+    # _get_tracer() builds a real AzureMonitorTraceExporter on the production
+    # connection string and claims the process-wide TracerProvider, neither of
+    # which a unit test may do.  Tests that exercise the pipeline itself patch
+    # the exporter and call it directly.
+    with (
+        patch("azure.monitor.opentelemetry.configure_azure_monitor") as mock_configure,
+        patch("fabric_dw.telemetry_spans.install_mcp_span_pipeline", return_value=True),
+    ):
         yield mock_configure
 
 

--- a/tests/unit/_mcp_session.py
+++ b/tests/unit/_mcp_session.py
@@ -1,0 +1,138 @@
+"""Drive a real MCP server over in-memory streams with hand-written JSON-RPC.
+
+``tests/unit/_call.py`` reaches past the protocol and calls a tool function
+directly, which is the right trade for the several hundred tests that assert on
+a tool's return value.  This helper is the opposite trade, for the handful of
+tests that are *about* the protocol layer: the middleware chain, the SDK's
+OpenTelemetry spans, the handshake.  None of that runs on the ``_call.py`` path.
+
+Messages are built by the caller as raw ``JSONRPCRequest`` /
+``JSONRPCNotification`` objects rather than through ``ClientSession``, because
+the interesting cases are the ones a well-behaved client cannot produce: a
+method the protocol does not define, a string request id, an ``initialize``
+without ``clientInfo``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import anyio
+from mcp.server.mcpserver import MCPServer
+from mcp.shared.memory import create_client_server_memory_streams
+from mcp.shared.message import SessionMessage
+from mcp_types import (
+    CLIENT_CAPABILITIES_META_KEY,
+    CLIENT_INFO_META_KEY,
+    PROTOCOL_VERSION_META_KEY,
+    JSONRPCNotification,
+    JSONRPCRequest,
+)
+
+__all__ = ["exchange", "handshake", "modern_request"]
+
+#: Protocol revision used by the handshake-era helpers below.
+HANDSHAKE_VERSION = "2025-06-18"
+
+#: Protocol revision used by the envelope-era helper below.
+MODERN_VERSION = "2026-07-28"
+
+
+async def exchange(server: MCPServer[Any], messages: list[Any]) -> list[dict[str, Any]]:
+    """Send *messages* to *server* over memory streams and return the responses.
+
+    One response per request, in order; notifications produce none.  The server
+    task is cancelled once the last response is in, so the caller does not have
+    to arrange a shutdown.
+
+    Args:
+        server: The server under test, already carrying its tools and middleware.
+        messages: Raw JSON-RPC requests and notifications, in send order.
+
+    Returns:
+        The decoded response envelopes, one per request in *messages*.
+    """
+    responses: list[dict[str, Any]] = []
+
+    async with create_client_server_memory_streams() as (client_streams, server_streams):
+        client_read, client_write = client_streams
+        server_read, server_write = server_streams
+
+        async with anyio.create_task_group() as tg:
+
+            async def _run() -> None:
+                await server._lowlevel_server.run(
+                    server_read,
+                    server_write,
+                    server._lowlevel_server.create_initialization_options(),
+                    raise_exceptions=False,
+                )
+
+            tg.start_soon(_run)
+
+            for message in messages:
+                await client_write.send(SessionMessage(message))
+                if isinstance(message, JSONRPCNotification):
+                    continue
+                out = await client_read.receive()
+                # The stream is typed to carry an exception instead of a reply
+                # when the transport tears down; surface it rather than hiding
+                # it behind an attribute error two lines later.
+                assert isinstance(out, SessionMessage), (
+                    f"transport raised instead of replying: {out!r}"
+                )
+                raw = out.message
+                responses.append(raw.model_dump(by_alias=True, mode="json", exclude_none=True))
+
+            tg.cancel_scope.cancel()
+
+    return responses
+
+
+def handshake(client_name: str | None = "test-client") -> list[Any]:
+    """Return the handshake-era opening messages: ``initialize`` plus the notification.
+
+    Args:
+        client_name: The name to put in ``clientInfo``.  ``None`` omits
+            ``clientInfo`` entirely, which the protocol permits.
+    """
+    params: dict[str, Any] = {"protocolVersion": HANDSHAKE_VERSION, "capabilities": {}}
+    if client_name is not None:
+        params["clientInfo"] = {"name": client_name, "version": "1.0"}
+    return [
+        JSONRPCRequest(jsonrpc="2.0", id=1, method="initialize", params=params),
+        JSONRPCNotification(jsonrpc="2.0", method="notifications/initialized", params={}),
+    ]
+
+
+def modern_request(
+    request_id: int,
+    method: str,
+    client_name: str | None = "test-client",
+    params: dict[str, Any] | None = None,
+) -> JSONRPCRequest:
+    """Return a 2026-07-28 request carrying the per-request ``_meta`` envelope.
+
+    That era has no handshake: the reserved ``_meta`` keys are what open the
+    connection and carry the client's identity, so the server builds its
+    ``Connection`` from them before the first message reaches middleware.
+
+    Args:
+        request_id: The JSON-RPC id.
+        method: The method to call.
+        client_name: The name to put in the client-info envelope key, or
+            ``None`` to leave that key out (capabilities alone are valid).
+        params: Extra params merged alongside ``_meta``.
+    """
+    meta: dict[str, Any] = {
+        PROTOCOL_VERSION_META_KEY: MODERN_VERSION,
+        CLIENT_CAPABILITIES_META_KEY: {},
+    }
+    if client_name is not None:
+        meta[CLIENT_INFO_META_KEY] = {"name": client_name, "version": "1.0"}
+    return JSONRPCRequest(
+        jsonrpc="2.0",
+        id=request_id,
+        method=method,
+        params={**(params or {}), "_meta": meta},
+    )

--- a/tests/unit/mcp/test_client_info.py
+++ b/tests/unit/mcp/test_client_info.py
@@ -207,3 +207,40 @@ def test_the_initialize_params_win_over_a_stale_session_value() -> None:
         session = _Session()
 
     assert client_name_from_context(_Ctx()) == "fresh-client"  # ty: ignore[invalid-argument-type]
+
+
+async def test_the_client_name_can_change_per_message_on_one_connection(
+    server: MCPServer[Any],
+) -> None:
+    """From 2026-07-28 on, the name is per message, not per connection.
+
+    It rides each request's ``_meta`` envelope rather than a handshake, so a
+    client can send a different one every time, with no reconnect. That is what
+    makes the name a channel rather than an identity, and why the recorded value
+    is bounded per process (see tests/unit/test_telemetry.py).
+    """
+    with patch(_SCOPE) as scope:
+        await exchange(
+            server,
+            [
+                modern_request(index, "tools/list", client_name=f"EXFIL-CHUNK-{index:04d}")
+                for index in range(3)
+            ],
+        )
+
+    assert _recorded(scope) == ["EXFIL-CHUNK-0000", "EXFIL-CHUNK-0001", "EXFIL-CHUNK-0002"]
+
+
+async def test_a_client_name_with_control_characters_is_recorded_clean(
+    server: MCPServer[Any],
+) -> None:
+    """End to end, since the filtering happens a layer below the middleware."""
+    tel = _live_telemetry()
+    tel._seen_mcp_clients.clear()
+
+    with patch(_EMIT_EVENT) as emit:
+        await exchange(server, handshake("claude\n\r\x00-ai"))
+
+    connected = [call for call in emit.call_args_list if call.args[0] == "mcp_client_connected"]
+    assert connected
+    assert connected[0].args[1] == {"mcp_client": "claude-ai"}

--- a/tests/unit/mcp/test_client_info.py
+++ b/tests/unit/mcp/test_client_info.py
@@ -1,0 +1,209 @@
+"""Tests for fabric_dw.mcp._client_info — recording which MCP client connected (#1048).
+
+Driven through a real server over in-memory streams rather than against a
+hand-built context, because the value's location is the whole difficulty here:
+it is in ``initialize``'s raw params in the handshake era and in the connection
+built from each request's ``_meta`` envelope in the 2026-07-28 era, and an
+earlier attempt at this feature looked in neither place and concluded the server
+could not see it at all.
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any, ClassVar
+from unittest.mock import patch
+
+import pytest
+from mcp.server.mcpserver import MCPServer
+from mcp_types import JSONRPCRequest
+
+from fabric_dw.mcp._client_info import ClientInfoMiddleware, client_name_from_context
+from fabric_dw.telemetry import MCP_CLIENT_UNKNOWN
+from tests.unit._mcp_session import exchange, handshake, modern_request
+
+# Patch targets, as strings: the middleware resolves telemetry through
+# ``sys.modules`` on every call, and tests/unit/test_telemetry.py replaces that
+# entry with a freshly imported module, so a target bound at import time here
+# would sometimes patch an object nothing uses.
+_SCOPE = "fabric_dw.telemetry.mcp_client_scope"
+_EMIT_EVENT = "fabric_dw.telemetry.emit_event"
+
+
+def _live_telemetry() -> Any:
+    """Return the telemetry module currently in ``sys.modules``."""
+    return importlib.import_module("fabric_dw.telemetry")
+
+
+@pytest.fixture
+def server() -> MCPServer[Any]:
+    """A server carrying the middleware and one tool, and nothing else."""
+    mcp: MCPServer[Any] = MCPServer(
+        "client-info-test", version="0.0.0", middleware=[ClientInfoMiddleware()]
+    )
+
+    @mcp.tool(name="echo")
+    async def _echo(value: str) -> str:
+        """Echo the value back."""
+        return value
+
+    return mcp
+
+
+def _recorded(scope_mock: Any) -> list[object]:
+    """The raw names handed to ``mcp_client_scope``, in order."""
+    return [call.args[0] for call in scope_mock.call_args_list]
+
+
+async def test_the_handshake_client_name_is_recorded(server: MCPServer[Any]) -> None:
+    """The 2025-era ``initialize`` carries ``clientInfo`` in its params.
+
+    Read from the raw params rather than from the connection, because the SDK
+    commits the handshake to ``Connection.client_params`` only *after* the
+    middleware chain returns, so a middleware asking the session during
+    ``initialize`` sees nothing.
+    """
+    with patch(_SCOPE) as scope:
+        await exchange(server, handshake("claude-ai"))
+
+    assert _recorded(scope)[0] == "claude-ai"
+
+
+async def test_the_client_is_still_known_after_the_handshake(server: MCPServer[Any]) -> None:
+    """Every later message on the connection must carry the client too.
+
+    ``command_invoked`` is emitted from inside a ``tools/call``, so a value that
+    were only available on ``initialize`` would answer nothing.
+    """
+    with patch(_SCOPE) as scope:
+        await exchange(
+            server,
+            [
+                *handshake("claude-ai"),
+                JSONRPCRequest(
+                    jsonrpc="2.0",
+                    id=2,
+                    method="tools/call",
+                    params={"name": "echo", "arguments": {"value": "hi"}},
+                ),
+            ],
+        )
+
+    assert _recorded(scope) == ["claude-ai", "claude-ai", "claude-ai"]
+
+
+async def test_the_envelope_era_client_name_is_recorded(server: MCPServer[Any]) -> None:
+    """2026-07-28 drops the handshake and puts client info in each request's ``_meta``.
+
+    The SDK turns that envelope into ``Connection.client_params`` before the
+    first message reaches middleware, so here the session is the accessor and
+    there is no ``initialize`` to read.
+    """
+    with patch(_SCOPE) as scope:
+        await exchange(server, [modern_request(1, "tools/list", client_name="vscode")])
+
+    assert _recorded(scope) == ["vscode"]
+
+
+async def test_a_client_that_identifies_itself_nowhere_is_still_served(
+    server: MCPServer[Any],
+) -> None:
+    """Client info is optional from 2026-07-28 on, so this is a supported client.
+
+    Not a case the handshake era can produce: there ``clientInfo`` is a required
+    field and the SDK answers INVALID_PARAMS without it, so the only way to be
+    anonymous is the envelope era, where capabilities are required and identity
+    is not.
+    """
+    with patch(_SCOPE) as scope:
+        responses = await exchange(server, [modern_request(1, "tools/list", client_name=None)])
+
+    assert "result" in responses[0], "an anonymous client must still be served"
+    assert _recorded(scope) == [None]
+
+
+async def test_an_unknown_client_is_recorded_under_the_placeholder(
+    server: MCPServer[Any],
+) -> None:
+    """End to end, the ``None`` above becomes the documented placeholder value."""
+    _live_telemetry()._seen_mcp_clients.clear()
+    with patch(_EMIT_EVENT) as emit:
+        await exchange(server, [modern_request(1, "tools/list", client_name=None)])
+
+    connected = [call for call in emit.call_args_list if call.args[0] == "mcp_client_connected"]
+    assert connected, "no mcp_client_connected event was emitted"
+    assert connected[0].args[1] == {"mcp_client": MCP_CLIENT_UNKNOWN}
+
+
+async def test_a_broken_client_info_shape_does_not_break_the_request(
+    server: MCPServer[Any],
+) -> None:
+    """Middleware runs before params validation, so the shape is not guaranteed.
+
+    A client sending ``clientInfo: "claude"`` gets its request served; the field
+    simply falls back to the placeholder.
+    """
+    request = JSONRPCRequest(
+        jsonrpc="2.0",
+        id=1,
+        method="initialize",
+        params={
+            "protocolVersion": "2025-06-18",
+            "capabilities": {},
+            "clientInfo": "not-an-object",
+        },
+    )
+
+    with patch(_SCOPE) as scope:
+        responses = await exchange(server, [request])
+
+    assert _recorded(scope) == [None]
+    assert responses[0].get("error", {}).get("code") != -32603, "must not be an internal error"
+
+
+async def test_telemetry_failing_never_breaks_the_server(server: MCPServer[Any]) -> None:
+    """The tool call has to go through even when the telemetry side throws.
+
+    A crash here would take down a working MCP server for the sake of a usage
+    counter, which is never the right trade.
+    """
+    with patch(_SCOPE, side_effect=RuntimeError("boom")):
+        responses = await exchange(
+            server,
+            [
+                *handshake("claude-ai"),
+                JSONRPCRequest(
+                    jsonrpc="2.0",
+                    id=2,
+                    method="tools/call",
+                    params={"name": "echo", "arguments": {"value": "hi"}},
+                ),
+            ],
+        )
+
+    assert "hi" in str(responses[-1])
+
+
+def test_the_initialize_params_win_over_a_stale_session_value() -> None:
+    """A connection reused by a different client must report the new one.
+
+    ``initialize`` is the point where identity changes, and its params are the
+    fresh value; the connection still holds whatever the previous handshake
+    committed.
+    """
+
+    class _Info:
+        name = "stale-client"
+
+    class _Params:
+        client_info = _Info()
+
+    class _Session:
+        client_params = _Params()
+
+    class _Ctx:
+        method = "initialize"
+        params: ClassVar[dict[str, Any]] = {"clientInfo": {"name": "fresh-client"}}
+        session = _Session()
+
+    assert client_name_from_context(_Ctx()) == "fresh-client"  # ty: ignore[invalid-argument-type]

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -32,6 +32,16 @@ def _reload_telemetry() -> Any:
     return importlib.import_module("fabric_dw.telemetry")
 
 
+def _live_telemetry() -> Any:
+    """Return the telemetry module currently in ``sys.modules``.
+
+    A module-level ``import`` would bind whichever object existed at collection
+    time, and :func:`_reload_telemetry` replaces that entry with a fresh module
+    whose globals are the ones the rest of the process then uses.
+    """
+    return importlib.import_module("fabric_dw.telemetry")
+
+
 # ---------------------------------------------------------------------------
 # Opt-out: telemetry_enabled()
 # ---------------------------------------------------------------------------
@@ -1494,12 +1504,13 @@ def test_operator_can_re_enable_customer_sdkstats(
 def test_get_tracer_leaves_the_logs_pipeline_enabled(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, request: pytest.FixtureRequest
 ) -> None:
-    """Disabling traces and metrics must NOT disable logs.
+    """Switching off the library's trace and metric pipelines must NOT touch logs.
 
     customEvents are emitted as OTel log records, so the logs pipeline is the one
     that has to stay on. Without this, adding ``OTEL_LOGS_EXPORTER`` to the
-    hard-set block (an easy symmetry mistake) would silently kill all telemetry
-    rather than just the parts we do not want.
+    hard-set block (an easy symmetry mistake) would silently kill all telemetry:
+    every lifecycle event, every ``command_invoked``, and the
+    ``mcp_client_connected`` event too, leaving only the spans.
     """
     mod, at_call, _after = _run_get_tracer(monkeypatch, tmp_path, request)
     try:
@@ -4068,3 +4079,97 @@ def test_azure_cli_without_azure_config_dir_env(
     # After override (simulating what record_auth_mode_from_default_credential does):
     mod.set_auth_mode("azure_cli")  # type: ignore[attr-defined]
     assert mod._build_envelope()["auth_mode"] == "azure_cli"
+
+
+# ---------------------------------------------------------------------------
+# Which MCP client is connected (#1048)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [None, "", "   ", 42, {"name": "claude-ai"}],
+)
+def test_an_unusable_client_name_falls_back_to_unknown(raw: object) -> None:
+    """The protocol lets a client send no client info at all, so this has a floor.
+
+    Recording ``unknown`` rather than dropping the field keeps the count of
+    anonymous clients visible instead of making them look like no client.
+    """
+    tel = _live_telemetry()
+
+    assert tel.normalise_mcp_client(raw) == tel.MCP_CLIENT_UNKNOWN
+
+
+def test_a_client_name_is_bounded_in_length() -> None:
+    """``clientInfo.name`` is client-chosen, so nothing on the wire bounds it."""
+    assert len(_live_telemetry().normalise_mcp_client("x" * 500)) == 64
+
+
+def test_a_client_name_is_recorded_verbatim() -> None:
+    """Deliberately not mapped onto a fixed list of known clients.
+
+    A fixed list can only confirm the clients somebody already thought of, and
+    turns every new or renamed one into ``other`` until a human notices.  The
+    long tail is the interesting part of this field.
+    """
+    assert (
+        _live_telemetry().normalise_mcp_client("  some-brand-new-client  ")
+        == "some-brand-new-client"
+    )
+
+
+def test_the_client_is_announced_once_per_process_and_readable_during_the_request() -> None:
+    """One event per distinct client, and the name available to command_invoked.
+
+    Once per client rather than once per message, because a busy server would
+    otherwise emit a connection event per inbound call.  The context variable is
+    what lets ``command_invoked`` attribute a tool call to the client that made
+    it, which is the question #1048 exists to answer.
+    """
+    tel = _live_telemetry()
+    tel._seen_mcp_clients.clear()
+
+    with patch.object(tel, "emit_event") as emit:
+        assert tel.current_mcp_client() is None
+        with tel.mcp_client_scope("claude-ai"):
+            assert tel.current_mcp_client() == "claude-ai"
+            with tel.mcp_client_scope("claude-ai"):
+                pass
+        assert tel.current_mcp_client() is None
+
+    assert [call.args[0] for call in emit.call_args_list] == ["mcp_client_connected"]
+    assert emit.call_args.args[1] == {"mcp_client": "claude-ai"}
+
+
+def test_a_second_client_on_the_same_process_is_announced_too() -> None:
+    """One MCP server can serve several clients; each one is worth counting."""
+    tel = _live_telemetry()
+    tel._seen_mcp_clients.clear()
+
+    with patch.object(tel, "emit_event") as emit:
+        with tel.mcp_client_scope("claude-ai"):
+            pass
+        with tel.mcp_client_scope("mcp-inspector"):
+            pass
+
+    assert [call.args[1]["mcp_client"] for call in emit.call_args_list] == [
+        "claude-ai",
+        "mcp-inspector",
+    ]
+
+
+def test_nothing_is_recorded_when_telemetry_is_opted_out(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The client field rides the existing opt-out; it adds no switch of its own."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setenv("FABRIC_DW_TELEMETRY_OPT_OUT", "1")
+
+    mod = _reload_telemetry()
+    mod._seen_mcp_clients.clear()
+
+    with patch.object(mod, "_get_tracer") as get_tracer, mod.mcp_client_scope("claude-ai"):
+        pass
+
+    get_tracer.assert_not_called()

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -4336,3 +4336,54 @@ async def test_concurrent_requests_do_not_cross_contaminate_the_client(
     for index, seen in enumerate(results):
         assert set(seen) == {f"client-{index}"}
     assert tel.current_mcp_client() is None
+
+
+@pytest.mark.parametrize(
+    ("span_pipeline_installed", "expected_logs_budget"),
+    [(False, 6000), (True, 3000)],
+)
+def test_the_logs_flush_budget_is_only_split_when_there_are_two_pipelines(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    span_pipeline_installed: bool,  # noqa: FBT001
+    expected_logs_budget: int,
+) -> None:
+    """The CLI must not pay for a span pipeline it does not have.
+
+    The logs pipeline is the critical one: it carries every ``command_invoked``
+    and ``app_exited``, and the App Insights POST typically takes 2 to 4 s.
+    Halving its budget unconditionally to make room for spans would be a pure
+    loss on the CLI surface, where no span pipeline exists and processes are
+    short-lived.
+    """
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    mod = _reload_telemetry()
+
+    fake_logger = object()
+    mod._sdk_initialised = True
+    mod._tracer = fake_logger
+    mod._otel_logger = fake_logger
+    mod._sdk_shutdown = False
+    mod._span_pipeline_installed = span_pipeline_installed
+
+    logs_budgets: list[int] = []
+    span_budgets: list[int] = []
+
+    fake_logs_mod: Any = types.ModuleType("opentelemetry._logs_fake")
+    fake_logs_mod.get_logger_provider = lambda: types.SimpleNamespace(
+        force_flush=lambda **kw: logs_budgets.append(kw["timeout_millis"]),
+        shutdown=lambda: None,
+    )
+    monkeypatch.setitem(sys.modules, "opentelemetry._logs", fake_logs_mod)
+    _install_fake_otel_trace(
+        monkeypatch,
+        types.SimpleNamespace(
+            force_flush=lambda **kw: span_budgets.append(kw["timeout_millis"]),
+            shutdown=lambda: None,
+        ),
+    )
+
+    mod.shutdown_telemetry()
+
+    assert logs_budgets == [expected_logs_budget]
+    assert span_budgets == ([3000] if span_pipeline_installed else [])

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -1121,8 +1121,24 @@ def test_get_tracer_passes_enable_performance_counters_false(
 
 
 # ---------------------------------------------------------------------------
-# Privacy: no span or metric exporter is ever installed (#1043)
+# The library never builds its own exporters (#1043, revised by #1049)
 # ---------------------------------------------------------------------------
+#
+# What changed with #1049
+# -----------------------
+# This project now DOES export spans: the MCP protocol spans the MCP SDK emits,
+# which #1049 decided are worth collecting. What it does not do is let
+# ``configure_azure_monitor`` build the trace pipeline, because the exporter that
+# call installs ships every span in the process verbatim, and parts of an MCP
+# span are chosen by the client (see tests/unit/test_telemetry_spans.py for the
+# measured list). The pipeline is built instead by
+# ``telemetry_spans.install_mcp_span_pipeline``, whose exporter drops non-MCP
+# spans and rebuilds the rest from an allowlist.
+#
+# So the intent these tests pin is: the metrics pipeline stays off entirely, the
+# library's own trace pipeline never gets built, the logs pipeline stays on, and
+# a user's ``OTEL_TRACES_EXPORTER`` still cannot cause the unfiltered exporter to
+# be installed.
 #
 # What these tests can and cannot do
 # ----------------------------------
@@ -1164,6 +1180,7 @@ def _run_get_tracer(
     tmp_path: Path,
     request: pytest.FixtureRequest,
     preset: dict[str, str] | None = None,
+    surface: str = "cli",
 ) -> tuple[Any, dict[str, str | None], dict[str, str | None]]:
     """Run ``_get_tracer()`` and capture the environment as the library would see it.
 
@@ -1174,7 +1191,8 @@ def _run_get_tracer(
     library reads them.
 
     *preset* seeds the environment beforehand, to exercise the case where the
-    caller's process already has these variables set.
+    caller's process already has these variables set.  *surface* sets the module
+    global the MCP span pipeline is gated on.
 
     The autouse ``_mock_configure_azure_monitor`` fixture is resolved through
     *request* rather than injected by name, because its value is needed (to hang
@@ -1207,6 +1225,7 @@ def _run_get_tracer(
     mod._sdk_initialised = False
     mod._tracer = None
     mod._otel_logger = None
+    mod._current_surface = surface
     mod._get_tracer()
 
     after = {k: os.environ.get(k) for k in _WATCHED_OTEL_VARS}
@@ -1238,10 +1257,23 @@ def _resolves_disabled(kind: str, env_at_call: dict[str, str | None]) -> bool:
         return bool(resolved[f"disable_{kind}"])
 
 
-def test_get_tracer_disables_the_trace_pipeline_effectively(
+def test_get_tracer_never_lets_the_library_build_the_trace_pipeline(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, request: pytest.FixtureRequest
 ) -> None:
-    """The environment the library sees must make it disable tracing.
+    """The environment the library sees must still make it skip tracing setup.
+
+    #1049 turned span collection ON, but not this way. What
+    ``configure_azure_monitor`` installs is an ``AzureMonitorTraceExporter``
+    wired straight to the batch processor, which exports every span in the
+    process exactly as produced. An MCP span as produced carries the
+    client-chosen prompt or tool name in its span name, the server's error text
+    in its status description, and, on the ``prompts/get`` path, an exception
+    event holding the message and the full stacktrace. Letting the library build
+    this pipeline would ship all of that.
+
+    ``telemetry_spans.install_mcp_span_pipeline`` builds the pipeline instead,
+    with a sanitising exporter in front. This test guards the boundary between
+    the two: the library's own pipeline must stay unbuilt.
 
     Asserting that ``configure_azure_monitor`` merely RECEIVES
     ``disable_tracing=True`` would be worthless: the library throws that value
@@ -1250,25 +1282,69 @@ def test_get_tracer_disables_the_trace_pipeline_effectively(
     ``OTEL_TRACES_EXPORTER``. So this captures the environment at call time and
     feeds it through that real decision function.
 
-    Why it matters: MCP Python SDK v2 installs an OpenTelemetry middleware on
-    every server unconditionally, emitting one SERVER span per inbound protocol
-    message with ``mcp.method.name``, ``jsonrpc.request.id``,
-    ``gen_ai.tool.name``, ``error.type`` and timings. That is metadata the
-    documented collection list in docs/telemetry.md does not cover.
-
     Do not "simplify" this into an assertion about kwargs.
     """
     mod, at_call, _after = _run_get_tracer(monkeypatch, tmp_path, request)
     try:
         assert at_call["OTEL_TRACES_EXPORTER"] == "none"
         assert _resolves_disabled("tracing", at_call), (
-            "The real library resolves tracing as ENABLED, so MCP protocol spans "
-            "would be exported to Application Insights."
+            "The real library resolves tracing as ENABLED, so it would install its own "
+            "unfiltered AzureMonitorTraceExporter alongside the sanitising one."
         )
     finally:
         mod._sdk_initialised = False
         mod._tracer = None
         mod._otel_logger = None
+
+
+@pytest.mark.parametrize(
+    ("surface", "expected"),
+    [("mcp", True), ("cli", False)],
+)
+def test_span_pipeline_is_installed_on_the_mcp_surface_only(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    request: pytest.FixtureRequest,
+    surface: str,
+    expected: bool,  # noqa: FBT001
+) -> None:
+    """Only the MCP server collects protocol spans; the CLI emits none.
+
+    Installing the pipeline on the CLI surface would claim the process-wide
+    ``TracerProvider`` and run a batch exporter thread for a stream that is
+    always empty, which also matters for an application that embeds this
+    package and wants to install a provider of its own.
+    """
+    with patch("fabric_dw.telemetry_spans.install_mcp_span_pipeline") as install:
+        mod, _at_call, _after = _run_get_tracer(monkeypatch, tmp_path, request, surface=surface)
+        try:
+            assert install.called is expected
+        finally:
+            mod._sdk_initialised = False
+            mod._tracer = None
+            mod._otel_logger = None
+
+
+def test_opting_out_also_means_no_span_pipeline(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Nothing is exported when telemetry is off, spans included.
+
+    The span pipeline is installed from ``_get_tracer``, which only runs behind
+    the ``telemetry_enabled()`` gate in ``emit_event``.  With no provider
+    installed the MCP SDK's spans go to OpenTelemetry's no-op provider and stop
+    there.
+    """
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setenv("FABRIC_DW_TELEMETRY_OPT_OUT", "1")
+
+    mod = _reload_telemetry()
+
+    with patch("fabric_dw.telemetry_spans.install_mcp_span_pipeline") as install:
+        mod.record_app_started("mcp")
+        mod.record_mcp_server_started()
+
+    install.assert_not_called()
 
 
 def test_get_tracer_disables_the_metrics_pipeline_effectively(
@@ -1298,15 +1374,19 @@ def test_preexisting_exporter_env_cannot_reopen_the_export_path(
     request: pytest.FixtureRequest,
     preset: str,
 ) -> None:
-    """A value already in the environment must not re-enable the export path.
+    """A value already in the environment must not open an unfiltered export path.
 
     This is the reason these variables are hard-set rather than defaulted. The
     library treats anything other than the exact string ``none`` as "exporter
     enabled", and what it then installs is the AzureMonitorTraceExporter pointed
-    at the maintainer's ingestion endpoint, NOT whatever the operator named. With
-    ``setdefault`` this test fails for every parameter below, and a user with
-    ``OTEL_TRACES_EXPORTER`` set for their own stack silently ships MCP protocol
-    spans to a third party.
+    at the maintainer's ingestion endpoint, NOT whatever the operator named.
+
+    That the project now exports MCP spans deliberately does not soften this.
+    The library's exporter takes spans exactly as produced, so under
+    ``setdefault`` a user who has ``OTEL_TRACES_EXPORTER`` set for their own
+    stack would ship raw, unsanitised spans to a third party, alongside the
+    sanitised ones. This test fails for every parameter below if the hard set
+    is ever relaxed.
 
     The empty string is included deliberately: it is falsy but not ``none``, and
     it is what an unset-looking ``export OTEL_TRACES_EXPORTER=`` produces.
@@ -1320,8 +1400,8 @@ def test_preexisting_exporter_env_cannot_reopen_the_export_path(
     try:
         assert _resolves_disabled("tracing", at_call), (
             f"OTEL_TRACES_EXPORTER={preset!r} in the caller's environment left the "
-            "trace pipeline ENABLED, so the Azure exporter would ship MCP protocol "
-            "spans to Application Insights."
+            "library's trace pipeline ENABLED, so its unfiltered exporter would ship "
+            "raw MCP protocol spans to Application Insights."
         )
         assert _resolves_disabled("metrics", at_call), (
             f"OTEL_METRICS_EXPORTER={preset!r} left the metrics pipeline ENABLED."

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -6,6 +6,7 @@ no real network calls (every Azure Monitor SDK interaction is mocked).
 
 from __future__ import annotations
 
+import asyncio
 import importlib
 import logging
 import os
@@ -2646,6 +2647,8 @@ def test_shutdown_telemetry_calls_provider_shutdown(
     mod._tracer = _fake_logger  # type: ignore[attr-defined]
     mod._otel_logger = _fake_logger  # type: ignore[attr-defined]
     mod._sdk_shutdown = False  # type: ignore[attr-defined]
+    # The tracer branch only runs for a provider this package installed.
+    mod._span_pipeline_installed = True  # type: ignore[attr-defined]
 
     shutdown_called: list[bool] = []
     fake_provider = types.SimpleNamespace(shutdown=lambda: shutdown_called.append(True))
@@ -2703,6 +2706,7 @@ def test_shutdown_telemetry_is_idempotent(monkeypatch: pytest.MonkeyPatch, tmp_p
     mod._tracer = _fake_logger  # type: ignore[attr-defined]
     mod._otel_logger = _fake_logger  # type: ignore[attr-defined]
     mod._sdk_shutdown = False  # type: ignore[attr-defined]
+    mod._span_pipeline_installed = True  # type: ignore[attr-defined]
 
     shutdown_call_count: list[int] = []
     fake_provider = types.SimpleNamespace(shutdown=lambda: shutdown_call_count.append(1))
@@ -4173,3 +4177,162 @@ def test_nothing_is_recorded_when_telemetry_is_opted_out(
         pass
 
     get_tracer.assert_not_called()
+
+
+def test_shutdown_never_touches_a_provider_this_package_did_not_install(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A host application's TracerProvider must survive our exit.
+
+    When ``install_mcp_span_pipeline`` correctly stands down because the host
+    already installed a provider, that provider is the host's. Shutting it down
+    here would close the host's own exporter permanently, which is the exact
+    opposite of the guarantee this package makes about embedding.
+    """
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    mod = _reload_telemetry()
+
+    fake_logger = object()
+    mod._sdk_initialised = True
+    mod._tracer = fake_logger
+    mod._otel_logger = fake_logger
+    mod._sdk_shutdown = False
+    mod._span_pipeline_installed = False  # the host's provider won
+
+    touched: list[str] = []
+    host_provider = types.SimpleNamespace(
+        shutdown=lambda: touched.append("shutdown"),
+        force_flush=lambda **_kw: touched.append("force_flush"),
+    )
+    _install_fake_otel_trace(monkeypatch, host_provider)
+
+    mod.shutdown_telemetry()
+    mod.flush_telemetry()
+
+    assert touched == [], f"the host's provider was {touched}"
+
+
+def test_flush_reaches_our_own_provider(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The other half of the same rule: our provider does get flushed."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    mod = _reload_telemetry()
+
+    fake_logger = object()
+    mod._sdk_initialised = True
+    mod._tracer = fake_logger
+    mod._otel_logger = fake_logger
+    mod._span_pipeline_installed = True
+
+    flushed: list[int] = []
+    provider = types.SimpleNamespace(force_flush=lambda **kw: flushed.append(kw["timeout_millis"]))
+    _install_fake_otel_trace(monkeypatch, provider)
+
+    mod.flush_telemetry(timeout_ms=1500)
+
+    assert flushed == [1500]
+
+
+# ---------------------------------------------------------------------------
+# The client name is a channel unless it is bounded (#1048 review)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("a\nb\r\nc\x00d", "abcd"),
+        ("\x00\x01\x02", "unknown"),
+        ("claude-ai", "claude-ai"),
+        ("  claude-ai  ", "claude-ai"),
+        ("clau\tde", "claude"),
+    ],
+)
+def test_control_characters_are_removed_from_a_client_name(raw: str, expected: str) -> None:
+    """``strip()`` only touches the ends, so embedded control bytes went straight through.
+
+    A newline or a NUL in the middle of a custom dimension is not something a
+    dashboard, a log query, or whoever reads it downstream should have to deal
+    with, and it is trivially client-controlled.
+    """
+    assert _live_telemetry().normalise_mcp_client(raw) == expected
+
+
+def test_the_number_of_distinct_client_names_is_bounded(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """One process records a handful of clients, then stops keeping names.
+
+    On protocol revision 2026-07-28 the name rides every request's ``_meta``
+    rather than a handshake, so it can differ per message on a single
+    connection. Without a cap, a client appending a counter or a session id to
+    its name (an ordinary bug, and a trivial exfiltration channel) emits one
+    ``mcp_client_connected`` per request and grows the seen-set forever.
+    """
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    tel = _live_telemetry()
+    tel._seen_mcp_clients.clear()
+
+    with patch.object(tel, "emit_event") as emit:
+        recorded = []
+        for index in range(50):
+            with tel.mcp_client_scope(f"EXFIL-CHUNK-{index:04d}"):
+                recorded.append(tel.current_mcp_client())
+
+    assert recorded[: tel._MCP_CLIENT_LIMIT] == [
+        f"EXFIL-CHUNK-{index:04d}" for index in range(tel._MCP_CLIENT_LIMIT)
+    ]
+    assert set(recorded[tel._MCP_CLIENT_LIMIT :]) == {tel.MCP_CLIENT_OTHER}
+
+    # One event per distinct recorded name, and the set cannot grow past the
+    # cap plus the "other" bucket itself.
+    assert emit.call_count == tel._MCP_CLIENT_LIMIT + 1
+    assert len(tel._seen_mcp_clients) == tel._MCP_CLIENT_LIMIT + 1
+
+
+def test_a_client_already_seen_is_still_reported_by_name_after_the_cap(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The cap must not start relabelling the clients it already knows."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    tel = _live_telemetry()
+    tel._seen_mcp_clients.clear()
+
+    with patch.object(tel, "emit_event"):
+        with tel.mcp_client_scope("claude-ai"):
+            pass
+        for index in range(20):
+            with tel.mcp_client_scope(f"noise-{index}"):
+                pass
+        with tel.mcp_client_scope("claude-ai") as _:
+            still_named = tel.current_mcp_client()
+
+    assert still_named == "claude-ai"
+
+
+async def test_concurrent_requests_do_not_cross_contaminate_the_client(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Several clients are served at once over HTTP, so this is not theoretical.
+
+    A module global here would report whichever client connected last. The
+    ContextVar is the reason that does not happen, and this pins it: each task
+    interleaves awaits inside its own scope and must still see its own name.
+    """
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    tel = _live_telemetry()
+    tel._seen_mcp_clients.clear()
+
+    async def _serve(name: str) -> list[str | None]:
+        seen: list[str | None] = []
+        with tel.mcp_client_scope(name):
+            for _ in range(20):
+                await asyncio.sleep(0)
+                seen.append(tel.current_mcp_client())
+        return seen
+
+    with patch.object(tel, "emit_event"):
+        results = await asyncio.gather(*(_serve(f"client-{index}") for index in range(6)))
+
+    for index, seen in enumerate(results):
+        assert set(seen) == {f"client-{index}"}
+    assert tel.current_mcp_client() is None

--- a/tests/unit/test_telemetry_commands.py
+++ b/tests/unit/test_telemetry_commands.py
@@ -6,6 +6,8 @@ Monitor SDK calls (every telemetry emission is mocked via monkeypatch).
 
 from __future__ import annotations
 
+import importlib
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import click
@@ -27,6 +29,16 @@ from tests.unit._tool_introspection import collect_live_mcp_tool_names
 # Telemetry patch targets (lazily imported inside emit_command_invoked).
 _TELEMETRY_ENABLED = "fabric_dw.telemetry.telemetry_enabled"
 _EMIT_EVENT = "fabric_dw.telemetry.emit_event"
+
+
+def _live_telemetry() -> Any:
+    """Return the telemetry module currently in ``sys.modules``.
+
+    ``emit_command_invoked`` imports it per call, and tests/unit/test_telemetry.py
+    replaces that entry with a freshly imported module, so anything bound at
+    collection time here would be a different object with different globals.
+    """
+    return importlib.import_module("fabric_dw.telemetry")
 
 
 # ---------------------------------------------------------------------------
@@ -388,6 +400,36 @@ class TestEmitCommandInvokedEnabled:
         )
         attrs: dict = mock.call_args[0][1]
         assert "destructive_op" not in attrs
+
+    def test_mcp_client_absent_outside_an_mcp_request(self) -> None:
+        """A CLI invocation has no connecting client, so the dimension must be absent.
+
+        An "unknown" placeholder would be worse than nothing here: it would look
+        like an MCP client that failed to identify itself.
+        """
+        mock = self._run(
+            name="warehouses.list",
+            status="success",
+            duration_ms=50.0,
+        )
+        attrs: dict = mock.call_args[0][1]
+        assert "mcp_client" not in attrs
+
+    def test_mcp_client_carried_from_the_request_scope(self) -> None:
+        """Inside an MCP request the tool call carries the client that sent it (#1048).
+
+        This is what makes usage breakable down per client: the connection event
+        alone cannot be joined to tool calls on a server serving several clients.
+        """
+        with (
+            patch(_TELEMETRY_ENABLED, return_value=True),
+            patch(_EMIT_EVENT) as mock_emit,
+            _live_telemetry().mcp_client_scope("claude-ai"),
+        ):
+            emit_command_invoked(name="list_warehouses", status="success", duration_ms=50.0)
+
+        attrs: dict = mock_emit.call_args[0][1]
+        assert attrs["mcp_client"] == "claude-ai"
 
     def test_no_identifiers_in_attributes(self) -> None:
         """The emitted attributes must not contain any identifier-like strings."""

--- a/tests/unit/test_telemetry_spans.py
+++ b/tests/unit/test_telemetry_spans.py
@@ -16,6 +16,7 @@ execution order.
 
 from __future__ import annotations
 
+import sys
 from types import SimpleNamespace
 from typing import Any
 
@@ -26,6 +27,7 @@ from mcp_types import JSONRPCRequest
 from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor, SpanExportResult
 from opentelemetry.sdk.trace.sampling import ALWAYS_ON
+from opentelemetry.sdk.util.instrumentation import InstrumentationScope
 from opentelemetry.trace import SpanKind, StatusCode
 
 from fabric_dw import telemetry_spans
@@ -477,3 +479,78 @@ def test_installing_the_pipeline_wires_the_sanitiser_in_front_of_azure(
     assert MARKER not in _blob(captured.spans)
 
     provider.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Failure modes
+# ---------------------------------------------------------------------------
+
+
+def test_an_unreadable_method_map_degrades_to_unknown_rather_than_passing_it_through(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the SDK's method maps cannot be read, no method name is exported.
+
+    The allowlist is what makes ``mcp.method.name`` safe, so losing it has to
+    fail towards recording nothing rather than towards recording whatever the
+    client sent.
+    """
+    monkeypatch.setitem(sys.modules, "mcp_types.methods", None)
+    telemetry_spans._known_methods.cache_clear()
+    try:
+        span = _make_span(MCP_SDK_SCOPE, "ping", {"mcp.method.name": "ping"})
+        sanitised = sanitise_span(span)
+
+        assert sanitised is not None
+        assert sanitised.name == UNKNOWN_METHOD
+    finally:
+        telemetry_spans._known_methods.cache_clear()
+
+
+def test_an_unreadable_version_list_drops_the_protocol_version(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Same failure direction for the protocol revision."""
+    monkeypatch.setitem(sys.modules, "mcp_types.version", None)
+    telemetry_spans._known_protocol_versions.cache_clear()
+    try:
+        span = _make_span(
+            MCP_SDK_SCOPE,
+            "ping",
+            {"mcp.method.name": "ping", "mcp.protocol.version": HANDSHAKE_VERSION},
+        )
+        sanitised = sanitise_span(span)
+
+        assert sanitised is not None
+        assert "mcp.protocol.version" not in (sanitised.attributes or {})
+    finally:
+        telemetry_spans._known_protocol_versions.cache_clear()
+
+
+def test_a_span_without_attributes_is_reduced_rather_than_rejected() -> None:
+    """A span carrying no attributes at all must not break the exporter.
+
+    ``ReadableSpan.attributes`` is a ``BoundedAttributes`` mapping when the SDK
+    fills it and ``None`` when it does not, and an early draft of this code
+    tested for ``dict``, which is neither.
+    """
+    span = ReadableSpan(
+        name="something",
+        instrumentation_scope=InstrumentationScope(MCP_SDK_SCOPE),
+        attributes=None,
+    )
+    sanitised = sanitise_span(span)
+
+    assert sanitised is not None
+    assert dict(sanitised.attributes or {}) == {"mcp.method.name": UNKNOWN_METHOD}
+
+
+def test_installing_the_pipeline_never_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Telemetry setup failing must not take the MCP server down with it."""
+
+    def _explode(_provider: Any) -> None:
+        raise RuntimeError("boom")
+
+    _patch_global_provider_hooks(monkeypatch, setter=_explode, getter=lambda: None)
+
+    assert install_mcp_span_pipeline(_CONNECTION_STRING, None) is False

--- a/tests/unit/test_telemetry_spans.py
+++ b/tests/unit/test_telemetry_spans.py
@@ -1,0 +1,479 @@
+"""Tests for fabric_dw.telemetry_spans — the sanitised MCP span export path.
+
+The headline test drives a real MCP server over in-memory streams with
+hand-written JSON-RPC, so the spans under test are produced by the SDK's own
+``OpenTelemetryMiddleware`` rather than by a fixture's idea of what that
+middleware writes.  That fidelity is the point: the first draft of the
+sanitiser passed a hand-rolled test and dropped every real span on the floor,
+because a span's attributes are a ``BoundedAttributes`` mapping and not a
+``dict``.
+
+None of these tests touch the global ``TracerProvider``.  The MCP SDK holds its
+tracer in ``mcp.shared._otel._tracer``, so pointing that at a test-local
+provider keeps the process global untouched and the tests independent of
+execution order.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import mcp.shared._otel
+import pytest
+from mcp.server.mcpserver import MCPServer
+from mcp_types import JSONRPCRequest
+from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor, SpanExportResult
+from opentelemetry.sdk.trace.sampling import ALWAYS_ON
+from opentelemetry.trace import SpanKind, StatusCode
+
+from fabric_dw import telemetry_spans
+from fabric_dw.telemetry_spans import (
+    MCP_SDK_SCOPE,
+    UNKNOWN_METHOD,
+    SanitisingSpanExporter,
+    install_mcp_span_pipeline,
+    sanitise_span,
+)
+from tests.unit._mcp_session import HANDSHAKE_VERSION, exchange, handshake
+
+# A value no protocol field may ever carry into Application Insights.  Every
+# assertion below searches for this string rather than for a specific field, so
+# a future SDK release that moves the client's input somewhere new still fails
+# the test.
+MARKER = "GEHEIM-wachtwoord-hunter2-klant-ACME"
+
+_CONNECTION_STRING = (
+    "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://127.0.0.1:1/"
+)
+
+
+class _CapturingExporter:
+    """Stands in for the Azure exporter and records what it was handed."""
+
+    def __init__(self) -> None:
+        self.spans: list[ReadableSpan] = []
+        self.shutdown_calls = 0
+        self.flush_calls = 0
+
+    def export(self, spans: Any, **_kwargs: Any) -> SpanExportResult:
+        self.spans.extend(spans)
+        return SpanExportResult.SUCCESS
+
+    def shutdown(self) -> None:
+        self.shutdown_calls += 1
+
+    def force_flush(self, timeout_millis: int = 30_000) -> bool:  # noqa: ARG002
+        self.flush_calls += 1
+        return True
+
+
+def _install_test_tracer(monkeypatch: pytest.MonkeyPatch) -> _CapturingExporter:
+    """Point the MCP SDK's tracer at a provider that exports through the sanitiser."""
+    captured = _CapturingExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(SanitisingSpanExporter(captured)))  # ty: ignore[invalid-argument-type]
+    monkeypatch.setattr(mcp.shared._otel, "_tracer", provider.get_tracer(MCP_SDK_SCOPE))
+    return captured
+
+
+def _blob(spans: list[ReadableSpan]) -> str:
+    """Render every field of every span into one string, for marker searching."""
+    return "\n".join(
+        f"{s.name} {s.status.status_code} {s.status.description} "
+        f"{dict(s.attributes or {})} {[(e.name, dict(e.attributes or {})) for e in s.events]} "
+        f"{list(s.links)}"
+        for s in spans
+    )
+
+
+async def _exchange(messages: list[Any]) -> list[dict[str, Any]]:
+    """Run a bare MCP server, with one tool and no middleware, against *messages*."""
+    server: MCPServer[Any] = MCPServer("span-test-server", version="0.0.0")
+
+    @server.tool(name="echo")
+    async def _echo(value: str) -> str:
+        """Echo the value back."""
+        return value
+
+    return await exchange(server, messages)
+
+
+def _handshake() -> list[Any]:
+    return handshake("span-test-client")
+
+
+# ---------------------------------------------------------------------------
+# The whole point: nothing the client chose reaches the exporter
+# ---------------------------------------------------------------------------
+
+
+async def test_client_supplied_values_never_reach_the_exporter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A marker sent through every client-controlled field must not be exported.
+
+    Measured against a server that registers no prompts, ``prompts/get`` puts
+    the client's string in four places at once: the span name, the status
+    description, ``gen_ai.prompt.name``, and an ``exception`` event carrying
+    both the message and the stacktrace.  ``tools/call`` echoes an unregistered
+    tool name into the span name and ``gen_ai.tool.name``.  An unknown method
+    lands in ``mcp.method.name`` verbatim, because the middleware wraps the
+    METHOD_NOT_FOUND path.  A string JSON-RPC id is client-chosen too.
+
+    Each of those is a request that the server *rejects*, which is exactly why
+    registering no prompts and no unknown tools is not protection: the error
+    text is what carries the value.
+    """
+    captured = _install_test_tracer(monkeypatch)
+
+    responses = await _exchange(
+        [
+            *_handshake(),
+            JSONRPCRequest(jsonrpc="2.0", id=2, method="prompts/get", params={"name": MARKER}),
+            JSONRPCRequest(
+                jsonrpc="2.0",
+                id=3,
+                method="tools/call",
+                params={"name": MARKER, "arguments": {}},
+            ),
+            JSONRPCRequest(jsonrpc="2.0", id=4, method=f"{MARKER}/probe", params={}),
+            JSONRPCRequest(jsonrpc="2.0", id=MARKER, method="tools/list", params={}),
+        ]
+    )
+
+    # The server really did see the marker: without this the test could pass by
+    # never having sent anything.
+    assert MARKER in str(responses), "the marker never reached the server"
+    assert captured.spans, "no spans were exported at all"
+
+    assert MARKER not in _blob(captured.spans)
+
+
+async def test_the_useful_fields_survive_sanitising(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Sanitising must not reduce the spans to something worthless.
+
+    The method name, the negotiated protocol revision, an integer request id,
+    the operation marker and the error classification are all SDK-generated and
+    all survive; timings and span kind come along untouched.
+    """
+    captured = _install_test_tracer(monkeypatch)
+
+    await _exchange(
+        [
+            *_handshake(),
+            JSONRPCRequest(
+                jsonrpc="2.0",
+                id=7,
+                method="tools/call",
+                params={"name": "echo", "arguments": {"value": "hello"}},
+            ),
+        ]
+    )
+
+    by_name = {span.name: span for span in captured.spans}
+    assert set(by_name) >= {"initialize", "notifications/initialized", "tools/call"}
+
+    call = by_name["tools/call"]
+    assert dict(call.attributes or {}) == {
+        "mcp.method.name": "tools/call",
+        "mcp.protocol.version": HANDSHAKE_VERSION,
+        "jsonrpc.request.id": "7",
+        "gen_ai.operation.name": "execute_tool",
+    }
+    assert call.kind is SpanKind.SERVER
+    assert call.start_time is not None
+    assert call.end_time is not None
+    assert call.end_time > call.start_time
+
+
+async def test_a_failing_tool_call_keeps_its_error_classification(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``error.type`` and the ERROR status code are the point of collecting these."""
+    captured = _install_test_tracer(monkeypatch)
+
+    await _exchange(
+        [
+            *_handshake(),
+            JSONRPCRequest(
+                jsonrpc="2.0", id=8, method="tools/call", params={"name": MARKER, "arguments": {}}
+            ),
+        ]
+    )
+
+    call = next(s for s in captured.spans if s.name == "tools/call")
+    assert call.status.status_code is StatusCode.ERROR
+    assert call.status.description is None, "the status description is dropped, not rewritten"
+    assert (call.attributes or {}).get("error.type") == "tool_error"
+
+
+async def test_an_unknown_method_is_reported_without_its_text(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A method the protocol does not define is counted, but not quoted.
+
+    Somebody probing this server with made-up methods is worth seeing in the
+    telemetry; the strings they probed with are not.
+    """
+    captured = _install_test_tracer(monkeypatch)
+
+    await _exchange(
+        [*_handshake(), JSONRPCRequest(jsonrpc="2.0", id=9, method=f"{MARKER}/probe", params={})]
+    )
+
+    span = next(s for s in captured.spans if s.name == UNKNOWN_METHOD)
+    assert (span.attributes or {})["mcp.method.name"] == UNKNOWN_METHOD
+    assert span.status.status_code is StatusCode.ERROR
+    assert (span.attributes or {}).get("rpc.response.status_code") == "-32601"
+
+
+async def test_a_string_request_id_is_dropped_and_an_integer_one_is_kept(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """JSON-RPC lets the client pick the id, so only an integer id is recorded."""
+    captured = _install_test_tracer(monkeypatch)
+
+    await _exchange(
+        [
+            *_handshake(),
+            JSONRPCRequest(jsonrpc="2.0", id=MARKER, method="tools/list", params={}),
+            JSONRPCRequest(jsonrpc="2.0", id=11, method="ping", params={}),
+        ]
+    )
+
+    listing = next(s for s in captured.spans if s.name == "tools/list")
+    assert "jsonrpc.request.id" not in (listing.attributes or {})
+
+    ping = next(s for s in captured.spans if s.name == "ping")
+    assert (ping.attributes or {})["jsonrpc.request.id"] == "11"
+
+
+# ---------------------------------------------------------------------------
+# sanitise_span on spans from other producers
+# ---------------------------------------------------------------------------
+
+
+def _make_span(
+    scope: str,
+    name: str,
+    attributes: dict[str, Any] | None = None,
+) -> ReadableSpan:
+    """Produce one real ended span from *scope* and return it, unsanitised."""
+    exporter = _CapturingExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))  # ty: ignore[invalid-argument-type]
+    tracer = provider.get_tracer(scope)
+    with tracer.start_as_current_span(name, attributes=attributes):
+        pass
+    return exporter.spans[0]
+
+
+def test_a_span_from_another_library_is_dropped_entirely() -> None:
+    """Only the MCP SDK's spans are collected; everything else is refused.
+
+    ``configure_azure_monitor`` installs a process-wide provider, so without
+    this rule any library that starts emitting spans, or an auto-instrumentor
+    someone re-enables, would be exporting to this project's Application
+    Insights.  An HTTP client span in particular carries request URLs, and this
+    project's URLs carry workspace and warehouse identifiers.
+    """
+    span = _make_span(
+        "opentelemetry.instrumentation.requests",
+        "GET",
+        {"url.full": f"https://api.fabric.microsoft.com/v1/workspaces/{MARKER}"},
+    )
+    assert sanitise_span(span) is None
+
+
+def test_an_unrecognised_mcp_span_is_reduced_rather_than_quoted() -> None:
+    """A shape this code does not know is exported with everything stripped.
+
+    Keeping the span records that something happened; the allowlist means an
+    attribute a future SDK adds is not exported until somebody vets it.
+    """
+    span = _make_span(MCP_SDK_SCOPE, "something/new", {"some.new.attribute": MARKER})
+    sanitised = sanitise_span(span)
+
+    assert sanitised is not None
+    assert sanitised.name == UNKNOWN_METHOD
+    assert dict(sanitised.attributes or {}) == {"mcp.method.name": UNKNOWN_METHOD}
+
+
+def test_an_unknown_protocol_version_is_dropped() -> None:
+    """The version is only kept when the SDK recognises it as a revision."""
+    span = _make_span(
+        MCP_SDK_SCOPE,
+        "ping",
+        {"mcp.method.name": "ping", "mcp.protocol.version": MARKER},
+    )
+    sanitised = sanitise_span(span)
+
+    assert sanitised is not None
+    assert "mcp.protocol.version" not in (sanitised.attributes or {})
+
+
+@pytest.mark.parametrize("request_id", ["1_0", " 12 ", "\u0661\u0662", "12a", ""])
+def test_only_a_plain_decimal_request_id_is_kept(request_id: str) -> None:
+    """Anything ``int()`` would accept is not automatically safe to export.
+
+    ``int()`` also swallows surrounding whitespace, digit separators and
+    non-ASCII numerals, so the check is a digit test instead.
+    """
+    span = _make_span(
+        MCP_SDK_SCOPE,
+        "ping",
+        {"mcp.method.name": "ping", "jsonrpc.request.id": request_id},
+    )
+    sanitised = sanitise_span(span)
+
+    assert sanitised is not None
+    assert "jsonrpc.request.id" not in (sanitised.attributes or {})
+
+
+def test_the_span_identity_is_preserved() -> None:
+    """Trace and span ids survive, so exported spans still correlate."""
+    span = _make_span(MCP_SDK_SCOPE, "ping", {"mcp.method.name": "ping"})
+    sanitised = sanitise_span(span)
+
+    assert sanitised is not None
+    original = span.get_span_context()
+    kept = sanitised.get_span_context()
+    assert original is not None
+    assert kept is not None
+    assert kept.trace_id == original.trace_id
+    assert kept.span_id == original.span_id
+    assert sanitised.resource is span.resource
+
+
+# ---------------------------------------------------------------------------
+# The exporter wrapper
+# ---------------------------------------------------------------------------
+
+
+def test_the_wrapper_does_not_call_the_inner_exporter_when_all_spans_are_dropped() -> None:
+    """An export cycle carrying only foreign spans must be a no-op, not an empty send."""
+    inner = _CapturingExporter()
+    wrapper = SanitisingSpanExporter(inner)  # ty: ignore[invalid-argument-type]
+
+    result = wrapper.export([_make_span("some.other.library", "work")])
+
+    assert result is SpanExportResult.SUCCESS
+    assert inner.spans == []
+
+
+def test_a_span_the_sanitiser_cannot_process_is_dropped_not_forwarded() -> None:
+    """Failing open would export exactly what the sanitiser exists to remove."""
+    inner = _CapturingExporter()
+    wrapper = SanitisingSpanExporter(inner)  # ty: ignore[invalid-argument-type]
+
+    class _Exploding:
+        @property
+        def instrumentation_scope(self) -> Any:
+            raise RuntimeError("boom")
+
+    assert wrapper.export([_Exploding()]) is SpanExportResult.SUCCESS  # ty: ignore[invalid-argument-type]
+    assert inner.spans == []
+
+
+def test_the_wrapper_forwards_shutdown_and_flush() -> None:
+    """The provider's teardown has to reach the real exporter through the wrapper."""
+    inner = _CapturingExporter()
+    wrapper = SanitisingSpanExporter(inner)  # ty: ignore[invalid-argument-type]
+
+    wrapper.shutdown()
+    assert wrapper.force_flush(1000) is True
+
+    assert inner.shutdown_calls == 1
+    assert inner.flush_calls == 1
+
+
+# ---------------------------------------------------------------------------
+# Installing the pipeline
+# ---------------------------------------------------------------------------
+
+
+def _patch_global_provider_hooks(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    setter: Any,
+    getter: Any,
+) -> None:
+    """Replace the module's handle on OpenTelemetry's global-provider functions.
+
+    The real ones must not run: ``set_tracer_provider`` claims a process-wide
+    global exactly once, so a test that reached it would both leak into the rest
+    of the session and be unrepeatable.
+
+    Patched through ``telemetry_spans._trace`` rather than on
+    ``opentelemetry.trace`` itself, because other modules in this suite install
+    fake ``opentelemetry.trace`` modules, which can leave the package attribute
+    and the ``sys.modules`` entry as two different objects for the rest of the
+    session.  Patching the wrong one of those two patches nothing at all and
+    lets the real function run.
+    """
+    monkeypatch.setattr(
+        telemetry_spans,
+        "_trace",
+        SimpleNamespace(set_tracer_provider=setter, get_tracer_provider=getter),
+    )
+
+
+def test_a_host_installed_tracer_provider_keeps_winning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An application that already set a provider must keep it, and its exporter.
+
+    OpenTelemetry refuses to override an existing global provider, so the
+    ``set_tracer_provider`` call below is silently ignored, exactly as it would
+    be in a host process.  The pipeline has to notice and stand down instead of
+    building an exporter nothing will ever feed.
+    """
+    host_provider = TracerProvider()
+    _patch_global_provider_hooks(
+        monkeypatch, setter=lambda _provider: None, getter=lambda: host_provider
+    )
+
+    built: list[object] = []
+    monkeypatch.setattr(
+        telemetry_spans, "_AzureMonitorTraceExporter", lambda **kw: built.append(kw)
+    )
+
+    assert install_mcp_span_pipeline(_CONNECTION_STRING, None) is False
+    assert built == [], "no exporter may be built when the host provider won"
+
+
+def test_installing_the_pipeline_wires_the_sanitiser_in_front_of_azure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The happy path: our provider wins, and the Azure exporter sits behind the sanitiser."""
+    installed: dict[str, Any] = {}
+    _patch_global_provider_hooks(
+        monkeypatch,
+        setter=lambda provider: installed.setdefault("p", provider),
+        getter=lambda: installed.get("p"),
+    )
+
+    captured = _CapturingExporter()
+    monkeypatch.setattr(telemetry_spans, "_AzureMonitorTraceExporter", lambda **_kw: captured)
+
+    assert install_mcp_span_pipeline(_CONNECTION_STRING, None) is True
+
+    provider = installed["p"]
+    # ALWAYS_ON, not the default ParentBased sampler: an MCP client propagates
+    # trace context into `_meta`, so ParentBased would hand the collection
+    # decision to the client's sampler.
+    assert provider.sampler is ALWAYS_ON
+
+    tracer = provider.get_tracer(MCP_SDK_SCOPE)
+    with tracer.start_as_current_span(
+        "prompts/get " + MARKER, attributes={"gen_ai.prompt.name": MARKER}
+    ):
+        pass
+    provider.force_flush(5000)
+
+    assert captured.spans, "the Azure exporter was never reached"
+    assert MARKER not in _blob(captured.spans)
+
+    provider.shutdown()

--- a/tests/unit/test_telemetry_spans.py
+++ b/tests/unit/test_telemetry_spans.py
@@ -53,6 +53,16 @@ from tests.unit._mcp_session import HANDSHAKE_VERSION, exchange, handshake
 # the test.
 MARKER = "GEHEIM-wachtwoord-hunter2-klant-ACME"
 
+# The same marker in the two places a client puts bytes of its own choosing into
+# a span's *identity* rather than its payload: the trace id and the parent span
+# id of the `traceparent` it sends, which Azure exports as `ai.operation.id` and
+# `ai.operation.parentId`. A traceparent is fixed-width hex, so the marker is
+# carried 16 and 8 bytes at a time.
+MARKER_TRACE_BYTES = MARKER.encode()[:16]
+MARKER_PARENT_BYTES = MARKER.encode()[16:24]
+MARKER_TRACEPARENT = f"00-{MARKER_TRACE_BYTES.hex()}-{MARKER_PARENT_BYTES.hex()}-01"
+MARKER_TRACESTATE = f"leak={MARKER_TRACE_BYTES.decode()}"
+
 _CONNECTION_STRING = (
     "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://127.0.0.1:1/"
 )
@@ -160,13 +170,29 @@ async def test_client_supplied_values_never_reach_the_exporter(
     Each of those is a request that the server *rejects*, which is exactly why
     registering no prompts and no unknown tools is not protection: the error
     text is what carries the value.
+
+    The `traceparent` and `tracestate` carry the same marker through the span's
+    identity rather than its payload. They are here rather than only in the
+    dedicated tests below because this is the test that advertises itself as the
+    guarantee: reverting the identity rebuild has to fail *this* one.
     """
     captured = _install_test_tracer(monkeypatch)
 
     responses = await _exchange(
         [
             *_handshake(),
-            JSONRPCRequest(jsonrpc="2.0", id=2, method="prompts/get", params={"name": MARKER}),
+            JSONRPCRequest(
+                jsonrpc="2.0",
+                id=2,
+                method="prompts/get",
+                params={
+                    "name": MARKER,
+                    "_meta": {
+                        "traceparent": MARKER_TRACEPARENT,
+                        "tracestate": MARKER_TRACESTATE,
+                    },
+                },
+            ),
             JSONRPCRequest(
                 jsonrpc="2.0",
                 id=3,
@@ -183,7 +209,15 @@ async def test_client_supplied_values_never_reach_the_exporter(
     assert MARKER in str(responses), "the marker never reached the server"
     assert captured.spans, "no spans were exported at all"
 
-    assert MARKER not in _blob(captured.spans)
+    blob = _blob(captured.spans)
+    assert MARKER not in blob
+    # As sent, as hex, and as the bytes the hex decodes back to.
+    assert MARKER_TRACEPARENT not in blob
+    assert MARKER_TRACESTATE not in blob
+    assert MARKER_TRACE_BYTES.hex() not in blob
+    assert MARKER_PARENT_BYTES.hex() not in blob
+    assert MARKER_TRACE_BYTES.decode() not in blob
+    assert MARKER_PARENT_BYTES.decode() not in blob
 
 
 async def test_the_useful_fields_survive_sanitising(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_telemetry_spans.py
+++ b/tests/unit/test_telemetry_spans.py
@@ -16,19 +16,26 @@ execution order.
 
 from __future__ import annotations
 
+import contextlib
 import sys
 from types import SimpleNamespace
 from typing import Any
 
 import mcp.shared._otel
 import pytest
+from azure.monitor.opentelemetry.exporter import AzureMonitorTraceExporter
+from azure.monitor.opentelemetry.exporter.export._base import ExportResult
+from azure.monitor.opentelemetry.exporter.statsbeat.customer._state import (
+    get_customer_stats_manager,
+)
 from mcp.server.mcpserver import MCPServer
 from mcp_types import JSONRPCRequest
 from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor, SpanExportResult
 from opentelemetry.sdk.trace.sampling import ALWAYS_ON
 from opentelemetry.sdk.util.instrumentation import InstrumentationScope
-from opentelemetry.trace import SpanKind, StatusCode
+from opentelemetry.trace import SpanContext, SpanKind, StatusCode, TraceState
+from opentelemetry.trace.status import Status
 
 from fabric_dw import telemetry_spans
 from fabric_dw.telemetry_spans import (
@@ -81,13 +88,39 @@ def _install_test_tracer(monkeypatch: pytest.MonkeyPatch) -> _CapturingExporter:
 
 
 def _blob(spans: list[ReadableSpan]) -> str:
-    """Render every field of every span into one string, for marker searching."""
-    return "\n".join(
-        f"{s.name} {s.status.status_code} {s.status.description} "
-        f"{dict(s.attributes or {})} {[(e.name, dict(e.attributes or {})) for e in s.events]} "
-        f"{list(s.links)}"
-        for s in spans
-    )
+    """Render every field of every span into one string, for marker searching.
+
+    Identity is in here as well as payload, and that is not decoration: a
+    client picks the trace id and the parent span id through the `traceparent`
+    it sends, so a sweep over names and attributes alone would have called the
+    first version of this sanitiser clean while it was exporting 24 bytes of
+    the client's choosing per message.  Rendering the ids as hex is how a
+    marker smuggled in as bytes shows up as text.
+    """
+    parts = []
+    for span in spans:
+        context = span.get_span_context()
+        identity = ""
+        if context is not None:
+            identity = (
+                f"{context.trace_id:032x} {context.span_id:016x} "
+                f"{bytes.fromhex(f'{context.trace_id:032x}')!r} "
+                f"{bytes.fromhex(f'{context.span_id:016x}')!r} "
+                f"{dict(context.trace_state.items() if context.trace_state else {})}"
+            )
+        parent = ""
+        if span.parent is not None:
+            parent = (
+                f"{span.parent.trace_id:032x} {span.parent.span_id:016x} "
+                f"{bytes.fromhex(f'{span.parent.span_id:016x}')!r}"
+            )
+        parts.append(
+            f"{span.name} {span.status.status_code} {span.status.description} "
+            f"{dict(span.attributes or {})} "
+            f"{[(e.name, dict(e.attributes or {})) for e in span.events]} "
+            f"{list(span.links)} {identity} {parent}"
+        )
+    return "\n".join(parts)
 
 
 async def _exchange(messages: list[Any]) -> list[dict[str, Any]]:
@@ -334,8 +367,14 @@ def test_only_a_plain_decimal_request_id_is_kept(request_id: str) -> None:
     assert "jsonrpc.request.id" not in (sanitised.attributes or {})
 
 
-def test_the_span_identity_is_preserved() -> None:
-    """Trace and span ids survive, so exported spans still correlate."""
+def test_the_span_id_is_kept_and_the_trace_id_is_remapped() -> None:
+    """Only the locally minted half of the span's identity survives as-is.
+
+    The span id is minted by the SDK. The trace id is not: the middleware
+    parents every inbound span on the W3C context in the request's `_meta`, so
+    the client picks it, and Azure exports it as `ai.operation.id`. Remapping
+    keeps spans of one trace grouped without the client choosing the value.
+    """
     span = _make_span(MCP_SDK_SCOPE, "ping", {"mcp.method.name": "ping"})
     sanitised = sanitise_span(span)
 
@@ -344,9 +383,76 @@ def test_the_span_identity_is_preserved() -> None:
     kept = sanitised.get_span_context()
     assert original is not None
     assert kept is not None
-    assert kept.trace_id == original.trace_id
     assert kept.span_id == original.span_id
+    assert kept.trace_id != original.trace_id
     assert sanitised.resource is span.resource
+
+
+def test_the_trace_id_remap_is_stable_within_the_process() -> None:
+    """Two spans of one trace must still land in one operation.
+
+    Minting a fresh random id per span would be just as safe and would throw
+    away the grouping the field exists for, so the mapping has to be a function
+    of the incoming id, not of the call.
+    """
+    first = _make_span(MCP_SDK_SCOPE, "ping", {"mcp.method.name": "ping"})
+    context = first.get_span_context()
+    assert context is not None
+    second = ReadableSpan(
+        name="ping",
+        context=SpanContext(trace_id=context.trace_id, span_id=99, is_remote=False),
+        instrumentation_scope=InstrumentationScope(MCP_SDK_SCOPE),
+        attributes={"mcp.method.name": "ping"},
+    )
+
+    one = sanitise_span(first)
+    two = sanitise_span(second)
+
+    assert one is not None
+    assert two is not None
+    one_context = one.get_span_context()
+    two_context = two.get_span_context()
+    assert one_context is not None
+    assert two_context is not None
+    assert one_context.trace_id == two_context.trace_id
+
+
+def test_the_parent_link_and_tracestate_are_dropped() -> None:
+    """Both are lifted off the wire, and both reach Application Insights.
+
+    `ai.operation.parentId` is exported straight from the parent span id, and
+    `trace_state` only fails to arrive because the current exporter happens not
+    to serialise it. Neither is left to chance.
+    """
+    remote_parent = SpanContext(
+        trace_id=int("74656e616e742d7365637265742d3031", 16),
+        span_id=int("3862797465735858", 16),
+        is_remote=True,
+        trace_state=TraceState([("client", "secret-value")]),
+    )
+    span = ReadableSpan(
+        name="ping",
+        context=SpanContext(
+            trace_id=remote_parent.trace_id,
+            span_id=7,
+            is_remote=False,
+            trace_state=remote_parent.trace_state,
+        ),
+        parent=remote_parent,
+        instrumentation_scope=InstrumentationScope(MCP_SDK_SCOPE),
+        attributes={"mcp.method.name": "ping"},
+    )
+
+    sanitised = sanitise_span(span)
+
+    assert sanitised is not None
+    assert sanitised.parent is None
+    kept = sanitised.get_span_context()
+    assert kept is not None
+    assert not list(kept.trace_state.items())
+    # The trace id decoded to `tenant-secret-01` before the remap existed.
+    assert b"secret" not in bytes.fromhex(f"{kept.trace_id:032x}")
+    assert "secret-value" not in _blob([sanitised])
 
 
 # ---------------------------------------------------------------------------
@@ -437,13 +543,13 @@ def test_a_host_installed_tracer_provider_keeps_winning(
         monkeypatch, setter=lambda _provider: None, getter=lambda: host_provider
     )
 
-    built: list[object] = []
-    monkeypatch.setattr(
-        telemetry_spans, "_AzureMonitorTraceExporter", lambda **kw: built.append(kw)
-    )
+    captured = _CapturingExporter()
+    monkeypatch.setattr(telemetry_spans, "_AzureMonitorTraceExporter", lambda **_kw: captured)
 
     assert install_mcp_span_pipeline(_CONNECTION_STRING, None) is False
-    assert built == [], "no exporter may be built when the host provider won"
+    # The exporter is built before the global is claimed, so losing the race
+    # means there is a batch worker and an exporter to close again.
+    assert captured.shutdown_calls == 1, "the provider we built and lost must be shut down"
 
 
 def test_installing_the_pipeline_wires_the_sanitiser_in_front_of_azure(
@@ -496,7 +602,7 @@ def test_an_unreadable_method_map_degrades_to_unknown_rather_than_passing_it_thr
     client sent.
     """
     monkeypatch.setitem(sys.modules, "mcp_types.methods", None)
-    telemetry_spans._known_methods.cache_clear()
+    telemetry_spans._methods_cache = None
     try:
         span = _make_span(MCP_SDK_SCOPE, "ping", {"mcp.method.name": "ping"})
         sanitised = sanitise_span(span)
@@ -504,7 +610,7 @@ def test_an_unreadable_method_map_degrades_to_unknown_rather_than_passing_it_thr
         assert sanitised is not None
         assert sanitised.name == UNKNOWN_METHOD
     finally:
-        telemetry_spans._known_methods.cache_clear()
+        telemetry_spans._methods_cache = None
 
 
 def test_an_unreadable_version_list_drops_the_protocol_version(
@@ -512,7 +618,7 @@ def test_an_unreadable_version_list_drops_the_protocol_version(
 ) -> None:
     """Same failure direction for the protocol revision."""
     monkeypatch.setitem(sys.modules, "mcp_types.version", None)
-    telemetry_spans._known_protocol_versions.cache_clear()
+    telemetry_spans._versions_cache = None
     try:
         span = _make_span(
             MCP_SDK_SCOPE,
@@ -524,7 +630,7 @@ def test_an_unreadable_version_list_drops_the_protocol_version(
         assert sanitised is not None
         assert "mcp.protocol.version" not in (sanitised.attributes or {})
     finally:
-        telemetry_spans._known_protocol_versions.cache_clear()
+        telemetry_spans._versions_cache = None
 
 
 def test_a_span_without_attributes_is_reduced_rather_than_rejected() -> None:
@@ -536,6 +642,7 @@ def test_a_span_without_attributes_is_reduced_rather_than_rejected() -> None:
     """
     span = ReadableSpan(
         name="something",
+        context=SpanContext(trace_id=1, span_id=2, is_remote=False),
         instrumentation_scope=InstrumentationScope(MCP_SDK_SCOPE),
         attributes=None,
     )
@@ -554,3 +661,195 @@ def test_installing_the_pipeline_never_raises(monkeypatch: pytest.MonkeyPatch) -
     _patch_global_provider_hooks(monkeypatch, setter=_explode, getter=lambda: None)
 
     assert install_mcp_span_pipeline(_CONNECTION_STRING, None) is False
+
+
+# ---------------------------------------------------------------------------
+# Bounded values
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("request_id", "kept"),
+    [
+        ("7", True),
+        ("-7", True),
+        ("9" * 19, True),
+        ("9" * 20, False),
+        ("0" * 400, False),
+        ("1" * 4000, False),
+    ],
+)
+def test_a_request_id_is_capped_at_the_int64_range(request_id: str, kept: bool) -> None:  # noqa: FBT001
+    """Digits alone are still a channel, so length is bounded as well as shape.
+
+    The attributes handed to the exporter are a plain dict rather than
+    ``BoundedAttributes``, so no OpenTelemetry attribute limit applies either,
+    and the only remaining ceiling was Azure's 8192-character field cap. A
+    4000-digit id measured 4824 bytes on the wire. Every SDK client counts small
+    integers.
+    """
+    span = _make_span(
+        MCP_SDK_SCOPE,
+        "ping",
+        {"mcp.method.name": "ping", "jsonrpc.request.id": request_id},
+    )
+    sanitised = sanitise_span(span)
+
+    assert sanitised is not None
+    assert ("jsonrpc.request.id" in (sanitised.attributes or {})) is kept
+
+
+@pytest.mark.parametrize(
+    ("value", "kept"),
+    [
+        ("tool_error", True),
+        ("-32601", True),
+        ("ValueError", True),
+        ("mcp.shared.exceptions.MCPError", True),
+        ("Unknown prompt: " + MARKER, False),
+        ("a" * 65, False),
+        ("", False),
+    ],
+)
+def test_error_type_is_checked_rather_than_assumed_safe(value: str, kept: bool) -> None:  # noqa: FBT001
+    """The three shapes the middleware writes are a property of the SDK, not of us.
+
+    Today `error.type` is a JSON-RPC code, the literal `tool_error`, or a
+    server-side exception class name, none of which can carry client input. That
+    holds only while this server sends no requests to the client; the
+    server-to-client direction would put a peer's error text here. Checking the
+    shape costs one comparison and makes the invariant ours.
+    """
+    span = _make_span(MCP_SDK_SCOPE, "ping", {"mcp.method.name": "ping", "error.type": value})
+    sanitised = sanitise_span(span)
+
+    assert sanitised is not None
+    assert ("error.type" in (sanitised.attributes or {})) is kept
+
+
+# ---------------------------------------------------------------------------
+# What the Azure exporter would actually put on the wire
+# ---------------------------------------------------------------------------
+
+
+def _envelopes_for(monkeypatch: pytest.MonkeyPatch, spans: list[ReadableSpan]) -> list[Any]:
+    """Run *spans* through the real Azure exporter and capture the envelopes.
+
+    Everything but the HTTP call is genuine: the real exporter, the real
+    envelope conversion, the real resource-metric branch. Only `_transmit` is
+    replaced, so nothing leaves the process.
+    """
+    monkeypatch.setenv("APPLICATIONINSIGHTS_STATSBEAT_DISABLED_ALL", "true")
+    monkeypatch.setenv("APPLICATIONINSIGHTS_SDKSTATS_DISABLED", "true")
+
+    # The resource-metric branch reads `tracer_provider.resource`, so it only
+    # fires when a real provider is in play, which is exactly the production
+    # situation: install_mcp_span_pipeline builds one and claims the global.
+    exporter = AzureMonitorTraceExporter(
+        connection_string=_CONNECTION_STRING,
+        disable_offline_storage=True,
+        tracer_provider=TracerProvider(),
+    )
+    captured: list[Any] = []
+
+    def _transmit(envelopes: Any) -> Any:
+        captured.extend(envelopes)
+        return ExportResult.SUCCESS
+
+    monkeypatch.setattr(exporter, "_transmit", _transmit)
+    try:
+        SanitisingSpanExporter(exporter).export(spans)
+    finally:
+        exporter.shutdown()
+        # Constructing a real exporter can start the customer-sdkstats metric
+        # reader, which then tries to POST to the connection string's endpoint
+        # on its own thread. Production never reaches that (telemetry.py sets
+        # APPLICATIONINSIGHTS_SDKSTATS_DISABLED before the first exporter
+        # exists), but in a test the manager may already be a live singleton
+        # from an earlier module, and a unit test must make no network calls.
+        with contextlib.suppress(Exception):
+            get_customer_stats_manager().shutdown()
+    return captured
+
+
+def test_a_span_batch_produces_no_metric_envelope(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The trace exporter smuggles a metric in unless an env var says otherwise.
+
+    It appends an `_OTELRESOURCE_` `MetricData` envelope to every non-empty
+    export batch, so switching spans on would have started sending metrics while
+    the docs promise none. The variable is read at export time, so it cannot be
+    scoped around construction the way the OTEL_*_EXPORTER pair is.
+    """
+    monkeypatch.delenv("APPLICATIONINSIGHTS_OPENTELEMETRY_RESOURCE_METRIC_DISABLED", raising=False)
+    span = _make_span(MCP_SDK_SCOPE, "ping", {"mcp.method.name": "ping"})
+
+    # Without the setting, to show the envelope is real and not hypothetical.
+    leaky = _envelopes_for(monkeypatch, [span])
+    assert any(e.data.base_type == "MetricData" for e in leaky)
+
+    # With it, as install_mcp_span_pipeline sets it.
+    monkeypatch.setenv("APPLICATIONINSIGHTS_OPENTELEMETRY_RESOURCE_METRIC_DISABLED", "true")
+    clean = _envelopes_for(monkeypatch, [span])
+    assert clean, "the span itself must still be exported"
+    assert not [e for e in clean if e.data.base_type == "MetricData"]
+
+
+def test_nothing_client_chosen_survives_into_the_azure_envelope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The end of the line: what the exporter would put on the wire.
+
+    `ai.operation.id` and `ai.operation.parentId` are written straight from the
+    span's trace id and parent span id, both of which the client controls
+    through `traceparent`, and neither is truncated or validated on the way.
+    """
+    monkeypatch.setenv("APPLICATIONINSIGHTS_OPENTELEMETRY_RESOURCE_METRIC_DISABLED", "true")
+    # "tenant-secret-01" and "8bytesXX" as hex, which is how a client sends them.
+    remote = SpanContext(
+        trace_id=int(b"tenant-secret-01".hex(), 16),
+        span_id=int(b"8bytesXX".hex(), 16),
+        is_remote=True,
+    )
+    span = ReadableSpan(
+        name=f"prompts/get {MARKER}",
+        context=SpanContext(trace_id=remote.trace_id, span_id=4242, is_remote=False),
+        parent=remote,
+        instrumentation_scope=InstrumentationScope(MCP_SDK_SCOPE),
+        attributes={"mcp.method.name": "prompts/get", "gen_ai.prompt.name": MARKER},
+        status=Status(StatusCode.ERROR, f"Unknown prompt: {MARKER}"),
+        start_time=1,
+        end_time=2,
+    )
+
+    envelopes = _envelopes_for(monkeypatch, [span])
+
+    assert len(envelopes) == 1
+    rendered = str(envelopes[0].as_dict())
+    assert MARKER not in rendered
+    operation_id = envelopes[0].tags["ai.operation.id"]
+    assert b"tenant-secret" not in bytes.fromhex(operation_id)
+    assert "ai.operation.parentId" not in envelopes[0].tags
+
+
+def test_a_failed_exporter_build_never_claims_the_global(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Claiming the global before the pipeline is whole is unrecoverable.
+
+    ``set_tracer_provider`` spends OpenTelemetry's one-shot ``Once``. If the
+    exporter then failed to build, an empty provider stayed installed for the
+    life of the process: every span fully recorded into nothing, the host locked
+    out for good, and the caller told the install had failed.
+    """
+    claimed: list[object] = []
+    _patch_global_provider_hooks(
+        monkeypatch, setter=claimed.append, getter=lambda: claimed[-1] if claimed else None
+    )
+
+    def _explode(**_kw: Any) -> Any:
+        raise RuntimeError("no exporter for you")
+
+    monkeypatch.setattr(telemetry_spans, "_AzureMonitorTraceExporter", _explode)
+
+    assert install_mcp_span_pipeline(_CONNECTION_STRING, None) is False
+    assert claimed == [], "the global was claimed despite the install failing"


### PR DESCRIPTION
Closes #1049
Closes #1048

Two telemetry features that both land in the MCP server, in one commit each.

## #1049: collect the MCP SDK's protocol spans

The SDK emits one OpenTelemetry span per inbound protocol message. That instrumentation is maintained upstream and covers every message type, including the ones `command_invoked` knows nothing about. Over `command_invoked` it adds the non-tool protocol methods, the negotiated protocol revision, exact timings instead of buckets, and a per-message error classification.

### What had to be stripped, measured rather than assumed

The issue named three places. Reproducing it against this server first turned up **six**, in a script that drives a real server with hand-written JSON-RPC:

| Value | Where it lands |
|---|---|
| the name on `prompts/get` | span name, status description (`Unknown prompt: <name>`), `gen_ai.prompt.name`, **and an `exception` event carrying the message plus the full stacktrace** |
| the name on `tools/call` for a tool that does not exist | span name, `gen_ai.tool.name` |
| a method the server does not implement | span name, `mcp.method.name` (the middleware wraps the METHOD_NOT_FOUND path) |
| a string JSON-RPC request id | `jsonrpc.request.id` |

The exception event was the one worth catching: it is the largest of the four `prompts/get` leaks, and the note in `telemetry.py` claiming `record_exception` never fires was true only for *tool* errors, not for the prompt path.

### How

`telemetry_spans.py` rebuilds every span from an allowlist rather than blocklisting the known-bad fields, so a field a future SDK release adds is dropped until someone vets it. Method names and protocol revisions are checked against `mcp_types`' own maps, which means new protocol methods are covered without a change here. Spans from any other instrumentation scope are dropped outright, so HTTP spans carrying workspace and warehouse identifiers stay out of the export path no matter what a future dependency starts doing.

`configure_azure_monitor` still never builds the trace pipeline, and `OTEL_TRACES_EXPORTER` stays hard-set to `none`: the exporter that call installs ships spans exactly as produced, so a user's own value must not be able to open that path. The pipeline is built afterwards instead, on the MCP surface only, with the sanitiser in front of the Azure exporter. A host application that already installed a `TracerProvider` keeps it and this one stands down.

Verified in a real process, with a real authenticated call to the Fabric API in the same flow (`GET /v1/workspaces` 200): the only spans produced in-process came from `mcp-python-sdk`, so no auto-instrumentor emits anything even with network traffic.

## #1048: record which MCP client is connected

The value is reachable, in two places, one per protocol era. In the handshake era `clientInfo` arrives in `initialize`'s raw params, which a middleware sees because it runs before params validation; it has to be read there, since the SDK commits it to the connection only *after* the middleware chain returns. From 2026-07-28 on there is no handshake and client info rides each request's `_meta` envelope, which the SDK has already turned into `ServerSession.client_params` by the time middleware runs. Reading both means the client is known from the first message of a connection either way.

On the timing question: `mcp_server_started` cannot carry the field, since it fires before any client has connected, and one long-lived HTTP server serves several clients anyway. So there is a separate `mcp_client_connected` event, plus a `ContextVar` so `command_invoked` is attributed to the client that actually made the call, which is what makes usage breakable down per client.

The name is recorded as sent, trimmed and capped at 64 characters, rather than mapped onto a fixed list. A fixed list can only confirm the clients somebody already thought of, and files every new or renamed one under `other` until a human notices. The version is not recorded. A client that sends no client info at all, which the protocol permits, is recorded as `unknown`.

## `docs/telemetry.md`

Trimmed to 107 lines, down from the 150 this branch started with, despite adding a collection category. The section on exporter mechanics (environment variable names, the keyword arguments the Azure library ignores, the sdkstats pipeline, the reasoning behind a hard set rather than a `setdefault`) is gone: it was written from the maintainer's point of view, it is already in comments in `telemetry.py`, and none of it changes what a user should expect or do. Both additions land as table rows rather than prose, and the "not collected" list is updated so it stays accurate now that spans are collected.

## Tests

`tests/unit/test_telemetry_spans.py` and `tests/unit/mcp/test_client_info.py` drive a real MCP server over in-memory streams with raw JSON-RPC, through the SDK's real middleware chain, because the interesting inputs are the ones a well-behaved client cannot produce. That fidelity paid for itself: the first draft of the sanitiser passed a hand-rolled test and silently dropped every real span, because span attributes are a `BoundedAttributes` mapping and not a `dict`.

The three tests in `test_telemetry.py` that pinned the off state are rewritten to pin the new intent rather than removed. The metrics pipeline and customer sdkstats stay off and keep their tests.

## Review round 1

Seven blocking findings, all fixed in `ee720d7`. The pattern in the first three: the sanitiser vetted what the middleware *writes onto* a span, not what the SDK *builds the span out of*, and vetted the shape of values without bounding their size.

| # | Finding | Fix |
|---|---|---|
| 1 | The client owns the trace id and parent span id through `traceparent`, and Azure exports both as `ai.operation.id` / `ai.operation.parentId`. 24 chosen bytes per message, notifications included. `trace_state` rode along too | The span id is the only locally minted half, so it is the only half kept; the trace id is remapped through a per-process HMAC (grouping survives, client control does not), the parent link is cut, `trace_state` dropped |
| 2 | `jsonrpc.request.id` was shape-checked but unbounded; a plain `dict` means no OTel attribute limit either | Capped at the int64 range |
| 3 | `clientInfo.name` is per *message* on 2026-07-28, not per connection, and the dedup set was unbounded | Control characters removed before the cap; eight distinct names per process, then `other`. The verbatim policy stands |
| 4 | `shutdown_telemetry` tore down a host application's `TracerProvider` in exactly the case where the pipeline correctly stood down | Both teardown paths gated on having installed it; flush budget split so logs cannot eat the spans' share |
| 5 | The global was claimed before the exporter was built, so a failed build left an empty provider installed permanently | Build first, claim last, shut down on losing the race; `get_tracer_provider()` read first so `OTEL_PYTHON_TRACER_PROVIDER` is seen |
| 6 | The Azure trace exporter appends an `_OTELRESOURCE_` `MetricData` envelope to every export unless an env var says otherwise | Set, with an envelope-level test. Third such side channel here after statsbeat and customer sdkstats |
| 7 | Two documentation errors: "tool names" listed as not collected while `command_invoked` documents exactly that, and the `<unknown>` gate described as this server's tool registry rather than the protocol's method list | Both scoped and corrected |

Also fixed: the headline privacy sweep now renders span identity, so it can see finding 1; the `_seen_mcp_clients` reset moved out of the self-managed-only branch; the tracer provider is force-flushed on shutdown; the method and version lookups no longer cache a failure permanently; and a concurrency test pins the `ContextVar` attribution.

## Not in scope

The auto-instrumentors stay disabled, metrics and customer sdkstats stay off, and no sampling or rate limiting was added. Everything rides the existing opt-out; there is no new switch.
