### PR TITLE
feat(tables): add tables sync-status for per-table metadata sync freshness

### DIFF
--- a/docs/commands/tables.md
+++ b/docs/commands/tables.md
@@ -411,11 +411,13 @@ fdw -w MyWorkspace --json tables health-check MySqlEndpoint dbo.FactSales
 
 Show when each table was last updated by the metadata sync, via `sys.dm_db_external_tables_log_status`. Only applies to SQL Analytics Endpoints created after `New metadata sync` (preview) was enabled under Workspace settings, Warehouse settings, for the workspace hosting the endpoint. On an endpoint using the legacy metadata sync, the command fails with an actionable message pointing back at that setting and at `fdw sql-endpoints refresh` as the fallback for refreshing the whole item.
 
-The listing is driven from `sys.tables`, so a table that has never been synced still appears, with `last_update_time_utc`, `latest_log_version`, `latest_checkpoint_version`, and `is_blocked` all empty. "Never updated" is a real answer to "when was this table last synced?".
+The listing is driven from `sys.tables`, so a table with no matching DMV row still appears, with `last_update_time_utc`, `latest_log_version`, `latest_checkpoint_version`, and `is_blocked` all empty. This means no sync information is available for that table, not that it provably never synced - Microsoft documents the DMV as describing the most recent update, not as a complete sync history.
+
+**Coverage limit:** only tables that exist in the endpoint catalog (`sys.tables`) are listed. On a SQL Analytics Endpoint that catalog is itself maintained by the metadata sync, so a Lakehouse table whose discovery has not completed, or has failed, does not appear at all - it is not shown as a row with empty fields, it is simply absent. If a table you expect is missing, run `fdw sql-endpoints refresh` to force an item-level sync and check again.
 
 | Field | Meaning |
 | --- | --- |
-| `last_update_time_utc` | When the metadata sync last processed this table (UTC). Empty if never synced. |
+| `last_update_time_utc` | When the metadata sync last processed this table (UTC). Empty when no sync information is available for this table. |
 | `latest_log_version` | The Delta transaction log version that was last processed. |
 | `latest_checkpoint_version` | The Delta checkpoint version that was last processed. |
 | `is_blocked` | Whether the last update attempt was blocked (for example, by a multi-part checkpoint, which the preview does not support). |
@@ -855,7 +857,11 @@ The proc is Generally Available (announced at Build 2026) but its output column 
 
 Show per-table metadata sync freshness via `sys.dm_db_external_tables_log_status`. Only supported on SQL Analytics Endpoints (not Data Warehouses), and only on endpoints created after the workspace's `New metadata sync` (preview) setting was enabled.
 
-The listing is driven from `sys.tables`, so a table that has never been synced still appears, with its sync fields `null` instead of the row being dropped.
+The listing is driven from `sys.tables`, so a table with no matching DMV row still appears, with its sync fields `null` instead of the row being dropped. A `null` row means no sync information is available for that table - it is not proof the table has never synced.
+
+!!! warning "Coverage limit: a missing table is not proof it doesn't exist"
+
+    This tool only returns tables already present in the endpoint's catalog (`sys.tables`), which is itself maintained by the metadata sync. A Lakehouse table whose discovery has not completed, or has failed, has no catalog row and is **absent from this result entirely** - it does not appear as a row with empty fields. Do not conclude a table was deleted, or never existed, just because it is missing from this list. If an expected table is missing, call `refresh_sql_endpoint_metadata` (or `fdw sql-endpoints refresh`) to force an item-level sync and check again.
 
 **Parameters:**
 
@@ -869,7 +875,7 @@ The listing is driven from `sys.tables`, so a table that has never been synced s
 - `schema_name` (`str`): schema name.
 - `name` (`str`): table name.
 - `qualified_name` (`str`): `schema.table`.
-- `last_update_time_utc` (`str | null`): ISO-8601 UTC timestamp of the last metadata sync update, or `null` if the table has never been synced.
+- `last_update_time_utc` (`str | null`): ISO-8601 UTC timestamp of the last metadata sync update, or `null` when no sync information is available for this table.
 - `latest_log_version` (`int | null`): the Delta transaction log version last processed.
 - `latest_checkpoint_version` (`int | null`): the Delta checkpoint version last processed.
 - `is_blocked` (`bool | null`): whether the last update attempt was blocked.

--- a/docs/commands/tables.md
+++ b/docs/commands/tables.md
@@ -405,6 +405,40 @@ fdw -w MyWorkspace tables health-check MySqlEndpoint dbo.FactSales
 fdw -w MyWorkspace --json tables health-check MySqlEndpoint dbo.FactSales
 ```
 
+### tables sync-status
+
+**Targets:** SQL Analytics Endpoint
+
+Show when each table was last updated by the metadata sync, via `sys.dm_db_external_tables_log_status`. Only applies to SQL Analytics Endpoints created after `New metadata sync` (preview) was enabled under Workspace settings, Warehouse settings, for the workspace hosting the endpoint. On an endpoint using the legacy metadata sync, the command fails with an actionable message pointing back at that setting and at `fdw sql-endpoints refresh` as the fallback for refreshing the whole item.
+
+The listing is driven from `sys.tables`, so a table that has never been synced still appears, with `last_update_time_utc`, `latest_log_version`, `latest_checkpoint_version`, and `is_blocked` all empty. "Never updated" is a real answer to "when was this table last synced?".
+
+| Field | Meaning |
+| --- | --- |
+| `last_update_time_utc` | When the metadata sync last processed this table (UTC). Empty if never synced. |
+| `latest_log_version` | The Delta transaction log version that was last processed. |
+| `latest_checkpoint_version` | The Delta checkpoint version that was last processed. |
+| `is_blocked` | Whether the last update attempt was blocked (for example, by a multi-part checkpoint, which the preview does not support). |
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] tables sync-status [OPTIONS] [ENDPOINT]
+```
+
+| Option | Description |
+| --- | --- |
+| `--schema NAME` | Only show tables in this schema. |
+| `--table SCHEMA.TABLE` | Only show this one table. Mutually exclusive with `--schema`. |
+
+**Example**
+
+```shell
+fdw -w MyWorkspace tables sync-status MyLakehouseEP
+fdw -w MyWorkspace tables sync-status MyLakehouseEP --schema dbo
+fdw -w MyWorkspace tables sync-status MyLakehouseEP --table dbo.FactSales
+```
+
 ### tables list
 
 **Targets:** Data Warehouse / SQL Analytics Endpoint
@@ -814,6 +848,35 @@ The proc is Generally Available (announced at Build 2026) but its output column 
 - `qualified_name` (`str`): dot-separated table name, e.g. `dbo.FactSales`.
 
 **Returns:** `{ "columns": list[str], "rows": list[list] }`: column names and rows passed through verbatim from the proc.
+
+### list_table_sync_status
+
+**Targets:** SQL Analytics Endpoint
+
+Show per-table metadata sync freshness via `sys.dm_db_external_tables_log_status`. Only supported on SQL Analytics Endpoints (not Data Warehouses), and only on endpoints created after the workspace's `New metadata sync` (preview) setting was enabled.
+
+The listing is driven from `sys.tables`, so a table that has never been synced still appears, with its sync fields `null` instead of the row being dropped.
+
+**Parameters:**
+
+- `workspace` (`str`): workspace name or GUID.
+- `item` (`str`): SQL Analytics Endpoint name or GUID. Data Warehouses are rejected with a `ToolError`.
+- `schema` (`str | null`, optional): when provided, only tables in this schema are returned.
+- `table` (`str | null`, optional): when provided, filter to this single (bare, unqualified) table name. Requires `schema` to also be given.
+
+**Returns:** `list[TableMetadataSyncStatus]`, one dict per table, each containing:
+
+- `schema_name` (`str`): schema name.
+- `name` (`str`): table name.
+- `qualified_name` (`str`): `schema.table`.
+- `last_update_time_utc` (`str | null`): ISO-8601 UTC timestamp of the last metadata sync update, or `null` if the table has never been synced.
+- `latest_log_version` (`int | null`): the Delta transaction log version last processed.
+- `latest_checkpoint_version` (`int | null`): the Delta checkpoint version last processed.
+- `is_blocked` (`bool | null`): whether the last update attempt was blocked.
+
+On an endpoint using the legacy metadata sync, the tool raises a `ToolError` with an actionable message naming the `New metadata sync` preview setting and pointing at `fdw sql-endpoints refresh` (or the `refresh_sql_endpoint_metadata` MCP tool) as the fallback for refreshing the whole item.
+
+Reference: [sys.dm_db_external_tables_log_status](https://learn.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-db-external-tables-log-status-transact-sql?view=fabric&WT.mc_id=MVP_310840)
 
 ### import_table_from_url
 

--- a/src/fabric_dw/cli/commands/tables.py
+++ b/src/fabric_dw/cli/commands/tables.py
@@ -370,9 +370,16 @@ async def sync_status_cmd(
     """Show per-table metadata sync freshness on ITEM (SQL Analytics Endpoint only).
 
     Reads sys.dm_db_external_tables_log_status, left-joined onto sys.tables so
-    that a table which has never been synced still appears, with empty sync
-    fields. Only supported on SQL Analytics Endpoints created after the
+    that a table with no DMV row still appears, with empty sync fields --
+    meaning no sync information is available, not that the table provably
+    never synced. Only supported on SQL Analytics Endpoints created after the
     workspace's 'New metadata sync' (preview) setting was enabled.
+
+    Coverage limit: only tables present in sys.tables are listed. On a SQL
+    Analytics Endpoint that catalog is itself maintained by the metadata sync,
+    so a Lakehouse table whose discovery has not completed, or has failed,
+    does not appear at all. If a table you expect is missing, run
+    'fdw sql-endpoints refresh' to force an item-level sync and check again.
     """
     if filter_schema is not None and filter_table is not None:
         raise click.UsageError("--schema and --table are mutually exclusive.")

--- a/src/fabric_dw/cli/commands/tables.py
+++ b/src/fabric_dw/cli/commands/tables.py
@@ -349,6 +349,58 @@ async def health_check_cmd(
         raise click.ClickException(str(exc)) from exc
 
 
+@tables_group.command("sync-status")
+@click.argument("item", required=False, default=None)
+@click.option("--schema", "filter_schema", default=None, metavar="NAME", help="Filter by schema.")
+@click.option(
+    "--table",
+    "filter_table",
+    default=None,
+    metavar="SCHEMA.TABLE",
+    help="Filter to a single qualified table (e.g. dbo.FactSales). Exclusive with --schema.",
+)
+@click.pass_obj
+@coro
+async def sync_status_cmd(
+    ctx: CliContext,
+    item: str | None,
+    filter_schema: str | None,
+    filter_table: str | None,
+) -> None:
+    """Show per-table metadata sync freshness on ITEM (SQL Analytics Endpoint only).
+
+    Reads sys.dm_db_external_tables_log_status, left-joined onto sys.tables so
+    that a table which has never been synced still appears, with empty sync
+    fields. Only supported on SQL Analytics Endpoints created after the
+    workspace's 'New metadata sync' (preview) setting was enabled.
+    """
+    if filter_schema is not None and filter_table is not None:
+        raise click.UsageError("--schema and --table are mutually exclusive.")
+    ws = resolve_workspace(ctx)
+    wh = resolve_warehouse_arg(ctx, item)
+    schema = filter_schema
+    table_name: str | None = None
+    if filter_table is not None:
+        schema, table_name = parse_qualified_name(filter_table, kind="table")
+    try:
+        async with build_http_client(ctx) as http:
+            target, entry = await build_sql_target(http, ws, wh)
+            items = await _tables_svc.list_table_sync_status(
+                target,
+                schema=schema,
+                table=table_name,
+                kind=entry.kind,
+                mode=ctx.auth,
+            )
+            render(
+                [t.model_dump(mode="json") for t in items],
+                json_output=ctx.json_output,
+                table_title="Table Metadata Sync Status",
+            )
+    except (ValueError, FabricError) as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
 @tables_group.command("create")
 @click.argument("item", required=False, default=None)
 @click.option("--name", "qualified_name", required=True, help="Qualified name: schema.table.")

--- a/src/fabric_dw/mcp/_domains.py
+++ b/src/fabric_dw/mcp/_domains.py
@@ -96,6 +96,7 @@ TOOL_DOMAINS: dict[str, str] = {
     # Tables
     "get_table_columns": "tables",
     "get_table_health_metrics": "tables",
+    "list_table_sync_status": "tables",
     "list_tables": "tables",
     "read_table": "tables",
     "count_table_rows": "tables",

--- a/src/fabric_dw/mcp/tools/tables.py
+++ b/src/fabric_dw/mcp/tools/tables.py
@@ -550,6 +550,50 @@ def register(mcp: MCPServer) -> None:  # noqa: PLR0915
             "rows": safe_rows(result.rows),
         }
 
+    @mcp.tool(name="list_table_sync_status")
+    async def list_table_sync_status(
+        workspace: str,
+        item: str,
+        schema: str | None = None,
+        table: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Show per-table metadata sync freshness via ``sys.dm_db_external_tables_log_status``.
+
+        Only supported on SQL Analytics Endpoints (not Data Warehouses), and only
+        on endpoints created after the workspace's 'New metadata sync' (preview)
+        setting was enabled. Tables that have never been synced still appear,
+        with their sync fields ``null`` instead of the row being dropped.
+
+        Args:
+            workspace: Workspace name or GUID.
+            item: SQL Analytics Endpoint name or GUID. Data Warehouses are
+                rejected with a ``ToolError``.
+            schema: When provided, only tables in this schema are returned.
+            table: When provided, filter to this single (bare, unqualified)
+                table name. Requires *schema* to also be given.
+        """
+        ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
+        try:
+            ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
+            _log.debug(
+                "list_table_sync_status ws=%s item=%s schema=%r table=%r",
+                ws_id,
+                entry.id,
+                schema,
+                table,
+            )
+            target = make_sql_target(ws_id, entry, item)
+            result = await tables_svc.list_table_sync_status(
+                target, schema=schema, table=table, kind=entry.kind, mode=ctx.auth_mode
+            )
+        except (ValueError, FabricError) as exc:
+            raise tool_err(exc) from exc
+        return [t.model_dump(mode="json") for t in result]
+
     @mutating_tool(mcp, "rename_table")
     async def rename_table(
         workspace: str, item: str, qualified_name: str, new_name: str

--- a/src/fabric_dw/mcp/tools/tables.py
+++ b/src/fabric_dw/mcp/tools/tables.py
@@ -561,8 +561,21 @@ def register(mcp: MCPServer) -> None:  # noqa: PLR0915
 
         Only supported on SQL Analytics Endpoints (not Data Warehouses), and only
         on endpoints created after the workspace's 'New metadata sync' (preview)
-        setting was enabled. Tables that have never been synced still appear,
-        with their sync fields ``null`` instead of the row being dropped.
+        setting was enabled. A table with no matching DMV row still appears, with
+        its sync fields ``null`` instead of the row being dropped -- this means no
+        sync information is available for that table, NOT that it has never
+        synced; do not treat a ``null`` row as proof the table has never synced.
+
+        IMPORTANT for agents: this listing only includes tables already present
+        in the endpoint's catalog (``sys.tables``), which is itself maintained by
+        the metadata sync. A Lakehouse table whose discovery has not completed,
+        or has failed, has no catalog row and so is **absent from this result
+        entirely** -- it will not appear as a row with empty fields, it simply
+        will not be there. Do not conclude a table does not exist, or was
+        deleted, just because it is missing from this list. If an expected
+        table is missing, call ``refresh_sql_endpoint_metadata`` (or tell the
+        user to run ``fdw sql-endpoints refresh``) to force an item-level sync,
+        then check again.
 
         Args:
             workspace: Workspace name or GUID.

--- a/src/fabric_dw/models.py
+++ b/src/fabric_dw/models.py
@@ -611,9 +611,17 @@ class TableMetadataSyncStatus(_FabricBase):
     (Fabric REST LRO). This model instead answers "when was this table's
     metadata last synced?" for a single table on a SQL Analytics Endpoint.
 
-    Tables from ``sys.tables`` that have never been synced by the new metadata
-    sync (preview) still appear, with all four DMV-sourced fields ``None`` --
-    "never updated" is a real answer, not a missing row.
+    A table with no matching DMV row still appears, with all four DMV-sourced
+    fields ``None`` -- absent sync information is a real, distinct answer, not
+    a missing row. It means no sync information is available for that table,
+    not that the table provably never synced: Microsoft documents the DMV as
+    describing the most recent update, not as a complete sync history.
+
+    Coverage limit: this listing is driven from ``sys.tables``, which on a SQL
+    Analytics Endpoint is itself populated by the metadata sync. A table whose
+    discovery has not completed, or has failed, has no ``sys.tables`` row and
+    so does not appear in this listing at all -- its absence from the result
+    set is not visible here.
 
     Unlike :attr:`Table.created` / :attr:`Table.modified`, which pass the
     driver's native datetime through unchanged, ``last_update_time_utc`` here

--- a/src/fabric_dw/models.py
+++ b/src/fabric_dw/models.py
@@ -603,6 +603,32 @@ class Table(_FabricBase):
     modified: datetime
 
 
+class TableMetadataSyncStatus(_FabricBase):
+    """Per-table metadata sync freshness from ``sys.dm_db_external_tables_log_status``.
+
+    This is a distinct model from :class:`TableSyncStatus`, which is the
+    per-table result of an item-level SQL Analytics Endpoint metadata refresh
+    (Fabric REST LRO). This model instead answers "when was this table's
+    metadata last synced?" for a single table on a SQL Analytics Endpoint.
+
+    Tables from ``sys.tables`` that have never been synced by the new metadata
+    sync (preview) still appear, with all four DMV-sourced fields ``None`` --
+    "never updated" is a real answer, not a missing row.
+
+    Unlike :attr:`Table.created` / :attr:`Table.modified`, which pass the
+    driver's native datetime through unchanged, ``last_update_time_utc`` here
+    is always coerced to a timezone-aware UTC value (or ``None``).
+    """
+
+    schema_name: str
+    name: str
+    qualified_name: str
+    last_update_time_utc: datetime | None
+    latest_log_version: int | None
+    latest_checkpoint_version: int | None
+    is_blocked: bool | None
+
+
 # ---------------------------------------------------------------------------
 # Statistics
 # ---------------------------------------------------------------------------

--- a/src/fabric_dw/services/tables.py
+++ b/src/fabric_dw/services/tables.py
@@ -166,8 +166,12 @@ ORDER BY s.name, t.name;
 
 # sys.dm_db_external_tables_log_status is a catalog DMV keyed by object_id — this
 # is metadata lookup, not SQL text parsing.  The listing is driven from sys.tables
-# with a LEFT JOIN so a table that has never been synced by the new metadata sync
-# (preview) still appears, with the DMV columns NULL, instead of vanishing.
+# with a LEFT JOIN so a table with no DMV row (no sync information available)
+# still appears, with the DMV columns NULL, instead of vanishing. Coverage
+# limit: sys.tables itself is populated by the metadata sync on a SQL Analytics
+# Endpoint, so a table whose discovery has not completed, or has failed, has no
+# sys.tables row and is absent from this listing entirely — see
+# list_table_sync_status's docstring.
 _TABLE_SYNC_STATUS_SQL = """\
 SELECT
     s.name AS schema_name,
@@ -256,10 +260,11 @@ def _row_to_table(cols: list[str], row: tuple[object, ...]) -> Table:
 def _row_to_sync_status(cols: list[str], row: tuple[object, ...]) -> TableMetadataSyncStatus:
     """Build a :class:`TableMetadataSyncStatus` from a column-name list and a result row.
 
-    The four DMV-sourced columns are ``None`` for a table that has never been
-    synced by the new metadata sync (preview) — the LEFT JOIN in
+    The four DMV-sourced columns are ``None`` when the table has no matching
+    row in ``sys.dm_db_external_tables_log_status`` — the LEFT JOIN in
     :data:`_TABLE_SYNC_STATUS_SQL` leaves them unmatched rather than dropping
-    the row.
+    the row. This means no sync information is available for that table, not
+    that it provably never synced.
     """
     data = dict(zip(cols, row, strict=True))
     schema_name = str(data["schema_name"])
@@ -1377,9 +1382,18 @@ async def list_table_sync_status(
     """Return per-table metadata sync freshness via ``sys.dm_db_external_tables_log_status``.
 
     Lists every table on *target* (driven from ``sys.tables``, left-joined to
-    the DMV on ``object_id``) so a table that has never been synced by the new
-    metadata sync (preview) still appears, with its sync fields ``None``
-    instead of being dropped from the result.
+    the DMV on ``object_id``) so a table with no matching DMV row still
+    appears, with its sync fields ``None`` instead of being dropped from the
+    result. ``None`` sync fields mean no sync information is available for
+    that table -- Microsoft documents the DMV as describing the most recent
+    update, not as proof a table has never synced.
+
+    Coverage limit: this listing only covers tables present in ``sys.tables``,
+    which on a SQL Analytics Endpoint is itself populated by the metadata
+    sync. A Lakehouse table whose discovery has not completed, or has failed,
+    has no ``sys.tables`` row and so is missing from this result entirely, not
+    merely shown with empty sync fields. If an expected table is absent, run
+    ``fdw sql-endpoints refresh`` to force an item-level sync and check again.
 
     Only available on SQL Analytics Endpoints created after the workspace's
     ``New metadata sync`` (preview) setting was enabled. On every other

--- a/src/fabric_dw/services/tables.py
+++ b/src/fabric_dw/services/tables.py
@@ -19,6 +19,7 @@ Public API
 - :func:`recluster_table`         — transactional CTAS-swap to change (or remove) clustering.
 - :func:`get_table_dependents`    — objects referencing a table by name.
 - :func:`get_table_health_metrics` — ``EXEC sp_get_table_health_metrics`` (SQL endpoint only).
+- :func:`list_table_sync_status`  — ``sys.dm_db_external_tables_log_status`` (SQL endpoint only).
 
 List-source note
 ----------------
@@ -45,6 +46,7 @@ from fabric_dw.models import (
     ColumnSpec,
     ResultSet,
     Table,
+    TableMetadataSyncStatus,
     TableRowCount,
     WarehouseKind,
 )
@@ -82,6 +84,7 @@ __all__ = [
     "infer_columns_from_csv",
     "infer_columns_from_json",
     "infer_columns_from_parquet",
+    "list_table_sync_status",
     "list_tables",
     "read_table",
     "recluster_table",
@@ -106,22 +109,43 @@ _WAREHOUSE_HEALTH_CHECK_MSG = (
     "Table health-check (sp_get_table_health_metrics) is only "
     "available on SQL Analytics Endpoints, not Data Warehouses."
 )
+_WAREHOUSE_SYNC_STATUS_MSG = (
+    "Table metadata sync-status (sys.dm_db_external_tables_log_status) is only "
+    "available on SQL Analytics Endpoints, not Data Warehouses."
+)
+
+# Fragment (lower-cased) of the "invalid object name" driver error that names the
+# DMV specifically, distinguishing "this endpoint predates the new metadata sync
+# preview" from an unrelated 208 raised for some other reason.
+_SYNC_STATUS_DMV_FRAGMENT = "dm_db_external_tables_log_status"
+_SYNC_STATUS_LEGACY_SYNC_MSG = (
+    "Table metadata sync-status requires the new metadata sync (preview) for "
+    "this SQL analytics endpoint. It only applies to endpoints created after "
+    "'New metadata sync' was enabled under Workspace settings, Warehouse "
+    "settings, in the workspace hosting this endpoint. On endpoints using the "
+    "legacy metadata sync, use 'fdw sql-endpoints refresh' to refresh the "
+    "whole item instead."
+)
 
 
-def _assert_sql_endpoint(kind: WarehouseKind) -> None:
+def _assert_sql_endpoint(kind: WarehouseKind, msg: str = _WAREHOUSE_HEALTH_CHECK_MSG) -> None:
     """Raise :class:`~fabric_dw.exceptions.ItemKindError` for non-SQL-Endpoint items.
 
-    ``sp_get_table_health_metrics`` targets the SQL Analytics Endpoint over
-    lakehouse Delta tables only — it is not available on Data Warehouses.
+    Shared guard for SQL-Analytics-Endpoint-only operations such as
+    ``sp_get_table_health_metrics`` and ``sys.dm_db_external_tables_log_status``,
+    neither of which is available on Data Warehouses.
 
     Args:
         kind: The :class:`~fabric_dw.models.WarehouseKind` of the resolved item.
+        msg: The error message to raise. Defaults to the health-check message
+            so the existing call site is unaffected; callers for other
+            SQL-Analytics-Endpoint-only operations should pass their own.
 
     Raises:
         ItemKindError: If *kind* is not :attr:`~fabric_dw.models.WarehouseKind.SQL_ENDPOINT`.
     """
     if kind != WarehouseKind.SQL_ENDPOINT:
-        raise ItemKindError(_WAREHOUSE_HEALTH_CHECK_MSG)
+        raise ItemKindError(msg)
 
 
 # ---------------------------------------------------------------------------
@@ -137,6 +161,25 @@ SELECT
 FROM sys.tables t
 JOIN sys.schemas s ON s.schema_id = t.schema_id
 WHERE ({schema_filter})
+ORDER BY s.name, t.name;
+"""
+
+# sys.dm_db_external_tables_log_status is a catalog DMV keyed by object_id — this
+# is metadata lookup, not SQL text parsing.  The listing is driven from sys.tables
+# with a LEFT JOIN so a table that has never been synced by the new metadata sync
+# (preview) still appears, with the DMV columns NULL, instead of vanishing.
+_TABLE_SYNC_STATUS_SQL = """\
+SELECT
+    s.name AS schema_name,
+    t.name,
+    dm.last_update_time_utc,
+    dm.latest_log_version,
+    dm.latest_checkpoint_version,
+    dm.is_blocked
+FROM sys.tables t
+JOIN sys.schemas s ON s.schema_id = t.schema_id
+LEFT JOIN sys.dm_db_external_tables_log_status dm ON dm.object_id = t.object_id
+WHERE ({filter})
 ORDER BY s.name, t.name;
 """
 
@@ -207,6 +250,42 @@ def _row_to_table(cols: list[str], row: tuple[object, ...]) -> Table:
         qualified_name=f"{schema_name}.{name}",
         created=cast(datetime, data["created"]),
         modified=cast(datetime, data["modified"]),
+    )
+
+
+def _row_to_sync_status(cols: list[str], row: tuple[object, ...]) -> TableMetadataSyncStatus:
+    """Build a :class:`TableMetadataSyncStatus` from a column-name list and a result row.
+
+    The four DMV-sourced columns are ``None`` for a table that has never been
+    synced by the new metadata sync (preview) — the LEFT JOIN in
+    :data:`_TABLE_SYNC_STATUS_SQL` leaves them unmatched rather than dropping
+    the row.
+    """
+    data = dict(zip(cols, row, strict=True))
+    schema_name = str(data["schema_name"])
+    name = str(data["name"])
+    last_update_time_utc = data.get("last_update_time_utc")
+    latest_log_version = data.get("latest_log_version")
+    latest_checkpoint_version = data.get("latest_checkpoint_version")
+    is_blocked = data.get("is_blocked")
+    return TableMetadataSyncStatus(
+        schema_name=schema_name,
+        name=name,
+        qualified_name=f"{schema_name}.{name}",
+        last_update_time_utc=(
+            coerce_to_utc(last_update_time_utc)
+            if isinstance(last_update_time_utc, datetime)
+            else None
+        ),
+        latest_log_version=(
+            int(cast("int", latest_log_version)) if latest_log_version is not None else None
+        ),
+        latest_checkpoint_version=(
+            int(cast("int", latest_checkpoint_version))
+            if latest_checkpoint_version is not None
+            else None
+        ),
+        is_blocked=bool(is_blocked) if is_blocked is not None else None,
     )
 
 
@@ -1283,6 +1362,96 @@ async def get_table_health_metrics(
     def _run() -> ResultSet:
         cols, rows = run_query(target, sql, mode=mode)
         return ResultSet(columns=cols, rows=list(rows))
+
+    return await asyncio.to_thread(_run)
+
+
+async def list_table_sync_status(
+    target: SqlTarget,
+    *,
+    schema: str | None = None,
+    table: str | None = None,
+    kind: WarehouseKind = WarehouseKind.WAREHOUSE,
+    mode: CredentialMode = CredentialMode.DEFAULT,
+) -> list[TableMetadataSyncStatus]:
+    """Return per-table metadata sync freshness via ``sys.dm_db_external_tables_log_status``.
+
+    Lists every table on *target* (driven from ``sys.tables``, left-joined to
+    the DMV on ``object_id``) so a table that has never been synced by the new
+    metadata sync (preview) still appears, with its sync fields ``None``
+    instead of being dropped from the result.
+
+    Only available on SQL Analytics Endpoints created after the workspace's
+    ``New metadata sync`` (preview) setting was enabled. On every other
+    endpoint the DMV does not exist; the raw "invalid object name" driver
+    error is translated into an actionable message pointing at the workspace
+    setting and at ``fdw sql-endpoints refresh`` as the fallback.
+
+    Args:
+        target: The SQL Analytics Endpoint to query. Data Warehouses are
+            rejected with :class:`~fabric_dw.exceptions.ItemKindError`.
+        schema: When provided, only tables in this schema are returned.
+            Must pass :func:`validate_identifier`.
+        table: When provided, filter to this single (bare, unqualified) table
+            name. Requires *schema* to also be given. Must pass
+            :func:`validate_identifier`.
+        kind: The :class:`~fabric_dw.models.WarehouseKind` of the item.
+            Only :attr:`~fabric_dw.models.WarehouseKind.SQL_ENDPOINT` is
+            accepted; Warehouse items raise :class:`~fabric_dw.exceptions.ItemKindError`.
+        mode: The credential mode for Entra authentication.
+
+    Returns:
+        A (possibly empty) list of :class:`~fabric_dw.models.TableMetadataSyncStatus`
+        instances, ordered by schema then table name.
+
+    Raises:
+        ItemKindError: If *kind* is not
+            :attr:`~fabric_dw.models.WarehouseKind.SQL_ENDPOINT`.
+            Message: ``"Table metadata sync-status
+            (sys.dm_db_external_tables_log_status) is only available on SQL
+            Analytics Endpoints, not Data Warehouses."``.
+        ValueError: If *table* is given without *schema*, or if *schema* or
+            *table* fails identifier validation.
+        NotFoundError: If the endpoint is on the legacy metadata sync (the DMV
+            does not exist), with a message naming the preview feature, the
+            workspace setting, and the ``fdw sql-endpoints refresh`` fallback.
+        PermissionDeniedError: If the driver reports a permission error.
+    """
+    _assert_sql_endpoint(kind, _WAREHOUSE_SYNC_STATUS_MSG)
+
+    if table is not None and schema is None:
+        msg = "The table filter requires schema to also be given."
+        raise ValueError(msg)
+
+    filter_params: list[object]
+    if schema is None:
+        filter_clause = "1=1"
+        filter_params = []
+    elif table is None:
+        validate_identifier(schema)
+        filter_clause = "s.name = ?"
+        filter_params = [schema]
+    else:
+        validate_identifier(schema)
+        validate_identifier(table)
+        filter_clause = "s.name = ? AND t.name = ?"
+        filter_params = [schema, table]
+
+    sync_status_sql = _TABLE_SYNC_STATUS_SQL.format(filter=filter_clause)
+
+    def _run() -> list[TableMetadataSyncStatus]:
+        try:
+            cols, rows = run_query(
+                target,
+                sync_status_sql,
+                params=filter_params or None,
+                mode=mode,
+            )
+        except NotFoundError as exc:
+            if _SYNC_STATUS_DMV_FRAGMENT in str(exc).lower():
+                raise NotFoundError(_SYNC_STATUS_LEGACY_SYNC_MSG) from exc
+            raise
+        return [_row_to_sync_status(cols, r) for r in rows]
 
     return await asyncio.to_thread(_run)
 

--- a/tests/integration/test_services_tables.py
+++ b/tests/integration/test_services_tables.py
@@ -720,6 +720,77 @@ async def test_get_table_health_metrics_on_sql_endpoint(
 
 
 # ===========================================================================
+# list_table_sync_status — sys.dm_db_external_tables_log_status (#1061)
+# ===========================================================================
+
+
+@pytest.mark.sql_endpoint
+async def test_list_table_sync_status_on_sql_endpoint(
+    shared_sql_endpoint: SharedSqlEndpointTarget,
+) -> None:
+    """list_table_sync_status against a live endpoint; skips on the legacy metadata sync.
+
+    Uses ``sample.colors`` (seeded via the parent Lakehouse during fixture setup)
+    as the probe table. ``sys.dm_db_external_tables_log_status`` only exists on
+    SQL Analytics Endpoints created after the workspace's 'New metadata sync'
+    (preview) setting was enabled, so a legacy endpoint is skipped rather than
+    failed — mirrors the skip idiom in
+    ``test_get_table_health_metrics_on_sql_endpoint`` above.
+    """
+    from fabric_dw.models import WarehouseKind  # noqa: PLC0415
+
+    sql_target = shared_sql_endpoint.sql_target
+    try:
+        rows = await tables.list_table_sync_status(
+            sql_target,
+            kind=WarehouseKind.SQL_ENDPOINT,
+        )
+    except NotFoundError as exc:
+        pytest.skip(
+            f"sys.dm_db_external_tables_log_status is not available on this endpoint "
+            f"(legacy metadata sync); skipping ({exc})"
+        )
+
+    assert isinstance(rows, list)
+    qualified_names = [r.qualified_name for r in rows]
+    seeded = [r for r in rows if r.schema_name == SEED_SCHEMA_NAME and r.name == "colors"]
+    assert seeded, f"expected seeded table {SEED_SCHEMA_NAME}.colors in {qualified_names!r}"
+    assert seeded[0].qualified_name == f"{SEED_SCHEMA_NAME}.colors"
+
+    # Microsoft's docs imply one DMV row per table, but that is inference, not
+    # documentation — verify rather than assume. If this fails the LEFT JOIN is
+    # duplicating rows and the query needs a deduplicating shape; report this
+    # back rather than silently working around it.
+    assert len(qualified_names) == len(set(qualified_names)), (
+        f"expected unique qualified_name per row, got duplicates in {qualified_names!r}"
+    )
+
+
+@pytest.mark.sql_endpoint
+async def test_list_table_sync_status_schema_filter_on_sql_endpoint(
+    shared_sql_endpoint: SharedSqlEndpointTarget,
+) -> None:
+    """--schema filter returns only rows from the seeded schema."""
+    from fabric_dw.models import WarehouseKind  # noqa: PLC0415
+
+    sql_target = shared_sql_endpoint.sql_target
+    try:
+        rows = await tables.list_table_sync_status(
+            sql_target,
+            schema=SEED_SCHEMA_NAME,
+            kind=WarehouseKind.SQL_ENDPOINT,
+        )
+    except NotFoundError as exc:
+        pytest.skip(
+            f"sys.dm_db_external_tables_log_status is not available on this endpoint "
+            f"(legacy metadata sync); skipping ({exc})"
+        )
+
+    assert rows, f"expected at least the seeded tables in schema {SEED_SCHEMA_NAME!r}"
+    assert all(r.schema_name == SEED_SCHEMA_NAME for r in rows)
+
+
+# ===========================================================================
 # export_table — Parquet round-trip
 # ===========================================================================
 

--- a/tests/unit/cli/commands/test_tables.py
+++ b/tests/unit/cli/commands/test_tables.py
@@ -4064,6 +4064,267 @@ class TestTablesHealthCheck:
         assert "(0 rows)" in result.output
 
 
+def _make_sync_status(
+    schema: str = "dbo",
+    name: str = "FactSales",
+    *,
+    synced: bool = True,
+) -> object:
+    """Build a TableMetadataSyncStatus. Pass synced=False for a never-synced row."""
+    from fabric_dw.models import TableMetadataSyncStatus  # noqa: PLC0415
+
+    if not synced:
+        return TableMetadataSyncStatus(
+            schema_name=schema,
+            name=name,
+            qualified_name=f"{schema}.{name}",
+            last_update_time_utc=None,
+            latest_log_version=None,
+            latest_checkpoint_version=None,
+            is_blocked=None,
+        )
+    return TableMetadataSyncStatus(
+        schema_name=schema,
+        name=name,
+        qualified_name=f"{schema}.{name}",
+        last_update_time_utc=_NOW,
+        latest_log_version=1284,
+        latest_checkpoint_version=1200,
+        is_blocked=False,
+    )
+
+
+class TestTablesSyncStatus:
+    """Tests for the ``tables sync-status`` CLI command (#1061)."""
+
+    def test_sync_status_exits_zero_on_endpoint(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.tables.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.tables.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_sql_endpoint_entry())),
+            ),
+            patch(
+                "fabric_dw.services.tables.list_table_sync_status",
+                new=AsyncMock(return_value=[_make_sync_status()]),
+            ),
+        ):
+            result = runner.invoke(cli, ["-w", WS_GUID, "tables", "sync-status", SE_GUID])
+        assert result.exit_code == 0, result.output
+        assert "Table Metadata Sync Status" in result.output
+
+    def test_sync_status_json_output(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.tables.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.tables.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_sql_endpoint_entry())),
+            ),
+            patch(
+                "fabric_dw.services.tables.list_table_sync_status",
+                new=AsyncMock(return_value=[_make_sync_status()]),
+            ),
+        ):
+            result = runner.invoke(cli, ["-w", WS_GUID, "--json", "tables", "sync-status", SE_GUID])
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.output)
+        assert isinstance(parsed, list)
+        assert parsed[0]["schema_name"] == "dbo"
+        assert parsed[0]["name"] == "FactSales"
+        assert parsed[0]["qualified_name"] == "dbo.FactSales"
+        assert parsed[0]["latest_log_version"] == 1284
+        assert parsed[0]["latest_checkpoint_version"] == 1200
+        assert parsed[0]["is_blocked"] is False
+
+    def test_sync_status_zero_rows_json_output_is_empty_list(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.tables.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.tables.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_sql_endpoint_entry())),
+            ),
+            patch(
+                "fabric_dw.services.tables.list_table_sync_status",
+                new=AsyncMock(return_value=[]),
+            ),
+        ):
+            result = runner.invoke(cli, ["-w", WS_GUID, "--json", "tables", "sync-status", SE_GUID])
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.output)
+        assert parsed == []
+
+    def test_sync_status_forwards_schema_filter(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        mock_svc = AsyncMock(return_value=[])
+        with (
+            patch(
+                "fabric_dw.cli.commands.tables.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.tables.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_sql_endpoint_entry())),
+            ),
+            patch("fabric_dw.services.tables.list_table_sync_status", new=mock_svc),
+        ):
+            result = runner.invoke(
+                cli, ["-w", WS_GUID, "tables", "sync-status", SE_GUID, "--schema", "dbo"]
+            )
+        assert result.exit_code == 0, result.output
+        _args, kwargs = mock_svc.call_args
+        assert kwargs["schema"] == "dbo"
+        assert kwargs["table"] is None
+
+    def test_sync_status_forwards_table_filter(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        mock_svc = AsyncMock(return_value=[])
+        with (
+            patch(
+                "fabric_dw.cli.commands.tables.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.tables.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_sql_endpoint_entry())),
+            ),
+            patch("fabric_dw.services.tables.list_table_sync_status", new=mock_svc),
+        ):
+            result = runner.invoke(
+                cli,
+                ["-w", WS_GUID, "tables", "sync-status", SE_GUID, "--table", "dbo.FactSales"],
+            )
+        assert result.exit_code == 0, result.output
+        _args, kwargs = mock_svc.call_args
+        assert kwargs["schema"] == "dbo"
+        assert kwargs["table"] == "FactSales"
+
+    def test_sync_status_both_filters_is_usage_error(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.tables.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.tables.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_sql_endpoint_entry())),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "-w",
+                    WS_GUID,
+                    "tables",
+                    "sync-status",
+                    SE_GUID,
+                    "--schema",
+                    "dbo",
+                    "--table",
+                    "dbo.FactSales",
+                ],
+            )
+        assert result.exit_code != 0
+        assert "mutually exclusive" in result.output
+
+    def test_sync_status_warehouse_raises_click_exception(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """sync-status on a Warehouse raises via the real _assert_sql_endpoint guard."""
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.tables.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.tables.build_sql_target",
+                # Warehouse entry — kind=WarehouseKind.WAREHOUSE
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            # Do NOT mock the service — let _assert_sql_endpoint fire for real.
+            patch("fabric_dw.sql.open_connection", return_value=MagicMock()),
+        ):
+            result = runner.invoke(cli, ["-w", WS_GUID, "tables", "sync-status", WH_GUID])
+        assert result.exit_code != 0
+        assert "SQL Analytics Endpoints" in result.output
+
+    def test_sync_status_legacy_endpoint_error_surfaces(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.tables.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.tables.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_sql_endpoint_entry())),
+            ),
+            patch(
+                "fabric_dw.services.tables.list_table_sync_status",
+                new=AsyncMock(
+                    side_effect=NotFoundError(
+                        "Table metadata sync-status requires the new metadata sync "
+                        "(preview) for this SQL analytics endpoint. On endpoints using "
+                        "the legacy metadata sync, use 'fdw sql-endpoints refresh' to "
+                        "refresh the whole item instead."
+                    )
+                ),
+            ),
+        ):
+            result = runner.invoke(cli, ["-w", WS_GUID, "tables", "sync-status", SE_GUID])
+        assert result.exit_code != 0
+        assert "new metadata sync" in result.output
+        assert "fdw sql-endpoints refresh" in result.output
+
+    def test_sync_status_null_fields_still_render(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.tables.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.tables.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_sql_endpoint_entry())),
+            ),
+            patch(
+                "fabric_dw.services.tables.list_table_sync_status",
+                new=AsyncMock(return_value=[_make_sync_status("dbo", "StagingRaw", synced=False)]),
+            ),
+        ):
+            result = runner.invoke(cli, ["-w", WS_GUID, "tables", "sync-status", SE_GUID])
+        assert result.exit_code == 0, result.output
+        assert "StagingRaw" in result.output
+
+
 class TestTablesHealthCheckDuplicateColumns:
     """tables health-check — duplicate column name handling (issue #833)."""
 

--- a/tests/unit/cli/commands/test_tables.py
+++ b/tests/unit/cli/commands/test_tables.py
@@ -4068,12 +4068,12 @@ def _make_sync_status(
     schema: str = "dbo",
     name: str = "FactSales",
     *,
-    synced: bool = True,
+    has_dmv_row: bool = True,
 ) -> object:
-    """Build a TableMetadataSyncStatus. Pass synced=False for a never-synced row."""
+    """Build a TableMetadataSyncStatus. Pass has_dmv_row=False for a row with no sync info."""
     from fabric_dw.models import TableMetadataSyncStatus  # noqa: PLC0415
 
-    if not synced:
+    if not has_dmv_row:
         return TableMetadataSyncStatus(
             schema_name=schema,
             name=name,
@@ -4317,7 +4317,9 @@ class TestTablesSyncStatus:
             ),
             patch(
                 "fabric_dw.services.tables.list_table_sync_status",
-                new=AsyncMock(return_value=[_make_sync_status("dbo", "StagingRaw", synced=False)]),
+                new=AsyncMock(
+                    return_value=[_make_sync_status("dbo", "StagingRaw", has_dmv_row=False)]
+                ),
             ),
         ):
             result = runner.invoke(cli, ["-w", WS_GUID, "tables", "sync-status", SE_GUID])

--- a/tests/unit/mcp/tools/test_tables.py
+++ b/tests/unit/mcp/tools/test_tables.py
@@ -23,7 +23,14 @@ import pytest
 from mcp.server.mcpserver.exceptions import ToolError
 
 from fabric_dw.exceptions import ItemKindError, NotFoundError
-from fabric_dw.models import ClusterColumn, ResultSet, Table, TableRowCount, WarehouseKind
+from fabric_dw.models import (
+    ClusterColumn,
+    ResultSet,
+    Table,
+    TableMetadataSyncStatus,
+    TableRowCount,
+    WarehouseKind,
+)
 from tests.unit._call import call_tool
 from tests.unit.mcp.conftest import (
     WH_NAME,
@@ -1192,6 +1199,169 @@ async def test_get_table_health_metrics_warehouse_raises_tool_error(mock_ctx, ct
             mcp,
             "get_table_health_metrics",
             {"workspace": WS_NAME, "item": WH_NAME, "qualified_name": "dbo.FactSales"},
+        )
+
+
+# ---------------------------------------------------------------------------
+# list_table_sync_status — contract tests (read-only, SQL-endpoint-only, #1061)
+# ---------------------------------------------------------------------------
+
+
+def _make_sync_status(schema: str = "dbo", name: str = "FactSales") -> TableMetadataSyncStatus:
+    _now = datetime(2024, 6, 1, 12, 0, 0, tzinfo=UTC)
+    return TableMetadataSyncStatus(
+        schema_name=schema,
+        name=name,
+        qualified_name=f"{schema}.{name}",
+        last_update_time_utc=_now,
+        latest_log_version=1284,
+        latest_checkpoint_version=1200,
+        is_blocked=False,
+    )
+
+
+async def test_list_table_sync_status_is_registered() -> None:
+    """list_table_sync_status is registered as an MCP tool."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    tool_names = {t.name for t in mcp._tool_manager.list_tools()}
+    assert "list_table_sync_status" in tool_names
+
+
+async def test_list_table_sync_status_is_not_mutating(
+    mock_ctx, ctx_patch, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """list_table_sync_status must NOT require the FABRIC_MCP_ALLOW_MUTATING flag."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    monkeypatch.delenv("FABRIC_MCP_ALLOW_MUTATING", raising=False)
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_sql_endpoint_entry())
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.tables.list_table_sync_status",
+            new=AsyncMock(return_value=[]),
+        ),
+    ):
+        # Must NOT raise ToolError — read-only tools don't check writes_allowed.
+        result = await call_tool(
+            mcp,
+            "list_table_sync_status",
+            {"workspace": WS_NAME, "item": WH_NAME},
+        )
+    assert isinstance(result, list)
+
+
+async def test_list_table_sync_status_happy_path(mock_ctx, ctx_patch) -> None:
+    """list_table_sync_status forwards args to the service and returns typed dicts."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_sql_endpoint_entry())
+
+    mock_svc = AsyncMock(return_value=[_make_sync_status()])
+
+    with (
+        ctx_patch,
+        patch("fabric_dw.services.tables.list_table_sync_status", new=mock_svc),
+    ):
+        result = await call_tool(
+            mcp,
+            "list_table_sync_status",
+            {"workspace": WS_NAME, "item": WH_NAME},
+        )
+
+    assert isinstance(result, list)
+    assert result[0]["schema_name"] == "dbo"
+    assert result[0]["name"] == "FactSales"
+    assert result[0]["qualified_name"] == "dbo.FactSales"
+    assert result[0]["latest_log_version"] == 1284
+    assert result[0]["is_blocked"] is False
+
+
+async def test_list_table_sync_status_forwards_schema_and_table(mock_ctx, ctx_patch) -> None:
+    """list_table_sync_status passes schema and table straight through to the service."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_sql_endpoint_entry())
+    mock_svc = AsyncMock(return_value=[])
+
+    with (
+        ctx_patch,
+        patch("fabric_dw.services.tables.list_table_sync_status", new=mock_svc),
+    ):
+        await call_tool(
+            mcp,
+            "list_table_sync_status",
+            {"workspace": WS_NAME, "item": WH_NAME, "schema": "dbo", "table": "FactSales"},
+        )
+
+    _args, kwargs = mock_svc.call_args
+    assert kwargs["schema"] == "dbo"
+    assert kwargs["table"] == "FactSales"
+
+
+async def test_list_table_sync_status_warehouse_raises_tool_error(mock_ctx, ctx_patch) -> None:
+    """list_table_sync_status raises ToolError when the service raises ItemKindError."""
+    from fabric_dw.exceptions import ItemKindError  # noqa: PLC0415
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    # Use a Warehouse entry so the service receives WarehouseKind.WAREHOUSE
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.tables.list_table_sync_status",
+            new=AsyncMock(
+                side_effect=ItemKindError(
+                    "Table metadata sync-status (sys.dm_db_external_tables_log_status) is "
+                    "only available on SQL Analytics Endpoints, not Data Warehouses."
+                )
+            ),
+        ),
+        pytest.raises(ToolError),
+    ):
+        await call_tool(
+            mcp,
+            "list_table_sync_status",
+            {"workspace": WS_NAME, "item": WH_NAME},
+        )
+
+
+async def test_list_table_sync_status_legacy_endpoint_raises_tool_error(
+    mock_ctx, ctx_patch
+) -> None:
+    """list_table_sync_status raises ToolError carrying the actionable preview message."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_sql_endpoint_entry())
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.tables.list_table_sync_status",
+            new=AsyncMock(
+                side_effect=NotFoundError(
+                    "Table metadata sync-status requires the new metadata sync "
+                    "(preview) for this SQL analytics endpoint. On endpoints using "
+                    "the legacy metadata sync, use 'fdw sql-endpoints refresh' to "
+                    "refresh the whole item instead."
+                )
+            ),
+        ),
+        pytest.raises(ToolError, match="new metadata sync"),
+    ):
+        await call_tool(
+            mcp,
+            "list_table_sync_status",
+            {"workspace": WS_NAME, "item": WH_NAME},
         )
 
 

--- a/tests/unit/services/test_tables.py
+++ b/tests/unit/services/test_tables.py
@@ -3156,7 +3156,7 @@ _SYNC_STATUS_COLS = [
     "is_blocked",
 ]
 _SYNC_ROW_SYNCED: tuple[object, ...] = ("dbo", "FactSales", _NOW, 1284, 1200, 0)
-_SYNC_ROW_NEVER_SYNCED: tuple[object, ...] = ("dbo", "StagingRaw", None, None, None, None)
+_SYNC_ROW_NO_DMV_ROW: tuple[object, ...] = ("dbo", "StagingRaw", None, None, None, None)
 
 
 class TestListTableSyncStatus:
@@ -3313,7 +3313,7 @@ class TestListTableSyncStatus:
 
     async def test_row_with_null_dmv_columns_yields_none_last_update(self) -> None:
         target = _make_target()
-        conn = _make_conn([_SYNC_ROW_NEVER_SYNCED], _SYNC_STATUS_COLS)
+        conn = _make_conn([_SYNC_ROW_NO_DMV_ROW], _SYNC_STATUS_COLS)
         with patch("fabric_dw.sql.open_connection", return_value=conn):
             result = await tables.list_table_sync_status(target, kind=WarehouseKind.SQL_ENDPOINT)
         assert len(result) == 1
@@ -3328,7 +3328,7 @@ class TestListTableSyncStatus:
 
     async def test_mixed_result_set_returns_both(self) -> None:
         target = _make_target()
-        conn = _make_conn([_SYNC_ROW_SYNCED, _SYNC_ROW_NEVER_SYNCED], _SYNC_STATUS_COLS)
+        conn = _make_conn([_SYNC_ROW_SYNCED, _SYNC_ROW_NO_DMV_ROW], _SYNC_STATUS_COLS)
         with patch("fabric_dw.sql.open_connection", return_value=conn):
             result = await tables.list_table_sync_status(target, kind=WarehouseKind.SQL_ENDPOINT)
         assert len(result) == 2

--- a/tests/unit/services/test_tables.py
+++ b/tests/unit/services/test_tables.py
@@ -3144,6 +3144,198 @@ class TestGetTableHealthMetrics:
 
 
 # ===========================================================================
+# list_table_sync_status — sys.dm_db_external_tables_log_status (#1061)
+# ===========================================================================
+
+_SYNC_STATUS_COLS = [
+    "schema_name",
+    "name",
+    "last_update_time_utc",
+    "latest_log_version",
+    "latest_checkpoint_version",
+    "is_blocked",
+]
+_SYNC_ROW_SYNCED: tuple[object, ...] = ("dbo", "FactSales", _NOW, 1284, 1200, 0)
+_SYNC_ROW_NEVER_SYNCED: tuple[object, ...] = ("dbo", "StagingRaw", None, None, None, None)
+
+
+class TestListTableSyncStatus:
+    """Tests for :func:`tables.list_table_sync_status`."""
+
+    async def test_returns_empty_when_no_rows(self) -> None:
+        target = _make_target()
+        conn = _make_conn([], _SYNC_STATUS_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            result = await tables.list_table_sync_status(target, kind=WarehouseKind.SQL_ENDPOINT)
+        assert result == []
+
+    async def test_happy_path_parses_all_fields(self) -> None:
+        target = _make_target()
+        conn = _make_conn([_SYNC_ROW_SYNCED], _SYNC_STATUS_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            result = await tables.list_table_sync_status(target, kind=WarehouseKind.SQL_ENDPOINT)
+        assert len(result) == 1
+        row = result[0]
+        assert row.schema_name == "dbo"
+        assert row.name == "FactSales"
+        assert row.qualified_name == "dbo.FactSales"
+        assert row.last_update_time_utc == _NOW
+        assert row.last_update_time_utc is not None
+        assert row.last_update_time_utc.tzinfo is not None
+        assert row.latest_log_version == 1284
+        assert row.latest_checkpoint_version == 1200
+        assert row.is_blocked is False
+        assert isinstance(row.is_blocked, bool)
+
+    async def test_sql_references_dmv_with_left_join(self) -> None:
+        target = _make_target()
+        conn = _make_conn([], _SYNC_STATUS_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await tables.list_table_sync_status(target, kind=WarehouseKind.SQL_ENDPOINT)
+        cursor = conn.cursor.return_value
+        call_sql: str = cursor.execute.call_args[0][0]
+        assert "sys.dm_db_external_tables_log_status" in call_sql
+        assert "LEFT JOIN" in call_sql
+
+    async def test_schema_filter_binds_param(self) -> None:
+        target = _make_target()
+        conn = _make_conn([], _SYNC_STATUS_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await tables.list_table_sync_status(
+                target, schema="dbo", kind=WarehouseKind.SQL_ENDPOINT
+            )
+        cursor = conn.cursor.return_value
+        call_args = cursor.execute.call_args
+        call_sql: str = call_args[0][0]
+        assert "s.name = ?" in call_sql
+        assert "t.name = ?" not in call_sql
+        params = call_args[0][1] if len(call_args[0]) > 1 else (call_args[1] or {}).get("params")
+        assert params is not None
+        assert list(params) == ["dbo"]
+
+    async def test_schema_and_table_filter_binds_both(self) -> None:
+        target = _make_target()
+        conn = _make_conn([], _SYNC_STATUS_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            await tables.list_table_sync_status(
+                target, schema="dbo", table="FactSales", kind=WarehouseKind.SQL_ENDPOINT
+            )
+        cursor = conn.cursor.return_value
+        call_args = cursor.execute.call_args
+        call_sql: str = call_args[0][0]
+        assert "s.name = ? AND t.name = ?" in call_sql
+        params = call_args[0][1] if len(call_args[0]) > 1 else (call_args[1] or {}).get("params")
+        assert params is not None
+        assert list(params) == ["dbo", "FactSales"]
+
+    async def test_table_without_schema_raises_value_error(self) -> None:
+        target = _make_target()
+        conn = _make_conn([], _SYNC_STATUS_COLS)
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(ValueError, match="requires schema"),
+        ):
+            await tables.list_table_sync_status(
+                target, table="FactSales", kind=WarehouseKind.SQL_ENDPOINT
+            )
+
+    async def test_bad_schema_identifier_raises_value_error(self) -> None:
+        target = _make_target()
+        conn = _make_conn([], _SYNC_STATUS_COLS)
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(ValueError, match="Invalid SQL identifier"),
+        ):
+            await tables.list_table_sync_status(
+                target, schema="bad]schema", kind=WarehouseKind.SQL_ENDPOINT
+            )
+
+    async def test_bad_table_identifier_raises_value_error(self) -> None:
+        target = _make_target()
+        conn = _make_conn([], _SYNC_STATUS_COLS)
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(ValueError, match="Invalid SQL identifier"),
+        ):
+            await tables.list_table_sync_status(
+                target, schema="dbo", table="bad;table", kind=WarehouseKind.SQL_ENDPOINT
+            )
+
+    async def test_warehouse_kind_raises_item_kind_error(self) -> None:
+        target = _make_target()
+        conn = _make_conn([], _SYNC_STATUS_COLS)
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(ItemKindError, match="SQL Analytics Endpoints"),
+        ):
+            await tables.list_table_sync_status(target, kind=WarehouseKind.WAREHOUSE)
+
+    async def test_sql_endpoint_kind_is_allowed(self) -> None:
+        target = _make_target()
+        conn = _make_conn([], _SYNC_STATUS_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            # Must not raise:
+            await tables.list_table_sync_status(target, kind=WarehouseKind.SQL_ENDPOINT)
+
+    async def test_legacy_endpoint_error_is_translated(self) -> None:
+        """A legacy (non-preview) endpoint raises an actionable NotFoundError."""
+        target = _make_target()
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.execute.side_effect = Exception(
+            "Invalid object name 'sys.dm_db_external_tables_log_status'."
+        )
+        conn.cursor.return_value = cursor
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(NotFoundError) as exc_info,
+        ):
+            await tables.list_table_sync_status(target, kind=WarehouseKind.SQL_ENDPOINT)
+        msg = str(exc_info.value)
+        assert "new metadata sync" in msg.lower()
+        assert "fdw sql-endpoints refresh" in msg
+
+    async def test_unrelated_not_found_error_propagates_unchanged(self) -> None:
+        """An invalid-object-name error naming something other than the DMV is untouched."""
+        target = _make_target()
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.execute.side_effect = Exception("Invalid object name 'dbo.SomeOtherTable'.")
+        conn.cursor.return_value = cursor
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(NotFoundError) as exc_info,
+        ):
+            await tables.list_table_sync_status(target, kind=WarehouseKind.SQL_ENDPOINT)
+        msg = str(exc_info.value)
+        assert "new metadata sync" not in msg.lower()
+        assert "SomeOtherTable" in msg
+
+    async def test_row_with_null_dmv_columns_yields_none_last_update(self) -> None:
+        target = _make_target()
+        conn = _make_conn([_SYNC_ROW_NEVER_SYNCED], _SYNC_STATUS_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            result = await tables.list_table_sync_status(target, kind=WarehouseKind.SQL_ENDPOINT)
+        assert len(result) == 1
+        row = result[0]
+        assert row.schema_name == "dbo"
+        assert row.name == "StagingRaw"
+        assert row.qualified_name == "dbo.StagingRaw"
+        assert row.last_update_time_utc is None
+        assert row.latest_log_version is None
+        assert row.latest_checkpoint_version is None
+        assert row.is_blocked is None
+
+    async def test_mixed_result_set_returns_both(self) -> None:
+        target = _make_target()
+        conn = _make_conn([_SYNC_ROW_SYNCED, _SYNC_ROW_NEVER_SYNCED], _SYNC_STATUS_COLS)
+        with patch("fabric_dw.sql.open_connection", return_value=conn):
+            result = await tables.list_table_sync_status(target, kind=WarehouseKind.SQL_ENDPOINT)
+        assert len(result) == 2
+        assert {r.name for r in result} == {"FactSales", "StagingRaw"}
+
+
+# ===========================================================================
 # read_table — Row normalisation (#718)
 # ===========================================================================
 # _FakeRow is imported from tests.unit.services._helpers (shared definition).


### PR DESCRIPTION
## Summary

Implements the read half of the design in #1060: surfaces `sys.dm_db_external_tables_log_status` so users can answer "when was this table last updated by the metadata sync?" on a SQL analytics endpoint. The per-table `refresh` command is a separate follow-up (#1062) and is not part of this PR.

## What changed

- **Model**: `TableMetadataSyncStatus` in `models.py`, placed right after `Table` and kept clearly distinct (in its docstring) from the unrelated `TableSyncStatus` (the REST LRO result of the item-level refresh). Fields: `schema_name`, `name`, `qualified_name`, `last_update_time_utc`, `latest_log_version`, `latest_checkpoint_version`, `is_blocked`. `object_id` is intentionally dropped.
- **Service**: `list_table_sync_status` in `services/tables.py`. Drives the listing from `sys.tables JOIN sys.schemas`, LEFT JOIN `sys.dm_db_external_tables_log_status` on `object_id` (a catalog join, not SQL text parsing), so a table that has never been synced still appears with its four DMV fields `None` instead of being dropped. `table` requires `schema` (raises `ValueError` otherwise); both are bound `?` parameters and also pass `validate_identifier`.
- **CLI**: `fdw [-w WORKSPACE] tables sync-status [ENDPOINT] [--schema NAME] [--table SCHEMA.TABLE]`, rendered as a Rich table titled "Table Metadata Sync Status". `--schema` and `--table` are mutually exclusive (`click.UsageError`). `--json` on the root command always emits a JSON array, including `[]` on zero rows.
- **MCP**: `list_table_sync_status(workspace, item, schema=None, table=None)`, plain `@mcp.tool` (read-only, no write gating), returning the same rows as typed dicts. Registered in `mcp/_domains.py` under the `tables` domain so `list_capabilities` doesn't bucket it as unknown.
- **Guard rail**: Data Warehouse targets are rejected up front with `ItemKindError`, the same way `tables health-check` does. `_assert_sql_endpoint` now takes an optional `msg` so the existing health-check call site is unaffected.
- **Legacy-endpoint error translation**: the DMV only exists on endpoints created after the workspace's `New metadata sync` (preview) setting was enabled. The raw "invalid object name" driver error (mapped to `NotFoundError` by `map_driver_error`) is caught and re-raised with an actionable message naming the preview setting and pointing at `fdw sql-endpoints refresh`, but **only when the error message names the DMV specifically** — an unrelated 208 error is re-raised unchanged rather than being misreported as a preview-sync issue.
- **Docs**: `docs/commands/tables.md` gets a `tables sync-status` CLI section (right after `tables health-check`) and a `list_table_sync_status` MCP section (right after `get_table_health_metrics`), including a field-meaning table and the MS Learn DMV reference link. No new page, so `zensical.toml` nav is unchanged. `docs/commands/sql-endpoints.md` is intentionally untouched — that cross-link belongs to #1062.

## Acceptance criteria

1. `fdw tables sync-status ENDPOINT` lists every table with sync status as a Rich table titled "Table Metadata Sync Status" — covered by CLI unit tests.
2. `--schema` / `--table` filtering, and their mutual exclusivity as a `UsageError` — covered.
3. `--json` always emits a JSON array, `[]` on zero rows — covered.
4. Data Warehouse targets rejected with `ItemKindError` — covered (both a mocked-service test and a real-guard test that lets `_assert_sql_endpoint` fire).
5. Legacy-sync endpoints get an actionable translated error naming the preview setting and `fdw sql-endpoints refresh` — covered, plus a test that an unrelated "invalid object name" error is *not* mistranslated.
6. MCP tool returns typed rows and is read-only — covered (a dedicated "not mutating" test with `FABRIC_MCP_ALLOW_MUTATING` unset).
7. Never-synced tables still appear via the LEFT JOIN, with empty sync fields — covered at the service, CLI, and MCP layers.
8. Unit test coverage per the plan's test list — 14 service tests, 9 CLI tests, 6 MCP tests, all passing.
9. Integration tests against a live SQL analytics endpoint, skipping cleanly via `NotFoundError` when the endpoint is on the legacy metadata sync — added (not run in this PR; integration tests need live Fabric credentials and run on `main`).
10. Docs updated, `zensical.toml` nav unchanged — done.

## Decision: `prune_null_columns`

Deliberately **did not** pass `prune_null_columns=True` to the CLI `render(...)` call (unlike `tables list`). On an endpoint where no table has ever been synced by the new metadata sync, every sync column would be `None` for every row — pruning would silently hide `last_update_time_utc`, `latest_log_version`, `latest_checkpoint_version`, and `is_blocked` entirely, defeating the point of the command. Keeping the columns visible (rendered as dimmed `NULL` via the existing, unmodified `_render.py` cell renderer) lets the user actually see that the values are absent, which is itself the answer to "has this ever synced?".

## Testing

- `uv run ruff check .` and `uv run ruff format --check .` — pass.
- `uv run ty check src tests` — pass.
- `uv run pytest tests/unit -q` — 5849 passed.
- Integration tests were **not** run against live Fabric (per project convention: they run on `main` and are triggered manually).

Closes #1061