### PR TITLE
fix(telemetry): disable the OneSettings control-plane poll and clean up the #1051 loose ends

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -78,6 +78,7 @@ Running the MCP server also records one entry per protocol message it handles, w
 | duration | How long the message took to handle. |
 | outcome | Whether it succeeded, and if not, the error code or the name of the error type. |
 | protocol version | The MCP revision the client and the server agreed on, e.g. `2025-06-18`. |
+| parent entry | Which other entry from this same server caused this one, so a sequence reads as one operation. Only ever an entry this server created itself; a parent a client puts in a request is dropped. |
 
 Anything you choose the content of is removed from these entries first: prompt and tool names, error messages, stack traces, and request IDs that are not plain numbers. A trace ID a client puts in a request is replaced by a hash of it, keyed with a random value this process never stores or sends, so entries from one trace still group together but the exported ID is not one you chose or can recover.
 
@@ -89,8 +90,7 @@ Anything you choose the content of is removed from these entries first: prompt a
 - File paths or environment variable values
 - Any other personally-identifiable information
 - Names you put in an MCP request: prompt names, and the tool name on a call for a tool that does not exist
-- Error messages and stack traces
-- Trace IDs taken off the wire, which are replaced by a keyed hash as described above
+- Error messages and stack traces, and trace IDs taken off the wire (replaced by the keyed hash described above)
 - Metrics of any kind
 
 ## Where telemetry data goes

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -96,6 +96,8 @@ Anything you choose the content of is removed from these entries first: prompt a
 
 Events are sent to a private Azure Application Insights resource operated by the `fabric-dw` maintainers, via a write-only connection string embedded in the package. The backing Log Analytics workspace has a daily ingestion cap to control costs.
 
+The events above are the only outbound traffic telemetry produces. The Azure SDK's own background channels are switched off, so it reports nothing about itself, and it does not poll Microsoft's configuration endpoint for settings that would let a third party change how this installation behaves.
+
 ## How to opt out
 
 Any of the following fully disables telemetry - no events are emitted and the SDK is never imported:

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -95,9 +95,7 @@ Anything you choose the content of is removed from these entries first: prompt a
 
 ## Where telemetry data goes
 
-Events are sent to a private Azure Application Insights resource operated by the `fabric-dw` maintainers, via a write-only connection string embedded in the package. The backing Log Analytics workspace has a daily ingestion cap to control costs.
-
-The events above are the only outbound traffic telemetry produces. The Azure SDK's own background channels are switched off, so it reports nothing about itself, and it does not poll Microsoft's configuration endpoint for settings that would let a third party change how this installation behaves.
+Events are sent to a private Azure Application Insights resource operated by the `fabric-dw` maintainers, via a write-only connection string embedded in the package. The backing Log Analytics workspace has a daily ingestion cap to control costs. The events above are the only thing sent there: the Azure SDK's background channels are all switched off, so it reports nothing about itself, does not poll Microsoft for settings that would change how this installation behaves, and does not probe the machine it runs on.
 
 ## How to opt out
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -25,7 +25,7 @@ Every telemetry event includes a shared envelope of standard fields:
 |---|---|---|
 | `app_started` | Once per process | - |
 | `mcp_server_started` | When the MCP server boots | - |
-| `mcp_client_connected` | First time each distinct MCP client identifies itself | `mcp_client` |
+| `mcp_client_connected` | First time each distinct MCP client identifies itself, for the first 8 distinct names a server process sees. After that they all count as one client, `other`. | `mcp_client` |
 | `app_exited` | On process exit | `duration_ms`, `exit_status` (ok / user_error / api_error), `error_category` |
 
 > `auth_mode` is omitted from the three start events: they fire before any sign-in, so there is nothing accurate to report yet. It appears on `command_invoked` and `app_exited`.
@@ -79,7 +79,7 @@ Running the MCP server also records one entry per protocol message it handles, w
 | outcome | Whether it succeeded, and if not, the error code or the name of the error type. |
 | protocol version | The MCP revision the client and the server agreed on, e.g. `2025-06-18`. |
 
-Anything you choose the content of is removed from these entries first: prompt and tool names, error messages, stack traces, request IDs that are not plain numbers, and the trace IDs a client can put in a request.
+Anything you choose the content of is removed from these entries first: prompt and tool names, error messages, stack traces, and request IDs that are not plain numbers. A trace ID a client puts in a request is replaced by a hash of it, keyed with a random value this process never stores or sends, so entries from one trace still group together but the exported ID is not one you chose or can recover.
 
 ### What is deliberately NOT collected
 
@@ -89,7 +89,8 @@ Anything you choose the content of is removed from these entries first: prompt a
 - File paths or environment variable values
 - Any other personally-identifiable information
 - Names you put in an MCP request: prompt names, and the tool name on a call for a tool that does not exist
-- Error messages, stack traces, and trace IDs taken off the wire
+- Error messages and stack traces
+- Trace IDs taken off the wire, which are replaced by a keyed hash as described above
 - Metrics of any kind
 
 ## Where telemetry data goes

--- a/src/fabric_dw/telemetry.py
+++ b/src/fabric_dw/telemetry.py
@@ -38,9 +38,26 @@ Architecture notes
   it, and its spans keep going wherever it chose.  That is correct and
   desirable; what this prevents is *this package* adding an export path the user
   did not ask for.
-- ``APPLICATIONINSIGHTS_SDKSTATS_DISABLED`` suppresses the customer-sdkstats
-  channel, which is separate from statsbeat and would otherwise run its own
-  metrics pipeline on our connection string.
+- Four side channels of the Azure Monitor stack are switched off, each behind an
+  environment variable of its own that nothing in the library's API surface
+  points to, and each found only by measuring a live process:
+
+  1. ``APPLICATIONINSIGHTS_STATSBEAT_DISABLED_ALL`` (statsbeat, plus its Azure
+     IMDS probe).
+  2. ``APPLICATIONINSIGHTS_SDKSTATS_DISABLED`` (customer sdkstats, separate from
+     statsbeat, which would otherwise run its own metrics pipeline on our
+     connection string).
+  3. ``APPLICATIONINSIGHTS_OPENTELEMETRY_RESOURCE_METRIC_DISABLED`` (the
+     ``_OTELRESOURCE_`` ``MetricData`` envelope appended to every span export,
+     set in :mod:`fabric_dw.telemetry_spans`).
+  4. ``APPLICATIONINSIGHTS_CONTROLPLANE_DISABLED`` (the OneSettings control
+     plane: an hourly outbound poll that also lets Microsoft toggle this
+     installation's offline storage remotely, #1053).
+
+  Treat that as a property of this stack rather than as four coincidences:
+  assume a fifth exists and check for it by measurement, not by reading the
+  configuration surface, whenever this dependency is upgraded or a new exporter
+  is added.
 - ``shutdown_on_exit`` is disabled; a bounded ``force_flush`` + ``provider.shutdown()``
   (≤8 s total) is performed at app exit in a daemon thread so the CLI never hangs.
   The explicit ``force_flush`` call before ``shutdown()`` is required to reliably
@@ -845,6 +862,31 @@ def _get_tracer() -> object | None:
             # OTEL_*_EXPORTER pair below), and the failure direction is benign: more
             # Microsoft-internal telemetry, opted into deliberately.
             os.environ.setdefault("APPLICATIONINSIGHTS_SDKSTATS_DISABLED", "true")
+
+            # OneSettings control plane: the third separately-gated channel set
+            # here, and the only side channel of the four that is also an INBOUND
+            # one (#1053).
+            #
+            # BaseExporter.__init__ calls get_configuration_manager(), which stands
+            # up a singleton manager plus a `ConfigurationWorker` daemon thread that
+            # polls https://settings.sdk.monitor.azure.com/ roughly hourly and
+            # describes this process to it (os, rp, attach, component, version,
+            # region and the instrumentation key).  The response is a feature-flag
+            # document, and the exporter registers a callback on it so Microsoft can
+            # toggle this installation's offline storage remotely.  The log exporter
+            # alone is enough to start it, so it ran on every CLI invocation and for
+            # the life of every MCP server.
+            #
+            # Two reasons to switch it off rather than document it: docs/telemetry.md
+            # presents a closed list of what leaves the machine and this was not on
+            # it, and a third party changing an installation's storage behaviour at
+            # runtime is not something this package should accept on the user's
+            # behalf.
+            #
+            # setdefault, like the two above: the gate is `== "true"`, so an operator
+            # setting any other value keeps the control plane and its remote
+            # kill-switch.
+            os.environ.setdefault("APPLICATIONINSIGHTS_CONTROLPLANE_DISABLED", "true")
 
             # Build the OTel Resource that populates native Part A fields and prevents
             # hostname fallback for cloud_RoleInstance / ai.device.id (#477).

--- a/src/fabric_dw/telemetry.py
+++ b/src/fabric_dw/telemetry.py
@@ -38,26 +38,41 @@ Architecture notes
   it, and its spans keep going wherever it chose.  That is correct and
   desirable; what this prevents is *this package* adding an export path the user
   did not ask for.
-- Four side channels of the Azure Monitor stack are switched off, each behind an
+- Five side channels of the Azure Monitor stack are switched off, each behind an
   environment variable of its own that nothing in the library's API surface
-  points to, and each found only by measuring a live process:
+  points to, and each found only by measuring a live process.  This list is the
+  checklist to re-verify, by measurement, on every bump of this dependency:
 
-  1. ``APPLICATIONINSIGHTS_STATSBEAT_DISABLED_ALL`` (statsbeat, plus its Azure
-     IMDS probe).
+  1. ``APPLICATIONINSIGHTS_STATSBEAT_DISABLED_ALL`` (statsbeat, including the
+     IMDS probe statsbeat itself makes; note that this does NOT cover the
+     separate IMDS probe from the resource detectors, which is number 5).
+     Set here, and deliberately never restored: see the comment at its
+     assignment site.
   2. ``APPLICATIONINSIGHTS_SDKSTATS_DISABLED`` (customer sdkstats, separate from
      statsbeat, which would otherwise run its own metrics pipeline on our
-     connection string).
+     connection string).  Set and restored, via ``_SCOPED_SIDE_CHANNELS_OFF``.
   3. ``APPLICATIONINSIGHTS_OPENTELEMETRY_RESOURCE_METRIC_DISABLED`` (the
-     ``_OTELRESOURCE_`` ``MetricData`` envelope appended to every span export,
-     set in :mod:`fabric_dw.telemetry_spans`).
+     ``_OTELRESOURCE_`` ``MetricData`` envelope appended to every span export).
+     Set in :mod:`fabric_dw.telemetry_spans`, and only on the path where that
+     module actually builds an exporter: a host process that already owns the
+     global ``TracerProvider`` returns before this point, which is correct,
+     because in that case no exporter of ours exists to smuggle a metric.  Never
+     restored either: it is read at export time, not at construction.
   4. ``APPLICATIONINSIGHTS_CONTROLPLANE_DISABLED`` (the OneSettings control
      plane: an hourly outbound poll that also lets Microsoft toggle this
-     installation's offline storage remotely, #1053).
+     installation's offline storage remotely, #1053).  Set and restored.
+  5. ``OTEL_EXPERIMENTAL_RESOURCE_DETECTORS`` (``configure_azure_monitor``
+     defaults it to ``azure_app_service,azure_vm`` and re-runs
+     ``Resource.create()``; the ``azure_vm`` detector calls the Azure IMDS
+     endpoint at 169.254.169.254 on every telemetry-enabled process, and on an
+     Azure VM would merge ``cloud.resource_id``, ``host.id`` and ``host.name``
+     into the exported Resource).  Set and restored.
 
-  Treat that as a property of this stack rather than as four coincidences:
-  assume a fifth exists and check for it by measurement, not by reading the
+  Treat that as a property of this stack rather than as five coincidences:
+  assume a sixth exists and check for it by measurement, not by reading the
   configuration surface, whenever this dependency is upgraded or a new exporter
-  is added.
+  is added.  Every one of the five was found this way, and none of them by
+  reading the library's API surface.
 - ``shutdown_on_exit`` is disabled; a bounded ``force_flush`` + ``provider.shutdown()``
   (≤8 s total) is performed at app exit in a daemon thread so the CLI never hangs.
   The explicit ``force_flush`` call before ``shutdown()`` is required to reliably
@@ -691,6 +706,68 @@ _OTEL_EXPORTERS_OFF: dict[str, str] = {
     "OTEL_METRICS_EXPORTER": "none",
 }
 
+# Side channels switched off with ``setdefault`` semantics AND restored
+# afterwards, so an embedding host is not left holding this package's choices
+# (#1052).  Each one was measured to be read only while the exporters are being
+# built, which is what makes restoring safe.  Two related variables are
+# deliberately NOT in here; both are documented at their assignment sites.
+_SCOPED_SIDE_CHANNELS_OFF: dict[str, str] = {
+    # The OneSettings control plane (#1053).  Its only read is
+    # get_configuration_manager(), from BaseExporter.__init__.  Measured after a
+    # restore, over a 35 s window covering the worker's 5-15 s startup delay: no
+    # ConfigurationWorker thread and no contact with the settings endpoint.
+    "APPLICATIONINSIGHTS_CONTROLPLANE_DISABLED": "true",
+    # Customer sdkstats.  The export-time checks read `manager.is_enabled`, a
+    # cached attribute rather than the environment, so a restore does not re-arm
+    # it.  Measured: `_should_collect_customer_sdkstats()` stays False on the
+    # live log exporter after the variable is removed.
+    "APPLICATIONINSIGHTS_SDKSTATS_DISABLED": "true",
+    # Resource detectors.  configure_azure_monitor does
+    # `environ.setdefault(OTEL_EXPERIMENTAL_RESOURCE_DETECTORS,
+    # "azure_app_service,azure_vm")` and then re-runs Resource.create(); the
+    # azure_vm detector calls urlopen() against the Azure IMDS endpoint at
+    # 169.254.169.254 on every telemetry-enabled process, on both surfaces.
+    # Measured before this line existed: `dns:169.254.169.254:80` followed by
+    # `tcp:('169.254.169.254', 80)`.  Nothing about the VM reaches the wire
+    # today, but on an Azure VM the detector merges `cloud.resource_id`
+    # (subscription id, resource group and VM name), `host.id` and `host.name`
+    # into the Resource, one configuration change away from being exported.
+    # Read only inside Resource.create(), so restoring is safe.
+    "OTEL_EXPERIMENTAL_RESOURCE_DETECTORS": "",
+}
+
+
+@contextlib.contextmanager
+def _scoped_env_defaults(defaults: dict[str, str]) -> Iterator[None]:
+    """Apply *defaults* with ``setdefault`` semantics, then put back what was there.
+
+    ``setdefault`` so an operator's explicit value still wins, and a restore
+    because fabric-dw can be embedded as a library: a host that later builds its
+    own Azure Monitor exporter must get its own defaults, not this package's.
+    Without the restore that leak is silent and one-directional, and the
+    provider-ownership check in :mod:`fabric_dw.telemetry_spans` does not cover
+    it, because these are written long before that check runs.
+
+    Only for variables measured to be read while the exporters are being built.
+    One read later, at export time say, must be left set for the exporter's
+    lifetime instead: restoring it would quietly re-arm the channel inside this
+    very process.
+
+    Args:
+        defaults: Variable name to the value this package wants as the default.
+    """
+    previous = {key: os.environ.get(key) for key in defaults}
+    for key, value in defaults.items():
+        os.environ.setdefault(key, value)
+    try:
+        yield
+    finally:
+        for key, old in previous.items():
+            if old is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = old
+
 
 def _harden_azure_sdk_logging() -> None:
     """Raise the level of noisy Azure SDK loggers to CRITICAL and detach them from root.
@@ -860,136 +937,130 @@ def _get_tracer() -> object | None:
             # an operator setting it to "false" genuinely re-enables collection.  That
             # makes it a real override rather than a discarded value (unlike the
             # OTEL_*_EXPORTER pair below), and the failure direction is benign: more
-            # Microsoft-internal telemetry, opted into deliberately.
-            os.environ.setdefault("APPLICATIONINSIGHTS_SDKSTATS_DISABLED", "true")
-
-            # OneSettings control plane: the third separately-gated channel set
-            # here, and the only side channel of the four that is also an INBOUND
-            # one (#1053).
+            # Microsoft-internal telemetry, opted into deliberately.  It is applied,
+            # and restored, by the _SCOPED_SIDE_CHANNELS_OFF block below.
             #
-            # BaseExporter.__init__ calls get_configuration_manager(), which stands
-            # up a singleton manager plus a `ConfigurationWorker` daemon thread that
-            # polls https://settings.sdk.monitor.azure.com/ roughly hourly and
-            # describes this process to it (os, rp, attach, component, version,
-            # region and the instrumentation key).  The response is a feature-flag
-            # document, and the exporter registers a callback on it so Microsoft can
-            # toggle this installation's offline storage remotely.  The log exporter
-            # alone is enough to start it, so it ran on every CLI invocation and for
-            # the life of every MCP server.
-            #
-            # Two reasons to switch it off rather than document it: docs/telemetry.md
-            # presents a closed list of what leaves the machine and this was not on
-            # it, and a third party changing an installation's storage behaviour at
-            # runtime is not something this package should accept on the user's
-            # behalf.
-            #
-            # setdefault, like the two above: the gate is `== "true"`, so an operator
-            # setting any other value keeps the control plane and its remote
-            # kill-switch.
-            os.environ.setdefault("APPLICATIONINSIGHTS_CONTROLPLANE_DISABLED", "true")
+            # The statsbeat switch above is the one exception to that restore, and
+            # deliberately so.  is_statsbeat_enabled() re-reads the environment on
+            # every call, and BaseExporter._should_collect_stats() calls it on every
+            # export, so putting the variable back would flip statsbeat bookkeeping
+            # on inside this process for the rest of its life.  Measured with the
+            # variable removed after init: is_statsbeat_enabled() False -> True and
+            # _should_collect_stats() False -> True on the live log exporter.  No
+            # statsbeat manager is ever initialised so nothing transmits, but the
+            # guarantee here is that the switch is off, not that the blast radius is
+            # small.  So it stays set for the exporter's lifetime and an embedding
+            # host inherits it.  Pre-existing; unchanged by #1052.
 
-            # Build the OTel Resource that populates native Part A fields and prevents
-            # hostname fallback for cloud_RoleInstance / ai.device.id (#477).
-            resource = _build_otel_resource(_current_surface)
+            # Everything from here through the span-pipeline install runs with the
+            # restorable side channels switched off.  The window deliberately extends
+            # PAST configure_azure_monitor: install_mcp_span_pipeline builds a second
+            # AzureMonitorTraceExporter afterwards, and that constructor reaches the
+            # very same control-plane and resource-detector code.
+            with _scoped_env_defaults(_SCOPED_SIDE_CHANNELS_OFF):
+                # Build the OTel Resource that populates native Part A fields and prevents
+                # hostname fallback for cloud_RoleInstance / ai.device.id (#477).
+                resource = _build_otel_resource(_current_surface)
 
-            configure_kwargs: dict[str, object] = {
-                "connection_string": _DEFAULT_CONNECTION_STRING,
-                "logger_name": "fabric_dw.telemetry",
-                # disable_logging=False (default) is intentional: the log/event
-                # exporter must be active so customEvents land in the customEvents
-                # table.  Without the logs pipeline, log records carrying
-                # microsoft.custom_event.name are silently dropped and events never
-                # appear in the App Insights "Usage → Events" or "Usage → Users" blades.
-                "disable_logging": False,
-                # NOTE: these next two are statements of intent, NOT the mechanism.
-                # azure-monitor-opentelemetry clobbers both with its own defaults
-                # (see _OTEL_EXPORTERS_OFF below, which is what actually disables
-                # these pipelines).  They are kept so the intent is visible at the
-                # call site and so the arguments become effective for free if
-                # upstream ever stops overwriting caller kwargs.
-                "disable_metrics": True,
-                "disable_tracing": True,
-                # A1: disable PerformanceCounters — not covered by disable_metrics in
-                # azure-monitor-opentelemetry 1.8+; its _get_processor_time callback
-                # divides by zero on short-lived processes and logs a traceback (#399).
-                "enable_performance_counters": False,
-                # A2: belt-and-suspenders — QuickPulse must never ping the LiveEndpoint.
-                # Suppresses _quickpulse/_exporter.py::_ping tracebacks on connection
-                # refused even if the default changes in a future SDK version (#411).
-                "enable_live_metrics": False,
-                # B2: disable unbounded (30 s) atexit flush — we do our own bounded flush.
-                "shutdown_on_exit": False,
-                # B1: disable all auto-HTTP / Azure SDK instrumentors (privacy).
-                "instrumentation_options": _INSTRUMENTATION_OPTIONS,
-            }
-            # Pass the resource when available so native Part A fields are populated
-            # (cloud_RoleName, cloud_RoleInstance, application_Version, ai.device.id).
-            if resource is not None:
-                configure_kwargs["resource"] = resource
+                configure_kwargs: dict[str, object] = {
+                    "connection_string": _DEFAULT_CONNECTION_STRING,
+                    "logger_name": "fabric_dw.telemetry",
+                    # disable_logging=False (default) is intentional: the log/event
+                    # exporter must be active so customEvents land in the customEvents
+                    # table.  Without the logs pipeline, log records carrying
+                    # microsoft.custom_event.name are silently dropped and events never
+                    # appear in the App Insights "Usage → Events" or "Usage → Users" blades.
+                    "disable_logging": False,
+                    # NOTE: these next two are statements of intent, NOT the mechanism.
+                    # azure-monitor-opentelemetry clobbers both with its own defaults
+                    # (see _OTEL_EXPORTERS_OFF below, which is what actually disables
+                    # these pipelines).  They are kept so the intent is visible at the
+                    # call site and so the arguments become effective for free if
+                    # upstream ever stops overwriting caller kwargs.
+                    "disable_metrics": True,
+                    "disable_tracing": True,
+                    # A1: disable PerformanceCounters — not covered by disable_metrics in
+                    # azure-monitor-opentelemetry 1.8+; its _get_processor_time callback
+                    # divides by zero on short-lived processes and logs a traceback (#399).
+                    "enable_performance_counters": False,
+                    # A2: belt-and-suspenders — QuickPulse must never ping the LiveEndpoint.
+                    # Suppresses _quickpulse/_exporter.py::_ping tracebacks on connection
+                    # refused even if the default changes in a future SDK version (#411).
+                    "enable_live_metrics": False,
+                    # B2: disable unbounded (30 s) atexit flush — we do our own bounded flush.
+                    "shutdown_on_exit": False,
+                    # B1: disable all auto-HTTP / Azure SDK instrumentors (privacy).
+                    "instrumentation_options": _INSTRUMENTATION_OPTIONS,
+                }
+                # Pass the resource when available so native Part A fields are populated
+                # (cloud_RoleName, cloud_RoleInstance, application_Version, ai.device.id).
+                if resource is not None:
+                    configure_kwargs["resource"] = resource
 
-            # PRIVACY, load-bearing.  These two env vars are the ONLY working way
-            # to switch off the trace and metric pipelines, and they must be set
-            # HARD, not with setdefault.
-            #
-            # Why the kwargs above do not do it: in azure-monitor-opentelemetry
-            # 1.8.9 `_get_configurations()` copies the caller's kwargs into a dict
-            # and THEN runs a `_default_*` pass in which `_default_disable_tracing`
-            # / `_default_disable_metrics` assign unconditionally, clobbering
-            # whatever the caller passed.  Contrast `_default_connection_string`,
-            # which early-returns when the key is already present.  Those defaults
-            # consult only these env vars, and only for an exact `== "none"` after
-            # lower/strip.
-            #
-            # Why NOT setdefault: any pre-existing value that is not literally
-            # "none" leaves the pipeline ON, and what then gets installed is the
-            # AzureMonitorTraceExporter pointed at the maintainer's ingestion
-            # endpoint, NOT the exporter the operator asked for.  Measured:
-            #     (unset)                     -> ProxyTracerProvider, no exporters
-            #     OTEL_TRACES_EXPORTER=otlp   -> AzureMonitorTraceExporter installed
-            #     OTEL_TRACES_EXPORTER=""     -> AzureMonitorTraceExporter installed
-            # So setdefault gives the operator no control (outside the separate
-            # auto-instrumentation entry point, `== "none"` is the only thing this
-            # distro ever reads these for) and one silent third-party export path.
-            # A host process that already installed its own TracerProvider is
-            # unaffected either way: OpenTelemetry refuses to override an existing
-            # provider, so the user's provider wins.
-            #
-            # Scoped and restored, because fabric-dw can be embedded as a library
-            # and must not mutate the host process environment beyond this call.
-            # Mutating os.environ is process-global, but the window is safe: it sits
-            # inside the double-checked _sdk_init_lock so it runs exactly once, and
-            # both entry points (the CLI and the MCP server) reach it on the main
-            # thread before any transport or worker concurrency starts.
-            # OTEL_LOGS_EXPORTER is deliberately NOT touched: a user setting it to
-            # "none" disables our own customEvents, which is the safe direction.
-            _prev_otel = {k: os.environ.get(k) for k in _OTEL_EXPORTERS_OFF}
-            os.environ.update(_OTEL_EXPORTERS_OFF)
-            try:
-                configure_azure_monitor(**configure_kwargs)
-            finally:
-                for _key, _old in _prev_otel.items():
-                    if _old is None:
-                        os.environ.pop(_key, None)
-                    else:
-                        os.environ[_key] = _old
+                # PRIVACY, load-bearing.  These two env vars are the ONLY working way
+                # to switch off the trace and metric pipelines, and they must be set
+                # HARD, not with setdefault.
+                #
+                # Why the kwargs above do not do it: in azure-monitor-opentelemetry
+                # 1.8.9 `_get_configurations()` copies the caller's kwargs into a dict
+                # and THEN runs a `_default_*` pass in which `_default_disable_tracing`
+                # / `_default_disable_metrics` assign unconditionally, clobbering
+                # whatever the caller passed.  Contrast `_default_connection_string`,
+                # which early-returns when the key is already present.  Those defaults
+                # consult only these env vars, and only for an exact `== "none"` after
+                # lower/strip.
+                #
+                # Why NOT setdefault: any pre-existing value that is not literally
+                # "none" leaves the pipeline ON, and what then gets installed is the
+                # AzureMonitorTraceExporter pointed at the maintainer's ingestion
+                # endpoint, NOT the exporter the operator asked for.  Measured:
+                #     (unset)                     -> ProxyTracerProvider, no exporters
+                #     OTEL_TRACES_EXPORTER=otlp   -> AzureMonitorTraceExporter installed
+                #     OTEL_TRACES_EXPORTER=""     -> AzureMonitorTraceExporter installed
+                # So setdefault gives the operator no control (outside the separate
+                # auto-instrumentation entry point, `== "none"` is the only thing this
+                # distro ever reads these for) and one silent third-party export path.
+                # A host process that already installed its own TracerProvider is
+                # unaffected either way: OpenTelemetry refuses to override an existing
+                # provider, so the user's provider wins.
+                #
+                # Scoped and restored, because fabric-dw can be embedded as a library
+                # and must not mutate the host process environment beyond this call.
+                # Mutating os.environ is process-global, but the window is safe: it sits
+                # inside the double-checked _sdk_init_lock so it runs exactly once, and
+                # both entry points (the CLI and the MCP server) reach it on the main
+                # thread before any transport or worker concurrency starts.
+                # OTEL_LOGS_EXPORTER is deliberately NOT touched: a user setting it to
+                # "none" disables our own customEvents, which is the safe direction.
+                _prev_otel = {k: os.environ.get(k) for k in _OTEL_EXPORTERS_OFF}
+                os.environ.update(_OTEL_EXPORTERS_OFF)
+                try:
+                    configure_azure_monitor(**configure_kwargs)
+                finally:
+                    for _key, _old in _prev_otel.items():
+                        if _old is None:
+                            os.environ.pop(_key, None)
+                        else:
+                            os.environ[_key] = _old
 
-            # MCP protocol spans (#1049).  Only on the MCP surface: the CLI
-            # produces no protocol spans, so installing a trace pipeline there
-            # would claim the process-wide TracerProvider and run a batch
-            # exporter thread for a stream that is always empty.
-            if _current_surface == "mcp":
-                from fabric_dw.telemetry_spans import (  # noqa: PLC0415
-                    install_mcp_span_pipeline,
-                )
+                # MCP protocol spans (#1049).  Only on the MCP surface: the CLI
+                # produces no protocol spans, so installing a trace pipeline there
+                # would claim the process-wide TracerProvider and run a batch
+                # exporter thread for a stream that is always empty.
+                if _current_surface == "mcp":
+                    from fabric_dw.telemetry_spans import (  # noqa: PLC0415
+                        install_mcp_span_pipeline,
+                    )
 
-                # Load-bearing, not bookkeeping: flush_telemetry and
-                # shutdown_telemetry must not touch a TracerProvider this
-                # package did not install.  When a host application already had
-                # one, shutting it down at our exit would kill the host's own
-                # exporter for the rest of its life.
-                _span_pipeline_installed = install_mcp_span_pipeline(
-                    _DEFAULT_CONNECTION_STRING, resource
-                )
+                    # Load-bearing, not bookkeeping: flush_telemetry and
+                    # shutdown_telemetry must not touch a TracerProvider this
+                    # package did not install.  When a host application already had
+                    # one, shutting it down at our exit would kill the host's own
+                    # exporter for the rest of its life.
+                    _span_pipeline_installed = install_mcp_span_pipeline(
+                        _DEFAULT_CONNECTION_STRING, resource
+                    )
+
             # Obtain the OTel Logger via the global LoggerProvider set up by
             # configure_azure_monitor.  This logger is used in emit_event to fire
             # customEvents as log records (not spans).

--- a/src/fabric_dw/telemetry_spans.py
+++ b/src/fabric_dw/telemetry_spans.py
@@ -455,9 +455,12 @@ def install_mcp_span_pipeline(connection_string: str, resource: object | None) -
         # is.  setdefault, like APPLICATIONINSIGHTS_SDKSTATS_DISABLED: the gate
         # is `!= "true"`, so an operator's explicit value is a real override.
         #
-        # Third one of these now (statsbeat, customer sdkstats, this): assume
-        # any Azure Monitor exporter has a side channel behind an environment
-        # variable until proven otherwise.
+        # One of four now: statsbeat, customer sdkstats, this, and the
+        # OneSettings control plane (APPLICATIONINSIGHTS_CONTROLPLANE_DISABLED,
+        # set in telemetry.py, #1053).  Assume any Azure Monitor exporter has a
+        # side channel behind an environment variable until proven otherwise,
+        # and expect a fifth: each of the four was found by measuring a running
+        # process, none by reading the library's API surface.
         os.environ.setdefault("APPLICATIONINSIGHTS_OPENTELEMETRY_RESOURCE_METRIC_DISABLED", "true")
 
         exporter = _AzureMonitorTraceExporter(connection_string=connection_string)

--- a/src/fabric_dw/telemetry_spans.py
+++ b/src/fabric_dw/telemetry_spans.py
@@ -76,12 +76,7 @@ from opentelemetry import trace as _trace
 from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor, SpanExporter, SpanExportResult
 from opentelemetry.sdk.trace.sampling import ALWAYS_ON
-from opentelemetry.trace import (
-    DEFAULT_TRACE_STATE,
-    SpanContext,
-    TraceFlags,
-)
-from opentelemetry.trace import ProxyTracerProvider as _ProxyTracerProvider
+from opentelemetry.trace import DEFAULT_TRACE_STATE, SpanContext, TraceFlags
 from opentelemetry.trace.status import Status
 
 if TYPE_CHECKING:
@@ -130,15 +125,19 @@ _TOOL_ERROR = "tool_error"
 #: 4000-digit id measured at 4824 bytes on the wire before this cap existed.
 _MAX_REQUEST_ID_DIGITS = 19
 
-#: Longest ``error.type`` recorded.  Server-side exception class names are far
-#: shorter; the cap exists so the invariant does not rest on that.
-_MAX_ERROR_TYPE_LEN = 64
+#: Longest ``error.type`` recorded, in BYTES of UTF-8.  Server-side exception
+#: class names are far shorter; the cap exists so the invariant does not rest on
+#: that.  Bytes rather than characters because ``str.isidentifier`` is
+#: Unicode-aware, so 64 characters of a non-ASCII class name is up to 256 bytes
+#: on the wire, and this module bounds its other fields by what actually gets
+#: transmitted.
+_MAX_ERROR_TYPE_BYTES = 64
 
 #: Longest ``rpc.response.status_code`` recorded, in digits: the int32 range.
 #: A JSON-RPC error code is a small integer (the spec reserves -32768..-32000
 #: and implementations add their own nearby), but ``ErrorData.code`` is a plain
 #: Python ``int``, so nothing upstream bounds it.  This used to borrow
-#: :data:`_MAX_ERROR_TYPE_LEN`, which allowed a 64-digit code: three times
+#: the ``error.type`` cap, which allowed a 64-digit code: three times
 #: looser than the 19 digits :data:`_MAX_REQUEST_ID_DIGITS` allows for a request
 #: id, under exactly the same argument that an unbounded numeric field is a
 #: channel (#1052).
@@ -284,7 +283,7 @@ def _is_qualname(value: str) -> bool:
     Non-ASCII is admitted too.  ``str.isidentifier`` is the actual language rule
     and it is Unicode-aware, so ``isascii()`` on top of it rejected class names
     written in any other script while adding nothing: the shape test is what
-    bounds the value, and the length cap bounds it in characters either way.
+    bounds the value, and :data:`_MAX_ERROR_TYPE_BYTES` bounds it on the wire.
     """
     return all(part == _QUALNAME_LOCALS or part.isidentifier() for part in value.split("."))
 
@@ -300,7 +299,7 @@ def _safe_error_type(value: object) -> str | None:
     put a peer's error on a span.  So the invariant is checked rather than
     assumed: a numeric code, the known literal, or a Python qualified name.
     """
-    if not isinstance(value, str) or not value or len(value) > _MAX_ERROR_TYPE_LEN:
+    if not isinstance(value, str) or not value or len(value.encode()) > _MAX_ERROR_TYPE_BYTES:
         return None
     if value == _TOOL_ERROR or _safe_status_code(value) is not None:
         return value
@@ -561,8 +560,18 @@ def install_mcp_span_pipeline(connection_string: str, resource: object | None) -
         # global and set_tracer_provider() would be refused.  Returning here is
         # what keeps standing down free of side effects: everything below builds
         # a live Azure exporter.
-        if not isinstance(_trace.get_tracer_provider(), _ProxyTracerProvider):
-            _log.debug("A TracerProvider was already installed; leaving it alone")
+        # Reached through the module handle rather than imported at module level:
+        # ProxyTracerProvider is not in opentelemetry.trace.__all__, unlike its
+        # three co-imported siblings, so it is the one name here that could be
+        # moved without a deprecation.  A module-level ImportError would be raised
+        # while telemetry._get_tracer() imports this module, which would take out
+        # every customEvent on the MCP surface and not merely the spans, reported
+        # at debug level only.
+        if not isinstance(_trace.get_tracer_provider(), _trace.ProxyTracerProvider):
+            _log.debug(
+                "A host TracerProvider already owns the global; standing down "
+                "before building anything"
+            )
             return False
 
         # The Azure trace exporter appends an `_OTELRESOURCE_` MetricData
@@ -573,12 +582,19 @@ def install_mcp_span_pipeline(connection_string: str, resource: object | None) -
         # is.  setdefault, like APPLICATIONINSIGHTS_SDKSTATS_DISABLED: the gate
         # is `!= "true"`, so an operator's explicit value is a real override.
         #
-        # One of four now: statsbeat, customer sdkstats, this, and the
-        # OneSettings control plane (APPLICATIONINSIGHTS_CONTROLPLANE_DISABLED,
-        # set in telemetry.py, #1053).  Assume any Azure Monitor exporter has a
-        # side channel behind an environment variable until proven otherwise,
-        # and expect a fifth: each of the four was found by measuring a running
-        # process, none by reading the library's API surface.
+        # One of five now: statsbeat, customer sdkstats, this, the OneSettings
+        # control plane and the Azure resource detectors' IMDS probe.  The other
+        # four are set in telemetry.py, which carries the full list.  Assume any
+        # Azure Monitor exporter has a side channel behind an environment
+        # variable until proven otherwise, and expect a sixth: every one of the
+        # five was found by measuring a running process, none by reading the
+        # library's API surface.
+        #
+        # Unlike most of those, this one is NOT restored afterwards, because it
+        # is read at export time.  It is also reached only when this function
+        # gets as far as building an exporter, which is right: a host that owns
+        # the global provider has already returned above, and in that case there
+        # is no exporter of ours to smuggle a metric envelope.
         os.environ.setdefault("APPLICATIONINSIGHTS_OPENTELEMETRY_RESOURCE_METRIC_DISABLED", "true")
 
         exporter = _AzureMonitorTraceExporter(connection_string=connection_string)
@@ -598,7 +614,13 @@ def install_mcp_span_pipeline(connection_string: str, resource: object | None) -
 
         _trace.set_tracer_provider(provider)
         if _trace.get_tracer_provider() is not provider:
-            _log.debug("A TracerProvider was already installed; leaving it alone")
+            # Distinct from the message above on purpose: this is the wasteful
+            # path, where a host claimed the global between the check and the
+            # claim, so an exporter was built and has to be torn down again.
+            _log.debug(
+                "A host TracerProvider was installed while this one was being "
+                "built; discarding the exporter we just made"
+            )
             # Stop the batch worker and close the exporter we built but lost.
             provider.shutdown()
             return False

--- a/src/fabric_dw/telemetry_spans.py
+++ b/src/fabric_dw/telemetry_spans.py
@@ -76,7 +76,12 @@ from opentelemetry import trace as _trace
 from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor, SpanExporter, SpanExportResult
 from opentelemetry.sdk.trace.sampling import ALWAYS_ON
-from opentelemetry.trace import DEFAULT_TRACE_STATE, SpanContext, TraceFlags
+from opentelemetry.trace import (
+    DEFAULT_TRACE_STATE,
+    SpanContext,
+    TraceFlags,
+)
+from opentelemetry.trace import ProxyTracerProvider as _ProxyTracerProvider
 from opentelemetry.trace.status import Status
 
 if TYPE_CHECKING:
@@ -128,6 +133,21 @@ _MAX_REQUEST_ID_DIGITS = 19
 #: Longest ``error.type`` recorded.  Server-side exception class names are far
 #: shorter; the cap exists so the invariant does not rest on that.
 _MAX_ERROR_TYPE_LEN = 64
+
+#: Longest ``rpc.response.status_code`` recorded, in digits: the int32 range.
+#: A JSON-RPC error code is a small integer (the spec reserves -32768..-32000
+#: and implementations add their own nearby), but ``ErrorData.code`` is a plain
+#: Python ``int``, so nothing upstream bounds it.  This used to borrow
+#: :data:`_MAX_ERROR_TYPE_LEN`, which allowed a 64-digit code: three times
+#: looser than the 19 digits :data:`_MAX_REQUEST_ID_DIGITS` allows for a request
+#: id, under exactly the same argument that an unbounded numeric field is a
+#: channel (#1052).
+_MAX_STATUS_CODE_DIGITS = 10
+
+#: The one qualname part that is not a Python identifier.  ``type(e).__qualname__``
+#: for an exception class defined inside a function is ``outer.<locals>.Inner``,
+#: which the identifier test alone would reject (#1052).
+_QUALNAME_LOCALS = "<locals>"
 
 # Per-process key for remapping trace ids.  The MCP SDK parents every inbound
 # span on trace context lifted off the wire, so the trace id and the parent span
@@ -240,13 +260,33 @@ def _safe_request_id(value: object) -> str | None:
 
 
 def _safe_status_code(value: object) -> str | None:
-    """Return *value* when it is a JSON-RPC error code, else ``None``."""
+    """Return *value* when it is a JSON-RPC error code, else ``None``.
+
+    Bounded at :data:`_MAX_STATUS_CODE_DIGITS`, which is what a JSON-RPC code
+    can plausibly be, rather than at the ``error.type`` length: digits alone are
+    still a channel, for the same reason they are on ``jsonrpc.request.id``.
+    """
     if not isinstance(value, str):
         return None
     digits = value.removeprefix("-")
-    if digits.isascii() and digits.isdigit() and len(digits) <= _MAX_ERROR_TYPE_LEN:
+    if digits.isascii() and digits.isdigit() and len(digits) <= _MAX_STATUS_CODE_DIGITS:
         return value
     return None
+
+
+def _is_qualname(value: str) -> bool:
+    """Return whether *value* has the shape of a Python qualified name.
+
+    ``<locals>`` is admitted as a whole part because it is what CPython puts in
+    the qualname of a class defined inside a function, and an exception class
+    defined in a function is ordinary code.
+
+    Non-ASCII is admitted too.  ``str.isidentifier`` is the actual language rule
+    and it is Unicode-aware, so ``isascii()`` on top of it rejected class names
+    written in any other script while adding nothing: the shape test is what
+    bounds the value, and the length cap bounds it in characters either way.
+    """
+    return all(part == _QUALNAME_LOCALS or part.isidentifier() for part in value.split("."))
 
 
 def _safe_error_type(value: object) -> str | None:
@@ -258,13 +298,13 @@ def _safe_error_type(value: object) -> str | None:
     that is a property of the current SDK rather than of this code, and the
     server-to-client direction (``sampling/createMessage`` and friends) would
     put a peer's error on a span.  So the invariant is checked rather than
-    assumed: a numeric code, the known literal, or a dotted Python identifier.
+    assumed: a numeric code, the known literal, or a Python qualified name.
     """
     if not isinstance(value, str) or not value or len(value) > _MAX_ERROR_TYPE_LEN:
         return None
     if value == _TOOL_ERROR or _safe_status_code(value) is not None:
         return value
-    if value.isascii() and all(part.isidentifier() for part in value.split(".")):
+    if _is_qualname(value):
         return value
     return None
 
@@ -300,6 +340,62 @@ def _sanitise_attributes(attributes: object) -> dict[str, Any]:
         out["rpc.response.status_code"] = status_code
 
     return out
+
+
+def _safe_parent(parent: object, trace_id: int, safe_trace_id: int) -> SpanContext | None:
+    """Return a parent context safe to export, or ``None`` to cut the link.
+
+    Azure writes the parent span id straight into ``ai.operation.parentId``, and
+    for an inbound message the parent is the W3C context the client put in the
+    request's ``_meta``: a value the client chooses, on a span it can produce at
+    will.  That link is cut.
+
+    A **locally** minted parent is a different thing and is kept, remapped onto
+    the same trace id its child now carries.  It is what makes a server-initiated
+    ``SpanKind.CLIENT`` span nest under the inbound server span that caused it in
+    the App Insights transaction view.  Nothing in this server sends requests to a
+    client today, so this is dormant until an elicitation or sampling call is
+    added, at which point the nesting works rather than needing to be discovered.
+
+    Everything that is not provably local fails closed, because getting this
+    wrong exports a client-chosen span id:
+
+    - ``is_remote`` must be exactly ``False``.  The strict identity test is
+      deliberate: a missing attribute, ``None``, or any other object is treated
+      as remote.  ``is_remote`` is written by OpenTelemetry's propagator when it
+      extracts context off the wire, never by the value the client sent, so it
+      is the real discriminator, but this code should not be the thing that
+      trusts it loosely.
+    - The parent must be a genuine :class:`SpanContext` with a valid, non-zero
+      trace id and span id.
+    - The parent must sit in the same trace as its child.  A local parent always
+      does, by construction; a mismatch means something built this span in a way
+      this code does not understand, and the fail-safe answer is no link.
+
+    Args:
+        parent: ``ReadableSpan.parent``, in whatever shape it arrived.
+        trace_id: The child's original (pre-remap) trace id.
+        safe_trace_id: The remapped trace id the child will be exported with.
+
+    Returns:
+        A :class:`SpanContext` carrying the local parent's span id under the
+        remapped trace id, or ``None``.
+    """
+    if not isinstance(parent, SpanContext):
+        return None
+    # `is not False` rather than `not ...`: only the actual boolean passes, so a
+    # context type that reports something else here is treated as remote.
+    if parent.is_remote is not False:
+        return None
+    if not parent.is_valid or parent.trace_id != trace_id:
+        return None
+    return SpanContext(
+        trace_id=safe_trace_id,
+        span_id=parent.span_id,
+        is_remote=False,
+        trace_flags=TraceFlags(TraceFlags.SAMPLED),
+        trace_state=DEFAULT_TRACE_STATE,
+    )
 
 
 def sanitise_span(span: ReadableSpan) -> ReadableSpan | None:
@@ -341,10 +437,11 @@ def sanitise_span(span: ReadableSpan) -> ReadableSpan | None:
     # the first two as `ai.operation.id` and `ai.operation.parentId`.  Only the
     # span id is minted locally, so only the span id is kept as-is; the trace id
     # is remapped so spans of one trace stay grouped without the client choosing
-    # the value, the parent link is cut, and the tracestate is dropped rather
-    # than relying on the exporter continuing not to serialise it.
+    # the value, and the tracestate is dropped rather than relying on the
+    # exporter continuing not to serialise it.
+    safe_trace_id = _remap_trace_id(context.trace_id)
     safe_context = SpanContext(
-        trace_id=_remap_trace_id(context.trace_id),
+        trace_id=safe_trace_id,
         span_id=context.span_id,
         is_remote=False,
         trace_flags=TraceFlags(TraceFlags.SAMPLED),
@@ -358,7 +455,7 @@ def sanitise_span(span: ReadableSpan) -> ReadableSpan | None:
         # `requests` table) from a server-initiated one (CLIENT, `dependencies`).
         name=method,
         context=safe_context,
-        parent=None,
+        parent=_safe_parent(span.parent, context.trace_id, safe_trace_id),
         resource=span.resource,
         attributes=attributes,
         # Dropped: the SDK's `record_exception` branch puts the exception
@@ -420,13 +517,26 @@ def install_mcp_span_pipeline(connection_string: str, resource: object | None) -
     the CLI produces no protocol spans, so there is nothing there for this
     pipeline to carry and no reason for it to claim the process-wide provider.
 
-    A host application that already installed a ``TracerProvider`` keeps it.
-    OpenTelemetry refuses to override an existing global provider, so this
-    function claims the global **last**, after the provider is fully built, and
-    checks whether the claim took effect.  Order matters: claiming first and
-    then failing to build the exporter would leave an empty provider installed
-    permanently, recording every span in the process into nothing and locking
-    the host out for good, while still reporting failure to the caller.
+    A host application that already installed a ``TracerProvider`` keeps it,
+    and this function stands down without side effects.  Two checks, in this
+    order, and both are needed:
+
+    - Before building anything, the current global is inspected and this
+      function returns early unless it is still the placeholder
+      ``ProxyTracerProvider``.  Without it, standing down was not free.
+      Measured in an embedded host: a real ``AzureMonitorTraceExporter`` was
+      constructed and thrown away, the process-wide
+      ``APPLICATIONINSIGHTS_OPENTELEMETRY_RESOURCE_METRIC_DISABLED`` was set on
+      the way there, and the host got an ``Overriding of current TracerProvider
+      is not allowed`` warning in its logs, all for a pipeline that never ran
+      (#1052).
+    - The claim itself still happens **last**, after the provider is fully
+      built, and is verified afterwards.  That is what covers a host that
+      claims the global between the check and the claim, and the ordering
+      matters on its own: claiming first and then failing to build the exporter
+      would leave an empty provider installed permanently, recording every span
+      in the process into nothing and locking the host out for good, while
+      still reporting failure to the caller.
 
     Args:
         connection_string: The Application Insights connection string.
@@ -445,7 +555,15 @@ def install_mcp_span_pipeline(connection_string: str, resource: object | None) -
         # A host that configured OTEL_PYTHON_TRACER_PROVIDER rather than calling
         # set_tracer_provider() has not claimed the global yet; this read is what
         # makes OpenTelemetry load and install it, so the check below sees it.
-        _trace.get_tracer_provider()
+        #
+        # ProxyTracerProvider is the placeholder OpenTelemetry hands out while no
+        # real provider has been set, so anything else means a host owns the
+        # global and set_tracer_provider() would be refused.  Returning here is
+        # what keeps standing down free of side effects: everything below builds
+        # a live Azure exporter.
+        if not isinstance(_trace.get_tracer_provider(), _ProxyTracerProvider):
+            _log.debug("A TracerProvider was already installed; leaving it alone")
+            return False
 
         # The Azure trace exporter appends an `_OTELRESOURCE_` MetricData
         # envelope to every non-empty export unless this is set, so switching

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -128,7 +128,20 @@ _SDK_ENV_VARS = (
     "APPLICATIONINSIGHTS_STATSBEAT_DISABLED_ALL",
     "APPLICATIONINSIGHTS_SDKSTATS_DISABLED",
     "APPLICATIONINSIGHTS_OPENTELEMETRY_RESOURCE_METRIC_DISABLED",
+    "APPLICATIONINSIGHTS_CONTROLPLANE_DISABLED",
+    "OTEL_EXPERIMENTAL_RESOURCE_DETECTORS",
 )
+
+# Kept deliberately wider than what ``_get_tracer()`` leaves behind today.  Most
+# of these are now applied inside ``telemetry._scoped_env_defaults`` and restored
+# by the code itself, so this fixture is a backstop rather than the mechanism.
+# The two that genuinely survive a real ``_get_tracer()`` are
+# ``APPLICATIONINSIGHTS_STATSBEAT_DISABLED_ALL`` and
+# ``APPLICATIONINSIGHTS_OPENTELEMETRY_RESOURCE_METRIC_DISABLED``; both are read
+# after construction, so the source cannot restore them.  A variable added to
+# ``_SCOPED_SIDE_CHANNELS_OFF`` belongs here too: if the scoping is ever dropped
+# the leak should show up as a test failure, not as a variable quietly set for
+# the rest of the pytest process.
 
 
 @pytest.fixture(autouse=True)
@@ -142,7 +155,7 @@ def _restore_sdk_env() -> Generator[None, None, None]:
     ``test_telemetry_commands.py``.
 
     Deliberately unconditional rather than gated on
-    ``_TELEMETRY_SELF_MANAGED_MODULES``: the cost is a dict of five lookups per
+    ``_TELEMETRY_SELF_MANAGED_MODULES``: the cost is one dict of lookups per
     test, and gating would mean a future module that reaches ``_get_tracer()``
     silently reintroduces the leak until someone remembers to extend the
     frozenset.  Nothing depends on these variables surviving a test.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -218,6 +218,11 @@ def _reset_telemetry_module_globals(
        - ``_sdk_initialised``, ``_tracer``, ``_otel_logger`` → initial values
          (prevents a test that calls ``_get_tracer()`` from leaving a live logger
          object that causes subsequent tests to skip the SDK init path entirely)
+       - ``_span_pipeline_installed`` → ``False``
+         (both ``flush_telemetry`` and ``shutdown_telemetry`` branch on it to
+         decide whether to tear down the global ``TracerProvider``; a leftover
+         ``True`` sends a later test down the span-pipeline teardown path for a
+         provider it never installed)
 
     All resets are applied *before* and *after* each test (yield fixture) so state
     never leaks from a previous test even if it raised.
@@ -295,6 +300,14 @@ def _reset_telemetry_module_globals(
             ns["_sdk_initialised"] = False
             ns["_tracer"] = None
             ns["_otel_logger"] = None
+            # Asserted by name because this one is newer than its neighbours and
+            # both teardown paths branch on it: a rename in telemetry.py should
+            # fail here loudly rather than leave a silent no-op behind.
+            assert "_span_pipeline_installed" in ns, (
+                "_span_pipeline_installed not found in fabric_dw.telemetry — "
+                "update both telemetry.py and tests/conftest.py"
+            )
+            ns["_span_pipeline_installed"] = False
 
     _reset()
     yield

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -1175,6 +1175,7 @@ _WATCHED_OTEL_VARS = (
     "OTEL_METRICS_EXPORTER",
     "OTEL_LOGS_EXPORTER",
     "APPLICATIONINSIGHTS_SDKSTATS_DISABLED",
+    "APPLICATIONINSIGHTS_CONTROLPLANE_DISABLED",
 )
 #
 # The real-process check was run by hand against the locked versions: point
@@ -1266,6 +1267,29 @@ def _resolves_disabled(kind: str, env_at_call: dict[str, str | None]) -> bool:
         resolved: dict[str, Any] = {f"disable_{kind}": True}
         fn(resolved)
         return bool(resolved[f"disable_{kind}"])
+
+
+def _control_plane_is_off(env_at_call: dict[str, str | None]) -> bool:
+    """Ask the REAL library whether the OneSettings control plane is off.
+
+    Same composition as :func:`_resolves_disabled`: the environment as the
+    library sees it at call time, fed through the library's own gate, so this
+    cannot pass while the control plane is live.  ``get_configuration_manager``
+    returns ``None`` only on the disabled branch, and that branch is checked
+    before the singleton is built, so asking is free of side effects.
+    """
+    from azure.monitor.opentelemetry.exporter._configuration._state import (  # noqa: PLC0415
+        get_configuration_manager,
+    )
+
+    var = "APPLICATIONINSIGHTS_CONTROLPLANE_DISABLED"
+    with patch.dict(os.environ, {}, clear=False):
+        value = env_at_call.get(var)
+        if value is None:
+            os.environ.pop(var, None)
+        else:
+            os.environ[var] = value
+        return get_configuration_manager() is None
 
 
 def test_get_tracer_never_lets_the_library_build_the_trace_pipeline(
@@ -1495,6 +1519,71 @@ def test_operator_can_re_enable_customer_sdkstats(
     try:
         assert at_call["APPLICATIONINSIGHTS_SDKSTATS_DISABLED"] == "false", (
             "an explicit operator value must survive"
+        )
+    finally:
+        mod._sdk_initialised = False
+        mod._tracer = None
+        mod._otel_logger = None
+
+
+def test_get_tracer_disables_the_onesettings_control_plane(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, request: pytest.FixtureRequest
+) -> None:
+    """The control plane must be off, on both surfaces, or two promises break.
+
+    ``BaseExporter.__init__`` calls ``get_configuration_manager()``, which starts
+    a ``ConfigurationWorker`` daemon thread polling
+    ``https://settings.sdk.monitor.azure.com/`` roughly hourly and describing this
+    process to it (os, rp, attach, component, version, region, instrumentation
+    key), then registers a callback so the response can toggle this
+    installation's offline storage remotely. The log exporter alone starts it, so
+    it ran on every CLI invocation and for the life of every MCP server.
+
+    ``docs/telemetry.md`` presents a closed list of what leaves the machine and
+    this was not on it, and an inbound remote switch is not something this
+    package should accept on a user's behalf (#1053).
+
+    Measured in a real process before the fix: a ``ConfigurationWorker`` thread
+    and a DNS lookup for ``settings.sdk.monitor.azure.com:443``. After: neither,
+    and ``get_configuration_manager()`` returns ``None``.
+    """
+    mod, at_call, _after = _run_get_tracer(monkeypatch, tmp_path, request)
+    try:
+        assert at_call["APPLICATIONINSIGHTS_CONTROLPLANE_DISABLED"] == "true", (
+            "the OneSettings control plane was left enabled (#1053)"
+        )
+        assert _control_plane_is_off(at_call), (
+            "the environment the library sees at call time still resolves to a live "
+            "control plane, so a ConfigurationWorker thread would start and poll "
+            "settings.sdk.monitor.azure.com."
+        )
+    finally:
+        mod._sdk_initialised = False
+        mod._tracer = None
+        mod._otel_logger = None
+
+
+def test_operator_can_re_enable_the_onesettings_control_plane(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, request: pytest.FixtureRequest
+) -> None:
+    """The control-plane switch is a setdefault, so an explicit value wins.
+
+    The library's gate is ``== "true"``, so any other value keeps the control
+    plane and its remote kill switch. Same treatment as statsbeat and customer
+    sdkstats: this package chooses the default, an operator keeps the choice.
+    """
+    mod, at_call, _after = _run_get_tracer(
+        monkeypatch,
+        tmp_path,
+        request,
+        preset={"APPLICATIONINSIGHTS_CONTROLPLANE_DISABLED": "false"},
+    )
+    try:
+        assert at_call["APPLICATIONINSIGHTS_CONTROLPLANE_DISABLED"] == "false", (
+            "an explicit operator value must survive"
+        )
+        assert not _control_plane_is_off(at_call), (
+            "an operator who asked for the control plane must get it"
         )
     finally:
         mod._sdk_initialised = False

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -1176,6 +1176,8 @@ _WATCHED_OTEL_VARS = (
     "OTEL_LOGS_EXPORTER",
     "APPLICATIONINSIGHTS_SDKSTATS_DISABLED",
     "APPLICATIONINSIGHTS_CONTROLPLANE_DISABLED",
+    "APPLICATIONINSIGHTS_STATSBEAT_DISABLED_ALL",
+    "OTEL_EXPERIMENTAL_RESOURCE_DETECTORS",
 )
 #
 # The real-process check was run by hand against the locked versions: point
@@ -1219,8 +1221,10 @@ def _run_get_tracer(
 
     # Start from a known-clean slate so a value inherited from the surrounding
     # process cannot make these tests pass for the wrong reason. Teardown is
-    # handled by the autouse _restore_sdk_env fixture, which also covers the
-    # assignments _get_tracer() makes directly to os.environ.
+    # handled by the autouse _restore_sdk_env fixture: monkeypatch.delenv records
+    # nothing when the key is already absent, so a raw setdefault inside
+    # _get_tracer() would otherwise survive teardown. Every variable _get_tracer()
+    # writes must therefore be in that fixture's _SDK_ENV_VARS as well as here.
     for key in _WATCHED_OTEL_VARS:
         monkeypatch.delenv(key, raising=False)
     for key, value in (preset or {}).items():
@@ -1274,9 +1278,14 @@ def _control_plane_is_off(env_at_call: dict[str, str | None]) -> bool:
 
     Same composition as :func:`_resolves_disabled`: the environment as the
     library sees it at call time, fed through the library's own gate, so this
-    cannot pass while the control plane is live.  ``get_configuration_manager``
-    returns ``None`` only on the disabled branch, and that branch is checked
-    before the singleton is built, so asking is free of side effects.
+    cannot pass while the control plane is live.
+
+    Not side-effect free on the enabled branch: ``get_configuration_manager()``
+    constructs and caches the process-global ``_ConfigurationManager`` there.  No
+    thread starts and no request is made (the worker starts from
+    ``initialize()``, which only ``BaseExporter.__init__`` calls), so the cost is
+    a cached singleton for the rest of the session.  On the disabled branch the
+    gate returns before the singleton is touched.
     """
     from azure.monitor.opentelemetry.exporter._configuration._state import (  # noqa: PLC0415
         get_configuration_manager,
@@ -1584,6 +1593,148 @@ def test_operator_can_re_enable_the_onesettings_control_plane(
         )
         assert not _control_plane_is_off(at_call), (
             "an operator who asked for the control plane must get it"
+        )
+    finally:
+        mod._sdk_initialised = False
+        mod._tracer = None
+        mod._otel_logger = None
+
+
+def test_get_tracer_disables_the_azure_vm_resource_detector(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, request: pytest.FixtureRequest
+) -> None:
+    """The resource detectors must be off, or every run probes the Azure IMDS endpoint.
+
+    ``configure_azure_monitor`` does
+    ``environ.setdefault(OTEL_EXPERIMENTAL_RESOURCE_DETECTORS,
+    "azure_app_service,azure_vm")`` and then re-runs ``Resource.create()``. The
+    ``azure_vm`` detector calls ``urlopen()`` against 169.254.169.254, on both
+    surfaces, on every telemetry-enabled process. Measured before this was set:
+    ``dns:169.254.169.254:80`` followed by ``tcp:('169.254.169.254', 80)``;
+    after: neither.
+
+    Nothing about the VM reaches the wire today, but on an Azure VM the detector
+    merges ``cloud.resource_id`` (subscription id, resource group and VM name),
+    ``host.id`` and ``host.name`` into the Resource, which is one configuration
+    change away from being exported.
+
+    Note what this test can and cannot do, same caveat as the OTEL_*_EXPORTER
+    tests above: ``configure_azure_monitor`` is mocked here, so no
+    ``Resource.create()`` runs and no probe could happen either way. What is
+    asserted is the environment the library sees at the moment it would decide,
+    which is the fact that determines the outcome.
+    """
+    mod, at_call, _after = _run_get_tracer(monkeypatch, tmp_path, request)
+    try:
+        assert at_call["OTEL_EXPERIMENTAL_RESOURCE_DETECTORS"] == "", (
+            "the Azure resource detectors were left enabled, so azure_vm probes IMDS"
+        )
+    finally:
+        mod._sdk_initialised = False
+        mod._tracer = None
+        mod._otel_logger = None
+
+
+def test_operator_can_re_enable_the_resource_detectors(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, request: pytest.FixtureRequest
+) -> None:
+    """setdefault, so an operator who wants the Azure detectors keeps them.
+
+    ``azure_app_service`` rather than ``azure_vm`` as the preset: this package's
+    own ``_build_otel_resource`` calls ``Resource.create()`` too, inside the
+    scoped window, so an operator asking for ``azure_vm`` really does get an IMDS
+    request here, and a unit test must make no network call. That is itself worth
+    recording: the window has to start before ``_build_otel_resource``, not just
+    before ``configure_azure_monitor``.
+    """
+    mod, at_call, _after = _run_get_tracer(
+        monkeypatch,
+        tmp_path,
+        request,
+        preset={"OTEL_EXPERIMENTAL_RESOURCE_DETECTORS": "azure_app_service"},
+    )
+    try:
+        assert at_call["OTEL_EXPERIMENTAL_RESOURCE_DETECTORS"] == "azure_app_service"
+    finally:
+        mod._sdk_initialised = False
+        mod._tracer = None
+        mod._otel_logger = None
+
+
+def test_get_tracer_hands_the_host_environment_back(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, request: pytest.FixtureRequest
+) -> None:
+    """fabric-dw can be embedded, so its side-channel choices must not outlive the call.
+
+    A host that later builds its own Azure Monitor exporter would otherwise
+    silently inherit them: a disabled OneSettings control plane means it also
+    loses its own offline-storage kill switch, and it never asked for that. The
+    provider-ownership check in ``telemetry_spans`` does not protect it, because
+    these variables are written long before that check runs (#1052).
+
+    The two exceptions are asserted in the other direction rather than left
+    untested, because both are deliberate; see
+    ``test_get_tracer_keeps_the_two_unrestorable_switches_set``.
+    """
+    mod, at_call, after = _run_get_tracer(monkeypatch, tmp_path, request)
+    try:
+        for var in mod._SCOPED_SIDE_CHANNELS_OFF:
+            assert at_call[var] is not None, f"{var} must be set while the SDK is built"
+            assert after[var] is None, (
+                f"{var} escaped into the host process; it started unset and must end unset"
+            )
+    finally:
+        mod._sdk_initialised = False
+        mod._tracer = None
+        mod._otel_logger = None
+
+
+def test_get_tracer_restores_an_operator_value_rather_than_its_own(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, request: pytest.FixtureRequest
+) -> None:
+    """Restoring means putting back what was there, not deleting the key."""
+    preset = {"APPLICATIONINSIGHTS_CONTROLPLANE_DISABLED": "false"}
+    mod, at_call, after = _run_get_tracer(monkeypatch, tmp_path, request, preset=preset)
+    try:
+        assert at_call["APPLICATIONINSIGHTS_CONTROLPLANE_DISABLED"] == "false"
+        assert after["APPLICATIONINSIGHTS_CONTROLPLANE_DISABLED"] == "false"
+    finally:
+        mod._sdk_initialised = False
+        mod._tracer = None
+        mod._otel_logger = None
+
+
+def test_get_tracer_keeps_the_two_unrestorable_switches_set(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, request: pytest.FixtureRequest
+) -> None:
+    """Statsbeat is the one switch that must survive the call, and here is why.
+
+    ``is_statsbeat_enabled()`` re-reads the environment on every call, and
+    ``BaseExporter._should_collect_stats()`` calls it on every export, so
+    restoring the variable flips statsbeat bookkeeping back on inside this
+    process for the rest of its life. Measured on a live log exporter with the
+    variable removed after init: ``is_statsbeat_enabled()`` False -> True and
+    ``_should_collect_stats()`` False -> True.
+
+    So this asserts the leak rather than the absence of one. If a future version
+    of the library moves that read to construction time, this test is the place
+    that says the switch can then move into ``_SCOPED_SIDE_CHANNELS_OFF``.
+
+    (``APPLICATIONINSIGHTS_OPENTELEMETRY_RESOURCE_METRIC_DISABLED`` is the other
+    one, for the same reason: it is read at export time. It is set inside
+    ``telemetry_spans`` and covered by that module's tests.)
+    """
+    mod, at_call, after = _run_get_tracer(monkeypatch, tmp_path, request)
+    try:
+        var = "APPLICATIONINSIGHTS_STATSBEAT_DISABLED_ALL"
+        assert at_call[var] == "true"
+        assert after[var] == "true", (
+            "statsbeat must stay disabled for the exporter's lifetime; restoring it "
+            "re-arms statsbeat bookkeeping inside this process"
+        )
+        assert var not in mod._SCOPED_SIDE_CHANNELS_OFF, (
+            "statsbeat cannot be scoped and restored; see the comment at its "
+            "assignment site in telemetry.py"
         )
     finally:
         mod._sdk_initialised = False

--- a/tests/unit/test_telemetry_spans.py
+++ b/tests/unit/test_telemetry_spans.py
@@ -17,6 +17,7 @@ execution order.
 from __future__ import annotations
 
 import contextlib
+import os
 import sys
 from types import SimpleNamespace
 from typing import Any
@@ -34,7 +35,13 @@ from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor, SpanExportResult
 from opentelemetry.sdk.trace.sampling import ALWAYS_ON
 from opentelemetry.sdk.util.instrumentation import InstrumentationScope
-from opentelemetry.trace import SpanContext, SpanKind, StatusCode, TraceState
+from opentelemetry.trace import (
+    ProxyTracerProvider,
+    SpanContext,
+    SpanKind,
+    StatusCode,
+    TraceState,
+)
 from opentelemetry.trace.status import Status
 
 from fabric_dw import telemetry_spans
@@ -554,6 +561,11 @@ def _patch_global_provider_hooks(
     and the ``sys.modules`` entry as two different objects for the rest of the
     session.  Patching the wrong one of those two patches nothing at all and
     lets the real function run.
+
+    ``getter`` must return a :class:`ProxyTracerProvider` for the "nobody has
+    claimed the global yet" state, which is the object OpenTelemetry itself
+    hands out then, because the install path checks for exactly that before it
+    builds anything.
     """
     monkeypatch.setattr(
         telemetry_spans,
@@ -562,27 +574,57 @@ def _patch_global_provider_hooks(
     )
 
 
-def test_a_host_installed_tracer_provider_keeps_winning(
+def test_a_host_installed_tracer_provider_costs_nothing_to_lose_to(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """An application that already set a provider must keep it, and its exporter.
+    """An application that already set a provider must keep it, at no cost to it.
 
-    OpenTelemetry refuses to override an existing global provider, so the
-    ``set_tracer_provider`` call below is silently ignored, exactly as it would
-    be in a host process.  The pipeline has to notice and stand down instead of
-    building an exporter nothing will ever feed.
+    OpenTelemetry refuses to override an existing global provider, so this
+    package has to stand down.  Standing down has to be free: building the real
+    Azure exporter first and discarding it set a process-wide environment
+    variable, opened the exporter's local storage, and put an ``Overriding of
+    current TracerProvider is not allowed`` warning in the host's logs, all for a
+    pipeline that never ran (#1052).
     """
     host_provider = TracerProvider()
+    claimed: list[object] = []
+    _patch_global_provider_hooks(monkeypatch, setter=claimed.append, getter=lambda: host_provider)
+
+    def _no_exporter_please(**_kw: Any) -> Any:
+        pytest.fail("an exporter was built for a pipeline that will never run")
+
+    monkeypatch.setattr(telemetry_spans, "_AzureMonitorTraceExporter", _no_exporter_please)
+    monkeypatch.delenv("APPLICATIONINSIGHTS_OPENTELEMETRY_RESOURCE_METRIC_DISABLED", raising=False)
+
+    assert install_mcp_span_pipeline(_CONNECTION_STRING, None) is False
+    assert claimed == [], "set_tracer_provider must not be called at all"
+    # Set on the way to building the exporter, so it is a proxy for having got
+    # that far, and it is process-wide state a host did not ask for.
+    assert "APPLICATIONINSIGHTS_OPENTELEMETRY_RESOURCE_METRIC_DISABLED" not in os.environ
+
+
+def test_a_host_claiming_the_global_late_still_gets_the_exporter_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The pre-check is not the whole guard; the post-claim check is still needed.
+
+    A host that claims the global between the check and the claim gets past the
+    early return, so the exporter is built after all.  That one has to be shut
+    down rather than left running with its batch worker and its storage folder.
+    """
+    host_provider = TracerProvider()
+    providers: list[object] = [ProxyTracerProvider(), host_provider]
     _patch_global_provider_hooks(
-        monkeypatch, setter=lambda _provider: None, getter=lambda: host_provider
+        monkeypatch,
+        setter=lambda _provider: None,
+        # First read is the pre-check, second is the verification after the claim.
+        getter=lambda: providers.pop(0) if providers else host_provider,
     )
 
     captured = _CapturingExporter()
     monkeypatch.setattr(telemetry_spans, "_AzureMonitorTraceExporter", lambda **_kw: captured)
 
     assert install_mcp_span_pipeline(_CONNECTION_STRING, None) is False
-    # The exporter is built before the global is claimed, so losing the race
-    # means there is a batch worker and an exporter to close again.
     assert captured.shutdown_calls == 1, "the provider we built and lost must be shut down"
 
 
@@ -591,10 +633,11 @@ def test_installing_the_pipeline_wires_the_sanitiser_in_front_of_azure(
 ) -> None:
     """The happy path: our provider wins, and the Azure exporter sits behind the sanitiser."""
     installed: dict[str, Any] = {}
+    proxy = ProxyTracerProvider()
     _patch_global_provider_hooks(
         monkeypatch,
         setter=lambda provider: installed.setdefault("p", provider),
-        getter=lambda: installed.get("p"),
+        getter=lambda: installed.get("p", proxy),
     )
 
     captured = _CapturingExporter()
@@ -692,7 +735,7 @@ def test_installing_the_pipeline_never_raises(monkeypatch: pytest.MonkeyPatch) -
     def _explode(_provider: Any) -> None:
         raise RuntimeError("boom")
 
-    _patch_global_provider_hooks(monkeypatch, setter=_explode, getter=lambda: None)
+    _patch_global_provider_hooks(monkeypatch, setter=_explode, getter=ProxyTracerProvider)
 
     assert install_mcp_span_pipeline(_CONNECTION_STRING, None) is False
 
@@ -740,7 +783,18 @@ def test_a_request_id_is_capped_at_the_int64_range(request_id: str, kept: bool) 
         ("-32601", True),
         ("ValueError", True),
         ("mcp.shared.exceptions.MCPError", True),
+        # A real `type(e).__qualname__` for an exception class defined inside a
+        # function, which the identifier test alone rejected (#1052).
+        ("handle.<locals>.RetryableError", True),
+        # `str.isidentifier` is Unicode-aware, and a class name in another script
+        # is ordinary code, not a smuggled string.
+        ("Ongeldigeİnvoer", True),
+        ("Ошибка", True),
         ("Unknown prompt: " + MARKER, False),
+        ("<locals>", True),
+        ("a.<locals", False),
+        ("locals>.Boom", False),
+        ("a..b", False),
         ("a" * 65, False),
         ("", False),
     ],
@@ -759,6 +813,174 @@ def test_error_type_is_checked_rather_than_assumed_safe(value: str, kept: bool) 
 
     assert sanitised is not None
     assert ("error.type" in (sanitised.attributes or {})) is kept
+
+
+@pytest.mark.parametrize(
+    ("value", "kept"),
+    [
+        ("-32601", True),
+        ("0", True),
+        ("9" * 10, True),
+        ("9" * 11, False),
+        ("-" + "9" * 11, False),
+        ("9" * 64, False),
+        ("tool_error", False),
+    ],
+)
+def test_a_status_code_is_capped_at_what_a_jsonrpc_code_can_be(value: str, kept: bool) -> None:  # noqa: FBT001
+    """A JSON-RPC error code is a small integer, so the field is bounded like one.
+
+    It used to borrow the 64-character ``error.type`` cap, which kept a 64-digit
+    value: three times looser than the 19 digits a request id gets, under exactly
+    the argument that an unbounded numeric field is a channel (#1052).
+    """
+    span = _make_span(
+        MCP_SDK_SCOPE,
+        "ping",
+        {"mcp.method.name": "ping", "rpc.response.status_code": value},
+    )
+    sanitised = sanitise_span(span)
+
+    assert sanitised is not None
+    assert ("rpc.response.status_code" in (sanitised.attributes or {})) is kept
+
+
+def test_an_overlong_numeric_error_type_is_dropped_too() -> None:
+    """``error.type`` accepts a numeric code through the same bounded check.
+
+    So tightening the status-code cap has to tighten this too, rather than
+    letting a 30-digit "code" fall through to some other branch and survive.
+    """
+    span = _make_span(
+        MCP_SDK_SCOPE,
+        "ping",
+        {"mcp.method.name": "ping", "error.type": "9" * 30},
+    )
+    sanitised = sanitise_span(span)
+
+    assert sanitised is not None
+    assert "error.type" not in (sanitised.attributes or {})
+
+
+# ---------------------------------------------------------------------------
+# The parent link
+# ---------------------------------------------------------------------------
+
+
+def _span_with_parent(
+    parent: SpanContext | None, *, kind: SpanKind = SpanKind.SERVER
+) -> ReadableSpan:
+    """Return an MCP-scoped span whose parent is *parent*, in the same trace."""
+    trace_id = parent.trace_id if parent is not None else 0x0BADC0DE0BADC0DE0BADC0DE0BADC0DE
+    return ReadableSpan(
+        name="tools/call",
+        context=SpanContext(trace_id=trace_id, span_id=0xAAAA, is_remote=False),
+        parent=parent,
+        kind=kind,
+        instrumentation_scope=InstrumentationScope(MCP_SDK_SCOPE),
+        attributes={"mcp.method.name": "tools/call"},
+        start_time=1,
+        end_time=2,
+    )
+
+
+def test_a_remote_parent_is_cut() -> None:
+    """The client chooses the parent span id of an inbound span, so it is dropped.
+
+    Azure writes it straight into ``ai.operation.parentId``.
+    """
+    remote = SpanContext(
+        trace_id=int(MARKER_TRACE_BYTES.hex(), 16),
+        span_id=int(MARKER_PARENT_BYTES.hex(), 16),
+        is_remote=True,
+    )
+    sanitised = sanitise_span(_span_with_parent(remote))
+
+    assert sanitised is not None
+    assert sanitised.parent is None
+
+
+def test_a_local_parent_survives_so_client_spans_still_nest() -> None:
+    """Cutting the remote parent must not cut the locally minted one as well.
+
+    The dispatcher's ``SpanKind.CLIENT`` span is parented on the inbound server
+    span this process created, and that link is what makes it nest in the App
+    Insights transaction view.  Nothing here sends requests to a client yet, so
+    the regression was invisible until an elicitation or sampling call was added
+    (#1052).
+    """
+    local_trace_id = 0x0BADC0DE0BADC0DE0BADC0DE0BADC0DE
+    local_parent = SpanContext(trace_id=local_trace_id, span_id=0xBBBB, is_remote=False)
+    span = _span_with_parent(local_parent, kind=SpanKind.CLIENT)
+
+    sanitised = sanitise_span(span)
+
+    assert sanitised is not None
+    assert sanitised.parent is not None
+    assert sanitised.parent.span_id == 0xBBBB, "the local parent's span id is minted here"
+    # The child's own trace id is remapped, so the parent has to be remapped with
+    # it or the link points at a trace that was never exported.
+    assert sanitised.parent.trace_id == sanitised.context.trace_id
+    assert sanitised.parent.trace_id != local_trace_id
+    assert sanitised.parent.is_remote is False
+    assert sanitised.parent.trace_state == TraceState()
+
+
+@pytest.mark.parametrize(
+    "parent",
+    [
+        pytest.param(None, id="no-parent"),
+        pytest.param(
+            SpanContext(trace_id=0, span_id=0xBBBB, is_remote=False), id="invalid-trace-id"
+        ),
+        pytest.param(
+            SpanContext(trace_id=0x0BADC0DE0BADC0DE0BADC0DE0BADC0DE, span_id=0, is_remote=False),
+            id="invalid-span-id",
+        ),
+        pytest.param(
+            SimpleNamespace(trace_id=1, span_id=2, is_remote=False, is_valid=True),
+            id="not-a-span-context",
+        ),
+        pytest.param(
+            SimpleNamespace(trace_id=1, span_id=2, is_valid=True), id="no-is-remote-at-all"
+        ),
+    ],
+)
+def test_only_a_provably_local_parent_is_kept(parent: Any) -> None:
+    """Anything not provably local fails closed, because the cost of being wrong
+    is exporting a span id the client chose."""
+    sanitised = sanitise_span(_span_with_parent(parent))
+
+    assert sanitised is not None
+    assert sanitised.parent is None
+
+
+def test_a_parent_from_another_trace_is_cut() -> None:
+    """A local parent always shares its child's trace id.
+
+    One that does not means this span was built in a way this code does not
+    understand, and the safe answer is no link rather than a remapped span id
+    hung off the child's trace.
+    """
+    stranger = SpanContext(
+        trace_id=0x11111111111111111111111111111111, span_id=0xBBBB, is_remote=False
+    )
+    span = ReadableSpan(
+        name="tools/call",
+        context=SpanContext(
+            trace_id=0x22222222222222222222222222222222, span_id=0xAAAA, is_remote=False
+        ),
+        parent=stranger,
+        instrumentation_scope=InstrumentationScope(MCP_SDK_SCOPE),
+        attributes={"mcp.method.name": "tools/call"},
+        start_time=1,
+        end_time=2,
+    )
+
+    sanitised = sanitise_span(span)
+
+    assert sanitised is not None
+    assert sanitised.parent is None
 
 
 # ---------------------------------------------------------------------------
@@ -880,8 +1102,9 @@ def test_a_failed_exporter_build_never_claims_the_global(
     out for good, and the caller told the install had failed.
     """
     claimed: list[object] = []
+    proxy = ProxyTracerProvider()
     _patch_global_provider_hooks(
-        monkeypatch, setter=claimed.append, getter=lambda: claimed[-1] if claimed else None
+        monkeypatch, setter=claimed.append, getter=lambda: claimed[-1] if claimed else proxy
     )
 
     def _explode(**_kw: Any) -> Any:

--- a/tests/unit/test_telemetry_spans.py
+++ b/tests/unit/test_telemetry_spans.py
@@ -775,6 +775,10 @@ def _envelopes_for(monkeypatch: pytest.MonkeyPatch, spans: list[ReadableSpan]) -
     """
     monkeypatch.setenv("APPLICATIONINSIGHTS_STATSBEAT_DISABLED_ALL", "true")
     monkeypatch.setenv("APPLICATIONINSIGHTS_SDKSTATS_DISABLED", "true")
+    # As telemetry.py sets it before the first exporter exists (#1053): otherwise
+    # constructing a real exporter starts the OneSettings ConfigurationWorker,
+    # which polls settings.sdk.monitor.azure.com from its own thread.
+    monkeypatch.setenv("APPLICATIONINSIGHTS_CONTROLPLANE_DISABLED", "true")
 
     # The resource-metric branch reads `tracer_provider.resource`, so it only
     # fires when a real provider is in play, which is exactly the production

--- a/tests/unit/test_telemetry_spans.py
+++ b/tests/unit/test_telemetry_spans.py
@@ -570,7 +570,15 @@ def _patch_global_provider_hooks(
     monkeypatch.setattr(
         telemetry_spans,
         "_trace",
-        SimpleNamespace(set_tracer_provider=setter, get_tracer_provider=getter),
+        SimpleNamespace(
+            set_tracer_provider=setter,
+            get_tracer_provider=getter,
+            # The real class, not a stand-in: the install path reads
+            # ProxyTracerProvider off this same handle rather than importing it at
+            # module level, and an isinstance() against a different object would
+            # make every test here pass for the wrong reason.
+            ProxyTracerProvider=ProxyTracerProvider,
+        ),
     )
 
 
@@ -790,6 +798,12 @@ def test_a_request_id_is_capped_at_the_int64_range(request_id: str, kept: bool) 
         # is ordinary code, not a smuggled string.
         ("Ongeldigeİnvoer", True),
         ("Ошибка", True),
+        # 24 characters, 48 bytes: comfortably inside the cap either way.
+        ("Ошибка" * 4, True),
+        # 42 characters but 84 bytes. Under a character cap this is KEPT and puts
+        # 84 bytes on the wire against a limit that says 64, which is why the cap
+        # counts encoded bytes (#1052 review).
+        ("Ошибка" * 7, False),
         ("Unknown prompt: " + MARKER, False),
         ("<locals>", True),
         ("a.<locals", False),
@@ -807,6 +821,11 @@ def test_error_type_is_checked_rather_than_assumed_safe(value: str, kept: bool) 
     holds only while this server sends no requests to the client; the
     server-to-client direction would put a peer's error text here. Checking the
     shape costs one comparison and makes the invariant ours.
+
+    The length cap counts UTF-8 bytes, not characters: `str.isidentifier` is
+    Unicode-aware, so a 64-character class name in another script is up to 256
+    bytes on the wire, and every other bound in this module is about what
+    actually gets transmitted.
     """
     span = _make_span(MCP_SDK_SCOPE, "ping", {"mcp.method.name": "ping", "error.type": value})
     sanitised = sanitise_span(span)
@@ -926,16 +945,38 @@ def test_a_local_parent_survives_so_client_spans_still_nest() -> None:
     assert sanitised.parent.trace_state == TraceState()
 
 
+_LOCAL_TRACE_ID = 0x0BADC0DE0BADC0DE0BADC0DE0BADC0DE
+
+
 @pytest.mark.parametrize(
     "parent",
     [
         pytest.param(None, id="no-parent"),
         pytest.param(
+            SpanContext(trace_id=_LOCAL_TRACE_ID, span_id=0xBBBB, is_remote=True), id="remote"
+        ),
+        pytest.param(
             SpanContext(trace_id=0, span_id=0xBBBB, is_remote=False), id="invalid-trace-id"
         ),
         pytest.param(
-            SpanContext(trace_id=0x0BADC0DE0BADC0DE0BADC0DE0BADC0DE, span_id=0, is_remote=False),
+            SpanContext(trace_id=_LOCAL_TRACE_ID, span_id=0, is_remote=False),
             id="invalid-span-id",
+        ),
+        # The two below are the whole reason the test is `is not False` rather
+        # than `if parent.is_remote:`.  SpanContext stores the field verbatim, so
+        # these are constructible, and under a truthiness test both would be
+        # KEPT and their span id exported.  Both are genuine SpanContexts, so
+        # they get past the isinstance guard and actually reach the comparison;
+        # the SimpleNamespace cases further down do not, and pin something else.
+        pytest.param(
+            # The suppression below is the point of the case: the parameter is
+            # annotated `bool` and the runtime stores whatever it is handed.
+            SpanContext(trace_id=_LOCAL_TRACE_ID, span_id=0xBBBB, is_remote=None),  # ty: ignore[invalid-argument-type]
+            id="is-remote-is-none",
+        ),
+        pytest.param(
+            SpanContext(trace_id=_LOCAL_TRACE_ID, span_id=0xBBBB, is_remote=0),  # ty: ignore[invalid-argument-type]
+            id="is-remote-is-zero",
         ),
         pytest.param(
             SimpleNamespace(trace_id=1, span_id=2, is_remote=False, is_valid=True),
@@ -953,6 +994,29 @@ def test_only_a_provably_local_parent_is_kept(parent: Any) -> None:
 
     assert sanitised is not None
     assert sanitised.parent is None
+
+
+def test_a_falsy_non_boolean_is_remote_is_treated_as_remote() -> None:
+    """Guards the identity comparison directly, not through the isinstance check.
+
+    ``SpanContext`` stores ``is_remote`` verbatim, so ``None`` and ``0`` are both
+    reachable, and a readability pass that rewrites the guard as
+    ``if parent.is_remote:`` keeps every other test in this module green while
+    starting to export the parent span id for both.  This one fails.
+    """
+    for value in (None, 0):
+        # Suppressed for the same reason as above: `is_remote` is annotated
+        # `bool` but never coerced, so these values are reachable at runtime.
+        parent = SpanContext(trace_id=_LOCAL_TRACE_ID, span_id=0xBBBB, is_remote=value)  # ty: ignore[invalid-argument-type]
+        assert parent.is_remote is value, "SpanContext must not be coercing the field"
+
+        sanitised = sanitise_span(_span_with_parent(parent))
+
+        assert sanitised is not None
+        assert sanitised.parent is None, (
+            f"is_remote={value!r} is not the boolean False, so the parent is not "
+            "provably local and its span id must not be exported"
+        )
 
 
 def test_a_parent_from_another_trace_is_cut() -> None:


### PR DESCRIPTION
Two telemetry follow-ups in one PR, one commit each, because they touch the same two files.

Closes #1053
Closes #1052

## #1053: the OneSettings control plane is switched off

`BaseExporter.__init__` calls `get_configuration_manager()`, which starts a `ConfigurationWorker` daemon thread polling `https://settings.sdk.monitor.azure.com/` roughly hourly, describes this process to it (os, rp, attach, component, version, region and the instrumentation key), and registers a callback so the response can toggle this installation's offline storage remotely. The log exporter alone starts it, so it ran on every CLI invocation and for the life of every MCP server.

Decision: disable it, rather than document it. `docs/telemetry.md` presents a closed list of what leaves the machine and users make their opt-out decision on that basis, and an inbound remote switch over this installation's behaviour is not something this package should accept on a user's behalf. That is what was already done for the three other side channels of this stack.

`APPLICATIONINSIGHTS_CONTROLPLANE_DISABLED` is set with `setdefault`, like the statsbeat and customer-sdkstats switches. The library's gate is `disabled.lower() == "true"`, so an operator who sets any other value keeps the control plane and its remote kill switch.

### Measured in a real process

Driving `telemetry._get_tracer()` on the MCP surface with `socket.getaddrinfo` and `socket.socket.connect` recorded, waiting out the worker's 5-15 second startup delay.

Before, on `main`:

```
"APPLICATIONINSIGHTS_CONTROLPLANE_DISABLED": null,
"configuration_manager_singleton": "_ConfigurationManager",
"configuration_worker_threads": ["ConfigurationWorker"],
"settings_endpoint_contacts": ["dns:settings.sdk.monitor.azure.com:443"],
"all_threads": ["AzureMonitorLogExporter Storage", "AzureMonitorTraceExporter Storage",
                "ConfigurationWorker", "MainThread", "OtelBatchLogRecordProcessor",
                "OtelBatchSpanRecordProcessor"]
```

After:

```
"APPLICATIONINSIGHTS_CONTROLPLANE_DISABLED": "true",
"configuration_manager_singleton": "NoneType",
"configuration_worker_threads": [],
"settings_endpoint_contacts": [],
"all_threads": ["AzureMonitorLogExporter Storage", "AzureMonitorTraceExporter Storage",
                "MainThread", "OtelBatchLogRecordProcessor", "OtelBatchSpanRecordProcessor"]
```

With `APPLICATIONINSIGHTS_CONTROLPLANE_DISABLED=false` pre-set, the manager, the worker thread and the DNS lookup all come back, so the operator override is real. The CLI surface measures the same as the MCP surface, since the log exporter is what starts the worker.

Pinned by `test_get_tracer_disables_the_onesettings_control_plane`, which asserts the environment as the library sees it at call time and then feeds that environment through the library's own `get_configuration_manager()` gate, the same composition the existing `OTEL_*_EXPORTER` tests use. Reverting the `setdefault` line makes it fail. `test_operator_can_re_enable_the_onesettings_control_plane` pins the override.

The comment enumerating these side channels now lists all four and says to expect a fifth, since each of the four was found by measuring a live process rather than by reading the library's API surface.

## #1052: six items

**1. Losing the provider race builds no exporter.** `install_mcp_span_pipeline` already read the global provider and discarded the result; it now returns early unless that is still a `ProxyTracerProvider`.

This does not reintroduce the ordering bug. The claim still happens last, after the provider is fully built, and is still verified afterwards. The pre-check only covers the case where a host already owns the global; the post-claim check still covers a host claiming it between the check and the claim, and the "build before claiming" ordering is what keeps a failed exporter build from leaving an empty provider installed for good. Both paths have a test (`test_a_host_installed_tracer_provider_costs_nothing_to_lose_to`, `test_a_host_claiming_the_global_late_still_gets_the_exporter_closed`), plus the existing `test_a_failed_exporter_build_never_claims_the_global`.

Measured in a real process with a host `TracerProvider` installed first, before:

```
"APPLICATIONINSIGHTS_OPENTELEMETRY_RESOURCE_METRIC_DISABLED": "true",
"overriding_warning": ["Overriding of current TracerProvider is not allowed"],
"configuration_worker_threads": ["ConfigurationWorker"]
```

after:

```
"APPLICATIONINSIGHTS_OPENTELEMETRY_RESOURCE_METRIC_DISABLED": null,
"overriding_warning": [],
"configuration_worker_threads": []
```

One correction to the issue: the leftover `/tmp/Microsoft-AzureMonitor-<hash>/opentelemetry-python-<ikey>/` directory is not attributable to the discarded trace exporter. Both exporters key that folder on the instrumentation key, so the log exporter creates the same path on every telemetry-enabled run. Measured with a scoped `TMPDIR`: the directory appears identically before and after this change, and also on a CLI-surface run where no span pipeline is built at all. The other three signals are fixed.

**2. `rpc.response.status_code` is bounded at 10 digits** (the int32 range) instead of borrowing the 64-character `error.type` cap. A JSON-RPC error code is a small integer, and `ErrorData.code` is a plain Python `int`, so nothing upstream bounds it. `error.type` accepts a numeric code through the same check, so it tightens with it.

**3. The local parent link survives while a remote parent is still cut.** The parent is kept only when it is a genuine `SpanContext` whose `is_remote` is exactly `False`, is valid, and sits in the same trace as its child; it is then remapped onto the child's remapped trace id so the link points at a trace that was actually exported.

On the "cannot be tricked into treating a remote parent as local" question: `is_remote` is written by OpenTelemetry's propagator when it extracts context off the wire, never by the text the client sent, so it is the real discriminator. The check does not lean on that alone. The test is `is not False`, an identity comparison, so a missing attribute, `None`, `0` or any other object is treated as remote; a non-`SpanContext` parent is rejected outright; and a parent from another trace is rejected too. Each of those is a parametrised test case.

**4. `_safe_error_type` keeps two shapes it used to drop**: a `<locals>` qualname, which is the real `type(e).__qualname__` for an exception class defined inside a function, and non-ASCII class names. `str.isidentifier` is the language rule and is already Unicode-aware, so the `isascii()` test on top of it rejected other scripts while adding nothing. `<locals>` is admitted as a whole part only, so `a.<locals` and `locals>.Boom` are still dropped.

**5. `_span_pipeline_installed` is reset** in the conftest teardown list, with the same name-exists assert its neighbours get. Renaming the global in `telemetry.py` makes that assert fire, verified.

**6. Two documentation corrections.** `mcp_client_connected` now mentions the eight-name cap in its table row, and the trace-id wording says remapped through a per-process keyed hash rather than "removed". `docs/telemetry.md` goes from 107 to 111 lines.

## Checks

- `just lint`: passed, including `ruff format --check` on 361 files
- `just type`: passed
- `uv run pytest tests/unit`: 6279 passed, 2 deselected
- `uv sync --locked --no-dev && fabric-dw-mcp --help`: passed

Each fix was mutation-checked: reverting the control-plane `setdefault`, the early return, the status-code cap, the parent-link call, or the qualname test each makes exactly one test fail.

No integration tests were triggered and no gating label was applied.

---

## Review round 1

Four blocking items, all fixed. Ten mutations tried against the final state, ten caught.

### A fifth side channel, and the sentence that denied it

The review found that the control-plane poll was gone but an IMDS probe was not. Confirmed on the branch:

```
"settings_endpoint_contacts": [],
"contacts_during_init": ["dns:169.254.169.254:80", "tcp:('169.254.169.254', 80)"]
```

`configure_azure_monitor` does `environ.setdefault(OTEL_EXPERIMENTAL_RESOURCE_DETECTORS, "azure_app_service,azure_vm")` and re-runs `Resource.create()`; the `azure_vm` detector calls `urlopen()` against 169.254.169.254. Both surfaces, every telemetry-enabled process. Switched off with the same `setdefault` treatment.

One thing the review's snippet does not cover: this package's own `_build_otel_resource()` calls `Resource.create()` too, so the switch has to be in place before that, not merely before `configure_azure_monitor`. A unit test presetting `azure_vm` tripped `pytest-socket` and is what surfaced it.

Measured after, both surfaces:

```
cli: contacts=[]  part_a={service.namespace: fabric-dw, service.name: cli,
     service.instance.id: <install id>, service.version: <version>, device.id: <install id>}
     azure_detector_attrs_present=[]
mcp: contacts=[]  same Part A fields, plus the trace exporter threads
```

So the detectors go off at no cost to the Part A fields from #477. The docs sentence is now true, the side-channel list says five, and the statsbeat entry no longer claims to cover "its Azure IMDS probe" as though that were blanket IMDS coverage.

### The switches leaked into an embedding host

`_scoped_env_defaults()` applies and restores them. The window extends past `configure_azure_monitor` on purpose, because `install_mcp_span_pipeline` builds a second exporter afterwards that reaches the same code.

Which ones can be scoped was measured, by removing each after init and watching a live process for 35 seconds:

| Variable | Restorable | Evidence |
|---|---|---|
| `APPLICATIONINSIGHTS_CONTROLPLANE_DISABLED` | yes | no `ConfigurationWorker`, no settings-endpoint contact after the restore |
| `APPLICATIONINSIGHTS_SDKSTATS_DISABLED` | yes | export-time check reads a cached manager attribute; `_should_collect_customer_sdkstats()` stays False |
| `OTEL_EXPERIMENTAL_RESOURCE_DETECTORS` | yes | read only inside `Resource.create()` |
| `APPLICATIONINSIGHTS_STATSBEAT_DISABLED_ALL` | **no** | `is_statsbeat_enabled()` re-reads the environment on every call and `_should_collect_stats()` calls it on every export; with the variable removed both go False to True on the live log exporter |
| `APPLICATIONINSIGHTS_OPENTELEMETRY_RESOURCE_METRIC_DISABLED` | **no** | read at export time, already documented |

So statsbeat stays set for the exporter's lifetime, documented at its assignment site and pinned by a test that asserts the leak deliberately, with the condition under which it could move. No statsbeat manager is ever initialised so nothing transmits, but the guarantee this package makes is that the switch is off, not that the blast radius is small.

Final state, MCP surface:

```
"env_after_get_tracer": {
  "APPLICATIONINSIGHTS_STATSBEAT_DISABLED_ALL": "true",
  "APPLICATIONINSIGHTS_SDKSTATS_DISABLED": null,
  "APPLICATIONINSIGHTS_CONTROLPLANE_DISABLED": null,
  "APPLICATIONINSIGHTS_OPENTELEMETRY_RESOURCE_METRIC_DISABLED": "true",
  "OTEL_EXPERIMENTAL_RESOURCE_DETECTORS": null
},
"contacts_during_init": [],
"configuration_manager": "NoneType"
```

### Test fixture

`_SDK_ENV_VARS` gains both new variables. The comment in `test_telemetry.py` that claimed the fixture already covered the direct assignments is corrected to say the opposite: every variable `_get_tracer()` writes must be listed there.

### The `is not False` check

It was the one mutation of nine that survived, and the review is right about why: the two cases meant to cover it used `SimpleNamespace`, which the isinstance guard rejects one line earlier. `SpanContext` stores `is_remote` verbatim (verified: `None` and `0` both survive the constructor), so there are now cases on genuine `SpanContext`s plus a dedicated test. `if parent.is_remote:` now fails three tests.

### Cheap items

All six done: byte-based `error.type` cap (pinned with a 42-character, 84-byte Cyrillic class name that a character cap keeps), distinct debug messages for the two stand-down paths, `_trace.ProxyTracerProvider` at call time with the test stub carrying the real class, the `ai.operation.parentId` table row, the side-channel list corrected to five with the note about where number 3 is set, and `_control_plane_is_off` no longer claiming to be side-effect free.

### Round-2 checks

- `just lint`: passed, including `ruff format --check` on 361 files
- `just type`: passed
- `uv run pytest tests/unit`: 6290 passed, 2 deselected
- `uv sync --locked --no-dev && fabric-dw-mcp --help`: passed
- `docs/telemetry.md`: 109 lines against 108 on the merge base, the one added line being the `parentId` table row

Mutations, all caught: `is_remote` to truthiness, resource detectors left on, scoped window removed, `error.type` byte cap to character cap, control-plane default removed, early return removed, status-code cap loosened, parent cut unconditionally, qualname test tightened back, `_span_pipeline_installed` renamed.
