### PR TITLE
docs: move protocol and transport detail off README and install guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,16 +183,6 @@ fabric-dw-mcp --transport http [--host 127.0.0.1] [--port 8000]
 
 It binds to loopback by default, where Host and Origin validation is handled for you. Binding anywhere else requires `FABRIC_MCP_ALLOW_REMOTE=1` and `--allowed-host`, and the endpoint has **no built-in authentication or TLS**, so always front it with an authenticating reverse proxy. See [Hosting the MCP server](https://fdw.debruyn.dev/reference/hosting-mcp-server/) for that setup.
 
-Request bodies are capped at 4 MiB; anything larger is rejected with HTTP 413. In practice only a multi-megabyte `execute_sql` script or object definition can reach that. The stdio transport has no such limit.
-
-#### Protocol versions
-
-The server speaks MCP revision `2026-07-28` and continues to serve `2025-11-25` clients from the same process, so no client change is needed. Two protocol-level notes for anyone driving the server directly.
-
-`ping` was removed in revision `2026-07-28`, but only for clients that negotiate that revision: a `2025-11-25` client can still call it and this server still answers. A `2026-07-28` client gets `-32601` instead. Note that the SDK's own client emits a deprecation warning from `send_ping()` in both cases, so the warning alone does not tell you whether the call worked.
-
-Unknown methods return `-32601` (method not found) under both revisions.
-
 ## Develop in a container
 
 Open the repo in [GitHub Codespaces](https://github.com/codespaces) or VS Code's Remote-Containers extension. The devcontainer pre-installs Python 3.14, uv, Azure CLI, and the GitHub CLI.

--- a/docs/install.md
+++ b/docs/install.md
@@ -480,7 +480,8 @@ It binds to loopback by default, where `Host` and `Origin` validation is handled
 
 ### Verify the MCP server
 
-The server speaks both current MCP protocol revisions from the same process, so you do not need to match a specific revision in your client; whichever one it negotiates, it gets served.
+!!! note "Protocol version"
+    The server supports every MCP protocol revision it implements from the same process, so whichever revision your client negotiates, the server serves it - no client change is needed. If `ping` gives you a deprecation warning, see [ping troubleshooting](troubleshooting.md#ping-deprecation-warning-doesnt-mean-the-call-failed).
 
 After configuring your client, restart it and ask the assistant to list its available tools. You should see over 100 entries, including `list_workspaces`, `get_warehouse`, `kill_session`, and `clear_cache`.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -478,17 +478,9 @@ fabric-dw-mcp --transport http [--host 127.0.0.1] [--port 8000]
 
 It binds to loopback by default, where `Host` and `Origin` validation is handled for you and there is nothing to configure. Binding anywhere else requires `FABRIC_MCP_ALLOW_REMOTE=1` and `--allowed-host`, and the endpoint needs an authenticating reverse proxy in front of it. See [Hosting the MCP server](reference/hosting-mcp-server.md) for that setup.
 
-Request bodies are capped at 4 MiB; anything larger is rejected with HTTP 413. In practice only a multi-megabyte `execute_sql` script or object definition can reach that. The stdio transport has no such limit.
-
-### Protocol versions
-
-The server speaks MCP revision `2026-07-28` and continues to serve `2025-11-25` clients from the same process, so no client change is needed. Two protocol-level notes for anyone driving the server directly.
-
-`ping` was removed in revision `2026-07-28`, but only for clients that negotiate that revision: a `2025-11-25` client can still call it and this server still answers. A `2026-07-28` client gets `-32601` instead. Note that the SDK's own client emits a deprecation warning from `send_ping()` in both cases, so the warning alone does not tell you whether the call worked.
-
-Unknown methods return `-32601` (method not found) under both revisions.
-
 ### Verify the MCP server
+
+The server speaks both current MCP protocol revisions from the same process, so you do not need to match a specific revision in your client; whichever one it negotiates, it gets served.
 
 After configuring your client, restart it and ask the assistant to list its available tools. You should see over 100 entries, including `list_workspaces`, `get_warehouse`, `kill_session`, and `clear_cache`.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -202,3 +202,11 @@ The client automatically retries on each 429 and waits exactly as long as the se
 HTTP 403 specifically means the request carried an `Origin` header and no `--allowed-origin` matched it. Browser-based clients send that header, and so do Electron renderers, VS Code webviews and `fetch`-based Deno or Node clients. Note that an origin is matched exactly, so a different port counts as a different origin.
 
 **Fix:** Pass `--allowed-host` with the exact name clients use, repeating the option per name, and `--allowed-origin` for a browser-based client. Both are described under [Hosting the MCP server](reference/hosting-mcp-server.md#host-and-origin-validation). To see what the server is actually enforcing, read its startup output: the allowlist it applied is logged at INFO level as `Host and Origin validation enabled`.
+
+## `ping` logs a deprecation warning and I can't tell if it worked
+
+**Symptom:** Calling `ping` (or the SDK's `send_ping()`) prints a deprecation warning. The warning appears every time, whether or not the call actually succeeded, so it gives you no signal either way.
+
+**Cause:** MCP revision `2026-07-28` removed `ping` from the protocol. A client that negotiates that revision gets `-32601` (method not found) back; a client that negotiates the older `2025-11-25` revision still gets a normal response, since this server keeps serving both revisions from the same process. The SDK's own client emits the deprecation warning unconditionally in both cases, so the warning by itself does not tell you which one happened.
+
+**Fix:** Ignore the warning and check the actual response or exception instead. If your code relies on `ping` returning normally, that only happens on `2025-11-25`; on `2026-07-28`, treat a `-32601` from `ping` as expected, not as a failure.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -203,10 +203,10 @@ HTTP 403 specifically means the request carried an `Origin` header and no `--all
 
 **Fix:** Pass `--allowed-host` with the exact name clients use, repeating the option per name, and `--allowed-origin` for a browser-based client. Both are described under [Hosting the MCP server](reference/hosting-mcp-server.md#host-and-origin-validation). To see what the server is actually enforcing, read its startup output: the allowlist it applied is logged at INFO level as `Host and Origin validation enabled`.
 
-## `ping` logs a deprecation warning and I can't tell if it worked
+## `ping` deprecation warning doesn't mean the call failed
 
 **Symptom:** Calling `ping` (or the SDK's `send_ping()`) prints a deprecation warning. The warning appears every time, whether or not the call actually succeeded, so it gives you no signal either way.
 
-**Cause:** MCP revision `2026-07-28` removed `ping` from the protocol. A client that negotiates that revision gets `-32601` (method not found) back; a client that negotiates the older `2025-11-25` revision still gets a normal response, since this server keeps serving both revisions from the same process. The SDK's own client emits the deprecation warning unconditionally in both cases, so the warning by itself does not tell you which one happened.
+**Cause:** MCP revision `2026-07-28` removed `ping` from the protocol. A client negotiating `2026-07-28` gets `-32601` (method not found) back; a client negotiating any earlier revision still gets a normal response, since this server serves every revision it supports from the same process. The SDK's own client emits the deprecation warning unconditionally either way, so the warning by itself does not tell you which one happened.
 
-**Fix:** Ignore the warning and check the actual response or exception instead. If your code relies on `ping` returning normally, that only happens on `2025-11-25`; on `2026-07-28`, treat a `-32601` from `ping` as expected, not as a failure.
+**Fix:** Ignore the warning and check the actual response or exception instead. `ping` works on every revision before `2026-07-28`; from `2026-07-28` onward it returns `-32601`, which is expected, not a bug.


### PR DESCRIPTION
## Summary

- Remove the duplicated 4 MiB request-body-limit paragraph from `README.md`; it stays on the [hosting the MCP server](https://fdw.debruyn.dev/reference/hosting-mcp-server/) page and in the [troubleshooting](https://fdw.debruyn.dev/troubleshooting/#http-413-from-the-http-transport) page's `HTTP 413` entry.
- Remove the same duplicated paragraph from `docs/install.md`, for the same reason.
- Remove the "Protocol versions" section from both `README.md` and `docs/install.md`. It opened by addressing "anyone driving the server directly", which is a niche audience for a landing page and an install guide.
- Keep one sentence in `docs/install.md`, under "Verify the MCP server", stating that the server serves both current protocol revisions from the same process, so no client change is needed. That answers the one question an installing reader actually has.
- Drop the "Unknown methods return -32601" sentence entirely: standard JSON-RPC behaviour, carries no information.
- Turn the `ping` deprecation-warning confusion into a proper symptom-first entry on `docs/troubleshooting.md`: the SDK's client emits the warning whether or not the call succeeded, so the warning alone tells you nothing about the outcome.

No information is lost: everything removed from `README.md` or `docs/install.md` still exists on exactly one appropriate page (`docs/reference/hosting-mcp-server.md` for the body limit, `docs/troubleshooting.md` for both the body limit and the `ping` behaviour).

## Test plan

- [x] `just lint` (ruff check + format check) passes
- [x] `uv run --group docs zensical build` completes with "No issues found"
- [x] `uv run pytest tests/unit -q` passes (6253 passed, 2 deselected)

Closes #1055