### PR TITLE
fix(tables): run refresh_table_metadata's batch with ODBC autocommit

### DIFF
--- a/src/fabric_dw/services/tables.py
+++ b/src/fabric_dw/services/tables.py
@@ -1564,6 +1564,15 @@ async def refresh_table_metadata(
     :class:`~fabric_dw.exceptions.FabricError` is raised instead of silently
     trusting whatever came back.
 
+    ``sys.sp_dw_refresh_ext_table`` refuses to run inside a user transaction
+    ("Stored procedure sp_dw_refresh_ext_table cannot be called inside an
+    existing transaction") -- the same class of restriction ``KILL`` hits
+    (issue #776). The batch is therefore run with ``autocommit=True``
+    (ODBC-level autocommit, not :func:`~fabric_dw.sql.run_query`'s ``commit``
+    flag), so the driver never wraps it in an explicit ``BEGIN TRANSACTION``
+    and each statement commits as it completes -- the refresh persists even
+    though no explicit ``conn.commit()`` is ever called.
+
     After a successful refresh, the table's refreshed sync-status row is
     fetched via :func:`list_table_sync_status` and returned, so callers see
     the new ``last_update_time_utc`` without a second call. If the table is
@@ -1616,12 +1625,16 @@ async def refresh_table_metadata(
 
     def _run() -> None:
         try:
+            # autocommit=True (ODBC-level), not commit=True: sys.sp_dw_refresh_ext_table
+            # rejects being called inside a user transaction (the same restriction
+            # KILL hits, #776), and run_query would otherwise open the connection
+            # without autocommit and wrap the batch in one. See the docstring above.
             cols, rows = run_query(
                 target,
                 _SP_REFRESH_TABLE_SQL,
                 params=[qualified],
                 mode=mode,
-                commit=True,
+                autocommit=True,
                 fetch="one",
             )
         except NotFoundError as exc:

--- a/tests/unit/services/test_tables.py
+++ b/tests/unit/services/test_tables.py
@@ -3398,15 +3398,41 @@ class TestRefreshTableMetadata:
         assert result.name == "FactSales"
         assert result.qualified_name == "dbo.FactSales"
 
-    async def test_commits_after_execute(self) -> None:
+    async def test_runs_with_autocommit_not_an_explicit_commit(self) -> None:
+        """Regression test for the live failure that followed the nvarchar fix.
+
+        Against a real endpoint, the refresh batch raised ``Stored procedure
+        sp_dw_refresh_ext_table cannot be called inside an existing
+        transaction`` -- the same restriction ``KILL`` hits (#776).
+        ``run_query``'s own ``commit=True`` still opens the connection
+        without ODBC-level autocommit and wraps the batch in one; only
+        ``autocommit=True`` opens the connection so the driver never wraps it
+        in a transaction at all. This asserts the connection is opened with
+        ``autocommit=True`` and that no explicit ``conn.commit()`` is called
+        (autocommit persists each statement as it completes), so a
+        regression back to ``commit=True`` is caught here rather than only
+        against a live endpoint.
+
+        What this does NOT catch: that the ODBC ``autocommit`` flag really
+        does suppress the driver's implicit transaction server-side -- that
+        is exactly what a live endpoint proved in the integration run this
+        fixes, and the mock has no transaction state to get wrong.
+        """
         target = _make_target()
         refresh_conn = _make_conn_for_rc(0)
         fetch_conn = _make_conn([_SYNC_ROW_SYNCED], _SYNC_STATUS_COLS)
-        with patch("fabric_dw.sql.open_connection", side_effect=[refresh_conn, fetch_conn]):
+        with patch(
+            "fabric_dw.sql.open_connection", side_effect=[refresh_conn, fetch_conn]
+        ) as mock_open_connection:
             await tables.refresh_table_metadata(
                 target, "dbo", "FactSales", kind=WarehouseKind.SQL_ENDPOINT
             )
-        refresh_conn.commit.assert_called_once()
+        refresh_call = mock_open_connection.call_args_list[0]
+        assert refresh_call.kwargs.get("autocommit") is True, (
+            f"expected the refresh connection to be opened with autocommit=True; "
+            f"got call {refresh_call!r}"
+        )
+        refresh_conn.commit.assert_not_called()
 
     async def test_qualified_name_is_bound_param_not_interpolated(self) -> None:
         target = _make_target()


### PR DESCRIPTION
## Summary

The integration run on `main` after #1068 merged confirmed the `nvarchar(517)` binding fix worked, but surfaced a second, previously-hidden bug behind it:

```
FabricServerError: [Microsoft][SQL Server]Stored procedure sp_dw_refresh_ext_table cannot be called inside an existing transaction.
```

`refresh_table_metadata` called `run_query(..., commit=True)`, which opens the connection without ODBC-level autocommit and commits explicitly afterwards -- the refresh batch still runs inside a driver-opened transaction for its whole duration. `sys.sp_dw_refresh_ext_table` refuses to run inside a user transaction at all.

## Fix

Same restriction, same fix as issue #776 (`KILL` hit this exact error). Pass `autocommit=True` instead of `commit=True`, so the driver opens the connection with ODBC-level autocommit and never wraps the batch in a transaction in the first place; each statement in the batch commits as it completes. `commit=True` is a no-op once `autocommit=True` (documented on `run_query` itself), so it's replaced rather than combined.

Verified from `open_connection` (`sql_pool.py`) that `autocommit` is passed straight through to the mssql-python driver's own `connect(..., autocommit=...)`, which sets the real ODBC `SQL_ATTR_AUTOCOMMIT` connection attribute -- not a Python-side wrapper that would leave a transaction open server-side while looking done client-side. This is the same connection-level mechanism `kill()` already relies on for the same class of error.

The `DECLARE @tableName nvarchar(517) = ?` typing from the previous fix is unchanged; only the transaction handling changed.

## Tests

**What the new unit test catches, and what it can't.** The old test asserted `refresh_conn.commit.assert_called_once()` -- that assertion is no longer true once `autocommit=True`, and it was never really testing the thing that mattered. Replaced it with a test that asserts the connection is opened with `autocommit=True` and that no explicit `conn.commit()` is called, so a regression back to `commit=True` is caught here in the unit suite. What it can NOT catch: whether the ODBC autocommit flag genuinely suppresses the transaction server-side -- the mock has no transaction state to get wrong, so this is exactly the same class of gap the nvarchar-type bug fell through last time. Only a live endpoint (the `sql_endpoint`-marked integration tests) can confirm that, and this is precisely why they exist.

The two integration tests (`test_refresh_table_metadata_on_sql_endpoint`, `test_refresh_table_metadata_on_unknown_table_settles_open_question`) needed no changes; they should now get further than before.

## Still open

`test_refresh_table_metadata_on_unknown_table_settles_open_question` has now crashed twice before reaching its actual subject (first on the nvarchar type mismatch, then on this transaction error). Whether `sp_dw_refresh_ext_table` creates a table that doesn't already exist in the endpoint's catalog is still unsettled -- that needs the next integration run against `main`, not something this PR can resolve.

Context: #1060.

## Test plan

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run ty check src tests`
- [x] `uv run pytest tests/unit -q` (5930 passed)
- [ ] Integration tests (`sql_endpoint`-marked) -- not run here per project convention; they need live credentials and run on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
