### PR TITLE
feat(tables): add tables refresh and Lakehouse discovery-gap check

### DIFF
--- a/docs/commands/sql-endpoints.md
+++ b/docs/commands/sql-endpoints.md
@@ -8,6 +8,8 @@ Manage Microsoft Fabric SQL Analytics Endpoints.
 
 **Targets:** SQL Analytics Endpoint
 
+Per-table freshness and refresh live in the `tables` group: see [`tables sync-status`](tables.md#tables-sync-status) and [`tables refresh`](tables.md#tables-refresh).
+
 ## CLI
 
 ### sql-endpoints get
@@ -96,6 +98,18 @@ fdw -w MyWorkspace sql-endpoints refresh --recreate-tables MyLakehouseEP
 fdw -w MyWorkspace --json sql-endpoints refresh MyLakehouseEP
 ```
 
+**Which refresh do I want?**
+
+| | `sql-endpoints refresh` | [`tables refresh`](tables.md#tables-refresh) |
+| --- | --- | --- |
+| Scope | Whole item | Single table |
+| Mechanism | Fabric REST LRO | T-SQL `sys.sp_dw_refresh_ext_table` |
+| Availability | Always | Preview: endpoints created after `New metadata sync` was enabled |
+| Picks up schema changes (tables added/dropped) | Yes | No |
+| Blast radius | Whole item; `--recreate-tables` drops and recreates every table | One table's data only |
+
+Use `sql-endpoints refresh` after adding or dropping tables in the underlying Lakehouse, or when a full resync is warranted. Use [`tables refresh`](tables.md#tables-refresh) for a cheap, targeted refresh of a single table you already know exists. Check [`tables sync-status`](tables.md#tables-sync-status) first to see whether a refresh is even needed.
+
 ## MCP tools
 
 ### get_sql_endpoint
@@ -128,7 +142,7 @@ List all SQL analytics endpoints in a workspace, or across all visible workspace
 
 **Targets:** SQL Analytics Endpoint
 
-Refresh metadata for a SQL analytics endpoint by syncing from the underlying Lakehouse delta tables. This is a long-running operation (LRO) polled to completion.
+Refresh metadata for a SQL analytics endpoint by syncing from the underlying Lakehouse delta tables. This is a long-running operation (LRO) polled to completion. Use this for **schema** changes (tables added or dropped). For cheap, per-table **data**-only staleness, use [`refresh_table_metadata`](tables.md#refresh_table_metadata) instead.
 
 **Parameters:**
 

--- a/docs/commands/tables.md
+++ b/docs/commands/tables.md
@@ -413,7 +413,13 @@ Show when each table was last updated by the metadata sync, via `sys.dm_db_exter
 
 The listing is driven from `sys.tables`, so a table with no matching DMV row still appears, with `last_update_time_utc`, `latest_log_version`, `latest_checkpoint_version`, and `is_blocked` all empty. This means no sync information is available for that table, not that it provably never synced - Microsoft documents the DMV as describing the most recent update, not as a complete sync history.
 
-**Coverage limit:** only tables that exist in the endpoint catalog (`sys.tables`) are listed. On a SQL Analytics Endpoint that catalog is itself maintained by the metadata sync, so a Lakehouse table whose discovery has not completed, or has failed, does not appear at all - it is not shown as a row with empty fields, it is simply absent. If a table you expect is missing, run `fdw sql-endpoints refresh` to force an item-level sync and check again.
+**Coverage limit:** by default, only tables that exist in the endpoint catalog (`sys.tables`) are listed. On a SQL Analytics Endpoint that catalog is itself maintained by the metadata sync, so a Lakehouse table whose discovery has not completed, or has failed, does not appear at all - it is not shown as a row with empty fields, it is simply absent. If a table you expect is missing, run `fdw sql-endpoints refresh` to force an item-level sync and check again, or pass `--check-lakehouse` (below) to see it listed directly.
+
+**Closing the gap with `--check-lakehouse`:** this flag cross-references the backing Lakehouse's own table inventory (via the Fabric REST "List Tables" API) and adds a row for every table it finds there but not in the endpoint catalog, with `in_endpoint_catalog: false` and every sync field empty (a table with no catalog row cannot have sync information yet). This costs at least one extra REST call beyond the normal single TDS query, so it is opt-in rather than always-on for a command you may run repeatedly. It only works for an endpoint backed by a **non-schema-enabled** Lakehouse:
+
+- If the endpoint's backing item cannot be resolved to a Lakehouse at all (a mirrored database, or similar), the flag prints a note and falls back to the catalog-only listing.
+- If the backing Lakehouse has schema support enabled, the flag also prints a note and falls back: the Lakehouse "List Tables" API does not attribute tables to a schema, so a bare table name could belong to any schema, and guessing would risk a false "missing" report for a table that actually exists under a different schema.
+- In both cases the fallback is stated in the output, not silent - getting no extra rows back does not by itself prove the endpoint is fully discovered. `--check-lakehouse` is mutually exclusive with `--schema` and `--table`: it always compares the whole endpoint.
 
 | Field | Meaning |
 | --- | --- |
@@ -421,6 +427,7 @@ The listing is driven from `sys.tables`, so a table with no matching DMV row sti
 | `latest_log_version` | The Delta transaction log version that was last processed. |
 | `latest_checkpoint_version` | The Delta checkpoint version that was last processed. |
 | `is_blocked` | Whether the last update attempt was blocked (for example, by a multi-part checkpoint, which the preview does not support). |
+| `in_endpoint_catalog` | `true` for every row sourced from `sys.tables` (i.e. every row without `--check-lakehouse`). `false` only for a `--check-lakehouse` row: present in the Lakehouse, absent from the endpoint catalog. |
 
 **Synopsis**
 
@@ -430,8 +437,9 @@ fdw [-w WORKSPACE] tables sync-status [OPTIONS] [ENDPOINT]
 
 | Option | Description |
 | --- | --- |
-| `--schema NAME` | Only show tables in this schema. |
-| `--table SCHEMA.TABLE` | Only show this one table. Mutually exclusive with `--schema`. |
+| `--schema NAME` | Only show tables in this schema. Exclusive with `--check-lakehouse`. |
+| `--table SCHEMA.TABLE` | Only show this one table. Mutually exclusive with `--schema`. Exclusive with `--check-lakehouse`. |
+| `--check-lakehouse` | Add rows for tables present in the backing Lakehouse but missing from the endpoint catalog entirely. See above for its cost and limits. |
 
 **Example**
 
@@ -439,7 +447,12 @@ fdw [-w WORKSPACE] tables sync-status [OPTIONS] [ENDPOINT]
 fdw -w MyWorkspace tables sync-status MyLakehouseEP
 fdw -w MyWorkspace tables sync-status MyLakehouseEP --schema dbo
 fdw -w MyWorkspace tables sync-status MyLakehouseEP --table dbo.FactSales
+
+# Also surface tables the metadata sync has never discovered at all
+fdw -w MyWorkspace tables sync-status MyLakehouseEP --check-lakehouse
 ```
+
+Reference: [Lakehouse - Tables - List Tables](https://learn.microsoft.com/en-us/rest/api/fabric/lakehouse/tables/list-tables?WT.mc_id=MVP_310840)
 
 ### tables refresh
 
@@ -896,14 +909,17 @@ The listing is driven from `sys.tables`, so a table with no matching DMV row sti
 
 !!! warning "Coverage limit: a missing table is not proof it doesn't exist"
 
-    This tool only returns tables already present in the endpoint's catalog (`sys.tables`), which is itself maintained by the metadata sync. A Lakehouse table whose discovery has not completed, or has failed, has no catalog row and is **absent from this result entirely** - it does not appear as a row with empty fields. Do not conclude a table was deleted, or never existed, just because it is missing from this list. If an expected table is missing, call `refresh_sql_endpoint_metadata` (or `fdw sql-endpoints refresh`) to force an item-level sync and check again.
+    By default, this tool only returns tables already present in the endpoint's catalog (`sys.tables`), which is itself maintained by the metadata sync. A Lakehouse table whose discovery has not completed, or has failed, has no catalog row and is **absent from this result entirely** - it does not appear as a row with empty fields. Do not conclude a table was deleted, or never existed, just because it is missing from this list.
+
+Pass `check_lakehouse=True` to close part of this gap: it cross-references the backing Lakehouse's own table inventory and adds a row with `in_endpoint_catalog: false` (and every sync field `null`) for a table it finds there but not in the catalog. This costs one or more extra REST calls, so avoid setting it on every call of a tool an agent may invoke repeatedly. It only works for an endpoint backed by a **non-schema-enabled** Lakehouse; for anything else (a mirrored database, a schema-enabled Lakehouse, or no Lakehouse match at all) it is a no-op and the result is identical to `check_lakehouse=False` - getting no extra rows back does **not** by itself prove the endpoint is fully discovered. `check_lakehouse=True` cannot be combined with `schema` or `table`.
 
 **Parameters:**
 
 - `workspace` (`str`): workspace name or GUID.
 - `item` (`str`): SQL Analytics Endpoint name or GUID. Data Warehouses are rejected with a `ToolError`.
-- `schema` (`str | null`, optional): when provided, only tables in this schema are returned.
-- `table` (`str | null`, optional): when provided, filter to this single (bare, unqualified) table name. Requires `schema` to also be given.
+- `schema` (`str | null`, optional): when provided, only tables in this schema are returned. Mutually exclusive with `check_lakehouse`.
+- `table` (`str | null`, optional): when provided, filter to this single (bare, unqualified) table name. Requires `schema` to also be given. Mutually exclusive with `check_lakehouse`.
+- `check_lakehouse` (`bool`, default `false`): also surface tables present in the backing Lakehouse but missing from the endpoint catalog entirely. See above for its cost and limits.
 
 **Returns:** `list[TableMetadataSyncStatus]`, one dict per table, each containing:
 
@@ -914,10 +930,11 @@ The listing is driven from `sys.tables`, so a table with no matching DMV row sti
 - `latest_log_version` (`int | null`): the Delta transaction log version last processed.
 - `latest_checkpoint_version` (`int | null`): the Delta checkpoint version last processed.
 - `is_blocked` (`bool | null`): whether the last update attempt was blocked.
+- `in_endpoint_catalog` (`bool`): `true` for every row sourced from `sys.tables` (i.e. every row when `check_lakehouse` is `false`). `false` only for a `check_lakehouse` row.
 
 On an endpoint using the legacy metadata sync, the tool raises a `ToolError` with an actionable message naming the `New metadata sync` preview setting and pointing at `fdw sql-endpoints refresh` (or the `refresh_sql_endpoint_metadata` MCP tool) as the fallback for refreshing the whole item.
 
-Reference: [sys.dm_db_external_tables_log_status](https://learn.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-db-external-tables-log-status-transact-sql?view=fabric&WT.mc_id=MVP_310840)
+References: [sys.dm_db_external_tables_log_status](https://learn.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-db-external-tables-log-status-transact-sql?view=fabric&WT.mc_id=MVP_310840), [Lakehouse - Tables - List Tables](https://learn.microsoft.com/en-us/rest/api/fabric/lakehouse/tables/list-tables?WT.mc_id=MVP_310840)
 
 ### refresh_table_metadata
 

--- a/docs/commands/tables.md
+++ b/docs/commands/tables.md
@@ -415,11 +415,11 @@ The listing is driven from `sys.tables`, so a table with no matching DMV row sti
 
 **Coverage limit:** by default, only tables that exist in the endpoint catalog (`sys.tables`) are listed. On a SQL Analytics Endpoint that catalog is itself maintained by the metadata sync, so a Lakehouse table whose discovery has not completed, or has failed, does not appear at all - it is not shown as a row with empty fields, it is simply absent. If a table you expect is missing, run `fdw sql-endpoints refresh` to force an item-level sync and check again, or pass `--check-lakehouse` (below) to see it listed directly.
 
-**Closing the gap with `--check-lakehouse`:** this flag cross-references the backing Lakehouse's own table inventory (via the Fabric REST "List Tables" API) and adds a row for every table it finds there but not in the endpoint catalog, with `in_endpoint_catalog: false` and every sync field empty (a table with no catalog row cannot have sync information yet). This costs at least one extra REST call beyond the normal single TDS query, so it is opt-in rather than always-on for a command you may run repeatedly. It only works for an endpoint backed by a **non-schema-enabled** Lakehouse:
+**Closing the gap with `--check-lakehouse`:** this flag cross-references the backing Lakehouse's own table inventory (via the Fabric REST "List Tables" API) and adds a row for every table it finds there but not in the endpoint catalog, with `in_endpoint_catalog: false` and every sync field empty (a table with no catalog row cannot have sync information yet). Names are compared **exactly (case-sensitively)**, matching Fabric's case-sensitive default collation - a Lakehouse `FactSales` and a catalog `factsales` are treated as distinct, and a Lakehouse table whose name differs from a catalog table only by case is reported with `case_mismatched_catalog_name` set to that catalog name, rather than as a flat "missing" table. This costs at least one extra REST call beyond the normal single TDS query, so it is opt-in rather than always-on for a command you may run repeatedly. It only works for an endpoint backed by a **non-schema-enabled** Lakehouse:
 
-- If the endpoint's backing item cannot be resolved to a Lakehouse at all (a mirrored database, or similar), the flag prints a note and falls back to the catalog-only listing.
-- If the backing Lakehouse has schema support enabled, the flag also prints a note and falls back: the Lakehouse "List Tables" API does not attribute tables to a schema, so a bare table name could belong to any schema, and guessing would risk a false "missing" report for a table that actually exists under a different schema.
-- In both cases the fallback is stated in the output, not silent - getting no extra rows back does not by itself prove the endpoint is fully discovered. `--check-lakehouse` is mutually exclusive with `--schema` and `--table`: it always compares the whole endpoint.
+- If the endpoint's backing item cannot be resolved to a Lakehouse at all (a mirrored database, or similar), `--check-lakehouse` fails with a clear error.
+- If the backing Lakehouse has schema support enabled, `--check-lakehouse` also fails: the Lakehouse "List Tables" API does not attribute tables to a schema, so a bare table name could belong to any schema, and guessing would risk a false "missing" report for a table that actually exists under a different schema.
+- Both cases are a hard failure (non-zero exit, no rows rendered), not a silent fallback to the catalog-only listing - you asked for the cross-check, so "no extra rows" must never be mistaken for "fully discovered". `--check-lakehouse` is mutually exclusive with `--schema` and `--table`: it always compares the whole endpoint.
 
 | Field | Meaning |
 | --- | --- |
@@ -427,7 +427,8 @@ The listing is driven from `sys.tables`, so a table with no matching DMV row sti
 | `latest_log_version` | The Delta transaction log version that was last processed. |
 | `latest_checkpoint_version` | The Delta checkpoint version that was last processed. |
 | `is_blocked` | Whether the last update attempt was blocked (for example, by a multi-part checkpoint, which the preview does not support). |
-| `in_endpoint_catalog` | `true` for every row sourced from `sys.tables` (i.e. every row without `--check-lakehouse`). `false` only for a `--check-lakehouse` row: present in the Lakehouse, absent from the endpoint catalog. |
+| `in_endpoint_catalog` | `true` for every row sourced from `sys.tables` (i.e. every row without `--check-lakehouse`). `false` only for a `--check-lakehouse` row: present in the Lakehouse, absent from the endpoint catalog under that exact name. |
+| `case_mismatched_catalog_name` | Only set on a `--check-lakehouse` row whose Lakehouse name matches an existing catalog table case-insensitively but not exactly - names the catalog table it likely corresponds to. `null` otherwise. |
 
 **Synopsis**
 
@@ -911,7 +912,9 @@ The listing is driven from `sys.tables`, so a table with no matching DMV row sti
 
     By default, this tool only returns tables already present in the endpoint's catalog (`sys.tables`), which is itself maintained by the metadata sync. A Lakehouse table whose discovery has not completed, or has failed, has no catalog row and is **absent from this result entirely** - it does not appear as a row with empty fields. Do not conclude a table was deleted, or never existed, just because it is missing from this list.
 
-Pass `check_lakehouse=True` to close part of this gap: it cross-references the backing Lakehouse's own table inventory and adds a row with `in_endpoint_catalog: false` (and every sync field `null`) for a table it finds there but not in the catalog. This costs one or more extra REST calls, so avoid setting it on every call of a tool an agent may invoke repeatedly. It only works for an endpoint backed by a **non-schema-enabled** Lakehouse; for anything else (a mirrored database, a schema-enabled Lakehouse, or no Lakehouse match at all) it is a no-op and the result is identical to `check_lakehouse=False` - getting no extra rows back does **not** by itself prove the endpoint is fully discovered. `check_lakehouse=True` cannot be combined with `schema` or `table`.
+Pass `check_lakehouse=True` to close part of this gap: it cross-references the backing Lakehouse's own table inventory and adds a row with `in_endpoint_catalog: false` (and every sync field `null`) for a table it finds there but not in the catalog. Names are compared **exactly (case-sensitively)**, matching Fabric's case-sensitive default collation - a Lakehouse table whose name matches a catalog table case-insensitively but not exactly gets `case_mismatched_catalog_name` set to that catalog name instead of being reported as a flat miss. This costs one or more extra REST calls, so avoid setting it on every call of a tool an agent may invoke repeatedly.
+
+It only works for an endpoint backed by a **non-schema-enabled** Lakehouse. For anything else (a mirrored database, a schema-enabled Lakehouse, or no Lakehouse match at all), `check_lakehouse=True` raises a `ToolError` explaining why, rather than silently returning the unchanged catalog-only result: a caller that explicitly asked for the cross-check must never read "no extra rows" as "fully discovered". `check_lakehouse=True` also raises a `ToolError` when combined with `schema` or `table`: it always compares the whole endpoint.
 
 **Parameters:**
 
@@ -919,7 +922,7 @@ Pass `check_lakehouse=True` to close part of this gap: it cross-references the b
 - `item` (`str`): SQL Analytics Endpoint name or GUID. Data Warehouses are rejected with a `ToolError`.
 - `schema` (`str | null`, optional): when provided, only tables in this schema are returned. Mutually exclusive with `check_lakehouse`.
 - `table` (`str | null`, optional): when provided, filter to this single (bare, unqualified) table name. Requires `schema` to also be given. Mutually exclusive with `check_lakehouse`.
-- `check_lakehouse` (`bool`, default `false`): also surface tables present in the backing Lakehouse but missing from the endpoint catalog entirely. See above for its cost and limits.
+- `check_lakehouse` (`bool`, default `false`): also surface tables present in the backing Lakehouse but missing from the endpoint catalog entirely. Raises a `ToolError` if it cannot run. See above for its cost and limits.
 
 **Returns:** `list[TableMetadataSyncStatus]`, one dict per table, each containing:
 
@@ -931,6 +934,7 @@ Pass `check_lakehouse=True` to close part of this gap: it cross-references the b
 - `latest_checkpoint_version` (`int | null`): the Delta checkpoint version last processed.
 - `is_blocked` (`bool | null`): whether the last update attempt was blocked.
 - `in_endpoint_catalog` (`bool`): `true` for every row sourced from `sys.tables` (i.e. every row when `check_lakehouse` is `false`). `false` only for a `check_lakehouse` row.
+- `case_mismatched_catalog_name` (`str | null`): only set on a `check_lakehouse` row whose Lakehouse name matches an existing catalog table case-insensitively but not exactly - names the catalog table it likely corresponds to. `null` otherwise.
 
 On an endpoint using the legacy metadata sync, the tool raises a `ToolError` with an actionable message naming the `New metadata sync` preview setting and pointing at `fdw sql-endpoints refresh` (or the `refresh_sql_endpoint_metadata` MCP tool) as the fallback for refreshing the whole item.
 

--- a/docs/commands/tables.md
+++ b/docs/commands/tables.md
@@ -441,6 +441,41 @@ fdw -w MyWorkspace tables sync-status MyLakehouseEP --schema dbo
 fdw -w MyWorkspace tables sync-status MyLakehouseEP --table dbo.FactSales
 ```
 
+### tables refresh
+
+**Targets:** SQL Analytics Endpoint
+
+Refresh a single table's data via `sys.sp_dw_refresh_ext_table`, without a full item-level metadata sync. Only applies to SQL Analytics Endpoints created after `New metadata sync` (preview) was enabled under Workspace settings, Warehouse settings, for the workspace hosting the endpoint. On an endpoint using the legacy metadata sync, the command fails with the same actionable message as `tables sync-status`.
+
+This refreshes **data only** - it re-reads the underlying Delta log for that one table. It does not pick up **schema** changes (tables added or dropped); for that, use [`fdw sql-endpoints refresh`](sql-endpoints.md#sql-endpoints-refresh) instead. See the "which refresh do I want" comparison on that page.
+
+On success, the command prints a one-line confirmation followed by the table's refreshed sync-status row (the same shape as [`tables sync-status`](#tables-sync-status)), so the new `last_update_time_utc` is visible without a second command. A non-zero procedure return code (the procedure returns `0` for success, `1` for failure) fails with a clear error and a non-zero exit code.
+
+`--json` emits a single JSON object, not an array - the command always acts on exactly one table, so `fdw tables refresh MyLakehouseEP dbo.FactSales --json | jq .last_update_time_utc` works without indexing.
+
+**Synopsis**
+
+```
+fdw [-w WORKSPACE] tables refresh [ENDPOINT] QUALIFIED_NAME
+```
+
+**Example**
+
+```shell
+fdw -w MyWorkspace tables refresh MyLakehouseEP dbo.FactSales
+```
+
+```
+Refreshed table metadata for dbo.FactSales.
+ schema_name  name       last_update_time_utc  latest_log_version  latest_checkpoint_version  is_blocked
+ ------------ ---------- --------------------- ------------------- -------------------------- ----------
+ dbo          FactSales  2026-09-03T09:14:03Z  1285                1200                       False
+```
+
+```shell
+fdw -w MyWorkspace --json tables refresh MyLakehouseEP dbo.FactSales | jq .last_update_time_utc
+```
+
 ### tables list
 
 **Targets:** Data Warehouse / SQL Analytics Endpoint
@@ -883,6 +918,28 @@ The listing is driven from `sys.tables`, so a table with no matching DMV row sti
 On an endpoint using the legacy metadata sync, the tool raises a `ToolError` with an actionable message naming the `New metadata sync` preview setting and pointing at `fdw sql-endpoints refresh` (or the `refresh_sql_endpoint_metadata` MCP tool) as the fallback for refreshing the whole item.
 
 Reference: [sys.dm_db_external_tables_log_status](https://learn.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-db-external-tables-log-status-transact-sql?view=fabric&WT.mc_id=MVP_310840)
+
+### refresh_table_metadata
+
+**Targets:** SQL Analytics Endpoint
+
+Refresh one table's metadata via `sys.sp_dw_refresh_ext_table`. This is the cheap, per-table refresh for **data**-only staleness: it re-reads the table's underlying Delta log without a full item-level sync. Use [`refresh_sql_endpoint_metadata`](sql-endpoints.md#refresh_sql_endpoint_metadata) instead when the **schema** changed (tables added or dropped) - this tool does not pick up schema changes.
+
+Only supported on SQL Analytics Endpoints (not Data Warehouses), and only on endpoints created after the workspace's `New metadata sync` (preview) setting was enabled.
+
+Mutating (respects `FABRIC_MCP_READONLY`) but **not** destructive: it never drops or recreates anything, so it does not require the `FABRIC_MCP_ALLOW_DESTRUCTIVE` opt-in.
+
+**Parameters:**
+
+- `workspace` (`str`): workspace name or GUID.
+- `item` (`str`): SQL Analytics Endpoint name or GUID. Data Warehouses are rejected with a `ToolError`.
+- `qualified_name` (`str`): dot-separated qualified table name, e.g. `dbo.sales`.
+
+**Returns:** `TableMetadataSyncStatus`: the refreshed sync-status row for the table (same shape as [`list_table_sync_status`](#list_table_sync_status)).
+
+On an endpoint using the legacy metadata sync, the tool raises a `ToolError` with the same actionable message as `list_table_sync_status`. A non-zero procedure return code (the procedure returns `0` for success, `1` for failure) also raises a `ToolError`. If the table is not present in the endpoint's catalog after a successful refresh, the tool raises a `ToolError` naming the table and pointing at `refresh_sql_endpoint_metadata` (or `fdw sql-endpoints refresh`) as the fallback.
+
+Reference: [sys.sp_dw_refresh_ext_table](https://learn.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sp-dw-refresh-ext-table-transact-sql?view=fabric&WT.mc_id=MVP_310840)
 
 ### import_table_from_url
 

--- a/src/fabric_dw/_fabric_api.py
+++ b/src/fabric_dw/_fabric_api.py
@@ -12,18 +12,94 @@ low-level module importing a service module) without resorting to lazy imports.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
+from uuid import UUID
 
 from fabric_dw.http_client import HttpBase
 
 if TYPE_CHECKING:
-    from uuid import UUID
-
     from fabric_dw.http_client import FabricHttpClient
 
 __all__ = [
+    "LakehouseMatch",
+    "resolve_backing_lakehouse",
     "resolve_lakehouse_connection_string",
 ]
+
+
+@dataclass(frozen=True)
+class LakehouseMatch:
+    """The Lakehouse item that backs a SQL analytics endpoint.
+
+    Attributes:
+        id: The Lakehouse item's UUID.
+        connection_string: The lakehouse's ``properties.sqlEndpointProperties.connectionString``,
+            or ``None`` if still empty (the endpoint is still provisioning).
+        default_schema: The lakehouse's ``properties.defaultSchema``, or ``None``.
+            Per the Fabric REST API reference, this property is returned **only**
+            for a schema-enabled lakehouse — its presence is therefore the
+            documented signal that the lakehouse has multiple schemas rather
+            than a single implicit ``dbo`` schema.
+    """
+
+    id: UUID
+    connection_string: str | None
+    default_schema: str | None
+
+
+async def resolve_backing_lakehouse(
+    http: FabricHttpClient,
+    workspace_id: UUID,
+    endpoint_id: UUID,
+) -> LakehouseMatch | None:
+    """Find the Lakehouse item that backs a SQL analytics endpoint, if any.
+
+    Pages ``GET /workspaces/{ws}/lakehouses`` and locates the lakehouse whose
+    ``properties.sqlEndpointProperties.id`` matches *endpoint_id*. There is no
+    reverse link on the ``/sqlEndpoints/{id}`` resource itself — a SQL analytics
+    endpoint does not carry a pointer back to its parent item — so a scan of
+    every lakehouse in the workspace is the only way to make this connection
+    with the APIs Fabric exposes today. This is the same scan
+    :func:`resolve_lakehouse_connection_string` already performs; the two share
+    this one implementation so the workspace is only paged once per call site.
+
+    Returns ``None`` when no lakehouse in the workspace pairs with *endpoint_id*
+    — either the endpoint belongs to something other than a Lakehouse (a
+    Warehouse, a mirrored database, etc., none of which appear in
+    ``/lakehouses``), or it is a lakehouse-derived endpoint whose parent
+    lakehouse has since been deleted.
+
+    Args:
+        http: An authenticated :class:`~fabric_dw.http_client.FabricHttpClient`.
+        workspace_id: The UUID of the workspace to search.
+        endpoint_id: The UUID of the SQL analytics endpoint to resolve.
+
+    Returns:
+        A :class:`LakehouseMatch` for the paired lakehouse, or ``None`` if no
+        lakehouse in the workspace pairs with *endpoint_id*.
+    """
+    # str(UUID) is always lowercase; lowercase the API value too so the match is
+    # robust against Fabric returning an uppercase/mixed-case UUID string.
+    endpoint_id_str = str(endpoint_id).lower()
+    async for lh in http.iter_paginated(HttpBase.FABRIC, f"/workspaces/{workspace_id}/lakehouses"):
+        props = lh.get("properties")
+        props_dict = cast("dict[str, Any]", props) if isinstance(props, dict) else {}
+        sql_ep = props_dict.get("sqlEndpointProperties")
+        sql_ep_dict = cast("dict[str, Any]", sql_ep) if isinstance(sql_ep, dict) else {}
+        if str(sql_ep_dict.get("id", "")).lower() != endpoint_id_str:
+            continue
+        conn = str(sql_ep_dict.get("connectionString", ""))
+        default_schema = props_dict.get("defaultSchema")
+        lh_id = lh.get("id")
+        if lh_id is None:
+            return None
+        return LakehouseMatch(
+            id=UUID(str(lh_id)),
+            connection_string=conn or None,
+            default_schema=str(default_schema) if default_schema else None,
+        )
+    return None
 
 
 async def resolve_lakehouse_connection_string(
@@ -38,12 +114,8 @@ async def resolve_lakehouse_connection_string(
     the parent Lakehouse at
     ``properties.sqlEndpointProperties.connectionString``.
 
-    This helper pages ``GET /workspaces/{ws}/lakehouses``, locates the lakehouse
-    whose ``properties.sqlEndpointProperties.id`` matches *endpoint_id*, and
-    returns that lakehouse's ``connectionString``.  Returns ``None`` when no
-    matching lakehouse is found (e.g. the endpoint belongs to a Warehouse, not a
-    Lakehouse) **or** when the matching lakehouse's connection string is still
-    empty (the endpoint is still provisioning).
+    Thin wrapper around :func:`resolve_backing_lakehouse` that extracts just the
+    connection string, kept for the existing connection-string-only call sites.
 
     Args:
         http: An authenticated :class:`~fabric_dw.http_client.FabricHttpClient`.
@@ -56,15 +128,5 @@ async def resolve_lakehouse_connection_string(
         if no lakehouse in the workspace has a paired endpoint with this ID (or
         the paired lakehouse has not yet exposed a connection string).
     """
-    # str(UUID) is always lowercase; lowercase the API value too so the match is
-    # robust against Fabric returning an uppercase/mixed-case UUID string.
-    endpoint_id_str = str(endpoint_id).lower()
-    async for lh in http.iter_paginated(HttpBase.FABRIC, f"/workspaces/{workspace_id}/lakehouses"):
-        props = lh.get("properties")
-        props_dict = cast("dict[str, Any]", props) if isinstance(props, dict) else {}
-        sql_ep = props_dict.get("sqlEndpointProperties")
-        sql_ep_dict = cast("dict[str, Any]", sql_ep) if isinstance(sql_ep, dict) else {}
-        if str(sql_ep_dict.get("id", "")).lower() == endpoint_id_str:
-            conn = str(sql_ep_dict.get("connectionString", ""))
-            return conn or None
-    return None
+    match = await resolve_backing_lakehouse(http, workspace_id, endpoint_id)
+    return match.connection_string if match else None

--- a/src/fabric_dw/cli/commands/_utils.py
+++ b/src/fabric_dw/cli/commands/_utils.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import os
 import re
-from collections.abc import AsyncIterator, Callable, Coroutine
+from collections.abc import AsyncIterator, Callable, Coroutine, Mapping
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime, timedelta
 from functools import wraps
@@ -694,3 +694,48 @@ def validate_workspace_option_or_all_workspaces(
     """
     if explicit_workspace is not None and all_workspaces:
         raise click.UsageError("-w/--workspace and --all-workspaces / -A are mutually exclusive.")
+
+
+# ---------------------------------------------------------------------------
+# Command-name hints for a plain click.Group
+# ---------------------------------------------------------------------------
+
+
+def group_with_hints(redirects: Mapping[str, str]) -> type[click.Group]:
+    """Return a :class:`click.Group` subclass that hints at commands living elsewhere.
+
+    Some CLI groups accumulate "shadow" names: a bare command name a user
+    might reasonably type in this group even though the command actually
+    lives in a different group (e.g. someone typing ``sql-endpoints
+    sync-status`` when the command is ``tables sync-status``). Pass a
+    *redirects* mapping from that bare name to the real invocation string
+    (e.g. ``"fdw tables sync-status"``) and use the returned class via
+    ``cls=`` on ``@click.group(...)``.
+
+    Only names that are NOT already registered as real commands in the group
+    are intercepted, so a redirect entry can never shadow an actual command
+    (including one added later). Anything not in *redirects* falls through to
+    Click's normal resolution unchanged, including its own "Did you mean?"
+    typo suggestions.
+
+    Args:
+        redirects: Mapping from a bare (unregistered) command name to the
+            full invocation string to show in the hint.
+
+    Returns:
+        A fresh :class:`click.Group` subclass bound to *redirects*.
+    """
+
+    class _HintedGroup(click.Group):
+        def resolve_command(
+            self, ctx: click.Context, args: list[str]
+        ) -> tuple[str | None, click.Command | None, list[str]]:
+            if args and self.get_command(ctx, args[0]) is None:
+                hint = redirects.get(args[0])
+                if hint is not None:
+                    raise click.UsageError(
+                        f"No such command {args[0]!r}. Did you mean {hint!r}?", ctx=ctx
+                    )
+            return super().resolve_command(ctx, args)
+
+    return _HintedGroup

--- a/src/fabric_dw/cli/commands/sql_endpoints.py
+++ b/src/fabric_dw/cli/commands/sql_endpoints.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING
 
 import click
@@ -14,6 +15,7 @@ from fabric_dw.cli._render import (
 from fabric_dw.cli.commands._utils import (
     build_http_client,
     coro,
+    group_with_hints,
     make_resolver,
     resolve_item,
     resolve_warehouse_arg,
@@ -85,9 +87,23 @@ async def _resolve_endpoint_or_hint(
         ) from None
 
 
-@click.group("sql-endpoints")
+# Bare command names a user might reasonably type in this group even though the
+# command actually lives in 'tables' (scope, not item kind, decides placement --
+# see #1060). Anything not in this mapping falls through to Click's normal
+# command resolution (including its own "Did you mean?" typo suggestions).
+_COMMAND_HINTS: Mapping[str, str] = {
+    "sync-status": "fdw tables sync-status",
+    "refresh-table": "fdw tables refresh",
+}
+
+
+@click.group("sql-endpoints", cls=group_with_hints(_COMMAND_HINTS))
 def sql_endpoints_group() -> None:
-    """Manage Microsoft Fabric SQL Analytics Endpoints."""
+    """Manage Microsoft Fabric SQL Analytics Endpoints.
+
+    Per-table freshness and refresh live in the 'tables' group: see
+    'fdw tables sync-status' and 'fdw tables refresh'.
+    """
 
 
 @sql_endpoints_group.command("list")

--- a/src/fabric_dw/cli/commands/tables.py
+++ b/src/fabric_dw/cli/commands/tables.py
@@ -408,6 +408,51 @@ async def sync_status_cmd(
         raise click.ClickException(str(exc)) from exc
 
 
+@tables_group.command("refresh")
+@click.argument("item", required=False, default=None)
+@click.argument("qualified_name")
+@click.pass_obj
+@coro
+async def refresh_cmd(
+    ctx: CliContext,
+    item: str | None,
+    qualified_name: str,
+) -> None:
+    """Refresh QUALIFIED_NAME (schema.table) on ITEM via sys.sp_dw_refresh_ext_table.
+
+    Refreshes a single table's data by re-reading its underlying Delta log,
+    without a full item-level metadata sync. Only supported on SQL Analytics
+    Endpoints created after the workspace's 'New metadata sync' (preview)
+    setting was enabled. This does not pick up schema changes (tables added
+    or dropped) -- for that, use 'fdw sql-endpoints refresh' instead.
+
+    On success, prints a one-line confirmation followed by the table's
+    refreshed sync-status row (the same shape as 'tables sync-status'), so
+    the new last_update_time_utc is visible without a second command.
+    --json emits a single JSON object (not an array), since this command
+    always acts on exactly one table.
+    """
+    ws = resolve_workspace(ctx)
+    wh = resolve_warehouse_arg(ctx, item)
+    schema, table_name = parse_qualified_name(qualified_name, kind="table")
+    try:
+        async with build_http_client(ctx) as http:
+            target, entry = await build_sql_target(http, ws, wh)
+            result = await _tables_svc.refresh_table_metadata(
+                target, schema, table_name, kind=entry.kind, mode=ctx.auth
+            )
+    except (ValueError, FabricError) as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    if not ctx.json_output:
+        click.echo(f"Refreshed table metadata for {schema}.{table_name}.")
+    render(
+        result.model_dump(mode="json"),
+        json_output=ctx.json_output,
+        table_title="Table Metadata Sync Status",
+    )
+
+
 @tables_group.command("create")
 @click.argument("item", required=False, default=None)
 @click.option("--name", "qualified_name", required=True, help="Qualified name: schema.table.")

--- a/src/fabric_dw/cli/commands/tables.py
+++ b/src/fabric_dw/cli/commands/tables.py
@@ -31,7 +31,8 @@ from fabric_dw.cli.commands._utils import (
 )
 from fabric_dw.exceptions import FabricError
 from fabric_dw.http_client import FabricHttpClient
-from fabric_dw.models import ColumnSpec, CopyIntoResult
+from fabric_dw.models import ColumnSpec, CopyIntoResult, TableMetadataSyncStatus
+from fabric_dw.services import sql_endpoints as _sql_endpoints_svc
 from fabric_dw.services import tables as _tables_svc
 from fabric_dw.services.columns import get_object_columns_or_raise as _get_columns
 from fabric_dw.services.load import (
@@ -359,6 +360,18 @@ async def health_check_cmd(
     metavar="SCHEMA.TABLE",
     help="Filter to a single qualified table (e.g. dbo.FactSales). Exclusive with --schema.",
 )
+@click.option(
+    "--check-lakehouse",
+    "check_lakehouse",
+    is_flag=True,
+    default=False,
+    help=(
+        "Cross-reference the backing Lakehouse's table inventory and add rows for "
+        "tables it has but the endpoint catalog does not (in_endpoint_catalog=false). "
+        "Costs at least one extra REST call; only works for a non-schema-enabled "
+        "Lakehouse-backed endpoint. Exclusive with --schema and --table."
+    ),
+)
 @click.pass_obj
 @coro
 async def sync_status_cmd(
@@ -366,6 +379,7 @@ async def sync_status_cmd(
     item: str | None,
     filter_schema: str | None,
     filter_table: str | None,
+    check_lakehouse: bool,
 ) -> None:
     """Show per-table metadata sync freshness on ITEM (SQL Analytics Endpoint only).
 
@@ -375,14 +389,26 @@ async def sync_status_cmd(
     never synced. Only supported on SQL Analytics Endpoints created after the
     workspace's 'New metadata sync' (preview) setting was enabled.
 
-    Coverage limit: only tables present in sys.tables are listed. On a SQL
-    Analytics Endpoint that catalog is itself maintained by the metadata sync,
-    so a Lakehouse table whose discovery has not completed, or has failed,
-    does not appear at all. If a table you expect is missing, run
-    'fdw sql-endpoints refresh' to force an item-level sync and check again.
+    Coverage limit: only tables present in sys.tables are listed by default.
+    On a SQL Analytics Endpoint that catalog is itself maintained by the
+    metadata sync, so a Lakehouse table whose discovery has not completed, or
+    has failed, does not appear at all. Pass --check-lakehouse to close this
+    gap: it cross-references the backing Lakehouse's own table inventory and
+    adds a row (in_endpoint_catalog=false, all sync fields empty) for every
+    table found there but missing from the endpoint catalog. This only works
+    for an endpoint backed by a non-schema-enabled Lakehouse -- for anything
+    else (a mirrored database, a schema-enabled Lakehouse, ...) the flag
+    prints an explanatory note and the listing falls back to today's
+    catalog-only behaviour, it never silently claims full coverage. Otherwise,
+    run 'fdw sql-endpoints refresh' to force an item-level sync and check again.
     """
     if filter_schema is not None and filter_table is not None:
         raise click.UsageError("--schema and --table are mutually exclusive.")
+    if check_lakehouse and (filter_schema is not None or filter_table is not None):
+        raise click.UsageError(
+            "--check-lakehouse cannot be combined with --schema or --table; it always "
+            "compares the whole endpoint against its backing Lakehouse."
+        )
     ws = resolve_workspace(ctx)
     wh = resolve_warehouse_arg(ctx, item)
     schema = filter_schema
@@ -399,6 +425,10 @@ async def sync_status_cmd(
                 kind=entry.kind,
                 mode=ctx.auth,
             )
+            if check_lakehouse:
+                items = await _apply_lakehouse_discovery_gap(
+                    http, UUID(target.workspace_id), entry.id, items, json_output=ctx.json_output
+                )
             render(
                 [t.model_dump(mode="json") for t in items],
                 json_output=ctx.json_output,
@@ -406,6 +436,58 @@ async def sync_status_cmd(
             )
     except (ValueError, FabricError) as exc:
         raise click.ClickException(str(exc)) from exc
+
+
+async def _apply_lakehouse_discovery_gap(
+    http: FabricHttpClient,
+    workspace_id: UUID,
+    endpoint_id: UUID,
+    items: list[TableMetadataSyncStatus],
+    *,
+    json_output: bool,
+) -> list[TableMetadataSyncStatus]:
+    """Cross-reference the backing Lakehouse and append discovery-gap rows to *items*.
+
+    Prints an explanatory note to stdout (human output only, never --json) when
+    the cross-check could not run, so the CLI never silently claims coverage it
+    does not have. Returns *items* unchanged when the check could not run.
+    """
+    known_dbo = frozenset(t.name for t in items if t.schema_name.casefold() == "dbo")
+    gap = await _sql_endpoints_svc.find_undiscovered_lakehouse_tables(
+        http, workspace_id, endpoint_id, known_dbo
+    )
+    if gap.status == _sql_endpoints_svc.LakehouseDiscoveryStatus.NOT_LAKEHOUSE_BACKED:
+        if not json_output:
+            click.echo(
+                "Note: --check-lakehouse could not run: this endpoint's backing item "
+                "could not be resolved to a Lakehouse (it may be backed by a mirrored "
+                "database or similar). Catalog-only results shown below."
+            )
+        return items
+    if gap.status == _sql_endpoints_svc.LakehouseDiscoveryStatus.SCHEMA_ENABLED_UNSUPPORTED:
+        if not json_output:
+            click.echo(
+                "Note: --check-lakehouse could not run: the backing Lakehouse has "
+                "schema support enabled, and the Lakehouse table-listing API does not "
+                "attribute tables to schemas. Catalog-only results shown below."
+            )
+        return items
+    if not gap.missing_table_names:
+        return items
+    extra = [
+        TableMetadataSyncStatus(
+            schema_name="dbo",
+            name=name,
+            qualified_name=f"dbo.{name}",
+            last_update_time_utc=None,
+            latest_log_version=None,
+            latest_checkpoint_version=None,
+            is_blocked=None,
+            in_endpoint_catalog=False,
+        )
+        for name in gap.missing_table_names
+    ]
+    return sorted([*items, *extra], key=lambda t: (t.schema_name, t.name))
 
 
 @tables_group.command("refresh")

--- a/src/fabric_dw/cli/commands/tables.py
+++ b/src/fabric_dw/cli/commands/tables.py
@@ -395,12 +395,16 @@ async def sync_status_cmd(
     has failed, does not appear at all. Pass --check-lakehouse to close this
     gap: it cross-references the backing Lakehouse's own table inventory and
     adds a row (in_endpoint_catalog=false, all sync fields empty) for every
-    table found there but missing from the endpoint catalog. This only works
-    for an endpoint backed by a non-schema-enabled Lakehouse -- for anything
-    else (a mirrored database, a schema-enabled Lakehouse, ...) the flag
-    prints an explanatory note and the listing falls back to today's
-    catalog-only behaviour, it never silently claims full coverage. Otherwise,
-    run 'fdw sql-endpoints refresh' to force an item-level sync and check again.
+    table found there but missing from the endpoint catalog, comparing names
+    exactly (case-sensitively). A Lakehouse table that differs from a catalog
+    table only by case is reported with case_mismatched_catalog_name set,
+    rather than as a flat miss. This only works for an endpoint backed by a
+    non-schema-enabled Lakehouse: for anything else (a mirrored database, a
+    schema-enabled Lakehouse, ...) --check-lakehouse fails with an explanatory
+    error rather than silently falling back to the catalog-only listing, since
+    a caller who explicitly asked for the cross-check must not read "no extra
+    rows" as "fully discovered". Otherwise, run 'fdw sql-endpoints refresh' to
+    force an item-level sync and check again.
     """
     if filter_schema is not None and filter_table is not None:
         raise click.UsageError("--schema and --table are mutually exclusive.")
@@ -427,7 +431,7 @@ async def sync_status_cmd(
             )
             if check_lakehouse:
                 items = await _apply_lakehouse_discovery_gap(
-                    http, UUID(target.workspace_id), entry.id, items, json_output=ctx.json_output
+                    http, UUID(target.workspace_id), entry.id, items
                 )
             render(
                 [t.model_dump(mode="json") for t in items],
@@ -438,41 +442,42 @@ async def sync_status_cmd(
         raise click.ClickException(str(exc)) from exc
 
 
+#: Shared wording for the CLI (ClickException) and MCP (ToolError) "the
+#: cross-check was explicitly requested but could not run" errors, so the two
+#: surfaces never drift.
+_CHECK_LAKEHOUSE_NOT_LAKEHOUSE_BACKED_MSG = (
+    "--check-lakehouse could not run: this endpoint's backing item could not be "
+    "resolved to a Lakehouse (it may be backed by a mirrored database or similar)."
+)
+_CHECK_LAKEHOUSE_SCHEMA_ENABLED_MSG = (
+    "--check-lakehouse could not run: the backing Lakehouse has schema support "
+    "enabled, and the Lakehouse table-listing API does not attribute tables to schemas."
+)
+
+
 async def _apply_lakehouse_discovery_gap(
     http: FabricHttpClient,
     workspace_id: UUID,
     endpoint_id: UUID,
     items: list[TableMetadataSyncStatus],
-    *,
-    json_output: bool,
 ) -> list[TableMetadataSyncStatus]:
     """Cross-reference the backing Lakehouse and append discovery-gap rows to *items*.
 
-    Prints an explanatory note to stdout (human output only, never --json) when
-    the cross-check could not run, so the CLI never silently claims coverage it
-    does not have. Returns *items* unchanged when the check could not run.
+    Raises a clean error when the cross-check cannot run at all (no matching
+    Lakehouse, or the Lakehouse has schema support enabled), rather than
+    silently returning *items* unchanged: the caller explicitly asked for the
+    cross-check, so "no extra rows" must never be readable as "fully
+    discovered" -- see #1064.
     """
     known_dbo = frozenset(t.name for t in items if t.schema_name.casefold() == "dbo")
     gap = await _sql_endpoints_svc.find_undiscovered_lakehouse_tables(
         http, workspace_id, endpoint_id, known_dbo
     )
     if gap.status == _sql_endpoints_svc.LakehouseDiscoveryStatus.NOT_LAKEHOUSE_BACKED:
-        if not json_output:
-            click.echo(
-                "Note: --check-lakehouse could not run: this endpoint's backing item "
-                "could not be resolved to a Lakehouse (it may be backed by a mirrored "
-                "database or similar). Catalog-only results shown below."
-            )
-        return items
+        raise click.ClickException(_CHECK_LAKEHOUSE_NOT_LAKEHOUSE_BACKED_MSG)
     if gap.status == _sql_endpoints_svc.LakehouseDiscoveryStatus.SCHEMA_ENABLED_UNSUPPORTED:
-        if not json_output:
-            click.echo(
-                "Note: --check-lakehouse could not run: the backing Lakehouse has "
-                "schema support enabled, and the Lakehouse table-listing API does not "
-                "attribute tables to schemas. Catalog-only results shown below."
-            )
-        return items
-    if not gap.missing_table_names:
+        raise click.ClickException(_CHECK_LAKEHOUSE_SCHEMA_ENABLED_MSG)
+    if not gap.missing_table_names and not gap.case_mismatched_table_names:
         return items
     extra = [
         TableMetadataSyncStatus(
@@ -486,6 +491,19 @@ async def _apply_lakehouse_discovery_gap(
             in_endpoint_catalog=False,
         )
         for name in gap.missing_table_names
+    ] + [
+        TableMetadataSyncStatus(
+            schema_name="dbo",
+            name=lakehouse_name,
+            qualified_name=f"dbo.{lakehouse_name}",
+            last_update_time_utc=None,
+            latest_log_version=None,
+            latest_checkpoint_version=None,
+            is_blocked=None,
+            in_endpoint_catalog=False,
+            case_mismatched_catalog_name=catalog_name,
+        )
+        for lakehouse_name, catalog_name in gap.case_mismatched_table_names
     ]
     return sorted([*items, *extra], key=lambda t: (t.schema_name, t.name))
 

--- a/src/fabric_dw/mcp/_domains.py
+++ b/src/fabric_dw/mcp/_domains.py
@@ -97,6 +97,7 @@ TOOL_DOMAINS: dict[str, str] = {
     "get_table_columns": "tables",
     "get_table_health_metrics": "tables",
     "list_table_sync_status": "tables",
+    "refresh_table_metadata": "tables",
     "list_tables": "tables",
     "read_table": "tables",
     "count_table_rows": "tables",

--- a/src/fabric_dw/mcp/tools/sql_endpoints.py
+++ b/src/fabric_dw/mcp/tools/sql_endpoints.py
@@ -93,7 +93,11 @@ def register(mcp: MCPServer) -> None:
         """Refresh metadata for a SQL analytics endpoint (sync from the underlying Lakehouse).
 
         This is a long-running operation (LRO) that is polled to completion.
-        Returns a list of per-table sync results.
+        Returns a list of per-table sync results. Use this tool for SCHEMA
+        changes (tables added or dropped). For cheap, per-table DATA-only
+        staleness on a table you already know exists, use
+        ``refresh_table_metadata`` instead -- it does not pick up schema
+        changes.
 
         Args:
             workspace: Workspace name or GUID.

--- a/src/fabric_dw/mcp/tools/tables.py
+++ b/src/fabric_dw/mcp/tools/tables.py
@@ -607,6 +607,55 @@ def register(mcp: MCPServer) -> None:  # noqa: PLR0915
             raise tool_err(exc) from exc
         return [t.model_dump(mode="json") for t in result]
 
+    @mutating_tool(mcp, "refresh_table_metadata")
+    async def refresh_table_metadata(
+        workspace: str, item: str, qualified_name: str
+    ) -> dict[str, Any]:
+        """Refresh one table's metadata via ``sys.sp_dw_refresh_ext_table``.
+
+        This is the cheap, per-table refresh for DATA-only staleness: it
+        re-reads the table's underlying Delta log without a full item-level
+        sync. Use ``refresh_sql_endpoint_metadata`` instead when the SCHEMA
+        changed (tables added or dropped) -- this tool does not pick up
+        schema changes.
+
+        Only supported on SQL Analytics Endpoints (not Data Warehouses), and
+        only on endpoints created after the workspace's 'New metadata sync'
+        (preview) setting was enabled. Mutating (respects
+        ``FABRIC_MCP_READONLY``) but NOT destructive -- it never drops or
+        recreates anything, so it does not require the
+        ``FABRIC_MCP_ALLOW_DESTRUCTIVE`` opt-in.
+
+        Args:
+            workspace: Workspace name or GUID.
+            item: SQL Analytics Endpoint name or GUID. Data Warehouses are
+                rejected with a ``ToolError``.
+            qualified_name: Dot-separated qualified table name, e.g.
+                ``dbo.sales``.
+        """
+        schema, table_name = parse_qualified_name(qualified_name, kind="table")
+        ctx = get_context()
+        assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
+        try:
+            ws_id, entry = await resolve_item(ctx.resolver, workspace, item)
+            assert_workspace_allowed(
+                workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
+            )
+            _log.debug(
+                "refresh_table_metadata ws=%s item=%s table=%s.%s",
+                ws_id,
+                entry.id,
+                schema,
+                table_name,
+            )
+            target = make_sql_target(ws_id, entry, item)
+            result = await tables_svc.refresh_table_metadata(
+                target, schema, table_name, kind=entry.kind, mode=ctx.auth_mode
+            )
+        except (ValueError, FabricError) as exc:
+            raise tool_err(exc) from exc
+        return result.model_dump(mode="json")
+
     @mutating_tool(mcp, "rename_table")
     async def rename_table(
         workspace: str, item: str, qualified_name: str, new_name: str

--- a/src/fabric_dw/mcp/tools/tables.py
+++ b/src/fabric_dw/mcp/tools/tables.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import logging
 from datetime import UTC, datetime
-from typing import Annotated, Any
+from typing import TYPE_CHECKING, Annotated, Any
+from uuid import UUID
 
 from mcp.server.mcpserver import MCPServer
 from pydantic import Field
@@ -23,9 +24,13 @@ from fabric_dw.mcp._helpers import (
     safe_rows,
     tool_err,
 )
-from fabric_dw.models import ColumnSpec
+from fabric_dw.models import ColumnSpec, TableMetadataSyncStatus
+from fabric_dw.services import sql_endpoints as sql_endpoints_svc
 from fabric_dw.services import tables as tables_svc
 from fabric_dw.services.columns import get_object_columns_or_raise as _get_columns
+
+if TYPE_CHECKING:
+    from fabric_dw.http_client import FabricHttpClient
 
 __all__ = ["register"]
 
@@ -44,6 +49,41 @@ def _parse_column_dict(i: int, col: object) -> ColumnSpec:
         raise ValueError(f"columns[{i}] must have 'name' and 'sql_type' keys")
     nullable = bool(col.get("nullable", True))
     return ColumnSpec(name=str(name), sql_type=str(sql_type), nullable=nullable)
+
+
+async def _apply_lakehouse_discovery_gap(
+    http: FabricHttpClient,
+    workspace_id: UUID,
+    endpoint_id: UUID,
+    items: list[TableMetadataSyncStatus],
+) -> list[TableMetadataSyncStatus]:
+    """Cross-reference the backing Lakehouse and append discovery-gap rows to *items*.
+
+    Returns *items* unchanged when the cross-check could not run (no matching
+    Lakehouse, or the Lakehouse has schema support enabled) -- callers must not
+    treat an unchanged result as proof of full discovery; see
+    ``list_table_sync_status``'s docstring for why.
+    """
+    known_dbo = frozenset(t.name for t in items if t.schema_name.casefold() == "dbo")
+    gap = await sql_endpoints_svc.find_undiscovered_lakehouse_tables(
+        http, workspace_id, endpoint_id, known_dbo
+    )
+    if gap.status != sql_endpoints_svc.LakehouseDiscoveryStatus.OK or not gap.missing_table_names:
+        return items
+    extra = [
+        TableMetadataSyncStatus(
+            schema_name="dbo",
+            name=name,
+            qualified_name=f"dbo.{name}",
+            last_update_time_utc=None,
+            latest_log_version=None,
+            latest_checkpoint_version=None,
+            is_blocked=None,
+            in_endpoint_catalog=False,
+        )
+        for name in gap.missing_table_names
+    ]
+    return sorted([*items, *extra], key=lambda t: (t.schema_name, t.name))
 
 
 _log = logging.getLogger(__name__)
@@ -556,6 +596,7 @@ def register(mcp: MCPServer) -> None:  # noqa: PLR0915
         item: str,
         schema: str | None = None,
         table: str | None = None,
+        check_lakehouse: bool = False,  # noqa: FBT001, FBT002
     ) -> list[dict[str, Any]]:
         """Show per-table metadata sync freshness via ``sys.dm_db_external_tables_log_status``.
 
@@ -566,16 +607,31 @@ def register(mcp: MCPServer) -> None:  # noqa: PLR0915
         sync information is available for that table, NOT that it has never
         synced; do not treat a ``null`` row as proof the table has never synced.
 
-        IMPORTANT for agents: this listing only includes tables already present
-        in the endpoint's catalog (``sys.tables``), which is itself maintained by
-        the metadata sync. A Lakehouse table whose discovery has not completed,
-        or has failed, has no catalog row and so is **absent from this result
-        entirely** -- it will not appear as a row with empty fields, it simply
-        will not be there. Do not conclude a table does not exist, or was
-        deleted, just because it is missing from this list. If an expected
-        table is missing, call ``refresh_sql_endpoint_metadata`` (or tell the
-        user to run ``fdw sql-endpoints refresh``) to force an item-level sync,
-        then check again.
+        IMPORTANT for agents: by default this listing only includes tables
+        already present in the endpoint's catalog (``sys.tables``), which is
+        itself maintained by the metadata sync. A Lakehouse table whose
+        discovery has not completed, or has failed, has no catalog row and so
+        is **absent from this result entirely** -- it will not appear as a row
+        with empty fields, it simply will not be there. Do not conclude a
+        table does not exist, or was deleted, just because it is missing from
+        this list.
+
+        Pass ``check_lakehouse=True`` to close part of that gap: it
+        cross-references the backing Lakehouse's own table inventory (one or
+        more extra REST calls -- avoid setting this on every call of a tool an
+        agent may invoke repeatedly) and adds a row with
+        ``in_endpoint_catalog=false`` and all sync fields ``null`` for every
+        table it finds there but not in the catalog. This only works for an
+        endpoint backed by a non-schema-enabled Lakehouse; for anything else
+        (a mirrored database, a schema-enabled Lakehouse, or no lakehouse
+        match at all) it is a no-op -- the result is unchanged, identical to
+        ``check_lakehouse=False``, so getting no extra rows back does NOT by
+        itself prove the endpoint is fully discovered. ``check_lakehouse=True``
+        cannot be combined with *schema* or *table*. If an expected table is
+        still missing after trying this, call
+        ``refresh_sql_endpoint_metadata`` (or tell the user to run
+        ``fdw sql-endpoints refresh``) to force an item-level sync, then check
+        again.
 
         Args:
             workspace: Workspace name or GUID.
@@ -584,7 +640,17 @@ def register(mcp: MCPServer) -> None:  # noqa: PLR0915
             schema: When provided, only tables in this schema are returned.
             table: When provided, filter to this single (bare, unqualified)
                 table name. Requires *schema* to also be given.
+            check_lakehouse: When ``True``, cross-reference the backing
+                Lakehouse's table inventory for tables missing from the
+                endpoint catalog entirely. See above for its limits. Mutually
+                exclusive with *schema* and *table*.
         """
+        if check_lakehouse and (schema is not None or table is not None):
+            msg = (
+                "check_lakehouse cannot be combined with schema or table; it always "
+                "compares the whole endpoint against its backing Lakehouse."
+            )
+            raise tool_err(ValueError(msg))
         ctx = get_context()
         assert_workspace_allowed(workspace, config_allowlist=ctx.workspace_allowlist)
         try:
@@ -593,16 +659,19 @@ def register(mcp: MCPServer) -> None:  # noqa: PLR0915
                 workspace, str(ws_id), config_allowlist=ctx.workspace_allowlist
             )
             _log.debug(
-                "list_table_sync_status ws=%s item=%s schema=%r table=%r",
+                "list_table_sync_status ws=%s item=%s schema=%r table=%r check_lakehouse=%s",
                 ws_id,
                 entry.id,
                 schema,
                 table,
+                check_lakehouse,
             )
             target = make_sql_target(ws_id, entry, item)
             result = await tables_svc.list_table_sync_status(
                 target, schema=schema, table=table, kind=entry.kind, mode=ctx.auth_mode
             )
+            if check_lakehouse:
+                result = await _apply_lakehouse_discovery_gap(ctx.http, ws_id, entry.id, result)
         except (ValueError, FabricError) as exc:
             raise tool_err(exc) from exc
         return [t.model_dump(mode="json") for t in result]

--- a/src/fabric_dw/mcp/tools/tables.py
+++ b/src/fabric_dw/mcp/tools/tables.py
@@ -51,6 +51,21 @@ def _parse_column_dict(i: int, col: object) -> ColumnSpec:
     return ColumnSpec(name=str(name), sql_type=str(sql_type), nullable=nullable)
 
 
+#: Shared wording for the CLI (ClickException) and MCP (ToolError) "the
+#: cross-check was explicitly requested but could not run" errors, kept in
+#: sync with the equivalent constants in cli/commands/tables.py by hand (the
+#: two surfaces use their own flag spelling, --check-lakehouse vs
+#: check_lakehouse, so are not literally shared).
+_CHECK_LAKEHOUSE_NOT_LAKEHOUSE_BACKED_MSG = (
+    "check_lakehouse could not run: this endpoint's backing item could not be "
+    "resolved to a Lakehouse (it may be backed by a mirrored database or similar)."
+)
+_CHECK_LAKEHOUSE_SCHEMA_ENABLED_MSG = (
+    "check_lakehouse could not run: the backing Lakehouse has schema support "
+    "enabled, and the Lakehouse table-listing API does not attribute tables to schemas."
+)
+
+
 async def _apply_lakehouse_discovery_gap(
     http: FabricHttpClient,
     workspace_id: UUID,
@@ -59,16 +74,22 @@ async def _apply_lakehouse_discovery_gap(
 ) -> list[TableMetadataSyncStatus]:
     """Cross-reference the backing Lakehouse and append discovery-gap rows to *items*.
 
-    Returns *items* unchanged when the cross-check could not run (no matching
-    Lakehouse, or the Lakehouse has schema support enabled) -- callers must not
-    treat an unchanged result as proof of full discovery; see
-    ``list_table_sync_status``'s docstring for why.
+    Raises :class:`ValueError` (funnelled to :class:`ToolError` by the caller's
+    ``except (ValueError, FabricError)`` block) when the cross-check cannot run
+    at all (no matching Lakehouse, or the Lakehouse has schema support
+    enabled), rather than silently returning *items* unchanged: the caller
+    explicitly asked for the cross-check, so "no extra rows" must never be
+    readable as "fully discovered" -- see #1064.
     """
     known_dbo = frozenset(t.name for t in items if t.schema_name.casefold() == "dbo")
     gap = await sql_endpoints_svc.find_undiscovered_lakehouse_tables(
         http, workspace_id, endpoint_id, known_dbo
     )
-    if gap.status != sql_endpoints_svc.LakehouseDiscoveryStatus.OK or not gap.missing_table_names:
+    if gap.status == sql_endpoints_svc.LakehouseDiscoveryStatus.NOT_LAKEHOUSE_BACKED:
+        raise ValueError(_CHECK_LAKEHOUSE_NOT_LAKEHOUSE_BACKED_MSG)
+    if gap.status == sql_endpoints_svc.LakehouseDiscoveryStatus.SCHEMA_ENABLED_UNSUPPORTED:
+        raise ValueError(_CHECK_LAKEHOUSE_SCHEMA_ENABLED_MSG)
+    if not gap.missing_table_names and not gap.case_mismatched_table_names:
         return items
     extra = [
         TableMetadataSyncStatus(
@@ -82,6 +103,19 @@ async def _apply_lakehouse_discovery_gap(
             in_endpoint_catalog=False,
         )
         for name in gap.missing_table_names
+    ] + [
+        TableMetadataSyncStatus(
+            schema_name="dbo",
+            name=lakehouse_name,
+            qualified_name=f"dbo.{lakehouse_name}",
+            last_update_time_utc=None,
+            latest_log_version=None,
+            latest_checkpoint_version=None,
+            is_blocked=None,
+            in_endpoint_catalog=False,
+            case_mismatched_catalog_name=catalog_name,
+        )
+        for lakehouse_name, catalog_name in gap.case_mismatched_table_names
     ]
     return sorted([*items, *extra], key=lambda t: (t.schema_name, t.name))
 
@@ -621,14 +655,22 @@ def register(mcp: MCPServer) -> None:  # noqa: PLR0915
         more extra REST calls -- avoid setting this on every call of a tool an
         agent may invoke repeatedly) and adds a row with
         ``in_endpoint_catalog=false`` and all sync fields ``null`` for every
-        table it finds there but not in the catalog. This only works for an
-        endpoint backed by a non-schema-enabled Lakehouse; for anything else
-        (a mirrored database, a schema-enabled Lakehouse, or no lakehouse
-        match at all) it is a no-op -- the result is unchanged, identical to
-        ``check_lakehouse=False``, so getting no extra rows back does NOT by
-        itself prove the endpoint is fully discovered. ``check_lakehouse=True``
-        cannot be combined with *schema* or *table*. If an expected table is
-        still missing after trying this, call
+        table it finds there but not in the catalog, comparing names exactly
+        (case-sensitively, matching Fabric's default collation). A Lakehouse
+        table that differs from a catalog table only by case gets
+        ``case_mismatched_catalog_name`` set to that catalog name instead of
+        being reported as a flat miss.
+
+        This only works for an endpoint backed by a non-schema-enabled
+        Lakehouse. For anything else (a mirrored database, a schema-enabled
+        Lakehouse, or no lakehouse match at all), ``check_lakehouse=True``
+        raises a ``ToolError`` explaining why, rather than silently returning
+        the unchanged catalog-only result: a caller that explicitly asked for
+        this cross-check must never read "no extra rows" as "fully
+        discovered". ``check_lakehouse=True`` also cannot be combined with
+        *schema* or *table* (raises a ``ToolError``): it always compares the
+        whole endpoint. If ``check_lakehouse=True`` fails or an expected table
+        is still missing after trying it, call
         ``refresh_sql_endpoint_metadata`` (or tell the user to run
         ``fdw sql-endpoints refresh``) to force an item-level sync, then check
         again.

--- a/src/fabric_dw/models.py
+++ b/src/fabric_dw/models.py
@@ -633,7 +633,15 @@ class TableMetadataSyncStatus(_FabricBase):
     are always ``None`` too, for the same reason. See
     :func:`~fabric_dw.services.sql_endpoints.find_undiscovered_lakehouse_tables`
     for the cross-check's own coverage limits (Lakehouse-backed, non-schema-enabled
-    endpoints only).
+    endpoints only), and for why the Lakehouse-vs-catalog comparison it performs
+    is exact (case-sensitive), matching Fabric's case-sensitive default collation.
+
+    A ``False`` row whose Lakehouse name differs from an existing catalog row
+    only by case (e.g. Lakehouse ``FactSales`` vs. catalog ``factsales``) sets
+    :attr:`case_mismatched_catalog_name` to that existing catalog name instead
+    of leaving it ``None``: a likely casing drift is a more specific, more
+    useful finding than a flat "missing", since the two names may in fact
+    resolve to the same object once the metadata sync catches up.
 
     Unlike :attr:`Table.created` / :attr:`Table.modified`, which pass the
     driver's native datetime through unchanged, ``last_update_time_utc`` here
@@ -648,6 +656,7 @@ class TableMetadataSyncStatus(_FabricBase):
     latest_checkpoint_version: int | None
     is_blocked: bool | None
     in_endpoint_catalog: bool = True
+    case_mismatched_catalog_name: str | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/src/fabric_dw/models.py
+++ b/src/fabric_dw/models.py
@@ -621,7 +621,19 @@ class TableMetadataSyncStatus(_FabricBase):
     Analytics Endpoint is itself populated by the metadata sync. A table whose
     discovery has not completed, or has failed, has no ``sys.tables`` row and
     so does not appear in this listing at all -- its absence from the result
-    set is not visible here.
+    set is not visible here, UNLESS the caller opted into the Lakehouse
+    discovery-gap cross-check (``tables sync-status --check-lakehouse`` /
+    ``list_table_sync_status(check_lakehouse=True)``). That cross-check appends
+    a synthetic row for exactly this case, with ``in_endpoint_catalog=False``:
+    a table present in the backing Lakehouse's OneLake table inventory but
+    absent from ``sys.tables`` entirely. This is a distinct condition from a
+    ``None`` ``last_update_time_utc`` on an ``in_endpoint_catalog=True`` row,
+    which means the table IS in the catalog but has no DMV row yet -- a
+    ``False`` row has no catalog row at all, so its four DMV-sourced fields
+    are always ``None`` too, for the same reason. See
+    :func:`~fabric_dw.services.sql_endpoints.find_undiscovered_lakehouse_tables`
+    for the cross-check's own coverage limits (Lakehouse-backed, non-schema-enabled
+    endpoints only).
 
     Unlike :attr:`Table.created` / :attr:`Table.modified`, which pass the
     driver's native datetime through unchanged, ``last_update_time_utc`` here
@@ -635,6 +647,7 @@ class TableMetadataSyncStatus(_FabricBase):
     latest_log_version: int | None
     latest_checkpoint_version: int | None
     is_blocked: bool | None
+    in_endpoint_catalog: bool = True
 
 
 # ---------------------------------------------------------------------------

--- a/src/fabric_dw/services/sql_endpoints.py
+++ b/src/fabric_dw/services/sql_endpoints.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from dataclasses import dataclass, field
+from enum import StrEnum
 from uuid import UUID
 
-from fabric_dw._fabric_api import resolve_lakehouse_connection_string
+from fabric_dw._fabric_api import resolve_backing_lakehouse, resolve_lakehouse_connection_string
 from fabric_dw.exceptions import (
     CapacityInactiveError,
     FabricServerError,
@@ -32,10 +34,14 @@ _CONN_STRING_POLL_INTERVAL: float = 5.0
 _CONN_STRING_POLL_TIMEOUT: float = 120.0
 
 __all__ = [
+    "LakehouseDiscoveryGap",
+    "LakehouseDiscoveryStatus",
+    "find_undiscovered_lakehouse_tables",
     "get_endpoint",
     "get_endpoint_connection_string",
     "list_all_workspaces",
     "list_endpoints",
+    "list_lakehouse_table_names",
     "refresh_metadata",
 ]
 
@@ -330,3 +336,160 @@ async def refresh_metadata(
 
     raw_items = raw_value if isinstance(raw_value, list) else []
     return [TableSyncStatus.model_validate(item) for item in raw_items]
+
+
+# ---------------------------------------------------------------------------
+# Lakehouse discovery-gap cross-check (#1064)
+# ---------------------------------------------------------------------------
+#
+# tables.list_table_sync_status (TDS-only) lists tables from sys.tables, which
+# on a SQL Analytics Endpoint is itself populated by the metadata sync -- a
+# Lakehouse Delta table whose discovery has not completed, or has failed, has
+# no sys.tables row and so is invisible to that function no matter what filter
+# is passed. The functions below close that gap for the one case Fabric's REST
+# API actually lets us check: a non-schema-enabled Lakehouse-backed endpoint.
+#
+# What was investigated and what it ruled out:
+#
+# - Resolving the endpoint back to its backing item: there is no reverse link
+#   on GET /sqlEndpoints/{id} itself. resolve_backing_lakehouse (_fabric_api.py)
+#   pages GET /workspaces/{ws}/lakehouses and matches on
+#   properties.sqlEndpointProperties.id -- the same scan get_endpoint already
+#   performs for the connection-string fallback. Returns None for anything that
+#   isn't a Lakehouse (a mirrored database, a mirrored warehouse, etc.), which
+#   this module cannot enumerate tables for at all -- there is no
+#   "list source tables" REST API for those item kinds, so a SQL-endpoint whose
+#   backing item is one of them keeps today's catalog-only coverage, degraded
+#   but stated rather than silently claimed complete.
+#
+# - Enumerating a Lakehouse's tables: GET /workspaces/{ws}/lakehouses/{id}/tables
+#   ("Lakehouse - List Tables") returns {name, type, format, location} per
+#   table -- no schema field. Microsoft's own Lakehouse-schemas documentation
+#   says explicitly that for a SCHEMA-ENABLED lakehouse you must use a
+#   different, Unity-Catalog-compatible API family instead
+#   (onelake.table.fabric.microsoft.com/delta/...), which needs its own base
+#   URL, its own name-based addressing scheme, and (unconfirmed from the docs
+#   alone) a different OAuth scope than FABRIC_SCOPE -- a materially bigger,
+#   riskier change to make untested. So List Tables is used here instead, and
+#   only when it is safe to: a lakehouse GET/list response's
+#   properties.defaultSchema field is documented as present ONLY for a
+#   schema-enabled lakehouse -- its presence is the signal used to refuse the
+#   cross-check rather than guess at which schema a bare table name belongs to.
+
+
+class LakehouseDiscoveryStatus(StrEnum):
+    """Outcome of :func:`find_undiscovered_lakehouse_tables`."""
+
+    #: The comparison ran; ``LakehouseDiscoveryGap.missing_table_names`` holds
+    #: the (possibly empty) result.
+    OK = "ok"
+    #: *endpoint_id* has no matching Lakehouse in the workspace's ``/lakehouses``
+    #: listing -- it backs something else (a mirrored database, a mirrored
+    #: warehouse, etc.), or its parent Lakehouse has since been deleted. There is
+    #: no REST API this codebase can use to enumerate that item kind's tables.
+    NOT_LAKEHOUSE_BACKED = "not_lakehouse_backed"
+    #: The backing Lakehouse has schema support enabled (``properties.defaultSchema``
+    #: is present). The classic "List Tables" REST API returns bare table names
+    #: with no schema attribution, so a comparison against ``sys.tables`` cannot
+    #: be trusted to attribute a table to the right schema -- refused rather
+    #: than risking a false "missing" report for a table that actually exists
+    #: under a different schema.
+    SCHEMA_ENABLED_UNSUPPORTED = "schema_enabled_unsupported"
+
+
+@dataclass(frozen=True)
+class LakehouseDiscoveryGap:
+    """Result of comparing a Lakehouse's table inventory against a known set.
+
+    Attributes:
+        status: Which of the three outcomes in :class:`LakehouseDiscoveryStatus`
+            applies.
+        missing_table_names: Bare (unqualified) table names present in the
+            Lakehouse's default (``dbo``) schema but absent from the
+            ``known_dbo_names`` set passed to
+            :func:`find_undiscovered_lakehouse_tables`. Only ever non-empty
+            when ``status is LakehouseDiscoveryStatus.OK``.
+    """
+
+    status: LakehouseDiscoveryStatus
+    missing_table_names: tuple[str, ...] = field(default_factory=tuple)
+
+
+async def list_lakehouse_table_names(
+    http: FabricHttpClient,
+    workspace_id: UUID,
+    lakehouse_id: UUID,
+) -> list[str]:
+    """Return every table name in a Lakehouse via the "List Tables" REST API.
+
+    Pages ``GET /workspaces/{ws}/lakehouses/{id}/tables``. The response array
+    lives under the ``"data"`` key (not the usual ``"value"``) and each entry
+    carries ``name``, ``type`` (``Managed``/``External``), ``format``, and
+    ``location`` -- no schema attribution, so callers must only use this for a
+    non-schema-enabled Lakehouse (see :func:`find_undiscovered_lakehouse_tables`,
+    which enforces that).
+
+    Args:
+        http: An authenticated :class:`~fabric_dw.http_client.FabricHttpClient`.
+        workspace_id: The UUID of the workspace containing the Lakehouse.
+        lakehouse_id: The UUID of the Lakehouse to list tables for.
+
+    Returns:
+        A (possibly empty) list of bare table names, in API response order.
+    """
+    names: list[str] = []
+    async for tbl in http.iter_paginated(
+        HttpBase.FABRIC,
+        f"/workspaces/{workspace_id}/lakehouses/{lakehouse_id}/tables",
+        key="data",
+    ):
+        name = tbl.get("name")
+        if name:
+            names.append(str(name))
+    return names
+
+
+async def find_undiscovered_lakehouse_tables(
+    http: FabricHttpClient,
+    workspace_id: UUID,
+    endpoint_id: UUID,
+    known_dbo_names: frozenset[str],
+) -> LakehouseDiscoveryGap:
+    """Find Lakehouse tables missing from a SQL endpoint's ``sys.tables`` catalog.
+
+    Resolves *endpoint_id* to its backing Lakehouse via
+    :func:`~fabric_dw._fabric_api.resolve_backing_lakehouse`, refuses the
+    comparison for anything that isn't a non-schema-enabled Lakehouse (see
+    :class:`LakehouseDiscoveryStatus`), and otherwise lists the Lakehouse's
+    tables (:func:`list_lakehouse_table_names`) and returns the ones absent
+    from *known_dbo_names* -- case-insensitively, matching T-SQL identifier
+    semantics.
+
+    This costs at least one extra REST call beyond ``list_table_sync_status``'s
+    single TDS query (a lakehouse scan, plus a paginated table listing when a
+    non-schema-enabled Lakehouse is found), so callers on a command that may
+    run repeatedly should make this opt-in rather than call it
+    unconditionally -- see ``tables sync-status --check-lakehouse`` /
+    ``list_table_sync_status(check_lakehouse=True)``.
+
+    Args:
+        http: An authenticated :class:`~fabric_dw.http_client.FabricHttpClient`.
+        workspace_id: The UUID of the workspace containing the endpoint.
+        endpoint_id: The UUID of the SQL analytics endpoint to check.
+        known_dbo_names: Bare table names already known to be present in the
+            endpoint's ``dbo`` schema (typically every ``dbo``-schema row
+            already returned by ``list_table_sync_status`` for this endpoint).
+
+    Returns:
+        A :class:`LakehouseDiscoveryGap` describing the outcome.
+    """
+    lakehouse = await resolve_backing_lakehouse(http, workspace_id, endpoint_id)
+    if lakehouse is None:
+        return LakehouseDiscoveryGap(status=LakehouseDiscoveryStatus.NOT_LAKEHOUSE_BACKED)
+    if lakehouse.default_schema is not None:
+        return LakehouseDiscoveryGap(status=LakehouseDiscoveryStatus.SCHEMA_ENABLED_UNSUPPORTED)
+
+    table_names = await list_lakehouse_table_names(http, workspace_id, lakehouse.id)
+    known_lower = {n.casefold() for n in known_dbo_names}
+    missing = tuple(n for n in table_names if n.casefold() not in known_lower)
+    return LakehouseDiscoveryGap(status=LakehouseDiscoveryStatus.OK, missing_table_names=missing)

--- a/src/fabric_dw/services/sql_endpoints.py
+++ b/src/fabric_dw/services/sql_endpoints.py
@@ -405,14 +405,26 @@ class LakehouseDiscoveryGap:
         status: Which of the three outcomes in :class:`LakehouseDiscoveryStatus`
             applies.
         missing_table_names: Bare (unqualified) table names present in the
-            Lakehouse's default (``dbo``) schema but absent from the
-            ``known_dbo_names`` set passed to
+            Lakehouse's default (``dbo``) schema that have NO match, exact or
+            otherwise, in the ``known_dbo_names`` set passed to
             :func:`find_undiscovered_lakehouse_tables`. Only ever non-empty
             when ``status is LakehouseDiscoveryStatus.OK``.
+        case_mismatched_table_names: ``(lakehouse_name, catalog_name)`` pairs
+            for a Lakehouse table that matches a name in ``known_dbo_names``
+            case-insensitively but not exactly -- e.g. Lakehouse ``FactSales``
+            against catalog ``factsales``. Reported separately from
+            ``missing_table_names`` rather than folded into it: on Fabric's
+            case-sensitive default collation these ARE two distinct possible
+            identifiers, so calling this "missing" would overstate the finding,
+            but an exact-only comparison that dropped it silently would hide
+            real casing drift just as badly as the case-insensitive comparison
+            this replaced did. Only ever non-empty when
+            ``status is LakehouseDiscoveryStatus.OK``.
     """
 
     status: LakehouseDiscoveryStatus
     missing_table_names: tuple[str, ...] = field(default_factory=tuple)
+    case_mismatched_table_names: tuple[tuple[str, str], ...] = field(default_factory=tuple)
 
 
 async def list_lakehouse_table_names(
@@ -461,9 +473,32 @@ async def find_undiscovered_lakehouse_tables(
     :func:`~fabric_dw._fabric_api.resolve_backing_lakehouse`, refuses the
     comparison for anything that isn't a non-schema-enabled Lakehouse (see
     :class:`LakehouseDiscoveryStatus`), and otherwise lists the Lakehouse's
-    tables (:func:`list_lakehouse_table_names`) and returns the ones absent
-    from *known_dbo_names* -- case-insensitively, matching T-SQL identifier
-    semantics.
+    tables (:func:`list_lakehouse_table_names`) and compares each one against
+    *known_dbo_names*.
+
+    The comparison is **exact (case-sensitive)**, matching Fabric's default
+    collation (``FABRIC_DEFAULT_COLLATION`` in ``models.py``,
+    ``Latin1_General_100_BIN2_UTF8``, which Microsoft documents as
+    case-sensitive). A case-insensitive comparison would silently hide the
+    exact kind of drift this check exists to catch: on the default collation,
+    ``FactSales`` and ``factsales`` are two distinct, independently valid
+    table names, so folding them together would let a genuinely undiscovered
+    ``FactSales`` disappear behind an unrelated ``factsales`` already in the
+    catalog. Exact comparison is the safer default even for a workspace
+    configured with a case-insensitive collation: it can produce a false
+    positive (a table reported missing that the engine would actually treat
+    as identical to an existing one), which is visible and judgeable by the
+    caller, never a false negative, which is invisible. This function has no
+    cheap way to read the endpoint's actual collation (it is TDS-only
+    information; the SQLEndpoint REST resource does not expose it -- see
+    ``list_endpoints``'s docstring above), so it does not attempt to branch on
+    it.
+
+    A Lakehouse table that fails the exact match but matches a
+    *known_dbo_names* entry case-insensitively is reported separately, in
+    ``case_mismatched_table_names``, rather than folded into
+    ``missing_table_names``: it is a more specific and more useful finding
+    (a likely casing drift) than a flat "missing" would be.
 
     This costs at least one extra REST call beyond ``list_table_sync_status``'s
     single TDS query (a lakehouse scan, plus a paginated table listing when a
@@ -490,6 +525,26 @@ async def find_undiscovered_lakehouse_tables(
         return LakehouseDiscoveryGap(status=LakehouseDiscoveryStatus.SCHEMA_ENABLED_UNSUPPORTED)
 
     table_names = await list_lakehouse_table_names(http, workspace_id, lakehouse.id)
-    known_lower = {n.casefold() for n in known_dbo_names}
-    missing = tuple(n for n in table_names if n.casefold() not in known_lower)
-    return LakehouseDiscoveryGap(status=LakehouseDiscoveryStatus.OK, missing_table_names=missing)
+    # Case-insensitive lookup is used ONLY to distinguish "no match at all"
+    # from "a case-only mismatch" below -- never to decide "found"/"not found"
+    # on its own, which is exactly the bug this replaces.
+    known_by_casefold: dict[str, str] = {}
+    for known_name in known_dbo_names:
+        known_by_casefold.setdefault(known_name.casefold(), known_name)
+
+    missing: list[str] = []
+    case_mismatched: list[tuple[str, str]] = []
+    for name in table_names:
+        if name in known_dbo_names:
+            continue
+        catalog_match = known_by_casefold.get(name.casefold())
+        if catalog_match is not None:
+            case_mismatched.append((name, catalog_match))
+        else:
+            missing.append(name)
+
+    return LakehouseDiscoveryGap(
+        status=LakehouseDiscoveryStatus.OK,
+        missing_table_names=tuple(missing),
+        case_mismatched_table_names=tuple(case_mismatched),
+    )

--- a/src/fabric_dw/services/tables.py
+++ b/src/fabric_dw/services/tables.py
@@ -297,6 +297,14 @@ def _row_to_sync_status(cols: list[str], row: tuple[object, ...]) -> TableMetada
     :data:`_TABLE_SYNC_STATUS_SQL` leaves them unmatched rather than dropping
     the row. This means no sync information is available for that table, not
     that it provably never synced.
+
+    ``in_endpoint_catalog`` is always ``True`` here: every row this function
+    builds comes from ``sys.tables`` by definition, via the FROM clause in
+    :data:`_TABLE_SYNC_STATUS_SQL`. A ``False`` row is never produced by a SQL
+    query at all -- it is a synthetic row the CLI/MCP layer appends only when
+    the caller opts into the Lakehouse discovery-gap cross-check (see
+    :class:`~fabric_dw.models.TableMetadataSyncStatus` and
+    :func:`~fabric_dw.services.sql_endpoints.find_undiscovered_lakehouse_tables`).
     """
     data = dict(zip(cols, row, strict=True))
     schema_name = str(data["schema_name"])
@@ -323,6 +331,7 @@ def _row_to_sync_status(cols: list[str], row: tuple[object, ...]) -> TableMetada
             else None
         ),
         is_blocked=bool(is_blocked) if is_blocked is not None else None,
+        in_endpoint_catalog=True,
     )
 
 
@@ -1420,12 +1429,22 @@ async def list_table_sync_status(
     that table -- Microsoft documents the DMV as describing the most recent
     update, not as proof a table has never synced.
 
-    Coverage limit: this listing only covers tables present in ``sys.tables``,
-    which on a SQL Analytics Endpoint is itself populated by the metadata
-    sync. A Lakehouse table whose discovery has not completed, or has failed,
-    has no ``sys.tables`` row and so is missing from this result entirely, not
-    merely shown with empty sync fields. If an expected table is absent, run
-    ``fdw sql-endpoints refresh`` to force an item-level sync and check again.
+    Coverage limit: this function alone only covers tables present in
+    ``sys.tables``, which on a SQL Analytics Endpoint is itself populated by
+    the metadata sync. A Lakehouse table whose discovery has not completed, or
+    has failed, has no ``sys.tables`` row and so is missing from this result
+    entirely, not merely shown with empty sync fields. If an expected table is
+    absent, run ``fdw sql-endpoints refresh`` to force an item-level sync and
+    check again, OR pass the ``tables sync-status --check-lakehouse`` CLI flag
+    (``list_table_sync_status(check_lakehouse=True)`` at the MCP layer) to
+    cross-reference the backing Lakehouse's own table inventory and surface
+    exactly this gap as synthetic rows with ``in_endpoint_catalog=False`` --
+    this function itself does not perform that cross-check (it is TDS-only; the
+    cross-check needs a REST call and lives in
+    :func:`~fabric_dw.services.sql_endpoints.find_undiscovered_lakehouse_tables`,
+    orchestrated by the CLI/MCP layer), and it only works for Lakehouse-backed
+    endpoints whose Lakehouse does not have schema support enabled -- see that
+    function's docstring for the full set of cases it cannot cover either.
 
     Only available on SQL Analytics Endpoints created after the workspace's
     ``New metadata sync`` (preview) setting was enabled. On every other

--- a/src/fabric_dw/services/tables.py
+++ b/src/fabric_dw/services/tables.py
@@ -20,6 +20,7 @@ Public API
 - :func:`get_table_dependents`    — objects referencing a table by name.
 - :func:`get_table_health_metrics` — ``EXEC sp_get_table_health_metrics`` (SQL endpoint only).
 - :func:`list_table_sync_status`  — ``sys.dm_db_external_tables_log_status`` (SQL endpoint only).
+- :func:`refresh_table_metadata`  — ``EXEC sys.sp_dw_refresh_ext_table`` (SQL endpoint only).
 
 List-source note
 ----------------
@@ -88,6 +89,7 @@ __all__ = [
     "list_tables",
     "read_table",
     "recluster_table",
+    "refresh_table_metadata",
     "rename_table",
     "transfer_table",
     "validate_identifier",
@@ -125,6 +127,23 @@ _SYNC_STATUS_LEGACY_SYNC_MSG = (
     "settings, in the workspace hosting this endpoint. On endpoints using the "
     "legacy metadata sync, use 'fdw sql-endpoints refresh' to refresh the "
     "whole item instead."
+)
+_WAREHOUSE_REFRESH_TABLE_MSG = (
+    "Table metadata refresh (sys.sp_dw_refresh_ext_table) is only "
+    "available on SQL Analytics Endpoints, not Data Warehouses."
+)
+
+# Fragment (lower-cased) of the "could not find stored procedure" driver error that
+# names the refresh procedure specifically, distinguishing "this endpoint predates
+# the new metadata sync preview" from an unrelated missing-procedure error.
+_REFRESH_TABLE_LEGACY_SYNC_FRAGMENT = "sp_dw_refresh_ext_table"
+_REFRESH_TABLE_LEGACY_SYNC_MSG = (
+    "Table metadata refresh requires the new metadata sync (preview) for this "
+    "SQL analytics endpoint. It only applies to endpoints created after 'New "
+    "metadata sync' was enabled under Workspace settings, Warehouse settings, "
+    "in the workspace hosting this endpoint. On endpoints using the legacy "
+    "metadata sync, use 'fdw sql-endpoints refresh' to refresh the whole item "
+    "instead."
 )
 
 
@@ -237,6 +256,19 @@ _SP_RENAME_SQL = "EXEC sp_rename ?, ?, 'OBJECT'"
 # is ever embedded.  The literal is enclosed in single quotes as T-SQL requires.
 # The output schema is GA-but-undocumented; columns are passed through generically.
 _SP_TABLE_HEALTH_METRICS_SQL = "EXEC sp_get_table_health_metrics '{schema}.{table}'"
+
+# sys.sp_dw_refresh_ext_table returns 0 (success) / 1 (failure) via an output
+# parameter and does not raise for a failed refresh, so the return code must be
+# captured explicitly. This is a fixed, code-authored batch; the only caller
+# value (the qualified table name) is bound as a ? parameter, never interpolated
+# into the SQL text -- authoring this constant is not "parsing SQL" under
+# CLAUDE.md, which concerns extracting/rewriting existing SQL, not issuing a
+# new statement.
+_SP_REFRESH_TABLE_SQL = """\
+DECLARE @rc int;
+EXEC @rc = sys.sp_dw_refresh_ext_table ?;
+SELECT @rc AS rc;
+"""
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -1468,6 +1500,127 @@ async def list_table_sync_status(
         return [_row_to_sync_status(cols, r) for r in rows]
 
     return await asyncio.to_thread(_run)
+
+
+async def refresh_table_metadata(
+    target: SqlTarget,
+    schema: str,
+    table_name: str,
+    *,
+    kind: WarehouseKind = WarehouseKind.WAREHOUSE,
+    mode: CredentialMode = CredentialMode.DEFAULT,
+) -> TableMetadataSyncStatus:
+    """Refresh one table's metadata via ``EXEC sys.sp_dw_refresh_ext_table``.
+
+    Refreshes the data for a single external table on a SQL Analytics Endpoint
+    by re-reading its underlying Delta log, without triggering a full
+    item-level metadata sync. This is the cheap, targeted counterpart to the
+    item-level Fabric REST LRO (``fdw sql-endpoints refresh`` /
+    ``refresh_sql_endpoint_metadata``), which additionally picks up schema
+    changes (tables added or dropped) at the cost of refreshing the whole item.
+
+    The procedure reports success (``0``) or failure (``1``) via an output
+    parameter and does NOT raise an error for a failed refresh, so the return
+    code is captured with an explicit ``DECLARE`` / ``EXEC @rc = ...`` /
+    ``SELECT`` batch (see :data:`_SP_REFRESH_TABLE_SQL`) and checked. A
+    non-zero return code raises :class:`~fabric_dw.exceptions.FabricError`
+    naming the return code and the table. The batch also guards against
+    misreading an unexpected result shape as the return code: if the returned
+    columns are not exactly a single ``rc`` column with one row,
+    :class:`~fabric_dw.exceptions.FabricError` is raised instead of silently
+    trusting whatever came back.
+
+    After a successful refresh, the table's refreshed sync-status row is
+    fetched via :func:`list_table_sync_status` and returned, so callers see
+    the new ``last_update_time_utc`` without a second call. If the table is
+    not (or no longer) present in the endpoint's catalog, that lookup comes
+    back empty and :class:`~fabric_dw.exceptions.NotFoundError` is raised
+    naming the table and pointing at ``fdw sql-endpoints refresh``.
+
+    Only available on SQL Analytics Endpoints created after the workspace's
+    ``New metadata sync`` (preview) setting was enabled. On every other
+    endpoint the procedure does not exist; the raw "could not find stored
+    procedure" driver error is translated into an actionable message pointing
+    at the workspace setting and at ``fdw sql-endpoints refresh`` as the
+    fallback.
+
+    Args:
+        target: The SQL Analytics Endpoint to refresh. Data Warehouses are
+            rejected with :class:`~fabric_dw.exceptions.ItemKindError`.
+        schema: The schema name. Must pass :func:`validate_identifier`.
+        table_name: The table name. Must pass :func:`validate_identifier`.
+        kind: The :class:`~fabric_dw.models.WarehouseKind` of the item.
+            Only :attr:`~fabric_dw.models.WarehouseKind.SQL_ENDPOINT` is
+            accepted; Warehouse items raise :class:`~fabric_dw.exceptions.ItemKindError`.
+        mode: The credential mode for Entra authentication.
+
+    Returns:
+        The refreshed :class:`~fabric_dw.models.TableMetadataSyncStatus` row
+        for *schema*.*table_name*.
+
+    Raises:
+        ItemKindError: If *kind* is not
+            :attr:`~fabric_dw.models.WarehouseKind.SQL_ENDPOINT`.
+        ValueError: If *schema* or *table_name* fails identifier validation.
+        NotFoundError: If the endpoint is on the legacy metadata sync (the
+            procedure does not exist), or if the table is not present in the
+            endpoint's catalog after a successful refresh.
+        FabricError: If the procedure reports a non-zero return code, or if
+            its result set does not have the expected single ``rc`` column.
+        PermissionDeniedError: If the driver reports a permission error.
+    """
+    _assert_sql_endpoint(kind, _WAREHOUSE_REFRESH_TABLE_MSG)
+    validate_identifier(schema)
+    validate_identifier(table_name)
+
+    # sp_dw_refresh_ext_table takes the two-part name as a plain string
+    # argument (not an ODBC-quoted identifier), bound as a ? parameter --
+    # mirrors rename_table's sp_rename argument handling.
+    qualified = f"{schema}.{table_name}"
+
+    def _run() -> None:
+        try:
+            cols, rows = run_query(
+                target,
+                _SP_REFRESH_TABLE_SQL,
+                params=[qualified],
+                mode=mode,
+                commit=True,
+                fetch="one",
+            )
+        except NotFoundError as exc:
+            if _REFRESH_TABLE_LEGACY_SYNC_FRAGMENT in str(exc).lower():
+                raise NotFoundError(_REFRESH_TABLE_LEGACY_SYNC_MSG) from exc
+            raise
+        if not rows or [c.casefold() for c in cols] != ["rc"]:
+            msg = (
+                "sys.sp_dw_refresh_ext_table returned an unexpected result shape "
+                f"while refreshing {qualified!r} (columns={cols!r}); expected a "
+                "single 'rc' column with one row."
+            )
+            raise FabricError(msg)
+        rc = int(rows[0][0])
+        if rc != 0:
+            msg = (
+                f"sys.sp_dw_refresh_ext_table reported failure (return code {rc}) "
+                f"refreshing table {qualified!r}."
+            )
+            raise FabricError(msg)
+
+    await asyncio.to_thread(_run)
+
+    refreshed = await list_table_sync_status(
+        target, schema=schema, table=table_name, kind=kind, mode=mode
+    )
+    if not refreshed:
+        msg = (
+            f"Table {qualified!r} was refreshed but is not present in the "
+            "endpoint's table catalog afterwards. If the table was recently "
+            "added to the underlying Lakehouse, run 'fdw sql-endpoints refresh' "
+            "to force an item-level sync and try again."
+        )
+        raise NotFoundError(msg)
+    return refreshed[0]
 
 
 async def rename_table(

--- a/tests/integration/test_services_sql_endpoints.py
+++ b/tests/integration/test_services_sql_endpoints.py
@@ -149,3 +149,78 @@ async def test_refresh_metadata_returns_table_sync_statuses(
         assert isinstance(entry, TableSyncStatus)
         assert entry.table_name
         assert entry.status
+
+
+# ---------------------------------------------------------------------------
+# Lakehouse discovery-gap cross-check (#1064)
+# ---------------------------------------------------------------------------
+#
+# ephemeral_sql_endpoint is backed by a SCHEMA-ENABLED Lakehouse (see its
+# fixture docstring above ephemeral_lakehouse), so it exercises the
+# SCHEMA_ENABLED_UNSUPPORTED refusal path deterministically and proves that
+# properties.defaultSchema really is present on a live schema-enabled
+# Lakehouse -- the assumption the whole refusal is built on.
+#
+# It cannot exercise the OK (successful comparison, gap found or not) path:
+# that needs a non-schema-enabled Lakehouse with a Delta table written
+# directly to OneLake but not yet synced to the endpoint catalog, a state
+# issue #1064 itself flagged as "awkward to produce on demand". That path is
+# unverified against a live tenant -- see the PR description.
+
+
+async def test_resolve_backing_lakehouse_finds_schema_enabled_lakehouse(
+    http: FabricHttpClient,
+    workspace_id: UUID,
+    ephemeral_lakehouse: dict[str, object],
+    ephemeral_sql_endpoint: Warehouse,
+) -> None:
+    """resolve_backing_lakehouse resolves the endpoint back to its Lakehouse.
+
+    Also confirms the core assumption find_undiscovered_lakehouse_tables relies
+    on: a live schema-enabled Lakehouse's GET/list response really does carry
+    properties.defaultSchema (here "dbo"), which is the documented signal used
+    to refuse the table comparison rather than guess at a bare name's schema.
+    """
+    from fabric_dw._fabric_api import resolve_backing_lakehouse  # noqa: PLC0415
+
+    match = await resolve_backing_lakehouse(http, workspace_id, ephemeral_sql_endpoint.id)
+    assert match is not None, (
+        f"expected to resolve endpoint {ephemeral_sql_endpoint.id} back to its "
+        f"Lakehouse {ephemeral_lakehouse.get('id')!r}"
+    )
+    assert str(match.id) == str(ephemeral_lakehouse.get("id"))
+    assert match.default_schema == "dbo", (
+        f"expected a schema-enabled lakehouse to report defaultSchema='dbo', got "
+        f"{match.default_schema!r}"
+    )
+
+
+async def test_find_undiscovered_tables_schema_enabled_lakehouse_is_unsupported(
+    http: FabricHttpClient,
+    workspace_id: UUID,
+    ephemeral_sql_endpoint: Warehouse,
+) -> None:
+    """A real schema-enabled Lakehouse-backed endpoint refuses the comparison."""
+    result = await sql_endpoints.find_undiscovered_lakehouse_tables(
+        http, workspace_id, ephemeral_sql_endpoint.id, frozenset()
+    )
+    assert result.status == sql_endpoints.LakehouseDiscoveryStatus.SCHEMA_ENABLED_UNSUPPORTED
+    assert result.missing_table_names == ()
+
+
+async def test_find_undiscovered_tables_non_lakehouse_endpoint_id(
+    http: FabricHttpClient, workspace_id: UUID
+) -> None:
+    """A UUID that pairs with no lakehouse at all resolves as NOT_LAKEHOUSE_BACKED.
+
+    No lakehouse in the workspace's /lakehouses listing pairs with a random
+    UUID, so the scan simply finds no match -- the same code path an endpoint
+    backed by a mirrored database (or anything else that isn't a Lakehouse)
+    would take.
+    """
+    bogus = uuid.uuid4()
+    result = await sql_endpoints.find_undiscovered_lakehouse_tables(
+        http, workspace_id, bogus, frozenset()
+    )
+    assert result.status == sql_endpoints.LakehouseDiscoveryStatus.NOT_LAKEHOUSE_BACKED
+    assert result.missing_table_names == ()

--- a/tests/integration/test_services_tables.py
+++ b/tests/integration/test_services_tables.py
@@ -791,6 +791,162 @@ async def test_list_table_sync_status_schema_filter_on_sql_endpoint(
 
 
 # ===========================================================================
+# refresh_table_metadata — sys.sp_dw_refresh_ext_table (#1062)
+# ===========================================================================
+
+# Driver message fragments that mean the procedure exists by name but this
+# endpoint's SQL engine version does not implement it yet (a tenant-level GA
+# rollout gap, not a bug) -- mirrors _HEALTH_METRICS_UNAVAILABLE_FRAGMENTS
+# above. Kept as its own list rather than reused verbatim: sp_dw_refresh_ext_table
+# is a different (newer) procedure and Fabric's wording for it is not yet
+# confirmed against a live endpoint.
+_REFRESH_TABLE_UNAVAILABLE_FRAGMENTS = (
+    "is not available in this version",
+    "stored procedure is not available",
+)
+
+
+def _is_refresh_table_unavailable(exc: BaseException) -> bool:
+    """Return True when *exc* means sp_dw_refresh_ext_table is not yet deployed."""
+    msg = str(exc).lower()
+    return any(frag in msg for frag in _REFRESH_TABLE_UNAVAILABLE_FRAGMENTS)
+
+
+@pytest.mark.sql_endpoint
+async def test_refresh_table_metadata_on_sql_endpoint(
+    shared_sql_endpoint: SharedSqlEndpointTarget,
+) -> None:
+    """refresh_table_metadata against the seeded probe table; skips on the legacy sync.
+
+    Uses ``sample.colors`` (seeded via the parent Lakehouse during fixture
+    setup) as the probe table, mirroring
+    ``test_list_table_sync_status_on_sql_endpoint`` and
+    ``test_get_table_health_metrics_on_sql_endpoint`` above.
+
+    Also guards against a #1000-class bug (a write that looks like it
+    succeeded but never actually committed): after the refresh, a second,
+    independent ``list_table_sync_status`` call must still see the table with
+    a populated ``last_update_time_utc``.
+    """
+    from fabric_dw.models import WarehouseKind  # noqa: PLC0415
+
+    sql_target = shared_sql_endpoint.sql_target
+    try:
+        result = await tables.refresh_table_metadata(
+            sql_target,
+            SEED_SCHEMA_NAME,
+            "colors",
+            kind=WarehouseKind.SQL_ENDPOINT,
+        )
+    except NotFoundError as exc:
+        pytest.skip(
+            f"sys.sp_dw_refresh_ext_table is not available on this endpoint "
+            f"(legacy metadata sync); skipping ({exc})"
+        )
+    except Exception as exc:
+        # Mirrors test_get_table_health_metrics_on_sql_endpoint: an engine
+        # version that recognises the proc name but doesn't implement it yet
+        # is NOT classified by map_driver_error() and propagates raw.
+        if not _is_refresh_table_unavailable(exc):
+            raise
+        pytest.skip(
+            f"sys.sp_dw_refresh_ext_table is not available in this SQL Analytics "
+            f"Endpoint's engine version ({exc}); skipping — re-run when the GA "
+            f"rollout reaches this endpoint"
+        )
+
+    assert result.schema_name == SEED_SCHEMA_NAME
+    assert result.name == "colors"
+    assert result.qualified_name == f"{SEED_SCHEMA_NAME}.colors"
+
+    verify_rows = await tables.list_table_sync_status(
+        sql_target,
+        schema=SEED_SCHEMA_NAME,
+        table="colors",
+        kind=WarehouseKind.SQL_ENDPOINT,
+    )
+    assert verify_rows, "expected the refreshed table to still be visible after refresh"
+    assert verify_rows[0].last_update_time_utc is not None, (
+        "last_update_time_utc is still empty after refresh_table_metadata — this "
+        "would indicate the EXEC did not actually commit (see #1000)"
+    )
+
+
+@pytest.mark.sql_endpoint
+async def test_refresh_table_metadata_on_unknown_table_settles_open_question(
+    shared_sql_endpoint: SharedSqlEndpointTarget,
+) -> None:
+    """Settles issue #1060's open question: does refreshing an unknown table create it?
+
+    Microsoft's guidance implies ``sp_dw_refresh_ext_table`` refreshes
+    existing tables only (schema changes -- tables added or dropped -- are
+    routed to the item-level REST API instead), but that is inference, not
+    documentation. This test observes the real behaviour against a live
+    endpoint rather than assuming it, and distinguishes outcomes by message
+    content rather than by exception type alone:
+
+    - **Expected** (per Microsoft's guidance): the procedure or the
+      post-refresh catalog lookup reports the table is not found --
+      ``refresh_table_metadata`` raises :class:`NotFoundError` naming the
+      table or the catalog. This test passes.
+    - **Unexpected**: the procedure succeeds and returns a row for a table
+      that was never created. This would mean ``tables refresh`` has an
+      item-scoped side effect, which #1060 flags as grounds to revisit its
+      group placement (currently under ``tables``, not ``sql-endpoints``).
+      This test fails loudly so the finding gets reported rather than
+      silently coded around.
+    - A :class:`NotFoundError` whose message matches neither the
+      not-in-catalog shape nor a legacy-sync/engine-unavailable shape means
+      the live driver returned something genuinely unrecognised; this also
+      fails loudly rather than being swallowed by a broad skip.
+    """
+    from fabric_dw.models import WarehouseKind  # noqa: PLC0415
+
+    sql_target = shared_sql_endpoint.sql_target
+    bogus_table = f"pytest_refresh_nonexistent_{int(time.time())}"
+
+    try:
+        result = await tables.refresh_table_metadata(
+            sql_target,
+            SEED_SCHEMA_NAME,
+            bogus_table,
+            kind=WarehouseKind.SQL_ENDPOINT,
+        )
+    except NotFoundError as exc:
+        msg = str(exc).lower()
+        if "new metadata sync" in msg:
+            pytest.skip(
+                f"sys.sp_dw_refresh_ext_table is not available on this endpoint "
+                f"(legacy metadata sync); skipping ({exc})"
+            )
+        if "not present in the endpoint" in msg or bogus_table.lower() in msg:
+            # Expected per Microsoft's guidance: the procedure does not create
+            # tables that are not already present in the endpoint's catalog.
+            return
+        pytest.fail(
+            "refresh_table_metadata raised NotFoundError with an unrecognised "
+            "message shape for an unknown table (neither the not-in-catalog "
+            f"message nor a legacy-sync message): {exc}"
+        )
+    except Exception as exc:
+        if _is_refresh_table_unavailable(exc):
+            pytest.skip(
+                f"sys.sp_dw_refresh_ext_table is not available in this SQL Analytics "
+                f"Endpoint's engine version ({exc}); skipping"
+            )
+        raise
+    else:
+        pytest.fail(
+            "sys.sp_dw_refresh_ext_table succeeded for a table that does not exist "
+            f"in the endpoint's catalog (got {result!r}). This means the procedure "
+            "DOES create tables on demand — report this finding on issue #1060: it "
+            "gives 'tables refresh' an item-scoped side effect and its group "
+            "placement (currently under 'tables', not 'sql-endpoints') needs "
+            "revisiting."
+        )
+
+
+# ===========================================================================
 # export_table — Parquet round-trip
 # ===========================================================================
 

--- a/tests/unit/cli/commands/test_sql_endpoints.py
+++ b/tests/unit/cli/commands/test_sql_endpoints.py
@@ -705,3 +705,32 @@ class TestRenderRefreshTable:
         output = buf.getvalue()
         # The title must still appear even with no rows.
         assert "Metadata Refresh Results" in output
+
+
+class TestSqlEndpointsCommandHints:
+    """The 'sql-endpoints' group hints at per-table commands living in 'tables' (#1062)."""
+
+    def test_sync_status_names_the_real_command(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli, ["sql-endpoints", "sync-status"])
+        assert result.exit_code != 0
+        assert "fdw tables sync-status" in result.output
+
+    def test_refresh_table_names_the_real_command(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli, ["sql-endpoints", "refresh-table"])
+        assert result.exit_code != 0
+        assert "fdw tables refresh" in result.output
+
+    def test_help_mentions_both_new_commands(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli, ["sql-endpoints", "--help"])
+        assert result.exit_code == 0, result.output
+        # --help word-wraps the docstring, so compare on whitespace-collapsed text.
+        collapsed = " ".join(result.output.split())
+        assert "fdw tables sync-status" in collapsed
+        assert "fdw tables refresh" in collapsed
+
+    def test_unrelated_typo_keeps_clicks_normal_behaviour(self, runner: CliRunner) -> None:
+        """A typo not in the hint mapping falls through to Click's own suggestion."""
+        result = runner.invoke(cli, ["sql-endpoints", "lst"])
+        assert result.exit_code != 0
+        assert "fdw tables" not in result.output
+        assert "No such command 'lst'" in result.output

--- a/tests/unit/cli/commands/test_tables.py
+++ b/tests/unit/cli/commands/test_tables.py
@@ -4327,6 +4327,275 @@ class TestTablesSyncStatus:
         assert "StagingRaw" in result.output
 
 
+class TestTablesSyncStatusCheckLakehouse:
+    """Tests for ``tables sync-status --check-lakehouse`` (#1064)."""
+
+    def test_check_lakehouse_with_schema_is_usage_error(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        _ = cache_env
+        result = runner.invoke(
+            cli,
+            [
+                "-w",
+                WS_GUID,
+                "tables",
+                "sync-status",
+                SE_GUID,
+                "--check-lakehouse",
+                "--schema",
+                "dbo",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "--check-lakehouse cannot be combined" in result.output
+
+    def test_check_lakehouse_with_table_is_usage_error(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        _ = cache_env
+        result = runner.invoke(
+            cli,
+            [
+                "-w",
+                WS_GUID,
+                "tables",
+                "sync-status",
+                SE_GUID,
+                "--check-lakehouse",
+                "--table",
+                "dbo.FactSales",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "--check-lakehouse cannot be combined" in result.output
+
+    def test_check_lakehouse_adds_missing_row(self, runner: CliRunner, cache_env: Path) -> None:
+        from fabric_dw.services.sql_endpoints import (  # noqa: PLC0415
+            LakehouseDiscoveryGap,
+            LakehouseDiscoveryStatus,
+        )
+
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.tables.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.tables.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_sql_endpoint_entry())),
+            ),
+            patch(
+                "fabric_dw.services.tables.list_table_sync_status",
+                new=AsyncMock(return_value=[_make_sync_status("dbo", "FactSales")]),
+            ),
+            patch(
+                "fabric_dw.services.sql_endpoints.find_undiscovered_lakehouse_tables",
+                new=AsyncMock(
+                    return_value=LakehouseDiscoveryGap(
+                        status=LakehouseDiscoveryStatus.OK,
+                        missing_table_names=("StagingRaw",),
+                    )
+                ),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "-w",
+                    WS_GUID,
+                    "--json",
+                    "tables",
+                    "sync-status",
+                    SE_GUID,
+                    "--check-lakehouse",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.output)
+        assert len(parsed) == 2
+        by_name = {row["name"]: row for row in parsed}
+        assert by_name["FactSales"]["in_endpoint_catalog"] is True
+        assert by_name["StagingRaw"]["in_endpoint_catalog"] is False
+        assert by_name["StagingRaw"]["qualified_name"] == "dbo.StagingRaw"
+        assert by_name["StagingRaw"]["last_update_time_utc"] is None
+
+    def test_check_lakehouse_no_gap_leaves_rows_unchanged(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        from fabric_dw.services.sql_endpoints import (  # noqa: PLC0415
+            LakehouseDiscoveryGap,
+            LakehouseDiscoveryStatus,
+        )
+
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.tables.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.tables.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_sql_endpoint_entry())),
+            ),
+            patch(
+                "fabric_dw.services.tables.list_table_sync_status",
+                new=AsyncMock(return_value=[_make_sync_status("dbo", "FactSales")]),
+            ),
+            patch(
+                "fabric_dw.services.sql_endpoints.find_undiscovered_lakehouse_tables",
+                new=AsyncMock(
+                    return_value=LakehouseDiscoveryGap(status=LakehouseDiscoveryStatus.OK)
+                ),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "-w",
+                    WS_GUID,
+                    "--json",
+                    "tables",
+                    "sync-status",
+                    SE_GUID,
+                    "--check-lakehouse",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.output)
+        assert len(parsed) == 1
+
+    def test_check_lakehouse_not_lakehouse_backed_prints_note_human(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        from fabric_dw.services.sql_endpoints import (  # noqa: PLC0415
+            LakehouseDiscoveryGap,
+            LakehouseDiscoveryStatus,
+        )
+
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.tables.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.tables.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_sql_endpoint_entry())),
+            ),
+            patch(
+                "fabric_dw.services.tables.list_table_sync_status",
+                new=AsyncMock(return_value=[_make_sync_status("dbo", "FactSales")]),
+            ),
+            patch(
+                "fabric_dw.services.sql_endpoints.find_undiscovered_lakehouse_tables",
+                new=AsyncMock(
+                    return_value=LakehouseDiscoveryGap(
+                        status=LakehouseDiscoveryStatus.NOT_LAKEHOUSE_BACKED
+                    )
+                ),
+            ),
+        ):
+            result = runner.invoke(
+                cli, ["-w", WS_GUID, "tables", "sync-status", SE_GUID, "--check-lakehouse"]
+            )
+        assert result.exit_code == 0, result.output
+        assert "could not run" in result.output
+        assert "mirrored" in result.output
+
+    def test_check_lakehouse_schema_enabled_prints_note_human(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        from fabric_dw.services.sql_endpoints import (  # noqa: PLC0415
+            LakehouseDiscoveryGap,
+            LakehouseDiscoveryStatus,
+        )
+
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.tables.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.tables.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_sql_endpoint_entry())),
+            ),
+            patch(
+                "fabric_dw.services.tables.list_table_sync_status",
+                new=AsyncMock(return_value=[_make_sync_status("dbo", "FactSales")]),
+            ),
+            patch(
+                "fabric_dw.services.sql_endpoints.find_undiscovered_lakehouse_tables",
+                new=AsyncMock(
+                    return_value=LakehouseDiscoveryGap(
+                        status=LakehouseDiscoveryStatus.SCHEMA_ENABLED_UNSUPPORTED
+                    )
+                ),
+            ),
+        ):
+            result = runner.invoke(
+                cli, ["-w", WS_GUID, "tables", "sync-status", SE_GUID, "--check-lakehouse"]
+            )
+        assert result.exit_code == 0, result.output
+        assert "could not run" in result.output
+        assert "schema" in result.output.lower()
+
+    def test_check_lakehouse_inconclusive_json_has_no_note_text(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """--json stays a clean array with no note text mixed in, even when inconclusive."""
+        from fabric_dw.services.sql_endpoints import (  # noqa: PLC0415
+            LakehouseDiscoveryGap,
+            LakehouseDiscoveryStatus,
+        )
+
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.tables.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.tables.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_sql_endpoint_entry())),
+            ),
+            patch(
+                "fabric_dw.services.tables.list_table_sync_status",
+                new=AsyncMock(return_value=[_make_sync_status("dbo", "FactSales")]),
+            ),
+            patch(
+                "fabric_dw.services.sql_endpoints.find_undiscovered_lakehouse_tables",
+                new=AsyncMock(
+                    return_value=LakehouseDiscoveryGap(
+                        status=LakehouseDiscoveryStatus.NOT_LAKEHOUSE_BACKED
+                    )
+                ),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "-w",
+                    WS_GUID,
+                    "--json",
+                    "tables",
+                    "sync-status",
+                    SE_GUID,
+                    "--check-lakehouse",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.output)  # must not raise: no stray note text in --json output
+        assert len(parsed) == 1
+
+
 class TestTablesRefresh:
     """Tests for the ``tables refresh`` CLI command (#1062)."""
 

--- a/tests/unit/cli/commands/test_tables.py
+++ b/tests/unit/cli/commands/test_tables.py
@@ -4468,9 +4468,64 @@ class TestTablesSyncStatusCheckLakehouse:
         parsed = json.loads(result.output)
         assert len(parsed) == 1
 
-    def test_check_lakehouse_not_lakehouse_backed_prints_note_human(
+    def test_check_lakehouse_adds_case_mismatch_row(
         self, runner: CliRunner, cache_env: Path
     ) -> None:
+        from fabric_dw.services.sql_endpoints import (  # noqa: PLC0415
+            LakehouseDiscoveryGap,
+            LakehouseDiscoveryStatus,
+        )
+
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.tables.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.tables.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_sql_endpoint_entry())),
+            ),
+            patch(
+                "fabric_dw.services.tables.list_table_sync_status",
+                new=AsyncMock(return_value=[_make_sync_status("dbo", "FactSales")]),
+            ),
+            patch(
+                "fabric_dw.services.sql_endpoints.find_undiscovered_lakehouse_tables",
+                new=AsyncMock(
+                    return_value=LakehouseDiscoveryGap(
+                        status=LakehouseDiscoveryStatus.OK,
+                        case_mismatched_table_names=(("factsales", "FactSales"),),
+                    )
+                ),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "-w",
+                    WS_GUID,
+                    "--json",
+                    "tables",
+                    "sync-status",
+                    SE_GUID,
+                    "--check-lakehouse",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.output)
+        assert len(parsed) == 2
+        mismatch_row = next(row for row in parsed if row["name"] == "factsales")
+        assert mismatch_row["in_endpoint_catalog"] is False
+        assert mismatch_row["case_mismatched_catalog_name"] == "FactSales"
+        exact_row = next(row for row in parsed if row["name"] == "FactSales")
+        assert exact_row["case_mismatched_catalog_name"] is None
+
+    def test_check_lakehouse_not_lakehouse_backed_fails(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """Requesting the cross-check when it cannot run is a hard failure, not a silent no-op."""
         from fabric_dw.services.sql_endpoints import (  # noqa: PLC0415
             LakehouseDiscoveryGap,
             LakehouseDiscoveryStatus,
@@ -4503,13 +4558,12 @@ class TestTablesSyncStatusCheckLakehouse:
             result = runner.invoke(
                 cli, ["-w", WS_GUID, "tables", "sync-status", SE_GUID, "--check-lakehouse"]
             )
-        assert result.exit_code == 0, result.output
+        assert result.exit_code != 0
         assert "could not run" in result.output
         assert "mirrored" in result.output
 
-    def test_check_lakehouse_schema_enabled_prints_note_human(
-        self, runner: CliRunner, cache_env: Path
-    ) -> None:
+    def test_check_lakehouse_schema_enabled_fails(self, runner: CliRunner, cache_env: Path) -> None:
+        """Requesting the cross-check when it cannot run is a hard failure, not a silent no-op."""
         from fabric_dw.services.sql_endpoints import (  # noqa: PLC0415
             LakehouseDiscoveryGap,
             LakehouseDiscoveryStatus,
@@ -4542,14 +4596,14 @@ class TestTablesSyncStatusCheckLakehouse:
             result = runner.invoke(
                 cli, ["-w", WS_GUID, "tables", "sync-status", SE_GUID, "--check-lakehouse"]
             )
-        assert result.exit_code == 0, result.output
+        assert result.exit_code != 0
         assert "could not run" in result.output
         assert "schema" in result.output.lower()
 
-    def test_check_lakehouse_inconclusive_json_has_no_note_text(
+    def test_check_lakehouse_inconclusive_fails_in_json_mode_too(
         self, runner: CliRunner, cache_env: Path
     ) -> None:
-        """--json stays a clean array with no note text mixed in, even when inconclusive."""
+        """The inconclusive failure fires the same way regardless of --json; nothing is rendered."""
         from fabric_dw.services.sql_endpoints import (  # noqa: PLC0415
             LakehouseDiscoveryGap,
             LakehouseDiscoveryStatus,
@@ -4591,9 +4645,10 @@ class TestTablesSyncStatusCheckLakehouse:
                     "--check-lakehouse",
                 ],
             )
-        assert result.exit_code == 0, result.output
-        parsed = json.loads(result.output)  # must not raise: no stray note text in --json output
-        assert len(parsed) == 1
+        assert result.exit_code != 0
+        # No partial/empty JSON array is emitted -- the command fails before rendering.
+        with pytest.raises(json.JSONDecodeError):
+            json.loads(result.output)
 
 
 class TestTablesRefresh:

--- a/tests/unit/cli/commands/test_tables.py
+++ b/tests/unit/cli/commands/test_tables.py
@@ -4327,6 +4327,188 @@ class TestTablesSyncStatus:
         assert "StagingRaw" in result.output
 
 
+class TestTablesRefresh:
+    """Tests for the ``tables refresh`` CLI command (#1062)."""
+
+    def test_refresh_exits_zero_prints_confirmation_and_row(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.tables.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.tables.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_sql_endpoint_entry())),
+            ),
+            patch(
+                "fabric_dw.services.tables.refresh_table_metadata",
+                new=AsyncMock(return_value=_make_sync_status()),
+            ),
+        ):
+            result = runner.invoke(
+                cli, ["-w", WS_GUID, "tables", "refresh", SE_GUID, "dbo.FactSales"]
+            )
+        assert result.exit_code == 0, result.output
+        assert "Refreshed" in result.output
+        assert "dbo.FactSales" in result.output
+        assert "Table Metadata Sync Status" in result.output
+
+    def test_refresh_json_output_is_bare_object(self, runner: CliRunner, cache_env: Path) -> None:
+        """--json emits a single JSON object, not an array (coordinator amendment 2)."""
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.tables.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.tables.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_sql_endpoint_entry())),
+            ),
+            patch(
+                "fabric_dw.services.tables.refresh_table_metadata",
+                new=AsyncMock(return_value=_make_sync_status()),
+            ),
+        ):
+            result = runner.invoke(
+                cli, ["-w", WS_GUID, "--json", "tables", "refresh", SE_GUID, "dbo.FactSales"]
+            )
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.output)
+        assert isinstance(parsed, dict)
+        assert parsed["schema_name"] == "dbo"
+        assert parsed["name"] == "FactSales"
+        assert parsed["qualified_name"] == "dbo.FactSales"
+        # No human-readable confirmation text is mixed into --json output.
+        assert "Refreshed" not in result.output
+
+    def test_refresh_forwards_schema_and_table(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        mock_svc = AsyncMock(return_value=_make_sync_status())
+        with (
+            patch(
+                "fabric_dw.cli.commands.tables.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.tables.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_sql_endpoint_entry())),
+            ),
+            patch("fabric_dw.services.tables.refresh_table_metadata", new=mock_svc),
+        ):
+            result = runner.invoke(
+                cli, ["-w", WS_GUID, "tables", "refresh", SE_GUID, "dbo.FactSales"]
+            )
+        assert result.exit_code == 0, result.output
+        args, _kwargs = mock_svc.call_args
+        assert args[1] == "dbo"
+        assert args[2] == "FactSales"
+
+    def test_refresh_warehouse_target_fails_with_clear_message(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        """Warehouse target rejected via the real _assert_sql_endpoint guard."""
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.tables.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.tables.build_sql_target",
+                # Warehouse entry — kind=WarehouseKind.WAREHOUSE
+                new=AsyncMock(return_value=(_make_sql_target(), _make_item_entry())),
+            ),
+            # Do NOT mock the service — let _assert_sql_endpoint fire for real.
+            patch("fabric_dw.sql.open_connection", return_value=MagicMock()),
+        ):
+            result = runner.invoke(
+                cli, ["-w", WS_GUID, "tables", "refresh", WH_GUID, "dbo.FactSales"]
+            )
+        assert result.exit_code != 0
+        assert "SQL Analytics Endpoints" in result.output
+
+    def test_refresh_nonzero_return_code_fails(self, runner: CliRunner, cache_env: Path) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.tables.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.tables.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_sql_endpoint_entry())),
+            ),
+            patch(
+                "fabric_dw.services.tables.refresh_table_metadata",
+                new=AsyncMock(
+                    side_effect=FabricError(
+                        "sys.sp_dw_refresh_ext_table reported failure (return code 1) "
+                        "refreshing table 'dbo.FactSales'."
+                    )
+                ),
+            ),
+        ):
+            result = runner.invoke(
+                cli, ["-w", WS_GUID, "tables", "refresh", SE_GUID, "dbo.FactSales"]
+            )
+        assert result.exit_code != 0
+        assert "return code 1" in result.output
+
+    def test_refresh_legacy_endpoint_error_has_no_raw_driver_text(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with (
+            patch(
+                "fabric_dw.cli.commands.tables.build_http_client",
+                new=_make_http_cm(mock_http),
+            ),
+            patch(
+                "fabric_dw.cli.commands.tables.build_sql_target",
+                new=AsyncMock(return_value=(_make_sql_target(), _make_sql_endpoint_entry())),
+            ),
+            patch(
+                "fabric_dw.services.tables.refresh_table_metadata",
+                new=AsyncMock(
+                    side_effect=NotFoundError(
+                        "Table metadata refresh requires the new metadata sync "
+                        "(preview) for this SQL analytics endpoint. On endpoints using "
+                        "the legacy metadata sync, use 'fdw sql-endpoints refresh' to "
+                        "refresh the whole item instead."
+                    )
+                ),
+            ),
+        ):
+            result = runner.invoke(
+                cli, ["-w", WS_GUID, "tables", "refresh", SE_GUID, "dbo.FactSales"]
+            )
+        assert result.exit_code != 0
+        assert "new metadata sync" in result.output
+        assert "Could not find" not in result.output
+
+    def test_refresh_qualified_name_without_dot_fails(
+        self, runner: CliRunner, cache_env: Path
+    ) -> None:
+        _ = cache_env
+        mock_http = AsyncMock()
+        with patch(
+            "fabric_dw.cli.commands.tables.build_http_client",
+            new=_make_http_cm(mock_http),
+        ):
+            result = runner.invoke(cli, ["-w", WS_GUID, "tables", "refresh", SE_GUID, "nodot"])
+        assert result.exit_code != 0
+
+
 class TestTablesHealthCheckDuplicateColumns:
     """tables health-check — duplicate column name handling (issue #833)."""
 

--- a/tests/unit/mcp/tools/test_tables.py
+++ b/tests/unit/mcp/tools/test_tables.py
@@ -1366,6 +1366,114 @@ async def test_list_table_sync_status_legacy_endpoint_raises_tool_error(
 
 
 # ---------------------------------------------------------------------------
+# list_table_sync_status(check_lakehouse=True) — Lakehouse discovery gap (#1064)
+# ---------------------------------------------------------------------------
+
+
+async def test_list_table_sync_status_check_lakehouse_with_schema_raises_tool_error(
+    mock_ctx, ctx_patch
+) -> None:
+    """check_lakehouse=True combined with schema is rejected before any service call."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_sql_endpoint_entry())
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.tables.list_table_sync_status",
+            new=AsyncMock(side_effect=AssertionError("must not be called")),
+        ),
+        pytest.raises(ToolError, match="cannot be combined"),
+    ):
+        await call_tool(
+            mcp,
+            "list_table_sync_status",
+            {"workspace": WS_NAME, "item": WH_NAME, "schema": "dbo", "check_lakehouse": True},
+        )
+
+
+async def test_list_table_sync_status_check_lakehouse_adds_missing_row(mock_ctx, ctx_patch) -> None:
+    """check_lakehouse=True appends a synthetic in_endpoint_catalog=False row."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+    from fabric_dw.services.sql_endpoints import (  # noqa: PLC0415
+        LakehouseDiscoveryGap,
+        LakehouseDiscoveryStatus,
+    )
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_sql_endpoint_entry())
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.tables.list_table_sync_status",
+            new=AsyncMock(return_value=[_make_sync_status("dbo", "FactSales")]),
+        ),
+        patch(
+            "fabric_dw.services.sql_endpoints.find_undiscovered_lakehouse_tables",
+            new=AsyncMock(
+                return_value=LakehouseDiscoveryGap(
+                    status=LakehouseDiscoveryStatus.OK,
+                    missing_table_names=("StagingRaw",),
+                )
+            ),
+        ),
+    ):
+        result = await call_tool(
+            mcp,
+            "list_table_sync_status",
+            {"workspace": WS_NAME, "item": WH_NAME, "check_lakehouse": True},
+        )
+
+    assert len(result) == 2
+    by_name = {row["name"]: row for row in result}
+    assert by_name["FactSales"]["in_endpoint_catalog"] is True
+    assert by_name["StagingRaw"]["in_endpoint_catalog"] is False
+    assert by_name["StagingRaw"]["qualified_name"] == "dbo.StagingRaw"
+    assert by_name["StagingRaw"]["last_update_time_utc"] is None
+
+
+async def test_list_table_sync_status_check_lakehouse_inconclusive_is_no_op(
+    mock_ctx, ctx_patch
+) -> None:
+    """check_lakehouse=True returns the unchanged result when the cross-check cannot run."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+    from fabric_dw.services.sql_endpoints import (  # noqa: PLC0415
+        LakehouseDiscoveryGap,
+        LakehouseDiscoveryStatus,
+    )
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_sql_endpoint_entry())
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.tables.list_table_sync_status",
+            new=AsyncMock(return_value=[_make_sync_status("dbo", "FactSales")]),
+        ),
+        patch(
+            "fabric_dw.services.sql_endpoints.find_undiscovered_lakehouse_tables",
+            new=AsyncMock(
+                return_value=LakehouseDiscoveryGap(
+                    status=LakehouseDiscoveryStatus.NOT_LAKEHOUSE_BACKED
+                )
+            ),
+        ),
+    ):
+        result = await call_tool(
+            mcp,
+            "list_table_sync_status",
+            {"workspace": WS_NAME, "item": WH_NAME, "check_lakehouse": True},
+        )
+
+    assert len(result) == 1
+    assert result[0]["name"] == "FactSales"
+
+
+# ---------------------------------------------------------------------------
 # refresh_table_metadata — contract tests (mutating, non-destructive, #1062)
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/mcp/tools/test_tables.py
+++ b/tests/unit/mcp/tools/test_tables.py
@@ -1435,10 +1435,14 @@ async def test_list_table_sync_status_check_lakehouse_adds_missing_row(mock_ctx,
     assert by_name["StagingRaw"]["last_update_time_utc"] is None
 
 
-async def test_list_table_sync_status_check_lakehouse_inconclusive_is_no_op(
+async def test_list_table_sync_status_check_lakehouse_not_lakehouse_backed_raises(
     mock_ctx, ctx_patch
 ) -> None:
-    """check_lakehouse=True returns the unchanged result when the cross-check cannot run."""
+    """check_lakehouse=True raises ToolError rather than silently returning unchanged rows.
+
+    A caller that explicitly asked for the cross-check must not read "no extra
+    rows" as "fully discovered" (#1064 review).
+    """
     from fabric_dw.mcp.server import mcp  # noqa: PLC0415
     from fabric_dw.services.sql_endpoints import (  # noqa: PLC0415
         LakehouseDiscoveryGap,
@@ -1462,6 +1466,79 @@ async def test_list_table_sync_status_check_lakehouse_inconclusive_is_no_op(
                 )
             ),
         ),
+        pytest.raises(ToolError, match="could not run"),
+    ):
+        await call_tool(
+            mcp,
+            "list_table_sync_status",
+            {"workspace": WS_NAME, "item": WH_NAME, "check_lakehouse": True},
+        )
+
+
+async def test_list_table_sync_status_check_lakehouse_schema_enabled_raises(
+    mock_ctx, ctx_patch
+) -> None:
+    """check_lakehouse=True raises ToolError when the backing Lakehouse is schema-enabled."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+    from fabric_dw.services.sql_endpoints import (  # noqa: PLC0415
+        LakehouseDiscoveryGap,
+        LakehouseDiscoveryStatus,
+    )
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_sql_endpoint_entry())
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.tables.list_table_sync_status",
+            new=AsyncMock(return_value=[_make_sync_status("dbo", "FactSales")]),
+        ),
+        patch(
+            "fabric_dw.services.sql_endpoints.find_undiscovered_lakehouse_tables",
+            new=AsyncMock(
+                return_value=LakehouseDiscoveryGap(
+                    status=LakehouseDiscoveryStatus.SCHEMA_ENABLED_UNSUPPORTED
+                )
+            ),
+        ),
+        pytest.raises(ToolError, match="could not run"),
+    ):
+        await call_tool(
+            mcp,
+            "list_table_sync_status",
+            {"workspace": WS_NAME, "item": WH_NAME, "check_lakehouse": True},
+        )
+
+
+async def test_list_table_sync_status_check_lakehouse_case_mismatch_row(
+    mock_ctx, ctx_patch
+) -> None:
+    """check_lakehouse=True reports a case-only difference distinctly, not as a flat miss."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+    from fabric_dw.services.sql_endpoints import (  # noqa: PLC0415
+        LakehouseDiscoveryGap,
+        LakehouseDiscoveryStatus,
+    )
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_sql_endpoint_entry())
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.tables.list_table_sync_status",
+            new=AsyncMock(return_value=[_make_sync_status("dbo", "FactSales")]),
+        ),
+        patch(
+            "fabric_dw.services.sql_endpoints.find_undiscovered_lakehouse_tables",
+            new=AsyncMock(
+                return_value=LakehouseDiscoveryGap(
+                    status=LakehouseDiscoveryStatus.OK,
+                    case_mismatched_table_names=(("factsales", "FactSales"),),
+                )
+            ),
+        ),
     ):
         result = await call_tool(
             mcp,
@@ -1469,8 +1546,12 @@ async def test_list_table_sync_status_check_lakehouse_inconclusive_is_no_op(
             {"workspace": WS_NAME, "item": WH_NAME, "check_lakehouse": True},
         )
 
-    assert len(result) == 1
-    assert result[0]["name"] == "FactSales"
+    assert len(result) == 2
+    mismatch_row = next(row for row in result if row["name"] == "factsales")
+    assert mismatch_row["in_endpoint_catalog"] is False
+    assert mismatch_row["case_mismatched_catalog_name"] == "FactSales"
+    exact_row = next(row for row in result if row["name"] == "FactSales")
+    assert exact_row["case_mismatched_catalog_name"] is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/mcp/tools/test_tables.py
+++ b/tests/unit/mcp/tools/test_tables.py
@@ -1366,6 +1366,155 @@ async def test_list_table_sync_status_legacy_endpoint_raises_tool_error(
 
 
 # ---------------------------------------------------------------------------
+# refresh_table_metadata — contract tests (mutating, non-destructive, #1062)
+# ---------------------------------------------------------------------------
+
+
+async def test_refresh_table_metadata_is_registered() -> None:
+    """refresh_table_metadata is registered as an MCP tool."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    tool_names = {t.name for t in mcp._tool_manager.list_tools()}
+    assert "refresh_table_metadata" in tool_names
+
+
+async def test_refresh_table_metadata_readonly_blocked(mock_ctx, ctx_patch) -> None:
+    """refresh_table_metadata raises ToolError when FABRIC_MCP_READONLY is set."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_sql_endpoint_entry())
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_READONLY": "1"}),
+        pytest.raises(ToolError, match="read-only"),
+    ):
+        await call_tool(
+            mcp,
+            "refresh_table_metadata",
+            {"workspace": WS_NAME, "item": WH_NAME, "qualified_name": "dbo.FactSales"},
+        )
+
+
+async def test_refresh_table_metadata_does_not_require_destructive_opt_in(
+    mock_ctx, ctx_patch, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """refresh_table_metadata succeeds without FABRIC_MCP_ALLOW_DESTRUCTIVE."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    monkeypatch.delenv("FABRIC_MCP_ALLOW_DESTRUCTIVE", raising=False)
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_sql_endpoint_entry())
+
+    with (
+        ctx_patch,
+        patch.dict(os.environ, {"FABRIC_MCP_WRITES": "true"}),
+        patch(
+            "fabric_dw.services.tables.refresh_table_metadata",
+            new=AsyncMock(return_value=_make_sync_status()),
+        ),
+    ):
+        result = await call_tool(
+            mcp,
+            "refresh_table_metadata",
+            {"workspace": WS_NAME, "item": WH_NAME, "qualified_name": "dbo.FactSales"},
+        )
+    assert isinstance(result, dict)
+
+
+async def test_refresh_table_metadata_happy_path(mock_ctx, ctx_patch) -> None:
+    """refresh_table_metadata forwards schema/table and returns the typed dict."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_sql_endpoint_entry())
+
+    mock_svc = AsyncMock(return_value=_make_sync_status())
+
+    with (
+        ctx_patch,
+        patch("fabric_dw.services.tables.refresh_table_metadata", new=mock_svc),
+        patch.dict(os.environ, {"FABRIC_MCP_WRITES": "true"}),
+    ):
+        result = await call_tool(
+            mcp,
+            "refresh_table_metadata",
+            {"workspace": WS_NAME, "item": WH_NAME, "qualified_name": "dbo.FactSales"},
+        )
+
+    args, _kwargs = mock_svc.call_args
+    # service is called positionally: target, schema, table_name
+    assert args[1] == "dbo"
+    assert args[2] == "FactSales"
+    assert result["schema_name"] == "dbo"
+    assert result["name"] == "FactSales"
+    assert result["qualified_name"] == "dbo.FactSales"
+
+
+async def test_refresh_table_metadata_warehouse_raises_tool_error(mock_ctx, ctx_patch) -> None:
+    """refresh_table_metadata raises ToolError when the service raises ItemKindError."""
+    from fabric_dw.exceptions import ItemKindError  # noqa: PLC0415
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    # Use a Warehouse entry so the service receives WarehouseKind.WAREHOUSE
+    mock_ctx.resolver.item = AsyncMock(return_value=make_item_entry())
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.tables.refresh_table_metadata",
+            new=AsyncMock(
+                side_effect=ItemKindError(
+                    "Table metadata refresh (sys.sp_dw_refresh_ext_table) is only "
+                    "available on SQL Analytics Endpoints, not Data Warehouses."
+                )
+            ),
+        ),
+        patch.dict(os.environ, {"FABRIC_MCP_WRITES": "true"}),
+        pytest.raises(ToolError),
+    ):
+        await call_tool(
+            mcp,
+            "refresh_table_metadata",
+            {"workspace": WS_NAME, "item": WH_NAME, "qualified_name": "dbo.FactSales"},
+        )
+
+
+async def test_refresh_table_metadata_legacy_endpoint_raises_tool_error(
+    mock_ctx, ctx_patch
+) -> None:
+    """refresh_table_metadata raises ToolError carrying the actionable preview message."""
+    from fabric_dw.mcp.server import mcp  # noqa: PLC0415
+
+    mock_ctx.resolver.workspace_id = AsyncMock(return_value=WS_ID)
+    mock_ctx.resolver.item = AsyncMock(return_value=make_sql_endpoint_entry())
+
+    with (
+        ctx_patch,
+        patch(
+            "fabric_dw.services.tables.refresh_table_metadata",
+            new=AsyncMock(
+                side_effect=NotFoundError(
+                    "Table metadata refresh requires the new metadata sync "
+                    "(preview) for this SQL analytics endpoint. On endpoints using "
+                    "the legacy metadata sync, use 'fdw sql-endpoints refresh' to "
+                    "refresh the whole item instead."
+                )
+            ),
+        ),
+        patch.dict(os.environ, {"FABRIC_MCP_WRITES": "true"}),
+        pytest.raises(ToolError, match="new metadata sync"),
+    ):
+        await call_tool(
+            mcp,
+            "refresh_table_metadata",
+            {"workspace": WS_NAME, "item": WH_NAME, "qualified_name": "dbo.FactSales"},
+        )
+
+
+# ---------------------------------------------------------------------------
 # transfer_table
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/services/test_sql_endpoints.py
+++ b/tests/unit/services/test_sql_endpoints.py
@@ -1047,8 +1047,17 @@ async def test_find_undiscovered_tables_ok_with_gap() -> None:
     assert result.missing_table_names == ("StagingRaw",)
 
 
-async def test_find_undiscovered_tables_case_insensitive_match() -> None:
-    """known_dbo_names matches case-insensitively, per T-SQL identifier semantics."""
+async def test_find_undiscovered_tables_comparison_is_case_sensitive_by_default() -> None:
+    """Regression for the case-folding bug (#1065 review): comparison is exact.
+
+    Fabric's default collation (FABRIC_DEFAULT_COLLATION) is case-sensitive, so
+    a Lakehouse "FactSales" and a catalog "factsales" are two distinct, valid
+    identifiers. Case-folding the comparison (the original implementation)
+    would silently treat them as the same table and hide a real gap. The fixed
+    behaviour must NOT report this as a plain match with an empty gap: it must
+    surface it, distinguished as a case mismatch rather than a flat "missing"
+    (see the next test) -- but it must not be silently absorbed either.
+    """
     from fabric_dw.services.sql_endpoints import (  # noqa: PLC0415
         LakehouseDiscoveryStatus,
         find_undiscovered_lakehouse_tables,
@@ -1069,7 +1078,62 @@ async def test_find_undiscovered_tables_case_insensitive_match() -> None:
             )
 
     assert result.status == LakehouseDiscoveryStatus.OK
+    # Not an exact match, so NOT silently treated as present:
     assert result.missing_table_names == ()
+    # ... but surfaced as a case mismatch, not dropped entirely:
+    assert result.case_mismatched_table_names == (("factsales", "FactSales"),)
+
+
+async def test_find_undiscovered_tables_exact_match_is_not_reported_at_all() -> None:
+    """An exact-name match is neither missing nor a case mismatch."""
+    from fabric_dw.services.sql_endpoints import (  # noqa: PLC0415
+        LakehouseDiscoveryStatus,
+        find_undiscovered_lakehouse_tables,
+    )
+
+    with respx.mock(assert_all_called=False) as mock_router:
+        mock_router.get(_LAKEHOUSES_URL).mock(
+            return_value=httpx.Response(200, json=_GAP_LAKEHOUSE_MATCH_PAYLOAD)
+        )
+        mock_router.get(_GAP_TABLES_URL).mock(
+            return_value=httpx.Response(200, json=_tables_page(["FactSales"]))
+        )
+
+        client = await _make_client()
+        async with client:
+            result = await find_undiscovered_lakehouse_tables(
+                client, _WORKSPACE_ID, _ENDPOINT_ID, frozenset({"FactSales"})
+            )
+
+    assert result.status == LakehouseDiscoveryStatus.OK
+    assert result.missing_table_names == ()
+    assert result.case_mismatched_table_names == ()
+
+
+async def test_find_undiscovered_tables_true_miss_is_not_a_case_mismatch() -> None:
+    """A table with no name match at all (exact or case-insensitive) is a true miss."""
+    from fabric_dw.services.sql_endpoints import (  # noqa: PLC0415
+        LakehouseDiscoveryStatus,
+        find_undiscovered_lakehouse_tables,
+    )
+
+    with respx.mock(assert_all_called=False) as mock_router:
+        mock_router.get(_LAKEHOUSES_URL).mock(
+            return_value=httpx.Response(200, json=_GAP_LAKEHOUSE_MATCH_PAYLOAD)
+        )
+        mock_router.get(_GAP_TABLES_URL).mock(
+            return_value=httpx.Response(200, json=_tables_page(["StagingRaw"]))
+        )
+
+        client = await _make_client()
+        async with client:
+            result = await find_undiscovered_lakehouse_tables(
+                client, _WORKSPACE_ID, _ENDPOINT_ID, frozenset({"FactSales"})
+            )
+
+    assert result.status == LakehouseDiscoveryStatus.OK
+    assert result.missing_table_names == ("StagingRaw",)
+    assert result.case_mismatched_table_names == ()
 
 
 async def test_list_lakehouse_table_names_follows_pagination() -> None:

--- a/tests/unit/services/test_sql_endpoints.py
+++ b/tests/unit/services/test_sql_endpoints.py
@@ -896,3 +896,205 @@ async def test_get_endpoint_connection_string_resolves_via_lakehouse_no_sleep() 
 
     assert result == _LAKEHOUSE_CONN_STRING
     mock_sleep.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# find_undiscovered_lakehouse_tables / list_lakehouse_table_names (#1064)
+# ---------------------------------------------------------------------------
+
+_GAP_LAKEHOUSE_ID = "11111111-0000-0000-0000-000000000001"
+_GAP_TABLES_URL = f"{_BASE}/workspaces/{_WORKSPACE_ID}/lakehouses/{_GAP_LAKEHOUSE_ID}/tables"
+
+# Lakehouse payload whose sqlEndpointProperties.id matches _ENDPOINT_ID and that
+# is NOT schema-enabled (no "defaultSchema" key), reused across the
+# find_undiscovered_lakehouse_tables tests below.
+_GAP_LAKEHOUSE_MATCH_PAYLOAD: dict[str, Any] = _LAKEHOUSES_WITH_MATCH_PAYLOAD
+
+# Same match, but schema-enabled (properties.defaultSchema present).
+_GAP_LAKEHOUSE_MATCH_SCHEMA_ENABLED_PAYLOAD: dict[str, Any] = {
+    "value": [
+        {
+            "id": _GAP_LAKEHOUSE_ID,
+            "displayName": "SalesLakehouse",
+            "workspaceId": str(_WORKSPACE_ID),
+            "properties": {
+                "sqlEndpointProperties": {
+                    "id": str(_ENDPOINT_ID),
+                    "connectionString": _LAKEHOUSE_CONN_STRING,
+                    "provisioningStatus": "Success",
+                },
+                "defaultSchema": "dbo",
+            },
+        }
+    ]
+}
+
+
+def _tables_page(names: list[str], *, continuation: str | None = None) -> dict[str, Any]:
+    """Build a "List Tables" response page (data[] + optional continuationUri)."""
+    page: dict[str, Any] = {
+        "data": [
+            {"type": "Managed", "name": n, "format": "Delta", "location": f".../Tables/{n}"}
+            for n in names
+        ]
+    }
+    if continuation:
+        page["continuationUri"] = continuation
+    return page
+
+
+async def test_find_undiscovered_tables_not_lakehouse_backed() -> None:
+    """No lakehouse in the workspace pairs with the endpoint -> NOT_LAKEHOUSE_BACKED.
+
+    The /tables endpoint must never be called in this case -- there is no
+    lakehouse ID to call it with.
+    """
+    from fabric_dw.services.sql_endpoints import (  # noqa: PLC0415
+        LakehouseDiscoveryStatus,
+        find_undiscovered_lakehouse_tables,
+    )
+
+    with respx.mock(assert_all_called=False) as mock_router:
+        mock_router.get(_LAKEHOUSES_URL).mock(
+            return_value=httpx.Response(200, json=_LAKEHOUSES_NO_MATCH_PAYLOAD)
+        )
+        mock_router.get(url__regex=r".*/tables.*").mock(
+            side_effect=AssertionError("must not call /tables when no lakehouse matches")
+        )
+
+        client = await _make_client()
+        async with client:
+            result = await find_undiscovered_lakehouse_tables(
+                client, _WORKSPACE_ID, _ENDPOINT_ID, frozenset()
+            )
+
+    assert result.status == LakehouseDiscoveryStatus.NOT_LAKEHOUSE_BACKED
+    assert result.missing_table_names == ()
+
+
+async def test_find_undiscovered_tables_schema_enabled_unsupported() -> None:
+    """A schema-enabled backing lakehouse refuses the comparison rather than risk a false report."""
+    from fabric_dw.services.sql_endpoints import (  # noqa: PLC0415
+        LakehouseDiscoveryStatus,
+        find_undiscovered_lakehouse_tables,
+    )
+
+    with respx.mock(assert_all_called=False) as mock_router:
+        mock_router.get(_LAKEHOUSES_URL).mock(
+            return_value=httpx.Response(200, json=_GAP_LAKEHOUSE_MATCH_SCHEMA_ENABLED_PAYLOAD)
+        )
+        mock_router.get(url__regex=r".*/tables.*").mock(
+            side_effect=AssertionError("must not call /tables for a schema-enabled lakehouse")
+        )
+
+        client = await _make_client()
+        async with client:
+            result = await find_undiscovered_lakehouse_tables(
+                client, _WORKSPACE_ID, _ENDPOINT_ID, frozenset()
+            )
+
+    assert result.status == LakehouseDiscoveryStatus.SCHEMA_ENABLED_UNSUPPORTED
+    assert result.missing_table_names == ()
+
+
+async def test_find_undiscovered_tables_ok_no_gap() -> None:
+    """Every Lakehouse table is already known -> OK with an empty gap."""
+    from fabric_dw.services.sql_endpoints import (  # noqa: PLC0415
+        LakehouseDiscoveryStatus,
+        find_undiscovered_lakehouse_tables,
+    )
+
+    with respx.mock(assert_all_called=False) as mock_router:
+        mock_router.get(_LAKEHOUSES_URL).mock(
+            return_value=httpx.Response(200, json=_GAP_LAKEHOUSE_MATCH_PAYLOAD)
+        )
+        mock_router.get(_GAP_TABLES_URL).mock(
+            return_value=httpx.Response(200, json=_tables_page(["FactSales", "DimCustomer"]))
+        )
+
+        client = await _make_client()
+        async with client:
+            result = await find_undiscovered_lakehouse_tables(
+                client, _WORKSPACE_ID, _ENDPOINT_ID, frozenset({"FactSales", "DimCustomer"})
+            )
+
+    assert result.status == LakehouseDiscoveryStatus.OK
+    assert result.missing_table_names == ()
+
+
+async def test_find_undiscovered_tables_ok_with_gap() -> None:
+    """A Lakehouse table absent from known_dbo_names is reported as missing."""
+    from fabric_dw.services.sql_endpoints import (  # noqa: PLC0415
+        LakehouseDiscoveryStatus,
+        find_undiscovered_lakehouse_tables,
+    )
+
+    with respx.mock(assert_all_called=False) as mock_router:
+        mock_router.get(_LAKEHOUSES_URL).mock(
+            return_value=httpx.Response(200, json=_GAP_LAKEHOUSE_MATCH_PAYLOAD)
+        )
+        mock_router.get(_GAP_TABLES_URL).mock(
+            return_value=httpx.Response(200, json=_tables_page(["FactSales", "StagingRaw"]))
+        )
+
+        client = await _make_client()
+        async with client:
+            result = await find_undiscovered_lakehouse_tables(
+                client, _WORKSPACE_ID, _ENDPOINT_ID, frozenset({"FactSales"})
+            )
+
+    assert result.status == LakehouseDiscoveryStatus.OK
+    assert result.missing_table_names == ("StagingRaw",)
+
+
+async def test_find_undiscovered_tables_case_insensitive_match() -> None:
+    """known_dbo_names matches case-insensitively, per T-SQL identifier semantics."""
+    from fabric_dw.services.sql_endpoints import (  # noqa: PLC0415
+        LakehouseDiscoveryStatus,
+        find_undiscovered_lakehouse_tables,
+    )
+
+    with respx.mock(assert_all_called=False) as mock_router:
+        mock_router.get(_LAKEHOUSES_URL).mock(
+            return_value=httpx.Response(200, json=_GAP_LAKEHOUSE_MATCH_PAYLOAD)
+        )
+        mock_router.get(_GAP_TABLES_URL).mock(
+            return_value=httpx.Response(200, json=_tables_page(["factsales"]))
+        )
+
+        client = await _make_client()
+        async with client:
+            result = await find_undiscovered_lakehouse_tables(
+                client, _WORKSPACE_ID, _ENDPOINT_ID, frozenset({"FactSales"})
+            )
+
+    assert result.status == LakehouseDiscoveryStatus.OK
+    assert result.missing_table_names == ()
+
+
+async def test_list_lakehouse_table_names_follows_pagination() -> None:
+    """list_lakehouse_table_names must follow continuationUri across pages."""
+    from fabric_dw.services.sql_endpoints import list_lakehouse_table_names  # noqa: PLC0415
+
+    call_count = 0
+
+    def side_effect(_request: httpx.Request) -> httpx.Response:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return httpx.Response(
+                200, json=_tables_page(["Table1"], continuation=f"{_GAP_TABLES_URL}?page=2")
+            )
+        return httpx.Response(200, json=_tables_page(["Table2"]))
+
+    with respx.mock(assert_all_called=False) as mock_router:
+        mock_router.get(url__regex=r".*/tables.*").mock(side_effect=side_effect)
+
+        client = await _make_client()
+        async with client:
+            result = await list_lakehouse_table_names(
+                client, _WORKSPACE_ID, UUID(_GAP_LAKEHOUSE_ID)
+            )
+
+    assert call_count == 2
+    assert result == ["Table1", "Table2"]

--- a/tests/unit/services/test_tables.py
+++ b/tests/unit/services/test_tables.py
@@ -25,6 +25,7 @@ from fabric_dw.models import (
     ColumnSpec,
     ResultSet,
     Table,
+    TableMetadataSyncStatus,
     TableRowCount,
     WarehouseKind,
 )
@@ -3333,6 +3334,212 @@ class TestListTableSyncStatus:
             result = await tables.list_table_sync_status(target, kind=WarehouseKind.SQL_ENDPOINT)
         assert len(result) == 2
         assert {r.name for r in result} == {"FactSales", "StagingRaw"}
+
+
+# ===========================================================================
+# refresh_table_metadata — sys.sp_dw_refresh_ext_table (#1062)
+# ===========================================================================
+
+
+class _DriverError(Exception):
+    """Mock driver exception carrying a ``ddbc_error`` attribute.
+
+    ``map_driver_error`` classifies known SQL Server error numbers (e.g. 2812,
+    "Could not find stored procedure") primarily by scanning ``exc.ddbc_error``
+    for an embedded native error number (see ``sql_errors._NATIVE_ERROR_RE``).
+    A plain ``Exception("Could not find stored procedure ...")`` does NOT match
+    any fragment in ``_NOT_FOUND_FRAGMENTS`` (unlike "invalid object name" used
+    by the sync-status tests), so it would NOT be mapped to ``NotFoundError``.
+    This mimics what the real mssql_python driver sets so the legacy-sync
+    translation path is exercised the same way it is in production.
+    """
+
+    def __init__(self, msg: str, ddbc_error: str) -> None:
+        super().__init__(msg)
+        self.ddbc_error = ddbc_error
+
+
+def _missing_procedure_error(proc_name: str) -> _DriverError:
+    msg = f"Could not find stored procedure '{proc_name}'."
+    return _DriverError(msg, f"[SQL Server]{msg} (2812)")
+
+
+def _make_conn_for_rc(rc: int, *, col_name: str = "rc") -> MagicMock:
+    """Return a mock DB-API connection for the DECLARE/EXEC/SELECT rc batch.
+
+    Unlike ``_make_conn`` (which only wires ``fetchall``), this wires
+    ``fetchone`` since ``refresh_table_metadata`` reads the return code via
+    ``run_query(..., fetch="one")``.
+    """
+    cursor = MagicMock()
+    cursor.description = [(col_name, None)]
+    cursor.fetchone.return_value = (rc,)
+    cursor.fetchall.return_value = []
+    cursor.rowcount = -1
+    cursor.nextset.return_value = False
+    conn = MagicMock()
+    conn.cursor.return_value = cursor
+    return conn
+
+
+class TestRefreshTableMetadata:
+    """Tests for :func:`tables.refresh_table_metadata`."""
+
+    async def test_happy_path_returns_refreshed_status(self) -> None:
+        target = _make_target()
+        refresh_conn = _make_conn_for_rc(0)
+        fetch_conn = _make_conn([_SYNC_ROW_SYNCED], _SYNC_STATUS_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[refresh_conn, fetch_conn]):
+            result = await tables.refresh_table_metadata(
+                target, "dbo", "FactSales", kind=WarehouseKind.SQL_ENDPOINT
+            )
+        assert isinstance(result, TableMetadataSyncStatus)
+        assert result.schema_name == "dbo"
+        assert result.name == "FactSales"
+        assert result.qualified_name == "dbo.FactSales"
+
+    async def test_commits_after_execute(self) -> None:
+        target = _make_target()
+        refresh_conn = _make_conn_for_rc(0)
+        fetch_conn = _make_conn([_SYNC_ROW_SYNCED], _SYNC_STATUS_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[refresh_conn, fetch_conn]):
+            await tables.refresh_table_metadata(
+                target, "dbo", "FactSales", kind=WarehouseKind.SQL_ENDPOINT
+            )
+        refresh_conn.commit.assert_called_once()
+
+    async def test_qualified_name_is_bound_param_not_interpolated(self) -> None:
+        target = _make_target()
+        refresh_conn = _make_conn_for_rc(0)
+        fetch_conn = _make_conn([_SYNC_ROW_SYNCED], _SYNC_STATUS_COLS)
+        with patch("fabric_dw.sql.open_connection", side_effect=[refresh_conn, fetch_conn]):
+            await tables.refresh_table_metadata(
+                target, "dbo", "FactSales", kind=WarehouseKind.SQL_ENDPOINT
+            )
+        cursor = refresh_conn.cursor.return_value
+        call_args = cursor.execute.call_args
+        call_sql: str = call_args[0][0]
+        assert "dbo.FactSales" not in call_sql
+        assert "sp_dw_refresh_ext_table" in call_sql.lower()
+        params = call_args[0][1] if len(call_args[0]) > 1 else (call_args[1] or {}).get("params")
+        assert params is not None
+        assert list(params) == ["dbo.FactSales"]
+
+    async def test_nonzero_return_code_raises_with_code_and_table(self) -> None:
+        target = _make_target()
+        refresh_conn = _make_conn_for_rc(1)
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=refresh_conn),
+            pytest.raises(FabricError) as exc_info,
+        ):
+            await tables.refresh_table_metadata(
+                target, "dbo", "FactSales", kind=WarehouseKind.SQL_ENDPOINT
+            )
+        msg = str(exc_info.value)
+        assert "1" in msg
+        assert "dbo.FactSales" in msg
+
+    async def test_unexpected_column_shape_raises_clear_error(self) -> None:
+        target = _make_target()
+        conn = _make_conn_for_rc(0, col_name="return_value")
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(FabricError, match="unexpected result shape"),
+        ):
+            await tables.refresh_table_metadata(
+                target, "dbo", "FactSales", kind=WarehouseKind.SQL_ENDPOINT
+            )
+
+    async def test_empty_row_shape_raises_clear_error(self) -> None:
+        target = _make_target()
+        conn = _make_conn_for_rc(0)
+        conn.cursor.return_value.fetchone.return_value = None
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(FabricError, match="unexpected result shape"),
+        ):
+            await tables.refresh_table_metadata(
+                target, "dbo", "FactSales", kind=WarehouseKind.SQL_ENDPOINT
+            )
+
+    async def test_warehouse_kind_raises_before_any_sql(self) -> None:
+        target = _make_target()
+        with (
+            patch("fabric_dw.sql.open_connection") as mock_open,
+            pytest.raises(ItemKindError, match="SQL Analytics Endpoints"),
+        ):
+            await tables.refresh_table_metadata(target, "dbo", "FactSales")
+        mock_open.assert_not_called()
+
+    async def test_invalid_schema_raises_before_any_sql(self) -> None:
+        target = _make_target()
+        with (
+            patch("fabric_dw.sql.open_connection") as mock_open,
+            pytest.raises(ValueError, match="Invalid SQL identifier"),
+        ):
+            await tables.refresh_table_metadata(
+                target, "bad]schema", "FactSales", kind=WarehouseKind.SQL_ENDPOINT
+            )
+        mock_open.assert_not_called()
+
+    async def test_invalid_table_raises_before_any_sql(self) -> None:
+        target = _make_target()
+        with (
+            patch("fabric_dw.sql.open_connection") as mock_open,
+            pytest.raises(ValueError, match="Invalid SQL identifier"),
+        ):
+            await tables.refresh_table_metadata(
+                target, "dbo", "bad;table", kind=WarehouseKind.SQL_ENDPOINT
+            )
+        mock_open.assert_not_called()
+
+    async def test_legacy_endpoint_missing_procedure_is_translated(self) -> None:
+        """A legacy (non-preview) endpoint raises an actionable NotFoundError."""
+        target = _make_target()
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.execute.side_effect = _missing_procedure_error("sys.sp_dw_refresh_ext_table")
+        conn.cursor.return_value = cursor
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(NotFoundError) as exc_info,
+        ):
+            await tables.refresh_table_metadata(
+                target, "dbo", "FactSales", kind=WarehouseKind.SQL_ENDPOINT
+            )
+        msg = str(exc_info.value)
+        assert "new metadata sync" in msg.lower()
+        assert "fdw sql-endpoints refresh" in msg
+
+    async def test_unrelated_missing_procedure_error_propagates_unchanged(self) -> None:
+        """A missing-procedure error naming something else is untouched."""
+        target = _make_target()
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.execute.side_effect = _missing_procedure_error("sys.some_other_proc")
+        conn.cursor.return_value = cursor
+        with (
+            patch("fabric_dw.sql.open_connection", return_value=conn),
+            pytest.raises(NotFoundError) as exc_info,
+        ):
+            await tables.refresh_table_metadata(
+                target, "dbo", "FactSales", kind=WarehouseKind.SQL_ENDPOINT
+            )
+        msg = str(exc_info.value)
+        assert "new metadata sync" not in msg.lower()
+        assert "some_other_proc" in msg
+
+    async def test_empty_post_refresh_lookup_raises_not_in_catalog(self) -> None:
+        target = _make_target()
+        refresh_conn = _make_conn_for_rc(0)
+        fetch_conn = _make_conn([], _SYNC_STATUS_COLS)
+        with (
+            patch("fabric_dw.sql.open_connection", side_effect=[refresh_conn, fetch_conn]),
+            pytest.raises(NotFoundError, match=r"dbo\.FactSales"),
+        ):
+            await tables.refresh_table_metadata(
+                target, "dbo", "FactSales", kind=WarehouseKind.SQL_ENDPOINT
+            )
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

Surfaces `sys.sp_dw_refresh_ext_table` so users can refresh one table's data on a SQL Analytics Endpoint without a full item-level metadata sync, completing the design in #1060 alongside the sync-status read that landed in #1061. Also closes the sync-status discovery gap tracked in #1064 (already closed by the coordinator as scope for this PR): `tables sync-status` gains an opt-in `--check-lakehouse` flag / `check_lakehouse` MCP parameter that surfaces a table the metadata sync has never discovered at all, for the one backing-item case Fabric's REST API actually lets us check.

- New `refresh_table_metadata` service function in `services/tables.py`, placed directly after `list_table_sync_status`.
- CLI: `fdw [-w WORKSPACE] tables refresh [ENDPOINT] QUALIFIED_NAME`.
- MCP: `refresh_table_metadata(workspace, item, qualified_name)`, registered as mutating but **not** destructive.
- Discoverability: `sql-endpoints --help` points at the new `tables` commands, and `sql-endpoints sync-status` / `sql-endpoints refresh-table` now name the real command instead of a bare "No such command".
- New `--check-lakehouse` (CLI) / `check_lakehouse` (MCP) opt-in on `tables sync-status` / `list_table_sync_status`, closing the discovery gap for non-schema-enabled Lakehouse-backed endpoints (#1064).
- Docs and tests per the project's definition of done.

## How each acceptance criterion is met

1. `fdw tables refresh ENDPOINT dbo.FactSales` refreshes that one table: `refresh_cmd` in `cli/commands/tables.py`.
2. On success it prints a one-line confirmation followed by the refreshed sync-status row (reusing `list_table_sync_status` rather than duplicating the query).
3. A non-zero procedure return code fails with a clear error and non-zero exit. `sys.sp_dw_refresh_ext_table` reports success/failure via a return code and does **not** raise for a failure, so the return code has to be observed explicitly: the SQL template is a `DECLARE @rc int; EXEC @rc = sys.sp_dw_refresh_ext_table ?; SELECT @rc AS rc;` batch executed with `run_query(..., fetch="one", commit=True)`. The result columns are checked to be exactly `["rc"]` with one row before trusting the value, so a driver returning an unexpected result set fails loudly instead of misreading some other column as the return code.
4. A Data Warehouse target is rejected with `ItemKindError` via `_assert_sql_endpoint`, before any SQL runs.
5. The legacy-metadata-sync "could not find stored procedure" driver error is translated into the same actionable message style used by `list_table_sync_status` in #1061, matched only when the error names `sp_dw_refresh_ext_table` specifically (an unrelated missing-procedure error passes through unchanged).
6. A table not present in the endpoint: after a successful EXEC, the post-refresh `list_table_sync_status` lookup is re-run; if it comes back empty, a distinct `NotFoundError` is raised naming the table and pointing at `fdw sql-endpoints refresh`, rather than letting an `IndexError` escape. Whether the procedure itself would also error for an unknown table, or silently succeed and create it, is what the new integration test `test_refresh_table_metadata_on_unknown_table_settles_open_question` is written to determine against a live endpoint: see "What could not be verified" below.
7. The MCP tool is registered via `mutating_tool(mcp, "refresh_table_metadata")` with no `destructive=True` (matches `create_table`'s registration, not `delete_table`'s), so it respects `FABRIC_MCP_READONLY` but does not require the `FABRIC_MCP_ALLOW_DESTRUCTIVE` opt-in. It returns the refreshed `TableMetadataSyncStatus` row.
8. `fdw sql-endpoints --help` carries a line pointing at `fdw tables sync-status` and `fdw tables refresh`.
9. `fdw sql-endpoints sync-status` / `fdw sql-endpoints refresh-table` produce a resolution error naming the real command. Added `group_with_hints()` in `cli/commands/_utils.py`: a small `click.Group` subclass factory (not `moved_command_group`: nothing was moved, these commands never lived in `sql-endpoints`) that intercepts only names in its redirect mapping which aren't already real commands, and falls through to Click's normal resolution (including its own typo suggestions) for everything else. Verified an unrelated typo (`sql-endpoints lst`) still gets the bare "No such command" with no hint text.
10. Unit tests cover all of the above: happy path + commit assertion, bound-parameter check, non-zero return code, unexpected result shape (including an empty row), warehouse rejection before any SQL, invalid identifiers before any SQL, legacy-sync translation (matched vs. unrelated), empty post-refresh lookup, plus the CLI and MCP layers (readonly gating, no destructive-opt-in requirement, `--json` bare-object shape, warehouse guard, non-zero-rc surfacing, legacy-sync surfacing) and the `sql-endpoints` hint/typo-fallthrough behaviour.
11. Integration tests added: one refreshes the seeded `sample.colors` probe table and independently re-reads it afterwards to guard against a #1000-class "looks like it worked but never committed" bug; the other targets a table name that does not exist and settles the open question (see below). Both skip cleanly on a legacy-sync endpoint or an engine version that doesn't yet implement the procedure, following the same idiom as `test_get_table_health_metrics_on_sql_endpoint`.
12. Docs: `docs/commands/tables.md` gained a `tables refresh` CLI section (documenting the `--json` bare-object shape) and a `refresh_table_metadata` MCP section; `docs/commands/sql-endpoints.md` gained a "which refresh do I want" comparison table and pointers to the new commands. No new page, so `zensical.toml` nav is unchanged (verified).

## How I established that the EXEC commits

`run_query`'s `commit` parameter calls `conn.commit()` **after** the execute+fetch phase completes, outside its retry loop: this is the same mechanism `rename_table` (`EXEC sp_rename`) already relies on for its own mutating `EXEC`. I passed `commit=True` explicitly and added `test_commits_after_execute`, which asserts `refresh_conn.commit.assert_called_once()` on the mocked connection. Because unit tests can't prove server-side persistence, the integration test additionally does an independent second `list_table_sync_status` call after the refresh and asserts `last_update_time_utc` is populated: the #1000 failure mode (write silently rolled back, looks like success) would leave that field unpopulated.

## `--json` output shape

Per the coordinator's plan amendment: `tables refresh --json` emits a **single JSON object**, not an array of one: the command acts on exactly one table by definition, matching how `sql-endpoints get` renders single-object results. `fdw tables refresh MyLakehouseEP dbo.FactSales --json | jq .last_update_time_utc` works without indexing. Documented in `docs/commands/tables.md`.

## Decisions I had to make that the plan didn't fully settle

- **MCP parameter shape**: the plan flagged that `item` should be the parameter name (settled), but didn't settle whether the table itself should be `qualified_name: str` or a split `schema`/`table` pair (the design doc in #1060 wrote `schema`/`table`, matching `list_table_sync_status`'s *filter* parameters). Since `refresh_table_metadata` always acts on exactly one, definite table, not an optional filter, I used `qualified_name: str`, matching the shape of every other single-table-targeting tool in this file (`get_table_health_metrics`, `rename_table`, `transfer_table`, `read_table`, `count_table_rows`), and parsed it with the same `parse_qualified_name` helper.
- **Exception type for a non-zero return code / unexpected result shape**: neither is an HTTP/LRO failure, so I used the general `FabricError` rather than `FabricServerError` (which is documented as being for persistent 5xx / failed-LRO errors and carries `is_retriable`/status semantics that don't apply here): matching `get_table_health_metrics`'s own docstring convention of raising plain `FabricError` when "the engine reports an error executing the proc."
- Added a one-line cross-reference from `refresh_sql_endpoint_metadata`'s own MCP docstring back to `refresh_table_metadata`, for symmetry with the design's requirement that both tool descriptions state the scope difference explicitly (not strictly required by the plan's file list, but a small, low-risk docstring-only change).

## What I could not verify (refresh_table_metadata)

This environment has no live Fabric credentials, so none of the integration tests were actually run: only unit-tested and syntax/collection-checked. In particular:

- **The open question from #1060/#1062** (whether `sp_dw_refresh_ext_table` creates a table that doesn't exist yet in the endpoint) is still open pending a real run of `test_refresh_table_metadata_on_unknown_table_settles_open_question`. That test is written to fail loudly (not skip) if the procedure turns out to create the table, with a message pointing back at #1060 since that would reopen `tables refresh`'s group placement. Whoever runs the integration suite against a live preview-enabled endpoint should watch for that specific failure and report back on #1060 if it fires.
- Whether `sys.sp_dw_refresh_ext_table` has its own "not available in this SQL engine version" wording (like `sp_get_table_health_metrics` does) is unconfirmed: I added a parallel skip-fragment list (`_REFRESH_TABLE_UNAVAILABLE_FRAGMENTS`) defensively, reusing the same two fragments as the health-metrics test, but this is unverified against a live driver message for this specific procedure.

## Plan accuracy (refresh_table_metadata)

The plan's assumed API shape (`run_query(target, sql, params=..., mode=mode, commit=True, fetch="one")`) matched the real `sql.py` signature exactly, including `fetch="one"` returning `(cols, [row])` via `fetchone()`. No exception class named in the plan turned out to be wrong. One thing worth flagging for future work off this precedent: a plain mocked `Exception("Could not find stored procedure ...")` does **not** get classified as `NotFoundError` by `map_driver_error`: only `exc.ddbc_error` containing the native SQL error number (2812) does, since "could not find stored procedure" isn't in `_NOT_FOUND_FRAGMENTS`'s message-fragment fallback (unlike "invalid object name", which #1061's tests relied on). My unit tests construct a mock exception with a realistic `ddbc_error` attribute to exercise this path faithfully.

## Discovery gap: `--check-lakehouse` / `check_lakehouse` (#1064)

### What I found investigating endpoint-to-backing-item resolution

There is **no reverse link on the `/sqlEndpoints/{id}` resource itself**: a SQL analytics endpoint does not carry a pointer back to whatever created it. The only working mechanism is the one this codebase already uses for a different purpose: `get_endpoint`'s connection-string fallback (`_fabric_api.resolve_lakehouse_connection_string`) pages `GET /workspaces/{ws}/lakehouses` and matches on `properties.sqlEndpointProperties.id`. I generalised that scan into `resolve_backing_lakehouse`, which returns the Lakehouse's `id` and `properties.defaultSchema` alongside the connection string; `resolve_lakehouse_connection_string` is now a thin wrapper over it, unchanged in behaviour (its existing tests, plus `resolver.py`'s use of it, still pass unmodified).

This scan only ever finds a **Lakehouse**. A SQL Analytics Endpoint can also be backed by a mirrored database, a mirrored warehouse, etc.: none of those appear in `/lakehouses`, and this codebase has no REST API reach to enumerate their source tables at all. For those, `find_undiscovered_lakehouse_tables` returns `NOT_LAKEHOUSE_BACKED` and the CLI/MCP layer treats it as a documented no-op, never a silent claim of coverage.

### Which backing item kinds can be enumerated, and the schema-enabled complication

For a Lakehouse, the Fabric REST "Lakehouse - List Tables" API (`GET /workspaces/{ws}/lakehouses/{id}/tables`) returns every table's bare `name`: but **no schema field**. Researching this (fetched the live Microsoft Learn pages, not assumed), I found Microsoft's own Lakehouse-schemas documentation states explicitly: for a **schema-enabled** lakehouse, "to list tables, schemas, or get table details, use the OneLake table APIs for Delta" instead: a completely different API family (`onelake.table.fabric.microsoft.com/delta/...`, Unity-Catalog-compatible, its own name-based addressing scheme, and an OAuth scope I could not confirm from the docs alone, since it's a different host than either `FABRIC_SCOPE` or the `STORAGE_SCOPE` already used for OneLake DFS uploads in `services/load.py`). Wiring that up untested felt like exactly the kind of workaround the brief said to stop and report rather than build.

So the cross-check uses the classic List Tables API only, and only when it is safe to trust: a Lakehouse's GET/list response carries `properties.defaultSchema` **only when the lakehouse has schema support enabled** (confirmed from the live Get-Lakehouse REST reference, which documents this explicitly). Its presence is the signal `find_undiscovered_lakehouse_tables` uses to refuse the comparison (`SCHEMA_ENABLED_UNSUPPORTED`) rather than risk attributing a bare table name to the wrong schema and reporting a false "missing" table. Its absence means every lakehouse table is implicitly `dbo` on the endpoint, which is exactly what the List Tables API already gives us.

**This resolution and refusal are verified against a real, live schema-enabled Lakehouse**, not just unit-mocked: `tests/integration/test_services_sql_endpoints.py` adds `test_resolve_backing_lakehouse_finds_schema_enabled_lakehouse` (asserts a real endpoint resolves back to its real Lakehouse and that `properties.defaultSchema` really does come back as `"dbo"`) and `test_find_undiscovered_tables_schema_enabled_lakehouse_is_unsupported` (asserts the real cross-check refuses on it), both using the existing `ephemeral_sql_endpoint` fixture, which is schema-enabled by construction.

### How it surfaces

Extra rows in `tables sync-status` itself (your stated preference), not a separate command: a new `in_endpoint_catalog: bool = True` field on `TableMetadataSyncStatus`. Every row the existing catalog query produces keeps `True`; a table found only in the Lakehouse gets a synthetic row with `in_endpoint_catalog=False` and every DMV-sourced field `None` (it has no catalog row, so it cannot have sync info yet: that's a different, new condition from an `in_endpoint_catalog=True` row whose `last_update_time_utc` is `None` because it just hasn't synced). `--schema`/`--table` (CLI) and `schema`/`table` (MCP) are rejected as a `UsageError`/`ToolError` when combined with the check, since it always compares the whole endpoint and a filtered comparison would be meaningless.

### Cost

This turns the single TDS catalog query into that query plus at least one REST call (the lakehouse scan), plus a second, paginated one when a non-schema-enabled Lakehouse is actually found. That's real overhead on a command people may run repeatedly, so I made it **opt-in**: `--check-lakehouse` (CLI, default off) / `check_lakehouse=False` (MCP default). When the check can't run (no Lakehouse match, or schema-enabled), the CLI prints an explanatory note to stdout in human mode (never mixed into `--json`, verified by a dedicated test) so a silent no-op is never mistaken for "fully discovered"; the MCP tool documents the same limitation in its description since its return shape (`list[dict]`) has no room for an out-of-band note without breaking the existing #1061 contract.

### What I could not verify (discovery gap)

The "success, gap found" and "success, no gap" paths (`LakehouseDiscoveryStatus.OK`) are unit-tested but **not exercised live**. Every Lakehouse fixture already in `tests/integration/conftest.py` (`ephemeral_lakehouse`, and `shared_sql_endpoint`'s backing lakehouse) is schema-enabled by construction, so none of them can reach the `OK` path. Producing the actual target scenario (a non-schema-enabled Lakehouse with a Delta table written directly to OneLake but not yet synced to the endpoint catalog) is exactly what issue #1064 itself called "awkward to produce on demand" and out of scope to solve here. I did not build a new fixture to force this state; a live run against a real non-schema-enabled Lakehouse endpoint (with a table added directly, before the metadata sync catches up) is the remaining manual/follow-up verification for this path.

## Review round: exact-match comparison and hard-fail on inconclusive check

Two real defects from the adversarial review, both fixed.

**Case-folding hid the gaps the check exists to find (high).** `find_undiscovered_lakehouse_tables` case-folded both the Lakehouse table inventory and the known catalog names before comparing. Fabric's default collation (`FABRIC_DEFAULT_COLLATION` in `models.py`) is case-sensitive, so a Lakehouse `FactSales` and a catalog `factsales` are two distinct, independently valid table names, on a default-configured endpoint the check would silently treat them as the same table and report nothing missing. Fixed: the comparison is now exact by default, matching the safer failure direction (a false positive from a case-insensitive collation is visible and judgeable; a false negative was invisible). I did not attempt to read the endpoint's actual collation: the SQL endpoint REST resource does not expose it (see `list_endpoints`'s own docstring on what fields it carries), and reading it would need a TDS round-trip this REST-only function has no `SqlTarget` for. Per your "prefer that if it is not much extra work" note, a Lakehouse table that fails the exact match but matches a catalog name case-insensitively is now reported separately: a new `case_mismatched_catalog_name` field on `TableMetadataSyncStatus`, set to the likely-corresponding catalog name, rather than folded into a flat "missing" report. Regression coverage: `test_find_undiscovered_tables_comparison_is_case_sensitive_by_default` (proves a case-only difference is no longer silently absorbed), `test_find_undiscovered_tables_exact_match_is_not_reported_at_all`, and `test_find_undiscovered_tables_true_miss_is_not_a_case_mismatch`, plus CLI/MCP tests asserting the new field appears correctly on a synthetic row.

**Inconclusive result was indistinguishable from "checked, clean" (medium).** When `check_lakehouse`/`--check-lakehouse` was requested but couldn't run, both surfaces returned the unchanged catalog-only rows, with only a human-readable CLI note as the signal, nothing an automated MCP caller could read. Went with your call: both surfaces now fail rather than fall back. CLI raises `click.ClickException` (non-zero exit, no rows rendered, verified in both human and `--json` mode via `test_check_lakehouse_inconclusive_fails_in_json_mode_too`, which asserts the output is not even valid JSON since the command fails before `render()` runs). MCP raises via the existing `except (ValueError, FabricError)` funnel, so `list_table_sync_status`'s `list[dict]` return contract is completely unchanged for the path that doesn't hit this. Running without the flag is untouched either way. Message wording is duplicated by hand between the two modules (`cli/commands/tables.py` and `mcp/tools/tables.py`), each phrased in that surface's own flag spelling (`--check-lakehouse` vs `check_lakehouse`), with a comment on each pointing at its counterpart.

Also merged `origin/main` (the click 8.5.0 bump, #1059) before any of the above: clean merge, no conflicts. Re-ran the full suite immediately after merging, before touching anything else: all green, and specifically re-ran the `sql-endpoints` command-hint tests (the `resolve_command`-overriding `click.Group` subclass this PR adds) since that is exactly the kind of thing a click bump could silently break. No `DeprecationWarning` surfaced anywhere (this repo turns those into test errors), so nothing newly deprecated in 8.5 touches this PR's code.

Docs (`docs/commands/tables.md`, both the CLI and MCP sections) updated for exact-match semantics, the new `case_mismatched_catalog_name` field, and the fail-instead-of-fallback behaviour.

## Verification

- `uv run ruff check .`: clean
- `uv run ruff format --check .`: clean
- `uv run ty check src tests`: clean
- `uv run pytest tests/unit -q`: 5904 passed
- Integration tests: not run (no live credentials in this environment); added but unverified except where noted above (the two discovery-gap tests are real, deterministic REST calls against a live schema-enabled Lakehouse fixture and would run against real credentials in CI like every other `pytest.mark.integration` test here). The exact-match fix does not change what those two integration tests assert (they exercise the refusal paths, not the exact/case-mismatch comparison itself), so they were not re-run against a live tenant for this round either.

